### PR TITLE
fix(engine): compare xattrs before reporting a local x change

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -110,7 +110,14 @@ pub(super) fn handle_dry_run(
             modify_window: context.options().modify_window(),
             prefetched_match,
         }) {
-            record_dry_run_skip(context, metadata, destination, record_path, existing);
+            record_dry_run_skip(
+                context,
+                metadata,
+                source,
+                destination,
+                record_path,
+                existing,
+            );
             return Ok(());
         }
     }
@@ -179,10 +186,20 @@ pub(super) fn handle_dry_run(
     // `>f.st......`) rather than a blank `>f.........`. Mirror the real-run
     // change set from execute/mod.rs so `-ni` matches `-i` byte-for-byte.
     let wrote_data = bytes_transferred > 0;
-    #[cfg(all(unix, feature = "xattr"))]
-    let xattrs_enabled = context.xattrs_enabled();
-    #[cfg(not(all(unix, feature = "xattr")))]
-    let xattrs_enabled = false;
+    // upstream: generator.c:566-572 - itemize() runs xattr_diff() in a dry run
+    // exactly as in a real one, and a dry run never writes the destination, so
+    // the comparison always sees the pre-transfer state.
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
+    let xattrs_changed = context.xattrs_enabled()
+        && crate::local_copy::xattrs_differ_from_source(
+            source,
+            destination,
+            false,
+            context.metadata_options().fake_super_enabled(),
+            context.filter_program(),
+        );
+    #[cfg(not(all(any(unix, windows), feature = "xattr")))]
+    let xattrs_changed = false;
     #[cfg(all(any(unix, windows), feature = "acl"))]
     let acls_enabled = context.acls_enabled();
     #[cfg(not(all(any(unix, windows), feature = "acl")))]
@@ -193,7 +210,7 @@ pub(super) fn handle_dry_run(
         &context.metadata_options(),
         destination_previously_existed,
         wrote_data,
-        xattrs_enabled,
+        xattrs_changed,
         acls_enabled,
         context.checksum_enabled(),
         context.options().modify_window(),
@@ -237,11 +254,30 @@ pub(super) fn handle_dry_run(
 fn record_dry_run_skip(
     context: &mut CopyContext,
     metadata: &fs::Metadata,
+    source: &Path,
     destination: &Path,
     record_path: &Path,
     existing: &fs::Metadata,
 ) {
     let metadata_options = context.metadata_options();
+    // upstream: generator.c:1816 -> itemize() with iflags=0. An up-to-date file
+    // still runs xattr_diff(), and ITEM_REPORT_XATTR is part of the emit gate
+    // (generator.c:582), so a drifted attribute prints `.f........x` even though
+    // nothing else changed - in a dry run exactly as in a real one.
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
+    let xattrs_changed = context.xattrs_enabled()
+        && crate::local_copy::xattrs_differ_from_source(
+            source,
+            destination,
+            false,
+            metadata_options.fake_super_enabled(),
+            context.filter_program(),
+        );
+    #[cfg(not(all(any(unix, windows), feature = "xattr")))]
+    let xattrs_changed = {
+        let _ = source;
+        false
+    };
     context.record_hard_link(metadata, destination);
     context.summary_mut().record_regular_file_matched();
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
@@ -252,7 +288,7 @@ fn record_dry_run_skip(
         &metadata_options,
         true,
         false,
-        false,
+        xattrs_changed,
         false,
         context.options().modify_window(),
     );

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -257,6 +257,23 @@ pub(crate) fn copy_file(
         return Ok(true);
     }
 
+    // upstream: generator.c:566-572 - itemize() lights ITEM_REPORT_XATTR only
+    // when xattr_diff() finds the destination's attributes differ from the
+    // sender's. Capture that here, before the transfer or the metadata apply
+    // can write the source attributes onto the destination; comparing after the
+    // sync would always report "same" and never report a real drift.
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
+    let xattrs_changed = preserve_xattrs
+        && crate::local_copy::xattrs_differ_from_source(
+            source,
+            destination,
+            false,
+            metadata_options.fake_super_enabled(),
+            context.filter_program(),
+        );
+    #[cfg(not(all(any(unix, windows), feature = "xattr")))]
+    let xattrs_changed = false;
+
     let transfer_flags = TransferFlags {
         append_allowed,
         append_verify,
@@ -270,6 +287,7 @@ pub(crate) fn copy_file(
         checksum_enabled,
         #[cfg(all(any(unix, windows), feature = "xattr"))]
         preserve_xattrs,
+        xattrs_changed,
         #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,
     };

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -178,7 +178,7 @@ pub(super) fn try_clone(
         &metadata_options,
         destination_previously_existed,
         true,
-        flags.xattrs_enabled(),
+        flags.xattrs_changed,
         flags.acls_enabled(),
         context.options().modify_window(),
     );

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -165,7 +165,7 @@ pub(super) fn try_clone(
         &metadata_options,
         destination_previously_existed,
         true,
-        flags.xattrs_enabled(),
+        flags.xattrs_changed,
         flags.acls_enabled(),
         context.options().modify_window(),
     );

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
@@ -132,7 +132,7 @@ pub(super) fn try_dispatch(
         &metadata_options,
         destination_previously_existed,
         true,
-        flags.xattrs_enabled(),
+        flags.xattrs_changed,
         flags.acls_enabled(),
         context.options().modify_window(),
     );

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -93,6 +93,9 @@ pub(in crate::local_copy) fn execute_transfer(
         size_only_enabled: _,
         ignore_times_enabled: _,
         checksum_enabled: _,
+        // Read straight off `flags` at the record site below, which needs it
+        // after the transfer has run.
+        xattrs_changed: _,
         // Consumed by the standard-path finalize call below on Unix; on
         // Windows the `CopyFileExW` fast path reconciles ADS itself, so this
         // field is unused in the standard path there.
@@ -751,7 +754,7 @@ pub(in crate::local_copy) fn execute_transfer(
         &metadata_options,
         is_reference_copy || destination_previously_existed,
         wrote_data && !is_reference_copy,
-        flags.xattrs_enabled(),
+        flags.xattrs_changed,
         flags.acls_enabled(),
         flags.checksum_enabled,
         context.options().modify_window(),

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
@@ -188,7 +188,7 @@ pub(super) fn record_metadata_only_skip(
         metadata_options,
         true,
         false,
-        flags.xattrs_enabled(),
+        flags.xattrs_changed,
         flags.acls_enabled(),
         context.options().modify_window(),
     );

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -169,7 +169,7 @@ pub(super) fn try_copy(
         &metadata_options,
         destination_previously_existed,
         true,
-        flags.xattrs_enabled(),
+        flags.xattrs_changed,
         flags.acls_enabled(),
         context.options().modify_window(),
     );

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/mod.rs
@@ -56,6 +56,14 @@ pub(super) struct TransferFlags {
     /// decide whether to keep or strip the streams the kernel copied.
     #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub preserve_xattrs: bool,
+    /// Whether the destination's extended attributes differed from the
+    /// source's before the copy touched them.
+    ///
+    /// Drives the itemize `x` column. upstream: `generator.c:566-572` sets
+    /// `ITEM_REPORT_XATTR` from `xattr_diff()`, never from `preserve_xattrs`
+    /// alone, so this is captured once in `copy_file` while the destination is
+    /// still untouched and carried down to every record site.
+    pub xattrs_changed: bool,
     /// Whether to preserve ACLs (Unix only).
     #[cfg(all(any(unix, windows), feature = "acl"))]
     pub preserve_acls: bool,
@@ -64,16 +72,19 @@ pub(super) struct TransferFlags {
 impl TransferFlags {
     /// Returns whether xattrs preservation is effectively enabled,
     /// accounting for compile-time feature flags.
+    ///
+    /// The sole caller is `wincopy::reconcile_copied_ads`, itself
+    /// `#[cfg(feature = "xattr")]` inside the `#[cfg(target_os = "windows")]`
+    /// `wincopy` module: it decides whether to keep or strip the Alternate Data
+    /// Streams `CopyFileExW` copied. The gate is that intersection exactly,
+    /// because `-D warnings` makes an unused method fatal.
+    ///
+    /// The itemize `x` column is driven by `xattrs_changed` instead, because
+    /// upstream reports it from a comparison rather than from the flag.
+    #[cfg(all(target_os = "windows", feature = "xattr"))]
     #[inline]
     pub(super) const fn xattrs_enabled(self) -> bool {
-        #[cfg(all(any(unix, windows), feature = "xattr"))]
-        {
-            self.preserve_xattrs
-        }
-        #[cfg(not(all(any(unix, windows), feature = "xattr")))]
-        {
-            false
-        }
+        self.preserve_xattrs
     }
 
     /// Returns whether ACL preservation is effectively enabled,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
@@ -93,7 +93,7 @@ pub(in crate::local_copy) fn copy_special_as_regular_file(
         &metadata_options,
         destination_previously_existed,
         false,
-        flags.xattrs_enabled(),
+        flags.xattrs_changed,
         flags.acls_enabled(),
         context.options().modify_window(),
     );

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -54,8 +54,19 @@ pub(crate) fn copy_device(
     // ITEM_REPORT_XATTR / ITEM_REPORT_ACL when those features are active and the
     // basis differs. Mirror the enabled flags across all platforms so the
     // recreate change-set is derivable without cfg branching at the record site.
+    // upstream: generator.c:566-572 - itemize() lights ITEM_REPORT_XATTR from
+    // xattr_diff(), not from `preserve_xattrs`. Compare here, before the node is
+    // unlinked and recreated, so the diff sees the destination that the row
+    // reports against.
     #[cfg(all(unix, feature = "xattr"))]
-    let itemize_xattrs = preserve_xattrs;
+    let itemize_xattrs = preserve_xattrs
+        && crate::local_copy::xattrs_differ_from_source(
+            source,
+            destination,
+            false,
+            metadata_options.fake_super_enabled(),
+            context.filter_program(),
+        );
     #[cfg(not(all(unix, feature = "xattr")))]
     let itemize_xattrs = false;
     #[cfg(all(any(unix, windows), feature = "acl"))]

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -58,8 +58,19 @@ pub(crate) fn copy_fifo(
     // ITEM_REPORT_XATTR / ITEM_REPORT_ACL when those features are active and the
     // basis differs. Surface the enabled flags on all platforms so the recreate
     // change-set is derivable without cfg branching at the record site.
+    // upstream: generator.c:566-572 - itemize() lights ITEM_REPORT_XATTR from
+    // xattr_diff(), not from `preserve_xattrs`. Compare here, before the node is
+    // unlinked and recreated, so the diff sees the destination that the row
+    // reports against.
     #[cfg(all(unix, feature = "xattr"))]
-    let itemize_xattrs = preserve_xattrs;
+    let itemize_xattrs = preserve_xattrs
+        && crate::local_copy::xattrs_differ_from_source(
+            source,
+            destination,
+            false,
+            metadata_options.fake_super_enabled(),
+            context.filter_program(),
+        );
     #[cfg(not(all(unix, feature = "xattr")))]
     let itemize_xattrs = false;
     #[cfg(all(any(unix, windows), feature = "acl"))]

--- a/crates/engine/src/local_copy/metadata_sync.rs
+++ b/crates/engine/src/local_copy/metadata_sync.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 ))]
 use super::LocalCopyExecution;
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(any(unix, windows), feature = "xattr"))]
 use super::FilterProgram;
 
 #[cfg(all(any(unix, windows), feature = "acl"))]
@@ -60,6 +60,84 @@ pub(crate) fn sync_xattrs_if_requested(
         }
     }
     Ok(())
+}
+
+/// Whether the destination's extended attributes differ from the source's, for
+/// the itemize `x` column.
+///
+/// Mirrors upstream `generator.c:566-572`, which calls `xattr_diff()` for every
+/// itemized entry under `preserve_xattrs`. In a local copy upstream still forks
+/// a sender and a generator, so the two sides collect their lists with
+/// different `rsync_xal_get()` globals: the sender with `am_sender = 1`
+/// (`user_only = 0`, plus the `rsync.%FOO` strip below `-XX`), the generator
+/// with `am_sender = 0` (`user_only = !am_root`, no strip). Reading each side
+/// with its own [`XattrRole`] reproduces that split; the comparison itself is
+/// [`::metadata::dest_xattrs_differ`], shared with the network receiver.
+///
+/// Call this before [`sync_xattrs_if_requested`] writes the source attributes
+/// onto the destination, or the comparison sees its own output and can never
+/// report a difference.
+///
+/// A source that cannot be read reports no difference, matching the destination
+/// side's failure handling: upstream's `get_xattr()` failure likewise leaves an
+/// empty list rather than inventing a change.
+#[cfg(all(unix, feature = "xattr"))]
+pub(crate) fn xattrs_differ_from_source(
+    source: &Path,
+    destination: &Path,
+    follow_symlinks: bool,
+    fake_super: bool,
+    filter_program: Option<&FilterProgram>,
+) -> bool {
+    let filter = filter_program
+        .filter(|program| program.has_xattr_rules())
+        .map(|program| move |name: &str| program.allows_xattr(name));
+    let sender_opts = ::metadata::XattrSendOptions {
+        role: ::metadata::XattrRole::Sender,
+        follow_symlinks,
+        am_root: ::metadata::am_root(),
+        // The local-copy options carry `-X` as a bool, so the `rsync.%FOO`
+        // strip always applies on the sender side. upstream: xattrs.c:260-267.
+        preserve_xattrs: 1,
+        fake_super,
+        filter: filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool),
+        // Both lists are read from local disk with full values, so the
+        // abbreviation digest is never consulted. upstream: xattrs.c:584-594.
+        checksum_seed: 0,
+    };
+    let Ok(sender) = ::metadata::read_xattrs_for_wire(source, &sender_opts) else {
+        return false;
+    };
+    ::metadata::dest_xattrs_differ(
+        &sender,
+        destination,
+        &::metadata::XattrSendOptions {
+            role: ::metadata::XattrRole::Generator,
+            ..sender_opts
+        },
+    )
+}
+
+/// Reports no difference on Windows, whose `-X` maps onto NTFS Alternate Data
+/// Streams rather than POSIX extended attributes.
+///
+/// The `x` column describes upstream's POSIX extended attributes; without a
+/// comparison there is nothing to report, and claiming a change on every file
+/// is worse than staying silent.
+///
+/// The gate is the callers' (`all(any(unix, windows), feature = "xattr")`) minus
+/// the Unix half the real implementation above covers, so no build carries a
+/// definition it never calls - `-D warnings` makes an unused `pub(crate)` item
+/// fatal, which is exactly how this landed red on the Windows daemon job.
+#[cfg(all(windows, feature = "xattr"))]
+pub(crate) const fn xattrs_differ_from_source(
+    _source: &std::path::Path,
+    _destination: &std::path::Path,
+    _follow_symlinks: bool,
+    _fake_super: bool,
+    _filter_program: Option<&FilterProgram>,
+) -> bool {
+    false
 }
 
 /// Synchronizes POSIX/extended ACLs from source to destination if requested.

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -132,6 +132,9 @@ pub use hard_links::{HardlinkApplyResult, HardlinkApplyTracker};
 
 pub(crate) use metadata_sync::map_metadata_error;
 
+#[cfg(all(any(unix, windows), feature = "xattr"))]
+pub(crate) use metadata_sync::xattrs_differ_from_source;
+
 #[cfg(all(any(unix, windows), feature = "acl"))]
 pub(crate) use metadata_sync::sync_acls_if_requested;
 

--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -23,7 +23,7 @@ impl LocalCopyChangeSet {
         metadata_options: &MetadataOptions,
         destination_previously_existed: bool,
         wrote_data: bool,
-        xattrs_enabled: bool,
+        xattrs_changed: bool,
         acls_enabled: bool,
         modify_window: ModifyWindow,
     ) -> Self {
@@ -33,7 +33,7 @@ impl LocalCopyChangeSet {
             metadata_options,
             destination_previously_existed,
             wrote_data,
-            xattrs_enabled,
+            xattrs_changed,
             acls_enabled,
             false,
             modify_window,
@@ -48,6 +48,13 @@ impl LocalCopyChangeSet {
     /// itemize line keeps `.` in slot 2. Callers that have an explicit
     /// `--checksum` flag should use this constructor and pass `true` only
     /// when checksum-mode is active.
+    ///
+    /// `xattrs_changed` is the *result* of the xattr comparison, not the `-X`
+    /// flag: upstream `generator.c:566-572` sets `ITEM_REPORT_XATTR` only when
+    /// `xattr_diff()` finds the destination's attributes differ from the
+    /// sender's. Compute it with
+    /// [`xattrs_differ_from_source`](crate::local_copy::xattrs_differ_from_source)
+    /// before anything writes the source attributes onto the destination.
     #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
     pub fn for_file_with_checksum(
         metadata: &fs::Metadata,
@@ -55,7 +62,7 @@ impl LocalCopyChangeSet {
         metadata_options: &MetadataOptions,
         destination_previously_existed: bool,
         wrote_data: bool,
-        xattrs_enabled: bool,
+        xattrs_changed: bool,
         acls_enabled: bool,
         checksum_enabled: bool,
         modify_window: ModifyWindow,
@@ -149,7 +156,7 @@ impl LocalCopyChangeSet {
             change_set = change_set.with_group_changed(true);
         }
 
-        if xattrs_enabled {
+        if xattrs_changed {
             change_set = change_set.with_xattr_changed(true);
         }
 
@@ -175,7 +182,7 @@ impl LocalCopyChangeSet {
         existing: &fs::Metadata,
         metadata_options: &MetadataOptions,
         omit_dir_times: bool,
-        xattrs_enabled: bool,
+        xattrs_changed: bool,
         acls_enabled: bool,
         modify_window: ModifyWindow,
     ) -> Self {
@@ -221,7 +228,7 @@ impl LocalCopyChangeSet {
             change_set = change_set.with_group_changed(true);
         }
 
-        if xattrs_enabled {
+        if xattrs_changed {
             change_set = change_set.with_xattr_changed(true);
         }
         if acls_enabled {
@@ -303,7 +310,7 @@ impl LocalCopyChangeSet {
         metadata_options: &MetadataOptions,
         modify_window: ModifyWindow,
         content_differs: bool,
-        xattrs_enabled: bool,
+        xattrs_changed: bool,
         acls_enabled: bool,
     ) -> Self {
         let mut change_set = Self::new();
@@ -359,7 +366,7 @@ impl LocalCopyChangeSet {
             change_set = change_set.with_group_changed(true);
         }
 
-        if xattrs_enabled {
+        if xattrs_changed {
             change_set = change_set.with_xattr_changed(true);
         }
         if acls_enabled {

--- a/crates/engine/src/local_copy/plan/change_set/tests.rs
+++ b/crates/engine/src/local_copy/plan/change_set/tests.rs
@@ -289,26 +289,35 @@ fn for_file_wrote_data_sets_checksum_changed() {
     assert!(change_set.checksum_changed());
 }
 
+/// The `x` glyph reports the *outcome* of the xattr comparison, so the
+/// constructor must forward the caller's verdict verbatim in both directions.
+///
+/// upstream: generator.c:566-572 - `if (xattr_diff(file, sxp, 1)) iflags |=
+/// ITEM_REPORT_XATTR`. Passing `-X` itself would light `x` on every row of an
+/// unchanged tree, which upstream never prints.
 #[test]
-fn for_file_xattrs_enabled_sets_xattr_changed() {
+fn for_file_reports_xattr_change_only_when_the_comparison_found_one() {
     let temp = tempfile::tempdir().expect("tempdir");
     let path = temp.path().join("file.txt");
     fs::write(&path, b"content").expect("write");
     let metadata = fs::metadata(&path).expect("metadata");
     let options = MetadataOptions::new();
 
-    let change_set = LocalCopyChangeSet::for_file(
-        &metadata,
-        Some(&metadata),
-        &options,
-        true,
-        false,
-        true, // xattrs enabled
-        false,
-        ModifyWindow::ZERO,
-    );
+    let build = |xattrs_changed| {
+        LocalCopyChangeSet::for_file(
+            &metadata,
+            Some(&metadata),
+            &options,
+            true,
+            false,
+            xattrs_changed,
+            false,
+            ModifyWindow::ZERO,
+        )
+    };
 
-    assert!(change_set.xattr_changed());
+    assert!(build(true).xattr_changed());
+    assert!(!build(false).xattr_changed());
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_xattrs.rs
+++ b/crates/engine/src/local_copy/tests/execute_xattrs.rs
@@ -935,4 +935,230 @@ mod xattr_tests {
             .expect("xattr present");
         assert_eq!(copied, b"real_value");
     }
+
+    /// Builds a `src`/`dst` pair whose files are byte-identical and share the
+    /// same mtimes, then returns the itemize records of a second `-aX` run.
+    ///
+    /// The second run takes the quick-check skip path, which is where upstream
+    /// itemizes an up-to-date file (`generator.c:1816` -> `itemize()` with
+    /// `iflags = 0`) and where an unconditional xattr flag is visible on every
+    /// row.
+    fn itemize_second_pass(src: &Path, dst: &Path) -> Vec<(String, bool)> {
+        let operands = vec![
+            OsString::from(format!("{}/", src.display())),
+            dst.to_path_buf().into_os_string(),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+        let options = LocalCopyOptions::default()
+            .recursive(true)
+            .xattrs(true)
+            .permissions(true)
+            .times(true)
+            .collect_events(true);
+        let report = plan
+            .execute_with_report(LocalCopyExecution::Apply, options)
+            .expect("copy succeeds");
+        report
+            .records()
+            .iter()
+            .map(|record| {
+                (
+                    record.relative_path().display().to_string(),
+                    record.change_set().xattr_changed(),
+                )
+            })
+            // The transfer root carries a "." row that upstream itemizes
+            // separately (generator.c:1480-1483); the xattr column under test
+            // belongs to the file rows.
+            .filter(|(name, _)| name != ".")
+            .collect()
+    }
+
+    /// Fails the caller when the second pass did not itemize both seeded files,
+    /// so an assertion over "every record" can never pass vacuously.
+    fn assert_both_files_itemized(records: &[(String, bool)]) {
+        let mut names: Vec<&str> = records.iter().map(|(name, _)| name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["a.txt", "b.txt"],
+            "the up-to-date pass must itemize both files: {records:?}"
+        );
+    }
+
+    /// Seeds `src` with two files carrying `user.color`, mirrors it into `dst`,
+    /// and returns the pair. `dst` is produced by a first `-aX` pass so both
+    /// sides agree on content, mtimes and xattrs.
+    fn seeded_tree(temp: &Path) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+        let src = temp.join("src");
+        let dst = temp.join("dst");
+        fs::create_dir_all(&src).expect("create src");
+        fs::write(src.join("a.txt"), b"alpha").expect("write a");
+        fs::write(src.join("b.txt"), b"beta").expect("write b");
+        if !xattrs_supported(&src.join("a.txt")) {
+            eprintln!("xattrs not supported, skipping test");
+            return None;
+        }
+        xattr::set(src.join("a.txt"), "user.color", b"red").expect("set a");
+        xattr::set(src.join("b.txt"), "user.color", b"blue").expect("set b");
+
+        seed_destination(&src, &dst);
+        Some((src, dst))
+    }
+
+    /// Runs a first `-aX` pass so `dst` mirrors `src` byte-for-byte, including
+    /// mtimes and xattrs.
+    fn seed_destination(src: &Path, dst: &Path) {
+        let operands = vec![
+            OsString::from(format!("{}/", src.display())),
+            dst.to_path_buf().into_os_string(),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+        plan.execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default()
+                .recursive(true)
+                .xattrs(true)
+                .permissions(true)
+                .times(true),
+        )
+        .expect("seed copy succeeds");
+    }
+
+    /// Case 1: an unchanged tree whose xattrs already match must not light the
+    /// itemize `x` column anywhere.
+    ///
+    /// upstream: generator.c:566-572 - `itemize()` sets `ITEM_REPORT_XATTR`
+    /// only when `xattr_diff()` reports a difference, and `ITEM_REPORT_XATTR`
+    /// is itself part of the emit gate (generator.c:582), so a spurious flag
+    /// both adds an `x` and prints a row upstream omits entirely. Verified
+    /// against rsync 3.4.4 (protocol 32), which prints nothing for this tree.
+    #[test]
+    fn itemize_matching_xattrs_report_no_change() {
+        let temp = tempdir().expect("tempdir");
+        let Some((src, dst)) = seeded_tree(temp.path()) else {
+            return;
+        };
+
+        let records = itemize_second_pass(&src, &dst);
+        assert_both_files_itemized(&records);
+        for (name, xattr_changed) in &records {
+            assert!(
+                !xattr_changed,
+                "{name} must not report an xattr change when both sides match"
+            );
+        }
+    }
+
+    /// Case 2: a genuine `user.*` difference lights `x` on that file alone.
+    ///
+    /// Pins both halves of the comparison: the file whose value drifted reports
+    /// the change, and its unchanged sibling stays silent. A flag that merely
+    /// echoed `-X` would pass the first assertion and fail the second, which is
+    /// exactly how the defect hid.
+    #[test]
+    fn itemize_differing_xattr_value_reports_only_that_file() {
+        let temp = tempdir().expect("tempdir");
+        let Some((src, dst)) = seeded_tree(temp.path()) else {
+            return;
+        };
+
+        // Only the destination's value drifts; content and mtime are untouched,
+        // so the entry still takes the quick-check skip path.
+        xattr::set(dst.join("b.txt"), "user.color", b"magenta").expect("drift b");
+
+        let records = itemize_second_pass(&src, &dst);
+        assert_both_files_itemized(&records);
+        let changed: Vec<_> = records
+            .iter()
+            .filter(|(_, xattr_changed)| *xattr_changed)
+            .map(|(name, _)| name.clone())
+            .collect();
+        assert_eq!(
+            changed,
+            vec!["b.txt".to_string()],
+            "only the drifted file may light the x column; got {records:?}"
+        );
+    }
+
+    /// A dry run itemizes the same `x` column as the real run.
+    ///
+    /// upstream: generator.c:1816 - the generator itemizes an up-to-date file
+    /// whether or not `do_xfers` is set, so `-naXi` and `-aXi` must agree. The
+    /// dry-run skip path previously hardcoded "no xattr change", which hid a
+    /// genuine drift instead of inventing one.
+    #[test]
+    fn dry_run_itemize_matches_the_real_run() {
+        let temp = tempdir().expect("tempdir");
+        let Some((src, dst)) = seeded_tree(temp.path()) else {
+            return;
+        };
+        xattr::set(dst.join("b.txt"), "user.color", b"magenta").expect("drift b");
+
+        let operands = vec![
+            OsString::from(format!("{}/", src.display())),
+            dst.clone().into_os_string(),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+        let report = plan
+            .execute_with_report(
+                LocalCopyExecution::DryRun,
+                LocalCopyOptions::default()
+                    .recursive(true)
+                    .xattrs(true)
+                    .permissions(true)
+                    .times(true)
+                    .collect_events(true),
+            )
+            .expect("dry run succeeds");
+        let changed: Vec<String> = report
+            .records()
+            .iter()
+            .filter(|record| record.change_set().xattr_changed())
+            .map(|record| record.relative_path().display().to_string())
+            .collect();
+        assert_eq!(
+            changed,
+            vec!["b.txt".to_string()],
+            "a dry run must report the same x column as the real run"
+        );
+    }
+
+    /// A value longer than `MAX_FULL_DATUM` that is identical on both sides
+    /// must not report a change.
+    ///
+    /// The local-copy generator reads both lists from disk with full values,
+    /// while the network generator receives an abbreviated sender list. Keying
+    /// the comparison on length alone would hash the local plaintext against
+    /// the destination plaintext and never match, so every large xattr would
+    /// light `x` forever. upstream: xattrs.c:584-594.
+    #[test]
+    fn itemize_large_matching_xattr_value_reports_no_change() {
+        let temp = tempdir().expect("tempdir");
+        let src = temp.path().join("src");
+        let dst = temp.path().join("dst");
+        fs::create_dir_all(&src).expect("create src");
+        fs::write(src.join("big.txt"), b"payload").expect("write");
+        if !xattrs_supported(&src.join("big.txt")) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+        let large = vec![b'z'; 512];
+        xattr::set(src.join("big.txt"), "user.large", &large).expect("set large");
+
+        seed_destination(&src, &dst);
+
+        let records = itemize_second_pass(&src, &dst);
+        assert_eq!(
+            records.len(),
+            1,
+            "the up-to-date pass must itemize the file: {records:?}"
+        );
+        for (name, xattr_changed) in &records {
+            assert!(
+                !xattr_changed,
+                "{name} carries an identical large xattr and must stay silent"
+            );
+        }
+    }
 }

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -284,7 +284,7 @@ pub use special::{
     create_fifo, create_fifo_node_from_parts, create_fifo_with_fake_super,
 };
 
-pub use xattr_send::{XattrRole, XattrSendOptions};
+pub use xattr_send::{XattrRole, XattrSendOptions, dest_xattrs_differ};
 
 #[cfg(all(feature = "xattr", any(unix, windows)))]
 pub use xattr::{

--- a/crates/metadata/src/xattr_send.rs
+++ b/crates/metadata/src/xattr_send.rs
@@ -6,6 +6,14 @@
 //! `preserve_xattrs`, and `saw_xattr_filter`. This crate has no globals, so the
 //! same inputs travel as an explicit options record rather than a long
 //! positional parameter list.
+//!
+//! The module also hosts [`dest_xattrs_differ`], the single destination-side
+//! comparison behind the itemize `x` column, shared by the network receiver and
+//! the local-copy executor.
+
+use std::path::Path;
+
+use protocol::xattr::{XattrList, xattr_diff};
 
 /// Which side of the transfer is collecting the attributes.
 ///
@@ -124,6 +132,43 @@ impl XattrSendOptions<'_> {
     pub fn user_only(&self) -> bool {
         self.role.user_only(self.am_root)
     }
+}
+
+/// Whether `destination`'s extended attributes differ from the `sender` set,
+/// for the `ITEM_REPORT_XATTR` (`x`) column of `--itemize-changes`.
+///
+/// Mirrors upstream `generator.c:566-572`: with `preserve_xattrs` the generator
+/// reads the destination's current attributes (`get_xattr`) and compares them
+/// against the sender's list (`xattr_diff`). `dest_opts` must therefore describe
+/// a *generator* read - [`XattrRole::Generator`] - so `user_only`
+/// (`xattrs.c:237`) confines an unprivileged process to `user.*` and a
+/// namespace it could never store cannot raise the column.
+///
+/// Callers must invoke this before applying the sender's attributes, so the
+/// comparison sees the pre-transfer destination. A destination that cannot be
+/// read (missing, or a filesystem without xattr support) reports no difference:
+/// upstream's `get_xattr` failure path likewise leaves the receiver list empty
+/// rather than inventing a change, and a missing destination is itemized as
+/// `ITEM_IS_NEW` where every column renders `+`.
+///
+/// Both the network receiver (sender list decoded from the flist) and the
+/// local-copy executor (sender list read from the source with
+/// [`XattrRole::Sender`]) route through here, so there is exactly one
+/// destination-side comparison in the codebase.
+#[must_use]
+pub fn dest_xattrs_differ(
+    sender: &XattrList,
+    destination: &Path,
+    dest_opts: &XattrSendOptions<'_>,
+) -> bool {
+    debug_assert!(
+        !dest_opts.role.is_sender(),
+        "the itemize xattr comparison reads the destination as the generator",
+    );
+    let Ok(dest) = crate::read_xattrs_for_wire(destination, dest_opts) else {
+        return false;
+    };
+    xattr_diff(sender, &dest, dest_opts.checksum_seed)
 }
 
 #[cfg(test)]

--- a/crates/protocol/src/xattr/diff.rs
+++ b/crates/protocol/src/xattr/diff.rs
@@ -6,26 +6,41 @@
 
 use std::cmp::Ordering;
 
+use crate::xattr::XattrList;
 use crate::xattr::wire::checksum_matches;
-use crate::xattr::{MAX_FULL_DATUM, XattrList};
 
 /// Returns `true` when the sender's extended-attribute list differs from the
 /// receiver's on-disk attributes.
 ///
 /// Mirrors upstream `xattrs.c:xattr_diff()`. `sender` is the flist xattr list as
-/// received: values longer than [`MAX_FULL_DATUM`] carry a checksum rather than
-/// the full datum (the abbreviation protocol). `receiver` holds the
-/// destination's current attributes with full values, as produced by
-/// `metadata::read_xattrs_for_wire`. Both lists must be sorted by name (the
-/// receiver sorts on read; the sender sorts before transmit).
+/// received: values longer than [`MAX_FULL_DATUM`](crate::xattr::MAX_FULL_DATUM)
+/// carry a checksum rather than the full datum (the abbreviation protocol).
+/// `receiver` holds the destination's current attributes with full values, as
+/// produced by `metadata::read_xattrs_for_wire`. Both lists must be sorted by
+/// name (the receiver sorts on read; the sender sorts before transmit).
 ///
 /// The comparison walks the two sorted lists in lockstep. A differing entry
-/// count means the sets differ. For a shared name, a value at or below
-/// `MAX_FULL_DATUM` is compared byte-for-byte, while a larger value is compared
-/// by checksum against the receiver's full datum - exactly upstream's split at
-/// `MAX_FULL_DATUM` (`xattrs.c:584-594`). The `find_all` bookkeeping upstream
-/// uses to mark entries for on-demand request does not affect the returned
-/// "do they differ" answer, so this stops at the first mismatch.
+/// count means the sets differ. For a shared name, an abbreviated sender value
+/// is compared by checksum against the receiver's full datum, while every value
+/// the sender carries in full is compared byte-for-byte - upstream's split at
+/// `MAX_FULL_DATUM` (`xattrs.c:584-594`), keyed on the sender entry's own
+/// abbreviation state rather than on its length.
+///
+/// Upstream can key that split on the length alone because `rsync_xal_get()`
+/// abbreviates on *both* sides (`xattrs.c:274-284`), so a long value is always
+/// checksum-vs-checksum there. oc keeps full data on the receiver side and
+/// abbreviates only on the wire, so a long value reaches this function
+/// abbreviated when it arrived over the wire and in full when both lists were
+/// read from local disk (the local-copy generator). Testing
+/// [`XattrEntry::is_abbreviated`](crate::xattr::XattrEntry::is_abbreviated)
+/// covers both: it is exactly `datum_len > MAX_FULL_DATUM` for a wire-received
+/// list, and it routes a locally-read long value to the byte-for-byte branch
+/// instead of hashing its plaintext against the peer's datum, which could never
+/// match.
+///
+/// The `find_all` bookkeeping upstream uses to mark entries for on-demand
+/// request does not affect the returned "do they differ" answer, so this stops
+/// at the first mismatch.
 #[must_use]
 pub fn xattr_diff(sender: &XattrList, receiver: &XattrList, checksum_seed: i32) -> bool {
     let snd = sender.entries();
@@ -49,12 +64,14 @@ pub fn xattr_diff(sender: &XattrList, receiver: &XattrList, checksum_seed: i32) 
 
         let same = if cmp == Ordering::Equal {
             let r = &rec[ri];
-            if s.datum_len() > MAX_FULL_DATUM {
-                // upstream: xattrs.c:584-587 - large values compare by checksum.
+            if s.is_abbreviated() {
+                // upstream: xattrs.c:584-587 - an abbreviated value compares by
+                // checksum.
                 s.datum_len() == r.datum_len()
                     && checksum_matches(s.datum(), r.datum(), checksum_seed)
             } else {
-                // upstream: xattrs.c:591-594 - small values compare byte-for-byte.
+                // upstream: xattrs.c:591-594 - a value carried in full compares
+                // byte-for-byte.
                 s.datum_len() == r.datum_len() && s.datum() == r.datum()
             }
         } else {
@@ -82,7 +99,7 @@ pub fn xattr_diff(sender: &XattrList, receiver: &XattrList, checksum_seed: i32) 
 mod tests {
     use super::*;
     use crate::xattr::wire::compute_xattr_checksum;
-    use crate::xattr::{XattrEntry, XattrList};
+    use crate::xattr::{MAX_FULL_DATUM, XattrEntry, XattrList};
 
     fn list(entries: Vec<XattrEntry>) -> XattrList {
         XattrList::with_entries(entries)
@@ -152,6 +169,28 @@ mod tests {
             sender_val.len(),
         )]);
         let receiver = list(vec![full("user.big", &receiver_val)]);
+        assert!(xattr_diff(&sender, &receiver, 0));
+    }
+
+    /// The local-copy generator reads both sides from disk, so a value over
+    /// `MAX_FULL_DATUM` arrives here in full on the sender side. Keying the
+    /// checksum branch off the length alone would hash-compare the plaintext
+    /// against the destination's identical plaintext and always report a
+    /// difference, lighting the itemize `x` column on every large xattr.
+    #[test]
+    fn identical_unabbreviated_large_values_do_not_differ() {
+        let big = vec![7u8; MAX_FULL_DATUM + 40];
+        let sender = list(vec![full("user.big", &big)]);
+        let receiver = list(vec![full("user.big", &big)]);
+        assert!(!xattr_diff(&sender, &receiver, 0));
+    }
+
+    /// The byte-for-byte branch must still catch a real difference in a large
+    /// value that both sides carry in full.
+    #[test]
+    fn differing_unabbreviated_large_values_differ() {
+        let sender = list(vec![full("user.big", &[7u8; MAX_FULL_DATUM + 40])]);
+        let receiver = list(vec![full("user.big", &[9u8; MAX_FULL_DATUM + 40])]);
         assert!(xattr_diff(&sender, &receiver, 0));
     }
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -725,13 +725,14 @@ impl ReceiverContext {
     /// Whether the destination's extended attributes differ from the sender's,
     /// for the `ITEM_REPORT_XATTR` (`x`) itemize column.
     ///
-    /// Mirrors upstream `generator.c:566-572`: with `preserve_xattrs` it reads
-    /// the destination's current xattrs (`get_xattr`) and compares them against
-    /// the received flist list (`xattr_diff`). Callers gate this on the `-X`
-    /// itemize path so the extra read matches upstream's lazy `get_xattr`, and
-    /// invoke it before applying the sender's xattrs so the comparison sees the
+    /// Resolves the sender's list from the flist and hands both sides to
+    /// [`metadata::dest_xattrs_differ`], the shared comparison that the
+    /// local-copy executor also uses. Callers gate this on the `-X` itemize path
+    /// so the extra read matches upstream's lazy `get_xattr`, and invoke it
+    /// before applying the sender's xattrs so the comparison sees the
     /// pre-transfer destination. A sender with no xattrs differs exactly when
-    /// the destination still carries some.
+    /// the destination still carries some, which the empty-list case expresses
+    /// without a second code path.
     pub(in crate::receiver) fn dest_xattrs_differ(&self, entry: &FileEntry, path: &Path) -> bool {
         let opts = metadata::XattrSendOptions {
             role: metadata::XattrRole::Generator,
@@ -748,14 +749,8 @@ impl ReceiverContext {
             filter: None,
             checksum_seed: self.checksum_seed,
         };
-        let dest = match metadata::read_xattrs_for_wire(path, &opts) {
-            Ok(list) => list,
-            Err(_) => return false,
-        };
-        match self.resolve_xattr_list(entry) {
-            Some(sender) => protocol::xattr::xattr_diff(&sender, &dest, self.checksum_seed),
-            None => !dest.is_empty(),
-        }
+        let sender = self.resolve_xattr_list(entry).unwrap_or_default();
+        metadata::dest_xattrs_differ(&sender, path, &opts)
     }
 
     /// Emits the upstream size-bound SKIP notice for a candidate whose flist


### PR DESCRIPTION
## Problem

`oc-rsync -a -X -i src/ dst/` (local copy) lit the itemize `x` column on **every**
file, performing no comparison at all: `plan/change_set/detection.rs` did
`if xattrs_enabled { with_xattr_changed(true) }`. Because `ITEM_REPORT_XATTR` is
itself part of upstream's emit gate (`generator.c:582`), this did not just add an
`x` - it printed a row for every file of an otherwise silent run.

Upstream `generator.c:566-572`:

```c
if (preserve_xattrs) {
        if (!XATTR_READY(*sxp))
                get_xattr(fnamecmp, sxp);
        if (xattr_diff(file, sxp, 1))
                iflags |= ITEM_REPORT_XATTR;
}
```

The flag comes from a comparison, never from `preserve_xattrs` alone.

## Reuse, not a second ladder

The network path's `dest_xattrs_differ` (landed in #6959) lives on the receiver in
`transfer`; the local-copy executor is in `engine`, and `engine` does not depend on
`transfer`. Rather than duplicate the comparison, the destination-side half moved
down to the crate both already depend on:

- `metadata::dest_xattrs_differ(&XattrList, &Path, &XattrSendOptions) -> bool`
  reads the destination with `read_xattrs_for_wire` and diffs it with
  `protocol::xattr::xattr_diff`. `metadata` already owned `read_xattrs_for_wire`
  and already depends on `protocol`, so nothing new was wired up.
- `Receiver::dest_xattrs_differ` is now a three-line wrapper that resolves the
  sender list from the flist and delegates. Its `None => !dest.is_empty()` special
  case collapsed into passing an empty `XattrList`, which `xattr_diff` already
  handles by the count check.
- `engine`'s `xattrs_differ_from_source` reads the *source* with
  `XattrRole::Sender` and hands both sides to the same primitive.

There is now exactly one destination-side xattr comparison in the codebase.

The two roles are not cosmetic. A local copy in upstream is still a forked
sender/generator pair, so each side collects with different globals
(`xattrs.c:237`, `int user_only = am_sender ? 0 : !am_root;`): the sender sees
every namespace but `system.*`, an unprivileged generator sees `user.*` only.
Reading both sides as one role would either drop SELinux labels from the source or
let a label the receiver could never store raise the column. Confirmed against
`rsync_xal_get()` ordering: the `x`-modifier filter branch and the namespace branch
are mutually exclusive (`xattrs.c:250-257`, the namespace test is the `else`), and
the `rsync.%FOO` strip is last (`xattrs.c:260-267`) - which is what
`read_xattrs_for_wire` already implements.

## Two further defects found on the way

**Dry run had the opposite bug.** `record_dry_run_skip` hardcoded "no xattr
change", so `-naXi` stayed silent on a drift that `-aXi` reported. Upstream
itemizes an up-to-date file the same way whether or not `do_xfers` is set
(`generator.c:1816`), so both paths now run the same comparison. Captured as
case E below.

**`xattr_diff` mishandled a locally read long value.** It keyed the checksum
branch on `s.datum_len() > MAX_FULL_DATUM`. Upstream can do that because
`rsync_xal_get()` abbreviates on *both* sides (`xattrs.c:274-284`), so a long value
is always checksum-vs-checksum there. oc keeps full data on the receiver side and
abbreviates only on the wire, so a value read from local disk arrives in full and
would have been hashed against the destination's identical plaintext - never
matching, lighting `x` on every large xattr forever. The branch is now keyed on the
entry's own `is_abbreviated()`, which is exactly `datum_len > MAX_FULL_DATUM` for
every wire-received list, so the network path is bit-for-bit unchanged. Captured as
case D below.

## Ordering

The comparison is captured in `copy_file` (and at the top of the device/FIFO
recreate paths) *before* the transfer or the metadata apply can write the source
attributes onto the destination. Comparing after the sync would always report
"same" - the same hazard the network path guards against.

## Verification against real upstream rsync 3.4.4

Captured against `rsync version 3.4.4 protocol version 32` (banner verified), on
macOS/APFS. Same fixture, same command, three binaries.

```
$ rsync --version | head -1
rsync  version 3.4.4  protocol version 32
```

Fixture: `src/{a.txt,b.txt}` each carrying `user.color`, mirrored to `dst/`; each
case perturbs one thing. Command is `-a -X -i src/ dst/` (case E adds `-n`).

### upstream 3.4.4

```
== A: identical xattrs on both sides
== B: genuine user.* value difference on b.txt
.f........x b.txt
== C: destination carries an extra user.* attr on a.txt
.f........x a.txt
== D: identical value larger than MAX_FULL_DATUM on a.txt
== E: dry run (-n) over the case-B tree
.f........x b.txt
```

### oc-rsync before

```
== A: identical xattrs on both sides
.f........x a.txt
.f........x b.txt
== B: genuine user.* value difference on b.txt
.f........x a.txt
.f........x b.txt
```

Every file, every case - and case A should print nothing at all.

### oc-rsync after

```
== A: identical xattrs on both sides
== B: genuine user.* value difference on b.txt
.f........x b.txt
== C: destination carries an extra user.* attr on a.txt
.f........x a.txt
== D: identical value larger than MAX_FULL_DATUM on a.txt
== E: dry run (-n) over the case-B tree
.f........x b.txt
```

Byte-for-byte identical to upstream on all five cases.

### Not verified here: the non-root `security.*` case

The third case from the original brief - a destination-only `security.*` attribute
as a non-root user must not raise `x` - **could not be observed and is pending.**
Two independent reasons:

1. The Linux validation host was unreachable during this work (100% packet loss,
   host down), so no Linux capture was possible.
2. The behaviour is inherently Linux-only. Upstream guards the namespace rule with
   `#ifdef HAVE_LINUX_XATTRS` (`xattrs.c:236-257`) and oc mirrors that -
   `is_xattr_permitted` returns `true` unconditionally off Linux. macOS has no
   xattr namespaces, so the case cannot be constructed here even in principle.
   Nor is it constructible by a non-root user on demand: writing `security.*`
   needs privilege. The real-world trigger is an SELinux host, where every file
   carries `security.selinux`.

What *is* pinned: the destination read goes through `XattrRole::Generator`, whose
`user_only` is `!am_root` (`xattr_send.rs`, tests
`user_only_mirrors_the_upstream_ternary` and
`options_derive_user_only_from_role_and_privilege`), and `dest_xattrs_differ`
debug-asserts it is never handed a sender-role options record. A Linux capture of
this case should be taken before relying on it.

## Tests

New, all failing without the fix (verified by reverting the guard and re-running):

- `itemize_matching_xattrs_report_no_change` - case A. Asserts both files are
  itemized first, so it cannot pass vacuously.
- `itemize_differing_xattr_value_reports_only_that_file` - case B. Pins both
  halves: the drifted file reports, its sibling stays silent. A flag that merely
  echoed `-X` passes the first assertion and fails the second, which is how the
  defect hid.
- `itemize_large_matching_xattr_value_reports_no_change` - case D.
- `dry_run_itemize_matches_the_real_run` - case E.
- `protocol`: `identical_unabbreviated_large_values_do_not_differ` and
  `differing_unabbreviated_large_values_differ` pin the `is_abbreviated()` branch
  from both directions.
- `for_file_xattrs_enabled_sets_xattr_changed` was renamed and rewritten: it
  asserted the old, wrong contract (`-X` implies `x`) and could not have caught
  this.

Green:

- `cargo fmt --all -- --check`
- `cargo clippy -p engine -p transfer -p metadata -p protocol --all-features --all-targets --no-deps -- -D warnings`
- `cargo nextest run -p engine --all-features --lib --no-fail-fast` - 4587 run,
  4585 passed. The 2 failures (`archive_preserves_mixed_permissions_across_files`,
  `execute_preserves_read_only_permissions`) reproduce identically on the parent
  commit; they are a pre-existing macOS-local `EPERM` on removing an xattr from a
  read-only file, unrelated to this change.
- `cargo nextest run -p metadata -p protocol --all-features -E 'test(xattr)'` -
  267 passed.
- `cargo nextest run -p transfer --all-features -E 'test(xattr) + test(itemize)'` -
  91 passed, including the network-path tests from #6959 and the upstream 3.4.4
  itemize golden.
- Same transfer suite with `--no-default-features --features xattr,acl`
  (`incremental-flist` off) - 29 passed.
