### PR TITLE
ci: make three interop harness checks able to fail

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -419,10 +419,14 @@ jobs:
         run: |
           set -euo pipefail
           OC_RSYNC="target/dist/oc-rsync"
+          # --rsync-path is resolved by the REMOTE shell, whose cwd is $HOME,
+          # so the oc-rsync path handed to upstream has to be absolute.
+          OC_RSYNC_ABS="$(pwd)/${OC_RSYNC}"
           SRC=$(mktemp -d)
           DST=$(mktemp -d)
           DST2=$(mktemp -d)
-          trap 'rm -rf "$SRC" "$DST" "$DST2"' EXIT
+          DST3=$(mktemp -d)
+          trap 'rm -rf "$SRC" "$DST" "$DST2" "$DST3"' EXIT
 
           # Create test data
           for i in $(seq 1 10); do
@@ -431,10 +435,17 @@ jobs:
           mkdir -p "$SRC/subdir"
           echo "nested" > "$SRC/subdir/nested.txt"
 
-          # Verify binaries
+          # Verify binaries. The upstream peer is only an oracle if it really
+          # is upstream 3.4.4, so assert on the --version banner and never on
+          # the path: if the install step above found no freshly built binary,
+          # `rsync` on PATH is silently the distro build instead.
           echo "oc-rsync: $($OC_RSYNC --version 2>&1 | head -1)"
           echo "upstream rsync: $(rsync --version 2>&1 | head -1)"
           echo "upstream rsync path: $(which rsync)"
+          rsync --version 2>&1 | head -1 | grep -qE '^rsync +version 3\.4\.4( |$)' || {
+            echo "expected upstream rsync 3.4.4 on PATH, got: $(rsync --version 2>&1 | head -1)" >&2
+            exit 1
+          }
 
           # Baseline: upstream rsync → upstream rsync via SSH
           echo "=== Baseline: upstream rsync SSH pull ==="
@@ -502,6 +513,17 @@ jobs:
           # SSH pull no-change
           timeout 60 "$OC_RSYNC" -av --timeout=30 "localhost:$SRC/" "$DST/"
           echo "PASS: SSH pull no-change sync"
+
+          # SSH pull with oc-rsync as the REMOTE SENDER: upstream rsync is the
+          # client and spawns oc-rsync as `--server --sender` over SSH. Every
+          # other SSH leg here runs oc-rsync as the client, so without this one
+          # oc-rsync's server-sender wire output has no upstream oracle: an
+          # oc<->oc transfer cannot see a divergence that both sides share.
+          echo "=== SSH pull: upstream rsync client <- oc-rsync remote sender ==="
+          timeout 60 rsync -av --timeout=30 --rsync-path="$OC_RSYNC_ABS" \
+            "localhost:$SRC/" "$DST3/" 2>&1
+          diff -r "$SRC" "$DST3"
+          echo "PASS: SSH pull with oc-rsync as remote sender"
 
           echo "All SSH interop tests passed."
 

--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -439,13 +439,14 @@ jobs:
           # is upstream 3.4.4, so assert on the --version banner and never on
           # the path: if the install step above found no freshly built binary,
           # `rsync` on PATH is silently the distro build instead.
+          UP_BANNER="$(rsync --version 2>&1 | head -1)"
           echo "oc-rsync: $($OC_RSYNC --version 2>&1 | head -1)"
-          echo "upstream rsync: $(rsync --version 2>&1 | head -1)"
+          echo "upstream rsync: $UP_BANNER"
           echo "upstream rsync path: $(which rsync)"
-          rsync --version 2>&1 | head -1 | grep -qE '^rsync +version 3\.4\.4( |$)' || {
-            echo "expected upstream rsync 3.4.4 on PATH, got: $(rsync --version 2>&1 | head -1)" >&2
-            exit 1
-          }
+          case "$UP_BANNER" in
+            "rsync  version 3.4.4 "*) ;;
+            *) echo "expected upstream rsync 3.4.4 on PATH, got: $UP_BANNER" >&2; exit 1 ;;
+          esac
 
           # Baseline: upstream rsync → upstream rsync via SSH
           echo "=== Baseline: upstream rsync SSH pull ==="

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -14,10 +14,45 @@
 #   4. oc-rsync gaps: known implementation gaps tracked for future fix
 
 # Unconditional known failures (direction:name).
-KNOWN_FAILURES=(
-  # UPSTREAM BUG: upstream rsync 3.4.1 cannot read back its own compressed
-  # delta batch files. Verified: upstream --write-batch -z produces a batch,
-  # then upstream --read-batch fails with "inflate returned -3" (exit 12).
+# Empty: every current entry is scoped by protocol or upstream version below.
+# A blanket entry can never report UNEXPECTED FAIL, so it hides the day the
+# limitation is fixed. Prefer a scoped rule in is_known_failure_from_conf().
+KNOWN_FAILURES=()
+
+# Newest upstream release still carrying the compressed-batch self-roundtrip
+# bug. Verified failing on 3.4.4 (the newest release) on both Linux/x86_64 and
+# macOS/arm64, so the defect is version-scoped, not platform-scoped. Bump this
+# only after re-verifying against the newer release; leaving it behind makes
+# the standalone test report UNEXPECTED FAIL once a fixed upstream enters the
+# matrix, which is the point.
+UPSTREAM_BATCH_SELF_ROUNDTRIP_FIXED_AFTER="3.4.4"
+
+# Returns 0 when dotted version $1 is <= dotted version $2.
+version_le() {
+  [[ "$1" == "$2" ]] && return 0
+  [[ "$(printf '%s\n%s\n' "$1" "$2" \
+        | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)" == "$1" ]]
+}
+
+# Protocol-specific and conditional known failure rules.
+# Returns 0 if the given test is a known failure, 1 otherwise.
+# Arguments: direction name forced_proto [upstream_version]
+is_known_failure_from_conf() {
+  local direction=$1 name=$2 forced_proto=$3 upstream_version=${4:-}
+  local key="${direction}:${name}"
+
+  # Check unconditional failures
+  if (( ${#KNOWN_FAILURES[@]} > 0 )); then
+    for kf in "${KNOWN_FAILURES[@]}"; do
+      [[ "$kf" == "$key" ]] && return 0
+    done
+  fi
+
+  # UPSTREAM BUG: upstream rsync cannot read back its own compressed delta
+  # batch files. Verified against a genuine 3.4.4 (banner-checked, not path-
+  # checked): upstream --write-batch -z --compress-choice=zlib produces a
+  # batch, then upstream --read-batch fails with "inflate returned -3"
+  # (exit 12) and leaves the destination unchanged.
   #
   # Root cause: the batch writer in token.c tees raw DEFLATED_DATA tokens
   # (zlib-compressed) to the batch fd, but the batch reader's inflate context
@@ -30,22 +65,16 @@ KNOWN_FAILURES=(
   #
   # upstream: token.c:608 - inflate fails without dictionary sync
   # upstream: compat.c:194-195 - batch read always assumes CPRES_ZLIB
-  # NOT FIXABLE: this is a bug in upstream rsync's batch reader, not oc-rsync
-  "standalone:upstream-compressed-batch-self-roundtrip"
-
-)
-
-# Protocol-specific and conditional known failure rules.
-# Returns 0 if the given test is a known failure, 1 otherwise.
-# Arguments: direction name forced_proto
-is_known_failure_from_conf() {
-  local direction=$1 name=$2 forced_proto=$3
-  local key="${direction}:${name}"
-
-  # Check unconditional failures
-  for kf in "${KNOWN_FAILURES[@]}"; do
-    [[ "$kf" == "$key" ]] && return 0
-  done
+  #
+  # Scoped to the affected releases. An unknown version is NOT suppressed:
+  # the caller could not identify the peer, so the result must be reported.
+  if [[ "$direction" == "standalone" \
+        && "$name" == "upstream-compressed-batch-self-roundtrip" ]]; then
+    [[ -n "$upstream_version" ]] || return 1
+    version_le "$upstream_version" \
+      "$UPSTREAM_BATCH_SELF_ROUNDTRIP_FIXED_AFTER" && return 0
+    return 1
+  fi
 
   # oc-rsync RECEIVER over the wire (daemon/remote) drops named-user POSIX ACL
   # entries and the ACL mask, keeping only the base user/group/other. The
@@ -127,9 +156,9 @@ is_known_failure_from_conf() {
 # test_method: "daemon" for scenario-based, "standalone" for standalone tests.
 # Keep in sync with actual known failure rules above.
 DASHBOARD_ENTRIES=(
-  # --- Upstream batch bug (unconditional) ---
-  # upstream rsync 3.4.1 can't read its own compressed delta batch files
-  "standalone:upstream-compressed-batch-self-roundtrip|upstream compressed batch self-roundtrip (token.c:608 inflate -3, upstream bug - oc-rsync reads correctly)|standalone"
+  # --- Upstream batch bug (scoped to upstream <= 3.4.4) ---
+  # upstream rsync can't read its own compressed delta batch files
+  "standalone:upstream-compressed-batch-self-roundtrip|upstream compressed batch self-roundtrip, upstream <= 3.4.4 (token.c:608 inflate -3, upstream bug - oc-rsync reads correctly)|standalone"
 
   # --- Proto <= 29: upstream hard-rejects features that need proto 30+ wire format ---
 

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -1910,6 +1910,14 @@ is_known_failure() {
   is_known_failure_from_conf "$@"
 }
 
+# Dotted release version of an upstream rsync binary, read from its --version
+# banner. The install path is not authoritative: a directory named 3.4.4 may
+# hold any binary, and /usr/bin/rsync on macOS is openrsync.
+upstream_release_version() {
+  "$1" --version 2>/dev/null | head -n1 \
+    | sed -n 's/^rsync[[:space:]]\{1,\}version[[:space:]]\{1,\}\([0-9][0-9.]*\).*/\1/p'
+}
+
 # ============================================================================
 # Standalone Interop Test Scenarios (#876-#884)
 # These tests require custom daemon configs, special setup, or non-standard
@@ -1917,6 +1925,8 @@ is_known_failure() {
 # ============================================================================
 
 # Helper: check if a standalone test is a known failure and report accordingly.
+# Uses global $standalone_upstream_version so version-scoped known-failure
+# rules can tell which upstream release produced the failure.
 run_standalone_test() {
   local name=$1
   local test_func=$2
@@ -1927,7 +1937,8 @@ run_standalone_test() {
     echo "    PASS"
     return 0
   else
-    if is_known_failure "standalone" "$name" ""; then
+    if is_known_failure "standalone" "$name" "" \
+        "${standalone_upstream_version:-}"; then
       echo "    SKIP (known limitation)"
       return 2
     else
@@ -3788,7 +3799,7 @@ WRAPPER
       >"${log}.compress-ssh-up-oc.out" 2>"${log}.compress-ssh-up-oc.err" || rc2=$?
 
   if [[ $rc2 -ne 0 ]]; then
-    echo "    upstream -> oc-rsync SSH/local -z pull failed (exit=$rc2)"
+    echo "    upstream -> oc-rsync SSH/local -z push failed (exit=$rc2)"
     echo "    stderr: $(head -5 "${log}.compress-ssh-up-oc.err")"
     return 1
   fi
@@ -10940,6 +10951,10 @@ run_standalone_interop_tests() {
 
   local total=0 passed=0 known=0 unexpected=0
   local standalone_log="${workdir}/standalone"
+
+  # Global: consumed by run_standalone_test for version-scoped known failures.
+  standalone_upstream_version=$(upstream_release_version "$upstream_binary")
+  echo "  [standalone] upstream release: ${standalone_upstream_version:-unknown}"
 
   local test_names=(
     "write-batch-read-batch"

--- a/tools/ci/run_interop_smoke.sh
+++ b/tools/ci/run_interop_smoke.sh
@@ -491,12 +491,24 @@ fi
 # Dry run should not create any files in the destination.
 if [[ "${up_daemon_available}" == "true" ]]; then
   reset_module_data "up"
-  run_wire "${OC_RSYNC}" -avn "${src}/" "${up_url}/" || true
+  # An empty destination is not evidence on its own: a refused connection
+  # leaves exactly the same empty tree as a correct dry run. Assert the exit
+  # code first, then assert output that only a session that really ran emits.
+  dry_out="$(run_wire "${OC_RSYNC}" -avn "${src}/" "${up_url}/")" \
+    || fail "dry-run: oc-rsync -> upstream daemon failed"
+  # `sending incremental file list` is emitted once the sender starts the
+  # file-list phase, and the `(DRY RUN)` totals line is only reached after the
+  # daemon has replied with its half of the session stats. Neither can appear
+  # if the connection was refused, so together they prove the run happened.
+  printf '%s\n' "${dry_out}" | grep -q '^sending incremental file list$' \
+    || fail "dry-run: oc-rsync -> upstream daemon never started the file list"
+  printf '%s\n' "${dry_out}" | grep -q '(DRY RUN)' \
+    || fail "dry-run: oc-rsync -> upstream daemon produced no dry-run summary"
   count="$(find "${workdir}/data-up" -type f 2>/dev/null | wc -l | tr -d ' ')"
   if [[ "${count}" -ne 0 ]]; then
     fail "dry-run: oc-rsync -> upstream daemon created files"
   fi
-  pass "dry-run: oc-rsync -> upstream daemon (no files created)"
+  pass "dry-run: oc-rsync -> upstream daemon (ran, created no files)"
 else
   echo "SKIP: dry-run: oc-rsync -> upstream daemon (upstream daemon unavailable on Windows)"
 fi


### PR DESCRIPTION
Three interop-harness checks were structurally incapable of reporting the failure they exist to detect. Each is fixed and each fix is demonstrated to fail against a deliberately broken condition.

## 1. Blanket known-failure entry (`tools/ci/known_failures.conf`)

`standalone:upstream-compressed-batch-self-roundtrip` sat in the unconditional `KNOWN_FAILURES` array, so `run_standalone_test` always reported `SKIP (known limitation)`. It could never report `UNEXPECTED FAIL`, which also means it could never notice the day upstream fixes the bug.

**The limitation is still real.** Reproduced against a genuine upstream 3.4.4 (verified from the `--version` banner, not the path):

```
rsync: --write-batch -z --no-whole-file --compress-choice=zlib   -> ok
rsync: --read-batch                                              -> inflate returned -3 (0 bytes)
       rsync error: error in rsync protocol data stream (code 12) at token.c(665) [receiver=3.4.4]
```

Same result on Linux/x86_64 and macOS/arm64, so the defect is **version-scoped, not platform-scoped**, and the entry is scoped by upstream release rather than deleted.

`is_known_failure_from_conf` takes an optional upstream version and suppresses the test only for releases `<= 3.4.4`. The version comes from the peer's `--version` banner via a new `upstream_release_version` helper - a directory named `3.4.4` may hold anything, and `/usr/bin/rsync` on macOS is openrsync. An unidentifiable peer is deliberately **not** suppressed.

Proof it can now fail:

| simulated upstream | result |
|---|---|
| 3.0.9 / 3.1.3 / 3.4.1 / 3.4.4 | `SKIP (known limitation)`, rc=2 |
| 3.4.5 / 3.5.0 / 4.0.0 | `UNEXPECTED FAIL`, rc=1 |
| unidentifiable banner | `UNEXPECTED FAIL`, rc=1 |

`upstream_release_version` parses `3.4.4` from the real 3.4.4 banner and returns empty for openrsync's `protocol version 29` banner.

## 2. Smoke dry-run scenario could not fail (`tools/ci/run_interop_smoke.sh`)

The scenario ran `run_wire ... || true` and then asserted only that the destination was empty. A dry run legitimately creates nothing, so a refused connection produced exactly the same empty tree as a correct run.

Now asserts the exit code, plus `sending incremental file list` and the `(DRY RUN)` totals line - output that only a session which reached the daemon and got its stats reply can produce.

Proof it can now fail, running the full smoke harness on macOS with the dry-run destination pointed at a dead port (port 1):

```
old harness: exit=0   PASS: dry-run: oc-rsync -> upstream daemon (no files created)
             (stderr shows "failed to read daemon greeting ... Connection refused")
new harness: exit=1   FAIL: dry-run: oc-rsync -> upstream daemon failed
```

And against an exit-0 impostor that never transfers anything:

```
new harness: exit=1   FAIL: dry-run: oc-rsync -> upstream daemon never started the file list
```

Unmodified, the full smoke suite still passes end to end (`All interop smoke scenarios passed on macos.`).

The scenario's Windows skip is left as is: it is already a printed `SKIP:` line, and it is only reachable on Windows because every other host `fail`s when the daemon will not start.

## 3. oc-rsync as SSH remote sender had no upstream oracle (`.github/workflows/_interop.yml`)

The sshd loopback job had three legs and ran oc-rsync as the **client** in all of them. `--rsync-path` appeared zero times in the workflow, and the only two `--rsync-path` legs in `run_interop.sh` are both pushes. Net effect: **oc-rsync running as `--server --sender` over SSH was never checked against upstream anywhere in the repo**, and an oc<->oc transfer cannot see a divergence both sides share.

Adds a fourth leg with upstream as the client pulling from an oc-rsync remote sender, followed by `diff -r` in the style of the existing legs. Linux-only by design; `_interop-macos.yml` and `_interop-windows.yml` both document SSH loopback as out of scope and are untouched.

Also asserts that the `rsync` on PATH really is 3.4.4 from its banner. The install step that puts upstream 3.4.4 there is conditional, so a missed build silently downgraded the oracle to the distro binary.

Proof, run on a Linux host with genuine `rsync version 3.4.4` over real ssh loopback:

```
[A] rsync -av --rsync-path=<oc-rsync> localhost:$SRC/ $DST3/
    transfer rc=0, diff -r clean                     -> PASS
[B] --rsync-path=/nonexistent/oc-rsync
    transfer rc=12                                   -> step fails under set -e
[C] remote sender wrapper that withholds a file
    transfer rc=30, diff -r reports missing files    -> step fails
```

Both arms of the new leg are load-bearing.

## Also

Corrects `run_interop.sh` where a failure message called a push leg a "pull" - the argv is `"${cz_src}/" "fakehost:${cz_dest_oc}/"`.

## Notes

- `KNOWN_FAILURES` is now empty; the loop over it is guarded so an empty array is safe under `set -u` on bash 3.2.
- `check_known_failures.sh` reads only `DASHBOARD_ENTRIES` and is unaffected beyond the reworded description.
- Out of scope on purpose: `tests/batch_interop_test.sh`, the batch blocks in `run_interop.sh`, and the `-e ssh` leg at `run_interop.sh:1884`.
