### PR TITLE
fix(batch): emit the --write-batch trailer where upstream does

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "mimalloc",
  "protocol",
  "tempfile",
+ "test-support",
  "tikv-jemallocator",
  "transfer",
  "windows-gnu-eh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ libc = { workspace = true }
 tempfile = { workspace = true }
 checksums = { path = "crates/checksums" }
 protocol = { path = "crates/protocol" }
+test-support = { path = "crates/test-support" }
 
 [target.'cfg(unix)'.dev-dependencies]
 xattr = { workspace = true }

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -2,7 +2,8 @@
 //!
 //! Handles both writing batch files during a transfer and replaying
 //! previously recorded batch files. Mirrors upstream `main.c:read_batch()`
-//! for replay and `main.c:374-383` for batch stats finalization.
+//! for replay and, for a local copy only, `main.c:374-383` for the stats
+//! trailer.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -141,19 +142,33 @@ pub(crate) fn write_batch_header(
     Ok(())
 }
 
-/// Writes trailing stats, flushes the batch file, and generates the replay script.
+/// Flushes the batch file and generates the replay script, optionally
+/// appending the stats trailer first.
 ///
 /// When filter rules are active in `config`, the replay script embeds them
 /// using the same heredoc format as upstream `batch.c:write_filter_rules()`,
 /// ensuring the replay applies identical filters.
 ///
-/// Called after a successful transfer to finalize the batch recording.
-/// Mirrors upstream `main.c:374-383` for stats writing.
+/// `write_trailer` says whether this call owns the batch trailer - the five
+/// varlong30 stats of upstream `main.c:374-383` plus the goodbye `NDX_DONE`.
+/// Only the local-copy path does, because it has no protocol stream to record
+/// from. Every remote transfer produces the trailer inside the transfer layer,
+/// where upstream produces it too:
+///
+/// - PUSH: `handle_stats(-1)` writes the stats to `batch_fd` before
+///   `read_final_goodbye()` tees the goodbye `NDX_DONE` (`main.c:1345-1347`).
+/// - PULL: both the stats (`main.c:364-373`) and the goodbye `NDX_DONE`
+///   (`main.c:904`) arrive over the wire, so the read tee records them.
+///
+/// Appending a second copy here would leave the batch with a trailer upstream
+/// `--read-batch` cannot parse: its `read_final_goodbye()` reads one `NDX_DONE`
+/// too many and aborts with `RERR_PROTOCOL`.
 pub(crate) fn finalize_batch(
     writer_arc: &Arc<Mutex<BatchWriter>>,
     batch_cfg: &BatchConfig,
     config: &ClientConfig,
     summary: &ClientSummary,
+    write_trailer: bool,
 ) -> Result<(), ClientError> {
     {
         let mut writer = writer_arc.lock().map_err(|_| {
@@ -163,46 +178,48 @@ pub(crate) fn finalize_batch(
             )
         })?;
 
-        // upstream: main.c:374-383 - write_varlong30(batch_fd, stats.total_read, 3)
-        let proto = batch_cfg.protocol_version;
-        let stats = BatchStats {
-            total_read: summary.bytes_received() as i64,
-            total_written: summary.bytes_sent() as i64,
-            total_size: summary.total_source_bytes() as i64,
-            flist_buildtime: if proto >= 29 {
-                Some(summary.file_list_generation_time().as_millis() as i64)
-            } else {
-                None
-            },
-            flist_xfertime: if proto >= 29 {
-                Some(summary.file_list_transfer_time().as_millis() as i64)
-            } else {
-                None
-            },
-        };
-        if let Err(e) = writer.write_stats(&stats) {
-            let msg = format!("failed to write batch stats: {e}");
-            return Err(ClientError::new(
-                1,
-                rsync_error!(1, "{}", msg).with_role(Role::Client),
-            ));
-        }
+        if write_trailer {
+            // upstream: main.c:374-383 - write_varlong30(batch_fd, stats.total_read, 3)
+            let proto = batch_cfg.protocol_version;
+            let stats = BatchStats {
+                total_read: summary.bytes_received() as i64,
+                total_written: summary.bytes_sent() as i64,
+                total_size: summary.total_source_bytes() as i64,
+                flist_buildtime: if proto >= 29 {
+                    Some(summary.file_list_generation_time().as_millis() as i64)
+                } else {
+                    None
+                },
+                flist_xfertime: if proto >= 29 {
+                    Some(summary.file_list_transfer_time().as_millis() as i64)
+                } else {
+                    None
+                },
+            };
+            if let Err(e) = writer.write_stats(&stats) {
+                let msg = format!("failed to write batch stats: {e}");
+                return Err(ClientError::new(
+                    1,
+                    rsync_error!(1, "{}", msg).with_role(Role::Client),
+                ));
+            }
 
-        // upstream: main.c:1119-1122 - write_ndx(f_out, NDX_DONE) as final
-        // goodbye after stats. read_final_goodbye() (main.c:875-906) reads
-        // this from the batch file. For protocol >= 30, NDX_DONE = 0x00
-        // (single byte). For protocol < 30, NDX_DONE = 0xFFFFFFFF (4 bytes).
-        let goodbye_bytes: &[u8] = if proto >= 30 {
-            &[0x00]
-        } else {
-            &[0xFF, 0xFF, 0xFF, 0xFF]
-        };
-        if let Err(e) = writer.write_data(goodbye_bytes) {
-            let msg = format!("failed to write batch goodbye NDX_DONE: {e}");
-            return Err(ClientError::new(
-                1,
-                rsync_error!(1, "{}", msg).with_role(Role::Client),
-            ));
+            // upstream: main.c:907 - write_ndx(f_out, NDX_DONE) inside
+            // read_final_goodbye() is the last thing a sender records, after
+            // the stats. For protocol >= 30, NDX_DONE = 0x00 (single byte);
+            // for protocol < 30 it is 0xFFFFFFFF (4 bytes).
+            let goodbye_bytes: &[u8] = if proto >= 30 {
+                &[0x00]
+            } else {
+                &[0xFF, 0xFF, 0xFF, 0xFF]
+            };
+            if let Err(e) = writer.write_data(goodbye_bytes) {
+                let msg = format!("failed to write batch goodbye NDX_DONE: {e}");
+                return Err(ClientError::new(
+                    1,
+                    rsync_error!(1, "{}", msg).with_role(Role::Client),
+                ));
+            }
         }
 
         if let Err(e) = writer.flush() {
@@ -639,7 +656,7 @@ mod tests {
         write_batch_header(&writer_arc, &config).unwrap();
 
         let summary = ClientSummary::from_summary(engine::local_copy::LocalCopySummary::default());
-        let result = finalize_batch(&writer_arc, &batch_cfg, &config, &summary);
+        let result = finalize_batch(&writer_arc, &batch_cfg, &config, &summary, true);
         assert!(result.is_ok());
 
         let script_path = batch_cfg.script_file_path();
@@ -673,7 +690,7 @@ mod tests {
         write_batch_header(&writer_arc, &config).unwrap();
 
         let summary = ClientSummary::from_summary(engine::local_copy::LocalCopySummary::default());
-        let result = finalize_batch(&writer_arc, &batch_cfg, &config, &summary);
+        let result = finalize_batch(&writer_arc, &batch_cfg, &config, &summary, true);
         assert!(result.is_ok());
 
         let script_path = batch_cfg.script_file_path();

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -225,16 +225,16 @@ fn run_client_internal(
             remote::run_daemon_transfer(&config, observer, batch_writer.clone())?
         };
 
-        // upstream: main.c:374-383 - the client writes trailing batch stats and
-        // the NDX_DONE terminator after a successful transfer. The SSH and
-        // local-copy paths finalize here too; the daemon path previously
-        // returned early and relied on `BatchWriter` drop to flush, which left
-        // the batch file without its stats trailer (and, under load, races the
-        // header write into the recorder tee).
+        // Flush the batch file and emit the replay script. The daemon path
+        // previously returned early and relied on `BatchWriter` drop to flush,
+        // which left the batch truncated (and, under load, raced the header
+        // write into the recorder tee). The trailer itself is not written here:
+        // a remote transfer records it inside the transfer layer, at the point
+        // upstream's `handle_stats()` runs.
         if let Some(ref writer_arc) = batch_writer
             && let Some(batch_cfg) = config.batch_config()
         {
-            batch::finalize_batch(writer_arc, batch_cfg, &config, &summary)?;
+            batch::finalize_batch(writer_arc, batch_cfg, &config, &summary, false)?;
         }
 
         return Ok(summary);
@@ -262,7 +262,7 @@ fn run_client_internal(
                 if let Some(ref writer_arc) = batch_writer
                     && let Some(batch_cfg) = config.batch_config()
                 {
-                    batch::finalize_batch(writer_arc, batch_cfg, &config, &summary)?;
+                    batch::finalize_batch(writer_arc, batch_cfg, &config, &summary, false)?;
                 }
 
                 return Ok(summary);
@@ -286,7 +286,7 @@ fn run_client_internal(
         if let Some(ref writer_arc) = batch_writer
             && let Some(batch_cfg) = config.batch_config()
         {
-            batch::finalize_batch(writer_arc, batch_cfg, &config, &summary)?;
+            batch::finalize_batch(writer_arc, batch_cfg, &config, &summary, false)?;
         }
 
         return Ok(summary);
@@ -410,10 +410,14 @@ fn run_client_internal(
         adapter.finalize();
     }
 
+    // A local copy has no protocol stream to tee, so the synthesized batch has
+    // no trailer yet: this is the one path that writes it here. upstream reaches
+    // the same bytes through `handle_stats(-1)` + `read_final_goodbye()`, since
+    // its local mode is an ordinary client sender over a socketpair.
     if let Some(ref writer_arc) = batch_writer
         && let Some(batch_cfg) = config.batch_config()
     {
-        batch::finalize_batch(writer_arc, batch_cfg, &config, &summary)?;
+        batch::finalize_batch(writer_arc, batch_cfg, &config, &summary, true)?;
     }
 
     Ok(summary)

--- a/crates/protocol/src/negotiation/capabilities/env_list.rs
+++ b/crates/protocol/src/negotiation/capabilities/env_list.rs
@@ -58,13 +58,33 @@ pub(super) struct EnvOverride {
 /// Returns the checksum candidate override from `RSYNC_CHECKSUM_LIST`, or
 /// `None` when the variable is unset or holds only whitespace - in which case
 /// the caller keeps the built-in default order.
-pub(super) fn checksum_candidates(is_server: bool) -> Option<EnvOverride> {
+///
+/// `write_batch` replaces the variable outright with the single old-style
+/// choice, so a `--write-batch` recording is decodable by a `--read-batch`
+/// replay - which negotiates nothing and has only the batch header to go on.
+/// upstream: `compat.c:412-414 getenv_nstr()`.
+pub(super) fn checksum_candidates(
+    is_server: bool,
+    write_batch: bool,
+    protocol: u8,
+) -> Option<EnvOverride> {
+    if write_batch {
+        let forced = if protocol >= 30 { "md5" } else { "md4" };
+        return parse_list(forced, resolve_checksum);
+    }
     parse_env(CHECKSUM_LIST_ENV, is_server, resolve_checksum)
 }
 
 /// Returns the compression candidate override from `RSYNC_COMPRESS_LIST`, or
 /// `None` when the variable is unset or holds only whitespace.
-pub(super) fn compression_candidates(is_server: bool) -> Option<EnvOverride> {
+///
+/// `write_batch` pins the list to `zlib` for the same reason
+/// [`checksum_candidates`] pins the checksum.
+/// upstream: `compat.c:412-414 getenv_nstr()`.
+pub(super) fn compression_candidates(is_server: bool, write_batch: bool) -> Option<EnvOverride> {
+    if write_batch {
+        return parse_list("zlib", resolve_compression);
+    }
     parse_env(COMPRESS_LIST_ENV, is_server, resolve_compression)
 }
 
@@ -287,6 +307,15 @@ fn parse_env(
         None => raw.as_str(),
     };
 
+    parse_list(scoped, resolve)
+}
+
+/// Resolves one already-scoped whitespace-separated name list.
+///
+/// Split out of [`parse_env`] so the `write_batch` pin can feed a literal list
+/// through the same `parse_nni_str()` semantics upstream applies to the
+/// environment value.
+fn parse_list(scoped: &str, resolve: impl Fn(&str) -> Option<&'static str>) -> Option<EnvOverride> {
     // upstream: compat.c:435-438 / 512,519 - an empty or all-whitespace value is
     // treated as unset, leaving the built-in default order in place.
     scoped.split_whitespace().next()?;

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -49,6 +49,16 @@ pub struct NegotiationConfig {
     /// value which stays `CLVL_NOT_SPECIFIED` (`INT_MIN`) unless
     /// `--compress-level` was passed (`options.c:88,767`).
     pub compression_level: i32,
+    /// Whether this process is recording a `--write-batch` file.
+    ///
+    /// Upstream pins both negotiation lists to their old-style choice while
+    /// `write_batch` is set, because a `--read-batch` replay never negotiates:
+    /// it has only the batch header, which records no algorithm. Advertising
+    /// the full default order would let a modern peer pick XXH3, leaving a
+    /// batch whose whole-file checksums no `--read-batch` can verify.
+    ///
+    /// upstream: `compat.c:412-414 getenv_nstr()`.
+    pub write_batch: bool,
 }
 
 /// Outcome of the protocol 30+ capability negotiation.
@@ -148,6 +158,7 @@ pub fn negotiate_capabilities(
             checksum_override: None,
             compression_override: None,
             compression_level: CLVL_NOT_SPECIFIED,
+            write_batch: false,
         },
     )
 }
@@ -184,6 +195,7 @@ pub fn negotiate_capabilities_with_override(
         checksum_override,
         compression_override,
         compression_level,
+        write_batch,
     } = *config;
     // Protocol < 30 doesn't support negotiation, use defaults
     if protocol.uses_fixed_encoding() {
@@ -333,12 +345,12 @@ pub fn negotiate_capabilities_with_override(
     // local candidate list used for selection; an empty value falls through to
     // get_default_nno_list() so the default wire bytes are unchanged.
     let checksum_env = if send_checksum {
-        env_list::checksum_candidates(is_server)
+        env_list::checksum_candidates(is_server, write_batch, protocol.as_u8())
     } else {
         None
     };
     let compression_env = if send_compression {
-        env_list::compression_candidates(is_server)
+        env_list::compression_candidates(is_server, write_batch)
     } else {
         None
     };

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -339,6 +339,7 @@ fn test_no_negotiation_client_emits_resolved_fallback_summaries() {
             checksum_override: None,
             compression_override: None,
             compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+            write_batch: false,
         },
     )
     .unwrap();
@@ -420,6 +421,7 @@ fn test_negotiate_nstr_compress_summary_renders_explicit_level() {
             checksum_override: None,
             compression_override: None,
             compression_level: 9,
+            write_batch: false,
         },
     )
     .unwrap();
@@ -476,6 +478,7 @@ fn test_negotiate_nstr_summary_omits_negotiated_when_forced() {
             checksum_override: Some(ChecksumAlgorithm::MD5),
             compression_override: None,
             compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+            write_batch: false,
         },
     )
     .unwrap();
@@ -535,6 +538,7 @@ fn test_checksum_override_forces_chosen_algorithm() {
             checksum_override: Some(ChecksumAlgorithm::XXH128),
             compression_override: None,
             compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+            write_batch: false,
         },
     )
     .unwrap();
@@ -3081,6 +3085,7 @@ fn compression_override_used_on_legacy_protocol() {
             checksum_override: None,
             compression_override: Some(CompressionAlgorithm::Zstd),
             compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+            write_batch: false,
         },
     )
     .unwrap();
@@ -3109,6 +3114,7 @@ fn compression_override_used_without_negotiation() {
             checksum_override: None,
             compression_override: Some(CompressionAlgorithm::LZ4),
             compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+            write_batch: false,
         },
     )
     .unwrap();
@@ -3137,6 +3143,7 @@ fn compression_override_none_falls_through_to_normal_negotiation() {
             checksum_override: None,
             compression_override: None,
             compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+            write_batch: false,
         },
     )
     .unwrap();
@@ -3184,10 +3191,10 @@ mod env_list_overrides {
         let _cs = EnvGuard::remove(CHECKSUM_ENV);
         let _cp = EnvGuard::remove(COMPRESS_ENV);
 
-        assert!(env_list::checksum_candidates(false).is_none());
-        assert!(env_list::checksum_candidates(true).is_none());
-        assert!(env_list::compression_candidates(false).is_none());
-        assert!(env_list::compression_candidates(true).is_none());
+        assert!(env_list::checksum_candidates(false, false, 32).is_none());
+        assert!(env_list::checksum_candidates(true, false, 32).is_none());
+        assert!(env_list::compression_candidates(false, false).is_none());
+        assert!(env_list::compression_candidates(true, false).is_none());
     }
 
     // (a') Unset env - a full negotiation advertises the built-in default list
@@ -3216,11 +3223,11 @@ mod env_list_overrides {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 xxh3"));
 
-        let client = env_list::checksum_candidates(false).unwrap();
+        let client = env_list::checksum_candidates(false, false, 32).unwrap();
         assert_eq!(client.candidates, vec!["md5", "xxh3"]);
         assert_eq!(client.advertised, "md5 xxh3");
 
-        let server = env_list::checksum_candidates(true).unwrap();
+        let server = env_list::checksum_candidates(true, false, 32).unwrap();
         assert_eq!(server.candidates, vec!["md5", "xxh3"]);
         assert_eq!(server.advertised, "md5 xxh3");
     }
@@ -3255,7 +3262,7 @@ mod env_list_overrides {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zlib zlibx"));
 
-        let client = env_list::compression_candidates(false).unwrap();
+        let client = env_list::compression_candidates(false, false).unwrap();
         assert_eq!(client.candidates, vec!["zlib", "zlibx"]);
         assert_eq!(client.advertised, "zlib zlibx");
     }
@@ -3292,7 +3299,7 @@ mod env_list_overrides {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("bogus md5 alsobad xxh3"));
 
-        let over = env_list::checksum_candidates(false).unwrap();
+        let over = env_list::checksum_candidates(false, false, 32).unwrap();
         assert_eq!(over.candidates, vec!["md5", "xxh3"]);
         assert_eq!(over.advertised, "md5 xxh3");
     }
@@ -3304,7 +3311,7 @@ mod env_list_overrides {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("bogus notreal"));
 
-        let over = env_list::checksum_candidates(false).unwrap();
+        let over = env_list::checksum_candidates(false, false, 32).unwrap();
         assert!(over.candidates.is_empty());
         assert_eq!(over.advertised, "INVALID");
 
@@ -3320,7 +3327,7 @@ mod env_list_overrides {
     fn whitespace_only_env_is_treated_as_unset() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("   \t "));
-        assert!(env_list::checksum_candidates(false).is_none());
+        assert!(env_list::checksum_candidates(false, false, 32).is_none());
     }
 
     // Duplicate names are removed, keeping first occurrence (upstream dedup).
@@ -3328,7 +3335,7 @@ mod env_list_overrides {
     fn duplicate_names_are_deduped() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 xxh3 md5 xxh3"));
-        let over = env_list::checksum_candidates(false).unwrap();
+        let over = env_list::checksum_candidates(false, false, 32).unwrap();
         assert_eq!(over.candidates, vec!["md5", "xxh3"]);
     }
 
@@ -3338,7 +3345,7 @@ mod env_list_overrides {
     fn xxhash_alias_is_canonicalised() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxhash md5"));
-        let over = env_list::checksum_candidates(false).unwrap();
+        let over = env_list::checksum_candidates(false, false, 32).unwrap();
         assert_eq!(over.candidates, vec!["xxh64", "md5"]);
         assert_eq!(over.advertised, "xxh64 md5");
     }
@@ -3350,7 +3357,7 @@ mod env_list_overrides {
     fn mixed_case_non_alias_preserves_original_bytes() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("MD5 XXH3"));
-        let over = env_list::checksum_candidates(false).unwrap();
+        let over = env_list::checksum_candidates(false, false, 32).unwrap();
         // Advertised bytes preserve the operator's casing.
         assert_eq!(over.advertised, "MD5 XXH3");
         // Candidates are canonical for case-insensitive selection.
@@ -3358,7 +3365,7 @@ mod env_list_overrides {
 
         // A mixed-case alias still canonicalises (case-insensitive match).
         let _cs2 = EnvGuard::set(CHECKSUM_ENV, OsStr::new("XxHaSh"));
-        let alias = env_list::checksum_candidates(false).unwrap();
+        let alias = env_list::checksum_candidates(false, false, 32).unwrap();
         assert_eq!(alias.advertised, "xxh64");
         assert_eq!(alias.candidates, vec!["xxh64"]);
     }
@@ -3370,10 +3377,10 @@ mod env_list_overrides {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 & xxh3 xxh128"));
 
-        let client = env_list::checksum_candidates(false).unwrap();
+        let client = env_list::checksum_candidates(false, false, 32).unwrap();
         assert_eq!(client.candidates, vec!["md5"]);
 
-        let server = env_list::checksum_candidates(true).unwrap();
+        let server = env_list::checksum_candidates(true, false, 32).unwrap();
         assert_eq!(server.candidates, vec!["xxh3", "xxh128"]);
     }
 
@@ -3521,6 +3528,7 @@ mod env_list_overrides {
                 checksum_override: Some(ChecksumAlgorithm::MD5),
                 compression_override: None,
                 compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+                write_batch: false,
             },
         )
         .unwrap_err();
@@ -3557,6 +3565,7 @@ mod env_list_overrides {
                 checksum_override: Some(ChecksumAlgorithm::MD5),
                 compression_override: None,
                 compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+                write_batch: false,
             },
         )
         .expect("client does not validate the choice against the env list");
@@ -3633,6 +3642,7 @@ mod env_list_overrides {
                 checksum_override: None,
                 compression_override: None,
                 compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+                write_batch: false,
             },
         )
     }

--- a/crates/test-support/src/upstream_compat.rs
+++ b/crates/test-support/src/upstream_compat.rs
@@ -125,19 +125,43 @@ pub fn locate_upstream_rsync(version: UpstreamVersion) -> Option<PathBuf> {
 /// reason in stderr.
 #[must_use]
 pub fn require_upstream_rsync(version: UpstreamVersion) -> Option<UpstreamRsync> {
-    match locate_upstream_rsync(version) {
-        Some(binary) => Some(UpstreamRsync { binary, version }),
-        None => {
+    let Some(binary) = locate_upstream_rsync(version) else {
+        eprintln!(
+            "Skipping upstream-compat test: upstream rsync {} not installed at \
+             target/interop/upstream-install/{}/bin/rsync (override via {})",
+            version.directory(),
+            version.directory(),
+            version.env_var(),
+        );
+        return None;
+    };
+
+    // A path is not proof of provenance. `/usr/bin/rsync` on macOS is
+    // openrsync, which speaks protocol 29 and shares none of the batch
+    // format; silently testing against it would turn a wire-compat
+    // assertion into a no-op. Take the version from the banner instead.
+    let banner = match Command::new(&binary).arg("--version").output() {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).into_owned(),
+        other => {
             eprintln!(
-                "Skipping upstream-compat test: upstream rsync {} not installed at \
-                 target/interop/upstream-install/{}/bin/rsync (override via {})",
-                version.directory(),
-                version.directory(),
-                version.env_var(),
+                "Skipping upstream-compat test: `{} --version` did not run cleanly ({other:?})",
+                binary.display(),
             );
-            None
+            return None;
         }
+    };
+    let first_line = banner.lines().next().unwrap_or_default();
+    let expected = format!("rsync  version {}", version.directory());
+    if !first_line.starts_with(&expected) {
+        eprintln!(
+            "Skipping upstream-compat test: {} is not upstream rsync {} (banner: {first_line:?})",
+            binary.display(),
+            version.directory(),
+        );
+        return None;
     }
+
+    Some(UpstreamRsync { binary, version })
 }
 
 /// Resolve the workspace root from `CARGO_MANIFEST_DIR`.

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -7,8 +7,8 @@
 //! workflow is driven by the `transfer` submodule via `GeneratorContext::run`.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
 
 use ::filters::FilterChain;
 use protocol::flist::{DualFileList, FileEntry};
@@ -168,6 +168,35 @@ pub struct GeneratorContext {
     /// advanced through `FileListTransfer`, `DeltaTransfer`, `Finalization`,
     /// and `Complete` as the generator progresses.
     pub(crate) pipeline: TransferPipeline,
+    /// Batch file to receive the `--write-batch` stats trailer, set only when
+    /// this process is a client SENDER recording a batch.
+    ///
+    /// This is upstream's `batch_fd`, deliberately distinct from the wire
+    /// writer: a client sender never puts its stats on the wire, it writes
+    /// them straight into the batch between the last transfer write and the
+    /// goodbye `NDX_DONE` (which does ride the wire, and so is teed).
+    /// Ordering is what makes the batch replayable, so the write has to happen
+    /// here rather than after the transfer returns.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:374-383` - `handle_stats()` `else if (write_batch)` arm,
+    ///   reached only when `am_sender` and `!am_server`.
+    pub(crate) batch_stats_sink: Option<BatchStatsSink>,
+}
+
+/// Handle on the `--write-batch` file, held by a client sender so it can write
+/// the stats trailer without routing it through the wire writer.
+///
+/// A newtype only so the enclosing [`GeneratorContext`] can keep deriving
+/// `Debug`, which a bare `dyn Write` cannot.
+#[derive(Clone)]
+pub(crate) struct BatchStatsSink(pub(crate) Arc<Mutex<dyn std::io::Write + Send>>);
+
+impl std::fmt::Debug for BatchStatsSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("BatchStatsSink")
+    }
 }
 
 impl GeneratorContext {
@@ -242,6 +271,7 @@ impl GeneratorContext {
             parallel_thresholds: crate::parallel_io::ParallelThresholds::default(),
             curr_dir: None,
             pipeline,
+            batch_stats_sink: None,
         }
     }
 

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -95,6 +95,7 @@ mod tests;
 mod timing;
 mod transfer;
 
+pub(crate) use self::context::BatchStatsSink;
 pub use self::context::GeneratorContext;
 pub use self::delta::{generate_delta_from_signature, generate_delta_from_signature_chunked};
 pub use self::diagnostics::{

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -166,14 +166,19 @@ impl GeneratorContext {
             .map_err(crate::fsm_error)?;
 
         // upstream: main.c:978-980 - do_server_sender() calls io_flush then handle_stats
-        // before read_final_goodbye. Server-sender writes transfer stats; client-sender
-        // handle_stats(-1) is a no-op (main.c:339-345).
+        // before read_final_goodbye. Server-sender writes transfer stats to the wire;
+        // client-sender handle_stats(-1) puts nothing on the wire but, under
+        // --write-batch, writes the same five values straight to batch_fd
+        // (main.c:374-383). Both land BEFORE read_final_goodbye tees the goodbye
+        // NDX_DONE, which is the order --read-batch parses them back in.
+        let flist_buildtime =
+            calculate_duration_ms(self.timing.flist_build_start, self.timing.flist_build_end);
+        let flist_xfertime =
+            calculate_duration_ms(self.timing.flist_xfer_start, self.timing.flist_xfer_end);
         if !self.config.connection.client_mode {
-            let flist_buildtime =
-                calculate_duration_ms(self.timing.flist_build_start, self.timing.flist_build_end);
-            let flist_xfertime =
-                calculate_duration_ms(self.timing.flist_xfer_start, self.timing.flist_xfer_end);
             self.send_stats(writer, &transfer_result, flist_buildtime, flist_xfertime)?;
+        } else {
+            self.record_batch_stats(&transfer_result, flist_buildtime, flist_xfertime)?;
         }
 
         let mut ndx_read_codec = transfer_result.ndx_read_codec;

--- a/crates/transfer/src/generator/transfer/stats.rs
+++ b/crates/transfer/src/generator/transfer/stats.rs
@@ -49,4 +49,47 @@ impl GeneratorContext {
         writer.flush()?;
         Ok(())
     }
+
+    /// Writes the `--write-batch` stats trailer into the batch file.
+    ///
+    /// A client sender puts nothing on the wire here, so the same five
+    /// varlong30 values a server sender would send are written straight to the
+    /// batch instead. No-op unless this process is a client sender recording a
+    /// batch (`batch_stats_sink` is `None` on a pull, where the trailer arrives
+    /// over the wire and the read tee already captured it).
+    ///
+    /// Position matters as much as content: `--read-batch` reads the five
+    /// values and then expects the goodbye `NDX_DONE`, so the trailer has to be
+    /// written before the goodbye exchange tees that byte, not after the
+    /// transfer returns.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:374-383` - `handle_stats()` `else if (write_batch)` arm
+    /// - `main.c:1345-1347` - `handle_stats(-1)` then `read_final_goodbye()`
+    pub(super) fn record_batch_stats(
+        &self,
+        transfer_result: &TransferLoopResult,
+        flist_buildtime_ms: u64,
+        flist_xfertime_ms: u64,
+    ) -> io::Result<()> {
+        let Some(sink) = self.batch_stats_sink.as_ref() else {
+            return Ok(());
+        };
+
+        let stats = TransferStats::with_bytes(
+            self.timing.total_bytes_read,
+            transfer_result.bytes_sent,
+            self.flist_send_stats.total_size,
+        )
+        .with_flist_times(flist_buildtime_ms, flist_xfertime_ms);
+
+        let mut guard = sink
+            .0
+            .lock()
+            .map_err(|_| io::Error::other("batch recorder lock poisoned"))?;
+        let mut batch: &mut dyn Write = &mut *guard;
+        stats.write_to(&mut batch, self.protocol)?;
+        batch.flush()
+    }
 }

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -676,6 +676,10 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         // upstream: compat.c:751-753 - abort when --crtimes is requested but the
         // negotiated peer lacks CF_VARINT_FLIST_FLAGS (rsync < 3.2.0).
         preserve_crtimes: config.flags.crtimes,
+        // upstream: compat.c:412-414 getenv_nstr() - only the client sets
+        // `write_batch`, and only it needs to pin the negotiation lists; the
+        // remote server is never told about the batch at all.
+        write_batch: batch.is_some(),
     };
     let setup_result = setup::setup_protocol(&mut stdout, &mut chained_stdin, &setup_config)?;
 
@@ -875,6 +879,11 @@ pub fn run_server_with_handshake_adopting<W: Write>(
     // but before file list data flows. The callback writes the batch header with
     // negotiated protocol values, then the recorder is attached at the multiplex layer.
     let mut chained_reader = reader;
+    // upstream: main.c:374-383 - a client sender writes the batch stats trailer
+    // straight to `batch_fd`, so keep a second handle on the batch file for the
+    // generator role. `None` on a pull: there the whole trailer arrives over the
+    // wire and the read tee already records it.
+    let mut batch_stats_sink = None;
     if let Some(batch_recording) = batch {
         (batch_recording.on_setup_complete)(
             i32::from(handshake.protocol),
@@ -883,6 +892,9 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         )?;
 
         if batch_recording.is_sender {
+            batch_stats_sink = Some(crate::generator::BatchStatsSink(
+                batch_recording.recorder.clone(),
+            ));
             writer.set_batch_recorder(batch_recording.recorder)?;
         } else {
             chained_reader.set_batch_recorder(batch_recording.recorder);
@@ -923,6 +935,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
             paths.extend(config.args.iter().map(std::path::PathBuf::from));
 
             let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
+            ctx.batch_stats_sink = batch_stats_sink;
             let stats = ctx.run(chained_reader, &mut writer, &paths, progress, itemize)?;
 
             Ok(ServerStats::Generator(stats))

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -174,6 +174,9 @@ pub fn setup_protocol_with<'a>(
                     checksum_override: config.checksum_choice,
                     compression_override: config.compress_choice,
                     compression_level: config.compression_level,
+                    // upstream: compat.c:412-414 getenv_nstr() - `write_batch`
+                    // overrides both lists with the old-style choice.
+                    write_batch: config.write_batch,
                 },
             )?;
 

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -80,6 +80,7 @@ fn ssh_server_flag_string_limits_compat_flags() {
         checksum_seed: Some(42),
         allow_inc_recurse: true,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let mock = MockNegotiator::new();
@@ -118,6 +119,7 @@ fn ssh_server_flag_string_enables_advertised_caps() {
         checksum_seed: Some(42),
         allow_inc_recurse: true,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let mock = MockNegotiator::new();
@@ -153,6 +155,7 @@ fn ssh_server_no_flag_string_uses_defaults() {
         checksum_seed: Some(42),
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result = setup_protocol(&mut stdout, &mut stdin, &config)
@@ -198,6 +201,7 @@ fn client_honors_negotiated_inc_recurse_regardless_of_local_allow() {
         checksum_seed: Some(42),
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     // The server hands back CF_INC_RECURSE among its negotiated flags.
@@ -357,6 +361,7 @@ fn setup_protocol_below_30_returns_none_for_algorithms_and_compat() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result =
@@ -399,6 +404,7 @@ fn setup_protocol_skip_compat_exchange_skips_flags() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result = setup_protocol(&mut stdout, &mut stdin, &config)
@@ -444,6 +450,7 @@ fn setup_protocol_server_writes_compat_flags_and_seed() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result =
@@ -502,6 +509,7 @@ fn setup_protocol_client_reads_compat_flags_from_server() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result =
@@ -548,6 +556,7 @@ fn setup_protocol_server_generates_deterministic_seeds() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let mut stdout1 = Vec::new();
@@ -600,6 +609,7 @@ fn setup_protocol_ssh_mode_bidirectional_exchange() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result = setup_protocol(&mut stdout, &mut stdin, &config)
@@ -646,6 +656,7 @@ fn setup_protocol_client_args_affects_compat_flags() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result_minimal = setup_protocol(&mut stdout, &mut stdin, &config_minimal)
@@ -680,6 +691,7 @@ fn setup_protocol_client_args_affects_compat_flags() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result_full = setup_protocol(&mut stdout, &mut stdin, &config_full)
@@ -726,6 +738,7 @@ fn setup_protocol_protocol_30_minimum_for_compat_exchange() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result =
@@ -1116,6 +1129,7 @@ fn setup_protocol_server_v_flag_uses_single_byte_encoding() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result =
@@ -1165,6 +1179,7 @@ fn setup_protocol_server_v_flag_enables_negotiation() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result =
@@ -1200,6 +1215,7 @@ fn setup_protocol_server_v_flag_with_both_v_and_uppercase_v() {
         checksum_seed: Some(42),
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result_v =
@@ -1222,6 +1238,7 @@ fn setup_protocol_server_v_flag_with_both_v_and_uppercase_v() {
         checksum_seed: Some(42),
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result_both = setup_protocol(&mut stdout_both, &mut stdin, &config_both)
@@ -1421,6 +1438,7 @@ fn setup_protocol_with_mock_negotiator_server_mode() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let mock = MockNegotiator::new();
@@ -1469,6 +1487,7 @@ fn setup_protocol_with_mock_negotiator_client_mode() {
         checksum_seed: None,
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let mock = MockNegotiator::new();
@@ -1766,6 +1785,7 @@ fn compress_choice_override_skips_vstring_and_uses_algorithm() {
         checksum_seed: Some(42),
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let mock = MockNegotiator::new();
@@ -1803,6 +1823,7 @@ fn compress_choice_none_allows_normal_negotiation() {
         checksum_seed: Some(42),
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let mock = MockNegotiator::new();
@@ -1840,6 +1861,7 @@ fn compress_choice_zlib_override_on_legacy_protocol() {
         checksum_seed: Some(42),
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let result = setup_protocol(&mut stdout, &mut stdin, &config)
@@ -1882,6 +1904,7 @@ fn checksum_choice_override_threads_into_negotiation() {
         checksum_seed: Some(42),
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let mock = MockNegotiator::new();
@@ -1919,6 +1942,7 @@ fn checksum_choice_none_allows_normal_negotiation() {
         checksum_seed: Some(42),
         allow_inc_recurse: false,
         preserve_crtimes: false,
+        write_batch: false,
     };
 
     let mock = MockNegotiator::new();

--- a/crates/transfer/src/setup/types.rs
+++ b/crates/transfer/src/setup/types.rs
@@ -146,6 +146,14 @@ pub struct ProtocolSetupConfig<'a> {
     ///
     /// Mirrors `preserve_crtimes` in upstream `compat.c:751-753`.
     pub preserve_crtimes: bool,
+    /// Whether this process is recording a `--write-batch` file.
+    ///
+    /// Pins both negotiation lists to their old-style choice so the recording
+    /// stays decodable by a `--read-batch` replay, which negotiates nothing.
+    ///
+    /// Mirrors upstream's `write_batch` global as read by
+    /// `compat.c:412-414 getenv_nstr()`.
+    pub write_batch: bool,
 }
 
 impl<'a> ProtocolSetupConfig<'a> {
@@ -179,6 +187,7 @@ impl<'a> ProtocolSetupConfig<'a> {
             checksum_seed: None,
             allow_inc_recurse: false,
             preserve_crtimes: false,
+            write_batch: false,
         }
     }
 

--- a/crates/transfer/tests/uts_15_e_daemon_pull_write_batch.rs
+++ b/crates/transfer/tests/uts_15_e_daemon_pull_write_batch.rs
@@ -43,6 +43,12 @@
 //! 4. A subsequent `oc-rsync --read-batch=FILE DEST_REPLAY/` (no remote
 //!    URL) reconstructs the same source tree from the batch file alone,
 //!    so the recorded batch is functional, not just non-empty.
+//! 5. Genuine upstream `rsync --read-batch=FILE` reconstructs the same
+//!    tree. Assertions 1-4 all passed while the recorded trailer was
+//!    unreadable by upstream, because oc's own `--read-batch` stops as
+//!    soon as it has the file data. Only upstream's
+//!    `read_final_goodbye()` (`main.c:893-924`) validates the tail.
+//!    Skipped with a printed reason when no genuine 3.4.4 is installed.
 //!
 //! # Platform gate
 //!
@@ -425,4 +431,58 @@ fn daemon_pull_write_batch_records_and_replays() {
         &replay_dir,
         "replay destination",
     );
+
+    replay_with_upstream(
+        &module_root,
+        &batch_path,
+        &scratch.root.join("replay-upstream"),
+    );
+}
+
+/// Replays `batch_path` with genuine upstream rsync and asserts it reconstructs
+/// `source`.
+///
+/// oc-rsync replaying its own batch is not an oracle for wire compatibility:
+/// its `--read-batch` stops as soon as it has what it needs, so a trailer with
+/// a duplicated stats block or an extra `NDX_DONE` replays clean. Upstream's
+/// `read_final_goodbye()` (`main.c:893-924`) does not - it reads one more index
+/// after the goodbye and aborts with `RERR_PROTOCOL` on anything but EOF. Only
+/// upstream can tell the two apart, which is why a batch recorded over a daemon
+/// pull was unreadable by `rsync --read-batch` while every oc-side assertion
+/// above passed.
+///
+/// Skips with a printed reason when no genuine 3.4.4 is installed - the
+/// interop cell (`tools/ci/run_interop.sh`) is the one that guarantees it.
+fn replay_with_upstream(source: &Path, batch_path: &Path, dest: &Path) {
+    let Some(upstream) =
+        test_support::require_upstream_rsync(test_support::UpstreamVersion::V3_4_4)
+    else {
+        return;
+    };
+
+    fs::create_dir_all(dest).expect("create upstream replay destination");
+    let mut read_batch_arg = std::ffi::OsString::from("--read-batch=");
+    read_batch_arg.push(batch_path.as_os_str());
+    let mut dest_arg = dest.to_path_buf().into_os_string();
+    dest_arg.push("/");
+
+    let output = upstream
+        .command()
+        .arg("--recursive")
+        .arg("--times")
+        .arg(&read_batch_arg)
+        .arg(&dest_arg)
+        .stdin(Stdio::null())
+        .output()
+        .expect("spawn upstream rsync (--read-batch)");
+
+    assert!(
+        output.status.success(),
+        "upstream rsync {} rejected the batch recorded over a daemon pull: {:?}\nstderr:\n{}",
+        upstream.version().directory(),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert_trees_match(source, "daemon source", dest, "upstream replay destination");
 }

--- a/tests/only_write_batch_remote_pull.rs
+++ b/tests/only_write_batch_remote_pull.rs
@@ -302,4 +302,47 @@ fn write_batch_pull_still_transfers_and_records() {
         "--write-batch must record a non-empty batch at {}",
         batch.display()
     );
+
+    replay_with_upstream(&batch, &src, &temp.path().join("replay-upstream"));
+}
+
+/// Replays `batch` with genuine upstream rsync and asserts it reconstructs
+/// `source`.
+///
+/// The oc-side replay above is not an oracle for wire compatibility: oc's
+/// `--read-batch` stops once it has the file data, so a trailer carrying a
+/// duplicated stats block or a stray `NDX_DONE` still replays clean. Upstream's
+/// `read_final_goodbye()` (`main.c:893-924`) reads one more index after the
+/// goodbye and aborts with `RERR_PROTOCOL` unless that read hits EOF, so only
+/// upstream can tell a well-formed trailer from a malformed one.
+///
+/// Skips with a printed reason when no genuine 3.4.4 is installed; the interop
+/// cell (`tools/ci/run_interop.sh`) is the one that guarantees it.
+fn replay_with_upstream(batch: &Path, source: &Path, dest: &Path) {
+    let Some(upstream) =
+        test_support::require_upstream_rsync(test_support::UpstreamVersion::V3_4_4)
+    else {
+        return;
+    };
+
+    fs::create_dir_all(dest).expect("create upstream replay destination");
+    let mut cmd = Command::new(upstream.binary());
+    cmd.arg("-a")
+        .arg(format!("--read-batch={}", batch.display()))
+        .arg(format!("{}/", dest.display()));
+    let output = spawn_with_timeout(cmd, RUN_TIMEOUT)
+        .expect("upstream --read-batch did not finish within the timeout");
+
+    assert!(
+        output.status.success(),
+        "upstream rsync {} rejected the batch recorded over a remote pull: {:?}\nstderr: {}",
+        upstream.version().directory(),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        file_tree(dest),
+        file_tree(source),
+        "upstream --read-batch must reconstruct the source tree from an oc-recorded pull batch"
+    );
 }

--- a/tests/only_write_batch_remote_push.rs
+++ b/tests/only_write_batch_remote_push.rs
@@ -269,4 +269,52 @@ fn write_batch_push_still_transfers_and_records() {
         "--write-batch must record a non-empty batch at {}",
         batch.display()
     );
+
+    replay_with_upstream(&batch, &src, &temp.path().join("replay-upstream"));
+}
+
+/// Replays `batch` with genuine upstream rsync and asserts it reconstructs
+/// `source`.
+///
+/// oc-rsync replaying its own batch proves nothing about wire compatibility:
+/// its `--read-batch` stops once it has the file data, so a trailer carrying a
+/// duplicated stats block or a stray `NDX_DONE` still replays clean. Upstream's
+/// `read_final_goodbye()` (`main.c:893-924`) reads one more index after the
+/// goodbye and aborts with `RERR_PROTOCOL` unless that read hits EOF, so only
+/// upstream can tell a well-formed trailer from a malformed one.
+///
+/// Skips with a printed reason when no genuine 3.4.4 is installed; the interop
+/// cell (`tools/ci/run_interop.sh`) is the one that guarantees it.
+fn replay_with_upstream(batch: &Path, source: &Path, dest: &Path) {
+    let Some(upstream) =
+        test_support::require_upstream_rsync(test_support::UpstreamVersion::V3_4_4)
+    else {
+        return;
+    };
+
+    fs::create_dir_all(dest).expect("create upstream replay destination");
+    let mut cmd = Command::new(upstream.binary());
+    cmd.arg("-a")
+        .arg(format!("--read-batch={}", batch.display()))
+        .arg(format!("{}/", dest.display()));
+    let output = spawn_with_timeout(cmd, RUN_TIMEOUT)
+        .expect("upstream --read-batch did not finish within the timeout");
+
+    assert!(
+        output.status.success(),
+        "upstream rsync {} rejected the batch recorded over a remote push: {:?}\nstderr: {}",
+        upstream.version().directory(),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        count_files(dest),
+        count_files(source),
+        "upstream --read-batch must reconstruct every file of an oc-recorded push batch"
+    );
+    assert_eq!(
+        fs::read(dest.join("alpha.txt")).unwrap(),
+        fs::read(source.join("alpha.txt")).unwrap(),
+        "upstream --read-batch must reconstruct the file contents byte-for-byte"
+    );
 }

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -2067,18 +2067,74 @@ CONF
     return 1
   fi
 
-  # Step 5: replay the batch file to a fresh destination
-  if ! timeout "$hard_timeout" "$oc_bin" -av \
+  # Step 5: replay the batch file to a fresh destination with UPSTREAM rsync.
+  # oc-rsync replaying its own batch is not an oracle for wire compatibility:
+  # its --read-batch stops once it has the file data, so a trailer with a
+  # duplicated stats block or a stray NDX_DONE replays clean. Upstream's
+  # read_final_goodbye() (main.c:893-924) reads one more index after the
+  # goodbye and aborts with RERR_PROTOCOL unless that read hits EOF.
+  local rc_daemon=0
+  timeout "$hard_timeout" "$upstream_binary" -av \
       --read-batch="$batch_daemon" --timeout=10 \
       "${replay_dest}/" \
-      >"${log}.read-batch-daemon.out" 2>"${log}.read-batch-daemon.err"; then
-    echo "    read-batch failed (daemon batch replay, exit=$?)"
+      >"${log}.read-batch-daemon.out" 2>"${log}.read-batch-daemon.err" || rc_daemon=$?
+  if [[ $rc_daemon -ne 0 ]]; then
+    echo "    read-batch failed (upstream reads daemon-push batch, exit=$rc_daemon)"
+    head -5 "${log}.read-batch-daemon.err" 2>/dev/null | sed 's/^/    stderr: /'
     return 1
   fi
 
   # Verify replayed destination matches source
   if ! comp_verify_transfer "$src_dir" "$replay_dest"; then
     echo "    content mismatch after daemon batch replay"
+    return 1
+  fi
+
+  # --- Daemon PULL roundtrip ---
+  # The push leg above records the batch on the sender side; a pull records it
+  # on the receiver side, from the read tee, which is a different code path and
+  # produced a different (unreadable) trailer. Both directions need the oracle.
+  local pull_replay_dest="${batch_dir}/pull-replay-dest"
+  local batch_daemon_pull="${batch_dir}/batch-daemon-pull.rsync"
+  local pull_dest="${batch_dir}/pull-dest"
+  mkdir -p "$pull_replay_dest" "$pull_dest"
+
+  start_oc_daemon "$daemon_conf" "$daemon_log" "$upstream_binary" "$daemon_pid" "$oc_port"
+
+  if ! timeout "$hard_timeout" "$oc_bin" -av \
+      --write-batch="$batch_daemon_pull" --timeout=10 \
+      "rsync://127.0.0.1:${oc_port}/interop/" "${pull_dest}/" \
+      >"${log}.write-batch-daemon-pull.out" 2>"${log}.write-batch-daemon-pull.err"; then
+    echo "    write-batch failed (daemon pull, exit=$?)"
+    stop_oc_daemon
+    return 1
+  fi
+
+  stop_oc_daemon
+
+  if [[ ! -f "$batch_daemon_pull" ]]; then
+    echo "    daemon pull batch file not created"
+    return 1
+  fi
+
+  if ! comp_verify_transfer "$src_dir" "$pull_dest"; then
+    echo "    content mismatch after daemon pull"
+    return 1
+  fi
+
+  local rc_pull=0
+  timeout "$hard_timeout" "$upstream_binary" -av \
+      --read-batch="$batch_daemon_pull" --timeout=10 \
+      "${pull_replay_dest}/" \
+      >"${log}.read-batch-daemon-pull.out" 2>"${log}.read-batch-daemon-pull.err" || rc_pull=$?
+  if [[ $rc_pull -ne 0 ]]; then
+    echo "    read-batch failed (upstream reads daemon-pull batch, exit=$rc_pull)"
+    head -5 "${log}.read-batch-daemon-pull.err" 2>/dev/null | sed 's/^/    stderr: /'
+    return 1
+  fi
+
+  if ! comp_verify_transfer "$src_dir" "$pull_replay_dest"; then
+    echo "    content mismatch after daemon pull batch replay"
     return 1
   fi
 


### PR DESCRIPTION
## Problem

`rsync --read-batch` from upstream 3.4.4 rejects any batch oc-rsync recorded over a remote transfer:

```
Invalid packet at end of run [receiver]
rsync error: protocol incompatibility (code 2) at main.c(1097) [receiver=3.4.4]
```

Both directions were affected, not just the pull.

## Root cause

Upstream writes the batch trailer - five `varlong30` stats plus the goodbye `NDX_DONE` - from `handle_stats()` (`main.c:374-383`), mid-transfer. oc-rsync appended it afterwards from `finalize_batch()`, unconditionally, from all four call sites.

- **PULL**: the stats (`main.c:364-373`) and the goodbye `NDX_DONE` (`main.c:904`) both arrive over the wire, so the read tee had already recorded the complete trailer. `finalize_batch` appended a second copy.
- **PUSH**: the write tee had already recorded the goodbye `NDX_DONE`, so the batch ended `[phases][goodbye][stats][NDX_DONE]` where upstream writes `[phases][stats][goodbye]`.

Either shape leaves one index too many after the goodbye, which is exactly what `read_final_goodbye()` (`main.c:893-924`) reads one more of before aborting with `RERR_PROTOCOL`.

Evidence, minimal corpus (one 4-byte file), tails of the recorded batches. Upstream's own push batch:

```
00001120: 0055 0000 2e11 0013 1000 0100 0000 0000
          ^^ NDX_DONE  [5 x 3-byte varlong30 stats]        ^^ goodbye
```

oc before this change, push - one extra `00` ahead of the stats:

```
00001120: 0000 3600 005b 1000 1310 0000 0000 0000
00001130: 00
```

oc before this change, pull - the whole 16-byte trailer twice:

```
00000080: 0012 0000 1c00 0004 0000 0200 0000 0000   <- teed from the wire, correct
00000090: 00a2 0000 1800 0004 0000 0000 0000 0000   <- appended by finalize_batch
```

The duplicated stats block opens with `0x00`, which decodes as `NDX_DONE` - which is why the error is the `main.c:1095` form without the `(%d)` operand in both directions.

## Fix

A push records the stats straight into the batch file at the point `handle_stats(-1)` runs, before the goodbye rides the wire (`GeneratorContext::record_batch_stats`, called from the generator orchestrator where `send_stats` already sits for the server case). A pull records nothing extra. A local copy, which has no protocol stream to tee, keeps writing the trailer in `finalize_batch`.

## Second defect found while verifying

With the trailer corrected, upstream parsed the batch to completion and then discarded every file:

```
WARNING: f.txt failed verification -- update discarded (may try again).
```

Upstream pins both negotiation lists to their old-style choice while `write_batch` is set (`compat.c:412-414 getenv_nstr()`, forcing `md5`/`md4` and `zlib`) precisely because `--read-batch` negotiates nothing - the batch header records no algorithm. oc-rsync implemented the `RSYNC_CHECKSUM_LIST` / `RSYNC_COMPRESS_LIST` overrides but not the `write_batch` pin, so a remote batch recorded whole-file checksums under the negotiated XXH3. The pin is included here; without it the trailer fix is not observable end-to-end.

Local batches were unaffected throughout: the local-copy path never negotiated XXH3 and its trailer was already correct.

## Test oracles

Every existing batch assertion replayed with oc-rsync itself, whose `--read-batch` stops once it has the file data and therefore accepts a malformed trailer. All of them passed for as long as the bug existed. Changed to replay with genuine upstream 3.4.4:

- `crates/transfer/tests/uts_15_e_daemon_pull_write_batch.rs` - the daemon-pull cell.
- `tests/only_write_batch_remote_pull.rs`, `tests/only_write_batch_remote_push.rs` - the remote-shell cells, both directions.
- `tools/ci/run_interop.sh` - the daemon leg replayed with `$oc_bin`; now `$upstream_binary`, plus a new daemon **PULL** leg beside the existing push one.

`test_support::require_upstream_rsync` now confirms the binary from its `--version` banner instead of trusting the path, so a stray `openrsync` (protocol 29) cannot silently turn the assertion into a no-op.

## Verification

x86_64 Linux, upstream `rsync 3.4.4 protocol version 32` built from source.

Before the fix, with the new oracles applied to an otherwise untouched tree:

```
FAIL transfer::uts_15_e_daemon_pull_write_batch daemon_pull_write_batch_records_and_replays
  upstream rsync 3.4.4 rejected the batch recorded over a daemon pull: Some(12)
FAIL bin::only_write_batch_remote_pull write_batch_pull_still_transfers_and_records
FAIL bin::only_write_batch_remote_push write_batch_push_still_transfers_and_records
```

After: all 6 batch cells pass. `cargo nextest run -p protocol -p transfer -p core -p batch --all-features` is 11382/11382. `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings` are clean.

End-to-end, over a 4.4 KB corpus (binary, text, nested subdirectory): oc's push and pull batches are now both 4400 bytes, the same size upstream produces for the same corpus, and both replay under upstream 3.4.4 with exit 0 and a byte-identical destination.
