### PR TITLE
fix(transfer): apply xattr filters to the destination read

### DIFF
--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -14,6 +14,8 @@
 //! - [`errors_and_timeouts`] - error categorization, failed-directory
 //!   propagation, legacy goodbye handling, input-multiplex activation,
 //!   daemon filter set, and path-traversal rejection.
+//! - [`xattr_filter`] - `x`-modifier filter screening on the generator's
+//!   destination xattr read.
 
 #[cfg(unix)]
 mod create_specials;
@@ -36,3 +38,5 @@ mod verbose_dir_names;
 mod windows_receiver_symlinks;
 #[cfg(windows)]
 mod windows_special_skip;
+#[cfg(unix)]
+mod xattr_filter;

--- a/crates/transfer/src/receiver/tests/xattr_filter.rs
+++ b/crates/transfer/src/receiver/tests/xattr_filter.rs
@@ -1,0 +1,153 @@
+//! The generator's destination xattr read honours `x`-modifier filter rules.
+//!
+//! upstream: `xattrs.c:250-257` - `saw_xattr_filter` is a global consulted
+//! inside `rsync_xal_get()` on *every* call, so it screens the generator's
+//! destination read exactly as it screens the sender's source read. An
+//! excluded name is therefore invisible to `xattr_diff()` on both sides and
+//! cannot raise the itemize `x` column.
+
+use protocol::flist::FileEntry;
+use tempfile::TempDir;
+
+use super::super::ReceiverContext;
+use super::support::{test_config, test_handshake};
+
+/// The on-disk spelling the filter has to match: upstream feeds
+/// `name_is_excluded()` the *local* name it read from `listxattr`
+/// (`xattrs.c:246-251`). Linux exposes namespaced names, every other unix a
+/// flat one, so the `user.` prefix is Linux-only.
+fn local_name(base: &str) -> String {
+    if cfg!(target_os = "linux") {
+        format!("user.{base}")
+    } else {
+        base.to_owned()
+    }
+}
+
+/// Materialises `base` on `path` so the destination read has something to see.
+/// Returns `false` when the filesystem cannot store it, so a caller can skip
+/// rather than fail on a backend without xattr support.
+fn set_dest_xattr(path: &std::path::Path, base: &str, value: &[u8]) -> bool {
+    xattr::set(path, local_name(base), value).is_ok()
+}
+
+/// Screens out attributes the operating system attaches on its own, so the
+/// assertions below turn on the one name the test controls.
+///
+/// macOS stamps `com.apple.provenance` onto every newly created file, which
+/// would otherwise leave the destination list non-empty no matter what the
+/// rule under test does. It is inert on platforms that add nothing.
+fn platform_noise_rule() -> ::filters::FilterRule {
+    ::filters::FilterRule::exclude("com.apple.*").with_xattr_only(true)
+}
+
+/// Builds a receiver whose global filter set carries `rules`.
+fn receiver_with(rules: Vec<::filters::FilterRule>) -> ReceiverContext {
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.xattrs = true;
+    config.flags.xattrs_level = 1;
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    let global = ::filters::FilterSet::from_rules(rules).expect("compile filter rules");
+    ctx.set_filter_chain(::filters::FilterChain::new(global));
+    ctx
+}
+
+/// An `x`-modifier exclusion hides the name from the destination read, so a
+/// destination-only attribute no longer counts as a difference.
+///
+/// This is the behaviour under test: without the filter on the generator's
+/// read, the excluded attribute survives on the destination list alone and
+/// `xattr_diff()` reports a change that upstream never reports - and that no
+/// transfer could settle, since the same filter stops the receiver from ever
+/// removing it (`xattrs.c:1026`).
+#[test]
+fn an_excluded_name_does_not_flip_the_x_column() {
+    let dir = TempDir::new().expect("temp dir");
+    let file = dir.path().join("f.txt");
+    std::fs::write(&file, b"content").expect("write file");
+    if !set_dest_xattr(&file, "drop", b"DSTVAL") {
+        eprintln!("xattrs unsupported here, skipping");
+        return;
+    }
+
+    let entry = FileEntry::new_file("f.txt".into(), 7, 0o644);
+
+    // Control: with the platform noise screened but no rule naming it, the
+    // destination-only attribute is a difference, exactly as `rsync -X -i`
+    // reports `.f........x`. Without this the negative assertion below could
+    // pass for the wrong reason.
+    let unfiltered = receiver_with(vec![platform_noise_rule()]);
+    assert!(
+        unfiltered.dest_xattrs_differ(&entry, &file),
+        "a destination-only xattr must raise the x column when nothing excludes it",
+    );
+
+    // `--filter '-x <name>'`: upstream drops the name inside rsync_xal_get()
+    // before it can reach xattr_diff(), so no `x` column is emitted.
+    let filtered = receiver_with(vec![
+        ::filters::FilterRule::exclude(local_name("drop")).with_xattr_only(true),
+        platform_noise_rule(),
+    ]);
+    assert!(
+        !filtered.dest_xattrs_differ(&entry, &file),
+        "an x-modifier exclusion must screen the generator's destination read",
+    );
+}
+
+/// The filter is not a blanket suppression: a name it admits still differs.
+///
+/// Guards the opposite failure mode - screening the destination read with a
+/// filter that happens to be present, rather than with the rule that actually
+/// matches, would silence real xattr changes and make `-X` a no-op whenever
+/// any `x` rule existed.
+#[test]
+fn a_name_the_filter_admits_still_flips_the_x_column() {
+    let dir = TempDir::new().expect("temp dir");
+    let file = dir.path().join("f.txt");
+    std::fs::write(&file, b"content").expect("write file");
+    if !set_dest_xattr(&file, "drop", b"DSTVAL") {
+        eprintln!("xattrs unsupported here, skipping");
+        return;
+    }
+
+    let entry = FileEntry::new_file("f.txt".into(), 7, 0o644);
+
+    // The rule names a different attribute, so `user.drop` is still collected.
+    // Everything the platform adds on its own is screened, which leaves that
+    // one attribute as the sole possible source of the difference.
+    let ctx = receiver_with(vec![
+        ::filters::FilterRule::exclude(local_name("other")).with_xattr_only(true),
+        platform_noise_rule(),
+    ]);
+    assert!(
+        ctx.dest_xattrs_differ(&entry, &file),
+        "an unrelated x-modifier rule must not suppress a real xattr difference",
+    );
+}
+
+/// A rule *without* the `x` modifier governs paths only and must leave the
+/// destination read alone.
+///
+/// upstream: `exclude.c:914` - `rule_matches()` gates every rule on
+/// `!(name_flags & NAME_IS_XATTR) ^ !(ex->rflags & FILTRULE_XATTR)`, and
+/// `saw_xattr_filter` is set only by `x`-modifier rules, so a plain `-` rule
+/// never reaches `rsync_xal_get()`.
+#[test]
+fn a_plain_path_rule_does_not_screen_the_destination_read() {
+    let dir = TempDir::new().expect("temp dir");
+    let file = dir.path().join("f.txt");
+    std::fs::write(&file, b"content").expect("write file");
+    if !set_dest_xattr(&file, "drop", b"DSTVAL") {
+        eprintln!("xattrs unsupported here, skipping");
+        return;
+    }
+
+    let entry = FileEntry::new_file("f.txt".into(), 7, 0o644);
+
+    let ctx = receiver_with(vec![::filters::FilterRule::exclude(local_name("drop"))]);
+    assert!(
+        ctx.dest_xattrs_differ(&entry, &file),
+        "a rule without the x modifier matches paths, never xattr names",
+    );
+}

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -725,19 +725,29 @@ impl ReceiverContext {
     /// pre-transfer destination. A sender with no xattrs differs exactly when
     /// the destination still carries some.
     pub(in crate::receiver) fn dest_xattrs_differ(&self, entry: &FileEntry, path: &Path) -> bool {
+        // upstream: xattrs.c:250-252 - `saw_xattr_filter` is a global consulted
+        // on every `rsync_xal_get()` call, so the generator's destination read
+        // screens names through the same `x`-modifier rules the sender applied
+        // to its side. Without it an excluded name survives on the destination
+        // list alone and flips the itemize `x` column upstream leaves clear.
+        let filter = self
+            .xattr_name_filter()
+            .map(|set| move |name: &str| set.xattr_name_allowed(name));
         let opts = metadata::XattrSendOptions {
             role: metadata::XattrRole::Generator,
             follow_symlinks: false,
             // upstream: xattrs.c:237 - `user_only = am_sender ? 0 : !am_root`,
             // so a non-root generator sees only the `user.*` namespace here. A
             // `security.*` or `trusted.*` difference it could never store must
-            // not raise the itemize `x` column.
+            // not raise the itemize `x` column. When a filter is present
+            // upstream skips this test entirely (xattrs.c:250-257 are the two
+            // arms of one `if`/`else if`), which `read_xattrs_for_wire` honours.
             am_root: metadata::am_root(),
             // upstream: xattrs.c:262 - the strip is gated on `am_sender`, so
             // the generator keeps rsync.%FOO at either level.
             preserve_xattrs: self.config.flags.xattrs_level,
             fake_super: self.config.fake_super,
-            filter: None,
+            filter: filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool),
             checksum_seed: self.checksum_seed,
         };
         let dest = match metadata::read_xattrs_for_wire(path, &opts) {


### PR DESCRIPTION
## Problem

`ReceiverContext::dest_xattrs_differ` built its `XattrSendOptions` with
`filter: None`, so an `x`-modifier `--filter` rule never screened the names the
generator collected from the **destination**.

Upstream's `saw_xattr_filter` is a global consulted inside `rsync_xal_get()` on
every call, which covers the generator's destination read exactly as it covers
the sender's source read:

```c
/* xattrs.c:250-257 */
if (saw_xattr_filter) {
        if (name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS))
                continue;
}
#ifdef HAVE_LINUX_XATTRS
/* Choose between ignoring the system namespace or (non-root) ignoring any non-user namespace. */
else if (user_only ? !HAS_PREFIX(name, USER_PREFIX) : HAS_PREFIX(name, SYSTEM_PREFIX))
        continue;
#endif
```

The two branches are one `if` / `else if`, so a transfer carrying `x` rules
never evaluates the namespace test - which is already what
`read_xattrs_for_wire` implements; it was simply never handed the filter on
this path.

Consequence: an excluded attribute survived on the destination list alone,
`xattr_diff()` reported a change, and the itemize `x` column was set where
upstream leaves it clear. Nothing could settle that difference either, because
the same filter stops the receiver from removing the attribute
(`xattrs.c:1026`).

## Fix

Thread the filter into the destination read. **The existing accessor was
reused, not duplicated**: `ReceiverContext::xattr_name_filter()`
(`receiver/context.rs`) already supplies the same `FilterSet` to every other
receiver-side xattr site, so this is the same one-line predicate shape used in
`sync.rs`, `creation.rs`, `pipeline.rs`, and elsewhere in `candidates.rs`. No
second rule ladder was introduced.

## Verification against real rsync 3.4.4

Reference binary: `rsync version 3.4.4 protocol version 32`. Receiver runs
**non-root** (`uid=1000`). `trusted.*` needs `CAP_SYS_ADMIN` even to set, so the
attributes used are `user.*`.

Fixture: source and destination hold identical content and mtime; `user.drop`
differs (`SRCVAL` vs `DSTVAL`); `user.keep` is identical on both sides. The
fixture is rebuilt before every case, because a real (non-dry) run syncs the
attribute and would otherwise poison the next case.

### Ground truth - upstream 3.4.4, Linux `user.*`, local

```
uid=1000 (non-root receiver)
=== A: -rtX -i  (no filter) ===
.f........x f.txt
=== B: -rtX -i --filter "-x user.drop" ===
=== C: -rtX -i --filter "-x user.keep" ===
.f........x f.txt
```

### Ground truth - upstream 3.4.4, Linux `user.*`, SSH pull

```
=== SSH PULL A: -rtX -i (no filter) ===
.f........x f.txt
=== SSH PULL B: --filter -x user.drop ===
=== SSH PULL C: --filter -x user.keep ===
.f........x f.txt
```

An excluded name never raises `x`; a name the rule does not match still does.

### The configuration this patch changes

`exclude.c:send_filter_list()` opens with

```c
if (local_server || (am_sender && !receiver_wants_list))
        f_out = -1;
```

so on a plain push the rules never cross the wire and a server-side receiver has
no `saw_xattr_filter` at all - upstream itself prints `x` there, and so does
oc-rsync, before and after this change. The rules do cross once the receiver
wants the list (`--delete`), and that is the configuration in which a
server-side receiver's destination read is filtered. Upstream, daemon push with
`--delete`:

```
=== PUSH A: --delete, no filter ===
.f........x f.txt
=== PUSH B: --delete --filter '-x user.drop' ===
=== PUSH C: --delete --filter '-x user.keep' ===
.f........x f.txt
```

### oc-rsync end-to-end: not observable yet, and why

The `x` column could not be captured before/after through an oc-rsync binary,
because oc's **server-side receiver emits no metadata-only itemize row at all**
- a gap that sits in front of this one and is independent of it. Built from this
branch and pushed to an oc daemon:

```
# 1. control - a CONTENT change does produce a row through the oc daemon
<f.s....... f.txt

# 2. a PERMS-only change: upstream 3.4.4 local prints a row ...
.f...p....x f.txt
#    ... but the oc daemon receiver prints nothing, for either client
   oc client:       []
   upstream client: []
```

An unchanged-but-differing file never yields a row, so neither the `p` column
nor the `x` column can be seen in the one configuration this change reaches
(server-side receiver with wire rules, i.e. push + `--delete`). A before/after
would read "nothing vs nothing" for a reason that has nothing to do with this
patch, so it is not presented as evidence. That missing row is tracked
separately as task 80.

The obvious alternative - capture through a pull, which upstream shows emitting
`.f........x` - does not work either: a client-mode receiver never populates
`filter_chain` from its own CLI rules, so the filter is absent there for
reasons unrelated to this patch (task 81, see below). Between the two, no
end-to-end path currently exposes the column.

What *is* pinned directly is the code path itself: reverting only
`candidates.rs` to `filter: None` and rebuilding makes the new test fail;
restoring it makes it pass. Upstream's required behaviour is captured above
against the real 3.4.4 binary. The missing server-receiver itemize row is worth
its own issue.

## Tests

`crates/transfer/src/receiver/tests/xattr_filter.rs` (3 tests):

- an `x`-modifier exclusion naming the destination-only attribute must not
  report a difference (this one **fails** on `master` and passes with the patch
  - verified by reverting `candidates.rs` alone and rebuilding);
- an `x` rule naming a *different* attribute must still report the difference,
  so the fix cannot degrade into blanket suppression;
- a rule *without* the `x` modifier governs paths only and must leave the
  destination read alone (`exclude.c:914`).

Each test carries a positive control, and the attributes the platform adds on
its own (macOS stamps `com.apple.provenance` on every new file) are screened so
the assertions turn on the one name the test controls.

The existing metadata xattr tests stay green: `-XX` keeps `rsync.%stat`, `-X`
strips it, `--fake-super` drops the three store suffixes, a filter bypasses the
namespace check, and `user_only` is honoured on the generator.

Validated with `incremental-flist` on (default features) and off
(`--no-default-features --features zstd,lz4,xattr`). `cargo fmt --all --
--check` and `cargo clippy -p transfer -p metadata --all-features --all-targets
--no-deps -- -D warnings` are clean.

## Follow-up (not in this PR)

A **client-mode** receiver (local, daemon-pull, SSH-pull) never populates
`filter_chain` from its own CLI rules - `receiver/transfer/setup/context.rs`
builds only `deletion_filter_chain` in that branch - so `xattr_name_filter()`
returns `None` there. That affects every consumer of the accessor, not only this
one. Upstream sets `saw_xattr_filter` in whichever process parsed the rule, so a
client pull should screen too. Separate, pre-existing gap, tracked as task 81.

Two more, also out of scope here: the missing server-receiver metadata-only
itemize row shown above (task 80), and #6965, which moves the comparison tail of
`dest_xattrs_differ` into `metadata` while leaving `filter: None` in the option
block. The two patches touch adjacent lines of the same function; whichever
lands second needs a trivial rebase, and the filter must survive it.
