### PR TITLE
fix(transfer): itemize `?` for a pre-29 peer that sends no iflags

### DIFF
--- a/crates/batch/src/replay/dispatch.rs
+++ b/crates/batch/src/replay/dispatch.rs
@@ -28,8 +28,8 @@ pub(super) const ITEM_BASIS_TYPE_FOLLOWS: u16 = 1 << 11;
 /// upstream: rsync.c:403-418
 pub(super) const ITEM_XNAME_FOLLOWS: u16 = 1 << 12;
 /// ITEM_TRANSFER - delta data follows after the per-file metadata block.
-/// upstream: rsync.c
-pub(super) const ITEM_TRANSFER: u16 = 0x8000;
+/// upstream: rsync.h:252 - `#define ITEM_TRANSFER (1<<15)`
+pub(super) const ITEM_TRANSFER: u16 = 1 << 15;
 
 /// Read the per-file iflags word and consume any optional trailing fields.
 ///
@@ -55,8 +55,12 @@ pub(super) fn read_iflags_and_skip_meta(
         })?;
         u16::from_le_bytes(buf)
     } else {
-        // upstream: rsync.c:384 - default to ITEM_TRANSFER | ITEM_MISSING_DATA
-        0x8000 | 0x0400
+        // upstream: rsync.c:383-384 - `ITEM_TRANSFER | ITEM_MISSING_DATA`.
+        // ITEM_MISSING_DATA is `1<<16` (rsync.h:254), a log-only bit that never
+        // fits this u16 framing word and that no consumer here inspects: the
+        // replay loop only tests ITEM_TRANSFER / ITEM_BASIS_TYPE_FOLLOWS /
+        // ITEM_XNAME_FOLLOWS to decide which trailing fields to consume.
+        ITEM_TRANSFER
     };
 
     if iflags & ITEM_BASIS_TYPE_FOLLOWS != 0 {

--- a/crates/batch/src/replay/tests.rs
+++ b/crates/batch/src/replay/tests.rs
@@ -199,3 +199,50 @@ fn cpres_zlib_false_for_zstd_codec() {
     let codec = CompressionCodec::Zstd;
     assert!(Some(codec) != Some(CompressionCodec::Zlib));
 }
+
+/// A pre-29 batch stream carries no iflags word, so the replay loop must
+/// synthesise one without consuming any bytes - consuming two here would
+/// desync every following field.
+///
+/// The value is `ITEM_TRANSFER` alone. Upstream's `ITEM_TRANSFER |
+/// ITEM_MISSING_DATA` (rsync.c:383-384) adds a log-only bit at `1<<16`
+/// (rsync.h:254) that cannot fit this u16 framing word and that replay never
+/// renders. It must not be approximated by `1<<10`, which is
+/// `ITEM_REPORT_CRTIME` (rsync.h:247) and would be a different flag entirely.
+#[test]
+fn read_iflags_pre_29_synthesises_item_transfer_without_reading() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("stream");
+    fs::write(&path, [0xAA, 0xBB]).expect("write stream");
+    let mut stream = std::io::BufReader::new(fs::File::open(&path).expect("open stream"));
+
+    for proto in [28, 27, 20] {
+        let iflags = super::dispatch::read_iflags_and_skip_meta(&mut stream, proto)
+            .expect("pre-29 fallback must not read");
+        assert_eq!(
+            iflags,
+            1 << 15,
+            "proto {proto} must yield bare ITEM_TRANSFER"
+        );
+        assert_eq!(iflags & (1 << 10), 0, "ITEM_REPORT_CRTIME must not be set");
+    }
+
+    // Nothing was consumed: the two bytes are still there for the real reader.
+    let mut rest = Vec::new();
+    std::io::Read::read_to_end(&mut stream, &mut rest).expect("read rest");
+    assert_eq!(rest, vec![0xAA, 0xBB]);
+}
+
+/// Protocol 29+ reads the 16-bit little-endian iflags word off the wire.
+///
+/// upstream: rsync.c:383 - `read_shortint(f_in)`
+#[test]
+fn read_iflags_proto_29_reads_shortint() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("stream");
+    fs::write(&path, [0x00, 0x80]).expect("write stream");
+    let mut stream = std::io::BufReader::new(fs::File::open(&path).expect("open stream"));
+
+    let iflags = super::dispatch::read_iflags_and_skip_meta(&mut stream, 29).expect("read iflags");
+    assert_eq!(iflags, 1 << 15);
+}

--- a/crates/protocol/src/version/protocol_version/capabilities.rs
+++ b/crates/protocol/src/version/protocol_version/capabilities.rs
@@ -89,7 +89,8 @@ impl ProtocolVersion {
 
     /// Returns `true` if this protocol version sends iflags after NDX.
     ///
-    /// - Protocol < 29: iflags default to `ITEM_TRANSFER`
+    /// - Protocol < 29: no iflags on the wire; the reader synthesises
+    ///   `ITEM_TRANSFER | ITEM_MISSING_DATA` (`rsync.c:383-384`)
     /// - Protocol >= 29: 2-byte iflags follow each NDX on the wire
     ///
     /// # Upstream Reference

--- a/crates/transfer/src/generator/item_flags.rs
+++ b/crates/transfer/src/generator/item_flags.rs
@@ -159,14 +159,27 @@ impl ItemFlags {
     /// Reads item flags from the wire.
     ///
     /// For protocol >= 29, reads 2 bytes little-endian (16-bit wire format).
-    /// For older protocols, returns ITEM_TRANSFER as default.
+    /// Protocol 28 and older carry no iflags on the wire, so the peer never
+    /// says what changed. Upstream synthesises `ITEM_TRANSFER |
+    /// ITEM_MISSING_DATA` for those protocols; `ITEM_MISSING_DATA` is a
+    /// log-only bit (bit 16, never sent on the wire) that makes
+    /// [`crate::generator::itemize`] fill columns 2..10 with `?` rather than
+    /// asserting `.` (nothing changed), yielding `>f?????????`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:383-384` - `iflags = protocol_version >= 29 ?
+    ///   read_shortint(f_in) : ITEM_TRANSFER | ITEM_MISSING_DATA`
+    /// - `log.c:736-737` - `ITEM_MISSING_DATA` renders `?` in columns 2..10
     pub fn read<R: Read>(reader: &mut R, protocol_version: u8) -> io::Result<Self> {
         if protocol_version >= 29 {
             let mut buf = [0u8; 2];
             reader.read_exact(&mut buf)?;
             Ok(Self::from_raw(u16::from_le_bytes(buf) as u32))
         } else {
-            Ok(Self::from_raw(Self::ITEM_TRANSFER))
+            Ok(Self::from_raw(
+                Self::ITEM_TRANSFER | Self::ITEM_MISSING_DATA,
+            ))
         }
     }
 

--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -389,6 +389,47 @@ mod tests {
         assert_eq!(result, ">f+++++++++");
     }
 
+    /// A pre-29 peer sends no iflags, so the row must read `?` ("the sender did
+    /// not say what changed"), never `.` ("nothing changed") - a claim no side
+    /// ever made.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:383-384` - synthesises `ITEM_TRANSFER | ITEM_MISSING_DATA`
+    /// - `log.c:736-737` - `ITEM_MISSING_DATA` fills columns 2..10 with `?`
+    #[test]
+    fn format_protocol_28_missing_data_is_unknown() {
+        let iflags = ItemFlags::read(&mut std::io::Cursor::new(&[][..]), 28).unwrap();
+        let entry = make_file_entry("test.txt");
+        assert_eq!(
+            format_iflags(&iflags, &entry, false, &default_ctx()),
+            ">f?????????"
+        );
+        assert_eq!(
+            format_iflags(&iflags, &entry, true, &default_ctx()),
+            "<f?????????"
+        );
+    }
+
+    /// `ITEM_IS_NEW` outranks `ITEM_MISSING_DATA`: a file the receiver is
+    /// creating is fully known to be new, so it stays `+++++++++` even on a
+    /// pre-29 link where the missing-data bit is also set.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:735-737` - `ch = iflags & ITEM_IS_NEW ? '+' : '?'`
+    #[test]
+    fn format_is_new_outranks_missing_data() {
+        let iflags = ItemFlags::from_raw(
+            ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_MISSING_DATA | ItemFlags::ITEM_IS_NEW,
+        );
+        let entry = make_file_entry("test.txt");
+        assert_eq!(
+            format_iflags(&iflags, &entry, false, &default_ctx()),
+            ">f+++++++++"
+        );
+    }
+
     #[test]
     fn format_metadata_only_no_changes() {
         let iflags = ItemFlags::from_raw(0);

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -1229,13 +1229,24 @@ fn item_flags_read_protocol_29_plus() {
 
 #[test]
 fn item_flags_read_protocol_28() {
-    // Protocol 28 and older defaults to ITEM_TRANSFER without reading
-    let data: [u8; 0] = [];
-    let mut cursor = Cursor::new(&data[..]);
+    // upstream: rsync.c:383-384 - protocol 28 and older carry no iflags on the
+    // wire, so the peer never says what changed. Upstream synthesises
+    // ITEM_TRANSFER | ITEM_MISSING_DATA rather than a bare ITEM_TRANSFER: the
+    // missing-data bit is what makes the itemize row read `?` ("unknown")
+    // instead of `.` ("unchanged"), which would be an assertion the sender
+    // never made.
+    for proto in [20u8, 28] {
+        let data: [u8; 0] = [];
+        let mut cursor = Cursor::new(&data[..]);
 
-    let flags = ItemFlags::read(&mut cursor, 28).unwrap();
-    assert_eq!(flags.raw(), ItemFlags::ITEM_TRANSFER);
-    assert!(flags.needs_transfer());
+        let flags = ItemFlags::read(&mut cursor, proto).unwrap();
+        assert_eq!(
+            flags.raw(),
+            ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_MISSING_DATA,
+            "protocol {proto} must synthesise ITEM_TRANSFER | ITEM_MISSING_DATA"
+        );
+        assert!(flags.needs_transfer());
+    }
 }
 
 #[test]

--- a/crates/transfer/src/receiver/tests/file_list/wire_attrs.rs
+++ b/crates/transfer/src/receiver/tests/file_list/wire_attrs.rs
@@ -182,11 +182,25 @@ fn sum_head_accepts_empty_whole_file() {
 
 #[test]
 fn sender_attrs_read_protocol_28_returns_default_iflags() {
-    // Protocol 28 just reads the NDX byte, no iflags
+    // Protocol 28 just reads the NDX byte, no iflags.
+    //
+    // The value is a bare ITEM_TRANSFER, deliberately NOT upstream's
+    // `ITEM_TRANSFER | ITEM_MISSING_DATA` (rsync.c:383-384). ITEM_MISSING_DATA
+    // is `1<<16` (rsync.h:254), a log-only bit that does not fit this u16 and
+    // that upstream itself masks off before the wire (`iflags &= 0xffff`,
+    // generator.c:581). These attrs only select which trailing wire fields to
+    // parse and are echoed back - they never reach a renderer - so the display
+    // bit would be dead state here. The generator's decode-to-display path
+    // (ItemFlags::read) is the one that carries it.
     let data = vec![0x05u8]; // NDX byte only
     let attrs = SenderAttrs::read(&mut Cursor::new(data), 28).unwrap();
 
     assert_eq!(attrs.iflags, SenderAttrs::ITEM_TRANSFER);
+    assert_eq!(
+        attrs.iflags & (1 << 10),
+        0,
+        "ITEM_REPORT_CRTIME must not stand in for the log-only missing-data bit"
+    );
     assert!(attrs.fnamecmp_type.is_none());
     assert!(attrs.xname.is_none());
 }

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -385,7 +385,14 @@ impl SenderAttrs {
             reader.read_exact(&mut iflags_buf)?;
             u16::from_le_bytes(iflags_buf)
         } else {
-            Self::ITEM_TRANSFER // Default for older protocols
+            // upstream: rsync.c:383-384 - `ITEM_TRANSFER | ITEM_MISSING_DATA`.
+            // ITEM_MISSING_DATA is `1<<16` (rsync.h:254), a log-only bit that
+            // does not fit this u16 framing word. It is deliberately omitted:
+            // this value only selects which trailing wire fields to parse and
+            // is echoed back, never rendered, so the display bit would be dead
+            // state here. Upstream likewise masks `iflags &= 0xffff` before the
+            // wire (generator.c:581).
+            Self::ITEM_TRANSFER
         };
 
         // Read optional fields based on iflags
@@ -470,7 +477,14 @@ impl SenderAttrs {
             reader.read_exact(&mut iflags_buf)?;
             u16::from_le_bytes(iflags_buf)
         } else {
-            Self::ITEM_TRANSFER // Default for older protocols
+            // upstream: rsync.c:383-384 - `ITEM_TRANSFER | ITEM_MISSING_DATA`.
+            // ITEM_MISSING_DATA is `1<<16` (rsync.h:254), a log-only bit that
+            // does not fit this u16 framing word. It is deliberately omitted:
+            // this value only selects which trailing wire fields to parse and
+            // is echoed back, never rendered, so the display bit would be dead
+            // state here. Upstream likewise masks `iflags &= 0xffff` before the
+            // wire (generator.c:581).
+            Self::ITEM_TRANSFER
         };
 
         // Read optional fields based on iflags


### PR DESCRIPTION
## The bug

Protocol 28 and older carry no iflags on the wire. Upstream synthesises a value
instead:

```c
/* rsync.c:383-384 */
iflags = protocol_version >= 29 ? read_shortint(f_in)
           : ITEM_TRANSFER | ITEM_MISSING_DATA;
```

`ITEM_MISSING_DATA` makes `log.c:736-737` fill itemize columns 2..10 with `?`,
so a proto-28 transfer renders `>f?????????` - "the peer did not tell me what
changed".

We synthesised a bare `ITEM_TRANSFER`, which rendered `>f.........` and
asserted "nothing changed" - a claim neither side ever made. We support
protocol 28-32, so this is reachable against any pre-29 peer.

## The fix

`ITEM_MISSING_DATA` is bit 16. Upstream deliberately keeps it off the wire
(`iflags &= 0xffff`, generator.c:581) and synthesises it only at the
decode-to-display site. Only one of our four pre-29 fallbacks reaches a
renderer, so only that one gains the bit - making all four agree with each
other would make them disagree with upstream.

| Site | Change |
|---|---|
| `generator/item_flags.rs` `ItemFlags::read` | now `ITEM_TRANSFER \| ITEM_MISSING_DATA`. Its sole caller feeds `write_iflags_into`; the echo path already masks `& 0xFFFF`, so the log-only bit cannot leak onto the wire. |
| `receiver/wire.rs` (x2) | unchanged - `SenderAttrs.iflags` is a u16 that only selects which trailing fields to parse and is echoed back, never rendered. A display bit would be dead state. Comments now record why. |
| `batch/replay/dispatch.rs` | returned `0x8000 \| 0x0400`. `0x0400` is `1<<10` = `ITEM_REPORT_CRTIME` (rsync.h:247), **not** `ITEM_MISSING_DATA` (`1<<16`, rsync.h:254) - it set an unrelated flag. Dropped; the named constant now carries its rsync.h citation. |

`itemize.rs` already gives `ITEM_IS_NEW` priority over `ITEM_MISSING_DATA`
(mirroring log.c:735-737), so a newly created file still renders `+++++++++`.
Confirmed rather than assumed, and pinned by a test.

## A test encoded the bug

`generator/tests.rs::item_flags_read_protocol_28` asserted the bare
`ITEM_TRANSFER` and its comment stated that behaviour as though intended. It is
updated to the upstream contract (and extended to cover proto 20) rather than
the code being bent to keep it green.

## Verification

Compared against a genuine upstream 3.4.4 (`rsync version 3.4.4 protocol
version 32`, confirmed from the `--version` banner), with the peer advertising
protocol 28 so the negotiated version is genuinely 28. Push rows, byte-for-byte:

```
before   <f......... changed.txt     <f......... new.txt
after    <f????????? changed.txt     <f????????? new.txt     <f????????? sub/deep.txt
upstream <f????????? changed.txt     <f????????? new.txt     <f????????? sub/deep.txt
```

Tests: `-p transfer -p batch -p protocol --all-features` 8678 passed; the same
crates with default features (incremental-flist off) 2732 passed. fmt + clippy
`--workspace --all-targets --all-features -D warnings` clean.

## Out of scope (filed as observations, not fixed here)

Two adjacent divergences surfaced during verification and are **not** addressed:

1. **`--protocol=N` is a no-op on the client's SSH path.** `oc-rsync -ai
   --protocol=28 <src> h:<dst>` produces argv and output identical to omitting
   the flag, and still sends the proto-32 capability suffix
   (`-logDtpre.iLsfxCIvu` where upstream at 28 sends `-logDtpr`). Clamping only
   happens when the *peer* advertises the lower version. This is why
   verification above forces 28 from the peer side.
2. **Pull-side itemize at proto 28** still renders locally-computed flags
   (`>f+++++++++` / row ordering) where upstream renders `>f?????????` after a
   leading `cd+++++++++`. That is a structural difference in where the receiver
   sources its itemize row, not a fallback-value bug.
