### PR TITLE
fix(transfer): share the receiver drive-mode dispatch

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -171,8 +171,26 @@ jobs:
             args: "-p checksums -p flist --features parallel"
             apt: ""
             needs_bin: false
-          - name: incremental-flist
-            args: "-p transfer --features incremental-flist"
+          # `incremental-flist` is in `transfer`'s own `default` list, so a row
+          # of the form `-p transfer --features incremental-flist` turns nothing
+          # on that was not already on - it re-tests the default configuration
+          # under a name that claims otherwise. The feature IS covered on:
+          # the `default-features` row above, the main `--all-features` test
+          # job, and every library consumer.
+          #
+          # What was NOT covered anywhere is the feature OFF. That matters more
+          # than the ON case: `bin` pins `transfer` with
+          # `default-features = false` (root Cargo.toml), so the SHIPPED BINARY
+          # runs the off-path receiver while every other job runs the on-path
+          # one. Production took one code path and CI tested the other, which is
+          # how four successive receiver-dispatch divergences reached master.
+          #
+          # The feature list is the musl job's (ci.yml), which is the only other
+          # place in the repo that builds with defaults off. Bare
+          # `--no-default-features` would also drop zstd/lz4/xattr and test a
+          # different question.
+          - name: no-incremental-flist
+            args: "--workspace --no-default-features --features zstd,lz4,xattr,iconv,parallel,copy_file_range"
             apt: ""
             needs_bin: true
           - name: compression

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -795,20 +795,14 @@ impl ReceiverContext {
             );
         }
 
-        // Under `-i`/`-vi` the itemize row already carries the directory name
-        // (upstream `-vi` uses `%i %n`), so the bare `-v` name is suppressed to
-        // avoid a duplicate line; only plain `-v` emits it.
-        if self.config.flags.verbose
-            && self.config.connection.client_mode
-            && !self.should_emit_itemize()
-        {
-            if relative_path.as_os_str() == "." {
-                info_log!(Name, 1, "./");
-            } else {
-                info_log!(Name, 1, "{}/", relative_path.display());
-            }
-        }
-
+        // The plain-`-v` directory name is NOT emitted here. Its caller
+        // (`run_pipelined_incremental`) decides it from `verbose_dir_name_lines`
+        // against the pre-transfer stat, exactly as `run_pipelined` does, so an
+        // unchanged directory stays silent (upstream names a directory only when
+        // `set_file_attrs()` changed it, generator.c:1503-1505) and the name can
+        // be interleaved with `--progress` in flist order. Naming it here also
+        // ran after this call's own metadata apply, which is too late to observe
+        // the pre-transfer state.
         Ok(Some((is_new, iflags)))
     }
 

--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -11,6 +11,9 @@
 //!   symlinks, and other special entries.
 //! - [`partial_resume`] - temp-file guard, relative-parent creation, and
 //!   reference-directory lookups used during partial/resume transfers.
+//! - [`mode_dispatch`] - the shared drive-mode decision and the wire shape of
+//!   each mode that moves no file data, asserted under both `incremental-flist`
+//!   settings.
 //! - [`errors_and_timeouts`] - error categorization, failed-directory
 //!   propagation, legacy goodbye handling, input-multiplex activation,
 //!   daemon filter set, and path-traversal rejection.
@@ -25,6 +28,7 @@ mod file_list;
 mod generator_keepalive;
 mod hard_links;
 mod incremental_flist_banner;
+mod mode_dispatch;
 #[cfg(unix)]
 mod munge_symlinks;
 mod parallel_delta_notice;

--- a/crates/transfer/src/receiver/tests/mode_dispatch.rs
+++ b/crates/transfer/src/receiver/tests/mode_dispatch.rs
@@ -1,0 +1,265 @@
+//! Regression: the receiver's drive-mode dispatch is decided once and
+//! implemented once, so the two pipelined drivers cannot diverge.
+//!
+//! # Why this file exists
+//!
+//! `run_pipelined` and `run_pipelined_incremental` each used to open-code an
+//! `if list_only { } else if dry_run { } else { }` ladder. A mode added to one
+//! was silently missing from the other, and the divergence was invisible
+//! because the two are never exercised together: the shipped binary sets
+//! `default-features = false` and takes `run_pipelined`, while
+//! `--workspace --all-features` (and every library consumer, since
+//! `incremental-flist` is a `transfer` default) takes
+//! `run_pipelined_incremental`. Production ran one ladder and CI tested the
+//! other. The same drift recurred four times.
+//!
+//! Every test here runs under BOTH feature settings, because
+//! `super::super::transfer::mode` is compiled unconditionally: no `#[cfg]`
+//! selects it. That is the point - the CI feature matrix runs this module with
+//! `incremental-flist` on and off, and both cells assert the same decision and
+//! the same wire shape.
+//!
+//! # Upstream Reference
+//!
+//! - `main.c:1839` - `if (write_batch < 0) dry_run = 1`, `do_xfers` stays 1.
+//! - `sender.c:442-443` - `write_ndx_and_attrs(f_out)` then
+//!   `write_sum_head(f_xfer)`: the sender reads a sum head per file whenever
+//!   `do_xfers` is set, so `--only-write-batch` must send one and `--dry-run`
+//!   must not.
+//! - `generator.c:1249` - `--list-only` sends no per-file request at all.
+
+use std::io::Cursor;
+use std::num::NonZeroU8;
+
+use protocol::codec::{NdxCodec, create_ndx_codec};
+use protocol::flist::FileEntry;
+
+use super::super::stats::TransferStats;
+use super::super::transfer::mode::{NonTransferMode, ReceiverMode};
+use super::super::{PipelineSetup, ReceiverContext};
+use super::support::test_handshake;
+use crate::config::ServerConfig;
+use crate::flags::ParsedServerFlags;
+use crate::role::ServerRole;
+
+/// Builds a receiver whose flag set is the one property under test.
+fn receiver(flags: ParsedServerFlags) -> ReceiverContext {
+    let handshake = test_handshake();
+    let config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: protocol::ProtocolVersion::try_from(32u8).unwrap(),
+        flags,
+        ..Default::default()
+    };
+    ReceiverContext::new_for_test(&handshake, config)
+}
+
+/// `--only-write-batch` implies `--dry-run` upstream (`main.c:1839` sets
+/// `dry_run = 1` while leaving `do_xfers = 1`), so the two flags are always
+/// seen together and only the check ORDER tells them apart.
+///
+/// WHY this matters rather than merely "the enum has the right variant": the
+/// dry-run body writes NDX + iflags and stops. Under `--only-write-batch` the
+/// peer's `send_files()` goes on to read a sum head (`sender.c:442-443`), so
+/// taking the dry-run body deadlocks the pair - the sender blocks on a read
+/// that never arrives while the receiver blocks on the echo. Reordering these
+/// two checks is therefore a hang, not a cosmetic difference.
+#[test]
+fn only_write_batch_outranks_the_dry_run_it_implies() {
+    let ctx = receiver(ParsedServerFlags {
+        only_write_batch: true,
+        dry_run: true,
+        ..Default::default()
+    });
+    assert_eq!(
+        ctx.select_mode(),
+        ReceiverMode::NonTransfer(NonTransferMode::OnlyWriteBatch),
+        "only-write-batch sets dry_run too (main.c:1839); the dry-run body \
+         omits the sum head sender.c:442-443 requires and hangs both ends"
+    );
+}
+
+/// `--list-only` renders every entry via `list_file_entry()` and sends no
+/// per-file NDX request at all (`generator.c:1249`), so it must outrank every
+/// mode that does send one - including a `-n --list-only` combination.
+#[test]
+fn list_only_outranks_every_requesting_mode() {
+    let ctx = receiver(ParsedServerFlags {
+        list_only: true,
+        dry_run: true,
+        only_write_batch: true,
+        ..Default::default()
+    });
+    assert_eq!(
+        ctx.select_mode(),
+        ReceiverMode::NonTransfer(NonTransferMode::ListOnly),
+        "list-only sends no per-file request; any other mode would put NDX \
+         requests on a wire the peer is not reading them from"
+    );
+}
+
+/// A plain `-n` with no batch flag takes the dry-run body.
+#[test]
+fn plain_dry_run_selects_dry_run() {
+    let ctx = receiver(ParsedServerFlags {
+        dry_run: true,
+        ..Default::default()
+    });
+    assert_eq!(
+        ctx.select_mode(),
+        ReceiverMode::NonTransfer(NonTransferMode::DryRun)
+    );
+}
+
+/// The default: a real transfer. This is the one mode whose body is allowed to
+/// differ per driver, so it must be the only value that is not `NonTransfer`.
+#[test]
+fn no_mode_flag_selects_the_full_transfer() {
+    let ctx = receiver(ParsedServerFlags::default());
+    assert_eq!(ctx.select_mode(), ReceiverMode::Transfer);
+}
+
+/// A server-side receiver (the remote end of a push) whose peer echoes one
+/// `NDX + iflags` response per request.
+///
+/// `client_mode = false` keeps `run_only_write_batch_loop` off the
+/// `discard_receive_data()` path (`receiver.c:813` gates it on `!am_server`),
+/// so the scripted response is exactly the echo and nothing more.
+fn echo_response(ndx: i32) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut codec = create_ndx_codec(32);
+    codec.write_ndx(&mut buf, ndx).expect("write echo ndx");
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf
+}
+
+/// Drives one non-transfer mode over a scripted echo and returns the bytes the
+/// receiver put on the wire.
+fn drive(mode: NonTransferMode, dest: &std::path::Path) -> Vec<u8> {
+    let entry = FileEntry::new_file("f".into(), 4, 0o644);
+    let mut ctx = receiver(ParsedServerFlags {
+        // Set both, as upstream does, and let `mode` pick the body: the request
+        // shape must follow the mode, not the raw flags.
+        dry_run: true,
+        only_write_batch: matches!(mode, NonTransferMode::OnlyWriteBatch),
+        ..Default::default()
+    });
+    ctx.config.connection.client_mode = false;
+    ctx.file_list = vec![entry];
+
+    let setup = PipelineSetup {
+        dest_dir: dest.to_path_buf(),
+        metadata_opts: metadata::MetadataOptions::default(),
+        checksum_length: NonZeroU8::new(2).expect("nonzero"),
+        // Any algorithm does: the basis is absent, so no strong sum is ever
+        // computed - only the sum head's presence is under test.
+        checksum_algorithm: signature::SignatureAlgorithm::Md4,
+        acl_cache: None,
+        acl_id_map: None,
+        #[cfg(unix)]
+        sandbox: None,
+    };
+
+    let files: Vec<(usize, &FileEntry, std::path::PathBuf, u32)> =
+        vec![(0, &ctx.file_list[0], dest.join("f"), 0)];
+    let sent = SharedBuf::default();
+    let mut reader = crate::reader::ServerReader::new_plain(Cursor::new(echo_response(0)));
+    let mut writer = crate::writer::ServerWriter::new_plain(sent.clone());
+    let mut stats = TransferStats::default();
+
+    ctx.run_non_transfer_mode(mode, &mut reader, &mut writer, &setup, &files, &mut stats)
+        .expect("non-transfer mode drives to completion");
+    drop(writer);
+    sent.take()
+}
+
+/// Capture sink for the bytes a driver puts on the wire. `ServerWriter` owns
+/// its sink and exposes no accessor, so the buffer is shared rather than
+/// reclaimed.
+#[derive(Clone, Default)]
+struct SharedBuf(std::rc::Rc<std::cell::RefCell<Vec<u8>>>);
+
+impl SharedBuf {
+    fn take(self) -> Vec<u8> {
+        std::mem::take(&mut *self.0.borrow_mut())
+    }
+}
+
+impl std::io::Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Reads the `NDX + iflags` request header off `bytes`, returning what remains.
+fn skip_request_header(bytes: &[u8]) -> &[u8] {
+    let mut cursor = Cursor::new(bytes);
+    let mut codec = create_ndx_codec(32);
+    codec.read_ndx(&mut cursor).expect("request carries an NDX");
+    let consumed = cursor.position() as usize;
+    &bytes[consumed + 2..]
+}
+
+/// The bug this whole change exists to make impossible: `--only-write-batch`
+/// must put a sum head on the wire and `--dry-run` must not.
+///
+/// WHY assert the wire and not just the enum: the enum is only a label. What
+/// the sender actually blocks on is `write_sum_head(f_xfer)`
+/// (`sender.c:442-443`), which it reads whenever `do_xfers` is set - and
+/// `--only-write-batch` leaves `do_xfers = 1` (`main.c:1839`). A receiver that
+/// took the dry-run body under `--only-write-batch` produced a byte-correct
+/// prefix and then hung, which no assertion over flags or exit codes catches.
+///
+/// Both halves are asserted together on purpose: pinning only the sum head
+/// would let the dry run start emitting one (desyncing the plain `-n` path in
+/// the opposite direction), and pinning only its absence would let the bug back.
+#[test]
+fn only_write_batch_sends_a_sum_head_and_dry_run_does_not() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Give the file a basis on disk so the sum head describes a REAL signature.
+    // Without one the head is all zeros and the assertion below could not tell
+    // a genuine `--only-write-batch` request from a zero-filled placeholder.
+    std::fs::write(dir.path().join("f"), b"data").expect("seed basis");
+
+    let batch = drive(NonTransferMode::OnlyWriteBatch, dir.path());
+    let after_batch_header = skip_request_header(&batch);
+    let mut batch_tail = Cursor::new(after_batch_header);
+    let sum_head = super::super::wire::SumHead::read(&mut batch_tail)
+        .expect("only-write-batch sends a sum head, sender.c:443");
+    assert_eq!(
+        sum_head.count, 1,
+        "the sum head must describe the basis block the generator computed \
+         (do_xfers stays 1 under --only-write-batch, main.c:1839)"
+    );
+    assert_eq!(
+        sum_head.s2length as u8, 2,
+        "the sum head must carry the phase-1 short checksum length the \
+         generator negotiated, not a placeholder"
+    );
+
+    let plain = drive(NonTransferMode::DryRun, dir.path());
+    assert!(
+        skip_request_header(&plain).is_empty(),
+        "a plain --dry-run request is NDX + iflags and nothing else \
+         (generator.c:1858-1959 skips write_sum_head); trailing bytes {:?} \
+         would be parsed by the sender as its next frame header",
+        skip_request_header(&plain)
+    );
+}
+
+/// `--list-only` puts no per-file request on the wire at all, and reports its
+/// entries through `stats.list_only_entries` instead (`generator.c:1249`).
+#[test]
+fn list_only_sends_no_per_file_request() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    assert!(
+        drive(NonTransferMode::ListOnly, dir.path()).is_empty(),
+        "list-only must send no NDX; the peer's send_files() is not reading \
+         per-file requests in this mode"
+    );
+}

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -12,8 +12,11 @@
 //! - `phases` - protocol phase exchange and goodbye handshake.
 //! - `candidates` - candidate-file selection for the pipelined paths.
 //! - `pipeline` - the inner `run_pipeline_loop_decoupled` plus dry-run loop.
+//! - `mode` - the single drive-mode decision both pipelined drivers share, plus
+//!   the one implementation of every mode that moves no file data.
 
 mod candidates;
+pub(in crate::receiver) mod mode;
 mod phases;
 mod pipeline;
 mod pipelined;

--- a/crates/transfer/src/receiver/transfer/mode.rs
+++ b/crates/transfer/src/receiver/transfer/mode.rs
@@ -1,0 +1,136 @@
+//! Shared receiver drive-mode selection and the non-transfer drive bodies.
+//!
+//! Every receiver driver (`run_pipelined`, `run_pipelined_incremental`) picks
+//! exactly one of a fixed set of mutually exclusive modes. The choice lives here
+//! once, in [`ReceiverContext::select_mode`], and every mode that drives no file
+//! data is *implemented* here once, in
+//! [`ReceiverContext::run_non_transfer_mode`]. A driver may only supply its own
+//! body for [`ReceiverMode::Transfer`].
+//!
+//! This shape is deliberate. The drivers previously each open-coded an
+//! `if list_only { } else if dry_run { } else { }` ladder, and a mode added to
+//! one ladder was silently missing from the other - the shipped binary and the
+//! CI feature set take different drivers, so the divergence was invisible to
+//! both. Now a new [`ReceiverMode`] variant fails to compile in every driver
+//! that does not handle it, and a new [`NonTransferMode`] variant fails to
+//! compile until its single shared body exists.
+
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+
+use protocol::flist::FileEntry;
+
+use crate::receiver::stats::TransferStats;
+use crate::receiver::{PipelineSetup, ReceiverContext};
+
+use super::candidates::new_dir_count;
+
+/// A receiver mode that moves no file data.
+///
+/// Each variant has exactly one implementation, in
+/// [`ReceiverContext::run_non_transfer_mode`], so every driver gets a new mode
+/// the moment it is added.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(in crate::receiver) enum NonTransferMode {
+    /// `--list-only`: render every flist entry, send no per-file request.
+    ListOnly,
+    /// `--only-write-batch`: real block checksums on the wire, nothing written
+    /// to the destination.
+    OnlyWriteBatch,
+    /// `--dry-run`: itemize and tally every entry, request no file data.
+    DryRun,
+}
+
+/// Which drive mode a receiver run takes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(in crate::receiver) enum ReceiverMode {
+    /// A mode with no file data, driven by the one shared body.
+    NonTransfer(NonTransferMode),
+    /// The full delta pipeline - the only mode whose body is driver-specific.
+    Transfer,
+}
+
+impl ReceiverContext {
+    /// Picks the one mode this run drives.
+    ///
+    /// The ordering is upstream's and is load-bearing:
+    ///
+    /// - `--list-only` first (`generator.c:1249`): it renders entries via
+    ///   `list_file_entry()` and sends no per-file NDX at all. It does *not*
+    ///   set `dry_run`, but checking it first keeps that independent of the
+    ///   flag's future wiring.
+    /// - `--only-write-batch` before `--dry-run` (`main.c:1839`): `write_batch
+    ///   < 0` forces `dry_run = 1` while leaving `do_xfers = 1`, so the flag
+    ///   pair is ambiguous and only the order disambiguates it. The generator
+    ///   still sends real block checksums and the sender expects a sum head per
+    ///   file (`sender.c:442-443`); taking the dry-run body here would send a
+    ///   bare NDX + iflags with no sum head and hang both ends.
+    /// - `--dry-run` last (`generator.c:1858-1959`): NDX + iflags, no sum head.
+    pub(in crate::receiver) const fn select_mode(&self) -> ReceiverMode {
+        if self.config.flags.list_only {
+            ReceiverMode::NonTransfer(NonTransferMode::ListOnly)
+        } else if self.config.flags.only_write_batch {
+            ReceiverMode::NonTransfer(NonTransferMode::OnlyWriteBatch)
+        } else if self.config.flags.dry_run {
+            ReceiverMode::NonTransfer(NonTransferMode::DryRun)
+        } else {
+            ReceiverMode::Transfer
+        }
+    }
+
+    /// Drives one non-transfer mode to completion.
+    ///
+    /// Returns `(files_transferred, transferred_file_size)` - the tallies
+    /// upstream still reports for a run that moves no data (`receiver.c:781-784`
+    /// bumps `stats.xferred_files` before the `if (!do_xfers)` continue).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1249` - `--list-only` renders entries, sends no request.
+    /// - `main.c:1839` - `if (write_batch < 0) dry_run = 1`, `do_xfers` stays 1.
+    /// - `generator.c:1858-1959` - the `!do_xfers` dry-run request shape.
+    pub(in crate::receiver) fn run_non_transfer_mode<
+        'a,
+        R: Read,
+        W: Write + crate::writer::MsgInfoSender + ?Sized,
+    >(
+        &'a self,
+        mode: NonTransferMode,
+        reader: &mut crate::reader::ServerReader<R>,
+        writer: &mut W,
+        setup: &PipelineSetup,
+        files_to_transfer: &[(usize, &'a FileEntry, PathBuf, u32)],
+        stats: &mut TransferStats,
+    ) -> io::Result<(usize, u64)> {
+        match mode {
+            NonTransferMode::ListOnly => {
+                stats.list_only_entries = self.collect_list_only_entries();
+                writer.flush()?;
+                Ok((0, 0))
+            }
+            NonTransferMode::OnlyWriteBatch => {
+                // The same reporting pass the plain dry run uses; only the wire
+                // loop differs (real block checksums, no plan). A push receiver
+                // reads no delta - the client sender diverted it into its own
+                // batch fd (sender.c:217) - while a pull receiver drains the
+                // remote sender's delta via discard_receive_data()
+                // (receiver.c:813-814).
+                let plan = self.plan_dry_run(&setup.dest_dir, files_to_transfer);
+                stats.directories_created = new_dir_count(&plan);
+                self.run_only_write_batch_loop(reader, writer, files_to_transfer, setup)?;
+                Ok((0, 0))
+            }
+            NonTransferMode::DryRun => {
+                // upstream: recv_generator() itemizes every entry and the
+                // receiver tallies every ITEM_IS_NEW even under --dry-run (only
+                // the data transfer and the filesystem mutation are skipped).
+                // The directory, symlink, and candidate passes early-return
+                // under skip_dest_writes(), so plan_dry_run is the one place the
+                // rows and created-file counts are produced.
+                let plan = self.plan_dry_run(&setup.dest_dir, files_to_transfer);
+                stats.directories_created = new_dir_count(&plan);
+                self.run_dry_run_loop(reader, writer, &plan)
+            }
+        }
+    }
+}

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -16,7 +16,7 @@ use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
 use crate::receiver::{REDO_CHECKSUM_LENGTH, ReceiverContext};
 
-use super::candidates::new_dir_count;
+use super::mode::ReceiverMode;
 
 impl ReceiverContext {
     /// Runs the pipelined receiver transfer loop.
@@ -48,15 +48,13 @@ impl ReceiverContext {
         // Interleave plain `-v` (name-only, no `-i`) client-mode file names
         // with --progress in flist order, matching upstream log_before_transfer
         // (receiver.c:1008-1012). `-i`/`-vi` itemize output is unaffected (it
-        // flows through the deferred itemize_rows path). Skips the non-transfer
-        // dispatches (list-only, dry-run, only-write-batch) so their existing
-        // emission order is untouched.
+        // flows through the deferred itemize_rows path). Every non-transfer mode
+        // is excluded via the shared `select_mode`, so a mode added there cannot
+        // silently acquire the interleaving.
         self.interleave_names = self.config.flags.verbose
             && self.config.connection.client_mode
             && !self.should_emit_itemize()
-            && !self.config.flags.list_only
-            && !self.config.flags.dry_run
-            && !self.config.flags.only_write_batch;
+            && matches!(self.select_mode(), ReceiverMode::Transfer);
         self.names_to_stderr = self.config.flags.msgs_to_stderr;
         self.progress_active = progress.is_some();
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
@@ -167,9 +165,10 @@ impl ReceiverContext {
             setup.acl_id_map.as_deref(),
         );
 
-        let mut files_transferred: usize = 0;
+        // Both assigned by every arm of the mode match below.
         // upstream: receiver.c:784 total_transferred_size, summed with files_transferred.
-        let mut transferred_file_size: u64 = 0;
+        let mut files_transferred: usize;
+        let mut transferred_file_size: u64;
         let mut bytes_received: u64 = 0;
         let mut literal_data: u64 = 0;
         let mut matched_data: u64 = 0;
@@ -187,120 +186,101 @@ impl ReceiverContext {
             }
         }
 
-        // upstream: generator.c:1249 - list-only renders every flist entry via
-        // list_file_entry() and sends NO per-file NDX request. Only the existing
-        // post-loop phase markers (NDX_DONE) and the goodbye handshake cross the
-        // wire. This branch must precede the dry_run check: list-only is not
-        // dry-run (dry-run streams an NDX request per file).
-        if self.config.flags.list_only {
-            stats.list_only_entries = self.collect_list_only_entries();
-            writer.flush()?;
-        } else if self.config.flags.only_write_batch {
-            // upstream: main.c:1839 `write_batch < 0` forces dry_run but leaves
-            // do_xfers = 1, so unlike a plain `-n` the generator still sends
-            // real block checksums while the receiver writes nothing to the
-            // destination (receiver.c:811-817). Checked before `dry_run`
-            // because only-write-batch sets both flags. A push receiver reads
-            // no delta (the client sender records it into its own batch fd,
-            // sender.c:217); a pull receiver drains the sender's delta via
-            // discard_receive_data() (receiver.c:813-814).
-            // Same shared reporting pass as the plain dry run below; only the
-            // wire loop differs (real block checksums, no plan).
-            let plan = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
-            stats.directories_created = new_dir_count(&plan);
-            self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
-        } else if self.config.flags.dry_run {
-            // upstream: recv_generator() itemizes every entry and the receiver
-            // tallies every ITEM_IS_NEW even under --dry-run (only the data
-            // transfer and filesystem mutation are skipped). The
-            // directory-creation, symlink, and candidate passes above
-            // early-return under skip_dest_writes(), so plan_dry_run is the one
-            // place the rows and created-file counts are produced - shared with
-            // run_pipelined_incremental so the two drivers cannot drift.
-            // Read-only: nothing is written to the destination.
-            let plan = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
-            stats.directories_created = new_dir_count(&plan);
-            (files_transferred, transferred_file_size) =
-                self.run_dry_run_loop(reader, writer, &plan)?;
-        } else {
-            let total_files = files_to_transfer.len();
-            let redo_config = pipeline_config.clone();
-            let redo_indices;
-            let delayed;
-            (
-                files_transferred,
-                transferred_file_size,
-                bytes_received,
-                literal_data,
-                matched_data,
-                redo_indices,
-                delayed,
-            ) = self.run_pipeline_loop_decoupled(
-                reader,
-                writer,
-                pipeline_config,
-                &setup,
-                files_to_transfer,
-                &mut metadata_errors,
-                false,
-                total_files,
-                &mut progress,
-            )?;
-            all_delayed_updates.extend(delayed);
-
-            // Phase 2: redo pass for files that failed checksum verification.
-            redo_count = redo_indices.len();
-            if !redo_indices.is_empty() {
-                setup.checksum_length = REDO_CHECKSUM_LENGTH;
-
-                // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
-                // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
-                let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
-                    .iter()
-                    .filter_map(|&idx| {
-                        self.file_list.get(idx).map(|entry| {
-                            let p = entry.path();
-                            let file_path = if p.as_os_str() == "." {
-                                setup.dest_dir.clone()
-                            } else {
-                                setup.dest_dir.join(p)
-                            };
-                            (
-                                idx,
-                                entry,
-                                file_path,
-                                crate::generator::ItemFlags::ITEM_TRANSFER,
-                            )
-                        })
-                    })
-                    .collect();
-
-                let (
-                    redo_transferred,
-                    redo_transferred_size,
-                    redo_bytes,
-                    redo_literal,
-                    redo_matched,
-                    _,
-                    redo_delayed,
+        // One shared decision (see `mode.rs`) with one shared body per
+        // non-transfer mode, so this driver and run_pipelined_incremental cannot
+        // drift again. The match is exhaustive by design: a new ReceiverMode
+        // variant is a compile error in every driver that does not handle it.
+        match self.select_mode() {
+            ReceiverMode::NonTransfer(non_transfer) => {
+                (files_transferred, transferred_file_size) = self.run_non_transfer_mode(
+                    non_transfer,
+                    reader,
+                    writer,
+                    &setup,
+                    &files_to_transfer,
+                    &mut stats,
+                )?;
+            }
+            ReceiverMode::Transfer => {
+                let total_files = files_to_transfer.len();
+                let redo_config = pipeline_config.clone();
+                let redo_indices;
+                let delayed;
+                (
+                    files_transferred,
+                    transferred_file_size,
+                    bytes_received,
+                    literal_data,
+                    matched_data,
+                    redo_indices,
+                    delayed,
                 ) = self.run_pipeline_loop_decoupled(
                     reader,
                     writer,
-                    redo_config,
+                    pipeline_config,
                     &setup,
-                    redo_files,
+                    files_to_transfer,
                     &mut metadata_errors,
-                    true,
+                    false,
                     total_files,
                     &mut progress,
                 )?;
+                all_delayed_updates.extend(delayed);
 
-                files_transferred += redo_transferred;
-                transferred_file_size += redo_transferred_size;
-                bytes_received += redo_bytes;
-                literal_data += redo_literal;
-                matched_data += redo_matched;
-                all_delayed_updates.extend(redo_delayed);
+                // Phase 2: redo pass for files that failed checksum verification.
+                redo_count = redo_indices.len();
+                if !redo_indices.is_empty() {
+                    setup.checksum_length = REDO_CHECKSUM_LENGTH;
+
+                    // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
+                    // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
+                    let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
+                        .iter()
+                        .filter_map(|&idx| {
+                            self.file_list.get(idx).map(|entry| {
+                                let p = entry.path();
+                                let file_path = if p.as_os_str() == "." {
+                                    setup.dest_dir.clone()
+                                } else {
+                                    setup.dest_dir.join(p)
+                                };
+                                (
+                                    idx,
+                                    entry,
+                                    file_path,
+                                    crate::generator::ItemFlags::ITEM_TRANSFER,
+                                )
+                            })
+                        })
+                        .collect();
+
+                    let (
+                        redo_transferred,
+                        redo_transferred_size,
+                        redo_bytes,
+                        redo_literal,
+                        redo_matched,
+                        _,
+                        redo_delayed,
+                    ) = self.run_pipeline_loop_decoupled(
+                        reader,
+                        writer,
+                        redo_config,
+                        &setup,
+                        redo_files,
+                        &mut metadata_errors,
+                        true,
+                        total_files,
+                        &mut progress,
+                    )?;
+
+                    files_transferred += redo_transferred;
+                    transferred_file_size += redo_transferred_size;
+                    bytes_received += redo_bytes;
+                    literal_data += redo_literal;
+                    matched_data += redo_matched;
+                    all_delayed_updates.extend(redo_delayed);
+                }
             }
         }
 

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -16,7 +16,7 @@ use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
 use crate::receiver::{REDO_CHECKSUM_LENGTH, ReceiverContext};
 
-use super::candidates::new_dir_count;
+use super::mode::ReceiverMode;
 
 impl ReceiverContext {
     /// Runs the receiver with incremental directory creation and failed-dir tracking.
@@ -43,6 +43,18 @@ impl ReceiverContext {
         // rather than oc's two-phase "all dirs, then all files" emission.
         // Mirrors run_pipelined; the async incremental path is out of scope.
         self.defer_itemize = true;
+        // Interleave plain `-v` (name-only, no `-i`) client-mode file names with
+        // --progress in flist order, matching upstream log_before_transfer
+        // (receiver.c:1008-1012). Set identically to run_pipelined: the flags
+        // are read by the shared run_pipeline_loop_decoupled, so leaving them
+        // unset here left the default feature set (this driver) rendering names
+        // as an end-of-run block while the shipped binary interleaved them.
+        self.interleave_names = self.config.flags.verbose
+            && self.config.connection.client_mode
+            && !self.should_emit_itemize()
+            && matches!(self.select_mode(), ReceiverMode::Transfer);
+        self.names_to_stderr = self.config.flags.msgs_to_stderr;
+        self.progress_active = progress.is_some();
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 
@@ -74,6 +86,22 @@ impl ReceiverContext {
         let mut failed_dirs = crate::receiver::directory::FailedDirectories::new();
         let mut metadata_errors: Vec<(PathBuf, String)> = Vec::new();
 
+        // Decide the plain-`-v` directory NAME lines from the PRE-transfer
+        // state, before the walk below applies metadata or a child mkdir bumps a
+        // parent's mtime. Upstream names a directory only when set_file_attrs()
+        // changed it (generator.c:1503-1505); a directory absent pre-transfer is
+        // treated as newly created and named. The walk itself no longer names
+        // them, so an unchanged re-sync is silent here exactly as in
+        // run_pipelined - it previously named every directory unconditionally.
+        let verbose_dir_lines = if self.config.flags.verbose
+            && self.config.connection.client_mode
+            && !self.should_emit_itemize()
+        {
+            self.verbose_dir_name_lines(&setup.dest_dir)
+        } else {
+            Vec::new()
+        };
+
         // upstream: generator.c:1329-1338 - make_path() for relative_paths
         self.ensure_relative_parents(&setup.dest_dir);
 
@@ -81,28 +109,8 @@ impl ReceiverContext {
         // below, exactly like `run_pipelined`. Running this walk too would
         // record every directory row and created-dir tally twice; it creates
         // nothing under `skip_dest_writes()` anyway (#6947). `--list-only` does
-        // not set `dry_run`, so its walk is untouched. Only the plain-`-v` name
-        // lines the walk emits as a side effect (creation.rs:777-786) are
-        // reproduced here, since `plan_dry_run` deals in itemize rows.
+        // not set `dry_run`, so its walk is untouched.
         let walk_dirs = !self.config.flags.dry_run;
-        if !walk_dirs
-            && self.config.flags.verbose
-            && self.config.connection.client_mode
-            && !self.should_emit_itemize()
-        {
-            for rel in self
-                .file_list
-                .iter()
-                .filter(|entry| entry.is_dir())
-                .map(protocol::flist::FileEntry::path)
-            {
-                if rel.as_os_str() == "." {
-                    info_log!(Name, 1, "./");
-                } else {
-                    info_log!(Name, 1, "{}/", rel.display());
-                }
-            }
-        }
         for (flist_idx, file_entry) in self.file_list.iter().enumerate() {
             if walk_dirs && file_entry.is_dir() {
                 let result = self.create_directory_incremental(
@@ -190,126 +198,136 @@ impl ReceiverContext {
             setup.acl_id_map.as_deref(),
         );
 
-        let mut files_transferred: usize = 0;
+        // Both assigned by every arm of the mode match below.
         // upstream: receiver.c:784 total_transferred_size, summed with files_transferred.
-        let mut transferred_file_size: u64 = 0;
+        let mut files_transferred: usize;
+        let mut transferred_file_size: u64;
         let mut bytes_received: u64 = 0;
         let mut literal_data: u64 = 0;
         let mut matched_data: u64 = 0;
         let mut redo_count: usize = 0;
         let mut all_delayed_updates: Vec<(PathBuf, PathBuf)> = Vec::new();
 
-        // upstream: generator.c:1249 - list-only renders every flist entry via
-        // list_file_entry() and sends NO per-file NDX request. This branch must
-        // precede the dry_run check: list-only is not dry-run.
-        if self.config.flags.list_only {
-            stats.list_only_entries = self.collect_list_only_entries();
-            writer.flush()?;
-        } else if self.config.flags.only_write_batch {
-            // upstream: main.c:1839 `write_batch < 0` forces dry_run but leaves
-            // do_xfers = 1, so unlike a plain `-n` the generator still sends
-            // real block checksums and the sender expects a sum head per file
-            // (sender.c:442-443). Checked before `dry_run` because
-            // only-write-batch sets both flags; falling through to
-            // `run_dry_run_loop` would send a bare NDX+iflags request with no
-            // sum head, leaving the sender blocked on a read that never
-            // completes while this loop blocks on the echo. A push receiver
-            // reads no delta (the client sender diverted it into its own batch
-            // fd, sender.c:217); a pull receiver drains the remote sender's
-            // delta via discard_receive_data() (receiver.c:813-814).
-            // Same shared reporting pass as the plain dry run below; only the
-            // wire loop differs (real block checksums, no plan).
-            let plan = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
-            stats.directories_created = new_dir_count(&plan);
-            self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
-        } else if self.config.flags.dry_run {
-            // The same shared dry-run pass `run_pipelined` uses. This driver
-            // previously produced only the directory rows its creation walk
-            // emitted as a side effect - no regular-file or symlink row at all -
-            // because it never had a reporting pass of its own.
-            let plan = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
-            stats.directories_created = new_dir_count(&plan);
-            (files_transferred, transferred_file_size) =
-                self.run_dry_run_loop(reader, writer, &plan)?;
-        } else {
-            let total_files = files_to_transfer.len();
-            let redo_config = pipeline_config.clone();
-            let redo_indices;
-            let delayed;
-            (
-                files_transferred,
-                transferred_file_size,
-                bytes_received,
-                literal_data,
-                matched_data,
-                redo_indices,
-                delayed,
-            ) = self.run_pipeline_loop_decoupled(
-                reader,
-                writer,
-                pipeline_config,
-                &setup,
-                files_to_transfer,
-                &mut metadata_errors,
-                false,
-                total_files,
-                &mut progress,
-            )?;
-            all_delayed_updates.extend(delayed);
+        // Buffer directory `-v` names under their flist index so each is
+        // released immediately before its first child is reached in the transfer
+        // loop below (upstream emits the directory row as its flist entry is
+        // reached, so a directory precedes its children). Trailing directories
+        // with no transferred child flush at end of run.
+        if self.interleave_names {
+            for (idx, name) in &verbose_dir_lines {
+                self.buffer_deferred_name(*idx, format!("{name}\n"));
+            }
+        }
 
-            // Phase 2: redo pass for files that failed checksum verification.
-            redo_count = redo_indices.len();
-            if !redo_indices.is_empty() {
-                setup.checksum_length = REDO_CHECKSUM_LENGTH;
-
-                // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
-                // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
-                let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
-                    .iter()
-                    .filter_map(|&idx| {
-                        self.file_list.get(idx).map(|entry| {
-                            let p = entry.path();
-                            let file_path = if p.as_os_str() == "." {
-                                setup.dest_dir.clone()
-                            } else {
-                                setup.dest_dir.join(p)
-                            };
-                            (
-                                idx,
-                                entry,
-                                file_path,
-                                crate::generator::ItemFlags::ITEM_TRANSFER,
-                            )
-                        })
-                    })
-                    .collect();
-
-                let (
-                    redo_transferred,
-                    redo_transferred_size,
-                    redo_bytes,
-                    redo_literal,
-                    redo_matched,
-                    _,
-                    redo_delayed,
+        // One shared decision (see `mode.rs`) with one shared body per
+        // non-transfer mode, so this driver and run_pipelined cannot drift
+        // again. The match is exhaustive by design: a new ReceiverMode variant
+        // is a compile error in every driver that does not handle it.
+        match self.select_mode() {
+            ReceiverMode::NonTransfer(non_transfer) => {
+                (files_transferred, transferred_file_size) = self.run_non_transfer_mode(
+                    non_transfer,
+                    reader,
+                    writer,
+                    &setup,
+                    &files_to_transfer,
+                    &mut stats,
+                )?;
+            }
+            ReceiverMode::Transfer => {
+                let total_files = files_to_transfer.len();
+                let redo_config = pipeline_config.clone();
+                let redo_indices;
+                let delayed;
+                (
+                    files_transferred,
+                    transferred_file_size,
+                    bytes_received,
+                    literal_data,
+                    matched_data,
+                    redo_indices,
+                    delayed,
                 ) = self.run_pipeline_loop_decoupled(
                     reader,
                     writer,
-                    redo_config,
+                    pipeline_config,
                     &setup,
-                    redo_files,
+                    files_to_transfer,
                     &mut metadata_errors,
-                    true,
+                    false,
                     total_files,
                     &mut progress,
                 )?;
+                all_delayed_updates.extend(delayed);
 
-                files_transferred += redo_transferred;
-                transferred_file_size += redo_transferred_size;
-                bytes_received += redo_bytes;
-                literal_data += redo_literal;
-                matched_data += redo_matched;
-                all_delayed_updates.extend(redo_delayed);
+                // Phase 2: redo pass for files that failed checksum verification.
+                redo_count = redo_indices.len();
+                if !redo_indices.is_empty() {
+                    setup.checksum_length = REDO_CHECKSUM_LENGTH;
+
+                    // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
+                    // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
+                    let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
+                        .iter()
+                        .filter_map(|&idx| {
+                            self.file_list.get(idx).map(|entry| {
+                                let p = entry.path();
+                                let file_path = if p.as_os_str() == "." {
+                                    setup.dest_dir.clone()
+                                } else {
+                                    setup.dest_dir.join(p)
+                                };
+                                (
+                                    idx,
+                                    entry,
+                                    file_path,
+                                    crate::generator::ItemFlags::ITEM_TRANSFER,
+                                )
+                            })
+                        })
+                        .collect();
+
+                    let (
+                        redo_transferred,
+                        redo_transferred_size,
+                        redo_bytes,
+                        redo_literal,
+                        redo_matched,
+                        _,
+                        redo_delayed,
+                    ) = self.run_pipeline_loop_decoupled(
+                        reader,
+                        writer,
+                        redo_config,
+                        &setup,
+                        redo_files,
+                        &mut metadata_errors,
+                        true,
+                        total_files,
+                        &mut progress,
+                    )?;
+
+                    files_transferred += redo_transferred;
+                    transferred_file_size += redo_transferred_size;
+                    bytes_received += redo_bytes;
+                    literal_data += redo_literal;
+                    matched_data += redo_matched;
+                    all_delayed_updates.extend(redo_delayed);
+                }
+            }
+        }
+
+        // When interleaving `-v` names (the plain `-v` client pull), directory
+        // names were buffered up front and released in flist order alongside
+        // their children in the transfer loop above, so skip this end-of-run
+        // block; any trailing directories flush just below via flush_names_all.
+        if self.config.flags.verbose
+            && self.config.connection.client_mode
+            && !self.interleave_names
+            && !self.should_emit_itemize()
+        {
+            for (_idx, name) in &verbose_dir_lines {
+                info_log!(Name, 1, "{name}");
             }
         }
 
@@ -386,8 +404,11 @@ impl ReceiverContext {
         // upstream: receiver.c:733-746 - stats.created_* accumulated locally.
         stats.created_stats = self.created_stats.get();
 
-        // Drain the deferred itemize rows in flist-index order before the
-        // goodbye handshake, matching upstream's single-pass emission ordering.
+        // Flush any trailing buffered `-v` directory names (those with no
+        // transferred child to release them mid-loop), then drain the deferred
+        // itemize rows in flist-index order before the goodbye handshake,
+        // matching upstream's single-pass emission ordering.
+        self.flush_names_all()?;
         self.flush_itemize_rows(writer)?;
 
         self.finalize_transfer(reader, writer)?;


### PR DESCRIPTION
## Problem

The receiver has two pipelined drivers, and each open-coded its own dispatch ladder:

```rust
// pipelined.rs                      // pipelined_incremental.rs
if list_only { }                     if list_only { }
else if only_write_batch { }         else if dry_run { }
else if dry_run { }                  else { }
else { }
```

Nothing catches a mode present in one and absent from the other, because the two are never exercised together. `bin` pins `transfer` with `default-features = false` (root `Cargo.toml`), so the **shipped binary** - and every interop harness, which builds `--bin oc-rsync` - runs `run_pipelined`. `--workspace --all-features`, and every library consumer (since `incremental-flist` is in `transfer`'s own `default` list), run `run_pipelined_incremental`. **Production takes one ladder and CI tests the other.**

That is why the same divergence recurred four times, each fixed on one side only.

## Fix

The deliverable is the exhaustiveness, not the missing arms.

`crates/transfer/src/receiver/transfer/mode.rs`:

- `select_mode() -> ReceiverMode` - the single decision, with upstream's ordering and the reason it is load-bearing attached to it (`main.c:1839` sets `dry_run` for `--only-write-batch` while leaving `do_xfers = 1`, so only the check order tells the two apart).
- `ReceiverMode::NonTransfer(NonTransferMode)` vs `ReceiverMode::Transfer`. Every non-transfer mode has exactly **one** body, in `run_non_transfer_mode`; `Transfer` is the only mode whose body a driver supplies itself.
- Both drivers `match` with no wildcard arm. A new `ReceiverMode` variant is a **compile error** in any driver that does not handle it; a new `NonTransferMode` variant is implemented once and both drivers get it.

`run_pipelined`'s `interleave_names` predicate open-coded the same ladder a fifth time (`!list_only && !dry_run && !only_write_batch`); it now asks `select_mode()`.

## Behaviour ported to the incremental driver

- **`interleave_names` / `names_to_stderr` / `progress_active`** - never set there. They are read by the *shared* `run_pipeline_loop_decoupled`, so under the default feature set plain `-v` names were rendered as a block after the summary instead of interleaved in flist order with `--progress`.
- **Plain-`-v` directory names** - were emitted unconditionally from inside `create_directory_incremental`, and emitted *after* that call had already applied the directory's metadata, which is too late to observe the pre-transfer state. Upstream names a directory only when `set_file_attrs()` changed it (`generator.c:1503-1505`), so an unchanged re-sync printed `./` and `sub/` that upstream does not print. The decision now comes from the shared `verbose_dir_name_lines()` against the pre-transfer stat, buffered under the flist index and released before the directory's first child - exactly as `run_pipelined` does.

Deliberately **not** ported: nothing. The `only_write_batch` arm and the shared `plan_dry_run` reporting pass had already landed on both sides; the two drivers' remaining differences (incremental directory creation, `failed_dirs` tracking, and the point at which `file_type_counts()` is taken - after the loop, because INC_RECURSE appends sub-lists as the transfer proceeds) are the reason the incremental driver exists and are left alone.

## Verification, both feature settings

Every cell below was run on x86_64 Linux against **rsync 3.4.4** (confirmed from the `--version` banner, not the path).

| Cell | Result |
|---|---|
| `--workspace --all-features` (feature ON) | 32112 passed |
| `--workspace --no-default-features --features zstd,lz4,xattr,iconv,parallel,copy_file_range` (feature OFF) | 31544 passed |
| `-p transfer --features incremental-flist` | 2502 passed |
| `-p transfer --no-default-features --features zstd,lz4,xattr` | 2480 passed |
| `clippy --workspace --all-targets` (both settings) | clean |

End-to-end over ssh, with `oc-rsync` built **both** ways and compared against upstream 3.4.4 - `--only-write-batch`, `--dry-run`, `--list-only`, plain `-v`, and an unchanged re-sync, push and pull:

- **Before:** 4 pull scenarios diverged between the two ladders (`--only-write-batch -v`, `--dry-run -v`, plain `-v`, `-v` re-sync).
- **After:** 0 of 14 scenarios diverge.
- Two pull scenarios (plain `-v`, `-v` re-sync) went from differing from upstream to matching it byte for byte on the incremental ladder.

Remaining differences from upstream in that sweep are identical on both ladders before and after this change (e.g. `>f.s.......` vs `>f.sT......`, name-vs-summary ordering on push) and are out of scope here.

## Regression test

`crates/transfer/src/receiver/tests/mode_dispatch.rs` - six tests, compiled unconditionally so **both** matrix cells run them:

- the flag-to-mode table, including `--only-write-batch` outranking the `--dry-run` it implies and `--list-only` outranking both;
- the wire shape, which is what actually hangs: `--only-write-batch` must put a real sum head on the wire (`sender.c:442-443`, `do_xfers` stays 1) and `--dry-run` must put nothing after `NDX + iflags`. Both halves are asserted together, so neither direction can regress into the other.

## CI feature matrix

`.github/workflows/_test-features.yml` had a row named `incremental-flist` running `-p transfer --features incremental-flist`. That turns on nothing `transfer`'s own `default` list had not already turned on - it re-tested the default configuration under a name claiming otherwise, which is the same class of defect as the bug: a label asserting coverage that does not exist. There was **no** feature-off row anywhere; the only workspace-wide off build in the repo was the musl cell, so off coverage was incidental rather than declared.

Replaced with a genuine `no-incremental-flist` cell over the whole workspace, reusing the musl job's feature list so only the flag under test varies (bare `--no-default-features` would also drop `zstd`/`lz4`/`xattr` and test a different question). The on case is already covered by the `default-features` row and the main `--all-features` job. The new regression test above runs in that cell.

## Note on scope

The prior drifts were end-to-end behaviours - dispatch, dry-run side effects, itemize and name output - not unit-testable logic, and the interop harness only ever builds `--bin oc-rsync`, which is always the feature-off ladder. So the interop suite structurally cannot cover the on-path receiver today. Running interop under both settings would close that gap, but it is a separate change to the interop harness and is not attempted here.
