### PR TITLE
fix(daemon): negotiate the daemon-auth digest server-side

### DIFF
--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -28,6 +28,16 @@ pub enum DaemonAuthDigest {
     Md5,
     /// MD4, accepted for compatibility with very old clients.
     Md4,
+    /// MD4 seeded with four zero bytes, upstream's `CSUM_MD4_OLD`.
+    ///
+    /// Not an advertisable name: upstream's table carries a single `md4` entry
+    /// and `negotiate_daemon_auth()` rewrites the *negotiated* item to
+    /// `CSUM_MD4_OLD` (compat.c:879-881) only when the peer sent no digest list
+    /// and the protocol-keyed fallback landed on `md4`. `sum_init()`
+    /// (checksum.c:604-610) then prefixes the seed as four bytes - zero here,
+    /// because both `gen_challenge()` and `generate_hash()` pass seed `0` - which
+    /// an explicitly negotiated `md4` does not get.
+    Md4Old,
 }
 
 impl DaemonAuthDigest {
@@ -39,7 +49,9 @@ impl DaemonAuthDigest {
             Self::Sha256 => "sha256",
             Self::Sha1 => "sha1",
             Self::Md5 => "md5",
-            Self::Md4 => "md4",
+            // upstream keeps `nni->name` as "md4" when it rewrites `num` to
+            // CSUM_MD4_OLD, so both spell the same wire token.
+            Self::Md4 | Self::Md4Old => "md4",
         }
     }
 
@@ -50,44 +62,51 @@ impl DaemonAuthDigest {
             Self::Sha512 => 86,
             Self::Sha256 => 43,
             Self::Sha1 => 27,
-            Self::Md5 | Self::Md4 => 22,
+            Self::Md5 | Self::Md4 | Self::Md4Old => 22,
         }
     }
 
-    /// Computes the raw digest bytes for the provided secret and challenge.
-    fn digest_bytes(self, secret: &[u8], challenge: &[u8]) -> Vec<u8> {
+    /// Computes the raw digest bytes over the concatenation of `parts`.
+    fn digest_bytes(self, parts: &[&[u8]]) -> Vec<u8> {
+        macro_rules! digest {
+            ($hasher:ty) => {{
+                let mut hasher = <$hasher>::new();
+                for part in parts {
+                    hasher.update(part);
+                }
+                hasher.finalize().to_vec()
+            }};
+        }
+
         match self {
-            Self::Sha512 => {
-                let mut hasher = Sha512::new();
-                hasher.update(secret);
-                hasher.update(challenge);
-                hasher.finalize().to_vec()
-            }
-            Self::Sha256 => {
-                let mut hasher = Sha256::new();
-                hasher.update(secret);
-                hasher.update(challenge);
-                hasher.finalize().to_vec()
-            }
-            Self::Sha1 => {
-                let mut hasher = Sha1::new();
-                hasher.update(secret);
-                hasher.update(challenge);
-                hasher.finalize().to_vec()
-            }
-            Self::Md5 => {
-                let mut hasher = Md5::new();
-                hasher.update(secret);
-                hasher.update(challenge);
-                hasher.finalize().to_vec()
-            }
-            Self::Md4 => {
+            Self::Sha512 => digest!(Sha512),
+            Self::Sha256 => digest!(Sha256),
+            Self::Sha1 => digest!(Sha1),
+            Self::Md5 => digest!(Md5),
+            Self::Md4 => digest!(Md4),
+            // upstream: checksum.c:604-610 - the MD4_OLD family seeds the digest
+            // with `SIVAL(s, 0, seed); sum_update(s, 4)`. Daemon auth always
+            // passes seed 0 (authenticate.c:76, :90), so the prefix is four zero
+            // bytes.
+            Self::Md4Old => {
                 let mut hasher = Md4::new();
-                hasher.update(secret);
-                hasher.update(challenge);
+                hasher.update(&[0u8; 4]);
+                for part in parts {
+                    hasher.update(part);
+                }
                 hasher.finalize().to_vec()
             }
         }
+    }
+
+    /// Returns the unpadded base64 encoding of this digest over `parts`.
+    ///
+    /// upstream: authenticate.c:80,95 - both `gen_challenge()` and
+    /// `generate_hash()` finish with `base64_encode(digest, len, out, 0)`, whose
+    /// trailing `0` suppresses `=` padding.
+    #[must_use]
+    pub fn base64_digest(self, parts: &[&[u8]]) -> String {
+        STANDARD_NO_PAD.encode(self.digest_bytes(parts))
     }
 }
 
@@ -170,54 +189,98 @@ pub fn select_daemon_digest(
     default_legacy_digest(protocol_version)
 }
 
-/// Returns the protocol-version-appropriate legacy digest.
+/// Returns the digest to use when the peer advertised no list at all.
 ///
-/// upstream: compat.c:858 - `protocol_version >= 30 ? "md5" : "md4"`
+/// upstream: compat.c:860 - the substitute list is
+/// `protocol_version >= 30 ? "md5" : "md4"`, and because that branch also sets
+/// `md4_is_old`, the `md4` outcome is rewritten to `CSUM_MD4_OLD`
+/// (compat.c:879-881). An `md4` the peer named explicitly stays plain `CSUM_MD4`.
 #[must_use]
 pub const fn default_legacy_digest(protocol_version: u8) -> DaemonAuthDigest {
     if protocol_version >= 30 {
         DaemonAuthDigest::Md5
     } else {
-        DaemonAuthDigest::Md4
+        DaemonAuthDigest::Md4Old
     }
 }
 
 /// Computes the base64-encoded daemon authentication response using the provided digest.
+///
+/// upstream: authenticate.c:88-96 `generate_hash()` hashes the secret followed by
+/// the challenge with the negotiated digest.
 #[must_use]
 pub fn compute_daemon_auth_response(
     secret: &[u8],
     challenge: &str,
     digest: DaemonAuthDigest,
 ) -> String {
-    let bytes = digest.digest_bytes(secret, challenge.as_bytes());
-    STANDARD_NO_PAD.encode(bytes)
+    digest.base64_digest(&[secret, challenge.as_bytes()])
 }
 
-/// Returns the supported digest candidates that match the supplied response length.
+/// Renders the daemon-auth digest list this implementation advertises.
+///
+/// upstream: compat.c:462 `get_default_nno_list()` walks
+/// `valid_auth_checksums_items[]` (checksum.c:71-84) in table order and joins the
+/// names with a single space. The list is never filtered by protocol version.
 #[must_use]
-pub const fn digests_for_response(response: &str) -> &'static [DaemonAuthDigest] {
-    match response.len() {
-        len if len == DaemonAuthDigest::Sha512.base64_len() => SHA512_ONLY,
-        len if len == DaemonAuthDigest::Sha256.base64_len() => SHA256_ONLY,
-        len if len == DaemonAuthDigest::Sha1.base64_len() => SHA1_ONLY,
-        len if len == DaemonAuthDigest::Md5.base64_len() => MD_LEGACY,
-        _ => &[],
-    }
+pub fn supported_daemon_digest_list() -> String {
+    SUPPORTED_DAEMON_DIGESTS
+        .iter()
+        .map(|digest| digest.name())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
-const SHA512_ONLY: &[DaemonAuthDigest] = &[DaemonAuthDigest::Sha512];
-const SHA256_ONLY: &[DaemonAuthDigest] = &[DaemonAuthDigest::Sha256];
-const SHA1_ONLY: &[DaemonAuthDigest] = &[DaemonAuthDigest::Sha1];
-const MD_LEGACY: &[DaemonAuthDigest] = &[DaemonAuthDigest::Md5, DaemonAuthDigest::Md4];
+/// No digest offered by the client is supported by this implementation.
+///
+/// upstream: compat.c:871-875 - when `parse_negotiate_str()` finds no mutual
+/// choice the daemon writes `@ERROR: your client does not support one of our
+/// daemon-auth checksums: <list>` and calls `exit_cleanup(RERR_UNSUPPORTED)`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("your client does not support one of our daemon-auth checksums")]
+pub struct NoMutualDaemonAuthDigest;
 
-/// Verifies whether the supplied daemon authentication response matches the secret and challenge.
+/// Negotiates the daemon-auth digest from the server's point of view.
 ///
-/// When `protocol_version` is provided and the response length is ambiguous between MD4 and MD5
-/// (both produce 22-character base64 output), only the protocol-appropriate digest is tried:
-/// MD5 for protocol >= 30, MD4 for protocol < 30. This matches upstream rsync's
-/// `negotiate_daemon_auth()` behavior in `compat.c:847`.
+/// `client_digests` is the raw digest name list captured from the client's
+/// `@RSYNCD:` greeting (upstream's `daemon_auth_choices`, clientserver.c:199-211).
 ///
-/// When `protocol_version` is `None`, both MD4 and MD5 are tried for backward compatibility.
+/// upstream: compat.c:848 `negotiate_daemon_auth(f_out, 0)`. With `am_server`
+/// set, `parse_negotiate_str()` (compat.c:333-356) walks the *client's* list and
+/// stops at the first name the server also supports - `if (best == 1 || am_server)
+/// break;` - so client preference order decides. When the client advertised no
+/// list at all (only reachable at protocol <= 31) upstream substitutes
+/// `protocol_version >= 30 ? "md5" : "md4"` (compat.c:860) and negotiates against
+/// that, which always succeeds because both names are compiled in.
+///
+/// # Errors
+///
+/// Returns [`NoMutualDaemonAuthDigest`] when the client offered a list but none of
+/// its names is supported here.
+pub fn negotiate_server_daemon_digest(
+    client_digests: Option<&str>,
+    protocol_version: u8,
+) -> Result<DaemonAuthDigest, NoMutualDaemonAuthDigest> {
+    let Some(list) = client_digests else {
+        return Ok(default_legacy_digest(protocol_version));
+    };
+
+    // `parse_daemon_digest_list` drops names this build does not implement while
+    // preserving the client's order, so the first survivor is exactly upstream's
+    // "first acceptable client choice".
+    parse_daemon_digest_list(Some(list))
+        .first()
+        .copied()
+        .ok_or(NoMutualDaemonAuthDigest)
+}
+
+/// Verifies a daemon authentication response against the secret and challenge.
+///
+/// `digest` must be the digest fixed by [`negotiate_server_daemon_digest`]: upstream
+/// derives both halves of the exchange from the single `valid_auth_checksums.
+/// negotiated_nni` (authenticate.c:76 `gen_challenge`, :90 `generate_hash`), so the
+/// challenge and the verification can never disagree. Inferring the algorithm from
+/// the response instead would let a client pick which digest it is checked against.
 ///
 /// # Security
 ///
@@ -231,29 +294,10 @@ pub fn verify_daemon_auth_response(
     secret: &[u8],
     challenge: &str,
     response: &str,
-    protocol_version: Option<u8>,
+    digest: DaemonAuthDigest,
 ) -> bool {
-    let candidates = digests_for_response(response);
-
-    candidates
-        .iter()
-        .filter(|digest| SUPPORTED_DAEMON_DIGESTS.contains(digest))
-        .filter(|digest| {
-            // When the protocol version is known and the response is ambiguous (MD4/MD5),
-            // only try the protocol-appropriate digest.
-            // upstream: compat.c:858 - protocol_version >= 30 ? "md5" : "md4"
-            if let Some(version) = protocol_version {
-                if candidates.len() > 1 {
-                    let expected = default_legacy_digest(version);
-                    return **digest == expected;
-                }
-            }
-            true
-        })
-        .any(|digest| {
-            let expected = compute_daemon_auth_response(secret, challenge, *digest);
-            constant_time_eq(expected.as_bytes(), response.as_bytes())
-        })
+    let expected = compute_daemon_auth_response(secret, challenge, digest);
+    constant_time_eq(expected.as_bytes(), response.as_bytes())
 }
 
 /// Compares two byte slices in constant time to prevent timing attacks.
@@ -318,9 +362,32 @@ mod tests {
     }
 
     #[test]
-    fn selection_falls_back_to_md4_for_protocol_below_30() {
-        assert_eq!(select_daemon_digest(&[], 29), DaemonAuthDigest::Md4);
-        assert_eq!(select_daemon_digest(&[], 28), DaemonAuthDigest::Md4);
+    fn selection_falls_back_to_seeded_md4_for_protocol_below_30() {
+        // upstream: compat.c:879-881 - the absent-list `md4` fallback is rewritten
+        // to CSUM_MD4_OLD, which seeds the digest with four zero bytes.
+        assert_eq!(select_daemon_digest(&[], 29), DaemonAuthDigest::Md4Old);
+        assert_eq!(select_daemon_digest(&[], 28), DaemonAuthDigest::Md4Old);
+    }
+
+    #[test]
+    fn seeded_md4_differs_from_plain_md4_and_is_never_advertised() {
+        let secret = b"pw";
+        let challenge = "challenge";
+        assert_ne!(
+            compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md4),
+            compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md4Old),
+        );
+        assert_eq!(DaemonAuthDigest::Md4Old.name(), "md4");
+        assert!(!SUPPORTED_DAEMON_DIGESTS.contains(&DaemonAuthDigest::Md4Old));
+        // An explicitly named `md4` stays plain, at every protocol version.
+        assert_eq!(
+            parse_daemon_digest_list(Some("md4")),
+            [DaemonAuthDigest::Md4]
+        );
+        assert_eq!(
+            negotiate_server_daemon_digest(Some("md4"), 29),
+            Ok(DaemonAuthDigest::Md4)
+        );
     }
 
     #[test]
@@ -329,14 +396,59 @@ mod tests {
         let challenge = "challenge";
         let response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Sha512);
         assert!(verify_daemon_auth_response(
-            secret, challenge, &response, None
+            secret,
+            challenge,
+            &response,
+            DaemonAuthDigest::Sha512
         ));
     }
 
     #[test]
-    fn digests_for_response_disambiguates_md4_and_md5() {
-        let len = DaemonAuthDigest::Md5.base64_len();
-        assert_eq!(digests_for_response(&"A".repeat(len)), MD_LEGACY);
+    fn advertised_digest_list_matches_upstream_order() {
+        assert_eq!(supported_daemon_digest_list(), "sha512 sha256 sha1 md5 md4");
+    }
+
+    #[test]
+    fn server_negotiation_takes_the_first_client_choice_it_supports() {
+        // upstream: compat.c:354 - `if (best == 1 || am_server) break;`, so the
+        // server honours the client's ordering rather than its own preference.
+        assert_eq!(
+            negotiate_server_daemon_digest(Some("md5 sha512"), 32),
+            Ok(DaemonAuthDigest::Md5)
+        );
+        assert_eq!(
+            negotiate_server_daemon_digest(Some("sha1 md5"), 32),
+            Ok(DaemonAuthDigest::Sha1)
+        );
+    }
+
+    #[test]
+    fn server_negotiation_skips_unsupported_client_names() {
+        assert_eq!(
+            negotiate_server_daemon_digest(Some("sponge blake3 sha256 md5"), 32),
+            Ok(DaemonAuthDigest::Sha256)
+        );
+    }
+
+    #[test]
+    fn server_negotiation_rejects_a_wholly_foreign_client_list() {
+        assert_eq!(
+            negotiate_server_daemon_digest(Some("sponge blake3"), 32),
+            Err(NoMutualDaemonAuthDigest)
+        );
+    }
+
+    #[test]
+    fn server_negotiation_falls_back_when_the_client_offered_no_list() {
+        // upstream: compat.c:860 - the absent-list substitute is protocol-keyed.
+        assert_eq!(
+            negotiate_server_daemon_digest(None, 31),
+            Ok(DaemonAuthDigest::Md5)
+        );
+        assert_eq!(
+            negotiate_server_daemon_digest(None, 29),
+            Ok(DaemonAuthDigest::Md4Old)
+        );
     }
 
     #[test]
@@ -378,10 +490,16 @@ mod tests {
         }
 
         assert!(verify_daemon_auth_response(
-            secret, challenge, &correct, None
+            secret,
+            challenge,
+            &correct,
+            DaemonAuthDigest::Sha256
         ));
         assert!(!verify_daemon_auth_response(
-            secret, challenge, &tampered, None
+            secret,
+            challenge,
+            &tampered,
+            DaemonAuthDigest::Sha256
         ));
     }
 
@@ -389,7 +507,12 @@ mod tests {
     fn verify_rejects_empty_response() {
         let secret = b"secret";
         let challenge = "challenge";
-        assert!(!verify_daemon_auth_response(secret, challenge, "", None));
+        assert!(!verify_daemon_auth_response(
+            secret,
+            challenge,
+            "",
+            DaemonAuthDigest::Md5
+        ));
     }
 
     #[test]
@@ -397,127 +520,43 @@ mod tests {
         let secret = b"secret";
         let challenge = "challenge";
         assert!(!verify_daemon_auth_response(
-            secret, challenge, "tooshort", None
+            secret,
+            challenge,
+            "tooshort",
+            DaemonAuthDigest::Md5
         ));
         assert!(!verify_daemon_auth_response(
             secret,
             challenge,
             &"A".repeat(100),
-            None,
+            DaemonAuthDigest::Md5,
         ));
     }
 
     #[test]
-    fn verify_uses_md5_for_protocol_30_plus() {
-        let secret = b"test_secret";
-        let challenge = "test_challenge";
-        let md5_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md5);
-        let md4_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md4);
-
-        assert!(verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md5_response,
-            Some(30)
-        ));
-        assert!(!verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md4_response,
-            Some(30)
-        ));
-        assert!(verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md5_response,
-            Some(31)
-        ));
-        assert!(!verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md4_response,
-            Some(31)
-        ));
-    }
-
-    #[test]
-    fn verify_uses_md4_for_protocol_below_30() {
-        let secret = b"test_secret";
-        let challenge = "test_challenge";
-        let md5_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md5);
-        let md4_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md4);
-
-        assert!(verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md4_response,
-            Some(29)
-        ));
-        assert!(!verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md5_response,
-            Some(29)
-        ));
-        assert!(verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md4_response,
-            Some(28)
-        ));
-        assert!(!verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md5_response,
-            Some(28)
-        ));
-    }
-
-    #[test]
-    fn verify_accepts_both_md4_and_md5_without_protocol() {
-        let secret = b"test_secret";
-        let challenge = "test_challenge";
-        let md5_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md5);
-        let md4_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md4);
-
-        assert!(verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md5_response,
-            None
-        ));
-        assert!(verify_daemon_auth_response(
-            secret,
-            challenge,
-            &md4_response,
-            None
-        ));
-    }
-
-    #[test]
-    fn verify_unambiguous_digests_unaffected_by_protocol() {
+    fn verify_is_pinned_to_the_negotiated_digest() {
+        // The response length no longer selects the algorithm: a client that
+        // negotiated SHA-512 cannot be verified with anything else, and a
+        // 22-character MD4 response is not accepted where MD5 was negotiated
+        // even though the two share a length.
         let secret = b"test_secret";
         let challenge = "test_challenge";
 
-        // SHA-512, SHA-256, SHA-1 are unambiguous (unique response lengths)
-        for digest in [
-            DaemonAuthDigest::Sha512,
-            DaemonAuthDigest::Sha256,
-            DaemonAuthDigest::Sha1,
-        ] {
-            let response = compute_daemon_auth_response(secret, challenge, digest);
+        for negotiated in *SUPPORTED_DAEMON_DIGESTS {
+            let response = compute_daemon_auth_response(secret, challenge, negotiated);
             assert!(verify_daemon_auth_response(
-                secret,
-                challenge,
-                &response,
-                Some(29)
+                secret, challenge, &response, negotiated
             ));
-            assert!(verify_daemon_auth_response(
-                secret,
-                challenge,
-                &response,
-                Some(31)
-            ));
+
+            for other in SUPPORTED_DAEMON_DIGESTS.iter().copied() {
+                assert_eq!(
+                    verify_daemon_auth_response(secret, challenge, &response, other),
+                    other == negotiated,
+                    "a {} response must not verify under {}",
+                    negotiated.name(),
+                    other.name(),
+                );
+            }
         }
     }
 

--- a/crates/daemon/benches/daemon_benchmark.rs
+++ b/crates/daemon/benches/daemon_benchmark.rs
@@ -29,15 +29,15 @@ fn bench_auth_challenge_response(c: &mut Criterion) {
 
     // Benchmark challenge generation for modern and legacy protocols
     group.bench_function("challenge_gen_md5", |b| {
-        b.iter(|| ChallengeGenerator::generate(peer_ip, Some(32)));
+        b.iter(|| ChallengeGenerator::generate(peer_ip, DaemonAuthDigest::Md5));
     });
 
     group.bench_function("challenge_gen_md4", |b| {
-        b.iter(|| ChallengeGenerator::generate(peer_ip, Some(29)));
+        b.iter(|| ChallengeGenerator::generate(peer_ip, DaemonAuthDigest::Md4));
     });
 
     // Benchmark response computation for each digest algorithm
-    let challenge = ChallengeGenerator::generate(peer_ip, Some(32));
+    let challenge = ChallengeGenerator::generate(peer_ip, DaemonAuthDigest::Md5);
     let digests = [
         ("sha512", DaemonAuthDigest::Sha512),
         ("sha256", DaemonAuthDigest::Sha256),
@@ -55,12 +55,12 @@ fn bench_auth_challenge_response(c: &mut Criterion) {
     // Benchmark full verify round-trip (compute + constant-time compare)
     let response_md5 = compute_auth_response(password, &challenge, DaemonAuthDigest::Md5);
     group.bench_function("verify_md5", |b| {
-        b.iter(|| verify_client_response(password, &challenge, &response_md5, Some(32)));
+        b.iter(|| verify_client_response(password, &challenge, &response_md5, DaemonAuthDigest::Md5));
     });
 
     let response_sha512 = compute_auth_response(password, &challenge, DaemonAuthDigest::Sha512);
     group.bench_function("verify_sha512", |b| {
-        b.iter(|| verify_client_response(password, &challenge, &response_sha512, Some(32)));
+        b.iter(|| verify_client_response(password, &challenge, &response_sha512, DaemonAuthDigest::Sha512));
     });
 
     group.finish();

--- a/crates/daemon/benches/daemon_benchmark.rs
+++ b/crates/daemon/benches/daemon_benchmark.rs
@@ -55,12 +55,21 @@ fn bench_auth_challenge_response(c: &mut Criterion) {
     // Benchmark full verify round-trip (compute + constant-time compare)
     let response_md5 = compute_auth_response(password, &challenge, DaemonAuthDigest::Md5);
     group.bench_function("verify_md5", |b| {
-        b.iter(|| verify_client_response(password, &challenge, &response_md5, DaemonAuthDigest::Md5));
+        b.iter(|| {
+            verify_client_response(password, &challenge, &response_md5, DaemonAuthDigest::Md5)
+        });
     });
 
     let response_sha512 = compute_auth_response(password, &challenge, DaemonAuthDigest::Sha512);
     group.bench_function("verify_sha512", |b| {
-        b.iter(|| verify_client_response(password, &challenge, &response_sha512, DaemonAuthDigest::Sha512));
+        b.iter(|| {
+            verify_client_response(
+                password,
+                &challenge,
+                &response_sha512,
+                DaemonAuthDigest::Sha512,
+            )
+        });
     });
 
     group.finish();

--- a/crates/daemon/src/auth.rs
+++ b/crates/daemon/src/auth.rs
@@ -30,7 +30,10 @@
 //!
 //! - **File permissions**: Must be readable only by owner (mode 0600 on Unix)
 //! - **Password storage**: Plain text (matching upstream rsync behavior)
-//! - **Challenge generation**: Uses cryptographically secure random + timestamp + PID
+//! - **Challenge generation**: Peer address + timestamp + PID, hashed with the
+//!   negotiated digest - upstream's `gen_challenge()` (authenticate.c:62-81)
+//!   verbatim. It is deliberately not a CSPRNG: matching upstream matters more
+//!   than the unobservable difference.
 //!
 //! # Supported Hash Algorithms
 //!
@@ -42,8 +45,12 @@
 //! - MD5 (historical default)
 //! - MD4 (legacy compatibility)
 //!
-//! The server advertises supported algorithms in the `@RSYNCD:` greeting, and clients
-//! select the strongest mutually supported algorithm.
+//! Both sides advertise their list in the `@RSYNCD:` greeting. A client picks the
+//! entry of the server's list that ranks highest in its own; a server takes the
+//! *first* entry of the client's list that it supports, so client preference wins
+//! (upstream: compat.c:333-356 `parse_negotiate_str`, whose `am_server` branch
+//! stops at the first acceptable client choice). The single winner then drives both
+//! the challenge and the verification.
 //!
 //! # Examples
 //!
@@ -101,8 +108,8 @@
 //!
 //! ## Improvements over upstream rsync
 //!
-//! - **Constant-time comparison**: Prevents timing attacks during response verification
-//! - **Cryptographically secure random**: Uses `getrandom` for challenge generation
+//! - **Constant-time comparison**: Prevents timing attacks during response
+//!   verification, where upstream uses a plain `strcmp()`. Not wire-observable.
 //!
 //! ## Known limitations (matching upstream)
 //!
@@ -135,7 +142,6 @@ use std::io;
 use std::net::IpAddr;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
-
 
 /// Generates authentication challenges for daemon mode.
 ///
@@ -588,7 +594,8 @@ mod tests {
     #[test]
     fn verify_client_response_ignores_a_non_negotiated_digest() {
         let password = b"secret";
-        let challenge = ChallengeGenerator::generate("10.0.0.1".parse().unwrap(), DaemonAuthDigest::Md5);
+        let challenge =
+            ChallengeGenerator::generate("10.0.0.1".parse().unwrap(), DaemonAuthDigest::Md5);
 
         let md4_resp = compute_auth_response(password, &challenge, DaemonAuthDigest::Md4);
         assert!(!verify_client_response(

--- a/crates/daemon/src/auth.rs
+++ b/crates/daemon/src/auth.rs
@@ -50,6 +50,7 @@
 //! ## Server-side authentication
 //!
 //! ```no_run
+//! use core::auth::{DaemonAuthDigest, negotiate_server_daemon_digest};
 //! use daemon::auth::{ChallengeGenerator, SecretsFile, verify_client_response};
 //! use std::net::IpAddr;
 //! use std::path::Path;
@@ -58,16 +59,20 @@
 //! // Load secrets file
 //! let secrets = SecretsFile::from_file(Path::new("/etc/rsyncd.secrets"))?;
 //!
+//! // Pin one digest for the whole exchange, from the client's greeting list.
+//! let digest = negotiate_server_daemon_digest(Some("sha512 md5"), 31)
+//!     .expect("client offered a supported digest");
+//!
 //! // Generate challenge
 //! let peer_ip: IpAddr = "192.168.1.1".parse().unwrap();
-//! let challenge = ChallengeGenerator::generate(peer_ip, Some(31));
+//! let challenge = ChallengeGenerator::generate(peer_ip, digest);
 //!
 //! // Client sends: "alice <response>"
 //! let client_response = "alice dGVzdHJlc3BvbnNl"; // Base64-encoded hash
 //!
-//! // Verify
+//! // Verify with the same negotiated digest
 //! if let Some(password) = secrets.lookup("alice") {
-//!     if verify_client_response(password.as_bytes(), &challenge, "dGVzdHJlc3BvbnNl", Some(31)) {
+//!     if verify_client_response(password.as_bytes(), &challenge, "dGVzdHJlc3BvbnNl", digest) {
 //!         println!("Authentication successful");
 //!     }
 //! }
@@ -118,8 +123,9 @@
 //! flow co-located with the module request handling code.
 
 pub use core::auth::{
-    DaemonAuthDigest, SUPPORTED_DAEMON_DIGESTS,
+    DaemonAuthDigest, NoMutualDaemonAuthDigest, SUPPORTED_DAEMON_DIGESTS,
     compute_daemon_auth_response as compute_auth_response, digests_for_protocol,
+    negotiate_server_daemon_digest, supported_daemon_digest_list,
     verify_daemon_auth_response as verify_client_response,
 };
 
@@ -130,9 +136,6 @@ use std::net::IpAddr;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD_NO_PAD;
-use checksums::strong::{Md4, Md5};
 
 /// Generates authentication challenges for daemon mode.
 ///
@@ -153,26 +156,27 @@ impl ChallengeGenerator {
     /// - Timestamp microseconds (4 bytes)
     /// - Process ID (4 bytes)
     ///
-    /// The digest algorithm depends on the negotiated protocol version:
-    /// - Protocol >= 30: MD5
-    /// - Protocol < 30: MD4
+    /// `digest` is the algorithm fixed by [`negotiate_server_daemon_digest`]; the
+    /// same one must verify the response.
     ///
-    /// upstream: compat.c:858 -- `protocol_version >= 30 ? "md5" : "md4"`
+    /// upstream: authenticate.c:76 `gen_challenge()` hashes the buffer with
+    /// `valid_auth_checksums.negotiated_nni`.
     ///
     /// # Examples
     ///
     /// ```
+    /// use core::auth::DaemonAuthDigest;
     /// use daemon::auth::ChallengeGenerator;
     /// use std::net::IpAddr;
     ///
     /// let peer_ip: IpAddr = "192.168.1.1".parse().unwrap();
-    /// let challenge = ChallengeGenerator::generate(peer_ip, Some(32));
+    /// let challenge = ChallengeGenerator::generate(peer_ip, DaemonAuthDigest::Md5);
     ///
     /// // Challenge is base64-encoded hash (22 characters without padding)
     /// assert_eq!(challenge.len(), 22);
     /// ```
     #[must_use]
-    pub fn generate(peer_ip: IpAddr, protocol_version: Option<u8>) -> String {
+    pub fn generate(peer_ip: IpAddr, digest: DaemonAuthDigest) -> String {
         let mut input = [0u8; 32];
 
         // First 16 bytes: IP address
@@ -194,18 +198,7 @@ impl ChallengeGenerator {
         let pid = std::process::id();
         input[24..28].copy_from_slice(&pid.to_le_bytes());
 
-        // Hash and encode using protocol-appropriate digest
-        let version = protocol_version.unwrap_or(32);
-        let digest = if version >= 30 {
-            let mut hasher = Md5::new();
-            hasher.update(&input);
-            hasher.finalize().to_vec()
-        } else {
-            let mut hasher = Md4::new();
-            hasher.update(&input);
-            hasher.finalize().to_vec()
-        };
-        STANDARD_NO_PAD.encode(digest)
+        digest.base64_digest(&[&input])
     }
 }
 
@@ -414,7 +407,7 @@ mod tests {
     #[test]
     fn challenge_generator_produces_valid_base64() {
         let peer_ip: IpAddr = "192.168.1.1".parse().unwrap();
-        let challenge = ChallengeGenerator::generate(peer_ip, Some(32));
+        let challenge = ChallengeGenerator::generate(peer_ip, DaemonAuthDigest::Md5);
 
         // MD5 hash is 16 bytes, base64 without padding is 22 characters
         assert_eq!(challenge.len(), 22);
@@ -430,7 +423,7 @@ mod tests {
     #[test]
     fn challenge_generator_produces_valid_base64_legacy_protocol() {
         let peer_ip: IpAddr = "192.168.1.1".parse().unwrap();
-        let challenge = ChallengeGenerator::generate(peer_ip, Some(29));
+        let challenge = ChallengeGenerator::generate(peer_ip, DaemonAuthDigest::Md4);
 
         // MD4 hash is also 16 bytes, base64 without padding is 22 characters
         assert_eq!(challenge.len(), 22);
@@ -445,12 +438,12 @@ mod tests {
     #[test]
     fn challenge_generator_produces_unique_values() {
         let peer_ip: IpAddr = "10.0.0.1".parse().unwrap();
-        let challenge1 = ChallengeGenerator::generate(peer_ip, Some(32));
+        let challenge1 = ChallengeGenerator::generate(peer_ip, DaemonAuthDigest::Md5);
 
         // Retry until the microsecond timestamp changes (bounded)
         let mut challenge2 = challenge1.clone();
         for i in 0..200 {
-            challenge2 = ChallengeGenerator::generate(peer_ip, Some(32));
+            challenge2 = ChallengeGenerator::generate(peer_ip, DaemonAuthDigest::Md5);
             if challenge2 != challenge1 {
                 break;
             }
@@ -524,15 +517,13 @@ mod tests {
         let password = b"mysecret";
         let challenge = "test_challenge";
 
-        // Compute response using MD5 (protocol >= 30 default)
         let response = compute_auth_response(password, challenge, DaemonAuthDigest::Md5);
 
-        // Verify should succeed with protocol 31
         assert!(verify_client_response(
             password,
             challenge,
             &response,
-            Some(31)
+            DaemonAuthDigest::Md5
         ));
     }
 
@@ -549,7 +540,7 @@ mod tests {
             wrong_password,
             challenge,
             &response,
-            Some(31),
+            DaemonAuthDigest::Md5,
         ));
     }
 
@@ -566,150 +557,54 @@ mod tests {
             password,
             challenge2,
             &response,
-            Some(31)
+            DaemonAuthDigest::Md5
         ));
     }
 
+    /// Every advertised digest must complete a full challenge/response round
+    /// trip when it is the one negotiation picked.
     #[test]
-    fn verify_client_response_supports_multiple_algorithms() {
-        let password = b"test";
-        let challenge = "ch";
-
-        // Test all supported algorithms (no protocol version restriction)
-        for &digest in SUPPORTED_DAEMON_DIGESTS {
-            let response = compute_auth_response(password, challenge, digest);
-            assert!(
-                verify_client_response(password, challenge, &response, None),
-                "Failed for digest: {digest:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn verify_client_response_protocol_version_selects_correct_digest() {
-        let password = b"secret";
-        let challenge = "challenge";
-
-        // Protocol >= 30 should use MD5
-        let md5_resp = compute_auth_response(password, challenge, DaemonAuthDigest::Md5);
-        assert!(verify_client_response(
-            password,
-            challenge,
-            &md5_resp,
-            Some(30)
-        ));
-
-        let md4_resp = compute_auth_response(password, challenge, DaemonAuthDigest::Md4);
-        assert!(!verify_client_response(
-            password,
-            challenge,
-            &md4_resp,
-            Some(30)
-        ));
-
-        // Protocol < 30 should use MD4
-        assert!(verify_client_response(
-            password,
-            challenge,
-            &md4_resp,
-            Some(29)
-        ));
-        assert!(!verify_client_response(
-            password,
-            challenge,
-            &md5_resp,
-            Some(29)
-        ));
-    }
-
-    /// Validates the complete auth round trip at protocol 32 for all
-    /// unambiguous-length digests (SHA-512, SHA-256, SHA-1) plus MD5 (the
-    /// protocol-appropriate choice for the ambiguous MD4/MD5 length at v32).
-    /// MD4 is intentionally excluded: its base64 length matches MD5, so the
-    /// verifier disambiguates by protocol version and picks MD5 for v32.
-    #[test]
-    fn full_auth_roundtrip_protocol_32_all_digests() {
+    fn verify_client_response_supports_every_negotiated_algorithm() {
         let password = b"daemon_secret";
-        let challenge = ChallengeGenerator::generate("10.0.0.1".parse().unwrap(), Some(32));
 
-        // Digests that should verify at protocol 32: all except MD4
-        let verifiable = [
-            DaemonAuthDigest::Sha512,
-            DaemonAuthDigest::Sha256,
-            DaemonAuthDigest::Sha1,
-            DaemonAuthDigest::Md5,
-        ];
-        for digest in verifiable {
+        for &digest in SUPPORTED_DAEMON_DIGESTS {
+            let challenge = ChallengeGenerator::generate("10.0.0.1".parse().unwrap(), digest);
+            assert_eq!(challenge.len(), digest.base64_len());
+
             let response = compute_auth_response(password, &challenge, digest);
             assert!(
-                verify_client_response(password, &challenge, &response, Some(32)),
-                "protocol 32 roundtrip failed for {digest:?}"
+                verify_client_response(password, &challenge, &response, digest),
+                "round trip failed for {digest:?}"
             );
         }
-
-        // MD4 should be rejected at protocol 32 (ambiguous length, verifier picks MD5)
-        let md4_resp = compute_auth_response(password, &challenge, DaemonAuthDigest::Md4);
-        assert!(
-            !verify_client_response(password, &challenge, &md4_resp, Some(32)),
-            "protocol 32 should reject MD4 (ambiguous length)"
-        );
     }
 
-    /// Validates the complete auth round trip at protocol 30 (MD5 + MD4).
-    /// MD5 must succeed and MD4 must be rejected for ambiguous responses.
+    /// A client cannot pick the algorithm it is checked against by choosing its
+    /// response length: MD4 and MD5 share a base64 length, yet only the digest
+    /// negotiation settled on may verify.
+    ///
+    /// upstream: authenticate.c:76,90 - both halves use
+    /// `valid_auth_checksums.negotiated_nni`.
     #[test]
-    fn full_auth_roundtrip_protocol_30() {
-        let password = b"p30_secret";
-        let challenge = ChallengeGenerator::generate("172.16.0.1".parse().unwrap(), Some(30));
+    fn verify_client_response_ignores_a_non_negotiated_digest() {
+        let password = b"secret";
+        let challenge = ChallengeGenerator::generate("10.0.0.1".parse().unwrap(), DaemonAuthDigest::Md5);
 
-        // MD5 should succeed
-        let md5_resp = compute_auth_response(password, &challenge, DaemonAuthDigest::Md5);
-        assert!(
-            verify_client_response(password, &challenge, &md5_resp, Some(30)),
-            "protocol 30 should accept MD5"
-        );
-
-        // MD4 should be rejected (ambiguous length, protocol picks MD5)
         let md4_resp = compute_auth_response(password, &challenge, DaemonAuthDigest::Md4);
-        assert!(
-            !verify_client_response(password, &challenge, &md4_resp, Some(30)),
-            "protocol 30 should reject MD4"
-        );
-
-        // SHA-256 and SHA-512 have unambiguous lengths and should verify
-        let sha256_resp = compute_auth_response(password, &challenge, DaemonAuthDigest::Sha256);
-        assert!(
-            verify_client_response(password, &challenge, &sha256_resp, Some(30)),
-            "protocol 30 should accept SHA-256 (unambiguous length)"
-        );
+        assert!(!verify_client_response(
+            password,
+            &challenge,
+            &md4_resp,
+            DaemonAuthDigest::Md5
+        ));
 
         let sha512_resp = compute_auth_response(password, &challenge, DaemonAuthDigest::Sha512);
-        assert!(
-            verify_client_response(password, &challenge, &sha512_resp, Some(30)),
-            "protocol 30 should accept SHA-512 (unambiguous length)"
-        );
-    }
-
-    /// Validates the complete auth round trip at protocol 29 (MD4 only).
-    /// MD4 must succeed and MD5 must be rejected for ambiguous responses.
-    #[test]
-    fn full_auth_roundtrip_protocol_29() {
-        let password = b"p29_secret";
-        let challenge = ChallengeGenerator::generate("192.168.1.100".parse().unwrap(), Some(29));
-
-        // MD4 should succeed
-        let md4_resp = compute_auth_response(password, &challenge, DaemonAuthDigest::Md4);
-        assert!(
-            verify_client_response(password, &challenge, &md4_resp, Some(29)),
-            "protocol 29 should accept MD4"
-        );
-
-        // MD5 should be rejected (ambiguous length, protocol picks MD4)
-        let md5_resp = compute_auth_response(password, &challenge, DaemonAuthDigest::Md5);
-        assert!(
-            !verify_client_response(password, &challenge, &md5_resp, Some(29)),
-            "protocol 29 should reject MD5"
-        );
+        assert!(!verify_client_response(
+            password,
+            &challenge,
+            &sha512_resp,
+            DaemonAuthDigest::Md5
+        ));
     }
 
     /// Validates that `digests_for_protocol` returns the correct set for each era.

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -30,13 +30,9 @@ use tracing::instrument;
 
 use std::process::{Command as ProcessCommand, Stdio};
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD_NO_PAD;
-
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
-use checksums::strong::{Md4, Md5};
 use clap::{Arg, ArgAction, Command, builder::OsStringValueParser};
 use core::client::TcpFastOpenMode;
 use core::{

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -40,7 +40,10 @@ use checksums::strong::{Md4, Md5};
 use clap::{Arg, ArgAction, Command, builder::OsStringValueParser};
 use core::client::TcpFastOpenMode;
 use core::{
-    auth::{digests_for_protocol, verify_daemon_auth_response},
+    auth::{
+        DaemonAuthDigest, digests_for_protocol, negotiate_server_daemon_digest,
+        supported_daemon_digest_list, verify_daemon_auth_response,
+    },
     bandwidth::{
         BandwidthLimitComponents, BandwidthLimiter, BandwidthParseError, LimiterChange,
         parse_bandwidth_limit,
@@ -58,7 +61,8 @@ use logging_sink::MessageSink;
 use protocol::{
     LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonMessage, MessageCode, MessageFrame, ProtocolVersion,
     filters::FilterRuleWireFormat, format_legacy_daemon_message, iconv::FilenameConverter,
-    is_version_banner, missing_greeting_token, parse_legacy_daemon_message,
+    is_version_banner, missing_greeting_token, parse_legacy_daemon_greeting_details,
+    parse_legacy_daemon_message,
 };
 
 use crate::{
@@ -147,6 +151,21 @@ pub(crate) const ACCESS_DENIED_PAYLOAD: &str =
 ///
 /// upstream: clientserver.c:764 - `@ERROR: auth failed on module %s\n`
 pub(crate) const AUTH_FAILED_PAYLOAD: &str = "@ERROR: auth failed on module {module}";
+/// Error payload sent when no digest the client offered is supported here.
+///
+/// `{digests}` is replaced with this build's own daemon-auth list, exactly as
+/// upstream re-renders `get_default_nno_list()` into the message.
+///
+/// upstream: compat.c:872-874 - `@ERROR: your client does not support one of our
+/// daemon-auth checksums: %s\n`, followed by `exit_cleanup(RERR_UNSUPPORTED)`.
+pub(crate) const UNSUPPORTED_AUTH_DIGEST_PAYLOAD: &str =
+    "@ERROR: your client does not support one of our daemon-auth checksums: {digests}";
+/// Exit code used when the client and daemon share no auth digest.
+///
+/// upstream: compat.c:875 - `exit_cleanup(RERR_UNSUPPORTED)`. The refusal happens
+/// in the per-connection child, so the listening parent is unaffected; only the
+/// single-session modes (stdio, inetd) surface it as the process exit status.
+pub(crate) const UNSUPPORTED_AUTH_DIGEST_EXIT_CODE: ExitCode = ExitCode::Unsupported;
 /// Error payload returned when a requested module does not exist.
 ///
 /// upstream: clientserver.c:732 - `@ERROR: Unknown module '%s'\n`
@@ -430,7 +449,7 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
         log_connection(log, peer_host.as_deref(), peer_addr);
     }
 
-    handle_legacy_session(
+    let outcome = handle_legacy_session(
         stream,
         peer_addr,
         LegacySessionParams {
@@ -442,17 +461,9 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
             peer_host,
             reverse_lookup,
         },
-    )
-    .map_err(|error| {
-        DaemonError::new(
-            SOCKET_IO_EXIT_CODE,
-            rsync_error!(
-                SOCKET_IO_EXIT_CODE,
-                format!("stdio daemon session failed: {error}")
-            )
-            .with_role(Role::Daemon),
-        )
-    })
+    );
+
+    single_session_exit(outcome, "stdio daemon session failed")
 }
 
 /// Runs the daemon orchestration using the hybrid tokio listener.

--- a/crates/daemon/src/daemon/sections/inetd.rs
+++ b/crates/daemon/src/daemon/sections/inetd.rs
@@ -122,7 +122,7 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
         log_connection(log, peer_host.as_deref(), peer_addr);
     }
 
-    handle_legacy_session(
+    let outcome = handle_legacy_session(
         stream,
         peer_addr,
         LegacySessionParams {
@@ -134,17 +134,9 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
             peer_host,
             reverse_lookup,
         },
-    )
-    .map_err(|error| {
-        DaemonError::new(
-            SOCKET_IO_EXIT_CODE,
-            rsync_error!(
-                SOCKET_IO_EXIT_CODE,
-                format!("inetd daemon session failed: {error}")
-            )
-            .with_role(Role::Daemon),
-        )
-    })
+    );
+
+    single_session_exit(outcome, "inetd daemon session failed")
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -22,6 +22,15 @@ enum AuthenticationStatus {
     },
     /// Authentication was denied (bad credentials or missing response).
     Denied,
+    /// No digest the client offered is implemented here, so the exchange cannot
+    /// start. The refusal line has already been written and no challenge was
+    /// sent.
+    ///
+    /// upstream: compat.c:871-875 - `negotiate_daemon_auth()` writes
+    /// `@ERROR: your client does not support one of our daemon-auth checksums`
+    /// and calls `exit_cleanup(RERR_UNSUPPORTED)` before `auth_server()` ever
+    /// reaches `gen_challenge()`.
+    DigestUnsupported,
 }
 
 /// Resolves the session's effective `read only` flag after authentication.
@@ -54,12 +63,16 @@ fn access_effective_read_only(module_read_only: bool, access: UserAccessLevel) -
 /// 2. Reads the client's response containing username and digest
 /// 3. Verifies the digest against the module's secrets file
 ///
-/// The `protocol_version` determines which digest algorithm to use for legacy
-/// (MD4/MD5) responses when the response length is ambiguous.
+/// `client_digests` is the digest name list the client advertised in its
+/// `@RSYNCD:` greeting; it fixes the single algorithm used for both the challenge
+/// and the verification.
 ///
-/// upstream: compat.c:858 - `protocol_version >= 30 ? "md5" : "md4"`
+/// upstream: authenticate.c:242 - `auth_server()` calls
+/// `negotiate_daemon_auth(f_out, 0)` *before* `gen_challenge()`, so a client with
+/// no acceptable digest is refused without ever receiving a challenge.
 ///
-/// Returns `Granted` if authentication succeeded, `Denied` otherwise.
+/// Returns `Granted` if authentication succeeded, `Denied` on bad credentials, or
+/// `DigestUnsupported` when negotiation found no mutual algorithm.
 fn perform_module_authentication(
     reader: &mut BufReader<DaemonStream>,
     limiter: &mut Option<BandwidthLimiter>,
@@ -67,8 +80,26 @@ fn perform_module_authentication(
     peer_ip: IpAddr,
     messages: &LegacyMessageCache,
     protocol_version: Option<ProtocolVersion>,
+    client_digests: Option<&str>,
 ) -> io::Result<AuthenticationStatus> {
-    let challenge = generate_auth_challenge(peer_ip, protocol_version);
+    // upstream: authenticate.c:76 `gen_challenge` and :90 `generate_hash` both
+    // call `sum_init(valid_auth_checksums.negotiated_nni, 0)`, so one negotiated
+    // digest drives both halves. Deriving it from the response instead would let
+    // the client choose which algorithm it is checked against.
+    let digest = match negotiate_server_daemon_digest(
+        client_digests,
+        protocol_version.map_or(ProtocolVersion::NEWEST.as_u8(), |v| v.as_u8()),
+    ) {
+        Ok(digest) => digest,
+        Err(_) => {
+            let payload = UNSUPPORTED_AUTH_DIGEST_PAYLOAD
+                .replace("{digests}", &supported_daemon_digest_list());
+            send_error(reader.get_mut(), limiter, &payload)?;
+            return Ok(AuthenticationStatus::DigestUnsupported);
+        }
+    };
+
+    let challenge = generate_auth_challenge(peer_ip, digest);
     {
         let stream = reader.get_mut();
         messages.write(
@@ -90,11 +121,11 @@ fn perform_module_authentication(
 
     let mut segments = response.splitn(2, |ch: char| ch.is_ascii_whitespace());
     let username = segments.next().unwrap_or_default();
-    let digest = segments.next().map_or("", |segment| {
+    let response_digest = segments.next().map_or("", |segment| {
         segment.trim_start_matches(|ch: char| ch.is_ascii_whitespace())
     });
 
-    if username.is_empty() || digest.is_empty() {
+    if username.is_empty() || response_digest.is_empty() {
         send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied);
     }
@@ -114,14 +145,7 @@ fn perform_module_authentication(
     // never match. The matched entry's verbatim token carries that group.
     let auth_group = auth_user.username.strip_prefix('@');
 
-    if !verify_secret_response(
-        module,
-        username,
-        auth_group,
-        &challenge,
-        digest,
-        protocol_version,
-    )? {
+    if !verify_secret_response(module, username, auth_group, &challenge, response_digest, digest)? {
         send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied);
     }
@@ -145,16 +169,15 @@ fn perform_module_authentication(
 /// Generates a unique authentication challenge string.
 ///
 /// The challenge is created by combining the peer IP address, current timestamp,
-/// and process ID, then hashing with the protocol-appropriate digest and encoding
-/// as base64. This produces a unique, time-sensitive challenge for each
+/// and process ID, then hashing with the negotiated digest and encoding as
+/// base64. This produces a unique, time-sensitive challenge for each
 /// authentication attempt.
 ///
-/// upstream: compat.c:858 - the digest used for the challenge depends on the
-/// negotiated protocol version: MD5 for protocol >= 30, MD4 for protocol < 30.
-fn generate_auth_challenge(
-    peer_ip: IpAddr,
-    protocol_version: Option<ProtocolVersion>,
-) -> String {
+/// upstream: authenticate.c:62-81 `gen_challenge()` - a 32-byte zeroed buffer
+/// holding `strlcpy(input, addr, 17)`, `SIVAL(input, 16, tv_sec)`,
+/// `SIVAL(input, 20, tv_usec)` and `SIVAL(input, 24, getpid())`, hashed with
+/// `valid_auth_checksums.negotiated_nni`. `SIVAL` is little-endian by definition.
+fn generate_auth_challenge(peer_ip: IpAddr, digest: DaemonAuthDigest) -> String {
     let mut input = [0u8; 32];
     let address_text = peer_ip.to_string();
     let address_bytes = address_text.as_bytes();
@@ -172,17 +195,7 @@ fn generate_auth_challenge(
     input[20..24].copy_from_slice(&micros.to_le_bytes());
     input[24..28].copy_from_slice(&pid.to_le_bytes());
 
-    let version = protocol_version.map_or(32, |v| v.as_u8());
-    let digest = if version >= 30 {
-        let mut hasher = Md5::new();
-        hasher.update(&input);
-        hasher.finalize().to_vec()
-    } else {
-        let mut hasher = Md4::new();
-        hasher.update(&input);
-        hasher.finalize().to_vec()
-    };
-    STANDARD_NO_PAD.encode(digest)
+    digest.base64_digest(&[&input])
 }
 
 /// Verifies a client's authentication response against the secrets file.
@@ -208,8 +221,9 @@ fn generate_auth_challenge(
 /// `(st.st_mode & 06) != 0`, and on a password mismatch sets `*ptr = NULL`
 /// ("Don't look for name again").
 ///
-/// The `protocol_version` is forwarded to `verify_daemon_auth_response` to
-/// select the correct digest for ambiguous MD4/MD5 responses.
+/// `digest` is the algorithm fixed by `negotiate_server_daemon_digest`; the same
+/// one that produced the challenge, exactly as upstream reuses
+/// `valid_auth_checksums.negotiated_nni` for both.
 ///
 /// Returns `true` if a matching key's digest matches, `false` otherwise.
 fn verify_secret_response(
@@ -218,7 +232,7 @@ fn verify_secret_response(
     group: Option<&str>,
     challenge: &str,
     response: &str,
-    protocol_version: Option<ProtocolVersion>,
+    digest: DaemonAuthDigest,
 ) -> io::Result<bool> {
     let secrets_path = match &module.secrets_file {
         Some(path) => path,
@@ -280,12 +294,7 @@ fn verify_secret_response(
         // upstream: authenticate.c:158-163 - the first key-matching line decides
         // the outcome; a digest match authenticates, a mismatch retires the key
         // (`*ptr = NULL`) so later duplicates cannot flip the denial.
-        if verify_daemon_auth_response(
-            secret.as_bytes(),
-            challenge,
-            response,
-            protocol_version.map(|v| v.as_u8()),
-        ) {
+        if verify_daemon_auth_response(secret.as_bytes(), challenge, response, digest) {
             return Ok(true);
         }
         *active = false;

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -32,6 +32,19 @@ struct ModuleRequestContext<'a> {
     /// upstream: clientserver.c:583-584 - the daemon writes `early_input` to
     /// the pre-xfer exec script's stdin.
     early_input_data: Option<Vec<u8>>,
+    /// Digest name list the client advertised in its `@RSYNCD:` greeting.
+    ///
+    /// upstream: clientserver.c:199-211 - `exchange_protocols()` stores it in the
+    /// `daemon_auth_choices` global, which `negotiate_daemon_auth()` consumes at
+    /// authentication time (compat.c:857).
+    client_digests: Option<&'a str>,
+    /// Set when the session must end the way upstream's forked child would
+    /// `exit_cleanup()`, carrying that exit code.
+    ///
+    /// The listening parent is never torn down by it: only the single-session
+    /// modes (stdio, inetd), where the process *is* the connection, surface it as
+    /// the process exit status.
+    session_exit_code: &'a mut Option<ExitCode>,
     /// Typed FSM state tracking the connection lifecycle phase.
     ///
     /// Every phase transition goes through `ConnectionState::transition()`,
@@ -448,7 +461,18 @@ fn handle_authentication(
         ctx.peer_ip,
         ctx.messages,
         protocol_version,
+        ctx.client_digests,
     )? {
+        AuthenticationStatus::DigestUnsupported => {
+            // upstream: compat.c:875 - `exit_cleanup(RERR_UNSUPPORTED)` right
+            // after the refusal line, with no challenge and no auth-failure log.
+            *ctx.session_exit_code = Some(UNSUPPORTED_AUTH_DIGEST_EXIT_CODE);
+            ctx.conn_state = ctx
+                .conn_state
+                .transition(ConnectionState::Closing)
+                .map_err(transition_error)?;
+            Ok(None)
+        }
         AuthenticationStatus::Denied => {
             if let Some(log) = ctx.log_sink {
                 log_module_auth_failure(log, ctx.effective_host(), ctx.peer_ip, ctx.request);
@@ -539,6 +563,8 @@ fn respond_with_module_request(
     reverse_lookup: bool,
     messages: &LegacyMessageCache,
     negotiated_protocol: Option<ProtocolVersion>,
+    client_digests: Option<&str>,
+    session_exit_code: &mut Option<ExitCode>,
     early_input_data: Option<Vec<u8>>,
     conn_state: ConnectionState,
 ) -> io::Result<()> {
@@ -602,6 +628,8 @@ fn respond_with_module_request(
         log_sink,
         messages,
         early_input_data,
+        client_digests,
+        session_exit_code,
         conn_state,
     };
 

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -6,7 +6,7 @@ mod module_access_tests {
     #[test]
     fn generate_auth_challenge_includes_ip_and_timestamp() {
         let peer_ip = "192.168.1.1".parse::<IpAddr>().unwrap();
-        let challenge = generate_auth_challenge(peer_ip, Some(ProtocolVersion::V32));
+        let challenge = generate_auth_challenge(peer_ip, DaemonAuthDigest::Md5);
 
         // Challenge should be base64-encoded hash (22 characters without padding)
         assert_eq!(challenge.len(), 22);
@@ -18,9 +18,9 @@ mod module_access_tests {
     }
 
     #[test]
-    fn generate_auth_challenge_uses_md4_for_legacy_protocol() {
+    fn generate_auth_challenge_uses_the_negotiated_md4_digest() {
         let peer_ip = "192.168.1.1".parse::<IpAddr>().unwrap();
-        let challenge = generate_auth_challenge(peer_ip, Some(ProtocolVersion::V29));
+        let challenge = generate_auth_challenge(peer_ip, DaemonAuthDigest::Md4);
 
         // MD4 also produces 16-byte hash = 22 base64 characters
         assert_eq!(challenge.len(), 22);
@@ -34,12 +34,12 @@ mod module_access_tests {
     #[test]
     fn generate_auth_challenge_produces_different_values() {
         let peer_ip = "10.0.0.1".parse::<IpAddr>().unwrap();
-        let challenge1 = generate_auth_challenge(peer_ip, Some(ProtocolVersion::V32));
+        let challenge1 = generate_auth_challenge(peer_ip, DaemonAuthDigest::Md5);
 
         // Retry until the microsecond timestamp changes (bounded)
         let mut challenge2 = challenge1.clone();
         for i in 0..200 {
-            challenge2 = generate_auth_challenge(peer_ip, Some(ProtocolVersion::V32));
+            challenge2 = generate_auth_challenge(peer_ip, DaemonAuthDigest::Md5);
             if challenge2 != challenge1 {
                 break;
             }
@@ -779,7 +779,7 @@ mod module_access_tests {
         // violation is an auth denial, not a fatal error: verify returns
         // Ok(false) so the daemon emits `@ERROR: auth failed on module X`
         // rather than dropping the socket mid-handshake.
-        let result = verify_secret_response(&module, "alice", None, "challenge", "response", None)
+        let result = verify_secret_response(&module, "alice", None, "challenge", "response", DaemonAuthDigest::Md5)
             .expect("strict-modes violation must be a denial, not an io error");
         assert!(
             !result,
@@ -804,7 +804,7 @@ mod module_access_tests {
 
         // With strict_modes disabled, the file is read even though it's world-readable.
         // Authentication will fail (wrong response), but no permission error is returned.
-        let result = verify_secret_response(&module, "alice", None, "challenge", "response", None)
+        let result = verify_secret_response(&module, "alice", None, "challenge", "response", DaemonAuthDigest::Md5)
             .expect("should not error on permissions");
         assert!(
             !result,
@@ -829,7 +829,7 @@ mod module_access_tests {
 
         // Permissions are fine, so the file is read. Auth will fail (wrong response)
         // but no permission error is returned.
-        let result = verify_secret_response(&module, "alice", None, "challenge", "response", None)
+        let result = verify_secret_response(&module, "alice", None, "challenge", "response", DaemonAuthDigest::Md5)
             .expect("should not error on permissions");
         assert!(!result, "auth should fail due to wrong response");
     }
@@ -870,13 +870,13 @@ mod module_access_tests {
 
         // Authorized via the `@devs` token: the group line is the credential.
         let granted =
-            verify_secret_response(&module, "alice", Some("devs"), challenge, &response, None)
+            verify_secret_response(&module, "alice", Some("devs"), challenge, &response, DaemonAuthDigest::Md5)
                 .expect("no io error");
         assert!(granted, "group member must authenticate via @devs shared secret");
 
         // upstream: authenticate.c:318 - a plain-username authorization passes a
         // NULL group, so `@group:` lines are never consulted. Denied here.
-        let denied = verify_secret_response(&module, "alice", None, challenge, &response, None)
+        let denied = verify_secret_response(&module, "alice", None, challenge, &response, DaemonAuthDigest::Md5)
             .expect("no io error");
         assert!(
             !denied,
@@ -908,7 +908,7 @@ mod module_access_tests {
 
         // The first `alice:` line mismatches, retiring the username; the later
         // `alice:rightpass` duplicate must NOT authenticate.
-        let denied = verify_secret_response(&module, "alice", None, challenge, &response, None)
+        let denied = verify_secret_response(&module, "alice", None, challenge, &response, DaemonAuthDigest::Md5)
             .expect("no io error");
         assert!(
             !denied,
@@ -924,7 +924,7 @@ mod module_access_tests {
             ..Default::default()
         };
         let granted =
-            verify_secret_response(&module_ok, "alice", None, challenge, &response, None)
+            verify_secret_response(&module_ok, "alice", None, challenge, &response, DaemonAuthDigest::Md5)
                 .expect("no io error");
         assert!(granted, "a correct first line must authenticate");
     }

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -108,19 +108,26 @@ fn handle_session(
 
     match style {
         SessionStyle::Binary => handle_binary_session(stream, daemon_limit, daemon_burst, log_sink),
-        SessionStyle::Legacy => handle_legacy_session(
-            stream,
-            peer_addr,
-            LegacySessionParams {
-                modules,
-                motd_lines,
-                daemon_limit,
-                daemon_burst,
-                log_sink,
-                peer_host,
-                reverse_lookup,
-            },
-        ),
+        SessionStyle::Legacy => {
+            // upstream: clientserver.c - the per-connection child owns its own
+            // `exit_cleanup()`, so a session-fatal refusal never reaches the
+            // listening parent. Drop the code here for the same reason: it must
+            // not tear down the accept loop.
+            handle_legacy_session(
+                stream,
+                peer_addr,
+                LegacySessionParams {
+                    modules,
+                    motd_lines,
+                    daemon_limit,
+                    daemon_burst,
+                    log_sink,
+                    peer_host,
+                    reverse_lookup,
+                },
+            )
+            .map(|_| ())
+        }
     }
 }
 
@@ -205,6 +212,33 @@ fn write_limited(
     }
 }
 
+/// Maps the outcome of a single-session daemon run onto a process exit status.
+///
+/// The stdio and inetd entry points serve exactly one connection, so the process
+/// plays the role of upstream's per-connection child: a session-fatal refusal
+/// becomes the exit status, exactly as `exit_cleanup()` ends that child. An I/O
+/// failure keeps the existing socket-IO code and `{context}: {error}` wording.
+pub(crate) fn single_session_exit(
+    outcome: io::Result<Option<ExitCode>>,
+    context: &str,
+) -> Result<(), DaemonError> {
+    match outcome {
+        Ok(None) => Ok(()),
+        Ok(Some(exit)) => {
+            let code = exit.as_i32();
+            Err(DaemonError::new(
+                code,
+                rsync_error!(code, exit.description()).with_role(Role::Daemon),
+            ))
+        }
+        Err(error) => Err(DaemonError::new(
+            SOCKET_IO_EXIT_CODE,
+            rsync_error!(SOCKET_IO_EXIT_CODE, format!("{context}: {error}"))
+                .with_role(Role::Daemon),
+        )),
+    }
+}
+
 /// Runs the legacy `@RSYNCD:` session protocol for a single connection.
 ///
 /// Sends the greeting with the protocol version and supported digest list,
@@ -215,12 +249,18 @@ fn write_limited(
 /// 1. Server sends `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n`
 /// 2. Client responds with `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n`
 /// 3. Client sends module name (or `#list`)
+///
+/// Returns `Some(code)` when the session ended the way upstream's per-connection
+/// child ends on `exit_cleanup()` (currently only compat.c:875's
+/// `RERR_UNSUPPORTED` auth-digest refusal). Upstream forks per connection, so the
+/// listening parent is unaffected; only the single-session entry points (stdio,
+/// inetd) turn the code into a process exit status.
 #[cfg_attr(feature = "tracing", instrument(skip(stream, params), fields(peer = %peer_addr), name = "legacy_session"))]
 fn handle_legacy_session(
     stream: DaemonStream,
     peer_addr: SocketAddr,
     params: LegacySessionParams<'_>,
-) -> io::Result<()> {
+) -> io::Result<Option<ExitCode>> {
     let LegacySessionParams {
         modules,
         motd_lines,
@@ -266,6 +306,8 @@ fn handle_legacy_session(
     let mut request = None;
     let mut refused_options = Vec::new();
     let mut negotiated_protocol = None;
+    let mut client_digests: Option<String> = None;
+    let mut session_exit_code: Option<ExitCode> = None;
     let mut early_input_data: Option<Vec<u8>> = None;
 
     // TCP_QUICKACK is one-shot; re-arm before each handshake read so every
@@ -288,10 +330,18 @@ fn handle_legacy_session(
             reader.get_mut().flush()?;
             // FSM: -> Closing after the fatal @ERROR refusal.
             let _ = conn_state.transition(ConnectionState::Closing);
-            return Ok(());
+            return Ok(None);
         }
         match parse_legacy_daemon_message(&line) {
             Ok(LegacyDaemonMessage::Version(version)) => {
+                // upstream: clientserver.c:199-203 exchange_protocols() -
+                // `daemon_auth_choices = strchr(buf + 9, ' ')` keeps the client's
+                // digest name list for negotiate_daemon_auth(). The Version
+                // variant carries only the version, so re-parse the raw line for
+                // the rest of it.
+                client_digests = parse_legacy_daemon_greeting_details(&line)
+                    .ok()
+                    .and_then(|greeting| greeting.digest_list().map(ToOwned::to_owned));
                 // Record the negotiated protocol version but do NOT send @RSYNCD: OK here.
                 // The OK is only sent after the module is selected and approved, not after
                 // the version exchange. Sending OK here causes the client to misinterpret
@@ -313,7 +363,7 @@ fn handle_legacy_session(
             Ok(LegacyDaemonMessage::Exit) => {
                 // FSM: -> Closing on client-initiated exit.
                 let _ = conn_state.transition(ConnectionState::Closing);
-                return Ok(());
+                return Ok(None);
             }
             Ok(
                 LegacyDaemonMessage::Ok
@@ -386,12 +436,14 @@ fn handle_legacy_session(
             reverse_lookup,
             messages,
             negotiated_protocol,
+            client_digests.as_deref(),
+            &mut session_exit_code,
             early_input_data,
             conn_state,
         )?;
     }
 
-    Ok(())
+    Ok(session_exit_code)
 }
 
 /// Command prefix for the early-input protocol message.

--- a/crates/daemon/src/daemon/sections/stdio_session.rs
+++ b/crates/daemon/src/daemon/sections/stdio_session.rs
@@ -111,7 +111,7 @@ pub fn run_stdio_session(
     // loopback address as the synthetic peer for log messages and access checks.
     let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
-    handle_legacy_session(
+    let outcome = handle_legacy_session(
         stream,
         peer_addr,
         LegacySessionParams {
@@ -123,12 +123,7 @@ pub fn run_stdio_session(
             peer_host: Some("localhost".to_owned()),
             reverse_lookup,
         },
-    )
-    .map_err(|error| {
-        DaemonError::new(
-            SOCKET_IO_EXIT_CODE,
-            rsync_error!(SOCKET_IO_EXIT_CODE, format!("stdio daemon session failed: {error}"))
-                .with_role(Role::Daemon),
-        )
-    })
+    );
+
+    single_session_exit(outcome, "stdio daemon session failed")
 }

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -33,6 +33,7 @@ use crate::daemon::{
     // From runtime_options.rs
     RuntimeOptions,
     TestSecretsEnvOverride,
+    UNSUPPORTED_AUTH_DIGEST_EXIT_CODE,
     advertised_capability_lines,
     // From sections/module_access.rs
     apply_module_bandwidth_limit,
@@ -71,7 +72,6 @@ use crate::daemon::{
     set_test_netgroup_members,
     // From sections/session_runtime.rs
     single_session_exit,
-    UNSUPPORTED_AUTH_DIGEST_EXIT_CODE,
 };
 
 // Only the unix-only post-xfer-exec abort test references this constant, so

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -69,6 +69,9 @@ use crate::daemon::{
     set_test_forward_override,
     set_test_hostname_override,
     set_test_netgroup_members,
+    // From sections/session_runtime.rs
+    single_session_exit,
+    UNSUPPORTED_AUTH_DIGEST_EXIT_CODE,
 };
 
 // Only the unix-only post-xfer-exec abort test references this constant, so
@@ -77,6 +80,7 @@ use crate::daemon::{
 use crate::daemon::MODULE_ABORT_EXIT_CODE;
 
 use core::{
+    auth::DaemonAuthDigest,
     bandwidth::{BandwidthLimiter, LimiterChange},
     branding::{self, Brand},
     exit_code::ExitCode,
@@ -280,6 +284,7 @@ include!("tests/chunks/daemon_delta_transfer.rs");
 include!("tests/chunks/daemon_negotiation_module_listing.rs");
 include!("tests/chunks/daemon_module_implicit_list_only.rs");
 include!("tests/chunks/daemon_negotiation_empty_module_lists_modules.rs");
+include!("tests/chunks/daemon_auth_digest_negotiation.rs");
 include!("tests/chunks/daemon_negotiation_authentication.rs");
 include!("tests/chunks/daemon_negotiation_version.rs");
 include!("tests/chunks/daemon_negotiation_error_handling.rs");

--- a/crates/daemon/src/tests/chunks/daemon_auth_digest_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/daemon_auth_digest_negotiation.rs
@@ -111,8 +111,11 @@ fn daemon_auth_uses_the_first_client_offered_digest_it_supports() {
 
     drop(reader);
     drop(stream);
-    let result = handle.join().expect("daemon thread");
-    assert!(result.is_ok(), "daemon should exit cleanly: {result:?}");
+    // Bounded join: an unconditional join() can wedge on Windows, where a
+    // blocking accept on a re-bound listener may linger (see finish_daemon).
+    if let Some(result) = finish_daemon(handle) {
+        assert!(result.is_ok(), "daemon should exit cleanly: {result:?}");
+    }
 }
 
 /// A client that negotiated a weak digest cannot present a response computed with
@@ -159,8 +162,11 @@ fn daemon_auth_rejects_a_response_computed_with_a_non_negotiated_digest() {
 
     drop(reader);
     drop(stream);
-    let result = handle.join().expect("daemon thread");
-    assert!(result.is_ok(), "daemon should exit cleanly: {result:?}");
+    // Bounded join: an unconditional join() can wedge on Windows, where a
+    // blocking accept on a re-bound listener may linger (see finish_daemon).
+    if let Some(result) = finish_daemon(handle) {
+        assert!(result.is_ok(), "daemon should exit cleanly: {result:?}");
+    }
 }
 
 /// When the client's list names nothing this build implements, the daemon refuses
@@ -195,8 +201,11 @@ fn daemon_auth_refuses_a_client_with_no_mutual_digest() {
 
     drop(reader);
     drop(stream);
-    let result = handle.join().expect("daemon thread");
-    assert!(result.is_ok(), "the listener survives a refused client");
+    // Bounded join: an unconditional join() can wedge on Windows, where a
+    // blocking accept on a re-bound listener may linger (see finish_daemon).
+    if let Some(result) = finish_daemon(handle) {
+        assert!(result.is_ok(), "the listener survives a refused client: {result:?}");
+    }
 }
 
 /// An unprotected module never negotiates, so a foreign digest list is harmless
@@ -251,7 +260,7 @@ fn daemon_skips_digest_negotiation_when_the_module_needs_no_auth() {
 
     drop(reader);
     drop(stream);
-    let _ = handle.join().expect("daemon thread");
+    let _ = finish_daemon(handle);
 }
 
 /// A protocol > 31 greeting that carries no digest list at all is refused before
@@ -288,7 +297,7 @@ fn daemon_refuses_a_protocol_32_greeting_without_a_digest_list() {
 
     drop(reader);
     drop(stream);
-    let _ = handle.join().expect("daemon thread");
+    let _ = finish_daemon(handle);
 }
 
 /// The single-session entry points (stdio, inetd) surface a session-fatal refusal

--- a/crates/daemon/src/tests/chunks/daemon_auth_digest_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/daemon_auth_digest_negotiation.rs
@@ -33,6 +33,7 @@ fn start_auth_digest_daemon(dir: &Path) -> (TcpStream, thread::JoinHandle<Result
         .arguments([
             OsString::from("--port"),
             OsString::from(port.to_string()),
+            OsString::from("--no-detach"),
             OsString::from("--once"),
             OsString::from("--config"),
             config_path.as_os_str().to_os_string(),
@@ -228,6 +229,7 @@ fn daemon_skips_digest_negotiation_when_the_module_needs_no_auth() {
         .arguments([
             OsString::from("--port"),
             OsString::from(port.to_string()),
+            OsString::from("--no-detach"),
             OsString::from("--once"),
             OsString::from("--config"),
             config_path.as_os_str().to_os_string(),

--- a/crates/daemon/src/tests/chunks/daemon_auth_digest_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/daemon_auth_digest_negotiation.rs
@@ -1,0 +1,310 @@
+/// Spins up a one-shot daemon serving a single auth-protected module named
+/// `protected` whose secrets file grants `alice:correctpassword`, and returns the
+/// connected client socket plus the daemon thread handle.
+///
+/// The caller has already consumed nothing: the server greeting is still queued.
+fn start_auth_digest_daemon(dir: &Path) -> (TcpStream, thread::JoinHandle<Result<(), crate::DaemonError>>) {
+    let module_dir = dir.join("module");
+    fs::create_dir_all(&module_dir).expect("module dir");
+    let secrets_path = dir.join("secrets.txt");
+    fs::write(&secrets_path, "alice:correctpassword\n").expect("write secrets");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&secrets_path, PermissionsExt::from_mode(0o600))
+            .expect("chmod secrets");
+    }
+
+    let config_path = dir.join("rsyncd.conf");
+    fs::write(
+        &config_path,
+        format!(
+            "[protected]\npath = {}\nauth users = alice\nsecrets file = {}\nuse chroot = false\n",
+            module_dir.display(),
+            secrets_path.display()
+        ),
+    )
+    .expect("write config");
+
+    let (port, held_listener) = allocate_test_port();
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--once"),
+            OsString::from("--config"),
+            config_path.as_os_str().to_os_string(),
+        ])
+        .build();
+
+    start_daemon(config, port, held_listener)
+}
+
+/// Drives the handshake up to the point where the daemon has answered the
+/// `protected` module request, returning that answer line.
+///
+/// `greeting` is the client's verbatim `@RSYNCD:` line including its digest list
+/// (or lack of one).
+fn negotiate_protected_module(
+    stream: &mut TcpStream,
+    reader: &mut BufReader<TcpStream>,
+    greeting: &str,
+) -> String {
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("server greeting");
+    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+
+    stream
+        .write_all(greeting.as_bytes())
+        .expect("send client greeting");
+    stream.write_all(b"protected\n").expect("send module request");
+    stream.flush().expect("flush handshake");
+
+    line.clear();
+    reader.read_line(&mut line).expect("daemon answer");
+    line.trim_end().to_owned()
+}
+
+/// The digest the daemon negotiated must drive the challenge it sends *and* the
+/// response it accepts. With `md5 sha512` offered, upstream's server-side rule
+/// takes the client's first acceptable name - MD5 - not the strongest one.
+///
+/// upstream: compat.c:354 - `if (best == 1 || am_server) break;` stops the walk of
+/// the client's list at its first supported entry; authenticate.c:76 and :90 then
+/// both hash with `valid_auth_checksums.negotiated_nni`.
+#[test]
+fn daemon_auth_uses_the_first_client_offered_digest_it_supports() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("config dir");
+    let (mut stream, handle) = start_auth_digest_daemon(dir.path());
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let answer = negotiate_protected_module(&mut stream, &mut reader, "@RSYNCD: 32.0 md5 sha512\n");
+    let challenge = answer
+        .strip_prefix("@RSYNCD: AUTHREQD ")
+        .unwrap_or_else(|| panic!("expected auth challenge, got: {answer}"));
+
+    // The challenge itself is MD5-sized, proving the negotiated digest - not the
+    // strongest mutually supported one - generated it.
+    assert_eq!(
+        challenge.len(),
+        DaemonAuthDigest::Md5.base64_len(),
+        "challenge must come from the negotiated MD5, not SHA-512"
+    );
+
+    let response =
+        core::auth::compute_daemon_auth_response(b"correctpassword", challenge, DaemonAuthDigest::Md5);
+    stream
+        .write_all(format!("alice {response}\n").as_bytes())
+        .expect("send response");
+    stream.flush().expect("flush response");
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("auth verdict");
+    assert_eq!(line.trim_end(), "@RSYNCD: OK");
+
+    drop(reader);
+    drop(stream);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok(), "daemon should exit cleanly: {result:?}");
+}
+
+/// A client that negotiated a weak digest cannot present a response computed with
+/// a different one, and vice versa. This is the downgrade case: before the digest
+/// was pinned at negotiation the verifier inferred the algorithm from the
+/// response *length*, so an 86-character SHA-512 response was checked as SHA-512
+/// no matter what the greeting had negotiated - letting the client choose.
+///
+/// upstream: authenticate.c:90 `generate_hash()` only ever hashes with
+/// `valid_auth_checksums.negotiated_nni`.
+#[test]
+fn daemon_auth_rejects_a_response_computed_with_a_non_negotiated_digest() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("config dir");
+    let (mut stream, handle) = start_auth_digest_daemon(dir.path());
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    // Offer SHA-512 first so it is what gets negotiated.
+    let answer = negotiate_protected_module(&mut stream, &mut reader, "@RSYNCD: 32.0 sha512 md5\n");
+    let challenge = answer
+        .strip_prefix("@RSYNCD: AUTHREQD ")
+        .unwrap_or_else(|| panic!("expected auth challenge, got: {answer}"));
+    assert_eq!(challenge.len(), DaemonAuthDigest::Sha512.base64_len());
+
+    // Answer with the correct password but the *wrong* (shorter) digest.
+    let short_response =
+        core::auth::compute_daemon_auth_response(b"correctpassword", challenge, DaemonAuthDigest::Md5);
+    assert_eq!(short_response.len(), DaemonAuthDigest::Md5.base64_len());
+    stream
+        .write_all(format!("alice {short_response}\n").as_bytes())
+        .expect("send response");
+    stream.flush().expect("flush response");
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("auth verdict");
+    assert_eq!(
+        line.trim_end(),
+        "@ERROR: auth failed on module protected",
+        "a digest other than the negotiated one must never authenticate"
+    );
+
+    drop(reader);
+    drop(stream);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok(), "daemon should exit cleanly: {result:?}");
+}
+
+/// When the client's list names nothing this build implements, the daemon refuses
+/// with upstream's exact wording - echoing its *own* list - and never sends a
+/// challenge.
+///
+/// upstream: compat.c:871-875 - `@ERROR: your client does not support one of our
+/// daemon-auth checksums: %s\n` followed by `exit_cleanup(RERR_UNSUPPORTED)`.
+/// Verified against rsync 3.4.4, which answers exactly this line and exits 4.
+#[test]
+fn daemon_auth_refuses_a_client_with_no_mutual_digest() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("config dir");
+    let (mut stream, handle) = start_auth_digest_daemon(dir.path());
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let answer =
+        negotiate_protected_module(&mut stream, &mut reader, "@RSYNCD: 32.0 sponge blake3\n");
+    assert_eq!(
+        answer,
+        "@ERROR: your client does not support one of our daemon-auth checksums: \
+         sha512 sha256 sha1 md5 md4"
+    );
+
+    // The refusal replaces the challenge: nothing else reaches the client.
+    let mut line = String::new();
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no challenge may follow the refusal, got: {line:?}");
+
+    drop(reader);
+    drop(stream);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok(), "the listener survives a refused client");
+}
+
+/// An unprotected module never negotiates, so a foreign digest list is harmless
+/// there.
+///
+/// upstream: authenticate.c:239-240 - `if (!users || !*users) return "";` returns
+/// before `negotiate_daemon_auth()` is ever called.
+#[test]
+fn daemon_skips_digest_negotiation_when_the_module_needs_no_auth() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("config dir");
+    let module_dir = dir.path().join("open");
+    fs::create_dir_all(&module_dir).expect("module dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(
+        &config_path,
+        format!(
+            "[open]\npath = {}\nuse chroot = false\n",
+            module_dir.display()
+        ),
+    )
+    .expect("write config");
+
+    let (port, held_listener) = allocate_test_port();
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--once"),
+            OsString::from("--config"),
+            config_path.as_os_str().to_os_string(),
+        ])
+        .build();
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("server greeting");
+    stream
+        .write_all(b"@RSYNCD: 32.0 sponge blake3\nopen\n")
+        .expect("send greeting and module");
+    stream.flush().expect("flush");
+
+    line.clear();
+    reader.read_line(&mut line).expect("daemon answer");
+    assert_eq!(line.trim_end(), "@RSYNCD: OK");
+
+    drop(reader);
+    drop(stream);
+    let _ = handle.join().expect("daemon thread");
+}
+
+/// A protocol > 31 greeting that carries no digest list at all is refused before
+/// any module is looked up.
+///
+/// upstream: clientserver.c:203-211 - `daemon_auth_choices` is NULL and
+/// `remote_protocol > 31`, so `exchange_protocols()` answers
+/// `@ERROR: your client omitted the digest name list: %s` echoing the raw line and
+/// returns -1. Verified against rsync 3.4.4.
+#[test]
+fn daemon_refuses_a_protocol_32_greeting_without_a_digest_list() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("config dir");
+    let (mut stream, handle) = start_auth_digest_daemon(dir.path());
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("server greeting");
+
+    stream
+        .write_all(b"@RSYNCD: 32.0\n")
+        .expect("send bare greeting");
+    stream.flush().expect("flush greeting");
+
+    line.clear();
+    reader.read_line(&mut line).expect("refusal");
+    assert_eq!(
+        line.trim_end(),
+        "@ERROR: your client omitted the digest name list: @RSYNCD: 32.0"
+    );
+
+    drop(reader);
+    drop(stream);
+    let _ = handle.join().expect("daemon thread");
+}
+
+/// The single-session entry points (stdio, inetd) surface a session-fatal refusal
+/// as the process exit status, the way upstream's forked child does.
+///
+/// upstream: compat.c:875 `exit_cleanup(RERR_UNSUPPORTED)`. Confirmed against
+/// rsync 3.4.4 driven as `rsync --server --daemon`: it prints the refusal and
+/// exits 4.
+#[test]
+fn single_session_exit_maps_a_refusal_to_upstream_exit_code_4() {
+    let clean = single_session_exit(Ok(None), "stdio daemon session failed");
+    assert!(clean.is_ok());
+
+    let refused = single_session_exit(
+        Ok(Some(UNSUPPORTED_AUTH_DIGEST_EXIT_CODE)),
+        "stdio daemon session failed",
+    );
+    let error = refused.expect_err("a refusal must not report success");
+    assert_eq!(error.exit_code(), ExitCode::Unsupported.as_i32());
+    assert_eq!(error.exit_code(), 4);
+}

--- a/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
@@ -66,10 +66,18 @@ fn run_daemon_accepts_valid_credentials() {
         .strip_prefix("@RSYNCD: AUTHREQD ")
         .expect("challenge prefix");
 
-    let mut hasher = Md5::new();
-    hasher.update(b"password");
-    hasher.update(challenge.as_bytes());
-    let digest = STANDARD_NO_PAD.encode(hasher.finalize());
+    // The greeting above offers sha512 first, and upstream's server takes the
+    // first client-offered name it supports rather than the strongest
+    // (compat.c:354 - `if (best == 1 || am_server) break;`), so the exchange is
+    // SHA-512. Verified against rsync 3.4.4: the same greeting yields an
+    // 86-character challenge and an MD5 response is refused.
+    assert_eq!(
+        challenge.len(),
+        DaemonAuthDigest::Sha512.base64_len(),
+        "sha512 leads the offered list, so it must be the negotiated digest"
+    );
+    let digest =
+        core::auth::compute_daemon_auth_response(b"password", challenge, DaemonAuthDigest::Sha512);
     let response_line = format!("alice {digest}\n");
     stream
         .write_all(response_line.as_bytes())
@@ -90,8 +98,14 @@ fn run_daemon_accepts_valid_credentials() {
     drop(stream);
     drop(reader);
 
-    // Verify the daemon thread completes successfully (no panic or timeout)
-    let result = handle.join().expect("daemon thread");
-    assert!(result.is_ok(), "daemon should handle connection close gracefully");
+    // Verify the daemon thread completes successfully (no panic or timeout).
+    // Bound the join: on Windows the accept loop can linger past the disconnect,
+    // so detach rather than wedge until nextest's 360s slow-timeout.
+    if let Some(result) = finish_daemon(handle) {
+        assert!(
+            result.is_ok(),
+            "daemon should handle connection close gracefully: {result:?}"
+        );
+    }
 }
 


### PR DESCRIPTION
The daemon parsed only the protocol *version* out of the client's `@RSYNCD:`
greeting and discarded the digest name list, so upstream's server-side
daemon-auth negotiation never ran. Two consequences:

1. The negotiated digest did not exist server-side, so the challenge was
   generated from a hardcoded protocol-version rule (MD5 at >= 30, MD4 below)
   regardless of what the client offered, and upstream's
   `@ERROR: your client does not support one of our daemon-auth checksums`
   refusal was unreachable.
2. Verification inferred the algorithm from the **response length**, which let
   the client decide which digest it was checked against - a downgrade surface.
   Upstream pins one digest at negotiation time and reuses it for both halves:
   `authenticate.c:76 gen_challenge()` and `:90 generate_hash()` both call
   `sum_init(valid_auth_checksums.negotiated_nni, 0)`.

## Changes

- Capture the client's digest list from the greeting and thread it to the
  authentication step (`clientserver.c:199-211` `daemon_auth_choices`).
- Add `negotiate_server_daemon_digest()`, implementing upstream's server rule:
  walk the *client's* list and stop at the first name we support, so client
  preference decides (`compat.c:333-356`, whose `am_server` branch breaks at the
  first acceptable client choice - not the strongest one).
- Negotiate inside the auth step, after the `auth users` check, so an
  unprotected module still never negotiates (`authenticate.c:239-240`
  `if (!users || !*users) return "";`).
- Emit the refusal with upstream's exact wording, echoing our own list, before
  any challenge is generated, and end the session with `RERR_UNSUPPORTED`
  (`compat.c:871-875`).
- Pin the negotiated digest to both the challenge and the verification, and
  delete the response-length sniffing (`digests_for_response`) outright rather
  than leaving it as a fallback, since a fallback would preserve the downgrade.
- Model `CSUM_MD4_OLD`. When the peer sends no digest list at all, upstream
  substitutes `protocol_version >= 30 ? "md5" : "md4"` and then rewrites that
  `md4` to `CSUM_MD4_OLD` (`compat.c:879-881`), which `sum_init()` seeds with
  four bytes (`checksum.c:604-610`) - zero here, as daemon auth always passes
  seed 0. An `md4` the peer names *explicitly* stays plain MD4.

## Verification against rsync 3.4.4

Every rule was checked against a real upstream daemon (banner
`rsync version 3.4.4 protocol version 32`) driven as `rsync --server --daemon`,
not against documentation:

| client greeting | upstream 3.4.4 |
|---|---|
| `32.0 md5 sha512` | 22-char challenge; MD5 accepted, SHA-1/256/512 rejected |
| `32.0 sha512 md5` | 86-char challenge; SHA-512 accepted, MD5 rejected |
| `32.0 md4` | plain MD4 (no seed prefix) |
| `29.0 md4` | plain MD4 |
| `29.0` (no list) | MD4 **with** the four-zero-byte seed prefix |
| `31.0` (no list) | MD5 |
| `32.0` (no list) | `@ERROR: your client omitted the digest name list: @RSYNCD: 32.0` |
| `32.0 sponge blake3`, protected module | `@ERROR: your client does not support one of our daemon-auth checksums: sha512 sha256 sha1 md5 md4`, **exit 4**, no challenge |
| `32.0 sponge blake3`, unprotected module | `@RSYNCD: OK` - no negotiation at all |

## Before / after

Identical probe, client offering `sha512 md5` against a protected module:

```
before:  challenge_len=22   verdict for an (unnegotiated) SHA-512 response: "@RSYNCD: OK"
after:   challenge_len=86   verdict for an (unnegotiated) MD5 response:     "@ERROR: auth failed on module protected"
upstream 3.4.4: challenge_len=86, MD5 rejected, SHA-512 accepted
```

Before the change the daemon ignored the list entirely *and* authenticated a
response computed with an algorithm nothing had negotiated. After it, the wire
behaviour matches upstream byte for byte.

## Tests

New `crates/daemon/src/tests/chunks/daemon_auth_digest_negotiation.rs` drives a
real auth-protected module end to end: first-client-choice negotiation used for
both challenge and verify, a non-negotiated digest rejected, the no-mutual-digest
refusal text with no challenge behind it, the omitted-list refusal, the
no-auth-module bypass, and the `RERR_UNSUPPORTED` exit-code mapping. Unit
coverage in `core::auth` pins the negotiation rule, the advertised list, and the
seeded-vs-plain MD4 distinction.

The new tests pass `--no-detach`. Without it the daemon forks and
`become_daemon()` calls `process::exit(0)` in the parent - which is the test
process - so the test would vanish mid-run and be scored as a pass. Existing
daemon tests using this harness do not pass the flag; that is noted separately
and left alone here.


## Known divergences left unfixed here (tracked separately)

Two greeting/negotiation gaps are deliberately out of scope for this PR. Both are
real and reachable - neither is theoretical:

1. **Trailing-space greeting grants access where upstream refuses.**
   `clientserver.c:199` is `daemon_auth_choices = strchr(buf + 9, ' ')`. For
   `@RSYNCD: 31.0 ` that finds the *trailing* space, so upstream holds a non-NULL
   **empty** string, takes the `if (daemon_auth_choices)` branch, fails
   `parse_negotiate_str()` on the empty walk, and refuses with exit 4. Confirmed
   against 3.4.4: `@RSYNCD: 31.0 ` is refused, `@RSYNCD: 31.0` is not. oc's shared
   greeting parser trims the remainder to `None`, so it takes the absent-list
   fallback and **authenticates**. One extra byte on an otherwise well-formed
   greeting is enough. Fixing it means changing the `None` / `Some("")` contract of
   a parser shared with the client path, so it belongs in its own change.

2. **Client-side no-mutual-choice fallback.** Where `recv_negotiate_str()` aborts
   with "Failed to negotiate a daemon auth checksum choice" (compat.c:383-386),
   oc's client still falls back to `default_legacy_digest`. This PR does not
   introduce that, but it does change what the wrong fallback emits: below
   protocol 30 it is now the seeded `Md4Old` rather than plain MD4.

Nothing in this PR depends on either behaviour; the server-side negotiation and
digest pinning below are correct independently of them.
