### PR TITLE
fix(core): follow symlinks when emitting --files-from implied parents

### DIFF
--- a/crates/transfer/src/generator/file_list/inc_recurse.rs
+++ b/crates/transfer/src/generator/file_list/inc_recurse.rs
@@ -27,6 +27,8 @@ use std::path::Path;
 use logging::debug_log;
 use protocol::flist::FileEntry;
 
+use super::super::io_error_flags;
+use super::super::protocol_io::SenderDiagnostic;
 use super::super::{DirSegment, GeneratorContext, PendingSegment, TaggedIndex};
 
 impl GeneratorContext {
@@ -35,12 +37,27 @@ impl GeneratorContext {
     /// Reorders `file_list` and `source_bases` so that initial (top-level)
     /// entries come first, then sub-directory entries in depth-first order. This
     /// makes NDX values correspond directly to indices in the reordered list.
+    ///
+    /// An entry whose parent directory is missing from the list cannot be
+    /// segmented; it is reported as a transfer error rather than emitted
+    /// silently, because the resulting initial-list row carries a non-empty
+    /// dirname and a conformant receiver aborts on it (`flist.c:2682-2697`).
     pub(in crate::generator) fn partition_file_list_for_inc_recurse(&mut self) {
         if !self.inc_recurse() || self.file_list.is_empty() {
             return;
         }
 
         let classification = Self::classify_file_list_entries(self.file_list.as_slice());
+        for name in &classification.orphans {
+            // upstream: flist.c:2691 - the receiver's wording for the same
+            // condition. Reported here, on the side that can name the offending
+            // source, and as FERROR_XFER so the run cannot exit 0 with a file
+            // list the peer will reject.
+            let text =
+                format!("rsync: [sender] parent directory is missing from the file list: {name}\n");
+            self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
+            self.add_io_error(io_error_flags::IOERR_GENERAL);
+        }
         self.reorder_and_build_segments(classification);
 
         debug_log!(
@@ -66,6 +83,7 @@ impl GeneratorContext {
         let mut dir_map: HashMap<String, (usize, usize, usize)> = HashMap::new();
         let mut initial_entries: Vec<TaggedIndex> = Vec::new();
         let mut segments: Vec<DirSegment> = Vec::new();
+        let mut orphans: Vec<String> = Vec::new();
         let mut node_id_counter: usize = 0;
 
         for (i, entry) in file_list.iter().enumerate() {
@@ -116,6 +134,19 @@ impl GeneratorContext {
                     node_id,
                 });
             } else {
+                // The parent directory is not in the file list, so there is no
+                // segment to attach this entry to. Upstream cannot reach this
+                // state - send_implied_dirs() emits every ancestor before its
+                // children - and its receiver treats it as fatal: an initial-list
+                // entry must have an empty dirname (flist.c:2682-2697) or the
+                // peer prints "ABORTING due to invalid path from sender" and
+                // exit_cleanup(RERR_UNSUPPORTED). Salvage the entry into the
+                // initial segment so the run does not desync here, but record it
+                // so the caller can report it instead of silently emitting a
+                // file list a conformant receiver rejects. A directory landing
+                // here is never registered in `dir_map`, so all of its children
+                // follow it in.
+                orphans.push(name.to_string());
                 initial_entries.push(TaggedIndex {
                     file_idx: i,
                     node_id: None,
@@ -128,6 +159,7 @@ impl GeneratorContext {
             segments,
             tree,
             num_dirs: node_id_counter,
+            orphans,
         }
     }
 
@@ -146,6 +178,7 @@ impl GeneratorContext {
             segments,
             mut tree,
             num_dirs,
+            orphans: _,
         } = cr;
 
         // Wrap in Option<T> for safe move-out by index.
@@ -275,4 +308,10 @@ struct ClassificationResult {
     tree: protocol::flist::DirectoryTree,
     /// Total number of directories (for pre-allocating dense lookup Vecs).
     num_dirs: usize,
+    /// Names of entries whose parent directory is absent from the file list.
+    ///
+    /// Always empty for a well-formed list: `send_implied_dirs()` guarantees
+    /// every ancestor precedes its children. See
+    /// [`GeneratorContext::partition_file_list_for_inc_recurse`].
+    orphans: Vec<String>,
 }

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -305,19 +305,32 @@ impl GeneratorContext {
                             continue;
                         }
                         let full = entry.base.join(&ancestor);
-                        if let Ok(meta) = std::fs::symlink_metadata(&full) {
-                            if meta.is_dir() {
-                                if let Ok(mut file_entry) =
-                                    self.create_entry(&full, ancestor.clone(), &meta)
-                                {
-                                    // upstream: flist.c:1949 - implied parents clear
-                                    // FLAG_CONTENT_DIR so a real upstream receiver does
-                                    // not scan them for --delete (over-delete data loss).
-                                    mark_implied_dir(&mut file_entry);
-                                    self.push_file_item(file_entry, full);
-                                }
-                            }
-                        }
+                        // upstream: flist.c:1983-1985 - send_implied_dirs() sets
+                        // `copy_links = xfer_dirs = 1` around the ancestor loop, so
+                        // the implied-parent stat FOLLOWS symlinks. symlink_metadata
+                        // reports a symlinked ancestor as a non-directory and drops
+                        // it, leaving the receiver with `link/file` and no `link`;
+                        // an upstream receiver rejects that with "ABORTING due to
+                        // invalid path from sender" (flist.c:2691, exit 4).
+                        let meta = match std::fs::metadata(&full) {
+                            Ok(m) if m.is_dir() => m,
+                            _ => continue,
+                        };
+                        let Ok(mut file_entry) = self.create_entry(&full, ancestor.clone(), &meta)
+                        else {
+                            continue;
+                        };
+                        // upstream: flist.c:1949 - implied parents clear
+                        // FLAG_CONTENT_DIR so a real upstream receiver does
+                        // not scan them for --delete (over-delete data loss).
+                        mark_implied_dir(&mut file_entry);
+                        self.push_file_item(file_entry, full);
+                        // Record the ancestor only once an entry has actually been
+                        // emitted. Marking a skipped ancestor as handled suppresses
+                        // every later retry AND adds it to `implied_only_dirs`, which
+                        // then suppresses the explicit top-level walk that could still
+                        // have emitted it - so the parent disappears from the list
+                        // entirely.
                         emitted_dirs.insert(key);
                     }
                 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3214,6 +3214,56 @@ mod files_from {
         );
     }
 
+    /// upstream: flist.c:1983-1985 send_implied_dirs() - `copy_links = xfer_dirs = 1`
+    /// is in force while the ancestor chain is emitted, so each implied parent is
+    /// stat-ed through symlinks. Stat-ing with `symlink_metadata` reports a
+    /// symlinked ancestor as a non-directory and emits nothing for it, so the
+    /// file list carries `link/file` with no `link`. A conformant receiver rejects
+    /// that with "ABORTING due to invalid path from sender" (flist.c:2691) and
+    /// exits 4 (RERR_UNSUPPORTED); upstream's sender lists `link` as a directory.
+    #[cfg(unix)]
+    #[test]
+    fn build_file_list_with_base_emits_symlinked_implied_parent() {
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        std::fs::create_dir_all(src.join("realdir")).unwrap();
+        std::fs::write(src.join("realdir/file.txt"), "hello").unwrap();
+        std::os::unix::fs::symlink("realdir", src.join("link")).unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        config.flags.relative = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        ctx.build_file_list_with_base(
+            &src,
+            &files_from_entries(&src, vec![src.join("link/file.txt")]),
+        )
+        .unwrap();
+
+        let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        assert!(
+            names.contains(&"link/file.txt"),
+            "expected the requested entry in {names:?}"
+        );
+        assert!(
+            names.contains(&"link"),
+            "symlinked implied parent must be listed, else the receiver aborts \
+             with \"invalid path from sender\": {names:?}"
+        );
+        let parent = ctx
+            .file_list()
+            .iter()
+            .find(|e| e.name() == "link")
+            .expect("implied parent entry");
+        assert!(
+            parent.is_dir(),
+            "implied parent must be sent as a directory (copy_links is on), \
+             not as a symlink"
+        );
+    }
+
     /// upstream: flist.c:1650-1674 send_file1() - a name that cannot be
     /// strictly transcoded under --iconv is dropped (io_error |= IOERR_GENERAL,
     /// "cannot convert filename", return NULL) so it never enters the file list.

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -416,6 +416,58 @@ fn inc_recurse_gap_ndx_round_trip_preserves_original() {
     );
 }
 
+/// An INC_RECURSE entry whose parent directory is absent from the file list
+/// cannot be placed in a sub-list. Upstream's receiver treats the resulting
+/// wire shape as fatal - an initial-list entry must have an empty dirname
+/// (`flist.c:2682-2697`) or it prints "ABORTING due to invalid path from
+/// sender" and calls `exit_cleanup(RERR_UNSUPPORTED)` (exit 4). Salvaging the
+/// entry into the initial segment without a word means oc emits a file list a
+/// conformant peer rejects and still exits 0, so the operator sees a remote
+/// abort with no local explanation. This pins the diagnostic, not the salvage.
+#[test]
+fn inc_recurse_orphan_entry_is_reported_not_silently_emitted() {
+    use protocol::CompatibilityFlags;
+    use protocol::flist::FileEntry;
+
+    let mut handshake = test_handshake_with_protocol(32);
+    handshake.compat_flags = Some(CompatibilityFlags::INC_RECURSE);
+    let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
+    assert!(ctx.inc_recurse());
+
+    // `link/file` with no `link` entry - exactly the list a --files-from build
+    // produced when a symlinked implied parent was stat-ed with lstat.
+    let empty_base: std::sync::Arc<Path> = std::sync::Arc::from(Path::new(""));
+    for entry in [
+        FileEntry::new_directory(".".into(), 0o755),
+        FileEntry::new_file("link/file".into(), 6, 0o644),
+    ] {
+        ctx.file_list.push(entry);
+        ctx.source_bases.push(std::sync::Arc::clone(&empty_base));
+    }
+
+    ctx.partition_file_list_for_inc_recurse();
+
+    let queued: Vec<&str> = ctx
+        .pending_flist_diagnostics
+        .iter()
+        .map(|(_, text)| text.as_str())
+        .collect();
+    assert!(
+        queued.iter().any(|t| t.contains("link/file")),
+        "the orphaned entry must be named on stderr, not emitted silently: {queued:?}"
+    );
+    assert!(
+        ctx.pending_flist_diagnostics
+            .iter()
+            .any(|(kind, _)| *kind == super::protocol_io::SenderDiagnostic::ErrorXfer),
+        "must be an FERROR_XFER so the run cannot exit 0 with a list the peer rejects"
+    );
+    assert_ne!(
+        ctx.io_error, 0,
+        "an unsendable file list is an I/O error, not a clean run"
+    );
+}
+
 #[test]
 fn inc_recurse_gap_ndx_itemizes_parent_directory() {
     // upstream: generator.c:2306-2313 - under INC_RECURSE every directory is

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -96,6 +96,10 @@ impl GeneratorContext {
             self.flush_flist_diagnostics(writer)?;
             build?;
             self.partition_file_list_for_inc_recurse();
+            // Partitioning can report an entry whose parent is missing from the
+            // list. Drain again so that line also precedes the first file-list
+            // byte; the queue was emptied above, so this is a no-op otherwise.
+            self.flush_flist_diagnostics(writer)?;
             self.send_file_list(writer)?
         };
 


### PR DESCRIPTION
A `--files-from` entry whose ancestor is a symlink to a directory is sent
without that ancestor, and a real rsync 3.4.4 receiver rejects the file list
with exit 4.

Two separable defects, one per commit.

## 1. The implied-parent stat did not follow symlinks

`build_file_list_with_base` stat-ed each implied ancestor with
`symlink_metadata`. A symlinked ancestor fails `is_dir()`, so no entry was
emitted for it - yet the ancestor was still inserted into `emitted_dirs`,
marking it handled. That insert is a second defect on its own: it suppresses
any later retry *and* puts the ancestor into `implied_only_dirs`, which then
suppresses the explicit top-level walk that could still have emitted it. The
ancestor now cannot appear from any path.

Upstream settles the stat question at `flist.c:1983-1985`: `send_implied_dirs()`
sets `copy_links = xfer_dirs = 1` around the ancestor loop, so implied-parent
stats follow symlinks. The positional `-R` emitter in the same file
(`emit_implied_parents`, `mod.rs:464`) already uses `std::fs::metadata` with a
comment explaining exactly this failure; the two paths now agree.

The ancestor is recorded only after an entry has actually been pushed.

## 2. The missing parent was then swallowed silently

With the parent absent, `classify_file_list_entries` fell through to the
initial segment with `node_id: None`. That row goes on the wire with a
non-empty dirname. Upstream's receiver treats it as fatal - `recv_file_list()`
requires every initial-list entry to have an empty dirname
(`flist.c:2682-2697`) and otherwise prints `ABORTING due to invalid path from
sender` and calls `exit_cleanup(RERR_UNSUPPORTED)` (exit 4). oc emitted that
list without a word and exited 0, so the operator saw a remote abort with no
local explanation. A *directory* landing there is never registered either, so
all of its children follow it in.

**Decision: loud FERROR_XFER diagnostic naming the path, plus `IOERR_GENERAL`
- not a sender-side abort.** Upstream's fatality lives in the receiver; its
sender has no equivalent check, because `send_implied_dirs()` makes the state
unreachable. Adding a sender abort would invent severity upstream does not
have. `FERROR_XFER` is the channel upstream already uses for sender-side
file-list failures (`flist.c:1846`, `1878`, `1924`), and it means the run can
no longer exit 0 with a file list the peer will reject. After commit 1 this is
unreachable via this route; the point is that it must not be quiet if anything
else ever reaches it.

Diagnostics are queued while no writer is in scope, so the queue is drained a
second time after partitioning - still before the first file-list byte.

## Evidence

oc as client-sender pushing to a genuine `rsync 3.4.4 protocol version 32`
receiver (`/opt/homebrew/bin/rsync`, confirmed from its `--version` banner).
`-r` is load-bearing: `--files-from` clears `recurse == 1` but preserves
`recurse == 2` (`options.c:2188`).

```
src/realdir/file
src/link -> realdir
files.txt: "link/file"

oc-rsync -r -v --files-from=files.txt --rsync-path=<3.4.4> src/ host:dest/
```

**Before**

```
ABORTING due to invalid path from sender: link/file
rsync error: requested action not supported (code 4) at flist.c(2693) [Receiver=3.4.4]
dest/ is empty
```

**After**

```
link/
link/file
sent 30 bytes  received 20 bytes
exit 0
dest/link/  ->  a real directory containing file
```

**Control A** - the same command with the 3.4.4 binary as *sender* succeeds and
creates `dest/link/` as a real directory. Confirms the destination shape is
upstream's, not an invention of this branch.

**`--debug=FLIST2`, both senders.** This difference needs no incremental
recursion and no remote abort - it is the root cause in one line, which is why
the commit-1 regression test can live in the normal test cells:

```
upstream 3.4.4 sender          oc, before                 oc, after
  make_file(link,*,2)            make_file(link/file,*,2)   make_file(link,*,2)
  make_file(link/file,*,2)                                  make_file(link/file,*,2)
```

## Tests

- `build_file_list_with_base_emits_symlinked_implied_parent` - drives the
  builder directly: no inc-recurse, no remote peer, runs in the normal cells.
  Verified to fail on the pre-fix code with
  `symlinked implied parent must be listed ... ["link/file.txt"]`, and to pass
  after. Also pins that the parent is sent as a *directory*, not a symlink,
  since `copy_links` is in force.
- `inc_recurse_orphan_entry_is_reported_not_silently_emitted` - pins the
  diagnostic and the I/O-error flag, not the salvage.
- `cargo nextest run -p transfer --all-features`: 2509 passed.
- `cargo clippy -p transfer --all-targets --all-features`: clean.

## Related, not fixed here

`--exclude` reaches implied parents through a second route, with the same
end state. `mod.rs` seeds `emitted_dirs` from `explicit_dirs`, so a parent that
is *itself* a `--files-from` entry is left to the explicit walk - and the walk
applies filters. Upstream's `send_implied_dirs()` explicitly clears
`filter_list` (`flist.c:1950`, `/* Don't filter implied dirs. */`).

Confirmed against the 3.4.4 binary with `files.txt` = `dir`, `dir/file` and
`--exclude=dir`:

```
upstream flist:  dir, dir/file
oc flist:        dir/file
```

and against a 3.4.4 receiver oc gets the identical
`ABORTING due to invalid path from sender: dir/file`, exit 4.

Left out of this PR deliberately: the fix is not the same one-line shape. It
means changing how `emitted_dirs` is seeded, which feeds `implied_only_dirs`
and the walk-dedup suppression, so it needs its own duplicate-emission
analysis against upstream's two `make_file(dir, ...)` calls and its own
verification pass.
