### PR TITLE
ci: preserve master post-merge runs and unpin the nightly toolchain

### DIFF
--- a/.github/workflows/bin-build-coverage.yml
+++ b/.github/workflows/bin-build-coverage.yml
@@ -29,7 +29,9 @@ permissions:
 
 concurrency:
   group: bin-build-coverage-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull request pushes still cancel; pushes to master do not, so
+  # every merge commit keeps a completed run for bisection.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   check:

--- a/.github/workflows/check-locked-flags.yml
+++ b/.github/workflows/check-locked-flags.yml
@@ -27,7 +27,9 @@ permissions:
 
 concurrency:
   group: check-locked-flags-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull request pushes still cancel; pushes to master do not, so
+  # every merge commit keeps a completed run for bisection.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull request pushes still cancel; pushes to master do not, so
+  # every merge commit keeps a completed run for bisection.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,10 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Nightly pinned to 2026-06-15 to dodge a rustc_ast attribute-parsing
-        # ICE in current nightly (compiler/rustc_ast/src/attr/mod.rs:307).
-        # Remove the date to track floating nightly once the regression lands.
-        toolchain: [stable, beta, nightly-2026-06-15]
+        toolchain: [stable, beta, nightly]
 
     steps:
       - name: Free disk space
@@ -245,10 +242,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Nightly pinned to 2026-06-15 to dodge a rustc_ast attribute-parsing
-        # ICE in current nightly (compiler/rustc_ast/src/attr/mod.rs:307).
-        # Remove the date to track floating nightly once the regression lands.
-        toolchain: [stable, beta, nightly-2026-06-15]
+        toolchain: [stable, beta, nightly]
 
     steps:
       - name: Checkout
@@ -588,10 +582,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Nightly pinned to 2026-06-15 to dodge a rustc_ast attribute-parsing
-        # ICE in current nightly (compiler/rustc_ast/src/attr/mod.rs:307).
-        # Remove the date to track floating nightly once the regression lands.
-        toolchain: [stable, beta, nightly-2026-06-15]
+        toolchain: [stable, beta, nightly]
 
     steps:
       - name: Checkout
@@ -656,10 +647,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Nightly pinned to 2026-06-15 to dodge a rustc_ast attribute-parsing
-        # ICE in current nightly (compiler/rustc_ast/src/attr/mod.rs:307).
-        # Remove the date to track floating nightly once the regression lands.
-        toolchain: [stable, beta, nightly-2026-06-15]
+        toolchain: [stable, beta, nightly]
 
     steps:
       - name: Checkout

--- a/.github/workflows/interop-validation.yml
+++ b/.github/workflows/interop-validation.yml
@@ -27,7 +27,9 @@ on:
 
 concurrency:
   group: interop-validation-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull request pushes still cancel; pushes to master do not, so
+  # every merge commit keeps a completed run for bisection.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read

--- a/.github/workflows/iouring-kernel-compat.yml
+++ b/.github/workflows/iouring-kernel-compat.yml
@@ -38,7 +38,9 @@ on:
 
 concurrency:
   group: iouring-kernel-compat-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull request pushes still cancel; pushes to master do not, so
+  # every merge commit keeps a completed run for bisection.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,9 @@ on:
 
 concurrency:
   group: security-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull request pushes still cancel; pushes to master do not, so
+  # every merge commit keeps a completed run for bisection.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read

--- a/.github/workflows/send-zc-5-15-lts.yml
+++ b/.github/workflows/send-zc-5-15-lts.yml
@@ -43,7 +43,9 @@ on:
 
 concurrency:
   group: send-zc-5-15-lts-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull request pushes still cancel; pushes to master do not, so
+  # every merge commit keeps a completed run for bisection.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Two independent CI-health fixes, one commit each.

## Commit 1 - stop cancelling master's post-merge CI

`concurrency.group` keys on `github.ref`. On a pull request branch that
varies, so superseded pushes correctly cancel. On master it is constant,
so **every merge cancelled the previous merge's run**.

Measured on master's last 40 `ci.yml` runs: **28 cancelled, 11 success,
1 running**. Five consecutive master commits (`ac17177a`, `a5fb8088`,
`532161fe`, `a661aeb4`, `7c71ced0`) have no completed CI at all. Only the
last commit of a merge burst is ever validated, which destroys per-commit
bisection exactly when it is most needed and misattributes any regression
to whichever merge happened to survive.

Fix is the standard ref guard:

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
```

**Pull request behaviour is unchanged** - superseded branch pushes still
cancel, which is what keeps the runner pool usable.

### Changed (7) - these trigger on a push to master

| Workflow | push branches |
|---|---|
| `ci.yml` | `master, main` |
| `interop-validation.yml` | `master, main` |
| `iouring-kernel-compat.yml` | `master, main` |
| `security.yml` | `master, main` |
| `send-zc-5-15-lts.yml` | `master, main` |
| `bin-build-coverage.yml` | `master` |
| `check-locked-flags.yml` | `master` |

### Left alone (18) - deliberately, no push-to-branch trigger

The group key already varies per run for these, so `cancel-in-progress:
true` is doing exactly what it should and nothing is lost.

- **Tag push only** (`github.ref` is the tag, unique per release):
  `benchmark.yml`, `benchmark-release.yml`, `release-cross.yml`
- **`pull_request` only**: `ci-skip.yml`, `labeler.yml`, `locked-gate.yml`
- **`pull_request_target` only** (keyed on PR number):
  `cargo-lockfile-sync.yml`
- **`schedule` / `workflow_dispatch` only**: `upstream-testsuite.yml`,
  `upstream-testsuite-root.yml`, `known-failures.yml`,
  `mdf-8-filter-diff.yml`
- **`pull_request` + `schedule` + `workflow_dispatch`, no push**:
  `bench-checksum-throughput.yml`, `bench-daemon-coldstart.yml`,
  `bench-daemon-concurrency.yml`, `bench-drain-throughput.yml`,
  `bench-zsync-matching.yml`, `reorder-spill-regression.yml`,
  `build-rsync-2-6-9.yml`

The classification was derived by parsing every workflow's `on:` block
rather than by eyeballing, and re-parsed afterwards to confirm no
remaining `cancel-in-progress: true` workflow has a push-to-branch
trigger.

Note: five of the seven changed workflows also list `main` as a push
branch. `main` does not exist in this repository and branch protection
targets `master`, so the guard names `master` only. If `main` ever
becomes real, the guard needs the second clause.

## Commit 2 - track floating nightly again

`ci.yml` pinned four matrices (Linux nextest, Windows, macOS, musl) to
`nightly-2026-06-15` for a `rustc_ast` attribute-parsing ICE
(`compiler/rustc_ast/src/attr/mod.rs:307`). The pin is six weeks old and
its stated exit condition ("remove the date once the regression lands")
was never re-checked.

The pin also guards the wrong path. `release-cross.yml` uses **floating
`nightly`** in four matrices (lines 104, 303, 526, 611) and it builds and
publishes **release artifacts** on `v*` tag push, including the
`oc-rsync@nightly.rb` Homebrew formula. With `fail-fast: false` there, a
live ICE would not fail a release - the nightly artifacts would just
silently never appear. So today the shipping path is exposed and the
non-shipping path is protected.

This commit unpins all four `ci.yml` matrices so CI itself answers
whether the ICE is still live. Those cells are `continue-on-error` and
non-required (`ci.yml:152-155`), so a red nightly blocks nothing.

### Verdict: the ICE is fixed - the unpin stands

All four unpinned cells passed on this PR against
**`rustc 1.99.0-nightly (008fa22ce 2026-07-25)`**:

| Cell | Result |
|---|---|
| `nextest (nightly)` | SUCCESS |
| `Windows (nightly)` | SUCCESS |
| `macOS (nightly)` | SUCCESS |
| `Linux musl (nightly)` | SUCCESS |

The `rustc_ast` attribute-parsing regression is gone, the pin has served
its purpose, and `ci.yml` now tracks the same floating `nightly` that
`release-cross.yml` already ships with. No `release-cross.yml` pin is
needed - CI and release are back in agreement.

## Follow-up, not addressed here

The eight `windows-nightly-*.yml` workflows all use `toolchain: stable` -
"nightly" in those names is the cron schedule, not the toolchain. Windows
therefore has no nightly-toolchain coverage outside `ci.yml`, despite the
naming implying otherwise. Worth a separate change.
