### PR TITLE
fix(protocol): drop the "."-first rule from the pre-29 file-list sort

### DIFF
--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -90,10 +90,16 @@ impl LocalCopyChangeSet {
             modify_window,
         ));
 
-        // upstream: generator.c:542-549 - `#ifndef CAN_CHMOD_SYMLINK` skips
-        // the perm-compare entirely for symlinks. On Linux/macOS chmod
-        // follows the link, so a symlink's own perms cannot be changed and
-        // upstream rsync never reports ITEM_REPORT_PERMS for them.
+        // Symlinks are excluded from the perm compare because oc does not
+        // currently apply a symlink's mode (nothing calls lchmod/setattrlist),
+        // so reporting a `p` change would promise an action never performed.
+        // This is NOT upstream's rule: upstream skips the compare only where
+        // `CAN_CHMOD_SYMLINK` is undefined (rsync.h:438-440 defines it whenever
+        // HAVE_LCHMOD or HAVE_SETATTRLIST, both probed by configure.ac:911,918),
+        // so on glibc >= 2.32 and on macOS the `#ifndef` block at
+        // generator.c:542-544 compiles out and upstream DOES compare.
+        // Revisit together with applying symlink modes so report and action
+        // cannot drift apart.
         let is_symlink = metadata.file_type().is_symlink();
 
         // upstream: generator.c:531-533 - itemize() sets ITEM_REPORT_ATIME when
@@ -280,10 +286,13 @@ impl LocalCopyChangeSet {
             }
         }
 
-        // upstream: generator.c:542-549 - `#ifndef CAN_CHMOD_SYMLINK` skips
-        // perm/owner/group bits for symlinks on platforms where chmod follows
-        // the link. Linux and macOS both behave that way for symlinks, so the
-        // itemize line never reports symlink perm changes in those slots.
+        // No perm/owner/group slots are lit for a recreated symlink: oc does
+        // not currently apply a symlink's mode (nothing calls lchmod or
+        // setattrlist), so it must not report a change it will not make.
+        // Upstream is not the reason - it chmods every file type
+        // (rsync.c:658-668, no S_ISLNK gate) and handles symlink portability
+        // inside do_chmod (syscall.c:761), which tries lchmod then
+        // setattrlist(FSOPT_NOFOLLOW). Revisit with symlink-mode support.
         change_set
     }
 

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -413,9 +413,15 @@ pub fn apply_symlink_metadata(
 
 /// Applies symbolic link metadata using explicit [`MetadataOptions`].
 ///
-/// Only ownership and timestamps are applied - permissions are not preserved
-/// for symlinks because most systems ignore symlink permission bits.
-// upstream: rsync.c:set_file_attrs() - skips chmod for symlinks
+/// Only ownership and timestamps are applied. oc does not currently set a
+/// symlink's own mode, so permissions are skipped here.
+///
+/// This is an oc limitation, not upstream behaviour: `rsync.c:658-668` calls
+/// `do_chmod_at()` for every file type with no `S_ISLNK` gate (the comment at
+/// `rsync.c:667`, "ret == 1 if symlink could not be set", shows a failed
+/// symlink chmod is a soft outcome). All the portability lives in
+/// `syscall.c:761 do_chmod()`, which tries `lchmod()`, falls through to
+/// `setattrlist(FSOPT_NOFOLLOW)` for `S_ISLNK`, and only then gives up.
 pub fn apply_symlink_metadata_with_options(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -433,9 +439,9 @@ pub fn apply_symlink_metadata_with_options(
 ///
 /// Mirrors [`apply_metadata_from_file_entry`] but uses `lstat` for the cached
 /// stat and `lutimes` / `utimensat(AT_SYMLINK_NOFOLLOW)` for timestamps so the
-/// link's own mtime is updated instead of the target's. Permissions are not
-/// preserved for symlinks because most systems ignore symlink permission bits;
-/// ownership (when applicable) is applied with `AT_SYMLINK_NOFOLLOW`.
+/// link's own mtime is updated instead of the target's. Permissions are
+/// skipped because oc does not currently set a symlink's own mode; ownership
+/// (when applicable) is applied with `AT_SYMLINK_NOFOLLOW`.
 ///
 /// This is the receiver-side counterpart to [`apply_symlink_metadata`] that
 /// works directly with `FileEntry` metadata from the wire protocol, so the
@@ -444,7 +450,10 @@ pub fn apply_symlink_metadata_with_options(
 ///
 /// # Upstream Reference
 ///
-/// - `rsync.c:set_file_attrs()` - skips chmod for symlinks
+/// - `rsync.c:658-668` - upstream chmods every file type with no `S_ISLNK`
+///   gate; skipping the mode here is an oc limitation, not upstream's rule.
+///   Symlink portability lives in `syscall.c:761 do_chmod()` (`lchmod()`, then
+///   `setattrlist(FSOPT_NOFOLLOW)`).
 /// - `rsync.c:set_times()` - uses `lutimes` when the target is a symlink
 /// - `generator.c:1604` - `set_file_attrs(fname, file, NULL, NULL, 0)` runs
 ///   after `atomic_create` -> `do_symlink` so the new symlink's mtime matches

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -16,7 +16,9 @@
 //! 4. Directory contents immediately follow the directory entry
 //!
 //! At protocol < 29, upstream uses plain lexicographic byte comparison
-//! without file-before-directory distinction or implicit trailing '/'.
+//! without file-before-directory distinction, implicit trailing '/', or the
+//! "."-sorts-first rule (that special case is gated on `t_PATH`, which pre-29
+//! never produces).
 //! upstream: flist.c:3258 - `protocol_version >= 29 ? t_PATH : t_ITEM`
 
 use std::cmp::Ordering;
@@ -97,16 +99,17 @@ pub fn compare_file_entries(a: &FileEntry, b: &FileEntry) -> Ordering {
 /// meaning directories are NOT treated specially - no implicit trailing
 /// slash, no files-before-dirs. This is a simple lexicographic sort.
 /// upstream: flist.c:3258 - `protocol_version >= 29 ? t_PATH : t_ITEM`
+///
+/// There is also NO "." sorts-first rule here. Upstream's special case
+/// (`flist.c:3275` and its `c2` twin at `:3287`) is gated on
+/// `type1 == t_PATH`, and `t_path` is `t_ITEM` below protocol 29, so the
+/// branch can never be taken. The root marker "." is compared as the plain
+/// byte 0x2E, which puts every name starting below 0x2E (`!"#$%&'()*+,-`
+/// and the control bytes) ahead of it. Sorting "." first regardless would
+/// shift every subsequent NDX against a real pre-29 peer.
 fn compare_with_keys_pre29(bytes_a: &[u8], bytes_b: &[u8]) -> Ordering {
-    // "." always comes first (even at protocol < 29)
-    match (bytes_a == b".", bytes_b == b".") {
-        (true, true) => return Ordering::Equal,
-        (true, false) => return Ordering::Less,
-        (false, true) => return Ordering::Greater,
-        (false, false) => {}
-    }
-
-    // Plain byte comparison - no file-before-dir, no implicit trailing '/'.
+    // Plain byte comparison - no file-before-dir, no implicit trailing '/',
+    // no "." special case.
     // upstream: f_name_cmp() with t_path = t_ITEM treats all entries identically.
     bytes_a.cmp(bytes_b)
 }
@@ -1022,20 +1025,73 @@ mod tests {
         assert_eq!(names, vec!["aardvark", "zebra.txt"]);
     }
 
-    /// Protocol < 29: "." still comes first.
+    /// Protocol < 29 has NO "."-sorts-first rule: "." is compared as the plain
+    /// byte 0x2E, so any name whose first byte is below 0x2E sorts BEFORE it.
+    ///
+    /// Upstream's special case (`flist.c:3275`, `:3287`) is gated on
+    /// `type1 == t_PATH`, and `t_path` is `t_ITEM` below protocol 29, so it can
+    /// never fire. Because "." is entry 0 of nearly every transfer
+    /// (`flist.c:2400`), hoisting it unconditionally would shift every later
+    /// NDX against a real pre-29 peer - wrong contents written under wrong
+    /// names, or "received non-regular file".
     #[test]
-    fn pre29_dot_first() {
-        let dot = make_dir(".");
-        let file = make_file("abc.txt");
-        let dot_bytes = dot.name_bytes();
-        let file_bytes = file.name_bytes();
+    fn pre29_dot_is_a_plain_byte_not_a_special_case() {
+        let dot = make_dir(".").name_bytes().to_vec();
+        // '!' (0x21), '-' (0x2D) and control bytes all sort below '.' (0x2E).
+        for earlier in ["!bang", "-dash", "+plus"] {
+            let other = make_file(earlier).name_bytes().to_vec();
+            assert_eq!(
+                compare_with_keys_pre29(&other, &dot),
+                Ordering::Less,
+                "{earlier} must sort before \".\" at protocol < 29"
+            );
+            assert_eq!(compare_with_keys_pre29(&dot, &other), Ordering::Greater);
+        }
+        // Names above 0x2E still sort after ".", as plain byte order dictates.
+        let later = make_file("abc.txt").name_bytes().to_vec();
+        assert_eq!(compare_with_keys_pre29(&dot, &later), Ordering::Less);
+        assert_eq!(compare_with_keys_pre29(&dot, &dot), Ordering::Equal);
+    }
+
+    /// Golden ordering captured from real upstream rsync 3.4.4 for the same
+    /// corpus, via `rsync --protocol=N -r --list-only`:
+    ///
+    /// ```text
+    /// protocol 28: !bang  -dash  .  abc.txt  sub  sub/x
+    /// protocol 32: .  !bang  -dash  abc.txt  sub  sub/x
+    /// ```
+    ///
+    /// At protocol 28 the "." root marker sits between `-dash` (0x2D) and
+    /// `abc.txt` (0x61) - exactly where plain byte order puts 0x2E. Only at
+    /// protocol 29+ is it hoisted to the front by the `t_PATH` special case.
+    #[test]
+    fn pre29_low_byte_name_sorts_ahead_of_dot_root() {
+        let build = || {
+            vec![
+                make_dir("."),
+                make_file("!bang"),
+                make_file("-dash"),
+                make_file("abc.txt"),
+                make_dir("sub"),
+                make_file("sub/x"),
+            ]
+        };
+
+        let mut pre29 = build();
+        sort_file_list(&mut pre29, false, true);
+        let names: Vec<&str> = pre29.iter().map(FileEntry::name).collect();
         assert_eq!(
-            compare_with_keys_pre29(&dot_bytes, &file_bytes),
-            Ordering::Less
+            names,
+            vec!["!bang", "-dash", ".", "abc.txt", "sub", "sub/x"]
         );
+
+        // Protocol 29+ keeps the "." special case (upstream flist.c:3275).
+        let mut modern = build();
+        sort_file_list(&mut modern, false, false);
+        let names: Vec<&str> = modern.iter().map(FileEntry::name).collect();
         assert_eq!(
-            compare_with_keys_pre29(&file_bytes, &dot_bytes),
-            Ordering::Greater
+            names,
+            vec![".", "!bang", "-dash", "abc.txt", "sub", "sub/x"]
         );
     }
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -692,10 +692,14 @@ impl ReceiverContext {
             {
                 iflags |= ItemFlags::ITEM_REPORT_ATIME;
             }
-            // upstream: generator.c:542-549 - `#ifndef CAN_CHMOD_SYMLINK` skips
-            // the whole perm compare for a symlink, because a platform without
-            // lchmod() can never change a symlink's own mode. Mirrors the same
-            // guard in engine's local-copy change-set detection.
+            // Symlinks are excluded because oc does not currently apply a
+            // symlink's own mode, so it must not report a `p` change it will
+            // not make. Not upstream's rule: `CAN_CHMOD_SYMLINK` is defined
+            // whenever HAVE_LCHMOD or HAVE_SETATTRLIST (rsync.h:438-440,
+            // probed at configure.ac:911,918), so on glibc >= 2.32 and macOS
+            // the `#ifndef` at generator.c:542-544 compiles out and upstream
+            // does compare. Mirrors the same guard in engine's local-copy
+            // change-set detection; revisit both with symlink-mode support.
             if self.config.flags.perms && !entry.is_symlink() {
                 const CHMOD_BITS: u32 = 0o7777;
                 if (dest_meta.mode() & CHMOD_BITS) != (entry.mode() & CHMOD_BITS) {


### PR DESCRIPTION
Two small, independent fixes.

## 1. `fix(protocol)`: pre-29 file-list sort must not hoist `.`

Upstream's "`.` sorts first" special case in `f_name_cmp()` (`flist.c:3275`, and its `c2` twin at `:3287`) is gated on `type1 == t_PATH`:

```c
enum fnc_type t_path = protocol_version >= 29 ? t_PATH : t_ITEM;   /* flist.c:3258 */
...
if (type1 == t_PATH && *c1 == '.' && !c1[1]) { ... }
```

Below protocol 29 `t_path` **is** `t_ITEM`, so `type1` can never be `t_PATH` and the branch never fires. Upstream compares `.` as the literal byte `0x2E`.

`compare_with_keys_pre29` applied the rule unconditionally. Any name whose first byte is below `0x2E` - ``! " # $ % & ' ( ) * + , -`` and the control bytes - therefore sorted *after* `.` in oc and *before* it upstream. Since `.` is entry 0 of nearly every transfer (`flist.c:2400`), one such filename shifts every subsequent NDX against a real pre-29 peer: file contents written under the wrong names, or `received non-regular file`.

Severity is low only because pre-29 peers are rare; the failure mode is not mild.

The protocol 29+ comparator is untouched - it keeps the special case, matching upstream.

### Ground truth

Real upstream rsync 3.4.4, same corpus, `--protocol=N -r --list-only`:

```
protocol 28: !bang  -dash  .  abc.txt  sub  sub/x
protocol 32: .  !bang  -dash  abc.txt  sub  sub/x
```

At protocol 28 `.` sits between `-dash` (`0x2D`) and `abc.txt` (`0x61`), exactly where plain byte order puts `0x2E`. That sequence is now a golden assertion in the unit tests, alongside a direct comparator test. Both new tests were confirmed to fail against the previous comparator before the fix was applied.

## 2. `docs`: correct the symlink-chmod rationale in the perms guards

Four comments justified skipping the symlink permission compare/apply by citing upstream, and every one had the citation backwards.

`#ifndef CAN_CHMOD_SYMLINK` does **not** mean upstream skips the compare on Linux and macOS. `rsync.h:438-440` defines the macro whenever `HAVE_LCHMOD` or `HAVE_SETATTRLIST` is present, and `configure.ac` probes both (`:911`, `:918`) - so on glibc >= 2.32 and on macOS the `#ifndef` block at `generator.c:542-544` compiles *out* and upstream **does** compare.

"`rsync.c:set_file_attrs()` - skips chmod for symlinks" is likewise false: `rsync.c:658-668` calls `do_chmod_at()` for every file type with no `S_ISLNK` gate, and the comment at `:667` ("`ret == 1 if symlink could not be set`") shows a failed symlink chmod is a soft outcome. All the portability handling lives in `syscall.c:761 do_chmod()`, which tries `lchmod()`, falls through to `setattrlist(FSOPT_NOFOLLOW)` for `S_ISLNK`, and only then gives up.

The comments now state the real reason: oc has no symlink-mode-setting caller anywhere, so it must not report or promise a change it never performs. (On Linux a symlink's `st_mode` is fixed at `0777` on both sides, so the comparison could not fire there in any case.)

**Every guard is left exactly as it was** - the diff is comment-only, verified mechanically. No `CAN_CHMOD_SYMLINK` constant is introduced; that belongs with the change that makes oc actually apply symlink modes, so report and action cannot drift apart. The adjacent atime citation (`generator.c:531-533`) is genuinely correct and is untouched.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy -p engine -p metadata -p transfer -p protocol --all-features --no-deps -- -D warnings` clean.
- `protocol` flist unit tests (600) plus `flist_sort_keys_rp28h`, `golden_protocol_v28_flist`, `flist_stress_tests` all green.
