### PR TITLE
fix(core): stop filtering --files-from implied parent dirs

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -237,13 +237,11 @@ impl GeneratorContext {
             }
         }
 
-        // Pre-populate the explicit-directory set with every --files-from
-        // entry that is itself a directory. The implied-parent loop below
-        // skips emission for entries already in this set so the explicit
-        // top-level walk owns their emission. Keys are the (base, wire-relative)
-        // pair so two entries that resolve to the same filesystem path but
-        // through different `/./` anchors do not collide on the wire-side
-        // dedup map.
+        // Every --files-from entry that is itself a directory. Used only to
+        // derive `implied_only_dirs` below, which suppresses the top-level walk
+        // for ancestors that are NOT also explicit entries. Keys are the
+        // (base, wire-relative) pair so two entries that resolve to the same
+        // filesystem path but through different `/./` anchors do not collide.
         let mut explicit_dirs: HashSet<(PathBuf, PathBuf)> = HashSet::new();
         for entry in entries {
             if let Ok(rel) = entry.path.strip_prefix(&entry.base) {
@@ -264,14 +262,28 @@ impl GeneratorContext {
         // upstream: flist.c:send_implied_dirs() - creates directory entries
         // for every intermediate path component of a --files-from entry.
         //
-        // `emitted_dirs` starts with the explicit-dir pre-population so a
-        // parent that is ALSO an explicit --files-from entry is not emitted
-        // here (the top-level walk below owns its emission). The loop adds
-        // every purely implied ancestor it pushes; the difference set
+        // upstream: flist.c:1950 - `filter_list.head = filter_list.tail = NULL;
+        // /* Don't filter implied dirs. */`. The implied-parent emission is
+        // structurally exempt from the filter chain: it stats and pushes each
+        // ancestor directly, never consulting the exclude rules. Seeding this
+        // set from `explicit_dirs` broke that exemption for an ancestor that is
+        // ALSO an explicit --files-from entry - emission was delegated to the
+        // filtered top-level walk, so an `--exclude` matching that parent
+        // dropped it from the list entirely and a real upstream receiver
+        // rejected the orphaned child ("ABORTING due to invalid path from
+        // sender", flist.c:2693 exit 4 under inc-recurse, generator.c:1326
+        // exit 2 without it). Starting empty restores the exemption and
+        // reproduces upstream's two `make_file()` calls for a directory that is
+        // both an implied parent and an unfiltered explicit argument: the
+        // duplicate rides the wire exactly as upstream sends it and the
+        // receiver merges the pair in `flist_sort_and_clean()`
+        // (flist.c:3073-3076, oc: `flist::sort::resolve_duplicate`).
+        //
+        // The loop records every ancestor it pushes; the difference set
         // `implied_only_dirs` is later consulted by
-        // `try_walk_source_entry_dedup` to suppress the duplicate top-level
-        // walk that would re-emit an implied parent.
-        let mut emitted_dirs: HashSet<(PathBuf, PathBuf)> = explicit_dirs.clone();
+        // `try_walk_source_entry_dedup` to suppress the top-level walk for
+        // ancestors that upstream never walks (not explicit arguments).
+        let mut emitted_dirs: HashSet<(PathBuf, PathBuf)> = HashSet::new();
         // upstream: options.c:2207-2208 - `if (!relative_paths) implied_dirs = 0;`.
         // Under --no-relative (relative_paths == 0) the sender FLATTENS every
         // --files-from entry to its transmitted name and emits NO implied parent
@@ -287,9 +299,8 @@ impl GeneratorContext {
         // without their source metadata. Mirror the same gate as the positional
         // path (build_file_list): emit only in relative mode, and then when
         // implied dirs are on OR the protocol forces them. When suppressed,
-        // `emitted_dirs` stays equal to `explicit_dirs`, so `implied_only_dirs`
-        // below is empty and the explicit top-level walk is left untouched
-        // (dedup unchanged).
+        // `emitted_dirs` stays empty, so `implied_only_dirs` below is empty and
+        // the explicit top-level walk is left untouched (dedup unchanged).
         if self.config.flags.relative
             && (!self.config.flags.no_implied_dirs || self.protocol.as_u8() >= 30)
         {
@@ -338,11 +349,14 @@ impl GeneratorContext {
         }
 
         // Directories emitted purely as implied parents of some other entry
-        // (i.e. not also listed explicitly in --files-from). The top-level
-        // walk skips these so we do not produce a duplicate file-list entry
-        // that upstream's `implied_filter_list` check (flist.c:1026) would
-        // reject as "unrequested". Explicit --files-from dirs remain walkable
-        // so their recursive contents continue to flow normally.
+        // (i.e. not also listed explicitly in --files-from). upstream only ever
+        // walks the arguments themselves (flist.c:2476 `send_if_directory()` is
+        // reached from the argument loop); `send_implied_dirs()` emits an
+        // ancestor as a bare entry and never recurses into it. Walking one here
+        // would inject its whole subtree, and those names ARE unrequested -
+        // upstream's `implied_filter_list` check (flist.c:1026) rejects them.
+        // Explicit --files-from dirs stay walkable so their recursive contents
+        // continue to flow normally.
         let implied_only_dirs: HashSet<(PathBuf, PathBuf)> =
             emitted_dirs.difference(&explicit_dirs).cloned().collect();
 

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3443,20 +3443,28 @@ mod files_from {
     }
 
     #[test]
-    fn build_file_list_with_base_deduplicates_explicit_dir_and_child_file() {
-        // UTS-21 regression: when --files-from contains both an explicit
-        // directory (e.g. `dir/subdir`) and a file inside it (e.g.
-        // `dir/subdir/child.txt`), the directory must appear in the wire
-        // file list exactly ONCE. Upstream's `implied_filter_list` check
-        // (flist.c:1026) rejects the second occurrence as
-        // "rejecting unrequested file-list name: dir/subdir", which broke
-        // upstream's `files-from.test` interop suite in the pull direction.
+    fn build_file_list_with_base_emits_explicit_dir_and_implied_parent() {
+        // WHY: when --files-from contains both an explicit directory
+        // (`dir/subdir`) and a file inside it (`dir/subdir/child.txt`),
+        // upstream emits the directory TWICE - once from
+        // `send_implied_dirs()` as the child's ancestor (flist.c:1990,
+        // ALL_FILTERS with the filter list cleared) and once from the
+        // argument loop for the explicit entry (flist.c:2483, NO_FILTERS).
+        // Verified against rsync 3.4.4: `--debug=FLIST2` prints
+        //   make_file(dir,*,2) make_file(dir/subdir,*,0)
+        //   make_file(dir,*,2) make_file(dir/subdir,*,2)
+        //   make_file(dir/subdir/child.txt,*,0)
+        // A non-incremental sender does not clean duplicates
+        // (flist.c:3039-3042), so both reach the wire and the receiver merges
+        // them in `flist_sort_and_clean()`. Collapsing the pair here made the
+        // implied-parent emission depend on the filtered top-level walk, so an
+        // `--exclude` matching the parent removed it from the list entirely
+        // (see `build_file_list_with_base_emits_implied_parent_matched_by_exclude`).
         //
-        // The implied-parent loop previously emitted `dir/subdir` because it
-        // is the parent of `child.txt`, and the top-level walk emitted it
-        // again because it is also an explicit --files-from entry. The fix
-        // pre-populates the explicit-dir set so the implied-parent loop
-        // skips it, leaving the top-level walk as the single emission site.
+        // The duplicate is not rejected by upstream's `implied_filter_list`
+        // check (flist.c:1026): that check tests the NAME, and a repeat of an
+        // accepted name is accepted. Confirmed by pulling this exact list
+        // through a real 3.4.4 receiver in both transfer directions.
         let temp_dir = TempDir::new().unwrap();
         let src = temp_dir.path().join("src");
         let nested = src.join("dir").join("subdir");
@@ -3466,6 +3474,9 @@ mod files_from {
         let handshake = test_handshake();
         let mut config = test_config();
         config.args = vec![OsString::from(&src)];
+        // upstream: options.c:2196 - --files-from turns --relative on, which is
+        // what gates the implied-parent emission (flist.c:2471).
+        config.flags.relative = true;
         config.flags.recursive = true;
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
@@ -3473,9 +3484,9 @@ mod files_from {
         ctx.build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
             .unwrap();
 
-        // Count occurrences of every distinct relative name. The subdir
-        // must appear exactly once; duplicates would re-trigger the
-        // upstream rejection.
+        // Count occurrences of every distinct relative name. The subdir is
+        // both an implied parent and an explicit argument, so it appears
+        // twice - exactly as upstream sends it.
         let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
         for entry in ctx.file_list().iter() {
             *counts.entry(entry.name().to_string()).or_insert(0) += 1;
@@ -3484,9 +3495,9 @@ mod files_from {
         let subdir_name = nested.strip_prefix(&src).unwrap().to_string_lossy();
         let subdir_count = counts.get(subdir_name.as_ref()).copied().unwrap_or(0);
         assert_eq!(
-            subdir_count, 1,
-            "explicit dir + child must emit subdir exactly once, got {subdir_count} \
-             across entries {counts:?}"
+            subdir_count, 2,
+            "explicit dir that is also an implied parent must emit twice like \
+             upstream, got {subdir_count} across entries {counts:?}"
         );
 
         // The child file must still be present so the receiver can transfer it.
@@ -3499,6 +3510,80 @@ mod files_from {
         assert!(
             counts.contains_key(&child_name),
             "child.txt must remain in the file list, got {counts:?}"
+        );
+    }
+
+    #[test]
+    fn build_file_list_with_base_emits_implied_parent_matched_by_exclude() {
+        // WHY: upstream's `send_implied_dirs()` clears the filter list before
+        // emitting ancestors - `filter_list.head = filter_list.tail = NULL;
+        // /* Don't filter implied dirs. */` (flist.c:1950) - so an implied
+        // parent reaches the wire even when an --exclude rule matches it. The
+        // receiver needs the directory entry before its contents arrive: a real
+        // rsync 3.4.4 receiver that sees `dir/file` without `dir` aborts with
+        // "ABORTING due to invalid path from sender: dir/file" (exit 4 at
+        // flist.c:2693 under inc-recurse, exit 2 at generator.c:1326 without
+        // it).
+        //
+        // `dir` here is BOTH an explicit --files-from entry and the implied
+        // parent of `dir/file`. Delegating its emission to the top-level walk -
+        // which does apply filters - let the --exclude drop it from the list
+        // entirely. Verified against rsync 3.4.4 for this exact input:
+        // `--debug=FLIST2` prints make_file(dir,*,2) then
+        // make_file(dir/file,*,0); the explicit `dir` argument is filtered out
+        // by `is_excluded()` (flist.c:2448) and only the unfiltered implied
+        // parent survives.
+        //
+        // Needs neither inc-recurse nor a remote peer: the missing entry is
+        // observable in the built file list itself.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        std::fs::create_dir_all(src.join("dir")).unwrap();
+        std::fs::write(src.join("dir/file"), "payload").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        config.flags.relative = true;
+        config.flags.recursive = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+        apply_filters(
+            &mut ctx,
+            vec![FilterRuleWireFormat::exclude("dir".to_owned())],
+        );
+
+        ctx.build_file_list_with_base(
+            &src,
+            &files_from_entries(&src, vec![src.join("dir"), src.join("dir/file")]),
+        )
+        .unwrap();
+
+        let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        assert!(
+            names.contains(&"dir/file"),
+            "the requested file must stay in the list: {names:?}"
+        );
+        assert!(
+            names.contains(&"dir"),
+            "an --exclude matching an implied parent must not remove it: \
+             upstream never filters implied dirs (flist.c:1950) and a real \
+             receiver aborts on the orphaned child: {names:?}"
+        );
+        let parent = ctx
+            .file_list()
+            .iter()
+            .find(|e| e.name() == "dir")
+            .expect("implied parent entry");
+        assert!(
+            parent.is_dir(),
+            "implied parent must be sent as a directory"
+        );
+        // upstream: flist.c:1949 - implied parents clear FLAG_CONTENT_DIR so an
+        // upstream receiver does not scan them for --delete.
+        assert!(
+            !parent.content_dir(),
+            "the surviving entry must be the implied-parent emission, which \
+             clears CONTENT_DIR"
         );
     }
 


### PR DESCRIPTION
## Problem

Upstream's `send_implied_dirs()` explicitly clears the filter list before emitting a path's ancestors:

```c
/* flist.c:1949-1950 */
flags = (flags | FLAG_IMPLIED_DIR) & ~(FLAG_TOP_DIR | FLAG_CONTENT_DIR);
filter_list.head = filter_list.tail = NULL; /* Don't filter implied dirs. */
```

An implied parent is emitted regardless of exclude rules, because the receiver needs the directory to exist before its contents arrive.

`build_file_list_with_base()` seeded `emitted_dirs` from `explicit_dirs`, so an ancestor that is *also* an explicit `--files-from` entry was skipped by the implied-parent loop and left to the ordinary top-level walk - and that walk applies filters. An `--exclude` matching such a parent therefore removed the directory from the file list entirely.

### Repro

`files.txt`:

```
dir
dir/file
```

plus `--exclude=dir`.

**Before**, oc-rsync pushing to a genuine rsync 3.4.4 receiver:

```
$ oc-rsync -r --inc-recursive --files-from=files.txt --exclude=dir src/ rsync://127.0.0.1/mod/
rsync: [sender] parent directory is missing from the file list: dir/file
ABORTING due to invalid path from sender: dir/file
rsync error: requested action not supported (code 4) at flist.c(2693) [Receiver=3.4.4]

$ oc-rsync -r --no-inc-recursive ... (same list)
ABORTING due to invalid path from sender: dir/file
rsync error: protocol incompatibility (code 2) at generator.c(1326) [generator=3.4.4]
```

**Control** - genuine rsync 3.4.4 as the sender, same list, same receiver: exit 0, both `dir` and `dir/file` created.

### `--debug=FLIST2` diff

Sender-side file list for the same input (local, no inc-recurse, no remote peer needed):

| | rsync 3.4.4 | oc-rsync before | oc-rsync after |
|---|---|---|---|
| | `make_file(dir,*,2)` | - | `make_file(dir,*,2)` |
| | `make_file(dir/file,*,0)` | `make_file(dir/file,*,2)` | `make_file(dir/file,*,2)` |

Upstream lists `dir`; oc did not. The `2` is `ALL_FILTERS`, the filter level `send_implied_dirs()` passes *after* clearing the list; the explicit `dir` argument never reaches `make_file()` at all because `is_excluded()` (flist.c:2448) drops it in the argument loop.

## Duplicate-emission analysis

Removing the seeding lets a directory that is both an implied parent and an unfiltered explicit argument be emitted twice. That is exactly what upstream does. Measured against rsync 3.4.4 with `--debug=FLIST2`, `--files-from` = `dir` + `dir/file`, no exclude:

```
[sender] make_file(dir,*,0)        <- explicit argument, NO_FILTERS
[sender] make_file(dir,*,2)        <- implied parent of dir/file
[sender] make_file(dir/file,*,0)
```

and the receiver confirms it on the wire: `received 4 names` / `received 3 names` depending on `-r`, with `recv_file_name(dir)` appearing twice. A non-incremental sender does **not** run the duplicate-clean pass (`flist.c:3039-3042` starts the loop at `used - 1` when `am_sender && !inc_recurse`), so both entries are transmitted and the receiver merges them in `flist_sort_and_clean()` (`flist.c:3073-3076`; oc's equivalent is `flist::sort::resolve_duplicate`, which already performs the same `TOP_DIR`/`CONTENT_DIR` union).

The duplicate is **not** rejected by upstream's `implied_filter_list` check (`flist.c:1026`): that check tests the *name*, and a repeat of an accepted name is accepted. Verified by pulling this list through a real 3.4.4 client (which populates `implied_filter_list` from the forwarded `--files-from` entries) against both an upstream daemon and an oc daemon - both succeed.

After the change oc's `make_file()` sequence matches upstream one-for-one in all four cells (`-r` / no `-r` x inc-recurse / no inc-recurse), for the excluded and the non-excluded input.

One pre-existing divergence is left untouched and is **not** made worse: oc dedups implied ancestors across `--files-from` entries with a set, where upstream uses an order-sensitive `lastpath` prefix cache that re-emits an ancestor when consecutive entries do not share its prefix. Upstream therefore sometimes sends one more copy of a shallow ancestor than oc does. Since a duplicate directory entry is merged by the receiver, only the *presence* of the parent is load-bearing; this is left for a separate change.

## Fix

`emitted_dirs` starts empty. The implied-parent loop stats and pushes each ancestor directly and never consults the filter chain, mirroring the locality of upstream's `filter_list` clear - no filter special case is threaded through the walk. `explicit_dirs` is retained solely to derive `implied_only_dirs`, which still suppresses the top-level walk for ancestors that are *not* explicit arguments (upstream never walks those; `send_implied_dirs()` emits a bare entry and never recurses into it, and walking one would inject an unrequested subtree).

## Relationship to #6972

#6972 fixed a different cause of the same abort - the implied-parent emitter used `symlink_metadata` where the sibling `-R` emitter correctly used `metadata`, skipping symlinked ancestors. This is the second, independent cause; a fix for one does not fix the other and neither test catches the other. The loud `FERROR_XFER` diagnostic #6972 added to the orphan fallthrough is what makes this one self-reporting (`parent directory is missing from the file list: dir/file`), but the file list was still wrong.

## Tests

- `build_file_list_with_base_emits_implied_parent_matched_by_exclude` (new) - an `--exclude` matching a parent that is also an explicit `--files-from` entry must not remove it. Needs neither inc-recurse nor a remote peer: the missing entry is observable in the built file list. Fails before the change with `["dir/file"]`.
- `build_file_list_with_base_deduplicates_explicit_dir_and_child_file` renamed to `..._emits_explicit_dir_and_implied_parent` and its expectation corrected from 1 to 2 occurrences, with the upstream `--debug=FLIST2` transcript recorded in the test. Its old rationale (that the second occurrence is rejected as "unrequested") does not hold - see the analysis above. The test also now sets `flags.relative`, without which it never reached the implied-parent loop at all and was vacuous with respect to the behaviour it claimed to guard.

## Validation

Against genuine rsync 3.4.4 (`rsync version 3.4.4 protocol version 32`), with and without `--inc-recursive`:

- oc sender -> upstream daemon receiver, `--exclude=dir`: was exit 4 / exit 2, now exit 0 with `dir` and `dir/file` present.
- oc sender -> upstream receiver over a remote shell (`support/lsh.sh` from the upstream tree): same result.
- upstream client pulling from an oc daemon (`implied_filter_list` active on the receiver): tree matches, both directions.
- `--exclude=dir` in the pull direction: oc and upstream produce byte-identical behaviour (`ERROR: rejecting excluded file-list name: dir`, exit 4 at `flist.c(1024)`) - upstream's own receiver-side server-filter check, unchanged by this PR.
- The `testsuite/files-from.test` file list shape (`from/./`, `from/./dir/subdir`, `from/./dir/subdir/subsubdir`, `from/./dir/subdir/subsubdir2/`, `from/./dir/subdir/foobar.baz`) reproduced by hand: oc's tree matches upstream's `chkdir` in push and pull, with and without inc-recurse.
- `cargo nextest run -p transfer --all-features`: 2521 passed. `-p cli -E 'test(files_from)'`: 125 passed. `-p core -E 'test(files_from) or test(interop)'`: 63 passed. fmt and clippy clean.
