### PR TITLE
fix(transfer): pace INC_RECURSE sub-lists against receiver progress

### DIFF
--- a/crates/transfer/src/generator/segments.rs
+++ b/crates/transfer/src/generator/segments.rs
@@ -8,18 +8,19 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:46` - `#define MIN_FILECNT_LOOKAHEAD 1000`
-//! - `flist.c:2498-2510` - `send_extra_file_list()` lookahead throttling
+//! - `rsync.h:151` - `#define MIN_FILECNT_LOOKAHEAD 1000`
+//! - `flist.c:2124-2139` - `send_extra_file_list()` lookahead throttling
 //! - `sender.c:231,265` - send loop calls into segment scheduling at top/bottom
 
-/// Minimum file count lookahead before the sender emits the next incremental
-/// sub-list. The sender accumulates at least this many unsent entries before
-/// flushing a new segment to the receiver, amortizing per-segment overhead.
+/// Entries the sender keeps queued in sub-lists beyond the one the receiver is
+/// currently working through. Once the backlog reaches this many entries the
+/// sender stops emitting sub-lists and waits for the receiver to catch up, so a
+/// peer that throttles is never flooded with the whole tree up front.
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:46` - `#define MIN_FILECNT_LOOKAHEAD 1000`
-/// - `sender.c:send_files()` line 250 - `send_extra_file_list(f, MIN_FILECNT_LOOKAHEAD)`
+/// - `rsync.h:151` - `#define MIN_FILECNT_LOOKAHEAD 1000`
+/// - `sender.c:231,265` - `send_extra_file_list(f_out, MIN_FILECNT_LOOKAHEAD)`
 pub const MIN_FILECNT_LOOKAHEAD: usize = 1000;
 
 /// A pending file list sub-segment for incremental recursion sending.
@@ -81,53 +82,116 @@ pub(crate) struct DirSegment {
 
 /// Cursor-based scheduler that yields pending segments on demand.
 ///
-/// Controls *when* sub-lists are sent during the transfer loop using
-/// upstream's `MIN_FILECNT_LOOKAHEAD` throttling heuristic. The transfer
-/// loop calls `next_if_needed()` at top and bottom of each iteration,
-/// matching upstream `sender.c:231,265`.
+/// Owns the whole of upstream's `send_extra_file_list()` throttling rule: both
+/// the `MIN_FILECNT_LOOKAHEAD` threshold and the `file_total - file_old_total`
+/// backlog it is compared against. The transfer loop drives it at the top and
+/// bottom of each iteration (upstream `sender.c:231,265`) and tells it when the
+/// receiver has finished a sub-list, but never re-derives the condition itself.
+///
+/// # Lookahead accounting
+///
+/// Upstream's loop condition is `file_total - file_old_total < at_least`
+/// (`flist.c:2139`), where `file_total` counts entries in every live file-list
+/// and `file_old_total` counts entries in the lists from `first_flist` through
+/// `cur_flist`. The difference is therefore the number of entries queued in
+/// sub-lists *beyond the one the receiver is currently working through* - a
+/// pure lookahead backlog. It is not "sent minus transferred": it steps by
+/// whole sub-lists, at `flist_free()` time, never per transferred file.
+///
+/// [`Self::lookahead_total`] reproduces that difference directly: dispatching a
+/// sub-list adds its entry count (`flist.c:2195` `file_total += flist->used`,
+/// with `file_old_total` untouched), and retiring the current sub-list on the
+/// receiver's `NDX_DONE` subtracts the count of the sub-list promoted in its
+/// place (`sender.c:247-251`).
 ///
 /// # Upstream Reference
 ///
 /// - `sender.c:231,265` - checks `inc_recurse` at top/bottom of send loop
-/// - `flist.c:2498` - `send_extra_file_list()` uses `MIN_FILECNT_LOOKAHEAD`
+/// - `flist.c:2124-2139` - `send_extra_file_list()` re-tests the lookahead
+///   condition on every iteration
 #[derive(Debug)]
 pub(crate) struct SegmentScheduler {
     segments: Vec<PendingSegment>,
+    /// Number of segments handed to the wire so far.
     cursor: usize,
+    /// Number of segments the receiver has already worked through, i.e. the
+    /// index of the segment playing upstream's `cur_flist` role. Always
+    /// `<= cursor`.
+    promoted: usize,
+    /// Entries in `segments[promoted..cursor]`: upstream's
+    /// `file_total - file_old_total`.
+    lookahead_total: usize,
 }
 
 impl SegmentScheduler {
     /// Creates a scheduler that will yield segments in order.
+    ///
+    /// The backlog starts at zero because the initial file list is `cur_flist`:
+    /// `send_file_list()` adds its `used` to both `file_total` and
+    /// `file_old_total` (`flist.c:2545-2546`), leaving the difference at 0.
     pub(crate) fn new(segments: Vec<PendingSegment>) -> Self {
         Self {
             segments,
             cursor: 0,
+            promoted: 0,
+            lookahead_total: 0,
         }
     }
 
-    /// Returns the next segment if the lookahead heuristic indicates we should send.
+    /// Returns the next segment when the lookahead backlog is under
+    /// `MIN_FILECNT_LOOKAHEAD`, accounting for the dispatch before returning.
     ///
-    /// Yields when `remaining_in_current` drops below `MIN_FILECNT_LOOKAHEAD`,
-    /// matching upstream's throttling in `flist.c:2498-2510`.
-    pub(crate) fn next_if_needed(
-        &mut self,
-        remaining_in_current: usize,
-    ) -> Option<&PendingSegment> {
-        if self.cursor >= self.segments.len() {
+    /// Because the backlog is updated here, driving this in a `while let` loop
+    /// re-evaluates upstream's condition on every iteration exactly as
+    /// `flist.c:2139` does, and the loop stops as soon as enough entries are
+    /// queued ahead.
+    pub(crate) fn next_to_send(&mut self) -> Option<&PendingSegment> {
+        if self.lookahead_total >= MIN_FILECNT_LOOKAHEAD {
             return None;
         }
-        if remaining_in_current < MIN_FILECNT_LOOKAHEAD {
-            let seg = &self.segments[self.cursor];
-            self.cursor += 1;
-            Some(seg)
-        } else {
-            None
+        self.advance()
+    }
+
+    /// Returns the next segment unconditionally, ignoring the lookahead.
+    ///
+    /// Used for the end-of-transfer flush, where every sub-list must reach the
+    /// receiver before `NDX_FLIST_EOF` regardless of the backlog.
+    pub(crate) fn next_forced(&mut self) -> Option<&PendingSegment> {
+        self.advance()
+    }
+
+    /// Hands out `segments[cursor]` and folds its entry count into the backlog.
+    fn advance(&mut self) -> Option<&PendingSegment> {
+        let idx = self.cursor;
+        let count = self.segments.get(idx)?.count;
+        self.cursor = idx + 1;
+        self.lookahead_total += count;
+        Some(&self.segments[idx])
+    }
+
+    /// Records that the receiver has finished the sub-list it was working on,
+    /// promoting the oldest queued segment to `cur_flist`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:247-251` - `file_old_total -= first_flist->used` followed by
+    ///   `flist_free()` and `file_old_total = cur_flist->used`
+    pub(crate) fn retire_current_flist(&mut self) {
+        if self.promoted < self.cursor {
+            self.lookahead_total -= self.segments[self.promoted].count;
+            self.promoted += 1;
         }
     }
 
-    /// Returns a slice of all remaining unconsumed segments.
-    pub(crate) fn remaining(&self) -> &[PendingSegment] {
-        &self.segments[self.cursor..]
+    /// Number of segments dispatched so far.
+    pub(crate) fn dispatched_count(&self) -> usize {
+        self.cursor
+    }
+
+    /// Entries queued in sub-lists beyond the receiver's current one.
+    #[cfg(test)]
+    pub(crate) fn lookahead_total(&self) -> usize {
+        self.lookahead_total
     }
 
     /// Returns `true` when all segments have been dispatched.

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -4661,134 +4661,153 @@ fn server_mode_flushes_writer_before_filter_list_read() {
     );
 }
 
+/// Builds `count` sub-lists of `per_segment` entries each.
+#[cfg(test)]
+fn scheduler_with(count: usize, per_segment: usize) -> super::segments::SegmentScheduler {
+    use super::segments::{PendingSegment, SegmentScheduler};
+
+    let segments = (0..count)
+        .map(|i| PendingSegment {
+            parent_dir_ndx: i as i32,
+            parent_flat_idx: i,
+            flist_start: 1 + i * per_segment,
+            count: per_segment,
+        })
+        .collect();
+    SegmentScheduler::new(segments)
+}
+
 #[test]
-fn segment_scheduler_dispatches_when_remaining_below_threshold() {
-    // When remaining entries known to the receiver are below
-    // MIN_FILECNT_LOOKAHEAD, the scheduler should dispatch the next segment.
-    use super::segments::{MIN_FILECNT_LOOKAHEAD, PendingSegment, SegmentScheduler};
+fn segment_scheduler_starts_with_an_empty_lookahead() {
+    // upstream flist.c:2545-2546 - send_file_list() adds the initial list's
+    // `used` to BOTH file_total and file_old_total, so the very first
+    // send_extra_file_list() call sees a backlog of 0 and always dispatches.
+    // The initial list is `cur_flist`, never lookahead.
+    let mut scheduler = scheduler_with(1, 500);
 
-    let seg = PendingSegment {
-        parent_dir_ndx: 0,
-        parent_flat_idx: 0,
-        flist_start: 10,
-        count: 500,
-    };
-    let mut scheduler = SegmentScheduler::new(vec![seg]);
-
-    // remaining = 13 (a small initial segment), well below 1000
-    let result = scheduler.next_if_needed(13);
+    assert_eq!(scheduler.lookahead_total(), 0);
     assert!(
-        result.is_some(),
-        "scheduler must dispatch when remaining ({}) < MIN_FILECNT_LOOKAHEAD ({})",
-        13,
-        MIN_FILECNT_LOOKAHEAD,
+        scheduler.next_to_send().is_some(),
+        "an empty backlog must always admit the next sub-list"
     );
 }
 
 #[test]
-fn segment_scheduler_blocks_when_remaining_at_threshold() {
-    // When remaining equals MIN_FILECNT_LOOKAHEAD, upstream's condition
-    // `file_total - file_old_total < at_least` is false (1000 < 1000 is false),
-    // so no dispatch should occur.
-    use super::segments::{MIN_FILECNT_LOOKAHEAD, PendingSegment, SegmentScheduler};
+fn segment_scheduler_stops_the_burst_once_the_backlog_is_reached() {
+    // upstream flist.c:2139 - `while (file_total - file_old_total < at_least)`
+    // is re-tested every iteration, and file_total grows by each sub-list it
+    // sends. Two 500-entry sub-lists reach exactly MIN_FILECNT_LOOKAHEAD, and
+    // `1000 < 1000` is false, so the third must not go out.
+    //
+    // The WHY: this is the whole of the pacing contract. A scheduler that
+    // ignored its own dispatches would hand out every sub-list in one burst,
+    // which an upstream receiver that throttles cannot absorb.
+    use super::segments::MIN_FILECNT_LOOKAHEAD;
 
-    let seg = PendingSegment {
-        parent_dir_ndx: 0,
-        parent_flat_idx: 0,
-        flist_start: 10,
-        count: 500,
-    };
-    let mut scheduler = SegmentScheduler::new(vec![seg]);
+    let mut scheduler = scheduler_with(3, MIN_FILECNT_LOOKAHEAD / 2);
 
-    let result = scheduler.next_if_needed(MIN_FILECNT_LOOKAHEAD);
+    assert!(scheduler.next_to_send().is_some(), "backlog 0");
     assert!(
-        result.is_none(),
-        "scheduler must NOT dispatch when remaining == MIN_FILECNT_LOOKAHEAD"
+        scheduler.next_to_send().is_some(),
+        "backlog {} is still below the threshold",
+        MIN_FILECNT_LOOKAHEAD / 2
+    );
+    assert_eq!(scheduler.lookahead_total(), MIN_FILECNT_LOOKAHEAD);
+    assert!(
+        scheduler.next_to_send().is_none(),
+        "backlog == MIN_FILECNT_LOOKAHEAD must block, matching `1000 < 1000` == false"
+    );
+    assert_eq!(scheduler.dispatched_count(), 2);
+}
+
+#[test]
+fn segment_scheduler_dispatches_one_sub_list_below_the_threshold() {
+    // A backlog one entry short of the threshold still admits a sub-list, even
+    // when that one overshoots: upstream tests the condition before sending,
+    // never the post-send total (flist.c:2139).
+    use super::segments::MIN_FILECNT_LOOKAHEAD;
+
+    let mut scheduler = scheduler_with(2, MIN_FILECNT_LOOKAHEAD - 1);
+
+    assert!(scheduler.next_to_send().is_some());
+    assert_eq!(scheduler.lookahead_total(), MIN_FILECNT_LOOKAHEAD - 1);
+    assert!(
+        scheduler.next_to_send().is_some(),
+        "backlog {} is one below the threshold, so one more sub-list goes out",
+        MIN_FILECNT_LOOKAHEAD - 1
+    );
+    assert!(
+        scheduler.next_to_send().is_none(),
+        "the overshooting sub-list closes the window"
     );
 }
 
 #[test]
-fn segment_scheduler_blocks_when_remaining_above_threshold() {
-    // When remaining exceeds MIN_FILECNT_LOOKAHEAD, no dispatch.
-    use super::segments::{MIN_FILECNT_LOOKAHEAD, PendingSegment, SegmentScheduler};
+fn segment_scheduler_resumes_when_the_receiver_finishes_a_sub_list() {
+    // upstream sender.c:247-251 - on the receiver's NDX_DONE the sender frees
+    // the oldest file-list and re-points file_old_total at the new cur_flist,
+    // which drops the backlog by exactly that list's entry count and lets the
+    // next send_extra_file_list() call push one more sub-list.
+    //
+    // The WHY: without this feedback the sender would stall forever once the
+    // backlog first hit the threshold - the mirror-image failure of the burst.
+    use super::segments::MIN_FILECNT_LOOKAHEAD;
 
-    let seg = PendingSegment {
-        parent_dir_ndx: 0,
-        parent_flat_idx: 0,
-        flist_start: 10,
-        count: 500,
-    };
-    let mut scheduler = SegmentScheduler::new(vec![seg]);
+    let half = MIN_FILECNT_LOOKAHEAD / 2;
+    let mut scheduler = scheduler_with(4, half);
 
-    let result = scheduler.next_if_needed(MIN_FILECNT_LOOKAHEAD + 1);
-    assert!(
-        result.is_none(),
-        "scheduler must NOT dispatch when remaining > MIN_FILECNT_LOOKAHEAD"
+    while scheduler.next_to_send().is_some() {}
+    assert_eq!(
+        scheduler.dispatched_count(),
+        2,
+        "burst stops at the backlog"
     );
-}
 
-#[test]
-fn segment_scheduler_boundary_dispatches_at_999() {
-    // remaining = 999, which is < 1000, so dispatch must occur.
-    use super::segments::{MIN_FILECNT_LOOKAHEAD, PendingSegment, SegmentScheduler};
-
-    let seg = PendingSegment {
-        parent_dir_ndx: 0,
-        parent_flat_idx: 0,
-        flist_start: 10,
-        count: 500,
-    };
-    let mut scheduler = SegmentScheduler::new(vec![seg]);
-
-    let result = scheduler.next_if_needed(MIN_FILECNT_LOOKAHEAD - 1);
+    scheduler.retire_current_flist();
+    assert_eq!(scheduler.lookahead_total(), half);
     assert!(
-        result.is_some(),
-        "scheduler must dispatch when remaining == {} (one below threshold)",
-        MIN_FILECNT_LOOKAHEAD - 1,
+        scheduler.next_to_send().is_some(),
+        "retiring a sub-list must free room for the next one"
     );
+    assert!(scheduler.next_to_send().is_none());
+    assert_eq!(scheduler.dispatched_count(), 3);
 }
 
 #[test]
 fn segment_scheduler_many_files_deadlock_scenario() {
-    // Regression test for the many-files deadlock (#5085).
-    // Scenario: 1013 total entries, 13 in the initial segment, 1000 in a
-    // pending sub-list. Using dispatched_entry_count (13) instead of
-    // file_list.len() (1013) gives remaining=13 which triggers dispatch.
-    use super::segments::{PendingSegment, SegmentScheduler};
+    // Regression test for the many-files deadlock (#5085): a 13-entry initial
+    // list followed by a single 1000-entry sub-list. The initial list is
+    // cur_flist, so the backlog is 0 and the sub-list must go out; an earlier
+    // revision compared MIN_FILECNT_LOOKAHEAD against the total file count
+    // (1013), blocked, and never sent NDX_FLIST_EOF.
+    let mut scheduler = scheduler_with(1, 1000);
 
-    let seg = PendingSegment {
-        parent_dir_ndx: 1,
-        parent_flat_idx: 0,
-        flist_start: 13,
-        count: 1000,
-    };
-    let mut scheduler = SegmentScheduler::new(vec![seg]);
-
-    // Bug: old code computed remaining = file_list.len() - transferred = 1013 - 0 = 1013
-    // which is >= 1000, so no dispatch occurred. Deadlock.
-    let remaining_buggy = 1013usize;
-    let result_buggy = scheduler.next_if_needed(remaining_buggy);
     assert!(
-        result_buggy.is_none(),
-        "with total file count (buggy), scheduler incorrectly blocks"
+        scheduler.next_to_send().is_some(),
+        "the sole sub-list must be dispatched or the transfer deadlocks"
     );
+    assert!(scheduler.is_exhausted());
+}
 
-    // Fix: remaining = dispatched_entry_count - transferred = 13 - 0 = 13
-    // Reset scheduler for the corrected test.
-    let seg = PendingSegment {
-        parent_dir_ndx: 1,
-        parent_flat_idx: 0,
-        flist_start: 13,
-        count: 1000,
-    };
-    let mut scheduler = SegmentScheduler::new(vec![seg]);
+#[test]
+fn segment_scheduler_forced_drain_ignores_the_backlog() {
+    // The end-of-transfer flush must land every sub-list before NDX_FLIST_EOF:
+    // the receiver will not send its final NDX_DONE until it sees EOF, so no
+    // one is left to drain the backlog.
+    use super::segments::MIN_FILECNT_LOOKAHEAD;
 
-    let remaining_fixed = 13usize;
-    let result_fixed = scheduler.next_if_needed(remaining_fixed);
-    assert!(
-        result_fixed.is_some(),
-        "with dispatched_entry_count (fixed), scheduler correctly dispatches"
-    );
+    let mut scheduler = scheduler_with(5, MIN_FILECNT_LOOKAHEAD);
+
+    assert!(scheduler.next_to_send().is_some());
+    assert!(scheduler.next_to_send().is_none(), "throttled after one");
+
+    let mut forced = 0;
+    while scheduler.next_forced().is_some() {
+        forced += 1;
+    }
+    assert_eq!(forced, 4);
+    assert!(scheduler.is_exhausted());
+    assert_eq!(scheduler.dispatched_count(), 5);
 }
 
 #[test]

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -170,6 +170,38 @@ impl GeneratorContext {
         sum_head.write(&mut XferSink::new(writer, divert))
     }
 
+    /// Dispatches queued INC_RECURSE sub-lists until the receiver has at least
+    /// `MIN_FILECNT_LOOKAHEAD` entries queued ahead of the list it is working
+    /// through.
+    ///
+    /// Upstream calls `send_extra_file_list(f_out, MIN_FILECNT_LOOKAHEAD)` from
+    /// two points in the send loop (`sender.c:231` and `sender.c:265`); this is
+    /// that one function, so both call sites share a single expression of the
+    /// rule. The loop condition lives in [`SegmentScheduler::next_to_send`],
+    /// which folds each dispatch into the backlog before returning - so, like
+    /// upstream's `while (file_total - file_old_total < at_least)`, the test is
+    /// re-evaluated on every iteration and stops the burst as soon as enough
+    /// entries are queued.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2124-2139` - `send_extra_file_list()` loop head
+    /// - `sender.c:231,265` - the two call sites this method serves
+    fn send_extra_file_lists<W: Write>(
+        &mut self,
+        writer: &mut super::super::super::writer::ServerWriter<W>,
+        scheduler: &mut SegmentScheduler,
+        flist_writer: &mut protocol::flist::FileListWriter,
+        ndx_codec: &mut MonotonicNdxWriter,
+        flist_done_remaining: &mut usize,
+    ) -> io::Result<()> {
+        while let Some(seg) = scheduler.next_to_send() {
+            self.encode_and_send_segment(&mut *writer, seg, flist_writer, ndx_codec.inner_mut())?;
+            *flist_done_remaining += 1;
+        }
+        Ok(())
+    }
+
     /// Runs the main file transfer loop, reading NDX requests from receiver.
     ///
     /// This method processes file transfer requests in phases until all phases complete.
@@ -301,23 +333,12 @@ impl GeneratorContext {
         // instance for sub-lists would diff-encode negative offsets against an
         // independent prev_negative, desyncing the receiver's unified read
         // state. Route sub-list writes through ndx_write_codec.inner_mut().
-        let mut segments_sent: usize = 0;
         // upstream: sender.c:242-250 - tracks remaining flist-free NDX_DONEs.
         // With INC_RECURSE, the client sends one NDX_DONE per completed flist
         // (initial + sub-lists). The sender echoes these without phase change
         // until all flists are freed, then falls through to the normal phase
         // transition. This counter tracks how many flist-free echoes remain.
         let mut flist_done_remaining: usize = 0;
-
-        // upstream: flist.c:104,2195 - file_total tracks entries the receiver
-        // knows about (initial segment + dispatched sub-lists). Used for the
-        // MIN_FILECNT_LOOKAHEAD comparison in send_extra_file_list().
-        // Unlike self.file_list.len() which includes undispatched segments,
-        // this only counts entries already sent to the receiver.
-        let mut dispatched_entry_count: usize = self
-            .incremental
-            .initial_segment_count
-            .unwrap_or(self.file_list.len());
 
         // upstream: sender.c - dry-run skips data transfer; daemon may close early
         let tolerant = self.config.flags.dry_run;
@@ -330,26 +351,23 @@ impl GeneratorContext {
             crate::shared::check_shutdown()?;
             // upstream: sender.c:227 - send extra file lists at top of loop
             if inc_recurse {
-                // upstream: flist.c:2139 - file_total - file_old_total < at_least
-                // remaining = entries the receiver knows about minus transferred
-                let remaining = dispatched_entry_count.saturating_sub(files_transferred);
-                while let Some(seg) = scheduler.next_if_needed(remaining) {
-                    self.encode_and_send_segment(
-                        &mut *writer,
-                        seg,
-                        &mut flist_writer,
-                        ndx_write_codec.inner_mut(),
-                    )?;
-                    segments_sent += 1;
-                    flist_done_remaining += 1;
-                    dispatched_entry_count += seg.count;
-                }
+                self.send_extra_file_lists(
+                    &mut *writer,
+                    &mut scheduler,
+                    &mut flist_writer,
+                    &mut ndx_write_codec,
+                    &mut flist_done_remaining,
+                )?;
 
                 // upstream: flist.c:2534-2545 - send NDX_FLIST_EOF when all sub-lists
                 // have been dispatched. Must happen inside the loop (not after) because
                 // the receiver waits for NDX_FLIST_EOF before sending NDX_DONE.
                 if !self.incremental.flist_eof_sent && scheduler.is_exhausted() {
-                    self.send_flist_eof(&mut *writer, ndx_write_codec.inner_mut(), segments_sent)?;
+                    self.send_flist_eof(
+                        &mut *writer,
+                        ndx_write_codec.inner_mut(),
+                        scheduler.dispatched_count(),
+                    )?;
                 }
             }
 
@@ -392,6 +410,13 @@ impl GeneratorContext {
                             // reduce RSS. Entries stay in place for NDX indexing but
                             // their PathBuf/extras allocations are freed.
                             self.reclaim_oldest_segment();
+                            // upstream: sender.c:251 - `file_old_total =
+                            // cur_flist->used`. The freed list drops out of the
+                            // lookahead backlog and the next sub-list becomes
+                            // the one the receiver is working through, so the
+                            // backlog shrinks by that list's entry count and
+                            // the throttle admits another segment.
+                            scheduler.retire_current_flist();
 
                             // upstream: sender.c:249-253 - after freeing the oldest
                             // flist, `if (first_flist)` is still true (another flist
@@ -1061,18 +1086,13 @@ impl GeneratorContext {
 
             // upstream: sender.c:261 - send extra file lists at bottom of loop
             if inc_recurse {
-                let remaining = dispatched_entry_count.saturating_sub(files_transferred);
-                while let Some(seg) = scheduler.next_if_needed(remaining) {
-                    self.encode_and_send_segment(
-                        &mut *writer,
-                        seg,
-                        &mut flist_writer,
-                        ndx_write_codec.inner_mut(),
-                    )?;
-                    segments_sent += 1;
-                    flist_done_remaining += 1;
-                    dispatched_entry_count += seg.count;
-                }
+                self.send_extra_file_lists(
+                    &mut *writer,
+                    &mut scheduler,
+                    &mut flist_writer,
+                    &mut ndx_write_codec,
+                    &mut flist_done_remaining,
+                )?;
             }
 
             // Check deadline at file boundary after sending each file.
@@ -1089,21 +1109,28 @@ impl GeneratorContext {
         }
 
         // Flush any remaining INC_RECURSE segments and send NDX_FLIST_EOF.
+        // The lookahead throttle is deliberately bypassed here: the receiver
+        // will not send its final NDX_DONE until it has seen NDX_FLIST_EOF, so
+        // there is no longer anyone to drain the backlog.
+        //
         // No need to track flist_done_remaining here: the EOF flush is the
         // final write loop in this function, so the counter is never read
-        // again. Mid-transfer increments at line ~435 are still needed for
-        // the in-loop accounting at line ~158.
+        // again. Mid-transfer increments in the NDX_DONE arm are still needed
+        // for the in-loop accounting.
         if inc_recurse && !self.incremental.flist_eof_sent {
-            for seg in scheduler.remaining() {
+            while let Some(seg) = scheduler.next_forced() {
                 self.encode_and_send_segment(
                     &mut *writer,
                     seg,
                     &mut flist_writer,
                     ndx_write_codec.inner_mut(),
                 )?;
-                segments_sent += 1;
             }
-            self.send_flist_eof(&mut *writer, ndx_write_codec.inner_mut(), segments_sent)?;
+            self.send_flist_eof(
+                &mut *writer,
+                ndx_write_codec.inner_mut(),
+                scheduler.dispatched_count(),
+            )?;
         }
 
         // Cache flist_writer back for potential reuse (e.g., phase 2).
@@ -1868,6 +1895,177 @@ mod append_redo_tests {
         assert_eq!(
             consumed, total,
             "resend left the redo block signature unread -> wire desync"
+        );
+    }
+}
+
+#[cfg(test)]
+mod inc_recurse_lookahead_tests {
+    //! Sub-list pacing guard for the INC_RECURSE sender.
+    //!
+    //! upstream: `sender.c:231,265` call `send_extra_file_list(f_out,
+    //! MIN_FILECNT_LOOKAHEAD)`, whose loop head
+    //! (`flist.c:2139 while (file_total - file_old_total < at_least)`) is
+    //! re-tested on every iteration. The sender therefore keeps roughly 1000
+    //! entries queued ahead of the sub-list the receiver is working through and
+    //! stops - it never pushes the whole tree up front.
+    //!
+    //! The WHY this pins: pacing is invisible in an oc-to-oc run, because both
+    //! halves are eager and neither ever blocks the other. It is only observable
+    //! against a peer that throttles, where an unbounded up-front burst fills the
+    //! socket buffer before the receiver has drained it. So the guard has to be
+    //! an ordering assertion - how many sub-lists reached the wire *before* the
+    //! sender first blocked for a receiver NDX - not an assertion on the final
+    //! wire contents, which are identical either way.
+
+    use std::cell::Cell;
+    use std::io::{self, Cursor, Read};
+    use std::path::Path;
+    use std::rc::Rc;
+    use std::sync::Arc;
+
+    use protocol::codec::{MonotonicNdxWriter, NdxCodec};
+    use protocol::flist::FileEntry;
+    use protocol::{CompatibilityFlags, ProtocolVersion};
+
+    use crate::config::ServerConfig;
+    use crate::generator::segments::MIN_FILECNT_LOOKAHEAD;
+    use crate::generator::{GeneratorContext, segment_dispatch_totals};
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+    use crate::writer::ServerWriter;
+
+    /// Sub-directories in the fixture; one INC_RECURSE sub-list each.
+    const DIRS: usize = 30;
+    /// Files per sub-directory, so each sub-list carries exactly this many
+    /// entries. Chosen to divide `MIN_FILECNT_LOOKAHEAD` evenly, making the
+    /// expected first burst an exact count rather than a range.
+    const FILES_PER_DIR: usize = 100;
+    /// Sub-lists the sender must send before it first blocks on the receiver:
+    /// enough to reach `MIN_FILECNT_LOOKAHEAD` queued entries, and no more.
+    const EXPECTED_FIRST_BURST: usize = MIN_FILECNT_LOOKAHEAD / FILES_PER_DIR;
+
+    /// Wire reader that records the sub-list dispatch count at the moment the
+    /// sender first blocks for a receiver NDX.
+    struct FirstReadProbe {
+        wire: Cursor<Vec<u8>>,
+        dispatched_at_first_read: Rc<Cell<Option<u64>>>,
+    }
+
+    impl Read for FirstReadProbe {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.dispatched_at_first_read.get().is_none() {
+                self.dispatched_at_first_read
+                    .set(Some(segment_dispatch_totals().0));
+            }
+            self.wire.read(buf)
+        }
+    }
+
+    /// Builds an INC_RECURSE generator over a `DIRS * FILES_PER_DIR` tree.
+    ///
+    /// Entries are pushed in the sorted order a real `-r` scan produces
+    /// (`.`, `d00`, `d00/f000`..., `d01`, ...) so the partitioner sees the same
+    /// shape it does in production.
+    fn generator_with_segmented_tree() -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: true,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: Some(CompatibilityFlags::INC_RECURSE),
+            checksum_seed: 0,
+        };
+        let config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            ..Default::default()
+        };
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+        assert!(ctx.inc_recurse(), "fixture must negotiate INC_RECURSE");
+
+        let base: Arc<Path> = Arc::from(Path::new(""));
+        let push = |ctx: &mut GeneratorContext, entry: FileEntry| {
+            ctx.file_list.push(entry);
+            ctx.source_bases.push(Arc::clone(&base));
+        };
+        push(&mut ctx, FileEntry::new_directory(".".into(), 0o755));
+        for d in 0..DIRS {
+            push(
+                &mut ctx,
+                FileEntry::new_directory(format!("d{d:02}").into(), 0o755),
+            );
+            for f in 0..FILES_PER_DIR {
+                push(
+                    &mut ctx,
+                    FileEntry::new_file(format!("d{d:02}/f{f:03}").into(), 0, 0o644),
+                );
+            }
+        }
+
+        ctx.partition_file_list_for_inc_recurse();
+        assert_eq!(
+            ctx.incremental.pending_segments.len(),
+            DIRS,
+            "one pending sub-list per sub-directory"
+        );
+        assert!(
+            ctx.incremental
+                .pending_segments
+                .iter()
+                .all(|s| s.count == FILES_PER_DIR),
+            "each sub-list must carry exactly {FILES_PER_DIR} entries"
+        );
+        ctx
+    }
+
+    #[test]
+    fn sub_lists_are_paced_against_receiver_progress() {
+        // The receiver acknowledges each completed file-list and then closes out
+        // the three phases; it never requests a transfer, so every read the
+        // sender performs is a genuine block on receiver progress.
+        let mut ndx = MonotonicNdxWriter::new(32);
+        let mut wire = Vec::new();
+        for _ in 0..(DIRS + 3) {
+            ndx.write_ndx_done(&mut wire).unwrap();
+        }
+
+        let dispatched_at_first_read = Rc::new(Cell::new(None));
+        let mut reader = FirstReadProbe {
+            wire: Cursor::new(wire),
+            dispatched_at_first_read: Rc::clone(&dispatched_at_first_read),
+        };
+        let mut writer = ServerWriter::new_plain(Vec::new());
+        let mut progress: Option<&mut dyn crate::TransferProgressCallback> = None;
+        let mut itemize: Option<&mut dyn crate::ItemizeCallback> = None;
+
+        let mut ctx = generator_with_segmented_tree();
+        let before = segment_dispatch_totals().0;
+        ctx.run_transfer_loop(&mut reader, &mut writer, &mut progress, &mut itemize)
+            .expect("sender loop must run to completion");
+        let after = segment_dispatch_totals().0;
+
+        let first_burst = dispatched_at_first_read
+            .get()
+            .expect("sender must block for a receiver NDX")
+            - before;
+
+        // Pre-fix, the lookahead was computed once outside the dispatch loop, so
+        // the very first `while` drained all DIRS sub-lists before the sender
+        // ever read a byte back. Upstream re-tests the condition each iteration
+        // and stops at MIN_FILECNT_LOOKAHEAD queued entries.
+        assert_eq!(
+            first_burst as usize, EXPECTED_FIRST_BURST,
+            "sender must queue {MIN_FILECNT_LOOKAHEAD} entries ahead and then wait, \
+             not push all {DIRS} sub-lists up front"
+        );
+        assert_eq!(
+            (after - before) as usize,
+            DIRS,
+            "every sub-list must still reach the receiver by end of transfer"
         );
     }
 }


### PR DESCRIPTION
## The bug

`transfer_loop.rs` bound the INC_RECURSE lookahead figure **once, outside** the dispatch loop:

```rust
// upstream: flist.c:2139 - file_total - file_old_total < at_least
let remaining = dispatched_entry_count.saturating_sub(files_transferred);
while let Some(seg) = scheduler.next_if_needed(remaining) {
    ...
    dispatched_entry_count += seg.count;   // never fed back into `remaining`
}
```

The comment cites the very upstream condition that `send_extra_file_list()` **re-evaluates on every iteration** (`flist.c:2124-2139`, `while (file_total - file_old_total < at_least)`). With the value frozen, the first time it dropped below `MIN_FILECNT_LOOKAHEAD` the loop drained **every** remaining sub-list in one burst - immediately, for any tree under 1000 files. The identical defect sat at the bottom-of-loop dispatch point.

This is the sender half of a symmetric divergence: the receiver drains all sub-lists up front as well, so an oc-to-oc run never exposes it. Only a peer that throttles - a real upstream receiver - sees the flood.

## `file_old_total` is not the analogue of `files_transferred`

`files_transferred` was the wrong quantity **in kind**, not just in when it was sampled:

- `file_total` counts entries in every live file-list; `file_old_total` counts entries in the lists from `first_flist` through `cur_flist`.
- Their difference is the number of entries queued in sub-lists **beyond the one the receiver is currently working through** - a pure lookahead backlog.
- It moves only at `flist_free()` time, in whole sub-lists (`sender.c:247-251`), never once per transferred file. Inside `send_extra_file_list()` it does not move at all; `file_total` is the side that grows.

Deriving it from a per-file counter is wrong in both directions. On a no-change re-sync `files_transferred` stays 0, so the figure never shrinks and the sender would *stall* rather than burst - had the burst not already emptied the queue first. Reproducing `file_total - file_old_total` directly avoids both failure modes.

## The fix

`SegmentScheduler` now owns the whole rule - threshold *and* backlog - so the caller asks it instead of re-deriving the condition:

- `next_to_send()` folds each dispatch into the backlog before returning, so a `while let` loop re-tests the condition every iteration exactly as `flist.c:2139` does.
- `retire_current_flist()` is called from the `NDX_DONE` flist-free arm, mirroring `sender.c:247-251`.
- `next_forced()` serves the end-of-transfer flush, which must bypass the throttle: the receiver will not send its final `NDX_DONE` until it has seen `NDX_FLIST_EOF`, so nobody is left to drain the backlog.

Both call sites now go through one `send_extra_file_lists()`, mirroring upstream's single function called from `sender.c:231` and `sender.c:265`.

## Testing

`sub_lists_are_paced_against_receiver_progress` drives the real `run_transfer_loop` over a 30-directory / 3000-file INC_RECURSE tree with a wire reader that snapshots the sub-list dispatch count the moment the sender first blocks for a receiver NDX. It asserts an ordering property - sub-lists emitted *relative to* transfer progress - because the final wire contents are identical either way.

Confirmed to fail before the fix:

```
assertion `left == right` failed: sender must queue 1000 entries ahead and then wait,
not push all 30 sub-lists up front
  left: 30
 right: 10
```

The scheduler unit tests were rewritten: the previous ones passed a caller-supplied `remaining` and so could not observe the burst at all.

## Verification against upstream 3.4.4

oc-sender pushing the 3000-file tree to an upstream `rsync 3.4.4 protocol version 32` receiver, `--debug=FLIST2`. Receiver-side sub-list arrivals, by log line:

| | sub-list arrival positions |
|---|---|
| before | 1..30 at 38, 141, 244 ... 3025 - a flat 103-line stride, the whole tree on the wire before a single file moved |
| after | 1..10 at 38 ... 965 (1000 entries queued), then 11 at 2101, 12 at 4211, 13 at 4314 - paced by receiver progress |

Also confirmed: same tree over an upstream 3.4.4 daemon, and a zero-transfer (`-rt`) re-sync - both identical trees, exit 0, no stall.

`cargo nextest run -p transfer --all-features`: 2522 passed. `cargo fmt --all --check` and workspace `clippy -D warnings` clean.
