### PR TITLE
fix(flist): keep log-file-only file-list banners off stdout

### DIFF
--- a/crates/flist/src/file_list_walker.rs
+++ b/crates/flist/src/file_list_walker.rs
@@ -29,7 +29,10 @@ impl FileListWalker {
         safe_links: bool,
     ) -> Result<Self, FileListError> {
         let root = absolutize(root)?;
-        debug_log!(Flist, 1, "building file list from {:?}", root);
+        // The walk root is deliberately not announced: upstream's counterpart
+        // (flist.c:2248 `rprintf(FLOG, "building file list\n")`) is an FLOG
+        // message that log.c:rwrite() drops for a client with no --log-file,
+        // whereas every DiagnosticEvent from this crate reaches stdout.
 
         // upstream: flist.c:readlink_stat() - use stat() when copy_links is
         // set, lstat() otherwise.

--- a/crates/flist/src/parallel.rs
+++ b/crates/flist/src/parallel.rs
@@ -7,7 +7,6 @@
 use std::fs;
 use std::path::PathBuf;
 
-use logging::info_log;
 use rayon::prelude::*;
 
 use crate::batched_stat::BatchedStatCache;
@@ -38,12 +37,12 @@ use crate::file_list_walker::FileListWalker;
 /// let entries = collect_entries(walker)?;
 /// println!("Found {} entries", entries.len());
 /// ```
+// Enumeration is silent: upstream announces a completed file list only via the
+// `sending incremental file list` FCLIENT banner (flist.c:2252) or the
+// `building file list ... done` progress pair (flist.c:2250/2524), never as an
+// entry count, so a count emitted here would have no upstream analog on stdout.
 pub fn collect_entries(walker: FileListWalker) -> Result<Vec<FileListEntry>, FileListError> {
-    let entries: Result<Vec<_>, _> = walker.collect();
-    if let Ok(ref list) = entries {
-        info_log!(Flist, 1, "built file list with {} entries", list.len());
-    }
-    entries
+    walker.collect()
 }
 
 /// Collects all file list entries sequentially from the walker.

--- a/crates/flist/tests/flog_banner_not_on_stdout.rs
+++ b/crates/flist/tests/flog_banner_not_on_stdout.rs
@@ -1,0 +1,101 @@
+//! Traversal must not put upstream's log-file-only file-list banner on stdout.
+//!
+//! upstream: flist.c:2248 announces the walk with
+//! `rprintf(FLOG, "building file list\n")`. log.c:rwrite() handles FLOG by
+//! writing to the log and returning (`if (code == FLOG || ...) return;`), and
+//! by returning outright (`else if (code == FLOG) return;`) when the client has
+//! neither `--log-file` nor daemon mode - so the line never reaches stdout.
+//! Verified against rsync 3.4.4: `-av` and `-avv` produce byte-identical stdout
+//! with and without `--log-file`, and only the log file gains
+//! `building file list`. Upstream has no per-entry "built file list with N
+//! entries" message at any verbosity or logcode.
+//!
+//! Every `DiagnosticEvent` emitted here is rendered onto the client's stdout by
+//! `cli::frontend::progress::diagnostic::render_diagnostic_events`, which has no
+//! FLOG dimension to discard. A file-list banner emitted from this crate would
+//! therefore appear on stdout at plain `-v`/`-vv`, where upstream shows nothing.
+
+use std::fs;
+
+use flist::FileListBuilder;
+use logging::{DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+/// Substrings of the upstream banners that must never reach a diagnostic event.
+const LOG_FILE_ONLY_BANNERS: [&str; 2] = ["building file list", "built file list with"];
+
+fn message(event: &DiagnosticEvent) -> &str {
+    match event {
+        DiagnosticEvent::Info { message, .. } | DiagnosticEvent::Debug { message, .. } => message,
+    }
+}
+
+fn leaked_banners(events: Vec<DiagnosticEvent>) -> Vec<String> {
+    events
+        .into_iter()
+        .filter(|event| {
+            let text = message(event);
+            LOG_FILE_ONLY_BANNERS
+                .iter()
+                .any(|banner| text.contains(banner))
+        })
+        .map(|event| message(&event).to_owned())
+        .collect()
+}
+
+fn tree() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let nested = temp.path().join("nested");
+    fs::create_dir_all(&nested).expect("create nested dir");
+    fs::write(temp.path().join("file.txt"), b"data").expect("write file");
+    fs::write(nested.join("more.txt"), b"data").expect("write nested file");
+    temp
+}
+
+/// `-vv` raises `DebugFlag::Flist` to 1 (upstream's `debug_verbosity[2]`
+/// includes `FLIST`), which is the level at which a walker-side announcement
+/// would fire. Upstream prints nothing to stdout there.
+#[test]
+fn walker_emits_no_file_list_banner_at_verbose_two() {
+    init(VerbosityConfig::from_verbose_level(2));
+    let _ = drain_events();
+
+    let temp = tree();
+    let walker = FileListBuilder::new(temp.path()).build().expect("walker");
+    let count = walker.count();
+    assert!(
+        count > 0,
+        "walker must yield entries for the assertion to mean anything"
+    );
+
+    let leaked = leaked_banners(drain_events());
+    assert!(
+        leaked.is_empty(),
+        "walker leaked upstream's log-file-only file-list banner to stdout: {leaked:?}"
+    );
+}
+
+/// A completed enumeration is reported upstream by the CLI-layer
+/// `sending incremental file list` banner, never by an entry count from the
+/// traversal itself.
+#[cfg(feature = "parallel")]
+#[test]
+fn collect_entries_emits_no_entry_count_at_verbose_two() {
+    use flist::parallel::collect_entries;
+
+    init(VerbosityConfig::from_verbose_level(2));
+    let _ = drain_events();
+
+    let temp = tree();
+    let walker = FileListBuilder::new(temp.path()).build().expect("walker");
+    let entries = collect_entries(walker).expect("collect entries");
+    assert!(
+        !entries.is_empty(),
+        "collection must yield entries for the assertion to mean anything"
+    );
+
+    let leaked = leaked_banners(drain_events());
+    assert!(
+        leaked.is_empty(),
+        "collect_entries leaked a file-list banner to stdout: {leaked:?}"
+    );
+}


### PR DESCRIPTION
## Problem

`crates/flist` emitted two file-list banners through the diagnostic queue:

- `crates/flist/src/parallel.rs:44` - `info_log!(Flist, 1, "built file list with {} entries", ...)`, which fires at a single `-v`.
- `crates/flist/src/file_list_walker.rs:32` - `debug_log!(Flist, 1, "building file list from {:?}", root)`, which fires at `-vv`.

Neither has an upstream analog on stdout.

## Upstream ground truth

`flist.c:2248` announces the walk with `rprintf(FLOG, "building file list\n")`. `log.c:rwrite()` handles FLOG by writing it to the log and returning (`if (code == FLOG || (am_daemon && !am_server)) return;`), and by returning outright (`else if (code == FLOG) return;`) when the client has neither `--log-file` nor daemon mode. FLOG therefore never reaches stdout.

Confirmed against rsync 3.4.4 over a daemon push, `-avn` and `-avvn`, each with and without `--log-file`:

| invocation | stdout | log file |
|---|---|---|
| `-avn` | `sending incremental file list`, per-file rows, summary | - |
| `-avn --log-file=F` | identical to the above | `building file list` + itemized rows + summary |
| `-avvn` | same, still no `building file list` | - |
| `-avvn --log-file=F` | same, still no `building file list` | `building file list` |

The with/without-`--log-file` pair is byte-identical on stdout; only the log file gains the line. Upstream has no `built file list with N entries` message at any verbosity or logcode - the string does not exist in the 3.4.4 source.

## Why these were leaks

`emit_info` / `emit_debug` buffer into a thread-local queue that `cli::frontend::progress::diagnostic::render_diagnostic_events` drains onto the client's **stdout** (stderr only under `--msgs-to-stderr`). `DiagnosticEvent` has no FLOG dimension, so nothing discards a log-file-only message. Any event emitted from the traversal path is stdout output.

The `InfoFlag::Flist` category itself is not mis-routed: `parallel.rs:44` was its only emitter in the tree, and every other `Flist` message is a `debug_log!` whose upstream counterpart genuinely is a `rprintf(FINFO, ...)` stdout line. Upstream's routing dimension is the per-message logcode, not the flag category, so there is no category-wide sink change to make here - the two invented messages are the whole divergence.

## Change

Drop both emissions and add `crates/flist/tests/flog_banner_not_on_stdout.rs`, which walks a small tree at `-vv` and fails if either banner text lands in the diagnostic queue. The guard was verified to be non-vacuous: with the two lines temporarily restored, both tests fail and name the leaked messages.

## Scope note

`crates/flist` is a standalone traversal utility that is not on the live transfer path (`crates/flist/src/lib.rs` documents this; the transfer pipeline uses `protocol::flist`). A binary built at `master` contains neither string, so no released-since behaviour changes - this closes a latent leak that would resurface the moment the crate is wired up, matching the guard the sender path already carries in `crates/transfer/src/generator/tests.rs`.

## Verification

- `cargo nextest run -p flist --all-features` - 546 passed, 7 skipped.
- `cargo clippy -p flist -p core --all-targets --all-features --no-deps -- -D warnings` - clean.
- `cargo fmt --all` - clean.
