### PR TITLE
fix(core): honor --protocol=N in the remote-shell server argv

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -1685,6 +1685,10 @@ mod server_option_fidelity_tests {
             .relative_paths(true)
             .implied_dirs(false)
             .build();
+        // The 4th argument is the REMOTE's role, not ours: `is_sender: false`
+        // means the daemon is the receiver, i.e. we are the sender (a push).
+        // The polarity is inverted at the top of build_full_daemon_args
+        // (`let we_are_sender = !is_sender;`) - do not "correct" it here.
         let push_28 = build_full_daemon_args(&config, &request(), ProtocolVersion::V28, false);
         assert!(
             !push_28.iter().any(|a| a == "--no-implied-dirs"),

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -699,12 +699,15 @@ pub(super) fn build_full_daemon_args(
     // (!am_sender || protocol_version >= 30)) --no-implied-dirs`. The flag is
     // forwarded only for relative transfers (implied dirs exist solely for
     // relative-rooted paths). The `(!am_sender || protocol_version >= 30)` guard
-    // is always satisfied on the daemon path (proto >= 30 for rsync:// modules),
-    // so gating on relative_paths alone matches upstream. Without the
-    // relative_paths gate a non-relative transfer with implied_dirs=0
-    // (options.c:2207) would wrongly forward the flag, which the remote sender
-    // then stats as a source path.
-    if config.relative_paths() && !config.implied_dirs() {
+    // drops the flag on a PUSH below protocol 30 - reachable here because
+    // `--protocol=N` caps the version negotiated from the `@RSYNCD:` greeting.
+    // Without the relative_paths gate a non-relative transfer with
+    // implied_dirs=0 (options.c:2207) would wrongly forward the flag, which the
+    // remote sender then stats as a source path.
+    if config.relative_paths()
+        && !config.implied_dirs()
+        && (!we_are_sender || protocol.as_u8() >= 30)
+    {
         args.push("--no-implied-dirs".to_owned());
     }
 
@@ -1669,6 +1672,28 @@ mod server_option_fidelity_tests {
             !args(&non_relative, false)
                 .iter()
                 .any(|a| a == "--no-implied-dirs")
+        );
+    }
+
+    // upstream: options.c:2976 - the `(!am_sender || protocol_version >= 30)`
+    // half of the guard. A daemon PUSH below protocol 30 (reachable once
+    // `--protocol=N` caps the `@RSYNCD:` negotiation) must not forward the
+    // option to a peer that predates it; a PULL forwards it at every version.
+    #[test]
+    fn no_implied_dirs_gated_on_protocol_for_daemon_push() {
+        let config = ClientConfig::builder()
+            .relative_paths(true)
+            .implied_dirs(false)
+            .build();
+        let push_28 = build_full_daemon_args(&config, &request(), ProtocolVersion::V28, false);
+        assert!(
+            !push_28.iter().any(|a| a == "--no-implied-dirs"),
+            "daemon push below protocol 30 must not forward --no-implied-dirs: {push_28:?}"
+        );
+        let pull_28 = build_full_daemon_args(&config, &request(), ProtocolVersion::V28, true);
+        assert!(
+            pull_28.iter().any(|a| a == "--no-implied-dirs"),
+            "daemon pull forwards --no-implied-dirs at every protocol: {pull_28:?}"
         );
     }
 

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -62,6 +62,22 @@ impl<'a> RemoteInvocationBuilder<'a> {
         Self { config, role }
     }
 
+    /// Returns the pre-negotiated protocol version that shapes the server argv.
+    ///
+    /// upstream: `options.c:84` seeds the global `protocol_version` with
+    /// `PROTOCOL_VERSION` and `options.c:846` lets `--protocol=N` lower it
+    /// before `server_options()` runs, so the argv is derived from the
+    /// *requested* ceiling rather than a negotiated value (which does not exist
+    /// yet - see the comment at `options.c:3025`). The actual session version is
+    /// `MIN(this, remote_protocol)` (compat.c:604-607), applied later by
+    /// `perform_handshake_with_max`; the request is therefore a cap composed
+    /// with peer negotiation, never an override that could raise the version.
+    fn requested_protocol(&self) -> protocol::ProtocolVersion {
+        self.config
+            .protocol_version()
+            .unwrap_or(protocol::ProtocolVersion::NEWEST)
+    }
+
     /// Builds the complete invocation argument vector.
     ///
     /// The first element is the rsync binary name (either from `--rsync-path`
@@ -203,10 +219,23 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // NDX_FLIST_EOF the remote still emits, leaving its trailing bytes
         // to trip read_varint overflow on the next decode.
         // upstream: io.c:1816 read_varint - rejects encodings with extra > 4.
-        let advertise_inc_recurse =
-            self.config.inc_recursive_send() && self.role != RemoteRole::Receiver;
-        flags.push_str(&build_capability_string_suffix(advertise_inc_recurse));
-        args.push(OsString::from(flags));
+        //
+        // upstream: options.c:3025-3028 maybe_add_e_option() - the whole `e.xxx`
+        // suffix is emitted ONLY when the pre-negotiated `protocol_version` is
+        // >= 30, "so that the user can use a --protocol=29 override to avoid the
+        // use of this -eFLAGS opt". At protocol 28/29 the compact flag string
+        // must end at the transfer letters (`-r`, not `-re.iLsfxCIvu`).
+        if self.requested_protocol().as_u8() >= 30 {
+            let advertise_inc_recurse =
+                self.config.inc_recursive_send() && self.role != RemoteRole::Receiver;
+            flags.push_str(&build_capability_string_suffix(advertise_inc_recurse));
+        }
+        // upstream: options.c:2730 - `if (x > 1) args[ac++] = argstr;`. A bare
+        // `-` is never emitted; below protocol 30 the capability suffix no
+        // longer guarantees a non-empty letter set, so the guard matters.
+        if flags.len() > 1 {
+            args.push(OsString::from(flags));
+        }
 
         if let Some(arg) = self.iconv_arg() {
             args.push(arg);
@@ -680,13 +709,17 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // "--no-implied-dirs";`. The flag is forwarded to the peer only when
         // relative paths are active; implied dirs exist solely for
         // relative-rooted transfers, so a non-relative transfer never sends it.
-        // The `(!am_sender || protocol_version >= 30)` guard is always satisfied
-        // for oc's modern protocol (>= 30), so gating on `relative_paths` alone
-        // matches upstream. Without the `relative_paths` gate a non-relative
-        // transfer with `implied_dirs = 0` (options.c:2207 forces this) would
-        // wrongly forward `--no-implied-dirs`, which the remote sender then
-        // link_stat()s as a source path (exit 23).
-        if self.config.relative_paths() && !self.config.implied_dirs() {
+        // The `(!am_sender || protocol_version >= 30)` guard suppresses the flag
+        // on a PUSH below protocol 30, where the pre-30 receiver derives implied
+        // dirs itself and does not understand the option. Without the
+        // `relative_paths` gate a non-relative transfer with `implied_dirs = 0`
+        // (options.c:2207 forces this) would wrongly forward
+        // `--no-implied-dirs`, which the remote sender then link_stat()s as a
+        // source path (exit 23).
+        if self.config.relative_paths()
+            && !self.config.implied_dirs()
+            && (self.role != RemoteRole::Sender || self.requested_protocol().as_u8() >= 30)
+        {
             args.push(OsString::from("--no-implied-dirs"));
         }
 

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -4628,3 +4628,111 @@ fn open_noatime_suppressed_with_double_atimes() {
         "-UU must suppress --open-noatime: {args:?}"
     );
 }
+
+// upstream: options.c:3025-3028 maybe_add_e_option() - "checking the
+// pre-negotiated value allows the user to use a --protocol=29 override to avoid
+// the use of this -eFLAGS opt". At protocol 28/29 the compact flag string must
+// carry the transfer letters ONLY; a stock 3.4.4 client sends `-r`, not
+// `-re.iLsfxCIvu`. Without this the requested version never reaches the server
+// argv and every pre-30 code path stays unreachable from the client side.
+#[test]
+fn capability_suffix_omitted_below_protocol_30() {
+    for requested in [28u8, 29] {
+        let version = protocol::ProtocolVersion::try_from(requested).expect("supported version");
+        let config = ClientConfig::builder()
+            .recursive(true)
+            .protocol_version(Some(version))
+            .build();
+        assert_eq!(
+            build_sender_args(&config),
+            vec!["rsync", "--server", "-r", ".", "/path"],
+            "protocol {requested} push argv must match upstream"
+        );
+        assert_eq!(
+            build_receiver_args(&config),
+            vec!["rsync", "--server", "--sender", "-r", ".", "/path"],
+            "protocol {requested} pull argv must match upstream"
+        );
+    }
+}
+
+// upstream: options.c:3028 - the `>= 30` gate keeps the suffix for every
+// protocol the capability string is defined for, so a 30/31/32 request is
+// wire-identical to the uncapped default.
+#[test]
+fn capability_suffix_retained_at_protocol_30_and_above() {
+    let suffix = build_capability_string_suffix(true);
+    for requested in [None, Some(30u8), Some(31), Some(32)] {
+        let version = requested
+            .map(|raw| protocol::ProtocolVersion::try_from(raw).expect("supported version"));
+        let config = ClientConfig::builder()
+            .recursive(true)
+            .protocol_version(version)
+            .build();
+        assert_eq!(
+            build_sender_args(&config),
+            vec![
+                "rsync".to_owned(),
+                "--server".to_owned(),
+                format!("-r{suffix}"),
+                ".".to_owned(),
+                "/path".to_owned()
+            ],
+            "protocol {requested:?} must still advertise capabilities"
+        );
+    }
+}
+
+// upstream: options.c:2730 - `if (x > 1) args[ac++] = argstr;`. Once the
+// capability suffix is gated on protocol >= 30 the compact flag string can
+// collapse to a bare `-`, which upstream never places on the command line.
+#[test]
+fn empty_flag_string_omitted_below_protocol_30() {
+    let version = protocol::ProtocolVersion::try_from(28).expect("supported version");
+    let config = ClientConfig::builder()
+        .recursive(false)
+        .protocol_version(Some(version))
+        .build();
+    assert_eq!(
+        build_sender_args(&config),
+        vec!["rsync", "--server", ".", "/path"],
+        "a bare '-' must never be emitted"
+    );
+}
+
+// upstream: options.c:2976 - `if (relative_paths && !implied_dirs && (!am_sender
+// || protocol_version >= 30))`. The `am_sender` half of the guard drops
+// --no-implied-dirs on a PUSH below protocol 30; a PULL forwards it at every
+// version.
+#[test]
+fn no_implied_dirs_gated_on_protocol_for_push_only() {
+    let version = protocol::ProtocolVersion::try_from(28).expect("supported version");
+    let config = ClientConfig::builder()
+        .relative_paths(true)
+        .implied_dirs(false)
+        .protocol_version(Some(version))
+        .build();
+    assert!(
+        !build_sender_args(&config)
+            .iter()
+            .any(|a| a == "--no-implied-dirs"),
+        "push below protocol 30 must not forward --no-implied-dirs"
+    );
+    assert!(
+        build_receiver_args(&config)
+            .iter()
+            .any(|a| a == "--no-implied-dirs"),
+        "pull forwards --no-implied-dirs at every protocol"
+    );
+
+    let modern = ClientConfig::builder()
+        .relative_paths(true)
+        .implied_dirs(false)
+        .build();
+    assert!(
+        build_sender_args(&modern)
+            .iter()
+            .any(|a| a == "--no-implied-dirs"),
+        "push at protocol 30+ forwards --no-implied-dirs"
+    );
+}


### PR DESCRIPTION
## Problem

`--protocol=N` had no effect on the client's remote-shell (SSH) path. With and
without `--protocol=28` the client emitted a byte-identical server argument
vector, including the protocol-32 capability suffix:

```
oc-rsync --protocol=28 -r src/ host:/dst/   ->  rsync --server -re.iLsfxCIvu . /dst/
rsync    --protocol=28 -r src/ host:/dst/   ->  rsync --server -r . /dst/
```

The wire-level cap was already correct (`perform_handshake_with_max` clamps to
`MIN(request, remote)`); what was lost is that the argv builder never consulted
the requested version at all.

## Upstream behaviour

Upstream seeds the global `protocol_version` with `PROTOCOL_VERSION`
(`options.c:84`) and lets `--protocol=N` lower it (`options.c:846`) *before*
`server_options()` runs, so the server argv is derived from the pre-negotiated
request. Three consequences, quoting `options.c:3025-3027`:

> We don't really know the actual protocol_version at this point, but checking
> the pre-negotiated value allows the user to use a `--protocol=29` override to
> avoid the use of this `-eFLAGS` opt.

- `maybe_add_e_option()` (`options.c:3028`) emits the `e.xxx` suffix only when
  `protocol_version >= 30`.
- `options.c:2730` (`if (x > 1)`) drops the compact flag string entirely when no
  transfer letters remain - reachable once the suffix is gated.
- `options.c:2976` gates `--no-implied-dirs` on
  `(!am_sender || protocol_version >= 30)`; the `am_sender` half was missing.

## Change

`RemoteInvocationBuilder` gains `requested_protocol()` -
`config.protocol_version().unwrap_or(NEWEST)`, oc's equivalent of upstream's
pre-negotiated global - and drives all three rules from it.

The request remains a **cap composed with peer negotiation, never an override**:
the argv is shaped by the request, and the session version is still
`MIN(request, remote_protocol)` in `perform_handshake_with_max`
(`compat.c:604-607`). A request can only lower, since the parser already caps
the accepted value at `PROTOCOL_VERSION` (32).

## Both transports checked

The daemon transport was **not** affected. `daemon_transfer/orchestration/arguments.rs`
already gates its capability suffix on `protocol.as_u8() >= 30`, and that
`protocol` is the value returned by `perform_daemon_handshake`, which computes
`MIN(config.protocol_version(), remote_protocol)` from the `@RSYNCD:` greeting.
The capability suffix therefore needed no change there.

It did carry the same `--no-implied-dirs` gap, though, so the second commit
applies the identical `(!am_sender || protocol_version >= 30)` guard on the
daemon push path - one rule with one meaning across both transports rather than
two implementations that drift.

## Verification

Server argv captured with a fake remote shell that dumps `"$@"`, oc vs
`rsync 3.4.4` (confirmed via its `--version` banner), for
`-r src/ host:/dst/`:

| `--protocol` | upstream 3.4.4 | oc before | oc after |
|---|---|---|---|
| 28 | `--server -r . /dst/` | `--server -re.iLsfxCIvu . /dst/` | `--server -r . /dst/` |
| 29 | `--server -r . /dst/` | `--server -re.iLsfxCIvu . /dst/` | `--server -r . /dst/` |
| 30 | `--server -re.iLsfxCIvu . /dst/` | same | same |
| 31 | `--server -re.iLsfxCIvu . /dst/` | same | same |
| 32 | `--server -re.iLsfxCIvu . /dst/` | same | same |
| none | `--server -re.iLsfxCIvu . /dst/` | same | same |

`diff` against upstream is now empty for every row, and also for the
no-transfer-letters case (`--protocol=28 src/a.txt host:/dst/` -> `--server .
/dst/` on both) and for `-R --no-implied-dirs` on push and pull.

A genuinely-28 session now results, so the pre-30 code paths are reachable from
the client side:

```
$ oc-rsync -e ./lsh_up.sh --protocol=28 --debug=proto -r src/ host:/dst/
(Server) Protocol versions: remote=28, negotiated=28
```

Push and pull against a stock 3.4.4 server were exercised at protocols 28, 29
and 32; all transferred the full tree.

## Out of scope, observed

- Pull-side itemize at protocol 28 is separately divergent - now reachable from
  the client side for the first time. `-ai` pull from a stock 3.4.4 server:

  ```
  upstream          oc
  .d..t...... ./    .d..t...... ./
  cd+++++++++ sub/  >f+++++++++ a.txt
  >f????????? a.txt cd+++++++++ sub/
  >f????????? sub/b.txt  >f+++++++++ sub/b.txt
  ```

  oc renders locally-computed flags where upstream renders `?`, and orders the
  rows differently. Structural (where the receiver sources its itemize row);
  belongs to the itemize cluster, not fixed here.
- Independently of `--protocol`, a push without `-r` advertises `i` in the
  capability string where upstream omits it: `set_allow_inc_recurse()`
  (`compat.c:172`) clears `allow_inc_recurse` when `!recurse`, but
  `inc_recursive_send()` does not. Pre-existing, unrelated to this option.

## Tests

Four tests in `crates/core/src/client/remote/invocation/tests.rs` pin the argv
per protocol, the bare-`-` suppression, and the push/pull asymmetry of
`--no-implied-dirs`; one more in `daemon_transfer/orchestration/arguments.rs`
covers the daemon push/pull asymmetry. `cargo test -p core --lib
--all-features`: 2491 passed.
