### PR TITLE
ci: let the batch and remote-shell interop legs fail

### DIFF
--- a/tests/batch_interop_test.sh
+++ b/tests/batch_interop_test.sh
@@ -3,11 +3,14 @@
 #
 # Tests batch mode compatibility between oc-rsync and upstream rsync versions.
 #
-# NOTE: All tests are currently informational. Failures do not block CI.
+# Exit status: non-zero when any sub-test fails without an exemption in
+# tools/ci/known_failures.conf, and also when an exempted sub-test passes -
+# an unexpected pass means the exemption has outlived the limitation and must
+# be deleted. Only the legs listed in that file may fail.
 #
 # oc-rsync can read upstream rsync batch files (including compressed delta
 # batches with CPRES_ZLIB dictionary sync). Cross-tool interop from oc-rsync
-# to upstream is limited because oc-rsync uses a different batch body format.
+# to upstream is exempted; see the batch rule in known_failures.conf.
 #
 # Known upstream bug: rsync 3.4.1+ cannot read back its own compressed delta
 # batch files due to missing inflate dictionary synchronization in the batch
@@ -16,7 +19,7 @@
 # Environment variable overrides:
 #   OC_RSYNC              - path to oc-rsync binary
 #   UPSTREAM_INSTALL_ROOT - root of upstream installs (expects {version}/bin/rsync)
-#   UPSTREAM_VERSIONS     - space-separated list of versions (default: "3.0.9 3.1.3 3.4.1 3.4.2")
+#   UPSTREAM_VERSIONS     - space-separated list of versions
 
 set -euo pipefail
 
@@ -27,7 +30,13 @@ WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Paths (overridable via environment)
 OC_RSYNC="${OC_RSYNC:-${WORKSPACE_ROOT}/target/release/oc-rsync}"
 UPSTREAM_INSTALL_ROOT="${UPSTREAM_INSTALL_ROOT:-${WORKSPACE_ROOT}/target/interop/upstream-install}"
-UPSTREAM_VERSIONS="${UPSTREAM_VERSIONS:-3.0.9 3.1.3 3.4.1 3.4.2}"
+# Default matches the versions built by tools/ci/run_interop.sh; anything else
+# is silently skipped because the binary is not installed.
+UPSTREAM_VERSIONS="${UPSTREAM_VERSIONS:-3.0.9 3.1.3 3.4.4}"
+
+# Shared known failure definitions (is_known_failure_from_conf, version_le).
+# shellcheck source=tools/ci/known_failures.conf
+source "${WORKSPACE_ROOT}/tools/ci/known_failures.conf"
 
 # Create a temp directory with cleanup trap
 TEST_DIR="$(mktemp -d)"
@@ -38,6 +47,8 @@ TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
 TESTS_SKIPPED=0
+TESTS_XFAIL=0
+TESTS_XPASS=0
 
 log_info() {
     echo "[INFO] $1"
@@ -54,6 +65,46 @@ log_error() {
 log_test() {
     echo ""
     echo "=== $1 ==="
+}
+
+# Is this leg exempted in tools/ci/known_failures.conf?
+# Arguments: known_failure_name upstream_version
+# An empty name means the leg carries no exemption and must pass.
+batch_leg_is_exempt() {
+    local kf_name=$1 version=$2
+    [ -n "$kf_name" ] || return 1
+    BATCH_KNOWN_FAILURE_REASON=""
+    is_known_failure_from_conf batch "$kf_name" "" "$version"
+}
+
+# Record a failed sub-test. Exempted legs are reported as XFAIL and do not
+# fail the run; every other failure does.
+# Arguments: known_failure_name upstream_version test_name detail
+record_fail() {
+    local kf_name=$1 version=$2 test_name=$3 detail=$4
+    if batch_leg_is_exempt "$kf_name" "$version"; then
+        log_info "$test_name: XFAIL ($detail)"
+        log_info "  expected: ${BATCH_KNOWN_FAILURE_REASON}"
+        TESTS_XFAIL=$((TESTS_XFAIL + 1))
+        return 0
+    fi
+    log_error "$test_name: FAIL ($detail)"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+# Record a passing sub-test. A pass on an exempted leg fails the run: the
+# exemption has outlived the limitation and must be deleted.
+# Arguments: known_failure_name upstream_version test_name
+record_pass() {
+    local kf_name=$1 version=$2 test_name=$3
+    if batch_leg_is_exempt "$kf_name" "$version"; then
+        log_error "$test_name: UNEXPECTED PASS"
+        log_error "  drop the batch:${kf_name} exemption from tools/ci/known_failures.conf"
+        TESTS_XPASS=$((TESTS_XPASS + 1))
+        return 0
+    fi
+    log_info "$test_name: PASS"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 }
 
 # Cross-platform checksum: prefers md5sum (Linux), falls back to md5 (macOS)
@@ -155,15 +206,13 @@ test_oc_roundtrip() {
     if ! "$OC_RSYNC" -av --no-whole-file --ignore-times \
         --write-batch="$work_dir/mybatch" \
         "$work_dir/src/" "$work_dir/dest/" > "$work_dir/write.log" 2>&1; then
-        log_warn "$test_name: oc-rsync --write-batch failed"
         cat "$work_dir/write.log" >&2
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "oc-rsync --write-batch failed"
         return 0
     fi
 
     if [ ! -f "$work_dir/mybatch" ]; then
-        log_warn "$test_name: Batch file not created"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "batch file not created"
         return 0
     fi
 
@@ -172,18 +221,15 @@ test_oc_roundtrip() {
 
     log_info "Replaying batch with oc-rsync..."
     if ! "$OC_RSYNC" --read-batch="$work_dir/mybatch" "$work_dir/final/" > "$work_dir/read.log" 2>&1; then
-        log_warn "$test_name: oc-rsync --read-batch failed (known limitation: batch format mismatch)"
         cat "$work_dir/read.log" >&2
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "oc-rsync --read-batch failed"
         return 0
     fi
 
     if verify_files_match "$work_dir/src/testfile.bin" "$work_dir/final/testfile.bin" "$test_name"; then
-        log_info "$test_name: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
+        record_pass "" "" "$test_name"
     else
-        log_warn "$test_name: FAIL (known limitation)"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "replayed file differs from source"
     fi
 }
 
@@ -208,15 +254,13 @@ test_oc_to_upstream() {
     if ! "$OC_RSYNC" -av --no-whole-file --ignore-times \
         --write-batch="$work_dir/mybatch" \
         "$work_dir/src/" "$work_dir/dest/" > "$work_dir/write.log" 2>&1; then
-        log_warn "$test_name: oc-rsync --write-batch failed"
         cat "$work_dir/write.log" >&2
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "oc-rsync --write-batch failed"
         return 0
     fi
 
     if [ ! -f "$work_dir/mybatch" ]; then
-        log_warn "$test_name: Batch file not created"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "batch file not created"
         return 0
     fi
 
@@ -224,18 +268,16 @@ test_oc_to_upstream() {
 
     log_info "Replaying batch with upstream rsync $version..."
     if ! "$upstream_rsync" --read-batch="$work_dir/mybatch" "$work_dir/final/" > "$work_dir/read.log" 2>&1; then
-        log_warn "$test_name: upstream rsync --read-batch failed (known limitation)"
         cat "$work_dir/read.log" >&2
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "oc-to-upstream" "$version" "$test_name" \
+            "upstream rsync --read-batch failed"
         return 0
     fi
 
     if verify_files_match "$work_dir/src/testfile.bin" "$work_dir/final/testfile.bin" "$test_name"; then
-        log_info "$test_name: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
+        record_pass "oc-to-upstream" "$version" "$test_name"
     else
-        log_warn "$test_name: files differ (known limitation)"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "oc-to-upstream" "$version" "$test_name" "replayed file differs from source"
     fi
 }
 
@@ -256,15 +298,13 @@ test_upstream_to_oc() {
     if ! "$upstream_rsync" -av --no-whole-file --ignore-times \
         --write-batch="$work_dir/mybatch" \
         "$work_dir/src/" "$work_dir/dest/" > "$work_dir/write.log" 2>&1; then
-        log_warn "$test_name: upstream rsync --write-batch failed"
         cat "$work_dir/write.log" >&2
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "upstream rsync --write-batch failed"
         return 0
     fi
 
     if [ ! -f "$work_dir/mybatch" ]; then
-        log_warn "$test_name: Batch file not created"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "batch file not created"
         return 0
     fi
 
@@ -272,18 +312,15 @@ test_upstream_to_oc() {
 
     log_info "Replaying batch with oc-rsync..."
     if ! "$OC_RSYNC" --read-batch="$work_dir/mybatch" "$work_dir/final/" > "$work_dir/read.log" 2>&1; then
-        log_warn "$test_name: oc-rsync --read-batch failed (known limitation)"
         cat "$work_dir/read.log" >&2
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "oc-rsync --read-batch failed"
         return 0
     fi
 
     if verify_files_match "$work_dir/src/testfile.bin" "$work_dir/final/testfile.bin" "$test_name"; then
-        log_info "$test_name: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
+        record_pass "" "" "$test_name"
     else
-        log_warn "$test_name: files differ (known limitation)"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "replayed file differs from source"
     fi
 }
 
@@ -319,15 +356,13 @@ test_upstream_compressed_to_oc() {
     if ! "$upstream_rsync" -av -z --no-whole-file --ignore-times \
         --write-batch="$work_dir/mybatch" \
         "$work_dir/src/" "$work_dir/dest/" > "$work_dir/write.log" 2>&1; then
-        log_warn "$test_name: upstream rsync --write-batch -z failed"
         cat "$work_dir/write.log" >&2
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "upstream rsync --write-batch -z failed"
         return 0
     fi
 
     if [ ! -f "$work_dir/mybatch" ]; then
-        log_warn "$test_name: Batch file not created"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "batch file not created"
         return 0
     fi
 
@@ -335,18 +370,15 @@ test_upstream_compressed_to_oc() {
 
     log_info "Replaying compressed batch with oc-rsync..."
     if ! "$OC_RSYNC" --read-batch="$work_dir/mybatch" "$work_dir/final/" > "$work_dir/read.log" 2>&1; then
-        log_warn "$test_name: oc-rsync --read-batch failed"
         cat "$work_dir/read.log" >&2
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "oc-rsync --read-batch failed"
         return 0
     fi
 
     if verify_files_match "$work_dir/src/testfile.bin" "$work_dir/final/testfile.bin" "$test_name"; then
-        log_info "$test_name: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
+        record_pass "" "" "$test_name"
     else
-        log_warn "$test_name: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
+        record_fail "" "" "$test_name" "replayed file differs from source"
     fi
 }
 
@@ -356,9 +388,8 @@ main() {
     log_info "Upstream install root: $UPSTREAM_INSTALL_ROOT"
     log_info "Test directory: $TEST_DIR"
     log_info ""
-    log_info "NOTE: All batch tests are currently informational."
-    log_info "The batch write/read pipeline has known format mismatches."
-    log_info "Results are reported for tracking but do not block CI."
+    log_info "Only the legs exempted in tools/ci/known_failures.conf may fail."
+    log_info "Any other failure, and any pass on an exempted leg, fails the run."
 
     # Verify oc-rsync binary exists
     if [ ! -x "$OC_RSYNC" ]; then
@@ -411,20 +442,17 @@ main() {
     echo "========================================="
     echo "Total tests run:    $TESTS_RUN"
     echo "Tests passed:       $TESTS_PASSED"
-    echo "Tests failed:       $TESTS_FAILED  (informational)"
+    echo "Tests failed:       $TESTS_FAILED"
+    echo "Expected failures:  $TESTS_XFAIL"
+    echo "Unexpected passes:  $TESTS_XPASS"
     echo "Tests skipped:      $TESTS_SKIPPED"
     echo "========================================="
 
-    if [ $TESTS_FAILED -gt 0 ]; then
-        log_info "Batch test failures are expected (known limitations)."
-        log_info "See test script header for details."
+    if [ $TESTS_FAILED -gt 0 ] || [ $TESTS_XPASS -gt 0 ]; then
+        log_error "Batch mode interoperability tests failed"
+        exit 1
     fi
 
-    if [ $TESTS_PASSED -gt 0 ]; then
-        log_info "$TESTS_PASSED test(s) passed!"
-    fi
-
-    # Always exit 0 — all tests are informational
     exit 0
 }
 

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -27,6 +27,20 @@ KNOWN_FAILURES=()
 # matrix, which is the point.
 UPSTREAM_BATCH_SELF_ROUNDTRIP_FIXED_AFTER="3.4.4"
 
+# Newest upstream release that refuses a protocol-32 batch header outright.
+# Upstream stamps the negotiated protocol into the batch header and rejects
+# anything newer than its own (compat.c:163/167, "The protocol version in the
+# batch file is too new"). Verified with banner-checked binaries: a batch
+# written by upstream 3.4.4 itself fails identically on 3.0.9 (32 > 30) and
+# 3.1.3 (32 > 31), so this is an upstream cross-version limitation, not an
+# oc-rsync divergence. Any newer upstream entering the matrix is not
+# suppressed by this bound.
+UPSTREAM_BATCH_PROTO32_UNREADABLE_UP_TO="3.1.3"
+
+# Set by is_known_failure_from_conf() for batch legs so the caller can report
+# which of the two causes applies to the upstream version at hand.
+BATCH_KNOWN_FAILURE_REASON=""
+
 # Returns 0 when dotted version $1 is <= dotted version $2.
 version_le() {
   [[ "$1" == "$2" ]] && return 0
@@ -74,6 +88,28 @@ is_known_failure_from_conf() {
     version_le "$upstream_version" \
       "$UPSTREAM_BATCH_SELF_ROUNDTRIP_FIXED_AFTER" && return 0
     return 1
+  fi
+
+  # BATCH MODE cross-tool leg (tests/batch_interop_test.sh).
+  # "oc-to-upstream" = oc-rsync --write-batch, upstream --read-batch.
+  # Two independent causes, split by upstream version. An unknown version is
+  # not suppressed: the caller could not identify the peer, so the result must
+  # be reported.
+  if [[ "$direction" == "batch" && "$name" == "oc-to-upstream" ]]; then
+    [[ -n "$upstream_version" ]] || return 1
+    if version_le "$upstream_version" \
+         "$UPSTREAM_BATCH_PROTO32_UNREADABLE_UP_TO"; then
+      BATCH_KNOWN_FAILURE_REASON="upstream <= ${UPSTREAM_BATCH_PROTO32_UNREADABLE_UP_TO} rejects a protocol-32 batch header (compat.c:163/167)"
+    else
+      # oc-rsync gap: oc records a whole-file-shaped sum_head (count=0,
+      # blength=0, s2length=16) for a delta batch, so upstream's receiver
+      # aborts with "Invalid block index 0 (count=0)" (receiver.c:417) or
+      # crashes. Deliberately not version-bounded - the batch harness reports
+      # an unexpected PASS as a failure, which is what forces this entry to be
+      # deleted the day the bug is fixed instead of silently outliving it.
+      BATCH_KNOWN_FAILURE_REASON="oc-rsync gap, issue #6978: delta batch body is not upstream's wire format"
+    fi
+    return 0
   fi
 
   # oc-rsync RECEIVER over the wire (daemon/remote) drops named-user POSIX ACL
@@ -155,6 +191,9 @@ is_known_failure_from_conf() {
 # Format: direction:name|description|test_method
 # test_method: "daemon" for scenario-based, "standalone" for standalone tests.
 # Keep in sync with actual known failure rules above.
+# batch:oc-to-upstream is intentionally absent: check_known_failures.sh has no
+# driver for batch legs, so a row here would report SKIPPED forever.
+# tests/batch_interop_test.sh runs and reports that leg itself.
 DASHBOARD_ENTRIES=(
   # --- Upstream batch bug (scoped to upstream <= 3.4.4) ---
   # upstream rsync can't read its own compressed delta batch files

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -1872,27 +1872,56 @@ comp_run_scenario() {
 # - up:size-only (do_compression check matched 'z' in --size-only long-form arg)
 # - up:compress-zstd (daemon --compress-choice parsing, zstd token codec, session-scoped TokenReader)
 #
-# SSH interop test: oc-rsync client transfers to localhost via SSH.
+# Locate a remote shell for the SSH interop leg.
+# Prefers upstream's support/lsh.sh, a local-shell stand-in that honours the
+# same "rsh [options] host command" contract as ssh and is what upstream's own
+# testsuite uses, so the leg runs on hosts without a reachable sshd. Falls back
+# to a real ssh loopback when the upstream source tree is unavailable.
+# Prints "<remote shell command>|<hostname>" on success.
+# upstream: support/lsh.sh
+resolve_remote_shell() {
+  local lsh
+  lsh=$(find "$upstream_src_root" -type f -name lsh.sh 2>/dev/null | head -n1 || true)
+  if [[ -n "$lsh" ]]; then
+    # "lh" is lsh.sh's no-cd hostname, so the absolute paths rsync hands to
+    # the server command are used verbatim.
+    printf '%s|%s\n' "bash ${lsh}" "lh"
+    return 0
+  fi
+  if command -v ssh >/dev/null 2>&1 \
+      && ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+           localhost true >/dev/null 2>&1; then
+    printf '%s|%s\n' "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" "localhost"
+    return 0
+  fi
+  return 1
+}
+
+# Remote-shell interop test: oc-rsync client -> oc-rsync server.
+# The destination carries a host prefix, which is the only thing that makes
+# rsync fork the remote shell; with two local paths the transfer degenerates
+# into a plain local copy and the remote-shell path is never exercised.
 run_ssh_interop_test() {
-  local oc_bin=$1 src_dir=$2 work_dir=$3 log=$4
+  local oc_bin=$1 src_dir=$2 work_dir=$3 log=$4 rsh=$5 rhost=$6
 
   local ssh_dest="${work_dir}/ssh_dest"
   rm -rf "$ssh_dest"
   mkdir -p "$ssh_dest"
 
   local transfer_log="${log}.ssh-transfer"
-  if ! timeout "$hard_timeout" "$oc_bin" -av \
-      -e "ssh -o StrictHostKeyChecking=no" \
+  local rc=0
+  timeout "$hard_timeout" "$oc_bin" -av \
+      -e "$rsh" \
+      --rsync-path="$oc_bin" \
       --timeout=10 \
-      "${src_dir}/" "${ssh_dest}/" \
-      >"$transfer_log.out" 2>"$transfer_log.err"; then
-    local rc=$?
-    cat "$transfer_log.err" >> "$log"
-    echo "    FAIL (SSH transfer error, exit=$rc)"
+      "${src_dir}/" "${rhost}:${ssh_dest}/" \
+      >"$transfer_log.out" 2>"$transfer_log.err" || rc=$?
+  cat "$transfer_log.err" >> "$log"
+  if (( rc != 0 )); then
+    echo "    FAIL (remote-shell transfer error, exit=$rc)"
     echo "    stderr: $(head -5 "$transfer_log.err")"
     return 1
   fi
-  cat "$transfer_log.err" >> "$log"
 
   if ! comp_verify_transfer "$src_dir" "$ssh_dest"; then
     echo "    dest contents: $(find "$ssh_dest" -type f | sort | head -20)"
@@ -2461,8 +2490,12 @@ test_compressed_batch_delta_interop() {
 # file format does not record which compression algorithm was used - only
 # that compression was active (bit 8 in stream flags).
 #
-# This test uses --compress-choice=zlib to ensure the roundtrip works.
-# Without it, upstream may fail reading its own batch on zstd-enabled builds.
+# This test pins --compress-choice=zlib so the failure is attributable: it
+# removes zstd auto-negotiation as a variable and leaves only the dictionary
+# desync. The roundtrip still fails - upstream writes a compressed delta batch
+# it cannot read back ("inflate returned -3", token.c(665), exit 12), verified
+# on Linux and macOS against 3.4.4 - which is why this leg is carried as a
+# version-scoped known failure in tools/ci/known_failures.conf.
 #
 # Key upstream source references:
 #   batch.c:59-76     - stream flags bitmap (bit 8 = do_compression)
@@ -11592,13 +11625,15 @@ run_comprehensive_interop_case() {
 
   stop_upstream_daemon
 
-  # SSH interop (only if SSH is available)
-  if command -v ssh >/dev/null 2>&1; then
+  # Remote-shell interop (only if a remote shell is usable)
+  local rsh_spec
+  if rsh_spec=$(resolve_remote_shell); then
+    local rsh="${rsh_spec%|*}" rhost="${rsh_spec##*|}"
     total=$((total + 1))
-    echo "  [oc-rsync SSH] local SSH transfer${sfx}"
+    echo "  [oc-rsync SSH] remote-shell transfer to ${rhost}${sfx}"
     local ssh_dir="${workdir}/ssh-${tag}"
     mkdir -p "$ssh_dir"
-    if run_ssh_interop_test "$oc_client" "$local_src" "$ssh_dir" "$olf"; then
+    if run_ssh_interop_test "$oc_client" "$local_src" "$ssh_dir" "$olf" "$rsh" "$rhost"; then
       echo "    PASS"
       passed=$((passed + 1))
     else


### PR DESCRIPTION
Two interop legs were structurally incapable of reporting a failure. Both are fixed, and both fixes are demonstrated to fail against a deliberately broken condition.

## `tests/batch_interop_test.sh` could never fail

Every failure path called `log_warn`, bumped a counter, and `main()` ended in `exit 0`. It is wired into `interop-validation.yml`, so the job could not go red - and it is the only batch coverage that exercises multiple upstream versions.

It now exits non-zero unless every failing leg is exempted in `tools/ci/known_failures.conf`, and it also exits non-zero when an exempted leg *passes*: an unexpected pass means the exemption has outlived the limitation and must be deleted. That is what keeps a non-version-bounded exemption from hiding the day the bug is fixed.

The default `UPSTREAM_VERSIONS` had drifted from the versions `run_interop.sh` actually builds (`3.0.9 3.1.3 3.4.4`): 3.4.2 was silently skipped and 3.4.4 was never exercised at all.

### Triage of every newly-red leg

Run against banner-verified binaries (`rsync version 3.0.9/3.1.3/3.4.1/3.4.4`), 13 legs over 4 upstream versions. 9 pass; 4 fail, in two groups:

**`oc-rsync -> upstream 3.0.9` and `-> 3.1.3` - genuine upstream version limitation.**

```
The protocol version in the batch file is too new (32 > 30).
rsync error: protocol incompatibility (code 2) at compat.c(163) [Receiver=3.0.9]
```

A batch written by upstream 3.4.4 *itself* fails identically on both releases, so this is not an oc-rsync divergence. Scoped with `UPSTREAM_BATCH_PROTO32_UNREADABLE_UP_TO="3.1.3"`, so any newer upstream entering the matrix is not suppressed.

**`oc-rsync -> upstream 3.4.1` and `-> 3.4.4` - real oc-rsync bug, filed as #6978, not fixed here.**

Upstream segfaults on one fixture and reports `Invalid block index 0 (count=0)` (`receiver.c:417`) on another. Cause: oc-rsync records a whole-file-shaped sum_head (`count=0, blength=0, s2length=16`) for a delta batch where upstream records `147/700/2/200`. Whole-file batches interop fine and oc reads its own delta batch fine, so the defect is confined to the delta body. This arm is deliberately not version-bounded; the unexpected-pass check is what forces the exemption out when #6978 lands.

### Proof it can now fail

Injected defect: a shim that swallows every `--read-batch` and exits 0.

```
[ERROR] oc-rsync roundtrip (write-batch -> read-batch): FAIL (replayed file differs from source)
[INFO]  oc-rsync -> upstream 3.0.9: XFAIL (upstream rsync --read-batch failed)
[ERROR] upstream 3.4.4 -> oc-rsync: FAIL (replayed file differs from source)
Tests failed: 5 | Expected failures: 2 | exit=1
```

Injected defect: claim a passing leg is exempt.

```
[ERROR] upstream 3.4.4 -> oc-rsync: UNEXPECTED PASS
[ERROR]   drop the batch:oc-to-upstream exemption from tools/ci/known_failures.conf
Unexpected passes: 1 | exit=1
```

Both reverted; the script then reports `10 run, 7 passed, 0 failed, 3 expected failures, exit=0`.

## The "SSH" interop leg was a local copy

`run_ssh_interop_test` passed `-e "ssh ..."` but both operands were local paths, so rsync never forked the remote shell. The leg was additionally skipped whenever `ssh` was absent, and its failure branch read `$?` after `if !` had already inverted it, so it printed `exit=0` for every failure.

The destination now carries a host prefix, so the remote shell is actually invoked. The shell is upstream's `support/lsh.sh` (the local-shell stand-in upstream's own testsuite uses), located under the cached upstream source tree, with a real `ssh` loopback as fallback. That removes the sshd dependency and the skip.

### Proof it can now fail

| command shape | remote shell | result |
|---|---|---|
| new (`lh:` prefixed dest) | working `lsh.sh` | PASS |
| new (`lh:` prefixed dest) | shim that exits 255 | **FAIL (remote-shell transfer error, exit=255)** |
| pre-fix (both operands local) | same shim that exits 255 | PASS - the shell was never invoked |

The third row is the defect itself: the old leg passed while its remote shell was guaranteed to fail.

No new failures surfaced on this leg: the full `setup_comprehensive_src` fixture (hardlinks, symlinks, nested dirs, 200 KB binary) round-trips through the remote-shell path and `comp_verify_transfer` passes.

## One comment corrected

`run_interop.sh` claimed the compressed-batch self-roundtrip "uses `--compress-choice=zlib` to ensure the roundtrip works". It does not - pinning zlib only removes zstd auto-negotiation as a variable; the roundtrip still fails, which is the whole reason the known-failure entry exists. Re-verified against a banner-checked 3.4.4:

```
inflate returned -3 (0 bytes)
rsync error: error in rsync protocol data stream (code 12) at token.c(665) [receiver=3.4.4]
```
