### PR TITLE
test(daemon): force test-started daemons to stay in the foreground

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,13 @@ jobs:
       - name: Shared-ring removal guard (IUR-6.c)
         run: bash tools/ci/check_shared_ring_removal.sh
 
+      # A daemon started from a test with detach enabled forks, and the parent -
+      # the test process - exits 0 before any assertion runs, so the test passes
+      # without proving anything. This lint keeps the foreground guard in the
+      # daemon test support module intact and stops the bypasses from regrowing.
+      - name: Daemon no-detach guard
+        run: bash tools/ci/check_daemon_no_detach.sh
+
   # ===========================================================================
   # Unsafe SAFETY Comment Audit - Informational (non-blocking) check
   # ---------------------------------------------------------------------------

--- a/crates/daemon/src/tests/chunks/daemon_acl_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_acl_push.rs
@@ -159,7 +159,7 @@ fn daemon_acl_push_preserves_acls() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_checksum_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_checksum_push.rs
@@ -71,7 +71,7 @@ fn daemon_checksum_push_detects_content_change_despite_matching_mtime() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Initial push (seeds destination with original content)

--- a/crates/daemon/src/tests/chunks/daemon_compare_dest_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_compare_dest_push.rs
@@ -81,7 +81,7 @@ fn daemon_compare_dest_push_skips_unchanged_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -207,7 +207,7 @@ fn daemon_link_dest_push_creates_hardlinks() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -358,7 +358,7 @@ fn daemon_copy_dest_push_copies_from_reference() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_compress_pull_drains_peer_goodbye.rs
+++ b/crates/daemon/src/tests/chunks/daemon_compress_pull_drains_peer_goodbye.rs
@@ -97,7 +97,7 @@ fn daemon_compress_pull_drains_peer_goodbye_for_uts_v3_cluster_a() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");

--- a/crates/daemon/src/tests/chunks/daemon_compress_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_compress_push.rs
@@ -83,7 +83,7 @@ fn daemon_compress_push_transfers_files_with_compression() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_copy_links_push_resolves_symlinks.rs
+++ b/crates/daemon/src/tests/chunks/daemon_copy_links_push_resolves_symlinks.rs
@@ -73,7 +73,7 @@ fn daemon_copy_links_push_resolves_symlinks() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_delete_pull_emits_stats.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delete_pull_emits_stats.rs
@@ -54,7 +54,7 @@ fn daemon_delete_pull_reports_delete_stats() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/pullmod/");

--- a/crates/daemon/src/tests/chunks/daemon_delete_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delete_push.rs
@@ -56,7 +56,7 @@ fn daemon_delete_push_removes_extraneous_destination_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Initial push - seed destination with A, B, C

--- a/crates/daemon/src/tests/chunks/daemon_delete_push_emits_stats.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delete_push_emits_stats.rs
@@ -65,7 +65,7 @@ fn daemon_delete_push_reports_delete_stats() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_delta_transfer.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delta_transfer.rs
@@ -67,7 +67,7 @@ fn daemon_delta_transfer_updates_modified_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Initial push (whole-file, seeds the destination)

--- a/crates/daemon/src/tests/chunks/daemon_dry_run_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_dry_run_push.rs
@@ -64,7 +64,7 @@ fn daemon_dry_run_push() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_dry_run_push_across_protocol_versions.rs
+++ b/crates/daemon/src/tests/chunks/daemon_dry_run_push_across_protocol_versions.rs
@@ -55,7 +55,7 @@ fn run_dry_run_push_at_protocol(protocol: ProtocolVersion) {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_fake_super_module_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_fake_super_module_push.rs
@@ -86,7 +86,7 @@ fn daemon_fake_super_module_directive_stores_ownership_in_xattr() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_files_from_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_files_from_push.rs
@@ -70,7 +70,7 @@ fn daemon_files_from_push_limits_transferred_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_files_from_stdin_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_files_from_stdin_pull.rs
@@ -83,7 +83,7 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_filter_merge_with_client_filters.rs
+++ b/crates/daemon/src/tests/chunks/daemon_filter_merge_with_client_filters.rs
@@ -56,7 +56,7 @@ fn daemon_exclude_overrides_client_include() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");
@@ -140,7 +140,7 @@ fn daemon_exclude_directory_blocks_subtree() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");
@@ -223,7 +223,7 @@ fn daemon_include_then_exclude_all_keeps_only_included() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");
@@ -307,7 +307,7 @@ fn daemon_exclude_from_file_matches_inline_exclude() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");

--- a/crates/daemon/src/tests/chunks/daemon_fuzzy_level2_pulls_basis_from_sibling_directories.rs
+++ b/crates/daemon/src/tests/chunks/daemon_fuzzy_level2_pulls_basis_from_sibling_directories.rs
@@ -84,7 +84,7 @@ fn daemon_fuzzy_level2_pulls_basis_from_sibling_directories() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_hardlinks_relative_receive.rs
+++ b/crates/daemon/src/tests/chunks/daemon_hardlinks_relative_receive.rs
@@ -99,7 +99,7 @@ fn daemon_hardlinks_relative_receive_preserves_links() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_inc_recurse_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_inc_recurse_push.rs
@@ -83,7 +83,7 @@ fn daemon_inc_recurse_push_nested_directories() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_inplace_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_inplace_push.rs
@@ -81,7 +81,7 @@ fn daemon_inplace_push_preserves_destination_inodes() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_itemize_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_itemize_pull.rs
@@ -74,7 +74,7 @@ fn daemon_itemize_pull_reports_events() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/pullmod/");

--- a/crates/daemon/src/tests/chunks/daemon_itemize_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_itemize_push.rs
@@ -74,7 +74,7 @@ fn daemon_itemize_push_reports_events() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_module_implicit_list_only.rs
+++ b/crates/daemon/src/tests/chunks/daemon_module_implicit_list_only.rs
@@ -44,7 +44,7 @@ fn daemon_module_implicit_list_only() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Single source operand, NO destination: the fix routes this to

--- a/crates/daemon/src/tests/chunks/daemon_munge_symlinks_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_munge_symlinks_pull.rs
@@ -91,7 +91,7 @@ fn daemon_munge_symlinks_pull_strips_prefix() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mungemod/");

--- a/crates/daemon/src/tests/chunks/daemon_munge_symlinks_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_munge_symlinks_push.rs
@@ -75,7 +75,7 @@ fn daemon_munge_symlinks_push_prepends_prefix() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
@@ -62,7 +62,7 @@ fn daemon_negotiation_auth_challenge_is_unique_per_session() {
     // release the test's holding listener so the daemon's bind to the same
     // port succeeds (the held listener was only needed to reserve the port).
     drop(held_listener);
-    let handle = thread::spawn(move || run_daemon(config));
+    let handle = spawn_daemon_pending_no_detach(config);
 
     let mut challenges = Vec::new();
     for _ in 0..2 {
@@ -154,7 +154,7 @@ fn daemon_negotiation_auth_denies_wrong_password() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -246,7 +246,7 @@ fn daemon_negotiation_auth_denies_unknown_user() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -329,7 +329,7 @@ fn daemon_negotiation_auth_skipped_for_unprotected_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -403,7 +403,7 @@ fn daemon_negotiation_auth_denies_empty_credentials() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -490,7 +490,7 @@ fn daemon_negotiation_auth_successful_sends_ok() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_empty_module_lists_modules.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_empty_module_lists_modules.rs
@@ -29,7 +29,7 @@ fn daemon_negotiation_empty_module_lists_modules() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
@@ -21,7 +21,7 @@ fn daemon_negotiation_error_unknown_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -75,7 +75,7 @@ fn daemon_negotiation_error_empty_module_request() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -136,7 +136,7 @@ fn daemon_negotiation_error_host_denied() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -200,7 +200,7 @@ fn daemon_negotiation_error_refused_options() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -283,7 +283,7 @@ fn daemon_negotiation_error_max_connections_exceeded() {
         ])
         .build();
 
-    let (mut stream1, handle) = start_daemon(config, port, held_listener);
+    let (mut stream1, handle) = start_daemon_pending_no_detach(config, port, held_listener);
 
     // First connection should succeed (up to the OK)
     let mut reader1 = BufReader::new(stream1.try_clone().expect("clone"));
@@ -358,7 +358,7 @@ fn daemon_negotiation_error_sanitizes_module_name_in_response() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -412,7 +412,7 @@ fn daemon_negotiation_error_no_exit_after_error() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -467,7 +467,7 @@ fn daemon_negotiation_error_connection_closed_early() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port, held_listener);
+    let (stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -501,7 +501,7 @@ fn daemon_negotiation_error_invalid_greeting_response() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
@@ -33,7 +33,7 @@ fn daemon_negotiation_error_host_allow_blocks_unlisted() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
@@ -28,7 +28,7 @@ fn daemon_negotiation_module_list_sends_listing_directly() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -91,7 +91,7 @@ fn daemon_negotiation_module_list_respects_listable_flag() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -154,7 +154,7 @@ fn daemon_negotiation_module_list_includes_comments() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -197,7 +197,7 @@ fn daemon_negotiation_module_list_empty_when_no_modules() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_version.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_version.rs
@@ -21,7 +21,7 @@ fn daemon_negotiation_version_sends_greeting_first() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port, held_listener);
+    let (stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     stream
         .set_read_timeout(Some(Duration::from_secs(5)))
         .expect("set timeout");
@@ -58,7 +58,7 @@ fn daemon_negotiation_version_greeting_format() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port, held_listener);
+    let (stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -114,7 +114,7 @@ fn daemon_negotiation_version_accepts_older_client_version() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -162,7 +162,7 @@ fn daemon_negotiation_version_includes_digest_list_for_protocol_31_plus() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port, held_listener);
+    let (stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream);
 
     let mut line = String::new();
@@ -224,7 +224,7 @@ fn daemon_negotiation_version_echoes_client_digests() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -270,7 +270,7 @@ fn daemon_negotiation_version_handles_whitespace_variations() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -315,7 +315,7 @@ fn daemon_negotiation_version_greeting_ends_with_newline() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port, held_listener);
+    let (stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream);
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs
+++ b/crates/daemon/src/tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs
@@ -32,7 +32,7 @@ fn daemon_pre_xfer_exec_rejects_on_nonzero_exit() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_protocol_28_forced_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/daemon_protocol_28_forced_negotiation.rs
@@ -33,7 +33,7 @@ fn daemon_protocol_28_forced_client_greeting_accepted() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read daemon greeting (server speaks newest protocol)
@@ -146,7 +146,7 @@ fn daemon_protocol_28_forced_version_negotiation_downgrade() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Daemon sends its greeting (protocol 32 with digest list)
@@ -224,7 +224,7 @@ fn daemon_protocol_28_forced_client_api_push() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -323,7 +323,7 @@ fn daemon_protocol_28_forced_client_api_pull() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/pullmod/");
@@ -424,7 +424,7 @@ fn daemon_protocol_28_forced_push_then_pull_roundtrip() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Push at forced protocol 28
@@ -552,7 +552,7 @@ fn daemon_protocol_28_forced_module_listing_works() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_pull_subpath.rs
+++ b/crates/daemon/src/tests/chunks/daemon_pull_subpath.rs
@@ -52,7 +52,7 @@ fn launch_subpath_daemon(
             OsString::from("3"),
         ])
         .build();
-    start_daemon(daemon_config, port, held)
+    start_daemon_pending_no_detach(daemon_config, port, held)
 }
 
 #[cfg(unix)]

--- a/crates/daemon/src/tests/chunks/daemon_push_pull_lifecycle.rs
+++ b/crates/daemon/src/tests/chunks/daemon_push_pull_lifecycle.rs
@@ -64,7 +64,7 @@ fn daemon_push_then_pull_roundtrip_preserves_content() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Push files to daemon module
@@ -212,7 +212,7 @@ fn daemon_push_incremental_update_lifecycle() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Initial push
@@ -345,7 +345,7 @@ fn daemon_pull_lifecycle_copies_full_tree() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/docs/");
@@ -458,7 +458,7 @@ fn daemon_push_lifecycle_preserves_permissions() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -554,7 +554,7 @@ fn daemon_push_lifecycle_rejects_read_only_module() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_relative_receive.rs
+++ b/crates/daemon/src/tests/chunks/daemon_relative_receive.rs
@@ -71,7 +71,7 @@ fn daemon_relative_receive_preserves_nested_paths() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_copy_links_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_copy_links_push.rs
@@ -74,7 +74,7 @@ fn daemon_safe_links_push_excludes_unsafe_preserves_safe() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -208,7 +208,7 @@ fn daemon_copy_links_push_replaces_symlinks_with_file_contents() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_pull.rs
@@ -83,7 +83,7 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_pull() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_push.rs
@@ -83,7 +83,7 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_push() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_receive.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_receive.rs
@@ -101,7 +101,7 @@ fn daemon_safe_links_receive() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_unicode_emoji_filenames.rs
+++ b/crates/daemon/src/tests/chunks/daemon_unicode_emoji_filenames.rs
@@ -74,7 +74,7 @@ fn daemon_unicode_emoji_filenames_roundtrip() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_xattr_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_xattr_push.rs
@@ -96,7 +96,7 @@ fn daemon_xattr_push_preserves_extended_attributes() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
@@ -41,7 +41,7 @@ fn run_daemon_accepts_valid_credentials() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
@@ -41,7 +41,7 @@ fn run_daemon_auth_failure_rejects_wrong_credentials() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_config_flag_overrides_default_path.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_config_flag_overrides_default_path.rs
@@ -41,7 +41,7 @@ fn run_daemon_config_flag_overrides_default_path() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Verify the daemon greeting

--- a/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
@@ -30,7 +30,7 @@ fn run_daemon_denies_module_when_host_not_allowed() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
@@ -30,7 +30,7 @@ fn run_daemon_enforces_bwlimit_during_module_list() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
@@ -40,7 +40,7 @@ fn run_daemon_enforces_module_connection_limit() {
         ])
         .build();
 
-    let (mut first_stream, handle) = start_daemon(config, port, held_listener);
+    let (mut first_stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut first_reader = BufReader::new(first_stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_handles_binary_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_handles_binary_negotiation.rs
@@ -19,7 +19,7 @@ fn run_daemon_handles_binary_negotiation() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     stream
         .set_read_timeout(Some(Duration::from_secs(5)))
         .expect("set read timeout");

--- a/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
@@ -17,7 +17,7 @@ fn run_daemon_handles_parallel_sessions() {
         .build();
 
     drop(held_listener);
-    let handle = thread::spawn(move || run_daemon(config));
+    let handle = spawn_daemon_pending_no_detach(config);
 
     let barrier = Arc::new(Barrier::new(2));
     let mut clients = Vec::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
@@ -17,7 +17,7 @@ fn run_daemon_honours_max_sessions() {
         .build();
 
     drop(held_listener);
-    let handle = thread::spawn(move || run_daemon(config));
+    let handle = spawn_daemon_pending_no_detach(config);
 
     let expected_greeting = legacy_daemon_greeting();
     for _ in 0..2 {

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_host_denied_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_host_denied_module.rs
@@ -30,7 +30,7 @@ fn run_daemon_lists_host_denied_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
@@ -20,7 +20,7 @@ fn run_daemon_lists_modules_on_request() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_module_timeout.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_module_timeout.rs
@@ -35,7 +35,7 @@ fn run_daemon_lists_modules_with_module_timeout() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
@@ -30,7 +30,7 @@ fn run_daemon_lists_modules_with_motd_lines() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_loads_modules_from_config_file.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_loads_modules_from_config_file.rs
@@ -31,7 +31,7 @@ fn run_daemon_loads_modules_from_config_file() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_loads_modules_from_inline_config_flag.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_loads_modules_from_inline_config_flag.rs
@@ -28,7 +28,7 @@ fn run_daemon_loads_modules_from_inline_config_flag() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
@@ -27,7 +27,7 @@ fn run_daemon_omits_unlisted_modules_from_listing() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
@@ -27,7 +27,7 @@ fn run_daemon_panic_isolation_keeps_daemon_alive() {
         .build();
 
     drop(held_listener);
-    let daemon_handle = thread::spawn(move || run_daemon(config));
+    let daemon_handle = spawn_daemon_pending_no_detach(config);
 
     // The daemon refuses the garbage sent in place of the client's version
     // banner (upstream clientserver.c:180-184 `@ERROR: protocol startup

--- a/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
@@ -59,7 +59,7 @@ fn run_daemon_per_module_cap_overrides_global_max_connections() {
         ])
         .build();
 
-    let (mut first_stream, handle) = start_daemon(config, port, held_listener);
+    let (mut first_stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut first_reader = BufReader::new(first_stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_pid_file_contains_correct_pid.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_pid_file_contains_correct_pid.rs
@@ -27,7 +27,7 @@ fn run_daemon_pid_file_contains_correct_pid() {
 
     let pid_clone = pid_path.clone();
     drop(held_listener);
-    let handle = thread::spawn(move || run_daemon(config));
+    let handle = spawn_daemon_pending_no_detach(config);
 
     let start = Instant::now();
     while !pid_clone.exists() {

--- a/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
@@ -45,7 +45,7 @@ fn run_daemon_post_ok_refused_option_uses_multiplexed_error() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Drain the daemon greeting and complete the version handshake.

--- a/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
@@ -27,7 +27,7 @@ fn run_daemon_records_log_file_entries() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
@@ -25,7 +25,7 @@ fn run_daemon_refuses_disallowed_module_options() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
@@ -32,7 +32,7 @@ fn run_daemon_rejects_push_to_default_read_only_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
@@ -31,7 +31,7 @@ fn run_daemon_rejects_push_to_read_only_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
@@ -24,7 +24,7 @@ fn run_daemon_rejects_unknown_hash_command() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
@@ -41,7 +41,7 @@ fn run_daemon_requests_authentication_for_protected_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_early_exec_failure.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_early_exec_failure.rs
@@ -47,7 +47,7 @@ fn run_daemon_runs_post_xfer_exec_on_early_exec_failure() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
@@ -58,7 +58,7 @@ fn run_daemon_runs_post_xfer_exec_on_read_only_refuse() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
@@ -26,7 +26,7 @@ fn run_daemon_sends_motd_before_unknown_module_error() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
@@ -15,7 +15,7 @@ fn run_daemon_serves_single_legacy_connection() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_writes_and_removes_pid_file.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_writes_and_removes_pid_file.rs
@@ -22,7 +22,7 @@ fn run_daemon_writes_and_removes_pid_file() {
 
     let pid_clone = pid_path.clone();
     drop(held_listener);
-    let handle = thread::spawn(move || run_daemon(config));
+    let handle = spawn_daemon_pending_no_detach(config);
 
     let start = Instant::now();
     while !pid_clone.exists() {

--- a/crates/daemon/src/tests/support.rs
+++ b/crates/daemon/src/tests/support.rs
@@ -220,6 +220,73 @@ pub(super) fn write_executable_script(path: &Path, contents: &str) {
     fs::set_permissions(path, permissions).expect("set script permissions");
 }
 
+/// Forces a test-started daemon to stay in the foreground.
+///
+/// `RuntimeOptions::detach` defaults to `true` on Unix
+/// (`daemon/runtime_options/types.rs`), so a daemon started with the arguments
+/// a test typically supplies calls `become_daemon()`, which forks. The parent
+/// of that fork is the test process itself, and it exits with status 0
+/// (`platform::daemonize::become_daemon`). The test binary therefore terminates
+/// successfully before a single assertion runs and the harness records a pass -
+/// an unconditional `assert!(false)` in such a test still reports PASSED.
+///
+/// Appending `--no-detach` after the caller's arguments makes that impossible:
+/// detach flags are applied in argument order and the last one wins
+/// (`daemon/runtime_options/parsing.rs`), so no caller-supplied argument can
+/// re-enable detaching. A caller that asks for `--detach` outright is rejected
+/// loudly rather than silently corrected, because that request can only be a
+/// mistake in a test.
+///
+/// upstream: clientserver.c:1513 - `become_daemon()`
+fn force_no_detach(config: crate::DaemonConfig) -> crate::DaemonConfig {
+    assert!(
+        !config
+            .arguments()
+            .iter()
+            .any(|argument| argument == "--detach"),
+        "daemon tests must never pass --detach: become_daemon() forks and the \
+         parent - this test process - exits 0 before any assertion runs, so the \
+         test would report a pass without proving anything"
+    );
+
+    let mut arguments = config.arguments().to_vec();
+    arguments.push(OsString::from("--no-detach"));
+    crate::DaemonConfigBuilder::from(config)
+        .arguments(arguments)
+        .build()
+}
+
+/// Spawns an in-process daemon thread that is guaranteed to stay in the
+/// foreground.
+///
+/// This is the only supported way for a test to run [`run_daemon`] on a thread;
+/// spawning it directly reintroduces the silent-pass defect described on
+/// [`force_no_detach`].
+pub(super) fn spawn_daemon(
+    config: crate::DaemonConfig,
+) -> thread::JoinHandle<Result<(), crate::DaemonError>> {
+    spawn_daemon_thread(force_no_detach(config))
+}
+
+/// Spawns a daemon thread without forcing `--no-detach`.
+///
+/// Temporary: the tests still calling this predate the foreground requirement
+/// and are vacuous on Unix for the reason described on [`force_no_detach`].
+/// They are migrated to [`spawn_daemon`] in separate slices so the assertions
+/// they start executing can be triaged a few at a time. Do not add call sites -
+/// `tools/ci/check_daemon_no_detach.sh` fails when the population grows.
+pub(super) fn spawn_daemon_pending_no_detach(
+    config: crate::DaemonConfig,
+) -> thread::JoinHandle<Result<(), crate::DaemonError>> {
+    spawn_daemon_thread(config)
+}
+
+fn spawn_daemon_thread(
+    config: crate::DaemonConfig,
+) -> thread::JoinHandle<Result<(), crate::DaemonError>> {
+    thread::spawn(move || run_daemon(config))
+}
+
 /// Spawn a daemon thread and connect, failing fast if the daemon exits early.
 ///
 /// Returns the connected stream and the daemon thread handle.  If the daemon
@@ -230,6 +297,10 @@ pub(super) fn write_executable_script(path: &Path, contents: &str) {
 /// The pre-bound `TcpListener` is passed directly to the daemon via
 /// `DaemonConfig`, eliminating the TOCTOU race between port allocation and
 /// daemon bind that previously caused flaky failures under CI load.
+///
+/// The daemon is forced into the foreground by [`force_no_detach`], so a caller
+/// that omits `--no-detach` still gets a test that actually runs its
+/// assertions.
 pub(super) fn start_daemon(
     config: crate::DaemonConfig,
     port: u16,
@@ -238,12 +309,53 @@ pub(super) fn start_daemon(
     TcpStream,
     thread::JoinHandle<Result<(), crate::DaemonError>>,
 ) {
-    // Inject the already-bound listener into the config so the daemon uses it
-    // directly instead of binding a new socket to the same port.
-    let config = crate::DaemonConfigBuilder::from(config)
+    connect_started_daemon(
+        spawn_daemon(with_pre_bound_listener(config, held_listener)),
+        port,
+    )
+}
+
+/// [`start_daemon`] without the foreground guarantee.
+///
+/// Temporary, for the same reason and with the same migration plan as
+/// [`spawn_daemon_pending_no_detach`]. Every call site is a test whose
+/// assertions do not run on Unix; Windows is the only platform where they do,
+/// because `become_daemon()` is `#[cfg(unix)]` and `detach` defaults to
+/// `cfg!(unix)`. These tests deliberately stay enabled on Windows: the daemon
+/// is supported there, and until the migration lands Windows is the only
+/// platform whose result means anything.
+pub(super) fn start_daemon_pending_no_detach(
+    config: crate::DaemonConfig,
+    port: u16,
+    held_listener: TcpListener,
+) -> (
+    TcpStream,
+    thread::JoinHandle<Result<(), crate::DaemonError>>,
+) {
+    connect_started_daemon(
+        spawn_daemon_pending_no_detach(with_pre_bound_listener(config, held_listener)),
+        port,
+    )
+}
+
+/// Injects an already-bound listener so the daemon reuses it instead of binding
+/// a new socket to the same port.
+fn with_pre_bound_listener(
+    config: crate::DaemonConfig,
+    held_listener: TcpListener,
+) -> crate::DaemonConfig {
+    crate::DaemonConfigBuilder::from(config)
         .pre_bound_listener(held_listener)
-        .build();
-    let handle = thread::spawn(move || run_daemon(config));
+        .build()
+}
+
+fn connect_started_daemon(
+    handle: thread::JoinHandle<Result<(), crate::DaemonError>>,
+    port: u16,
+) -> (
+    TcpStream,
+    thread::JoinHandle<Result<(), crate::DaemonError>>,
+) {
     let stream = connect_to_daemon(port, Some(&handle));
     (stream, handle)
 }

--- a/tools/ci/check_daemon_no_detach.sh
+++ b/tools/ci/check_daemon_no_detach.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regression guard against daemon tests that silently pass without running.
+#
+# Background: `RuntimeOptions::detach` defaults to true on Unix, so a daemon
+# started from a test with the usual arguments calls `become_daemon()`, which
+# forks. The parent of that fork is the test process, and it exits with status
+# 0. The test binary therefore terminates successfully before any assertion
+# runs and the harness records a pass - an unconditional `assert!(false)` in
+# such a test still reports PASSED.
+#
+# `crates/daemon/src/tests/support.rs` closes this by appending `--no-detach`
+# after the caller's arguments in `force_no_detach()`; detach flags are applied
+# in argument order and the last one wins, so no caller can opt back out.
+#
+# What it checks:
+#   1. `force_no_detach()` still appends `--no-detach` in the test support
+#      module - the guard itself has not been deleted or defeated.
+#   2. Daemon tests do not spawn `run_daemon` on a thread directly, which
+#      bypasses the support helpers entirely.
+#   3. The population of call sites still using the temporary
+#      `*_pending_no_detach` helpers only ever shrinks. Those tests predate the
+#      foreground requirement and are migrated in separate slices; the ceiling
+#      below must be lowered as they are, never raised.
+#
+# Usage:
+#   tools/ci/check_daemon_no_detach.sh
+#
+# Exit codes:
+#   0 - No violations found.
+#   1 - Violation detected.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TESTS_DIR="${REPO_ROOT}/crates/daemon/src/tests"
+SUPPORT="${TESTS_DIR}/support.rs"
+
+# Lower this when a migration slice converts call sites to the guarded helpers.
+# It must never be raised.
+PENDING_CEILING=110
+
+violations=0
+
+printf '=== daemon no-detach guard ===\n'
+
+if [ ! -f "${SUPPORT}" ]; then
+    printf 'FAIL: cannot locate %s\n' "${SUPPORT}" >&2
+    exit 1
+fi
+
+# 1. The guard itself must still be in place.
+if ! grep -q 'arguments.push(OsString::from("--no-detach"));' "${SUPPORT}"; then
+    printf 'FAIL: force_no_detach() no longer appends --no-detach in %s\n' \
+        "crates/daemon/src/tests/support.rs" >&2
+    printf '      Without it every daemon test forks and exits 0 before asserting.\n' >&2
+    violations=$((violations + 1))
+else
+    printf 'OK: force_no_detach() appends --no-detach\n'
+fi
+
+# 2. No test may spawn run_daemon on a thread directly. `support.rs` is the one
+#    sanctioned spawn point: every helper there routes through force_no_detach()
+#    or the explicitly named temporary escape hatch.
+bypasses="$(grep -rn 'thread::spawn(.*[^_]run_daemon(' "${TESTS_DIR}/chunks" \
+    --include='*.rs' || true)"
+if [ -n "${bypasses}" ]; then
+    printf 'FAIL: daemon tests spawn run_daemon directly, bypassing the guard:\n' >&2
+    printf '%s\n' "${bypasses}" >&2
+    printf '      Use spawn_daemon() from crates/daemon/src/tests/support.rs.\n' >&2
+    violations=$((violations + 1))
+else
+    printf 'OK: no direct run_daemon thread spawns in daemon tests\n'
+fi
+
+# 3. The pending-migration population may only shrink.
+pending="$(grep -ro '\(start\|spawn\)_daemon_pending_no_detach(' "${TESTS_DIR}/chunks" \
+    --include='*.rs' | wc -l | tr -d ' ')"
+printf 'Pending-migration call sites: %s (ceiling %s)\n' "${pending}" "${PENDING_CEILING}"
+if [ "${pending}" -gt "${PENDING_CEILING}" ]; then
+    printf 'FAIL: %s call sites still start a detaching daemon, ceiling is %s.\n' \
+        "${pending}" "${PENDING_CEILING}" >&2
+    printf '      New daemon tests must use start_daemon()/spawn_daemon().\n' >&2
+    violations=$((violations + 1))
+fi
+
+if [ "${violations}" -ne 0 ]; then
+    printf '\n%s violation(s) found.\n' "${violations}" >&2
+    exit 1
+fi
+
+printf '\nNo violations found.\n'


### PR DESCRIPTION
## The defect

Daemon tests build a `DaemonConfig` whose arguments usually omit `--no-detach`.
`RuntimeOptions::detach` defaults to `cfg!(unix)`, so `run_daemon()` reaches
`become_daemon()` (`daemon/sections/daemonize.rs`, upstream
`clientserver.c:1513`), which forks. The parent of that fork is the *test
process*, and it exits with status 0. The test binary therefore terminates
successfully before a single assertion runs, and the harness records a pass.

Reproduced directly: a throwaway test that starts a daemon the way the existing
tests do and ends in an unconditional `assert!(false)` reports **PASSED**.

110 call sites across `crates/daemon/src/tests/chunks/` start a daemon this way.
Only 5 pass `--no-detach`.

## The guard

`crates/daemon/src/tests/support.rs` gains `force_no_detach()`, which appends
`--no-detach` *after* the caller's arguments. Detach flags are applied in
argument order and the last one wins
(`daemon/runtime_options/parsing.rs`), so no caller-supplied argument can
re-enable detaching - a call site that simply forgets the flag now gets a test
that actually runs. A caller that passes `--detach` outright is rejected with a
panic instead of being silently corrected, because in a test that request can
only be a mistake.

`start_daemon()` and the new `spawn_daemon()` both route through it, and
`spawn_daemon()` replaces the six tests that spawned `run_daemon` on a thread
directly, bypassing the support module altogether.

## What this PR deliberately does not do

The tests that predate the requirement keep their current behaviour. They move
mechanically to `start_daemon_pending_no_detach()` / `spawn_daemon_pending_no_detach()`,
which are the previous code paths under explicit names. That rename is the only
edit to those 74 files - no assertion, argument or timing was touched.
Un-skipping them, and triaging the failures that surfaces, is separate work
sliced so it stays reviewable. The escape-hatch name makes the remaining
population greppable for those slices.

`tools/ci/check_daemon_no_detach.sh` (wired into the `ci.yml` lint job, in the
style of `check_shared_ring_removal.sh`) asserts the injection is still present,
forbids direct `run_daemon` thread spawns in daemon tests, and ratchets the
pending population: the ceiling may be lowered as slices land, never raised.

## Proof the guard fires

Three throwaway probes, run on x86_64 Linux, then removed:

| Probe | Path | Result |
| --- | --- | --- |
| Config without `--no-detach`, body ends in `assert!(false)` | `start_daemon_pending_no_detach()` | **PASSED** - the defect, and proof the rename preserved behaviour |
| Same body, same config | `start_daemon()` | **FAILED** at the assertion - the guard makes it run |
| Config with `--detach` | `start_daemon()` | **FAILED**: `daemon tests must never pass --detach: become_daemon() forks and the parent - this test process - exits 0 before any assertion runs` |

## Windows

Settled explicitly rather than left to cfg gating: these tests stay enabled on
Windows. `become_daemon()` is `#[cfg(unix)]` and `detach` defaults to
`cfg!(unix)`, so Windows never forks and is currently the only platform where
the assertions execute. Daemon mode itself is supported there - `accept_loop.rs`
has no non-Unix rejection, and the Windows Service dispatcher feeds it signal
flags. Gating them off Windows would delete the only honest signal these tests
still produce. The guard is a no-op on Windows (`--no-detach` where detach is
already off), so nothing about that signal changes here.

## Verification

- `cargo nextest run -p daemon --all-features`: 1772 passed, 6 skipped (x86_64 Linux).
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `bash tools/ci/check_daemon_no_detach.sh`: clean; also verified it fails when
  the injection is removed and when a direct `run_daemon` spawn is present.
