### PR TITLE
fix(receiver): restore the missing itemize flag producers

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -9,6 +9,8 @@ mod ownership;
 mod permissions;
 mod timestamps;
 
+pub use ownership::group_is_settable;
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -277,6 +277,33 @@ pub(super) fn gate_preserved_group(group: Option<unix_fs::Gid>) -> Option<unix_f
     group.filter(|gid| nix::unistd::geteuid().is_root() || process_in_group(*gid))
 }
 
+/// Whether this process may set a file's group to `gid`, i.e. whether upstream
+/// would leave `FLAG_SKIP_GROUP` clear for it.
+///
+/// upstream: `uidlist.c:284` - `flag = idlist_ptr == &gidlist && !am_root
+/// && !is_in_group(id2) ? FLAG_SKIP_GROUP : 0`. The flag is the negation of
+/// this predicate, and its consumers test `!(file->flags & FLAG_SKIP_GROUP)`:
+/// the group chown itself (`rsync.c:527`), the itemize `g` column
+/// (`generator.c:434`, `:555`), and the `-vv` name line (`log.c:575`). A
+/// non-root process that does not belong to `gid` can never set it, so
+/// upstream neither attempts the chown nor reports the group as changed.
+///
+/// Always `true` off unix, where there is no POSIX group to gate.
+#[must_use]
+pub fn group_is_settable(gid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // See `gate_preserved_group`: nix (libc `geteuid`) so a fakeroot euid
+        // counts as root, matching upstream's `am_root`.
+        nix::unistd::geteuid().is_root() || process_in_group(unix_fs::Gid::from_raw(gid))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = gid;
+        true
+    }
+}
+
 /// Resolves the preserved owner of `entry` to a local uid.
 ///
 /// `--usermap` is consulted first on the raw sender id (its rules match numeric

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -251,6 +251,7 @@ pub use acl_noop::{
     sync_acls, sync_acls_via_fake_super,
 };
 
+pub use apply::group_is_settable;
 #[cfg(unix)]
 pub use apply::{
     apply_dest_mode_pre_transfer, apply_file_metadata_with_fd,

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -368,14 +368,16 @@ pub struct ParsedServerFlags {
 
     /// Preserve executability (long-form `--executability` / `-E`).
     ///
-    /// Receiver-side only. Not part of the compact flag string built by
-    /// `build_server_flag_string`: upstream `options.c:2692-2693` packs `'E'`
-    /// into `server_options` only inside the `else if (preserve_executability &&
-    /// am_sender)` branch, so on a pull the flag is never sent over the wire and
-    /// the local client (which IS the receiver) must apply it itself. When set
-    /// without `--perms`, the receiver copies only the executability bits from
-    /// the source mode, mirroring upstream `rsync.c:457-465` (`set_file_attrs()`
-    /// layers `-E` on top when `!preserve_perms`).
+    /// Receiver-side in effect, but it reaches the receiver by two different
+    /// routes. Upstream `options.c:2692-2693` packs `'E'` into
+    /// `server_options` inside the `else if (preserve_executability &&
+    /// am_sender)` branch: on a **push** the flag rides the compact string to
+    /// the remote server, which is the receiver, so the flag parser has to
+    /// accept it; on a **pull** it is never sent, because the local client IS
+    /// the receiver and applies it itself. When set without `--perms`, the
+    /// receiver copies only the executability bits from the source mode,
+    /// mirroring upstream `rsync.c:457-465` (`set_file_attrs()` layers `-E` on
+    /// top when `!preserve_perms`).
     pub preserve_executability: bool,
 
     /// Engage the opt-in parallel sender-side delta scan for large files
@@ -584,6 +586,15 @@ impl ParsedServerFlags {
             // upstream: options.c:2631 - 'b' = backup.
             b'b' => self.backup = true,
             b'N' => self.crtimes = true,
+            // upstream: options.c:2692-2693 - `'E'` rides the compact flag
+            // string in the `else if (preserve_executability && am_sender)`
+            // branch, i.e. on a *push*, where the remote server IS the
+            // receiver and has to honour it. (On a pull the local client is
+            // the receiver and applies `-E` itself, which is why the field's
+            // doc calls it receiver-side.) Without parsing it a pushed `-E`
+            // left the server receiver with executability preservation off:
+            // it neither copied the exec bit nor reported the `p` column.
+            b'E' => self.preserve_executability = true,
             // upstream: options.c:764 - 'L' = copy_links (resolve symlinks).
             b'L' => self.copy_links = true,
             // upstream: options.c:688 - 'K' = keep_dirlinks (preserve
@@ -799,6 +810,21 @@ mod tests {
     fn one_file_system_not_set_by_default() {
         let flags = ParsedServerFlags::parse("-r").unwrap();
         assert_eq!(flags.one_file_system, 0);
+    }
+
+    #[test]
+    fn parses_executability_flag_from_a_push_flag_string() {
+        // upstream: options.c:2692-2693 - a pushing client packs 'E' into the
+        // compact string, e.g. `--server -tEre.iLsfxCIvu`.
+        let flags = ParsedServerFlags::parse("-tEre.iLsfxCIvu").unwrap();
+        assert!(flags.preserve_executability);
+        assert!(flags.times);
+        assert!(flags.recursive);
+        assert!(
+            !ParsedServerFlags::parse("-tre.")
+                .unwrap()
+                .preserve_executability
+        );
     }
 
     #[test]

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -649,6 +649,15 @@ impl ReceiverContext {
         // preserve_xattrs >= 2, so the level has to reach the reader.
         .with_xattr_level(u32::from(self.config.flags.xattrs_level))
         .with_preserve_atimes(self.config.flags.atimes)
+        // upstream: flist.c:743-746 - `recv_file_entry()` reads the crtime
+        // varlong whenever `crtimes_ndx` is set and XMIT_CRTIME_EQ_MTIME is
+        // clear, exactly as it reads the atime above. Without this the receiver
+        // desynchronises from the sender's file list the moment a file's birth
+        // time differs from its mtime: the crtime bytes get parsed as the mode
+        // field and the transfer dies with "received file entry with
+        // zero-length filename". The generator side already sets it
+        // (generator/context.rs:467).
+        .with_preserve_crtimes(self.config.flags.crtimes)
         .with_delete_missing_args(self.config.file_selection.delete_missing_args)
         .with_relative_paths(self.config.flags.relative);
 

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -402,7 +402,7 @@ impl ReceiverContext {
                     // compensation still fires `cd+++++++++ ./` when the
                     // pre-flight mkdir created the root.
                     let raw = match pre_mkdir_meta.get(pos).and_then(Option::as_ref) {
-                        Some(meta) => self.itemize_existing_flags(entry, Some(meta), 0),
+                        Some(meta) => self.itemize_existing_flags(entry, dir_path, Some(meta), 0),
                         None => self.existing_dir_iflags(entry, dir_path),
                     };
                     crate::generator::ItemFlags::from_raw(raw)

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -103,7 +103,7 @@ impl ReceiverContext {
         dir_path: &std::path::Path,
     ) -> u32 {
         match std::fs::metadata(dir_path) {
-            Ok(meta) => self.itemize_existing_flags(entry, Some(&meta), 0),
+            Ok(meta) => self.itemize_existing_flags(entry, dir_path, Some(&meta), 0),
             // Not `None`: a failed stat is upstream's benign "no change"
             // outcome here, not the `statret < 0` ITEM_IS_NEW leg.
             Err(_) => 0,
@@ -169,7 +169,7 @@ impl ReceiverContext {
                     // upstream: itemize() compares an existing dir's pre-apply
                     // stat and prints its name only when an attribute differs.
                     Ok(meta) if meta.is_dir() => crate::generator::ItemFlags::from_raw(
-                        self.itemize_existing_flags(entry, Some(&meta), 0),
+                        self.itemize_existing_flags(entry, &dir_path, Some(&meta), 0),
                     )
                     .has_significant_flags(),
                     // Present but not a directory: upstream deletes it and

--- a/crates/transfer/src/receiver/tests/file_list/crtime_wire.rs
+++ b/crates/transfer/src/receiver/tests/file_list/crtime_wire.rs
@@ -1,0 +1,110 @@
+//! Receiver-side decoding of the `--crtimes` (`-N`) file-list field.
+//!
+//! upstream: `flist.c:743-746` - `recv_file_entry()` reads a crtime varlong
+//! whenever `crtimes_ndx` is set and `XMIT_CRTIME_EQ_MTIME` is clear. The field
+//! sits between the mtime block and the mode, so a receiver that does not
+//! consume it parses the crtime bytes as the mode and every following field
+//! shifts.
+
+use std::ffi::OsString;
+use std::io::Cursor;
+
+use protocol::ProtocolVersion;
+use protocol::flist::{FileEntry, FileListWriter};
+
+use super::super::super::ReceiverContext;
+use super::super::support::test_handshake;
+use crate::config::ServerConfig;
+use crate::role::ServerRole;
+
+const PROTOCOL: u8 = 32;
+
+/// A `-N` receiver: `--times --crtimes`, matching the flag string the sender
+/// is handed in `oc-rsync -rtN`.
+fn crtimes_config() -> ServerConfig {
+    let mut config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(PROTOCOL).unwrap(),
+        flag_string: "-rtNe.".to_owned(),
+        args: vec![OsString::from(".")],
+        ..Default::default()
+    };
+    config.flags.recursive = true;
+    config.flags.times = true;
+    config.flags.crtimes = true;
+    config
+}
+
+/// Encodes `entries` the way a `--crtimes` sender does.
+fn crtimes_wire_bytes(entries: &[FileEntry]) -> Vec<u8> {
+    let mut data = Vec::new();
+    let mut writer = FileListWriter::new(ProtocolVersion::try_from(PROTOCOL).unwrap())
+        .with_preserve_crtimes(true);
+    for entry in entries {
+        writer.write_entry(&mut data, entry).unwrap();
+    }
+    writer.write_end(&mut data, None).unwrap();
+    data
+}
+
+/// A crtime that differs from the mtime puts a varlong on the wire
+/// (`XMIT_CRTIME_EQ_MTIME` is only set when the two are equal,
+/// `flist.c:XMIT_CRTIME_EQ_MTIME`). The receiver must consume it.
+///
+/// Why it matters: without `with_preserve_crtimes` on the receiver's reader,
+/// those bytes were parsed as the mode field and everything after it shifted.
+/// A real `oc-rsync -rtN` pull from an upstream 3.4.4 sender died with
+/// "received file entry with zero-length filename" (exit 12) for any file
+/// whose birth time was not its mtime; upstream transferred it fine.
+#[test]
+fn crtime_differing_from_mtime_does_not_desync_the_file_list() {
+    let mut first = FileEntry::new_file("alpha.txt".into(), 42, 0o644);
+    first.set_mtime(1_893_448_800, 0);
+    first.set_crtime(1_600_000_000);
+    let mut second = FileEntry::new_file("beta.txt".into(), 7, 0o600);
+    second.set_mtime(1_893_448_800, 0);
+    second.set_crtime(1_500_000_000);
+    let data = crtimes_wire_bytes(&[first, second]);
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, crtimes_config());
+    let count = ctx
+        .receive_file_list(&mut Cursor::new(data))
+        .expect("a -N file list must decode without desynchronising");
+
+    assert_eq!(count, 2);
+    let list = ctx.file_list();
+    let names: Vec<&str> = list.iter().map(FileEntry::name).collect();
+    assert_eq!(names, vec!["alpha.txt", "beta.txt"]);
+    // The fields *after* the crtime are the ones a missed read corrupts.
+    assert_eq!(
+        list[0].mode() & 0o7777,
+        0o644,
+        "mode shifted past the crtime"
+    );
+    assert_eq!(list[0].size(), 42, "size shifted past the crtime");
+    assert_eq!(
+        list[0].crtime(),
+        1_600_000_000,
+        "the crtime itself must reach the entry so itemize() can compare it"
+    );
+    assert_eq!(list[1].crtime(), 1_500_000_000);
+}
+
+/// The equal-crtime case sends no varlong (`XMIT_CRTIME_EQ_MTIME`), so it
+/// decoded correctly even before the fix. Pin it so the reader keeps
+/// reconstructing `crtime == mtime` rather than leaving zero, which would make
+/// every up-to-date file report a spurious `n` column.
+#[test]
+fn crtime_equal_to_mtime_is_reconstructed_from_the_mtime() {
+    let mut entry = FileEntry::new_file("gamma.txt".into(), 3, 0o644);
+    entry.set_mtime(1_700_000_000, 0);
+    entry.set_crtime(1_700_000_000);
+    let data = crtimes_wire_bytes(&[entry]);
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, crtimes_config());
+    ctx.receive_file_list(&mut Cursor::new(data)).unwrap();
+
+    assert_eq!(ctx.file_list()[0].crtime(), 1_700_000_000);
+}

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -31,10 +31,13 @@
 //! - [`delete_backup`] - `--backup` / `--backup-dir` preservation of each
 //!   extraneous file victim before the receiver's delete pass unlinks it,
 //!   across the immediate, delayed, and capped removal sites.
+//! - [`crtime_wire`] - receiver-side decoding of the `--crtimes` file-list
+//!   field, whose omission desynchronised the whole entry stream.
 //! - [`iconv_wire_order`] - regression coverage for the receiver-side
 //!   `--iconv` ordering invariant (file_list stays in sender wire-emit
 //!   order, never re-sorted on local-charset bytes).
 
+mod crtime_wire;
 mod dedup;
 #[cfg(unix)]
 mod delete_backup;

--- a/crates/transfer/src/receiver/tests/xattr_filter.rs
+++ b/crates/transfer/src/receiver/tests/xattr_filter.rs
@@ -79,7 +79,7 @@ fn an_excluded_name_does_not_flip_the_x_column() {
     // pass for the wrong reason.
     let unfiltered = receiver_with(vec![platform_noise_rule()]);
     assert!(
-        unfiltered.dest_xattrs_differ(&entry, &file),
+        unfiltered.dest_xattrs_differ(&entry, Some(&file)),
         "a destination-only xattr must raise the x column when nothing excludes it",
     );
 
@@ -90,7 +90,7 @@ fn an_excluded_name_does_not_flip_the_x_column() {
         platform_noise_rule(),
     ]);
     assert!(
-        !filtered.dest_xattrs_differ(&entry, &file),
+        !filtered.dest_xattrs_differ(&entry, Some(&file)),
         "an x-modifier exclusion must screen the generator's destination read",
     );
 }
@@ -121,7 +121,7 @@ fn a_name_the_filter_admits_still_flips_the_x_column() {
         platform_noise_rule(),
     ]);
     assert!(
-        ctx.dest_xattrs_differ(&entry, &file),
+        ctx.dest_xattrs_differ(&entry, Some(&file)),
         "an unrelated x-modifier rule must not suppress a real xattr difference",
     );
 }
@@ -147,7 +147,7 @@ fn a_plain_path_rule_does_not_screen_the_destination_read() {
 
     let ctx = receiver_with(vec![::filters::FilterRule::exclude(local_name("drop"))]);
     assert!(
-        ctx.dest_xattrs_differ(&entry, &file),
+        ctx.dest_xattrs_differ(&entry, Some(&file)),
         "a rule without the x modifier matches paths, never xattr names",
     );
 }

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -40,6 +40,27 @@ pub(in crate::receiver) type DryRunItem<'a> = (usize, &'a FileEntry, u32);
 ///
 /// upstream: `receiver.c:736-738` - `stats.created_dirs++` under
 /// `iflags & ITEM_IS_NEW`, which runs whether or not the mkdir happened.
+/// The itemize seed for a regular file the generator is about to request.
+///
+/// upstream: `generator.c:1940-1942`
+///
+/// ```c
+/// int iflags = ITEM_TRANSFER;
+/// if (always_checksum > 0)
+///     iflags |= ITEM_REPORT_CHANGE;
+/// ```
+///
+/// Shared by the live candidate pass and the `--dry-run` planner so `-i` and
+/// `-ni` cannot disagree about the `c` glyph.
+const fn transfer_seed(always_checksum: bool) -> u32 {
+    use crate::generator::ItemFlags;
+    if always_checksum {
+        ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_REPORT_CHANGE
+    } else {
+        ItemFlags::ITEM_TRANSFER
+    }
+}
+
 /// The destination's mtime in whole seconds since the epoch, as upstream's
 /// `sxp->st.st_mtime` supplies it to `mtime_differs()` (`generator.c:396`).
 ///
@@ -269,6 +290,14 @@ impl ReceiverContext {
         // per-file method dispatch for the common no-itemize case.
         let emit_itemize = self.should_emit_itemize();
 
+        // upstream: generator.c:1940-1942 - the seed the generator hands to
+        // itemize() at `notify_others` is `ITEM_TRANSFER`, plus
+        // `ITEM_REPORT_CHANGE` whenever `always_checksum > 0`. Under
+        // `--checksum` every transferred file therefore carries the position-2
+        // `c` glyph, because the checksum - not the mtime - is what decided the
+        // file changed.
+        let transfer_seed = transfer_seed(always_checksum.is_some());
+
         // Pre-compute whether ACLs and xattrs are enabled. When disabled
         // (the common case), the per-file function call overhead is avoided
         // entirely in the no-change path. At 100K files this eliminates
@@ -444,12 +473,8 @@ impl ReceiverContext {
             // changes against the pre-transfer destination. A non-existent dest
             // (statret < 0) is ITEM_IS_NEW; an existing one OR-s the per-attr
             // report bits onto ITEM_TRANSFER.
-            let base_iflags = self.itemize_existing_flags(
-                entry,
-                &file_path,
-                dest_meta.as_ref(),
-                crate::generator::ItemFlags::ITEM_TRANSFER,
-            );
+            let base_iflags =
+                self.itemize_existing_flags(entry, &file_path, dest_meta.as_ref(), transfer_seed);
             if base_iflags & crate::generator::ItemFlags::ITEM_IS_NEW != 0 {
                 // upstream: receiver.c:777-778 - a regular file being received
                 // whose destination was absent (ITEM_IS_NEW) bumps
@@ -632,11 +657,11 @@ impl ReceiverContext {
                     ) {
                         0
                     } else {
-                        ItemFlags::ITEM_TRANSFER
+                        transfer_seed(always_checksum.is_some())
                     };
                     self.itemize_existing_flags(entry, dest_path, Some(&meta), base)
                 }
-                Err(_) => new_iflags(ItemFlags::ITEM_TRANSFER),
+                Err(_) => new_iflags(transfer_seed(always_checksum.is_some())),
             }
         }
     }
@@ -721,6 +746,41 @@ impl ReceiverContext {
         };
         if report_time {
             iflags |= ItemFlags::ITEM_REPORT_TIME;
+        }
+        // upstream: generator.c:535-540 - under `--crtimes` the generator reads
+        // the destination's creation time and reports a difference through
+        // `same_time()`:
+        //
+        //     if (crtimes_ndx) {
+        //         if (sxp->crtime == 0)
+        //             sxp->crtime = get_create_time(fnamecmp, &sxp->st);
+        //         if (!same_time(sxp->crtime, 0, F_CRTIME(file), 0))
+        //             iflags |= ITEM_REPORT_CRTIME;
+        //     }
+        //
+        // `get_create_time()` yields 0 when the birth time cannot be read
+        // (utils.c), which `created()` returning `Err` reproduces: 0 differs
+        // from any real sender crtime, so the column reports a change - the
+        // same direction upstream takes. Upstream places this test between the
+        // atime and perms comparisons; the order of independently OR-ed bits is
+        // immaterial, and keeping it out of the `cfg(unix)` block below lets
+        // Windows (which does carry a creation time) report the column too.
+        if self.config.flags.crtimes {
+            let dest_crtime = dest_meta
+                .created()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map_or(0, |d| d.as_secs() as i64);
+            // upstream: util1.c:1478 - `same_time()` honours `--modify-window`,
+            // and both crtime arguments carry a zero nsec component.
+            if !self.config.file_selection.modify_window.same_time(
+                dest_crtime,
+                0,
+                entry.crtime(),
+                0,
+            ) {
+                iflags |= ItemFlags::ITEM_REPORT_CRTIME;
+            }
         }
         #[cfg(unix)]
         {
@@ -1028,6 +1088,8 @@ mod itemize_order_tests {
     use std::ffi::OsString;
     use std::path::Path;
 
+    use super::transfer_seed;
+
     use protocol::ProtocolVersion;
     use protocol::flist::FileEntry;
 
@@ -1268,6 +1330,81 @@ mod itemize_order_tests {
             off & ItemFlags::ITEM_REPORT_XATTR == 0,
             "the `x` column is gated on --xattrs: {off:#06x}"
         );
+    }
+
+    /// upstream: generator.c:535-540. Under `--crtimes` the row reports the
+    /// destination's creation time against the sender's through `same_time()`.
+    ///
+    /// Why it matters: the `n` glyph (log.c:725) was rendered but never
+    /// produced on a network receive, so `-N -i` printed `.f.........` where
+    /// upstream prints `.f......n..`. The column is gated on `--crtimes`: a run
+    /// without it must never surface a birth-time difference.
+    #[test]
+    fn itemize_existing_flags_reports_crtime_only_under_dash_n() {
+        use crate::generator::ItemFlags;
+
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, b"x").unwrap();
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+        let Ok(created) = meta.created() else {
+            // No birth time on this filesystem; upstream's get_create_time
+            // would return 0 here too, so there is nothing to compare.
+            return;
+        };
+        let created_secs = created
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs() as i64);
+
+        let mut entry = FileEntry::new_file("f.txt".into(), 1, 0o644);
+        entry.set_mtime(1_600_000_000, 0);
+        // Mirror the destination's mtime so only the crtime can differ.
+        let hs = handshake();
+        let mut with_n = itemize_client_config();
+        with_n.flags.times = false;
+        with_n.flags.crtimes = true;
+
+        entry.set_crtime(created_secs + 86_400);
+        let ctx = ReceiverContext::new_for_test(&hs, with_n.clone());
+        let differs = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            differs & ItemFlags::ITEM_REPORT_CRTIME != 0,
+            "a differing crtime must report `n` under --crtimes: {differs:#06x}"
+        );
+
+        entry.set_crtime(created_secs);
+        let same = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            same & ItemFlags::ITEM_REPORT_CRTIME == 0,
+            "an equal crtime must leave `n` clear: {same:#06x}"
+        );
+
+        entry.set_crtime(created_secs + 86_400);
+        let mut without_n = itemize_client_config();
+        without_n.flags.crtimes = false;
+        let ctx = ReceiverContext::new_for_test(&hs, without_n);
+        let off = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            off & ItemFlags::ITEM_REPORT_CRTIME == 0,
+            "the `n` column is gated on --crtimes: {off:#06x}"
+        );
+    }
+
+    /// upstream: generator.c:1940-1942. `--checksum` seeds every transfer with
+    /// `ITEM_REPORT_CHANGE`, because the checksum - not the mtime - is what
+    /// decided the file changed, so `rsync -rtci` prints `>fc........`.
+    ///
+    /// The live pass and the `--dry-run` planner share this seed, so `-i` and
+    /// `-ni` cannot disagree about the `c` glyph.
+    #[test]
+    fn transfer_seed_carries_change_only_under_checksum() {
+        use crate::generator::ItemFlags;
+
+        assert_eq!(
+            transfer_seed(true),
+            ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_REPORT_CHANGE
+        );
+        assert_eq!(transfer_seed(false), ItemFlags::ITEM_TRANSFER);
     }
 
     /// upstream: generator.c:572-576. The `statret < 0` leg runs

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -61,24 +61,27 @@ const fn transfer_seed(always_checksum: bool) -> u32 {
     }
 }
 
-/// The destination's mtime in whole seconds since the epoch, as upstream's
-/// `sxp->st.st_mtime` supplies it to `mtime_differs()` (`generator.c:396`).
+/// The destination's mtime as `(seconds, nanoseconds)`, the pair upstream's
+/// `mtime_differs()` reads out of `stp->st_mtime` / `stp->ST_MTIME_NSEC`
+/// (`generator.c:396-401`).
 ///
+/// The nanosecond component only participates when `--modify-window` is
+/// negative (`util1.c:1482`), but it has to be carried so that mode works.
 /// A destination whose mtime predates the epoch or cannot be read compares as
-/// `0`, which differs from any real sender mtime and therefore reports the
+/// `(0, 0)`, which differs from any real sender mtime and therefore reports the
 /// time as changed - the safe direction.
-fn dest_mtime_secs(meta: &fs::Metadata) -> i64 {
+fn dest_mtime(meta: &fs::Metadata) -> (i64, u32) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
-        meta.mtime()
+        (meta.mtime(), meta.mtime_nsec() as u32)
     }
     #[cfg(not(unix))]
     {
         meta.modified()
             .ok()
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map_or(0, |d| d.as_secs() as i64)
+            .map_or((0, 0), |d| (d.as_secs() as i64, d.subsec_nanos()))
     }
 }
 
@@ -682,9 +685,8 @@ impl ReceiverContext {
     /// pre-transfer destination stat). Both regular files (quick-check match)
     /// and existing directories reach this path: the `ITEM_REPORT_SIZE` check
     /// is gated on `entry.is_file()` so it never fires for a directory, and
-    /// `keep_time` reduces to the `--times` preservation flag in both cases
-    /// (`--omit-dir-times` is not modelled by the server flag set, matching
-    /// [`super::super::directory::creation`]'s `touch_up_dirs`).
+    /// `keep_time` follows upstream's per-type gating on `--omit-dir-times` /
+    /// `--omit-link-times` (`generator.c:513-517`).
     pub(in crate::receiver) fn itemize_existing_flags(
         &self,
         entry: &FileEntry,
@@ -723,9 +725,34 @@ impl ReceiverContext {
         // changed, because the receiver is about to leave the destination mtime
         // at "now" instead of the sender's value - which is what makes a plain
         // `rsync -i src/ dst/` print `>f..T......` rather than `>f.........`.
-        let keep_time = self.config.flags.times;
+        // upstream: generator.c:513-517 - `keep_time` is not `preserve_mtimes`;
+        // it is type-gated:
+        //
+        //     int keep_time = !preserve_mtimes ? 0
+        //         : S_ISDIR(file->mode) ? !omit_dir_times
+        //         : S_ISLNK(file->mode) ? !omit_link_times
+        //         : 1;
+        //
+        // Under `-O`/`-J` the receiver deliberately leaves that type's mtime
+        // alone, so upstream drops to the `!keep_time` branch for it rather
+        // than comparing a timestamp it is not going to set. Both flags do
+        // reach the receiver's flag set (core sets them on the embedded-SSH and
+        // daemon pull paths); an older comment here claimed otherwise.
+        let keep_time = self.config.flags.times
+            && !(entry.is_dir() && self.config.flags.omit_dir_times)
+            && !(entry.is_symlink() && self.config.flags.omit_link_times);
         let report_time = if keep_time {
-            dest_mtime_secs(dest_meta) != entry.mtime()
+            // upstream: generator.c:396-401 - `mtime_differs()` is
+            // `!same_time(...)`, which applies the `--modify-window` tolerance
+            // and, for a negative window, compares nanoseconds too
+            // (util1.c:1478-1489). A raw `!=` on whole seconds ignored both.
+            let (dest_secs, dest_nsec) = dest_mtime(dest_meta);
+            !self.config.file_selection.modify_window.same_time(
+                dest_secs,
+                dest_nsec,
+                entry.mtime(),
+                entry.mtime_nsec(),
+            )
         } else {
             // upstream: generator.c:528-530 - all three conjuncts.
             //
@@ -785,13 +812,21 @@ impl ReceiverContext {
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;
-            // upstream: generator.c:531-533 - atimes_ndx && !S_ISDIR && !S_ISLNK
-            //   && !same_time(F_ATIME(file), 0, st_atime, 0). same_time with a
-            //   zero nsec compares whole seconds, matching the mtime check above.
+            // upstream: generator.c:531-533 - `atimes_ndx && !S_ISDIR &&
+            // !S_ISLNK && !same_time(F_ATIME(file), 0, sxp->st.st_atime, 0)`.
+            // Both nsec arguments are literal zeros upstream, but the
+            // comparison still goes through `same_time()`, so a positive
+            // `--modify-window` tolerates drift here exactly as it does for the
+            // mtime. A raw `!=` ignored the window.
             if self.config.flags.atimes
                 && !entry.is_dir()
                 && !entry.is_symlink()
-                && dest_meta.atime() != entry.atime()
+                && !self.config.file_selection.modify_window.same_time(
+                    entry.atime(),
+                    0,
+                    dest_meta.atime(),
+                    0,
+                )
             {
                 iflags |= ItemFlags::ITEM_REPORT_ATIME;
             }
@@ -1329,6 +1364,116 @@ mod itemize_order_tests {
         assert!(
             off & ItemFlags::ITEM_REPORT_XATTR == 0,
             "the `x` column is gated on --xattrs: {off:#06x}"
+        );
+    }
+
+    /// upstream: generator.c:513-517. `keep_time` is type-gated, not simply
+    /// `preserve_mtimes`: under `--omit-dir-times` a directory and under
+    /// `--omit-link-times` a symlink drop to the `!keep_time` branch, because
+    /// the receiver is not going to set that type's mtime at all.
+    ///
+    /// Why it matters: oc compared the mtime for every type, so `-tO` printed
+    /// `.d..t...... sub/` for a directory whose mtime differs while rsync 3.4.4
+    /// prints nothing.
+    #[test]
+    fn keep_time_is_gated_per_type_by_omit_dir_and_link_times() {
+        use crate::generator::ItemFlags;
+
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("sub");
+        std::fs::create_dir(&path).unwrap();
+        filetime::set_file_mtime(&path, filetime::FileTime::from_unix_time(1_600_000_000, 0))
+            .unwrap();
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+
+        let mut entry = FileEntry::new_directory("sub".into(), 0o755);
+        entry.set_mtime(1_700_000_000, 0);
+
+        let hs = handshake();
+
+        let mut plain = itemize_client_config();
+        plain.flags.times = true;
+        let ctx = ReceiverContext::new_for_test(&hs, plain);
+        let reported = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            reported & ItemFlags::ITEM_REPORT_TIME != 0,
+            "a directory mtime difference is reported under plain -t: {reported:#06x}"
+        );
+
+        let mut omit_dirs = itemize_client_config();
+        omit_dirs.flags.times = true;
+        omit_dirs.flags.omit_dir_times = true;
+        let ctx = ReceiverContext::new_for_test(&hs, omit_dirs);
+        let omitted = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            omitted & ItemFlags::ITEM_REPORT_TIME == 0,
+            "-O drops the directory to the !keep_time branch, and base == 0 \
+             there is neither a transfer nor a local change: {omitted:#06x}"
+        );
+
+        // --omit-link-times must not affect a directory.
+        let mut omit_links = itemize_client_config();
+        omit_links.flags.times = true;
+        omit_links.flags.omit_link_times = true;
+        let ctx = ReceiverContext::new_for_test(&hs, omit_links);
+        let unaffected = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            unaffected & ItemFlags::ITEM_REPORT_TIME != 0,
+            "-J is symlink-only and must leave the directory comparison alone: {unaffected:#06x}"
+        );
+    }
+
+    /// upstream: generator.c:396-401 + util1.c:1478-1489. `mtime_differs()` is
+    /// `!same_time(...)`, so the mtime comparison honours `--modify-window`
+    /// (and, for a negative window, nanoseconds). oc used a raw `!=` on whole
+    /// seconds and so reported `t` for a difference the user asked it to
+    /// tolerate: `-t --modify-window=200` on files two minutes apart printed
+    /// `.f..t...... f` where rsync 3.4.4 prints nothing.
+    #[test]
+    fn mtime_comparison_honours_the_modify_window() {
+        use crate::generator::ItemFlags;
+
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, b"x").unwrap();
+        filetime::set_file_mtime(
+            &path,
+            filetime::FileTime::from_unix_time(1_600_000_000, 500),
+        )
+        .unwrap();
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+
+        let mut entry = FileEntry::new_file("f.txt".into(), 1, 0o644);
+        entry.set_mtime(1_600_000_120, 900);
+
+        let hs = handshake();
+        let mut config = itemize_client_config();
+        config.flags.times = true;
+
+        let ctx = ReceiverContext::new_for_test(&hs, config.clone());
+        let outside = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            outside & ItemFlags::ITEM_REPORT_TIME != 0,
+            "120s apart with a zero window is a difference: {outside:#06x}"
+        );
+
+        config.file_selection.modify_window = metadata::ModifyWindow::from_secs(200);
+        let ctx = ReceiverContext::new_for_test(&hs, config.clone());
+        let inside = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            inside & ItemFlags::ITEM_REPORT_TIME == 0,
+            "a 200s window tolerates a 120s difference: {inside:#06x}"
+        );
+
+        // upstream: util1.c:1482 - a negative window compares nanoseconds too,
+        // which a whole-second `!=` could never express.
+        entry.set_mtime(1_600_000_000, 900);
+        config.file_selection.modify_window = metadata::ModifyWindow::from_secs(-1);
+        let ctx = ReceiverContext::new_for_test(&hs, config);
+        let nsec = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            nsec & ItemFlags::ITEM_REPORT_TIME != 0,
+            "a negative window makes the nsec difference significant: {nsec:#06x}"
         );
     }
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -375,14 +375,12 @@ impl ReceiverContext {
                     // up-to-date file; the attr-comparison may still surface a
                     // metadata-only row (perms/owner/group differing while
                     // size+mtime match).
-                    let mut unchanged_iflags = self.itemize_existing_flags(entry, Some(meta), 0);
-                    // upstream: generator.c:566-572 - ITEM_REPORT_XATTR when the
-                    // destination's xattrs differ from the sender's. Computed on
-                    // the -X itemize path only (matching upstream's lazy
-                    // get_xattr) and before the apply below overwrites them.
-                    if emit_itemize && has_xattrs && self.dest_xattrs_differ(entry, &file_path) {
-                        unchanged_iflags |= crate::generator::ItemFlags::ITEM_REPORT_XATTR;
-                    }
+                    // The `x` column is now part of itemize_existing_flags
+                    // itself (upstream generator.c:564-571), and this call
+                    // still runs before the apply below overwrites the
+                    // destination's xattrs.
+                    let unchanged_iflags =
+                        self.itemize_existing_flags(entry, &file_path, Some(meta), 0);
                     self.apply_no_change_metadata(
                         writer,
                         idx,
@@ -448,6 +446,7 @@ impl ReceiverContext {
             // report bits onto ITEM_TRANSFER.
             let base_iflags = self.itemize_existing_flags(
                 entry,
+                &file_path,
                 dest_meta.as_ref(),
                 crate::generator::ItemFlags::ITEM_TRANSFER,
             );
@@ -635,7 +634,7 @@ impl ReceiverContext {
                     } else {
                         ItemFlags::ITEM_TRANSFER
                     };
-                    self.itemize_existing_flags(entry, Some(&meta), base)
+                    self.itemize_existing_flags(entry, dest_path, Some(&meta), base)
                 }
                 Err(_) => new_iflags(ItemFlags::ITEM_TRANSFER),
             }
@@ -664,14 +663,21 @@ impl ReceiverContext {
     pub(in crate::receiver) fn itemize_existing_flags(
         &self,
         entry: &FileEntry,
+        path: &Path,
         dest_meta: Option<&fs::Metadata>,
         base: u32,
     ) -> u32 {
         use crate::generator::ItemFlags;
         let mut iflags = base;
         let Some(dest_meta) = dest_meta else {
-            // upstream: generator.c:578 - the `statret < 0` leg contributes only
-            // ITEM_IS_NEW; there is no destination stat to compare against.
+            // upstream: generator.c:572-576 - the `statret < 0` leg is not
+            // ITEM_IS_NEW alone: it first runs `xattr_diff(file, NULL, 1)`,
+            // which compares the sender's list against an empty destination
+            // (xattrs.c:555-561 sets `rec_cnt = 0` for a NULL `sxp`), so a
+            // brand-new file carrying xattrs reports the `x` column too.
+            if self.xattr_itemize_active() && self.dest_xattrs_differ(entry, None) {
+                iflags |= ItemFlags::ITEM_REPORT_XATTR;
+            }
             return iflags | ItemFlags::ITEM_IS_NEW;
         };
         // upstream: generator.c:521 - S_ISREG(file->mode) && F_LENGTH(file) != st_size
@@ -760,7 +766,25 @@ impl ReceiverContext {
                 }
             }
         }
+        // upstream: generator.c:564-571 - the last thing the `statret >= 0` leg
+        // does is a lazy `get_xattr(fnamecmp, sxp)` followed by
+        // `xattr_diff(file, sxp, 1)`. It runs for every itemized entry, not
+        // just for one that was skipped as up to date.
+        if self.xattr_itemize_active() && self.dest_xattrs_differ(entry, Some(path)) {
+            iflags |= ItemFlags::ITEM_REPORT_XATTR;
+        }
         iflags
+    }
+
+    /// Whether the `x` column's destination read should run at all.
+    ///
+    /// `preserve_xattrs` is the only gate upstream places *inside* `itemize()`
+    /// (`generator.c:564`); the `itemizing` test sits at each of its call sites
+    /// (`generator.c:1816`, `:1939`). Folding both in here keeps the extra
+    /// `listxattr`/`getxattr` pair off the no-itemize scan path, where oc calls
+    /// this function for its `ITEM_IS_NEW` answer alone.
+    fn xattr_itemize_active(&self) -> bool {
+        self.config.flags.xattrs && self.should_emit_itemize()
     }
 
     /// Whether the destination's extended attributes differ from the sender's,
@@ -774,7 +798,16 @@ impl ReceiverContext {
     /// pre-transfer destination. A sender with no xattrs differs exactly when
     /// the destination still carries some, which the empty-list case expresses
     /// without a second code path.
-    pub(in crate::receiver) fn dest_xattrs_differ(&self, entry: &FileEntry, path: &Path) -> bool {
+    ///
+    /// `path` is `None` for upstream's `xattr_diff(file, NULL, 1)`
+    /// (`generator.c:573`): there is no destination to read, so the sender's
+    /// list is compared against an empty one and the answer is simply "does
+    /// the sender carry any xattrs".
+    pub(in crate::receiver) fn dest_xattrs_differ(
+        &self,
+        entry: &FileEntry,
+        path: Option<&Path>,
+    ) -> bool {
         // upstream: xattrs.c:250-252 - `saw_xattr_filter` is a global consulted
         // on every `rsync_xal_get()` call, so the generator's destination read
         // screens names through the same `x`-modifier rules the sender applied
@@ -801,7 +834,16 @@ impl ReceiverContext {
             checksum_seed: self.checksum_seed,
         };
         let sender = self.resolve_xattr_list(entry).unwrap_or_default();
-        metadata::dest_xattrs_differ(&sender, path, &opts)
+        match path {
+            Some(path) => metadata::dest_xattrs_differ(&sender, path, &opts),
+            // upstream: xattrs.c:555-561 - a NULL `sxp` yields `rec_cnt = 0`,
+            // so the count test at :574 already decides the answer.
+            None => protocol::xattr::xattr_diff(
+                &sender,
+                &protocol::xattr::XattrList::default(),
+                self.checksum_seed,
+            ),
+        }
     }
 
     /// Emits the upstream size-bound SKIP notice for a candidate whose flist
@@ -1068,7 +1110,7 @@ mod itemize_order_tests {
         with_u.flags.times = true;
         with_u.flags.atimes = true;
         let ctx = ReceiverContext::new_for_test(&hs, with_u);
-        let flags = ctx.itemize_existing_flags(&entry, Some(&meta), 0);
+        let flags = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
         assert!(
             flags & ItemFlags::ITEM_REPORT_ATIME != 0,
             "atime row missing under -U: {flags:#06x}"
@@ -1082,7 +1124,7 @@ mod itemize_order_tests {
         without_u.flags.times = true;
         without_u.flags.atimes = false;
         let ctx = ReceiverContext::new_for_test(&hs, without_u);
-        let flags = ctx.itemize_existing_flags(&entry, Some(&meta), 0);
+        let flags = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
         assert!(
             flags & ItemFlags::ITEM_REPORT_ATIME == 0,
             "atime row must be gated on --atimes: {flags:#06x}"
@@ -1128,19 +1170,21 @@ mod itemize_order_tests {
         no_times.flags.times = false;
         let ctx = ReceiverContext::new_for_test(&hs, no_times);
 
-        let transfer = ctx.itemize_existing_flags(&entry, Some(&meta), ItemFlags::ITEM_TRANSFER);
+        let transfer =
+            ctx.itemize_existing_flags(&entry, &path, Some(&meta), ItemFlags::ITEM_TRANSFER);
         assert!(
             transfer & ItemFlags::ITEM_REPORT_TIME != 0,
             "a transfer without --times must report the time as changed: {transfer:#06x}"
         );
 
-        let local = ctx.itemize_existing_flags(&entry, Some(&meta), ItemFlags::ITEM_LOCAL_CHANGE);
+        let local =
+            ctx.itemize_existing_flags(&entry, &path, Some(&meta), ItemFlags::ITEM_LOCAL_CHANGE);
         assert!(
             local & ItemFlags::ITEM_REPORT_TIME != 0,
             "ITEM_LOCAL_CHANGE is the second half of upstream's first conjunct: {local:#06x}"
         );
 
-        let metadata_only = ctx.itemize_existing_flags(&entry, Some(&meta), 0);
+        let metadata_only = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
         assert!(
             metadata_only & ItemFlags::ITEM_REPORT_TIME == 0,
             "an attribute-only row is neither a transfer nor a local change: {metadata_only:#06x}"
@@ -1150,10 +1194,105 @@ mod itemize_order_tests {
         let mut with_times = itemize_client_config();
         with_times.flags.times = true;
         let ctx = ReceiverContext::new_for_test(&hs, with_times);
-        let kept = ctx.itemize_existing_flags(&entry, Some(&meta), ItemFlags::ITEM_TRANSFER);
+        let kept = ctx.itemize_existing_flags(&entry, &path, Some(&meta), ItemFlags::ITEM_TRANSFER);
         assert!(
             kept & ItemFlags::ITEM_REPORT_TIME == 0,
             "--times with equal mtimes must leave the time column clear: {kept:#06x}"
+        );
+    }
+
+    /// upstream: generator.c:564-571 (`statret >= 0`) and :573-575
+    /// (`statret < 0`). Both legs of `itemize()` compare xattrs, so the `x`
+    /// column belongs on the *transfer* seed as much as on the up-to-date row.
+    ///
+    /// Why it matters: the comparison used to live at the quick-check skip site
+    /// alone, so `x` could only ever appear on a file that was NOT transferred.
+    /// A file whose data and xattrs both changed printed `>f.s.......` where
+    /// upstream prints `>f.s......x`.
+    ///
+    /// Linux-only: macOS attaches `com.apple.provenance` to every file, which
+    /// the sender and the generator-side read do not currently agree on (a
+    /// separate, pre-existing defect in the shared comparison), so the
+    /// destination-read half of this assertion is not stable there.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn itemize_existing_flags_reports_xattr_on_a_transfer() {
+        use crate::generator::ItemFlags;
+        use protocol::xattr::{XattrEntry, XattrList};
+
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, b"x").unwrap();
+        // The destination carries an xattr; the sender entry carries none, so
+        // upstream's `xattr_diff` reports a differing count.
+        let list = XattrList::with_entries(vec![XattrEntry::new(
+            b"user.itemize".to_vec(),
+            b"v".to_vec(),
+        )]);
+        if metadata::apply_xattrs_from_list(&path, &list, true, None).is_err() {
+            // A filesystem without user-namespace xattr support cannot
+            // exercise the comparison; skip rather than assert a false pass.
+            return;
+        }
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+
+        let mut entry = FileEntry::new_file("f.txt".into(), 1, 0o644);
+        entry.set_mtime(1_600_000_000, 0);
+
+        let hs = handshake();
+        let mut with_x = itemize_client_config();
+        with_x.flags.times = true;
+        with_x.flags.xattrs = true;
+        let ctx = ReceiverContext::new_for_test(&hs, with_x);
+
+        let transfer =
+            ctx.itemize_existing_flags(&entry, &path, Some(&meta), ItemFlags::ITEM_TRANSFER);
+        assert!(
+            transfer & ItemFlags::ITEM_REPORT_XATTR != 0,
+            "a transferred file with differing xattrs must report `x`: {transfer:#06x}"
+        );
+
+        let skipped = ctx.itemize_existing_flags(&entry, &path, Some(&meta), 0);
+        assert!(
+            skipped & ItemFlags::ITEM_REPORT_XATTR != 0,
+            "the up-to-date row must keep reporting `x`: {skipped:#06x}"
+        );
+
+        // Without -X the destination is never read and the column stays clear.
+        let mut without_x = itemize_client_config();
+        without_x.flags.times = true;
+        without_x.flags.xattrs = false;
+        let ctx = ReceiverContext::new_for_test(&hs, without_x);
+        let off = ctx.itemize_existing_flags(&entry, &path, Some(&meta), ItemFlags::ITEM_TRANSFER);
+        assert!(
+            off & ItemFlags::ITEM_REPORT_XATTR == 0,
+            "the `x` column is gated on --xattrs: {off:#06x}"
+        );
+    }
+
+    /// upstream: generator.c:572-576. The `statret < 0` leg runs
+    /// `xattr_diff(file, NULL, 1)` before adding ITEM_IS_NEW, and a NULL `sxp`
+    /// means an empty receiver list (xattrs.c:555-561). A sender entry with no
+    /// xattrs must therefore leave the `x` column clear - otherwise every
+    /// brand-new file under `-X` would print `x` instead of `+`.
+    #[test]
+    fn itemize_existing_flags_absent_dest_reports_xattr_only_when_the_sender_has_some() {
+        use crate::generator::ItemFlags;
+
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("absent.txt");
+        let entry = FileEntry::new_file("absent.txt".into(), 1, 0o644);
+
+        let hs = handshake();
+        let mut with_x = itemize_client_config();
+        with_x.flags.xattrs = true;
+        let ctx = ReceiverContext::new_for_test(&hs, with_x);
+
+        let flags = ctx.itemize_existing_flags(&entry, &path, None, ItemFlags::ITEM_TRANSFER);
+        assert_eq!(
+            flags,
+            ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW,
+            "an absent destination with no sender xattrs is ITEM_IS_NEW alone: {flags:#06x}"
         );
     }
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -838,9 +838,30 @@ impl ReceiverContext {
             // the `#ifndef` at generator.c:542-544 compiles out and upstream
             // does compare. Mirrors the same guard in engine's local-copy
             // change-set detection; revisit both with symlink-mode support.
-            if self.config.flags.perms && !entry.is_symlink() {
-                const CHMOD_BITS: u32 = 0o7777;
-                if (dest_meta.mode() & CHMOD_BITS) != (entry.mode() & CHMOD_BITS) {
+            //
+            // The compare itself is an if/else-if (generator.c:546-552), not a
+            // lone `preserve_perms` test:
+            //
+            //     if (preserve_perms) {
+            //         if (!BITS_EQUAL(sxp->st.st_mode, file->mode, CHMOD_BITS))
+            //             iflags |= ITEM_REPORT_PERMS;
+            //     } else if (preserve_executability
+            //      && ((sxp->st.st_mode & 0111 ? 1 : 0) ^ (file->mode & 0111 ? 1 : 0)))
+            //         iflags |= ITEM_REPORT_PERMS;
+            //
+            // Under `-E` without `-p` the receiver copies only the
+            // executability bit, so only a change in *whether* the file is
+            // executable is a permission change - the other mode bits stay as
+            // they are and must not raise the `p` column.
+            if !entry.is_symlink() {
+                if self.config.flags.perms {
+                    const CHMOD_BITS: u32 = 0o7777;
+                    if (dest_meta.mode() & CHMOD_BITS) != (entry.mode() & CHMOD_BITS) {
+                        iflags |= ItemFlags::ITEM_REPORT_PERMS;
+                    }
+                } else if self.config.flags.preserve_executability
+                    && (dest_meta.mode() & 0o111 != 0) != (entry.mode() & 0o111 != 0)
+                {
                     iflags |= ItemFlags::ITEM_REPORT_PERMS;
                 }
             }
@@ -852,10 +873,18 @@ impl ReceiverContext {
                     }
                 }
             }
-            // upstream: generator.c:555-556 - gid_ndx && !FLAG_SKIP_GROUP && gid differs
+            // upstream: generator.c:555-556 - `gid_ndx && !(file->flags &
+            // FLAG_SKIP_GROUP) && sxp->st.st_gid != (gid_t)F_GROUP(file)`.
+            //
+            // FLAG_SKIP_GROUP is stamped on the mapped id at uidlist.c:284
+            // (`!am_root && !is_in_group(id2)`), so a non-root receiver that
+            // does not belong to the sender's group neither chowns
+            // (rsync.c:527) nor reports the group as changed. Without this
+            // test an unprivileged pull printed `g` on every file whose group
+            // it could never set.
             if self.config.flags.group {
                 if let Some(gid) = entry.gid() {
-                    if dest_meta.gid() != gid {
+                    if dest_meta.gid() != gid && metadata::group_is_settable(gid) {
                         iflags |= ItemFlags::ITEM_REPORT_GROUP;
                     }
                 }
@@ -1365,6 +1394,132 @@ mod itemize_order_tests {
             off & ItemFlags::ITEM_REPORT_XATTR == 0,
             "the `x` column is gated on --xattrs: {off:#06x}"
         );
+    }
+
+    /// upstream: generator.c:542-552. The permission compare is an
+    /// `if (preserve_perms) ... else if (preserve_executability ...)`, so `-E`
+    /// without `-p` reports `p` only when the *executability* changes - the
+    /// only bit the receiver is going to copy.
+    ///
+    /// Why it matters: oc tested `preserve_perms` alone, so `-tE` never
+    /// produced a `p` column at all; rsync 3.4.4 prints `.f...p..... f` when
+    /// the exec bit differs and nothing when only the other mode bits do.
+    #[cfg(unix)]
+    #[test]
+    fn perms_column_follows_the_executability_leg_without_dash_p() {
+        use crate::generator::ItemFlags;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, b"x").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+
+        let hs = handshake();
+        let mut dash_e = itemize_client_config();
+        dash_e.flags.times = true;
+        dash_e.flags.perms = false;
+        dash_e.flags.preserve_executability = true;
+        let ctx = ReceiverContext::new_for_test(&hs, dash_e);
+
+        let mut executable = FileEntry::new_file("f.txt".into(), 1, 0o755);
+        executable.set_mtime(1_600_000_000, 0);
+        let flipped = ctx.itemize_existing_flags(&executable, &path, Some(&meta), 0);
+        assert!(
+            flipped & ItemFlags::ITEM_REPORT_PERMS != 0,
+            "-E reports a change in executability: {flipped:#06x}"
+        );
+
+        // Same executability, different other bits: nothing -E would copy.
+        let mut same_exec = FileEntry::new_file("f.txt".into(), 1, 0o640);
+        same_exec.set_mtime(1_600_000_000, 0);
+        let unchanged = ctx.itemize_existing_flags(&same_exec, &path, Some(&meta), 0);
+        assert!(
+            unchanged & ItemFlags::ITEM_REPORT_PERMS == 0,
+            "-E must ignore mode bits it does not copy: {unchanged:#06x}"
+        );
+
+        // -p takes the other branch and compares all CHMOD_BITS.
+        let mut with_p = itemize_client_config();
+        with_p.flags.times = true;
+        with_p.flags.perms = true;
+        let ctx = ReceiverContext::new_for_test(&hs, with_p);
+        let full = ctx.itemize_existing_flags(&same_exec, &path, Some(&meta), 0);
+        assert!(
+            full & ItemFlags::ITEM_REPORT_PERMS != 0,
+            "-p compares every CHMOD bit: {full:#06x}"
+        );
+
+        // Neither flag: no permission comparison at all.
+        let mut neither = itemize_client_config();
+        neither.flags.times = true;
+        let ctx = ReceiverContext::new_for_test(&hs, neither);
+        let off = ctx.itemize_existing_flags(&executable, &path, Some(&meta), 0);
+        assert!(
+            off & ItemFlags::ITEM_REPORT_PERMS == 0,
+            "without -p or -E the `p` column stays clear: {off:#06x}"
+        );
+    }
+
+    /// upstream: generator.c:555-556 + uidlist.c:284. FLAG_SKIP_GROUP is
+    /// stamped on any group a non-root process does not belong to, and the
+    /// itemize test is `!(file->flags & FLAG_SKIP_GROUP)`.
+    ///
+    /// Why it matters: an unprivileged pull of a root:wheel file reported
+    /// `.f.....g...` in oc for a group it could never set; rsync 3.4.4 prints
+    /// no row. Verified against a real `/usr/share/dict/propernames` (gid 0)
+    /// pull with the destination chgrp'd to a group the user does belong to.
+    ///
+    /// Running as root makes every group settable, so the negative half only
+    /// means something unprivileged; it is skipped under root rather than
+    /// asserted vacuously.
+    #[cfg(unix)]
+    #[test]
+    fn group_column_skips_a_group_the_process_cannot_set() {
+        use crate::generator::ItemFlags;
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, b"x").unwrap();
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+
+        let hs = handshake();
+        let mut config = itemize_client_config();
+        config.flags.times = true;
+        config.flags.group = true;
+        let ctx = ReceiverContext::new_for_test(&hs, config);
+
+        // A gid the process can set: its own, made to differ from the
+        // destination's by picking a different member group when possible.
+        let dest_gid = meta.gid();
+        let mut settable = FileEntry::new_file("f.txt".into(), 1, 0o644);
+        settable.set_mtime(1_600_000_000, 0);
+        settable.set_gid(dest_gid.wrapping_add(1));
+        if metadata::group_is_settable(dest_gid.wrapping_add(1)) {
+            let flags = ctx.itemize_existing_flags(&settable, &path, Some(&meta), 0);
+            assert!(
+                flags & ItemFlags::ITEM_REPORT_GROUP != 0,
+                "a settable, differing group reports `g`: {flags:#06x}"
+            );
+        }
+
+        if metadata::am_root() {
+            return;
+        }
+        // gid 0 (wheel/root) is not a supplementary group of an ordinary user.
+        if !metadata::group_is_settable(0) && dest_gid != 0 {
+            let mut unsettable = FileEntry::new_file("f.txt".into(), 1, 0o644);
+            unsettable.set_mtime(1_600_000_000, 0);
+            unsettable.set_gid(0);
+            let flags = ctx.itemize_existing_flags(&unsettable, &path, Some(&meta), 0);
+            assert!(
+                flags & ItemFlags::ITEM_REPORT_GROUP == 0,
+                "FLAG_SKIP_GROUP suppresses `g` for a group the process cannot \
+                 set: {flags:#06x}"
+            );
+        }
     }
 
     /// upstream: generator.c:513-517. `keep_time` is type-gated, not simply

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -40,6 +40,27 @@ pub(in crate::receiver) type DryRunItem<'a> = (usize, &'a FileEntry, u32);
 ///
 /// upstream: `receiver.c:736-738` - `stats.created_dirs++` under
 /// `iflags & ITEM_IS_NEW`, which runs whether or not the mkdir happened.
+/// The destination's mtime in whole seconds since the epoch, as upstream's
+/// `sxp->st.st_mtime` supplies it to `mtime_differs()` (`generator.c:396`).
+///
+/// A destination whose mtime predates the epoch or cannot be read compares as
+/// `0`, which differs from any real sender mtime and therefore reports the
+/// time as changed - the safe direction.
+fn dest_mtime_secs(meta: &fs::Metadata) -> i64 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        meta.mtime()
+    }
+    #[cfg(not(unix))]
+    {
+        meta.modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map_or(0, |d| d.as_secs() as i64)
+    }
+}
+
 pub(in crate::receiver) fn new_dir_count(plan: &[DryRunItem<'_>]) -> u64 {
     plan.iter()
         .filter(|(_, entry, iflags)| {
@@ -657,27 +678,43 @@ impl ReceiverContext {
         if entry.is_file() && entry.size() != dest_meta.len() {
             iflags |= ItemFlags::ITEM_REPORT_SIZE;
         }
-        // upstream: generator.c:526-530 - keep_time ? mtime_differs(&st, file).
-        // For regular files keep_time == preserve_mtimes (`--times`).
-        if self.config.flags.times {
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::MetadataExt;
-                if dest_meta.mtime() != entry.mtime() {
-                    iflags |= ItemFlags::ITEM_REPORT_TIME;
-                }
-            }
-            #[cfg(not(unix))]
-            {
-                let dest_secs = dest_meta
-                    .modified()
-                    .ok()
-                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                    .map(|d| d.as_secs() as i64);
-                if dest_secs != Some(entry.mtime()) {
-                    iflags |= ItemFlags::ITEM_REPORT_TIME;
-                }
-            }
+        // upstream: generator.c:526-530 - REPORT_TIME is a TWO-branch ternary,
+        // not a single `keep_time &&` test:
+        //
+        //     } else if (keep_time
+        //      ? mtime_differs(&sxp->st, file)
+        //      : iflags & (ITEM_TRANSFER|ITEM_LOCAL_CHANGE) && !(iflags & ITEM_MATCHED)
+        //       && (!(iflags & ITEM_XNAME_FOLLOWS) || *xname))
+        //             iflags |= ITEM_REPORT_TIME;
+        //
+        // With `keep_time` the row reports a genuine mtime difference. Without
+        // it (no `--times`) every transfer/local-change row reports the time as
+        // changed, because the receiver is about to leave the destination mtime
+        // at "now" instead of the sender's value - which is what makes a plain
+        // `rsync -i src/ dst/` print `>f..T......` rather than `>f.........`.
+        let keep_time = self.config.flags.times;
+        let report_time = if keep_time {
+            dest_mtime_secs(dest_meta) != entry.mtime()
+        } else {
+            // upstream: generator.c:528-530 - all three conjuncts.
+            //
+            // ITEM_MATCHED (rsync.h:229, log-only bit 18) is set by upstream's
+            // `unchanged_attrs()`/hard-link bookkeeping; nothing in oc sets it
+            // yet, so this conjunct cannot fire today. It is written out
+            // anyway so the predicate stays a faithful transcription and
+            // starts working the moment the bit is produced.
+            //
+            // The third conjunct is `!(iflags & ITEM_XNAME_FOLLOWS) || *xname`.
+            // `xname` (the fuzzy-basis / hard-link-leader name) is not part of
+            // this function's inputs and no call site seeds
+            // ITEM_XNAME_FOLLOWS, so the `|| *xname` alternative is
+            // unreachable; the conservative `== 0` half is transcribed here.
+            iflags & (ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_LOCAL_CHANGE) != 0
+                && iflags & ItemFlags::ITEM_MATCHED == 0
+                && iflags & ItemFlags::ITEM_XNAME_FOLLOWS == 0
+        };
+        if report_time {
+            iflags |= ItemFlags::ITEM_REPORT_TIME;
         }
         #[cfg(unix)]
         {
@@ -1049,6 +1086,74 @@ mod itemize_order_tests {
         assert!(
             flags & ItemFlags::ITEM_REPORT_ATIME == 0,
             "atime row must be gated on --atimes: {flags:#06x}"
+        );
+    }
+
+    /// upstream: generator.c:526-530. REPORT_TIME is a two-branch ternary. The
+    /// `!keep_time` branch is what makes a plain `rsync -i` (no `--times`)
+    /// print `>f..T......` for every transferred file: the receiver is about to
+    /// leave the destination mtime at "now", so the time column reports a
+    /// change even though nothing was compared.
+    ///
+    /// Why it matters: without this branch the `T` glyph is unreachable on the
+    /// receiver, so `-i` without `-t` silently under-reports. Verified against
+    /// rsync 3.4.4, which prints `>f.sT......` where oc printed `>f.s.......`.
+    ///
+    /// The branch must stay inert for a metadata-only row (`base == 0`, no
+    /// ITEM_TRANSFER / ITEM_LOCAL_CHANGE) - upstream's first conjunct - and must
+    /// not fire when `--times` is on and the mtimes agree.
+    #[test]
+    fn itemize_existing_flags_reports_time_without_times_on_transfer() {
+        use crate::generator::ItemFlags;
+
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, b"x").unwrap();
+        filetime::set_file_times(
+            &path,
+            filetime::FileTime::from_unix_time(1_600_000_000, 0),
+            filetime::FileTime::from_unix_time(1_600_000_000, 0),
+        )
+        .unwrap();
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+
+        // Source mtime deliberately equals the destination's, so the
+        // `keep_time` branch can never be the reason the bit appears.
+        let mut entry = FileEntry::new_file("f.txt".into(), 1, 0o644);
+        entry.set_mtime(1_600_000_000, 0);
+
+        let hs = handshake();
+
+        let mut no_times = itemize_client_config();
+        no_times.flags.times = false;
+        let ctx = ReceiverContext::new_for_test(&hs, no_times);
+
+        let transfer = ctx.itemize_existing_flags(&entry, Some(&meta), ItemFlags::ITEM_TRANSFER);
+        assert!(
+            transfer & ItemFlags::ITEM_REPORT_TIME != 0,
+            "a transfer without --times must report the time as changed: {transfer:#06x}"
+        );
+
+        let local = ctx.itemize_existing_flags(&entry, Some(&meta), ItemFlags::ITEM_LOCAL_CHANGE);
+        assert!(
+            local & ItemFlags::ITEM_REPORT_TIME != 0,
+            "ITEM_LOCAL_CHANGE is the second half of upstream's first conjunct: {local:#06x}"
+        );
+
+        let metadata_only = ctx.itemize_existing_flags(&entry, Some(&meta), 0);
+        assert!(
+            metadata_only & ItemFlags::ITEM_REPORT_TIME == 0,
+            "an attribute-only row is neither a transfer nor a local change: {metadata_only:#06x}"
+        );
+
+        // With --times the `keep_time` branch governs, and the mtimes agree.
+        let mut with_times = itemize_client_config();
+        with_times.flags.times = true;
+        let ctx = ReceiverContext::new_for_test(&hs, with_times);
+        let kept = ctx.itemize_existing_flags(&entry, Some(&meta), ItemFlags::ITEM_TRANSFER);
+        assert!(
+            kept & ItemFlags::ITEM_REPORT_TIME == 0,
+            "--times with equal mtimes must leave the time column clear: {kept:#06x}"
         );
     }
 


### PR DESCRIPTION
`ReceiverContext::itemize_existing_flags` is oc's port of upstream `itemize()`
(`generator.c:511-576`). Compared line by line against rsync 3.4.4 it implemented
8 of the 20 behaviours that function has, so four itemize columns were rendered
by the renderer and never produced by any receiver-side producer.

One commit per predicate, each independently revertable. Every row below was
captured against a genuine rsync 3.4.4 (protocol 32) binary and is byte-identical
after the change; the "before" column is the same capture with the commit
reverted.

### 1. `T` - the `!keep_time` branch of REPORT_TIME

`generator.c:526-530` is a two-branch ternary; only the `keep_time` arm was
implemented, so the `T` glyph was unreachable without `--times`.

| case | upstream | before | after |
|---|---|---|---|
| size differs, `-r` | `>f.sT......` | `>f.s.......` | `>f.sT......` |
| size+perms, `-rp` | `>f.sTp.....` | `>f.s.p.....` | `>f.sTp.....` |
| size differs, `-rt` | `>f.s.......` | `>f.s.......` | `>f.s.......` |

All three conjuncts of the else-branch are transcribed. `ITEM_MATCHED` has no
producer in the tree yet and no call site seeds `ITEM_XNAME_FOLLOWS`, so those
two cannot fire; both are written out with a comment rather than dropped.

### 2. `x` - REPORT_XATTR on the transfer seed, both legs

`generator.c:564-571` (`statret >= 0`) and `:573-575` (`statret < 0`). The
comparison lived at the quick-check skip site alone, so `x` could only appear on
a file that was *not* transferred.

| case | upstream | before | after |
|---|---|---|---|
| transferred + sender xattr, `-rtX` | `>f.s......x` | `>f.s.......` | `>f.s......x` |
| subdir xattr differs, `-rtX` | `.d........x sub/` | (no row) | `.d........x sub/` |
| identical xattrs, `-rtX` | (no row) | (no row) | (no row) |

The comparison moves into `itemize_existing_flags` so every caller inherits it;
the function gains the `path` parameter upstream's `itemize()` already takes as
`fnamecmp`. `dest_xattrs_differ` takes `Option<&Path>` to model `sxp == NULL`.
No new comparison code - `metadata::dest_xattrs_differ` is still the only one.

### 3. `-N` file-list decode (prerequisite)

`flist.c:743-746`. The receiver's `FileListReader` was built without
`with_preserve_crtimes()`, so it never consumed the crtime varlong and parsed it
as the mode. Invisible while a file's birth time equals its mtime
(`XMIT_CRTIME_EQ_MTIME` puts nothing on the wire); the moment they differ the
entry stream desynchronises:

```
$ printf 'aaaa\n' > src/f && touch -t 203001010000 src/f
$ rsync    -rtNi <remote>:src/ dst/   ->  >f+++++++++ f
$ oc-rsync -rtNi <remote>:src/ dst/   ->  error: received file entry with
                                          zero-length filename (code 12)
```

The generator side has always set it; only the receiver was missing.

### 4. `n` and `c` - REPORT_CRTIME and REPORT_CHANGE

`generator.c:535-540` and `generator.c:1940-1942`.

| case | upstream | before | after |
|---|---|---|---|
| same size, content differs, `-rtc` | `>fc........` | `>f.........` | `>fc........` |
| same, dry run `-rtcn` | `>fc........` | `>f.........` | `>fc........` |
| size also differs, `-rtc` | `>fcs.......` | `>f.s.......` | `>fcs.......` |
| crtime differs only, `-rtN` | `.f......n..` | exit 12 | `.f......n..` |

`ITEM_REPORT_CHANGE` is a property of the transfer *seed*, so it lives in a
shared `transfer_seed()` used by both the live pass and the `--dry-run` planner;
`-i` and `-ni` cannot disagree about `c`.

### 5. `keep_time` type gating and `same_time` tolerance

`generator.c:513-517` (per-type `--omit-dir-times` / `--omit-link-times`) and
`generator.c:396-401` + `util1.c:1478-1489` (`mtime_differs()` is
`!same_time(...)`; the atime test calls `same_time()` directly). oc compared raw
whole seconds with `!=`, so `--modify-window` was ignored on both and a negative
window could not be expressed.

| case | upstream | before | after |
|---|---|---|---|
| dir mtime differs, `-rt` | `.d..t...... sub/` | `.d..t...... sub/` | `.d..t...... sub/` |
| dir mtime differs, `-rtO` | (no row) | `.d..t...... sub/` | (no row) |
| 120s apart, `-rt` | `>f..t......` | `>f..t......` | `>f..t......` |
| 120s apart, `--modify-window=200` | (no row) | `.f..t......` | (no row) |

### 6. `-E` perms leg and `FLAG_SKIP_GROUP`

`generator.c:547-552` is an `if (preserve_perms) ... else if
(preserve_executability ...)`, and `generator.c:555-556` skips a group the
process cannot set (`uidlist.c:284`).

| case | upstream | before | after |
|---|---|---|---|
| exec bit differs, `-rtE` | `.f...p.....` | (no row) | `.f...p.....` |
| other mode bits differ, `-rtE` | (no row) | (no row) | (no row) |
| other mode bits differ, `-rtp` | `.f...p.....` | `.f...p.....` | `.f...p.....` |
| src gid 0 (non-member), dst gid 20, `-tg` | (no row) | `.f.....g...` | (no row) |
| src gid 20, dst gid 12 (both member), `-rtg` | `.f.....g...` | `.f.....g...` | `.f.....g...` |

`FLAG_SKIP_GROUP`'s predicate already existed in `metadata` as the private
`process_in_group()`; it is exposed as `metadata::group_is_settable()` rather
than reimplemented.

### 7. `-E` on the compact server flag string

`options.c:2692-2693` packs `'E'` in the `am_sender` branch, so on a push the
flag rides the wire to the remote server - which is the receiver. oc emitted it
(`--server -tEre.iLsfxCIvu`, byte-identical to 3.4.4) but never parsed it.

## Verification

Rows captured against `rsync 3.4.4 protocol 32`, over a loopback remote shell
(so the row comes from the receiver path under test) and again in daemon mode
with each implementation serving its own daemon. Pull and push both exercised,
and the whole matrix re-run under `--no-inc-recursive` so both receiver drivers
(`run_pipelined` and `run_pipelined_incremental`) are covered - the producers
are shared, and the rows are identical either way. The xattr rows were captured
on x86_64 Linux; macOS attaches `com.apple.provenance` to every file and the
sender/generator reads disagree about it there, which is a separate pre-existing
defect (see below).

Full workspace `cargo nextest run --workspace --all-features`: 32154 passed,
0 failed (x86_64 Linux).

## Deliberately not in this PR

- **`ITEM_REPORT_ACL`.** `protocol::acl::RsyncAcl::equal_enough` is not a port of
  upstream's `rsync_acl_equal_enough` (`acls.c:205-224`): upstream compares only
  `mask_obj`, `group_obj` (against `(m >> 3) & 7` when the sender's is
  `NO_ENTRY`) and the named entries, and deliberately ignores
  `user_obj`/`other_obj` because its second argument is a *condensed* ACL. oc's
  version compares them and takes no mode argument, so wiring it to
  `set_acl(NULL, ...)` would light `a` on essentially every file under `-A`.
  `acl_cache` also still has to be threaded to four call sites that cannot
  supply it. Both are follow-ups.
- **`FLAG_TIME_FAILED`.** Upstream sets it when `set_modtime()` on a symlink
  returns 1 - the distinct "this platform cannot set symlink times" answer, not
  an error. oc surfaces a single `Err` and cannot tell that outcome apart, so
  there is no signal to key `ITEM_REPORT_TIMEFAIL` on. Left out rather than
  approximated.

## Found while verifying, not fixed here

- `-E` is parsed and reported but never *applied*: a pull with `-rtE` leaves the
  destination at `644` where rsync 3.4.4 chmods to `755`. The itemize column is
  now right; the metadata apply is a separate defect.
- A push emits no metadata-only itemize rows at all. `-rtp` with a perms-only
  difference prints `.f...p..... f` upstream and nothing in oc, although oc does
  perform the chmod.
- `transfer_ops/request.rs:132-134` masks `ITEM_REPORT_XATTR` out of the wire
  iflags and re-derives it from `XattrList` state rather than from the value
  diff, so the push path still prints `<f.s.......` where upstream prints
  `<f.s......x`.
- Symlink and device/special *recreate* pass `ITEM_LOCAL_CHANGE|ITEM_IS_NEW`
  where upstream passes `ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE` with `statret`
  unchanged (`generator.c:1609`, `:1681`): a re-pointed symlink prints
  `cL+++++++++` in oc and `cLc........` upstream. The live path is in
  `receiver/directory`, and fixing only the dry-run half would make `-i` and
  `-ni` disagree, so it needs one atomic change across both.
- An existing symlink whose mtime differs prints `.L..t......` upstream and no
  row in oc - the receiver's symlink path does not route through `itemize()`.
- The transfer root `.` does not report the `n` column under `-N` while a
  subdirectory does, so `-rtN` prints `.d......n.. ./` upstream and nothing in
  oc for the root only.
- `quick_check_matches` forces a transfer whenever `!preserve_times`; upstream
  gates that on `ignore_times` alone (`generator.c:642`), so `rsync -r` (no
  `-t`) skips an already-identical file where oc re-sends it.
- On macOS `dest_xattrs_differ` reports a difference for identical files,
  because the sender's list and the generator's destination read disagree about
  `com.apple.provenance`. Pre-existing on the file row; this PR extends the same
  comparison to directories, so it becomes visible there too. Linux is clean.
