### PR TITLE
fix(core): gate the INC_RECURSE capability on recursion

### DIFF
--- a/crates/cli/tests/inc_recurse_capability_gate.rs
+++ b/crates/cli/tests/inc_recurse_capability_gate.rs
@@ -1,0 +1,139 @@
+//! The `-e` capability string advertises `i` only for a recursive transfer.
+//!
+//! upstream: `compat.c:162-179 set_allow_inc_recurse()` runs
+//! `if (!recurse || use_qsort) allow_inc_recurse = 0;` from `server_options()`
+//! (options.c:2725), immediately before `maybe_add_e_option()` decides whether
+//! to append `i` (options.c:3039). `allow_inc_recurse` initialises to 1
+//! (options.c:114), so without that gate every non-recursive push advertises a
+//! capability upstream withholds.
+//!
+//! `recurse` is a level, not a flag: `-r` sets 2 (options.c:621), `-a` sets 1
+//! (options.c:1551), `--files-from` clears only level 1 (options.c:2188-2189)
+//! and `--old-dirs` re-forces 1 afterwards (options.c:2197-2199). The gate is a
+//! plain non-zero test, so `-r --files-from` still advertises `i` while
+//! `-a --files-from` does not.
+//!
+//! Expectations below are the server argv rsync 3.4.4 (protocol 32) produced
+//! for the same invocations, captured with a stub remote shell.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+use test_support::oc_rsync_bin;
+
+/// Writes a remote-shell stub that appends its argv to `log` and exits 0.
+fn write_shell_stub(dir: &Path, log: &Path) -> std::path::PathBuf {
+    let stub = dir.join("argv-stub.sh");
+    fs::write(
+        &stub,
+        format!(
+            "#!/bin/sh\nprintf '%s ' \"$@\" >> '{}'\nprintf '\\n' >> '{}'\nexit 0\n",
+            log.display(),
+            log.display()
+        ),
+    )
+    .expect("write stub");
+    fs::set_permissions(&stub, fs::Permissions::from_mode(0o755)).expect("chmod stub");
+    stub
+}
+
+/// Runs `oc-rsync` against a stub remote shell and returns the compact flag
+/// string it sent (the first single-dash argument of the server argv).
+fn server_flag_string(extra: &[&str]) -> String {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src/adir")).expect("src tree");
+    fs::write(root.join("src/a.txt"), b"a").expect("src file");
+    fs::write(root.join("src/adir/b.txt"), b"b").expect("nested file");
+    fs::write(root.join("list.txt"), b"adir\n").expect("files-from list");
+
+    let log = root.join("argv.log");
+    let stub = write_shell_stub(root, &log);
+
+    let mut cmd = Command::new(oc_rsync_bin());
+    cmd.current_dir(root).arg("-e").arg(&stub);
+    cmd.args(extra);
+    cmd.arg("src/").arg("host:dst/");
+    let output = cmd.output().expect("spawn oc-rsync");
+    assert!(
+        log.is_file(),
+        "remote shell was never invoked for {extra:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let argv = fs::read_to_string(&log).expect("read argv log");
+    argv.split_whitespace()
+        .find(|a| a.starts_with('-') && !a.starts_with("--"))
+        .unwrap_or_else(|| panic!("no compact flag string in server argv: {argv}"))
+        .to_owned()
+}
+
+/// Returns the capability characters following `e.` in a compact flag string.
+fn capabilities(flags: &str) -> &str {
+    flags
+        .split("e.")
+        .nth(1)
+        .unwrap_or_else(|| panic!("no capability suffix in {flags}"))
+}
+
+#[test]
+fn non_recursive_push_omits_inc_recurse_capability() {
+    // rsync 3.4.4: `--server -e.LsfxCIvu . dst/`
+    for extra in [&[][..], &["-d"][..], &["--inc-recursive"][..]] {
+        let flags = server_flag_string(extra);
+        assert!(
+            !capabilities(&flags).contains('i'),
+            "non-recursive push with {extra:?} must not advertise 'i': {flags}"
+        );
+    }
+}
+
+#[test]
+fn qsort_push_omits_inc_recurse_capability() {
+    // rsync 3.4.4: `--server -re.LsfxCIvu --use-qsort . dst/`
+    let flags = server_flag_string(&["-r", "--qsort"]);
+    assert!(
+        !capabilities(&flags).contains('i'),
+        "--qsort must not advertise 'i' (upstream compat.c:172 use_qsort): {flags}"
+    );
+}
+
+#[test]
+fn recursive_push_still_advertises_inc_recurse_capability() {
+    // rsync 3.4.4: `-r` -> `-re.iLsfxCIvu`, `-a` -> `-logDtpre.iLsfxCIvu`.
+    for extra in [&["-r"][..], &["-a"][..]] {
+        let flags = server_flag_string(extra);
+        assert!(
+            capabilities(&flags).contains('i'),
+            "recursive push with {extra:?} must advertise 'i': {flags}"
+        );
+    }
+}
+
+#[test]
+fn files_from_keeps_inc_recurse_only_for_explicit_recursion() {
+    // rsync 3.4.4: `-r --files-from` -> `-rRe.iLsfxCIvu`, but
+    // `-a --files-from` -> `-logDtpRe.LsfxCIvu` and a bare `--files-from` ->
+    // `-Re.LsfxCIvu`, because only `recurse == 1` is cleared at options.c:2189.
+    let explicit = server_flag_string(&["-r", "--files-from=list.txt"]);
+    assert!(
+        capabilities(&explicit).contains('i'),
+        "an explicit -r survives --files-from and keeps 'i': {explicit}"
+    );
+
+    for extra in [
+        &["-a", "--files-from=list.txt"][..],
+        &["--files-from=list.txt"][..],
+    ] {
+        let flags = server_flag_string(extra);
+        assert!(
+            !capabilities(&flags).contains('i'),
+            "{extra:?} clears recursion, so 'i' must go with it: {flags}"
+        );
+    }
+}

--- a/crates/core/src/client/config/client/performance.rs
+++ b/crates/core/src/client/config/client/performance.rs
@@ -231,6 +231,33 @@ impl ClientConfig {
     pub const fn inc_recursive_send(&self) -> bool {
         self.inc_recursive_send
     }
+
+    /// Resolves whether this side may advertise the INC_RECURSE (`'i'`)
+    /// capability, mirroring upstream `set_allow_inc_recurse()`.
+    ///
+    /// Upstream runs the resolution from `server_options()` immediately before
+    /// it builds the `-e` string, so `--inc-recursive` never survives a
+    /// non-recursive or `--qsort` transfer: `if (!recurse || use_qsort)
+    /// allow_inc_recurse = 0;`. `recurse` is a level rather than a flag - `-r`
+    /// sets 2, `-a` and `--old-dirs` set 1, and `--files-from` clears only
+    /// level 1 - but the gate is a plain non-zero test, which is exactly what
+    /// `recursive()` already answers once the CLI has folded those rules in.
+    ///
+    /// Upstream's remaining clause (`!am_sender` with `--delete-before`,
+    /// `--delete-after`, `--delay-updates` or `--prune-empty-dirs`) needs no
+    /// mirror here: oc-rsync never advertises `'i'` from a receiving client at
+    /// all, which is a strict superset of that condition. Both callers apply
+    /// that role restriction on top of this value.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `compat.c:172 set_allow_inc_recurse()` - `!recurse || use_qsort`.
+    /// - `options.c:2725` - the call site inside `server_options()`.
+    /// - `options.c:3039 maybe_add_e_option()` - `if (allow_inc_recurse)`.
+    #[must_use]
+    pub const fn allow_inc_recurse(&self) -> bool {
+        self.inc_recursive_send && self.recursive && !self.qsort
+    }
 }
 
 #[cfg(test)]
@@ -342,5 +369,50 @@ mod tests {
     fn inc_recursive_send_default_is_true() {
         let config = default_config();
         assert!(config.inc_recursive_send());
+    }
+
+    #[test]
+    fn allow_inc_recurse_requires_recursion() {
+        // upstream: compat.c:172 - `if (!recurse || use_qsort)
+        // allow_inc_recurse = 0;`. `--inc-recursive` does not survive it.
+        assert!(!default_config().allow_inc_recurse());
+        assert!(
+            !ClientConfig::builder()
+                .recursive(false)
+                .inc_recursive_send(true)
+                .build()
+                .allow_inc_recurse()
+        );
+        assert!(
+            !ClientConfig::builder()
+                .recursive(false)
+                .dirs(true)
+                .build()
+                .allow_inc_recurse()
+        );
+        assert!(
+            ClientConfig::builder()
+                .recursive(true)
+                .build()
+                .allow_inc_recurse()
+        );
+    }
+
+    #[test]
+    fn allow_inc_recurse_is_cleared_by_qsort_and_no_inc_recursive() {
+        assert!(
+            !ClientConfig::builder()
+                .recursive(true)
+                .qsort(true)
+                .build()
+                .allow_inc_recurse()
+        );
+        assert!(
+            !ClientConfig::builder()
+                .recursive(true)
+                .inc_recursive_send(false)
+                .build()
+                .allow_inc_recurse()
+        );
     }
 }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -314,8 +314,11 @@ pub(super) fn build_full_daemon_args(
 
     if protocol.as_u8() >= 30 {
         // upstream: compat.c:162-181 set_allow_inc_recurse() and
-        // options.c:3036 maybe_add_e_option() - 'i' is only advertised when
-        // the local side actually honors INC_RECURSE on its receive path.
+        // options.c:3036 maybe_add_e_option() - `allow_inc_recurse` resolves
+        // the option state (`ClientConfig::allow_inc_recurse`, which folds in
+        // upstream's `!recurse || use_qsort` gate); the local restriction on
+        // top is that 'i' is only advertised when this side actually honors
+        // INC_RECURSE on its receive path.
         // For daemon pull (`is_sender=true` means daemon is sender; we are
         // receiver) the receiver clears CF_INC_RECURSE in compat.rs after
         // reading it. If we still advertise 'i' the daemon writes the file
@@ -324,7 +327,7 @@ pub(super) fn build_full_daemon_args(
         // trips `read_varint` overflow on the next decode.
         // upstream: io.c:1816 read_varint - rejects encodings with extra > 4.
         let we_are_receiver = is_sender;
-        let advertise_inc_recurse = config.inc_recursive_send() && !we_are_receiver;
+        let advertise_inc_recurse = config.allow_inc_recurse() && !we_are_receiver;
         let capability_suffix = build_capability_string_suffix(advertise_inc_recurse);
         flag_string.push_str(&capability_suffix);
     }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -149,12 +149,13 @@ mod protect_args_daemon_tests {
     #[test]
     fn build_full_args_push_includes_inc_recurse_capability_by_default() {
         // ISI.h: sender-side INC_RECURSE is default-on, matching upstream
-        // rsync 3.4.x. The daemon push capability includes 'i' by default.
-        // upstream: capability string is embedded in the compact flag string.
+        // rsync 3.4.x. A recursive daemon push capability includes 'i' by
+        // default. upstream: the capability string is embedded in the compact
+        // flag string.
         let protocol = ProtocolVersion::try_from(32u8).unwrap();
         let request = test_daemon_request();
 
-        let config_default = ClientConfig::default();
+        let config_default = ClientConfig::builder().recursive(true).build();
         let args_default = build_full_daemon_args(&config_default, &request, protocol, false);
         let flags_default = find_flag_string(&args_default);
         let caps_default = flags_default
@@ -166,7 +167,10 @@ mod protect_args_daemon_tests {
             "default push capability must include 'i': {flags_default}"
         );
 
-        let config_off = ClientConfig::builder().inc_recursive_send(false).build();
+        let config_off = ClientConfig::builder()
+            .recursive(true)
+            .inc_recursive_send(false)
+            .build();
         let args_off = build_full_daemon_args(&config_off, &request, protocol, false);
         let flags_off = find_flag_string(&args_off);
         let caps_off = flags_off
@@ -177,6 +181,30 @@ mod protect_args_daemon_tests {
             !caps_off.contains('i'),
             "--no-inc-recursive must suppress 'i' on push capability: {flags_off}"
         );
+    }
+
+    #[test]
+    fn build_full_args_push_omits_inc_recurse_without_recursion() {
+        // upstream: compat.c:172 set_allow_inc_recurse() clears
+        // allow_inc_recurse when `!recurse || use_qsort`, and options.c:3039
+        // only emits 'i' when it survives. Verified against rsync 3.4.4: a
+        // non-recursive push sends `-e.LsfxCIvu` and `-r --qsort` sends
+        // `-re.LsfxCIvu`, while `-r` alone sends `-re.iLsfxCIvu`.
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let request = test_daemon_request();
+
+        for (label, config) in [
+            ("non-recursive", ClientConfig::default()),
+            (
+                "--qsort",
+                ClientConfig::builder().recursive(true).qsort(true).build(),
+            ),
+        ] {
+            let args = build_full_daemon_args(&config, &request, protocol, false);
+            let flags = find_flag_string(&args);
+            let caps = flags.split("e.").nth(1).expect("capability suffix present");
+            assert!(!caps.contains('i'), "{label} push must omit 'i': {flags}");
+        }
     }
 
     #[test]

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -212,12 +212,15 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // `-e.xxx` argument would confuse the server-side parser which treats
         // only the first short-flag argument as the compact flag string.
         // upstream: compat.c:162-181 set_allow_inc_recurse(),
-        // options.c:3036 maybe_add_e_option() - 'i' is only advertised when
-        // the local side honors INC_RECURSE on its receive path. The local
-        // Receiver role strips CF_INC_RECURSE from compat_flags after reading
-        // (compat.c:723) but receive_extra_file_lists then skips the
-        // NDX_FLIST_EOF the remote still emits, leaving its trailing bytes
-        // to trip read_varint overflow on the next decode.
+        // options.c:3036 maybe_add_e_option() - `allow_inc_recurse` resolves
+        // the option state (`ClientConfig::allow_inc_recurse`, which folds in
+        // upstream's `!recurse || use_qsort` gate); the local restriction on
+        // top is that 'i' is only advertised when this side honors INC_RECURSE
+        // on its receive path. The local Receiver role strips CF_INC_RECURSE
+        // from compat_flags after reading (compat.c:723) but
+        // receive_extra_file_lists then skips the NDX_FLIST_EOF the remote
+        // still emits, leaving its trailing bytes to trip read_varint overflow
+        // on the next decode.
         // upstream: io.c:1816 read_varint - rejects encodings with extra > 4.
         //
         // upstream: options.c:3025-3028 maybe_add_e_option() - the whole `e.xxx`
@@ -227,7 +230,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // must end at the transfer letters (`-r`, not `-re.iLsfxCIvu`).
         if self.requested_protocol().as_u8() >= 30 {
             let advertise_inc_recurse =
-                self.config.inc_recursive_send() && self.role != RemoteRole::Receiver;
+                self.config.allow_inc_recurse() && self.role != RemoteRole::Receiver;
             flags.push_str(&build_capability_string_suffix(advertise_inc_recurse));
         }
         // upstream: options.c:2730 - `if (x > 1) args[ac++] = argstr;`. A bare

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -107,6 +107,41 @@ fn ssh_sender_omits_inc_recurse_when_no_inc_recursive_set() {
 }
 
 #[test]
+fn ssh_sender_omits_inc_recurse_without_recursion_or_under_qsort() {
+    // upstream: compat.c:172 set_allow_inc_recurse() runs `if (!recurse ||
+    // use_qsort) allow_inc_recurse = 0;` from server_options() right before
+    // maybe_add_e_option(), so a non-recursive push never advertises 'i' even
+    // though `allow_inc_recurse` initializes to 1 (options.c:114).
+    //
+    // Ground truth from rsync 3.4.4 (protocol 32), server argv captured with a
+    // stub `-e` shell:
+    //   rsync src/a.txt host:dst/     -> --server -e.LsfxCIvu
+    //   rsync -d src/ host:dst/       -> --server -de.LsfxCIvu
+    //   rsync -r --qsort src/ host:dst/ -> --server -re.LsfxCIvu --use-qsort
+    //   rsync -r src/ host:dst/       -> --server -re.iLsfxCIvu
+    for (label, config) in [
+        (
+            "non-recursive",
+            ClientConfig::builder().recursive(false).build(),
+        ),
+        (
+            "--dirs without -r",
+            ClientConfig::builder().recursive(false).dirs(true).build(),
+        ),
+        ("--qsort", ClientConfig::builder().qsort(true).build()),
+    ] {
+        let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+        let args = builder.build("/remote/path");
+        let flag_str = args[2].to_string_lossy();
+        let caps_portion = flag_str.split("e.").nth(1).expect("e. separator");
+        assert!(
+            !caps_portion.contains('i'),
+            "{label} sender must omit 'i': {flag_str}"
+        );
+    }
+}
+
+#[test]
 fn ssh_receiver_omits_inc_recurse_capability_by_default() {
     // The local Receiver never advertises 'i' because its receive path
     // strips CF_INC_RECURSE from compat_flags (lib.rs::compute_allow_inc_recurse).


### PR DESCRIPTION
## Problem

Upstream resolves `allow_inc_recurse` from `server_options()` immediately before it builds the `-e` capability string:

```c
/* compat.c:172, called from options.c:2725 */
if (!recurse || use_qsort)
        allow_inc_recurse = 0;
```

and `maybe_add_e_option()` appends `i` only when it survives (`options.c:3039`). Since `allow_inc_recurse` initialises to `1` (`options.c:114`), that gate is the only thing keeping a non-recursive transfer from advertising the capability.

oc had no such gate on the client argv path: `inc_recursive_send` defaults to `true` and was cleared only by `--no-inc-recursive`, so a non-recursive push told the peer it honours INC_RECURSE where upstream says nothing. `--qsort` was unhandled there as well - it was already folded into the server-side `compute_allow_inc_recurse`, but never reached the argv emitters.

## Evidence

Server argv captured against rsync 3.4.4 (protocol 32, `--version` banner confirmed) using a stub remote shell, over an 18-invocation matrix. Seven diverged:

| invocation | rsync 3.4.4 | oc before | oc after |
|---|---|---|---|
| `src/a.txt host:dst/` | `-e.LsfxCIvu` | `-e.iLsfxCIvu` | `-e.LsfxCIvu` |
| `-d src/ host:dst/` | `-de.LsfxCIvu` | `-de.iLsfxCIvu` | `-de.LsfxCIvu` |
| `-a --no-r src/ host:dst/` | `-logDtpe.LsfxCIvu` | `-logDtpe.iLsfxCIvu` | `-logDtpe.LsfxCIvu` |
| `-a --files-from=L src/ host:dst/` | `-logDtpRe.LsfxCIvu` | `-logDtpRe.iLsfxCIvu` | `-logDtpRe.LsfxCIvu` |
| `--files-from=L src/ host:dst/` | `-Re.LsfxCIvu` | `-Re.iLsfxCIvu` | `-Re.LsfxCIvu` |
| `-r --qsort src/ host:dst/` | `-re.LsfxCIvu --use-qsort` | `-re.iLsfxCIvu --use-qsort` | `-re.LsfxCIvu --use-qsort` |
| `--inc-recursive src/a.txt host:dst/` | `-e.LsfxCIvu` | `-e.iLsfxCIvu` | `-e.LsfxCIvu` |

All seven now match byte for byte. The cases that must keep `i` still do: `-r` (`-re.iLsfxCIvu`), `-a` (`-logDtpre.iLsfxCIvu`), `-r --files-from` (`-rRe.iLsfxCIvu`), `--old-dirs --files-from` (`-rRe.iLsfxCIvu`), and `-r --delete-before` push (`-re.iLsfxCIvu`).

The one remaining matrix difference is pre-existing and out of scope: a `-r` pull omits `i` because oc's receiver path deliberately never advertises it (documented at both call sites).

## Fix

The resolution now lives in one place, `ClientConfig::allow_inc_recurse()`, which both flag-string emitters consult instead of reading the raw option:

- `crates/core/src/client/remote/invocation/builder.rs` (SSH)
- `crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs` (daemon)

Each keeps applying its own role restriction on top.

### Modelling upstream's non-boolean `recurse`

Upstream's `recurse` is a level, not a flag: `-r` sets 2 (`options.c:621`), `-a` sets 1 (`options.c:1551`), `--files-from` clears only level 1 (`options.c:2188-2189`), and `--old-dirs` re-forces 1 *after* that clearing (`options.c:2197-2199`). But the capability gate is a plain non-zero test, and `config.recursive()` already answers exactly that - #6927 folded the level rules into the CLI, carrying the explicit-vs-implied distinction through `recursive_override`. So `-r --files-from` keeps `i` and `-a --files-from` loses it, matching the table above, with no new state.

Upstream's remaining clause (`!am_sender` combined with `--delete-before`, `--delete-after`, `--delay-updates` or `--prune-empty-dirs`) needs no mirror here: oc never advertises `i` from a receiving client at all, which is a strict superset of it. Verified - all four pull variants already match upstream.

## Tests

- `crates/cli/tests/inc_recurse_capability_gate.rs` (new) drives the real binary through a stub remote shell and asserts the capability suffix across the non-recursive, `-d`, `--inc-recursive`, `--qsort`, `-r`, `-a` and three `--files-from` cases. Unit tests alone would not have caught this - the gate spans CLI, config and two emitters.
- `ClientConfig::allow_inc_recurse()` unit tests for the recursion, `--qsort` and `--no-inc-recursive` clauses.
- `build_full_args_push_omits_inc_recurse_without_recursion` for the daemon emitter.
- `build_full_args_push_includes_inc_recurse_capability_by_default` asserted `i` for a `ClientConfig::default()`, which is **non-recursive** - it encoded the missing gate. It now uses a recursive config and pins the upstream behaviour.

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` are clean; `cargo nextest run -p core -p cli --all-features` passes except two pre-existing host-environment failures unrelated to this change (a TZ-dependent timestamp assertion and an APFS sparse-allocation assertion).
