### PR TITLE
fix(batch): record the real sum_head for a delta --write-batch

### DIFF
--- a/crates/batch/src/replay/delta.rs
+++ b/crates/batch/src/replay/delta.rs
@@ -6,7 +6,6 @@
 //!
 //! - [`apply_delta_ops`] writes the reconstructed file from a basis + ops.
 //! - [`write_literals_to_file`] handles the no-basis (literal-only) path.
-//! - [`choose_block_length`] mirrors upstream `match.c:choose_block_size()`.
 //! - [`default_xfer_sum_len`] returns the per-file transfer checksum length.
 
 use std::fs::{File, OpenOptions};
@@ -63,16 +62,29 @@ pub(super) fn write_literals_to_file(
     Ok(())
 }
 
+/// Widens a wire block index for [`protocol::wire::SumHead::block_span`],
+/// which mirrors upstream's signed `i < 0 || i >= sum.count` test.
+///
+/// A `u32` past [`i32::MAX`] is an index upstream would have read back as
+/// negative, so it maps to -1 and is rejected rather than truncated.
+pub(super) const fn block_index_as_i32(block_index: u32) -> i32 {
+    if block_index > i32::MAX as u32 {
+        -1
+    } else {
+        block_index as i32
+    }
+}
+
 /// Applies delta operations to reconstruct a file from a basis file.
 ///
 /// Reads copy and literal tokens from `delta_ops` and writes the
 /// reconstructed output to `dest_path`. Copy tokens reference blocks in
 /// `basis_path` at offsets computed as `block_index * block_length`.
 ///
-/// `block_count` is the number of blocks in the basis file's signature.
-/// `remainder` is the size of the last block (which may be shorter than
-/// `block_length`). For the last block (index == block_count - 1), the copy
-/// uses `remainder` bytes instead of `block_length`.
+/// `sum_head` is the block geometry the batch advertised for this file. Every
+/// copy token is resolved through it, so a token that references a block the
+/// header does not describe fails here rather than reconstructing the wrong
+/// bytes - the same check upstream performs at `receiver.c:414`.
 ///
 /// upstream: receiver.c:recv_files() / match.c - block_length for all blocks
 /// except the last, which uses remainder.
@@ -80,14 +92,13 @@ pub(super) fn write_literals_to_file(
 /// # Errors
 ///
 /// Returns [`BatchError::Io`] if the basis file cannot be opened, the output
-/// file cannot be created, or any read/write/seek operation fails.
+/// file cannot be created, any read/write/seek operation fails, or a copy
+/// token references a block outside `sum_head`.
 pub fn apply_delta_ops(
     basis_path: &Path,
     dest_path: &Path,
     delta_ops: Vec<protocol::wire::DeltaOp>,
-    block_length: usize,
-    block_count: u32,
-    remainder: usize,
+    sum_head: protocol::wire::SumHead,
 ) -> BatchResult<()> {
     let basis_file = File::open(basis_path).map_err(|e| {
         BatchError::Io(std::io::Error::new(
@@ -133,7 +144,19 @@ pub fn apply_delta_ops(
                 block_index,
                 length,
             } => {
-                let offset = u64::from(block_index) * (block_length as u64);
+                // Token-format block matches encode length=0 because the
+                // receiver derives the block span from the advertised
+                // geometry. Resolving through the sum_head is what rejects a
+                // header that does not describe this body.
+                // upstream: receiver.c:414-422
+                let (offset, span) = sum_head
+                    .block_span(block_index_as_i32(block_index))
+                    .map_err(|error| {
+                        BatchError::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("{error} while replaying '{}'", dest_path.display()),
+                        ))
+                    })?;
 
                 basis.seek(SeekFrom::Start(offset)).map_err(|e| {
                     BatchError::Io(std::io::Error::new(
@@ -142,17 +165,10 @@ pub fn apply_delta_ops(
                     ))
                 })?;
 
-                // Token-format block matches encode length=0 because the
-                // receiver derives block size from the signature. Use
-                // block_length for all blocks except the last, which uses
-                // remainder (the last block is typically shorter).
-                // upstream: receiver.c - block size for last block is remainder.
                 let effective_length = if length > 0 {
                     length as usize
-                } else if block_count > 0 && block_index == block_count - 1 {
-                    remainder
                 } else {
-                    block_length
+                    span as usize
                 };
                 let mut remaining = effective_length;
                 while remaining > 0 {
@@ -194,23 +210,4 @@ pub fn apply_delta_ops(
 pub(super) fn default_xfer_sum_len(protocol_version: i32) -> usize {
     let _ = protocol_version;
     16
-}
-
-/// Chooses block length using the same heuristic as upstream rsync.
-///
-/// Upstream `match.c:choose_block_size()` computes the block length as the
-/// integer square root of the file size, clamped to `[BLOCK_SIZE (700),
-/// MAX_BLOCK_SIZE (128 * 1024)]`. For batch replay the exact same
-/// derivation ensures copy-token offsets align with the blocks that the
-/// sender used during the original transfer.
-pub(super) fn choose_block_length(file_size: u64) -> usize {
-    const MIN_BLOCK: usize = 700;
-    const MAX_BLOCK: usize = 128 * 1024;
-
-    if file_size == 0 {
-        return MIN_BLOCK;
-    }
-
-    let sqrt = (file_size as f64).sqrt() as usize;
-    sqrt.clamp(MIN_BLOCK, MAX_BLOCK)
 }

--- a/crates/batch/src/replay/delta_phase.rs
+++ b/crates/batch/src/replay/delta_phase.rs
@@ -23,7 +23,7 @@ use super::ReplayResult;
 #[cfg(feature = "zstd")]
 use super::codec::detect_compression_codec;
 use super::codec::{CompressionCodec, create_compressed_decoder};
-use super::delta::{choose_block_length, default_xfer_sum_len};
+use super::delta::default_xfer_sum_len;
 use super::dispatch::{
     ITEM_TRANSFER, apply_file_delta, read_and_discard_file_checksum,
     read_compressed_deltas_streaming, read_iflags_and_skip_meta, read_sum_head,
@@ -253,7 +253,6 @@ fn process_file_ndx(
     };
 
     let entry_name = entries[flat_index].name().to_owned();
-    let entry_size = entries[flat_index].size();
     // Only regular files are valid delta targets. A directory or symlink must
     // never be opened as a basis file or overwritten with literal data - on
     // Unix `File::open` on a directory succeeds (so a stray transfer record is
@@ -267,22 +266,16 @@ fn process_file_ndx(
     let stream = reader
         .inner_reader()
         .ok_or_else(|| BatchError::Io(std::io::Error::other("batch file not open")))?;
-    let (block_count, block_length_wire, remainder_wire) = read_sum_head(stream)?;
+    // The advertised geometry is the only description of the body that
+    // follows. Substituting a guessed block length when the header carries
+    // zeros is what let a whole-file-shaped head sit in front of a body full
+    // of block matches: oc replayed it happily while upstream aborted at
+    // receiver.c:414. Every copy token below is resolved through this head.
+    let sum_head = read_sum_head(stream)?;
 
-    // Compute block geometry before token reading - needed for CPRES_ZLIB
-    // see_token() calls which reference basis blocks by index. A non-regular
-    // dest never has a usable basis (and must not be opened as one).
+    // A non-regular dest never has a usable basis (and must not be opened as
+    // one).
     let basis_exists = is_regular && dest_path.exists();
-    let block_length = if block_length_wire > 0 {
-        block_length_wire as usize
-    } else {
-        choose_block_length(entry_size)
-    };
-    let remainder = if remainder_wire > 0 {
-        remainder_wire as usize
-    } else {
-        block_length
-    };
 
     // Auto-detect compression codec on the first compressed file before
     // building delta operations. Detection runs once per batch.
@@ -294,9 +287,7 @@ fn process_file_ndx(
         &dest_path,
         basis_exists,
         &entry_name,
-        block_length,
-        block_count,
-        remainder,
+        sum_head,
     )?;
 
     {
@@ -315,14 +306,7 @@ fn process_file_ndx(
     // files; directories and symlinks were created in the flist phase and must
     // not be overwritten with a delta-reconstructed file.
     if is_regular {
-        apply_file_delta(
-            &dest_path,
-            basis_exists,
-            delta_ops,
-            block_length,
-            block_count as u32,
-            remainder,
-        )
+        apply_file_delta(&dest_path, basis_exists, delta_ops, sum_head)
     } else {
         Ok(())
     }
@@ -336,16 +320,13 @@ fn process_file_ndx(
 ///
 /// upstream: token.c:recv_token() dispatches to recv_deflated_token() or
 /// simple_recv_token() based on do_compression.
-#[allow(clippy::too_many_arguments)]
 fn read_delta_tokens(
     reader: &mut BatchReader,
     codec_state: &mut CodecState,
     dest_path: &Path,
     basis_exists: bool,
     entry_name: &str,
-    block_length: usize,
-    block_count: i32,
-    remainder: usize,
+    sum_head: protocol::wire::SumHead,
 ) -> BatchResult<Vec<protocol::wire::DeltaOp>> {
     let Some(decoder) = codec_state.decoder.as_mut() else {
         return reader.read_file_delta_tokens().map_err(|e| {
@@ -369,15 +350,7 @@ fn read_delta_tokens(
         let stream = reader
             .inner_reader()
             .ok_or_else(|| BatchError::Io(std::io::Error::other("batch file not open")))?;
-        read_compressed_deltas_streaming(
-            decoder,
-            stream,
-            &basis_data,
-            entry_name,
-            block_length,
-            block_count,
-            remainder,
-        )
+        read_compressed_deltas_streaming(decoder, stream, &basis_data, entry_name, sum_head)
     } else {
         // CPRES_ZLIBX or no basis: eager read - see_token() is a no-op.
         reader.read_compressed_delta_tokens(decoder).map_err(|e| {

--- a/crates/batch/src/replay/dispatch.rs
+++ b/crates/batch/src/replay/dispatch.rs
@@ -19,7 +19,7 @@ use protocol::wire::{CompressedToken, CompressedTokenDecoder};
 
 use crate::error::{BatchError, BatchResult};
 
-use super::delta::{apply_delta_ops, write_literals_to_file};
+use super::delta::{apply_delta_ops, block_index_as_i32, write_literals_to_file};
 
 /// ITEM_BASIS_TYPE_FOLLOWS - 1-byte fnamecmp_type follows iflags.
 /// upstream: rsync.c:403-418
@@ -107,24 +107,20 @@ pub(super) fn read_iflags_and_skip_meta(
     Ok(iflags)
 }
 
-/// Read the 16-byte `sum_head` and return `(block_count, block_length_wire, remainder_wire)`.
+/// Read the 16-byte `sum_head` describing the delta body that follows.
 ///
-/// upstream: receiver.c:338 - `read_sum_head()` reads 4 x i32.
-/// The `s2length` field is read and discarded - oc-rsync derives the strong
-/// checksum length from the negotiated checksum algorithm, not from the wire.
-pub(super) fn read_sum_head(stream: &mut BufReader<File>) -> BatchResult<(i32, i32, i32)> {
-    let mut sum_buf = [0u8; 16];
-    stream.read_exact(&mut sum_buf).map_err(|e| {
+/// upstream: receiver.c:338 - `read_sum_head()` reads 4 x i32 and rejects any
+/// field that cannot describe a block layout. Decoding through
+/// [`protocol::wire::SumHead`] applies those same rules, and every copy token
+/// in the body is later resolved through the returned geometry, so a header
+/// that does not match its body is refused instead of guessed at.
+pub(super) fn read_sum_head(stream: &mut BufReader<File>) -> BatchResult<protocol::wire::SumHead> {
+    protocol::wire::SumHead::read(stream).map_err(|e| {
         BatchError::Io(std::io::Error::new(
             e.kind(),
             format!("failed to read sum_head: {e}"),
         ))
-    })?;
-    let block_count = i32::from_le_bytes([sum_buf[0], sum_buf[1], sum_buf[2], sum_buf[3]]);
-    let block_length_wire = i32::from_le_bytes([sum_buf[4], sum_buf[5], sum_buf[6], sum_buf[7]]);
-    let _s2length = i32::from_le_bytes([sum_buf[8], sum_buf[9], sum_buf[10], sum_buf[11]]);
-    let remainder_wire = i32::from_le_bytes([sum_buf[12], sum_buf[13], sum_buf[14], sum_buf[15]]);
-    Ok((block_count, block_length_wire, remainder_wire))
+    })
 }
 
 /// Read the per-file transfer checksum and discard it.
@@ -160,9 +156,7 @@ pub(super) fn read_compressed_deltas_streaming(
     stream: &mut BufReader<File>,
     basis_data: &[u8],
     entry_name: &str,
-    block_length: usize,
-    block_count: i32,
-    remainder: usize,
+    sum_head: protocol::wire::SumHead,
 ) -> BatchResult<Vec<protocol::wire::DeltaOp>> {
     let mut ops = Vec::new();
     loop {
@@ -183,14 +177,20 @@ pub(super) fn read_compressed_deltas_streaming(
             }
             CompressedToken::BlockMatch(block_index) => {
                 // Feed matched block's basis data into dictionary.
-                // upstream: receiver.c - see_token(map, len) after block match
-                let offset = block_index as usize * block_length;
-                let len = if block_index == block_count as u32 - 1 {
-                    remainder
-                } else {
-                    block_length
-                };
-                let end = (offset + len).min(basis_data.len());
+                // upstream: receiver.c - see_token(map, len) after block match.
+                // The span comes from the advertised geometry, so a token the
+                // sum_head cannot describe aborts here instead of underflowing
+                // the block-count arithmetic.
+                let (offset, len) = sum_head
+                    .block_span(block_index_as_i32(block_index))
+                    .map_err(|error| {
+                        BatchError::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("{error} while replaying '{entry_name}'"),
+                        ))
+                    })?;
+                let offset = offset as usize;
+                let end = (offset + len as usize).min(basis_data.len());
                 if offset < basis_data.len() {
                     decoder
                         .see_token(&basis_data[offset..end])
@@ -216,23 +216,14 @@ pub(super) fn apply_file_delta(
     dest_path: &Path,
     basis_exists: bool,
     delta_ops: Vec<protocol::wire::DeltaOp>,
-    block_length: usize,
-    block_count: u32,
-    remainder: usize,
+    sum_head: protocol::wire::SumHead,
 ) -> BatchResult<()> {
     if !basis_exists {
         write_literals_to_file(dest_path, &delta_ops)?;
         return Ok(());
     }
     let temp_path = dest_path.with_extension("~batch-tmp");
-    apply_delta_ops(
-        dest_path,
-        &temp_path,
-        delta_ops,
-        block_length,
-        block_count,
-        remainder,
-    )?;
+    apply_delta_ops(dest_path, &temp_path, delta_ops, sum_head)?;
     fs::rename(&temp_path, dest_path).map_err(|e| {
         BatchError::Io(std::io::Error::new(
             e.kind(),

--- a/crates/batch/src/replay/mod.rs
+++ b/crates/batch/src/replay/mod.rs
@@ -25,7 +25,7 @@
 //! - `codec` - compression codec detection (`zlib` vs `zstd`) and decoder
 //!   construction.
 //! - `delta` - low-level delta-application primitives (`apply_delta_ops`,
-//!   `write_literals_to_file`, `choose_block_length`).
+//!   `write_literals_to_file`).
 //! - `dispatch` - per-file helpers used by the main loop: iflags decoding,
 //!   sum-head reading, compressed-token streaming, temp-file commit.
 //! - `delta_phase` - the NDX-stream loop that drives per-file delta application.

--- a/crates/batch/src/replay/tests.rs
+++ b/crates/batch/src/replay/tests.rs
@@ -1,35 +1,18 @@
 //! Unit tests for the replay submodules.
 //!
-//! These tests cover the low-level building blocks: block-length derivation,
-//! delta application, literal-only writes, and compressed-token decoder
-//! construction. The end-to-end replay path is covered by the integration
+//! These tests cover the low-level building blocks: delta application,
+//! literal-only writes, and compressed-token decoder construction. The end-to-end replay path is covered by the integration
 //! tests in `crates/batch/src/tests.rs`.
 
 use std::fs;
 use tempfile::TempDir;
 
 use super::codec::{CompressionCodec, create_compressed_decoder};
-use super::delta::{apply_delta_ops, choose_block_length, write_literals_to_file};
+use super::delta::{apply_delta_ops, write_literals_to_file};
 
-#[test]
-fn choose_block_length_small_file() {
-    // Files smaller than 700^2 = 490_000 bytes get MIN_BLOCK (700).
-    assert_eq!(choose_block_length(0), 700);
-    assert_eq!(choose_block_length(1000), 700);
-    assert_eq!(choose_block_length(489_999), 700);
-}
-
-#[test]
-fn choose_block_length_medium_file() {
-    assert_eq!(choose_block_length(1_000_000), 1000);
-}
-
-#[test]
-fn choose_block_length_large_file() {
-    // Files larger than (128*1024)^2 get MAX_BLOCK.
-    let max_block = 128 * 1024;
-    let threshold = (max_block as u64) * (max_block as u64);
-    assert_eq!(choose_block_length(threshold + 1), max_block);
+/// Builds the geometry a batch would have advertised for these tests.
+fn head(count: u32, blength: u32, remainder: u32) -> protocol::wire::SumHead {
+    protocol::wire::SumHead::with_blocks(count, blength, 2, remainder).expect("valid geometry")
 }
 
 #[test]
@@ -41,7 +24,13 @@ fn apply_delta_ops_literal_only() {
     fs::write(&basis_path, b"").unwrap();
 
     let ops = vec![protocol::wire::DeltaOp::Literal(b"hello world".to_vec())];
-    apply_delta_ops(&basis_path, &dest_path, ops, 700, 0, 700).unwrap();
+    apply_delta_ops(
+        &basis_path,
+        &dest_path,
+        ops,
+        protocol::wire::SumHead::WHOLE_FILE,
+    )
+    .unwrap();
 
     let result = fs::read(&dest_path).unwrap();
     assert_eq!(result, b"hello world");
@@ -59,7 +48,7 @@ fn apply_delta_ops_copy_from_basis() {
         block_index: 0,
         length: 10,
     }];
-    apply_delta_ops(&basis_path, &dest_path, ops, 10, 1, 10).unwrap();
+    apply_delta_ops(&basis_path, &dest_path, ops, head(1, 10, 10)).unwrap();
 
     let result = fs::read(&dest_path).unwrap();
     assert_eq!(result, b"0123456789");
@@ -81,7 +70,7 @@ fn apply_delta_ops_mixed() {
         },
         protocol::wire::DeltaOp::Literal(b"<<".to_vec()),
     ];
-    apply_delta_ops(&basis_path, &dest_path, ops, 5, 1, 5).unwrap();
+    apply_delta_ops(&basis_path, &dest_path, ops, head(1, 5, 5)).unwrap();
 
     let result = fs::read(&dest_path).unwrap();
     assert_eq!(result, b">>ABCDE<<");
@@ -97,7 +86,7 @@ fn apply_delta_ops_nonexistent_basis() {
         block_index: 0,
         length: 10,
     }];
-    let result = apply_delta_ops(&basis_path, &dest_path, ops, 10, 1, 10);
+    let result = apply_delta_ops(&basis_path, &dest_path, ops, head(1, 10, 10));
     assert!(result.is_err());
 }
 
@@ -123,7 +112,7 @@ fn apply_delta_last_block_uses_remainder() {
         },
         protocol::wire::DeltaOp::Literal(b"END".to_vec()),
     ];
-    apply_delta_ops(&basis_path, &dest_path, ops, 10, 2, 5).unwrap();
+    apply_delta_ops(&basis_path, &dest_path, ops, head(2, 10, 5)).unwrap();
 
     let result = fs::read(&dest_path).unwrap();
     // Must copy 5 bytes from block 1 ("12345"), not 10 bytes (would overread).

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -240,6 +240,21 @@ pub(crate) struct CopyContext<'a> {
     /// Data contains iflags + sum_head + tokens + checksum without NDX.
     /// NDX is computed from sort-order mapping at flush time.
     batch_delta_entries: Vec<(i32, Vec<u8>)>,
+    /// Basis block geometry the current file's delta body is being built
+    /// against, and the offset of the reserved sum_head slot inside
+    /// `batch_delta_buf`.
+    ///
+    /// `begin_batch_file_delta()` reserves the slot with the whole-file head,
+    /// the delta executor records the real geometry through
+    /// `record_batch_delta_geometry()`, and `finalize_batch_file_delta()`
+    /// patches the slot. Emitting the head before the body is composed is what
+    /// let `--write-batch` advertise `count=0` ahead of block-match tokens.
+    ///
+    /// upstream: `io.c:write_sum_head()`; `receiver.c:414` rejects a block
+    /// index that the advertised count cannot cover.
+    batch_delta_sum_head: protocol::wire::SumHead,
+    /// Byte offset of the reserved sum_head inside `batch_delta_buf`.
+    batch_delta_sum_head_offset: usize,
     /// Sort metadata for each flist entry in traversal order: (name_bytes, is_dir).
     /// Used to compute the traversal→sorted index mapping that upstream's
     /// `flist_sort_and_clean()` produces after reading the batch flist.

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -5,6 +5,46 @@ pub(super) struct SparseCopy<'state> {
     state: &'state mut SparseWriteState,
 }
 
+/// Derives the `sum_head` describing the basis a delta body is matched against.
+///
+/// The three geometry fields are read straight off the index the matcher uses,
+/// so the header a `--write-batch` records and the block indices its tokens
+/// carry can only ever come from the same block layout.
+///
+/// upstream: `generator.c:sum_sizes_sqroot()` fills `struct sum_struct`, whose
+/// four fields `io.c:write_sum_head()` serialises; `remainder` is the length of
+/// the trailing short block, or 0 when the basis divides evenly.
+fn batch_sum_head(
+    index: &DeltaSignatureIndex,
+) -> Result<protocol::wire::SumHead, LocalCopyError> {
+    let reject = |detail: String| {
+        LocalCopyError::io(
+            "derive batch sum_head",
+            std::path::PathBuf::new(),
+            io::Error::new(io::ErrorKind::InvalidData, detail),
+        )
+    };
+    let field = |value: usize, name: &str| {
+        u32::try_from(value).map_err(|_| reject(format!("basis {name} {value} exceeds the wire field")))
+    };
+
+    let count = field(index.block_count(), "block count")?;
+    let blength = field(index.block_length(), "block length")?;
+    let s2length = field(index.strong_length(), "strong sum length")?;
+    let remainder = match count.checked_sub(1) {
+        // upstream: the trailing block is short only when the basis does not
+        // divide evenly, in which case `remainder` carries its real length.
+        Some(last) => {
+            let last_len = field(index.block(last as usize).len(), "trailing block length")?;
+            if last_len == blength { 0 } else { last_len }
+        }
+        None => 0,
+    };
+
+    protocol::wire::SumHead::with_blocks(count, blength, s2length, remainder)
+        .map_err(|error| reject(error.to_string()))
+}
+
 impl<'a> CopyContext<'a> {
     /// Copies `source`'s content to `writer` by matching blocks against
     /// `index` and writing literal bytes for the unmatched runs in between.
@@ -45,6 +85,12 @@ impl<'a> CopyContext<'a> {
         // is freshly opened and contains nothing. Force every matched block
         // through the copy path by treating the run as non-inplace.
         let inplace_mode = self.inplace_enabled() && !basis_separate_from_writer;
+
+        // The batch body about to be written references blocks of this basis,
+        // so the reserved sum_head must describe exactly this geometry.
+        // upstream: match.c:match_sums() writes the sum_head it received from
+        // the generator immediately before the tokens built against it.
+        self.record_batch_delta_geometry(batch_sum_head(index)?);
 
         // On NTFS the sparse zero-run seeks below only deallocate blocks once
         // the handle is flagged sparse via FSCTL_SET_SPARSE. Elsewhere this is a
@@ -490,6 +536,11 @@ impl<'a> CopyContext<'a> {
         }
 
         let block_index = matched.descriptor().index() as u32;
+
+        // The token references a basis block by index, so the sum_head this
+        // file reserved must already describe that block. Anything else is the
+        // stream upstream aborts on at receiver.c:414.
+        self.check_batch_block_index(block_index)?;
 
         let mut see_data = Vec::new();
         if self.batch_token_encoder.is_some() {

--- a/crates/engine/src/local_copy/context_impl/options/batch.rs
+++ b/crates/engine/src/local_copy/context_impl/options/batch.rs
@@ -260,6 +260,13 @@ impl<'a> CopyContext<'a> {
     /// after reading it from the batch file, so NDX values must reference
     /// sorted positions, not traversal order.
     ///
+    /// The sum_head is likewise deferred: which blocks the body will reference
+    /// is not known until the copy has run, so a whole-file placeholder is
+    /// reserved here and [`Self::finalize_batch_file_delta`] overwrites it with
+    /// the geometry the body was actually built against. Composing the head up
+    /// front is what produced batches advertising `count=0` ahead of a body
+    /// full of block matches, which upstream rejects at `receiver.c:414`.
+    ///
     /// Must be called before any token writes for this file (before
     /// `capture_batch_whole_file` or inline delta token writes).
     ///
@@ -306,29 +313,65 @@ impl<'a> CopyContext<'a> {
                 })?;
         }
 
-        // upstream: io.c:read_sum_head() / sender.c - write sum_head (4 x i32 LE).
-        // For local copy whole-file transfers: count=0, blength=0, s2length=16
-        // (MD5 checksum length), remainder=0.
-        const FILE_SUM_LENGTH: i32 = 16;
-        let count: i32 = 0;
-        let blength: i32 = 0;
-        let s2length: i32 = FILE_SUM_LENGTH;
-        let remainder: i32 = 0;
-
-        let mut sum_buf = [0u8; 16];
-        sum_buf[0..4].copy_from_slice(&count.to_le_bytes());
-        sum_buf[4..8].copy_from_slice(&blength.to_le_bytes());
-        sum_buf[8..12].copy_from_slice(&s2length.to_le_bytes());
-        sum_buf[12..16].copy_from_slice(&remainder.to_le_bytes());
-        delta_file.write_all(&sum_buf).map_err(|e| {
-            crate::local_copy::LocalCopyError::io(
-                "write batch sum_head",
-                std::path::PathBuf::new(),
-                e,
-            )
-        })?;
+        // upstream: io.c:write_sum_head() - four i32 LE fields. Reserve the
+        // slot with the whole-file (all-zero) head; the delta path replaces it
+        // via `record_batch_delta_geometry` once the basis geometry is known,
+        // and `finalize_batch_file_delta` patches the reserved bytes.
+        self.batch_delta_sum_head = protocol::wire::SumHead::WHOLE_FILE;
+        self.batch_delta_sum_head_offset = delta_file.get_ref().len();
+        delta_file
+            .write_all(&protocol::wire::SumHead::WHOLE_FILE.encode())
+            .map_err(|e| {
+                crate::local_copy::LocalCopyError::io(
+                    "write batch sum_head",
+                    std::path::PathBuf::new(),
+                    e,
+                )
+            })?;
 
         Ok(())
+    }
+
+    /// Records the basis geometry the current file's delta body is being built
+    /// against.
+    ///
+    /// Called by the delta executor once it has a basis signature, before any
+    /// block-match token is emitted. Every subsequent match token is validated
+    /// against this head, and the head is what
+    /// [`Self::finalize_batch_file_delta`] writes into the reserved slot - so
+    /// the head and the body it describes can only ever be built together.
+    ///
+    /// A file that never reaches the delta path keeps the whole-file head,
+    /// matching upstream's `write_sum_head(f, NULL)`.
+    pub(crate) fn record_batch_delta_geometry(&mut self, head: protocol::wire::SumHead) {
+        if self.batch_delta_buf.is_some() {
+            self.batch_delta_sum_head = head;
+        }
+    }
+
+    /// Resolves a basis block index against the current file's recorded
+    /// geometry, refusing to record a token the replaying receiver would
+    /// reject.
+    ///
+    /// upstream: `receiver.c:414` aborts with `RERR_PROTOCOL` on an index that
+    /// is not below `sum.count`. Checking here means a sum_head/body mismatch
+    /// fails while writing the batch instead of silently shipping a file that
+    /// crashes the peer replaying it.
+    pub(crate) fn check_batch_block_index(
+        &self,
+        block_index: u32,
+    ) -> Result<(), crate::local_copy::LocalCopyError> {
+        let index = i32::try_from(block_index).unwrap_or(-1);
+        self.batch_delta_sum_head
+            .block_span(index)
+            .map(|_| ())
+            .map_err(|error| {
+                crate::local_copy::LocalCopyError::io(
+                    "write batch block match token",
+                    std::path::PathBuf::new(),
+                    std::io::Error::from(error),
+                )
+            })
     }
 
     /// Writes a token-format end marker and file checksum to the batch delta
@@ -398,8 +441,32 @@ impl<'a> CopyContext<'a> {
 
         // Move the completed per-file data to batch_delta_entries.
         // The NDX will be written at flush time using the sort-order mapping.
-        let data = std::mem::take(delta_file.get_mut());
+        let mut data = std::mem::take(delta_file.get_mut());
         delta_file.set_position(0);
+
+        // Patch the reserved sum_head with the geometry the body was built
+        // against. Deferring it to here is what keeps the head and the tokens
+        // it describes in agreement: the delta path records the basis geometry
+        // as it matches blocks, and a whole-file body never records one, so it
+        // keeps upstream's all-zero head.
+        let head = std::mem::replace(
+            &mut self.batch_delta_sum_head,
+            protocol::wire::SumHead::WHOLE_FILE,
+        );
+        let start = self.batch_delta_sum_head_offset;
+        let end = start + protocol::wire::SumHead::WIRE_LEN;
+        let Some(slot) = data.get_mut(start..end) else {
+            return Err(crate::local_copy::LocalCopyError::io(
+                "write batch sum_head",
+                source.to_path_buf(),
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "batch delta buffer is missing its reserved sum_head",
+                ),
+            ));
+        };
+        slot.copy_from_slice(&head.encode());
+
         let idx = self.batch_current_delta_idx;
         self.batch_delta_entries.push((idx, data));
 

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -169,6 +169,8 @@ impl<'a> CopyContext<'a> {
             batch_flist_writer,
             batch_delta_buf,
             batch_delta_entries: Vec::new(),
+            batch_delta_sum_head: protocol::wire::SumHead::WHOLE_FILE,
+            batch_delta_sum_head_offset: 0,
             batch_entry_sort_data: Vec::new(),
             batch_current_delta_idx: 0,
             batch_flist_index: 0,

--- a/crates/engine/tests/write_batch_delta_sum_head.rs
+++ b/crates/engine/tests/write_batch_delta_sum_head.rs
@@ -1,0 +1,180 @@
+//! Regression test: a `--write-batch` delta body must be preceded by the
+//! `sum_head` that describes it.
+//!
+//! `begin_batch_file_delta()` used to emit a fixed whole-file-shaped header
+//! (`count=0, blength=0, s2length=16, remainder=0`) before the executor knew
+//! whether the body would be literals or block matches. A `--no-whole-file`
+//! transfer then produced a batch whose tokens referenced basis blocks while
+//! the header advertised none. oc-rsync replayed it anyway - its reader
+//! substituted a guessed block length whenever the header carried zeros - but
+//! upstream rsync 3.4.1 and 3.4.4 either abort with `Invalid block index 0
+//! (count=0)` or walk off the end of a zero-length block table and crash.
+//!
+//! The header is now reserved at `begin_batch_file_delta()` and patched at
+//! `finalize_batch_file_delta()` from the geometry the matcher actually used,
+//! so the two cannot be composed independently.
+//!
+//! # Upstream Reference
+//!
+//! - `io.c:write_sum_head()` - four i32 LE fields; a whole-file transfer sends
+//!   the all-zero `null_sum`, `s2length` included.
+//! - `generator.c:sum_sizes_sqroot()` - a 100 KiB basis yields
+//!   `blength = 700`, `count = 147`, `remainder = 200`.
+//! - `receiver.c:414` - `Invalid block index %d (count=%ld)` aborts with
+//!   `RERR_PROTOCOL` when a match token names a block the header omits.
+
+use std::fs;
+use std::sync::{Arc, Mutex};
+
+use batch::{BatchConfig, BatchFlags, BatchMode, BatchWriter};
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use protocol::CompatibilityFlags;
+use tempfile::tempdir;
+
+/// Basis size chosen so upstream's square-root block sizing is fully
+/// determined: below `700 * 700` every basis uses the default 700-byte block.
+const BASIS_LEN: usize = 100 * 1024;
+
+/// Geometry upstream 3.4.4 advertises for a [`BASIS_LEN`]-byte basis,
+/// confirmed by diffing its own `--write-batch` output.
+const EXPECTED_COUNT: u32 = 147;
+const EXPECTED_BLENGTH: u32 = 700;
+const EXPECTED_REMAINDER: u32 = 200;
+
+fn make_writer(path: &std::path::Path) -> Arc<Mutex<BatchWriter>> {
+    let compat_flags = CompatibilityFlags::SAFE_FILE_LIST
+        | CompatibilityFlags::AVOID_XATTR_OPTIMIZATION
+        | CompatibilityFlags::CHECKSUM_SEED_FIX
+        | CompatibilityFlags::INPLACE_PARTIAL_DIR
+        | CompatibilityFlags::VARINT_FLIST_FLAGS;
+    let config = BatchConfig::new(BatchMode::Write, path.to_string_lossy().into_owned(), 32)
+        .with_compat_flags(compat_flags.bits() as i32)
+        .with_checksum_seed(1);
+    let mut writer = BatchWriter::new(config).expect("create batch writer");
+    let flags = BatchFlags {
+        recurse: true,
+        preserve_links: true,
+        ..Default::default()
+    };
+    writer.write_header(flags).expect("write batch header");
+    Arc::new(Mutex::new(writer))
+}
+
+/// Records a delta `--write-batch` and returns the raw batch bytes.
+///
+/// The destination starts as an exact copy of the pre-modification source, so
+/// `--no-whole-file --ignore-times` forces a genuine block-matching pass
+/// instead of a whole-file resend.
+fn record_delta_batch() -> Vec<u8> {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    let batch_path = temp.path().join("batch.bin");
+    fs::create_dir_all(&source).expect("create source dir");
+    fs::create_dir_all(&dest).expect("create dest dir");
+
+    let basis = vec![b'A'; BASIS_LEN];
+    fs::write(source.join("large.dat"), &basis).expect("write source");
+    fs::write(dest.join("large.dat"), &basis).expect("write basis");
+
+    let mut modified = basis;
+    modified[50_000..50_008].copy_from_slice(b"MODIFIED");
+    fs::write(source.join("large.dat"), &modified).expect("modify source");
+
+    let writer = make_writer(&batch_path);
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .whole_file(false)
+        .ignore_times(true)
+        .batch_writer(Some(Arc::clone(&writer)));
+
+    let mut src_os = source.into_os_string();
+    src_os.push("/");
+    let operands = vec![src_os, dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("delta write-batch succeeds");
+
+    Arc::try_unwrap(writer)
+        .expect("writer uniquely owned")
+        .into_inner()
+        .expect("writer mutex not poisoned")
+        .finalize()
+        .expect("finalize batch writer");
+
+    fs::read(&batch_path).expect("read batch bytes")
+}
+
+/// The recorded header must carry the basis geometry, byte for byte, so a
+/// peer replaying the batch resolves the body's match tokens to the same
+/// basis ranges the matcher used.
+#[test]
+fn delta_write_batch_records_the_basis_geometry() {
+    let bytes = record_delta_batch();
+
+    let expected = protocol::wire::SumHead::with_blocks(
+        EXPECTED_COUNT,
+        EXPECTED_BLENGTH,
+        // The batch carries no block sums, so `s2length` simply reports the
+        // strong-sum width the local basis signature was built with.
+        16,
+        EXPECTED_REMAINDER,
+    )
+    .expect("valid geometry")
+    .encode();
+
+    assert!(
+        bytes.windows(expected.len()).any(|w| w == expected),
+        "batch must embed the basis sum_head {expected:02x?}"
+    );
+}
+
+/// The header that shipped before this fix - `count=0, blength=0,
+/// s2length=16` - is what upstream crashes on. It must never reappear in a
+/// delta batch.
+#[test]
+fn delta_write_batch_never_records_a_whole_file_header() {
+    let bytes = record_delta_batch();
+
+    let mut regression = [0u8; protocol::wire::SumHead::WIRE_LEN];
+    regression[8] = 16;
+    assert!(
+        !bytes.windows(regression.len()).any(|w| w == regression),
+        "a delta batch must not advertise a whole-file sum_head"
+    );
+}
+
+/// Every match token in the body must resolve against the recorded header.
+///
+/// This is the invariant upstream enforces at `receiver.c:414`; oc-rsync's own
+/// reader now enforces it too, so a writer that drifts from its header fails
+/// here rather than shipping a batch that only upstream rejects.
+#[test]
+fn delta_write_batch_replays_through_the_strict_reader() {
+    let temp = tempdir().expect("tempdir");
+    let batch_path = temp.path().join("batch.bin");
+    let replay_root = temp.path().join("replay");
+    fs::create_dir_all(&replay_root).expect("create replay dir");
+    fs::write(&batch_path, record_delta_batch()).expect("write batch");
+
+    // The replay side starts from the same basis the batch was recorded
+    // against, which is what makes the match tokens meaningful.
+    let basis = vec![b'A'; BASIS_LEN];
+    fs::write(replay_root.join("large.dat"), &basis).expect("seed basis");
+
+    let read_cfg = BatchConfig::new(
+        BatchMode::Read,
+        batch_path.to_string_lossy().into_owned(),
+        32,
+    );
+    batch::replay::replay(&read_cfg, &replay_root, 0).expect("replay accepts the batch");
+
+    let mut expected = basis;
+    expected[50_000..50_008].copy_from_slice(b"MODIFIED");
+    assert_eq!(
+        fs::read(replay_root.join("large.dat")).expect("read replayed file"),
+        expected,
+        "replay must reconstruct the modified source byte for byte"
+    );
+}

--- a/crates/protocol/src/wire/delta/mod.rs
+++ b/crates/protocol/src/wire/delta/mod.rs
@@ -22,12 +22,14 @@
 //! ## Submodules
 //!
 //! - `int_encoding` - Fundamental 4-byte LE integer read/write primitives
+//! - `sum_head` - Block geometry every token stream is read and written against
 //! - `token` - Upstream token-based wire format (literals, block matches, end markers)
 //! - `internal` - Internal opcode-based delta format for backward compatibility
 //! - `types` - Core types and constants (`DeltaOp`, `CHUNK_SIZE`)
 
 mod int_encoding;
 mod internal;
+mod sum_head;
 mod token;
 mod types;
 
@@ -36,6 +38,7 @@ mod tests;
 
 pub use self::int_encoding::{read_int, write_int};
 pub use self::internal::{read_delta, read_delta_op, write_delta, write_delta_op};
+pub use self::sum_head::{MAX_BLOCK_SIZE, MAX_STRONG_SUM_LEN, SumHead, SumHeadError};
 pub use self::token::{
     check_literal_token_len, read_token, write_token_block_match, write_token_end,
     write_token_literal, write_token_stream, write_whole_file_delta,

--- a/crates/protocol/src/wire/delta/sum_head.rs
+++ b/crates/protocol/src/wire/delta/sum_head.rs
@@ -1,0 +1,526 @@
+#![deny(unsafe_code)]
+//! The per-file `sum_head` that precedes every delta token stream.
+//!
+//! Upstream writes four little-endian 32-bit fields ahead of the tokens:
+//!
+//! | field       | meaning                                             |
+//! |-------------|-----------------------------------------------------|
+//! | `count`     | number of basis blocks the tokens may reference     |
+//! | `blength`   | length of every block except possibly the last      |
+//! | `s2length`  | width of the per-block strong sum (protocol >= 27)  |
+//! | `remainder` | length of the final block, or 0 when it is full     |
+//!
+//! upstream: `io.c:write_sum_head()` / `io.c:read_sum_head()`.
+//!
+//! [`SumHead`] is the single owner of that geometry. Whoever emits a delta
+//! body derives the head from the same [`SumHead`] it validates each block
+//! match against, and whoever replays a body resolves every match token
+//! through [`SumHead::block_span`]. A head that does not describe the body it
+//! precedes therefore cannot be produced or accepted - which is what upstream
+//! enforces at `receiver.c:414` before it indexes the block table.
+
+use std::io::{self, Read, Write};
+
+use thiserror::Error;
+
+use crate::protocol_violation::protocol_violation;
+
+/// Largest block length any protocol era may advertise, in bytes.
+///
+/// upstream: `rsync.h` `MAX_BLOCK_SIZE ((int32)1 << 29)`. Used as the
+/// permissive ceiling so a header accepted by either protocol era decodes
+/// here; the narrower protocol-30 ceiling is a sizing choice made by the
+/// generator, not a decoding rule.
+pub const MAX_BLOCK_SIZE: u32 = 1 << 29;
+
+/// Largest strong-sum width a `sum_head` may advertise, in bytes.
+///
+/// upstream: `io.c:2056` bounds `s2length` by `xfer_sum_len`. SHA1 at 20
+/// bytes is the widest transfer digest oc-rsync negotiates.
+pub const MAX_STRONG_SUM_LEN: u32 = 20;
+
+/// Wire bytes each signature block occupies: a 4-byte rolling sum plus a
+/// strong sum of at most [`MAX_STRONG_SUM_LEN`].
+const MAX_BLOCK_ENTRY_LEN: usize = 4 + MAX_STRONG_SUM_LEN as usize;
+
+/// Errors raised when a `sum_head` cannot describe the body that follows it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Error)]
+pub enum SumHeadError {
+    /// A block-match token referenced a block the `sum_head` does not describe.
+    ///
+    /// upstream: `receiver.c:414` - `Invalid block index %d (count=%ld)`,
+    /// which aborts the transfer with `RERR_PROTOCOL`.
+    #[error("Invalid block index {index} (count={count})")]
+    InvalidBlockIndex {
+        /// The block index carried by the match token.
+        index: i32,
+        /// The block count advertised by the `sum_head`.
+        count: i32,
+    },
+
+    /// The block count is negative, or large enough that sizing the block
+    /// table from it would overflow.
+    ///
+    /// upstream: `io.c:2029` and `io.c:2039-2048`.
+    #[error("invalid checksum count {count}")]
+    InvalidCount {
+        /// The rejected count.
+        count: i32,
+    },
+
+    /// The block length is negative, past [`MAX_BLOCK_SIZE`], or zero while
+    /// blocks are advertised - which would make every block empty.
+    ///
+    /// upstream: `io.c:2050-2054`.
+    #[error("invalid block length {blength}")]
+    InvalidBlockLength {
+        /// The rejected block length.
+        blength: i32,
+    },
+
+    /// The strong-sum width is negative or past [`MAX_STRONG_SUM_LEN`].
+    ///
+    /// upstream: `io.c:2056-2060`.
+    #[error("invalid checksum length {s2length}")]
+    InvalidStrongSumLength {
+        /// The rejected strong-sum width.
+        s2length: i32,
+    },
+
+    /// The trailing-block length is negative or wider than a whole block.
+    ///
+    /// upstream: `io.c:2061-2066`.
+    #[error("invalid remainder length {remainder}")]
+    InvalidRemainder {
+        /// The rejected remainder.
+        remainder: i32,
+    },
+}
+
+impl From<SumHeadError> for io::Error {
+    /// Maps a rejected `sum_head` onto the `RERR_PROTOCOL` (exit 2) path.
+    ///
+    /// upstream: `io.c:2032-2065` `read_sum_head()` calls
+    /// `exit_cleanup(RERR_PROTOCOL)` on any out-of-range field.
+    fn from(error: SumHeadError) -> Self {
+        protocol_violation(format!("malformed sum_head: {error}"))
+    }
+}
+
+/// Block geometry shared by a delta body and the `sum_head` that precedes it.
+///
+/// upstream: `rsync.h:200` `struct sum_struct`, serialised by
+/// `io.c:write_sum_head()` and parsed by `io.c:read_sum_head()`.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SumHead {
+    count: u32,
+    blength: u32,
+    s2length: u32,
+    remainder: u32,
+}
+
+impl SumHead {
+    /// Serialised width of a `sum_head` for protocol >= 27, in bytes.
+    ///
+    /// Four 32-bit little-endian fields. Protocol 26 and older omit
+    /// `s2length`, which oc-rsync does not negotiate.
+    pub const WIRE_LEN: usize = 16;
+
+    /// The all-zero head a whole-file transfer advertises.
+    ///
+    /// upstream: `io.c:write_sum_head()` substitutes a `static struct
+    /// sum_struct null_sum` when the generator sent no sums, so every field -
+    /// including `s2length` - goes out as zero.
+    pub const WHOLE_FILE: Self = Self {
+        count: 0,
+        blength: 0,
+        s2length: 0,
+        remainder: 0,
+    };
+
+    /// Builds a head describing `count` basis blocks.
+    ///
+    /// `remainder` is the length of the final block when it is short, or 0
+    /// when the basis divides evenly into `blength`-sized blocks.
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`SumHeadError`] variant for whichever field cannot
+    /// describe a real block layout.
+    pub const fn with_blocks(
+        count: u32,
+        blength: u32,
+        s2length: u32,
+        remainder: u32,
+    ) -> Result<Self, SumHeadError> {
+        let head = Self {
+            count,
+            blength,
+            s2length,
+            remainder,
+        };
+        match head.check() {
+            Ok(()) => Ok(head),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Applies upstream's `read_sum_head()` field checks.
+    ///
+    /// The fields size downstream allocations (`Vec::with_capacity(count)`,
+    /// `vec![0u8; s2length]`), so an unbounded header from an authenticated
+    /// but untrusted peer is a memory-exhaustion vector.
+    const fn check(self) -> Result<(), SumHeadError> {
+        // upstream: io.c:2029 - the field is signed on the wire, so a negative
+        // count arrives here as a u32 above `i32::MAX` and is rejected.
+        //
+        // upstream: io.c:2039-2048 - the block table is sized `count *
+        // (4 + s2length)`; bound the first factor so that product cannot
+        // overflow on a 32-bit target either.
+        if self.count > i32::MAX as u32 || self.count as usize > usize::MAX / MAX_BLOCK_ENTRY_LEN {
+            return Err(SumHeadError::InvalidCount {
+                count: self.count as i32,
+            });
+        }
+        // upstream: io.c:2050-2054 - blength in (0, MAX_BLOCK_SIZE]; a zero
+        // block length with blocks advertised would make every block empty.
+        if self.blength > MAX_BLOCK_SIZE || (self.count > 0 && self.blength == 0) {
+            return Err(SumHeadError::InvalidBlockLength {
+                blength: self.blength as i32,
+            });
+        }
+        // upstream: io.c:2056-2060 - s2length in [0, xfer_sum_len].
+        if self.s2length > MAX_STRONG_SUM_LEN {
+            return Err(SumHeadError::InvalidStrongSumLength {
+                s2length: self.s2length as i32,
+            });
+        }
+        // upstream: io.c:2061-2066 - remainder in [0, blength].
+        if self.remainder > self.blength {
+            return Err(SumHeadError::InvalidRemainder {
+                remainder: self.remainder as i32,
+            });
+        }
+        Ok(())
+    }
+
+    /// Number of basis blocks a match token may reference.
+    #[inline]
+    #[must_use]
+    pub const fn count(self) -> u32 {
+        self.count
+    }
+
+    /// Length of every basis block except a short trailing one.
+    #[inline]
+    #[must_use]
+    pub const fn blength(self) -> u32 {
+        self.blength
+    }
+
+    /// Width of each per-block strong sum, in bytes.
+    #[inline]
+    #[must_use]
+    pub const fn s2length(self) -> u32 {
+        self.s2length
+    }
+
+    /// Length of the trailing basis block, or 0 when it is full-length.
+    #[inline]
+    #[must_use]
+    pub const fn remainder(self) -> u32 {
+        self.remainder
+    }
+
+    /// Whether the body may contain block-match tokens at all.
+    #[inline]
+    #[must_use]
+    pub const fn describes_blocks(self) -> bool {
+        self.count > 0
+    }
+
+    /// Total basis length this geometry covers.
+    ///
+    /// upstream: `receiver.c:289-291` - `sum.flength = count * blength;
+    /// if (remainder) flength -= blength - remainder`. Append mode starts
+    /// writing at this offset.
+    #[inline]
+    #[must_use]
+    pub const fn flength(self) -> u64 {
+        if self.count == 0 {
+            return 0;
+        }
+        let total = self.count as u64 * self.blength as u64;
+        if self.remainder > 0 {
+            total - self.blength as u64 + self.remainder as u64
+        } else {
+            total
+        }
+    }
+
+    /// Resolves a match token's block index to a basis offset and length.
+    ///
+    /// This is the one place a block index becomes a byte range, so a head
+    /// that does not describe the body it precedes fails here instead of
+    /// indexing a block table that has no such entry.
+    ///
+    /// upstream: `receiver.c:414-422`
+    ///
+    /// ```text
+    /// i = -(i+1);
+    /// if (i < 0 || i >= sum.count) { ...Invalid block index... }
+    /// offset2 = i * (OFF_T)sum.blength;
+    /// len = sum.blength;
+    /// if (i == (int)sum.count-1 && sum.remainder != 0)
+    ///         len = sum.remainder;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SumHeadError::InvalidBlockIndex`] when `index` is negative or
+    /// not below [`SumHead::count`] - including every index against a
+    /// whole-file head, which describes no blocks.
+    pub const fn block_span(self, index: i32) -> Result<(u64, u32), SumHeadError> {
+        if index < 0 || index as u32 >= self.count {
+            return Err(SumHeadError::InvalidBlockIndex {
+                index,
+                count: self.count as i32,
+            });
+        }
+        let index = index as u32;
+        let offset = index as u64 * self.blength as u64;
+        let len = if index == self.count - 1 && self.remainder != 0 {
+            self.remainder
+        } else {
+            self.blength
+        };
+        Ok((offset, len))
+    }
+
+    /// Encodes the head into its 16 wire bytes.
+    #[inline]
+    #[must_use]
+    pub const fn encode(self) -> [u8; Self::WIRE_LEN] {
+        let count = (self.count as i32).to_le_bytes();
+        let blength = (self.blength as i32).to_le_bytes();
+        let s2length = (self.s2length as i32).to_le_bytes();
+        let remainder = (self.remainder as i32).to_le_bytes();
+        [
+            count[0],
+            count[1],
+            count[2],
+            count[3],
+            blength[0],
+            blength[1],
+            blength[2],
+            blength[3],
+            s2length[0],
+            s2length[1],
+            s2length[2],
+            s2length[3],
+            remainder[0],
+            remainder[1],
+            remainder[2],
+            remainder[3],
+        ]
+    }
+
+    /// Decodes a head from its 16 wire bytes, rejecting impossible geometry.
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`SumHeadError`] variant for whichever field upstream's
+    /// `read_sum_head()` would reject.
+    pub const fn decode(bytes: [u8; Self::WIRE_LEN]) -> Result<Self, SumHeadError> {
+        // Fields are signed on the wire (write_int/read_int). A negative value
+        // becomes a huge u32 and is caught by the ceilings in `check`.
+        let head = Self {
+            count: u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+            blength: u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+            s2length: u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+            remainder: u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
+        };
+        match head.check() {
+            Ok(()) => Ok(head),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Writes the head to `writer`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any write error from the underlying stream.
+    #[inline]
+    pub fn write<W: Write + ?Sized>(self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(&self.encode())
+    }
+
+    /// Reads a head from `reader`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when the 16 bytes cannot be read, or a
+    /// `RERR_PROTOCOL`-tagged error when they do not describe a block layout.
+    #[inline]
+    pub fn read<R: Read + ?Sized>(reader: &mut R) -> io::Result<Self> {
+        let mut buf = [0u8; Self::WIRE_LEN];
+        reader.read_exact(&mut buf)?;
+        Self::decode(buf).map_err(io::Error::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Upstream substitutes an all-zero `sum_struct` for a whole-file
+    /// transfer, `s2length` included; advertising a non-zero strong-sum width
+    /// there would describe blocks the body does not contain.
+    #[test]
+    fn whole_file_head_is_all_zero() {
+        assert_eq!(SumHead::WHOLE_FILE.encode(), [0u8; SumHead::WIRE_LEN]);
+        assert!(!SumHead::WHOLE_FILE.describes_blocks());
+        assert_eq!(SumHead::WHOLE_FILE.flength(), 0);
+    }
+
+    /// A whole-file head must reject every block index: a body that emits one
+    /// under this head is the stream that crashes upstream's receiver.
+    #[test]
+    fn whole_file_head_rejects_every_block_index() {
+        assert_eq!(
+            SumHead::WHOLE_FILE.block_span(0),
+            Err(SumHeadError::InvalidBlockIndex { index: 0, count: 0 })
+        );
+    }
+
+    /// The geometry upstream 3.4.4 writes for a 100 KiB basis, so the encoding
+    /// is pinned to observed bytes rather than to our own writer.
+    #[test]
+    fn encodes_the_upstream_geometry_for_a_100k_basis() {
+        let head = SumHead::with_blocks(147, 700, 2, 200).expect("valid geometry");
+        assert_eq!(
+            head.encode(),
+            [
+                0x93, 0, 0, 0, // count = 147
+                0xbc, 0x02, 0, 0, // blength = 700
+                0x02, 0, 0, 0, // s2length = 2
+                0xc8, 0, 0, 0, // remainder = 200
+            ]
+        );
+        assert_eq!(SumHead::decode(head.encode()), Ok(head));
+        assert_eq!(head.flength(), 102_400);
+    }
+
+    /// Only the final block is short, and only when `remainder` is set.
+    #[test]
+    fn block_span_shortens_only_the_final_block() {
+        let head = SumHead::with_blocks(147, 700, 2, 200).expect("valid geometry");
+        assert_eq!(head.block_span(0), Ok((0, 700)));
+        assert_eq!(head.block_span(145), Ok((145 * 700, 700)));
+        assert_eq!(head.block_span(146), Ok((146 * 700, 200)));
+        assert_eq!(
+            head.block_span(147),
+            Err(SumHeadError::InvalidBlockIndex {
+                index: 147,
+                count: 147,
+            })
+        );
+        assert_eq!(
+            head.block_span(-1),
+            Err(SumHeadError::InvalidBlockIndex {
+                index: -1,
+                count: 147,
+            })
+        );
+    }
+
+    /// An evenly divided basis leaves every block full-length.
+    #[test]
+    fn zero_remainder_keeps_the_final_block_full_length() {
+        let head = SumHead::with_blocks(4, 700, 2, 0).expect("valid geometry");
+        assert_eq!(head.block_span(3), Ok((3 * 700, 700)));
+        assert_eq!(head.flength(), 2800);
+    }
+
+    /// Blocks without a block length would each be empty, so the geometry is
+    /// refused at both construction and decode.
+    #[test]
+    fn blocks_without_a_block_length_are_malformed() {
+        assert_eq!(
+            SumHead::with_blocks(147, 0, 2, 0),
+            Err(SumHeadError::InvalidBlockLength { blength: 0 })
+        );
+        let mut bytes = [0u8; SumHead::WIRE_LEN];
+        bytes[0] = 0x93;
+        assert!(SumHead::decode(bytes).is_err());
+    }
+
+    /// Negative fields arrive as huge unsigned values and must be rejected by
+    /// the same ceilings upstream applies.
+    ///
+    /// Each case starts from a header that is otherwise valid, so the rejection
+    /// can only be attributed to the field under test - a blanket all-zero
+    /// buffer would let a bad `count` be caught by the `blength` rule instead.
+    #[test]
+    fn negative_fields_are_rejected() {
+        let valid = SumHead::with_blocks(4, 512, 16, 0).expect("valid geometry");
+        let negative = (-1i32).to_le_bytes();
+        let expected = [
+            SumHeadError::InvalidCount { count: -1 },
+            SumHeadError::InvalidBlockLength { blength: -1 },
+            SumHeadError::InvalidStrongSumLength { s2length: -1 },
+            SumHeadError::InvalidRemainder { remainder: -1 },
+        ];
+        for (field, want) in expected.into_iter().enumerate() {
+            let mut bytes = valid.encode();
+            bytes[field * 4..field * 4 + 4].copy_from_slice(&negative);
+            assert_eq!(SumHead::decode(bytes), Err(want), "field {field}");
+        }
+    }
+
+    #[test]
+    fn out_of_range_fields_are_rejected() {
+        assert_eq!(
+            SumHead::with_blocks(1, MAX_BLOCK_SIZE + 1, 2, 0),
+            Err(SumHeadError::InvalidBlockLength {
+                blength: (MAX_BLOCK_SIZE + 1) as i32,
+            })
+        );
+        assert_eq!(
+            SumHead::with_blocks(1, 700, MAX_STRONG_SUM_LEN + 1, 0),
+            Err(SumHeadError::InvalidStrongSumLength {
+                s2length: (MAX_STRONG_SUM_LEN + 1) as i32,
+            })
+        );
+        assert_eq!(
+            SumHead::with_blocks(1, 700, 2, 701),
+            Err(SumHeadError::InvalidRemainder { remainder: 701 })
+        );
+    }
+
+    #[test]
+    fn round_trips_through_a_stream() {
+        let head = SumHead::with_blocks(3, 1024, 16, 512).expect("valid geometry");
+        let mut buf = Vec::new();
+        head.write(&mut buf).expect("write");
+        assert_eq!(buf.len(), SumHead::WIRE_LEN);
+        assert_eq!(SumHead::read(&mut buf.as_slice()).expect("read"), head);
+    }
+
+    /// A rejected header maps to `RERR_PROTOCOL`, not a stream I/O error.
+    #[test]
+    fn reading_malformed_geometry_is_a_protocol_violation() {
+        let mut bytes = [0u8; SumHead::WIRE_LEN];
+        bytes[0] = 0x93;
+        let error = SumHead::read(&mut bytes.as_slice()).expect_err("malformed");
+        assert!(error.to_string().contains("malformed sum_head"));
+        assert!(
+            error
+                .get_ref()
+                .and_then(|inner| inner.downcast_ref::<crate::ProtocolViolation>())
+                .is_some(),
+            "a rejected sum_head must map to RERR_PROTOCOL, not RERR_STREAMIO"
+        );
+    }
+}

--- a/crates/protocol/src/wire/mod.rs
+++ b/crates/protocol/src/wire/mod.rs
@@ -37,6 +37,11 @@ pub use self::delta::{
     CHUNK_SIZE,
     // Internal format
     DeltaOp,
+    MAX_BLOCK_SIZE,
+    MAX_STRONG_SUM_LEN,
+    // Block geometry shared by a delta body and the head that describes it
+    SumHead,
+    SumHeadError,
     read_delta,
     read_delta_op,
     read_int,

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -174,13 +174,18 @@ impl SumHead {
 
     /// Writes the sum_head to the wire in rsync format.
     ///
-    /// All four fields are written as 32-bit little-endian integers.
+    /// All four fields are written as 32-bit little-endian integers. The
+    /// geometry is checked against the same rules the read path applies, so a
+    /// header this peer would reject is never one it emits.
     pub fn write<W: Write + ?Sized>(&self, writer: &mut W) -> io::Result<()> {
-        writer.write_all(&(self.count as i32).to_le_bytes())?;
-        writer.write_all(&(self.blength as i32).to_le_bytes())?;
-        writer.write_all(&(self.s2length as i32).to_le_bytes())?;
-        writer.write_all(&(self.remainder as i32).to_le_bytes())?;
-        Ok(())
+        protocol::wire::SumHead::with_blocks(
+            self.count,
+            self.blength,
+            self.s2length,
+            self.remainder,
+        )
+        .map_err(Self::malformed)?
+        .write(writer)
     }
 
     /// Decodes and validates a sum_head from its 16-byte little-endian wire
@@ -201,73 +206,23 @@ impl SumHead {
     /// - `io.c:2025-2067` - `read_sum_head()` validates every field and calls
     ///   `exit_cleanup(RERR_PROTOCOL)` on any out-of-range value.
     fn from_wire_bytes(buf: &[u8; 16]) -> io::Result<Self> {
-        // Fields are signed on the wire (write_int/read_int); decode as i32 so
-        // the negative-value guards below mirror upstream's `< 0` checks.
-        let count = i32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
-        let blength = i32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
-        let s2length = i32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
-        let remainder = i32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]);
-
-        // upstream: io.c:2029 - reject negative block count.
-        if count < 0 {
-            return Err(Self::malformed(format!("invalid checksum count {count}")));
-        }
-        // upstream: io.c:2039-2048 - guard against overflow in the downstream
-        // `count * per_entry_size` allocation arithmetic. Each signature block
-        // occupies `4 + s2length` wire bytes; MAX_STRONG_SUM_LEN bounds the
-        // second factor so the product cannot overflow usize.
-        let per_entry = 4usize + Self::MAX_STRONG_SUM_LEN;
-        if (count as usize).checked_mul(per_entry).is_none() {
-            return Err(Self::malformed(format!(
-                "invalid checksum count {count} (allocation overflow)"
-            )));
-        }
-        // upstream: io.c:2050-2054 - blength in (0, max_blength]. We use the
-        // legacy MAX_BLOCK_SIZE (1<<29) as the permissive ceiling so any header
-        // accepted by either protocol era is accepted here; a zero/negative
-        // block length is nonsense (division-by-zero) when count > 0.
-        if blength < 0
-            || blength as u32 > signature::MAX_BLOCK_SIZE_OLD
-            || (count > 0 && blength == 0)
-        {
-            return Err(Self::malformed(format!("invalid block length {blength}")));
-        }
-        // upstream: io.c:2056-2060 - s2length in [0, xfer_sum_len]. oc's longest
-        // negotiable transfer digest is SHA1 at MAX_STRONG_SUM_LEN (20) bytes.
-        if s2length < 0 || s2length as usize > Self::MAX_STRONG_SUM_LEN {
-            return Err(Self::malformed(format!(
-                "invalid checksum length {s2length}"
-            )));
-        }
-        // upstream: io.c:2061-2066 - remainder in [0, blength].
-        if remainder < 0 || remainder > blength {
-            return Err(Self::malformed(format!(
-                "invalid remainder length {remainder}"
-            )));
-        }
-
+        let head = protocol::wire::SumHead::decode(*buf).map_err(Self::malformed)?;
         Ok(Self {
-            count: count as u32,
-            blength: blength as u32,
-            s2length: s2length as u32,
-            remainder: remainder as u32,
+            count: head.count(),
+            blength: head.blength(),
+            s2length: head.s2length(),
+            remainder: head.remainder(),
         })
     }
-
-    /// Maximum strong-sum length accepted in a sum_head, in bytes.
-    ///
-    /// Mirrors upstream's `xfer_sum_len` ceiling (`io.c:2056`): the length of
-    /// the longest transfer checksum oc can negotiate. SHA1 (20 bytes) is the
-    /// longest supported transfer digest, so s2length may not exceed 20.
-    const MAX_STRONG_SUM_LEN: usize = 20;
 
     /// Builds a `RERR_PROTOCOL`-mapped error for a malformed sum_head field.
     ///
     /// upstream: io.c:2032-2065 `read_sum_head()` validates every field and
     /// calls `exit_cleanup(RERR_PROTOCOL)` (exit 2) on any out-of-range value.
     /// The error is tagged so the core exit-code mapper yields RERR_PROTOCOL(2)
-    /// rather than RERR_STREAMIO(12).
-    fn malformed(detail: String) -> io::Error {
+    /// rather than RERR_STREAMIO(12), and carries the role trailer upstream
+    /// prints via `who_am_i()`.
+    fn malformed(detail: protocol::wire::SumHeadError) -> io::Error {
         protocol::protocol_violation(format!(
             "malformed sum_head: {detail} {}{}",
             crate::role_trailer::error_location!(),

--- a/tests/batch_interop_test.sh
+++ b/tests/batch_interop_test.sh
@@ -266,8 +266,14 @@ test_oc_to_upstream() {
 
     cp "$work_dir/basis/testfile.bin" "$work_dir/final/testfile.bin"
 
+    # A delta batch must be replayed with the option set it was recorded
+    # under - that is exactly what upstream's generated "<batch>.sh" companion
+    # re-runs (batch.c:write_batch_shell_file). Replaying a delta batch bare
+    # crashes upstream 3.4.1 and 3.4.4 with SIGSEGV, reproducible with a batch
+    # upstream wrote itself, so a bare invocation here tests the wrong thing.
     log_info "Replaying batch with upstream rsync $version..."
-    if ! "$upstream_rsync" --read-batch="$work_dir/mybatch" "$work_dir/final/" > "$work_dir/read.log" 2>&1; then
+    if ! "$upstream_rsync" -a --no-whole-file --ignore-times \
+        --read-batch="$work_dir/mybatch" "$work_dir/final/" > "$work_dir/read.log" 2>&1; then
         cat "$work_dir/read.log" >&2
         record_fail "oc-to-upstream" "$version" "$test_name" \
             "upstream rsync --read-batch failed"

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -92,24 +92,19 @@ is_known_failure_from_conf() {
 
   # BATCH MODE cross-tool leg (tests/batch_interop_test.sh).
   # "oc-to-upstream" = oc-rsync --write-batch, upstream --read-batch.
-  # Two independent causes, split by upstream version. An unknown version is
-  # not suppressed: the caller could not identify the peer, so the result must
-  # be reported.
+  # Only the upstream cross-version header rejection remains exempt; a peer
+  # that can read a protocol-32 batch header must replay an oc-rsync delta
+  # batch cleanly (the whole-file-shaped sum_head gap of issue #6978 is
+  # fixed). An unknown version is not suppressed: the caller could not
+  # identify the peer, so the result must be reported.
   if [[ "$direction" == "batch" && "$name" == "oc-to-upstream" ]]; then
     [[ -n "$upstream_version" ]] || return 1
     if version_le "$upstream_version" \
          "$UPSTREAM_BATCH_PROTO32_UNREADABLE_UP_TO"; then
       BATCH_KNOWN_FAILURE_REASON="upstream <= ${UPSTREAM_BATCH_PROTO32_UNREADABLE_UP_TO} rejects a protocol-32 batch header (compat.c:163/167)"
-    else
-      # oc-rsync gap: oc records a whole-file-shaped sum_head (count=0,
-      # blength=0, s2length=16) for a delta batch, so upstream's receiver
-      # aborts with "Invalid block index 0 (count=0)" (receiver.c:417) or
-      # crashes. Deliberately not version-bounded - the batch harness reports
-      # an unexpected PASS as a failure, which is what forces this entry to be
-      # deleted the day the bug is fixed instead of silently outliving it.
-      BATCH_KNOWN_FAILURE_REASON="oc-rsync gap, issue #6978: delta batch body is not upstream's wire format"
+      return 0
     fi
-    return 0
+    return 1
   fi
 
   # oc-rsync RECEIVER over the wire (daemon/remote) drops named-user POSIX ACL


### PR DESCRIPTION
Closes #6978.

## Problem

`--write-batch` on a delta transfer recorded a batch upstream cannot replay. Upstream 3.4.4 aborts:

```
Invalid block index 0 (count=0) [receiver]
rsync error: protocol incompatibility (code 2) at receiver.c(417) [receiver=3.4.4]
```

and upstream 3.4.1 is worse - it accepts the stream and reconstructs the wrong bytes.

## Root cause

`begin_batch_file_delta()` emitted a fixed, whole-file-shaped `sum_head` **before** the executor knew what the body would contain:

```rust
const FILE_SUM_LENGTH: i32 = 16;
let count: i32 = 0;
let blength: i32 = 0;
let s2length: i32 = FILE_SUM_LENGTH;
let remainder: i32 = 0;
```

The delta executor then appended block-match tokens against a basis the header claimed did not exist. For a 100 KiB basis:

| field | upstream 3.4.4 | oc before | oc after |
|---|---|---|---|
| count | 147 | **0** | 147 |
| blength | 700 | **0** | 700 |
| s2length | 2 | 16 | 16 |
| remainder | 200 | **0** | 200 |

`count`, `blength` and `remainder` now match upstream byte for byte. `s2length` still reports 16 because that is the strong-sum width oc's local basis signature genuinely uses; the batch carries no block sums, upstream's receiver never reads the field on the replay path, and narrowing it to upstream's phase-1 value would mean matching blocks on 2-byte sums with no phase-2 redo to catch a collision. Reporting a width the signature does not have would be the same class of defect as the one being fixed.

The token stream itself was already correct: on a fixture with distinct block content, oc's delta body is **byte-identical** to upstream's.

**This is not the same defect as #6967.** That one was about *where* the trailer is written on the remote tee paths (`core/client/run/batch.rs`, `transfer/generator/`). This one is in the local-copy batch composer (`engine/local_copy/context_impl/options/batch.rs`), which synthesises the stream rather than teeing it. They share a theme - the batch was composed by parts that never checked each other - but no code and no root cause.

## Why it shipped

oc's reader was tolerant in exactly the complementary way:

```rust
let block_length = if block_length_wire > 0 { .. } else { choose_block_length(entry_size) };
let remainder    = if remainder_wire   > 0 { .. } else { block_length };
```

A zeroed header was silently replaced with a guess, and `count` was never checked at all - `dispatch.rs` even computed `block_count as u32 - 1`, which underflows at `count = 0`. oc read its own malformed batches perfectly, so oc-to-oc testing could never surface this.

The CI harness could not surface it either: `tests/batch_interop_test.sh` replayed the batch **bare**, with none of the options it was recorded under. A delta batch must be replayed with its recorded option set - that is precisely what upstream's generated `<batch>.sh` companion re-runs (`batch.c:write_batch_shell_file`). A bare replay **segfaults 3.4.1 and 3.4.4 on a batch upstream wrote itself**, verified with `--no-inc-recursive` so the bare invocation is accepted at all, so the leg could never have passed regardless of the writer. That is corrected here.

## Fix

**One owner for the invariant.** The geometry, its field-range rules (`io.c:read_sum_head`) and the block-index rule (`receiver.c:414`) now live in `protocol::wire::SumHead`, the layer `engine`, `batch` and `transfer` all share. `SumHead::block_span()` is the only way a block index becomes a byte range, so a header that does not describe its body fails there instead of being worked around.

`transfer`'s existing `SumHead` keeps its public API but delegates encode/decode to the shared type instead of carrying a second copy of the rules - and it now checks on write what it checks on read.

**Writer.** `begin_batch_file_delta()` reserves the 16 bytes with upstream's all-zero `null_sum`; the delta executor records the basis geometry through `record_batch_delta_geometry()` as it matches; `finalize_batch_file_delta()` patches the reserved slot. Every match token is validated against the recorded head as it is written, so a drift fails while writing rather than shipping a batch that only upstream rejects. A whole-file body records no geometry and keeps the all-zero head - which also fixes `s2length`, previously written as 16 where `io.c:write_sum_head()` sends 0.

**Reader.** The guessed block length is gone (`choose_block_length` deleted - it had no remaining production caller), and every copy token resolves through `block_span()`. oc now rejects the pre-fix batch with upstream's own diagnostic:

```
Invalid block index 0 (count=0) while replaying '.../r.~batch-tmp'
```

## Verification

Binaries banner-verified, never by path:

```
oc-rsync v0.6.4 (revision #7ea2c56f9) protocol version 32
rsync  version 3.4.4  protocol version 32
rsync  version 3.4.1  protocol version 32
```

Both fixtures from #6978 (100 KiB of `'A'` patched at 50000, and 100 KiB of zeros patched with 100 random bytes) recorded with `-a --no-whole-file --ignore-times --write-batch` and replayed under genuine 3.4.1 **and** 3.4.4: **exit 0, byte-identical destination** in all four combinations. Whole-file batches still replay clean under 3.4.1, 3.4.4 and oc itself.

`tests/batch_interop_test.sh` against real 3.4.1 and 3.4.4 - all seven legs pass:

```
oc-rsync roundtrip (write-batch -> read-batch): PASS
oc-rsync -> upstream 3.4.1: PASS
oc-rsync -> upstream 3.4.4: PASS
upstream 3.4.1 -> oc-rsync: PASS
upstream 3.4.4 -> oc-rsync: PASS
upstream 3.4.1 -z -> oc-rsync (compressed batch): PASS
upstream 3.4.4 -z -> oc-rsync (compressed batch): PASS
```

The same harness run against a pre-fix binary reports 2 failures, so the leg genuinely detects this defect.

New tests fail against the pre-fix writer (checked by reverting the patch step):

- `crates/engine/tests/write_batch_delta_sum_head.rs` - the recorded header must carry the basis geometry, must never be whole-file-shaped, and must survive the strict reader.
- `crates/protocol/src/wire/delta/sum_head.rs` - encoding pinned to bytes observed from upstream 3.4.4, the `receiver.c:414` index rule, and per-field rejection of every impossible geometry.

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings` are clean; `protocol`, `batch` and `transfer` are fully green.

Two `engine` permission tests (`execute_preserves_read_only_permissions`, `archive_preserves_mixed_permissions_across_files`) fail on this macOS host, and fail identically on a pristine `origin/master` worktree - pre-existing and unrelated.

## Notes

- The harness edit overlaps #6980, which makes these legs able to fail. If #6980 lands first this needs a trivial rebase; if this lands first, #6980 gets a leg that already passes.
- The 3.0.9 / 3.1.3 legs remain a genuine upstream limitation (`The protocol version in the batch file is too new (32 > 30)`, `compat.c(163)`), reproducible with a batch written by upstream 3.4.4 itself. Unrelated to this change and already scoped in `known_failures.conf`.
- Residual byte divergences from upstream in a delta batch, all pre-existing and accepted by upstream on replay: the 4-byte checksum seed, three bytes in the post-flist region, and the trailing stats values.
