### PR TITLE
fix(daemon): advertise our own digests in the client greeting

### DIFF
--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -222,13 +222,14 @@ pub fn compute_daemon_auth_response(
 /// upstream: compat.c:462 `get_default_nno_list()` walks
 /// `valid_auth_checksums_items[]` (checksum.c:71-84) in table order and joins the
 /// names with a single space. The list is never filtered by protocol version.
+///
+/// The names live in `protocol` because the client's `@RSYNCD:` greeting is built
+/// there and `protocol` sits below this crate. Deriving the string here instead
+/// would give the wire two producers that could drift apart;
+/// `advertised_digest_names_match_the_wire_table` pins them together.
 #[must_use]
 pub fn supported_daemon_digest_list() -> String {
-    SUPPORTED_DAEMON_DIGESTS
-        .iter()
-        .map(|digest| digest.name())
-        .collect::<Vec<_>>()
-        .join(" ")
+    protocol::daemon_auth_digest_list()
 }
 
 /// No digest offered by the client is supported by this implementation.
@@ -406,6 +407,21 @@ mod tests {
     #[test]
     fn advertised_digest_list_matches_upstream_order() {
         assert_eq!(supported_daemon_digest_list(), "sha512 sha256 sha1 md5 md4");
+    }
+
+    // The advertised names are spelled in `protocol` so the client greeting can
+    // reach them, while negotiation preference lives here in
+    // `SUPPORTED_DAEMON_DIGESTS`. The two orderings are the same fact, and a
+    // digest added to one but not the other would either be advertised and then
+    // refused, or supported and never offered. Neither is detectable from the
+    // list string alone, so compare the tables element by element.
+    #[test]
+    fn advertised_digest_names_match_the_wire_table() {
+        let preferred: Vec<&str> = SUPPORTED_DAEMON_DIGESTS
+            .iter()
+            .map(|digest| digest.name())
+            .collect();
+        assert_eq!(preferred, protocol::DAEMON_AUTH_DIGEST_NAMES.to_vec());
     }
 
     #[test]

--- a/crates/protocol/src/legacy/greeting/format.rs
+++ b/crates/protocol/src/legacy/greeting/format.rs
@@ -55,6 +55,55 @@ pub fn format_legacy_daemon_greeting(version: ProtocolVersion) -> String {
     banner
 }
 
+/// Daemon-auth digest names this build advertises, in upstream table order.
+///
+/// upstream: checksum.c:71-84 `valid_auth_checksums_items[]`. This is the wire
+/// spelling of the set, and the only place it is written down; `core::auth` maps
+/// its `DaemonAuthDigest` preference order onto this table and a lockstep test
+/// keeps the two from drifting.
+///
+/// The seeded `CSUM_MD4_OLD` variant is deliberately absent. It shares the `md4`
+/// token with plain MD4 and exists only as the sub-protocol-30 substitute for an
+/// *absent* list (compat.c:857-862), so advertising it would emit `md4` twice.
+pub const DAEMON_AUTH_DIGEST_NAMES: [&str; 5] = ["sha512", "sha256", "sha1", "md5", "md4"];
+
+/// Writes the advertised daemon-auth digest names, space separated, with no newline.
+///
+/// upstream: compat.c:462 `get_default_nno_list()` walks the table in order and
+/// joins the names with a single space.
+///
+/// # Errors
+///
+/// Propagates any error reported by `writer`.
+pub fn write_daemon_auth_digest_list<W: FmtWrite>(writer: &mut W) -> fmt::Result {
+    for (index, name) in DAEMON_AUTH_DIGEST_NAMES.iter().enumerate() {
+        if index > 0 {
+            writer.write_char(' ')?;
+        }
+        writer.write_str(name)?;
+    }
+
+    Ok(())
+}
+
+/// Returns the daemon-auth digest list this build advertises in its `@RSYNCD:` greeting.
+///
+/// The list states *our own* capabilities and is never derived from the peer's
+/// greeting, on either side of the connection: `output_daemon_greeting()`
+/// (compat.c:838-842) renders `get_default_nno_list()` and is called before the
+/// peer's greeting has even been read (clientserver.c:157 precedes the
+/// `read_line_old()` at clientserver.c:174).
+///
+/// It is likewise never filtered by protocol version. Verified against rsync
+/// 3.4.4: a client forced to `--protocol=28` still greets with
+/// `@RSYNCD: 28.0 sha512 sha256 sha1 md5 md4`.
+#[must_use]
+pub fn daemon_auth_digest_list() -> String {
+    let mut list = String::with_capacity(32);
+    write_daemon_auth_digest_list(&mut list).expect("writing to a String cannot fail");
+    list
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,5 +158,33 @@ mod tests {
     fn greeting_contains_version_and_minor() {
         let greeting = format_legacy_daemon_greeting(ProtocolVersion::V32);
         assert!(greeting.contains(".0"));
+    }
+
+    // upstream: checksum.c:71-84 joined by compat.c:462 `get_default_nno_list()`.
+    // Measured against rsync 3.4.4 driven at a stub daemon: every greeting it
+    // sends carries exactly this list, so the bytes are load-bearing.
+    #[test]
+    fn daemon_auth_digest_list_matches_upstream_bytes() {
+        assert_eq!(daemon_auth_digest_list(), "sha512 sha256 sha1 md5 md4");
+    }
+
+    // The seeded CSUM_MD4_OLD shares the "md4" token with plain MD4, so a table
+    // built by mapping over digest variants would advertise `md4` twice and
+    // upstream's parser would see a duplicate this build never intends to offer.
+    #[test]
+    fn daemon_auth_digest_names_are_unique() {
+        for (index, name) in DAEMON_AUTH_DIGEST_NAMES.iter().enumerate() {
+            assert!(
+                !DAEMON_AUTH_DIGEST_NAMES[..index].contains(name),
+                "{name} is advertised more than once",
+            );
+        }
+    }
+
+    #[test]
+    fn write_daemon_auth_digest_list_appends_without_newline() {
+        let mut sink = String::from("@RSYNCD: 28.0 ");
+        write_daemon_auth_digest_list(&mut sink).expect("writing to a String cannot fail");
+        assert_eq!(sink, "@RSYNCD: 28.0 sha512 sha256 sha1 md5 md4");
     }
 }

--- a/crates/protocol/src/legacy/greeting/mod.rs
+++ b/crates/protocol/src/legacy/greeting/mod.rs
@@ -11,7 +11,10 @@ mod tokens;
 mod types;
 mod validate;
 
-pub use format::{format_legacy_daemon_greeting, write_legacy_daemon_greeting};
+pub use format::{
+    DAEMON_AUTH_DIGEST_NAMES, daemon_auth_digest_list, format_legacy_daemon_greeting,
+    write_daemon_auth_digest_list, write_legacy_daemon_greeting,
+};
 pub use parse::{
     parse_legacy_daemon_greeting, parse_legacy_daemon_greeting_details,
     parse_legacy_daemon_greeting_owned,

--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -47,7 +47,11 @@ pub use bytes::{
 pub use greeting::write_legacy_daemon_greeting;
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every consumer
 pub use greeting::{
-    DigestListTokens, LegacyDaemonGreeting, LegacyDaemonGreetingOwned, MissingGreetingToken,
+    DAEMON_AUTH_DIGEST_NAMES, DigestListTokens, LegacyDaemonGreeting, LegacyDaemonGreetingOwned,
+    MissingGreetingToken, daemon_auth_digest_list, write_daemon_auth_digest_list,
+};
+#[allow(unused_imports)] // REASON: convenience re-export; not all items used in every consumer
+pub use greeting::{
     format_legacy_daemon_greeting, is_version_banner, missing_greeting_token,
     parse_legacy_daemon_greeting, parse_legacy_daemon_greeting_details,
     parse_legacy_daemon_greeting_owned,

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -178,8 +178,11 @@ pub use iconv::{
     converter_from_locale,
 };
 pub use legacy::{
-    DigestListTokens, LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN,
-    LegacyDaemonGreeting, LegacyDaemonGreetingOwned, LegacyDaemonMessage, MissingGreetingToken,
+    DAEMON_AUTH_DIGEST_NAMES, DigestListTokens, LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES,
+    LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonGreeting, LegacyDaemonGreetingOwned, LegacyDaemonMessage,
+    MissingGreetingToken, daemon_auth_digest_list, write_daemon_auth_digest_list,
+};
+pub use legacy::{
     format_legacy_daemon_greeting, format_legacy_daemon_message, is_version_banner,
     missing_greeting_token, parse_legacy_daemon_greeting, parse_legacy_daemon_greeting_bytes,
     parse_legacy_daemon_greeting_bytes_details, parse_legacy_daemon_greeting_bytes_owned,

--- a/crates/rsync_io/src/daemon/negotiate.rs
+++ b/crates/rsync_io/src/daemon/negotiate.rs
@@ -5,7 +5,7 @@ use crate::negotiation::{
 use logging::debug_log;
 use protocol::{
     LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonGreetingOwned, NegotiationPrologue,
-    NegotiationPrologueSniffer, ProtocolVersion,
+    NegotiationPrologueSniffer, ProtocolVersion, write_daemon_auth_digest_list,
 };
 use std::cmp;
 use std::io::{self, Read, Write};
@@ -61,7 +61,7 @@ where
 /// [`sniff_negotiation_stream`] (or its sniffer-backed counterpart) and drives
 /// the remainder of the daemon handshake without repeating the prologue
 /// detection. The stream is verified to contain the `@RSYNCD:` prefix before the
-/// greeting is parsed and echoed back to the server.
+/// server's greeting is parsed and this client's own greeting is sent.
 ///
 /// # Errors
 ///
@@ -116,17 +116,25 @@ where
     ))
 }
 
+/// Renders the client's `@RSYNCD:` greeting line.
+///
+/// The advertised digest list states *this build's* daemon-auth capabilities and
+/// is never derived from the server's greeting. Upstream cannot derive it even in
+/// principle: `exchange_protocols()` calls `output_daemon_greeting()`
+/// (clientserver.c:157) before `read_line_old()` has read the server's line
+/// (clientserver.c:174), so the client always renders its own
+/// `get_default_nno_list()` (compat.c:462). Echoing the server's list instead
+/// would let the server pick the digest out of a set it fully controls, since a
+/// name we confirm as ours is a name we have agreed to accept.
+///
+/// The list is also never filtered by protocol version. Verified against rsync
+/// 3.4.4: a client forced to `--protocol=28` still greets with
+/// `@RSYNCD: 28.0 sha512 sha256 sha1 md5 md4`.
 fn build_client_greeting(
     server_greeting: &LegacyDaemonGreetingOwned,
     negotiated_protocol: ProtocolVersion,
 ) -> Vec<u8> {
-    let mut greeting = String::with_capacity(
-        LEGACY_DAEMON_PREFIX.len()
-            + 16
-            + server_greeting
-                .digest_list()
-                .map_or(0, |list| list.len() + 1),
-    );
+    let mut greeting = String::with_capacity(LEGACY_DAEMON_PREFIX.len() + 48);
 
     greeting.push_str(LEGACY_DAEMON_PREFIX);
     greeting.push(' ');
@@ -140,10 +148,8 @@ fn build_client_greeting(
     };
     greeting.push_str(&fractional.to_string());
 
-    if let Some(digests) = server_greeting.digest_list() {
-        greeting.push(' ');
-        greeting.push_str(digests);
-    }
+    greeting.push(' ');
+    write_daemon_auth_digest_list(&mut greeting).expect("writing to a String cannot fail");
 
     greeting.push('\n');
     greeting.into_bytes()
@@ -210,31 +216,56 @@ mod tests {
         assert!(greeting_str.contains("29.0"), "got: {greeting_str}");
     }
 
+    // The greeting must state OUR capabilities, never the server's. Measured
+    // against rsync 3.4.4 driven at a stub advertising exactly `md4 md5 xxh3`:
+    // the client still answered `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4`.
+    // A server that advertises only weak names must not be able to make us
+    // confirm that narrowed set as our own, because a name we advertise is a
+    // name we have agreed to accept.
     #[test]
-    fn build_greeting_includes_digest_list_when_present() {
+    fn build_greeting_advertises_our_digests_not_the_servers() {
         let server = parse_greeting("@RSYNCD: 31.0 md4 md5 xxh3");
         let protocol = ProtocolVersion::from_supported(31).unwrap();
         let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.contains("md4 md5 xxh3"), "got: {greeting_str}");
+        assert_eq!(greeting, b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n");
     }
 
+    // upstream: clientserver.c:157 sends the greeting before clientserver.c:174
+    // reads the server's, so a server that names no list cannot suppress ours.
     #[test]
-    fn build_greeting_omits_digest_list_when_absent() {
+    fn build_greeting_advertises_digests_when_the_server_named_none() {
         let server = parse_greeting("@RSYNCD: 30.0");
         let protocol = ProtocolVersion::from_supported(30).unwrap();
         let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert_eq!(greeting_str.trim(), "@RSYNCD: 30.0");
+        assert_eq!(greeting, b"@RSYNCD: 30.0 sha512 sha256 sha1 md5 md4\n");
     }
 
+    // The narrowest possible restriction: a single weak name. Verified against
+    // rsync 3.4.4 under the same stub - the list it sends is unchanged.
     #[test]
-    fn build_greeting_with_single_digest() {
-        let server = parse_greeting("@RSYNCD: 31.0 xxh3");
+    fn build_greeting_ignores_a_single_digest_restriction() {
+        let server = parse_greeting("@RSYNCD: 31.0 md5");
         let protocol = ProtocolVersion::from_supported(31).unwrap();
         let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.contains(" xxh3"), "got: {greeting_str}");
+        assert_eq!(greeting, b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n");
+    }
+
+    // upstream: compat.c:838-842 `output_daemon_greeting()` emits
+    // `get_default_nno_list()` verbatim with no version filtering. Verified
+    // against rsync 3.4.4: `--protocol=28` through `--protocol=32` all send the
+    // identical five names, differing only in the version field.
+    #[test]
+    fn build_greeting_digest_list_is_protocol_independent() {
+        for version in [28u8, 29, 30, 31, 32] {
+            let server = parse_greeting(&format!("@RSYNCD: {version}.0"));
+            let protocol = ProtocolVersion::from_supported(version).unwrap();
+            let greeting = build_client_greeting(&server, protocol);
+            assert_eq!(
+                greeting,
+                format!("@RSYNCD: {version}.0 sha512 sha256 sha1 md5 md4\n").into_bytes(),
+                "protocol {version} must advertise the full list",
+            );
+        }
     }
 
     #[test]
@@ -282,26 +313,34 @@ mod tests {
     }
 
     #[test]
-    fn build_greeting_complete_without_digests() {
-        let server = parse_greeting("@RSYNCD: 30.0");
-        let protocol = ProtocolVersion::from_supported(30).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        assert_eq!(greeting, b"@RSYNCD: 30.0\n");
-    }
-
-    #[test]
-    fn build_greeting_complete_with_digests() {
-        let server = parse_greeting("@RSYNCD: 31.0 md5 xxh3");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        assert_eq!(greeting, b"@RSYNCD: 31.0 md5 xxh3\n");
-    }
-
-    #[test]
-    fn build_greeting_downgraded_with_digests() {
+    fn build_greeting_downgraded_still_advertises_our_digests() {
         let server = parse_greeting("@RSYNCD: 31.5 md4 md5");
         let protocol = ProtocolVersion::from_supported(29).unwrap();
         let greeting = build_client_greeting(&server, protocol);
-        assert_eq!(greeting, b"@RSYNCD: 29.0 md4 md5\n");
+        assert_eq!(greeting, b"@RSYNCD: 29.0 sha512 sha256 sha1 md5 md4\n");
+    }
+
+    // The greeting is a pure function of what WE support, so no combination of
+    // server-controlled digest names may change the bytes after the version.
+    #[test]
+    fn build_greeting_digest_list_is_independent_of_the_server_greeting() {
+        let protocol = ProtocolVersion::from_supported(31).unwrap();
+        let expected = b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n".to_vec();
+
+        for advertised in [
+            "@RSYNCD: 31.0",
+            "@RSYNCD: 31.0 md5",
+            "@RSYNCD: 31.0 sha512 md5",
+            "@RSYNCD: 31.0 md4",
+            "@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4",
+            "@RSYNCD: 31.0 blake3 sponge",
+        ] {
+            let server = parse_greeting(advertised);
+            assert_eq!(
+                build_client_greeting(&server, protocol),
+                expected,
+                "server greeting {advertised:?} must not change our advertised list",
+            );
+        }
     }
 }

--- a/crates/rsync_io/src/daemon/tests/common.rs
+++ b/crates/rsync_io/src/daemon/tests/common.rs
@@ -1,5 +1,20 @@
 use std::io::{self, Cursor, Read, Write};
 
+/// The `@RSYNCD:` line the client sends once the legacy handshake completes.
+///
+/// The greeting's exact contents - in particular that the advertised digest list
+/// is this build's own and not the server's - are pinned by literal-byte
+/// assertions in `daemon::negotiate`'s unit tests. Here the line is incidental:
+/// these tests check that it survives the stream wrappers intact, so they name it
+/// rather than restate it.
+pub(super) fn client_greeting(version: u8) -> Vec<u8> {
+    format!(
+        "@RSYNCD: {version}.0 {}\n",
+        protocol::daemon_auth_digest_list()
+    )
+    .into_bytes()
+}
+
 #[derive(Clone, Debug)]
 pub(super) struct MemoryTransport {
     reader: Cursor<Vec<u8>>,

--- a/crates/rsync_io/src/daemon/tests/mapping.rs
+++ b/crates/rsync_io/src/daemon/tests/mapping.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use super::common::{InstrumentedTransport, MemoryTransport};
+use super::common::{InstrumentedTransport, MemoryTransport, client_greeting};
 use protocol::ProtocolVersion;
 use std::io::{self, Write};
 
@@ -33,7 +33,10 @@ fn map_stream_inner_preserves_state_and_transforms_transport() {
 
     let inner = instrumented.into_inner();
     assert_eq!(inner.flushes(), 2);
-    assert_eq!(inner.written(), b"@RSYNCD: 31.0\n@RSYNCD: OK\n");
+    assert_eq!(
+        inner.written(),
+        [client_greeting(31), b"@RSYNCD: OK\n".to_vec()].concat()
+    );
 }
 
 #[test]
@@ -88,7 +91,10 @@ fn parts_map_stream_inner_transforms_transport() {
     assert_eq!(instrumented.flushes(), 1);
 
     let inner = instrumented.into_inner();
-    assert_eq!(inner.written(), b"@RSYNCD: 31.0\nOK\n");
+    assert_eq!(
+        inner.written(),
+        [client_greeting(31), b"OK\n".to_vec()].concat()
+    );
 }
 
 #[test]
@@ -167,5 +173,5 @@ fn try_map_stream_inner_preserves_original_on_error() {
     assert_eq!(err.error().kind(), io::ErrorKind::Other);
     let original = err.into_original();
     let transport = original.into_stream().into_inner();
-    assert_eq!(transport.written(), b"@RSYNCD: 31.0\n");
+    assert_eq!(transport.written(), client_greeting(31));
 }

--- a/crates/rsync_io/src/daemon/tests/negotiation.rs
+++ b/crates/rsync_io/src/daemon/tests/negotiation.rs
@@ -1,9 +1,9 @@
 use super::super::*;
-use super::common::MemoryTransport;
+use super::common::{MemoryTransport, client_greeting};
 use crate::RemoteProtocolAdvertisement;
 use protocol::{
     LEGACY_DAEMON_PREFIX_LEN, NegotiationError, NegotiationPrologue, NegotiationPrologueSniffer,
-    ProtocolVersion, format_legacy_daemon_greeting,
+    ProtocolVersion,
 };
 use std::io::{self, Read, Write};
 
@@ -31,7 +31,7 @@ fn negotiate_legacy_daemon_session_exchanges_banners() {
     assert!(!handshake.local_protocol_was_capped());
 
     let transport = handshake.into_stream().into_inner();
-    assert_eq!(transport.written(), b"@RSYNCD: 31.0\n");
+    assert_eq!(transport.written(), client_greeting(31));
     assert_eq!(transport.flushes(), 1);
 }
 
@@ -68,7 +68,7 @@ fn negotiate_respects_requested_protocol_cap() {
     );
 
     let transport = parts.into_handshake().into_stream().into_inner();
-    assert_eq!(transport.written(), b"@RSYNCD: 30.0\n");
+    assert_eq!(transport.written(), client_greeting(30));
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn negotiate_clamps_future_advertisement() {
     );
 
     let transport = parts.into_handshake().into_stream().into_inner();
-    assert_eq!(transport.written(), b"@RSYNCD: 32.0\n");
+    assert_eq!(transport.written(), client_greeting(32));
 }
 
 #[test]
@@ -167,7 +167,10 @@ fn into_parts_round_trips_legacy_handshake() {
 
     let transport = rebuilt.into_stream().into_inner();
     assert_eq!(transport.flushes(), 2);
-    assert_eq!(transport.written(), b"@RSYNCD: 31.0\n@RSYNCD: OK\n");
+    assert_eq!(
+        transport.written(),
+        [client_greeting(31), b"@RSYNCD: OK\n".to_vec()].concat()
+    );
 }
 
 #[test]
@@ -257,10 +260,7 @@ fn into_stream_parts_exposes_legacy_state() {
 
     let transport = stream.into_inner();
     assert_eq!(transport.flushes(), 1);
-    assert_eq!(
-        transport.written(),
-        format_legacy_daemon_greeting(negotiated).as_bytes()
-    );
+    assert_eq!(transport.written(), client_greeting(negotiated.as_u8()));
 }
 
 #[test]
@@ -320,9 +320,12 @@ fn from_stream_parts_rehydrates_legacy_handshake() {
     let transport = rehydrated.into_stream().into_inner();
     assert_eq!(transport.flushes(), 2);
 
-    let mut expected = format_legacy_daemon_greeting(negotiated);
-    expected.push_str("@RSYNCD: OK\n");
-    assert_eq!(transport.written(), expected.as_bytes());
+    let expected = [
+        client_greeting(negotiated.as_u8()),
+        b"@RSYNCD: OK\n".to_vec(),
+    ]
+    .concat();
+    assert_eq!(transport.written(), expected);
 }
 
 #[test]
@@ -349,9 +352,22 @@ fn legacy_handshake_round_trips_from_components() {
     assert_eq!(rebuilt.stream().buffered(), expected_buffer.as_slice());
 }
 
+/// The client must advertise its own digest set, never the server's.
+///
+/// The stub restricts its advertisement to `sha512 md5`, which is what makes
+/// this test able to fail: a client that echoed would answer `sha512 md5`.
+/// Measured against rsync 3.4.4 driven at a stub sending this exact greeting -
+/// it answers with the full five-name list below, byte for byte.
+///
+/// This matters beyond formatting. The advertised list states which digests we
+/// have agreed to accept, so echoing lets a malicious or compromised server
+/// narrow the negotiation to a set it chose - it can advertise only weak
+/// algorithms and have the client confirm them as its own, removing the
+/// client's floor. Upstream cannot do this even accidentally: the greeting goes
+/// out at clientserver.c:157, before the server's is read at clientserver.c:174.
 #[test]
-fn legacy_client_greeting_echoes_digest_list() {
-    let transport = MemoryTransport::new(b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n");
+fn legacy_client_greeting_advertises_our_digests_not_the_servers() {
+    let transport = MemoryTransport::new(b"@RSYNCD: 31.0 sha512 md5\n");
 
     let handshake = negotiate_legacy_daemon_session(transport, ProtocolVersion::NEWEST)
         .expect("handshake should succeed");
@@ -369,6 +385,29 @@ fn legacy_client_greeting_echoes_digest_list() {
     );
 }
 
+/// The narrowest restriction a server can attempt: a single weak digest.
+///
+/// Verified against rsync 3.4.4 under a stub advertising exactly `md5` - its
+/// greeting is unchanged from the unrestricted case.
+#[test]
+fn legacy_client_greeting_ignores_a_single_weak_server_digest() {
+    let transport = MemoryTransport::new(b"@RSYNCD: 31.0 md5\n");
+
+    let handshake = negotiate_legacy_daemon_session(transport, ProtocolVersion::NEWEST)
+        .expect("handshake should succeed");
+
+    let inner = handshake.into_stream().into_inner();
+    assert_eq!(
+        inner.written(),
+        b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n"
+    );
+}
+
+/// Capping the protocol changes the version field and nothing else.
+///
+/// upstream: compat.c:838-842 emits `get_default_nno_list()` verbatim, so the
+/// list is never filtered by version. Verified against rsync 3.4.4:
+/// `--protocol=29` sends `@RSYNCD: 29.0 sha512 sha256 sha1 md5 md4`.
 #[test]
 fn legacy_client_greeting_respects_protocol_cap() {
     let desired = ProtocolVersion::from_supported(29).expect("protocol 29 supported");
@@ -386,6 +425,6 @@ fn legacy_client_greeting_respects_protocol_cap() {
     let inner = stream.into_inner();
     assert_eq!(
         inner.written(),
-        b"@RSYNCD: 29.0 sha512 sha256\n@RSYNCD: OK\n"
+        b"@RSYNCD: 29.0 sha512 sha256 sha1 md5 md4\n@RSYNCD: OK\n"
     );
 }

--- a/crates/rsync_io/src/daemon/tests/parts.rs
+++ b/crates/rsync_io/src/daemon/tests/parts.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use super::common::MemoryTransport;
+use super::common::{MemoryTransport, client_greeting};
 use crate::RemoteProtocolAdvertisement;
 use protocol::ProtocolVersion;
 use std::io::Write;
@@ -38,5 +38,8 @@ fn parts_stream_parts_mut_allows_inner_mutation() {
 
     let inner = parts.into_handshake().into_stream().into_inner();
     assert_eq!(inner.flushes(), 2);
-    assert_eq!(inner.written(), b"@RSYNCD: 31.0\n@RSYNCD: OK\n");
+    assert_eq!(
+        inner.written(),
+        [client_greeting(31), b"@RSYNCD: OK\n".to_vec()].concat()
+    );
 }

--- a/crates/rsync_io/src/session/tests/basics.rs
+++ b/crates/rsync_io/src/session/tests/basics.rs
@@ -88,7 +88,7 @@ fn negotiate_session_detects_legacy_transport() {
         Err(_) => panic!("legacy handshake expected"),
     };
 
-    assert_eq!(transport.writes(), b"@RSYNCD: 31.0\n");
+    assert_eq!(transport.writes(), client_greeting(31));
     assert_eq!(transport.flushes(), 1);
 }
 
@@ -244,7 +244,7 @@ fn session_into_inner_returns_legacy_transport() {
         negotiate_session(transport, ProtocolVersion::NEWEST).expect("legacy handshake succeeds");
 
     let mut raw = handshake.into_inner();
-    assert_eq!(raw.writes(), b"@RSYNCD: 31.0\n");
+    assert_eq!(raw.writes(), client_greeting(31));
     assert_eq!(raw.flushes(), 1);
 
     let mut replay = Vec::new();
@@ -282,7 +282,7 @@ fn session_parts_into_inner_returns_legacy_transport() {
         negotiate_session_parts(transport, ProtocolVersion::NEWEST).expect("legacy parts succeed");
 
     let mut raw = parts.into_inner();
-    assert_eq!(raw.writes(), b"@RSYNCD: 31.0\n");
+    assert_eq!(raw.writes(), client_greeting(31));
     assert_eq!(raw.flushes(), 1);
 
     let mut replay = Vec::new();
@@ -338,7 +338,7 @@ fn negotiate_session_parts_from_stream_handles_legacy_transport() {
     assert_eq!(greeting.advertised_protocol(), 31);
 
     let transport = parts.into_handshake().into_inner();
-    assert_eq!(transport.writes(), b"@RSYNCD: 31.0\n");
+    assert_eq!(transport.writes(), client_greeting(31));
     assert_eq!(transport.flushes(), 1);
 }
 
@@ -387,7 +387,7 @@ fn negotiate_session_parts_exposes_legacy_metadata() {
 
     let stream_parts = legacy_parts.into_stream_parts();
     let transport = stream_parts.into_stream().into_inner();
-    assert_eq!(transport.writes(), b"@RSYNCD: 31.0\n");
+    assert_eq!(transport.writes(), client_greeting(31));
     assert_eq!(transport.flushes(), 1);
 }
 
@@ -446,7 +446,7 @@ fn negotiate_session_parts_with_sniffer_supports_reuse() {
 
     let (_greeting, _negotiated, stream_parts) = parts2.into_legacy().expect("legacy parts");
     let transport2 = stream_parts.into_stream().into_inner();
-    assert_eq!(transport2.writes(), b"@RSYNCD: 31.0\n");
+    assert_eq!(transport2.writes(), client_greeting(31));
     assert_eq!(transport2.flushes(), 1);
 }
 
@@ -492,6 +492,6 @@ fn negotiate_session_with_sniffer_supports_reuse() {
         .expect("second handshake is legacy")
         .into_stream()
         .into_inner();
-    assert_eq!(transport2.writes(), b"@RSYNCD: 31.0\n");
+    assert_eq!(transport2.writes(), client_greeting(31));
     assert_eq!(transport2.flushes(), 1);
 }

--- a/crates/rsync_io/src/session/tests/clones.rs
+++ b/crates/rsync_io/src/session/tests/clones.rs
@@ -173,12 +173,12 @@ fn session_handshake_parts_clone_preserves_legacy_stream_state() {
     let original_transport = legacy.into_stream().into_inner();
     let cloned_transport = cloned.into_stream().into_inner();
 
-    let mut expected_original = format_legacy_daemon_greeting(negotiated).into_bytes();
+    let mut expected_original = client_greeting(negotiated.as_u8());
     expected_original.extend_from_slice(b"module\n");
     assert_eq!(original_transport.writes(), expected_original.as_slice());
     assert_eq!(original_transport.flushes(), 1);
 
-    let mut expected_clone = format_legacy_daemon_greeting(negotiated).into_bytes();
+    let mut expected_clone = client_greeting(negotiated.as_u8());
     expected_clone.extend_from_slice(b"other\n");
     assert_eq!(cloned_transport.writes(), expected_clone.as_slice());
     assert_eq!(cloned_transport.flushes(), 1);
@@ -457,6 +457,6 @@ fn session_handshake_parts_from_legacy_components_round_trips() {
         .into_stream()
         .into_inner();
 
-    assert_eq!(transport.writes(), b"@RSYNCD: 31.0\n");
+    assert_eq!(transport.writes(), client_greeting(31));
     assert_eq!(transport.flushes(), 1);
 }

--- a/crates/rsync_io/src/session/tests/mapping.rs
+++ b/crates/rsync_io/src/session/tests/mapping.rs
@@ -72,7 +72,7 @@ fn as_variant_mut_helpers_allow_mutating_streams() {
         .expect("handshake remains legacy")
         .into_stream()
         .into_inner();
-    let mut expected = b"@RSYNCD: 31.0\n".to_vec();
+    let mut expected = client_greeting(31);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.writes(), expected.as_slice());
 }

--- a/crates/rsync_io/src/session/tests/mod.rs
+++ b/crates/rsync_io/src/session/tests/mod.rs
@@ -6,9 +6,7 @@ use crate::daemon::{
 };
 use crate::negotiation::{NEGOTIATION_PROLOGUE_UNDETERMINED_MSG, NegotiatedStream};
 use crate::sniff_negotiation_stream;
-use protocol::{
-    NegotiationPrologue, NegotiationPrologueSniffer, ProtocolVersion, format_legacy_daemon_greeting,
-};
+use protocol::{NegotiationPrologue, NegotiationPrologueSniffer, ProtocolVersion};
 use std::convert::TryFrom;
 use std::io::{self, Cursor, Read, Write};
 

--- a/crates/rsync_io/src/session/tests/roundtrip.rs
+++ b/crates/rsync_io/src/session/tests/roundtrip.rs
@@ -188,7 +188,7 @@ fn session_handshake_parts_round_trip_legacy_handshake() {
         .expect("write succeeds");
 
     let transport = legacy.into_stream().into_inner();
-    let mut expected = b"@RSYNCD: 31.0\n".to_vec();
+    let mut expected = client_greeting(31);
     expected.extend_from_slice(b"module\n");
     assert_eq!(transport.writes(), expected.as_slice());
     assert_eq!(transport.flushes(), 1);

--- a/crates/rsync_io/src/session/tests/support.rs
+++ b/crates/rsync_io/src/session/tests/support.rs
@@ -81,3 +81,18 @@ impl Write for InstrumentedTransport {
 pub(crate) fn binary_handshake_bytes(version: ProtocolVersion) -> [u8; 4] {
     u32::from(version.as_u8()).to_le_bytes()
 }
+
+/// The `@RSYNCD:` line the client sends once the legacy handshake completes.
+///
+/// The greeting's exact contents - in particular that the advertised digest list
+/// is this build's own and not the server's - are pinned by literal-byte
+/// assertions in `daemon::negotiate`'s unit tests. Here the line is incidental:
+/// these tests check that it survives the stream wrappers intact, so they name it
+/// rather than restate it.
+pub(crate) fn client_greeting(version: u8) -> Vec<u8> {
+    format!(
+        "@RSYNCD: {version}.0 {}\n",
+        protocol::daemon_auth_digest_list()
+    )
+    .into_bytes()
+}


### PR DESCRIPTION
## Problem

The module-listing client built its `@RSYNCD:` greeting from the digest list the server had just advertised, echoing it back verbatim:

```rust
if let Some(digests) = server_greeting.digest_list() {
    greeting.push(' ');
    greeting.push_str(digests);   // the SERVER's list
}
```

The advertised list is meant to state the sender's own capabilities. Echoing it means the negotiated daemon-auth digest is chosen from a set the **server controls entirely** — a malicious or compromised daemon can advertise only weak algorithms and have the client confirm them as its own, removing the client's floor. A name we advertise is a name we have agreed to accept.

This is the mirror image of the auth-verify digest issue fixed in #6971, with the roles reversed.

## Upstream behaviour

Upstream cannot derive the greeting from the peer even in principle. `exchange_protocols()` calls `output_daemon_greeting()` at clientserver.c:157, *before* `read_line_old()` reads the server's line at clientserver.c:174. The greeting is always its own `get_default_nno_list()` (compat.c:462 over the `valid_auth_checksums_items[]` table at checksum.c:71-84), and is never filtered by protocol version.

## Measured against rsync 3.4.4

Driving `/opt/homebrew/bin/rsync` (`rsync version 3.4.4 protocol version 32`, confirmed from the `--version` banner) and `oc-rsync` at the same stub daemon and capturing the client's greeting line:

| stub advertises | upstream 3.4.4 | oc before | oc after |
|---|---|---|---|
| `sha512 md5` | `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4` | `@RSYNCD: 32.0 sha512 md5` | `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4` |
| `md5` | `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4` | `@RSYNCD: 32.0 md5` | `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4` |
| `md4` | `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4` | `@RSYNCD: 32.0 md4` | `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4` |
| (no list) | `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4` | `@RSYNCD: 32.0` | `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4` |

All four are now byte-for-byte identical to upstream. `--protocol=28` through `--protocol=32` likewise match, differing only in the version field — confirming the list is protocol-independent on both sides.

The greeting being right is necessary but not sufficient, so the digest actually negotiated afterwards was checked too, driving a full `AUTHREQD` exchange and identifying the digest from the response:

| stub advertises | upstream 3.4.4 | oc after |
|---|---|---|
| `md5 sha512` | sha512 | sha512 |
| `sha512 md5` | sha512 | sha512 |
| `sha1 md5` | sha1 | sha1 |
| `md5` | md5 | md5 |

The `md5 sha512` row is the discriminating one: the server lists the weak digest first and both clients still choose SHA-512, so *our* preference order decides among the mutually supported names rather than the server's ordering (compat.c:333-356 with `am_server == 0`).

## Single source for the list

The advertised names move into `protocol`, which sits below both `core` and `rsync_io` and already owns the greeting types. `rsync_io` cannot depend on `core` — `core` already depends on `rsync_io`, so that direction is a cycle — which is why leaving the table in `core::auth` would have required a second producer of the same wire string.

`core::auth::supported_daemon_digest_list()` now delegates to it, and a new `advertised_digest_names_match_the_wire_table` pins the negotiation preference order in `SUPPORTED_DAEMON_DIGESTS` against the wire table element by element. A digest added to one but not the other would either be advertised and then refused, or supported and never offered — neither is visible from the list string alone.

The seeded `CSUM_MD4_OLD` stays out of the table deliberately: it shares the `md4` token with plain MD4 and exists only as the sub-protocol-30 substitute for an *absent* list (compat.c:857-862), so including it would advertise `md4` twice.

## The test that pinned the wrong contract

`legacy_client_greeting_echoes_digest_list` asserted the echo behaviour, but could not actually detect it — its stub advertised the full five-name list, so echoing and advertising our own produced identical bytes. It was a vacuous guard for the property its name claimed.

It is replaced by tests whose stubs advertise **restricted** lists, so they discriminate. Against the pre-fix code, 9 tests fail:

```
FAIL daemon::negotiate::tests::build_greeting_advertises_our_digests_not_the_servers
FAIL daemon::negotiate::tests::build_greeting_advertises_digests_when_the_server_named_none
FAIL daemon::negotiate::tests::build_greeting_ignores_a_single_digest_restriction
FAIL daemon::negotiate::tests::build_greeting_digest_list_is_protocol_independent
FAIL daemon::negotiate::tests::build_greeting_digest_list_is_independent_of_the_server_greeting
FAIL daemon::negotiate::tests::build_greeting_downgraded_still_advertises_our_digests
FAIL daemon::tests::negotiation::legacy_client_greeting_advertises_our_digests_not_the_servers
FAIL daemon::tests::negotiation::legacy_client_greeting_ignores_a_single_weak_server_digest
FAIL daemon::tests::negotiation::legacy_client_greeting_respects_protocol_cap
```

All pass after. Tests where the greeting is incidental plumbing now name it through a `client_greeting()` helper rather than restating the bytes; the bytes themselves stay as literal assertions in the tests that pin the contract.

## Verification

- `cargo nextest run -p protocol -p rsync_io -p core -p daemon --all-features` — 11543 passed, 78 skipped
- `cargo nextest run --workspace -E 'binary(/daemon/)'` — 1867 passed, 61 skipped
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Note on #6981

#6981 (`fix/daemon-empty-digest-list-refusal`) is still open and touches `crates/rsync_io/src/daemon/negotiate.rs`, renaming `digest_list()` to `digest_names()` at the two call sites this PR **deletes**, plus `crates/core/src/auth/mod.rs` where it re-documents `supported_daemon_digest_list()` just above the body changed here. Both resolve trivially in favour of this deletion/delegation, but whichever lands second should expect to resolve them. #6981 also removes `digests_for_protocol`, the version-filtered third producer of this list, which is complementary to the consolidation here.

## Out of scope, filed separately

The same function still derives the greeting's **protocol version and subprotocol** from the server. Upstream sends its own: against a `@RSYNCD: 30.0 md5 md4` stub, rsync 3.4.4 still answers `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4`. The subprotocol echo is a live divergence — an upstream daemon does `if (protocol_version == remote_protocol && remote_sub != our_sub) protocol_version--` (clientserver.c:217-219), so echoing its subprotocol suppresses a decrement that should occur. Left for a separate change to keep this one scoped to the security fix.
