### PR TITLE
ci: raise soak daemon listen backlog above accept-queue overflow

### DIFF
--- a/.github/workflows/bench-daemon-concurrency.yml
+++ b/.github/workflows/bench-daemon-concurrency.yml
@@ -91,10 +91,19 @@ jobs:
           # Pick a free localhost port for the oc-rsync daemon.
           OC_PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')"
 
+          # This job regression-tests the daemon's concurrency CEILING, not
+          # the kernel accept queue. The upstream-faithful default backlog of
+          # 5 (daemon-parm.txt: listen_backlog) overflows under 64 parallel
+          # connects, resetting a handful of pulls before the greeting (job
+          # 89938299936 saw 8/3000 pulls die rc=12 with the daemon healthy).
+          # Raise the backlog explicitly so accept-queue overflow - which is
+          # upstream-faithful behaviour and not under test here - cannot fail
+          # the soak.
           cat > "$WORK/oc-rsyncd.conf" <<CONF
           use chroot = no
           port = $OC_PORT
           max connections = ${DAEMON_MAX_CONNECTIONS}
+          listen backlog = 128
           pid file = $WORK/oc-rsyncd.pid
           log file = $WORK/oc-rsyncd.log
           [soak]

--- a/crates/daemon/src/daemon/runtime_options/tests.rs
+++ b/crates/daemon/src/daemon/runtime_options/tests.rs
@@ -484,6 +484,40 @@ mod runtime_options_tests {
     }
 
     #[test]
+    fn parse_config_without_listen_backlog_leaves_option_unset() {
+        // upstream: daemon-parm.txt declares `INTEGER listen_backlog 5`. An
+        // absent directive must leave the option unset so the accept loop
+        // falls back to DEFAULT_LISTEN_BACKLOG, pinned at upstream's 5 by
+        // default_listen_backlog_matches_upstream.
+        let mut file = NamedTempFile::new().expect("config file");
+        writeln!(file, "[share]\npath = /srv/share\n").expect("write config");
+
+        let args = vec![
+            OsString::from("--config"),
+            file.path().as_os_str().to_os_string(),
+        ];
+        let options = RuntimeOptions::parse(&args).expect("parse");
+        assert_eq!(options.listen_backlog(), None);
+    }
+
+    #[test]
+    fn parse_config_listen_backlog_directive_overrides_default() {
+        // upstream: socket.c:554 passes lp_listen_backlog() to listen(2), so
+        // a configured `listen backlog` must reach RuntimeOptions intact or
+        // the directive is cosmetic and the accept queue silently stays at 5.
+        let mut file = NamedTempFile::new().expect("config file");
+        writeln!(file, "listen backlog = 128\n[share]\npath = /srv/share\n")
+            .expect("write config");
+
+        let args = vec![
+            OsString::from("--config"),
+            file.path().as_os_str().to_os_string(),
+        ];
+        let options = RuntimeOptions::parse(&args).expect("parse");
+        assert_eq!(options.listen_backlog(), Some(128));
+    }
+
+    #[test]
     fn unsupported_option_is_rejected() {
         let args = vec![OsString::from("--unknown-option")];
         let result = RuntimeOptions::parse(&args);


### PR DESCRIPTION
## Summary

The "Daemon concurrency ceiling regression" job is probabilistically red by design: it asserts 0 failed pulls while firing `SOAK_PARALLELISM=64` concurrent connects into the daemon's upstream-default listen backlog of 5.

In job 89938299936, 8 of 3000 pulls died with rc=12 ("Connection reset by peer" on the first greeting byte); daemon-side accounting showed those 8 never reached arg-read and the daemon stayed healthy with bounded RSS. That is kernel accept-queue overflow, and it is upstream-faithful behaviour: `daemon-parm.txt` declares `INTEGER listen_backlog 5` and `socket.c:554` passes `lp_listen_backlog()` to `listen(2)`, which oc-rsync mirrors.

## Changes

- The soak's embedded rsyncd config now sets `listen backlog = 128` explicitly, with a comment explaining why: the job regression-tests the concurrency ceiling, not the default backlog's overflow behaviour.
- Two runtime-options tests pin the directive's semantics: an absent directive leaves the option unset (the accept loop then falls back to `DEFAULT_LISTEN_BACKLOG`, pinned at upstream's 5 by `default_listen_backlog_matches_upstream`), and a configured `listen backlog = 128` reaches `RuntimeOptions` intact.

The directive's plumbing was verified end-to-end before making this change: config parse (`dispatch.rs`) -> `RuntimeOptions` (`config.rs`) -> accept loop (`accept_loop.rs`) -> `bind_with_backlog` -> `socket.listen(backlog)` (`listener.rs`), so the config change genuinely deepens the accept queue.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`
- `cargo nextest run -p daemon --all-features -E 'test(listen_backlog)'` - 3 passed
- Workflow YAML validated
