### PR TITLE
fix(tests): anchor upstream-binary lookups at the workspace root

### DIFF
--- a/crates/core/benches/transfer_benchmark.rs
+++ b/crates/core/benches/transfer_benchmark.rs
@@ -24,9 +24,13 @@ use std::time::{Duration, Instant};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tempfile::TempDir;
 
-// Upstream binary paths
-const UPSTREAM_341: &str = "target/interop/upstream-install/3.4.1/bin/rsync";
-const OC_RSYNC: &str = "target/release/oc-rsync";
+// Binary paths, anchored at the workspace root at compile time; benches run
+// with CWD `crates/core/`, where a CWD-relative path would never resolve.
+const UPSTREAM_341: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../target/interop/upstream-install/3.4.1/bin/rsync"
+);
+const OC_RSYNC: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/release/oc-rsync");
 
 // Port allocation for benchmarks
 static NEXT_PORT: AtomicU16 = AtomicU16::new(14000);

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -30,15 +30,29 @@ const DEFAULT_READY_TIMEOUT: Duration = Duration::from_secs(5);
 /// Polling interval for TCP readiness probe.
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-/// Upstream rsync binary paths (relative to workspace root).
+/// Upstream rsync binary paths, anchored at the workspace root at compile
+/// time. Cargo runs these tests with CWD `crates/core/`, so a path relative
+/// to the CWD would never resolve and every consumer would silently skip.
 #[allow(dead_code)]
-pub const UPSTREAM_3_0_9: &str = "target/interop/upstream-install/3.0.9/bin/rsync";
+pub const UPSTREAM_3_0_9: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../target/interop/upstream-install/3.0.9/bin/rsync"
+);
 #[allow(dead_code)]
-pub const UPSTREAM_3_1_3: &str = "target/interop/upstream-install/3.1.3/bin/rsync";
+pub const UPSTREAM_3_1_3: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../target/interop/upstream-install/3.1.3/bin/rsync"
+);
 #[allow(dead_code)]
-pub const UPSTREAM_3_4_1: &str = "target/interop/upstream-install/3.4.1/bin/rsync";
+pub const UPSTREAM_3_4_1: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../target/interop/upstream-install/3.4.1/bin/rsync"
+);
 #[allow(dead_code)]
-pub const UPSTREAM_3_4_4: &str = "target/interop/upstream-install/3.4.4/bin/rsync";
+pub const UPSTREAM_3_4_4: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../target/interop/upstream-install/3.4.4/bin/rsync"
+);
 
 /// Selects which daemon binary to launch.
 #[allow(dead_code)]
@@ -313,7 +327,10 @@ pub fn require_upstream(binary_path: &str) {
 #[allow(dead_code)]
 const UPSTREAM_CANDIDATES: &[&str] = &[
     UPSTREAM_3_4_4,
-    "target/interop/upstream-src/rsync-3.4.4/rsync",
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../target/interop/upstream-src/rsync-3.4.4/rsync"
+    ),
     UPSTREAM_3_4_1,
     "/opt/homebrew/bin/rsync",
     "/usr/local/bin/rsync",

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -24,7 +24,7 @@ pub use skip::{
 };
 pub use upstream_compat::{
     UpstreamRsync, UpstreamVersion, locate_upstream_rsync, require_upstream_rsync,
-    upstream_compat_enabled,
+    upstream_compat_enabled, upstream_install_bin, workspace_root,
 };
 
 use std::sync::{Mutex, MutexGuard, OnceLock};

--- a/crates/test-support/src/upstream_compat.rs
+++ b/crates/test-support/src/upstream_compat.rs
@@ -105,18 +105,27 @@ pub fn locate_upstream_rsync(version: UpstreamVersion) -> Option<PathBuf> {
         }
     }
 
-    let workspace_root = workspace_root()?;
-    let candidate = workspace_root
+    upstream_install_bin(version.directory())
+}
+
+/// Locate the interop-harness install of upstream rsync `version`.
+///
+/// Resolves `target/interop/upstream-install/<version>/bin/rsync` anchored
+/// at the workspace root, so the result is identical no matter which
+/// directory Cargo happens to run the test from. Accepts any version
+/// string the harness installs (e.g. `"3.4.2"`), not just the
+/// [`UpstreamVersion`] variants. Returns `None` when the binary is absent,
+/// letting callers self-skip or fall back.
+#[must_use]
+pub fn upstream_install_bin(version: &str) -> Option<PathBuf> {
+    let candidate = workspace_root()?
         .join("target")
         .join("interop")
         .join("upstream-install")
-        .join(version.directory())
+        .join(version)
         .join("bin")
         .join("rsync");
-    if candidate.is_file() {
-        return Some(candidate);
-    }
-    None
+    candidate.is_file().then_some(candidate)
 }
 
 /// Self-skip helper. Returns `Some(UpstreamRsync)` when the binary
@@ -164,13 +173,62 @@ pub fn require_upstream_rsync(version: UpstreamVersion) -> Option<UpstreamRsync>
     Some(UpstreamRsync { binary, version })
 }
 
-/// Resolve the workspace root from `CARGO_MANIFEST_DIR`.
+/// Resolve the workspace root from the consuming test's `CARGO_MANIFEST_DIR`.
 ///
-/// `CARGO_MANIFEST_DIR` for the consuming test crate points at
-/// `crates/<crate>/`. The workspace root is its parent's parent.
-fn workspace_root() -> Option<PathBuf> {
-    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")?;
-    let manifest_dir = PathBuf::from(manifest_dir);
-    let crates_dir = manifest_dir.parent()?;
-    crates_dir.parent().map(Path::to_path_buf)
+/// Cargo runs every test with its CWD and `CARGO_MANIFEST_DIR` set to the
+/// PACKAGE root, not the workspace root, so `target/...` paths built
+/// relative to either are wrong for any test target under
+/// `crates/<name>/tests/`. This walks up from the manifest dir to the
+/// first directory whose `Cargo.toml` declares `[workspace]`, which also
+/// handles the root package (its manifest dir IS the workspace root).
+#[must_use]
+pub fn workspace_root() -> Option<PathBuf> {
+    let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR")?);
+    manifest_dir
+        .ancestors()
+        .find(|dir| {
+            std::fs::read_to_string(dir.join("Cargo.toml"))
+                .is_ok_and(|manifest| manifest.contains("[workspace]"))
+        })
+        .map(Path::to_path_buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_root_is_an_ancestor_declaring_a_workspace() {
+        // Why: every anchored upstream-binary lookup rests on this walk-up.
+        // If it ever resolved a non-workspace dir (or None), the lookups
+        // would silently miss target/interop and tests would dark-skip -
+        // the exact failure mode the anchoring exists to eliminate.
+        let root = workspace_root().expect("workspace root resolves under cargo");
+        let manifest =
+            std::fs::read_to_string(root.join("Cargo.toml")).expect("workspace Cargo.toml");
+        assert!(manifest.contains("[workspace]"));
+        assert!(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).starts_with(&root),
+            "workspace root must be an ancestor of the consuming manifest dir"
+        );
+    }
+
+    #[test]
+    fn upstream_install_bin_is_workspace_anchored_and_cwd_independent() {
+        // Why: the resolver must produce the same path no matter where
+        // Cargo set the CWD; a CWD-relative probe is exactly the bug this
+        // module replaces. The binary may legitimately be absent (macOS
+        // dev machines), so assert on the anchored shape via the root
+        // rather than on existence.
+        let root = workspace_root().expect("workspace root resolves under cargo");
+        let expected = root.join("target/interop/upstream-install/3.4.4/bin/rsync");
+        match upstream_install_bin("3.4.4") {
+            Some(found) => assert_eq!(found, expected),
+            None => assert!(
+                !expected.is_file(),
+                "resolver returned None while {} exists",
+                expected.display()
+            ),
+        }
+    }
 }

--- a/crates/transfer/benches/isi_g_sender_inc_recurse_start_time.rs
+++ b/crates/transfer/benches/isi_g_sender_inc_recurse_start_time.rs
@@ -216,10 +216,18 @@ impl Sender {
         }
     }
 
+    /// Default binary path, anchored at the workspace root at compile time;
+    /// benches run with CWD `crates/transfer/`, where a CWD-relative path
+    /// would never resolve.
     fn default_path(self) -> &'static str {
         match self {
-            Sender::Baseline | Sender::IncRecurse => "target/release/oc-rsync",
-            Sender::Upstream => "target/interop/upstream-install/3.4.1/bin/rsync",
+            Sender::Baseline | Sender::IncRecurse => {
+                concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/release/oc-rsync")
+            }
+            Sender::Upstream => concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../target/interop/upstream-install/3.4.1/bin/rsync"
+            ),
         }
     }
 

--- a/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
+++ b/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
@@ -83,12 +83,10 @@ const MAX_SLOWDOWN_RATIO: f64 = 5.0;
 /// Locate the upstream rsync binary for the requested version.
 ///
 /// Looks under `target/interop/upstream-install/<version>/bin/rsync`,
-/// the canonical install path populated by `tools/ci/run_interop.sh`.
+/// the canonical install path populated by `tools/ci/run_interop.sh`,
+/// anchored at the workspace root (the test CWD is `crates/transfer/`).
 fn upstream_rsync_binary(version: &str) -> Option<PathBuf> {
-    let path = PathBuf::from(format!(
-        "target/interop/upstream-install/{version}/bin/rsync"
-    ));
-    if path.is_file() { Some(path) } else { None }
+    test_support::upstream_install_bin(version)
 }
 
 /// Build a ~1 MiB source tree spread across small directories.

--- a/tests/client_empty_flist_skips_recv_loop.rs
+++ b/tests/client_empty_flist_skips_recv_loop.rs
@@ -83,11 +83,11 @@ fn upstream_rsync() -> Option<PathBuf> {
     if let Some(explicit) = std::env::var_os("OC_RSYNC_UPSTREAM_RSYNC") {
         candidates.push(PathBuf::from(explicit));
     }
-    for version in ["3.4.4", "3.4.1", "3.1.3"] {
-        candidates.push(PathBuf::from(format!(
-            "target/interop/upstream-install/{version}/bin/rsync"
-        )));
-    }
+    candidates.extend(
+        ["3.4.4", "3.4.1", "3.1.3"]
+            .into_iter()
+            .filter_map(test_support::upstream_install_bin),
+    );
     candidates.push(PathBuf::from("rsync"));
 
     candidates.into_iter().find(|candidate| {

--- a/tests/daemon_sender_per_file_error_no_hang.rs
+++ b/tests/daemon_sender_per_file_error_no_hang.rs
@@ -87,11 +87,11 @@ fn upstream_rsync_client() -> Option<PathBuf> {
     if let Some(explicit) = std::env::var_os("OC_RSYNC_UPSTREAM_RSYNC") {
         candidates.push(PathBuf::from(explicit));
     }
-    for version in ["3.4.4", "3.4.1", "3.1.3"] {
-        candidates.push(PathBuf::from(format!(
-            "target/interop/upstream-install/{version}/bin/rsync"
-        )));
-    }
+    candidates.extend(
+        ["3.4.4", "3.4.1", "3.1.3"]
+            .into_iter()
+            .filter_map(test_support::upstream_install_bin),
+    );
     candidates.push(PathBuf::from("rsync"));
 
     candidates.into_iter().find(|candidate| {

--- a/tests/filter_nested_rsync_filter_stress.rs
+++ b/tests/filter_nested_rsync_filter_stress.rs
@@ -42,7 +42,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
-/// Candidate locations for the upstream rsync 3.4.2 binary.
+/// Candidate locations for the upstream rsync 3.4.2 binary, relative to
+/// the workspace root.
 const UPSTREAM_CANDIDATES: &[&str] = &[
     "target/interop/upstream-install/3.4.2/bin/rsync",
     "target/interop/upstream-src/rsync-3.4.2/rsync",
@@ -51,19 +52,14 @@ const UPSTREAM_CANDIDATES: &[&str] = &[
 /// Default timeout for spawned rsync processes.
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Locate the upstream rsync 3.4.2 binary, walking upward from the test cwd
-/// so the lookup works regardless of which crate triggered the test.
+/// Locate the upstream rsync 3.4.2 binary, anchored at the workspace root
+/// so the lookup works regardless of the CWD Cargo runs the test from.
 fn locate_upstream() -> Option<PathBuf> {
-    let cwd = std::env::current_dir().ok()?;
-    for ancestor in cwd.ancestors() {
-        for candidate in UPSTREAM_CANDIDATES {
-            let path = ancestor.join(candidate);
-            if path.is_file() {
-                return Some(path);
-            }
-        }
-    }
-    None
+    let root = test_support::workspace_root()?;
+    UPSTREAM_CANDIDATES
+        .iter()
+        .map(|candidate| root.join(candidate))
+        .find(|path| path.is_file())
 }
 
 /// Build a nested source tree with `.rsync-filter` files at four depth levels.

--- a/tests/integration/helpers.rs
+++ b/tests/integration/helpers.rs
@@ -697,9 +697,9 @@ impl TransferResult {
 }
 
 /// Locate an upstream rsync binary by version.
+///
+/// Delegates to the workspace-anchored resolver so the lookup is
+/// independent of the CWD Cargo runs the test from.
 pub fn upstream_rsync_binary(version: &str) -> Option<PathBuf> {
-    let path = PathBuf::from(format!(
-        "target/interop/upstream-install/{version}/bin/rsync"
-    ));
-    if path.is_file() { Some(path) } else { None }
+    test_support::upstream_install_bin(version)
 }

--- a/tests/integration_protocol_versions.rs
+++ b/tests/integration_protocol_versions.rs
@@ -34,35 +34,20 @@
 
 mod integration;
 
-use std::path::Path;
-
 use filetime::{FileTime, set_file_times};
 use integration::helpers::*;
 use std::fs;
 
-/// Path to upstream rsync 3.0.9 binary (protocol 30).
-const UPSTREAM_RSYNC_3_0_9: &str = "target/interop/upstream-install/3.0.9/bin/rsync";
-
-/// Path to upstream rsync 3.1.3 binary (protocol 31).
-const UPSTREAM_RSYNC_3_1_3: &str = "target/interop/upstream-install/3.1.3/bin/rsync";
-
-/// Path to upstream rsync 3.4.1 binary (protocol 32).
-const UPSTREAM_RSYNC_3_4_1: &str = "target/interop/upstream-install/3.4.1/bin/rsync";
-
 // ============ Helper Functions ============
 
-/// Check if an upstream rsync binary is available.
-fn upstream_binary_available(path: &str) -> bool {
-    Path::new(path).is_file()
-}
-
-/// Skip test if upstream binary is not available.
+/// Skip test if the workspace-anchored upstream binary is not available.
 macro_rules! require_upstream_binary {
-    ($path:expr, $version:expr) => {
-        if !upstream_binary_available($path) {
+    ($version:expr) => {
+        if integration::helpers::upstream_rsync_binary($version).is_none() {
             eprintln!(
-                "Skipping test: upstream rsync {} not found at {}",
-                $version, $path
+                "Skipping test: upstream rsync {} not found under \
+                 target/interop/upstream-install/",
+                $version
             );
             eprintln!("Run interop build script to install upstream versions");
             return;
@@ -74,7 +59,7 @@ macro_rules! require_upstream_binary {
 
 #[test]
 fn oc_rsync_compatible_with_rsync_3_0_9() {
-    require_upstream_binary!(UPSTREAM_RSYNC_3_0_9, "3.0.9");
+    require_upstream_binary!("3.0.9");
 
     let test_dir = TestDir::new().expect("create test dir");
     let src_dir = test_dir.mkdir("src").unwrap();
@@ -101,7 +86,7 @@ fn oc_rsync_compatible_with_rsync_3_0_9() {
 
 #[test]
 fn oc_rsync_compatible_with_rsync_3_1_3() {
-    require_upstream_binary!(UPSTREAM_RSYNC_3_1_3, "3.1.3");
+    require_upstream_binary!("3.1.3");
 
     let test_dir = TestDir::new().expect("create test dir");
     let src_dir = test_dir.mkdir("src").unwrap();
@@ -128,7 +113,7 @@ fn oc_rsync_compatible_with_rsync_3_1_3() {
 
 #[test]
 fn oc_rsync_compatible_with_rsync_3_4_1() {
-    require_upstream_binary!(UPSTREAM_RSYNC_3_4_1, "3.4.1");
+    require_upstream_binary!("3.4.1");
 
     let test_dir = TestDir::new().expect("create test dir");
     let src_dir = test_dir.mkdir("src").unwrap();

--- a/tests/live_interop_fuzz_1196.rs
+++ b/tests/live_interop_fuzz_1196.rs
@@ -378,13 +378,10 @@ fn upstream_binary() -> Option<PathBuf> {
             return Some(p);
         }
     }
-    // Fall back to the versions installed by tools/ci/run_interop.sh.
-    for candidate in [
-        "target/interop/upstream-install/3.4.2/bin/rsync",
-        "target/interop/upstream-install/3.4.1/bin/rsync",
-    ] {
-        let p = PathBuf::from(candidate);
-        if p.is_file() {
+    // Fall back to the versions installed by tools/ci/run_interop.sh,
+    // anchored at the workspace root so the lookup is CWD-independent.
+    for version in ["3.4.2", "3.4.1"] {
+        if let Some(p) = test_support::upstream_install_bin(version) {
             return Some(p);
         }
     }

--- a/tests/missing_source_arg_exits_partial.rs
+++ b/tests/missing_source_arg_exits_partial.rs
@@ -78,11 +78,11 @@ fn upstream_rsync() -> Option<PathBuf> {
     if let Some(explicit) = std::env::var_os("OC_RSYNC_UPSTREAM_RSYNC") {
         candidates.push(PathBuf::from(explicit));
     }
-    for version in ["3.4.4", "3.4.1", "3.1.3"] {
-        candidates.push(PathBuf::from(format!(
-            "target/interop/upstream-install/{version}/bin/rsync"
-        )));
-    }
+    candidates.extend(
+        ["3.4.4", "3.4.1", "3.1.3"]
+            .into_iter()
+            .filter_map(test_support::upstream_install_bin),
+    );
     candidates.push(PathBuf::from("rsync"));
 
     candidates.into_iter().find(|candidate| {


### PR DESCRIPTION
## Problem

Upstream-binary resolution in tests used CWD-relative paths. Cargo sets the test CWD to the PACKAGE root, not the workspace root, so for any test or bench target under `crates/<name>/` the path `target/interop/upstream-install/<ver>/bin/rsync` resolved to `crates/<name>/target/...`, which never exists. The helpers returned `None` and the tests silently skipped their upstream oracle even when the binary was installed.

Measured before/after (binary present at `<workspace>/target/interop/upstream-install/3.4.1/bin/rsync`):

- Before: `cargo nextest run -p core -E 'test(test_upstream_3_4_1_client_handshake)' --run-ignored all` printed `Skipping: upstream rsync 3.4.1 not found at target/interop/upstream-install/3.4.1/bin/rsync` and PASSED vacuously.
- After: the same command resolves the binary and executes it. (On the dev Mac it then fails with an exec-format error because the cached binaries are Linux aarch64 ELF; a genuine end-to-end pass needs the Linux host. These tests are `#[ignore]`-gated and do not run in CI nextest cells.)

## Site inventory

Sweep: `grep -rn "target/interop" --include='*.rs' crates/ tests/` - 142 lines (MEASURED). Non-comment resolution sites classify as:

Unanchored, fixed here (11 sites, 11 files):

- `tests/integration/helpers.rs` - `upstream_rsync_binary()` (shared by 7 root test binaries) now delegates to the shared resolver.
- `tests/daemon_sender_per_file_error_no_hang.rs`, `tests/missing_source_arg_exits_partial.rs`, `tests/client_empty_flist_skips_recv_loop.rs` - candidate loops now use the shared resolver.
- `tests/filter_nested_rsync_filter_stress.rs` - CWD-ancestors walk replaced with workspace-root anchoring.
- `tests/integration_protocol_versions.rs` - relative consts + `upstream_binary_available()` replaced by the anchored helper.
- `tests/live_interop_fuzz_1196.rs` - relative fallback candidates anchored.
- `crates/core/tests/common/mod.rs` - `UPSTREAM_3_0_9/3_1_3/3_4_1/3_4_4` consts and `UPSTREAM_CANDIDATES` anchored at compile time via `concat!(env!("CARGO_MANIFEST_DIR"), ..)` (they must stay `&'static str`; ~130 call sites across three interop suites consume them directly).
- `crates/core/benches/transfer_benchmark.rs`, `crates/transfer/benches/isi_g_sender_inc_recurse_start_time.rs` - bench binary defaults anchored the same way.
- `crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs` - delegates to the shared resolver.

Already anchored, verified and left unchanged (6 sites): `crates/test-support/src/upstream_compat.rs` (robustified, see below), `crates/transfer/tests/daemon_push_refused_file_reports_error.rs`, `crates/metadata/tests/acl_root_root_interop.rs`, `tests/delete_during_stream_error_1895.rs`, `tests/integration/delete_event_order_harness.rs`, `tests/integration/acl_xattr_interop_harness.rs`.

## The resolver

`crates/test-support` already owns binary resolution (`bin_path::workspace_bin` bakes the profile dir from `OUT_DIR`; `upstream_compat::locate_upstream_rsync` anchors via `CARGO_MANIFEST_DIR`), so the shared resolver extends `upstream_compat` rather than inventing a second convention:

- `workspace_root()` - was a private `parent().parent()` guess (wrong for the root package); now public and walks up from `CARGO_MANIFEST_DIR` to the first manifest declaring `[workspace]`.
- `upstream_install_bin(version: &str)` - anchored lookup for any harness-installed version (including 3.4.2, which the enum lacks); `locate_upstream_rsync` now delegates to it.

Unit tests cover both: the walk-up must land on a `[workspace]` manifest that is an ancestor of the consuming crate, and the resolved path must be workspace-anchored regardless of CWD. Verified identical resolution invoking nextest from the workspace root and from `crates/core/` (35/35 passed both ways, MEASURED).

## Newly-awakened tests

Every upstream-requiring test in `crates/core` that the bug silenced is `#[ignore]`-gated (`--run-ignored` only), and `v61d_2` in `crates/transfer` is compiled out on macOS, so no CI nextest cell changes behavior: CI cells have no `target/interop` tree and the tests keep their skip path. On hosts with the interop tree populated, `--run-ignored` interop runs and `v61d_2` now exercise the real oracle instead of dark-skipping; `v61d_2` (perf ratio assert vs upstream 3.4.1) should be validated on the Linux interop host.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- Targeted nextest: test-support (35 passed), affected root-package binaries (13 passed, 9 env-gated skips), core interop binaries (7 passed, ignored tests excluded as before).
