### PR TITLE
fix(metadata): apply -E executability on up-to-date files

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -305,6 +305,18 @@ pub fn metadata_unchanged(
             return false;
         }
 
+        // upstream: generator.c:418-426 perms_differ() - without --perms,
+        // --executability compares only executability presence. dest_mode()
+        // (rsync.c:449-473) tweaks x-bits solely for regular files, so
+        // non-regular entries never differ on this leg.
+        if !options.permissions()
+            && options.executability()
+            && entry.file_type().is_regular()
+            && (cached_meta.mode() & 0o111 != 0) != (entry.permissions() & 0o111 != 0)
+        {
+            return false;
+        }
+
         // upstream: generator.c:496-497 - ownership_differs(file, sxp)
         if options.owner() {
             if let Some(uid) = entry.uid() {

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1712,6 +1712,97 @@ fn metadata_unchanged_ignores_perms_when_not_preserved() {
     );
 }
 
+/// upstream: generator.c:418-426 perms_differ() - without --perms,
+/// --executability must flag an executability-presence mismatch so the
+/// receiver's quick-check skip path still runs the attribute pass. Before the
+/// fix the network attr-only path left an up-to-date 0644 file at 0644 when
+/// the source was 0755 under `-rtE`.
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_detects_executability_presence_mismatch() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("exec-mismatch.txt");
+    fs::write(&dest, b"data").expect("write dest");
+    fs::set_permissions(&dest, fs::Permissions::from_mode(0o644)).expect("chmod dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    let mut entry = FileEntry::new_file("exec-mismatch.txt".into(), 4, 0o755);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+
+    // MetadataOptions::new() defaults preserve_permissions to true; -E
+    // without -p means it must be explicitly off here, otherwise the perms
+    // leg masks the executability leg and the test passes pre-fix.
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_executability(true)
+        .preserve_times(true);
+
+    assert!(
+        !metadata_unchanged(&entry, &opts, &meta),
+        "executable source vs non-executable dest must force the attr pass"
+    );
+
+    // The reverse direction (source lost its exec bits) must also differ.
+    let mut entry = FileEntry::new_file("exec-mismatch.txt".into(), 4, 0o600);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+    fs::set_permissions(&dest, fs::Permissions::from_mode(0o755)).expect("chmod dest");
+    let meta = fs::metadata(&dest).expect("metadata");
+    assert!(
+        !metadata_unchanged(&entry, &opts, &meta),
+        "non-executable source vs executable dest must force the attr pass"
+    );
+}
+
+/// upstream: generator.c:423-426 - perms_differ() under --executability
+/// compares only exec-bit PRESENCE; read/write differences and matching
+/// presence must not trigger the attribute pass, and non-regular entries are
+/// never tweaked by dest_mode() (rsync.c:456 S_ISREG check).
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_executability_ignores_matching_presence_and_non_files() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("exec-match.txt");
+    fs::write(&dest, b"data").expect("write dest");
+    fs::set_permissions(&dest, fs::Permissions::from_mode(0o654)).expect("chmod dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_executability(true)
+        .preserve_times(true);
+
+    // Both sides executable (any exec bit counts) with differing rw bits.
+    let mut entry = FileEntry::new_file("exec-match.txt".into(), 4, 0o700);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+    assert!(
+        metadata_unchanged(&entry, &opts, &meta),
+        "matching exec presence must not force the attr pass"
+    );
+
+    // A directory whose exec presence differs is out of scope for -E.
+    let dir = temp.path().join("subdir");
+    fs::create_dir(&dir).expect("create dir");
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o600)).expect("chmod dir");
+    let dir_meta = fs::metadata(&dir).expect("dir metadata");
+    let dir_mtime = FileTime::from_last_modification_time(&dir_meta);
+    let mut dir_entry = FileEntry::new_directory("subdir".into(), 0o755);
+    dir_entry.set_mtime(dir_mtime.unix_seconds(), dir_mtime.nanoseconds());
+    assert!(
+        metadata_unchanged(&dir_entry, &opts, &dir_meta),
+        "-E never applies to directories"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn metadata_unchanged_returns_false_when_chmod_would_change_mode() {

--- a/crates/transfer/tests/uts_executability_flag_transfer.rs
+++ b/crates/transfer/tests/uts_executability_flag_transfer.rs
@@ -25,7 +25,8 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
-use test_support::{OcRsyncCliRunner, create_tempdir, require_binary};
+use filetime::{FileTime, set_file_mtime};
+use test_support::{LSH_STUB_BIN, LshRunnerStub, OcRsyncCliRunner, create_tempdir, require_binary};
 
 fn mode_of(path: &Path) -> u32 {
     fs::metadata(path).expect("stat file").permissions().mode() & 0o7777
@@ -33,6 +34,54 @@ fn mode_of(path: &Path) -> u32 {
 
 fn set_mode(path: &Path, mode: u32) {
     fs::set_permissions(path, fs::Permissions::from_mode(mode)).expect("set mode");
+}
+
+/// Writes `content` and pins mode + a fixed mtime so a later `-t` transfer
+/// takes the quick-check (attribute-only) path rather than re-sending data.
+fn write_fixed(path: &Path, content: &[u8], mode: u32) {
+    fs::write(path, content).expect("write file");
+    set_mode(path, mode);
+    set_file_mtime(path, FileTime::from_unix_time(1_600_000_000, 0)).expect("set mtime");
+}
+
+/// Builds the up-to-date source/destination pair used by the remote-shell
+/// attribute-only tests: identical bytes and mtimes, differing exec bits.
+fn attr_only_fixture(from: &Path, to: &Path) {
+    fs::create_dir_all(from).expect("create from dir");
+    fs::create_dir_all(to).expect("create to dir");
+    // gains exec: source executable, destination not
+    write_fixed(&from.join("gain"), b"aaa\n", 0o755);
+    write_fixed(&to.join("gain"), b"aaa\n", 0o644);
+    // loses exec: source not executable, destination is
+    write_fixed(&from.join("lose"), b"bbb\n", 0o644);
+    write_fixed(&to.join("lose"), b"bbb\n", 0o755);
+    // keeps exec: both sides carry an exec bit, dest bits stay verbatim
+    write_fixed(&from.join("keep"), b"ccc\n", 0o755);
+    write_fixed(&to.join("keep"), b"ccc\n", 0o654);
+}
+
+/// Asserts the upstream `dest_mode()` outcome for [`attr_only_fixture`].
+///
+/// upstream: rsync.c:449-473 dest_mode() - existing dest keeps its perm bits;
+/// with `-E` a non-executable source strips 0111, an executable source grants
+/// exec to every class that can read, and a dest that already has any exec
+/// bit is left verbatim.
+fn assert_attr_only_outcome(to: &Path) {
+    assert_eq!(
+        mode_of(&to.join("gain")),
+        0o755,
+        "-E must grant exec to every readable class on an up-to-date dest"
+    );
+    assert_eq!(
+        mode_of(&to.join("lose")),
+        0o644,
+        "-E must strip exec bits when the source is not executable"
+    );
+    assert_eq!(
+        mode_of(&to.join("keep")),
+        0o654,
+        "-E must leave a dest that already has an exec bit verbatim"
+    );
 }
 
 /// Full three-phase replay of the upstream `executability.test`: a plain
@@ -140,5 +189,118 @@ fn executability_flag_transfers_only_exec_bits() {
         mode_of(&d2) & 0o666,
         0o604,
         "-E must leave dest 2's read/write bits untouched"
+    );
+}
+
+/// Regression: `-rtE` over a remote shell (push) must chmod up-to-date files.
+///
+/// With identical bytes and mtimes the quick check skips the transfer, so the
+/// only way the exec bits can follow the source is the receiver's
+/// attribute-only pass. The network receiver used to skip that pass because
+/// `metadata_unchanged` never consulted `--executability`, leaving the
+/// destination at its old mode while the itemized output claimed a `p` change.
+///
+/// upstream: generator.c:418-426 perms_differ() feeds unchanged_attrs(), so an
+/// executability-presence mismatch forces set_file_attrs() on the skip path
+/// (generator.c:1827).
+#[test]
+fn executability_applies_on_up_to_date_files_over_rsh_push() {
+    if !require_binary("oc-rsync") || !require_binary(LSH_STUB_BIN) {
+        return;
+    }
+    let stub = LshRunnerStub::locate().expect("lsh-stub located");
+
+    let tmp = create_tempdir();
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    attr_only_fixture(&from, &to);
+
+    OcRsyncCliRunner::new()
+        .arg("-rtE")
+        .arg(format!("--rsh={}", stub.path().display()))
+        .arg(format!(
+            "--rsync-path={}",
+            test_support::oc_rsync_bin().display()
+        ))
+        .arg(format!("{}/", from.display()))
+        .arg(format!("localhost:{}/", to.display()))
+        .run()
+        .expect("push run")
+        .assert_success();
+
+    assert_attr_only_outcome(&to);
+}
+
+/// Regression: `-rtE` over a remote shell (pull) must chmod up-to-date files.
+///
+/// Same attribute-only scenario as the push test, but the local client is the
+/// receiver. Note `-E` never rides the wire on a pull (options.c:2692 packs
+/// 'E' only when `am_sender`); the local receiver must honour its own flag.
+#[test]
+fn executability_applies_on_up_to_date_files_over_rsh_pull() {
+    if !require_binary("oc-rsync") || !require_binary(LSH_STUB_BIN) {
+        return;
+    }
+    let stub = LshRunnerStub::locate().expect("lsh-stub located");
+
+    let tmp = create_tempdir();
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    attr_only_fixture(&from, &to);
+
+    OcRsyncCliRunner::new()
+        .arg("-rtE")
+        .arg(format!("--rsh={}", stub.path().display()))
+        .arg(format!(
+            "--rsync-path={}",
+            test_support::oc_rsync_bin().display()
+        ))
+        .arg(format!("localhost:{}/", from.display()))
+        .arg(format!("{}/", to.display()))
+        .run()
+        .expect("pull run")
+        .assert_success();
+
+    assert_attr_only_outcome(&to);
+}
+
+/// `-rtpE`: `--perms` wins and `-E` is a no-op - up-to-date files get the
+/// source mode copied exactly, including the read/write bits `-E` alone would
+/// leave untouched.
+///
+/// upstream: options.c:2690-2693 - the server arg string carries 'p', never
+/// 'E', when both are set; generator.c:418-421 perms_differ() compares the
+/// full mode under preserve_perms.
+#[test]
+fn executability_is_noop_when_perms_active_over_rsh() {
+    if !require_binary("oc-rsync") || !require_binary(LSH_STUB_BIN) {
+        return;
+    }
+    let stub = LshRunnerStub::locate().expect("lsh-stub located");
+
+    let tmp = create_tempdir();
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    attr_only_fixture(&from, &to);
+
+    OcRsyncCliRunner::new()
+        .arg("-rtpE")
+        .arg(format!("--rsh={}", stub.path().display()))
+        .arg(format!(
+            "--rsync-path={}",
+            test_support::oc_rsync_bin().display()
+        ))
+        .arg(format!("{}/", from.display()))
+        .arg(format!("localhost:{}/", to.display()))
+        .run()
+        .expect("push run with -p")
+        .assert_success();
+
+    assert_eq!(mode_of(&to.join("gain")), 0o755, "-p copies the exact mode");
+    assert_eq!(mode_of(&to.join("lose")), 0o644, "-p copies the exact mode");
+    assert_eq!(
+        mode_of(&to.join("keep")),
+        0o755,
+        "-p overrides -E and copies the exact source mode"
     );
 }


### PR DESCRIPTION
## Problem

`-E`/`--executability` was parsed and reflected in itemized output, but the network receiver never applied it on the quick-check skip path. After `-rtE` with an up-to-date destination (same size and mtime), a file that is 0755 at the source stayed 0644 at the destination, where upstream rsync 3.4.4 chmods it to 0755. Both directions (push and pull) were affected; the local-copy executor and the full-transfer path were already correct.

## Root cause

The receiver gates the whole attribute pass on `metadata_unchanged()` (`crates/metadata/src/apply/mod.rs`), oc's equivalent of upstream `unchanged_attrs()`. Upstream `perms_differ()` (generator.c:418-426) has a second leg: without `--perms`, `--executability` compares executability presence between the flist mode and the destination stat, forcing `set_file_attrs()` on the skip path (generator.c:1827). `metadata_unchanged()` had no such leg, so with `-E` and no `-p` it reported "unchanged" and the receiver skipped `apply_metadata_with_cached_stat()` entirely - whose permission logic already implements the `dest_mode()` exec-bit tweak (rsync.c:449-473).

## Fix

Add the missing `perms_differ()` executability leg to `metadata_unchanged()`: without `--perms`, with `--executability`, on regular files only (dest_mode's `S_ISREG` gate, rsync.c:456), an executability-presence mismatch forces the attribute pass. One predicate, shared by both network receiver call sites; no duplicate mode logic.

## Verification vs upstream 3.4.4 (protocol 32)

Fixture: `gain` src 755 / dest 644, `lose` src 644 / dest 755, `keep` src 755 / dest 654 (dest already has an exec bit), `new` src 750 / no dest. Matrix run for local copy, push, and pull over a loopback remote shell, for `-rtE` (attribute-only), `-rE` (re-transfer), and `-rtpE`:

| case | upstream | oc before | oc after |
|------|----------|-----------|----------|
| `-rtE` gain (attr-only, push/pull) | 755 | 644 | 755 |
| `-rtE` lose (attr-only, push/pull) | 644 | 755 | 644 |
| `-rtE` keep (attr-only, push/pull) | 654 | 654 | 654 |
| `-rE` re-transfer (all paths) | match | match | match |
| new file (no dest) | 750 | 750 | 750 |
| `-rtpE` (perms wins) | exact source mode | exact source mode | exact source mode |

## Tests

- `metadata_unchanged_detects_executability_presence_mismatch` and `metadata_unchanged_executability_ignores_matching_presence_and_non_files` (unit, `crates/metadata/src/apply/tests.rs`).
- `executability_applies_on_up_to_date_files_over_rsh_push` / `_pull` and `executability_is_noop_when_perms_active_over_rsh` (end-to-end over the lsh stub, `crates/transfer/tests/uts_executability_flag_transfer.rs`).

Fail-on-pre-fix proven: with the one-hunk fix reverted, the presence-mismatch unit test and both remote-shell tests fail (dest stays 0644); with the fix restored all 15 executability/metadata_unchanged tests pass.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`, full `-p metadata` suite (572 passed), and 168 related transfer tests all green.

## Out of scope (pre-existing, surfaced for tracking)

- Itemize `-ii` rows for attribute-only `p` changes still diverge from upstream on the network path (itemize emission is owned separately this cycle); the chmod itself now happens.
- Local-copy `--chmod` applies modifiers to existing up-to-date files where upstream's `dest_mode()` keeps destination bits; present before this change and independent of `-E`.
