### PR TITLE
refactor(logging): add upstream logcode dimension to diagnostic events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,6 +2065,7 @@ version = "0.6.4"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -61,6 +61,7 @@ pub fn render_diagnostic_events<O: Write, E: Write>(
                 flag: _,
                 level: _,
                 message,
+                ..
             } => {
                 if msgs2stderr {
                     writeln!(err, "{message}")?;
@@ -72,6 +73,7 @@ pub fn render_diagnostic_events<O: Write, E: Write>(
                 flag: _,
                 level: _,
                 message,
+                ..
             } => {
                 // upstream: log.c:rwrite() prints debug messages verbatim via
                 // rprintf(FINFO, ...) with no flag-category bracket. FINFO
@@ -120,13 +122,14 @@ pub fn flush_diagnostics<O: Write, E: Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use logging::{DebugFlag, InfoFlag};
+    use logging::{DebugFlag, InfoFlag, LogCode};
 
     #[test]
     fn test_info_event_renders_to_stdout() {
         let events = vec![DiagnosticEvent::Info {
             flag: InfoFlag::Progress,
             level: 1,
+            code: LogCode::Info,
             message: "transferred 1024 bytes".to_owned(),
         }];
 
@@ -150,6 +153,7 @@ mod tests {
         let events = vec![DiagnosticEvent::Debug {
             flag: DebugFlag::Filter,
             level: 1,
+            code: LogCode::Info,
             message: "excluding file foo.txt".to_owned(),
         }];
 
@@ -171,11 +175,13 @@ mod tests {
             DiagnosticEvent::Info {
                 flag: InfoFlag::Progress,
                 level: 1,
+                code: LogCode::Info,
                 message: "info message".to_owned(),
             },
             DiagnosticEvent::Debug {
                 flag: DebugFlag::Filter,
                 level: 1,
+                code: LogCode::Info,
                 message: "debug message".to_owned(),
             },
         ];
@@ -200,16 +206,19 @@ mod tests {
             DiagnosticEvent::Info {
                 flag: InfoFlag::Progress,
                 level: 1,
+                code: LogCode::Info,
                 message: "first".to_owned(),
             },
             DiagnosticEvent::Debug {
                 flag: DebugFlag::Io,
                 level: 2,
+                code: LogCode::Info,
                 message: "second".to_owned(),
             },
             DiagnosticEvent::Info {
                 flag: InfoFlag::Stats,
                 level: 1,
+                code: LogCode::Info,
                 message: "third".to_owned(),
             },
         ];

--- a/crates/flist/src/file_list_walker.rs
+++ b/crates/flist/src/file_list_walker.rs
@@ -32,7 +32,9 @@ impl FileListWalker {
         // The walk root is deliberately not announced: upstream's counterpart
         // (flist.c:2248 `rprintf(FLOG, "building file list\n")`) is an FLOG
         // message that log.c:rwrite() drops for a client with no --log-file,
-        // whereas every DiagnosticEvent from this crate reaches stdout.
+        // whereas every DiagnosticEvent from this crate reaches stdout. Once
+        // the renderer routes by `DiagnosticEvent::code()`, the banner can be
+        // emitted as a `LogCode::Log` event for --log-file parity.
 
         // upstream: flist.c:readlink_stat() - use stat() when copy_links is
         // set, lstat() otherwise.

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -23,6 +23,7 @@ tracing = ["dep:tracing", "dep:tracing-subscriber"]
 
 [dependencies]
 serde = { workspace = true, optional = true }
+thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -78,6 +78,7 @@ mod config;
 /// Upstream-compatible error and warning formatting.
 pub mod error_format;
 mod levels;
+mod log_code;
 mod macros;
 mod phase_timer;
 mod thread_local;
@@ -93,10 +94,11 @@ pub use error_format::{
     file_basename, format_rsync_error, format_rsync_warning, strip_repo_prefix,
 };
 pub use levels::{DebugFlag, DebugLevels, InfoFlag, InfoLevels};
+pub use log_code::{LogCode, ParseLogCodeError};
 pub use phase_timer::PhaseTimer;
 pub use thread_local::{
     DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events, emit_debug,
-    emit_info, info_gte, init,
+    emit_debug_coded, emit_info, emit_info_coded, info_gte, init,
 };
 
 #[cfg(feature = "tracing")]

--- a/crates/logging/src/log_code.rs
+++ b/crates/logging/src/log_code.rs
@@ -1,51 +1,77 @@
-use ::core::convert::TryFrom;
-use ::core::fmt;
-use ::core::str::FromStr;
+//! Upstream rsync's `enum logcode` vocabulary.
+//!
+//! Every upstream diagnostic carries a logcode that `rwrite()` uses to pick
+//! its destination: the client's stdout/stderr, the daemon log or `--log-file`,
+//! or the multiplexed message stream (upstream: rsync.h:275-282, log.c:rwrite()).
+//! This module is the single canonical definition of that vocabulary; the
+//! `protocol` crate re-exports it for wire-side `MSG_*` conversions and the
+//! diagnostics event model tags every [`DiagnosticEvent`](crate::DiagnosticEvent)
+//! with one of these codes.
 
-use std::string::String;
+use std::fmt;
+use std::str::FromStr;
 
 /// Log classification used by upstream rsync's `enum logcode` table.
 ///
-/// The numeric values mirror the identifiers found in `rsync.h` so the logging
-/// subsystem can translate between multiplexed tags and the log severities used
-/// by upstream traces. While only a subset of log codes flow over the
-/// multiplexed stream, the complete enum is provided for parity (including
-/// `FNONE`, which upstream reserves for internal use).
+/// The numeric values mirror the identifiers found in `rsync.h:275-282` so the
+/// logging subsystem can translate between multiplexed tags and the log
+/// destinations used by upstream traces. While only a subset of log codes flow
+/// over the multiplexed stream, the complete enum is provided for parity
+/// (including `FNONE`, which upstream reserves for internal use).
+///
+/// Each variant documents its routing rule from `log.c:rwrite()`.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(u8)]
 pub enum LogCode {
     #[doc(alias = "FNONE")]
-    /// Placeholder that is never transmitted on the wire (`FNONE`).
+    /// Placeholder that is never passed to `rwrite()` and never transmitted
+    /// on the wire (`FNONE`, upstream: rsync.h:276 "never sent").
     None = 0,
     #[doc(alias = "FERROR_XFER")]
-    /// Fatal transfer error (`FERROR_XFER`).
+    /// Transfer error (`FERROR_XFER`). Routed to stderr and records that a
+    /// transfer error occurred (upstream: log.c:310-316 sets `got_xfer_error`);
+    /// sent over the socket as `MSG_ERROR_XFER` at every protocol
+    /// (upstream: rsync.h:277).
     ErrorXfer = 1,
     #[doc(alias = "FINFO")]
-    /// Informational log message (`FINFO`).
+    /// Informational message (`FINFO`). Routed to the client's stdout unless
+    /// `--quiet` (upstream: log.c:317-320) and additionally to the daemon
+    /// log/`--log-file` when one is active (upstream: log.c:290-305).
     Info = 2,
     #[doc(alias = "FERROR")]
-    /// Non-fatal error (`FERROR`).
+    /// Non-transfer error (`FERROR`). Routed to stderr (upstream:
+    /// log.c:313-316); sent over the socket as `MSG_ERROR` at protocols >= 30
+    /// and downgraded to `MSG_ERROR_XFER` below (upstream: log.c:332-335).
     Error = 3,
     #[doc(alias = "FWARNING")]
-    /// Warning message (`FWARNING`).
+    /// Warning (`FWARNING`). Routed to stderr (upstream: log.c:314-316); sent
+    /// over the socket as `MSG_WARNING` at protocols >= 30 and downgraded to
+    /// `MSG_INFO` below (upstream: log.c:332-337).
     Warning = 4,
     #[doc(alias = "FERROR_SOCKET")]
-    /// Error emitted by the sibling process over the receiver/generator pipe
-    /// (`FERROR_SOCKET`).
+    /// Error travelling over the receiver -> generator pipe (`FERROR_SOCKET`);
+    /// a non-sibling simplifies it to `FERROR` on arrival (upstream:
+    /// log.c:281-282, rsync.h:279).
     ErrorSocket = 5,
     #[doc(alias = "FLOG")]
-    /// Log message only written to the daemon logs (`FLOG`).
+    /// Log-file-only message (`FLOG`). Written to the daemon log/`--log-file`
+    /// and never to the client's stdout; discarded outright when no log
+    /// destination is active (upstream: log.c:290-307).
     Log = 6,
     #[doc(alias = "FCLIENT")]
-    /// Client-only message (`FCLIENT`).
+    /// Client-only message (`FCLIENT`). Never transmitted on the wire and
+    /// converted to `FINFO` before dispatch, skipping the daemon-log branch
+    /// (upstream: log.c:288-289, rsync.h:281).
     Client = 7,
     #[doc(alias = "FERROR_UTF8")]
-    /// UTF-8 conversion problem reported by a sibling (`FERROR_UTF8`).
+    /// UTF-8-encoded error travelling over the receiver -> generator pipe
+    /// (`FERROR_UTF8`); flags the text as UTF-8 and becomes `FERROR`
+    /// (upstream: log.c:283-286, rsync.h:280).
     ErrorUtf8 = 8,
 }
 
 impl LogCode {
-    /// Ordered list of all log codes understood by rsync 3.4.1.
+    /// Ordered list of all log codes understood by rsync 3.4.4.
     pub const ALL: [LogCode; 9] = [
         LogCode::None,
         LogCode::ErrorXfer,
@@ -146,10 +172,10 @@ impl FromStr for LogCode {
 /// Error returned when parsing a log code from its representation fails.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum ParseLogCodeError {
-    /// The provided numeric identifier is not known to rsync 3.4.1.
+    /// The provided numeric identifier is not known to rsync 3.4.4.
     #[error("unknown log code value: {0}")]
     InvalidValue(u8),
-    /// The provided mnemonic name is not known to rsync 3.4.1.
+    /// The provided mnemonic name is not known to rsync 3.4.4.
     #[error("unknown log code name: \"{0}\"")]
     InvalidName(String),
 }
@@ -188,17 +214,27 @@ impl ParseLogCodeError {
 mod tests {
     use super::*;
 
+    /// Pins the variant set 1:1 against upstream's `enum logcode` table
+    /// (upstream: rsync.h:275-282). A new upstream code, a renamed code, or a
+    /// changed discriminant must fail here.
     #[test]
-    fn as_u8_returns_correct_values() {
-        assert_eq!(LogCode::None.as_u8(), 0);
-        assert_eq!(LogCode::ErrorXfer.as_u8(), 1);
-        assert_eq!(LogCode::Info.as_u8(), 2);
-        assert_eq!(LogCode::Error.as_u8(), 3);
-        assert_eq!(LogCode::Warning.as_u8(), 4);
-        assert_eq!(LogCode::ErrorSocket.as_u8(), 5);
-        assert_eq!(LogCode::Log.as_u8(), 6);
-        assert_eq!(LogCode::Client.as_u8(), 7);
-        assert_eq!(LogCode::ErrorUtf8.as_u8(), 8);
+    fn variant_set_matches_upstream_enum_logcode() {
+        const UPSTREAM: [(&str, u8); 9] = [
+            ("FNONE", 0),         // rsync.h:276 - never sent
+            ("FERROR_XFER", 1),   // rsync.h:277 - sent over socket for any protocol
+            ("FINFO", 2),         // rsync.h:277 - sent over socket for any protocol
+            ("FERROR", 3),        // rsync.h:278 - sent over socket for protocols >= 30
+            ("FWARNING", 4),      // rsync.h:278 - sent over socket for protocols >= 30
+            ("FERROR_SOCKET", 5), // rsync.h:279 - receiver -> generator pipe only
+            ("FLOG", 6),          // rsync.h:279 - receiver -> generator pipe only
+            ("FCLIENT", 7),       // rsync.h:281 - never transmitted
+            ("FERROR_UTF8", 8),   // rsync.h:280 - receiver -> generator pipe only
+        ];
+        assert_eq!(LogCode::ALL.len(), UPSTREAM.len());
+        for (code, (name, value)) in LogCode::ALL.iter().zip(UPSTREAM) {
+            assert_eq!(code.name(), name);
+            assert_eq!(code.as_u8(), value);
+        }
     }
 
     #[test]
@@ -214,25 +250,6 @@ mod tests {
         assert!(LogCode::from_u8(9).is_none());
         assert!(LogCode::from_u8(100).is_none());
         assert!(LogCode::from_u8(255).is_none());
-    }
-
-    #[test]
-    fn all_contains_9_codes() {
-        assert_eq!(LogCode::ALL.len(), 9);
-        assert_eq!(LogCode::all().len(), 9);
-    }
-
-    #[test]
-    fn name_returns_f_prefix() {
-        assert_eq!(LogCode::None.name(), "FNONE");
-        assert_eq!(LogCode::ErrorXfer.name(), "FERROR_XFER");
-        assert_eq!(LogCode::Info.name(), "FINFO");
-        assert_eq!(LogCode::Error.name(), "FERROR");
-        assert_eq!(LogCode::Warning.name(), "FWARNING");
-        assert_eq!(LogCode::ErrorSocket.name(), "FERROR_SOCKET");
-        assert_eq!(LogCode::Log.name(), "FLOG");
-        assert_eq!(LogCode::Client.name(), "FCLIENT");
-        assert_eq!(LogCode::ErrorUtf8.name(), "FERROR_UTF8");
     }
 
     #[test]

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -17,6 +17,7 @@
 
 use super::config::VerbosityConfig;
 use super::levels::{DebugFlag, InfoFlag};
+use super::log_code::LogCode;
 use std::cell::RefCell;
 
 thread_local! {
@@ -28,7 +29,9 @@ thread_local! {
 /// A diagnostic event collected during execution.
 ///
 /// Events are buffered per-thread and drained by the caller for output.
-/// The two variants correspond to the info and debug flag systems.
+/// The two variants correspond to the info and debug flag systems. Every
+/// event additionally carries the upstream [`LogCode`] that classifies its
+/// destination (upstream: log.c:rwrite() dispatches on `enum logcode`).
 #[derive(Clone, Debug)]
 pub enum DiagnosticEvent {
     /// Info-level diagnostic event.
@@ -37,6 +40,8 @@ pub enum DiagnosticEvent {
         flag: InfoFlag,
         /// The verbosity level.
         level: u8,
+        /// The upstream log code classifying the event's destination.
+        code: LogCode,
         /// The diagnostic message.
         message: String,
     },
@@ -46,9 +51,21 @@ pub enum DiagnosticEvent {
         flag: DebugFlag,
         /// The verbosity level.
         level: u8,
+        /// The upstream log code classifying the event's destination.
+        code: LogCode,
         /// The diagnostic message.
         message: String,
     },
+}
+
+impl DiagnosticEvent {
+    /// Returns the upstream [`LogCode`] carried by this event.
+    #[must_use]
+    pub const fn code(&self) -> LogCode {
+        match self {
+            DiagnosticEvent::Info { code, .. } | DiagnosticEvent::Debug { code, .. } => *code,
+        }
+    }
 }
 
 /// Initialize verbosity configuration for the current thread.
@@ -79,12 +96,27 @@ pub fn debug_gte(flag: DebugFlag, level: u8) -> bool {
 ///
 /// The caller is responsible for checking [`info_gte`] first; the
 /// [`info_log!`](crate::info_log) macro handles this automatically.
+///
+/// The event is tagged [`LogCode::Info`], the code whose upstream routing
+/// (client stdout, subject to verbosity) matches how the renderer treats
+/// every drained event today. Producers that mirror a different upstream
+/// `rprintf()` code use [`emit_info_coded`].
 // upstream: log.c:rwrite() dispatches FINFO messages
 pub fn emit_info(flag: InfoFlag, level: u8, message: String) {
+    emit_info_coded(flag, level, LogCode::Info, message);
+}
+
+/// Emit an info diagnostic event carrying an explicit upstream [`LogCode`].
+///
+/// Use this when the producing site mirrors an upstream `rprintf(code, ...)`
+/// whose code is not `FINFO` (upstream: log.c:rwrite() dispatches on the
+/// code to pick the client stream versus the log file).
+pub fn emit_info_coded(flag: InfoFlag, level: u8, code: LogCode, message: String) {
     EVENTS.with(|e| {
         e.borrow_mut().push(DiagnosticEvent::Info {
             flag,
             level,
+            code,
             message,
         });
     });
@@ -94,12 +126,26 @@ pub fn emit_info(flag: InfoFlag, level: u8, message: String) {
 ///
 /// The caller is responsible for checking [`debug_gte`] first; the
 /// [`debug_log!`](crate::debug_log) macro handles this automatically.
-// upstream: log.c:rwrite() dispatches FLOG/FCLIENT debug messages
+///
+/// The event is tagged [`LogCode::Info`]: upstream debug traces are emitted
+/// through `rprintf(FINFO, ...)` and share FINFO routing. Producers that
+/// mirror a different upstream code use [`emit_debug_coded`].
+// upstream: log.c:rwrite() dispatches FINFO debug messages
 pub fn emit_debug(flag: DebugFlag, level: u8, message: String) {
+    emit_debug_coded(flag, level, LogCode::Info, message);
+}
+
+/// Emit a debug diagnostic event carrying an explicit upstream [`LogCode`].
+///
+/// Use this when the producing site mirrors an upstream `rprintf(code, ...)`
+/// whose code is not `FINFO` (upstream: log.c:rwrite() dispatches on the
+/// code to pick the client stream versus the log file).
+pub fn emit_debug_coded(flag: DebugFlag, level: u8, code: LogCode, message: String) {
     EVENTS.with(|e| {
         e.borrow_mut().push(DiagnosticEvent::Debug {
             flag,
             level,
+            code,
             message,
         });
     });
@@ -167,6 +213,7 @@ mod tests {
                 flag,
                 level,
                 message,
+                ..
             } => {
                 assert_eq!(*flag, InfoFlag::Copy);
                 assert_eq!(*level, 1);
@@ -180,6 +227,7 @@ mod tests {
                 flag,
                 level,
                 message,
+                ..
             } => {
                 assert_eq!(*flag, DebugFlag::Recv);
                 assert_eq!(*level, 2);
@@ -191,11 +239,62 @@ mod tests {
         assert_eq!(drain_events().len(), 0);
     }
 
+    /// The behaviour-preserving default: every event emitted through the
+    /// legacy emitters (and therefore through `info_log!`/`debug_log!`) is
+    /// tagged FINFO, the code whose upstream routing - client stdout,
+    /// subject to verbosity (upstream: log.c:317-320) - matches how the
+    /// renderer already treats all drained events.
+    #[test]
+    fn default_emitters_tag_events_finfo() {
+        init(VerbosityConfig::default());
+        drain_events();
+
+        emit_info(InfoFlag::Copy, 1, "info default".to_owned());
+        emit_debug(DebugFlag::Recv, 1, "debug default".to_owned());
+
+        let events = drain_events();
+        assert_eq!(events.len(), 2);
+        for event in &events {
+            assert_eq!(event.code(), LogCode::Info);
+        }
+    }
+
+    /// Coded emitters attach the producer's real upstream logcode, e.g. FLOG
+    /// for log-file-only banners (upstream: log.c:290-307).
+    #[test]
+    fn coded_emitters_carry_explicit_logcode() {
+        init(VerbosityConfig::default());
+        drain_events();
+
+        emit_info_coded(
+            InfoFlag::Flist,
+            1,
+            LogCode::Log,
+            "building file list".to_owned(),
+        );
+        emit_debug_coded(
+            DebugFlag::Recv,
+            1,
+            LogCode::Client,
+            "client-only".to_owned(),
+        );
+
+        let events = drain_events();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].code(), LogCode::Log);
+        assert_eq!(events[1].code(), LogCode::Client);
+        assert!(matches!(
+            &events[0],
+            DiagnosticEvent::Info { code: LogCode::Log, message, .. } if message == "building file list"
+        ));
+    }
+
     #[test]
     fn diagnostic_event_clone() {
         let info_event = DiagnosticEvent::Info {
             flag: InfoFlag::Copy,
             level: 1,
+            code: LogCode::Info,
             message: "test".to_owned(),
         };
         let cloned = info_event;
@@ -204,6 +303,7 @@ mod tests {
                 flag,
                 level,
                 message,
+                ..
             } => {
                 assert_eq!(flag, InfoFlag::Copy);
                 assert_eq!(level, 1);
@@ -215,6 +315,7 @@ mod tests {
         let debug_event = DiagnosticEvent::Debug {
             flag: DebugFlag::Bind,
             level: 2,
+            code: LogCode::Info,
             message: "debug".to_owned(),
         };
         let cloned = debug_event;
@@ -223,6 +324,7 @@ mod tests {
                 flag,
                 level,
                 message,
+                ..
             } => {
                 assert_eq!(flag, DebugFlag::Bind);
                 assert_eq!(level, 2);
@@ -237,6 +339,7 @@ mod tests {
         let info_event = DiagnosticEvent::Info {
             flag: InfoFlag::Del,
             level: 3,
+            code: LogCode::Info,
             message: "delete".to_owned(),
         };
         let debug = format!("{info_event:?}");
@@ -246,6 +349,7 @@ mod tests {
         let debug_event = DiagnosticEvent::Debug {
             flag: DebugFlag::Io,
             level: 4,
+            code: LogCode::Info,
             message: "io debug".to_owned(),
         };
         let debug = format!("{debug_event:?}");

--- a/crates/logging/src/tracing_bridge_tests.rs
+++ b/crates/logging/src/tracing_bridge_tests.rs
@@ -35,6 +35,7 @@ fn test_tracing_with_verbosity_level_2() {
             flag,
             level,
             message,
+            ..
         } => {
             assert_eq!(*flag, DebugFlag::Deltasum);
             assert_eq!(*level, 1);

--- a/crates/logging/tests/debug_log_behavior.rs
+++ b/crates/logging/tests/debug_log_behavior.rs
@@ -25,6 +25,7 @@ fn debug_log_emits_when_level_sufficient() {
             flag,
             level,
             message,
+            ..
         } => {
             assert_eq!(*flag, DebugFlag::Recv);
             assert_eq!(*level, 1);

--- a/crates/logging/tests/edge_cases.rs
+++ b/crates/logging/tests/edge_cases.rs
@@ -6,7 +6,7 @@
 //! Reference: rsync 3.4.1 log.c for message handling edge cases.
 
 use logging::{
-    DebugFlag, DiagnosticEvent, InfoFlag, VerbosityConfig, apply_info_flag, debug_log,
+    DebugFlag, DiagnosticEvent, InfoFlag, LogCode, VerbosityConfig, apply_info_flag, debug_log,
     drain_events, info_log, init,
 };
 
@@ -449,6 +449,7 @@ fn diagnostic_event_info_fields() {
             flag,
             level,
             message,
+            ..
         } => {
             assert_eq!(*flag, InfoFlag::Copy);
             assert_eq!(*level, 2);
@@ -474,6 +475,7 @@ fn diagnostic_event_debug_fields() {
             flag,
             level,
             message,
+            ..
         } => {
             assert_eq!(*flag, DebugFlag::Recv);
             assert_eq!(*level, 2);
@@ -489,6 +491,7 @@ fn diagnostic_event_clone() {
     let event = DiagnosticEvent::Info {
         flag: InfoFlag::Name,
         level: 1,
+        code: LogCode::Info,
         message: "cloneable".to_owned(),
     };
 
@@ -498,6 +501,7 @@ fn diagnostic_event_clone() {
             flag,
             level,
             message,
+            ..
         } => {
             assert_eq!(flag, InfoFlag::Name);
             assert_eq!(level, 1);
@@ -513,6 +517,7 @@ fn diagnostic_event_debug_trait() {
     let event = DiagnosticEvent::Debug {
         flag: DebugFlag::Io,
         level: 3,
+        code: LogCode::Info,
         message: "debug trait test".to_owned(),
     };
 

--- a/crates/logging/tests/info_log_formatting.rs
+++ b/crates/logging/tests/info_log_formatting.rs
@@ -25,6 +25,7 @@ fn info_log_emits_when_level_sufficient() {
             flag,
             level,
             message,
+            ..
         } => {
             assert_eq!(*flag, InfoFlag::Name);
             assert_eq!(*level, 1);

--- a/crates/logging/tests/verbose_level_1_output.rs
+++ b/crates/logging/tests/verbose_level_1_output.rs
@@ -76,6 +76,7 @@ fn verbose_1_emits_file_names() {
                 flag: InfoFlag::Name,
                 level: 1,
                 message,
+                ..
             } => Some(message.clone()),
             _ => None,
         })
@@ -207,6 +208,7 @@ fn verbose_1_no_itemize_format() {
             flag: InfoFlag::Name,
             level: 1,
             message,
+            ..
         } => {
             assert_eq!(message, "file.txt");
             // Should NOT contain itemize characters like ">f+++++++++"

--- a/crates/logging/tests/verbose_level_2_output.rs
+++ b/crates/logging/tests/verbose_level_2_output.rs
@@ -147,6 +147,7 @@ fn verbose_level_2_outputs_itemized_changes() {
                 flag: InfoFlag::Name,
                 level: 2,
                 message,
+                ..
             } => Some(message.as_str()),
             _ => None,
         })

--- a/crates/protocol/src/envelope/conversion.rs
+++ b/crates/protocol/src/envelope/conversion.rs
@@ -1,7 +1,7 @@
 use ::core::convert::TryFrom;
 
-use super::log_code::LogCode;
 use super::message_code::MessageCode;
+use logging::LogCode;
 use thiserror::Error;
 
 /// Errors that arise when converting between [`LogCode`] and [`MessageCode`].

--- a/crates/protocol/src/envelope/message_code.rs
+++ b/crates/protocol/src/envelope/message_code.rs
@@ -4,7 +4,7 @@ use ::core::str::FromStr;
 use std::string::String;
 
 use super::error::EnvelopeError;
-use super::log_code::LogCode;
+use logging::LogCode;
 use thiserror::Error;
 
 /// Tags used for multiplexed messages flowing over the rsync protocol stream.

--- a/crates/protocol/src/envelope/mod.rs
+++ b/crates/protocol/src/envelope/mod.rs
@@ -14,14 +14,16 @@ mod constants;
 mod conversion;
 mod error;
 mod header;
-mod log_code;
 mod message_code;
 
 pub use constants::{HEADER_LEN, MAX_PAYLOAD_LENGTH, MPLEX_BASE};
 pub use conversion::LogCodeConversionError;
 pub use error::EnvelopeError;
 pub use header::MessageHeader;
-pub use log_code::{LogCode, ParseLogCodeError};
+// The canonical `enum logcode` vocabulary lives in the `logging` crate so the
+// diagnostics event model can carry it; re-exported here so wire-side users
+// keep their `protocol::LogCode` paths.
+pub use logging::{LogCode, ParseLogCodeError};
 pub use message_code::{MessageCode, ParseMessageCodeError};
 
 pub(crate) use constants::PAYLOAD_MASK;


### PR DESCRIPTION
## Summary

Adds the upstream `enum logcode` dimension to the diagnostics event model, behaviour-neutral for stdout/stderr. Foundation for routing `--log-file` output by logcode in a follow-up.

Upstream model: every message passes through `log.c:rwrite(enum logcode code, ...)`, which dispatches on the code (rsync.h:275-282):

| Upstream | oc `LogCode` | Routing (log.c:rwrite) |
|---|---|---|
| `FNONE` (0) | `None` | never passed to rwrite (rsync.h:276) |
| `FERROR_XFER` (1) | `ErrorXfer` | stderr + sets `got_xfer_error` (log.c:310-316) |
| `FINFO` (2) | `Info` | client stdout unless quiet (log.c:317-320); daemon log/`--log-file` too (log.c:290-305) |
| `FERROR` (3) | `Error` | stderr (log.c:313-316); pre-30 downgrade to `MSG_ERROR_XFER` (log.c:332-335) |
| `FWARNING` (4) | `Warning` | stderr (log.c:314-316); pre-30 downgrade to `MSG_INFO` (log.c:332-337) |
| `FERROR_SOCKET` (5) | `ErrorSocket` | simplified to `FERROR` for a non-sibling (log.c:281-282) |
| `FLOG` (6) | `Log` | log file/syslog only, never client stdout (log.c:290-307) |
| `FCLIENT` (7) | `Client` | converted to `FINFO`, skips the daemon-log branch (log.c:288-289) |
| `FERROR_UTF8` (8) | `ErrorUtf8` | flags UTF-8, becomes `FERROR` (log.c:283-286) |

## Changes

- Move the canonical `LogCode` enum from `protocol::envelope` into `logging` (the event model's home; `protocol` depends on `logging`, so this is the only cycle-free single home). `protocol` re-exports it at all existing paths - one vocabulary, no per-crate copies.
- Tag every `DiagnosticEvent::{Info,Debug}` with a `code: LogCode` and expose `DiagnosticEvent::code()`.
- `emit_info`/`emit_debug` (and `info_log!`/`debug_log!`) default to `LogCode::Info` - the code whose upstream routing matches how `render_diagnostic_events` already treats all drained events - so this is a pure data-model extension. No routing or output changes.
- New `emit_info_coded`/`emit_debug_coded` let producers attach their real upstream code; assigning real codes and routing by them is deliberately left to the follow-up.
- The file-list FLOG banner site (#6977) stays deleted (it was fixed by removing the producer, not by a flag); its comment now points at the `LogCode::Log` path that will restore it for `--log-file` parity, and its regression guard stays in force.

## Verification

- Byte-identical output: a matrix of `-av`, `-avv`, `-ai`, `-av --stats`, missing-source error, up-to-date re-run, and `-avvn` was captured (stdout, stderr, exit code each) with binaries built before and after; `diff -r` is empty.
- New test pins the variant set and discriminants 1:1 against upstream's `enum logcode` table with citations; tests assert the FINFO default on the legacy emitters and the explicit code on the coded emitters.
- `cargo fmt`, `clippy --workspace --all-targets --all-features -D warnings`, targeted nextest (logging, cli diagnostics, flist banner guard, protocol public API/envelope): 536 passed.
