### PR TITLE
fix(transfer): forward metadata-only itemize rows to the pushing client

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -332,6 +332,21 @@ pub struct ReceiverContext {
     /// before [`Self::read_expected_ndx_done`] expects the sender's NDX_DONE.
     /// `Cell` because the emit site runs behind a `&self` pipeline closure.
     pub(in crate::receiver) hardlink_follower_echoes: std::cell::Cell<usize>,
+    /// Metadata-only itemize records a server-mode receiver must forward over
+    /// the wire, as `(flist index, wire iflags)` in flist order.
+    ///
+    /// A quick-check-matched file whose attributes still differ produces no
+    /// transfer request, but upstream's generator writes `NDX +
+    /// write_shortint(iflags)` for it anyway (generator.c:582-593) so the
+    /// pushing client's sender can print the `.f...p.....`-style row
+    /// (sender.c:292-293 `maybe_log_item`). The candidate scan records those
+    /// rows here and the transfer loop interleaves them with the file requests
+    /// in flist-index order, consuming the sender's per-record echo
+    /// (sender.c:294 `write_ndx_and_attrs`) inline. Empty on a pull: a
+    /// client-mode receiver prints its rows locally instead.
+    ///
+    /// upstream: generator.c:582-593 - `itemize()` wire emission gate.
+    pub(in crate::receiver) server_no_transfer_itemize: RefCell<Vec<(usize, u16)>>,
     /// Per-type tally of entries this receiver created (destination absent
     /// before the transfer), keyed by `ITEM_IS_NEW`. Reconstructs the
     /// `--stats` "Number of created files" breakdown locally, exactly as
@@ -449,6 +464,7 @@ impl ReceiverContext {
             names_to_stderr: false,
             progress_active: false,
             hardlink_follower_echoes: std::cell::Cell::new(0),
+            server_no_transfer_itemize: RefCell::new(Vec::new()),
             created_stats: std::cell::Cell::new(protocol::stats::CreatedStats::new()),
             got_xfer_error: std::cell::Cell::new(false),
             delayed_delete_victims: Vec::new(),

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -411,6 +411,7 @@ impl ReceiverContext {
                 // flist-index order (immediately before its children) at flush
                 // time; emitted immediately on every other path.
                 let _ = self.emit_or_record_itemize(writer, *idx, &iflags, entry);
+                self.record_server_no_transfer_itemize(*idx, iflags.raw());
             }
         }
 

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -145,6 +145,7 @@ impl ReceiverContext {
                     // upstream: generator.c:1565 - symlink up-to-date, metadata only
                     let iflags = ItemFlags::from_raw(0);
                     let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
+                    self.record_server_no_transfer_itemize(flist_idx, iflags.raw());
                     // upstream: log.c log_item / send_directory NAME emissions
                     // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
@@ -329,6 +330,7 @@ impl ReceiverContext {
             // upstream: generator.c:1594 - itemize new symlink after creation
             let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
             let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
+            self.record_server_no_transfer_itemize(flist_idx, iflags.raw());
             if !dest_existed {
                 // upstream: receiver.c:740-741 - a newly created symlink
                 // (destination was absent) bumps stats.created_symlinks.
@@ -443,6 +445,7 @@ impl ReceiverContext {
                     // upstream: generator.c:1565 - symlink up-to-date, metadata only
                     let iflags = ItemFlags::from_raw(0);
                     let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
+                    self.record_server_no_transfer_itemize(flist_idx, iflags.raw());
                     // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
@@ -546,6 +549,7 @@ impl ReceiverContext {
             // upstream: generator.c:1594 - itemize new symlink after creation
             let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
             let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
+            self.record_server_no_transfer_itemize(flist_idx, iflags.raw());
             if !dest_existed {
                 // upstream: receiver.c:740-741 - a newly created symlink
                 // (destination was absent) bumps stats.created_symlinks.

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -249,6 +249,7 @@ impl ReceiverContext {
                 // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                 let iflags = ItemFlags::from_raw(0);
                 let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
+                self.record_server_no_transfer_itemize(flist_idx, iflags.raw());
                 info_log!(Name, 2, "{} is uptodate", relative_path.display());
             } else {
                 // upstream: generator.c:1462 itemize() sets ITEM_IS_NEW when the
@@ -256,6 +257,7 @@ impl ReceiverContext {
                 let iflags =
                     ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
                 let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
+                self.record_server_no_transfer_itemize(flist_idx, iflags.raw());
                 if !dest_existed {
                     // upstream: receiver.c:743-746 - a newly created device
                     // (created_devices) or FIFO/socket (created_specials),

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -635,6 +635,55 @@ impl ReceiverContext {
         Ok(())
     }
 
+    /// Records a metadata-only itemize record a server-mode receiver must
+    /// forward over the wire, so the pushing client's sender prints the row.
+    ///
+    /// Mirrors the wire half of upstream's `itemize()`: at protocol >= 29 the
+    /// generator writes `NDX + write_shortint(iflags)` for a quick-check-matched
+    /// file whose attributes still differ, and the peer's sender - not this
+    /// process - renders the client-visible row. A client-mode receiver (a
+    /// pull) prints locally instead and records nothing here.
+    ///
+    /// The framing bits (`ITEM_BASIS_TYPE_FOLLOWS`, `ITEM_XNAME_FOLLOWS`) and
+    /// `ITEM_REPORT_XATTR` are stripped: a no-change record carries no basis
+    /// byte, no xname vstring, and this path writes no trailing xattr request
+    /// (the transfer-request path strips the same bits, see
+    /// `send_file_request_xattr`), so leaving them set would make the sender
+    /// read trailing fields that never arrive.
+    ///
+    /// The significance gate mirrors `generator.c:582-583`: emit when any
+    /// significant flag survives, under `-vv` (`INFO_GTE(NAME, 2)`), or under
+    /// `-ii` (`stdout_format_has_i > 1`, tracked as `itemize_unchanged`).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:582-593` - `itemize()` wire emission and its gate
+    /// - `sender.c:292-294` - the sender logs the row and echoes the attrs
+    pub(in crate::receiver) fn record_server_no_transfer_itemize(
+        &self,
+        flist_idx: usize,
+        iflags: u32,
+    ) {
+        if self.config.connection.client_mode || !self.protocol.supports_iflags() {
+            return;
+        }
+        const STRIPPED: u32 = crate::generator::ItemFlags::ITEM_REPORT_XATTR
+            | crate::generator::ItemFlags::ITEM_BASIS_TYPE_FOLLOWS
+            | crate::generator::ItemFlags::ITEM_XNAME_FOLLOWS;
+        // upstream: generator.c:581 `iflags &= 0xffff` - the full low word goes
+        // on the wire; the significance mask below is only the emission gate.
+        let wire = ((iflags & !STRIPPED) & 0xFFFF) as u16;
+        if wire & (crate::generator::ItemFlags::SIGNIFICANT_ITEM_FLAGS as u16) == 0
+            && !logging::info_gte(logging::InfoFlag::Name, 2)
+            && !self.config.flags.info_flags.itemize_unchanged
+        {
+            return;
+        }
+        self.server_no_transfer_itemize
+            .borrow_mut()
+            .push((flist_idx, wire));
+    }
+
     /// Emits an itemize row immediately, or buffers it for the deferred
     /// flist-index-order flush when [`Self::defer_itemize`] is set.
     ///

--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -34,6 +34,7 @@ mod munge_symlinks;
 mod parallel_delta_notice;
 mod partial_resume;
 mod post_decision_name_emission;
+mod push_metadata_itemize;
 mod support;
 mod symlinks_and_devices;
 #[cfg(unix)]

--- a/crates/transfer/src/receiver/tests/push_metadata_itemize.rs
+++ b/crates/transfer/src/receiver/tests/push_metadata_itemize.rs
@@ -83,7 +83,9 @@ fn server_push_pipeline_forwards_metadata_only_record_and_drains_echo() {
     let mut ctx = push_receiver();
     ctx.file_list = vec![FileEntry::new_file("f".into(), 1, 0o600)];
     let iflags = ItemFlags::ITEM_REPORT_PERMS as u16;
-    ctx.server_no_transfer_itemize.borrow_mut().push((0, iflags));
+    ctx.server_no_transfer_itemize
+        .borrow_mut()
+        .push((0, iflags));
 
     let dir = test_support::create_tempdir();
     let setup = PipelineSetup {
@@ -97,8 +99,7 @@ fn server_push_pipeline_forwards_metadata_only_record_and_drains_echo() {
         sandbox: None,
     };
 
-    let mut reader =
-        crate::reader::ServerReader::new_plain(Cursor::new(sender_echo(0, iflags)));
+    let mut reader = crate::reader::ServerReader::new_plain(Cursor::new(sender_echo(0, iflags)));
     let sent = SharedBuf::default();
     let mut writer = crate::writer::ServerWriter::new_plain(sent.clone());
     let mut metadata_errors = Vec::new();

--- a/crates/transfer/src/receiver/tests/push_metadata_itemize.rs
+++ b/crates/transfer/src/receiver/tests/push_metadata_itemize.rs
@@ -1,0 +1,148 @@
+//! Wire shape of the server-mode metadata-only itemize records on a push.
+//!
+//! On a push the remote receiver's generator owns the itemize decision, but
+//! the CLIENT's sender owns the printing: upstream writes `NDX +
+//! write_shortint(iflags)` for every quick-check-matched entry whose
+//! attributes still differ (`generator.c:582-593`), the sender prints the row
+//! (`sender.c:292-293 maybe_log_item`) and echoes the attrs back
+//! (`sender.c:294 write_ndx_and_attrs`). These tests pin the record's exact
+//! wire bytes and prove the pipeline drains the sender's echo, so a
+//! metadata-only run cannot desync the phase-done handshake.
+
+use std::io::{Cursor, Read};
+use std::num::NonZeroU8;
+use std::path::PathBuf;
+
+use protocol::codec::{NdxCodec, create_ndx_codec};
+use protocol::flist::FileEntry;
+
+use super::super::{PipelineSetup, ReceiverContext};
+use super::support::test_handshake;
+use crate::config::ServerConfig;
+use crate::flags::{InfoFlags, ParsedServerFlags};
+use crate::generator::ItemFlags;
+use crate::role::ServerRole;
+
+/// Capture sink for the bytes the receiver puts on the wire. `ServerWriter`
+/// owns its sink and exposes no accessor, so the buffer is shared.
+#[derive(Clone, Default)]
+struct SharedBuf(std::rc::Rc<std::cell::RefCell<Vec<u8>>>);
+
+impl SharedBuf {
+    fn take(self) -> Vec<u8> {
+        std::mem::take(&mut *self.0.borrow_mut())
+    }
+}
+
+impl std::io::Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A server-mode (push) receiver with `-i` requested by the client.
+fn push_receiver() -> ReceiverContext {
+    let handshake = test_handshake();
+    let mut config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: protocol::ProtocolVersion::try_from(32u8).unwrap(),
+        flags: ParsedServerFlags {
+            info_flags: InfoFlags {
+                itemize: true,
+                ..InfoFlags::default()
+            },
+            ..ParsedServerFlags::default()
+        },
+        ..Default::default()
+    };
+    config.connection.client_mode = false;
+    ReceiverContext::new_for_test(&handshake, config)
+}
+
+/// The sender's echo of one non-transfer record: `NDX + iflags`, nothing else.
+fn sender_echo(ndx: i32, iflags: u16) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut codec = create_ndx_codec(32);
+    codec.write_ndx(&mut buf, ndx).expect("write echo ndx");
+    buf.extend_from_slice(&iflags.to_le_bytes());
+    buf
+}
+
+/// A recorded metadata-only row must reach the wire as exactly
+/// `NDX + write_shortint(iflags)` - no sum head, basis byte, or xname - and
+/// its echo must be consumed by the same loop, in FIFO order. Pre-fix, the
+/// pipeline dropped the record entirely: the pushing client's sender had
+/// nothing to render and a chmod-only push printed no row at all.
+#[test]
+fn server_push_pipeline_forwards_metadata_only_record_and_drains_echo() {
+    let mut ctx = push_receiver();
+    ctx.file_list = vec![FileEntry::new_file("f".into(), 1, 0o600)];
+    let iflags = ItemFlags::ITEM_REPORT_PERMS as u16;
+    ctx.server_no_transfer_itemize.borrow_mut().push((0, iflags));
+
+    let dir = test_support::create_tempdir();
+    let setup = PipelineSetup {
+        dest_dir: dir.path().to_path_buf(),
+        metadata_opts: metadata::MetadataOptions::default(),
+        checksum_length: NonZeroU8::new(2).expect("nonzero"),
+        checksum_algorithm: signature::SignatureAlgorithm::Md4,
+        acl_cache: None,
+        acl_id_map: None,
+        #[cfg(unix)]
+        sandbox: None,
+    };
+
+    let mut reader =
+        crate::reader::ServerReader::new_plain(Cursor::new(sender_echo(0, iflags)));
+    let sent = SharedBuf::default();
+    let mut writer = crate::writer::ServerWriter::new_plain(sent.clone());
+    let mut metadata_errors = Vec::new();
+    let files: Vec<(usize, &FileEntry, PathBuf, u32)> = Vec::new();
+    let result = ctx
+        .run_pipeline_loop_decoupled(
+            &mut reader,
+            &mut writer,
+            crate::pipeline::PipelineConfig::default(),
+            &setup,
+            files,
+            &mut metadata_errors,
+            false,
+            0,
+            &mut None,
+        )
+        .expect("metadata-only phase must complete without hanging on the echo");
+
+    assert_eq!(result.0, 0, "a metadata-only record transfers no file");
+    assert!(
+        ctx.server_no_transfer_itemize.borrow().is_empty(),
+        "the phase-1 loop must consume the recorded rows"
+    );
+
+    // Decode with the peer sender's own reader path so this fails if the
+    // emitted bytes ever diverge from what the sender consumes.
+    let bytes = sent.take();
+    let mut cur = Cursor::new(bytes.as_slice());
+    let mut rd = create_ndx_codec(32);
+    assert_eq!(
+        rd.read_ndx(&mut cur).expect("record NDX must decode"),
+        0,
+        "the record carries the entry's flist NDX"
+    );
+    let mut wire_iflags = [0u8; 2];
+    cur.read_exact(&mut wire_iflags).expect("iflags shortint");
+    assert_eq!(
+        u16::from_le_bytes(wire_iflags),
+        iflags,
+        "the shortint carries the attribute-diff bits the client renders"
+    );
+    assert_eq!(
+        cur.position() as usize,
+        bytes.len(),
+        "no sum head or trailing fields may follow a metadata-only record"
+    );
+}

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -1098,6 +1098,7 @@ impl ReceiverContext {
             // metadata-only row interleaves with directory and transfer rows in
             // flist-index order at flush time; emitted immediately otherwise.
             let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
+            self.record_server_no_transfer_itemize(flist_idx, unchanged_iflags);
         }
 
         // upstream: generator.c:468 unchanged_attrs() - fast-path check avoids
@@ -1196,6 +1197,118 @@ mod itemize_order_tests {
         };
         config.connection.client_mode = true;
         config
+    }
+
+    /// A server-mode push receiver with `-i`: the remote end of a push.
+    fn itemize_server_config() -> ServerConfig {
+        let mut config = itemize_client_config();
+        config.connection.client_mode = false;
+        config
+    }
+
+    /// upstream: generator.c:582-593 - on a push the server-side generator
+    /// writes `NDX + write_shortint(iflags)` for a quick-check-matched file
+    /// whose attributes still differ; the pushing client's sender renders the
+    /// `.f...p.....` row from those wire iflags (sender.c:292-293
+    /// `maybe_log_item`). A server receiver that drops the record makes every
+    /// metadata-only change invisible under `-i` on a push - against another
+    /// oc peer and against upstream 3.4.4 alike - while a pull stays correct,
+    /// so only the push direction ever exposes the loss.
+    #[cfg(unix)]
+    #[test]
+    fn server_push_candidate_scan_records_metadata_only_wire_row() {
+        use std::os::unix::fs::PermissionsExt;
+
+        use crate::generator::ItemFlags;
+
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        let path = dest.join("f.txt");
+        std::fs::write(&path, b"x").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let t = filetime::FileTime::from_unix_time(1_600_000_000, 0);
+        filetime::set_file_times(&path, t, t).unwrap();
+
+        let mut entry = FileEntry::new_file("f.txt".into(), 1, 0o600);
+        entry.set_mtime(1_600_000_000, 0);
+
+        let hs = handshake();
+        let run = |client_mode: bool| {
+            let mut config = itemize_server_config();
+            config.connection.client_mode = client_mode;
+            config.flags.times = true;
+            config.flags.perms = true;
+            let mut ctx = ReceiverContext::new_for_test(&hs, config);
+            ctx.file_list = vec![entry.clone()];
+            let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+            let mut metadata_errors = Vec::new();
+            let mut stats = TransferStats::default();
+            let files = ctx.build_files_to_transfer(
+                &mut writer,
+                dest,
+                &metadata::MetadataOptions::default(),
+                None,
+                &mut metadata_errors,
+                &mut stats,
+                None,
+                None,
+            );
+            assert!(
+                files.is_empty(),
+                "a quick-check match must not request a transfer"
+            );
+            ctx.server_no_transfer_itemize.borrow().clone()
+        };
+
+        assert_eq!(
+            run(false),
+            vec![(0usize, ItemFlags::ITEM_REPORT_PERMS as u16)],
+            "the server-mode candidate scan must record the metadata-only row \
+             for the wire; without it the pushing client prints nothing"
+        );
+        assert!(
+            run(true).is_empty(),
+            "a client-mode (pull) receiver prints its row locally; recording \
+             it for the wire too would double every row"
+        );
+    }
+
+    /// upstream: generator.c:581-583 - `iflags &= 0xffff` puts the full low
+    /// word on the wire, but the record is only emitted when a significant
+    /// flag survives (or `-ii` / `-vv` force unchanged rows), and this
+    /// no-trailing-fields path must never advertise `ITEM_REPORT_XATTR`,
+    /// `ITEM_BASIS_TYPE_FOLLOWS`, or `ITEM_XNAME_FOLLOWS` - the peer's sender
+    /// would block reading a basis byte, xname vstring, or xattr request that
+    /// never arrives.
+    #[test]
+    fn record_server_no_transfer_itemize_strips_framing_and_gates_significance() {
+        use crate::generator::ItemFlags;
+
+        let hs = handshake();
+        let ctx = ReceiverContext::new_for_test(&hs, itemize_server_config());
+        ctx.record_server_no_transfer_itemize(
+            2,
+            ItemFlags::ITEM_REPORT_PERMS
+                | ItemFlags::ITEM_REPORT_XATTR
+                | ItemFlags::ITEM_BASIS_TYPE_FOLLOWS
+                | ItemFlags::ITEM_XNAME_FOLLOWS,
+        );
+        ctx.record_server_no_transfer_itemize(3, 0);
+        assert_eq!(
+            ctx.server_no_transfer_itemize.borrow().as_slice(),
+            &[(2usize, ItemFlags::ITEM_REPORT_PERMS as u16)],
+            "framing bits are stripped and an all-clear record is dropped"
+        );
+
+        let mut ii = itemize_server_config();
+        ii.flags.info_flags.itemize_unchanged = true;
+        let ctx = ReceiverContext::new_for_test(&hs, ii);
+        ctx.record_server_no_transfer_itemize(3, 0);
+        assert_eq!(
+            ctx.server_no_transfer_itemize.borrow().as_slice(),
+            &[(3usize, 0u16)],
+            "-ii (stdout_format_has_i > 1) keeps the unchanged record"
+        );
     }
 
     /// upstream: generator.c:531-533. Under `--atimes` (`-U`), an otherwise

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -82,15 +82,16 @@ impl ReceiverContext {
     /// `(files_transferred, bytes, literal, matched, redo_indices, delayed_updates)`.
     #[allow(clippy::too_many_arguments)]
     pub(in crate::receiver) fn run_pipeline_loop_decoupled<
+        'a,
         R: Read,
         W: Write + crate::writer::MsgInfoSender + ?Sized,
     >(
-        &self,
+        &'a self,
         reader: &mut crate::reader::ServerReader<R>,
         writer: &mut W,
         pipeline_config: PipelineConfig,
         setup: &PipelineSetup,
-        files_to_transfer: Vec<(usize, &FileEntry, PathBuf, u32)>,
+        files_to_transfer: Vec<(usize, &'a FileEntry, PathBuf, u32)>,
         metadata_errors: &mut Vec<(PathBuf, String)>,
         is_redo_pass: bool,
         total_files: usize,
@@ -99,6 +100,36 @@ impl ReceiverContext {
         use crate::disk_commit::{BackupConfig, DiskCommitConfig, PartialMode};
         use crate::pipeline::receiver::PipelinedReceiver;
         use crate::shared::TransferDeadline;
+
+        // upstream: generator.c:582-593 - itemize() also writes NDX + iflags
+        // for entries with significant attribute diffs but no ITEM_TRANSFER,
+        // interleaved with the transfer requests in flist order; the peer's
+        // sender prints each row and echoes the attrs back (sender.c:292-294).
+        // Merge the recorded metadata-only rows into the request stream so the
+        // wire order matches upstream's single flist walk. The recording passes
+        // (directories, then symlinks, then specials, then the candidate scan)
+        // are each ascending but run back to back, so restore global
+        // flist-index order before merging with the ascending transfer list.
+        let mut no_transfer_rows =
+            std::mem::take(&mut *self.server_no_transfer_itemize.borrow_mut());
+        no_transfer_rows.sort_by_key(|&(idx, _)| idx);
+        let files_to_transfer = if no_transfer_rows.is_empty() {
+            files_to_transfer
+        } else {
+            let mut merged = Vec::with_capacity(files_to_transfer.len() + no_transfer_rows.len());
+            let mut rows = no_transfer_rows.into_iter().peekable();
+            for item in files_to_transfer {
+                while let Some(&(idx, iflags)) = rows.peek().filter(|&&(idx, _)| idx < item.0) {
+                    rows.next();
+                    merged.push((idx, &self.file_list[idx], PathBuf::new(), u32::from(iflags)));
+                }
+                merged.push(item);
+            }
+            for (idx, iflags) in rows {
+                merged.push((idx, &self.file_list[idx], PathBuf::new(), u32::from(iflags)));
+            }
+            merged
+        };
 
         // Early return when there is nothing to transfer - avoids spawning
         // the disk-commit thread, creating codecs, and pipeline state.
@@ -272,7 +303,13 @@ impl ReceiverContext {
                         let sig_results: Vec<_> = if batch.len() >= sig_threshold {
                             batch
                                 .par_iter()
-                                .map(|(_, file_entry, file_path, _)| {
+                                .map(|(_, file_entry, file_path, base_iflags)| {
+                                    // A metadata-only record transfers no data,
+                                    // so no basis search is needed.
+                                    if base_iflags & crate::generator::ItemFlags::ITEM_TRANSFER == 0
+                                    {
+                                        return crate::receiver::basis::BasisFileResult::EMPTY;
+                                    }
                                     let basis_config = BasisFileConfig {
                                         file_path,
                                         dest_dir,
@@ -294,7 +331,11 @@ impl ReceiverContext {
                         } else {
                             batch
                                 .iter()
-                                .map(|(_, file_entry, file_path, _)| {
+                                .map(|(_, file_entry, file_path, base_iflags)| {
+                                    if base_iflags & crate::generator::ItemFlags::ITEM_TRANSFER == 0
+                                    {
+                                        return crate::receiver::basis::BasisFileResult::EMPTY;
+                                    }
                                     let basis_config = BasisFileConfig {
                                         file_path,
                                         dest_dir,
@@ -319,6 +360,19 @@ impl ReceiverContext {
                         for ((file_idx, file_entry, file_path, base_iflags), basis_result) in
                             batch.into_iter().zip(sig_results)
                         {
+                            if base_iflags & crate::generator::ItemFlags::ITEM_TRANSFER == 0 {
+                                self.send_no_transfer_itemize(
+                                    writer,
+                                    &mut ndx_write_codec,
+                                    &mut pipeline,
+                                    &mut pending_files_info,
+                                    file_idx,
+                                    file_entry,
+                                    file_path,
+                                    base_iflags,
+                                )?;
+                                continue;
+                            }
                             let pending = send_file_request(
                                 writer,
                                 &mut ndx_write_codec,
@@ -344,6 +398,19 @@ impl ReceiverContext {
                     } else {
                         // Redo pass or empty batch: no basis files, skip signatures.
                         for (file_idx, file_entry, file_path, base_iflags) in batch {
+                            if base_iflags & crate::generator::ItemFlags::ITEM_TRANSFER == 0 {
+                                self.send_no_transfer_itemize(
+                                    writer,
+                                    &mut ndx_write_codec,
+                                    &mut pipeline,
+                                    &mut pending_files_info,
+                                    file_idx,
+                                    file_entry,
+                                    file_path,
+                                    base_iflags,
+                                )?;
+                                continue;
+                            }
                             let pending = send_file_request(
                                 writer,
                                 &mut ndx_write_codec,
@@ -384,6 +451,20 @@ impl ReceiverContext {
                 flushed_pending = flushed_pending.saturating_sub(1);
                 let (file_idx, file_path, file_entry, base_iflags) =
                     pending_files_info.pop_front().expect("pipeline not empty");
+
+                // upstream: sender.c:292-294 - a non-transfer item is logged by
+                // the sender and echoed back via write_ndx_and_attrs(); consume
+                // the echo here so the response stream stays aligned with the
+                // transfer replies that follow it in FIFO order.
+                if base_iflags & crate::generator::ItemFlags::ITEM_TRANSFER == 0 {
+                    let _ = crate::receiver::wire::SenderAttrs::read_with_codec_xattr(
+                        &mut *reader,
+                        &mut ndx_read_codec,
+                        request_config.preserve_xattrs,
+                        request_config.want_xattr_optim,
+                    )?;
+                    continue;
+                }
 
                 // upstream: receiver.c:708-709 DEBUG_GTE(RECV, 1)
                 debug_log!(Recv, 1, "recv_files({})", file_entry.path().display());
@@ -563,6 +644,43 @@ impl ReceiverContext {
         let _ = pipelined_receiver.shutdown();
 
         result
+    }
+
+    /// Writes one metadata-only itemize record (`NDX + iflags`, nothing else)
+    /// and queues its pending echo behind the in-flight transfer requests.
+    ///
+    /// The record produces no sum head, basis byte, or xname - the framing
+    /// bits were stripped at record time (`record_server_no_transfer_itemize`).
+    /// The sender answers it with a bare `write_ndx_and_attrs()` echo, so a
+    /// placeholder pending rides the FIFO queue and the pop side consumes the
+    /// echo in order with the transfer replies.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:584-587` - `write_ndx()` + `write_shortint(iflags)`
+    /// - `sender.c:292-294` - the sender logs the row, then echoes the attrs
+    #[allow(clippy::too_many_arguments)]
+    fn send_no_transfer_itemize<'a, W: Write + ?Sized>(
+        &self,
+        writer: &mut W,
+        ndx_write_codec: &mut impl protocol::codec::NdxCodec,
+        pipeline: &mut PipelineState,
+        pending_files_info: &mut VecDeque<(usize, PathBuf, &'a FileEntry, u32)>,
+        file_idx: usize,
+        file_entry: &'a FileEntry,
+        file_path: PathBuf,
+        base_iflags: u32,
+    ) -> io::Result<()> {
+        let wire_ndx = self.flat_to_wire_ndx(file_idx);
+        ndx_write_codec.write_ndx(&mut *writer, wire_ndx)?;
+        writer.write_all(&((base_iflags & 0xFFFF) as u16).to_le_bytes())?;
+        pipeline.push(crate::pipeline::PendingTransfer::new_full_transfer(
+            wire_ndx,
+            file_path.clone(),
+            0,
+        ));
+        pending_files_info.push_back((file_idx, file_path, file_entry, base_iflags));
+        Ok(())
     }
 
     /// Dry-run transfer loop: sends NDX requests without data transfer.

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -144,6 +144,7 @@ impl ReceiverContext {
                         // flist-index order immediately before its children at
                         // flush time, matching run_pipelined and upstream.
                         let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, file_entry);
+                        self.record_server_no_transfer_itemize(flist_idx, iflags.raw());
                     }
                     None => {
                         stats.directories_failed += 1;


### PR DESCRIPTION
## Problem

On a push, oc emitted no metadata-only itemize rows at all. A chmod-only change that upstream 3.4.4 reports as `.f...p..... f` printed nothing - over SSH and daemon transports alike, with an oc peer and with upstream on either end. Transferred-file rows worked; only the non-transfer rows (attribute-only files, directories, new/changed symlinks, specials) were lost. Pull and local copy were unaffected, so the loss was invisible to oc<->oc pull testing.

## Upstream mechanism

- `generator.c:582-593` - at protocol >= 29 the receiving side's generator writes `NDX + write_shortint(iflags)` for every entry with significant attribute-diff flags, not just `ITEM_TRANSFER` ones, interleaved with the transfer requests in flist order.
- `sender.c:236,292-294` - the pushing client's sender reads them via `read_ndx_and_attrs()` (`rsync.c:322`), prints the row through `maybe_log_item()` (`log.c:828`, gated on `!am_server`), and echoes the attrs back with `write_ndx_and_attrs()`.

oc's client-side sender already implements the read/print/echo half (`generator/protocol_io.rs`, `transfer_loop.rs:560-586`). The root cause was server-side: the receiver's candidate scan quick-check-matched a metadata-only file, applied the metadata, and `continue`d without ever putting `NDX + iflags` on the wire; the directory/symlink/special passes likewise emitted only client-local rows.

## Fix

- `record_server_no_transfer_itemize()` (receiver/itemize.rs): a server-mode receiver records `(flist idx, wire iflags)` for each non-transfer row, mirroring the `generator.c:582-583` gate (significant flags, `-vv`, or `-ii`), stripping the framing bits (`ITEM_BASIS_TYPE_FOLLOWS`, `ITEM_XNAME_FOLLOWS`) and `ITEM_REPORT_XATTR` so the peer never waits on trailing fields this path does not write. Recording sites: the candidate scan's quick-check-match arm, both directory-creation passes, symlinks, and specials.
- `run_pipeline_loop_decoupled()` merges the recorded rows into the request stream in flist-index order (matching upstream's single walk), writes each as a bare `NDX + shortint`, and consumes the sender's echo through the same FIFO pipeline so the response stream stays aligned. Covers both pipelined receiver ladders; the redo pass re-takes an empty buffer.

## Verification vs real rsync 3.4.4 (`/opt/homebrew/bin/rsync`, banner-confirmed)

Reference captured first; oc-before printed no row in every push cell; oc-after is byte-identical to upstream:

| scenario | upstream 3.4.4 | oc before | oc after |
|---|---|---|---|
| push chmod-only `-ai` (ssh-style + daemon) | `.f...p..... f` | (nothing) | `.f...p..... f` |
| push mtime-only `-ai --size-only` | `.f..t...... f` | (nothing) | `.f..t...... f` |
| push mtime-only `-ri --size-only` (no `-t`) | (no row) | (no row) | (no row) |
| push group-only `-ai` | `.f.....g... f` | (nothing) | `.f.....g... f` |
| push dir-mtime-only `-ai` | `.d..t...... ./` + `sub/` | (nothing) | identical |
| push new dir / new symlink | `cd+++++++++`, `cL+++++++++` | (nothing) | identical |
| push `-aii` unchanged rows | `.d ./` + `.f...p f` | (nothing) | identical |
| 500-file mixed (metadata/changed/new) push | full row set | rows missing | `diff` identical incl. order |

Cross-interop: upstream client -> oc server and oc client -> upstream server both now match. Pull, local copy, `--dry-run` push, `--delete` push, and hardlink push (`hf` follower rows) re-verified unchanged. Both receiver ladders (`incremental-flist` on and off) verified at the binary level. Daemon MOTD banner ordering is unaffected (banner first, rows after, matching upstream).

Owner-only rows require root and were not exercised; the same `ITEM_REPORT_OWNER` bit rides the identical path as the verified group bit.

## Known remaining gaps (pre-existing, out of scope)

- Up-to-date symlink attr rows (`.L..t...... l -> f`): the receiver computes `iflags = 0` for an up-to-date symlink instead of comparing attributes (`links.rs`), so the row is missing on pull as well; direction-independent flags gap, not a wire gap.
- `ITEM_REPORT_XATTR` (`x` column) on non-transfer push rows would need the generator-side `send_xattr_request()` payload; stripped for now, consistent with the transfer-request path.

## Tests

- `server_push_candidate_scan_records_metadata_only_wire_row` - the server-mode scan records the row; the client-mode (pull) scan records nothing (would double).
- `record_server_no_transfer_itemize_strips_framing_and_gates_significance` - framing bits stripped, all-clear rows dropped unless `-ii`.
- `server_push_pipeline_forwards_metadata_only_record_and_drains_echo` - pins the exact wire bytes (`NDX + shortint`, nothing else), decodes them with the sender's own codec path, and proves the echo is drained without hanging.

Full `transfer` suite: 2537 passed. Workspace clippy `-D warnings` and `cargo fmt --check` clean.
