### PR TITLE
docs(daemon): fix unresolved intra-doc link breaking the Pages build

### DIFF
--- a/crates/daemon/src/auth.rs
+++ b/crates/daemon/src/auth.rs
@@ -126,7 +126,7 @@
 //! - `daemon::sections::module_access`: Server-side authentication flow during module requests
 //! - This module: High-level documentation and helper utilities
 //!
-//! [`ChallengeGenerator`] is the sole challenge implementation; the module-access
+//! `ChallengeGenerator` is the sole challenge implementation; the module-access
 //! authentication flow calls it rather than keeping a second copy.
 
 pub use core::auth::{


### PR DESCRIPTION
The `Pages` workflow's `Build rustdoc (workspace, all features, no deps)` step has been failing on master with:

```
error: unresolved link to `ChallengeGenerator`
```

The `daemon::auth` module doc linked `ChallengeGenerator` with an intra-doc link, but a module's `//!` docs resolve against the crate-root namespace, where the type is not re-exported. Under `-D rustdoc::broken_intra_doc_links` this fails the build. The sibling references in the same doc block already use plain code spans; this makes `ChallengeGenerator` consistent.

Fixes the latest master Pages failure (run on the actions-group bump commit).
