### PR TITLE
docs: point daemon config references at config_parsing module

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ This document outlines the crate boundaries, role separation, and design pattern
 | `matching` | Block matching and delta generation | `lib.rs` |
 | `batch` | Batch mode recording and replay | `format.rs`, `writer.rs`, `reader.rs`, `script.rs` |
 | `protocol` | Wire format, multiplex codec, negotiation, flist | `multiplex/`, `negotiation.rs`, `flist/` |
-| `daemon` | Daemon mode, config parsing, session management (thread-per-connection; see `DAEMON_PROCESS_MODEL.md`) | `daemon.rs`, `config.rs`, `rsyncd_config.rs` |
+| `daemon` | Daemon mode, config parsing, session management (thread-per-connection; see `DAEMON_PROCESS_MODEL.md`) | `daemon.rs`, `config.rs`, `daemon/sections/config_parsing/` |
 | `filters` | Filter rules (include/exclude), pattern matching | `set.rs`, `rule.rs`, `merge.rs` |
 | `checksums` | Rolling (SIMD) and strong checksums (XXH3, MD5, etc.) | `rolling/`, `strong/` |
 | `compress` | Compression algorithms (zlib, zstd, lz4) | `zlib.rs`, `zstd.rs`, `lz4.rs` |

--- a/docs/contributing/upstream-cross-references.md
+++ b/docs/contributing/upstream-cross-references.md
@@ -115,7 +115,7 @@ traceability.
 | File | Missing reference | Upstream source |
 |------|------------------|-----------------|
 | `auth.rs` | Challenge-response MD4/MD5 computation | authenticate.c:auth_server() |
-| `rsyncd_config/` (various) | Configuration parameter parsing | loadparm.c (partially covered) |
+| `daemon/sections/config_parsing/` (various) | Configuration parameter parsing | loadparm.c (partially covered) |
 
 ### Checksums Crate
 

--- a/docs/design/adaptive-thread-pool-sizing.md
+++ b/docs/design/adaptive-thread-pool-sizing.md
@@ -515,10 +515,10 @@ transfer-worker-threads = 0           # treat as default (adaptive)
 ```
 
 Parsed at config load by extending the existing
-`crates/daemon/src/rsyncd_config/sections.rs` parser. Validation lives
-in `crates/daemon/src/rsyncd_config/validation.rs`. The validator
-accepts the literal string `adaptive` or any positive integer in the
-range `[1, 4096]` (an upper sanity bound).
+`crates/daemon/src/daemon/sections/config_parsing/global_directives.rs`
+parser, which validates directives inline as it parses them. The
+validator accepts the literal string `adaptive` or any positive integer
+in the range `[1, 4096]` (an upper sanity bound).
 
 ### 11.3 BufferPool API
 
@@ -611,8 +611,8 @@ listed here so reviewers can plan implementation order:
   `BufferPoolStats::shard_overflows` and the shard hit rate.
 - **Daemon worker pool integration TODO**: wire
   `TransferWorkerPool` to the sizer; extend
-  `crates/daemon/src/rsyncd_config/sections.rs` for the
-  `adaptive | <fixed>` parser; gate behind the existing
+  `crates/daemon/src/daemon/sections/config_parsing/global_directives.rs`
+  for the `adaptive | <fixed>` parser; gate behind the existing
   `async-daemon` feature so non-async builds keep the sync model.
 - **Telemetry / dashboard TODO**: add the `-vv` structured-log line in
   every sizing decision; add the `BufferPoolStats` snapshot of the

--- a/docs/design/daemon-async-accept-sync-workers.md
+++ b/docs/design/daemon-async-accept-sync-workers.md
@@ -242,8 +242,9 @@ Behaviour:
 - If unset, `N = num_cpus::get() * 2`.
 - If set to a positive integer, that value is used verbatim.
 - If set to `0`, fall back to the default.
-- Validated at config parse time via the existing
-  `crates/daemon/src/rsyncd_config/validation.rs` machinery.
+- Validated at config parse time by the existing
+  `crates/daemon/src/daemon/sections/config_parsing/` parser (validation
+  is inline in the directive parsing, not a separate pass).
 
 The knob is intentionally a global; per-module worker sizing would force
 per-module pools and would not interact well with `--max-connections`. A
@@ -554,10 +555,9 @@ Files that the implementation phase will add or extend:
 - `crates/daemon/src/daemon/async_session/listener.rs` - replace the
   inline `tokio::spawn(handle_async_session(...))` with a handoff into
   `TransferWorkerPool`.
-- `crates/daemon/src/rsyncd_config/sections.rs` - add
-  `transfer-worker-threads` directive parsing.
-- `crates/daemon/src/rsyncd_config/validation.rs` - validate the new
-  directive.
+- `crates/daemon/src/daemon/sections/config_parsing/global_directives.rs` -
+  add `transfer-worker-threads` directive parsing and validate the new
+  directive inline.
 - `crates/daemon/Cargo.toml` - no change required; the existing
   `async` feature flag is the on/off switch.
 

--- a/docs/design/daemon-async-runtime-choice.md
+++ b/docs/design/daemon-async-runtime-choice.md
@@ -220,8 +220,8 @@ What still needs to happen:
    `.await` the join handle. The blocking closure is the existing
    worker body factored out of `connection.rs`.
 3. Add `use-async-listener` as a boolean directive in
-   `crates/daemon/src/rsyncd_config/sections.rs` and validate it in
-   `crates/daemon/src/rsyncd_config/validation.rs`. Default false.
+   `crates/daemon/src/daemon/sections/config_parsing/global_directives.rs`
+   and validate it inline in the same parser. Default false.
 4. The async features the daemon needs are exactly
    `["rt-multi-thread", "net", "macros", "signal", "sync", "time"]`.
    `rt-multi-thread` and `signal` are not currently in the daemon's

--- a/docs/design/differential-filter-fuzzer.md
+++ b/docs/design/differential-filter-fuzzer.md
@@ -64,7 +64,7 @@ inclusion decisions over the entire tree.
   one-shot merges via `merge`/`.` directives.
 - **Daemon directives**: `rsyncd.conf` `filter`, `exclude`, `include`,
   `exclude from`, `include from` parameters consumed by
-  `crates/daemon/src/rsyncd_config/sections.rs:155-159` and assembled
+  `crates/daemon/src/daemon/sections/config_parsing/module_directives.rs` and assembled
   into the daemon filter list at
   `crates/daemon/src/daemon/sections/module_access/helpers.rs:223-280`.
   This addresses the gap noted in #1366 and the daemon hide/show

--- a/docs/design/fuzz-coverage-matrix.md
+++ b/docs/design/fuzz-coverage-matrix.md
@@ -34,7 +34,6 @@ The matrix below tracks per-target coverage metrics. Columns:
 | Target                    | Category | Lines | Branches | Edge % | Corpus | Last run |
 | ------------------------- | -------- | ----- | -------- | ------ | ------ | -------- |
 | `filter_list_wire`        | parser   | -     | -        | -      | 0      | -        |
-| `rsyncd_conf`             | parser   | -     | -        | -      | 0      | -        |
 | `capability_flags`        | parser   | -     | -        | -      | 0      | -        |
 | `auth_response`           | parser   | -     | -        | -      | 0      | -        |
 | `vstring`                 | parser   | -     | -        | -      | 0      | -        |
@@ -89,7 +88,6 @@ distance below threshold. Update this list after each coverage run.
 | P3       | `flist_entry_decode`    | protocol | -              | -     | Seed from interop captures        |
 | P4       | `incremental_flist`     | protocol | -              | -     | Generate multi-segment INC corpus |
 | P5       | `filter_list_wire`      | parser   | -              | -     | Expand rule-grammar seeds         |
-| P6       | `rsyncd_conf`           | parser   | -              | -     | Real-world rsyncd.conf samples    |
 
 Targets with existing corpora (e.g., `varint_decode` with 14 seeds) may
 already be adequate - verify by running coverage collection.
@@ -143,7 +141,7 @@ set -euo pipefail
 TARGETS=(
     protocol_wire multiplex_frame_parse flist_entry_decode incremental_flist
     ndx_codec varint_decode legacy_greeting daemon_greeting
-    filter_list_wire rsyncd_conf capability_flags auth_response
+    filter_list_wire capability_flags auth_response
     vstring batch_reader acl_xattr_wire bwlimit
     decompressor_zlib decompressor_zstd simd_checksum_parity
     filter_differential filter_rules_vs_upstream

--- a/docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md
+++ b/docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md
@@ -144,7 +144,7 @@ auth complete -> validate_module_path -> apply_module_privilege_restrictions
 
 The set of paths passed to `restrict_to_paths` is the union of:
 
-1. `module.path` - mandatory, always present (`crates/daemon/src/rsyncd_config/sections.rs:142`).
+1. `module.path` - mandatory, always present (parsed in `crates/daemon/src/daemon/sections/config_parsing/module_directives.rs`).
 2. The module lock file directory, if configured (`module.lock_file` - the daemon needs to update the file during the connection).
 3. Any auxiliary log paths the daemon writes per-connection (transfer log, xfer log).
 


### PR DESCRIPTION
## Summary

The daemon's `rsyncd.conf` parsing was unified onto a single path (PR #6672),
which removed the old `daemon::rsyncd_config` module. Its replacement now lives
under `crates/daemon/src/daemon/sections/config_parsing/` as `pub(crate)` code
(`parse_config_modules` returning `ParsedConfigModules`). Documentation still
pointed at the removed `rsyncd_config/` paths. Separately, the `rsyncd_conf`
fuzz target was deleted (PR #6997), but the design fuzz-coverage matrix still
listed it.

This is a documentation-only cleanup. No code is touched.

## Changes

- `docs/ARCHITECTURE.md` - daemon crate file list now points at
  `daemon/sections/config_parsing/`.
- `docs/design/differential-filter-fuzzer.md` - daemon filter-directive
  parsing now cites `config_parsing/module_directives.rs`.
- `docs/design/daemon-async-accept-sync-workers.md`,
  `docs/design/adaptive-thread-pool-sizing.md`,
  `docs/design/daemon-async-runtime-choice.md` - directive parsing/validation
  references updated to `config_parsing/global_directives.rs`. There is no
  separate `validation.rs`; validation is inline in the parser, and the text
  now says so.
- `docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md` - `module.path`
  parsing location updated.
- `docs/design/fuzz-coverage-matrix.md` - removed the deleted `rsyncd_conf`
  fuzz-target rows and its entry in the regeneration target list.
- `docs/contributing/upstream-cross-references.md` - daemon config-parsing row
  now points at `daemon/sections/config_parsing/`.

Dated audit reports under `docs/audits/` and `docs/audit/` retain their original
`rsyncd_config`/`rsyncd_conf` citations as historical point-in-time evidence.

## Verification

- Stale references outside the dated audit reports are gone.
- `git diff --stat` shows docs-only changes (8 files).
