### PR TITLE
fix(transfer): gate receiver quick-check on ignore_times, not times

### DIFF
--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -43,13 +43,17 @@ pub(super) fn is_hardlink_follower(entry: &FileEntry) -> bool {
 /// 1. Size mismatch - always needs transfer
 /// 2. `always_checksum` - compute file checksum and compare (ignores mtime)
 /// 3. `size_only` - size matched, skip transfer
-/// 4. `!preserve_times` (implies `ignore_times`) - force transfer
+/// 4. `ignore_times` (`-I`) - force transfer regardless of mtime
 /// 5. mtime comparison, tolerating `--modify-window` seconds of drift
+///
+/// Note: `-t`/`--times` affects only whether mtime is *applied* to the
+/// destination, never whether this quick-check compares it (upstream
+/// `generator.c:642` gates solely on `ignore_times`).
 pub(super) fn quick_check_matches(
     entry: &FileEntry,
     dest_path: &Path,
     dest_meta: &fs::Metadata,
-    preserve_times: bool,
+    ignore_times: bool,
     size_only: bool,
     always_checksum: Option<protocol::ChecksumAlgorithm>,
     modify_window: ModifyWindow,
@@ -72,8 +76,8 @@ pub(super) fn quick_check_matches(
     if size_only {
         return true;
     }
-    // upstream: generator.c:642 - ignore_times forces transfer
-    if !preserve_times {
+    // upstream: generator.c:642 - `if (ignore_times) return 0;` forces transfer
+    if ignore_times {
         return false;
     }
     // upstream: generator.c:645 - `mtime_differs()` -> `same_time()` applies the
@@ -262,7 +266,7 @@ fn best_reference_match<'a>(
     entry: &FileEntry,
     relative_path: &Path,
     reference_directories: &'a [ReferenceDirectory],
-    preserve_times: bool,
+    ignore_times: bool,
     size_only: bool,
     always_checksum: Option<protocol::ChecksumAlgorithm>,
     modify_window: ModifyWindow,
@@ -288,7 +292,7 @@ fn best_reference_match<'a>(
             entry,
             &ref_path,
             &ref_meta,
-            preserve_times,
+            ignore_times,
             size_only,
             always_checksum,
             modify_window,
@@ -355,7 +359,7 @@ pub(super) fn try_reference_dest(
     entry: &FileEntry,
     dest_dir: &Path,
     reference_directories: &[ReferenceDirectory],
-    preserve_times: bool,
+    ignore_times: bool,
     size_only: bool,
     always_checksum: Option<protocol::ChecksumAlgorithm>,
     modify_window: ModifyWindow,
@@ -374,7 +378,7 @@ pub(super) fn try_reference_dest(
         entry,
         relative_path,
         reference_directories,
-        preserve_times,
+        ignore_times,
         size_only,
         always_checksum,
         modify_window,
@@ -1072,6 +1076,8 @@ mod symlink_basis_tests {
             &entry,
             dest_dir,
             std::slice::from_ref(&reference),
+            // ignore_times=false: exercise the real quick-check path; size_only
+            // below short-circuits before the mtime gate regardless.
             false,
             true,
             None,
@@ -1282,7 +1288,7 @@ mod modify_window_tests {
     use super::{ModifyWindow, quick_check_matches};
 
     /// Builds a dest file at `dest_secs` and a source entry claiming `src_secs`,
-    /// both the same size, then runs the quick-check with `preserve_times=true`,
+    /// both the same size, then runs the quick-check with `ignore_times=false`,
     /// `size_only=false`, no checksum, at the given `window`.
     fn run_window(src_secs: i64, dest_secs: i64, window: ModifyWindow) -> bool {
         run_window_nsec(src_secs, 0, dest_secs, 0, window)
@@ -1316,7 +1322,7 @@ mod modify_window_tests {
         let mut entry = FileEntry::new_file("payload.bin".into(), payload.len() as u64, 0o644);
         entry.set_mtime(src_secs, src_nsec);
 
-        quick_check_matches(&entry, &dest_path, &dest_meta, true, false, None, window)
+        quick_check_matches(&entry, &dest_path, &dest_meta, false, false, None, window)
     }
 
     /// A destination whose mtime is within `--modify-window=2` of the source
@@ -1452,7 +1458,7 @@ mod alt_dest_match_level_tests {
         entry: &FileEntry,
         dest_dir: &Path,
         refs: &[ReferenceDirectory],
-        preserve_times: bool,
+        ignore_times: bool,
         size_only: bool,
     ) -> bool {
         let opts = MetadataOptions::default();
@@ -1461,7 +1467,7 @@ mod alt_dest_match_level_tests {
             entry,
             dest_dir,
             refs,
-            preserve_times,
+            ignore_times,
             size_only,
             None,
             ModifyWindow::from_secs(0),
@@ -1505,7 +1511,7 @@ mod alt_dest_match_level_tests {
             path: ref_dir.clone(),
         }];
 
-        let handled = run(&entry, &dest_dir, &refs, true, true);
+        let handled = run(&entry, &dest_dir, &refs, false, true);
         let dest_path = dest_dir.join("payload.bin");
 
         assert!(handled, "a matching basis must be handled locally");
@@ -1543,7 +1549,7 @@ mod alt_dest_match_level_tests {
             path: ref_dir.clone(),
         }];
 
-        let handled = run(&entry, &dest_dir, &refs, true, false);
+        let handled = run(&entry, &dest_dir, &refs, false, false);
         let dest_path = dest_dir.join("payload.bin");
 
         assert!(handled, "identical basis must be handled locally");
@@ -1581,7 +1587,7 @@ mod alt_dest_match_level_tests {
             path: ref_dir.clone(),
         }];
 
-        let handled = run(&entry, &dest_dir, &refs, true, false);
+        let handled = run(&entry, &dest_dir, &refs, false, false);
         let dest_path = dest_dir.join("payload.bin");
 
         assert!(handled, "level-2 compare-dest must handle the file locally");
@@ -1611,7 +1617,7 @@ mod alt_dest_match_level_tests {
             path: ref_dir.clone(),
         }];
 
-        let handled = run(&entry, &dest_dir, &refs, true, false);
+        let handled = run(&entry, &dest_dir, &refs, false, false);
         let dest_path = dest_dir.join("payload.bin");
 
         assert!(
@@ -1657,7 +1663,7 @@ mod alt_dest_match_level_tests {
             },
         ];
 
-        let handled = run(&entry, &dest_dir, &refs, true, false);
+        let handled = run(&entry, &dest_dir, &refs, false, false);
         let dest_path = dest_dir.join("payload.bin");
 
         assert!(handled, "a level-3 basis in a later dir must be handled");

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -275,7 +275,9 @@ impl ReceiverContext {
                 .collect();
         }
 
-        let preserve_times = self.config.flags.times && !self.config.flags.ignore_times;
+        // upstream: generator.c:642 - the quick-check mtime gate keys on
+        // ignore_times alone; -t/--times only governs whether mtime is applied.
+        let ignore_times = self.config.flags.ignore_times;
         let size_only = self.config.file_selection.size_only;
         // upstream: generator.c:quick_check_ok() -> same_time() honours the
         // `--modify-window` tolerance for every transfer, not just local copies.
@@ -357,7 +359,7 @@ impl ReceiverContext {
                             entry,
                             &file_path,
                             meta,
-                            preserve_times,
+                            ignore_times,
                             size_only,
                             always_checksum,
                             modify_window,
@@ -398,7 +400,7 @@ impl ReceiverContext {
                     entry,
                     &file_path,
                     meta,
-                    preserve_times,
+                    ignore_times,
                     size_only,
                     always_checksum,
                     modify_window,
@@ -457,7 +459,7 @@ impl ReceiverContext {
                         entry,
                         dest_dir,
                         &self.config.reference_directories,
-                        preserve_times,
+                        ignore_times,
                         size_only,
                         always_checksum,
                         modify_window,
@@ -553,7 +555,9 @@ impl ReceiverContext {
         dest_dir: &Path,
         candidates: &[(usize, &'a FileEntry, PathBuf, u32)],
     ) -> Vec<DryRunItem<'a>> {
-        let preserve_times = self.config.flags.times && !self.config.flags.ignore_times;
+        // upstream: generator.c:642 - the quick-check mtime gate keys on
+        // ignore_times alone; -t/--times only governs whether mtime is applied.
+        let ignore_times = self.config.flags.ignore_times;
         let size_only = self.config.file_selection.size_only;
         let modify_window = self.config.file_selection.modify_window;
         let always_checksum = if self.config.flags.checksum {
@@ -577,7 +581,7 @@ impl ReceiverContext {
             let raw = self.dry_run_entry_iflags(
                 entry,
                 &dest_path,
-                preserve_times,
+                ignore_times,
                 size_only,
                 always_checksum,
                 modify_window,
@@ -608,7 +612,7 @@ impl ReceiverContext {
         &self,
         entry: &FileEntry,
         dest_path: &Path,
-        preserve_times: bool,
+        ignore_times: bool,
         size_only: bool,
         always_checksum: Option<protocol::ChecksumAlgorithm>,
         modify_window: metadata::ModifyWindow,
@@ -653,7 +657,7 @@ impl ReceiverContext {
                         entry,
                         dest_path,
                         &meta,
-                        preserve_times,
+                        ignore_times,
                         size_only,
                         always_checksum,
                         modify_window,
@@ -1028,7 +1032,7 @@ impl ReceiverContext {
         entry: &FileEntry,
         dest_path: &Path,
         dest_meta: &fs::Metadata,
-        preserve_times: bool,
+        ignore_times: bool,
         size_only: bool,
         always_checksum: Option<protocol::ChecksumAlgorithm>,
         modify_window: metadata::ModifyWindow,
@@ -1043,7 +1047,7 @@ impl ReceiverContext {
             entry,
             dest_path,
             dest_meta,
-            preserve_times,
+            ignore_times,
             size_only,
             always_checksum,
             modify_window,
@@ -1270,6 +1274,100 @@ mod itemize_order_tests {
             run(true).is_empty(),
             "a client-mode (pull) receiver prints its row locally; recording \
              it for the wire too would double every row"
+        );
+    }
+
+    /// upstream: generator.c:642 `quick_check_ok()` - the mtime quick-check runs
+    /// whenever `ignore_times` is off; `-t`/`--times` only decides whether the
+    /// mtime is *applied* to the destination, never whether the comparison runs.
+    /// A bare `-r` (recursion, no `-t`, no `-I`) over an unchanged tree must
+    /// therefore request zero transfers - the same result upstream produces.
+    ///
+    /// This encodes WHY the divergence mattered: gating on `!preserve_times`
+    /// (i.e. `!times || ignore_times`) re-sent every byte of an already-current
+    /// tree under a plain `-r`, an invisible efficiency regression because the
+    /// on-disk result stayed byte-identical. The matrix below pins each gate to
+    /// its own upstream rule so the fix cannot over-correct: `-I` still forces,
+    /// `--size-only` still skips on a size match regardless of mtime.
+    #[cfg(unix)]
+    #[test]
+    fn recursive_without_times_still_quick_checks_mtime() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        let path = dest.join("f.txt");
+        std::fs::write(&path, b"payload").unwrap();
+        let matching = filetime::FileTime::from_unix_time(1_600_000_000, 0);
+        filetime::set_file_times(&path, matching, matching).unwrap();
+
+        let mut entry = FileEntry::new_file("f.txt".into(), b"payload".len() as u64, 0o644);
+        entry.set_mtime(1_600_000_000, 0);
+
+        let hs = handshake();
+        // Returns how many files the generator would request a transfer for,
+        // starting from a bare `-r` config the closure may further mutate.
+        let requested = |mutate: &dyn Fn(&std::path::Path, &mut ServerConfig)| -> usize {
+            let mut config = itemize_client_config();
+            config.flags.times = false;
+            config.flags.ignore_times = false;
+            config.flags.perms = false;
+            config.file_selection.size_only = false;
+            mutate(&path, &mut config);
+            let mut ctx = ReceiverContext::new_for_test(&hs, config);
+            ctx.file_list = vec![entry.clone()];
+            let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+            let mut metadata_errors = Vec::new();
+            let mut stats = TransferStats::default();
+            ctx.build_files_to_transfer(
+                &mut writer,
+                dest,
+                &metadata::MetadataOptions::default(),
+                None,
+                &mut metadata_errors,
+                &mut stats,
+                None,
+                None,
+            )
+            .len()
+        };
+
+        // Bare `-r`, size+mtime match -> skip (upstream requests 0). Pre-fix oc
+        // forced a transfer here because `!preserve_times` was true without -t.
+        assert_eq!(
+            requested(&|_, _| {}),
+            0,
+            "-r without -t must skip an unchanged (size+mtime) file"
+        );
+
+        // `-I`/--ignore-times is the sole flag that forces a transfer on a match.
+        assert_eq!(
+            requested(&|_, config| config.flags.ignore_times = true),
+            1,
+            "-I must force the transfer despite matching size+mtime"
+        );
+
+        // --size-only skips on a size match even when the mtime differs, which
+        // distinguishes it from the plain mtime gate (which would transfer).
+        assert_eq!(
+            requested(&|p, config| {
+                config.file_selection.size_only = true;
+                let stale = filetime::FileTime::from_unix_time(1_500_000_000, 0);
+                filetime::set_file_times(p, stale, stale).unwrap();
+            }),
+            0,
+            "--size-only skips on a size match regardless of mtime"
+        );
+
+        // Restore the matching mtime the size-only case perturbed, then confirm
+        // the plain mtime gate DOES transfer when only the mtime differs - so the
+        // -r skip above is genuinely the size+mtime match, not a dead gate.
+        filetime::set_file_times(&path, matching, matching).unwrap();
+        assert_eq!(
+            requested(&|p, _| {
+                let stale = filetime::FileTime::from_unix_time(1_500_000_000, 0);
+                filetime::set_file_times(p, stale, stale).unwrap();
+            }),
+            1,
+            "-r with a differing mtime (same size) must transfer"
         );
     }
 


### PR DESCRIPTION
## Summary

The receiver generator forced a transfer whenever `!preserve_times` (computed as `times && !ignore_times`), so a bare `-r` without `-t` re-transferred every file of an already-current tree - a silent efficiency divergence invisible to tree-diff oracles because the on-disk result is identical, only the work differs.

Upstream `generator.c:642` (`quick_check_ok`) gates the mtime quick-check solely on `ignore_times`:

```c
if (size_only > 0)      return 1;   // generator.c:639
if (ignore_times)       return 0;   // generator.c:642
if (mtime_differs(...))  return 0;  // generator.c:645
```

`-t`/`--times` affects only whether mtime is *applied* to the destination, never whether the size+mtime comparison runs.

## Fix

Thread `ignore_times` (in place of the misleading `preserve_times`) through `quick_check_matches`, `best_reference_match`, `try_reference_dest`, and the dry-run / ignore-existing itemize helpers, and key the force-transfer gate on it directly. `--size-only` and `--checksum` keep their own upstream precedence.

## Verification vs rsync 3.4.4

| Flags | Unchanged tree (same size+mtime) | rsync 3.4.4 | oc post-fix |
|-------|----------------------------------|-------------|-------------|
| `-r` (no `-t`) | files transferred | **0** | **0** |
| `-r -I` (`--ignore-times`) | files transferred | 2 (`>f..T......`) | 2 (`>f..T......`) |
| `-r --size-only` (mtime differs) | files transferred | 0 | 0 |

Pre-fix oc transferred N under a bare `-r`. The local-copy executor (`engine/.../comparison.rs`) already gated on `ignore_times`, so only the remote receiver path (SSH and daemon, push and pull) was affected.

## Tests

New regression test `recursive_without_times_still_quick_checks_mtime` drives the receiver generator (`build_files_to_transfer`) with explicit, filetime-set mtimes and asserts the distinguishing matrix: bare `-r` skips (0 requested), `-I` forces (1), `--size-only` skips on size match, plain mtime mismatch transfers. Proven to fail on pre-fix logic (bare `-r` requested 1 instead of 0) and pass after the fix.

Gates: `cargo fmt` clean, `clippy -p transfer -D warnings` clean, targeted nextest green.
