### PR TITLE
fix(daemon): advertise own version in client greeting, apply subprotocol decrement

### DIFF
--- a/crates/rsync_io/src/daemon/negotiate.rs
+++ b/crates/rsync_io/src/daemon/negotiate.rs
@@ -5,7 +5,8 @@ use crate::negotiation::{
 use logging::debug_log;
 use protocol::{
     LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonGreetingOwned, NegotiationPrologue,
-    NegotiationPrologueSniffer, ProtocolVersion, write_daemon_auth_digest_list,
+    NegotiationPrologueSniffer, ProtocolVersion, check_sub_protocol, get_subprotocol_version,
+    write_daemon_auth_digest_list,
 };
 use std::cmp;
 use std::io::{self, Read, Write};
@@ -95,7 +96,11 @@ where
         server_greeting.subprotocol()
     );
 
-    let negotiated_protocol = cmp::min(desired_protocol, server_greeting.protocol());
+    // upstream: clientserver.c:155 `our_sub = get_subprotocol_version()` is read
+    // from this side's configured protocol version, so a release build always
+    // advertises subprotocol 0.
+    let our_sub = get_subprotocol_version(desired_protocol.as_u8());
+    let negotiated_protocol = negotiate_protocol(desired_protocol, &server_greeting, our_sub);
 
     debug_log!(
         Proto,
@@ -105,7 +110,10 @@ where
         desired_protocol.as_u8()
     );
 
-    let banner = build_client_greeting(&server_greeting, negotiated_protocol);
+    // upstream: clientserver.c:157 writes this side's own greeting BEFORE
+    // clientserver.c:174 reads the server's, so the banner advertises our own
+    // configured version and subprotocol, never the server's.
+    let banner = build_client_greeting(desired_protocol, our_sub);
     stream.write_all(&banner)?;
     stream.flush()?;
 
@@ -116,37 +124,62 @@ where
     ))
 }
 
+/// Reconciles this side's configured protocol against the server's greeting.
+///
+/// upstream: clientserver.c:213-226. After reading the server's `@RSYNCD:` line,
+/// the client clamps its own `protocol_version` down to the server's and then,
+/// mirroring `check_sub_protocol()`, drops one further step whenever the peer's
+/// subprotocol is incompatible with ours. `min(desired, server)` followed by
+/// `check_sub_protocol()` reproduces that block exactly: after the clamp the
+/// peer's version is never below ours, so only the equal/greater branches fire,
+/// and a nonzero server subprotocol against our release `our_sub == 0` forces the
+/// documented one-step downgrade. A stock release server (subprotocol 0) leaves
+/// the clamped version unchanged.
+fn negotiate_protocol(
+    desired_protocol: ProtocolVersion,
+    server_greeting: &LegacyDaemonGreetingOwned,
+    our_sub: u8,
+) -> ProtocolVersion {
+    let clamped = cmp::min(desired_protocol, server_greeting.protocol());
+    // upstream: clientserver.c:180 stores the server's raw `remote_protocol` from
+    // `sscanf`; the `protocol_version < remote_protocol` branch (clientserver.c:222)
+    // needs that un-clamped value so a server advertising a newer protocol is not
+    // mistaken for an equal one whose nonzero subprotocol would force a downgrade.
+    let their_protocol = u8::try_from(server_greeting.advertised_protocol()).unwrap_or(u8::MAX);
+    let their_sub = u8::try_from(server_greeting.subprotocol()).unwrap_or(u8::MAX);
+    let reconciled = check_sub_protocol(clamped.as_u8(), our_sub, their_protocol, their_sub);
+    if reconciled == clamped.as_u8() {
+        return clamped;
+    }
+    // check_sub_protocol never raises the version. Clamp a sub-OLDEST downgrade to
+    // the floor so the direction is preserved, matching upstream which advertises
+    // the lowered value and lets the later version guard reject anything too old.
+    let floor = ProtocolVersion::OLDEST.as_u8();
+    ProtocolVersion::try_from(reconciled.max(floor)).unwrap_or(clamped)
+}
+
 /// Renders the client's `@RSYNCD:` greeting line.
 ///
-/// The advertised digest list states *this build's* daemon-auth capabilities and
-/// is never derived from the server's greeting. Upstream cannot derive it even in
-/// principle: `exchange_protocols()` calls `output_daemon_greeting()`
-/// (clientserver.c:157) before `read_line_old()` has read the server's line
-/// (clientserver.c:174), so the client always renders its own
-/// `get_default_nno_list()` (compat.c:462). Echoing the server's list instead
-/// would let the server pick the digest out of a set it fully controls, since a
-/// name we confirm as ours is a name we have agreed to accept.
+/// upstream: clientserver.c:157 calls `output_daemon_greeting()` (compat.c:833)
+/// BEFORE clientserver.c:174 reads the server's line, so every field is this
+/// side's own advertisement, never derived from the server. The banner therefore
+/// carries our configured `protocol_version` and `get_subprotocol_version()`
+/// (compat.c:842 `io_printf(f_out, "@RSYNCD: %d.%d %s\n", protocol_version,
+/// our_sub, tmpbuf)`) regardless of what the server advertised. Verified against
+/// rsync 3.4.4: a client answering a server that greeted `@RSYNCD: 30.5` still
+/// sends `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4`.
 ///
-/// The list is also never filtered by protocol version. Verified against rsync
-/// 3.4.4: a client forced to `--protocol=28` still greets with
+/// The digest list is `get_default_nno_list()` (compat.c:840) and is likewise
+/// never filtered by protocol version: `--protocol=28` still greets with
 /// `@RSYNCD: 28.0 sha512 sha256 sha1 md5 md4`.
-fn build_client_greeting(
-    server_greeting: &LegacyDaemonGreetingOwned,
-    negotiated_protocol: ProtocolVersion,
-) -> Vec<u8> {
+fn build_client_greeting(advertised_protocol: ProtocolVersion, subprotocol: u8) -> Vec<u8> {
     let mut greeting = String::with_capacity(LEGACY_DAEMON_PREFIX.len() + 48);
 
     greeting.push_str(LEGACY_DAEMON_PREFIX);
     greeting.push(' ');
-    greeting.push_str(&negotiated_protocol.as_u8().to_string());
+    greeting.push_str(&advertised_protocol.as_u8().to_string());
     greeting.push('.');
-
-    let fractional = if negotiated_protocol == server_greeting.protocol() {
-        server_greeting.subprotocol()
-    } else {
-        0
-    };
-    greeting.push_str(&fractional.to_string());
+    greeting.push_str(&subprotocol.to_string());
 
     greeting.push(' ');
     write_daemon_auth_digest_list(&mut greeting).expect("writing to a String cannot fail");
@@ -164,183 +197,164 @@ mod tests {
         parse_legacy_daemon_greeting_owned(line).expect("valid greeting")
     }
 
+    fn proto(value: u8) -> ProtocolVersion {
+        ProtocolVersion::from_supported(value).expect("supported protocol")
+    }
+
     #[test]
     fn build_greeting_includes_prefix() {
-        let server = parse_greeting("@RSYNCD: 31.0");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
+        let greeting = build_client_greeting(proto(31), 0);
         assert!(greeting.starts_with(b"@RSYNCD:"));
     }
 
     #[test]
     fn build_greeting_ends_with_newline() {
-        let server = parse_greeting("@RSYNCD: 31.0");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
+        let greeting = build_client_greeting(proto(31), 0);
         assert!(greeting.ends_with(b"\n"));
     }
 
     #[test]
-    fn build_greeting_includes_protocol_version() {
-        let server = parse_greeting("@RSYNCD: 31.0");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.contains("31."));
+    fn build_greeting_has_space_after_prefix() {
+        let greeting = build_client_greeting(proto(30), 0);
+        assert!(greeting.starts_with(b"@RSYNCD: "));
     }
 
     #[test]
-    fn build_greeting_preserves_subprotocol_when_matching() {
-        let server = parse_greeting("@RSYNCD: 31.9");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.contains("31.9"), "got: {greeting_str}");
+    fn build_greeting_has_dot_between_major_minor() {
+        let greeting = build_client_greeting(proto(31), 0);
+        assert!(greeting.contains(&b'.'));
     }
 
     #[test]
-    fn build_greeting_uses_zero_subprotocol_when_downgraded() {
-        let server = parse_greeting("@RSYNCD: 31.5");
-        let protocol = ProtocolVersion::from_supported(30).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.contains("30.0"), "got: {greeting_str}");
+    fn build_greeting_format_is_valid_ascii() {
+        let greeting = build_client_greeting(proto(31), 0);
+        assert!(greeting.iter().all(u8::is_ascii));
     }
 
+    // A release oc build always advertises subprotocol 0, so the greeting is
+    // byte-exact. Pinned per version to guard the `<major>.<minor>` field.
     #[test]
-    fn build_greeting_zero_subprotocol_when_server_has_none() {
-        let server = parse_greeting("@RSYNCD: 29.0");
-        let protocol = ProtocolVersion::from_supported(29).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.contains("29.0"), "got: {greeting_str}");
+    fn build_greeting_renders_version_and_subprotocol() {
+        assert_eq!(
+            build_client_greeting(proto(32), 0),
+            b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n",
+        );
+        assert_eq!(
+            build_client_greeting(proto(28), 0),
+            b"@RSYNCD: 28.0 sha512 sha256 sha1 md5 md4\n",
+        );
     }
 
-    // The greeting must state OUR capabilities, never the server's. Measured
-    // against rsync 3.4.4 driven at a stub advertising exactly `md4 md5 xxh3`:
-    // the client still answered `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4`.
-    // A server that advertises only weak names must not be able to make us
-    // confirm that narrowed set as our own, because a name we advertise is a
-    // name we have agreed to accept.
+    // The subprotocol field is not hard-coded: a hypothetical pre-release build
+    // (SUBPROTOCOL_VERSION != 0) would render its own nonzero value. Guards the
+    // field against being silently pinned to 0.
     #[test]
-    fn build_greeting_advertises_our_digests_not_the_servers() {
-        let server = parse_greeting("@RSYNCD: 31.0 md4 md5 xxh3");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        assert_eq!(greeting, b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n");
+    fn build_greeting_renders_a_nonzero_subprotocol_verbatim() {
+        assert_eq!(
+            build_client_greeting(proto(32), 7),
+            b"@RSYNCD: 32.7 sha512 sha256 sha1 md5 md4\n",
+        );
     }
 
-    // upstream: clientserver.c:157 sends the greeting before clientserver.c:174
-    // reads the server's, so a server that names no list cannot suppress ours.
-    #[test]
-    fn build_greeting_advertises_digests_when_the_server_named_none() {
-        let server = parse_greeting("@RSYNCD: 30.0");
-        let protocol = ProtocolVersion::from_supported(30).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        assert_eq!(greeting, b"@RSYNCD: 30.0 sha512 sha256 sha1 md5 md4\n");
-    }
-
-    // The narrowest possible restriction: a single weak name. Verified against
-    // rsync 3.4.4 under the same stub - the list it sends is unchanged.
-    #[test]
-    fn build_greeting_ignores_a_single_digest_restriction() {
-        let server = parse_greeting("@RSYNCD: 31.0 md5");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        assert_eq!(greeting, b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n");
-    }
-
-    // upstream: compat.c:838-842 `output_daemon_greeting()` emits
+    // upstream: compat.c:840-842 `output_daemon_greeting()` emits
     // `get_default_nno_list()` verbatim with no version filtering. Verified
     // against rsync 3.4.4: `--protocol=28` through `--protocol=32` all send the
     // identical five names, differing only in the version field.
     #[test]
     fn build_greeting_digest_list_is_protocol_independent() {
         for version in [28u8, 29, 30, 31, 32] {
-            let server = parse_greeting(&format!("@RSYNCD: {version}.0"));
-            let protocol = ProtocolVersion::from_supported(version).unwrap();
-            let greeting = build_client_greeting(&server, protocol);
             assert_eq!(
-                greeting,
+                build_client_greeting(proto(version), 0),
                 format!("@RSYNCD: {version}.0 sha512 sha256 sha1 md5 md4\n").into_bytes(),
                 "protocol {version} must advertise the full list",
             );
         }
     }
 
+    // upstream: clientserver.c:213-226. A stock release server (subprotocol 0)
+    // clamps but never triggers the extra decrement.
     #[test]
-    fn build_greeting_with_protocol_28() {
-        let server = parse_greeting("@RSYNCD: 28.0");
-        let protocol = ProtocolVersion::from_supported(28).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.contains("28.0"), "got: {greeting_str}");
+    fn negotiate_protocol_release_server_only_clamps() {
+        // Server older, no subprotocol: clamp to the server's version.
+        assert_eq!(
+            negotiate_protocol(proto(32), &parse_greeting("@RSYNCD: 30.0"), 0),
+            proto(30),
+        );
+        // Server equal, no subprotocol: no change.
+        assert_eq!(
+            negotiate_protocol(proto(32), &parse_greeting("@RSYNCD: 32.0"), 0),
+            proto(32),
+        );
+        // Server newer: clamp to our own newest, no decrement for a release side.
+        assert_eq!(
+            negotiate_protocol(proto(32), &parse_greeting("@RSYNCD: 33.9"), 0),
+            proto(32),
+        );
     }
 
+    // upstream: clientserver.c:215-219 - a nonzero server subprotocol forces the
+    // one-step decrement, both when the server is older and when it is equal.
+    // Verified against rsync 3.4.4: greeting bytes stay `32.0` while the session
+    // protocol drops. This case is invisible to an echo, which would report the
+    // subprotocols as "matching" and suppress the decrement.
     #[test]
-    fn build_greeting_with_highest_subprotocol() {
-        let server = parse_greeting("@RSYNCD: 31.99");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.contains("31.99"), "got: {greeting_str}");
+    fn negotiate_protocol_decrements_on_nonzero_server_subprotocol() {
+        // Server older AND pre-release: min to 30, then decrement to 29.
+        assert_eq!(
+            negotiate_protocol(proto(32), &parse_greeting("@RSYNCD: 30.5"), 0),
+            proto(29),
+        );
+        // Server equal, pre-release, our release sub 0 differs: decrement to 31.
+        assert_eq!(
+            negotiate_protocol(proto(32), &parse_greeting("@RSYNCD: 32.7"), 0),
+            proto(31),
+        );
+        // A capped desired still clamps first, then decrements.
+        assert_eq!(
+            negotiate_protocol(proto(31), &parse_greeting("@RSYNCD: 30.5"), 0),
+            proto(29),
+        );
     }
 
+    // The core of task #149: the greeting advertises OUR version and subprotocol,
+    // never the server's. A discriminating stub (different version AND nonzero
+    // subprotocol) makes echo and advertise byte-distinct: an echo would send
+    // `30.5`, upstream 3.4.4 sends `32.0`. Simultaneously the negotiated session
+    // protocol decrements to 29, proving the two are independent.
     #[test]
-    fn build_greeting_format_is_valid_ascii() {
-        let server = parse_greeting("@RSYNCD: 31.0 md5");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        assert!(greeting.iter().all(|&b| b.is_ascii()));
+    fn greeting_advertises_our_version_while_session_protocol_decrements() {
+        let server = parse_greeting("@RSYNCD: 30.5 md4 md5 xxh3");
+        let desired = proto(32);
+        let our_sub = get_subprotocol_version(desired.as_u8());
+
+        let greeting = build_client_greeting(desired, our_sub);
+        assert_eq!(
+            greeting, b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n",
+            "greeting must advertise our own 32.0, not the server's 30.5",
+        );
+
+        assert_eq!(
+            negotiate_protocol(desired, &server, our_sub),
+            proto(29),
+            "the session protocol decrements even though the greeting stays 32.0",
+        );
     }
 
+    // The greeting is a pure function of what WE support, so no server-controlled
+    // digest names may change the bytes after the version.
     #[test]
-    fn build_greeting_has_space_after_prefix() {
-        let server = parse_greeting("@RSYNCD: 30.0");
-        let protocol = ProtocolVersion::from_supported(30).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.starts_with("@RSYNCD: "));
-    }
-
-    #[test]
-    fn build_greeting_has_dot_between_major_minor() {
-        let server = parse_greeting("@RSYNCD: 31.5");
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        let greeting_str = String::from_utf8_lossy(&greeting);
-        assert!(greeting_str.contains('.'));
-    }
-
-    #[test]
-    fn build_greeting_downgraded_still_advertises_our_digests() {
-        let server = parse_greeting("@RSYNCD: 31.5 md4 md5");
-        let protocol = ProtocolVersion::from_supported(29).unwrap();
-        let greeting = build_client_greeting(&server, protocol);
-        assert_eq!(greeting, b"@RSYNCD: 29.0 sha512 sha256 sha1 md5 md4\n");
-    }
-
-    // The greeting is a pure function of what WE support, so no combination of
-    // server-controlled digest names may change the bytes after the version.
-    #[test]
-    fn build_greeting_digest_list_is_independent_of_the_server_greeting() {
-        let protocol = ProtocolVersion::from_supported(31).unwrap();
-        let expected = b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n".to_vec();
-
+    fn build_greeting_digest_list_is_independent_of_the_server() {
+        let expected = b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n".to_vec();
         for advertised in [
             "@RSYNCD: 31.0",
             "@RSYNCD: 31.0 md5",
-            "@RSYNCD: 31.0 sha512 md5",
             "@RSYNCD: 31.0 md4",
             "@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4",
             "@RSYNCD: 31.0 blake3 sponge",
         ] {
-            let server = parse_greeting(advertised);
-            assert_eq!(
-                build_client_greeting(&server, protocol),
-                expected,
-                "server greeting {advertised:?} must not change our advertised list",
-            );
+            // The server greeting is parsed but must not influence our bytes.
+            let _ = parse_greeting(advertised);
+            assert_eq!(build_client_greeting(proto(32), 0), expected);
         }
     }
 }

--- a/crates/rsync_io/src/daemon/tests/mapping.rs
+++ b/crates/rsync_io/src/daemon/tests/mapping.rs
@@ -35,7 +35,7 @@ fn map_stream_inner_preserves_state_and_transforms_transport() {
     assert_eq!(inner.flushes(), 2);
     assert_eq!(
         inner.written(),
-        [client_greeting(31), b"@RSYNCD: OK\n".to_vec()].concat()
+        [client_greeting(32), b"@RSYNCD: OK\n".to_vec()].concat()
     );
 }
 
@@ -93,7 +93,7 @@ fn parts_map_stream_inner_transforms_transport() {
     let inner = instrumented.into_inner();
     assert_eq!(
         inner.written(),
-        [client_greeting(31), b"OK\n".to_vec()].concat()
+        [client_greeting(32), b"OK\n".to_vec()].concat()
     );
 }
 
@@ -173,5 +173,5 @@ fn try_map_stream_inner_preserves_original_on_error() {
     assert_eq!(err.error().kind(), io::ErrorKind::Other);
     let original = err.into_original();
     let transport = original.into_stream().into_inner();
-    assert_eq!(transport.written(), client_greeting(31));
+    assert_eq!(transport.written(), client_greeting(32));
 }

--- a/crates/rsync_io/src/daemon/tests/negotiation.rs
+++ b/crates/rsync_io/src/daemon/tests/negotiation.rs
@@ -322,11 +322,8 @@ fn from_stream_parts_rehydrates_legacy_handshake() {
     let transport = rehydrated.into_stream().into_inner();
     assert_eq!(transport.flushes(), 2);
 
-    let expected = [
-        client_greeting(negotiated.as_u8()),
-        b"@RSYNCD: OK\n".to_vec(),
-    ]
-    .concat();
+    // The greeting advertises our own desired protocol, not the negotiated value.
+    let expected = [client_greeting(desired.as_u8()), b"@RSYNCD: OK\n".to_vec()].concat();
     assert_eq!(transport.written(), expected);
 }
 

--- a/crates/rsync_io/src/daemon/tests/negotiation.rs
+++ b/crates/rsync_io/src/daemon/tests/negotiation.rs
@@ -31,7 +31,7 @@ fn negotiate_legacy_daemon_session_exchanges_banners() {
     assert!(!handshake.local_protocol_was_capped());
 
     let transport = handshake.into_stream().into_inner();
-    assert_eq!(transport.written(), client_greeting(31));
+    assert_eq!(transport.written(), client_greeting(32));
     assert_eq!(transport.flushes(), 1);
 }
 
@@ -169,7 +169,7 @@ fn into_parts_round_trips_legacy_handshake() {
     assert_eq!(transport.flushes(), 2);
     assert_eq!(
         transport.written(),
-        [client_greeting(31), b"@RSYNCD: OK\n".to_vec()].concat()
+        [client_greeting(32), b"@RSYNCD: OK\n".to_vec()].concat()
     );
 }
 
@@ -260,7 +260,9 @@ fn into_stream_parts_exposes_legacy_state() {
 
     let transport = stream.into_inner();
     assert_eq!(transport.flushes(), 1);
-    assert_eq!(transport.written(), client_greeting(negotiated.as_u8()));
+    // upstream: clientserver.c:157 - the greeting advertises this side's own
+    // desired protocol, not the negotiated (possibly clamped/decremented) value.
+    assert_eq!(transport.written(), client_greeting(desired.as_u8()));
 }
 
 #[test]
@@ -379,9 +381,11 @@ fn legacy_client_greeting_advertises_our_digests_not_the_servers() {
     stream.flush().expect("flush propagates");
 
     let inner = stream.into_inner();
+    // Version is our own 32.0 (upstream advertises its max before reading the
+    // server), digests are our full list - never the server's `sha512 md5`.
     assert_eq!(
         inner.written(),
-        b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n@RSYNCD: OK\n"
+        b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n@RSYNCD: OK\n"
     );
 }
 
@@ -399,7 +403,7 @@ fn legacy_client_greeting_ignores_a_single_weak_server_digest() {
     let inner = handshake.into_stream().into_inner();
     assert_eq!(
         inner.written(),
-        b"@RSYNCD: 31.0 sha512 sha256 sha1 md5 md4\n"
+        b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n"
     );
 }
 
@@ -427,4 +431,35 @@ fn legacy_client_greeting_respects_protocol_cap() {
         inner.written(),
         b"@RSYNCD: 29.0 sha512 sha256 sha1 md5 md4\n@RSYNCD: OK\n"
     );
+}
+
+// Task #149 end-to-end regression: a discriminating stub advertises a DIFFERENT
+// version (30) AND a nonzero subprotocol (5). Pre-fix code echoed the server's
+// `30.5` into the client greeting and negotiated protocol 30 (a bare min); a
+// non-discriminating fixture whose version equals ours would hide both bugs.
+//
+// upstream: clientserver.c:157 writes our own greeting before reading the
+// server's, so rsync 3.4.4 sends `@RSYNCD: 32.0 ...` here (verified against the
+// real binary), and clientserver.c:215-219 decrements the session protocol to 29
+// because the server's nonzero subprotocol differs from our release sub 0.
+#[test]
+fn discriminating_server_greeting_advertises_ours_and_decrements() {
+    let transport = MemoryTransport::new(b"@RSYNCD: 30.5 sha512 sha256 sha1 md5 md4\n");
+    let handshake = negotiate_legacy_daemon_session(transport, ProtocolVersion::NEWEST)
+        .expect("handshake should succeed");
+
+    // The session protocol decrements: min(32, 30) = 30, then -1 for the nonzero
+    // server subprotocol.
+    assert_eq!(
+        handshake.negotiated_protocol(),
+        ProtocolVersion::from_supported(29).expect("protocol 29 supported"),
+    );
+    assert_eq!(
+        handshake.server_protocol(),
+        ProtocolVersion::from_supported(30).expect("protocol 30 supported"),
+    );
+
+    // The greeting advertises our own 32.0, never the server's 30.5.
+    let transport = handshake.into_stream().into_inner();
+    assert_eq!(transport.written(), client_greeting(32));
 }

--- a/crates/rsync_io/src/daemon/tests/parts.rs
+++ b/crates/rsync_io/src/daemon/tests/parts.rs
@@ -38,8 +38,9 @@ fn parts_stream_parts_mut_allows_inner_mutation() {
 
     let inner = parts.into_handshake().into_stream().into_inner();
     assert_eq!(inner.flushes(), 2);
+    // The greeting advertises our own newest version (32), not the server's 31.
     assert_eq!(
         inner.written(),
-        [client_greeting(31), b"@RSYNCD: OK\n".to_vec()].concat()
+        [client_greeting(32), b"@RSYNCD: OK\n".to_vec()].concat()
     );
 }

--- a/crates/rsync_io/src/daemon/types/handshake.rs
+++ b/crates/rsync_io/src/daemon/types/handshake.rs
@@ -26,10 +26,13 @@ impl<R> LegacyDaemonHandshake<R> {
         self.negotiated_protocol
     }
 
-    /// Returns the protocol version the client advertised to the daemon.
+    /// Returns the effective local protocol after negotiation.
     ///
-    /// Mirrors [`Self::negotiated_protocol`] (the legacy client echoes the
-    /// final value); exposed for API symmetry with the binary handshake.
+    /// Returns the same value as [`Self::negotiated_protocol`]; exposed for API
+    /// symmetry with the binary handshake. Note this is the negotiated
+    /// (post-clamp) protocol, not the version placed in the greeting line - the
+    /// greeting advertises the caller's own newest/`--protocol` cap ahead of
+    /// reading the server (upstream: clientserver.c:157), which may be higher.
     #[doc(alias = "--protocol")]
     #[must_use]
     pub const fn local_advertised_protocol(&self) -> ProtocolVersion {

--- a/crates/rsync_io/src/daemon/types/parts.rs
+++ b/crates/rsync_io/src/daemon/types/parts.rs
@@ -53,10 +53,13 @@ impl<R> LegacyDaemonHandshakeParts<R> {
         self.negotiated_protocol
     }
 
-    /// Returns the protocol version the client advertised to the daemon.
+    /// Returns the effective local protocol after negotiation.
     ///
-    /// Mirrors [`Self::negotiated_protocol`] (the legacy handshake echoes the
-    /// final value); exposed explicitly to match the binary helper shape.
+    /// Returns the same value as [`Self::negotiated_protocol`]; exposed
+    /// explicitly to match the binary helper shape. Note this is the negotiated
+    /// (post-clamp) protocol, not the version placed in the greeting line - the
+    /// greeting advertises the caller's own newest/`--protocol` cap ahead of
+    /// reading the server (upstream: clientserver.c:157), which may be higher.
     #[doc(alias = "--protocol")]
     #[must_use]
     pub const fn local_advertised_protocol(&self) -> ProtocolVersion {

--- a/crates/rsync_io/src/session/tests/basics.rs
+++ b/crates/rsync_io/src/session/tests/basics.rs
@@ -88,7 +88,7 @@ fn negotiate_session_detects_legacy_transport() {
         Err(_) => panic!("legacy handshake expected"),
     };
 
-    assert_eq!(transport.writes(), client_greeting(31));
+    assert_eq!(transport.writes(), client_greeting(32));
     assert_eq!(transport.flushes(), 1);
 }
 
@@ -244,7 +244,7 @@ fn session_into_inner_returns_legacy_transport() {
         negotiate_session(transport, ProtocolVersion::NEWEST).expect("legacy handshake succeeds");
 
     let mut raw = handshake.into_inner();
-    assert_eq!(raw.writes(), client_greeting(31));
+    assert_eq!(raw.writes(), client_greeting(32));
     assert_eq!(raw.flushes(), 1);
 
     let mut replay = Vec::new();
@@ -282,7 +282,7 @@ fn session_parts_into_inner_returns_legacy_transport() {
         negotiate_session_parts(transport, ProtocolVersion::NEWEST).expect("legacy parts succeed");
 
     let mut raw = parts.into_inner();
-    assert_eq!(raw.writes(), client_greeting(31));
+    assert_eq!(raw.writes(), client_greeting(32));
     assert_eq!(raw.flushes(), 1);
 
     let mut replay = Vec::new();
@@ -338,7 +338,7 @@ fn negotiate_session_parts_from_stream_handles_legacy_transport() {
     assert_eq!(greeting.advertised_protocol(), 31);
 
     let transport = parts.into_handshake().into_inner();
-    assert_eq!(transport.writes(), client_greeting(31));
+    assert_eq!(transport.writes(), client_greeting(32));
     assert_eq!(transport.flushes(), 1);
 }
 
@@ -387,7 +387,7 @@ fn negotiate_session_parts_exposes_legacy_metadata() {
 
     let stream_parts = legacy_parts.into_stream_parts();
     let transport = stream_parts.into_stream().into_inner();
-    assert_eq!(transport.writes(), client_greeting(31));
+    assert_eq!(transport.writes(), client_greeting(32));
     assert_eq!(transport.flushes(), 1);
 }
 
@@ -446,7 +446,7 @@ fn negotiate_session_parts_with_sniffer_supports_reuse() {
 
     let (_greeting, _negotiated, stream_parts) = parts2.into_legacy().expect("legacy parts");
     let transport2 = stream_parts.into_stream().into_inner();
-    assert_eq!(transport2.writes(), client_greeting(31));
+    assert_eq!(transport2.writes(), client_greeting(32));
     assert_eq!(transport2.flushes(), 1);
 }
 
@@ -492,6 +492,6 @@ fn negotiate_session_with_sniffer_supports_reuse() {
         .expect("second handshake is legacy")
         .into_stream()
         .into_inner();
-    assert_eq!(transport2.writes(), client_greeting(31));
+    assert_eq!(transport2.writes(), client_greeting(32));
     assert_eq!(transport2.flushes(), 1);
 }

--- a/crates/rsync_io/src/session/tests/clones.rs
+++ b/crates/rsync_io/src/session/tests/clones.rs
@@ -173,12 +173,12 @@ fn session_handshake_parts_clone_preserves_legacy_stream_state() {
     let original_transport = legacy.into_stream().into_inner();
     let cloned_transport = cloned.into_stream().into_inner();
 
-    let mut expected_original = client_greeting(negotiated.as_u8());
+    let mut expected_original = client_greeting(ProtocolVersion::NEWEST.as_u8());
     expected_original.extend_from_slice(b"module\n");
     assert_eq!(original_transport.writes(), expected_original.as_slice());
     assert_eq!(original_transport.flushes(), 1);
 
-    let mut expected_clone = client_greeting(negotiated.as_u8());
+    let mut expected_clone = client_greeting(ProtocolVersion::NEWEST.as_u8());
     expected_clone.extend_from_slice(b"other\n");
     assert_eq!(cloned_transport.writes(), expected_clone.as_slice());
     assert_eq!(cloned_transport.flushes(), 1);
@@ -457,6 +457,6 @@ fn session_handshake_parts_from_legacy_components_round_trips() {
         .into_stream()
         .into_inner();
 
-    assert_eq!(transport.writes(), client_greeting(31));
+    assert_eq!(transport.writes(), client_greeting(32));
     assert_eq!(transport.flushes(), 1);
 }

--- a/crates/rsync_io/src/session/tests/mapping.rs
+++ b/crates/rsync_io/src/session/tests/mapping.rs
@@ -72,7 +72,7 @@ fn as_variant_mut_helpers_allow_mutating_streams() {
         .expect("handshake remains legacy")
         .into_stream()
         .into_inner();
-    let mut expected = client_greeting(31);
+    let mut expected = client_greeting(32);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.writes(), expected.as_slice());
 }

--- a/crates/rsync_io/src/session/tests/roundtrip.rs
+++ b/crates/rsync_io/src/session/tests/roundtrip.rs
@@ -188,7 +188,7 @@ fn session_handshake_parts_round_trip_legacy_handshake() {
         .expect("write succeeds");
 
     let transport = legacy.into_stream().into_inner();
-    let mut expected = client_greeting(31);
+    let mut expected = client_greeting(32);
     expected.extend_from_slice(b"module\n");
     assert_eq!(transport.writes(), expected.as_slice());
     assert_eq!(transport.flushes(), 1);


### PR DESCRIPTION
## Summary

The legacy `rsync://` daemon client greeting echoed the server's negotiated
version and subprotocol instead of advertising this side's own values.

Upstream writes its greeting (`clientserver.c:157` `output_daemon_greeting`)
*before* reading the server's (`clientserver.c:174`), so the two greetings are
independent advertisements. The client always sends its configured
`protocol_version` and `get_subprotocol_version()` (0 for a release build),
never the server's. Verified against rsync 3.4.4: a client answering a server
that greets `@RSYNCD: 30.5` still sends `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4`.

Echoing had a second effect: it suppressed the `protocol_version--` decrement
(`clientserver.c:215-219`), because a nonzero server subprotocol always looked
like it "matched" ours. The daemon negotiation only did `min(desired, server)`.

## Changes

- `build_client_greeting` now takes `(advertised_protocol, subprotocol)` and
  renders our own configured version and subprotocol - no server-derived fields.
- New `negotiate_protocol` runs `check_sub_protocol()` over the clamped version
  and the server's *raw* advertised version/subprotocol, reproducing
  `clientserver.c:213-226` exactly. A pre-release server now triggers the
  documented one-step downgrade (server `30.5` -> session protocol `29`) while
  the greeting stays `32.0`.
- Corrected `local_advertised_protocol()` docs, which described the old echo.
- Replaced tests that encoded the echo (greeting bytes asserted at the negotiated
  version) and added a discriminating end-to-end regression using a stub with a
  different version *and* a nonzero subprotocol - it fails on the pre-fix code.

## Verification

- Client greeting bytes captured from rsync 3.4.4 against stub servers at
  `30.5`, `32.7`, `33.9`, and `29.0`: all answer `@RSYNCD: 32.0 ...`.
- `cargo fmt -p rsync_io -- --check`
- `cargo clippy -p rsync_io --all-targets --all-features --no-deps -- -D warnings`
- `cargo nextest run -p rsync_io -E 'test(daemon::)'` - 80 passed.
