### PR TITLE
ci(fuzz): make the fuzz-workspace guard tolerate lockfile drift on a cold cache

### DIFF
--- a/tools/ci/check_fuzz_workspaces.sh
+++ b/tools/ci/check_fuzz_workspaces.sh
@@ -11,6 +11,18 @@
 # No fuzzing and no sanitizer instrumentation happen here: `cargo check`
 # type-checks the fuzz targets without linking libFuzzer, so the stable
 # toolchain is sufficient and the run stays cheap and cache-friendly.
+#
+# Lockfile drift is tolerated by design. The fuzz workspaces are excluded
+# from the root workspace, so a dependency edge a main-workspace crate gains
+# (e.g. a new `thiserror` use) never refreshes their standalone lockfiles.
+# `cargo check` is run online and WITHOUT `--locked`: in one pass it both
+# minimally re-syncs each fuzz lockfile against the current manifests and
+# type-checks every fuzz target. A genuine API-drift compile break still
+# fails loudly; only stale-lockfile false positives self-heal. An offline
+# pre-sync (`cargo update --offline`) cannot do this - it dies on a cold
+# registry cache and leaves `--locked` to reject the very drift this guard
+# exists to absorb. Dropping `--locked` here is the sole sanctioned
+# exception, recorded in tools/ci/check_locked_flags.sh's ALLOWLIST.
 
 set -euo pipefail
 
@@ -27,14 +39,8 @@ for ws in "${FUZZ_WORKSPACES[@]}"; do
         echo "error: expected fuzz workspace ${ws}/Cargo.toml is missing" >&2
         exit 1
     fi
-    # Re-sync the lockfile against Cargo.toml first (same idiom as the lint
-    # job) so workspace version bumps that did not refresh the fuzz lockfile
-    # do not block CI. Offline regen can fail on a cold registry cache; the
-    # --locked check below still surfaces any real mismatch loudly.
-    echo "==> cargo update --workspace --offline (${ws})"
-    cargo update --workspace --offline --manifest-path "${ws}/Cargo.toml" || true
     echo "==> cargo check (${ws})"
-    cargo check --locked --manifest-path "${ws}/Cargo.toml"
+    cargo check --manifest-path "${ws}/Cargo.toml"
     echo "==> cargo fmt --check (${ws})"
     cargo fmt --manifest-path "${ws}/Cargo.toml" --all -- --check
 done

--- a/tools/ci/check_locked_flags.sh
+++ b/tools/ci/check_locked_flags.sh
@@ -96,11 +96,19 @@ GATED_SUBCOMMANDS=(
 # the repo-relative path. Add new entries only with reviewer signoff
 # and document the rationale here.
 #
-# Currently empty: the lockfile-sync workflows
-# (`cargo-lockfile-weekly.yml`, `cargo-lockfile-sync.yml`) only invoke
-# `cargo update`, which is not a gated subcommand, so they need no
-# explicit allowlist entry.
+# The lockfile-sync workflows (`cargo-lockfile-weekly.yml`,
+# `cargo-lockfile-sync.yml`) only invoke `cargo update`, which is not a
+# gated subcommand, so they need no explicit allowlist entry.
+#
+# check_fuzz_workspaces.sh:43 - the fuzz-workspace guard runs `cargo check`
+# WITHOUT --locked on purpose. Its whole job is to tolerate lockfile drift
+# in the excluded fuzz workspaces (whose standalone lockfiles are never
+# refreshed by main-workspace manifest changes) while still catching real
+# fuzz-target compile breaks. Running online without --locked lets that one
+# `cargo check` both re-sync the fuzz lockfile and compile; --locked would
+# reject the drift the guard exists to absorb. See that script's header.
 ALLOWLIST=(
+    "tools/ci/check_fuzz_workspaces.sh:43"
 )
 
 # Scan roots. Tests can replace these via OC_RSYNC_LOCKED_SCAN_ROOTS


### PR DESCRIPTION
## Problem

The three fuzz workspaces (`fuzz`, `crates/protocol/fuzz`, `crates/filters/fuzz`) are excluded from the root cargo workspace, so a dependency edge a main-workspace crate gains (e.g. the local `logging` crate's new `thiserror` use) never refreshes their standalone `Cargo.lock` files.

`tools/ci/check_fuzz_workspaces.sh` tried to absorb that drift with an offline pre-sync:

```
cargo update --workspace --offline ... || true   # dies on a cold registry cache, swallowed
cargo check --locked ...                          # then rejects the still-stale lockfile
```

On CI's cold registry cache the offline update fails (`no matching package named ...`), the `|| true` hides it, and `cargo check --locked` fails on the stale lockfile. Result: **every branch cut from master goes red on this guard** on a lockfile edge that has nothing to do with the PR. The guard's own header states its intent is to catch fuzz-target compile breaks while *tolerating* lockfile drift - but `--locked` makes that impossible.

## Fix

Replace the offline pre-sync + `cargo check --locked` with a single **online `cargo check` without `--locked`**. In one pass it minimally re-syncs each fuzz lockfile against the current manifests (no pin bumps) and type-checks every fuzz target:

- **lockfile drift self-heals** - the stale edge is added on the fly, no red PR;
- **real API-drift compile breaks still fail loudly** - the core guarantee (the #6997/#136 case) is intact.

`--locked` is dropped only here, and only for this reason. Recorded as the sole sanctioned exception in `tools/ci/check_locked_flags.sh`'s `ALLOWLIST` with a rationale comment, so the repo-wide `--locked` invariant stays enforced everywhere else.

## Verification

- **Drift passes:** on master's drifted lockfiles the guard exits 0 and self-syncs the three `Cargo.lock` files.
- **Real break fails:** injecting a type error into a fuzz target makes the guard exit 101 (`error[E0308]: mismatched types` / `could not compile`).
- `check_locked_flags.sh` passes with the new allowlist entry; its self-test is green (13/13).

Scope: two CI helper scripts only - no lockfile content is committed, since the guard now self-syncs.

Closes #171. Makes #170 (per-branch lockfile syncing) moot - the guard no longer needs the lockfiles to be pre-synced.