### PR TITLE
fix(engine): report zero literal/matched data under --dry-run

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -176,9 +176,15 @@ pub(super) fn handle_dry_run(
     context.capture_batch_whole_file(source, file_size)?;
     context.finalize_batch_file_delta(source)?;
 
+    // upstream: sender.c:342-343 counts the file into stats.xferred_files and
+    // stats.total_transferred_size, then the `if (!do_xfers)` guard `continue`s
+    // before match_sums(), so stats.literal_data (match.c:436) and
+    // stats.matched_data (match.c:121) stay 0 under --dry-run. record_file would
+    // fold `bytes_transferred` into the literal tally; record_dry_run_file keeps
+    // those transferred-byte counters at 0 while still counting the file.
     context
         .summary_mut()
-        .record_file(file_size, bytes_transferred, None);
+        .record_dry_run_file(file_size, bytes_transferred);
 
     // upstream: generator.c:1942-1960 - a dry-run still itemizes the file
     // against the existing destination via itemize()/report_flags, so an

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -742,6 +742,23 @@ impl LocalCopySummary {
         }
     }
 
+    /// Records a would-be transfer for a `--dry-run`, mirroring upstream's
+    /// sender under `dry_run`.
+    ///
+    /// upstream: `sender.c:342-343` increments `stats.xferred_files` and
+    /// `stats.total_transferred_size += F_LENGTH(file)` before the
+    /// `if (!do_xfers)` guard, so both count the file even in a dry run. The
+    /// guard then `continue`s before `match_sums()`, which is the sole place
+    /// `stats.literal_data` (`match.c:436`) and `stats.matched_data`
+    /// (`match.c:121`) are accumulated - so both stay 0 under `--dry-run`.
+    /// `transmitted` feeds `bytes_sent` (total written) exactly as `record_file`
+    /// would, keeping the "Total bytes sent" line unchanged.
+    pub(in crate::local_copy) fn record_dry_run_file(&mut self, file_size: u64, transmitted: u64) {
+        self.files_copied = self.files_copied.saturating_add(1);
+        self.transferred_file_size = self.transferred_file_size.saturating_add(file_size);
+        self.bytes_sent = self.bytes_sent.saturating_add(transmitted);
+    }
+
     pub(in crate::local_copy) const fn record_regular_file_total(&mut self) {
         self.regular_files_total = self.regular_files_total.saturating_add(1);
     }
@@ -1209,6 +1226,26 @@ mod tests {
         assert_eq!(summary.compressed_bytes(), 400);
         assert!(summary.compression_used());
         assert_eq!(summary.bytes_sent(), 400);
+    }
+
+    #[test]
+    fn record_dry_run_file_leaves_literal_and_matched_zero() {
+        // upstream: under --dry-run the sender counts the file
+        // (sender.c:342-343) but never reaches match_sums(), so
+        // stats.literal_data (match.c:436) and stats.matched_data (match.c:121)
+        // stay 0. A dry-run that WOULD transfer must not inflate either.
+        let mut summary = LocalCopySummary::default();
+        summary.record_dry_run_file(1000, 1000);
+
+        assert_eq!(summary.files_copied(), 1);
+        assert_eq!(summary.transferred_file_size(), 1000);
+        assert_eq!(summary.bytes_copied(), 0, "Literal data must be 0 under -n");
+        assert_eq!(
+            summary.matched_bytes(),
+            0,
+            "Matched data must be 0 under -n"
+        );
+        assert_eq!(summary.bytes_sent(), 1000);
     }
 
     #[test]

--- a/crates/engine/src/local_copy/tests/execute_dry_run.rs
+++ b/crates/engine/src/local_copy/tests/execute_dry_run.rs
@@ -26,9 +26,12 @@ fn dry_run_single_file_lists_but_does_not_copy() {
         .execute_with_options(LocalCopyExecution::DryRun, LocalCopyOptions::default())
         .expect("dry run succeeds");
 
-    // Summary reports what *would* happen.
+    // Summary reports what *would* happen. upstream: a dry run counts the file
+    // and its size (sender.c:342-343) but never reaches match_sums(), so
+    // literal_data (match.c:436) stays 0 - only transferred_file_size is 7.
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(summary.bytes_copied(), 7); // "payload" is 7 bytes
+    assert_eq!(summary.bytes_copied(), 0);
+    assert_eq!(summary.transferred_file_size(), 7); // "payload" is 7 bytes
     assert!(!destination.exists(), "dry run must not create destination file");
 }
 
@@ -529,10 +532,19 @@ fn dry_run_statistics_match_apply_mode_statistics() {
         summary_apply.directories_created(),
         "directories_created should match between dry-run and apply"
     );
+    // upstream: the transferred *size* (sender.c:342-343) matches between a dry
+    // run and a real run, but literal_data (match.c:436) is only accumulated by
+    // the real run - a dry run never calls match_sums(), so its bytes_copied
+    // stays 0 while the apply run reports the moved bytes.
+    assert_eq!(
+        summary_dry.transferred_file_size(),
+        summary_apply.transferred_file_size(),
+        "transferred_file_size should match between dry-run and apply"
+    );
     assert_eq!(
         summary_dry.bytes_copied(),
-        summary_apply.bytes_copied(),
-        "bytes_copied should match between dry-run and apply"
+        0,
+        "dry-run literal data is always 0"
     );
     assert_eq!(
         summary_dry.total_source_bytes(),
@@ -558,7 +570,9 @@ fn dry_run_total_source_bytes_correct() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 2);
-    assert_eq!(summary.bytes_copied(), 10);
+    // upstream: dry-run literal_data stays 0; the scanned size is still tallied.
+    assert_eq!(summary.bytes_copied(), 0);
+    assert_eq!(summary.transferred_file_size(), 10);
     assert_eq!(summary.total_source_bytes(), 10);
 }
 
@@ -819,7 +833,11 @@ fn dry_run_multiple_files_all_reported() {
 
     let summary = report.summary();
     assert_eq!(summary.files_copied(), 3);
-    assert_eq!(summary.bytes_copied(), 24); // 8 * 3
+    // upstream: a --dry-run never reaches match_sums(), so stats.literal_data
+    // (match.c:436) stays 0; only the scan-derived transferred size (8 * 3)
+    // and the transferred-file count are tallied (sender.c:342-343).
+    assert_eq!(summary.bytes_copied(), 0);
+    assert_eq!(summary.transferred_file_size(), 24); // 8 * 3
 
     let records = report.records();
     let file_paths: Vec<_> = records
@@ -852,7 +870,9 @@ fn dry_run_is_idempotent() {
             .expect("dry run succeeds");
 
         assert_eq!(summary.files_copied(), 1);
-        assert_eq!(summary.bytes_copied(), 14);
+        // upstream: dry-run literal_data stays 0; the scanned size is tallied.
+        assert_eq!(summary.bytes_copied(), 0);
+        assert_eq!(summary.transferred_file_size(), 14);
         assert!(!ctx.dest.exists());
     }
 }
@@ -878,7 +898,9 @@ fn dry_run_large_file_reports_correct_byte_count() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(summary.bytes_copied(), 256 * 1024);
+    // upstream: dry-run literal_data stays 0; the scanned size is tallied.
+    assert_eq!(summary.bytes_copied(), 0);
+    assert_eq!(summary.transferred_file_size(), 256 * 1024);
     assert!(!destination.exists());
 }
 
@@ -1015,7 +1037,9 @@ fn dry_run_whole_file_reports_transfer() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(summary.bytes_copied(), 18);
+    // upstream: dry-run literal_data stays 0; the scanned size is tallied.
+    assert_eq!(summary.bytes_copied(), 0);
+    assert_eq!(summary.transferred_file_size(), 18);
     assert!(!destination.exists());
 }
 
@@ -1086,7 +1110,9 @@ fn dry_run_with_no_implied_dirs_and_missing_parent_succeeds() {
         .expect("dry run with --no-implied-dirs must succeed");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(summary.bytes_copied(), 5);
+    // upstream: dry-run literal_data stays 0; the scanned size is tallied.
+    assert_eq!(summary.bytes_copied(), 0);
+    assert_eq!(summary.transferred_file_size(), 5);
     assert!(
         !dest_root.join("sub").exists(),
         "dry run must not create directories"

--- a/crates/engine/src/local_copy/tests/execute_whole_file.rs
+++ b/crates/engine/src/local_copy/tests/execute_whole_file.rs
@@ -414,9 +414,12 @@ fn execute_whole_file_dry_run_reports_transfer() {
         )
         .expect("dry run succeeds");
 
-    // Dry run should report what would be done
+    // Dry run should report what would be done. upstream: a dry run counts the
+    // file size (sender.c:342-343) but never reaches match_sums(), so both
+    // literal_data (match.c:436) and matched_data (match.c:121) stay 0.
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(summary.bytes_copied(), content.len() as u64);
+    assert_eq!(summary.bytes_copied(), 0);
+    assert_eq!(summary.transferred_file_size(), content.len() as u64);
     assert_eq!(summary.matched_bytes(), 0);
 
     // Destination should remain unchanged

--- a/tests/dry_run_local_stats_literal.rs
+++ b/tests/dry_run_local_stats_literal.rs
@@ -1,0 +1,123 @@
+//! A local `--dry-run` must report `Literal data: 0` and `Matched data: 0`.
+//!
+//! upstream: the sender counts the file into `stats.xferred_files` and
+//! `stats.total_transferred_size` (`sender.c:342-343`) before the
+//! `if (!do_xfers)` guard, but that guard `continue`s before `match_sums()`,
+//! the sole accumulator of `stats.literal_data` (`match.c:436`) and
+//! `stats.matched_data` (`match.c:121`). So a dry run that WOULD transfer a
+//! file still reports `Literal data: 0 bytes` / `Matched data: 0 bytes`, while
+//! `Total transferred file size` and the transferred-file count stay non-zero.
+//! A real transfer of the same file must still report non-zero literal data.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    if built.is_file() {
+        return built;
+    }
+    PathBuf::from("oc-rsync")
+}
+
+/// Returns the value part of a `--stats` line, e.g. `42 bytes`.
+fn stat_line<'a>(stdout: &'a str, prefix: &str) -> &'a str {
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix))
+        .map(str::trim)
+        .unwrap_or_else(|| panic!("missing {prefix:?} in --stats output:\n{stdout}"))
+}
+
+fn run_stats(
+    binary: &PathBuf,
+    dry_run: bool,
+    src: &std::path::Path,
+    dest: &std::path::Path,
+) -> String {
+    let mut cmd = Command::new(binary);
+    if dry_run {
+        cmd.arg("-n");
+    }
+    cmd.arg("--stats").arg(src).arg(dest);
+    let output = cmd.output().expect("run oc-rsync");
+    assert!(
+        output.status.success(),
+        "transfer must exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn local_dry_run_reports_zero_literal_and_matched() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src = temp.path().join("f.txt");
+    let dest = temp.path().join("dest");
+    std::fs::create_dir(&dest).expect("mkdir dest");
+    // 42 bytes of content that WOULD be sent as literal data on a real run.
+    std::fs::write(&src, b"hello world, some literal content!\n123456\n").expect("write src");
+
+    let stdout = run_stats(&binary, true, &src, &dest);
+
+    // The would-be transfer must never inflate the transferred-byte counters.
+    assert_eq!(
+        stat_line(&stdout, "Literal data:"),
+        "0 bytes",
+        "dry run must report zero literal data\nfull stdout:\n{stdout}"
+    );
+    assert_eq!(
+        stat_line(&stdout, "Matched data:"),
+        "0 bytes",
+        "dry run must report zero matched data\nfull stdout:\n{stdout}"
+    );
+    // But the scan-derived counters still reflect the file, exactly as upstream.
+    assert_eq!(
+        stat_line(&stdout, "Total transferred file size:"),
+        "42 bytes",
+        "dry run still counts the transferred file size\nfull stdout:\n{stdout}"
+    );
+    assert_eq!(
+        stat_line(&stdout, "Number of regular files transferred:"),
+        "1",
+        "dry run still counts the transferred file\nfull stdout:\n{stdout}"
+    );
+    // A dry run must not touch the destination.
+    assert!(
+        !dest.join("f.txt").exists(),
+        "dry run must not create the destination file"
+    );
+}
+
+#[test]
+fn local_real_transfer_reports_nonzero_literal() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src = temp.path().join("f.txt");
+    let dest = temp.path().join("dest");
+    std::fs::create_dir(&dest).expect("mkdir dest");
+    std::fs::write(&src, b"hello world, some literal content!\n123456\n").expect("write src");
+
+    let stdout = run_stats(&binary, false, &src, &dest);
+
+    // A real transfer of a new file sends the whole file as literal data.
+    assert_eq!(
+        stat_line(&stdout, "Literal data:"),
+        "42 bytes",
+        "real transfer must report the full literal data\nfull stdout:\n{stdout}"
+    );
+    assert!(
+        dest.join("f.txt").exists(),
+        "real transfer must create the destination file"
+    );
+}


### PR DESCRIPTION
## Problem

A local `--dry-run` reported non-zero `Literal data` in `--stats` output. A dry run transfers nothing, so upstream rsync reports `Literal data: 0 bytes`.

Before (oc, `-n --stats` on a would-transfer file):
```
Total transferred file size: 42 bytes
Literal data: 42 bytes      <- wrong
Matched data: 0 bytes
```

rsync 3.4.4 (`-n --stats`, same file):
```
Total transferred file size: 42 bytes
Literal data: 0 bytes
Matched data: 0 bytes
```

## Upstream behaviour

The sender counts the file into `stats.xferred_files` and `stats.total_transferred_size` (`sender.c:342-343`) before the `if (!do_xfers)` guard. That guard `continue`s before `match_sums()`, which is the sole accumulator of `stats.literal_data` (`match.c:436`) and `stats.matched_data` (`match.c:121`). So under `--dry-run` both transferred-byte counters stay 0, while the scan-derived `Total file size`, `Total transferred file size`, `Number of regular files transferred`, and `File list size` still reflect the scan. Confirmed against rsync 3.4.4 for both a new-file copy and a delta/update.

## Fix

The local-copy dry-run path folded the whole file size into `bytes_copied` (the literal tally) by calling `record_file`. Added `record_dry_run_file`, which counts the file and its transferred size but leaves `bytes_copied` and `matched_bytes` at 0, matching upstream's structure at the accounting source so all derived stats stay consistent.

## Verification

- `-n --stats` on a would-transfer file: `Literal data: 0 bytes` / `Matched data: 0 bytes`; `Total transferred file size` and transferred count unchanged.
- Real (non-dry) transfer still reports the full literal data (no regression), matching 3.4.4.
- New integration test (`tests/dry_run_local_stats_literal.rs`) asserts both directions; it fails on pre-fix code.
- Updated engine dry-run unit tests that had encoded the pre-fix behaviour to assert `bytes_copied == 0` with `transferred_file_size` retained.

fmt clean, clippy `-D warnings` clean on the touched crate, all 118 dry-run engine tests plus the remote dry-run and total-transferred-size stats tests pass.
