### PR TITLE
ci(deps): track fuzz workspace lockfiles in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,18 @@
 version: 2
 
 updates:
-  # Rust dependencies
+  # Rust dependencies. The root workspace and the three cargo-fuzz
+  # workspaces each carry their own Cargo.lock, so all four directories
+  # are listed here to keep every lockfile in step on a shared-dep bump
+  # (the fuzz workspaces are excluded from the root workspace). The groups
+  # below apply across every directory, so one shared bump updates all
+  # four lockfiles in a single PR.
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories:
+      - "/"
+      - "/fuzz"
+      - "/crates/protocol/fuzz"
+      - "/crates/filters/fuzz"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary

Dependabot's single `cargo` ecosystem entry pointed at `directory: "/"`, so it only ever refreshed the root `Cargo.lock`. The three cargo-fuzz workspaces each carry their own lockfile and are excluded from the root workspace:

- `fuzz/Cargo.lock`
- `crates/protocol/fuzz/Cargo.lock`
- `crates/filters/fuzz/Cargo.lock`

A shared-dependency bump (for example the base64 bump behind #6989) updated the root lockfile but left these three stale, tripping the fuzz-lockfile drift guard.

## Change

Convert the single `directory: "/"` to a `directories:` array listing all four locations on one cargo ecosystem entry. This is the preferred low-noise form: the existing `groups:` (`rustcrypto`, `cargo-metadata`, `minor-and-patch`) apply across every directory, so a shared bump updates all four lockfiles in a single grouped PR rather than four separate PRs that each fail the guard until the last one lands.

All unrelated config is preserved unchanged: weekly Monday schedule, open-PR limit, commit-message prefix/scope, labels, the three dependency groups, and the `github-actions` ecosystem entry.

## Verification

- YAML parses and validates against the documented dependabot v2 schema (`directories` array is the supported multi-directory form for a single ecosystem entry).
- `git diff` touches only `.github/dependabot.yml`.
- CI-config only; no code changes.
