### PR TITLE
perf(transfer): batch network sender writes to match upstream cadence

### DIFF
--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -28,6 +28,7 @@ use super::super::{
     GeneratorContext, SegmentScheduler, TransferLoopResult, flush_with_count, is_early_close_error,
 };
 use crate::delta_config::DeltaGeneratorConfig;
+use crate::reader::BufferedInputHint;
 use crate::receiver::SumHead;
 use crate::writer::{BatchRoute, MsgInfoSender};
 
@@ -211,7 +212,7 @@ impl GeneratorContext {
     ///
     /// - `sender.c:send_files()` - Main send loop (lines 210-462)
     /// - `io.c:read_ndx/write_ndx` - NDX protocol encoding
-    pub(super) fn run_transfer_loop<R: Read, W: Write>(
+    pub(super) fn run_transfer_loop<R: Read + BufferedInputHint, W: Write>(
         &mut self,
         reader: &mut R,
         writer: &mut super::super::super::writer::ServerWriter<W>,
@@ -371,11 +372,20 @@ impl GeneratorContext {
                 }
             }
 
-            // upstream: io.c perform_io() flushes buffered output while waiting
-            // for input via select(). Our Read/Write traits are independent, so
-            // we must explicitly flush before blocking on read to prevent deadlock
-            // when buffered delta data hasn't reached the receiver yet.
-            flush_with_count(writer)?;
+            // upstream: io.c:640-724 perform_io() flushes buffered output only
+            // while genuinely waiting for input via select(); when the next
+            // request is already buffered (iobuf.in.len >= needed, io.c:643) it
+            // returns immediately without draining output. Our Read/Write traits
+            // are independent, so we mirror that: flush before a read that would
+            // actually block (no demuxed request buffered), but skip it while
+            // more requests remain in the reader's frame buffer. Skipping is
+            // deadlock-safe precisely because a buffered read cannot block, and
+            // it lets the writer coalesce per-file deltas up to its buffer bound
+            // - ~24 files per socket write, matching upstream's iobuf.out
+            // batching instead of one write() per file.
+            if !reader.has_buffered_input() {
+                flush_with_count(writer)?;
+            }
 
             // upstream: generator.c:2138-2144 - during the send loop, emit a
             // keepalive once the I/O lull has elapsed so the receiver's timeout
@@ -1643,6 +1653,11 @@ mod phase2_guard_tests {
     use crate::role::ServerRole;
     use crate::writer::ServerWriter;
 
+    // The crafted-wire tests feed a plain in-memory cursor, which has no
+    // peekable frame buffer: it keeps the conservative pre-read flush (the
+    // trait default), so these tests exercise the unchanged flush cadence.
+    impl crate::reader::BufferedInputHint for Cursor<Vec<u8>> {}
+
     /// `ITEM_TRANSFER` (0x8000) as its 2-byte little-endian wire encoding, the
     /// shortint iflags the receiver sends for a real file transfer request
     /// (proto >= 29, `item_flags.rs::read`).
@@ -1962,6 +1977,12 @@ mod inc_recurse_lookahead_tests {
         }
     }
 
+    // The probe models a peer whose NDXs the sender must genuinely block for,
+    // so it keeps the conservative pre-read flush (the trait default). The
+    // pacing assertion measures dispatch-before-first-block, which the flush
+    // gate does not affect.
+    impl crate::reader::BufferedInputHint for FirstReadProbe {}
+
     /// Builds an INC_RECURSE generator over a `DIRS * FILES_PER_DIR` tree.
     ///
     /// Entries are pushed in the sorted order a real `-r` scan produces
@@ -2066,6 +2087,167 @@ mod inc_recurse_lookahead_tests {
             (after - before) as usize,
             DIRS,
             "every sub-list must still reach the receiver by end of transfer"
+        );
+    }
+}
+
+#[cfg(test)]
+mod sender_batch_flush_tests {
+    //! Daemon-sender write-batching guard (#190).
+    //!
+    //! upstream: io.c:640-724 `perform_io()` drains `iobuf.out` only while
+    //! blocking on input; a request already buffered (io.c:643
+    //! `iobuf.in.len >= needed`) returns without a flush, so the sender
+    //! coalesces many per-file deltas into one socket write (~24 files/write)
+    //! rather than forcing a flush per file. This pins that contract: with every
+    //! request already buffered, the sender must NOT flush once per transferred
+    //! file. The WHY: the extra flushes are invisible in an oc-to-oc run (both
+    //! ends keep pace), and only show up as a syscall-rate regression against a
+    //! real peer - so the guard has to assert flush cadence, not wire contents,
+    //! which are byte-identical either way.
+
+    use std::cell::Cell;
+    use std::ffi::OsString;
+    use std::io::{self, Cursor, Read, Write};
+    use std::path::PathBuf;
+    use std::rc::Rc;
+
+    use protocol::ProtocolVersion;
+    use protocol::codec::{MonotonicNdxWriter, NdxCodec};
+
+    use crate::config::ServerConfig;
+    use crate::generator::GeneratorContext;
+    use crate::handshake::HandshakeResult;
+    use crate::reader::BufferedInputHint;
+    use crate::receiver::SumHead;
+    use crate::role::ServerRole;
+    use crate::writer::ServerWriter;
+
+    /// `ITEM_TRANSFER` (0x8000) little-endian, the iflags for a file request.
+    const ITEM_TRANSFER_LE: [u8; 2] = [0x00, 0x80];
+
+    /// Reader modelling a peer whose entire request stream is already buffered
+    /// in user space: while any wire byte remains unread the next read cannot
+    /// block, so `has_buffered_input` is true and the sender may skip its
+    /// pre-read flush - exactly upstream's `iobuf.in.len >= needed` fast path.
+    struct FullyBufferedWire {
+        cur: Cursor<Vec<u8>>,
+    }
+
+    impl Read for FullyBufferedWire {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            self.cur.read(buf)
+        }
+    }
+
+    impl BufferedInputHint for FullyBufferedWire {
+        fn has_buffered_input(&self) -> bool {
+            (self.cur.position() as usize) < self.cur.get_ref().len()
+        }
+    }
+
+    /// Plain sink that counts `flush()` calls. In plain mode `ServerWriter`
+    /// delegates `flush` straight through, so the count is the sender's
+    /// socket-write cadence.
+    struct FlushCountingSink {
+        flushes: Rc<Cell<usize>>,
+    }
+
+    impl Write for FlushCountingSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.flushes.set(self.flushes.get() + 1);
+            Ok(())
+        }
+    }
+
+    fn test_handshake() -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    /// Builds a generator over `n` small source files, so wire NDX `0..n` are
+    /// valid in-range whole-file transfer requests.
+    fn generator_with_files(n: usize) -> (tempfile::TempDir, GeneratorContext, Vec<PathBuf>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut paths = Vec::with_capacity(n);
+        for i in 0..n {
+            let file = dir.path().join(format!("f{i:03}.txt"));
+            std::fs::write(&file, format!("payload-{i}")).expect("write source");
+            paths.push(file);
+        }
+        let handshake = test_handshake();
+        let config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: paths.iter().map(OsString::from).collect(),
+            ..Default::default()
+        };
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+        ctx.build_file_list(&paths).expect("build file list");
+        (dir, ctx, paths)
+    }
+
+    #[test]
+    fn buffered_requests_do_not_flush_per_file() {
+        const FILES: usize = 12;
+        let (_dir, mut ctx, _paths) = generator_with_files(FILES);
+
+        // Receiver request stream: one whole-file transfer request per file
+        // (NDX + ITEM_TRANSFER iflags + empty sum_head), then three NDX_DONEs to
+        // drain phases 0 -> 1 -> 2 -> break.
+        let mut ndx = MonotonicNdxWriter::new(32);
+        let mut wire = Vec::new();
+        for i in 0..FILES {
+            ndx.write_ndx(&mut wire, i as i32).unwrap();
+            wire.extend_from_slice(&ITEM_TRANSFER_LE);
+            SumHead::empty().write(&mut wire).unwrap();
+        }
+        ndx.write_ndx_done(&mut wire).unwrap();
+        ndx.write_ndx_done(&mut wire).unwrap();
+        ndx.write_ndx_done(&mut wire).unwrap();
+
+        let flushes = Rc::new(Cell::new(0usize));
+        let mut reader = FullyBufferedWire {
+            cur: Cursor::new(wire),
+        };
+        let mut writer = ServerWriter::new_plain(FlushCountingSink {
+            flushes: Rc::clone(&flushes),
+        });
+        let mut progress: Option<&mut dyn crate::TransferProgressCallback> = None;
+        let mut itemize: Option<&mut dyn crate::ItemizeCallback> = None;
+
+        let result = ctx
+            .run_transfer_loop(&mut reader, &mut writer, &mut progress, &mut itemize)
+            .expect("sender loop completes with batched writes");
+
+        assert_eq!(
+            result.files_transferred, FILES,
+            "every requested file must still transfer"
+        );
+        // Pre-fix the top-of-loop flush ran unconditionally, so the sender
+        // flushed once per iteration: FILES transfers plus the phase-boundary
+        // NDX_DONE echoes = FILES + 2 flushes. With the buffered-input gate the
+        // per-file flush is skipped entirely and only the phase-boundary echoes
+        // flush. The strict `< FILES` bound fails the instant a per-file flush
+        // returns.
+        assert!(
+            flushes.get() < FILES,
+            "sender flushed {} times for {FILES} files - expected batched writes, \
+             not one flush per file",
+            flushes.get()
         );
     }
 }

--- a/crates/transfer/src/reader/mod.rs
+++ b/crates/transfer/src/reader/mod.rs
@@ -16,3 +16,25 @@ pub(crate) use counting::CountingReader;
 pub use multiplex::RemoteExitError;
 pub(crate) use multiplex::{DeletedRender, MultiplexReader};
 pub use server::ServerReader;
+
+/// Reports whether the next `Read` call is serviceable entirely from an
+/// in-memory buffer, so no socket read - and therefore no blocking - will
+/// occur.
+///
+/// The sender loop consults this before its pre-read flush. Upstream's
+/// `perform_io()` (io.c:640-724) drains buffered output only while genuinely
+/// waiting on input via `select()`; when the next request is already buffered
+/// it returns immediately without touching output. Skipping the flush in that
+/// case lets the writer coalesce per-file deltas up to its buffer bound,
+/// matching upstream's `iobuf.out` batching (~24 files per socket write)
+/// instead of forcing one write per file.
+///
+/// The default is the conservative `false` (assume a read may block, so flush
+/// first); only the multiplex-capable [`ServerReader`] overrides it.
+pub(crate) trait BufferedInputHint {
+    /// Returns true when a subsequent read cannot block because its bytes are
+    /// already buffered in user space.
+    fn has_buffered_input(&self) -> bool {
+        false
+    }
+}

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -266,6 +266,20 @@ impl<R> MultiplexReader<R> {
         }
     }
 
+    /// Returns true when the next `read()` is serviceable entirely from the
+    /// already-demuxed frame buffer, so it never touches `inner` and cannot
+    /// block.
+    ///
+    /// This is the exact guard `Read::read` uses to short-circuit into
+    /// `drain_buffered`: deliverable payload exists only when no frame is
+    /// mid-decode (`!in_progress`) and `pos` has not caught up to the buffered
+    /// length. The sender loop consults it to skip its pre-read flush while more
+    /// requests remain buffered, matching upstream `perform_io()` (io.c:640-724)
+    /// which drains output only while genuinely waiting on input.
+    pub(super) fn has_buffered_payload(&self) -> bool {
+        !self.frames.in_progress() && self.pos < self.buffer.len()
+    }
+
     /// Enables client-side rendering of received `MSG_DELETED` frames.
     ///
     /// Called only on the client-sender reader (a push, where the remote

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -317,6 +317,19 @@ impl<R: Read> ServerReader<R> {
     }
 }
 
+impl<R: Read> super::BufferedInputHint for ServerReader<R> {
+    /// Only the multiplex reader tracks a demuxed frame buffer whose remaining
+    /// bytes guarantee a non-blocking next read. Plain and compressed modes have
+    /// no such peekable buffer, so they answer `false` and keep the conservative
+    /// pre-read flush.
+    fn has_buffered_input(&self) -> bool {
+        match &self.inner {
+            ServerReaderInner::Multiplex(mux) => mux.has_buffered_payload(),
+            ServerReaderInner::Plain(_) | ServerReaderInner::Compressed(_) => false,
+        }
+    }
+}
+
 impl<R: Read> Read for ServerReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match &mut self.inner {

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -80,6 +80,47 @@ fn server_reader_plain_empty_read() {
 }
 
 #[test]
+fn buffered_input_hint_plain_is_false() {
+    // A plain reader has no peekable frame buffer, so it always keeps the
+    // conservative pre-read flush.
+    let reader = ServerReader::new_plain(Cursor::new(vec![1u8, 2, 3]));
+    assert!(!reader.has_buffered_input());
+}
+
+#[test]
+fn buffered_input_hint_tracks_demuxed_frame() {
+    // has_buffered_input mirrors Read::read's short-circuit: it is true exactly
+    // while unconsumed demuxed payload remains, guaranteeing the next read is
+    // served from the buffer without touching the socket.
+    let mut stream = Vec::new();
+    protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"hello").unwrap();
+    let mut reader = ServerReader::new_plain(Cursor::new(stream))
+        .activate_multiplex()
+        .unwrap();
+
+    // Nothing demuxed yet: the next read must go to the socket.
+    assert!(!reader.has_buffered_input());
+
+    // Read 2 of 5 payload bytes; 3 remain buffered.
+    let mut buf = [0u8; 2];
+    assert_eq!(reader.read(&mut buf).unwrap(), 2);
+    assert_eq!(&buf, b"he");
+    assert!(
+        reader.has_buffered_input(),
+        "unconsumed demuxed payload must report buffered input"
+    );
+
+    // Drain the rest; the buffer empties, so a further read would block again.
+    let mut rest = [0u8; 3];
+    assert_eq!(reader.read(&mut rest).unwrap(), 3);
+    assert_eq!(&rest, b"llo");
+    assert!(
+        !reader.has_buffered_input(),
+        "a drained frame buffer must report no buffered input"
+    );
+}
+
+#[test]
 fn server_reader_activate_compression_on_plain_fails() {
     let data = vec![1, 2, 3, 4, 5];
     let reader = ServerReader::new_plain(Cursor::new(data));


### PR DESCRIPTION
## Problem

Every network sender flushed its output writer at the top of each transfer-loop iteration, before reading the next NDX request. Because each iteration services one file, this forced one socket write per file. All network senders share one send loop - `run_transfer_loop`, driven by `GeneratorContext::run` over a multiplex `ServerReader` - so the per-file flush hit daemon-pull, daemon-push, ssh-pull and ssh-push alike. Measured with `strace -c` on a 10k-small-file daemon pull (x86_64): oc-rsync issued ~10,317 `sendto` where upstream rsync 3.4.4 issues ~424 `write` (24x more). This is the sole cause of the small-file cold-start network-transfer slowness; bulk and steady transfers are already at parity or faster, and local copy is unaffected (inherent per-file dest writes).

## Upstream reference

`perform_io()` (`io.c:640-724`) drains `iobuf.out` only while genuinely blocking on input via `select()`. When the next request is already buffered (`io.c:643`, `iobuf.in.len >= needed`) it returns immediately without touching output, so many per-file deltas coalesce into one ~24-file socket write. Upstream never flushes per file.

## Fix

Gate the pre-read flush on whether the reader already holds a demuxed request in its frame buffer. When it does, the next read cannot block, so skipping the flush is deadlock-safe and lets the writer coalesce deltas up to its buffer bound. Adds `BufferedInputHint` (default `false`; `ServerReader` consults the multiplex frame buffer via the same guard `Read::read` uses to short-circuit).

Input multiplex is active for both roles (server `proto>=30`, client `proto>=23`), and all four network-sender directions run this one loop with a `ServerReader`, so the single gate covers server-mode senders (daemon-pull, ssh-pull) and client-mode senders (daemon-push, ssh-push) with no per-direction code. Phase-boundary and goodbye flushes are unchanged, so the post-demultiplex protocol byte stream and its order are identical; only the flush cadence (and therefore how the payload is chunked into `MSG_DATA` frames) changes, exactly as upstream's own framing varies with `iobuf.out` fill timing.

## Verification (x86_64, 500-file corpus, `strace -c` of the sender)

Socket-write syscalls, before (master `3b496b7de`) vs after, all `rc=0`, all 500 files landed, reconstruction byte-identical (source tree hash == every after-dest):

| direction | sender role | syscall | before | after | reduction |
|-----------|-------------|---------|-------:|------:|----------:|
| daemon-pull | server-mode | `sendto` | 525 | 41 | 12.8x |
| daemon-push | client-mode | `sendto` | 549 | 40 | 13.7x |
| ssh-pull | server-mode (remote) | `write` | 995 | 45 | 22x |
| ssh-push | client-mode (local) | `write` | 535 | 26 | 20.6x |

From ~1 write/file to ~1 per 12-20 files (files-per-write scales with how many fit the 64 KB output buffer). No deadlock, no corruption.

## Tests

- `buffered_input_hint_*`: the hint is true exactly while unconsumed demuxed payload remains.
- `buffered_requests_do_not_flush_per_file`: with every request already buffered, the sender flushes fewer than once per transferred file (pre-fix it flushed `files + 2` times).
- Existing crafted-wire sender tests (plain readers) keep the conservative flush and stay green.
