### PR TITLE
fix(cli): imply list-only for a bare local source

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -766,11 +766,13 @@ where
     // it is never forwarded. Capture the explicit bit before the OR.
     let list_only_arg = list_only;
     // upstream: options.c:2194-2195 - `if (argc < 2 && !read_batch && !am_server)
-    // list_only |= 1;`. A single remote source with no destination (e.g.
-    // `host::module` or `rsync://host/module`) implies list-only mode: list the
-    // module's contents instead of erroring "need source and destination".
-    let list_only =
-        list_only || (transfer_operands.len() == 1 && read_batch.is_none() && is_daemon_transfer);
+    // list_only |= 1;`. A single source with no destination implies list-only
+    // mode regardless of transport: a local path (`rsync src/`), an SSH source
+    // (`rsync host:path`), or a daemon module (`host::module`,
+    // `rsync://host/module`) all list their contents instead of erroring "need
+    // source and destination". The rule is transport-agnostic; `am_server` never
+    // applies on the client path.
+    let list_only = list_only || (transfer_operands.len() == 1 && read_batch.is_none());
 
     // upstream: options.c:2187-2188 - relative_paths defaults to 1 when files_from
     let effective_relative = if files_from_active && relative.is_none() {

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -112,6 +112,39 @@ fn list_only_lists_bare_directory_without_recursion_or_slash() {
     assert!(!rendered.contains("file.txt"));
 }
 
+/// A bare source operand with no destination and no `--list-only` flag implies
+/// list-only mode regardless of transport. upstream: options.c:2194-2195 -
+/// `if (argc < 2 && !read_batch && !am_server) list_only |= 1;`. The rule is not
+/// gated on the transport, so a local `oc-rsync src/` lists the directory and
+/// exits 0 (RERR_OK) rather than erroring "need source and destination" (which
+/// oc previously reported as exit 23).
+#[test]
+fn implicit_list_only_lists_local_source_without_destination() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("src");
+    fs::create_dir(&source_dir).expect("create src dir");
+    fs::write(source_dir.join("file.txt"), b"contents").expect("write source file");
+
+    let (code, stdout, stderr) =
+        run_with_args([OsString::from(RSYNC), source_dir.clone().into_os_string()]);
+
+    assert_eq!(code, 0, "bare local source implies list-only and exits 0");
+    assert!(stderr.is_empty());
+
+    let rendered = String::from_utf8(stdout).expect("utf8 stdout");
+    let directory_line = rendered
+        .lines()
+        .find(|line| line.ends_with("src"))
+        .expect("bare directory operand entry present");
+    assert!(directory_line.starts_with('d'));
+    assert!(!directory_line.ends_with('/'));
+    // Without -r the directory's children must not be listed.
+    assert!(!rendered.contains("file.txt"));
+}
+
 #[cfg(unix)]
 #[test]
 fn list_only_matches_rsync_format_for_regular_file() {

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -426,18 +426,19 @@ mod exit_code_23_partial_transfer {
     }
 
     #[test]
-    fn missing_operands_returns_partial_transfer() {
-        // Running without source operands
-        let test_dir = TestDir::new().expect("create test dir");
-        let dest_dir = test_dir.mkdir("dest").unwrap();
+    fn missing_operands_returns_syntax_error() {
+        // Genuinely missing operands means zero positional arguments. upstream
+        // main.c:1791 - `rsync` with no operands prints usage and exits 1
+        // (syntax/usage error), not 23. A lone existing operand is NOT a
+        // missing-operands case: upstream options.c:2194 (`argc < 2 &&
+        // !read_batch && !am_server => list_only`) reinterprets it as a source
+        // to list and exits 0.
+        let output = run_rsync(&[]);
 
-        let output = run_rsync(&[dest_dir.to_str().unwrap()]);
-
-        // Note: Missing operands typically returns 23 (partial) in upstream
         let code = output.status.code().unwrap_or(-1);
         assert!(
-            code == 1 || code == 23,
-            "Missing operands should return 1 (syntax) or 23 (partial), got {code}"
+            code == 1,
+            "no operands should return 1 (syntax/usage), got {code}"
         );
     }
 }

--- a/tests/interop/behavior/scenarios.toml
+++ b/tests/interop/behavior/scenarios.toml
@@ -447,8 +447,17 @@ echo "file1" > src/file1.txt
 echo "file2" > src/file2.txt
 """
 compare = ["exit_code"]
-skip = true
-known_difference = "oc-rsync returns exit code 23 for --list-only on local paths; upstream returns 0"
+
+[[scenario]]
+name = "list_only_implicit"
+description = "A bare source with no destination implies list-only"
+args = ["src/"]
+setup = """
+mkdir -p src
+echo "file1" > src/file1.txt
+echo "file2" > src/file2.txt
+"""
+compare = ["exit_code"]
 
 # ============== Relative Path Handling ==============
 


### PR DESCRIPTION
## Summary

A bare single source operand with no destination implies list-only mode in upstream rsync, regardless of transport:

```c
/* options.c:2194-2195 */
if (argc < 2 && !read_batch && !am_server)
    list_only |= 1;
```

oc-rsync gated this implicit rule on `is_daemon_transfer`, so a local `oc-rsync src/` (and an SSH source with no destination) fell through to the missing-operands path and exited **23** instead of listing the directory and exiting **0**.

## Fix

Remove the transport gate in `crates/cli/src/frontend/execution/drive/workflow/run.rs`. Local, SSH, and daemon single-operand invocations now all list their contents and return `RERR_OK`, matching upstream. The daemon path is unaffected (it already had the flag set); the change only adds the local and SSH cases.

## Verification vs rsync 3.4.4

| Command | upstream | oc pre-fix | oc post-fix |
|---------|----------|-----------|-------------|
| `rsync src/` (bare dir) | 0 | 23 | 0 |
| `rsync src/file` (bare file) | 0 | 23 | 0 |
| `rsync --list-only src/` | 0 | 0 | 0 |
| `rsync /nonexistent` | 23 | 23 | 23 |

Listing output matches upstream 3.4.4 byte-for-byte (`diff` clean) for bare, recursive, and file operands.

## Tests

- Un-skipped the `list_only` interop behavior scenario and added a `list_only_implicit` scenario (bare source, no `--list-only`) - both compare exit codes against real upstream.
- Added `implicit_list_only_lists_local_source_without_destination` unit test asserting exit 0, correct directory listing, and no child leakage. Fails on pre-fix code (exit 23).
