### PR TITLE
test: run empty file-list transfer control on all platforms

### DIFF
--- a/crates/cli/src/frontend/tests/empty_flist_transfer.rs
+++ b/crates/cli/src/frontend/tests/empty_flist_transfer.rs
@@ -1,0 +1,46 @@
+//! End-to-end control for the empty file-list contract, exercised on every
+//! platform (including Windows).
+//!
+//! A recursive transfer whose source tree is empty produces an empty transfer
+//! file list and must complete with exit code 0 - the sender frames only the
+//! implied root and no `io_error` bit, so nothing may be reported as an error.
+//! This is the observable end-to-end counterpart to the wire-level empty-flist
+//! coverage (`receiver_empty_file_list`, `send_empty_file_list`,
+//! `protocol_flist_empty`). The behaviour is platform-agnostic: it needs no
+//! POSIX-only surface, so it runs unconditionally rather than being gated to
+//! Unix.
+
+use super::common::*;
+use super::*;
+
+/// An empty source directory should transfer successfully with exit code 0.
+///
+/// Verifies that recursive transfer of an empty tree does not spuriously
+/// report errors on any platform.
+#[test]
+fn empty_source_directory_transfers_successfully() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+
+    std::fs::create_dir(&src).expect("create src");
+
+    let mut src_trailing = src.into_os_string();
+    src_trailing.push("/");
+
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-r"),
+        src_trailing,
+        dst.into_os_string(),
+    ]);
+
+    assert_eq!(
+        code,
+        0,
+        "empty directory sync should exit 0: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+}

--- a/crates/cli/src/frontend/tests/error_recovery_integration.rs
+++ b/crates/cli/src/frontend/tests/error_recovery_integration.rs
@@ -570,38 +570,6 @@ fn vanished_source_directory_yields_error_remaining_files_transfer() {
     );
 }
 
-/// An empty source directory should transfer successfully with exit code 0.
-/// This is a control test for the error scenarios above, verifying that
-/// recursive transfer of an empty tree does not spuriously report errors.
-#[cfg(unix)]
-#[test]
-fn empty_source_directory_transfers_successfully() {
-    use tempfile::tempdir;
-
-    let tmp = tempdir().expect("tempdir");
-    let src = tmp.path().join("src");
-    let dst = tmp.path().join("dst");
-
-    std::fs::create_dir(&src).expect("create src");
-
-    let mut src_trailing = src.into_os_string();
-    src_trailing.push("/");
-
-    let (code, _stdout, stderr) = run_with_args([
-        OsString::from(RSYNC),
-        OsString::from("-r"),
-        src_trailing,
-        dst.into_os_string(),
-    ]);
-
-    assert_eq!(
-        code,
-        0,
-        "empty directory sync should exit 0: {}",
-        String::from_utf8_lossy(&stderr)
-    );
-}
-
 /// When the destination directory does not exist and --mkpath is not used,
 /// a single-file transfer into a new path should still succeed (the
 /// destination is treated as the target file name).

--- a/crates/cli/src/frontend/tests/mod.rs
+++ b/crates/cli/src/frontend/tests/mod.rs
@@ -60,6 +60,8 @@ mod daemon_tests;
 mod delete_tests;
 #[path = "dry_run.rs"]
 mod dry_run_tests;
+#[path = "empty_flist_transfer.rs"]
+mod empty_flist_transfer_tests;
 #[cfg(unix)]
 #[path = "error_recovery_integration.rs"]
 mod error_recovery_integration_tests;


### PR DESCRIPTION
## Problem

The empty-source-directory transfer control lived inside the Unix-only
`error_recovery_integration` test module (gated at the `mod` declaration in
`tests/mod.rs`, with a redundant per-function `#[cfg(unix)]`). On Windows the
whole file is never compiled, so the test did not run there at all - yet its
behaviour, a recursive transfer of an empty tree completing with exit code 0,
is entirely platform-agnostic and uses no POSIX-only surface. The test's
claimed coverage (an end-to-end control living among "local transfer"
integration tests) did not match its actual coverage.

## What runs where now

- Wire-level empty file-list behaviour was already covered cross-platform
  (`receiver_empty_file_list`, `send_empty_file_list`, `protocol_flist_empty`,
  `write_and_read_empty_flist`, `empty_file_list_returns_zero`).
- The end-to-end empty-tree exit-0 control ran on Unix only.

## Change

Move the control into a dedicated, ungated `empty_flist_transfer` module so the
end-to-end empty file-list exit-0 contract is exercised on every platform,
including Windows. The move relies only on cross-platform helpers already used
by other Windows-green local-transfer tests (`compression`, `exclude_lsh_matrix`).
The sibling tests that genuinely require Unix (unreadable directories via
permission bits, vanished-during-scan races) stay gated as before.

## Verification

- `cargo fmt -p cli -- --check`: clean.
- `cargo clippy -p cli --all-targets --all-features --no-deps -- -D warnings`: clean.
- `cargo nextest run -p cli -E 'test(empty_source_directory_transfers_successfully)'`: 1 passed.
- Windows cfg-fallout: the new module carries no `cfg(unix)` and uses the same
  cross-platform API surface as existing Windows-green tests; a mod-level
  Windows simulation confirmed the new module is not a compile-failure point.
  The CI Windows cell is the authoritative gate.
