### PR TITLE
feat(transfer): light itemize `a` column on ACL differences

### DIFF
--- a/crates/metadata/src/acl_diff.rs
+++ b/crates/metadata/src/acl_diff.rs
@@ -1,0 +1,276 @@
+//! Destination-side ACL comparison for the itemize `a` column
+//! (`ITEM_REPORT_ACL`).
+//!
+//! Mirrors upstream's `itemize()` ACL leg (`generator.c:557-563`), which reads
+//! the destination's current ACL (`get_acl`) and probes whether applying the
+//! sender's cached ACL would change it (`set_acl(NULL, file, sxp, mode)`,
+//! `acls.c:1013-1057`). The single destination read plus comparison lives here
+//! so both the network receiver and any future local path share one mechanism,
+//! matching the placement of [`crate::dest_xattrs_differ`].
+
+use crate::AclIdMapper;
+use protocol::acl::{NAME_IS_USER, NO_ENTRY, RsyncAcl};
+use std::path::Path;
+
+/// Clones `acl`, remapping every named-entry id through `id_map` so the
+/// comparison sees the same local ids the apply path would write.
+///
+/// Mirrors upstream `match_acl_ids()` (`acls.c:1059-1081`), which converts each
+/// named entry id through the uid/gid table before the cached ACL is used. Only
+/// the id changes; the access bits (including [`NAME_IS_USER`]) and any carried
+/// name are preserved. With no mapper the ACL is returned unchanged.
+fn remap_named_ids(acl: &RsyncAcl, id_map: Option<&AclIdMapper>) -> RsyncAcl {
+    let Some(mapper) = id_map else {
+        return acl.clone();
+    };
+    let mut out = acl.clone();
+    out.names = acl
+        .names
+        .iter()
+        .map(|ida| {
+            let mut mapped = ida.clone();
+            mapped.id = if ida.access & NAME_IS_USER != 0 {
+                mapper.map_uid(ida.id)
+            } else {
+                mapper.map_gid(ida.id)
+            };
+            mapped
+        })
+        .collect();
+    out
+}
+
+/// Reports whether applying the sender's cached ACL(s) to `path` would change
+/// the destination, i.e. whether the itemize `a` column must light.
+///
+/// Mirrors upstream `itemize()` -> `set_acl(NULL, file, sxp, mode)`
+/// (`generator.c:561`, `acls.c:1024-1054`): the access ACL is compared with
+/// [`RsyncAcl::equal_enough`] (the extended entries plus a mask-gated
+/// `group_obj`, the rest left to mode preservation), and a directory's default
+/// ACL - transmitted un-stripped - is compared for strict equality with
+/// [`RsyncAcl::equal`].
+///
+/// `sender_access` / `sender_default` are the sender's cached (condensed) ACLs
+/// resolved from the flist by index; either is `None` when the sender shipped no
+/// ACL of that kind, matching upstream's `ndx >= 0` guard, so an absent sender
+/// ACL never raises the column. The destination is read fresh via
+/// [`crate::get_rsync_acl`] so the comparison sees the pre-transfer state; a
+/// destination whose ACL cannot be read falls back to a mode-derived ACL exactly
+/// as upstream's `get_acl` does.
+///
+/// The comparison order matches upstream: the destination read is the
+/// fully-populated `racl1` (`self`) and the sender's cached ACL is the condensed
+/// `racl2` (`other`).
+#[must_use]
+pub fn dest_acl_differs(
+    path: &Path,
+    sender_access: Option<&RsyncAcl>,
+    sender_default: Option<&RsyncAcl>,
+    mode: u32,
+    is_dir: bool,
+    id_map: Option<&AclIdMapper>,
+) -> bool {
+    // upstream: acls.c:1024-1037 - access ACL leg. `ndx >= 0` gates the whole
+    // block, so no sender access ACL means no change to report.
+    if let Some(sender) = sender_access {
+        let dest = crate::get_rsync_acl(path, mode, false);
+        let mut sender = remap_named_ids(sender, id_map);
+        // upstream: acls.c:773-776 recv_rsync_acl() - an ACCESS ACL that carries
+        // named entries but no transmitted mask is cached with
+        // `mask_obj = (mode >> 3) & 7`, because a POSIX ACL with named entries
+        // must have a mask. oc leaves the received access mask NO_ENTRY and
+        // reconstructs it at apply time, so restore it here to feed
+        // `equal_enough` the same condensed form upstream compares against;
+        // otherwise the mask-presence check would light `a` on an identical ACL.
+        if !sender.names.is_empty() && sender.mask_obj == NO_ENTRY {
+            sender.mask_obj = ((mode >> 3) & 7) as u8;
+        }
+        if !dest.equal_enough(&sender, mode) {
+            return true;
+        }
+    }
+
+    // upstream: acls.c:1039-1054 - the default ACL leg runs for directories only
+    // and uses strict `rsync_acl_equal`.
+    if is_dir {
+        if let Some(sender) = sender_default {
+            let dest = crate::get_rsync_acl(path, mode, true);
+            let sender = remap_named_ids(sender, id_map);
+            if !dest.equal(&sender) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(all(
+    test,
+    feature = "acl",
+    any(target_os = "linux", target_os = "macos", target_os = "freebsd")
+))]
+mod tests {
+    use super::*;
+    use protocol::acl::{IdAccess, RsyncAcl};
+    use std::collections::HashMap;
+
+    #[cfg(unix)]
+    fn mapper(uid: HashMap<u32, u32>, gid: HashMap<u32, u32>) -> AclIdMapper {
+        AclIdMapper::new(uid, gid, None, None, false)
+    }
+    #[cfg(not(unix))]
+    fn mapper(uid: HashMap<u32, u32>, gid: HashMap<u32, u32>) -> AclIdMapper {
+        AclIdMapper::new(uid, gid, false)
+    }
+
+    /// A named-user id is rewritten through the uid table; a group id is left
+    /// alone when it is not in the gid table.
+    #[test]
+    fn remap_rewrites_named_user_id_via_mapper() {
+        let mut acl = RsyncAcl::from_mode(0o644);
+        acl.names.push(IdAccess::user(1000, 0o6));
+        acl.names.push(IdAccess::group(2000, 0o4));
+        let mut uid = HashMap::new();
+        uid.insert(1000, 5000);
+        let remapped = remap_named_ids(&acl, Some(&mapper(uid, HashMap::new())));
+        let ids: Vec<u32> = remapped.names.iter().map(|ida| ida.id).collect();
+        assert_eq!(ids, vec![5000, 2000]);
+    }
+
+    /// Without a mapper the ACL is returned verbatim.
+    #[test]
+    fn remap_without_mapper_is_identity() {
+        let mut acl = RsyncAcl::from_mode(0o644);
+        acl.names.push(IdAccess::user(1000, 0o6));
+        let remapped = remap_named_ids(&acl, None);
+        assert_eq!(remapped.names.iter().next().unwrap().id, 1000);
+    }
+}
+
+/// Integration tests that exercise the real destination ACL read against a
+/// filesystem via `setfacl`/`getfacl`. Gated to Linux/FreeBSD, whose POSIX ACL
+/// model matches upstream's `get_acl`; macOS uses a different (NFSv4) model.
+/// Each test degrades gracefully when the temp filesystem lacks ACL support,
+/// so they are safe to compile everywhere but only assert on a capable host -
+/// the aarch64/x86_64 Linux hosts are the merge gate.
+#[cfg(all(test, feature = "acl", any(target_os = "linux", target_os = "freebsd")))]
+mod integration_tests {
+    use super::*;
+    use protocol::acl::IdAccess;
+    use tempfile::tempdir;
+
+    /// Reads a path's real access ACL and condenses it exactly as the sender
+    /// would before shipping it (`strip_perms_for_send`), yielding the
+    /// receiver-cached form used as `equal_enough`'s condensed `other`.
+    fn sender_access_acl(path: &std::path::Path, mode: u32) -> RsyncAcl {
+        let mut acl = crate::get_rsync_acl(path, mode, false);
+        acl.strip_perms_for_send(mode);
+        acl
+    }
+
+    /// A file whose destination ACL is byte-identical to the sender's must not
+    /// light the `a` column. This is the identical-ACL false-positive guard.
+    #[test]
+    fn identical_named_user_acl_does_not_differ() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("f");
+        std::fs::write(&file, b"x").expect("write");
+        let mode = 0o644;
+
+        let entries = vec![exacl::AclEntry::allow_user(
+            "1000",
+            exacl::Perm::READ | exacl::Perm::WRITE,
+            None,
+        )];
+        if exacl::setfacl(&[&file], &entries, None).is_err() {
+            return; // filesystem without ACL support
+        }
+
+        let sender = sender_access_acl(&file, mode);
+        assert!(
+            !dest_acl_differs(&file, Some(&sender), None, mode, false, None),
+            "identical access ACL must not light the `a` column",
+        );
+    }
+
+    /// A trivial file (no extended ACL) must not light `a` either: the sender's
+    /// condensed ACL strips to the mode and the full destination read recovers
+    /// the same via `equal_enough`.
+    #[test]
+    fn trivial_acl_does_not_differ() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("f");
+        std::fs::write(&file, b"x").expect("write");
+        let mode = 0o644;
+        let sender = sender_access_acl(&file, mode);
+        assert!(!dest_acl_differs(
+            &file,
+            Some(&sender),
+            None,
+            mode,
+            false,
+            None
+        ));
+    }
+
+    /// When the sender carries a named entry the destination lacks, the access
+    /// ACL differs and the `a` column lights.
+    #[test]
+    fn extra_named_user_on_sender_differs() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("f");
+        std::fs::write(&file, b"x").expect("write");
+        let mode = 0o644;
+
+        // Destination has a named user 1000; the sender's cached ACL adds a
+        // second named user 1001, so equal_enough sees unequal name counts.
+        let entries = vec![exacl::AclEntry::allow_user("1000", exacl::Perm::READ, None)];
+        if exacl::setfacl(&[&file], &entries, None).is_err() {
+            return;
+        }
+
+        let mut sender = sender_access_acl(&file, mode);
+        sender.names.push(IdAccess::user(1001, 0x04));
+        assert!(
+            dest_acl_differs(&file, Some(&sender), None, mode, false, None),
+            "an extra sender named entry must light the `a` column",
+        );
+    }
+
+    /// The default-ACL leg is directory-only and uses strict equality. A
+    /// directory carrying no default ACL reads back as an empty ACL, so a sender
+    /// default that also reads empty must not light `a`, while a sender default
+    /// with an extra entry must. Exercises both arms of the default leg without
+    /// depending on setting a (necessarily complete) POSIX default ACL on disk.
+    #[test]
+    fn default_acl_on_dir() {
+        let dir = tempdir().expect("tempdir");
+        let sub = dir.path().join("d");
+        std::fs::create_dir(&sub).expect("mkdir");
+        let mode = 0o755;
+
+        // No default ACL on disk -> dest default reads back empty.
+        let dest_default = crate::get_rsync_acl(&sub, mode, true);
+        assert!(
+            !dest_acl_differs(&sub, None, Some(&dest_default), mode, true, None),
+            "an identical (empty) default ACL must not light `a`",
+        );
+
+        let mut changed = dest_default.clone();
+        changed.names.push(IdAccess::group(2000, 0x04));
+        assert!(
+            dest_acl_differs(&sub, None, Some(&changed), mode, true, None),
+            "a differing default ACL must light `a`",
+        );
+
+        // The default leg must never fire for a non-directory even when a
+        // default ACL is supplied (upstream gates on S_ISDIR).
+        let file = dir.path().join("f");
+        std::fs::write(&file, b"x").expect("write");
+        assert!(
+            !dest_acl_differs(&file, None, Some(&changed), 0o644, false, None),
+            "default ACL leg must not run for a non-directory",
+        );
+    }
+}

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -149,6 +149,10 @@ pub use device_size::device_readable_size;
 /// would otherwise escape the module root.
 pub mod symlink_munge;
 
+/// Destination-side ACL comparison for the itemize `a` column.
+pub mod acl_diff;
+pub use acl_diff::dest_acl_differs;
+
 pub mod xattr_send;
 
 #[cfg(all(feature = "xattr", any(unix, windows)))]

--- a/crates/protocol/src/acl/entry.rs
+++ b/crates/protocol/src/acl/entry.rs
@@ -487,6 +487,31 @@ impl RsyncAcl {
         self.other_obj = NO_ENTRY;
     }
 
+    /// Reports whether two ACLs are exactly equal in every object and named
+    /// entry. Used for the default ACL of a directory, which upstream compares
+    /// with strict equality (default ACLs are transmitted un-stripped, so both
+    /// sides carry a fully-populated `rsync_acl`).
+    ///
+    /// # Upstream Reference
+    ///
+    /// Mirrors `rsync_acl_equal()` in `acls.c` lines 190-197.
+    #[must_use]
+    pub fn equal(&self, other: &RsyncAcl) -> bool {
+        // upstream: acls.c:192-196 - all four permission objects plus the named
+        // entries must match (ida_entries_equal compares count and each
+        // (access, id) pair in order).
+        self.user_obj == other.user_obj
+            && self.group_obj == other.group_obj
+            && self.mask_obj == other.mask_obj
+            && self.other_obj == other.other_obj
+            && self.names.len() == other.names.len()
+            && self
+                .names
+                .iter()
+                .zip(other.names.iter())
+                .all(|(a, b)| a.access == b.access && a.id == b.id)
+    }
+
     /// Reports whether the extended (non-permission-bit) entries of two ACLs
     /// match closely enough that the rest of the ACL is handled by the normal
     /// mode-preservation code. Meaningful only for access ACLs.

--- a/crates/protocol/src/acl/tests.rs
+++ b/crates/protocol/src/acl/tests.rs
@@ -1812,6 +1812,66 @@ mod equal_enough_tests {
     }
 }
 
+/// Tests for `RsyncAcl::equal`, the strict comparison used for a directory's
+/// default ACL (upstream `rsync_acl_equal()`, `acls.c` lines 190-197). Unlike
+/// `equal_enough`, every object and named entry participates.
+mod equal_tests {
+    use super::*;
+
+    #[test]
+    fn reflexive() {
+        let acl = RsyncAcl::from_mode(0o755);
+        assert!(acl.equal(&acl));
+    }
+
+    #[test]
+    fn differing_user_obj_is_not_equal() {
+        // WHY: acls.c:192 - user_obj IS part of the strict comparison (it is
+        // not for equal_enough), so a difference here rejects.
+        let a = RsyncAcl::from_mode(0o755);
+        let mut b = a.clone();
+        b.user_obj = 1;
+        assert!(!a.equal(&b));
+    }
+
+    #[test]
+    fn differing_other_obj_is_not_equal() {
+        // WHY: acls.c:195 - other_obj participates in the strict comparison.
+        let a = RsyncAcl::from_mode(0o755);
+        let mut b = a.clone();
+        b.other_obj = 0;
+        assert!(!a.equal(&b));
+    }
+
+    #[test]
+    fn identical_named_entries_are_equal() {
+        let mut a = RsyncAcl::from_mode(0o644);
+        a.mask_obj = 7;
+        a.names.push(IdAccess::user(1000, 0x06));
+        a.names.push(IdAccess::group(2000, 0x04));
+        let b = a.clone();
+        assert!(a.equal(&b));
+    }
+
+    #[test]
+    fn differing_named_entry_id_is_not_equal() {
+        // WHY: acls.c:196 - ida_entries_equal compares each (access, id) pair.
+        let mut a = RsyncAcl::from_mode(0o644);
+        a.names.push(IdAccess::user(1000, 0x06));
+        let mut b = a.clone();
+        b.names = std::iter::once(IdAccess::user(1001, 0x06)).collect();
+        assert!(!a.equal(&b));
+    }
+
+    #[test]
+    fn differing_named_entry_count_is_not_equal() {
+        let mut a = RsyncAcl::from_mode(0o644);
+        a.names.push(IdAccess::user(1000, 0x06));
+        let b = RsyncAcl::from_mode(0o644);
+        assert!(!a.equal(&b));
+    }
+}
+
 /// Tests for `IdaEntries::clear`.
 mod ida_entries_clear_tests {
     use super::*;

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -894,6 +894,15 @@ impl ReceiverContext {
                 }
             }
         }
+        // upstream: generator.c:557-563 - with `preserve_acls` and a non-symlink
+        // the generator reads the destination ACL (`get_acl`) and probes whether
+        // applying the sender's cached ACL would change it
+        // (`set_acl(NULL, file, sxp, file->mode)`); a non-zero return lights the
+        // `a` column. Symlinks are excluded exactly as upstream's
+        // `!S_ISLNK(file->mode)` guard, since their own ACL is never applied.
+        if self.acl_itemize_active() && !entry.is_symlink() && self.dest_acl_differs(entry, path) {
+            iflags |= ItemFlags::ITEM_REPORT_ACL;
+        }
         // upstream: generator.c:564-571 - the last thing the `statret >= 0` leg
         // does is a lazy `get_xattr(fnamecmp, sxp)` followed by
         // `xattr_diff(file, sxp, 1)`. It runs for every itemized entry, not
@@ -972,6 +981,57 @@ impl ReceiverContext {
                 self.checksum_seed,
             ),
         }
+    }
+
+    /// Whether the `a` column's destination ACL read should run at all.
+    ///
+    /// Mirrors the two gates upstream places on the ACL leg: `preserve_acls`
+    /// inside `itemize()` (`generator.c:558`) and the `itemizing` test at each
+    /// call site. Folding both in here keeps the extra `getfacl` off the
+    /// no-itemize scan path, matching [`Self::xattr_itemize_active`].
+    fn acl_itemize_active(&self) -> bool {
+        self.config.flags.acls && self.should_emit_itemize()
+    }
+
+    /// Whether the destination's ACL differs from the sender's, for the
+    /// `ITEM_REPORT_ACL` (`a`) itemize column.
+    ///
+    /// Resolves the sender's cached (condensed) access and, for directories,
+    /// default ACLs from the flist reader's ACL cache - the same cache the apply
+    /// path reads - and hands both sides to [`metadata::dest_acl_differs`], which
+    /// reads the pre-transfer destination ACL and probes it exactly as upstream's
+    /// `set_acl(NULL, file, sxp, mode)` does (`generator.c:561`,
+    /// `acls.c:1024-1054`). Named-entry ids are remapped through the same
+    /// cross-host id map the apply path uses (`build_acl_id_mapper`), so the
+    /// comparison sees the local ids the receiver would write and an identical
+    /// ACL never lights the column.
+    ///
+    /// An entry with no cached ACL index (`acl_ndx() == None`) yields `None`
+    /// sender ACLs, matching upstream's `ndx >= 0` guard: no sender ACL, no `a`.
+    pub(in crate::receiver) fn dest_acl_differs(&self, entry: &FileEntry, path: &Path) -> bool {
+        let Some(reader) = self.flist_reader_cache.as_ref() else {
+            return false;
+        };
+        let cache = reader.acl_cache();
+        let sender_access = entry.acl_ndx().and_then(|ndx| cache.get_access(ndx));
+        let sender_default = entry.def_acl_ndx().and_then(|ndx| cache.get_default(ndx));
+        if sender_access.is_none() && sender_default.is_none() {
+            return false;
+        }
+        // upstream: acls.c:1059-1081 match_acl_ids() - the cached ACL's named
+        // entries are converted to local ids before use. Built per call because
+        // the ACL itemize path is off unless `-A` and already dominated by the
+        // `getfacl` syscall; the snapshot is otherwise identical to the one the
+        // apply path builds once at setup.
+        let id_map = self.build_acl_id_mapper();
+        metadata::dest_acl_differs(
+            path,
+            sender_access,
+            sender_default,
+            entry.mode(),
+            entry.is_dir(),
+            Some(&id_map),
+        )
     }
 
     /// Emits the upstream size-bound SKIP notice for a candidate whose flist

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -709,7 +709,7 @@ impl ReceiverContext {
     ///
     /// upstream: uidlist.c:483-484 + acls.c:1059-1081 - `match_acl_ids()`.
     #[cfg(unix)]
-    fn build_acl_id_mapper(&self) -> metadata::AclIdMapper {
+    pub(in crate::receiver) fn build_acl_id_mapper(&self) -> metadata::AclIdMapper {
         metadata::AclIdMapper::new(
             self.uid_list.resolved_map(),
             self.gid_list.resolved_map(),
@@ -721,7 +721,7 @@ impl ReceiverContext {
 
     /// Builds the cross-host ACL id remapper (non-Unix: no `--usermap`).
     #[cfg(not(unix))]
-    fn build_acl_id_mapper(&self) -> metadata::AclIdMapper {
+    pub(in crate::receiver) fn build_acl_id_mapper(&self) -> metadata::AclIdMapper {
         metadata::AclIdMapper::new(
             self.uid_list.resolved_map(),
             self.gid_list.resolved_map(),


### PR DESCRIPTION
## Summary

Wire `ITEM_REPORT_ACL` so `--itemize-changes` reports an ACL change in the `a` column. Mirrors upstream `itemize()`'s ACL leg (`generator.c:557-563`): with `-A` and a non-symlink, the generator reads the destination ACL (`get_acl`) and probes whether applying the sender's cached ACL would change it (`set_acl(NULL, file, sxp, mode)`, `acls.c:1024-1054`); a non-zero result lights `a`.

## Design — one mechanism

- **`metadata::dest_acl_differs`** (new, shared, un-gated like `dest_xattrs_differ`): reads the pre-transfer destination ACL via `get_rsync_acl` and compares
  - the sender's cached **access** ACL with `RsyncAcl::equal_enough` (extended entries + mask-gated `group_obj`, the rest left to mode preservation), and
  - for a directory, the un-stripped **default** ACL with the new strict `RsyncAcl::equal` (`rsync_acl_equal`, `acls.c:190-197`).
  - Named-entry ids are remapped through the same cross-host id map the apply path uses (`match_acl_ids` parity, `acls.c:1059-1081`).
- **Receiver wiring**: the ACL leg is added inside `itemize_existing_flags`, reading everything from `self` — the sender ACLs resolve from the flist reader's ACL cache by index, exactly as the xattr `x` column resolves its list. No plumbing is added to the individual itemize call sites.
- An entry with no cached ACL index reports no change, matching upstream's `ndx >= 0` guard.

## The identical-ACL guard (no false `a`)

Upstream `recv_rsync_acl` (`acls.c:773-776`) reconstructs the access mask into the cached ACL as `(mode >> 3) & 7` when named entries exist and no mask was transmitted; oc defers that reconstruction to apply time, leaving the cached access mask `NO_ENTRY`. Feeding `equal_enough` that form would fail the mask-presence check and light `a` on an **identical** ACL. The comparison path restores the mask from the mode before comparing, so an unchanged ACL never lights the column. Verified by unit and (Linux) integration tests.

## Tests

- `protocol`: `equal_tests` for the new strict `RsyncAcl::equal` (5 cases).
- `metadata`: `acl_diff` remap unit tests (run on macOS); `integration_tests` behind `cfg(feature = "acl", any(linux, freebsd))` exercising real `getfacl`/`setfacl`: identical named-user ACL (no `a`), trivial ACL (no `a`), extra sender named entry (lights `a`), default-ACL-on-dir both arms, and the non-directory default-leg guard. They degrade gracefully on a filesystem without ACL support.

## Verification status

- macOS: `fmt`, `clippy -D warnings` (protocol/metadata/transfer, all-features), and all unit tests green. Existing itemize tests unchanged.
- **Merge gate**: the `metadata::acl_diff::integration_tests` ACL-syscall matrix must be run on a Linux host (POSIX ACL model; the macOS NFSv4 model differs and is not exercised). The `a`-column behavior against real 3.4.4 (`-A -i`: ACL-only change ⇒ `.f.....a...`, ACL+content ⇒ both, no-ACL-change ⇒ no `a`, default-ACL-on-dir, non-root silent-drop interaction) should be confirmed on Linux before merge.
