### PR TITLE
fix(transfer): populate client receiver filter_chain from CLI rules

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -158,10 +158,13 @@ pub struct ReceiverContext {
     /// it can reload each destination directory's per-directory merge files
     /// while scanning, but those rules must not perturb prune-empty-dirs.
     ///
-    /// On a local-client pull the wire filter list is never received
-    /// (`should_read_filter_list()` is false in client mode), so this is built
-    /// in `setup_transfer` from the local CLI filter rules. On a daemon/server
-    /// receiver it is cloned from the wire-populated `filter_chain`.
+    /// Cloned from `filter_chain` (with `--delete-excluded` folded in) by the
+    /// single `compile_receiver_filter_chains` path in `setup_transfer`. On a
+    /// daemon/server receiver `filter_chain` is wire-populated; on a
+    /// local-client pull the wire filter list is never received
+    /// (`should_read_filter_list()` is false in client mode) so it is populated
+    /// from the local CLI filter rules instead - either way both chains carry
+    /// the same rules.
     ///
     /// # Upstream Reference
     ///

--- a/crates/transfer/src/receiver/file_list/prune.rs
+++ b/crates/transfer/src/receiver/file_list/prune.rs
@@ -32,10 +32,17 @@ use protocol::flist::FileEntry;
 /// subtrees contain no kept non-directory entries, mirroring upstream
 /// `flist.c:3121-3184`.
 ///
-/// `filter_chain` is consulted via [`FilterChain::allows`] with `is_dir=true`
-/// to mirror upstream's `is_excluded(name, NAME_IS_DIR, ALL_FILTERS)` call.
-/// Upstream returns 1 when the dir is excluded; we mirror that by checking
-/// `!filter_chain.allows(path, true)`.
+/// `filter_chain` is consulted via [`FilterChain::allows_deletion`] with
+/// `is_dir=true` to mirror upstream's `is_excluded(name, NAME_IS_DIR,
+/// ALL_FILTERS)` call. `ALL_FILTERS` evaluates the receiver-side view of the
+/// rule list (`exclude.c:name_is_excluded` walks `filter_list` without the
+/// sender's `LOCAL_RULE` elision), so a receiver-only rule - a `protect`/`P`
+/// or an `-r` receiver-side exclude - counts as excluded here even though the
+/// sender never applied it and shipped the directory. The transfer-side
+/// [`FilterChain::allows`] elides exactly those rules, so it is the wrong
+/// predicate for the prune reprieve. Upstream returns 1 when the dir is
+/// excluded; we mirror that by checking `!filter_chain.allows_deletion(path,
+/// true)`.
 ///
 /// Pruned entries are cleared in place (name reset, mode zeroed) rather than
 /// removed so that flat-array indices continue to map directly to the
@@ -102,8 +109,12 @@ pub(in crate::receiver) fn prune_empty_dirs_pass(
 
             // upstream: flist.c:3142 - is_excluded(name, 1, ALL_FILTERS).
             // Returns 1 when the dir is excluded by the receiver's filter
-            // chain. In that branch, upstream reprieves the chain.
-            let dir_is_excluded = !filter_chain.allows(entry.path().as_path(), true);
+            // chain. In that branch, upstream reprieves the chain. ALL_FILTERS
+            // is the receiver-side view, so use allows_deletion (which honours
+            // protect/risk and receiver-side rules) rather than the sender-side
+            // allows(), which elides exactly the rules that leave a shipped dir
+            // excluded on the receiver.
+            let dir_is_excluded = !filter_chain.allows_deletion(entry.path().as_path(), true);
 
             if dir_is_excluded {
                 // upstream: flist.c:3143-3150 - "Keep dirs through this dir."
@@ -303,6 +314,70 @@ mod tests {
                 "expected {empty} to be pruned, kept={kept:?}"
             );
         }
+    }
+
+    /// A receiver-only rule must reprieve an otherwise-empty directory,
+    /// mirroring upstream `flist.c:3142` `is_excluded(name, 1, ALL_FILTERS)`.
+    ///
+    /// A `protect`/`P` rule is receiver-side only: the sender never applies it
+    /// and ships the empty directory, so the prune pass is the only place the
+    /// client's rule can act. It must consult the receiver-side decision
+    /// (`allows_deletion`), which honours protect/risk and `-r` rules, rather
+    /// than the sender-side `allows`, which elides exactly those rules and
+    /// would prune the directory the user asked to keep. Verified against real
+    /// rsync 3.4.4: `--prune-empty-dirs --filter='P emptyprot'` keeps the dir.
+    #[test]
+    fn receiver_side_rule_reprieves_empty_dir() {
+        use filters::{FilterRule, FilterSet};
+
+        let mut list = vec![
+            FileEntry::new_directory(PathBuf::from("keep"), 0o755),
+            FileEntry::new_file(PathBuf::from("keep/real.txt"), 4, 0o644),
+            FileEntry::new_directory(PathBuf::from("emptyprot"), 0o755),
+        ];
+        sort_file_list(&mut list, false, false);
+
+        let global = FilterSet::from_rules([FilterRule::protect("emptyprot")]).unwrap();
+        prune_empty_dirs_pass(&mut list, &FilterChain::new(global));
+
+        let kept: Vec<String> = list
+            .iter()
+            .filter(|e| !e.name().is_empty())
+            .map(|e| e.name().to_string())
+            .collect();
+        assert!(
+            kept.iter().any(|n| n == "emptyprot"),
+            "a receiver-side protect rule must reprieve the empty dir, kept={kept:?}"
+        );
+        assert!(kept.iter().any(|n| n == "keep/real.txt"));
+    }
+
+    /// Control for [`receiver_side_rule_reprieves_empty_dir`]: with no matching
+    /// rule the same empty directory IS pruned, proving the reprieve is driven
+    /// by the filter rule rather than an unconditional keep.
+    #[test]
+    fn empty_dir_without_matching_rule_is_pruned() {
+        use filters::{FilterRule, FilterSet};
+
+        let mut list = vec![
+            FileEntry::new_directory(PathBuf::from("keep"), 0o755),
+            FileEntry::new_file(PathBuf::from("keep/real.txt"), 4, 0o644),
+            FileEntry::new_directory(PathBuf::from("emptyprot"), 0o755),
+        ];
+        sort_file_list(&mut list, false, false);
+
+        let global = FilterSet::from_rules([FilterRule::protect("other")]).unwrap();
+        prune_empty_dirs_pass(&mut list, &FilterChain::new(global));
+
+        let kept: Vec<String> = list
+            .iter()
+            .filter(|e| !e.name().is_empty())
+            .map(|e| e.name().to_string())
+            .collect();
+        assert!(
+            !kept.iter().any(|n| n == "emptyprot"),
+            "an unrelated protect rule must not reprieve the empty dir, kept={kept:?}"
+        );
     }
 
     /// Empty flist must be a no-op.

--- a/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
@@ -259,6 +259,47 @@ fn receiver_set_and_get_filter_chain() {
     assert!(!ctx.filter_chain().is_empty());
 }
 
+/// A local-client pull never reads a wire filter list, but its own CLI
+/// `--filter`/`--exclude`/`--include` rules must still reach the receiver's
+/// `filter_chain` so consumers that read it - the `--prune-empty-dirs` pass -
+/// honour the client's rules. Before this fix the client path built only the
+/// deletion chain and left `filter_chain` empty, so prune silently ignored a
+/// client-side rule.
+///
+/// upstream: `exclude.c:parse_filter_str()` parses argv rules into the single
+/// `filter_list` that `flist.c:3142 is_excluded()` consults during prune.
+#[test]
+fn client_pull_populates_filter_chain_from_cli_rules() {
+    use protocol::filters::{FilterRuleWireFormat, RuleType};
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.connection.client_mode = true;
+    config.connection.filter_rules = vec![FilterRuleWireFormat {
+        rule_type: RuleType::Protect,
+        pattern: "emptyprot".to_owned(),
+        ..FilterRuleWireFormat::default()
+    }];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // A client-mode receiver starts with an empty chain and only gets one
+    // when it compiles its own CLI rules (no wire list is ever read).
+    assert!(ctx.filter_chain().is_empty());
+    ctx.populate_client_filter_chains().unwrap();
+
+    // The client's own rule now lives in filter_chain, and it is a
+    // receiver-side rule (protect) so the prune reprieve can see it.
+    assert!(
+        !ctx.filter_chain().is_empty(),
+        "client CLI filter rules must populate filter_chain"
+    );
+    assert!(
+        !ctx.filter_chain()
+            .allows_deletion(std::path::Path::new("emptyprot"), true),
+        "the client's protect rule must be visible to the prune reprieve"
+    );
+}
+
 /// UTS-16.b.7 regression: an ordinary in-module subdir deletion must succeed
 /// with no io_error bits set, even when the sandbox is plumbed. Pins the
 /// "no over-correction" invariant: the chdir-symlink-race fix in

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -121,7 +121,7 @@ impl ReceiverContext {
         } else if self.config.connection.client_mode
             && !self.config.connection.filter_rules.is_empty()
         {
-            self.build_client_deletion_filter_chain()?;
+            self.populate_client_filter_chains()?;
         }
 
         // FSM: filter list reading is complete. Advance to FileListTransfer.
@@ -522,90 +522,84 @@ impl ReceiverContext {
             combined
         };
 
-        // Build a FilterChain from the combined rules for deletion filtering.
+        // Compile the combined rules into the receiver's filter chains.
         // upstream: generator.c:delete_in_dir() - is_excluded() before deletion
         if !combined.is_empty() {
-            let (filter_set, merge_configs) =
-                parse_wire_filters_for_receiver(&combined).map_err(|e| {
-                    io::Error::new(
-                        e.kind(),
-                        format!(
-                            "filter error: {e} {}{}",
-                            crate::role_trailer::error_location!(),
-                            crate::role_trailer::receiver()
-                        ),
-                    )
-                })?;
-            let mut chain = FilterChain::new(filter_set);
-            for config in merge_configs {
-                chain.add_merge_config(config);
-            }
-            self.filter_chain = chain;
-
-            // upstream: exclude.c:recv_filter_list() parses every received rule
-            // into the same `filter_list` the generator's delete_in_dir()
-            // consults via change_local_filter_dir()/push_local_filters(). A
-            // server-side receiver must therefore register the client's
-            // transmitted dir-merge directive (a `-F` `.rsync-filter`, sent as a
-            // per-directory merge rule by exclude.c:send_rules()) on the
-            // dedicated deletion chain, not only on `filter_chain`. Without it a
-            // merge file's own protect rule is absent when the --delete pass
-            // decides candidates, so up-client -> oc-receiver + dir-merge deletes
-            // entries upstream -> upstream preserves. Mirror the local-pull
-            // build_client_deletion_filter_chain(): same combined rules, with
-            // --delete-excluded applied. Cloned from `filter_chain` so the global
-            // rules and merge configs stay identical; the delete-pass consults
-            // this chain (deletion.rs) whenever it is non-empty.
-            self.deletion_filter_chain = self
-                .filter_chain
-                .clone()
-                .with_delete_excluded(self.config.deletion.delete_excluded);
+            self.compile_receiver_filter_chains(&combined)?;
         }
         Ok(())
     }
 
-    /// Builds the dedicated deletion-pass filter chain from the local CLI filter
-    /// rules on a local-client pull, where the wire filter list is never
-    /// received.
+    /// Populates the client-receiver's filter chains from its own CLI
+    /// `--filter`/`--exclude`/`--include` rules on a local-client pull, where
+    /// the wire filter list is never received
+    /// (`should_read_filter_list()` is false in client mode).
     ///
-    /// upstream: generator.c:delete_in_dir() -> change_local_filter_dir()
-    /// reloads each DESTINATION directory's per-directory merge files before
-    /// deciding deletions. On a local-client pull the wire filter list is never
-    /// received (`should_read_filter_list()` is false in client mode), so the
-    /// receiver's `--delete` pass would otherwise run against an empty filter
-    /// chain and mis-handle dir-merge-governed trees (over-deleting
-    /// self-protected `.filt`/`.filt2` merge files, under-deleting extraneous
-    /// entries in filter-hidden dirs). Build a dedicated deletion chain from the
-    /// same local CLI filter rules the generator consumes (generator/filters.rs),
-    /// so the per-directory merge reload in `delete_extraneous_files` has the
-    /// dir-merge configs. Held separately from `filter_chain` so
-    /// `--prune-empty-dirs` is unaffected. Only the deletion pass consults this,
-    /// so it is inert when `--delete` is not active.
-    fn build_client_deletion_filter_chain(&mut self) -> io::Result<()> {
-        let (filter_set, merge_configs) =
-            parse_wire_filters_for_receiver(&self.config.connection.filter_rules).map_err(|e| {
-                io::Error::new(
-                    e.kind(),
-                    format!(
-                        "filter error: {e} {}{}",
-                        crate::role_trailer::error_location!(),
-                        crate::role_trailer::receiver()
-                    ),
-                )
-            })?;
-        let mut chain =
-            FilterChain::new(filter_set).with_delete_excluded(self.config.deletion.delete_excluded);
+    /// A server-receiver reads its rules off the wire and compiles them in
+    /// [`apply_received_filter_rules`](Self::apply_received_filter_rules); the
+    /// client-receiver has no wire list and keeps its rules in
+    /// `config.connection.filter_rules`. Both funnel through the same
+    /// [`compile_receiver_filter_chains`](Self::compile_receiver_filter_chains)
+    /// so the receiver holds an identical `filter_chain` +
+    /// `deletion_filter_chain` regardless of transfer role.
+    pub(in crate::receiver) fn populate_client_filter_chains(&mut self) -> io::Result<()> {
+        let rules = self.config.connection.filter_rules.clone();
+        self.compile_receiver_filter_chains(&rules)
+    }
+
+    /// Compiles the receiver's own filter rules into both the transfer-facing
+    /// `filter_chain` (consulted by the `--prune-empty-dirs` pass) and the
+    /// dedicated `deletion_filter_chain` (consulted by the `--delete` pass, with
+    /// `--delete-excluded` folded in).
+    ///
+    /// This is the single population path shared by a server-receiver (whose
+    /// `rules` are the wire list its client transmitted, prepended with any
+    /// daemon rules) and a local-client pull (whose `rules` are its own CLI
+    /// filter rules). On either side these are the same single rule list, so
+    /// keeping one compilation site means the client's `-f`/`--exclude`/
+    /// `--include` reach every receiver decision point exactly as a server's
+    /// wire rules do - including `--prune-empty-dirs`, which reads
+    /// `filter_chain` and previously saw an empty chain in client mode.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `exclude.c:recv_filter_list()` parses every rule into the single
+    ///   `filter_list` that both `generator.c:delete_in_dir()` (the `--delete`
+    ///   pass) and `flist.c:3142` (`is_excluded()` in the `--prune-empty-dirs`
+    ///   pass) consult. The client parses its argv rules into that same list at
+    ///   startup (`exclude.c:parse_filter_str`), so its own rules reach both
+    ///   decision points unchanged. `deletion_filter_chain` is cloned from
+    ///   `filter_chain` and folds in `--delete-excluded` (exclude.c:1685) so the
+    ///   per-directory merge reload in `delete_extraneous_files` keeps the same
+    ///   global rules and dir-merge configs while `--prune-empty-dirs` stays
+    ///   unperturbed.
+    fn compile_receiver_filter_chains(&mut self, rules: &[FilterRuleWireFormat]) -> io::Result<()> {
+        let (filter_set, merge_configs) = parse_wire_filters_for_receiver(rules).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "filter error: {e} {}{}",
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::receiver()
+                ),
+            )
+        })?;
+        let mut chain = FilterChain::new(filter_set);
         for config in merge_configs {
             chain.add_merge_config(config);
         }
+        self.filter_chain = chain;
+        self.deletion_filter_chain = self
+            .filter_chain
+            .clone()
+            .with_delete_excluded(self.config.deletion.delete_excluded);
         logging::debug_log!(
             Del,
             2,
-            "deletion filter chain built: delete_excluded={} merge_configs_active={}",
+            "receiver filter chains built: delete_excluded={} merge_configs_active={}",
             self.config.deletion.delete_excluded,
-            chain.has_per_dir_merge()
+            self.deletion_filter_chain.has_per_dir_merge()
         );
-        self.deletion_filter_chain = chain;
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

A local-client pull never reads a wire filter list (`should_read_filter_list()` is false in client mode), so the receiver compiled only its `--delete` chain and left `filter_chain` empty. The `--prune-empty-dirs` pass reads `filter_chain`, so a client's own filter rules were silently ignored there.

Concretely, an empty directory the client asked to keep with a receiver-side rule (`protect`/`P`, or a receiver-side `-r` exclude) was pruned instead of preserved.

## Upstream reference

Upstream parses the client's argv rules (`exclude.c:parse_filter_str`) into the single `filter_list` that both `generator.c:delete_in_dir()` and `flist.c:3142 is_excluded(name, NAME_IS_DIR, ALL_FILTERS)` consult, so the client's rules reach every receiver decision point. `ALL_FILTERS` is the receiver-side view (`exclude.c:name_is_excluded`), so a `protect`/`-r` rule counts as excluded there even though the sender never applied it and shipped the directory.

## Fix

- Compile the client-receiver's CLI rules into `filter_chain` (and the derived `deletion_filter_chain`) through one shared `compile_receiver_filter_chains` path used by both the server-receiver (wire rules) and the client-receiver (argv rules) - neither side forks its own population logic.
- Evaluate the prune reprieve with the receiver-side `allows_deletion`, matching `is_excluded(..., ALL_FILTERS)`. The transfer-side `allows()` elides protect/risk and receiver-side rules - exactly the rules a shipped-but-excluded directory carries - so it was the wrong predicate.

The transfer itself is unchanged: on a pull the sender already filters the file list, and deletion still consults `deletion_filter_chain`, so rules are not double-applied.

## Verification

Against rsync 3.4.4, client pull from a daemon module with `--prune-empty-dirs --filter='P emptyprot'` (empty dir):

| | `emptyprot` |
|---|---|
| oc before | pruned (rule ignored) |
| oc after | kept |
| upstream 3.4.4 | kept |

`-r emptyprot` behaves the same. `--delete --exclude='junk/'` still protects `junk/` and deletes other extraneous files (no double-apply, no regression).

New tests fail on pre-fix logic and pass after:
- `prune::tests::receiver_side_rule_reprieves_empty_dir` (+ control) - encodes that a receiver-side rule must reach the prune reprieve.
- `filter_chain::client_pull_populates_filter_chain_from_cli_rules` - encodes that the client path populates `filter_chain`, not just the delete chain.

Gates: `cargo fmt --all --check` clean; `cargo clippy -p transfer --all-targets --all-features -- -D warnings` clean; targeted nextest `87/87` pass.
