### PR TITLE
perf(transfer): share the receiver file list via Arc instead of deep-cloning it

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -45,7 +45,15 @@ pub struct ReceiverContext {
     /// Server configuration.
     pub(in crate::receiver) config: ServerConfig,
     /// List of files to receive.
-    pub(in crate::receiver) file_list: Vec<FileEntry>,
+    ///
+    /// Shared via `Arc` with the disk-commit pipeline (`DiskCommitConfig`) so a
+    /// pull transfer keeps a single resident copy of the flist rather than
+    /// deep-cloning it for the commit thread. The receiver uniquely owns the
+    /// `Arc` while it builds, sorts, and cleans the list (see
+    /// [`file_list_mut`](Self::file_list_mut)); it is shared only for the
+    /// read-only transfer window and reclaimed afterward once the disk thread
+    /// has released its clone.
+    pub(in crate::receiver) file_list: Arc<Vec<FileEntry>>,
     /// Negotiated checksum and compression algorithms from Protocol 30+ capability negotiation.
     /// None for protocols < 30 or when negotiation was skipped.
     pub(in crate::receiver) negotiated_algorithms: Option<NegotiationResult>,
@@ -430,7 +438,7 @@ impl ReceiverContext {
         Self {
             protocol: handshake.protocol,
             config,
-            file_list: Vec::new(),
+            file_list: Arc::new(Vec::new()),
             negotiated_algorithms: handshake.negotiated_algorithms,
             compat_flags: handshake.compat_flags,
             checksum_seed: handshake.checksum_seed,
@@ -905,9 +913,28 @@ impl ReceiverContext {
             first
         );
 
-        for entry in &mut self.file_list[start..end] {
-            entry.reclaim_heap_data();
+        // Reclaim runs during finalization, after the disk-commit thread has
+        // released its shared clone of the flist, so the receiver is the sole
+        // owner here. Freeing per-entry heap is a pure RSS optimization: if a
+        // clone somehow lingers, skip the reclaim rather than deep-clone the
+        // whole list (which would defeat the sharing this reclaim complements).
+        if let Some(list) = Arc::get_mut(&mut self.file_list) {
+            for entry in &mut list[start..end] {
+                entry.reclaim_heap_data();
+            }
         }
         self.first_segment_idx += 1;
+    }
+
+    /// Returns a mutable reference to the owned file list.
+    ///
+    /// The receiver mutates the flist only while it uniquely owns the `Arc`
+    /// (during reception, sort, clean, prune, and hardlink matching, all of
+    /// which precede the point where the disk-commit pipeline is handed a shared
+    /// clone). `Arc::make_mut` therefore returns the existing allocation without
+    /// copying; it would clone only if called while the list is shared, which
+    /// the receive workflow never does.
+    pub(in crate::receiver) fn file_list_mut(&mut self) -> &mut Vec<FileEntry> {
+        Arc::make_mut(&mut self.file_list)
     }
 }

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -555,7 +555,7 @@ impl ReceiverContext {
 
         let mut created: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
 
-        for entry in &self.file_list {
+        for entry in self.file_list.iter() {
             let relative_path = entry.path();
             if relative_path.as_os_str() == "." {
                 continue;
@@ -1136,7 +1136,8 @@ mod touch_up_dirs_tests {
 
         let hs = handshake();
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
-        ctx.file_list = vec![FileEntry::new_directory("missing".into(), 0o755)];
+        ctx.file_list =
+            std::sync::Arc::new(vec![FileEntry::new_directory("missing".into(), 0o755)]);
 
         let opts = metadata::MetadataOptions::default();
         let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
@@ -1200,7 +1201,10 @@ mod touch_up_dirs_tests {
         // bumps the root's on-disk mtime mid-pass.
         let mut root_entry = FileEntry::new_directory(".".into(), 0o755);
         root_entry.set_mtime(root_secs, 0);
-        ctx.file_list = vec![root_entry, FileEntry::new_directory("sub".into(), 0o755)];
+        ctx.file_list = std::sync::Arc::new(vec![
+            root_entry,
+            FileEntry::new_directory("sub".into(), 0o755),
+        ]);
 
         let opts = metadata::MetadataOptions::default();
         let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
@@ -1258,7 +1262,7 @@ mod touch_up_dirs_tests {
         let hs = handshake();
         let config = config_with_times(true);
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
-        ctx.file_list = vec![entry];
+        ctx.file_list = std::sync::Arc::new(vec![entry]);
 
         ctx.touch_up_dirs(
             dir.path(),
@@ -1299,7 +1303,7 @@ mod touch_up_dirs_tests {
         let mut config = config_with_times(true);
         config.flags.omit_dir_times = true;
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
-        ctx.file_list = vec![entry];
+        ctx.file_list = std::sync::Arc::new(vec![entry]);
 
         ctx.touch_up_dirs(
             dir.path(),
@@ -1357,7 +1361,7 @@ mod touch_up_dirs_tests {
         let hs = handshake();
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         // Read-only directory mode: r-xr-xr-x, no user write bit.
-        ctx.file_list = vec![FileEntry::new_directory("sub".into(), 0o555)];
+        ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_directory("sub".into(), 0o555)]);
 
         let opts = metadata::MetadataOptions::default();
         let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
@@ -1412,7 +1416,7 @@ mod touch_up_dirs_tests {
         let hs = handshake();
         let config = config_with_times(false);
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
-        ctx.file_list = vec![entry];
+        ctx.file_list = std::sync::Arc::new(vec![entry]);
 
         ctx.touch_up_dirs(
             dir.path(),
@@ -1451,7 +1455,7 @@ mod touch_up_dirs_tests {
         let config = config_with_times(true);
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         // Parent comes first in file list (natural order).
-        ctx.file_list = vec![parent_entry, child_entry];
+        ctx.file_list = std::sync::Arc::new(vec![parent_entry, child_entry]);
 
         ctx.touch_up_dirs(
             dir.path(),
@@ -1485,7 +1489,7 @@ mod touch_up_dirs_tests {
         let hs = handshake();
         let config = config_with_times(true);
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
-        ctx.file_list = vec![entry];
+        ctx.file_list = std::sync::Arc::new(vec![entry]);
 
         ctx.touch_up_dirs(
             dir.path(),
@@ -1514,7 +1518,7 @@ mod touch_up_dirs_tests {
         let hs = handshake();
         let config = config_with_times(true);
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
-        ctx.file_list = vec![file_entry];
+        ctx.file_list = std::sync::Arc::new(vec![file_entry]);
 
         ctx.touch_up_dirs(
             dir.path(),

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -665,7 +665,7 @@ impl ReceiverContext {
         let mut root_is_content_dir = false;
         let mut content_dirs: HashSet<PathBuf> = HashSet::new();
 
-        for entry in &self.file_list {
+        for entry in self.file_list.iter() {
             let relative = entry.path();
             if relative.as_os_str() == "." {
                 if entry.is_dir() && entry.content_dir() {

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -666,7 +666,7 @@ impl ReceiverContext {
             // Leaders committed during pipelined transfer are already recorded;
             // this covers leaders that matched quick-check (not transferred) or
             // were processed via the sync path.
-            for entry in &self.file_list {
+            for entry in self.file_list.iter() {
                 if entry.hlink_first() {
                     let gnum = match entry.hardlink_idx() {
                         Some(idx) => idx,

--- a/crates/transfer/src/receiver/directory/missing_args.rs
+++ b/crates/transfer/src/receiver/directory/missing_args.rs
@@ -66,7 +66,7 @@ impl ReceiverContext {
             return Ok(());
         }
 
-        for entry in &self.file_list {
+        for entry in self.file_list.iter() {
             // upstream: generator.c:1348 - sentinel is identified by mode == 0.
             if entry.mode() != 0 {
                 continue;

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -287,7 +287,7 @@ impl ReceiverContext {
             return Ok(());
         }
 
-        for entry in &self.file_list {
+        for entry in self.file_list.iter() {
             let gated = (entry.is_device() && self.config.flags.devices)
                 || (entry.is_special() && self.config.flags.specials);
             if !gated {

--- a/crates/transfer/src/receiver/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/file_list/filter_recheck.rs
@@ -88,7 +88,7 @@ impl ReceiverContext {
             return Ok(());
         };
 
-        for entry in &self.file_list {
+        for entry in self.file_list.iter() {
             let path = entry.path().as_path();
             // upstream: flist.c:1019 - the transfer root (`.` / `/.`) is never
             // re-checked. Cleared entries (empty name, mode 0) are no-ops.
@@ -184,7 +184,7 @@ impl ReceiverContext {
             return Ok(());
         }
 
-        for entry in &self.file_list {
+        for entry in self.file_list.iter() {
             let path = entry.path().as_path();
             // upstream: flist.c:1019 - the transfer root (`.` / `/.`) is exempt.
             if path.as_os_str().is_empty() || path == Path::new(".") {

--- a/crates/transfer/src/receiver/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/file_list/id_lists.rs
@@ -170,7 +170,7 @@ impl ReceiverContext {
             let names = self.uid_list.names_snapshot();
             let has_rules = mapping.as_ref().is_some_and(|m| !m.is_empty());
             if !uid_map.is_empty() || has_rules {
-                for entry in self.file_list.iter_mut() {
+                for entry in self.file_list_mut().iter_mut() {
                     if let Some(uid) = entry.uid() {
                         let mapped = mapping.as_ref().and_then(|m| {
                             m.map_uid_named(uid, names.get(&uid).map(Vec::as_slice), false)
@@ -189,7 +189,7 @@ impl ReceiverContext {
             let names = self.gid_list.names_snapshot();
             let has_rules = mapping.as_ref().is_some_and(|m| !m.is_empty());
             if !gid_map.is_empty() || has_rules {
-                for entry in self.file_list.iter_mut() {
+                for entry in self.file_list_mut().iter_mut() {
                     if let Some(gid) = entry.gid() {
                         let mapped = mapping.as_ref().and_then(|m| {
                             m.map_gid_named(gid, names.get(&gid).map(Vec::as_slice), false)

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -478,8 +478,11 @@ mod tests {
         // receive_file_list); ensure_flat_idx must never touch the reader.
         let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
         ctx.flist_eof = true;
-        ctx.file_list
-            .push(FileEntry::new_file("only.txt".into(), 7, 0o100644));
+        std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+            "only.txt".into(),
+            7,
+            0o100644,
+        ));
 
         // A reader that would error if read from, proving no wire access.
         let mut reader = Cursor::new(Vec::<u8>::new());

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -7,6 +7,7 @@
 
 use std::io::{self, Read};
 use std::path::Path;
+use std::sync::Arc;
 
 use logging::debug_log;
 use protocol::CompatibilityFlags;
@@ -49,7 +50,7 @@ impl ReceiverContext {
         while let Some(entry) =
             flist_reader.read_entry_with_flist(reader, &self.file_list[seg_start..])?
         {
-            self.file_list.push(entry);
+            self.file_list_mut().push(entry);
             count += 1;
         }
 
@@ -109,7 +110,7 @@ impl ReceiverContext {
         if self.config.flags.hard_links {
             let &(_flat_start, ndx_start) =
                 self.ndx_segments.last().expect("initial segment exists");
-            for (i, entry) in self.file_list.iter_mut().enumerate() {
+            for (i, entry) in self.file_list_mut().iter_mut().enumerate() {
                 if entry.hlink_first() {
                     entry.set_hardlink_idx((ndx_start + i as i32) as u32);
                 }
@@ -152,13 +153,13 @@ impl ReceiverContext {
         // sides".
         let pre29 = self.protocol.as_u8() < 29;
         if !self.iconv_reorder_suppressed() {
-            let list = std::mem::take(&mut self.file_list);
+            let list = std::mem::take(self.file_list_mut());
             // am_sender=false: the receiver always runs the duplicate-clean,
             // tombstoning dropped duplicates in place so NDX stays aligned with
             // the sender's full un-deduped array (flist.c:3031,3089).
             let (cleaned, _clean) =
                 sort_and_clean_file_list(list, self.config.qsort, pre29, false, inc_recurse);
-            self.file_list = cleaned;
+            *self.file_list_mut() = cleaned;
         }
 
         // upstream: flist.c:recv_file_list() appends every directory to
@@ -178,10 +179,16 @@ impl ReceiverContext {
         // match_hard_links() in recv_file_list(). Only the receiver runs this
         // pass (am_sender is false); the sender ships every directory.
         if self.config.flags.prune_empty_dirs {
-            prune_empty_dirs_pass(&mut self.file_list, &self.filter_chain);
+            prune_empty_dirs_pass(
+                Arc::make_mut(&mut self.file_list).as_mut_slice(),
+                &self.filter_chain,
+            );
         }
 
-        match_hard_links(&mut self.file_list, &mut self.prior_hlinks);
+        match_hard_links(
+            Arc::make_mut(&mut self.file_list).as_mut_slice(),
+            &mut self.prior_hlinks,
+        );
 
         // For protocol < 30, normalize (dev, ino) pairs into hardlink_idx and
         // hlink_first flags so the rest of the code handles both protocol versions
@@ -189,7 +196,7 @@ impl ReceiverContext {
         // no-op for pre-30 entries that lack hardlink_idx).
         // upstream: hlink.c:init_hard_links() builds the idev table from dev/ino
         if self.protocol.as_u8() < 30 && self.config.flags.hard_links {
-            normalize_pre30_hardlinks(&mut self.file_list);
+            normalize_pre30_hardlinks(self.file_list_mut());
         }
 
         // upstream: flist.c:recv_file_entry() uses static variables that persist
@@ -320,7 +327,7 @@ impl ReceiverContext {
         while let Some(entry) =
             flist_reader.read_entry_with_flist(reader, &self.file_list[flat_start..])?
         {
-            self.file_list.push(entry);
+            self.file_list_mut().push(entry);
             segment_count += 1;
         }
 
@@ -335,7 +342,10 @@ impl ReceiverContext {
         // upstream: flist.c:1646 - leader GNUM is readdir-order wire NDX,
         // assigned before sorting.
         if self.config.flags.hard_links {
-            for (i, entry) in self.file_list[flat_start..].iter_mut().enumerate() {
+            for (i, entry) in Arc::make_mut(&mut self.file_list)[flat_start..]
+                .iter_mut()
+                .enumerate()
+            {
                 if entry.hlink_first() {
                     entry.set_hardlink_idx((seg_ndx_start + i as i32) as u32);
                 }
@@ -358,16 +368,19 @@ impl ReceiverContext {
         // array in scan order so the receiver can resolve generator requests
         // against the bytes the sender emitted.
         if !self.iconv_reorder_suppressed() {
-            let tail = self.file_list.split_off(flat_start);
+            let tail = self.file_list_mut().split_off(flat_start);
             // Receiver sub-list clean: am_sender=false, inc_recurse=true.
             let (cleaned, _clean) = sort_and_clean_file_list(tail, true, false, false, true);
-            self.file_list.extend(cleaned);
+            self.file_list_mut().extend(cleaned);
         }
-        match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);
+        match_hard_links(
+            &mut Arc::make_mut(&mut self.file_list)[flat_start..],
+            &mut self.prior_hlinks,
+        );
 
         // Normalize pre-30 hardlinks in this segment.
         if self.protocol.as_u8() < 30 && self.config.flags.hard_links {
-            normalize_pre30_hardlinks(&mut self.file_list[flat_start..]);
+            normalize_pre30_hardlinks(&mut self.file_list_mut()[flat_start..]);
         }
 
         // upstream: flist.c:2695-2701 - directories in this sub-list are appended
@@ -505,7 +518,7 @@ impl ReceiverContext {
                 let basename = self.file_list[i].name().to_owned();
                 let cur = self.file_list[i].dirname().display().to_string();
                 // Drop this segment's entries so nothing escapes the tree.
-                self.file_list.truncate(flat_start);
+                self.file_list_mut().truncate(flat_start);
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
                     format!(

--- a/crates/transfer/src/receiver/file_list/sanitize.rs
+++ b/crates/transfer/src/receiver/file_list/sanitize.rs
@@ -35,7 +35,7 @@ impl ReceiverContext {
         } else {
             let original_len = self.file_list.len();
 
-            self.file_list.retain(|entry| {
+            self.file_list_mut().retain(|entry| {
                 let path = entry.path();
 
                 // Check for absolute paths (reject unless --relative is active).
@@ -103,7 +103,7 @@ impl ReceiverContext {
         // Runs unconditionally: leading-slash stripping is a functional
         // requirement for --relative mode, not a security check.
         if relative_paths {
-            for entry in &mut self.file_list {
+            for entry in self.file_list_mut() {
                 if entry.path().has_root() {
                     entry.strip_leading_slashes();
                 }

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -44,7 +44,7 @@ impl ReceiverContext {
         let mut symlinks = 0u64;
         let mut devices = 0u64;
         let mut specials = 0u64;
-        for entry in &self.file_list {
+        for entry in self.file_list.iter() {
             if entry.is_dir() {
                 dirs += 1;
             } else if entry.is_symlink() {
@@ -588,7 +588,7 @@ impl ReceiverContext {
         // its leader in the xname the peer renders after "=>".
         let mut leader_names: std::collections::HashMap<u32, &str> =
             std::collections::HashMap::new();
-        for entry in &self.file_list {
+        for entry in self.file_list.iter() {
             if entry.hlink_first() {
                 if let Some(gnum) = entry.hardlink_idx() {
                     leader_names.entry(gnum).or_insert_with(|| entry.name());

--- a/crates/transfer/src/receiver/tests/create_specials.rs
+++ b/crates/transfer/src/receiver/tests/create_specials.rs
@@ -72,7 +72,7 @@ fn receiver_creates_fifo_from_flist_entry() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, special_receiver_config());
-    ctx.file_list = vec![FileEntry::new_fifo("pipe".into(), 0o640)];
+    ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_fifo("pipe".into(), 0o640)]);
 
     let mut writer = CapturingMsgInfoWriter;
     ctx.create_specials(dest, None, &mut writer)
@@ -114,7 +114,12 @@ fn receiver_creates_char_device_from_flist_entry() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, special_receiver_config());
-    ctx.file_list = vec![FileEntry::new_char_device("nulllike".into(), 0o600, 1, 3)];
+    ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_char_device(
+        "nulllike".into(),
+        0o600,
+        1,
+        3,
+    )]);
 
     let mut writer = CapturingMsgInfoWriter;
     ctx.create_specials(dest, None, &mut writer)
@@ -155,7 +160,7 @@ fn receiver_backs_up_existing_entry_before_creating_special() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = vec![FileEntry::new_fifo("pipe".into(), 0o640)];
+    ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_fifo("pipe".into(), 0o640)]);
 
     let mut writer = CapturingMsgInfoWriter;
     ctx.create_specials(dest, None, &mut writer)
@@ -190,7 +195,7 @@ fn receiver_skips_fifo_without_specials_flag() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = vec![FileEntry::new_fifo("pipe".into(), 0o640)];
+    ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_fifo("pipe".into(), 0o640)]);
 
     let mut writer = CapturingMsgInfoWriter;
     ctx.create_specials(dest, None, &mut writer)

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/sanitize_file_list.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/sanitize_file_list.rs
@@ -25,7 +25,7 @@ fn receiver_with_trust(entries: Vec<FileEntry>, trust_sender: bool) -> ReceiverC
         ..Default::default()
     };
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = entries;
+    ctx.file_list = std::sync::Arc::new(entries);
     ctx
 }
 
@@ -47,7 +47,7 @@ fn receiver_with_trust_and_relative(
         ..Default::default()
     };
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = entries;
+    ctx.file_list = std::sync::Arc::new(entries);
     ctx
 }
 

--- a/crates/transfer/src/receiver/tests/file_list/delete_backup.rs
+++ b/crates/transfer/src/receiver/tests/file_list/delete_backup.rs
@@ -45,10 +45,12 @@ fn build_receiver(
     config.args = vec![OsString::from(dest.to_str().unwrap())];
 
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("keep.txt".into(), 6, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "keep.txt".into(),
+        6,
+        0o644,
+    ));
     ctx
 }
 

--- a/crates/transfer/src/receiver/tests/file_list/delete_pipeline_hook.rs
+++ b/crates/transfer/src/receiver/tests/file_list/delete_pipeline_hook.rs
@@ -41,7 +41,7 @@ fn delete_pipeline_hook_publishes_one_plan_per_segment() {
     // Build a flist matching what the receiver would have after the
     // initial segment plus two INC_RECURSE segments. Segment table is
     // laid out so wire NDX 1 -> "sub1", wire NDX 2 -> "sub2".
-    ctx.file_list = vec![
+    ctx.file_list = std::sync::Arc::new(vec![
         FileEntry::new_directory(PathBuf::from("sub1"), 0o755),
         FileEntry::new_directory(PathBuf::from("sub2"), 0o755),
         // sub1 segment entries (flat 2..=3)
@@ -50,7 +50,7 @@ fn delete_pipeline_hook_publishes_one_plan_per_segment() {
         // sub2 segment entries (flat 4..=5)
         FileEntry::new_file(PathBuf::from("keep"), 0, 0o644),
         FileEntry::new_directory(PathBuf::from("nested2"), 0o755),
-    ];
+    ]);
     // Initial segment owns wire 1..=2 at flat 0..=1; segments owning
     // wire 4..=5 at flat 2..=3, then 7..=8 at flat 4..=5.
     ctx.ndx_segments = vec![(0, 1), (2, 4), (4, 7)];
@@ -125,7 +125,8 @@ fn delete_pipeline_hook_is_noop_when_no_context_attached() {
     let handshake = test_handshake();
     let config = test_config();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = vec![FileEntry::new_directory(PathBuf::from("sub"), 0o755)];
+    ctx.file_list =
+        std::sync::Arc::new(vec![FileEntry::new_directory(PathBuf::from("sub"), 0o755)]);
     ctx.ndx_segments = vec![(0, 1)];
 
     // Should not panic, should not touch any external state. The

--- a/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
+++ b/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
@@ -123,10 +123,13 @@ fn delete_delay_defers_unlink_until_execute_phase() {
         config.deletion.late_delete = true; // --delete-delay
         config.args = vec![OsString::from(dest.to_str().unwrap())];
         let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-        ctx.file_list
+        std::sync::Arc::make_mut(&mut ctx.file_list)
             .push(FileEntry::new_directory(".".into(), 0o755));
-        ctx.file_list
-            .push(FileEntry::new_file("keep.txt".into(), 6, 0o644));
+        std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+            "keep.txt".into(),
+            6,
+            0o644,
+        ));
         ctx
     };
 
@@ -220,14 +223,19 @@ fn build_receiver_with_perdir_merge(dest: &std::path::Path) -> ReceiverContext {
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("sub".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("source.txt".into(), 11, 0o644));
-    ctx.file_list
-        .push(FileEntry::new_file(".rsync-filter".into(), 8, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "source.txt".into(),
+        11,
+        0o644,
+    ));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        ".rsync-filter".into(),
+        8,
+        0o644,
+    ));
 
     // Register the dest-side per-directory `.rsync-filter` merge config on the
     // receiver's wire-populated `filter_chain`, exactly as a server receiver does

--- a/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
@@ -28,10 +28,12 @@ fn receiver_filter_chain_protects_from_deletion() {
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
     // File list includes "." and "source.txt" - anything else at dest is extraneous
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("source.txt".into(), 11, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "source.txt".into(),
+        11,
+        0o644,
+    ));
 
     // Set up filter chain with protect rule for *.conf
     let global =
@@ -84,10 +86,12 @@ fn receiver_filter_chain_empty_allows_all_deletions() {
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
     // File list has "." and "keep.txt" - file1/file2 are extraneous
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("keep.txt".into(), 4, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "keep.txt".into(),
+        4,
+        0o644,
+    ));
 
     // Empty filter chain - all deletions should proceed
     let mut writer = TestDeletionWriter;
@@ -133,10 +137,12 @@ fn single_char_wildcard_exclude_does_not_block_top_level_deletion() {
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
     // Source advertises only `.` and `keep.txt`; `delete.txt` is extraneous.
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("keep.txt".into(), 5, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "keep.txt".into(),
+        5,
+        0o644,
+    ));
 
     // Daemon-level `exclude = ? foobar.baz` reproduction.
     let global = ::filters::FilterSet::from_rules([
@@ -207,12 +213,15 @@ fn implied_non_content_subdir_is_not_scanned_for_deletion() {
     // `subdir/file` is an actual transferred entry.
     let mut root = FileEntry::new_directory(".".into(), 0o755);
     root.set_content_dir(false);
-    ctx.file_list.push(root);
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(root);
     let mut implied = FileEntry::new_directory("subdir".into(), 0o755);
     implied.set_content_dir(false);
-    ctx.file_list.push(implied);
-    ctx.file_list
-        .push(FileEntry::new_file("subdir/file".into(), 11, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(implied);
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "subdir/file".into(),
+        11,
+        0o644,
+    ));
 
     let mut writer = TestDeletionWriter;
     let (stats, _, _) = ctx
@@ -295,12 +304,14 @@ fn delete_ordinary_subdir_succeeds_with_no_io_error() {
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
     // Sender's flist: "." + subdir + subdir/keep.txt. extraneous.txt is missing.
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("subdir".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("subdir/keep.txt".into(), 4, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "subdir/keep.txt".into(),
+        4,
+        0o644,
+    ));
 
     let sandbox = Arc::new(::fast_io::DirSandbox::open_root(&dest).expect("open sandbox"));
 
@@ -386,11 +397,10 @@ fn delete_symlinked_subdir_surfaces_ioerr_general() {
     // attacker-controlled destination is a symlink, so the
     // sandbox-anchored `read_dir` must refuse the leaf with ELOOP /
     // ENOTDIR rather than enumerating the outside tree.
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("symlinkattack".into(), 0o755));
-    ctx.file_list.push(FileEntry::new_file(
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
         "symlinkattack/keep.txt".into(),
         4,
         0o644,

--- a/crates/transfer/src/receiver/tests/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_recheck.rs
@@ -29,12 +29,17 @@ fn chain_excluding(pattern: &str) -> FilterChain {
 fn excluded_name_rejected_via_filter_chain() {
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
     ctx.set_filter_chain(chain_excluding("*.log"));
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("keep.txt".into(), 10, 0o644));
-    ctx.file_list
-        .push(FileEntry::new_file("debug.log".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "keep.txt".into(),
+        10,
+        0o644,
+    ));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "debug.log".into(),
+        20,
+        0o644,
+    ));
 
     let err = ctx.recheck_received_filter().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
@@ -48,11 +53,13 @@ fn excluded_name_rejected_via_filter_chain() {
 fn included_names_pass_via_filter_chain() {
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
     ctx.set_filter_chain(chain_excluding("*.log"));
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("keep.txt".into(), 10, 0o644));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "keep.txt".into(),
+        10,
+        0o644,
+    ));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("subdir".into(), 0o755));
 
     ctx.recheck_received_filter()
@@ -67,8 +74,11 @@ fn trust_sender_skips_recheck() {
     config.trust_sender = true;
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
     ctx.set_filter_chain(chain_excluding("*.log"));
-    ctx.file_list
-        .push(FileEntry::new_file("debug.log".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "debug.log".into(),
+        20,
+        0o644,
+    ));
 
     ctx.recheck_received_filter()
         .expect("trust_sender must skip the receiver-side re-check");
@@ -78,8 +88,11 @@ fn trust_sender_skips_recheck() {
 fn empty_filter_chain_is_a_no_op() {
     // No receiver-owned rules: a normal transfer must not be disturbed.
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
-    ctx.file_list
-        .push(FileEntry::new_file("anything.log".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "anything.log".into(),
+        20,
+        0o644,
+    ));
 
     ctx.recheck_received_filter()
         .expect("an empty filter chain re-checks nothing");
@@ -96,8 +109,11 @@ fn per_dir_merge_defers_to_sender() {
 
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
     ctx.set_filter_chain(chain);
-    ctx.file_list
-        .push(FileEntry::new_file("debug.log".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "debug.log".into(),
+        20,
+        0o644,
+    ));
 
     ctx.recheck_received_filter()
         .expect("a per-directory merge rule defers filtering to the sender");
@@ -112,10 +128,12 @@ fn client_pull_excluded_name_rejected() {
     config.connection.client_mode = true;
     config.connection.filter_rules = vec![FilterRuleWireFormat::exclude("*.log".to_owned())];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("secret.log".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "secret.log".into(),
+        20,
+        0o644,
+    ));
 
     let err = ctx.recheck_received_filter().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
@@ -135,8 +153,11 @@ fn delete_excluded_does_not_weaken_recheck() {
     config.deletion.delete_excluded = true;
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
     ctx.set_filter_chain(chain_excluding("*.log"));
-    ctx.file_list
-        .push(FileEntry::new_file("x.log".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "x.log".into(),
+        20,
+        0o644,
+    ));
 
     let err = ctx.recheck_received_filter().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
@@ -156,14 +177,16 @@ fn anchored_dir_exclude_does_not_reject_included_children() {
             .unwrap();
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
     ctx.set_filter_chain(FilterChain::new(global));
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("bar".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("bar/down".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("bar/down/to/file".into(), 10, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "bar/down/to/file".into(),
+        10,
+        0o644,
+    ));
 
     ctx.recheck_received_filter().expect(
         "children under an included parent must not be rejected by a slashless \
@@ -188,12 +211,11 @@ fn directory_only_wire_rule_does_not_reject_files_under_it() {
         FilterRuleWireFormat::exclude("foo/*".to_owned()).with_directory_only(true),
     ];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("bar/down/to/foo".into(), 0o755));
     // A regular file directly under `foo` - a dir-only rule must NOT match it.
-    ctx.file_list.push(FileEntry::new_file(
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
         "bar/down/to/foo/+ file3".into(),
         6,
         0o644,
@@ -215,9 +237,8 @@ fn directory_only_wire_rule_still_rejects_a_smuggled_directory() {
     config.connection.filter_rules =
         vec![FilterRuleWireFormat::exclude("foo/*".to_owned()).with_directory_only(true)];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("foo/secret".into(), 0o755));
 
     let err = ctx.recheck_received_filter().unwrap_err();
@@ -230,8 +251,7 @@ fn transfer_root_never_rejected() {
     // re-check even when a catch-all exclude would otherwise match it.
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
     ctx.set_filter_chain(chain_excluding("*"));
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
 
     ctx.recheck_received_filter()
         .expect("the transfer root must never be rejected by the re-check");

--- a/crates/transfer/src/receiver/tests/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/tests/file_list/id_lists.rs
@@ -152,7 +152,7 @@ fn remap_rewrites_flist_uid_from_sent_name() {
     // A file owned by the nonexistent sender uid.
     let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
     entry.set_uid(4_000_123);
-    ctx.file_list.push(entry);
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(entry);
 
     ctx.remap_flist_ownership_from_id_lists();
 
@@ -176,7 +176,7 @@ fn remap_keeps_raw_uid_under_numeric_ids() {
 
     let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
     entry.set_uid(4_000_123);
-    ctx.file_list.push(entry);
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(entry);
 
     ctx.remap_flist_ownership_from_id_lists();
 
@@ -212,7 +212,7 @@ fn remap_uid_with_usermap(sender_uid: u32, sender_name: &[u8], usermap: &str) ->
 
     let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
     entry.set_uid(sender_uid);
-    ctx.file_list.push(entry);
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(entry);
 
     ctx.remap_flist_ownership_from_id_lists();
     ctx.file_list[0].uid()

--- a/crates/transfer/src/receiver/tests/file_list/implied_recheck.rs
+++ b/crates/transfer/src/receiver/tests/file_list/implied_recheck.rs
@@ -25,14 +25,19 @@ fn injected_name_rejected_with_exit_code_4() {
     config.flags.recursive = true;
     config.connection.implied_source_args = vec!["dir".to_owned()];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("dir".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("dir/wanted.txt".into(), 10, 0o644));
-    ctx.file_list
-        .push(FileEntry::new_file("evil".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "dir/wanted.txt".into(),
+        10,
+        0o644,
+    ));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "evil".into(),
+        20,
+        0o644,
+    ));
 
     let err = ctx.recheck_received_implied_includes().unwrap_err();
     // io::ErrorKind::Unsupported maps to ExitCode::Unsupported (4), matching
@@ -50,14 +55,19 @@ fn requested_names_and_subtree_pass() {
     config.flags.recursive = true;
     config.connection.implied_source_args = vec!["dir".to_owned()];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("dir".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("dir/a.txt".into(), 10, 0o644));
-    ctx.file_list
-        .push(FileEntry::new_file("dir/sub/b.txt".into(), 10, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "dir/a.txt".into(),
+        10,
+        0o644,
+    ));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "dir/sub/b.txt".into(),
+        10,
+        0o644,
+    ));
 
     ctx.recheck_received_implied_includes()
         .expect("names under the requested directory must pass");
@@ -72,16 +82,17 @@ fn relative_implied_parent_directories_pass() {
     config.flags.relative = true;
     config.connection.implied_source_args = vec!["a/b/c".to_owned()];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_directory("a".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory("a".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("a/b".into(), 0o755));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("a/b/c".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("a/b/c/leaf".into(), 10, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "a/b/c/leaf".into(),
+        10,
+        0o644,
+    ));
 
     ctx.recheck_received_implied_includes()
         .expect("implied parent directories of a relative arg must pass");
@@ -96,10 +107,12 @@ fn relative_sibling_injection_rejected() {
     config.flags.relative = true;
     config.connection.implied_source_args = vec!["a/b/c".to_owned()];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_directory("a".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("a/evil".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory("a".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "a/evil".into(),
+        20,
+        0o644,
+    ));
 
     let err = ctx.recheck_received_implied_includes().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
@@ -118,15 +131,21 @@ fn wildcard_arg_stays_active_and_admits_matching_names() {
     config.flags.recursive = true;
     config.connection.implied_source_args = vec!["d*".to_owned()];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("data".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("data/file".into(), 10, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "data/file".into(),
+        10,
+        0o644,
+    ));
     ctx.recheck_received_implied_includes()
         .expect("names matching the wildcard request must pass");
 
-    ctx.file_list
-        .push(FileEntry::new_file("evil".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "evil".into(),
+        20,
+        0o644,
+    ));
     let err = ctx.recheck_received_implied_includes().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
     assert_eq!(
@@ -154,14 +173,19 @@ fn daemon_files_from_subdir_entry_passes_without_module_strip() {
     config.connection.implied_skip_daemon_module = false;
     config.connection.implied_source_args = vec!["a.txt".to_owned(), "sub/d.txt".to_owned()];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("a.txt".into(), 10, 0o644));
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "a.txt".into(),
+        10,
+        0o644,
+    ));
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("sub".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("sub/d.txt".into(), 10, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "sub/d.txt".into(),
+        10,
+        0o644,
+    ));
 
     ctx.recheck_received_implied_includes()
         .expect("a files-from subdir entry on a daemon pull must not be rejected");
@@ -179,8 +203,11 @@ fn daemon_files_from_still_rejects_unrequested_name() {
     config.connection.implied_skip_daemon_module = false;
     config.connection.implied_source_args = vec!["a.txt".to_owned(), "sub/d.txt".to_owned()];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_file("evil".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "evil".into(),
+        20,
+        0o644,
+    ));
 
     let err = ctx.recheck_received_implied_includes().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
@@ -202,10 +229,13 @@ fn daemon_module_operand_still_strips_module_name() {
     config.connection.implied_skip_daemon_module = true;
     config.connection.implied_source_args = vec!["m/dir".to_owned()];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
+    std::sync::Arc::make_mut(&mut ctx.file_list)
         .push(FileEntry::new_directory("dir".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("dir/file".into(), 10, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "dir/file".into(),
+        10,
+        0o644,
+    ));
 
     ctx.recheck_received_implied_includes()
         .expect("module-stripped daemon operand must admit its own subtree");
@@ -221,8 +251,11 @@ fn trust_sender_skips_implied_check() {
     config.flags.recursive = true;
     config.connection.implied_source_args = vec!["dir".to_owned()];
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_file("evil".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "evil".into(),
+        20,
+        0o644,
+    ));
 
     ctx.recheck_received_implied_includes()
         .expect("trust_sender must skip the implied-include check");
@@ -235,8 +268,11 @@ fn no_source_args_is_a_no_op() {
     let mut config = test_config();
     config.flags.recursive = true;
     let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
-    ctx.file_list
-        .push(FileEntry::new_file("anything".into(), 20, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "anything".into(),
+        20,
+        0o644,
+    ));
 
     ctx.recheck_received_implied_includes()
         .expect("no recorded source args means nothing to validate");

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -798,10 +798,13 @@ mod incremental_mode_tests {
         let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
         // Sender's flist: "." plus the single kept file.
-        ctx.file_list
+        std::sync::Arc::make_mut(&mut ctx.file_list)
             .push(FileEntry::new_directory(".".into(), 0o755));
-        ctx.file_list
-            .push(FileEntry::new_file("keep.txt".into(), 4, 0o644));
+        std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+            "keep.txt".into(),
+            4,
+            0o644,
+        ));
 
         // Call the delete pass the same way `run_pipelined_incremental` does.
         let mut writer = TestDeletionWriter;
@@ -881,12 +884,15 @@ mod incremental_mode_tests {
 
         // Sender's flist references `subdir/child.txt`, so the worker
         // map keys `subdir` as a scan target.
-        ctx.file_list
+        std::sync::Arc::make_mut(&mut ctx.file_list)
             .push(FileEntry::new_directory(".".into(), 0o755));
-        ctx.file_list
+        std::sync::Arc::make_mut(&mut ctx.file_list)
             .push(FileEntry::new_directory("subdir".into(), 0o755));
-        ctx.file_list
-            .push(FileEntry::new_file("subdir/child.txt".into(), 4, 0o644));
+        std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+            "subdir/child.txt".into(),
+            4,
+            0o644,
+        ));
 
         let mut writer = TestDeletionWriter;
         let (_stats, _limit_exceeded, io_bits) = ctx
@@ -965,16 +971,22 @@ fn delete_itemize_order_is_deterministic_and_upstream_sorted() {
         config.args = vec![OsString::from(dest.to_str().unwrap())];
         let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-        ctx.file_list
+        std::sync::Arc::make_mut(&mut ctx.file_list)
             .push(FileEntry::new_directory(".".into(), 0o755));
-        ctx.file_list
+        std::sync::Arc::make_mut(&mut ctx.file_list)
             .push(FileEntry::new_directory("alpha".into(), 0o755));
-        ctx.file_list
+        std::sync::Arc::make_mut(&mut ctx.file_list)
             .push(FileEntry::new_directory("beta".into(), 0o755));
-        ctx.file_list
-            .push(FileEntry::new_file("alpha/keep.txt".into(), 1, 0o644));
-        ctx.file_list
-            .push(FileEntry::new_file("beta/keep.txt".into(), 1, 0o644));
+        std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+            "alpha/keep.txt".into(),
+            1,
+            0o644,
+        ));
+        std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+            "beta/keep.txt".into(),
+            1,
+            0o644,
+        ));
 
         let mut writer = CapturingDeletionWriter::default();
         ctx.delete_extraneous_files(dest, None, &mut writer)

--- a/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
@@ -430,7 +430,7 @@ fn receiver_reclaim_oldest_segment_frees_entries() {
 
     // Manually populate the file list with 6 entries across 3 segments.
     for i in 0..6 {
-        ctx.file_list.push(FileEntry::new_file(
+        std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
             format!("file_{i}.txt").into(),
             (i + 1) as u64 * 100,
             0o644,
@@ -467,8 +467,11 @@ fn receiver_reclaim_noop_with_single_segment() {
     let config = test_config();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list
-        .push(FileEntry::new_file("f.txt".into(), 100, 0o644));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_file(
+        "f.txt".into(),
+        100,
+        0o644,
+    ));
     // Single segment - no reclamation possible.
     ctx.reclaim_oldest_segment();
     assert_eq!(ctx.first_segment_idx, 0);

--- a/crates/transfer/src/receiver/tests/file_list/missing_args_sentinel.rs
+++ b/crates/transfer/src/receiver/tests/file_list/missing_args_sentinel.rs
@@ -110,9 +110,8 @@ fn receiver_ignores_sentinel_when_delete_missing_args_off() {
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list.push(sentinel_entry("ghost.txt"));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(sentinel_entry("ghost.txt"));
 
     ctx.process_missing_args_sentinels(
         dest,
@@ -140,9 +139,8 @@ fn receiver_sentinel_for_missing_destination_is_noop() {
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list.push(sentinel_entry("never-existed.txt"));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(sentinel_entry("never-existed.txt"));
 
     // Should not error even though the destination path does not exist.
     ctx.process_missing_args_sentinels(
@@ -169,9 +167,8 @@ fn receiver_sentinel_dry_run_skips_deletion() {
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list.push(sentinel_entry("ghost.txt"));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(sentinel_entry("ghost.txt"));
 
     ctx.process_missing_args_sentinels(
         dest,
@@ -203,9 +200,8 @@ fn receiver_sentinel_removes_directory_recursively() {
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list
-        .push(FileEntry::new_directory(".".into(), 0o755));
-    ctx.file_list.push(sentinel_entry("ghost-dir"));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(FileEntry::new_directory(".".into(), 0o755));
+    std::sync::Arc::make_mut(&mut ctx.file_list).push(sentinel_entry("ghost-dir"));
 
     ctx.process_missing_args_sentinels(
         dest,

--- a/crates/transfer/src/receiver/tests/file_list/ndx_convert.rs
+++ b/crates/transfer/src/receiver/tests/file_list/ndx_convert.rs
@@ -83,9 +83,11 @@ fn wire_to_flat_ndx_round_trips_with_flat_to_wire() {
 
     // Simulate INC_RECURSE: initial segment (0, 1) plus two extras.
     ctx.ndx_segments = vec![(0, 1), (5, 7), (12, 15)];
-    ctx.file_list = (0..18)
-        .map(|i| FileEntry::new_file(PathBuf::from(format!("f{i}")), 0, 0o644))
-        .collect();
+    ctx.file_list = std::sync::Arc::new(
+        (0..18)
+            .map(|i| FileEntry::new_file(PathBuf::from(format!("f{i}")), 0, 0o644))
+            .collect(),
+    );
 
     for flat in 0..18usize {
         let wire = ctx.flat_to_wire_ndx(flat);

--- a/crates/transfer/src/receiver/tests/generator_keepalive.rs
+++ b/crates/transfer/src/receiver/tests/generator_keepalive.rs
@@ -153,10 +153,10 @@ fn touch_up_dirs_keepalive_gated_on_timeout() {
     let dir = test_support::create_tempdir();
 
     let mut ctx = ReceiverContext::new_for_test(&hs, config_with_times());
-    ctx.file_list = vec![
+    ctx.file_list = std::sync::Arc::new(vec![
         FileEntry::new_directory("a".into(), 0o755),
         FileEntry::new_directory("b".into(), 0o755),
-    ];
+    ]);
 
     let (mut writer, sink) = mux_writer(Some(Duration::ZERO));
     ctx.touch_up_dirs(dir.path(), &mut writer);
@@ -181,10 +181,10 @@ fn build_files_to_transfer_keepalive_gated_on_timeout() {
     let mut ctx = ReceiverContext::new_for_test(&hs, test_config());
     // New regular files with no destination present take the no-output new-file
     // path, so the loop's only wire output is the per-file keepalive.
-    ctx.file_list = vec![
+    ctx.file_list = std::sync::Arc::new(vec![
         FileEntry::new_file("f1".into(), 4, 0o644),
         FileEntry::new_file("f2".into(), 4, 0o644),
-    ];
+    ]);
 
     let (mut writer, sink) = mux_writer(Some(Duration::ZERO));
     let mut errors = Vec::new();

--- a/crates/transfer/src/receiver/tests/hard_links.rs
+++ b/crates/transfer/src/receiver/tests/hard_links.rs
@@ -306,7 +306,7 @@ fn create_hardlinks_skipped_when_disabled() {
         ..Default::default()
     };
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = entries;
+    ctx.file_list = std::sync::Arc::new(entries);
 
     let mut writer = TestDeletionWriter;
     call_create_hardlinks(&mut ctx, dest, &mut writer);
@@ -343,7 +343,7 @@ fn create_hardlinks_skipped_in_dry_run() {
         ..Default::default()
     };
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = entries;
+    ctx.file_list = std::sync::Arc::new(entries);
 
     let mut writer = TestDeletionWriter;
     call_create_hardlinks(&mut ctx, dest, &mut writer);
@@ -481,10 +481,10 @@ fn create_hardlinks_tracker_preserves_state_across_calls() {
     let tracker = ctx.hardlink_tracker.as_ref().unwrap();
     assert_eq!(tracker.leader_count(), 1);
 
-    ctx.file_list = vec![
+    ctx.file_list = std::sync::Arc::new(vec![
         make_hlink_leader("leader.txt", 10, 50),
         make_hlink_follower("follower.txt", 10, 50),
-    ];
+    ]);
     call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     assert!(dest.join("follower.txt").exists());
@@ -725,7 +725,7 @@ fn pull_receiver_with_hardlinks(entries: Vec<FileEntry>) -> ReceiverContext {
         ..Default::default()
     };
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = entries;
+    ctx.file_list = std::sync::Arc::new(entries);
     ctx
 }
 

--- a/crates/transfer/src/receiver/tests/mode_dispatch.rs
+++ b/crates/transfer/src/receiver/tests/mode_dispatch.rs
@@ -145,7 +145,7 @@ fn drive(mode: NonTransferMode, dest: &std::path::Path) -> Vec<u8> {
         ..Default::default()
     });
     ctx.config.connection.client_mode = false;
-    ctx.file_list = vec![entry];
+    ctx.file_list = std::sync::Arc::new(vec![entry]);
 
     let setup = PipelineSetup {
         dest_dir: dest.to_path_buf(),

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -86,10 +86,10 @@ fn receiver_prepends_munge_prefix_to_on_disk_symlink() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, munge_receiver_config());
-    ctx.file_list = vec![FileEntry::new_symlink(
+    ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_symlink(
         "escape".into(),
         "/etc/passwd".into(),
-    )];
+    )]);
 
     let mut writer = CapturingMsgInfoWriter;
     ctx.create_symlinks(dest, None, &mut writer)
@@ -145,10 +145,10 @@ fn create_symlinks_surfaces_non_eacces_error() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, plain_receiver_config());
-    ctx.file_list = vec![FileEntry::new_symlink(
+    ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_symlink(
         "blocked".into(),
         "/etc/passwd".into(),
-    )];
+    )]);
 
     let mut writer = CapturingMsgInfoWriter;
     let err = ctx
@@ -220,7 +220,7 @@ fn receiver_preserves_symlink_mtime_on_creation() {
     const SOURCE_MTIME_SECS: i64 = 7_200;
     let mut entry = FileEntry::new_symlink("nolf-symlink".into(), "nolf".into());
     entry.set_mtime(SOURCE_MTIME_SECS, 0);
-    ctx.file_list = vec![entry];
+    ctx.file_list = std::sync::Arc::new(vec![entry]);
 
     let mut writer = CapturingMsgInfoWriter;
     ctx.create_symlinks(dest, None, &mut writer)
@@ -247,10 +247,10 @@ fn receiver_writes_unmunged_target_when_disabled() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, plain_receiver_config());
-    ctx.file_list = vec![FileEntry::new_symlink(
+    ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_symlink(
         "escape".into(),
         "/etc/passwd".into(),
-    )];
+    )]);
 
     let mut writer = CapturingMsgInfoWriter;
     ctx.create_symlinks(dest, None, &mut writer)

--- a/crates/transfer/src/receiver/tests/partial_resume.rs
+++ b/crates/transfer/src/receiver/tests/partial_resume.rs
@@ -197,7 +197,7 @@ mod relative_parents {
             ..Default::default()
         };
         let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-        ctx.file_list = entries;
+        ctx.file_list = std::sync::Arc::new(entries);
         ctx
     }
 
@@ -211,7 +211,7 @@ mod relative_parents {
             ..Default::default()
         };
         let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-        ctx.file_list = entries;
+        ctx.file_list = std::sync::Arc::new(entries);
         ctx
     }
 
@@ -332,11 +332,11 @@ mod relative_parents {
             ..Default::default()
         };
         let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-        ctx.file_list = vec![FileEntry::new_file(
+        ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_file(
             "deep/nested/file.txt".into(),
             100,
             0o644,
-        )];
+        )]);
 
         ctx.ensure_relative_parents(dest);
 

--- a/crates/transfer/src/receiver/tests/push_metadata_itemize.rs
+++ b/crates/transfer/src/receiver/tests/push_metadata_itemize.rs
@@ -81,7 +81,7 @@ fn sender_echo(ndx: i32, iflags: u16) -> Vec<u8> {
 #[test]
 fn server_push_pipeline_forwards_metadata_only_record_and_drains_echo() {
     let mut ctx = push_receiver();
-    ctx.file_list = vec![FileEntry::new_file("f".into(), 1, 0o600)];
+    ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_file("f".into(), 1, 0o600)]);
     let iflags = ItemFlags::ITEM_REPORT_PERMS as u16;
     ctx.server_no_transfer_itemize
         .borrow_mut()

--- a/crates/transfer/src/receiver/tests/support.rs
+++ b/crates/transfer/src/receiver/tests/support.rs
@@ -140,7 +140,7 @@ pub(super) fn receiver_with_hardlinks(entries: Vec<FileEntry>) -> ReceiverContex
         ..Default::default()
     };
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = entries;
+    ctx.file_list = std::sync::Arc::new(entries);
     ctx
 }
 

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -487,7 +487,10 @@ fn receiver_backs_up_existing_symlink_before_replacing() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = vec![FileEntry::new_symlink("mylink".into(), "new-target".into())];
+    ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_symlink(
+        "mylink".into(),
+        "new-target".into(),
+    )]);
 
     let mut writer = MockMsgInfoWriter::new();
     ctx.create_symlinks(dest, None, &mut writer)

--- a/crates/transfer/src/receiver/tests/verbose_dir_names.rs
+++ b/crates/transfer/src/receiver/tests/verbose_dir_names.rs
@@ -30,7 +30,7 @@ fn ctx_with(entries: Vec<FileEntry>, times: bool) -> ReceiverContext {
         ..Default::default()
     };
     let mut c = ReceiverContext::new_for_test(&handshake, config);
-    c.file_list = entries;
+    c.file_list = std::sync::Arc::new(entries);
     c.config.connection.client_mode = true;
     c
 }

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -1243,7 +1243,7 @@ mod itemize_order_tests {
             config.flags.times = true;
             config.flags.perms = true;
             let mut ctx = ReceiverContext::new_for_test(&hs, config);
-            ctx.file_list = vec![entry.clone()];
+            ctx.file_list = std::sync::Arc::new(vec![entry.clone()]);
             let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
             let mut metadata_errors = Vec::new();
             let mut stats = TransferStats::default();
@@ -1313,7 +1313,7 @@ mod itemize_order_tests {
             config.file_selection.size_only = false;
             mutate(&path, &mut config);
             let mut ctx = ReceiverContext::new_for_test(&hs, config);
-            ctx.file_list = vec![entry.clone()];
+            ctx.file_list = std::sync::Arc::new(vec![entry.clone()]);
             let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
             let mut metadata_errors = Vec::new();
             let mut stats = TransferStats::default();
@@ -1972,12 +1972,12 @@ mod itemize_order_tests {
         let hs = handshake();
         let mut ctx = ReceiverContext::new_for_test(&hs, itemize_client_config());
         ctx.defer_itemize = true;
-        ctx.file_list = vec![
+        ctx.file_list = std::sync::Arc::new(vec![
             FileEntry::new_directory("a".into(), 0o755),  // idx 0
             FileEntry::new_file("a/f1".into(), 5, 0o644), // idx 1
             FileEntry::new_directory("b".into(), 0o755),  // idx 2
             FileEntry::new_file("b/f2".into(), 5, 0o644), // idx 3
-        ];
+        ]);
 
         let opts = metadata::MetadataOptions::default();
         let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
@@ -2110,11 +2110,11 @@ mod itemize_order_tests {
         config.flags.dry_run = true;
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.defer_itemize = true;
-        ctx.file_list = vec![
+        ctx.file_list = std::sync::Arc::new(vec![
             FileEntry::new_directory("d".into(), 0o755),  // idx 0
             FileEntry::new_file("d/f1".into(), 5, 0o644), // idx 1
             FileEntry::new_symlink("d/lnk".into(), "target".into()), // idx 2
-        ];
+        ]);
 
         // Read-only pass against an empty destination: every entry is new.
         let (plan, rows) = dry_run_pass(&ctx, dest);
@@ -2190,7 +2190,7 @@ mod itemize_order_tests {
         config.flags.dry_run = true;
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.defer_itemize = true;
-        ctx.file_list = vec![FileEntry::new_file("f".into(), 1, 0o644)];
+        ctx.file_list = std::sync::Arc::new(vec![FileEntry::new_file("f".into(), 1, 0o644)]);
 
         let (plan, rows) = dry_run_pass(&ctx, dest);
 
@@ -2221,10 +2221,10 @@ mod itemize_order_tests {
         config.connection.client_mode = false;
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.defer_itemize = true;
-        ctx.file_list = vec![
+        ctx.file_list = std::sync::Arc::new(vec![
             FileEntry::new_directory("d".into(), 0o755),
             FileEntry::new_file("d/f1".into(), 5, 0o644),
-        ];
+        ]);
 
         let (plan, rows) = dry_run_pass(&ctx, dest);
 
@@ -2332,7 +2332,7 @@ mod skip_notice_tests {
 
         let hs = handshake();
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
-        ctx.file_list = files;
+        ctx.file_list = std::sync::Arc::new(files);
 
         let mut writer = CaptureWriter::default();
         let opts = MetadataOptions::default();

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -207,7 +207,11 @@ impl ReceiverContext {
         } else {
             None
         };
-        let file_list_arc = Arc::new(self.file_list.clone());
+        // Share the receiver's flist with the disk-commit thread instead of
+        // deep-cloning it: the list is read-only for the whole transfer window
+        // (this method borrows `&self`), so an Arc pointer clone keeps a single
+        // resident copy rather than two.
+        let file_list_arc = Arc::clone(&self.file_list);
         // upstream: cleanup.c - compute partial mode from --partial / --partial-dir flags
         let partial_mode = if let Some(ref dir) = self.config.partial_dir {
             PartialMode::PartialDir(dir.clone())

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -504,12 +504,12 @@ mod itemize_order_tests {
         let hs = handshake();
         let mut ctx = ReceiverContext::new_for_test(&hs, itemize_client_config());
         ctx.defer_itemize = true;
-        ctx.file_list = vec![
+        ctx.file_list = std::sync::Arc::new(vec![
             FileEntry::new_directory("a".into(), 0o755),  // idx 0
             FileEntry::new_file("a/f1".into(), 5, 0o644), // idx 1
             FileEntry::new_directory("b".into(), 0o755),  // idx 2
             FileEntry::new_file("b/f2".into(), 5, 0o644), // idx 3
-        ];
+        ]);
 
         let opts = metadata::MetadataOptions::default();
         let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
@@ -617,10 +617,10 @@ mod itemize_order_tests {
         config.flags.dry_run = true;
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.defer_itemize = true;
-        ctx.file_list = vec![
+        ctx.file_list = std::sync::Arc::new(vec![
             FileEntry::new_directory("newdir".into(), 0o755),
             FileEntry::new_file("newdir/f1".into(), 5, 0o644),
-        ];
+        ]);
 
         let opts = metadata::MetadataOptions::default();
         let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -695,7 +695,7 @@ impl ReceiverContext {
         if basename_path.components().count() != 1 {
             return dest_dir;
         }
-        if let Some(entry) = self.file_list.first_mut() {
+        if let Some(entry) = self.file_list_mut().first_mut() {
             entry.set_name(PathBuf::from(&target_basename));
         }
         parent.unwrap_or_else(|| PathBuf::from("."))


### PR DESCRIPTION
## Problem

The pull receiver kept **two full copies** of the file list resident, doubling
its peak flist RSS (measured ~460 MB at 1M files vs ~227 MB for a local copy):

1. `ReceiverContext::file_list` — the owned list, held for the whole session.
2. `Arc::new(self.file_list.clone())` at `receiver/transfer/pipeline.rs:210` —
   a **deep** clone of the entire `Vec<FileEntry>` handed to the disk-commit
   pipeline (`DiskCommitConfig.file_list`) and kept alive for the full
   disk-commit window.

Because each `FileEntry` owns a heap-allocated `name`, that clone duplicates the
whole flist. The arithmetic matches the profile: receiver ≈ 2× the flist.

## Fix

A lifetime/sharing change, not an algorithm change. The field becomes
`Arc<Vec<FileEntry>>` and the disk-commit config receives a pointer clone
(`Arc::clone(&self.file_list)`) instead of a deep copy, so a single flist
allocation is shared between the receiver and the commit thread.

- Reads are unaffected: `Arc<Vec<FileEntry>>` derefs to `[FileEntry]`, so
  indexing, `.iter()`, `.len()`, `.get()` compile unchanged. Only mutations and
  assignments were touched.
- Construction mutations (reception, sort/clean, prune, hardlink matching)
  go through `Arc::make_mut`, which returns the existing allocation without
  copying because the receiver uniquely owns the Arc at that point.

## Mutation-safety check

Every mutation of `self.file_list` was audited against the point where the Arc
is shared with the disk-commit (`pipeline.rs:210`):

- **Before the share (construction):** `receive_file_list`, `sanitize_file_list`,
  the sort/clean pass, `prune_empty_dirs_pass`, `match_hard_links`,
  `normalize_pre30_hardlinks`, id remapping, and the INC_RECURSE sub-list
  materialization (`ensure_all_segments_loaded`, which upstream and this code
  both complete *before* the transfer loop). All run while the receiver is the
  sole owner.
- **During the share (transfer loop):** none. `run_pipeline_loop_decoupled`
  borrows `&self` and holds only shared `&FileEntry` references into the list,
  so the borrow checker guarantees the list is read-only for the whole window
  the Arc is shared.
- **After the share (finalization):** `reclaim_oldest_segment` frees per-entry
  heap for completed INC_RECURSE segments. It runs in `exchange_phase_done`,
  after `run_pipelined` has called `pipelined_receiver.shutdown()` (joining the
  disk thread and dropping its Arc clone). It now mutates through
  `Arc::get_mut` and simply skips the (pure-RSS) reclaim if a clone somehow
  lingers, rather than deep-cloning the list — which would defeat the sharing.

No late mutation required relocation; the sharing window is provably
read-only.

## Correctness

This cannot change wire bytes, sort order, itemize rows, or stats — it only
changes how the one list is owned. The receiver disk-commit, incremental,
directory, hardlink, sanitize, and golden itemize test suites pass unchanged.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p transfer --all-targets --all-features --no-deps -- -D warnings` — clean
- `cargo nextest run -p transfer --all-features` (receiver / pipeline / disk-commit /
  incremental / directory / itemize / hardlink / sanitize subsets) — all pass,
  including `itemize_rows_match_upstream_3_4_4_golden`.

The ~184 MB/1M RSS recovery (receiver 460 MB -> ~227 MB) is host-verified
separately in #208.
