### PR TITLE
refactor(fast_io): single-source the default io_uring ring depth

### DIFF
--- a/crates/fast_io/src/io_uring/per_thread_ring.rs
+++ b/crates/fast_io/src/io_uring/per_thread_ring.rs
@@ -71,14 +71,10 @@ use super::config::IoUringConfig;
 
 /// Default submission queue depth for per-thread rings.
 ///
-/// 64 entries match the default of [`IoUringConfig::sq_entries`] and the
-/// session-wide `IoUringDiskBatch` ring, so bench comparisons between
-/// shared-ring and per-thread topologies are like-for-like. See IUR-2
-/// design doc section 2.2 for the sizing rationale (32 is too shallow
-/// for batched `POLL_ADD + SEND` pairs, 256 inflates per-ring pinned
-/// pages without bench evidence the receiver write path queues that
-/// deeply).
-pub const DEFAULT_RING_DEPTH: u32 = 64;
+/// Re-exported from the single source of truth in
+/// [`crate::io_uring_depth::DEFAULT_IO_URING_DEPTH`] so the real ring and its
+/// non-Linux stub cannot drift. See that constant for the sizing rationale.
+pub const DEFAULT_RING_DEPTH: u32 = crate::io_uring_depth::DEFAULT_IO_URING_DEPTH;
 
 /// Newtype wrapping the underlying [`io_uring::IoUring`] for the
 /// per-thread topology.

--- a/crates/fast_io/src/io_uring_depth.rs
+++ b/crates/fast_io/src/io_uring_depth.rs
@@ -17,6 +17,19 @@ pub const IO_URING_DEPTH_MIN: u32 = 1;
 /// rejected at parse time rather than at ring construction time.
 pub const IO_URING_DEPTH_MAX: u32 = 32768;
 
+/// Default submission queue depth for io_uring rings when the
+/// `--io-uring-depth` tunable is left unset.
+///
+/// Single source of truth shared by the Linux per-thread ring and its
+/// non-Linux stub (both re-export it as `PER_THREAD_RING_DEPTH`). 64 entries
+/// match `IoUringConfig::sq_entries` and the session-wide `IoUringDiskBatch`
+/// ring, so bench comparisons between shared-ring and per-thread topologies
+/// stay like-for-like. See IUR-2 design doc section 2.2 for the sizing
+/// rationale (32 is too shallow for batched `POLL_ADD + SEND` pairs; 256
+/// inflates per-ring pinned pages without bench evidence the receiver write
+/// path queues that deeply).
+pub const DEFAULT_IO_URING_DEPTH: u32 = 64;
+
 /// Errors returned by [`validate_io_uring_depth`] when the requested submission
 /// queue depth is outside the supported range or not a power of two.
 ///

--- a/crates/fast_io/src/io_uring_stub/per_thread_ring.rs
+++ b/crates/fast_io/src/io_uring_stub/per_thread_ring.rs
@@ -13,11 +13,12 @@ use std::io;
 
 /// Default submission queue depth declared for cross-platform API parity.
 ///
-/// The Linux backend uses this value when lazily constructing the
-/// per-thread ring. On non-Linux targets the constant is retained so
-/// callers can compile against the same surface; the stub `with_ring`
-/// always returns [`io::ErrorKind::Unsupported`].
-pub const DEFAULT_RING_DEPTH: u32 = 64;
+/// Re-exported from the single source of truth in
+/// [`crate::io_uring_depth::DEFAULT_IO_URING_DEPTH`] so the stub and the Linux
+/// backend cannot drift. On non-Linux targets the constant is retained so
+/// callers compile against the same surface; the stub `with_ring` always
+/// returns [`io::ErrorKind::Unsupported`].
+pub const DEFAULT_RING_DEPTH: u32 = crate::io_uring_depth::DEFAULT_IO_URING_DEPTH;
 
 /// Always returns [`io::ErrorKind::Unsupported`] on this platform.
 ///


### PR DESCRIPTION
## Summary

The default per-thread io_uring ring depth (`64`) was hard-coded in two
independent constants that could silently drift:

- `crates/fast_io/src/io_uring/per_thread_ring.rs` (Linux backend)
- `crates/fast_io/src/io_uring_stub/per_thread_ring.rs` (non-Linux stub)

Both are `#[cfg]`-selected mirrors of the same public surface, so a change
to one without the other would go unnoticed until a bench or interop run
surfaced the mismatch.

## Change

Define the value once as `DEFAULT_IO_URING_DEPTH` in the
unconditionally-compiled `io_uring_depth` module - already the home of
`IO_URING_DEPTH_MIN` / `IO_URING_DEPTH_MAX` and the natural place for the
depth tunable. Both `per_thread_ring` sites now derive their
`DEFAULT_RING_DEPTH` from that single constant:

```rust
pub const DEFAULT_RING_DEPTH: u32 = crate::io_uring_depth::DEFAULT_IO_URING_DEPTH;
```

The shared module compiles on every target, so the constant is reachable
from both the Linux real path and the non-Linux stub path. The public
re-export `PER_THREAD_RING_DEPTH` is preserved on both.

Behaviour-neutral: the value stays `64` and `--io-uring-depth` continues to
override it at runtime. Drift is now impossible by construction - both
sites resolve to the same `const`.

## Other duplicated tunables surveyed (not folded)

Scanned the `io_uring` and `io_uring_stub` trees for sibling const pairs
with the same drift risk. One clean pair was found and deliberately left
out to keep this PR focused:

- `SEND_ZC_DISPATCH_MIN_BYTES = 4 * 1024` - duplicated in
  `io_uring/send_zc.rs` and `io_uring_stub/send_zc.rs`. Unlike the ring
  depth, it has no natural unconditionally-compiled home (it is a send-zc
  dispatch threshold, unrelated to the depth module). Consolidating it
  belongs with a send-zc-focused change rather than this one.

No other real/stub tunable duplications (buffer capacities, batch sizes)
were found.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy -p fast_io --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run -p fast_io --all-features` (depth + per_thread_ring) - 6 passed
