### PR TITLE
chore(ci): ignore serial_test major bumps (MSRV exceeds pinned toolchain)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,14 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    ignore:
+      # serial_test 4.x raises its MSRV to rustc 1.93.1; this workspace pins
+      # Rust 1.88.0 (rust-toolchain.toml), so its major bumps are not takeable
+      # without a toolchain upgrade. Hold at 3.x until the pinned toolchain moves.
+      - dependency-name: "serial_test"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "serial_test_derive"
+        update-types: ["version-update:semver-major"]
     groups:
       # RustCrypto trait family must move together: md4/sha1/sha2 internally
       # depend on a specific digest version range, and cargo_metadata's


### PR DESCRIPTION
Follow-up to closing #7016. `serial_test` 4.x (and `serial_test_derive` 4.x) raise their MSRV to rustc 1.93.1, but this workspace pins Rust 1.88.0 (`rust-toolchain.toml`), so the `fmt + clippy` job fails to build the dependency (`requires rustc 1.93.1`).

This adds a dependabot `ignore` for `serial_test`/`serial_test_derive` major-version updates so the incompatible bump is not re-proposed. Minor and patch updates within 3.x still flow normally. Remove the ignore when the pinned toolchain moves past 1.93.1.

