### PR TITLE
fix(transfer): stop masking the xattr bit off the push itemize wire

### DIFF
--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -499,12 +499,16 @@ mod tests {
         );
     }
 
-    /// The managed trailing-field bits (XATTR/BASIS/XNAME) must never leak from
-    /// `base_iflags` into the wire shortint, since they demand trailing bytes
-    /// this call site does not write for a plain FNAME request.
+    /// The trailing-field bits (BASIS/XNAME) must never leak from `base_iflags`
+    /// into the wire shortint, since this call site re-derives them from
+    /// `fnamecmp_type`/`xname` and owns the bytes they demand. ITEM_REPORT_XATTR
+    /// is dropped here only because `request_bytes` runs with `-X` off; with
+    /// `preserve_xattrs` false, upstream itemize() never sets it either
+    /// (generator.c:566/575).
     #[test]
     fn base_iflags_managed_bits_are_masked_off() {
-        // Deliberately pollute base_iflags with the managed bits.
+        // Deliberately pollute base_iflags with the trailing-field bits and the
+        // xattr bit that only survives under preserve_xattrs.
         let polluted = u32::from(
             SenderAttrs::ITEM_TRANSFER
                 | SenderAttrs::ITEM_REPORT_XATTR
@@ -512,11 +516,53 @@ mod tests {
                 | SenderAttrs::ITEM_XNAME_FOLLOWS,
         );
         let bytes = request_bytes(polluted);
-        // Only ITEM_TRANSFER (0x8000, LE 00 80) survives; none of the managed
-        // bits (which would each demand a trailing wire field) appear.
+        // Only ITEM_TRANSFER (0x8000, LE 00 80) survives: BASIS/XNAME are managed
+        // trailing-field bits and XATTR is gated off by preserve_xattrs = false.
         assert!(
             bytes.windows(2).any(|w| w == [0x00, 0x80]),
             "masked request keeps ITEM_TRANSFER only: {bytes:02x?}"
+        );
+        assert!(
+            !bytes.windows(2).any(|w| w == [0x00, 0x81]),
+            "xattr bit must stay off without -X: {bytes:02x?}"
+        );
+    }
+
+    /// upstream: generator.c:581 `iflags &= 0xffff` keeps ITEM_REPORT_XATTR
+    /// (1<<8). A push of a file whose xattrs differ carries the bit into the
+    /// wire shortint (0x8100, LE 00 81) so the row prints `<f.s......x`, and the
+    /// terminating xattr-request byte follows it (send_xattr_request writes
+    /// `write_byte(0)` when no abbreviated value is outstanding). Pre-fix code
+    /// masked the bit off unconditionally, dropping the `x` column on the push.
+    #[test]
+    fn xattr_diff_bit_survives_on_push() {
+        use protocol::codec::MonotonicNdxWriter;
+        let mut config = iflags_request_config();
+        config.preserve_xattrs = true;
+        let mut ndx_codec = MonotonicNdxWriter::new(config.protocol.as_u8());
+        let mut bytes: Vec<u8> = Vec::new();
+        // base_iflags as itemize_existing_flags would produce it for a
+        // transferred file whose destination xattrs differ: ITEM_TRANSFER plus
+        // the xattr value-diff bit.
+        let base =
+            u32::from(SenderAttrs::ITEM_TRANSFER | SenderAttrs::ITEM_REPORT_XATTR);
+        send_file_request(
+            &mut bytes,
+            &mut ndx_codec,
+            0,
+            std::path::PathBuf::from("data.txt"),
+            None,
+            None,
+            protocol::FnameCmpType::Fname,
+            None,
+            0,
+            base,
+            &config,
+        )
+        .expect("request encodes");
+        assert!(
+            bytes.windows(2).any(|w| w == [0x00, 0x81]),
+            "push request must carry ITEM_TRANSFER|ITEM_REPORT_XATTR (0x8100): {bytes:02x?}"
         );
     }
 

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -544,8 +544,7 @@ mod tests {
         // base_iflags as itemize_existing_flags would produce it for a
         // transferred file whose destination xattrs differ: ITEM_TRANSFER plus
         // the xattr value-diff bit.
-        let base =
-            u32::from(SenderAttrs::ITEM_TRANSFER | SenderAttrs::ITEM_REPORT_XATTR);
+        let base = u32::from(SenderAttrs::ITEM_TRANSFER | SenderAttrs::ITEM_REPORT_XATTR);
         send_file_request(
             &mut bytes,
             &mut ndx_codec,

--- a/crates/transfer/src/transfer_ops/request.rs
+++ b/crates/transfer/src/transfer_ops/request.rs
@@ -121,15 +121,33 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
         // bits from itemize(), including ITEM_IS_NEW when the destination did
         // not exist). The sender reads them, echoes them back, and prints the
         // row via log_item(FCLIENT), so on a push a brand-new file shows
-        // `<f+++++++++` rather than `<f.........`. Keep only the low 16-bit
-        // report/new bits and drop the ones this function manages itself
-        // (XATTR/BASIS/XNAME require trailing wire fields written below);
-        // always force ITEM_TRANSFER so the sender still reads the sum head.
-        const MANAGED: u16 = SenderAttrs::ITEM_REPORT_XATTR
-            | SenderAttrs::ITEM_BASIS_TYPE_FOLLOWS
-            | SenderAttrs::ITEM_XNAME_FOLLOWS;
-        let mut iflags = ((base_iflags & 0xFFFF) as u16 & !MANAGED) | SenderAttrs::ITEM_TRANSFER;
-        if has_xattr_request && config.preserve_xattrs {
+        // `<f+++++++++` rather than `<f.........`.
+        //
+        // upstream: generator.c:581 `iflags &= 0xffff` keeps every low-16
+        // report bit - including ITEM_REPORT_XATTR (1<<8), which itemize() set
+        // from the xattr_diff() comparison (generator.c:565-576). Only bits
+        // 16-18 (ITEM_MISSING_DATA/DELETED/MATCHED, all log-only locals) are
+        // masked off, and ITEM_REPORT_XATTR is not among them. We additionally
+        // strip the two trailing-field bits (BASIS/XNAME) because this function
+        // re-derives them from fnamecmp_type/xname below and writes their
+        // payloads itself; the xattr bit is re-applied from the value diff so a
+        // pushed file with differing xattrs shows `<f.s......x`, not
+        // `<f.s.......`. Always force ITEM_TRANSFER so the sender still reads
+        // the sum head.
+        const MANAGED: u16 =
+            SenderAttrs::ITEM_BASIS_TYPE_FOLLOWS | SenderAttrs::ITEM_XNAME_FOLLOWS;
+        let mut iflags = ((base_iflags & 0xFFFF) as u16
+            & !(MANAGED | SenderAttrs::ITEM_REPORT_XATTR))
+            | SenderAttrs::ITEM_TRANSFER;
+        // upstream: generator.c:566/575 gate the xattr comparison on
+        // preserve_xattrs, so base_iflags only carries the bit when -X is
+        // active; re-gate here for safety. The bit is set from the itemized
+        // value diff (base_iflags) or from a TODO/abbrev request in xattr_list.
+        let base_reports_xattr =
+            base_iflags & u32::from(SenderAttrs::ITEM_REPORT_XATTR) != 0;
+        let report_xattr =
+            config.preserve_xattrs && (base_reports_xattr || has_xattr_request);
+        if report_xattr {
             iflags |= SenderAttrs::ITEM_REPORT_XATTR;
         }
         // upstream: generator.c:1942-1943 - a non-FNAME basis sets
@@ -161,10 +179,27 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
             protocol::write_vstring(writer, xname.unwrap_or(&[]))?;
         }
 
-        // upstream: sender.c:193-196 - write xattr request data after iflags
-        if has_xattr_request && config.preserve_xattrs {
-            if let Some(list) = xattr_list {
-                write_xattr_request(writer, list)?;
+        // upstream: generator.c:592-599 - the xattr request payload follows the
+        // basis/xname fields whenever ITEM_REPORT_XATTR is on the wire; the
+        // peer's send_files() reads it under the identical condition
+        // (sender.c:85-87). want_xattr_optim combined with
+        // ITEM_XNAME_FOLLOWS+ITEM_LOCAL_CHANGE suppresses the payload on both
+        // sides (generator.c:595-596), so the bit rides the wire with no
+        // trailing request. Coupling the payload to the same `report_xattr`
+        // value that set the bit keeps the two in lockstep: an upstream sender
+        // that sees the bit always reads exactly the bytes we write here.
+        if report_xattr {
+            let optim_skip = config.want_xattr_optim
+                && iflags & SenderAttrs::ITEM_XNAME_FOLLOWS != 0
+                && iflags & SenderAttrs::ITEM_LOCAL_CHANGE != 0;
+            if !optim_skip {
+                match xattr_list {
+                    Some(list) => write_xattr_request(writer, list)?,
+                    // upstream: send_xattr_request() with no XSTATE_TODO items
+                    // writes only the terminating `write_byte(f_out, 0)`, read
+                    // back as a varint by recv_xattr_request (xattrs.c:685).
+                    None => protocol::write_varint(writer, 0)?,
+                }
             }
         }
     }

--- a/crates/transfer/src/transfer_ops/request.rs
+++ b/crates/transfer/src/transfer_ops/request.rs
@@ -134,8 +134,7 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
         // pushed file with differing xattrs shows `<f.s......x`, not
         // `<f.s.......`. Always force ITEM_TRANSFER so the sender still reads
         // the sum head.
-        const MANAGED: u16 =
-            SenderAttrs::ITEM_BASIS_TYPE_FOLLOWS | SenderAttrs::ITEM_XNAME_FOLLOWS;
+        const MANAGED: u16 = SenderAttrs::ITEM_BASIS_TYPE_FOLLOWS | SenderAttrs::ITEM_XNAME_FOLLOWS;
         let mut iflags = ((base_iflags & 0xFFFF) as u16
             & !(MANAGED | SenderAttrs::ITEM_REPORT_XATTR))
             | SenderAttrs::ITEM_TRANSFER;
@@ -143,10 +142,8 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
         // preserve_xattrs, so base_iflags only carries the bit when -X is
         // active; re-gate here for safety. The bit is set from the itemized
         // value diff (base_iflags) or from a TODO/abbrev request in xattr_list.
-        let base_reports_xattr =
-            base_iflags & u32::from(SenderAttrs::ITEM_REPORT_XATTR) != 0;
-        let report_xattr =
-            config.preserve_xattrs && (base_reports_xattr || has_xattr_request);
+        let base_reports_xattr = base_iflags & u32::from(SenderAttrs::ITEM_REPORT_XATTR) != 0;
+        let report_xattr = config.preserve_xattrs && (base_reports_xattr || has_xattr_request);
         if report_xattr {
             iflags |= SenderAttrs::ITEM_REPORT_XATTR;
         }


### PR DESCRIPTION
## Problem

A push of a file whose xattrs differ printed `<f.s.......` where upstream
rsync 3.4.4 (protocol 32) prints `<f.s......x` - the `x` column was
dropped. The receiver/pull side was fixed earlier; this is the surviving
send-side defect.

## Root cause

`send_file_request_xattr()` stripped `ITEM_REPORT_XATTR` from `base_iflags`
in its `MANAGED` mask and re-derived the bit only from `XattrList` state
(`needs_send`/`needs_request`). Every production caller passes
`xattr_list = None`, so the bit was never restored.

Upstream `generator.c:581` masks the itemize iflags with `iflags &= 0xffff`
before `write_shortint()`. That mask drops only bits 16-18
(`ITEM_MISSING_DATA`/`ITEM_DELETED`/`ITEM_MATCHED`, all log-only locals per
`rsync.h:254-256`). `ITEM_REPORT_XATTR` is bit 8 and is kept; `itemize()`
sets it from the `xattr_diff()` comparison (`generator.c:565-576`), which
oc now performs in `itemize_existing_flags()`, so `base_iflags` already
carries the correct bit on the transfer path.

## Investigation

`git log -L` on the lines: the mask was introduced in df205ec5d
("forward full itemize iflags on push so new files show +++"), which
widened the wire iflags to carry `ITEM_IS_NEW`. That change folded
`ITEM_REPORT_XATTR` into the same strip as `ITEM_BASIS_TYPE_FOLLOWS`/
`ITEM_XNAME_FOLLOWS`. The basis/xname bits belong there - this function
re-derives them from `fnamecmp_type`/`xname` and owns their trailing wire
fields - but the xattr bit is a plain report bit that only needed its
trailing request payload kept in lockstep. The strip was over-broad, not
papering over a peer encoding error, so it is removed for the xattr bit.

## Fix

- `MANAGED` now strips only `BASIS`/`XNAME`.
- `ITEM_REPORT_XATTR` is taken from the `base_iflags` value diff (or a
  TODO/abbrev `XattrList`), gated on `preserve_xattrs` exactly as upstream
  `itemize()` gates it (`generator.c:566/575`).
- The xattr-request payload is coupled to the same decision and honours the
  `want_xattr_optim` + `XNAME` + `LOCAL_CHANGE` suppression
  (`generator.c:595-596`, mirrored on the peer read in `sender.c:85-87`), so
  an upstream sender that sees the bit always reads exactly the bytes
  written here. With no `XattrList` threaded through, the lone terminating
  `varint 0` is written, matching `send_xattr_request()`'s `write_byte(0)`.

## Verification

Push to a real rsync 3.4.4 daemon (protocol 32) with `-X -i -r -t`,
upstream as receiver:

| case | upstream 3.4.4 | oc-rsync |
|------|----------------|----------|
| xattr-only change | `.f........x xonly.txt` | `.f........x xonly.txt` |
| xattr + content change | `<f.st.....x xcontent.txt` | `<f.st.....x xcontent.txt` |

Byte-for-byte match. New regression test `xattr_diff_bit_survives_on_push`
asserts the wire shortint carries `0x8100` on a `preserve_xattrs` push; it
fails on the pre-fix code, which emitted `0x8000`.

Gates: `cargo fmt --all -- --check` clean; `cargo clippy -p transfer
--all-targets --all-features --no-deps -- -D warnings` clean;
`cargo nextest run -p transfer` targeted (itemize/xattr/push/request/iflags,
143 tests) all pass.
