### PR TITLE
feat(metadata): apply symlink mode where the OS supports it (macOS)

### DIFF
--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -90,17 +90,17 @@ impl LocalCopyChangeSet {
             modify_window,
         ));
 
-        // Symlinks are excluded from the perm compare because oc does not
-        // currently apply a symlink's mode (nothing calls lchmod/setattrlist),
-        // so reporting a `p` change would promise an action never performed.
-        // This is NOT upstream's rule: upstream skips the compare only where
-        // `CAN_CHMOD_SYMLINK` is undefined (rsync.h:438-440 defines it whenever
-        // HAVE_LCHMOD or HAVE_SETATTRLIST, both probed by configure.ac:911,918),
-        // so on glibc >= 2.32 and on macOS the `#ifndef` block at
-        // generator.c:542-544 compiles out and upstream DOES compare.
-        // Revisit together with applying symlink modes so report and action
-        // cannot drift apart.
+        // Symlinks join the perm compare only where oc can actually chmod a
+        // link (`metadata::CAN_CHMOD_SYMLINK` = macOS/BSD), so report and
+        // action never drift: a reported `p` is always backed by the matching
+        // apply in metadata::apply_symlink_permissions_like. Upstream skips the
+        // compare only where `CAN_CHMOD_SYMLINK` is undefined (rsync.h:438-440,
+        // HAVE_LCHMOD or HAVE_SETATTRLIST, probed at configure.ac:911,918); the
+        // `#ifndef` block at generator.c:542-544 then compiles out. On Linux
+        // the const is false and a link's `st_mode` is a fixed 0777, so nothing
+        // is reported or applied. Mirrors the receiver itemize guard.
         let is_symlink = metadata.file_type().is_symlink();
+        let symlink_perms_ok = !is_symlink || ::metadata::CAN_CHMOD_SYMLINK;
 
         // upstream: generator.c:531-533 - itemize() sets ITEM_REPORT_ATIME when
         // `atimes_ndx` (`-U`) is active for a non-dir, non-symlink whose access
@@ -125,14 +125,14 @@ impl LocalCopyChangeSet {
             change_set = change_set.with_access_time_changed(true);
         }
 
-        if !is_symlink
+        if symlink_perms_ok
             && metadata_options.permissions()
             && permissions_changed(metadata, existing, destination_previously_existed)
         {
             change_set = change_set.with_permissions_changed(true);
         }
 
-        if !is_symlink && metadata_options.chmod().is_some() {
+        if symlink_perms_ok && metadata_options.chmod().is_some() {
             change_set = change_set.with_permissions_changed(true);
         }
 

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -427,21 +427,24 @@ pub fn apply_symlink_metadata(
 
 /// Applies symbolic link metadata using explicit [`MetadataOptions`].
 ///
-/// Only ownership and timestamps are applied. oc does not currently set a
-/// symlink's own mode, so permissions are skipped here.
+/// Applies ownership, permissions, and timestamps. The link's own mode is set
+/// only on platforms where [`crate::CAN_CHMOD_SYMLINK`] holds (macOS/BSD);
+/// elsewhere the chmod is a no-op, matching upstream where `CAN_CHMOD_SYMLINK`
+/// is undefined and a symlink's `st_mode` is a fixed `0o777`.
 ///
-/// This is an oc limitation, not upstream behaviour: `rsync.c:658-668` calls
-/// `do_chmod_at()` for every file type with no `S_ISLNK` gate (the comment at
-/// `rsync.c:667`, "ret == 1 if symlink could not be set", shows a failed
-/// symlink chmod is a soft outcome). All the portability lives in
-/// `syscall.c:761 do_chmod()`, which tries `lchmod()`, falls through to
-/// `setattrlist(FSOPT_NOFOLLOW)` for `S_ISLNK`, and only then gives up.
+/// `rsync.c:658-668` calls `do_chmod_at()` for every file type with no
+/// `S_ISLNK` gate (the comment at `rsync.c:667`, "ret == 1 if symlink could
+/// not be set", shows a failed symlink chmod is a soft outcome). All the
+/// portability lives in `syscall.c:761 do_chmod()`, which tries `lchmod()`,
+/// falls through to `setattrlist(FSOPT_NOFOLLOW)` for `S_ISLNK`, and only then
+/// gives up.
 pub fn apply_symlink_metadata_with_options(
     destination: &Path,
     metadata: &fs::Metadata,
     options: &MetadataOptions,
 ) -> Result<(), MetadataError> {
     ownership::set_owner_like(metadata, destination, false, options, None)?;
+    permissions::apply_symlink_permissions_like(destination, metadata, options)?;
     if options.times() {
         timestamps::set_timestamp_like(metadata, destination, false, None, Some(options))?;
     }
@@ -453,8 +456,8 @@ pub fn apply_symlink_metadata_with_options(
 ///
 /// Mirrors [`apply_metadata_from_file_entry`] but uses `lstat` for the cached
 /// stat and `lutimes` / `utimensat(AT_SYMLINK_NOFOLLOW)` for timestamps so the
-/// link's own mtime is updated instead of the target's. Permissions are
-/// skipped because oc does not currently set a symlink's own mode; ownership
+/// link's own mtime is updated instead of the target's. The link's own mode is
+/// set only where [`crate::CAN_CHMOD_SYMLINK`] holds (macOS/BSD); ownership
 /// (when applicable) is applied with `AT_SYMLINK_NOFOLLOW`.
 ///
 /// This is the receiver-side counterpart to [`apply_symlink_metadata`] that
@@ -465,9 +468,9 @@ pub fn apply_symlink_metadata_with_options(
 /// # Upstream Reference
 ///
 /// - `rsync.c:658-668` - upstream chmods every file type with no `S_ISLNK`
-///   gate; skipping the mode here is an oc limitation, not upstream's rule.
-///   Symlink portability lives in `syscall.c:761 do_chmod()` (`lchmod()`, then
-///   `setattrlist(FSOPT_NOFOLLOW)`).
+///   gate; oc mirrors this on platforms where [`crate::CAN_CHMOD_SYMLINK`]
+///   holds. Symlink portability lives in `syscall.c:761 do_chmod()`
+///   (`lchmod()`, then `setattrlist(FSOPT_NOFOLLOW)`).
 /// - `rsync.c:set_times()` - uses `lutimes` when the target is a symlink
 /// - `generator.c:1604` - `set_file_attrs(fname, file, NULL, NULL, 0)` runs
 ///   after `atomic_create` -> `do_symlink` so the new symlink's mtime matches
@@ -492,6 +495,13 @@ pub fn apply_symlink_metadata_from_entry(
         let _ = options;
         let _ = cached_meta.as_ref();
     }
+
+    permissions::apply_symlink_permissions_from_entry(
+        destination,
+        entry,
+        options,
+        cached_meta.as_ref(),
+    )?;
 
     if options.times() {
         timestamps::apply_symlink_timestamps_from_entry(

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -652,6 +652,107 @@ fn chmod_path_honoring_keep_dirlinks(
     Ok(())
 }
 
+/// Chmods a symbolic link's own permission bits, matching the itemize `p`
+/// decision the receiver reports from a `FileEntry`.
+///
+/// Only runs where [`crate::CAN_CHMOD_SYMLINK`] holds (macOS/BSD). Reproduces
+/// upstream `generator.c:546-552`: under `-p` the link is chmod'd to the
+/// sender's mode bits; under `-E` (without `-p`) only the execute bits track
+/// the source. The chmod uses `fchmodat(AT_SYMLINK_NOFOLLOW)` via
+/// [`fast_io::secure_chmod_at`] (`follow_symlinks = false`) so the link
+/// itself, not its target, is modified.
+///
+/// upstream: rsync.c:658-668 (`set_file_attrs()` chmods every file type with
+/// no `S_ISLNK` gate) + syscall.c:761 `do_chmod()`. The symlink chmod is a
+/// SOFT outcome (`rsync.c:667`, `ret == 1`), so any failure is swallowed and
+/// never propagated - exactly as an unsupported symlink chmod is on any
+/// platform that compiled the const to `true` but hit a filesystem that
+/// refuses it at runtime.
+pub(super) fn apply_symlink_permissions_from_entry(
+    destination: &Path,
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+    cached_meta: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
+    #[cfg(unix)]
+    if crate::CAN_CHMOD_SYMLINK {
+        use std::os::unix::fs::PermissionsExt;
+
+        let current_mode = match cached_meta {
+            Some(meta) => meta.permissions().mode(),
+            None => match fs::symlink_metadata(destination) {
+                Ok(meta) => meta.permissions().mode(),
+                Err(_) => return Ok(()),
+            },
+        };
+        let current = current_mode & 0o7777;
+        let target = if options.permissions() {
+            Some(entry.mode() & 0o7777)
+        } else if options.executability() {
+            Some((current & !0o111) | (entry.mode() & 0o111))
+        } else {
+            None
+        };
+        if let Some(target) = target
+            && current != target
+        {
+            let _ = fast_io::secure_chmod_at(destination, target, false);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = (destination, entry, options, cached_meta);
+    Ok(())
+}
+
+/// Chmods a symbolic link's own permission bits from a source [`fs::Metadata`],
+/// matching the local-copy change-set `p` decision.
+///
+/// The local-copy counterpart to [`apply_symlink_permissions_from_entry`].
+/// Reproduces the change-set detection compare (`-p` full-bits, `-E`
+/// exec-bits) plus the `--chmod` tweak that upstream `tweak_mode()` layers on
+/// every file type. Only runs where [`crate::CAN_CHMOD_SYMLINK`] holds; the
+/// chmod is a SOFT outcome and any error is swallowed.
+///
+/// upstream: rsync.c:658-668 + syscall.c:761 `do_chmod()`.
+pub(super) fn apply_symlink_permissions_like(
+    destination: &Path,
+    source_metadata: &fs::Metadata,
+    options: &MetadataOptions,
+) -> Result<(), MetadataError> {
+    #[cfg(unix)]
+    if crate::CAN_CHMOD_SYMLINK {
+        use std::os::unix::fs::PermissionsExt;
+
+        let current = match fs::symlink_metadata(destination) {
+            Ok(meta) => meta.permissions().mode() & 0o7777,
+            Err(_) => return Ok(()),
+        };
+        let source = source_metadata.permissions().mode();
+        let base = if options.permissions() {
+            Some(source & 0o7777)
+        } else if options.executability() {
+            Some((current & !0o111) | (source & 0o111))
+        } else {
+            None
+        };
+        let target = match options.chmod() {
+            Some(modifiers) => {
+                let start = base.unwrap_or(current);
+                Some(modifiers.apply(start, source_metadata.file_type()) & 0o7777)
+            }
+            None => base,
+        };
+        if let Some(target) = target
+            && current != target
+        {
+            let _ = fast_io::secure_chmod_at(destination, target, false);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = (destination, source_metadata, options);
+    Ok(())
+}
+
 /// Computes the intended full mode (`S_IFMT` + perms) that upstream's
 /// `set_file_attrs()` would chmod a non-fake-super destination to.
 ///

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -2344,3 +2344,119 @@ fn local_atimes_zeroes_atime_nsec() {
         "upstream zeroes the atime nanosecond field"
     );
 }
+
+// Symlink-mode application only exists where the OS can chmod a link
+// (`CAN_CHMOD_SYMLINK` = macOS/BSD). The two tests below encode WHY it matters:
+// a receiver/local-copy that reports a `p` column for a symlink must also apply
+// that mode, or report and action would drift (upstream rsync.c:658-668 chmods
+// every file type; syscall.c:761 do_chmod() uses lchmod/setattrlist for
+// symlinks). They fail on pre-fix code, which skipped the symlink chmod.
+#[cfg(target_os = "macos")]
+#[test]
+fn symlink_own_mode_applied_from_entry_under_preserve_perms() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    assert!(
+        crate::CAN_CHMOD_SYMLINK,
+        "macOS must advertise symlink chmod support"
+    );
+
+    let temp = tempdir().expect("tempdir");
+    let target = temp.path().join("target.txt");
+    let link = temp.path().join("link");
+    fs::write(&target, b"data").expect("write target");
+    symlink(&target, &link).expect("create link");
+
+    // Seed the link at a mode that differs from the sender's, so a correct
+    // apply is observable as a state change rather than a no-op.
+    fast_io::secure_chmod_at(&link, 0o777, false).expect("seed link mode");
+    assert_eq!(
+        fs::symlink_metadata(&link).unwrap().permissions().mode() & 0o7777,
+        0o777
+    );
+
+    let mut entry = FileEntry::new_symlink("link".into(), "target.txt".into());
+    entry.set_mode(0o120741);
+
+    super::apply_symlink_metadata_from_entry(
+        &link,
+        &entry,
+        &MetadataOptions::new().preserve_permissions(true),
+    )
+    .expect("apply symlink metadata");
+
+    assert_eq!(
+        fs::symlink_metadata(&link).unwrap().permissions().mode() & 0o7777,
+        0o741,
+        "the link's own mode must track the sender under -p"
+    );
+    // The chmod must not have followed the link into its target.
+    assert_eq!(
+        fs::metadata(&target).unwrap().permissions().mode() & 0o7777,
+        0o644,
+        "the symlink chmod must not touch the target file"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn symlink_own_mode_applied_from_source_metadata_local_copy() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let temp = tempdir().expect("tempdir");
+    let target = temp.path().join("t.txt");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    fs::write(&target, b"data").expect("write target");
+    symlink(&target, &src).expect("create src link");
+    symlink(&target, &dst).expect("create dst link");
+
+    fast_io::secure_chmod_at(&src, 0o714, false).expect("seed src mode");
+    fast_io::secure_chmod_at(&dst, 0o777, false).expect("seed dst mode");
+
+    let src_meta = fs::symlink_metadata(&src).expect("src link metadata");
+    super::apply_symlink_metadata_with_options(
+        &dst,
+        &src_meta,
+        &MetadataOptions::new().preserve_permissions(true),
+    )
+    .expect("apply symlink metadata");
+
+    assert_eq!(
+        fs::symlink_metadata(&dst).unwrap().permissions().mode() & 0o7777,
+        0o714,
+        "local-copy must carry the source link's own mode where the OS allows"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn symlink_own_mode_is_noop_on_linux() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    // On Linux a symlink's st_mode is a fixed 0o777 and fchmodat rejects
+    // AT_SYMLINK_NOFOLLOW, so the capability const is false and the apply must
+    // neither error nor change anything - report and action stay silent as one.
+    assert!(!crate::CAN_CHMOD_SYMLINK);
+
+    let temp = tempdir().expect("tempdir");
+    let target = temp.path().join("t.txt");
+    let dst = temp.path().join("dst");
+    fs::write(&target, b"data").expect("write target");
+    symlink(&target, &dst).expect("create dst link");
+
+    let src_meta = fs::symlink_metadata(&dst).expect("dst link metadata");
+    super::apply_symlink_metadata_with_options(
+        &dst,
+        &src_meta,
+        &MetadataOptions::new().preserve_permissions(true),
+    )
+    .expect("apply must be a no-op, not an error, on Linux");
+
+    assert_eq!(
+        fs::symlink_metadata(&dst).unwrap().permissions().mode() & 0o7777,
+        0o777,
+        "a Linux symlink keeps its fixed 0o777 mode"
+    );
+}

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -204,6 +204,28 @@ pub fn am_root() -> bool {
     }
 }
 
+/// Whether this platform can change a symbolic link's own permission bits.
+///
+/// Mirrors upstream rsync's `CAN_CHMOD_SYMLINK` (`rsync.h:438-440`), defined
+/// whenever `HAVE_LCHMOD` or `HAVE_SETATTRLIST` is probed
+/// (`configure.ac:911,918`). Upstream `syscall.c:761 do_chmod()` chmods a
+/// symlink with `lchmod()` and then `setattrlist(..., FSOPT_NOFOLLOW)`; both
+/// exist on macOS and the BSDs but not on Linux, where `fchmodat(2)` rejects
+/// `AT_SYMLINK_NOFOLLOW` with `EOPNOTSUPP` and every symlink's `st_mode` is a
+/// fixed `0o777`.
+///
+/// This const gates BOTH the itemize `p` comparison and the symlink chmod so
+/// oc can never report a permission change it will not perform - reporting a
+/// `p` change that is never applied would be worse than staying silent.
+pub const CAN_CHMOD_SYMLINK: bool = cfg!(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "dragonfly",
+));
+
 pub use acl_idmap::AclIdMapper;
 
 #[cfg(all(

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -834,14 +834,16 @@ impl ReceiverContext {
             {
                 iflags |= ItemFlags::ITEM_REPORT_ATIME;
             }
-            // Symlinks are excluded because oc does not currently apply a
-            // symlink's own mode, so it must not report a `p` change it will
-            // not make. Not upstream's rule: `CAN_CHMOD_SYMLINK` is defined
-            // whenever HAVE_LCHMOD or HAVE_SETATTRLIST (rsync.h:438-440,
-            // probed at configure.ac:911,918), so on glibc >= 2.32 and macOS
-            // the `#ifndef` at generator.c:542-544 compiles out and upstream
-            // does compare. Mirrors the same guard in engine's local-copy
-            // change-set detection; revisit both with symlink-mode support.
+            // Symlinks join the perm compare only where oc can actually chmod
+            // a link (`metadata::CAN_CHMOD_SYMLINK` = macOS/BSD), so a reported
+            // `p` is always backed by an applied chmod. Upstream defines
+            // `CAN_CHMOD_SYMLINK` whenever HAVE_LCHMOD or HAVE_SETATTRLIST
+            // (rsync.h:438-440, probed at configure.ac:911,918); where it is
+            // undefined the `#ifndef` at generator.c:542-544 skips the compare.
+            // On Linux the const is false and a link's `st_mode` is a fixed
+            // 0777, so nothing is reported or applied. The matching apply lives
+            // in metadata::apply_symlink_permissions_from_entry, and the same
+            // guard gates engine's local-copy change-set detection.
             //
             // The compare itself is an if/else-if (generator.c:546-552), not a
             // lone `preserve_perms` test:
@@ -857,7 +859,7 @@ impl ReceiverContext {
             // executability bit, so only a change in *whether* the file is
             // executable is a permission change - the other mode bits stay as
             // they are and must not raise the `p` column.
-            if !entry.is_symlink() {
+            if !entry.is_symlink() || metadata::CAN_CHMOD_SYMLINK {
                 if self.config.flags.perms {
                     const CHMOD_BITS: u32 = 0o7777;
                     if (dest_meta.mode() & CHMOD_BITS) != (entry.mode() & CHMOD_BITS) {


### PR DESCRIPTION
## Summary

Apply a symbolic link's own permission bits on platforms where the OS
supports it (macOS and the BSDs), and keep the itemize `p` reporting and the
actual chmod coupled so they can never drift.

## Upstream reference

- `rsync.c:658-668` (`set_file_attrs`) calls `do_chmod` for **every** file
  type - there is no `S_ISLNK` gate. An unsupported symlink chmod is a soft
  outcome (`rsync.c:667`, `ret == 1`), never a skip.
- `syscall.c:761` (`do_chmod`) holds the portability: try `lchmod`, then
  `setattrlist(FSOPT_NOFOLLOW)` for `S_ISLNK`, then give up.
- `rsync.h:438-440` defines `CAN_CHMOD_SYMLINK` whenever `HAVE_LCHMOD` or
  `HAVE_SETATTRLIST` is probed (`configure.ac:911,918`) - true on macOS/BSD,
  false on Linux, where `fchmodat(2)` rejects `AT_SYMLINK_NOFOLLOW` with
  `EOPNOTSUPP` and a symlink's `st_mode` is a fixed `0o777`.

Before this change oc applied ownership and timestamps to a symlink but never
its mode, and both itemize paths excluded symlinks from the `p` compare
outright.

## Primitive-verification finding

The task flagged that `AT_SYMLINK_NOFOLLOW` on `fchmodat(2)` is **not**
honored by Linux, so the pre-existing `fast_io` `fchmodat` wrapper had to be
confirmed on macOS before relying on it. A standalone C probe on this host
confirms macOS `fchmodat(AT_FDCWD, link, mode, AT_SYMLINK_NOFOLLOW)` chmods
the **link itself** (`755 -> 741`, target left at `644`). The existing safe
wrapper `fast_io::secure_chmod_at(path, mode, follow_symlinks=false)` already
routes to exactly that syscall (parent walked through `secure_open_dir`, leaf
`fchmodat` with `AT_SYMLINK_NOFOLLOW`). So **no new unsafe and no new fast_io
code were needed** - the symlink apply reuses the same safe primitive the
symlink chown/utimes paths already use.

## Report / apply coupling

A single `#[cfg]`-gated `pub const metadata::CAN_CHMOD_SYMLINK` (via `cfg!`)
mirrors upstream's define and gates, together:

- the receiver itemize `p` comparison (`receiver/transfer/candidates.rs`),
- the engine local-copy change-set `p` detection (`change_set/detection.rs`),
- the apply, in both `apply_symlink_metadata_from_entry` (network/batch) and
  `apply_symlink_metadata_with_options` (local copy / backup).

The apply reproduces exactly what each itemize site reports (`-p` full bits,
`-E` exec bits, and `--chmod` on the local-copy path), so a reported `p` is
always backed by a chmod. The chmod is a soft outcome: any failure is
swallowed, matching upstream `ret == 1`.

On Linux the const is `false`, so both the report guard and the apply compile
to the prior no-op - nothing is reported or changed, which also matches
upstream since a Linux symlink's mode is a fixed `0o777`.

## macOS verification vs rsync 3.4.4

`/opt/homebrew/bin/rsync` (banner `rsync version 3.4.4 protocol version 32`).
`-rlp -i` of a symlink whose own mode is `0741` into a destination link at
`0777`:

| | itemize row | applied link mode |
|---|---|---|
| upstream 3.4.4 | `.L...p..... link -> tgt` | `lrwxr----x` (0741) |
| oc-rsync | `.L...p..... link -> tgt` | `lrwxr----x` (0741) |

Byte-identical output and identical applied mode.

## Tests

- Two macOS-gated regression tests (receiver `FileEntry` path and local-copy
  `fs::Metadata` path) that assert the link's own mode tracks the source and
  that the chmod does not follow into the target. Both **fail on pre-fix
  code** (verified: `left: 511` vs `right: 481`).
- A Linux-gated test asserting the const is `false` and the apply is a
  no-op, not an error.

`cargo fmt --all --check`, `clippy -p metadata -p fast_io --all-targets
--all-features --no-deps -D warnings`, and the touched-crate symlink/itemize
suites all pass.
