### PR TITLE
fix(core): stop re-printing forwarded rsync errors from the SSH stderr block

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -213,11 +213,14 @@ pub(crate) fn invalid_argument_error_typed_with_role(
 /// rerr_name (log.c:903) - or "unexplained error" for an unknown raw code
 /// (log.c:904-905) - as `rsync error: <name> (code N) at ... [<role>=<ver>]`.
 /// The role is who_am_i() (rsync.c:823): the local process role, not "client".
-/// `context` carries any captured remote stderr and is appended verbatim.
+///
+/// Any stderr the remote/child wrote (genuine ssh-transport diagnostics or the
+/// remote rsync's own error lines) is streamed to our stderr in real time by
+/// the SSH aux-channel drain, mirroring upstream's inherited ssh fd2
+/// passthrough, so it is never re-appended here.
 #[cold]
-pub(crate) fn remote_exit_error(exit_code: ExitCode, role: Role, context: &str) -> ClientError {
-    let text = format!("{}{context}", exit_code.description());
-    let message = rsync_error!(exit_code.as_i32(), "{}", text).with_role(role);
+pub(crate) fn remote_exit_error(exit_code: ExitCode, role: Role) -> ClientError {
+    let message = rsync_error!(exit_code.as_i32(), "{}", exit_code.description()).with_role(role);
     ClientError::with_code(exit_code, message)
 }
 
@@ -954,7 +957,7 @@ mod tests {
         /// and the role from who_am_i() (rsync.c:823).
         #[test]
         fn remote_exit_error_renders_unexplained_error_with_sender_role() {
-            let error = remote_exit_error(ExitCode::Other(42), Role::Sender, "");
+            let error = remote_exit_error(ExitCode::Other(42), Role::Sender);
 
             assert_eq!(error.exit_code(), 42);
             assert_eq!(error.code(), ExitCode::Other(42));
@@ -979,7 +982,7 @@ mod tests {
         /// `log_exit()` for both winning-code paths.
         #[test]
         fn remote_exit_error_uses_receiver_role_and_named_rerr() {
-            let error = remote_exit_error(ExitCode::StreamIo, Role::Receiver, "");
+            let error = remote_exit_error(ExitCode::StreamIo, Role::Receiver);
             let rendered = error.to_string();
             assert!(
                 rendered.contains("error in rsync protocol data stream (code 12)"),
@@ -988,15 +991,20 @@ mod tests {
             assert!(rendered.contains("[receiver="), "missing role: {rendered}");
         }
 
-        /// Captured remote stderr context is appended after the rerr_name so
-        /// the leading upstream phrasing still matches.
+        /// The remote/child's stderr is live-forwarded by the SSH aux-channel
+        /// drain, never merged into this error line, so the rendered text is
+        /// exactly the rerr_name and role - no trailing stderr echo.
         #[test]
-        fn remote_exit_error_appends_stderr_context() {
-            let error = remote_exit_error(ExitCode::Other(42), Role::Sender, ": boom");
+        fn remote_exit_error_never_appends_stderr_context() {
+            let error = remote_exit_error(ExitCode::Other(42), Role::Sender);
             let rendered = error.to_string();
             assert!(
-                rendered.contains("unexplained error: boom (code 42)"),
-                "context must trail the rerr_name: {rendered}"
+                rendered.contains("unexplained error (code 42)"),
+                "rerr_name must stand alone: {rendered}"
+            );
+            assert!(
+                !rendered.contains("SSH stderr"),
+                "captured ssh stderr must not be re-appended: {rendered}"
             );
         }
 

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -280,7 +280,7 @@ fn map_server_transfer_error(error: std::io::Error, role: Role) -> ClientError {
     }
     if let Some(code) = remote_exit_code(&error) {
         let exit = ExitCode::from_i32(code).unwrap_or(ExitCode::PartialTransfer);
-        return remote_exit_error(exit, role, "");
+        return remote_exit_error(exit, role);
     }
     invalid_argument_error(&format!("transfer failed: {error}"), 23)
 }

--- a/crates/core/src/client/remote/remote_to_remote.rs
+++ b/crates/core/src/client/remote/remote_to_remote.rs
@@ -301,20 +301,16 @@ fn run_bidirectional_relay(
             }
         })??;
 
-    // upstream: propagate the worst exit code from either child.
-    let (source_exit, source_stderr) = match source_handle.wait_with_stderr() {
-        Ok((status, stderr_bytes)) => (
-            super::ssh_transfer::map_child_exit_status(status),
-            stderr_bytes,
-        ),
-        Err(_) => (ExitCode::WaitChild, Vec::new()),
+    // upstream: propagate the worst exit code from either child. `wait()` joins
+    // each child's stderr drain (which already live-forwarded any diagnostics)
+    // and hands back only the exit status.
+    let source_exit = match source_handle.wait() {
+        Ok(status) => super::ssh_transfer::map_child_exit_status(status),
+        Err(_) => ExitCode::WaitChild,
     };
-    let (dest_exit, dest_stderr) = match dest_handle.wait_with_stderr() {
-        Ok((status, stderr_bytes)) => (
-            super::ssh_transfer::map_child_exit_status(status),
-            stderr_bytes,
-        ),
-        Err(_) => (ExitCode::WaitChild, Vec::new()),
+    let dest_exit = match dest_handle.wait() {
+        Ok(status) => super::ssh_transfer::map_child_exit_status(status),
+        Err(_) => ExitCode::WaitChild,
     };
 
     let worst_exit = if source_exit.as_i32() >= dest_exit.as_i32() {
@@ -324,16 +320,14 @@ fn run_bidirectional_relay(
     };
 
     if !worst_exit.is_success() {
-        let mut combined_stderr = source_stderr;
-        if !combined_stderr.is_empty() && !dest_stderr.is_empty() {
-            combined_stderr.push(b'\n');
-        }
-        combined_stderr.extend_from_slice(&dest_stderr);
-        let stderr_text = super::ssh_transfer::format_stderr_context(&combined_stderr);
-
+        // Each remote child's stderr is live-forwarded to our stderr by its
+        // SSH aux-channel drain (rsync_io::ssh drain_loop), mirroring upstream's
+        // inherited ssh fd2 passthrough. Re-appending the captured bytes here
+        // would print every diagnostic a second time, so the error line carries
+        // only the worst exit code's description.
         return Err(invalid_argument_error_typed(
             &format!(
-                "remote process exited with error: {}{stderr_text}",
+                "remote process exited with error: {}",
                 worst_exit.description()
             ),
             worst_exit,

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -28,9 +28,7 @@ use super::super::implied_source::implied_source_args_for_pull;
 use super::super::invocation::{RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role};
 use super::super::itemize_sink::ItemizeEventSink;
 use super::connection::build_ssh_connection;
-use super::exit_status::{
-    convert_server_stats_to_summary, format_stderr_context, map_child_exit_status,
-};
+use super::exit_status::{convert_server_stats_to_summary, map_child_exit_status};
 use super::parse::{parse_remote_operands, parse_single_remote, remote_operand_source_paths};
 use super::progress::ServerProgressAdapter;
 use super::server_config::{build_server_config_for_generator, build_server_config_for_receiver};
@@ -345,12 +343,16 @@ fn run_server_over_ssh_connection(
             // failure exiting 255) must survive rather than be masked by the
             // handshake error.
             drop(writer);
-            let (child_exit, stderr_text) = match child_handle.wait_with_stderr() {
-                Ok((status, stderr_bytes)) => (
-                    map_child_exit_status(status),
-                    format_stderr_context(&stderr_bytes),
-                ),
-                Err(_) => (ExitCode::WaitChild, String::new()),
+            // Genuine ssh-transport diagnostics on the child's stderr (auth
+            // failures, "connection refused", "command not found") are already
+            // streamed to our stderr in real time by the aux-channel drain
+            // thread (rsync_io::ssh drain_loop), mirroring upstream's inherited
+            // ssh fd2 passthrough. `wait()` joins that drain so the output is
+            // flushed before we build the error; re-appending the captured
+            // bytes here would print every line a second time.
+            let child_exit = match child_handle.wait() {
+                Ok(status) => map_child_exit_status(status),
+                Err(_) => ExitCode::WaitChild,
             };
 
             // upstream: io.c:232 whine_about_eof() maps an unexpected EOF
@@ -374,14 +376,14 @@ fn run_server_over_ssh_connection(
                 // the final `rsync error:` line reports that winning code by its
                 // rerr_name, or "unexplained error" for an unknown raw code
                 // (log.c:903-905), not the EOF whine text.
-                return Err(remote_exit_error(child_exit, local_role, &stderr_text));
+                return Err(remote_exit_error(child_exit, local_role));
             }
             let detail = if base == ExitCode::StreamIo {
                 // upstream: io.c:228-232 - the EOF whine omits the underlying
                 // error and reports the byte count received so far.
-                format!("connection unexpectedly closed (0 bytes received so far){stderr_text}")
+                "connection unexpectedly closed (0 bytes received so far)".to_string()
             } else {
-                format!("handshake failed: {e}{stderr_text}")
+                format!("handshake failed: {e}")
             };
             return Err(invalid_argument_error_typed_with_role(
                 &detail, base, local_role,
@@ -441,13 +443,14 @@ fn run_server_over_ssh_connection(
 
     let collected_events = itemize_sink.take_events();
 
-    // upstream: main.c wait_process_with_flush() - wait for child and map status.
-    let (child_exit_code, stderr_text) = match child_handle.wait_with_stderr() {
-        Ok((status, stderr_bytes)) => {
-            let stderr_text = format_stderr_context(&stderr_bytes);
-            (map_child_exit_status(status), stderr_text)
-        }
-        Err(_) => (ExitCode::WaitChild, String::new()),
+    // upstream: main.c wait_process_with_flush() - wait for child and map
+    // status. The child's stderr was live-forwarded by the aux-channel drain
+    // thread (see the handshake-failure path above); `wait()` joins that drain
+    // so it is flushed before we build the final error. We take only the exit
+    // status - re-appending the captured stderr would double-print it.
+    let child_exit_code = match child_handle.wait() {
+        Ok(status) => map_child_exit_status(status),
+        Err(_) => ExitCode::WaitChild,
     };
 
     match transfer_result {
@@ -458,16 +461,16 @@ fn run_server_over_ssh_connection(
             } else {
                 // upstream: log.c:912 log_exit() renders the winning child code
                 // by its rerr_name tagged with the local role, not "client".
-                Err(remote_exit_error(child_exit_code, local_role, &stderr_text))
+                Err(remote_exit_error(child_exit_code, local_role))
             }
         }
         Err(transfer_error) => {
             let transfer_exit = ExitCode::from_io_error(&transfer_error);
             if child_exit_code.as_i32() > transfer_exit.as_i32() {
-                Err(remote_exit_error(child_exit_code, local_role, &stderr_text))
+                Err(remote_exit_error(child_exit_code, local_role))
             } else {
                 Err(invalid_argument_error(
-                    &format!("transfer failed: {transfer_error}{stderr_text}"),
+                    &format!("transfer failed: {transfer_error}"),
                     transfer_exit.as_i32(),
                 ))
             }

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -1,10 +1,11 @@
-//! Result mapping: server statistics to client summary, SSH child exit-status
-//! to rsync exit codes, and stderr context formatting.
+//! Result mapping: server statistics to client summary and SSH child
+//! exit-status to rsync exit codes.
 //!
-//! These helpers translate the outcome of an SSH transfer (the server stats,
-//! the remote child's exit status, and any captured stderr) into the
-//! client-facing summary and error surfaces, mirroring upstream
-//! `main.c:wait_process_with_flush()` and `log.c:log_exit()`.
+//! These helpers translate the outcome of an SSH transfer (the server stats and
+//! the remote child's exit status) into the client-facing summary and error
+//! surfaces, mirroring upstream `main.c:wait_process_with_flush()` and
+//! `log.c:log_exit()`. The remote child's stderr is streamed to our stderr in
+//! real time by the SSH aux-channel drain, not formatted here.
 
 use std::time::Duration;
 
@@ -135,22 +136,4 @@ pub(in crate::client::remote) fn map_child_exit_status(
         // upstream: main.c:206/218 - a failed waitpid() maps to RERR_WAITCHILD.
         None => ExitCode::WaitChild,
     }
-}
-
-/// Formats captured SSH stderr output as a suffix for error messages.
-///
-/// Returns an empty string when `stderr_bytes` is empty. Otherwise returns
-/// a newline-separated block prefixed with "SSH stderr:" that gives the user
-/// visibility into what the remote process wrote to stderr before exiting.
-/// The output is trimmed to remove trailing whitespace.
-pub(in crate::client::remote) fn format_stderr_context(stderr_bytes: &[u8]) -> String {
-    if stderr_bytes.is_empty() {
-        return String::new();
-    }
-    let text = String::from_utf8_lossy(stderr_bytes);
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        return String::new();
-    }
-    format!("\nSSH stderr:\n{trimmed}")
 }

--- a/crates/core/src/client/remote/ssh_transfer/mod.rs
+++ b/crates/core/src/client/remote/ssh_transfer/mod.rs
@@ -34,7 +34,7 @@ mod progress;
 mod server_config;
 
 pub use drive::run_ssh_transfer;
-pub(super) use exit_status::{format_stderr_context, map_child_exit_status};
+pub(super) use exit_status::map_child_exit_status;
 
 #[cfg(any(feature = "async-ssh", feature = "embedded-ssh"))]
 pub(super) use exit_status::convert_server_stats_to_summary;
@@ -227,39 +227,6 @@ mod tests {
     fn no_warning_when_neither_compresses() {
         assert!(!should_warn_double_compression(false, false));
         warn_double_compression_once(false, false);
-    }
-
-    #[test]
-    fn format_stderr_context_empty_input() {
-        assert_eq!(format_stderr_context(&[]), "");
-    }
-
-    #[test]
-    fn format_stderr_context_whitespace_only() {
-        assert_eq!(format_stderr_context(b"  \n\n  "), "");
-    }
-
-    #[test]
-    fn format_stderr_context_single_line() {
-        let output = format_stderr_context(b"Permission denied (publickey).\n");
-        assert_eq!(output, "\nSSH stderr:\nPermission denied (publickey).");
-    }
-
-    #[test]
-    fn format_stderr_context_multi_line() {
-        let input = b"Warning: Permanently added 'host' to known hosts.\nrsync error: some error\n";
-        let output = format_stderr_context(input);
-        assert!(output.starts_with("\nSSH stderr:\n"));
-        assert!(output.contains("Warning: Permanently added"));
-        assert!(output.contains("rsync error: some error"));
-    }
-
-    #[test]
-    fn format_stderr_context_invalid_utf8() {
-        let input = b"error: \xff\xfe bad bytes\n";
-        let output = format_stderr_context(input);
-        assert!(output.starts_with("\nSSH stderr:\n"));
-        assert!(output.contains("error:"));
     }
 
     #[cfg(unix)]

--- a/crates/core/tests/ssh_transfer.rs
+++ b/crates/core/tests/ssh_transfer.rs
@@ -439,21 +439,22 @@ fn ssh_rsync_path_not_found() {
     });
 }
 
-/// Verify that SSH stderr output is captured and included in the error message
-/// when a connection fails.
+/// Verify a failed SSH connection maps to the child's exit code without
+/// re-appending the child's stderr to the returned error message.
 ///
-/// This validates the fix from PR #3183: when `perform_handshake()` fails because
-/// the SSH process exited (e.g., "Connection refused"), the stderr from the SSH
-/// child must be captured via `wait_with_stderr()` and surfaced in the error
-/// message. Previously, stderr was lost because the error returned before the
-/// child was waited on.
+/// The SSH child's stderr (here "Connection refused") is streamed to our own
+/// stderr in real time by the aux-channel drain thread, mirroring upstream's
+/// inherited ssh fd 2 passthrough. The returned `rsync error:` line must NOT
+/// additionally embed that text under an `SSH stderr:` header - doing so
+/// printed every diagnostic twice. Live-stream visibility itself is covered by
+/// the binary-level test in `tests/ssh_stderr_no_double_print.rs`, which can
+/// capture the process's real stderr; here we assert the message-level
+/// non-duplication contract.
 ///
 /// The test uses a shell script as a fake SSH program that writes a known error
 /// to stderr and exits with code 255, simulating a connection-refused scenario.
-/// This avoids dependency on a running SSH server while exercising the full
-/// stderr capture pipeline through `run_server_over_ssh_connection`.
 #[test]
-fn ssh_stderr_visible_on_connection_failure() {
+fn ssh_stderr_not_reappended_to_error_message() {
     run_with_timeout(SSH_TIMEOUT, || {
         let temp = tempdir().expect("tempdir");
         let src_dir = temp.path().join("src");
@@ -496,15 +497,20 @@ fn ssh_stderr_visible_on_connection_failure() {
         let err = result.expect_err("connection with fake SSH should fail");
         let err_msg = err.to_string();
 
-        // The error message must contain the SSH stderr output so the user
-        // knows why the connection failed.
-        assert!(
-            err_msg.contains("Connection refused"),
-            "error message should contain SSH stderr 'Connection refused', got: {err_msg}"
+        // ssh exits 255; the returned diagnostic reports that raw code, tagged
+        // with the local role - never the invented "SSH stderr:" echo.
+        assert_eq!(
+            err.code().as_i32(),
+            255,
+            "ssh 255 must propagate, got: {err_msg}"
         );
         assert!(
-            err_msg.contains("SSH stderr:"),
-            "error message should contain 'SSH stderr:' prefix, got: {err_msg}"
+            !err_msg.contains("SSH stderr:"),
+            "captured ssh stderr must not be re-appended to the error line: {err_msg}"
+        );
+        assert!(
+            !err_msg.contains("Connection refused"),
+            "the live drain owns that line; it must not also ride the error: {err_msg}"
         );
     });
 }

--- a/tests/ssh_stderr_no_double_print.rs
+++ b/tests/ssh_stderr_no_double_print.rs
@@ -1,0 +1,216 @@
+//! Regression tests: the SSH client must not print a remote/child stderr line
+//! twice.
+//!
+//! Over a remote shell, oc-rsync drains the child's stderr on a background
+//! thread that forwards each line to our own stderr in real time - mirroring
+//! upstream rsync, which inherits ssh's fd 2 so ssh (and the remote rsync's own
+//! `msgs2stderr=2` diagnostics) print straight to the terminal. A prior bug
+//! also appended the same captured bytes to the final `rsync error:` line under
+//! an invented `SSH stderr:` header, so every diagnostic printed twice.
+//!
+//! Upstream never re-emits ssh's stderr after the child exits; the live stream
+//! is the one and only copy. These tests spawn the real binary (the only way to
+//! observe the process's actual stderr) and assert each diagnostic appears
+//! exactly once, while still confirming genuine ssh-transport errors survive.
+//!
+//! Two paths are covered:
+//!  - exit 255 handshake-failure path: a fake ssh that fails before any
+//!    handshake (auth failure / connection refused / command not found). This
+//!    is deterministic and needs no external rsync.
+//!  - exit 23 post-transfer path: oc-rsync pulling a missing source from a real
+//!    upstream rsync server, whose sender writes `link_stat ... failed` to its
+//!    own fd 2 (upstream `log.c:330`, default `msgs2stderr=2`). Gated on a real
+//!    rsync being available; skipped cleanly otherwise.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Locates the binary under test. `CARGO_BIN_EXE_oc-rsync` is a compile-time
+/// variable, so it must be read with `env!`, never `env::var_os`.
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
+}
+
+/// Writes an executable POSIX script at `path` with `body` and `0o755` perms.
+fn write_script(path: &Path, body: &str) {
+    fs::write(path, body).expect("write script");
+    let mut perms = fs::metadata(path).expect("stat script").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod script");
+}
+
+/// Spawns oc-rsync with a wall-clock cap; returns the captured output.
+fn run_oc_rsync(args: &[OsString]) -> Output {
+    let mut child = Command::new(oc_rsync_binary())
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn oc-rsync");
+
+    let deadline = Instant::now() + RUN_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return child.wait_with_output().expect("collect oc-rsync output"),
+            Ok(None) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "oc-rsync did not exit within {RUN_TIMEOUT:?}"
+                );
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => panic!("waiting for oc-rsync failed: {e}"),
+        }
+    }
+}
+
+/// Counts non-overlapping occurrences of `needle` in `haystack`.
+fn count(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+/// A genuine ssh-transport failure (bad target, auth failure, command not
+/// found) writes to ssh's stderr and exits 255 before any rsync handshake. The
+/// error must still reach the user - exactly once - and must not be echoed a
+/// second time under an `SSH stderr:` header.
+#[test]
+fn genuine_ssh_error_prints_exactly_once() {
+    let temp = TempDir::new().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+
+    // A fake ssh that mimics OpenSSH's auth failure: one stderr line, exit 255.
+    let fake_ssh = temp.path().join("fake_ssh.sh");
+    let marker = "Permission denied (publickey).";
+    write_script(
+        &fake_ssh,
+        &format!("#!/bin/sh\nprintf '%s\\n' '{marker}' 1>&2\nexit 255\n"),
+    );
+
+    let rsh = format!("--rsh={}", fake_ssh.display());
+    let dst_arg = format!("{}/", dst.display());
+    let args: Vec<OsString> = ["--no-aes", &rsh, "dummyhost:/src", &dst_arg]
+        .iter()
+        .map(OsString::from)
+        .collect();
+
+    let out = run_oc_rsync(&args);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !out.status.success(),
+        "transfer should fail when ssh exits 255: {stderr}"
+    );
+    assert_eq!(
+        count(&stderr, marker),
+        1,
+        "genuine ssh error must print exactly once (not zero, not doubled): {stderr}"
+    );
+    assert!(
+        !stderr.contains("SSH stderr:"),
+        "must not re-emit captured stderr under an invented header: {stderr}"
+    );
+}
+
+/// Locates a usable upstream rsync for the exit-23 path. Honours
+/// `OC_RSYNC_UPSTREAM_RSYNC`, else falls back to `rsync` on PATH. Returns
+/// `None` (test skips) when none runs.
+fn upstream_rsync() -> Option<PathBuf> {
+    let candidates = std::env::var_os("OC_RSYNC_UPSTREAM_RSYNC")
+        .map(PathBuf::from)
+        .into_iter()
+        .chain(std::iter::once(PathBuf::from("rsync")));
+    for cand in candidates {
+        let ok = Command::new(&cand)
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            return Some(cand);
+        }
+    }
+    None
+}
+
+/// oc-rsync pulling a missing source from a real upstream rsync server. The
+/// remote sender reports `link_stat "<path>" failed` on its own fd 2 (upstream
+/// default `msgs2stderr=2`), which flows back over the remote shell's stderr.
+/// It must surface exactly once; before the fix it printed twice (once live,
+/// once under `SSH stderr:`). Exercises the post-transfer (exit 23) code path.
+#[test]
+fn upstream_sender_error_prints_exactly_once() {
+    let Some(rsync) = upstream_rsync() else {
+        eprintln!("skipping: no usable upstream rsync found (set OC_RSYNC_UPSTREAM_RSYNC)");
+        return;
+    };
+
+    let temp = TempDir::new().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+
+    // A remote-shell wrapper that drops the host operand and execs the server
+    // command locally, emulating ssh handing the connection to the remote
+    // rsync. The server's fd 2 rides the wrapper's stderr, exactly as ssh
+    // forwards the remote fd 2.
+    let wrapper = temp.path().join("rsh.sh");
+    write_script(&wrapper, "#!/bin/sh\nshift\nexec \"$@\"\n");
+
+    let missing = "/oc-rsync-nonexistent-source-xyz";
+    let rsh = format!("--rsh={}", wrapper.display());
+    let rsync_path = format!("--rsync-path={}", rsync.display());
+    let src_arg = format!("dummyhost:{missing}");
+    let dst_arg = format!("{}/", dst.display());
+    let args: Vec<OsString> = ["-a", &rsh, &rsync_path, &src_arg, &dst_arg]
+        .iter()
+        .map(OsString::from)
+        .collect();
+
+    let out = run_oc_rsync(&args);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // Any rsync 3.x reports the missing source this way; if this rsync does not
+    // (e.g. a very old build), the scenario under test never triggers - skip
+    // rather than assert against an absent diagnostic.
+    if !stderr.contains("link_stat") {
+        eprintln!(
+            "skipping: rsync at {} did not emit a link_stat error: {stderr}",
+            rsync.display()
+        );
+        return;
+    }
+
+    assert_eq!(
+        out.status.code(),
+        Some(23),
+        "missing source must exit 23 (RERR_PARTIAL): {stderr}"
+    );
+    assert_eq!(
+        count(&stderr, "link_stat"),
+        1,
+        "the remote sender error must print exactly once, not doubled: {stderr}"
+    );
+    assert!(
+        !stderr.contains("SSH stderr:"),
+        "must not re-emit the remote stderr under an invented header: {stderr}"
+    );
+}


### PR DESCRIPTION
## Problem

For an SSH client transfer, a single remote diagnostic prints twice. Example: `oc-rsync -e ssh host:/missing dst/` (exit 23) shows the sender's `link_stat "..." failed` line once bare, then again under an `SSH stderr:` header appended to the `rsync error:` line.

## Root cause

Over a remote shell, the SSH child's stderr is drained on a background thread (`rsync_io::ssh` `drain_loop`) that forwards each line to our own stderr in real time via `eprint!`. This faithfully mirrors upstream rsync, which inherits ssh's fd 2 so both ssh's own diagnostics and the remote rsync's error lines (upstream default `msgs2stderr=2`, `log.c:330` writes them to fd 2, not the multiplex stream) print straight to the terminal.

On top of that live stream, the post-transfer and handshake-failure paths in `run_server_over_ssh_connection` also captured the same bytes and appended them to the final error message under an invented `SSH stderr:` header (`format_stderr_context`). Result: every remote diagnostic printed twice. The daemon path never did this because it has no stderr side channel - that is the tell.

## The transport-vs-framed distinction

Trying to separate genuine ssh-transport stderr (auth failure, connection refused, command not found) from the remote rsync's own forwarded diagnostics is unnecessary: both classes ride the child's stderr, both are already live-forwarded exactly once by the drain, and upstream re-emits neither after the child exits. So the correct fix is to remove the duplicating layer rather than gate it:

- `remote_exit_error` drops its stderr `context` parameter.
- The SSH driver (`drive.rs`) and the remote-to-remote proxy take only the child exit status via `wait()`, which still joins the drain so the live output is flushed before the error is built.
- `format_stderr_context` and its `SSH stderr:` header are deleted.

Genuine ssh-transport errors still print - they arrive only on the child's stderr and the drain forwards them once - so nothing is lost.

## Verification (against real rsync 3.4.4 over a remote shell)

1. `oc` client -> upstream server, missing source (exit 23): `link_stat "..." failed` now prints exactly once (twice before), matching upstream byte-for-byte.
2. Bad ssh target / auth failure (exit 255): the ssh error still prints, exactly once.

Both are covered by new binary-level regression tests that capture the process's real stderr (`tests/ssh_stderr_no_double_print.rs`). The exit-23 guard fails on pre-fix code (count == 2).

## Gates

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p core --all-targets --all-features --no-deps -- -D warnings`: clean, no waivers
- Targeted `nextest`: new regression tests pass; 167 SSH/remote/proxy tests pass; `remote_exit_error` and ssh_transfer unit tests updated and green
