### PR TITLE
chore(bench): drop the stale hardcoded cold-start reference ratio

### DIFF
--- a/scripts/benchmark_daemon_cold_start.sh
+++ b/scripts/benchmark_daemon_cold_start.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Daemon cold-start benchmark harness for oc-rsync vs upstream rsync.
 #
-# Reproduces the DIS-1 baseline gap: a single rsync pull from an oc-rsync
-# daemon currently costs ~1.35s end-to-end vs ~0.36s for upstream rsync on
-# the same corpus and host (~3.7x slower). The harness exists so DIS-2
-# profiling and DIS-4.a-e audits can measure progress against a stable
-# reference number, and DIS-6 fixes can prove regressions/improvements.
+# Measures the daemon cold-start gap: a single rsync pull from an oc-rsync
+# daemon vs upstream rsync on the same corpus and host. The harness exists
+# so DIS-2 profiling and DIS-4.a-e audits can measure progress, and DIS-6
+# fixes can prove regressions/improvements, always against freshly measured
+# numbers rather than a baked-in reference.
 #
 # Design notes:
 #   - Two daemons (oc-rsync, upstream) run side-by-side on different ports
@@ -353,8 +353,8 @@ run_cold_start_bench() {
 }
 
 print_ratio() {
-    # When --export-json is set, parse it and print the ratio explicitly so
-    # the 3.7x reference gap is visible without re-reading the JSON.
+    # When --export-json is set, parse it and print the measured oc/upstream
+    # ratio explicitly without re-reading the JSON.
     if [[ -z "${JSON_FILE}" ]] || ! command -v python3 >/dev/null 2>&1; then
         return 0
     fi
@@ -378,7 +378,6 @@ print("=== Cold-start ratio ===")
 print(f"  upstream-daemon mean:  {up_ms:8.2f} ms")
 print(f"  oc-rsync-daemon mean:  {oc_ms:8.2f} ms")
 print(f"  ratio (oc / upstream): {ratio:6.2f}x")
-print("  DIS-1 reference gap:     ~3.70x  (1.35s vs 0.36s)")
 PY
 }
 


### PR DESCRIPTION
## What

`scripts/benchmark_daemon_cold_start.sh` printed a stale hardcoded reference
line in its ratio summary:

```
print("  DIS-1 reference gap:     ~3.70x  (1.35s vs 0.36s)")
```

and its header comment asserted the daemon "currently costs ~1.35s ... (~3.7x
slower)" as present-day fact.

## Why it was wrong

That ~3.70x figure was an early fossil. It became the source of a false
"daemon-pull is 3.37x slower" alarm that later measurement disproved: the real
gap was ~1.33x on small files, since fixed. Baking the old constant into the
output invited every future run to be read against a number that no longer
reflects reality, re-triggering the same false alarm.

## Change

- Removed the hardcoded `~3.70x` reference line from the ratio summary. The
  block already prints the actual measured `upstream mean`, `oc mean`, and
  `ratio (oc / upstream)` for each run, so no baseline is lost.
- Rewrote the header comment and the `print_ratio` comment to describe the
  harness in terms of freshly measured numbers rather than a baked-in
  reference. No benchmarking logic changed.

## Verification

- `bash -n scripts/benchmark_daemon_cold_start.sh` passes.
- `shellcheck scripts/benchmark_daemon_cold_start.sh` is clean.
