### PR TITLE
fix(core): stop forwarding oc-specific tuning flags to the remote server

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -507,20 +507,6 @@ pub(super) fn build_full_daemon_args(
         args.push(format!("--checksum-seed={seed}"));
     }
 
-    // oc-specific: forward `--zero-copy`/`--no-zero-copy` to the daemon-sender
-    // (pull) so its socket write side can opt into io_uring SEND_ZC. This is a
-    // non-upstream flag with no `server_options()` counterpart, forwarded only
-    // when the daemon is the sender (`is_sender`) and the user set a non-Auto
-    // policy - same opt-in precedent as `--io-uring-depth`. Auto is the default
-    // and is never forwarded, so the daemon keeps its byte-identical writer.
-    if is_sender {
-        match config.zero_copy_policy() {
-            fast_io::ZeroCopyPolicy::Enabled => args.push("--zero-copy".to_owned()),
-            fast_io::ZeroCopyPolicy::Disabled => args.push("--no-zero-copy".to_owned()),
-            fast_io::ZeroCopyPolicy::Auto => {}
-        }
-    }
-
     // upstream: options.c:2896-2897
     if config.ignore_errors() {
         args.push("--ignore-errors".to_owned());
@@ -569,9 +555,6 @@ pub(super) fn build_full_daemon_args(
         }
         if config.fsync() {
             args.push("--fsync".to_owned());
-        }
-        if let Some(depth) = config.io_uring_depth() {
-            args.push(format!("--io-uring-depth={depth}"));
         }
 
         // upstream: options.c:2933-2941 - --compare-dest/copy-dest/link-dest
@@ -1721,68 +1704,183 @@ mod server_option_fidelity_tests {
 }
 
 #[cfg(test)]
-mod zero_copy_forwarding_tests {
+mod oc_flag_forwarding_tests {
+    use std::num::{NonZeroU8, NonZeroUsize};
+    use std::path::PathBuf;
+
     use super::build_full_daemon_args;
     use crate::client::ClientConfig;
+    use crate::client::config::TcpFastOpenMode;
     use crate::client::remote::daemon_transfer::connection::DaemonTransferRequest;
     use protocol::ProtocolVersion;
+
+    /// Long options recognized by upstream rsync 3.4.4 (options.c
+    /// long_options[]) that this arg builder may emit. Upstream's `--server`
+    /// aborts the whole transfer on the first unknown option, so every `--`
+    /// token the builder produces MUST appear in this allowlist. oc-invented
+    /// tuning flags (--io-uring-depth, --zero-copy, ...) are local resource
+    /// knobs and must never reach the peer argv.
+    const UPSTREAM_SERVER_LONG_OPTS: &[&str] = &[
+        "--append",
+        "--append-verify",
+        "--backup-dir",
+        "--block-size",
+        "--bwlimit",
+        "--checksum-choice",
+        "--checksum-seed",
+        "--compare-dest",
+        "--compress-choice",
+        "--compress-level",
+        "--copy-dest",
+        "--copy-devices",
+        "--copy-unsafe-links",
+        "--debug",
+        "--delay-updates",
+        "--delete",
+        "--delete-after",
+        "--delete-before",
+        "--delete-delay",
+        "--delete-during",
+        "--delete-excluded",
+        "--delete-missing-args",
+        "--existing",
+        "--files-from",
+        "--force",
+        "--from0",
+        "--fsync",
+        "--groupmap",
+        "--iconv",
+        "--ignore-errors",
+        "--ignore-existing",
+        "--ignore-missing-args",
+        "--ignore-times",
+        "--info",
+        "--inplace",
+        "--link-dest",
+        "--list-only",
+        "--log-format",
+        "--max-alloc",
+        "--max-delete",
+        "--max-size",
+        "--min-size",
+        "--mkpath",
+        "--modify-window",
+        "--msgs2stderr",
+        "--new-compress",
+        "--no-implied-dirs",
+        "--no-msgs2stderr",
+        "--no-r",
+        "--no-relative",
+        "--no-specials",
+        "--numeric-ids",
+        "--old-compress",
+        "--only-write-batch",
+        "--open-noatime",
+        "--partial",
+        "--partial-dir",
+        "--preallocate",
+        "--read-batch",
+        "--remove-sent-files",
+        "--remove-source-files",
+        "--safe-links",
+        "--secluded-args",
+        "--sender",
+        "--server",
+        "--size-only",
+        "--skip-compress",
+        "--specials",
+        "--stop-at",
+        "--suffix",
+        "--temp-dir",
+        "--timeout",
+        // upstream: options.c:2908-2909 - server_options() spells the qsort
+        // request as `--use-qsort` even though the popt table entry is
+        // `qsort`; we mirror the emitted spelling.
+        "--use-qsort",
+        "--usermap",
+        "--write-batch",
+        "--write-devices",
+    ];
 
     fn request() -> DaemonTransferRequest {
         DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path").expect("valid rsync url")
     }
 
-    fn args_for(policy: fast_io::ZeroCopyPolicy, is_sender: bool) -> Vec<String> {
-        let config = ClientConfig::builder().zero_copy_policy(policy).build();
-        build_full_daemon_args(&config, &request(), ProtocolVersion::V31, is_sender)
+    /// Sets every oc-invented tuning knob to a non-default value. These are
+    /// local resource knobs with no upstream counterpart; a real upstream
+    /// 3.4.4 daemon rejects any of them with an unknown-option error.
+    fn kitchen_sink_config() -> ClientConfig {
+        ClientConfig::builder()
+            .io_uring_policy(fast_io::IoUringPolicy::Enabled)
+            .io_uring_depth(Some(128))
+            .cow_policy(fast_io::CowPolicy::Required)
+            .zero_copy_policy(fast_io::ZeroCopyPolicy::Enabled)
+            .parallel_delta_scan(true)
+            .compression_threads(NonZeroU8::new(4))
+            .xxh64_dedup(true)
+            .rayon_threads(NonZeroUsize::new(8))
+            .tokio_threads(NonZeroUsize::new(4))
+            .sparse_detect(engine::SparseDetectStrategy::Map)
+            .tcp_fastopen(TcpFastOpenMode::On)
+            .spill_dir(Some(PathBuf::from("/tmp/spill")))
+            .spill_threshold_bytes(Some(1024))
+            .build()
     }
 
-    // The daemon-sender (pull, `is_sender = true`) socket write side is the
-    // only place SEND_ZC helps, so `--zero-copy` is forwarded there when the
-    // user opted in. Both ends must be oc-rsync for the daemon to parse it.
+    fn assert_upstream_recognized(args: &[String]) {
+        for arg in args {
+            if let Some(rest) = arg.strip_prefix("--") {
+                let name = rest.split('=').next().unwrap_or(rest);
+                let long = format!("--{name}");
+                assert!(
+                    UPSTREAM_SERVER_LONG_OPTS.contains(&long.as_str()),
+                    "`{arg}` is not an upstream rsync 3.4.4 option; an \
+                     upstream `--server` peer aborts the transfer on it \
+                     (full argv: {args:?})"
+                );
+            }
+        }
+    }
+
     #[test]
-    fn enabled_forwards_zero_copy_on_daemon_sender() {
-        let args = args_for(fast_io::ZeroCopyPolicy::Enabled, true);
-        assert!(
-            args.iter().any(|a| a == "--zero-copy"),
-            "daemon-sender pull with --zero-copy must forward the flag: {args:?}"
+    fn oc_tuning_flags_never_reach_daemon_sender_argv() {
+        let baseline = build_full_daemon_args(
+            &ClientConfig::builder().build(),
+            &request(),
+            ProtocolVersion::V31,
+            true,
         );
-        assert!(!args.iter().any(|a| a == "--no-zero-copy"));
-    }
-
-    // Default (Auto) must never forward the flag: the daemon then keeps its
-    // byte- and behavior-identical writer. This is the HARD default-path
-    // invariant, asserted at the wire-arg boundary.
-    #[test]
-    fn auto_never_forwards_zero_copy() {
-        let args = args_for(fast_io::ZeroCopyPolicy::Auto, true);
-        assert!(
-            !args
-                .iter()
-                .any(|a| a == "--zero-copy" || a == "--no-zero-copy"),
-            "Auto policy must not forward any zero-copy flag: {args:?}"
+        let args = build_full_daemon_args(
+            &kitchen_sink_config(),
+            &request(),
+            ProtocolVersion::V31,
+            true,
+        );
+        assert_upstream_recognized(&args);
+        assert_eq!(
+            args, baseline,
+            "oc-invented tuning knobs must not alter the daemon peer argv"
         );
     }
 
-    // `--no-zero-copy` pins the daemon-sender's policy to Disabled explicitly.
     #[test]
-    fn disabled_forwards_no_zero_copy_on_daemon_sender() {
-        let args = args_for(fast_io::ZeroCopyPolicy::Disabled, true);
-        assert!(
-            args.iter().any(|a| a == "--no-zero-copy"),
-            "Disabled policy must forward --no-zero-copy: {args:?}"
+    fn oc_tuning_flags_never_reach_daemon_receiver_argv() {
+        let baseline = build_full_daemon_args(
+            &ClientConfig::builder().build(),
+            &request(),
+            ProtocolVersion::V31,
+            false,
         );
-        assert!(!args.iter().any(|a| a == "--zero-copy"));
-    }
-
-    // On a push (`is_sender = false`, daemon is the receiver) the daemon's
-    // socket write side carries no bulk data, so SEND_ZC is not forwarded even
-    // when the user opted in - matching the sender-only benefit.
-    #[test]
-    fn enabled_does_not_forward_on_daemon_receiver() {
-        let args = args_for(fast_io::ZeroCopyPolicy::Enabled, false);
-        assert!(
-            !args.iter().any(|a| a == "--zero-copy"),
-            "daemon-receiver push must not forward --zero-copy: {args:?}"
+        let args = build_full_daemon_args(
+            &kitchen_sink_config(),
+            &request(),
+            ProtocolVersion::V31,
+            false,
+        );
+        assert_upstream_recognized(&args);
+        assert_eq!(
+            args, baseline,
+            "oc-invented tuning knobs must not alter the daemon peer argv"
         );
     }
 }

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -353,10 +353,6 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--fsync"));
         }
 
-        if let Some(depth) = self.config.io_uring_depth() {
-            args.push(OsString::from(format!("--io-uring-depth={depth}")));
-        }
-
         // upstream: options.c:2747-2748 - `if (list_only > 1) "--list-only"`.
         // Only the EXPLICIT `--list-only` (list_only == 2) is forwarded; the
         // implicit single-source listing (list_only == 1) is not. The compact

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -4771,3 +4771,166 @@ fn no_implied_dirs_gated_on_protocol_for_push_only() {
         "push at protocol 30+ forwards --no-implied-dirs"
     );
 }
+
+mod oc_flag_forwarding {
+    use std::num::{NonZeroU8, NonZeroUsize};
+    use std::path::PathBuf;
+
+    use super::super::RemoteRole;
+    use super::super::builder::RemoteInvocationBuilder;
+    use crate::client::config::{ClientConfig, TcpFastOpenMode};
+
+    /// Long options recognized by upstream rsync 3.4.4 (options.c
+    /// long_options[]) that the remote invocation builder may emit. Upstream's
+    /// `rsync --server` aborts the whole transfer on the first unknown option,
+    /// so every `--` token in the built argv MUST appear in this allowlist.
+    /// oc-invented tuning flags (--io-uring-depth, --zero-copy, ...) are local
+    /// resource knobs and must never reach the peer argv.
+    const UPSTREAM_SERVER_LONG_OPTS: &[&str] = &[
+        "--append",
+        "--append-verify",
+        "--backup-dir",
+        "--block-size",
+        "--bwlimit",
+        "--checksum-choice",
+        "--checksum-seed",
+        "--compare-dest",
+        "--compress-choice",
+        "--compress-level",
+        "--copy-dest",
+        "--copy-devices",
+        "--copy-unsafe-links",
+        "--debug",
+        "--delay-updates",
+        "--delete",
+        "--delete-after",
+        "--delete-before",
+        "--delete-delay",
+        "--delete-during",
+        "--delete-excluded",
+        "--delete-missing-args",
+        "--existing",
+        "--files-from",
+        "--force",
+        "--from0",
+        "--fsync",
+        "--groupmap",
+        "--iconv",
+        "--ignore-errors",
+        "--ignore-existing",
+        "--ignore-missing-args",
+        "--ignore-times",
+        "--info",
+        "--inplace",
+        "--link-dest",
+        "--list-only",
+        "--log-format",
+        "--max-alloc",
+        "--max-delete",
+        "--max-size",
+        "--min-size",
+        "--mkpath",
+        "--modify-window",
+        "--msgs2stderr",
+        "--new-compress",
+        "--no-implied-dirs",
+        "--no-msgs2stderr",
+        "--no-r",
+        "--no-relative",
+        "--no-specials",
+        "--numeric-ids",
+        "--old-compress",
+        "--only-write-batch",
+        "--open-noatime",
+        "--partial",
+        "--partial-dir",
+        "--preallocate",
+        "--read-batch",
+        "--remove-sent-files",
+        "--remove-source-files",
+        "--safe-links",
+        "--secluded-args",
+        "--sender",
+        "--server",
+        "--size-only",
+        "--skip-compress",
+        "--specials",
+        "--stop-at",
+        "--suffix",
+        "--temp-dir",
+        "--timeout",
+        // upstream: options.c:2908-2909 - server_options() spells the qsort
+        // request as `--use-qsort` even though the popt table entry is
+        // `qsort`; we mirror the emitted spelling.
+        "--use-qsort",
+        "--usermap",
+        "--write-batch",
+        "--write-devices",
+    ];
+
+    /// Sets every oc-invented tuning knob to a non-default value. These are
+    /// local resource knobs with no upstream counterpart; a real upstream
+    /// 3.4.4 server rejects any of them with an unknown-option error.
+    fn kitchen_sink_config() -> ClientConfig {
+        ClientConfig::builder()
+            .io_uring_policy(fast_io::IoUringPolicy::Enabled)
+            .io_uring_depth(Some(128))
+            .cow_policy(fast_io::CowPolicy::Required)
+            .zero_copy_policy(fast_io::ZeroCopyPolicy::Enabled)
+            .parallel_delta_scan(true)
+            .compression_threads(NonZeroU8::new(4))
+            .xxh64_dedup(true)
+            .rayon_threads(NonZeroUsize::new(8))
+            .tokio_threads(NonZeroUsize::new(4))
+            .sparse_detect(engine::SparseDetectStrategy::Map)
+            .tcp_fastopen(TcpFastOpenMode::On)
+            .spill_dir(Some(PathBuf::from("/tmp/spill")))
+            .spill_threshold_bytes(Some(1024))
+            .build()
+    }
+
+    fn build_args(config: &ClientConfig, role: RemoteRole) -> Vec<String> {
+        RemoteInvocationBuilder::new(config, role)
+            .build("/remote/path")
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn assert_upstream_recognized(args: &[String]) {
+        for arg in args {
+            if let Some(rest) = arg.strip_prefix("--") {
+                let name = rest.split('=').next().unwrap_or(rest);
+                let long = format!("--{name}");
+                assert!(
+                    UPSTREAM_SERVER_LONG_OPTS.contains(&long.as_str()),
+                    "`{arg}` is not an upstream rsync 3.4.4 option; an \
+                     upstream `--server` peer aborts the transfer on it \
+                     (full argv: {args:?})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn oc_tuning_flags_never_reach_ssh_pull_argv() {
+        let baseline = build_args(&ClientConfig::builder().build(), RemoteRole::Receiver);
+        let args = build_args(&kitchen_sink_config(), RemoteRole::Receiver);
+        assert_upstream_recognized(&args);
+        assert_eq!(
+            args, baseline,
+            "oc-invented tuning knobs must not alter the remote --server argv"
+        );
+    }
+
+    #[test]
+    fn oc_tuning_flags_never_reach_ssh_push_argv() {
+        let baseline = build_args(&ClientConfig::builder().build(), RemoteRole::Sender);
+        let args = build_args(&kitchen_sink_config(), RemoteRole::Sender);
+        assert_upstream_recognized(&args);
+        assert_eq!(
+            args, baseline,
+            "oc-invented tuning knobs must not alter the remote --server argv"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Three sites forwarded oc-invented tuning flags into the remote peer's `rsync --server` argv. Upstream rsync rejects the first unknown option and the whole transfer aborts, so any transfer against an upstream server or daemon failed the moment the user set one of these flags. oc<->oc runs never see it because both ends parse the flags, and the defaults (`None`/`Auto`) are never forwarded, so default-path interop tests pass.

Leak sites:

1. SSH: `crates/core/src/client/remote/invocation/builder.rs` pushed `--io-uring-depth=N` into the remote argv (no role guard, so both push and pull leaked).
2. Daemon push: `crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs` pushed `--io-uring-depth=N` in the `we_are_sender` branch.
3. Daemon pull: same file pushed `--zero-copy`/`--no-zero-copy` in the `is_sender` branch.

## History

- `3bbce8a11` (#3742) introduced `--io-uring-depth` and forwarded it from both builders so the peer would use the same ring depth - a tuning hand-off that only works when both ends are oc-rsync.
- `d62d60036` (#6349) added the `--zero-copy` daemon-pull forward, citing the `--io-uring-depth` forward as precedent, and added tests asserting the forwarding. Those tests encoded the interop bug and are replaced here by tests asserting the opposite.

## Fix

These flags are local resource knobs; remote-side tuning belongs to the remote host's own configuration. All three forwarding sites are removed. The flags still apply to the local process exactly as before - only the peer argv changes.

## Reproduction against upstream 3.4.4

Pull over a remote-shell wrapper invoking upstream rsync 3.4.4 with `--io-uring-depth=128`, before the fix:

```
rsync: on remote machine: --io-uring-depth=128: unknown option
rsync error: syntax or usage error (code 1) at main.c(1806) [server=3.4.4]
```

Daemon pull with `--zero-copy` from an upstream 3.4.4 daemon, before the fix:

```
rsync: on remote machine: --zero-copy: unknown option
```

Daemon push with `--io-uring-depth=128`, before the fix:

```
rsync error: requested action not supported (code 4) at clientserver.c(1185) [Receiver=3.4.4]
```

After the fix all three commands succeed with byte-identical destinations.

## Guard

New kitchen-sink tests for both builders (`oc_flag_forwarding` / `oc_flag_forwarding_tests`) set every oc-invented tuning knob to a non-default value, build the full `--server` argv for both roles, and assert:

- every `--` token appears in an allowlist of long options recognized by upstream rsync 3.4.4 (`options.c` `long_options[]`), and
- the argv is byte-identical to the default-config argv, so no local tuning knob can ever alter the peer argv again.

All four tests fail on the pre-fix code.

## Validation

- `cargo fmt --all -- --check` clean
- `cargo clippy -p core --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p core --all-features -E 'test(oc_flag_forwarding) or test(invocation) or test(arguments) or test(server_arg)'`: 362 passed
- Manual interop vs upstream rsync 3.4.4 (SSH-wrapper pull, daemon pull, daemon push) as above
