### PR TITLE
fix(engine): drop the dead OC_RSYNC_FALLBACK hint and correct the spill-threshold doc

### DIFF
--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -433,10 +433,9 @@ impl LocalCopyArgumentError {
             Self::ReplaceNonDirectoryWithDirectory => {
                 "cannot replace non-directory destination with directory"
             }
-            Self::RemoteOperandUnsupported => concat!(
-                "remote operands are not supported: this build handles local filesystem copies only; ",
-                "set OC_RSYNC_FALLBACK to point to an upstream rsync binary for remote transfers",
-            ),
+            Self::RemoteOperandUnsupported => {
+                "remote operands are not supported: this build handles local filesystem copies only"
+            }
         }
     }
 }
@@ -638,11 +637,13 @@ mod tests {
         assert!(error.message().contains("existing directory"));
     }
 
+    /// The external-rsync delegation mechanism was removed, so the message
+    /// must not steer users toward the dead `OC_RSYNC_FALLBACK` env var.
     #[test]
     fn local_copy_argument_error_remote_operand_message() {
         let error = LocalCopyArgumentError::RemoteOperandUnsupported;
         assert!(error.message().contains("remote operands"));
-        assert!(error.message().contains("OC_RSYNC_FALLBACK"));
+        assert!(!error.message().contains("OC_RSYNC_FALLBACK"));
     }
 
     #[test]

--- a/docs/operator-migration-guide-vNEXT.md
+++ b/docs/operator-migration-guide-vNEXT.md
@@ -270,7 +270,7 @@ existing operators see no behavioural change.
 
 | Variable | Maps to | Accepted values |
 |----------|---------|-----------------|
-| `OC_RSYNC_SPILL_THRESHOLD_BYTES` | `threshold_bytes` | Integer with optional `K`/`M`/`G` suffix (case-insensitive, base 1024). Empty string clears. `0` is rejected. |
+| `OC_RSYNC_SPILL_THRESHOLD_BYTES` | `threshold_bytes` | Unsigned integer byte count; no `K`/`M`/`G` suffixes. Invalid values are logged and ignored, leaving the field unchanged. |
 | `OC_RSYNC_SPILL_DIR` | `dir` | Absolute or relative path. Created on first spill via `create_dir_all`. |
 | `OC_RSYNC_SPILL_RECLAIM` | `reclaim_mode` | `keep` (default) or `re-spill`. |
 | `OC_RSYNC_SPILL_GRANULARITY` | `granularity` | `whole-batch` (default) or `per-item`. |


### PR DESCRIPTION
## Summary

Two honesty fixes: an error-message hint that points at a removed mechanism, and a doc claim that overstates what an env var parser accepts.

## Dead `OC_RSYNC_FALLBACK` hint

`LocalCopyArgumentError::RemoteOperandUnsupported` told users to "set OC_RSYNC_FALLBACK to point to an upstream rsync binary for remote transfers". No production code reads that variable anymore. `git log -S OC_RSYNC_FALLBACK` shows the external-rsync delegation mechanism was dead-coded (both `configured_fallback_binary()` functions returned `None`, the CLI path was guarded by `if false &&`) and then fully deleted in #2483 ("refactor: remove dead delegation/fallback code from daemon, core, and CLI", ~6,000 lines across daemon, core, and cli). `docs/oc-extension-env-reference.md` already lists `OC_RSYNC_FALLBACK` under "Legacy variables ... no longer consulted by any production code path". The message is oc-specific (upstream 3.4.4 has no equivalent local-only rejection path, so there is no upstream wording to mirror), and no replacement mechanism exists, so the hint sentence is dropped. The unit test now asserts the message does not steer users toward the dead variable.

## Spill-threshold doc correction

`docs/operator-migration-guide-vNEXT.md` claimed `OC_RSYNC_SPILL_THRESHOLD_BYTES` accepts an integer "with optional K/M/G suffix (case-insensitive, base 1024). Empty string clears. 0 is rejected." The actual parser (`crates/engine/src/concurrent_delta/spill/env.rs`, `apply_threshold`) is `val.parse::<u64>()`: plain bytes only, no suffixes, and any invalid value (including the empty string) is logged and ignored, leaving the field unchanged. The table row now matches the code; `docs/oc-extension-env-reference.md` and `docs/oc-rsync.1.md` already described it correctly. No behavior change.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings`
- `cargo nextest run -p engine --all-features -E 'test(error) or test(fallback)'` - 250 passed
