### PR TITLE
feat(transfer): env-configurable disk-commit channel capacity

### DIFF
--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -4,6 +4,7 @@
 //! control how the disk thread writes, syncs, commits files, and handles
 //! interrupted transfers.
 
+use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -75,6 +76,30 @@ const MIN_CHANNEL_CAPACITY: usize = 8;
 /// Maximum allowed channel capacity (prevents unbounded memory growth).
 const MAX_CHANNEL_CAPACITY: usize = 4096;
 
+/// Environment variable overriding the default disk-commit channel capacity.
+///
+/// Parsed as an unsigned integer and clamped to `[8, 4096]`. Unset or
+/// unparseable values fall back to [`DEFAULT_CHANNEL_CAPACITY`]. Local
+/// tuning knob only - never forwarded to a remote peer and never observable
+/// on the wire.
+pub const ENV_CHANNEL_CAPACITY: &str = "OC_RSYNC_DISK_COMMIT_CHANNEL_CAP";
+
+/// Resolves the default channel capacity, honoring [`ENV_CHANNEL_CAPACITY`].
+///
+/// Read once at config construction. Invalid values are ignored in favor
+/// of [`DEFAULT_CHANNEL_CAPACITY`], matching the tolerant parse style of
+/// the other `OC_RSYNC_*` tuning knobs.
+fn channel_capacity_from_env() -> usize {
+    env::var(ENV_CHANNEL_CAPACITY)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .map_or(DEFAULT_CHANNEL_CAPACITY, |value| {
+            usize::try_from(value)
+                .unwrap_or(MAX_CHANNEL_CAPACITY)
+                .clamp(MIN_CHANNEL_CAPACITY, MAX_CHANNEL_CAPACITY)
+        })
+}
+
 /// Configuration for the disk commit thread.
 #[derive(Debug, Clone)]
 pub struct DiskCommitConfig {
@@ -138,7 +163,9 @@ pub struct DiskCommitConfig {
     /// network thread and the disk thread. Clamped to
     /// `MIN_CHANNEL_CAPACITY..=MAX_CHANNEL_CAPACITY` at runtime.
     ///
-    /// Defaults to [`DEFAULT_CHANNEL_CAPACITY`] (128).
+    /// Defaults to [`DEFAULT_CHANNEL_CAPACITY`] (128), overridable via the
+    /// [`ENV_CHANNEL_CAPACITY`] environment variable read at config
+    /// construction.
     pub channel_capacity: usize,
     /// Policy controlling io_uring usage for disk writes.
     ///
@@ -239,7 +266,7 @@ impl Default for DiskCommitConfig {
             acl_cache: None,
             acl_id_map: None,
             xattr_filter: None,
-            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+            channel_capacity: channel_capacity_from_env(),
             io_uring_policy: fast_io::IoUringPolicy::Auto,
             io_uring_depth: None,
             iocp_policy: fast_io::IocpPolicy::Auto,

--- a/crates/transfer/src/disk_commit/mod.rs
+++ b/crates/transfer/src/disk_commit/mod.rs
@@ -36,7 +36,7 @@ mod tests_partial_interrupt_parity;
 
 pub use self::config::{
     BackupConfig, DEFAULT_CHANNEL_CAPACITY, DELAY_UPDATES_PARTIAL_DIR, DiskCommitConfig,
-    PartialMode,
+    ENV_CHANNEL_CAPACITY, PartialMode,
 };
 pub use self::process::{DelayedUpdateEntry, delay_updates_staging_path, handle_delayed_updates};
 pub use self::thread::{DiskThreadHandle, spawn_disk_thread};

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -12,6 +12,8 @@ use super::thread::spawn_disk_thread;
 
 #[test]
 fn default_config() {
+    let _lock = channel_cap_env::ENV_LOCK.lock().unwrap();
+    let _guard = platform::env::EnvGuard::remove(super::config::ENV_CHANNEL_CAPACITY);
     let config = DiskCommitConfig::default();
     assert!(!config.do_fsync);
     assert!(!config.delay_updates);
@@ -20,6 +22,71 @@ fn default_config() {
         super::config::DEFAULT_CHANNEL_CAPACITY
     );
     assert_eq!(config.io_uring_policy, fast_io::IoUringPolicy::Auto);
+}
+
+mod channel_cap_env {
+    use std::ffi::OsStr;
+    use std::sync::Mutex;
+
+    use platform::env::EnvGuard;
+
+    use crate::disk_commit::config::{
+        DEFAULT_CHANNEL_CAPACITY, DiskCommitConfig, ENV_CHANNEL_CAPACITY,
+    };
+
+    /// Serializes env mutation across this module's tests so concurrent
+    /// test threads do not race on shared process state.
+    pub(super) static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn unset_uses_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::remove(ENV_CHANNEL_CAPACITY);
+        let config = DiskCommitConfig::default();
+        assert_eq!(config.channel_capacity, DEFAULT_CHANNEL_CAPACITY);
+        assert_eq!(config.effective_channel_capacity(), 128);
+    }
+
+    #[test]
+    fn valid_value_applied() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_CHANNEL_CAPACITY, OsStr::new("256"));
+        let config = DiskCommitConfig::default();
+        assert_eq!(config.channel_capacity, 256);
+        assert_eq!(config.effective_channel_capacity(), 256);
+    }
+
+    #[test]
+    fn below_min_clamped() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_CHANNEL_CAPACITY, OsStr::new("1"));
+        let config = DiskCommitConfig::default();
+        assert_eq!(config.channel_capacity, 8);
+    }
+
+    #[test]
+    fn above_max_clamped() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_CHANNEL_CAPACITY, OsStr::new("100000"));
+        let config = DiskCommitConfig::default();
+        assert_eq!(config.channel_capacity, 4096);
+    }
+
+    #[test]
+    fn garbage_falls_back_to_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_CHANNEL_CAPACITY, OsStr::new("not_a_number"));
+        let config = DiskCommitConfig::default();
+        assert_eq!(config.channel_capacity, DEFAULT_CHANNEL_CAPACITY);
+    }
+
+    #[test]
+    fn negative_falls_back_to_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_CHANNEL_CAPACITY, OsStr::new("-8"));
+        let config = DiskCommitConfig::default();
+        assert_eq!(config.channel_capacity, DEFAULT_CHANNEL_CAPACITY);
+    }
 }
 
 #[test]

--- a/crates/transfer/src/pipeline/mod.rs
+++ b/crates/transfer/src/pipeline/mod.rs
@@ -34,7 +34,8 @@
 //!    requests. This simplifies synchronization.
 //!
 //! 2. **Bounded pipeline window**: Limits memory usage and prevents overwhelming
-//!    the sender. Configurable via `--pipeline-window` CLI option.
+//!    the sender. Configurable via the `OC_RSYNC_PIPELINE_WINDOW` environment
+//!    variable.
 //!
 //! 3. **Signature generation during wait**: While waiting for responses, we can
 //!    generate signatures for upcoming files, utilizing otherwise idle CPU time.
@@ -61,6 +62,8 @@ pub mod receiver;
 pub mod spsc;
 mod state;
 
+use std::env;
+
 pub use job::{FileJob, FileList, MAX_RETRY_COUNT, TransferFlags};
 pub use pending::PendingTransfer;
 pub use state::PipelineState;
@@ -81,6 +84,30 @@ pub const MIN_PIPELINE_WINDOW: usize = 1;
 /// Limits memory usage. 256 requests × ~500 bytes = ~128KB.
 pub const MAX_PIPELINE_WINDOW: usize = 256;
 
+/// Environment variable overriding the default pipeline window size.
+///
+/// Parsed as an unsigned integer and clamped to `[1, 256]`. Unset or
+/// unparseable values fall back to [`DEFAULT_PIPELINE_WINDOW`]. Local
+/// tuning knob only - never forwarded to a remote peer and never observable
+/// on the wire.
+pub const ENV_PIPELINE_WINDOW: &str = "OC_RSYNC_PIPELINE_WINDOW";
+
+/// Resolves the default window size, honoring [`ENV_PIPELINE_WINDOW`].
+///
+/// Read once at config construction. Invalid values are ignored in favor
+/// of [`DEFAULT_PIPELINE_WINDOW`], matching the tolerant parse style of
+/// the other `OC_RSYNC_*` tuning knobs.
+fn window_size_from_env() -> usize {
+    env::var(ENV_PIPELINE_WINDOW)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .map_or(DEFAULT_PIPELINE_WINDOW, |value| {
+            usize::try_from(value)
+                .unwrap_or(MAX_PIPELINE_WINDOW)
+                .clamp(MIN_PIPELINE_WINDOW, MAX_PIPELINE_WINDOW)
+        })
+}
+
 /// Configuration for pipelined transfers.
 #[derive(Debug, Clone)]
 pub struct PipelineConfig {
@@ -91,7 +118,7 @@ pub struct PipelineConfig {
 impl Default for PipelineConfig {
     fn default() -> Self {
         Self {
-            window_size: DEFAULT_PIPELINE_WINDOW,
+            window_size: window_size_from_env(),
         }
     }
 }
@@ -113,10 +140,61 @@ impl PipelineConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
+    use std::sync::Mutex;
+
+    use platform::env::EnvGuard;
+
     use super::*;
+
+    /// Serializes env mutation across this module's tests so concurrent
+    /// test threads do not race on shared process state.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn default_config_uses_default_window() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::remove(ENV_PIPELINE_WINDOW);
+        let config = PipelineConfig::default();
+        assert_eq!(config.window_size, DEFAULT_PIPELINE_WINDOW);
+    }
+
+    #[test]
+    fn env_window_valid_value_applied() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_PIPELINE_WINDOW, OsStr::new("32"));
+        let config = PipelineConfig::default();
+        assert_eq!(config.window_size, 32);
+    }
+
+    #[test]
+    fn env_window_below_min_clamped() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_PIPELINE_WINDOW, OsStr::new("0"));
+        let config = PipelineConfig::default();
+        assert_eq!(config.window_size, MIN_PIPELINE_WINDOW);
+    }
+
+    #[test]
+    fn env_window_above_max_clamped() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_PIPELINE_WINDOW, OsStr::new("100000"));
+        let config = PipelineConfig::default();
+        assert_eq!(config.window_size, MAX_PIPELINE_WINDOW);
+    }
+
+    #[test]
+    fn env_window_garbage_falls_back_to_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_PIPELINE_WINDOW, OsStr::new("not_a_number"));
+        let config = PipelineConfig::default();
+        assert_eq!(config.window_size, DEFAULT_PIPELINE_WINDOW);
+    }
+
+    #[test]
+    fn env_window_negative_falls_back_to_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set(ENV_PIPELINE_WINDOW, OsStr::new("-4"));
         let config = PipelineConfig::default();
         assert_eq!(config.window_size, DEFAULT_PIPELINE_WINDOW);
     }

--- a/docs/oc-extension-env-reference.md
+++ b/docs/oc-extension-env-reference.md
@@ -82,6 +82,24 @@ value (`0`, `false`, `off`, `no` - case-insensitive) pins the
 deterministic static queue depth with no controller, for reproducible
 runs and debugging. Any other value (or unset) keeps adaptation on.
 
+### OC_RSYNC_DISK_COMMIT_CHANNEL_CAP
+
+Capacity, in messages, of the SPSC channel between the receiver's network
+thread and the disk-commit thread. Unsigned integer, clamped to 8..=4096.
+Default: 128 (roughly 4 MiB of buffered chunks at the average chunk
+size). Unset or unparseable values fall back to the default. Read at
+disk-commit config construction. Purely a memory/pipelining trade-off:
+larger values absorb burstier disk latency at the cost of peak RSS.
+
+### OC_RSYNC_PIPELINE_WINDOW
+
+Number of concurrent file requests the pipelined receiver keeps in
+flight. Unsigned integer, clamped to 1..=256 (`1` is synchronous
+operation). Default: 64. Unset or unparseable values fall back to the
+default. Read at pipeline config construction. Larger windows hide more
+per-file round-trip latency on high-latency links; each pending request
+costs roughly 500 bytes.
+
 ### OC_RSYNC_REORDER_RING_CAP
 
 Pins the per-file reorder-ring capacity used by the parallel delta


### PR DESCRIPTION
Makes the two hardcoded receiver-pipeline buffer capacities runtime-configurable via environment variables, enabling buffer-sizing sweeps without recompiles.

## Knobs added

| Variable | Controls | Clamp | Default |
|---|---|---|---|
| `OC_RSYNC_DISK_COMMIT_CHANNEL_CAP` | SPSC file-queue capacity between the network thread and the disk-commit thread (`disk_commit/config.rs`) | 8..=4096 | 128 |
| `OC_RSYNC_PIPELINE_WINDOW` | Concurrent in-flight file requests in the pipelined receiver (`pipeline/mod.rs`) | 1..=256 | 64 |

The pipeline window was previously fixed at `PipelineConfig::default()` in every production call site (no CLI flag or `TransferConfig` path sets it), so it qualified as a truly uncovered bound. The buffer-pool knobs (`OC_RSYNC_BYTE_BUDGET`, `OC_RSYNC_BUFFER_POOL_SIZE`, `OC_BUFFER_POOL_BLOCK_SIZE`) already have env coverage and are untouched.

## Behavior

- Tolerant parse, matching the existing `OC_RSYNC_*` tuning knobs (e.g. the spill env overrides): the value parses as an unsigned integer and clamps to the bounds above; unset, empty, negative, or garbage values are ignored and the compiled default applies. Never aborts a transfer.
- Read once at config construction; changing the variable has no effect on a running process.
- Env-only by design (tuning/experiment knob - no CLI flag), never forwarded to a remote peer.
- Observable-neutral: capacity changes memory footprint and timing only; wire bytes, stats, stdout/stderr, and exit codes are identical. With the variables unset, behavior is byte-identical to before.

## Tests

Per knob: unset -> default, valid -> applied, below-min -> clamped, above-max -> clamped, garbage -> default, negative -> default. Env mutation is isolated via the shared `platform::env::EnvGuard` plus a module-level lock.

Both variables are documented in `docs/oc-extension-env-reference.md` under Concurrency.

## Use case

Enables the planned buffer-sizing sweep: benchmark harnesses can vary the disk-commit queue depth and pipeline window across runs from the environment, with the clamps guaranteeing every swept value stays inside the ranges the code already supports.
