### PR TITLE
perf(daemon): block the accept loop on readiness instead of busy-polling

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -53,12 +53,10 @@ daemon-seccomp = ["dep:seccompiler"]
 daemon-zero-copy = ["fast_io/iouring-send-zc"]
 # macOS-only, default-off: source accepted connections in the daemon accept
 # loop from a `kqueue(2)` `EVFILT_READ` readiness wait instead of the portable
-# non-blocking-accept-plus-50ms-sleep busy-poll. Event-driven (parks in the
-# kernel until a connection arrives or the signal-check timeout elapses) rather
-# than busy-waiting, dropping first-connection latency on a quiet daemon from up
-# to 50ms to a syscall round-trip. Falls back to the portable engines if kqueue
-# setup fails, so it never breaks connection service. Off by default: the
-# default build uses the portable accept path unchanged. No-op on non-macOS.
+# engines' per-listener `poll(2)` park, giving a single kernel wait over all
+# listener fds. Falls back to the portable engines if kqueue setup fails, so it
+# never breaks connection service. Off by default: the default build uses the
+# portable accept path unchanged. No-op on non-macOS.
 macos-kqueue = []
 
 [dependencies]
@@ -85,8 +83,9 @@ checksums = { path = "../checksums" }
 libc = { workspace = true }
 # `process` enables nix::sys::prctl for PR_SET_NO_NEW_PRIVS startup hardening
 # (Linux only); `fs` enables nix::fcntl for the per-slot record locks in the
-# connection limiter, used on every unix target.
-nix = { workspace = true, features = ["process", "fs"] }
+# connection limiter, used on every unix target; `poll` enables nix::poll for
+# the accept loop's listener readiness park.
+nix = { workspace = true, features = ["process", "fs", "poll"] }
 
 # fast_io carries the Landlock LSM defense-in-depth helper (SEC-1.p). On
 # non-Linux targets the stub module compiles with the same public surface

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
@@ -41,11 +41,55 @@ enum AcceptOutcome {
     Closed,
 }
 
-/// Single-listener accept engine: non-blocking `accept` with a 50ms idle sleep.
+/// Signal-check cadence for the portable engines' readiness wait, in
+/// milliseconds.
+///
+/// Bounds the `poll(2)` park so shutdown/reload/graceful-exit flags are
+/// re-inspected at the same 50ms interval the previous `WouldBlock` sleep
+/// provided - shutdown latency is unchanged, only the idle mechanism differs.
+const READINESS_WAIT_MILLIS: u16 = 50;
+
+/// Parks until `listener` has a pending connection or `timeout_millis` elapses.
+///
+/// Returns `Ok(true)` when the listener is readable (an `accept` attempt is
+/// warranted) and `Ok(false)` on timeout or `EINTR` (the caller re-checks
+/// signal flags and parks again). Replaces the previous
+/// non-blocking-`accept`-plus-sleep idle shape, which burned one `accept4`
+/// `EAGAIN` per wakeup on a quiet daemon; parking on readiness means `accept`
+/// is invoked roughly once per connection.
+///
+/// upstream: socket.c `start_accept_loop()` parks in `select(2)` over the
+/// listener fds before calling `accept(2)`; this is the single-fd equivalent.
+#[cfg(unix)]
+fn wait_for_incoming(listener: &TcpListener, timeout_millis: u16) -> io::Result<bool> {
+    use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+    use std::os::fd::AsFd;
+
+    let mut fds = [PollFd::new(listener.as_fd(), PollFlags::POLLIN)];
+    match poll(&mut fds, PollTimeout::from(timeout_millis)) {
+        Ok(0) => Ok(false),
+        Ok(_) => Ok(true),
+        Err(nix::errno::Errno::EINTR) => Ok(false),
+        Err(errno) => Err(io::Error::from(errno)),
+    }
+}
+
+/// Portable fallback for targets without `poll(2)`: sleep the signal-check
+/// interval, then report readiness so the caller falls back to a non-blocking
+/// `accept` probe - the pre-readiness idle shape, kept only where no readiness
+/// primitive is available (the daemon accept path is Unix-only in practice).
+#[cfg(not(unix))]
+fn wait_for_incoming(_listener: &TcpListener, timeout_millis: u16) -> io::Result<bool> {
+    thread::sleep(Duration::from_millis(u64::from(timeout_millis)));
+    Ok(true)
+}
+
+/// Single-listener accept engine: parks on listener readiness, then accepts.
 ///
 /// Used when exactly one address family is bound (IPv4-only or IPv6-only). The
-/// 50ms WouldBlock interval bounds first-connection latency on a quiet daemon
-/// while still letting the loop body re-check signal flags promptly.
+/// bounded readiness wait ([`READINESS_WAIT_MILLIS`]) lets the loop body
+/// re-check signal flags promptly while a quiet daemon sleeps in the kernel
+/// instead of busy-polling `accept`.
 struct SingleListenerEngine {
     listener: TcpListener,
     local_addr: SocketAddr,
@@ -71,6 +115,20 @@ impl SingleListenerEngine {
 
 impl AcceptEngine for SingleListenerEngine {
     fn poll(&mut self) -> Result<AcceptOutcome, DaemonError> {
+        match wait_for_incoming(&self.listener, READINESS_WAIT_MILLIS) {
+            Ok(true) => {}
+            // Timeout or EINTR: let the caller re-check signal flags. The
+            // wait itself parked, so no additional sleep is needed.
+            Ok(false) => return Ok(AcceptOutcome::Idle),
+            Err(error) => {
+                // A poll(2) failure on a valid listener fd is as transient as
+                // an accept(2) failure: log, back off so a persistent error
+                // cannot hot-spin, and keep serving.
+                warn_transient_accept_failure(self.log_sink.as_ref(), self.local_addr, &error);
+                thread::sleep(Duration::from_millis(50));
+                return Ok(AcceptOutcome::Idle);
+            }
+        }
         match self.listener.accept() {
             Ok((tcp_stream, raw_peer_addr)) => {
                 if let Err(error) = tcp_stream.set_nonblocking(false) {
@@ -85,11 +143,9 @@ impl AcceptEngine for SingleListenerEngine {
                 Ok(AcceptOutcome::Connection(tcp_stream, raw_peer_addr))
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                // No pending connection - sleep briefly then let the caller
-                // re-check signal flags. The 50ms interval matches the
-                // dual-stack engine so first-connection latency on a quiet
-                // daemon is bounded by half the sleep interval.
-                thread::sleep(Duration::from_millis(50));
+                // Spurious readiness (the pending connection was reset before
+                // accept could take it). No sleep: the next poll parks in the
+                // readiness wait again.
                 Ok(AcceptOutcome::Idle)
             }
             Err(error) if error.kind() == io::ErrorKind::Interrupted => Ok(AcceptOutcome::Idle),
@@ -162,10 +218,10 @@ fn relay_accept_item(
 /// Dual-stack accept engine: one acceptor thread per listener, fanned into an
 /// MPSC channel.
 ///
-/// Used when multiple address families are bound. Each acceptor thread runs a
-/// non-blocking accept loop so it can observe the shutdown flag, and forwards
-/// accepted (blocking) streams through the channel. A single family failing
-/// does not tear down the daemon: the engine tracks live acceptors and only
+/// Used when multiple address families are bound. Each acceptor thread parks
+/// on its listener's readiness with a bounded wait so it can observe the
+/// shutdown flag, and forwards accepted (blocking) streams through the
+/// channel. A single family failing does not tear down the daemon: the engine tracks live acceptors and only
 /// escalates an accept error to a fatal exit once every family has dropped out.
 ///
 /// upstream: socket.c `start_accept_loop()` - one busted descriptor does not
@@ -200,7 +256,8 @@ impl MultiListenerEngine {
             let log_sink = log_sink.clone();
 
             // Set non-blocking so acceptor threads can check the shutdown flag
-            // without getting stuck in a blocking accept() call.
+            // without getting stuck in a blocking accept() call; the bounded
+            // readiness wait below does the actual idle parking.
             if let Err(error) = listener.set_nonblocking(true) {
                 return Err(bind_error(local_addr, error));
             }
@@ -209,6 +266,23 @@ impl MultiListenerEngine {
                 while !shutdown.load(Ordering::Relaxed)
                     && !graceful_exit.load(Ordering::Relaxed)
                 {
+                    match wait_for_incoming(&listener, READINESS_WAIT_MILLIS) {
+                        Ok(true) => {}
+                        // Timeout or EINTR: re-check the shutdown flags.
+                        Ok(false) => continue,
+                        Err(error) => {
+                            // Transient like an accept(2) failure: log, back
+                            // off so a persistent error cannot hot-spin, keep
+                            // accepting.
+                            warn_transient_accept_failure(
+                                log_sink.as_ref(),
+                                local_addr,
+                                &error,
+                            );
+                            thread::sleep(Duration::from_millis(50));
+                            continue;
+                        }
+                    }
                     match listener.accept() {
                         Ok((stream, peer_addr)) => {
                             // BSD-derived kernels (macOS, FreeBSD) propagate the
@@ -228,7 +302,8 @@ impl MultiListenerEngine {
                             }
                         }
                         Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                            thread::sleep(Duration::from_millis(50));
+                            // Spurious readiness; the next iteration parks in
+                            // the readiness wait again, so no sleep here.
                             continue;
                         }
                         Err(error) if error.kind() == io::ErrorKind::Interrupted => {
@@ -316,12 +391,10 @@ impl AcceptEngine for MultiListenerEngine {
 /// macOS `kqueue` accept engine: one `EVFILT_READ` registration per listener,
 /// readiness-driven `accept` that yields exactly one connection per poll.
 ///
-/// Replaces the busy-wait shape of the portable engines (non-blocking `accept`
-/// plus a 50ms `WouldBlock` sleep) with a single `kevent(2)` wait over all
-/// listener fds. On a quiet daemon the thread parks in the kernel until a
-/// connection arrives or the 100ms signal-check timeout elapses, so
-/// first-connection latency drops from up to 50ms to a syscall round-trip while
-/// still bounding shutdown-flag inspection to the same 100ms cadence the
+/// Replaces the portable engines' per-listener `poll(2)` park with a single
+/// `kevent(2)` wait over all listener fds. On a quiet daemon the thread parks
+/// in the kernel until a connection arrives or the 100ms signal-check timeout
+/// elapses, bounding shutdown-flag inspection to the same cadence the
 /// dual-stack engine uses.
 ///
 /// # One connection per poll (admission correctness)

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1621,9 +1621,9 @@ fn warn_per_family_accept_failure_labels_ipv4() {
 
 #[test]
 fn single_listener_engine_poll_idle_when_no_connection() {
-    // A quiet daemon must yield control rather than error: the non-blocking
-    // accept returns WouldBlock, which the engine maps to AcceptOutcome::Idle
-    // after its bounded sleep so the accept loop can re-check signal flags.
+    // A quiet daemon must yield control rather than error: the bounded
+    // readiness wait times out, which the engine maps to AcceptOutcome::Idle
+    // so the accept loop can re-check signal flags.
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let local = listener.local_addr().expect("local addr");
     let mut engine = SingleListenerEngine::new(listener, local, None).expect("engine");
@@ -1632,6 +1632,151 @@ fn single_listener_engine_poll_idle_when_no_connection() {
         matches!(engine.poll().expect("poll"), AcceptOutcome::Idle),
         "poll with no pending connection must yield Idle"
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn wait_for_incoming_times_out_on_idle_listener() {
+    // With no pending connection the readiness wait must report Ok(false)
+    // after its bounded timeout - the signal-check path - instead of readable.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    assert!(
+        !wait_for_incoming(&listener, 10).expect("poll(2)"),
+        "an idle listener must time out as not-readable"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn wait_for_incoming_wakes_on_connection_while_parked() {
+    // The park must wake on real readiness, not run its timeout to completion:
+    // with a generous 5s timeout and a client connecting shortly after the
+    // wait begins, the call must return readable well before the timeout. A
+    // sleep-then-probe implementation (the pre-fix busy-poll shape, or the
+    // non-unix stub) would burn the full interval before reporting readiness.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let local = listener.local_addr().expect("local addr");
+
+    let client = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(50));
+        TcpStream::connect(local).expect("connect")
+    });
+
+    let start = std::time::Instant::now();
+    let readable = wait_for_incoming(&listener, 5000).expect("poll(2)");
+    let elapsed = start.elapsed();
+
+    assert!(readable, "a pending connection must report readable");
+    assert!(
+        elapsed < Duration::from_secs(4),
+        "the park must wake on readiness, not run the 5s timeout down \
+         (took {elapsed:?})"
+    );
+    let _ = client.join();
+}
+
+#[test]
+fn single_listener_engine_accepts_queued_connection_on_first_poll() {
+    // Promptness contract, count-based: with a connection already queued on
+    // the listen backlog, the very FIRST poll() must return Connection - no
+    // Idle iterations, no polling-interval delay before the accept happens.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let local = listener.local_addr().expect("local addr");
+
+    let _client = TcpStream::connect(local).expect("connect");
+    // Let the kernel finish the loopback handshake and queue the connection.
+    thread::sleep(Duration::from_millis(20));
+
+    let mut engine = SingleListenerEngine::new(listener, local, None).expect("engine");
+    assert!(
+        matches!(
+            engine.poll().expect("poll"),
+            AcceptOutcome::Connection(_, _)
+        ),
+        "a queued connection must be delivered on the first poll"
+    );
+}
+
+#[test]
+fn accept_loop_stops_after_shutdown_signal_while_parked() {
+    // A shutdown flag raised while the engine is parked in its readiness wait
+    // must still stop the accept loop: the park is bounded by the signal-check
+    // interval, after which check_signals_and_maintain observes the flag and
+    // breaks. Event-based: the scoped join only completes if the loop exits
+    // (a wedged loop hangs the test until the harness timeout kills it).
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let local = listener.local_addr().expect("local addr");
+
+    let flags = no_op_signal_flags();
+    let shutdown = Arc::clone(&flags.shutdown);
+    let config_path: Option<PathBuf> = None;
+    let limiter: Option<Arc<ConnectionLimiter>> = None;
+    let log_sink: Option<SharedLogSink> = None;
+    let notifier = systemd::ServiceNotifier::new();
+
+    thread::scope(|scope| {
+        let handle = scope.spawn(|| {
+            let mut engine =
+                SingleListenerEngine::new(listener, local, None).expect("engine");
+            let mut state = test_accept_loop_state(
+                &flags,
+                &config_path,
+                &limiter,
+                &log_sink,
+                &notifier,
+                ConnectionCounter::new(),
+                None,
+            );
+            run_accept_loop(&mut engine, &mut state)
+        });
+
+        // Give the loop time to enter the parked readiness wait, then raise
+        // the flag. The sleep only steers WHICH code path is parked when the
+        // flag lands; the assertion does not depend on it.
+        thread::sleep(Duration::from_millis(20));
+        shutdown.store(true, Ordering::Relaxed);
+
+        let result = handle.join().expect("accept loop thread");
+        assert!(
+            result.is_ok(),
+            "shutdown while parked must stop the loop cleanly"
+        );
+    });
+}
+
+#[test]
+fn multi_listener_engine_shutdown_joins_parked_acceptors() {
+    // Dual-stack teardown: shutdown() must wake and join acceptor threads that
+    // are parked in their readiness wait with no traffic. Event-based - a
+    // parked acceptor that never re-checks the flag would wedge join() and
+    // hang the test until the harness timeout kills it.
+    // Two loopback listeners stand in for the dual-stack pair; the engine is
+    // family-agnostic and some CI sandboxes lack IPv6.
+    let first = TcpListener::bind("127.0.0.1:0").expect("bind first");
+    let second = TcpListener::bind("127.0.0.1:0").expect("bind second");
+    let addrs = [
+        first.local_addr().expect("first addr"),
+        second.local_addr().expect("second addr"),
+    ];
+
+    let flags = no_op_signal_flags();
+    let config_path: Option<PathBuf> = None;
+    let limiter: Option<Arc<ConnectionLimiter>> = None;
+    let log_sink: Option<SharedLogSink> = None;
+    let notifier = systemd::ServiceNotifier::new();
+    let state = test_accept_loop_state(
+        &flags,
+        &config_path,
+        &limiter,
+        &log_sink,
+        &notifier,
+        ConnectionCounter::new(),
+        None,
+    );
+
+    let mut engine =
+        MultiListenerEngine::new(vec![first, second], &addrs, &state).expect("engine");
+    engine.shutdown();
 }
 
 #[test]


### PR DESCRIPTION
## Problem

strace on a single daemon pull measured `accept4 = 344` calls with **342 EAGAIN**: the portable accept engines ran a non-blocking `accept` probe and slept 50ms on `WouldBlock`, so a quiet daemon burned one failed `accept4` per wakeup, cost idle CPU, and contributed tail variance (sigma 51.9ms, max 381ms on daemon-pull).

## Fix

Park the accept path on real readiness instead of probe-and-sleep:

- New `wait_for_incoming(listener, timeout_ms)` helper parks in `poll(2)` (`POLLIN` on the listener fd) via the `nix::poll` safe wrapper already in the daemon's dependency tree (only the `poll` feature flag is new). The daemon crate stays free of unsafe code.
- `SingleListenerEngine::poll` and each dual-stack acceptor thread now wait for readiness first and call `accept` only when the listener is readable, so `accept4` runs roughly once per connection.
- The park is bounded by the **same 50ms cadence** the removed `WouldBlock` sleeps provided, so shutdown / graceful-exit / reload flags are re-inspected at an unchanged interval - shutdown latency is preserved exactly; only the idle mechanism differs. No wake-fd plumbing and no async runtime: this stays minimal and local, and the planned shared readiness primitive (the perform_io work) may later absorb the helper.
- `WouldBlock` after a readable poll is spurious readiness (client reset before accept): return Idle with no sleep; the next iteration parks again.
- A `poll(2)` failure is treated exactly like a transient `accept(2)` failure - warn, brief backoff, keep serving (upstream: socket.c:593 `if (fd < 0) continue;`).
- Targets without `poll(2)` keep the previous sleep-then-probe shape as a fallback stub; the daemon accept path is Unix-only in practice.

upstream: socket.c `start_accept_loop()` parks in `select(2)` over the listener fds before calling `accept(2)`; this is the per-listener equivalent. The macOS kqueue engine already had this shape; its docs are updated to reflect that the portable engines no longer busy-poll.

## Preserved behavior

- Shutdown/graceful-exit latency: identical bounded flag-check cadence (50ms portable, 100ms dual-stack relay / kqueue).
- `--max-connections`: still one connection per poll through the shared admission path; the relay bound (256) and acceptor fan-in are untouched.
- Transient accept errors stay non-fatal (the EMFILE regression test still passes with the new shape).
- Accepted streams are still reset to blocking before handoff.

## Tests

- `wait_for_incoming_times_out_on_idle_listener` - bounded timeout reports not-readable.
- `wait_for_incoming_wakes_on_connection_while_parked` - a 5s park wakes on a mid-park connection instead of running the timeout down (discriminates parking from sleep-then-probe).
- `single_listener_engine_accepts_queued_connection_on_first_poll` - count-based promptness: the first `poll()` returns the queued connection, no Idle iterations.
- `accept_loop_stops_after_shutdown_signal_while_parked` - `run_accept_loop` exits cleanly when shutdown is raised while the engine is parked.
- `multi_listener_engine_shutdown_joins_parked_acceptors` - teardown joins acceptor threads parked with no traffic.
- Existing engine/accept/soak tests unchanged and green, including `single_listener_engine_poll_survives_transient_accept_error`.

`cargo fmt --all -- --check`, `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`, and `cargo nextest run -p daemon --all-features -E 'test(accept) or test(listener) or test(shutdown) or test(soak) or test(wait_for_incoming)'` (69 passed) are clean.

Host strace verification (`accept4` ~1/connection, idle CPU ~0) is deferred to the follow-up profiling gate.
