### PR TITLE
fix(transfer): print the => hardlink leader on itemized follower rows

### DIFF
--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -791,10 +791,18 @@ impl ReceiverContext {
                             if link_meta.dev() == leader_meta.dev()
                                 && link_meta.ino() == leader_meta.ino()
                             {
-                                // upstream: hlink.c - hardlink already correct, metadata only
+                                // upstream: hlink.c:218-222 - hardlink already
+                                // correct, metadata only; the itemize xname is
+                                // the empty string, so no ` => ` suffix renders
+                                // (log.c:644 gates on `hlink && *hlink`).
                                 let iflags = ItemFlags::from_raw(0);
-                                let _ =
-                                    self.emit_itemize_indexed(writer, follower_ndx, &iflags, entry);
+                                let _ = self.emit_itemize_indexed(
+                                    writer,
+                                    follower_ndx,
+                                    &iflags,
+                                    entry,
+                                    None,
+                                );
                                 // upstream: hlink.c:223 - "%s is uptodate"
                                 // emitted at INFO_GTE(NAME, 2) when the
                                 // destination already hard-links to the leader.
@@ -896,13 +904,24 @@ impl ReceiverContext {
                     self.hardlink_tracker = Some(tracker);
                     return Err(e);
                 }
-                // upstream: hlink.c:finish_hard_link() - itemize new hardlink
+                // upstream: hlink.c:finish_hard_link() - itemize new hardlink.
+                // The xname is the leader's transfer-relative name so the row
+                // renders the `%L` ` => <leader>` suffix (hlink.c:232-234 pass
+                // `realname`; log.c:643-646 render ` => hlink`).
                 let iflags = ItemFlags::from_raw(
                     ItemFlags::ITEM_LOCAL_CHANGE
                         | ItemFlags::ITEM_XNAME_FOLLOWS
                         | ItemFlags::ITEM_IS_NEW,
                 );
-                let _ = self.emit_itemize_indexed(writer, follower_ndx, &iflags, entry);
+                let leader_rel = leader_path.strip_prefix(dest_dir).unwrap_or(&leader_path);
+                let xname = leader_rel.display().to_string();
+                let _ = self.emit_itemize_indexed(
+                    writer,
+                    follower_ndx,
+                    &iflags,
+                    entry,
+                    Some(xname.as_bytes()),
+                );
                 // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1)
                 // when a hardlink follower is linked to its leader.
                 info_log!(

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -304,19 +304,23 @@ impl ReceiverContext {
     /// rows.
     ///
     /// Pure formatting: applies the created-root-directory override and the
-    /// significance gate, then formats via `format_itemize_line`. Routing to a
-    /// sink (stdout vs MSG_INFO vs suppression) is the caller's concern - see
-    /// [`Self::emit_itemize`].
+    /// significance gate, then formats via `format_itemize_line`. `xname` is the
+    /// alternate-basis name (the hard-link leader from `hlink.c:232-234`); when
+    /// present and non-empty it renders the `%L` ` => <xname>` suffix. Routing
+    /// to a sink (stdout vs MSG_INFO vs suppression) is the caller's concern -
+    /// see [`Self::emit_itemize`].
     ///
     /// # Upstream Reference
     ///
     /// - `generator.c:574-576` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
     /// - `main.c:803-805` - `FLAG_DIR_CREATED` for a pre-flight-mkdir'd root
+    /// - `log.c:643-655` - `%L` renders ` => hlink` for a non-empty xname
     /// - `log.c:707-710` - direction glyph selection
     pub(in crate::receiver) fn render_itemize_line(
         &self,
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
+        xname: Option<&[u8]>,
     ) -> Option<String> {
         let effective_iflags = self.itemize_effective_flags(iflags, entry)?;
         let ctx = self.itemize_context();
@@ -325,7 +329,7 @@ impl ReceiverContext {
             entry,
             self.itemize_is_sender(),
             &ctx,
-            None,
+            xname,
         ))
     }
 
@@ -480,6 +484,7 @@ impl ReceiverContext {
         writer: &mut W,
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
+        xname: Option<&[u8]>,
     ) -> std::io::Result<()> {
         if !self.should_emit_itemize() {
             return Ok(());
@@ -493,7 +498,7 @@ impl ReceiverContext {
         if self.collect_out_format_events() {
             return Ok(());
         }
-        let Some(line) = self.render_itemize_line(iflags, entry) else {
+        let Some(line) = self.render_itemize_line(iflags, entry, xname) else {
             return Ok(());
         };
         if self.config.connection.client_mode {
@@ -516,9 +521,12 @@ impl ReceiverContext {
     /// Unlike symlinks and specials (which route through
     /// [`emit_or_record_itemize`](Self::emit_or_record_itemize) so their default
     /// `-i` rows also defer into flist order), a follower's default `-i` row keeps
-    /// the immediate path: its deferred string form cannot yet reproduce the
-    /// ` => leader` xname suffix, and its leader-selection order is a separate
-    /// divergence, so deferring it would change more than ordering.
+    /// the immediate path: its leader-selection order is a separate divergence,
+    /// so deferring it would change more than ordering.
+    ///
+    /// `xname` carries the hard-link leader's transfer-relative name so the
+    /// default `-i` row renders the `%L` ` => <leader>` suffix
+    /// (upstream `hlink.c:232-234` + `log.c:643-646`).
     ///
     /// Off a custom `--out-format` this defers to the unchanged immediate path.
     pub(in crate::receiver) fn emit_itemize_indexed<W: crate::writer::MsgInfoSender + ?Sized>(
@@ -527,12 +535,13 @@ impl ReceiverContext {
         flist_idx: usize,
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
+        xname: Option<&[u8]>,
     ) -> std::io::Result<()> {
         if self.collect_out_format_events() {
             self.record_itemize(flist_idx, iflags, entry);
             return Ok(());
         }
-        self.emit_itemize(writer, iflags, entry)
+        self.emit_itemize(writer, iflags, entry, xname)
     }
 
     /// Emits over-the-wire itemize records for every hardlink follower so a
@@ -703,7 +712,7 @@ impl ReceiverContext {
             self.record_itemize(flist_idx, iflags, entry);
             Ok(())
         } else {
-            self.emit_itemize(writer, iflags, entry)
+            self.emit_itemize(writer, iflags, entry, None)
         }
     }
 
@@ -742,7 +751,7 @@ impl ReceiverContext {
         if !self.should_emit_itemize() {
             return;
         }
-        if let Some(line) = self.render_itemize_line(iflags, entry) {
+        if let Some(line) = self.render_itemize_line(iflags, entry, None) {
             self.itemize_rows
                 .borrow_mut()
                 .entry(flist_idx)

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -62,7 +62,7 @@ fn render_itemize_new_file_transfer() {
     // upstream: log.c:707-710 - a server-mode receiver is the remote end of a
     // push (the client is the sender), so the transfer glyph is `<`.
     assert_eq!(
-        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        ctx.render_itemize_line(&iflags, &entry, None).as_deref(),
         Some("<f+++++++++ docs/readme.txt\n")
     );
 }
@@ -78,7 +78,7 @@ fn render_itemize_updated_file_transfer() {
 
     // upstream: log.c:707-710 - server-mode receiver renders the push `<` glyph.
     assert_eq!(
-        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        ctx.render_itemize_line(&iflags, &entry, None).as_deref(),
         Some("<f......... data.bin\n")
     );
 }
@@ -93,7 +93,7 @@ fn render_itemize_directory_creation() {
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
     assert_eq!(
-        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        ctx.render_itemize_line(&iflags, &entry, None).as_deref(),
         Some("cd+++++++++ subdir/\n")
     );
 }
@@ -116,7 +116,7 @@ fn render_itemize_root_directory_emits_creation_glyph_when_freshly_created() {
     let iflags = ItemFlags::from_raw(0);
 
     assert_eq!(
-        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        ctx.render_itemize_line(&iflags, &entry, None).as_deref(),
         Some("cd+++++++++ ./\n")
     );
 }
@@ -137,7 +137,7 @@ fn render_itemize_root_directory_no_glyph_when_dest_root_preexisted() {
     let entry = FileEntry::new_directory(".".into(), 0o755);
     let iflags = ItemFlags::from_raw(0);
 
-    assert_eq!(ctx.render_itemize_line(&iflags, &entry), None);
+    assert_eq!(ctx.render_itemize_line(&iflags, &entry, None), None);
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn render_itemize_up_to_date_file() {
 
     // upstream: generator.c:574-576 - no line when iflags has no significant
     // flags (file is completely unchanged)
-    assert_eq!(ctx.render_itemize_line(&iflags, &entry), None);
+    assert_eq!(ctx.render_itemize_line(&iflags, &entry, None), None);
 }
 
 #[test]
@@ -171,7 +171,8 @@ fn emit_itemize_server_mode_does_not_forward_msg_info() {
     let entry = FileEntry::new_file("docs/readme.txt".into(), 1024, 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
 
-    ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
+    ctx.emit_itemize(&mut writer, &iflags, &entry, None)
+        .unwrap();
 
     assert!(writer.messages.is_empty());
 }
@@ -191,7 +192,8 @@ fn emit_itemize_client_mode_uses_stdout_not_msg_info() {
     let entry = FileEntry::new_file("test.txt".into(), 100, 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
 
-    ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
+    ctx.emit_itemize(&mut writer, &iflags, &entry, None)
+        .unwrap();
 
     assert!(writer.messages.is_empty());
 }
@@ -340,7 +342,7 @@ fn indexed_emit_off_out_format_uses_immediate_path() {
     let entry = FileEntry::new_file("leader.txt".into(), 10, 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
-    ctx.emit_itemize_indexed(&mut writer, 1, &iflags, &entry)
+    ctx.emit_itemize_indexed(&mut writer, 1, &iflags, &entry, None)
         .unwrap();
 
     // Server-mode receiver writes no client-visible row and collects nothing.
@@ -397,7 +399,8 @@ fn emit_itemize_skipped_without_itemize_flag() {
     let entry = FileEntry::new_file("test.txt".into(), 100, 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
 
-    ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
+    ctx.emit_itemize(&mut writer, &iflags, &entry, None)
+        .unwrap();
 
     assert!(writer.messages.is_empty());
 }
@@ -412,7 +415,7 @@ fn render_itemize_symlink_with_target() {
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
     assert_eq!(
-        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        ctx.render_itemize_line(&iflags, &entry, None).as_deref(),
         Some("cL+++++++++ mylink -> target\n")
     );
 }

--- a/tests/itemize_hardlink_leader_remote.rs
+++ b/tests/itemize_hardlink_leader_remote.rs
@@ -1,0 +1,247 @@
+//! Itemized hardlink-follower rows must name their leader over a remote shell.
+//!
+//! Upstream renders the `%L` suffix of the default `-i` format (`%i %n%L`) as
+//! ` => <leader>` for a file hard-linked to an earlier-transferred entry:
+//!
+//! ```c
+//! /* log.c:643-646 - the hlink form wins over the symlink arrow */
+//! case 'L':
+//!         if (hlink && *hlink) {
+//!                 n = hlink;
+//!                 strlcpy(buf2, " => ", sizeof buf2);
+//!
+//! /* hlink.c:232-234 - each linked follower itemizes with the leader name */
+//! itemize(fname, file, ndx, statret, sxp,
+//!         ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS, 0,
+//!         realname);
+//! ```
+//!
+//! Only followers carry the name: the first-of-set is transferred as a plain
+//! `>f+++++++++` / `<f+++++++++` row with no ` => ` suffix. Verified against
+//! rsync 3.4.4 (protocol 32): a 3-link set itemizes as one transfer row plus
+//! two `hf+++++++++ <follower> => <leader>` rows in every transport.
+//!
+//! WHY this lives at the binary level: on a pull the client receiver renders
+//! the follower rows itself (`create_hardlinks`), while on a push they travel
+//! as wire iflags + xname and the client sender renders them. A unit test can
+//! only see one renderer; this file exercises both roles for real, on whichever
+//! receiver driver (`incremental-flist` on/off) the build selected.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the shim uses `/bin/sh`).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    if built.is_file() {
+        return built;
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    for profile in ["debug", "release", "dist"] {
+        let candidate = PathBuf::from(manifest_dir)
+            .join("target")
+            .join(profile)
+            .join("oc-rsync");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    PathBuf::from("oc-rsync")
+}
+
+/// Writes the `--rsh` shim: drops the SSH-style options and host placeholder,
+/// then execs the server command locally over a pipe pair.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    let body = "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n";
+    fs::write(&script, body).expect("write rsh shim");
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+    script
+}
+
+fn spawn_with_timeout(mut cmd: Command, timeout: Duration) -> Option<Output> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    // Drain both pipes on their own threads so the child never blocks writing
+    // into a full OS pipe buffer while we poll try_wait().
+    let mut child_stdout = child.stdout.take()?;
+    let mut child_stderr = child.stderr.take()?;
+    let stdout_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stdout.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stderr.read_to_end(&mut buf);
+        buf
+    });
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().ok()? {
+            Some(status) => {
+                return Some(Output {
+                    status,
+                    stdout: stdout_reader.join().unwrap_or_default(),
+                    stderr: stderr_reader.join().unwrap_or_default(),
+                });
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            None => thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// Lays out a 3-link hardlink set (`aaa` sorts first and becomes the leader on
+/// oc's receiving side) plus an empty destination.
+fn setup() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let temp = tempfile::TempDir::new().expect("create temp dir");
+    let root = temp.path();
+    let src = root.join("src");
+    let dest = root.join("dest");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(src.join("aaa"), b"shared hardlink payload\n").unwrap();
+    fs::hard_link(src.join("aaa"), src.join("bbb")).unwrap();
+    fs::hard_link(src.join("aaa"), src.join("ccc")).unwrap();
+    (temp, src, dest)
+}
+
+/// Runs `-aHi` over the shim in the requested direction.
+fn run_transfer(shim: &Path, binary: &Path, src: &Path, dest: &Path, push: bool) -> Output {
+    let (from, to) = if push {
+        (
+            format!("{}/", src.display()),
+            format!("hlhost:{}/", dest.display()),
+        )
+    } else {
+        (
+            format!("hlhost:{}/", src.display()),
+            format!("{}/", dest.display()),
+        )
+    };
+    let mut cmd = Command::new(binary);
+    cmd.arg("-aHi")
+        .arg("--rsh")
+        .arg(shim)
+        .arg("--rsync-path")
+        .arg(binary)
+        .arg(from)
+        .arg(to);
+    spawn_with_timeout(cmd, RUN_TIMEOUT).expect("transfer did not finish within the timeout")
+}
+
+/// Asserts one direction: the transferred first-of-set row carries no ` => `
+/// suffix, every `hf` follower row names the leader, and the destination set
+/// really shares one inode.
+fn assert_follower_rows(push: bool) {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let (temp, src, dest) = setup();
+    let shim = write_rsh_shim(temp.path());
+
+    let output = run_transfer(&shim, &binary, &src, &dest, push);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let label = if push { "push" } else { "pull" };
+
+    assert!(
+        output.status.success(),
+        "{label} must exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // upstream: the first-of-set is a plain transfer row - no hardlink suffix.
+    let direction = if push { '<' } else { '>' };
+    let leader_row = format!("{direction}f+++++++++ aaa");
+    assert!(
+        stdout.lines().any(|line| line == leader_row),
+        "{label}: first-of-set must itemize as {leader_row:?} with no ` => `\
+         suffix; got:\n{stdout}"
+    );
+
+    // upstream: hlink.c:232-234 + log.c:643-646 - each follower renders
+    // `hf+++++++++ <name> => <leader>`.
+    for follower in ["bbb", "ccc"] {
+        let follower_row = format!("hf+++++++++ {follower} => aaa");
+        assert!(
+            stdout.lines().any(|line| line == follower_row),
+            "{label}: follower must itemize as {follower_row:?}; got:\n{stdout}"
+        );
+    }
+
+    // The pre-fix symptom was a bare `hf` row: `ITEM_XNAME_FOLLOWS` set but the
+    // leader name dropped. Guard against any suffix-less follower row.
+    for line in stdout.lines() {
+        if line.starts_with("hf") {
+            assert!(
+                line.contains(" => "),
+                "{label}: every hf row must carry the ` => leader` suffix,\
+                 got {line:?} in:\n{stdout}"
+            );
+        }
+    }
+
+    // The rows must describe a real hardlink set at the destination.
+    {
+        use std::os::unix::fs::MetadataExt;
+        let ino_a = fs::metadata(dest.join("aaa")).unwrap().ino();
+        for follower in ["bbb", "ccc"] {
+            assert_eq!(
+                fs::metadata(dest.join(follower)).unwrap().ino(),
+                ino_a,
+                "{label}: {follower} must share the leader's inode"
+            );
+        }
+    }
+
+    drop(temp);
+}
+
+#[test]
+fn pull_hardlink_followers_itemize_with_leader_suffix() {
+    assert_follower_rows(false);
+}
+
+#[test]
+fn push_hardlink_followers_itemize_with_leader_suffix() {
+    assert_follower_rows(true);
+}


### PR DESCRIPTION
## Summary

The default `-i` itemize row for a hardlink follower on a pull omitted the ` => leader` suffix, printing a bare `hf+++++++++ name` where upstream rsync 3.4.4 prints `hf+++++++++ name => leader`.

Upstream renders the `%L` field of the default `-i` format (`%i %n%L`) as ` => <hlink>` whenever the item carries a non-empty alternate-basis name (`log.c:643-646`), and each linked follower is itemized with `ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS` plus the leader's relative name as the xname (`hlink.c:232-234`). At protocol >= 29 the name travels as a vstring after the iflags (`generator.c:590-591`).

oc's push path (server receiver forwards wire xname, client sender renders) and local path already produced the suffix; the pull path (client receiver renders follower rows itself in `create_hardlinks`) dropped the name.

## Changes

- `crates/transfer/src/receiver/directory/links.rs`: `create_hardlinks` derives the leader's transfer-relative name from the resolved leader path and passes it as the itemize xname for each freshly linked follower. The already-linked (uptodate) case keeps an empty xname, matching upstream's `hlink.c:218-222` (no suffix, `log.c:644` gates on `*hlink`).
- `crates/transfer/src/receiver/itemize.rs`: threads an `xname: Option<&[u8]>` through `emit_itemize_indexed` -> `emit_itemize` -> `render_itemize_line` into the existing `format_itemize_line` `%L` renderer; all non-hardlink call sites pass `None`.

## Verification

Byte-compared against rsync 3.4.4 (protocol 32) on a 3-link set with `-aHi`: local, SSH-shim push and pull, and daemon push and pull all now render `hf+++++++++ <follower> => <leader>` on follower rows and a plain transfer row on the first of the set. Cross pairings (upstream client + oc server, oc client + upstream server) agree in both directions.

## Tests

- `tests/itemize_hardlink_leader_remote.rs`: real two-process `-aHi` transfers over an `--rsh` shim in both directions; asserts the exact follower rows (` => leader` present), the leader row (no suffix), no suffix-less `hf` row, and a shared destination inode. The pull case fails on pre-fix code.
