### PR TITLE
perf(engine): stop building an io_uring instance per hardlink

### DIFF
--- a/crates/engine/src/local_copy/hard_links/tests/hard_link_dispatch_tests.rs
+++ b/crates/engine/src/local_copy/hard_links/tests/hard_link_dispatch_tests.rs
@@ -1,13 +1,17 @@
-//! Tests for the io_uring LINKAT dispatch in hardlink creation.
+//! Tests for hardlink creation dispatch through `fast_io::hard_link`.
 //!
-//! These tests verify that `fast_io::hard_link` works correctly regardless
-//! of whether io_uring handles the link or `std::fs::hard_link` does.
+//! `fast_io::hard_link` issues a direct `linkat(2)` / `link(2)` syscall on
+//! every platform - upstream's model (`hlink.c:hard_link_one()` ->
+//! `syscall.c:do_link_at()`). These tests verify the engine's link paths
+//! produce correct hardlinks through that direct-syscall entry point; the
+//! structure-level assertion that no io_uring ring is built per link lives
+//! in `fast_io::io_uring_ops`.
 
 use crate::local_copy::hard_links::{HardlinkApplyResult, HardlinkApplyTracker};
 use crate::local_copy::test_support;
 
 #[test]
-fn hard_link_via_io_uring_or_fallback_creates_link() {
+fn hard_link_direct_syscall_creates_link() {
     let temp = test_support::create_tempdir();
     let src = temp.path().join("linkat_src.txt");
     let dst = temp.path().join("linkat_dst.txt");
@@ -25,7 +29,7 @@ fn hard_link_via_io_uring_or_fallback_creates_link() {
 
 #[cfg(unix)]
 #[test]
-fn hard_link_via_io_uring_or_fallback_shares_inode() {
+fn hard_link_direct_syscall_shares_inode() {
     use std::os::unix::fs::MetadataExt;
 
     let temp = test_support::create_tempdir();
@@ -41,7 +45,7 @@ fn hard_link_via_io_uring_or_fallback_shares_inode() {
 }
 
 #[test]
-fn apply_follower_uses_io_uring_or_fallback() {
+fn apply_follower_links_via_direct_syscall() {
     let temp = test_support::create_tempdir();
     let leader = temp.path().join("leader_dispatch.txt");
     let follower = temp.path().join("follower_dispatch.txt");
@@ -59,7 +63,7 @@ fn apply_follower_uses_io_uring_or_fallback() {
 }
 
 #[test]
-fn resolve_deferred_uses_io_uring_or_fallback() {
+fn resolve_deferred_links_via_direct_syscall() {
     let temp = test_support::create_tempdir();
     let leader = temp.path().join("deferred_leader.txt");
     let follower1 = temp.path().join("deferred_f1.txt");
@@ -91,17 +95,4 @@ fn resolve_deferred_uses_io_uring_or_fallback() {
         std::fs::read_to_string(&follower2).unwrap(),
         "deferred content"
     );
-}
-
-#[test]
-fn try_hard_link_via_io_uring_returns_consistent_availability() {
-    let dir = test_support::create_tempdir();
-    let src = dir.path().join("probe_src.txt");
-    let dst1 = dir.path().join("probe_dst1.txt");
-    let dst2 = dir.path().join("probe_dst2.txt");
-    std::fs::write(&src, b"data").unwrap();
-
-    let first = fast_io::try_hard_link_via_io_uring(&src, &dst1).is_some();
-    let second = fast_io::try_hard_link_via_io_uring(&src, &dst2).is_some();
-    assert_eq!(first, second, "availability must be consistent");
 }

--- a/crates/engine/src/local_copy/hard_links/tests/mod.rs
+++ b/crates/engine/src/local_copy/hard_links/tests/mod.rs
@@ -1,7 +1,7 @@
 //! Test modules for the `hard_links` decomposition.
 
 mod apply_tracker_tests;
-mod io_uring_linkat_dispatch_tests;
+mod hard_link_dispatch_tests;
 mod tracker_tests;
 
 #[cfg(unix)]

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -51,10 +51,9 @@ where
 
 /// Creates a hard link from `source` to `destination`.
 ///
-/// On Linux 5.15+ with io_uring available, the link is submitted as an
-/// `IORING_OP_LINKAT` SQE instead of a synchronous `link(2)` syscall.
-/// Falls back to `std::fs::hard_link` on all other platforms or when the
-/// kernel lacks the opcode.
+/// Delegates to `fast_io::hard_link`, which issues a direct `linkat(2)` /
+/// `link(2)` syscall on every platform, matching upstream's
+/// `hlink.c:hard_link_one()` -> `syscall.c:do_link_at()`.
 pub(super) fn create_hard_link(source: &Path, destination: &Path) -> io::Result<()> {
     #[cfg(test)]
     if let Some(result) = HARD_LINK_OVERRIDE.with(|cell| {

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
@@ -254,9 +254,9 @@ pub fn symlinkat_via_sandbox_or_fallback(
 ///   limits this cutover to single-component leaves under
 ///   `dest_dir`.
 /// - In every other case the helper falls back to
-///   [`fast_io::hard_link`](crate::hard_link) which preserves the
-///   existing io_uring `LINKAT` fast path plus
-///   [`std::fs::hard_link`] error semantics (`EXDEV`, `EPERM`, ...).
+///   [`fast_io::hard_link`](crate::hard_link), a direct `linkat(2)`
+///   syscall that preserves [`std::fs::hard_link`] error semantics
+///   (`EXDEV`, `EPERM`, ...).
 ///
 /// # Errors
 ///

--- a/crates/fast_io/src/io_uring/linkat.rs
+++ b/crates/fast_io/src/io_uring/linkat.rs
@@ -97,6 +97,15 @@ pub fn linkat_supported() -> bool {
     }
 }
 
+/// Test-only: whether the process-wide LINKAT support probe has run.
+///
+/// Lets tests assert that the direct-syscall `crate::hard_link` path never
+/// consults the io_uring LINKAT machinery.
+#[cfg(test)]
+pub(crate) fn linkat_probe_initialized() -> bool {
+    LINKAT_SUPPORTED.get().is_some()
+}
+
 /// Probes the live kernel for `IORING_OP_LINKAT` support.
 ///
 /// Mirrors the convention used by `shared_ring::probe_poll_add`: short-

--- a/crates/fast_io/src/io_uring_ops.rs
+++ b/crates/fast_io/src/io_uring_ops.rs
@@ -3,9 +3,9 @@
 //!
 //! Each `try_*` function returns `Option<io::Result<_>>` so callers can
 //! distinguish "io_uring not available" (`None`) from "io_uring tried and
-//! returned an error" (`Some(Err(_))`). The combined [`hard_link`] helper
-//! folds the try-then-fallback pattern into a single call for the common
-//! case where the caller does not care which mechanism was used.
+//! returned an error" (`Some(Err(_))`). The [`hard_link`] helper is the
+//! deliberate exception: it issues the plain syscall directly because a
+//! per-call transient ring costs far more than the `linkat(2)` it wraps.
 
 use crate::io_uring::StatxResult;
 #[cfg(all(target_os = "linux", feature = "io_uring"))]
@@ -183,38 +183,27 @@ fn try_statx_batch_via_io_uring_impl(
     None
 }
 
-/// Creates a hard link from `src` to `dst`, trying io_uring first.
-///
-/// On Linux 5.15+ with io_uring `IORING_OP_LINKAT` support, the link is
-/// submitted as an asynchronous SQE on a transient ring, avoiding a
-/// synchronous `linkat(2)` syscall. On all other platforms, older kernels,
-/// or when the `io_uring` feature is disabled, falls back to
-/// [`std::fs::hard_link`].
+/// Creates a hard link from `src` to `dst` via a direct syscall.
 ///
 /// This is the recommended single entry point for hard-link creation across
-/// the codebase. It consolidates the try-io_uring-then-fallback pattern so
-/// callers do not need to handle the `Option` from
-/// [`try_hard_link_via_io_uring`] themselves.
+/// the codebase. It deliberately does NOT route through io_uring: the only
+/// available submission mode ([`try_hard_link_via_io_uring`]) builds a
+/// transient ring per call, and the ring setup/teardown (`io_uring_setup(2)`
+/// plus two `mmap(2)`/`munmap(2)` pairs) dwarfs the single cheap `linkat(2)`
+/// it wraps. On a 1900-hardlink local `-aH` copy that per-file churn was
+/// measured at 40% of total syscall time.
 ///
 /// # Errors
 ///
-/// Returns an error when both the io_uring path and the `std::fs::hard_link`
-/// fallback fail (e.g., `EEXIST`, `EACCES`, `EXDEV`).
+/// Returns the `std::fs::hard_link` error unchanged (e.g., `EEXIST`,
+/// `EACCES`, `EXDEV`).
 ///
 /// # Upstream reference
 ///
-/// Upstream rsync uses synchronous `link(2)` / `linkat(2)` for hardlink
-/// creation (`hlink.c`). The io_uring fast path is a latency optimisation.
+/// Upstream rsync uses a synchronous `linkat(2)` / `link(2)` for hardlink
+/// creation (`hlink.c:hard_link_one()` -> `syscall.c:do_link_at()`); this
+/// matches that model.
 pub fn hard_link(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
-    if let Some(result) = try_hard_link_via_io_uring(src, dst) {
-        return result;
-    }
-    logging::debug_log!(
-        Io,
-        2,
-        "io_uring LINKAT unavailable, falling back to std::fs::hard_link for {}",
-        dst.display()
-    );
     std::fs::hard_link(src, dst)
 }
 
@@ -480,6 +469,28 @@ mod hard_link_convenience_tests {
 
         let result = hard_link(&src, &dst);
         assert!(result.is_err(), "must fail when source does not exist");
+    }
+
+    /// Structure-level assertion for the direct-syscall path: `hard_link`
+    /// must never consult the io_uring LINKAT machinery, so the process-wide
+    /// support probe stays uninitialized after a link is created. Relies on
+    /// nextest's process-per-test model: nothing else in this process
+    /// initializes the probe.
+    #[cfg(all(target_os = "linux", feature = "io_uring"))]
+    #[test]
+    fn hard_link_does_not_touch_io_uring_probe() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("hl_probe_src.txt");
+        let dst = dir.path().join("hl_probe_dst.txt");
+        fs::write(&src, b"probe check").unwrap();
+
+        hard_link(&src, &dst).unwrap();
+
+        assert!(dst.exists(), "hard link must be created");
+        assert!(
+            !crate::io_uring::linkat::linkat_probe_initialized(),
+            "hard_link must take the direct syscall path, not io_uring LINKAT"
+        );
     }
 
     /// Verifies that writing to the source after hard-linking is visible

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -841,9 +841,9 @@ impl ReceiverContext {
                 // 0)` so a mid-syscall symlink swap on the follower's
                 // parent cannot redirect the create to an
                 // attacker-chosen directory. Falls back to
-                // `fast_io::hard_link` (io_uring LINKAT on Linux 5.15+,
-                // else `std::fs::hard_link`) for the multi-component
-                // and no-sandbox cases, preserving the existing
+                // `fast_io::hard_link` (direct `linkat(2)` syscall) for
+                // the multi-component and no-sandbox cases, preserving
+                // the existing
                 // `EXDEV` / `EPERM` error semantics. Windows stays on
                 // the path-based fallback per the SEC-1.l NTFS-handle
                 // audit.


### PR DESCRIPTION
## Problem

Local `-aH` hardlink-heavy copies measured 1.46x slower than upstream rsync. strace on a 1900-hardlink local copy showed `io_uring_setup` called 1902x plus 3915 `mmap` / 3817 `munmap` - 0.192s, 40% of total syscall time. Upstream issues ~1900 plain `linkat(2)` calls with no ring at all.

## Root cause

Every hardlink funnels through `fast_io::hard_link` -> `try_hard_link_via_io_uring` -> `submit_linkat_blocking` (`crates/fast_io/src/io_uring/linkat.rs`), which builds a private 2-entry `IoUring::new(2)` per call. Each transient ring costs one `io_uring_setup(2)` plus two `mmap(2)`/`munmap(2)` pairs - far more than the single cheap `linkat(2)` it wraps.

The wrapper was added in #3738 with the stated intent that "the receiver can submit hardlink creation alongside disk writes on the same ring". That shared-ring integration never happened: `submit_linkat_blocking` documents itself as being for "tests, one-shot hardlink creation in slow paths", yet the engine local-copy hot path (`create_hard_link`, cohort follower linking) and the receiver paths all call it per file.

## Fix: bypass io_uring for hardlink creation

Chosen over reusing the per-thread ring: a hardlink is a single cheap metadata syscall with nothing to batch or overlap - a ring gains nothing even when amortized, and upstream's model (`hlink.c:hard_link_one()` -> `syscall.c:do_link_at()`) is a direct `linkat(2)`. `fast_io::hard_link` now calls `std::fs::hard_link` directly on every platform. Per-file ring construction on the link path is gone.

Behavior is identical: same links created, same error values (`EEXIST`, `EXDEV`, `EPERM`, ...) since the io_uring path already surfaced raw OS errors, and `std::fs::hard_link` was already the fallback everywhere.

`try_hard_link_via_io_uring` / `submit_linkat_blocking` remain public (no production caller) pending the wider io_uring keep/cut review; the rename (`RENAMEAT2`) transient-ring path is out of scope here and tracked by that same review.

## Tests

- New structure-level assertion (`hard_link_does_not_touch_io_uring_probe`, Linux + `io_uring` feature): `hard_link` must leave the process-wide LINKAT support probe uninitialized, proving the direct-syscall path is taken.
- Engine dispatch tests renamed `io_uring_linkat_dispatch_tests.rs` -> `hard_link_dispatch_tests.rs`; assertions unchanged (links created, inode shared, follower/deferred resolution).
- `cargo nextest run -p engine -E 'test(hardlink) or test(link)'`: 358 passed.
- `cargo nextest run -p fast_io -E 'test(hard_link) or test(linkat) or test(rename)'`: 57 passed.
- fmt clean; `cargo clippy -p engine -p fast_io --all-targets --all-features --no-deps -- -D warnings` clean.

## Deferred verification

Host-side strace confirmation (io_uring_setup count dropping to O(1)/0 on the 1900-hardlink workload and the 1.46x ratio closing to parity) is deferred to the Linux host measurement pass.
