### PR TITLE
fix(transfer): print sending-flist banner before per-file names on push

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -139,7 +139,15 @@ where
     //   push and a local copy, and the receiver on a pull (which separately
     //   prints "receiving incremental file list"), so suppress it on a pull
     //   (`!config.is_pull()`) to avoid printing both banners.
-    let emit_flist_banner = config.recursive() && info_gte(InfoFlag::Flist, 1) && !config.is_pull();
+    //
+    // A remote push prints the banner live at file-list-send time instead
+    // (generator/transfer/orchestrator.rs `announce_incremental_flist`), ahead
+    // of the per-file rows that stream straight to stdout during the transfer;
+    // rendering it here again would both duplicate it and print it dead last.
+    // Only a local copy - whose per-file rows are all rendered post-hoc from
+    // the collected events - still gets the banner from this deferred path.
+    let emit_flist_banner =
+        config.recursive() && info_gte(InfoFlag::Flist, 1) && !config.is_pull() && !is_sender;
     // Capture the preserve-links state before `config` is consumed so the
     // `--list-only` renderer knows whether to append the ` -> <target>` arrow
     // to symlink rows (upstream: generator.c:1183 gates it on preserve_links).

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -273,8 +273,10 @@ fn send_file_list_first_byte_latency_recorded_for_empty_list() {
 fn sender_flist_path_emits_no_debug_instrumentation_at_verbose() {
     // Regression: a verbose (-v) push must not leak the sender's internal
     // file-list instrumentation to stdout. Upstream's only stdout file-list
-    // line is the "sending incremental file list" banner (emitted by the CLI
-    // layer). "building file list", "built file list with N", and the
+    // line is the "sending incremental file list" banner (written directly by
+    // `announce_incremental_flist` at file-list-send time on a client-mode
+    // push, and by the CLI's deferred renderer on a local copy).
+    // "building file list", "built file list with N", and the
     // first-byte latency timing are development-only diagnostics with no
     // upstream stdout analog; every DiagnosticEvent::Info renders to the
     // client's stdout, so any such event on the sender path is a leak.
@@ -6051,4 +6053,47 @@ fn flist_vanished_warning_downgrades_to_info_below_protocol_30() {
             "the flush must drain the queue so a later flush cannot repeat it"
         );
     }
+}
+
+/// Builds a generator context with the given client/recursive flags for the
+/// `sending incremental file list` banner gate tests.
+fn banner_ctx(client_mode: bool, recursive: bool) -> GeneratorContext {
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.connection.client_mode = client_mode;
+    config.flags.recursive = recursive;
+    GeneratorContext::new_for_test(&handshake, config)
+}
+
+/// The canonical case: a recursive client-side push at `-v` (FLIST level 1)
+/// announces the incremental file list (upstream flist.c:2248-2252).
+#[test]
+fn client_recursive_flist1_announces_sending_banner() {
+    logging::init(logging::VerbosityConfig::from_verbose_level(1));
+    assert!(banner_ctx(true, true).should_announce_incremental_flist());
+}
+
+/// `--info=flist0` (FLIST level 0) suppresses the banner even for a recursive
+/// client push, mirroring the upstream `INFO_GTE(FLIST, 1)` gate.
+#[test]
+fn flist0_suppresses_sending_banner() {
+    logging::init(logging::VerbosityConfig::from_verbose_level(0));
+    assert!(!banner_ctx(true, true).should_announce_incremental_flist());
+}
+
+/// A non-recursive `-v` push prints no banner: upstream leaves inc_recurse
+/// off without `-r` (compat.c:172-173), so flist.c:2252 is not reached.
+#[test]
+fn non_recursive_prints_no_sending_banner() {
+    logging::init(logging::VerbosityConfig::from_verbose_level(1));
+    assert!(!banner_ctx(true, false).should_announce_incremental_flist());
+}
+
+/// A server-side sender (`am_server`) never prints the banner locally; on a
+/// pull the client receiver announces `receiving incremental file list`
+/// instead (flist.c:2606-2607).
+#[test]
+fn server_mode_prints_no_sending_banner() {
+    logging::init(logging::VerbosityConfig::from_verbose_level(1));
+    assert!(!banner_ctx(false, true).should_announce_incremental_flist());
 }

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -22,6 +22,36 @@ use crate::role_trailer::error_location;
 use crate::transfer_state::TransferPhase;
 
 impl GeneratorContext {
+    /// Prints the `sending incremental file list` banner on the client's own
+    /// output at file-list-send time, ahead of any per-file rows.
+    ///
+    /// Mirrors upstream `flist.c:2248-2252`: the banner fires only for a
+    /// client-side sender (`!am_server` -> `client_mode`), under incremental
+    /// recursion - which upstream disables when `!recurse` (compat.c:172-173),
+    /// so a non-recursive single-file `-v` push prints nothing - and when the
+    /// FLIST info category is at level >= 1, so `--info=flist0` suppresses it
+    /// even at `-v`. This is the send-side twin of the receiver's `receiving
+    /// incremental file list` banner in `receiver/transfer/setup/context.rs`.
+    fn announce_incremental_flist(&self) -> io::Result<()> {
+        if !self.should_announce_incremental_flist() {
+            return Ok(());
+        }
+        let banner: &[u8] = b"sending incremental file list\n";
+        if self.config.flags.msgs_to_stderr {
+            io::stderr().write_all(banner)
+        } else {
+            io::stdout().write_all(banner)
+        }
+    }
+
+    /// Whether this sender prints the `sending incremental file list` banner
+    /// on its own client-visible output (see [`Self::announce_incremental_flist`]).
+    pub(crate) fn should_announce_incremental_flist(&self) -> bool {
+        self.config.connection.client_mode
+            && self.config.flags.recursive
+            && logging::info_gte(logging::InfoFlag::Flist, 1)
+    }
+
     /// Runs the generator role to completion.
     ///
     /// Orchestrates the full send operation: build file list, send it, process
@@ -67,6 +97,16 @@ impl GeneratorContext {
 
         // upstream: main.c:1276 - recv_filter_list() in server mode
         self.receive_filter_list_if_server(&mut reader)?;
+
+        // upstream: flist.c:2248-2252 send_file_list() - a client-side sender
+        // announces `sending incremental file list` at file-list-send time,
+        // before the walk produces any per-file output. Write it DIRECTLY to
+        // the client stream: the deferred `info_log!` event buffer is only
+        // drained by the CLI after the live per-file rows and the summary
+        // stats, which would print the banner dead last on every ssh/daemon
+        // push. Mirrors the receive-side banner in
+        // `receiver/transfer/setup/context.rs`.
+        self.announce_incremental_flist()?;
 
         // upstream: flist.c:2240-2264 - resolve --files-from paths if configured
         let files_from_entries = self.resolve_files_from_paths(paths, &mut reader)?;

--- a/tests/flist_banner_before_names.rs
+++ b/tests/flist_banner_before_names.rs
@@ -1,0 +1,340 @@
+//! The `sending incremental file list` banner must precede every per-file
+//! name row, on every transport.
+//!
+//! Upstream prints the banner at the START of `send_file_list()` - before the
+//! source walk emits anything - so it is always the first stdout line of a
+//! recursive verbose push (flist.c:2248-2252, gated on `inc_recurse &&
+//! INFO_GTE(FLIST, 1) && !am_server`). Verified against rsync 3.4.4
+//! (protocol 32):
+//!
+//! ```text
+//! $ rsync -nv -r src/ host:dest/
+//! sending incremental file list
+//! ./
+//! f1
+//! sub/
+//! sub/f2
+//! ...
+//! ```
+//!
+//! oc-rsync used to render the sender banner only from the CLI's post-run
+//! summary stage. A local copy renders its per-file rows from the same
+//! deferred stage, so the order looked right there - but on an ssh or daemon
+//! push the per-file rows stream to stdout live during the transfer, which
+//! printed every name BEFORE the banner. The fix emits the banner at
+//! file-list-send time from the client-side sender
+//! (`generator/transfer/orchestrator.rs::announce_incremental_flist`), the
+//! send-side twin of the receiver's early `receiving incremental file list`
+//! banner.
+//!
+//! WHY this lives at the binary level: the mis-order was invisible to unit
+//! tests because it is a cross-stage interleaving between the live transfer
+//! output and the CLI's deferred renderer. Only a real two-process run
+//! observes the actual stdout byte order.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Read;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(120);
+const DAEMON_READY_TIMEOUT: Duration = Duration::from_secs(30);
+const BANNER: &str = "sending incremental file list";
+
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read
+/// with `env!`, not `env::var_os`: at run time it is unset and the lookup
+/// would fall through to whatever stale `target/debug/oc-rsync` happens to be
+/// on disk - silently testing a different build than the one just compiled.
+fn oc_rsync_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Writes the `--rsh` shim.
+///
+/// oc-rsync invokes it with an SSH-style argv - `[<opts>..., <host>, <rsync
+/// path>, "--server", ...]`. The shim drops the options and the host, then
+/// execs the rest locally, giving a real two-process transfer over a pipe
+/// pair without needing an SSH server.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    let body = "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         # $1 is the host placeholder; the server command follows it.\n\
+         shift || true\n\
+         exec \"$@\"\n";
+    fs::write(&script, body).expect("write rsh shim");
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+    script
+}
+
+fn spawn_with_timeout(mut cmd: Command, timeout: Duration) -> Output {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn oc-rsync client");
+    // Drain both pipes on their own threads. Polling try_wait() while the
+    // pipes fill would deadlock: the child blocks writing into a full OS pipe
+    // buffer and therefore never exits.
+    let mut child_stdout = child.stdout.take().expect("child stdout");
+    let mut child_stderr = child.stderr.take().expect("child stderr");
+    let stdout_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stdout.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stderr.read_to_end(&mut buf);
+        buf
+    });
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("wait for client") {
+            Some(status) => {
+                return Output {
+                    status,
+                    stdout: stdout_reader.join().unwrap_or_default(),
+                    stderr: stderr_reader.join().unwrap_or_default(),
+                };
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("client did not finish within {timeout:?}");
+            }
+            None => thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// Lays out a small recursive source tree: a file at the root and one in a
+/// subdirectory, so the verbose listing has multiple name rows to mis-order.
+fn setup() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::TempDir::new().expect("create temp dir");
+    let src = temp.path().join("src");
+    fs::create_dir_all(src.join("sub")).unwrap();
+    fs::write(src.join("f1"), b"one\n").unwrap();
+    fs::write(src.join("sub").join("f2"), b"two two\n").unwrap();
+    (temp, src)
+}
+
+/// Asserts the upstream stdout contract for a recursive verbose push: the
+/// banner is the FIRST line, printed exactly once, and the per-file rows
+/// follow it.
+fn assert_banner_first(output: &Output, label: &str) {
+    assert!(
+        output.status.success(),
+        "{label}: transfer failed: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines.first().copied(),
+        Some(BANNER),
+        "{label}: banner must be the first stdout line (upstream flist.c:2248-2252 \
+         prints it before the walk emits any per-file row)\nstdout:\n{stdout}",
+    );
+    assert_eq!(
+        lines.iter().filter(|line| **line == BANNER).count(),
+        1,
+        "{label}: banner must print exactly once\nstdout:\n{stdout}",
+    );
+    for name in ["f1", "sub/f2"] {
+        assert!(
+            lines.contains(&name),
+            "{label}: expected per-file row `{name}` after the banner\nstdout:\n{stdout}",
+        );
+    }
+}
+
+fn run_local(src: &Path, dest: &Path, dry_run: bool) -> Output {
+    let mut cmd = Command::new(oc_rsync_binary());
+    if dry_run {
+        cmd.arg("-n");
+    }
+    cmd.arg("-v")
+        .arg("-r")
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dest.display()));
+    spawn_with_timeout(cmd, RUN_TIMEOUT)
+}
+
+fn run_ssh_push(shim: &Path, src: &Path, dest: &Path, dry_run: bool) -> Output {
+    let binary = oc_rsync_binary();
+    let mut cmd = Command::new(&binary);
+    if dry_run {
+        cmd.arg("-n");
+    }
+    cmd.arg("-v")
+        .arg("-r")
+        .arg("--rsh")
+        .arg(shim)
+        .arg("--rsync-path")
+        .arg(&binary)
+        .arg(format!("{}/", src.display()))
+        .arg(format!("fakehost:{}/", dest.display()));
+    spawn_with_timeout(cmd, RUN_TIMEOUT)
+}
+
+/// Reserves an ephemeral port by binding it and immediately releasing it.
+fn allocate_port() -> u16 {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+/// A spawned `oc-rsync --daemon` whose stdio is drained continuously; an
+/// undrained pipe wedges the daemon once the OS buffer fills.
+struct Daemon {
+    child: Child,
+    port: u16,
+}
+
+impl Daemon {
+    fn spawn(root: &Path, module_root: &Path) -> Self {
+        let config = root.join("rsyncd.conf");
+        fs::write(
+            &config,
+            format!(
+                "use chroot = no\n[mod]\n    path = {}\n    read only = no\n",
+                module_root.display()
+            ),
+        )
+        .expect("write daemon config");
+        let port = allocate_port();
+        let mut child = Command::new(oc_rsync_binary())
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--config")
+            .arg(&config)
+            .arg("--port")
+            .arg(port.to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn oc-rsync daemon");
+        if let Some(mut out) = child.stdout.take() {
+            thread::spawn(move || {
+                let mut sink = Vec::new();
+                let _ = out.read_to_end(&mut sink);
+            });
+        }
+        if let Some(mut err) = child.stderr.take() {
+            thread::spawn(move || {
+                let mut sink = Vec::new();
+                let _ = err.read_to_end(&mut sink);
+            });
+        }
+        let daemon = Self { child, port };
+        daemon.wait_until_listening();
+        daemon
+    }
+
+    /// Polls the listening socket until the daemon accepts connections.
+    fn wait_until_listening(&self) {
+        let target = SocketAddr::from((Ipv4Addr::LOCALHOST, self.port));
+        let deadline = Instant::now() + DAEMON_READY_TIMEOUT;
+        while Instant::now() < deadline {
+            if TcpStream::connect_timeout(&target, Duration::from_millis(250)).is_ok() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        panic!("daemon did not start listening on port {}", self.port);
+    }
+
+    fn url(&self) -> String {
+        format!("rsync://127.0.0.1:{}/mod/", self.port)
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn run_daemon_push(daemon: &Daemon, src: &Path, dry_run: bool) -> Output {
+    let mut cmd = Command::new(oc_rsync_binary());
+    if dry_run {
+        cmd.arg("-n");
+    }
+    cmd.arg("-v")
+        .arg("-r")
+        .arg(format!("{}/", src.display()))
+        .arg(daemon.url());
+    spawn_with_timeout(cmd, RUN_TIMEOUT)
+}
+
+#[test]
+fn local_verbose_banner_precedes_names() {
+    let (temp, src) = setup();
+    let dest = temp.path().join("dest");
+    assert_banner_first(&run_local(&src, &dest, false), "local -v");
+}
+
+#[test]
+fn local_dry_run_verbose_banner_precedes_names() {
+    let (temp, src) = setup();
+    let dest = temp.path().join("dest");
+    assert_banner_first(&run_local(&src, &dest, true), "local -nv");
+}
+
+#[test]
+fn ssh_push_verbose_banner_precedes_names() {
+    let (temp, src) = setup();
+    let shim = write_rsh_shim(temp.path());
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&dest).unwrap();
+    assert_banner_first(&run_ssh_push(&shim, &src, &dest, false), "ssh push -v");
+}
+
+#[test]
+fn ssh_push_dry_run_verbose_banner_precedes_names() {
+    let (temp, src) = setup();
+    let shim = write_rsh_shim(temp.path());
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&dest).unwrap();
+    assert_banner_first(&run_ssh_push(&shim, &src, &dest, true), "ssh push -nv");
+}
+
+#[test]
+fn daemon_push_verbose_banner_precedes_names() {
+    let (temp, src) = setup();
+    let module_root = temp.path().join("mod");
+    fs::create_dir_all(&module_root).unwrap();
+    let daemon = Daemon::spawn(temp.path(), &module_root);
+    assert_banner_first(&run_daemon_push(&daemon, &src, false), "daemon push -v");
+}
+
+#[test]
+fn daemon_push_dry_run_verbose_banner_precedes_names() {
+    let (temp, src) = setup();
+    let module_root = temp.path().join("mod");
+    fs::create_dir_all(&module_root).unwrap();
+    let daemon = Daemon::spawn(temp.path(), &module_root);
+    assert_banner_first(&run_daemon_push(&daemon, &src, true), "daemon push -nv");
+}


### PR DESCRIPTION
## Problem

Upstream rsync prints `sending incremental file list` at the START of `send_file_list()` (flist.c:2248-2252), so the banner is always the first stdout line of a recursive verbose push, ahead of every per-file name row.

oc-rsync rendered the sender banner only from the CLI's post-run summary stage. A local copy renders its per-file rows from that same deferred stage, so the order looked right there - but on an ssh or daemon push the per-file rows stream to stdout live during the transfer, which printed every name BEFORE the banner:

```
$ oc-rsync -v -r src/ rsync://host/mod/     # before
f1
sub/
sub/f2
sending incremental file list
...
```

This affected ssh push and daemon push, both `-v` and `-nv` (dry run).

## Fix

- Emit the banner directly from the client-side sender at file-list-send time (`generator/transfer/orchestrator.rs::announce_incremental_flist`), gated exactly like upstream: `client_mode` (`!am_server`), `recursive` (upstream disables inc_recurse without `-r`, compat.c:172-173), and `INFO_GTE(FLIST, 1)` (so `--info=flist0` suppresses it). This is the send-side twin of the receiver's early `receiving incremental file list` banner.
- Keep the deferred CLI banner only for local copies (`!is_local_sender()`), whose per-file rows are all rendered post-hoc from collected events, so nothing prints twice.

## Verification

Byte-order compared against rsync 3.4.4 (protocol 32) on the same trees: local `-nv`/`-v`, ssh push `-nv`/`-v`, daemon push `-nv`/`-v`. The banner is now the first stdout line on every path and the per-file rows match upstream line-for-line. Remaining diffs are pre-existing and unrelated: sent/received stats byte counts, and the missing `created directory` line on remote push.

## Tests

- `tests/flist_banner_before_names.rs`: six binary-level regression tests (local, ssh push via `--rsh` shim, daemon push; `-v` and `-nv` each) asserting the banner is the first stdout line, printed exactly once, with the per-file rows present. Verified to fail on pre-fix code (first line was `f1`).
- Unit tests for the sender banner gate (client/recursive/flist-level/server-mode) in `crates/transfer/src/generator/tests.rs`, mirroring the existing receiver-side gate tests.
