### PR TITLE
docs: correct the spill env-variable rows in the migration guide

### DIFF
--- a/docs/oc-extension-env-reference.md
+++ b/docs/oc-extension-env-reference.md
@@ -264,3 +264,9 @@ executable name. Intended for testing and development.
 `OC_RSYNC_FALLBACK` and `OC_RSYNC_DAEMON_FALLBACK` are historical names
 that are no longer consulted by any production code path; setting them
 has no effect on current builds.
+
+`OC_RSYNC_SPILL_RECLAIM` and `OC_RSYNC_SPILL_GRANULARITY` appeared in
+early spill-policy design documents but were never wired to a read
+site; setting them has no effect on current builds. The corresponding
+`SpillPolicy` fields (`reclaim_mode`, `granularity`) are settable only
+through the builder API.

--- a/docs/operator-migration-guide-vNEXT.md
+++ b/docs/operator-migration-guide-vNEXT.md
@@ -264,17 +264,22 @@ existing operators see no behavioural change.
   table and rationale are in
   [`docs/design/spill-policy-public-api.md`](design/spill-policy-public-api.md)
   section 2.
-- **Environment variables.** All five `SpillPolicy` fields are
-  reachable through `OC_RSYNC_SPILL_*` env vars; precedence (highest
-  wins) is CLI flag > env var > programmatic policy > default.
+- **Environment variables.** Three of the five `SpillPolicy` fields
+  are reachable through `OC_RSYNC_SPILL_*` env vars; precedence
+  (highest wins) is CLI flag > env var > programmatic policy >
+  default. The remaining two fields (`reclaim_mode` and
+  `granularity`) are settable only through the `SpillPolicy` builder
+  API.
 
 | Variable | Maps to | Accepted values |
 |----------|---------|-----------------|
 | `OC_RSYNC_SPILL_THRESHOLD_BYTES` | `threshold_bytes` | Integer with optional `K`/`M`/`G` suffix (case-insensitive, base 1024). Empty string clears. `0` is rejected. |
 | `OC_RSYNC_SPILL_DIR` | `dir` | Absolute or relative path. Created on first spill via `create_dir_all`. |
-| `OC_RSYNC_SPILL_RECLAIM` | `reclaim_mode` | `keep` (default) or `re-spill`. |
-| `OC_RSYNC_SPILL_GRANULARITY` | `granularity` | `whole-batch` (default) or `per-item`. |
 | `OC_RSYNC_SPILL_COMPRESSION` | `compression` | `none` (default), `zstd`, or `zstd:LEVEL` where `LEVEL` is in `[-22, 22]`. |
+
+  `OC_RSYNC_SPILL_RECLAIM` and `OC_RSYNC_SPILL_GRANULARITY` appeared
+  in earlier drafts of this guide but are not consulted by any
+  production code path; setting them has no effect on current builds.
 
 - **When to override.**
   - *Memory-constrained receivers* (containers with tight cgroup
@@ -284,23 +289,23 @@ existing operators see no behavioural change.
     `OC_RSYNC_SPILL_DIR` at a fast tmpfs or local SSD.
   - *Adversarial fan-out workloads* (deep INC_RECURSE trees with
     many unfinished segments held in the reorder window) benefit
-    from `OC_RSYNC_SPILL_RECLAIM=re-spill` to keep the post-reload
-    footprint bounded under sustained pressure.
+    from `ReclaimMode::ReSpillIfPressureContinues` (builder API) to
+    keep the post-reload footprint bounded under sustained pressure.
   - *Slow or SMR spill directories* should set
     `OC_RSYNC_SPILL_COMPRESSION=zstd` to trade CPU for disk
     bandwidth; default level 3 is usually appropriate, raise to
     `zstd:7` only when the spill device is the bottleneck.
   - *Diagnostic granularity* on benchmark runs:
-    `OC_RSYNC_SPILL_GRANULARITY=per-item` smooths the memory curve
-    at the cost of more syscalls per spill event.
+    `SpillGranularity::PerItem` (builder API) smooths the memory
+    curve at the cost of more syscalls per spill event.
 - **When to stay on the default.** Every workload that fits inside
   the documented 64 MiB high-water mark on the audit baseline. Spill
   is opt-in for a reason: the in-memory path is the fastest and
   byte-stable.
 - **CLI flags.** `--spill-dir` and `--spill-threshold-bytes` are
   planned for STN-11 and will land in a future release; they shadow
-  the two highest-value env vars. The remaining three knobs stay
-  env-only.
+  the two highest-value env vars. The remaining knob,
+  `OC_RSYNC_SPILL_COMPRESSION`, stays env-only.
 - **References.** Public-API surface and validation rules:
   [`docs/design/spill-policy-public-api.md`](design/spill-policy-public-api.md).
   Spillable buffer internals:


### PR DESCRIPTION
## Summary

The vNEXT operator migration guide documented `OC_RSYNC_SPILL_RECLAIM` and `OC_RSYNC_SPILL_GRANULARITY` as live environment variables. A full workspace grep (all crates, build scripts, and tools) shows neither name has a read site: `crates/engine/src/concurrent_delta/spill/env.rs` parses only `OC_RSYNC_SPILL_DIR`, `OC_RSYNC_SPILL_THRESHOLD_BYTES`, `OC_RSYNC_SPILL_COMPRESSION`, and `OC_RSYNC_NO_SPILL`. The `reclaim_mode` and `granularity` fields of `SpillPolicy` are settable only through the builder API.

## Changes

- `docs/operator-migration-guide-vNEXT.md`
  - Drop the two dead rows from the env-variable table and correct the "all five fields are reachable through env vars" claim to three of five.
  - Add a note, mirroring the legacy-variables style of `docs/oc-extension-env-reference.md`, stating the two names are not consulted by any production code path.
  - Rewrite the two "When to override" bullets that recommended the dead vars to reference the builder-API equivalents (`ReclaimMode::ReSpillIfPressureContinues`, `SpillGranularity::PerItem`).
  - Fix the now-stale "remaining three knobs stay env-only" count.
- `docs/oc-extension-env-reference.md`
  - Record both names in the existing "Legacy variables" section so operators searching for them find the no-effect verdict.

`docs/design/spill-policy-public-api.md` still lists the vars as part of the original STN design plan; it is a historical design document, not operator guidance, so it is left unchanged.

Docs only; no code changes.
