### PR TITLE
fix(engine): clamp the reorder-ring env override; single-source the early-input cap

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -9,7 +9,9 @@ use std::path::Path;
 
 use protocol::ProtocolVersion;
 use protocol::nstr::{trace_daemon_auth_negotiated, trace_daemon_greeting_auth_list};
-use protocol::{advertised_digests_in_greeting, missing_greeting_token};
+use protocol::{
+    EARLY_INPUT_CMD, EARLY_INPUT_MAX_SIZE, advertised_digests_in_greeting, missing_greeting_token,
+};
 
 use crate::auth::{compute_daemon_auth_response, negotiate_client_daemon_digest};
 
@@ -386,20 +388,6 @@ pub(crate) fn perform_daemon_handshake<R: std::io::Read, W: Write>(
 
     Ok(negotiated)
 }
-
-/// Maximum early-input file size in bytes.
-///
-/// Upstream rsync limits the file to `BIGPATHBUFLEN` (typically 5120 bytes on
-/// systems where `MAXPATHLEN >= 4096`). The manpage documents this as "up to
-/// 5K of data".
-///
-/// upstream: rsync.h - `BIGPATHBUFLEN` is `MAXPATHLEN + 1024` or `4096 + 1024`.
-pub(crate) const EARLY_INPUT_MAX_SIZE: usize = 5120;
-
-/// Command prefix for the early-input protocol message.
-///
-/// upstream: clientserver.c - `#define EARLY_INPUT_CMD "#early_input="`
-const EARLY_INPUT_CMD: &str = "#early_input=";
 
 /// Reads the early-input file content, capping at [`EARLY_INPUT_MAX_SIZE`] bytes.
 ///

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -55,10 +55,10 @@ use core::{
 };
 use logging_sink::MessageSink;
 use protocol::{
-    AdvertisedDigests, LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonMessage, MessageCode, MessageFrame,
-    ProtocolVersion, filters::FilterRuleWireFormat, format_legacy_daemon_message,
-    iconv::FilenameConverter, is_version_banner, missing_greeting_token,
-    parse_legacy_daemon_greeting_details, parse_legacy_daemon_message,
+    AdvertisedDigests, EARLY_INPUT_CMD, EARLY_INPUT_MAX_SIZE, LEGACY_DAEMON_PREFIX_LEN,
+    LegacyDaemonMessage, MessageCode, MessageFrame, ProtocolVersion, filters::FilterRuleWireFormat,
+    format_legacy_daemon_message, iconv::FilenameConverter, is_version_banner,
+    missing_greeting_token, parse_legacy_daemon_greeting_details, parse_legacy_daemon_message,
 };
 
 use crate::{

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -450,16 +450,6 @@ fn handle_legacy_session(
     Ok(session_exit_code)
 }
 
-/// Command prefix for the early-input protocol message.
-///
-/// upstream: clientserver.c - `#define EARLY_INPUT_CMD "#early_input="`
-const EARLY_INPUT_CMD: &str = "#early_input=";
-
-/// Maximum early-input data size in bytes.
-///
-/// upstream: rsync.h - `BIGPATHBUFLEN` is `MAXPATHLEN + 1024` (typically 5120).
-const EARLY_INPUT_MAX_SIZE: usize = 5120;
-
 /// Checks whether `line` is an `#early_input=<len>` command and, if so, reads
 /// the specified number of raw bytes from the stream.
 ///

--- a/crates/engine/src/concurrent_delta/parallel_apply/ring_cap_env.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/ring_cap_env.rs
@@ -24,26 +24,48 @@
 //! - Unset env var is the common case; [`resolve_ring_capacity`] returns the
 //!   caller-supplied default with no allocation or syscall.
 //!
-//! The override has no upper clamp by design: operators who set
+//! The override is clamped to `[1, MAX_RING_CAP]` (65536). Operators who set
 //! `OC_RSYNC_REORDER_RING_CAP=8192` to confirm a hypothesis about adversarial
-//! workload reordering should get exactly 8192. The natural ceiling is
-//! [`usize::MAX`], which would OOM the host before it could damage the
-//! applier; the parser rejects `0` since a zero-capacity ring would panic
-//! [`super::ReorderBuffer::new`] at construction time.
+//! workload reordering get exactly 8192; the ceiling is 1024x the hard 64
+//! default, far deeper than any in-flight window the worker pool can produce,
+//! so every legitimate experiment fits below it. Values above the ceiling
+//! are almost always unit typos (a byte count pasted as a slot count), and
+//! because the ring is per-file and spill-to-disk is disabled by default,
+//! honouring them verbatim would pin unbounded RAM with no relief valve.
+//! Over-max values warn and clamp to the ceiling; the parser rejects `0`
+//! since a zero-capacity ring would panic [`super::ReorderBuffer::new`] at
+//! construction time.
 
 use std::sync::OnceLock;
 
 /// Environment variable that pins the per-file reorder-ring capacity for
 /// every [`super::ParallelDeltaApplier`] constructed in this process.
 ///
-/// Accepts any positive integer parseable as [`usize`]. `0` and unparseable
-/// values trigger a one-shot `eprintln!` warning and the applier falls back
-/// to the caller-supplied default (typically
-/// [`super::ParallelDeltaApplier::DEFAULT_PER_FILE_REORDER_CAPACITY`]).
+/// Accepts a positive integer parseable as [`usize`], clamped to
+/// [`MAX_RING_CAP`]. `0` and unparseable values trigger a one-shot
+/// `eprintln!` warning and the applier falls back to the caller-supplied
+/// default (typically
+/// [`super::ParallelDeltaApplier::DEFAULT_PER_FILE_REORDER_CAPACITY`]);
+/// values above the ceiling warn and clamp.
 ///
 /// Read once per process at first construction; subsequent reads return the
 /// cached value without touching the environment again.
 pub(super) const RING_CAP_ENV: &str = "OC_RSYNC_REORDER_RING_CAP";
+
+/// Upper clamp for the [`RING_CAP_ENV`] override.
+///
+/// 65536 is 1024x the hard 64 default
+/// ([`super::ParallelDeltaApplier::DEFAULT_PER_FILE_REORDER_CAPACITY`]),
+/// which comfortably covers the deepest documented experiment (pinning 8192
+/// to study adversarial reordering) while refusing typo-scale values. The
+/// ring is allocated per file and spill-to-disk is disabled by default, so an
+/// uncapped override (e.g. a byte count pasted as a slot count) would pin
+/// unbounded RAM with no relief valve. Sibling knobs are clamped the same
+/// way: disk-commit channel capacity uses `[8, 4096]`
+/// (`transfer::disk_commit::config`) and [`super::shard_sizing`] uses
+/// `[4, 1024]`; this ceiling is wider only because deep-ring experiments are
+/// a documented use of the knob.
+pub(super) const MAX_RING_CAP: usize = 65536;
 
 /// Process-wide cache for the parsed override value.
 ///
@@ -55,11 +77,12 @@ static OVERRIDE: OnceLock<Option<usize>> = OnceLock::new();
 
 /// Resolves the per-file reorder-ring capacity for a fresh applier.
 ///
-/// Returns the cached env-override when set to a positive integer; otherwise
-/// returns `default`. Initialisation reads the environment at most once per
-/// process; an unparseable or zero-valued env var emits a one-shot
-/// `eprintln!` warning on the first call so operators learn about the typo
-/// rather than silently inheriting the default.
+/// Returns the cached env-override when set to a positive integer (clamped
+/// to [`MAX_RING_CAP`]); otherwise returns `default`. Initialisation reads
+/// the environment at most once per process; an unparseable, zero-valued, or
+/// over-max env var emits a one-shot `eprintln!` warning on the first call
+/// so operators learn about the typo rather than silently inheriting the
+/// default or an unbounded ring.
 #[must_use]
 pub(super) fn resolve_ring_capacity(default: usize) -> usize {
     OVERRIDE.get_or_init(load_from_env).unwrap_or(default)
@@ -82,6 +105,12 @@ fn load_from_env() -> Option<usize> {
                 "oc-rsync: {RING_CAP_ENV}=0 is invalid (capacity must be positive); falling back to default"
             );
             None
+        }
+        Ok(n) if n > MAX_RING_CAP => {
+            eprintln!(
+                "oc-rsync: {RING_CAP_ENV}={n} exceeds the maximum of {MAX_RING_CAP}; clamping to {MAX_RING_CAP}"
+            );
+            Some(MAX_RING_CAP)
         }
         Ok(n) => Some(n),
         Err(err) => {
@@ -164,12 +193,32 @@ mod tests {
     }
 
     #[test]
-    fn load_from_env_accepts_very_large_value() {
-        // No upper clamp: an operator pinning a deep ring for an adversarial
-        // workload must get exactly the value they set. Memory exhaustion is
-        // the natural ceiling; the parser only refuses zero.
+    fn load_from_env_accepts_deep_experimental_value() {
+        // The documented adversarial-reorder experiment pins 8192; the clamp
+        // ceiling must never take that use case away.
+        let _guard = EnvGuard::set("8192");
+        assert_eq!(load_from_env(), Some(8192));
+    }
+
+    #[test]
+    fn load_from_env_accepts_max_ring_cap_exactly() {
+        let _guard = EnvGuard::set(&MAX_RING_CAP.to_string());
+        assert_eq!(load_from_env(), Some(MAX_RING_CAP));
+    }
+
+    #[test]
+    fn load_from_env_clamps_above_max_ring_cap() {
+        // A typo-scale value (a byte count pasted as a slot count) must not
+        // pin an unbounded per-file ring: the parser warns and clamps to
+        // MAX_RING_CAP instead of honouring it verbatim.
         let _guard = EnvGuard::set("1048576");
-        assert_eq!(load_from_env(), Some(1_048_576));
+        assert_eq!(load_from_env(), Some(MAX_RING_CAP));
+    }
+
+    #[test]
+    fn load_from_env_clamps_usize_max() {
+        let _guard = EnvGuard::set(&usize::MAX.to_string());
+        assert_eq!(load_from_env(), Some(MAX_RING_CAP));
     }
 
     #[test]

--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -34,6 +34,27 @@ pub const LEGACY_DAEMON_PREFIX_LEN: usize = LEGACY_DAEMON_PREFIX.len();
 /// conversions via [`str::as_bytes`].
 pub const LEGACY_DAEMON_PREFIX_BYTES: &[u8; LEGACY_DAEMON_PREFIX_LEN] = b"@RSYNCD:";
 
+/// Command prefix for the early-input exchange in the legacy daemon handshake.
+///
+/// The client announces `--early-input` data by sending this prefix followed
+/// by the payload length before the module request line; the daemon detects
+/// the same prefix when parsing the first non-`@RSYNCD:` line. Both sides
+/// share this constant so the wire literal cannot drift.
+///
+/// upstream: clientserver.c - `#define EARLY_INPUT_CMD "#early_input="`
+pub const EARLY_INPUT_CMD: &str = "#early_input=";
+
+/// Maximum early-input payload size in bytes for the legacy daemon handshake.
+///
+/// Upstream caps the `--early-input` file at `BIGPATHBUFLEN` bytes; the
+/// manpage documents this as "up to 5K of data". The client truncates the
+/// file to this size before sending and the daemon rejects announced lengths
+/// above it, so both crates must agree on the exact value.
+///
+/// upstream: rsync.h - `BIGPATHBUFLEN` is `MAXPATHLEN + 1024` (`4096 + 1024`
+/// = 5120 on systems where `MAXPATHLEN >= 4096`).
+pub const EARLY_INPUT_MAX_SIZE: usize = 5120;
+
 mod bytes;
 mod greeting;
 mod lines;
@@ -88,6 +109,15 @@ pub(super) fn lossy_trimmed_input(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn early_input_constants_match_upstream() {
+        // upstream: clientserver.c EARLY_INPUT_CMD; rsync.h BIGPATHBUFLEN
+        // (MAXPATHLEN + 1024 = 5120). Both daemon and client crates consume
+        // these constants, so this pin is the single drift guard.
+        assert_eq!(EARLY_INPUT_CMD, "#early_input=");
+        assert_eq!(EARLY_INPUT_MAX_SIZE, 4096 + 1024);
+    }
 
     #[test]
     fn lossy_trimmed_input_drops_trailing_newlines() {

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -178,12 +178,12 @@ pub use iconv::{
     converter_from_locale,
 };
 pub use legacy::{
-    AdvertisedDigests, DAEMON_AUTH_DIGEST_NAMES, DigestListTokens, LEGACY_DAEMON_PREFIX,
-    LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonGreeting,
-    LegacyDaemonGreetingOwned, LegacyDaemonMessage, MissingGreetingToken,
-    advertised_digests_in_greeting, daemon_auth_digest_list, format_legacy_daemon_greeting,
-    format_legacy_daemon_message, is_version_banner, missing_greeting_token,
-    parse_legacy_daemon_greeting, parse_legacy_daemon_greeting_bytes,
+    AdvertisedDigests, DAEMON_AUTH_DIGEST_NAMES, DigestListTokens, EARLY_INPUT_CMD,
+    EARLY_INPUT_MAX_SIZE, LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES,
+    LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonGreeting, LegacyDaemonGreetingOwned, LegacyDaemonMessage,
+    MissingGreetingToken, advertised_digests_in_greeting, daemon_auth_digest_list,
+    format_legacy_daemon_greeting, format_legacy_daemon_message, is_version_banner,
+    missing_greeting_token, parse_legacy_daemon_greeting, parse_legacy_daemon_greeting_bytes,
     parse_legacy_daemon_greeting_bytes_details, parse_legacy_daemon_greeting_bytes_owned,
     parse_legacy_daemon_greeting_details, parse_legacy_daemon_greeting_owned,
     parse_legacy_daemon_message, parse_legacy_daemon_message_bytes, parse_legacy_error_message,


### PR DESCRIPTION
Two small bound-hygiene fixes from the sizing inventory.

## 1. engine: clamp the `OC_RSYNC_REORDER_RING_CAP` override

The per-file reorder-ring override (`ring_cap_env.rs`, ROB-11) was the only sizing knob with no upper bound, while its siblings are clamped (disk-commit channel capacity `[8, 4096]`, shard sizing `[4, 1024]`). The ring is allocated per file and spill-to-disk is disabled by default, so a unit typo (a byte count pasted as a slot count) pinned unbounded RAM with no relief valve.

- New ceiling: `MAX_RING_CAP = 65536` (1024x the hard 64 default). Wider than the sibling caps because deep-ring experiments are a documented use of this knob (the module docs bless pinning 8192 for adversarial-reorder studies); `git log` shows no bench depends on values beyond that, so the ceiling preserves every legitimate use while refusing typo-scale input.
- Over-max values emit the same one-shot tolerant-parse warning as the existing zero/unparseable branches, then clamp to the ceiling.
- Values `<= 65536` behave exactly as before; the parser still rejects `0`.
- Tests: over-max clamps (1 MiB and `usize::MAX`), exact-max passes through, 8192 experiment unchanged, all prior parser branches untouched.

## 2. core+daemon: single-source the early-input cap

`EARLY_INPUT_MAX_SIZE = 5120` (and the adjacent `EARLY_INPUT_CMD` prefix) were defined independently in `crates/core/.../daemon_transfer/connection/mod.rs` and `crates/daemon/.../session_runtime.rs` - the same drift class as the io_uring ring-depth duplication fixed in #7018.

Both crates already depend on `protocol`, and the early-input exchange is part of the legacy ASCII daemon handshake, so the constants now live in `protocol::legacy` next to `LEGACY_DAEMON_PREFIX` and are re-exported at the crate root. Doc comments cite the upstream origin (`rsync.h`: `BIGPATHBUFLEN` = `MAXPATHLEN + 1024` = 5120; `clientserver.c`: `#define EARLY_INPUT_CMD "#early_input="`), and a pin test in `protocol::legacy` guards the value. Behaviour-neutral: both sides used 5120 before and after.

## Note: independent 256 KiB batch-buffer constants (not unified)

The sizing inventory also observed five independent 256 KiB batch-buffer constants. They serve different subsystems with independent tuning rationales, so they are deliberately left separate; listed here for the record:

- `crates/transfer/src/disk_commit/writer.rs` - `WRITE_BUF_SIZE`
- `crates/fast_io/src/io_uring/disk_batch.rs` - `DEFAULT_BUFFER_CAPACITY`
- `crates/fast_io/src/iocp/disk_batch/mod.rs` - `DEFAULT_BUFFER_CAPACITY`
- `crates/transfer/src/generator/delta.rs:638` - `MAX_READ_SIZE`
- `crates/transfer/src/generator/delta.rs:728` - `MAX_READ_SIZE`

## Gates

- `cargo fmt --all` clean
- `cargo clippy -p engine -p core -p daemon -p protocol --all-targets --all-features --no-deps -- -D warnings` clean
- Targeted nextest `test(ring_cap) or test(early_input) or test(reorder)`: 158 passed
