### PR TITLE
fix(logging): route --log-file by logcode and add the upstream line prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ name = "logging-sink"
 version = "0.6.4"
 dependencies = [
  "core",
+ "platform",
  "syslog",
 ]
 

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -10,8 +10,8 @@ use core::{
     },
     message::Message,
 };
-use logging::{InfoFlag, info_gte};
-use logging_sink::MessageSink;
+use logging::{InfoFlag, LogCode, info_gte};
+use logging_sink::{MessageSink, logfile::LogFileWriter};
 
 use crate::frontend::{
     out_format::{OutFormat, OutFormatContext},
@@ -25,8 +25,12 @@ use super::messages::emit_message_with_fallback;
 use super::with_output_writer;
 
 /// Configuration for writing transfer output to a log file.
+///
+/// The handle is wrapped in a [`LogFileWriter`] so every line the renderers
+/// produce is stamped with upstream's `"%Y/%m/%d %H:%M:%S [pid] "` prefix
+/// (upstream: log.c:122-132 `logit()`).
 pub(crate) struct LogFileConfig {
-    pub(crate) file: File,
+    pub(crate) file: LogFileWriter<File>,
     pub(crate) format: OutFormat,
 }
 
@@ -225,6 +229,7 @@ where
                 && let Err(error) = emit_log_output(EmitLogOutputParams {
                     summary: &summary,
                     log: &mut log,
+                    flog_events: logging::drain_events_coded(LogCode::Log),
                     verbosity,
                     stats_level,
                     list_only,
@@ -279,6 +284,10 @@ where
 struct EmitLogOutputParams<'a> {
     summary: &'a ClientSummary,
     log: &'a mut LogFileConfig,
+    /// FLOG-classified diagnostic events consumed from the thread-local queue
+    /// (e.g. `building file list`, flist.c:2248). These lines belong to the
+    /// log file only (upstream: log.c:304-305).
+    flog_events: Vec<logging::DiagnosticEvent>,
     verbosity: u8,
     stats_level: u8,
     list_only: bool,
@@ -318,6 +327,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
     let EmitLogOutputParams {
         summary,
         log,
+        flog_events,
         verbosity,
         stats_level,
         list_only,
@@ -349,9 +359,18 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         .with_eight_bit_output(eight_bit_output)
         .with_preserve_links(preserve_links)
         .with_full_checksum(full_checksum_algorithm, always_checksum);
+    // upstream: log.c:290-305 - FLOG messages are written to the log file
+    // before any client-stream output and never reach stdout. The queue holds
+    // them in emission order, so "building file list" (flist.c:2248) or
+    // "receiving file list" (flist.c:2608) precedes the per-file lines.
+    for event in &flog_events {
+        let (logging::DiagnosticEvent::Info { message, .. }
+        | logging::DiagnosticEvent::Debug { message, .. }) = event;
+        writeln!(log.file, "{message}")?;
+    }
     // The FCLIENT "sending incremental file list" banner is stdout only;
     // upstream's parallel "building file list" line (flist.c:2248) is an FLOG
-    // log-file message that a plain client without --log-file discards.
+    // log-file message consumed from the FLOG event queue above.
     emit_transfer_summary(
         summary,
         verbosity,
@@ -376,5 +395,21 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         eight_bit_output,
         &mut log.file,
     )?;
+    // upstream: cleanup.c:222-226 gates log_exit() on
+    // `logfile_name && (am_server || !INFO_GTE(STATS, 1))`, and log_exit()
+    // writes the FLOG-only totals trailer
+    // `sent %s bytes  received %s bytes  total size %s` via `big_num()`
+    // (plain digits, inums.h:19-23) at log.c:894-899. A `-v`/`--stats` run
+    // raises STATS >= 1 and mirrors the FINFO trailer into the log instead
+    // (rendered by emit_transfer_summary above).
+    if verbosity == 0 && stats_level == 0 {
+        writeln!(
+            log.file,
+            "sent {} bytes  received {} bytes  total size {}",
+            summary.bytes_sent(),
+            summary.bytes_received(),
+            summary.total_source_bytes(),
+        )?;
+    }
     log.file.flush()
 }

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -673,7 +673,9 @@ where
         match open_log_file(path) {
             Ok(file) => {
                 log_file_for_local = Some(summary::LogFileConfig {
-                    file,
+                    // upstream: log.c:122-132 logit() - every log-file line is
+                    // stamped with `%Y/%m/%d %H:%M:%S [pid] `.
+                    file: logging_sink::logfile::LogFileWriter::new(file),
                     format: template.clone(),
                 });
             }

--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -56,6 +56,14 @@ pub fn render_diagnostic_events<O: Write, E: Write>(
     msgs2stderr: bool,
 ) -> io::Result<()> {
     for event in events {
+        // upstream: log.c:304-307 - an FLOG message goes to the log file when
+        // one is active and is otherwise discarded; it never reaches the
+        // client's stdout/stderr. The log-file sink consumes FLOG events via
+        // `logging::drain_events_coded` before this renderer runs, so any
+        // FLOG event still queued here has no log destination and is dropped.
+        if event.code() == logging::LogCode::Log {
+            continue;
+        }
         match event {
             DiagnosticEvent::Info {
                 flag: _,

--- a/crates/cli/src/frontend/tests/log_file.rs
+++ b/crates/cli/src/frontend/tests/log_file.rs
@@ -1,6 +1,31 @@
 use super::common::*;
 use super::*;
 
+/// Asserts the upstream log-file line prefix shape
+/// `^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \[\d+\] ` (upstream: log.c:127).
+fn assert_upstream_log_prefix(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let shape_ok = bytes.len() > 21
+        && bytes[..19].iter().enumerate().all(|(i, b)| match i {
+            4 | 7 => *b == b'/',
+            10 => *b == b' ',
+            13 | 16 => *b == b':',
+            _ => b.is_ascii_digit(),
+        })
+        && bytes[19] == b' '
+        && bytes[20] == b'[';
+    assert!(
+        shape_ok,
+        "log line missing upstream `%Y/%m/%d %H:%M:%S [pid] ` prefix (log.c:127): {line:?}"
+    );
+    let (pid, body) = line[21..].split_once("] ").expect("prefix `] ` separator");
+    assert!(
+        !pid.is_empty() && pid.bytes().all(|b| b.is_ascii_digit()),
+        "pid field must be numeric: {line:?}"
+    );
+    body
+}
+
 #[test]
 fn local_transfer_appends_default_log_entries() {
     use tempfile::tempdir;
@@ -64,8 +89,19 @@ fn local_transfer_respects_custom_log_format() {
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
+    // upstream routing for a verbosity-0 `--log-file` run: the FLOG banner
+    // (flist.c:2248), the per-file logfile-format line (log.c:818-826), and
+    // the FLOG totals trailer (log.c:894-899 via the cleanup.c:222-226
+    // `!INFO_GTE(STATS, 1)` gate) - each stamped by logit() (log.c:122-132).
     let logged = std::fs::read_to_string(&log_path).expect("read log file");
-    assert_eq!(logged, "custom.txt 6\n");
+    let bodies: Vec<&str> = logged.lines().map(assert_upstream_log_prefix).collect();
+    assert_eq!(bodies.len(), 3, "unexpected log lines: {logged:?}");
+    assert_eq!(bodies[0], "building file list");
+    assert_eq!(bodies[1], "custom.txt 6");
+    assert!(
+        bodies[2].starts_with("sent ") && bodies[2].contains("  total size "),
+        "missing FLOG totals trailer (log.c:895): {logged:?}"
+    );
 }
 
 #[test]
@@ -277,5 +313,58 @@ fn log_file_successive_transfers_append() {
     assert!(
         logged.contains("second.txt"),
         "second transfer should be appended: {logged:?}"
+    );
+}
+
+/// upstream: rwrite() mirrors FINFO to the log when `--log-file` is active
+/// (log.c:290-303): a `-v` run logs the `bytes/sec` + `speedup` trailer pair
+/// instead of the FLOG totals line, which cleanup.c:222-226 suppresses once
+/// `INFO_GTE(STATS, 1)` holds. FLOG lines never reach stdout (log.c:304-307).
+#[test]
+fn verbose_log_file_mirrors_info_trailer_and_keeps_flog_off_stdout() {
+    use tempfile::tempdir;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("mirror.txt");
+    let destination_dir = temp.path().join("dest");
+    std::fs::write(&source, b"mirror").expect("write source");
+    std::fs::create_dir(&destination_dir).expect("create destination dir");
+
+    let log_path = temp.path().join("mirror.log");
+
+    let (code, stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-v"),
+        OsString::from("--log-file"),
+        log_path.clone().into_os_string(),
+        source.into_os_string(),
+        destination_dir.into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    let stdout = String::from_utf8_lossy(&stdout);
+    assert!(
+        !stdout.contains("building file list"),
+        "FLOG banner must never reach stdout (log.c:304-307): {stdout:?}"
+    );
+
+    let logged = std::fs::read_to_string(&log_path).expect("read log file");
+    let bodies: Vec<&str> = logged.lines().map(assert_upstream_log_prefix).collect();
+    assert_eq!(bodies.first(), Some(&"building file list"));
+    assert!(
+        bodies.iter().any(|body| body.contains(" bytes/sec")),
+        "FINFO trailer must be mirrored into the log (log.c:290-303): {logged:?}"
+    );
+    assert!(
+        bodies.iter().any(|body| body.starts_with("total size is ")),
+        "FINFO speedup line must be mirrored into the log: {logged:?}"
+    );
+    assert!(
+        !bodies.iter().any(|body| body.contains("  total size ")),
+        "the FLOG totals line is suppressed when STATS >= 1 (cleanup.c:222-226): {logged:?}"
+    );
+    assert!(
+        logged.lines().all(|line| !line.trim().is_empty()),
+        "FCLIENT blank separators never reach the log (log.c:288-289): {logged:?}"
     );
 }

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -211,6 +211,24 @@ fn run_client_internal(
         None
     };
 
+    // upstream: send_file_list() announces the walk with an FLOG-only
+    // `rprintf(FLOG, "building file list\n")` (flist.c:2248), and the first
+    // recv_file_list() mirrors it with `rprintf(FLOG, "receiving file list\n")`
+    // (flist.c:2608). Both are unconditional (no verbosity gate): rwrite()
+    // routes FLOG to the log file when one is active and discards it
+    // otherwise (log.c:290-307), so the event is emitted here regardless of
+    // `-v` and the sink decides its fate by consuming the FLOG code.
+    logging::emit_info_coded(
+        logging::InfoFlag::Flist,
+        1,
+        logging::LogCode::Log,
+        if config.is_pull() {
+            "receiving file list".to_owned()
+        } else {
+            "building file list".to_owned()
+        },
+    );
+
     let has_daemon_url = config.transfer_args().iter().any(|arg| {
         arg.to_string_lossy().starts_with("rsync://") || arg.to_string_lossy().contains("::")
     });

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -24,7 +24,7 @@ use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime};
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
@@ -50,7 +50,7 @@ use core::{
     rsync_error, rsync_info, rsync_warning,
     server::{
         HandshakeResult, ReferenceDirectory, ReferenceDirectoryKind, ServerConfig, ServerResult,
-        ServerRole, run_server_with_handshake,
+        ServerRole, ServerStats, run_server_with_handshake,
     },
 };
 use logging_sink::MessageSink;
@@ -253,7 +253,9 @@ pub(crate) use self::module_state::{
     set_test_netgroup_members,
 };
 
-type SharedLogSink = Arc<Mutex<MessageSink<std::fs::File>>>;
+// upstream: log.c:122-132 logit() - every daemon log-file line is stamped
+// with `%Y/%m/%d %H:%M:%S [pid] `, provided by the LogFileWriter wrapper.
+type SharedLogSink = Arc<Mutex<MessageSink<logging_sink::logfile::LogFileWriter<std::fs::File>>>>;
 
 include!("daemon/runtime_options/types.rs");
 include!("daemon/runtime_options/parsing.rs");

--- a/crates/daemon/src/daemon/sections/hardening.rs
+++ b/crates/daemon/src/daemon/sections/hardening.rs
@@ -144,7 +144,10 @@ mod hardening_tests {
     fn capturing_sink() -> (SharedLogSink, std::fs::File) {
         let file = tempfile::tempfile().expect("create capturing tempfile");
         let reader = file.try_clone().expect("clone capturing tempfile");
-        let sink = Arc::new(Mutex::new(MessageSink::with_brand(file, Brand::Oc)));
+        let sink = Arc::new(Mutex::new(MessageSink::with_brand(
+            logging_sink::logfile::LogFileWriter::new(file),
+            Brand::Oc,
+        )));
         (sink, reader)
     }
 

--- a/crates/daemon/src/daemon/sections/log_format.rs
+++ b/crates/daemon/src/daemon/sections/log_format.rs
@@ -141,61 +141,6 @@ fn log_transfer(format: &str, ctx: &LogFormatContext<'_>, log_sink: &SharedLogSi
     log_message(log_sink, &message);
 }
 
-/// Maximum epoch seconds accepted for timestamp formatting.
-///
-/// Corresponds to 9999-12-31 23:59:59 UTC - the last representable date in
-/// a 4-digit year `YYYY/MM/DD HH:MM:SS` format. Values beyond this would
-/// produce a 5+ digit year that breaks fixed-width log formats.
-///
-/// upstream: log.c `timestring()` returns "unknown" when `localtime_r()`
-/// returns NULL for out-of-range `time_t` values (3.4.3 defence-in-depth).
-const MAX_TIMESTAMP_EPOCH_SECS: u64 = 253_402_300_799;
-
-/// Formats a Unix epoch timestamp as `YYYY/MM/DD HH:MM:SS`.
-///
-/// Returns a fallback placeholder for out-of-range values, matching upstream
-/// rsync's `timestring()` NULL-check on `localtime_r()` (3.4.3).
-///
-/// Upstream: `log.c` uses `strftime("%Y/%m/%d %H:%M:%S", ...)` via `timestring()`.
-/// This implementation performs the conversion manually to avoid external crate
-/// dependencies while matching the upstream output format.
-fn format_daemon_timestamp(epoch_secs: u64) -> String {
-    // upstream: log.c timestring() - NULL-check equivalent (3.4.3)
-    if epoch_secs > MAX_TIMESTAMP_EPOCH_SECS {
-        return "0000/00/00 00:00:00".to_owned();
-    }
-
-    // Days from 1970-01-01 to the given epoch seconds.
-    let total_days = epoch_secs / 86400;
-    let day_seconds = (epoch_secs % 86400) as u32;
-    let hours = day_seconds / 3600;
-    let minutes = (day_seconds % 3600) / 60;
-    let seconds = day_seconds % 60;
-
-    // Civil date from day count using the algorithm from
-    // Howard Hinnant's `chrono`-compatible date conversion.
-    let (year, month, day) = civil_from_days(total_days as i64);
-
-    format!("{year:04}/{month:02}/{day:02} {hours:02}:{minutes:02}:{seconds:02}")
-}
-
-/// Converts a day count (days since 1970-01-01) to a civil date (year, month, day).
-///
-/// Algorithm from Howard Hinnant's date library (public domain).
-fn civil_from_days(days: i64) -> (i32, u32, u32) {
-    let z = days + 719468;
-    let era = if z >= 0 { z } else { z - 146096 } / 146097;
-    let doe = (z - era * 146097) as u32;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    (y as i32, m, d)
-}
-
 /// Returns the effective log format string for a module.
 ///
 /// Falls back to `DEFAULT_LOG_FORMAT` when the module does not specify a
@@ -484,59 +429,6 @@ mod log_format_tests {
 
 
     #[test]
-    fn timestamp_unix_epoch() {
-        assert_eq!(format_daemon_timestamp(0), "1970/01/01 00:00:00");
-    }
-
-    #[test]
-    fn timestamp_known_date() {
-        // 2026-02-21 14:30:00 UTC = 1771684200 epoch seconds
-        // (verified via `datetime.datetime(2026,2,21,14,30,0,tzinfo=utc).timestamp()`)
-        let ts = format_daemon_timestamp(1_771_684_200);
-        assert_eq!(ts, "2026/02/21 14:30:00");
-    }
-
-    #[test]
-    fn timestamp_end_of_day() {
-        // 1970-01-01 23:59:59 = 86399
-        assert_eq!(format_daemon_timestamp(86399), "1970/01/01 23:59:59");
-    }
-
-    #[test]
-    fn timestamp_start_of_second_day() {
-        // 1970-01-02 00:00:00 = 86400
-        assert_eq!(format_daemon_timestamp(86400), "1970/01/02 00:00:00");
-    }
-
-    #[test]
-    fn timestamp_leap_year_date() {
-        // 2024-02-29 12:00:00 UTC = 1709208000
-        let ts = format_daemon_timestamp(1_709_208_000);
-        assert_eq!(ts, "2024/02/29 12:00:00");
-    }
-
-    /// upstream: log.c timestring() NULL-check equivalent (3.4.3)
-    #[test]
-    fn timestamp_out_of_range_returns_placeholder() {
-        // Values beyond year 9999 should return the fallback placeholder.
-        assert_eq!(
-            format_daemon_timestamp(MAX_TIMESTAMP_EPOCH_SECS + 1),
-            "0000/00/00 00:00:00"
-        );
-        assert_eq!(
-            format_daemon_timestamp(u64::MAX),
-            "0000/00/00 00:00:00"
-        );
-    }
-
-    /// The boundary value (9999-12-31 23:59:59) should format correctly.
-    #[test]
-    fn timestamp_at_max_boundary() {
-        let ts = format_daemon_timestamp(MAX_TIMESTAMP_EPOCH_SECS);
-        assert_eq!(ts, "9999/12/31 23:59:59");
-    }
-
-    #[test]
     fn push_u64_zero() {
         let mut buf = String::new();
         push_u64(&mut buf, 0);
@@ -555,17 +447,5 @@ mod log_format_tests {
         let mut buf = String::new();
         push_u32(&mut buf, 12345);
         assert_eq!(buf, "12345");
-    }
-
-
-    #[test]
-    fn civil_from_days_epoch() {
-        assert_eq!(civil_from_days(0), (1970, 1, 1));
-    }
-
-    #[test]
-    fn civil_from_days_known_date() {
-        // 2026-02-21 is day 20505 from epoch
-        assert_eq!(civil_from_days(20505), (2026, 2, 21));
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -60,7 +60,13 @@ pub(crate) fn open_log_sink(path: &Path, brand: Brand) -> Result<SharedLogSink, 
         .append(true)
         .open(path)
         .map_err(|error| log_file_error(path, error))?;
-    Ok(Arc::new(Mutex::new(MessageSink::with_brand(file, brand))))
+    // upstream: log.c:122-132 logit() stamps `%Y/%m/%d %H:%M:%S [pid] ` on
+    // every log-file line; the wrapper applies the same shared formatter used
+    // by the client `--log-file` sink.
+    Ok(Arc::new(Mutex::new(MessageSink::with_brand(
+        logging_sink::logfile::LogFileWriter::new(file),
+        brand,
+    ))))
 }
 
 /// Reopens the connection's log sink to the selected module's `log file`.
@@ -130,10 +136,22 @@ fn lock_file_error(path: &Path, error: io::Error) -> DaemonError {
 }
 
 /// Writes a message to the shared log sink with proper locking.
+///
+/// upstream: log.c:122-132 logit() writes the raw `rwrite()` buffer after the
+/// timestamp prefix. FINFO/FLOG bodies carry no severity tag (e.g.
+/// `connect from host (addr)`, clientserver.c:1393), so info messages are
+/// written as bare text; error and warning bodies already embed their
+/// `rsync error:`-style text upstream, so they keep the sink's rendering.
 fn log_message(log: &SharedLogSink, message: &Message) {
-    if let Ok(mut sink) = log.lock()
-        && sink.write(message).is_ok()
-    {
+    let Ok(mut sink) = log.lock() else {
+        return;
+    };
+    let written = if message.severity() == core::message::Severity::Info {
+        writeln!(sink.writer_mut(), "{}", message.text()).is_ok()
+    } else {
+        sink.write(message).is_ok()
+    };
+    if written {
         let _ = sink.flush();
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -321,6 +321,16 @@ fn execute_transfer(
         );
         let message = rsync_info!(text).with_role(Role::Daemon);
         log_message(log, &message);
+
+        // upstream: the daemon sender announces the walk with the FLOG-only
+        // `building file list` (flist.c:2248) and the daemon receiver mirrors
+        // it with `receiving file list` (flist.c:2608); both land in the
+        // daemon log via rwrite()'s am_daemon branch (log.c:290-303).
+        let banner = match role {
+            ServerRole::Generator => "building file list",
+            ServerRole::Receiver => "receiving file list",
+        };
+        log_message(log, &rsync_info!(banner).with_role(Role::Daemon));
     }
 
     // Use standard buffered I/O for daemon socket communication.
@@ -330,8 +340,19 @@ fn execute_transfer(
     // matching upstream rsync's socket I/O model.
     let result = run_daemon_transfer(config, handshake, read_stream, write_stream);
 
+    // upstream: log.c:290-305 - FLOG-classified diagnostics emitted while the
+    // transfer ran belong in the daemon log only; they never travel to the
+    // client. Consume them from the thread-local queue by log code.
+    if let Some(log) = ctx.log_sink {
+        for event in logging::drain_events_coded(logging::LogCode::Log) {
+            let (logging::DiagnosticEvent::Info { message, .. }
+            | logging::DiagnosticEvent::Debug { message, .. }) = event;
+            log_message(log, &rsync_info!(message).with_role(Role::Daemon));
+        }
+    }
+
     match result {
-        Ok(_server_stats) => {
+        Ok(server_stats) => {
             if let Some(log) = ctx.log_sink {
                 if module.transfer_logging {
                     let operation = match role {
@@ -341,11 +362,10 @@ fn execute_transfer(
                     let addr_str = ctx.peer_ip.to_string();
                     let path_str = module.path.display().to_string();
                     let pid = std::process::id();
-                    let now = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default();
-                    let secs = now.as_secs();
-                    let timestamp = format_daemon_timestamp(secs);
+                    // upstream: log.c:664 `%t` renders timestring(time(NULL)) -
+                    // the same localtime formatter that stamps log-file lines.
+                    let timestamp =
+                        logging_sink::logfile::format_log_timestamp(SystemTime::now());
 
                     let log_ctx = LogFormatContext {
                         operation,
@@ -367,14 +387,23 @@ fn execute_transfer(
                     log_transfer(fmt, &log_ctx, log);
                 }
 
+                // upstream: cleanup.c:222-226 - `am_daemon` always runs
+                // log_exit(), whose FLOG totals trailer
+                // `sent %s bytes  received %s bytes  total size %s`
+                // (log.c:894-899, plain `big_num()` digits) closes every
+                // daemon transfer in the log.
+                let (sent, received, total_size) = match &server_stats {
+                    ServerStats::Generator(stats) => {
+                        (stats.bytes_sent, stats.bytes_read, stats.total_size)
+                    }
+                    ServerStats::Receiver(stats) => {
+                        (stats.bytes_sent, stats.bytes_received, stats.total_source_bytes)
+                    }
+                };
                 let text = format!(
-                    "transfer to {} ({}): module={} status=success",
-                    ctx.effective_host().unwrap_or("unknown"),
-                    ctx.peer_ip,
-                    ctx.request
+                    "sent {sent} bytes  received {received} bytes  total size {total_size}"
                 );
-                let message = rsync_info!(text).with_role(Role::Daemon);
-                log_message(log, &message);
+                log_message(log, &rsync_info!(text).with_role(Role::Daemon));
             }
             0
         }

--- a/crates/daemon/src/daemon/sections/privilege.rs
+++ b/crates/daemon/src/daemon/sections/privilege.rs
@@ -432,14 +432,20 @@ fn open_privilege_fallback_sink() -> SharedLogSink {
         .unwrap_or_else(|_| {
             tempfile::tempfile().expect("open temporary file for privilege log sink")
         });
-    Arc::new(Mutex::new(MessageSink::with_brand(file, Brand::Oc)))
+    Arc::new(Mutex::new(MessageSink::with_brand(
+        logging_sink::logfile::LogFileWriter::new(file),
+        Brand::Oc,
+    )))
 }
 
 /// Creates a [`SharedLogSink`] backed by a temporary file for testing.
 #[cfg(test)]
 fn test_log_sink() -> SharedLogSink {
     let file = tempfile::tempfile().expect("create temp file for test log sink");
-    Arc::new(Mutex::new(MessageSink::with_brand(file, Brand::Oc)))
+    Arc::new(Mutex::new(MessageSink::with_brand(
+        logging_sink::logfile::LogFileWriter::new(file),
+        Brand::Oc,
+    )))
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+/// Strips the upstream `%Y/%m/%d %H:%M:%S [pid] ` log-file prefix
+/// (upstream: log.c:122-132 logit()) so body assertions see the rendered text.
+fn log_body(contents: &str) -> &str {
+    contents.split_once("] ").map_or(contents, |(_, body)| body)
+}
+
 #[test]
 fn format_connection_status_zero_connections() {
     assert_eq!(format_connection_status(0), "Idle; waiting for connections");
@@ -587,7 +593,7 @@ fn parse_socket_options_unknown_option_logs_warning() {
     drop(log_sink);
     let contents = std::fs::read_to_string(&log_path).expect("read log");
     assert!(
-        contents.starts_with("oc-rsync warning:"),
+        log_body(&contents).starts_with("oc-rsync warning:"),
         "expected warning level, got: {contents}"
     );
     assert!(
@@ -613,7 +619,7 @@ fn parse_socket_options_opt_on_value_warns_and_applies() {
     drop(log_sink);
     let contents = std::fs::read_to_string(&log_path).expect("read log");
     assert!(
-        contents.starts_with("oc-rsync warning:"),
+        log_body(&contents).starts_with("oc-rsync warning:"),
         "expected warning level, got: {contents}"
     );
     assert!(
@@ -811,7 +817,7 @@ fn apply_socket_options_warns_and_continues_on_per_option_failure() {
     drop(log_sink);
     let contents = std::fs::read_to_string(&log_path).expect("read log");
     assert!(
-        contents.starts_with("oc-rsync warning:"),
+        log_body(&contents).starts_with("oc-rsync warning:"),
         "expected warning level, got: {contents}"
     );
     assert!(
@@ -1122,7 +1128,7 @@ fn refuse_if_at_capacity_emits_structured_warning() {
 
     let contents = std::fs::read_to_string(&log_path).expect("read log");
     assert!(
-        contents.starts_with("oc-rsync warning:"),
+        log_body(&contents).starts_with("oc-rsync warning:"),
         "expected warning level, got: {contents}"
     );
     assert!(

--- a/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
+++ b/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
@@ -17,8 +17,11 @@ fn log_module_limit_logs_cap_reached() {
     drop(log);
 
     let contents = fs::read_to_string(&path).expect("read log");
+    // upstream: log.c:122-132 logit() stamps `%Y/%m/%d %H:%M:%S [pid] ` ahead
+    // of the rendered warning body.
+    let body = contents.split_once("] ").map_or(contents.as_str(), |(_, body)| body);
     assert!(
-        contents.starts_with("oc-rsync warning:"),
+        body.starts_with("oc-rsync warning:"),
         "expected warning-level message, got: {contents}"
     );
     assert!(

--- a/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
@@ -69,12 +69,36 @@ fn run_daemon_records_log_file_entries() {
     }
 
     let log_contents = fs::read_to_string(&log_path).expect("read log file");
+    // upstream: log.c:122-132 logit() writes the raw rwrite() buffer after
+    // the `%Y/%m/%d %H:%M:%S [pid] ` prefix; FLOG/FINFO bodies carry no
+    // severity tag (e.g. `rsyncd version %s starting`, clientserver.c:1580).
     assert!(
         log_contents
             .lines()
-            .any(|line| line.contains("oc-rsync info: rsyncd version")),
-        "log should use oc-rsync branding: {log_contents:?}"
+            .any(|line| line.contains("rsyncd version") && !line.contains("info:")),
+        "log lines must carry the raw upstream body: {log_contents:?}"
     );
+    let prefix_ok = |line: &str| {
+        let bytes = line.as_bytes();
+        bytes.len() > 21
+            && bytes[..19].iter().enumerate().all(|(i, b)| match i {
+                4 | 7 => *b == b'/',
+                10 => *b == b' ',
+                13 | 16 => *b == b':',
+                _ => b.is_ascii_digit(),
+            })
+            && bytes[19] == b' '
+            && bytes[20] == b'['
+            && line[21..]
+                .split_once("] ")
+                .is_some_and(|(pid, _)| !pid.is_empty() && pid.bytes().all(|b| b.is_ascii_digit()))
+    };
+    for line in log_contents.lines() {
+        assert!(
+            prefix_ok(line),
+            "log line missing upstream `timestamp [pid] ` prefix (log.c:127): {line:?}"
+        );
+    }
     assert!(log_contents.contains("connect from"));
     assert!(log_contents.contains("127.0.0.1"));
     assert!(log_contents.contains("module 'docs'"));

--- a/crates/logging-sink/Cargo.toml
+++ b/crates/logging-sink/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 core = { path = "../core", default-features = false }
+platform = { path = "../platform" }
 
 [target.'cfg(unix)'.dependencies]
 syslog = "7"

--- a/crates/logging-sink/src/lib.rs
+++ b/crates/logging-sink/src/lib.rs
@@ -72,6 +72,8 @@
 //! - `logging` crate for verbosity flags and the `info_log!`/`debug_log!` macros.
 
 mod line_mode;
+/// Upstream `logit()`-compatible log-file line formatting.
+pub mod logfile;
 mod sink;
 /// Syslog backend for daemon-mode logging.
 ///

--- a/crates/logging-sink/src/logfile.rs
+++ b/crates/logging-sink/src/logfile.rs
@@ -1,0 +1,281 @@
+//! Upstream-compatible log-file line formatting.
+//!
+//! Upstream rsync writes every log-file line through one function:
+//! `logit()` prefixes the message with `timestring(time(NULL))` and the
+//! writer's pid - `"%s [%d] %s"` (upstream: log.c:122-132). `timestring()`
+//! renders local time as `%4d/%02d/%02d %02d:%02d:%02d`
+//! (upstream: util1.c:1456-1473). Both the client `--log-file` sink and the
+//! daemon `log file` sink share that formatter; this module is its single
+//! oc-rsync counterpart.
+
+use std::io::{self, Write};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Maximum epoch seconds accepted for timestamp formatting.
+///
+/// Corresponds to 9999-12-31 23:59:59 UTC - the last representable date in a
+/// 4-digit-year `YYYY/MM/DD HH:MM:SS` layout. upstream: util1.c:1463-1466
+/// `timestring()` falls back to a placeholder when `localtime_r()` fails.
+const MAX_TIMESTAMP_EPOCH_SECS: i64 = 253_402_300_799;
+
+/// Formats an instant as `YYYY/MM/DD HH:MM:SS` in the local timezone.
+///
+/// upstream: util1.c:1456-1473 `timestring()` - `localtime_r()` followed by
+/// `"%4d/%02d/%02d %02d:%02d:%02d"`. The local offset is computed per instant
+/// (DST-correct) via `platform::local_time`, matching `localtime_r`.
+/// Out-of-range instants render the placeholder `0000/00/00 00:00:00`,
+/// mirroring the upstream NULL-`localtime_r` fallback.
+#[must_use]
+pub fn format_log_timestamp(instant: SystemTime) -> String {
+    let unix_secs = match instant.duration_since(UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_secs()).unwrap_or(i64::MAX),
+        Err(before_epoch) => -i64::try_from(before_epoch.duration().as_secs()).unwrap_or(i64::MAX),
+    };
+    let offset = i64::from(platform::local_time::local_utc_offset_seconds(unix_secs));
+    let local_secs = unix_secs.saturating_add(offset);
+    if !(0..=MAX_TIMESTAMP_EPOCH_SECS).contains(&local_secs) {
+        // upstream: util1.c:1463-1466 timestring() NULL-check equivalent.
+        return "0000/00/00 00:00:00".to_owned();
+    }
+
+    let day_seconds = (local_secs % 86_400) as u32;
+    let hours = day_seconds / 3_600;
+    let minutes = (day_seconds % 3_600) / 60;
+    let seconds = day_seconds % 60;
+    let (year, month, day) = civil_from_days(local_secs / 86_400);
+    format!("{year:04}/{month:02}/{day:02} {hours:02}:{minutes:02}:{seconds:02}")
+}
+
+/// Converts a day count (days since 1970-01-01) to a civil `(year, month, day)`.
+///
+/// Algorithm from Howard Hinnant's date library (public domain).
+fn civil_from_days(days: i64) -> (i32, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u32;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = i64::from(yoe) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m, d)
+}
+
+/// Returns the prefix upstream stamps on every log-file line, for `instant`
+/// and `pid`: `"YYYY/MM/DD HH:MM:SS [pid] "`.
+///
+/// upstream: log.c:127 `fprintf(logfile_fp, "%s [%d] %s", timestring(time(NULL)),
+/// (int)getpid(), buf)`.
+#[must_use]
+pub fn format_log_line_prefix(instant: SystemTime, pid: u32) -> String {
+    format!("{} [{pid}] ", format_log_timestamp(instant))
+}
+
+/// Returns the log-file line prefix for the current instant and process.
+#[must_use]
+pub fn log_line_prefix_now() -> String {
+    format_log_line_prefix(SystemTime::now(), std::process::id())
+}
+
+/// Writer adapter that stamps the upstream log-file prefix on every line.
+///
+/// Wraps the log-file handle so that each written line starts with
+/// `"YYYY/MM/DD HH:MM:SS [pid] "` (upstream: log.c:122-132 `logit()`), with
+/// the timestamp taken when the line starts. Lines that would be empty are
+/// dropped: upstream emits cosmetic blank separators as `FCLIENT` messages
+/// (e.g. main.c:427/461 `rprintf(FCLIENT, "\n")`), and `rwrite()` converts
+/// `FCLIENT` to `FINFO` *after* skipping the log-file branch
+/// (upstream: log.c:288-289), so a blank line never reaches the log file.
+#[derive(Debug)]
+pub struct LogFileWriter<W: Write> {
+    inner: W,
+    at_line_start: bool,
+}
+
+impl<W: Write> LogFileWriter<W> {
+    /// Wraps `inner` so every line it receives is stamped with the upstream
+    /// log-file prefix.
+    pub fn new(inner: W) -> Self {
+        Self {
+            inner,
+            at_line_start: true,
+        }
+    }
+
+    /// Returns a shared reference to the wrapped writer.
+    pub const fn get_ref(&self) -> &W {
+        &self.inner
+    }
+
+    /// Consumes the adapter, returning the wrapped writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: Write> Write for LogFileWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Copy line segments through in batches, stamping the prefix whenever
+        // a non-empty line starts and dropping FCLIENT-style blank separators
+        // (log.c:288-289 - FCLIENT never reaches the log file).
+        let mut rest = buf;
+        while !rest.is_empty() {
+            if self.at_line_start && rest[0] == b'\n' {
+                rest = &rest[1..];
+                continue;
+            }
+            if self.at_line_start {
+                self.inner.write_all(log_line_prefix_now().as_bytes())?;
+                self.at_line_start = false;
+            }
+            match rest.iter().position(|&byte| byte == b'\n') {
+                Some(newline) => {
+                    self.inner.write_all(&rest[..=newline])?;
+                    self.at_line_start = true;
+                    rest = &rest[newline + 1..];
+                }
+                None => {
+                    self.inner.write_all(rest)?;
+                    rest = &[];
+                }
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn prefix_pattern_matches(line: &str) -> bool {
+        // ^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \[\d+\]
+        let bytes = line.as_bytes();
+        if bytes.len() < 23 {
+            return false;
+        }
+        let digits = |range: std::ops::Range<usize>| bytes[range].iter().all(u8::is_ascii_digit);
+        digits(0..4)
+            && bytes[4] == b'/'
+            && digits(5..7)
+            && bytes[7] == b'/'
+            && digits(8..10)
+            && bytes[10] == b' '
+            && digits(11..13)
+            && bytes[13] == b':'
+            && digits(14..16)
+            && bytes[16] == b':'
+            && digits(17..19)
+            && bytes[19] == b' '
+            && bytes[20] == b'['
+            && line[21..]
+                .split_once("] ")
+                .is_some_and(|(pid, _)| !pid.is_empty() && pid.bytes().all(|b| b.is_ascii_digit()))
+    }
+
+    /// upstream: log.c:127 - every log-file line starts with
+    /// `YYYY/MM/DD HH:MM:SS [pid] `.
+    #[test]
+    fn prefix_has_upstream_shape() {
+        let prefix = log_line_prefix_now();
+        assert!(
+            prefix_pattern_matches(&prefix),
+            "prefix {prefix:?} does not match upstream logit() shape"
+        );
+        assert!(prefix.ends_with("] "));
+        assert!(prefix.contains(&format!("[{}] ", std::process::id())));
+    }
+
+    /// upstream: util1.c:1467-1469 - zero-padded `%4d/%02d/%02d %02d:%02d:%02d`.
+    #[test]
+    fn timestamp_is_zero_padded() {
+        let rendered = format_log_timestamp(UNIX_EPOCH + std::time::Duration::from_secs(3_723));
+        // 1970-01-01 01:02:03 UTC; the local offset may shift it, but the
+        // shape must remain fixed-width.
+        assert_eq!(rendered.len(), 19);
+        assert_eq!(&rendered[4..5], "/");
+        assert_eq!(&rendered[7..8], "/");
+        assert_eq!(&rendered[10..11], " ");
+    }
+
+    /// upstream: util1.c:1461 - `localtime_r`, not UTC: the rendered hour
+    /// must reflect the host offset for the instant.
+    #[test]
+    fn timestamp_applies_local_offset() {
+        let instant = UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        let offset = i64::from(platform::local_time::local_utc_offset_seconds(
+            1_700_000_000,
+        ));
+        let shifted = 1_700_000_000_i64 + offset;
+        let expected_hour = (shifted % 86_400) / 3_600;
+        let rendered = format_log_timestamp(instant);
+        assert_eq!(&rendered[11..13], format!("{expected_hour:02}").as_str());
+    }
+
+    /// upstream: util1.c:1463-1466 - out-of-range instants render the
+    /// placeholder instead of overflowing the fixed-width year.
+    #[test]
+    fn timestamp_out_of_range_renders_placeholder() {
+        let far = UNIX_EPOCH + std::time::Duration::from_secs(u64::MAX / 2);
+        assert_eq!(format_log_timestamp(far), "0000/00/00 00:00:00");
+    }
+
+    /// upstream: log.c:122-132 - each line written through the sink gains
+    /// exactly one prefix, and multi-line writes prefix every line.
+    #[test]
+    fn writer_prefixes_every_line() {
+        let mut writer = LogFileWriter::new(Vec::new());
+        writer.write_all(b"building file list\n").unwrap();
+        writer.write_all(b"first\nsecond\n").unwrap();
+        let output = String::from_utf8(writer.into_inner()).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 3);
+        for line in &lines {
+            assert!(
+                prefix_pattern_matches(line),
+                "line {line:?} lacks the upstream prefix"
+            );
+        }
+        assert!(lines[0].ends_with("building file list"));
+        assert!(lines[1].ends_with("first"));
+        assert!(lines[2].ends_with("second"));
+    }
+
+    /// A line split across separate `write` calls must receive one prefix,
+    /// stamped when the line starts (upstream logs one prefix per message).
+    #[test]
+    fn writer_stamps_split_line_once() {
+        let mut writer = LogFileWriter::new(Vec::new());
+        writer.write_all(b"sent 42 bytes").unwrap();
+        writer.write_all(b"  total size 7\n").unwrap();
+        let output = String::from_utf8(writer.into_inner()).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 1);
+        assert!(prefix_pattern_matches(lines[0]));
+        assert!(lines[0].ends_with("sent 42 bytes  total size 7"));
+    }
+
+    /// upstream: main.c:427/461 emit blank separators as FCLIENT, which never
+    /// reaches the log file (log.c:288-289): an empty line must vanish rather
+    /// than appear as a bare prefix.
+    #[test]
+    fn writer_drops_blank_lines() {
+        let mut writer = LogFileWriter::new(Vec::new());
+        writer.write_all(b"\n").unwrap();
+        writer.write_all(b"totals\n\n").unwrap();
+        let output = String::from_utf8(writer.into_inner()).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "blank lines must not reach the log: {output:?}"
+        );
+        assert!(lines[0].ends_with("totals"));
+    }
+}

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -97,8 +97,8 @@ pub use levels::{DebugFlag, DebugLevels, InfoFlag, InfoLevels};
 pub use log_code::{LogCode, ParseLogCodeError};
 pub use phase_timer::PhaseTimer;
 pub use thread_local::{
-    DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events, emit_debug,
-    emit_debug_coded, emit_info, emit_info_coded, info_gte, init,
+    DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events,
+    drain_events_coded, emit_debug, emit_debug_coded, emit_info, emit_info_coded, info_gte, init,
 };
 
 #[cfg(feature = "tracing")]

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -159,6 +159,29 @@ pub fn drain_events() -> Vec<DiagnosticEvent> {
     EVENTS.with(|e| e.borrow_mut().drain(..).collect())
 }
 
+/// Drain only the events carrying `code`, leaving all other events queued.
+///
+/// This is how a log-file sink consumes `FLOG`-classified events without
+/// disturbing the client-stream events that a later [`drain_events`] renders:
+/// upstream's `rwrite()` writes an FLOG message to the log file and returns
+/// before the client-stream dispatch (upstream: log.c:290-307), so the two
+/// destinations drain independently. Returns matches in emission order.
+pub fn drain_events_coded(code: LogCode) -> Vec<DiagnosticEvent> {
+    EVENTS.with(|e| {
+        let mut events = e.borrow_mut();
+        let mut matched = Vec::new();
+        events.retain(|event| {
+            if event.code() == code {
+                matched.push(event.clone());
+                false
+            } else {
+                true
+            }
+        });
+        matched
+    })
+}
+
 /// Apply an info flag token to the current thread's configuration.
 ///
 /// Parses tokens like `"copy2"` or `"del"` and updates the corresponding


### PR DESCRIPTION
## Summary

Makes `--log-file` routing and line format match upstream rsync 3.4.4's `log.c`, for both the client `--log-file` sink and the daemon `log file` sink, sharing one formatter.

## Upstream routing matrix (log.c:rwrite)

| Code | Log file (when `am_daemon \|\| logfile_name`) | Client streams |
|------|----------------------------------------------|----------------|
| `FLOG` | written (log.c:290-303), then **returns** (log.c:304-305) | never; discarded outright when no log destination (log.c:306-307) |
| `FINFO` | mirrored (log.c:290-303) | stdout unless `--quiet` (log.c:317-320) |
| `FERROR`/`FERROR_XFER`/`FWARNING` | mirrored (log.c:290-303) | stderr (log.c:309-316) |
| `FCLIENT` | **skipped** - converted to `FINFO` *before* the log branch (log.c:288-289) | stdout |

Additional branches: `am_daemon && !am_server` stops after the log write (log.c:304-305); `am_server` forwards client-stream output over the multiplex instead of writing locally (log.c:330-346); a busted-socket daemon converts everything to `FLOG` (log.c:266-273). The FLOG totals trailer `sent %s bytes  received %s bytes  total size %s` (log.c:894-899, plain `big_num()` digits per inums.h:19-23) fires under cleanup.c:222-226's gate: `logfile_name && (am_server || !INFO_GTE(STATS, 1))` - so a plain run logs it while `-v`/`--stats` logs the mirrored FINFO trailer pair instead.

## Line format (log.c:logit)

Every log-file line is `timestring(time(NULL)) + " [pid] " + raw buffer` (log.c:127); `timestring()` is localtime `%4d/%02d/%02d %02d:%02d:%02d` (util1.c:1456-1473). One shared formatter now serves the client `--log-file`, the daemon log, and the daemon `%t` escape.

## Changes

- **logging-sink**: new `logfile` module - `format_log_timestamp` (localtime via `platform::local_time`, upstream util1.c:1456-1473), `format_log_line_prefix`/`log_line_prefix_now` (log.c:127), and `LogFileWriter<W>`, a `Write` adapter that stamps the prefix at each line start and drops the FCLIENT-style blank separators that never reach the log upstream (main.c:427/461 + log.c:288-289).
- **logging**: `drain_events_coded(LogCode)` drains only events with a given code, so the log-file sink consumes the FLOG lane without disturbing client-stream events. The renderer (`render_diagnostic_events`) now drops `FLOG`-coded events instead of printing them to stdout (log.c:304-307).
- **core**: the client run emits the FLOG banner as a `LogCode::Log` event - `building file list` (flist.c:2248) or `receiving file list` on a pull (flist.c:2608) - unconditionally, letting the sink route it.
- **cli**: the `--log-file` handle is wrapped in `LogFileWriter`; `emit_log_output` writes drained FLOG events first, then the per-file/`--log-file-format` lines and the mirrored FINFO trailer, and appends the FLOG totals trailer when `verbosity == 0 && stats_level == 0` (cleanup.c:222-226).
- **daemon**: the daemon log sink and its privilege/test sinks use the same `LogFileWriter`; `log_message` writes info bodies raw (upstream FLOG/FINFO bodies carry no severity tag - e.g. `connect from %s (%s)`, clientserver.c:1393) while errors/warnings keep their rendered text; the transfer path logs `building file list`/`receiving file list` by role, drains FLOG-coded events into the module log, and replaces the invented `transfer to ... status=success` line with upstream's FLOG totals trailer (log.c:894-899 via cleanup.c's `am_daemon` arm). The `%t` escape and the deleted local UTC formatter now use the shared localtime formatter.

## Verification vs rsync 3.4.4 (banner-confirmed, /opt/homebrew/bin/rsync)

- Local `-av --log-file`: upstream and oc logs both read banner, `%i %n%L` lines, mirrored `bytes/sec` + `speedup` pair; no blank line; no FLOG totals.
- Local `-a --log-file`: both logs end with `sent N bytes  received N bytes  total size N` (plain digits) and contain no mirrored FINFO pair.
- Single-file `--log-file-format='%f %l'`: both logs are exactly banner + format line + FLOG totals (3 lines).
- Daemon with `log file`: prefixes, raw bodies, `building file list`/`receiving file list` per role, and the totals trailer now match upstream's line classes for pull and push.
- Client `--log-file` over a remote-shell wrapper and over `rsync://`: banner, mirrored trailer, prefixes match.
- Format asserted in tests via the `^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \[\d+\] ` shape; new tests fail before this change.

## Known remaining gaps (pre-existing, out of scope here)

- Remote transfers (`rsync://`, remote shell) do not yet record per-file `%i %n%L` lines in the client log: the client-side event pipeline does not surface per-file itemize entries to the log renderer for remote paths (confirmed identical in v0.6.3). Local transfers log them correctly.
- Daemon connection/auth line bodies keep their existing oc wording (`module 'x' requested from ...` vs upstream `rsync on x/ from ...`, clientserver.c:1128-1134); aligning those texts is daemon-log content parity work beyond this sink change.
- The daemon still does not mirror mid-transfer FINFO/FERROR sender diagnostics into its own log (upstream log.c:290-303); this PR adds the FLOG lane (banner, totals, drained FLOG events), so the daemon-sender-diagnostics task remains open for the FINFO/FERROR mirror.
