### PR TITLE
fix(transfer): itemize replaced symlinks as changes, not creates

### DIFF
--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -251,8 +251,10 @@ impl LocalCopyChangeSet {
     /// `itemize(... ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE ...)`.
     /// `ITEM_REPORT_CHANGE` lights up the `c` glyph in position 2 to signal
     /// that the link target itself changed. `itemize()` then adds
-    /// `ITEM_REPORT_TIME` when the symlink's mtime differs from the existing
-    /// link's mtime (gated by `!omit_link_times`).
+    /// `ITEM_REPORT_TIME` when `keep_time` holds and the symlink's mtime
+    /// differs from the existing link's mtime; without `keep_time` (no `-t`,
+    /// or `-J`) the `ITEM_LOCAL_CHANGE` branch at generator.c:526-530 sets it
+    /// unconditionally.
     ///
     /// The mtime comparison uses `same_time()` semantics via
     /// `system_time_within_window`, not exact equality: upstream `itemize()` at
@@ -284,6 +286,18 @@ impl LocalCopyChangeSet {
                     change_set = change_set.with_time_change(Some(TimeChange::Modified));
                 }
             }
+        } else {
+            // upstream: generator.c:526-530 - without `keep_time` the
+            // ITEM_LOCAL_CHANGE branch sets ITEM_REPORT_TIME unconditionally
+            // for a recreated link. log.c:714-717 renders it `t` when mtimes
+            // are preserved (`-J` only drops keep_time, not preserve_mtimes)
+            // and `T` when they are not.
+            let change = if metadata_options.times() {
+                TimeChange::Modified
+            } else {
+                TimeChange::TransferTime
+            };
+            change_set = change_set.with_time_change(Some(change));
         }
 
         // No perm/owner/group slots are lit for a recreated symlink: oc does

--- a/crates/engine/src/local_copy/plan/change_set/tests.rs
+++ b/crates/engine/src/local_copy/plan/change_set/tests.rs
@@ -899,7 +899,7 @@ fn for_recreated_symlink_ignores_sub_second_mtime_drift() {
 
 #[cfg(unix)]
 #[test]
-fn for_recreated_symlink_omit_link_times_suppresses_time_flag() {
+fn for_recreated_symlink_omit_link_times_still_reports_time() {
     use filetime::{FileTime, set_symlink_file_times};
     use std::os::unix::fs::symlink;
 
@@ -935,7 +935,11 @@ fn for_recreated_symlink_omit_link_times_suppresses_time_flag() {
     );
 
     assert!(change_set.checksum_changed());
-    assert_eq!(change_set.time_change(), None);
+    // upstream: generator.c:526-530 - `-J` drops keep_time, so the recreate
+    // path sets ITEM_REPORT_TIME unconditionally; with `-t` still active
+    // log.c:714-717 renders it as a lowercase `t` (`cLc.t......`), verified
+    // against rsync 3.4.4.
+    assert_eq!(change_set.time_change(), Some(TimeChange::Modified));
 }
 
 #[cfg(unix)]

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -109,17 +109,16 @@ impl ReceiverContext {
 
             let link_path = dest_dir.join(relative_path);
 
-            // Track whether the destination already existed (symlink or
-            // obstacle) before this create. Upstream only sets ITEM_IS_NEW - and
-            // thus only bumps stats.created_symlinks - when recv_generator's
-            // link_stat finds the destination absent (generator.c:1561,
-            // `statret < 0`); a re-pointed link or a replaced obstacle is a
-            // change, not a creation.
-            let mut dest_existed = false;
+            // upstream: generator.c:1606-1609 - the post-create itemize keeps
+            // `statret == 0` when the replaced destination was itself a
+            // symlink, diffing attributes against the pre-replace lstat; a
+            // non-symlink obstacle has `statret` forced to -1 and an absent
+            // destination arrives with it, so both render ITEM_IS_NEW.
+            // Capture the old lstat before the obstacle is backed up/unlinked.
+            let mut pre_replace_symlink_meta: Option<fs::Metadata> = None;
 
             // upstream: generator.c:1573 - quick_check_ok(FT_SYMLINK, ...)
             if let Ok(existing_target) = std::fs::read_link(&link_path) {
-                dest_existed = true;
                 if existing_target == *target {
                     // upstream: generator.c:1575 - even on the up-to-date branch
                     // `set_file_attrs(fname, file, &sx, NULL, maybe_ATTRS_REPORT)`
@@ -151,6 +150,7 @@ impl ReceiverContext {
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
                 }
+                pre_replace_symlink_meta = fs::symlink_metadata(&link_path).ok();
                 // upstream: generator.c:2018-2020 atomic_create - back the old
                 // symlink up before it is removed when --backup is set; on
                 // backup-mechanism failure upstream skips the entry.
@@ -195,7 +195,6 @@ impl ReceiverContext {
             )
             .is_ok()
             {
-                dest_existed = true;
                 // SEC-1.f: when the sandbox is plumbed and the destination
                 // parent is the sandbox root, the obstacle stat goes through
                 // `fstatat(AT_SYMLINK_NOFOLLOW)` so a TOCTOU symlink swap on
@@ -327,13 +326,23 @@ impl ReceiverContext {
                     error
                 );
             }
-            // upstream: generator.c:1594 - itemize new symlink after creation
-            let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+            // upstream: generator.c:1604-1610 - itemize after atomic_create
+            // with base ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE: a replaced
+            // symlink itemizes as a change against the pre-replace lstat
+            // (`statret == 0`); an absent destination or a non-symlink
+            // obstacle (`statret` forced to -1) renders the all-new row.
+            let raw = self.itemize_existing_flags(
+                entry,
+                &link_path,
+                pre_replace_symlink_meta.as_ref(),
+                ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_REPORT_CHANGE,
+            );
+            let iflags = ItemFlags::from_raw(raw);
             let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
             self.record_server_no_transfer_itemize(flist_idx, iflags.raw());
-            if !dest_existed {
-                // upstream: receiver.c:740-741 - a newly created symlink
-                // (destination was absent) bumps stats.created_symlinks.
+            if raw & ItemFlags::ITEM_IS_NEW != 0 {
+                // upstream: receiver.c:733-741 - only an ITEM_IS_NEW row bumps
+                // stats.created_files / created_symlinks.
                 self.record_created(entry.mode());
             }
         }
@@ -413,14 +422,15 @@ impl ReceiverContext {
 
             let link_path = dest_dir.join(relative_path);
 
-            // Track whether the destination already existed before this create;
-            // only a truly absent destination is ITEM_IS_NEW and bumps
-            // stats.created_symlinks (upstream generator.c:1561, `statret < 0`).
-            let mut dest_existed = false;
+            // upstream: generator.c:1606-1609 - the post-create itemize keeps
+            // `statret == 0` when the replaced destination was itself a
+            // symlink, diffing attributes against the pre-replace lstat; a
+            // non-symlink obstacle has `statret` forced to -1 and an absent
+            // destination arrives with it, so both render ITEM_IS_NEW.
+            let mut pre_replace_symlink_meta: Option<fs::Metadata> = None;
 
             // upstream: generator.c:1573 - quick_check_ok(FT_SYMLINK, ...)
             if let Ok(existing_target) = std::fs::read_link(&link_path) {
-                dest_existed = true;
                 if existing_target == *target {
                     // upstream: generator.c:1563 - refresh metadata even when the
                     // link is already up-to-date so a stale mtime is corrected.
@@ -450,6 +460,7 @@ impl ReceiverContext {
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
                 }
+                pre_replace_symlink_meta = fs::symlink_metadata(&link_path).ok();
                 // upstream: generator.c:2018-2020 atomic_create - back the old
                 // symlink up before removal when --backup is set.
                 match self.backup_existing_before_replace(&link_path, relative_path, dest_dir) {
@@ -469,7 +480,6 @@ impl ReceiverContext {
                     }
                 }
             } else if fs::symlink_metadata(&link_path).is_ok() {
-                dest_existed = true;
                 // upstream: generator.c:2018-2020 atomic_create - back the old
                 // obstacle up before removal when --backup is set.
                 match self.backup_existing_before_replace(&link_path, relative_path, dest_dir) {
@@ -546,13 +556,23 @@ impl ReceiverContext {
                     error
                 );
             }
-            // upstream: generator.c:1594 - itemize new symlink after creation
-            let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+            // upstream: generator.c:1604-1610 - itemize after atomic_create
+            // with base ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE: a replaced
+            // symlink itemizes as a change against the pre-replace lstat
+            // (`statret == 0`); an absent destination or a non-symlink
+            // obstacle (`statret` forced to -1) renders the all-new row.
+            let raw = self.itemize_existing_flags(
+                entry,
+                &link_path,
+                pre_replace_symlink_meta.as_ref(),
+                ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_REPORT_CHANGE,
+            );
+            let iflags = ItemFlags::from_raw(raw);
             let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
             self.record_server_no_transfer_itemize(flist_idx, iflags.raw());
-            if !dest_existed {
-                // upstream: receiver.c:740-741 - a newly created symlink
-                // (destination was absent) bumps stats.created_symlinks.
+            if raw & ItemFlags::ITEM_IS_NEW != 0 {
+                // upstream: receiver.c:733-741 - only an ITEM_IS_NEW row bumps
+                // stats.created_files / created_symlinks.
                 self.record_created(entry.mode());
             }
         }

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -506,3 +506,132 @@ fn receiver_backs_up_existing_symlink_before_replacing() {
         "the prior symlink target must be preserved in the ~ backup",
     );
 }
+
+/// A pull-mode receiver context with `-i`, `-l`, and `-t` that defers itemize
+/// rows so tests can read them back in flist-index order.
+#[cfg(unix)]
+fn repointed_symlink_ctx(file_list: Vec<FileEntry>) -> ReceiverContext {
+    let mut config = test_config();
+    config.flags.links = true;
+    config.flags.times = true;
+    config.flags.info_flags.itemize = true;
+    config.connection.client_mode = true;
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.defer_itemize = true;
+    ctx.file_list = file_list;
+    ctx
+}
+
+/// #241/#248: replacing a destination symlink that points elsewhere must
+/// itemize as a CHANGE against the pre-replace lstat - `cLc........` - and
+/// must NOT bump the created-symlinks tally.
+///
+/// upstream: generator.c:1604-1610 - after `atomic_create`, `itemize()` runs
+/// with `ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE` and `statret == 0` (the old
+/// destination entry IS a symlink), so ITEM_IS_NEW never fires and the row
+/// carries attribute dots, not `+++++++++`. receiver.c:733-741 counts creates
+/// only from ITEM_IS_NEW.
+#[test]
+#[cfg(unix)]
+fn replaced_symlink_itemizes_as_change_not_create() {
+    use std::os::unix::fs::MetadataExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+    std::os::unix::fs::symlink("old-target", dest.join("mylink")).expect("seed old symlink");
+    let old_meta = std::fs::symlink_metadata(dest.join("mylink")).expect("lstat old symlink");
+
+    let mut entry = FileEntry::new_symlink("mylink".into(), "new-target".into());
+    // Same whole second as the on-disk link: `t` must stay dark (same_time()
+    // compares whole seconds at modify_window 0, util1.c:1478).
+    entry.set_mtime(old_meta.mtime(), 0);
+    let ctx = repointed_symlink_ctx(vec![entry]);
+
+    let mut writer = MockMsgInfoWriter::new();
+    ctx.create_symlinks(dest, None, &mut writer)
+        .expect("create_symlinks must succeed");
+
+    let buffered = ctx.itemize_rows.borrow();
+    let rows = buffered.get(&0).expect("row buffered at flist index 0");
+    assert_eq!(rows.len(), 1);
+    assert!(
+        rows[0].starts_with("cLc........ "),
+        "a re-pointed symlink is a change row, not all-new: {:?}",
+        rows[0]
+    );
+    assert!(
+        rows[0].contains("mylink -> new-target"),
+        "row = {:?}",
+        rows[0]
+    );
+    assert_eq!(
+        ctx.created_stats.get().symlinks,
+        0,
+        "a replaced symlink is not a creation (receiver.c:733-741)"
+    );
+}
+
+/// Control for #241/#248: a genuinely absent destination symlink still renders
+/// the all-new row (`cL+++++++++`) and bumps the created tally.
+///
+/// upstream: generator.c:1608 with `statret < 0` -> itemize() adds ITEM_IS_NEW
+/// (generator.c:578); receiver.c:733-741 counts it.
+#[test]
+#[cfg(unix)]
+fn absent_symlink_still_itemizes_as_all_new() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    let entry = FileEntry::new_symlink("mylink".into(), "new-target".into());
+    let ctx = repointed_symlink_ctx(vec![entry]);
+
+    let mut writer = MockMsgInfoWriter::new();
+    ctx.create_symlinks(dest, None, &mut writer)
+        .expect("create_symlinks must succeed");
+
+    let buffered = ctx.itemize_rows.borrow();
+    let rows = buffered.get(&0).expect("row buffered at flist index 0");
+    assert!(
+        rows[0].starts_with("cL+++++++++ "),
+        "an absent symlink is the true all-new case: {:?}",
+        rows[0]
+    );
+    assert_eq!(ctx.created_stats.get().symlinks, 1, "created_symlinks");
+}
+
+/// A non-symlink obstacle replaced by a symlink renders all-new AND counts as
+/// a creation: upstream forces `statret = -1` when `stype != FT_SYMLINK`
+/// (generator.c:1606-1607), so the wire carries ITEM_IS_NEW and
+/// receiver.c:733-741 bumps created_symlinks.
+#[test]
+#[cfg(unix)]
+fn non_symlink_obstacle_replacement_itemizes_as_all_new() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+    std::fs::write(dest.join("mylink"), b"obstacle").expect("seed obstacle file");
+
+    let entry = FileEntry::new_symlink("mylink".into(), "new-target".into());
+    let ctx = repointed_symlink_ctx(vec![entry]);
+
+    let mut writer = MockMsgInfoWriter::new();
+    ctx.create_symlinks(dest, None, &mut writer)
+        .expect("create_symlinks must succeed");
+
+    assert_eq!(
+        std::fs::read_link(dest.join("mylink")).expect("symlink replaces obstacle"),
+        std::path::Path::new("new-target"),
+    );
+    let buffered = ctx.itemize_rows.borrow();
+    let rows = buffered.get(&0).expect("row buffered at flist index 0");
+    assert!(
+        rows[0].starts_with("cL+++++++++ "),
+        "a replaced non-symlink obstacle renders all-new (statret forced to -1): {:?}",
+        rows[0]
+    );
+    assert_eq!(
+        ctx.created_stats.get().symlinks,
+        1,
+        "an obstacle replacement is ITEM_IS_NEW and counts as created"
+    );
+}

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -627,17 +627,21 @@ impl ReceiverContext {
                 Err(_) => new_iflags(ItemFlags::ITEM_LOCAL_CHANGE),
             }
         } else if entry.is_symlink() {
-            // upstream: generator.c:1561-1594 - an up-to-date symlink (same
-            // target) is metadata-only; an absent, obstructed, or re-pointed one
-            // is (re)created and itemized ITEM_LOCAL_CHANGE (+ ITEM_IS_NEW when
-            // absent). Mirror the receiver's own create_symlinks classification.
+            // upstream: generator.c:1572-1610 - an up-to-date symlink (same
+            // target) is metadata-only. A recreated one is itemized with base
+            // ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE (generator.c:1608-1609):
+            // when the existing destination is itself a symlink, `statret`
+            // stays 0 and itemize() diffs the attributes against that lstat; a
+            // non-symlink obstacle flips `statret` to -1 (generator.c:1606-1607)
+            // and an absent destination arrives with it, so both are
+            // ITEM_IS_NEW. Mirror the receiver's create_symlinks classification.
+            let base = ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_REPORT_CHANGE;
             match fs::symlink_metadata(dest_path) {
                 Ok(meta) if meta.file_type().is_symlink() => match fs::read_link(dest_path) {
                     Ok(target) if entry.link_target() == Some(&target) => 0,
-                    _ => new_iflags(ItemFlags::ITEM_LOCAL_CHANGE),
+                    _ => self.itemize_existing_flags(entry, dest_path, Some(&meta), base),
                 },
-                Ok(_) => new_iflags(ItemFlags::ITEM_LOCAL_CHANGE),
-                Err(_) => new_iflags(ItemFlags::ITEM_LOCAL_CHANGE),
+                Ok(_) | Err(_) => self.itemize_existing_flags(entry, dest_path, None, base),
             }
         } else if entry.is_device() || entry.is_special() {
             // upstream: generator.c:1462 - a node newly materialised via do_mknod
@@ -2206,7 +2210,16 @@ mod itemize_order_tests {
             vec![
                 (0, ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW),
                 (1, ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW),
-                (2, ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW),
+                // upstream: generator.c:1608-1609 - the symlink create path
+                // passes ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE to itemize(), so
+                // the wire bits carry REPORT_CHANGE even when ITEM_IS_NEW makes
+                // the rendered row all `+`.
+                (
+                    2,
+                    ItemFlags::ITEM_LOCAL_CHANGE
+                        | ItemFlags::ITEM_REPORT_CHANGE
+                        | ItemFlags::ITEM_IS_NEW,
+                ),
             ],
             "the wire plan must carry the directory and symlink too, each with \
              the itemize flags a real run would have sent"
@@ -2297,6 +2310,59 @@ mod itemize_order_tests {
             ],
             "the client sender renders `cd+++++++++` / `<f+++++++++` from exactly \
              these bits, so they must survive the server-mode row suppression"
+        );
+    }
+
+    /// #241/#248 dry-run leg: a destination symlink pointing elsewhere must
+    /// classify as a CHANGE (`ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE`, statret
+    /// kept at 0 - generator.c:1604-1610), never ITEM_IS_NEW, and must not
+    /// bump the created tally (receiver.c:733-741 counts only ITEM_IS_NEW).
+    #[test]
+    #[cfg(unix)]
+    fn dry_run_plan_classifies_repointed_symlink_as_change() {
+        use crate::generator::ItemFlags;
+
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        std::os::unix::fs::symlink("oldtgt", dest.join("lnk")).expect("seed dest symlink");
+
+        let hs = handshake();
+        let mut config = itemize_client_config();
+        config.flags.dry_run = true;
+        config.flags.links = true;
+        // With `-t` and a same-whole-second mtime the `t` column stays dark,
+        // leaving exactly the base change bits on the wire.
+        config.flags.times = true;
+        let mut ctx = ReceiverContext::new_for_test(&hs, config);
+        ctx.defer_itemize = true;
+        let mut entry = FileEntry::new_symlink("lnk".into(), "newtgt".into());
+        {
+            use std::os::unix::fs::MetadataExt;
+            let old_meta = std::fs::symlink_metadata(dest.join("lnk")).expect("lstat");
+            entry.set_mtime(old_meta.mtime(), 0);
+        }
+        ctx.file_list = vec![entry];
+
+        let (plan, rows) = dry_run_pass(&ctx, dest);
+
+        assert_eq!(
+            plan,
+            vec![(
+                0,
+                ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_REPORT_CHANGE
+            )],
+            "a re-pointed symlink keeps statret == 0: change bits, no ITEM_IS_NEW"
+        );
+        assert_eq!(rows.len(), 1);
+        assert!(
+            rows[0].1.starts_with("cLc"),
+            "dry-run row is a change row, not `cL+++++++++`: {:?}",
+            rows[0].1
+        );
+        assert_eq!(
+            ctx.created_stats.get().symlinks,
+            0,
+            "a replaced symlink is not a creation"
         );
     }
 }


### PR DESCRIPTION
## Problem

A destination symlink that already exists but points elsewhere was itemized as an all-new entry (`cL+++++++++`) on every receive path. Upstream itemizes it as a change against the existing entry: `cLc........` when only the target differs, `cLc.t......` when the mtime differs too.

## Upstream model (rsync 3.4.4)

- `generator.c:1604-1610` - after `atomic_create()` the symlink leg calls `itemize(fnamecmp, file, ndx, statret, &sx, ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE, 0, NULL)`. `statret` stays `0` when the replaced destination entry was itself a symlink, so `itemize()` diffs attributes against the pre-replace lstat.
- `generator.c:1606-1607` - only a non-symlink obstacle flips `statret` to `-1`; that and a truly absent destination are the `ITEM_IS_NEW` (`+++++++++`) cases (`generator.c:578`).
- `generator.c:526-530` - without `keep_time` (no `-t`, or `-J`) the `ITEM_LOCAL_CHANGE` branch sets `ITEM_REPORT_TIME` unconditionally; `log.c:714-717` renders `t` while mtimes are preserved and `T` otherwise.
- `receiver.c:733-741` - created stats are bumped only from `ITEM_IS_NEW`.

## Fix

- **Receiver `create_symlinks` (Unix and Windows)**: capture the pre-replace lstat and derive the itemize flags through `itemize_existing_flags` with base `ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE`; key the created-stats bump on `ITEM_IS_NEW`.
- **Dry-run planner**: same classification for the symlink leg, including `ITEM_REPORT_CHANGE` on the wire for the all-new row, matching upstream's `itemize()` call arguments.
- **Local-copy change set**: `for_recreated_symlink` now reports the time column when `keep_time` is off, matching `-rli` (`cLc.T......`) and `-rlti -J` (`cLc.t......`).

## Verification

Byte-for-byte against rsync 3.4.4 (protocol 32) on Linux for re-pointed, re-pointed-same-second, and absent symlinks under `-rlti` and `-rli`:

- local: all match (including the `cLc........` same-second boundary and the `cL+++++++++` absent control)
- daemon push and daemon pull: all match
- `-rlti -J` re-pointed: `cLc.t......` matches

Regression tests fail pre-fix: the re-pointed receiver test reproduced `cL+++++++++`, the dry-run planner test reproduced `ITEM_IS_NEW` wire bits, and the `-J` change-set test previously encoded the missing time column.
