### PR TITLE
test: make upstream-binary skips loud in the uts oracle tests

### DIFF
--- a/crates/test-support/src/skip.rs
+++ b/crates/test-support/src/skip.rs
@@ -44,21 +44,55 @@ pub fn locate_workspace_binary(name: &str) -> Option<PathBuf> {
 
 /// Skip unless the workspace binary `name` is present.
 ///
-/// Wraps [`locate_workspace_binary`] with the self-skip convention: prints the
-/// exact path that was probed and returns `false` when the binary is not
-/// built. Tests that must never be allowed to self-skip should call
-/// [`crate::workspace_bin`] instead, which panics.
+/// Wraps [`locate_workspace_binary`] with the self-skip convention: prints a
+/// `SKIP <test>: ...` line naming the exact path that was probed, so harness
+/// logs record the coverage hole, and returns `false` when the binary is not
+/// built. Call through [`crate::require_binaries!`], which supplies the
+/// enclosing test name. Tests that must never be allowed to self-skip should
+/// call [`crate::workspace_bin`] instead, which panics.
 #[must_use]
-pub fn require_binary(name: &str) -> bool {
+pub fn require_binary(test: &str, name: &str) -> bool {
     if locate_workspace_binary(name).is_some() {
         true
     } else {
         eprintln!(
-            "Skipping upstream-compat test: workspace binary '{name}' not built at {}",
+            "SKIP {test}: workspace binary '{name}' not built at {}",
             crate::bin_path::workspace_bin_path(name).display()
         );
         false
     }
+}
+
+/// Fully qualified name of the enclosing function.
+///
+/// Expands to a `&'static str` such as
+/// `uts_chmod_option::chmod_option_applies_dest_modes`, resolved at compile
+/// time from the type name of a local item. Self-skip lines use it so a
+/// harness log attributes every skip to the exact test that did not run.
+#[macro_export]
+macro_rules! test_name {
+    () => {{
+        fn here() {}
+        let name = ::std::any::type_name_of_val(&here);
+        name.strip_suffix("::here").unwrap_or(name)
+    }};
+}
+
+/// Loud self-skip gate for upstream-compat ports.
+///
+/// Probes each workspace binary in order via [`require_binary`]; on the first
+/// miss it prints `SKIP <test>: workspace binary '<name>' not built at <path>`
+/// and returns from the enclosing test, so nextest still reports the test
+/// green while the log shows the coverage hole.
+#[macro_export]
+macro_rules! require_binaries {
+    ($($name:expr),+ $(,)?) => {
+        $(
+            if !$crate::require_binary($crate::test_name!(), $name) {
+                return;
+            }
+        )+
+    };
 }
 
 /// Locate an external command on `PATH`.
@@ -160,6 +194,35 @@ mod tests {
         // there is always at least the deps dir. A missing-name lookup must
         // return None rather than panic.
         assert!(locate_workspace_binary("definitely-not-built-xyzzy").is_none());
+    }
+
+    #[test]
+    fn test_name_names_the_enclosing_function() {
+        // Why: the macro exists to attribute a skip line to the test that
+        // skipped; a wrong or truncated name would make a logged skip
+        // untraceable, which is the silent-coverage hole all over again.
+        let name = crate::test_name!();
+        assert!(
+            name.ends_with("tests::test_name_names_the_enclosing_function"),
+            "unexpected enclosing-function name: {name}"
+        );
+    }
+
+    #[test]
+    fn require_binary_skips_a_missing_binary() {
+        // Why: the predicate must agree with the locator, or a port could
+        // run against a binary that is not there (opaque spawn failure) or
+        // skip while it is present (dark coverage loss).
+        assert!(!require_binary("skip::tests", "definitely-not-built-xyzzy"));
+    }
+
+    #[test]
+    fn require_binaries_returns_early_on_a_missing_binary() {
+        // Why: the early return is the macro's whole contract - without it
+        // the test body would fall through and fail opaquely inside
+        // Command::spawn instead of skipping loudly.
+        crate::require_binaries!("definitely-not-built-xyzzy");
+        panic!("must not reach past a missing-binary gate");
     }
 
     #[test]

--- a/crates/transfer/tests/uts_atimes_preserve.rs
+++ b/crates/transfer/tests/uts_atimes_preserve.rs
@@ -36,7 +36,7 @@ use std::fs;
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries};
 
 /// Fixed source atime, matching the spirit of upstream's
 /// `touch -a -t 200102031717.42` (2001-02-03 17:17:42 UTC = 981_213_462).
@@ -67,9 +67,7 @@ fn atime_secs(path: &Path) -> i64 {
 // upstream: --atimes restores st_atime on the receiver
 #[test]
 fn atimes_flag_preserves_source_access_time() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root = tempfile::tempdir().expect("tempdir");
     let from = root.path().join("from");
     let to = root.path().join("to");

--- a/crates/transfer/tests/uts_backup_suffix_and_dir.rs
+++ b/crates/transfer/tests/uts_backup_suffix_and_dir.rs
@@ -48,7 +48,7 @@ use std::path::Path;
 
 use filetime::{FileTime, set_file_mtime};
 use tempfile::TempDir;
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries};
 
 /// A fixed old timestamp used to backdate destination files so rsync's
 /// quick-check (matching size + mtime) never short-circuits the transfer.
@@ -66,9 +66,7 @@ fn seed_dest(dest: &Path, old: &str) {
 
 #[test]
 fn backup_default_suffix_preserves_prior_version() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
     let from = base.join("from");
@@ -107,9 +105,7 @@ fn backup_default_suffix_preserves_prior_version() {
 
 #[test]
 fn backup_custom_suffix_names_the_backup() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
     let from = base.join("from");
@@ -149,9 +145,7 @@ fn backup_custom_suffix_names_the_backup() {
 
 #[test]
 fn backup_dir_relocates_prior_version_without_suffix() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
     let from = base.join("from");

--- a/crates/transfer/tests/uts_chmod_option.rs
+++ b/crates/transfer/tests/uts_chmod_option.rs
@@ -45,7 +45,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries, test_name};
 
 /// Low 12 permission bits (`0o7777`) of `path`, following the entry itself.
 fn mode_bits(path: &Path) -> u32 {
@@ -84,9 +84,7 @@ fn running_as_root() -> bool {
 /// - `dir2`: 0770 -> `a+rX` -> 0775; `D+w` keeps group/other write (0775).
 #[test]
 fn chmod_strip_setid_and_add_rx_dir_write() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root = tempfile::tempdir().expect("tempdir");
     let from = root.path().join("from");
     let to = root.path().join("to");
@@ -142,9 +140,7 @@ fn chmod_strip_setid_and_add_rx_dir_write() {
 /// - `foo`: directory untouched by the `F`-only chmod -> 0755.
 #[test]
 fn chmod_file_only_clears_world_execute() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root = tempfile::tempdir().expect("tempdir");
     let from = root.path().join("from");
     let to = root.path().join("to");
@@ -191,7 +187,9 @@ fn chmod_file_only_clears_world_execute() {
 /// script must observe, not silently succeed.
 #[test]
 fn chmod_transfer_root_self_locks_without_owner_execute() {
-    if !require_binary("oc-rsync") || running_as_root() {
+    require_binaries!("oc-rsync");
+    if running_as_root() {
+        eprintln!("SKIP {}: requires a non-root user", test_name!());
         return;
     }
     for (spec, expected_mode) in [("ug=rw", 0o665u32), ("a=r,g=w", 0o424), ("u=r", 0o455)] {
@@ -252,7 +250,9 @@ fn chmod_transfer_root_self_locks_without_owner_execute() {
 /// leaves it at 0o455 (owner not writable, strict mode restored).
 #[test]
 fn chmod_subdir_owner_writable_regains_execute() {
-    if !require_binary("oc-rsync") || running_as_root() {
+    require_binaries!("oc-rsync");
+    if running_as_root() {
+        eprintln!("SKIP {}: requires a non-root user", test_name!());
         return;
     }
     for (spec, expected_mode) in [("ug=rw", 0o765u32), ("u=r", 0o455)] {

--- a/crates/transfer/tests/uts_clean_fname_underflow.rs
+++ b/crates/transfer/tests/uts_clean_fname_underflow.rs
@@ -39,7 +39,7 @@
 
 use std::fs;
 
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries};
 
 /// The server-sender invocation with the crafted `merge a/../test` filter must
 /// terminate cleanly - any exit code is acceptable, a signal death is not.
@@ -51,9 +51,7 @@ use test_support::{OcRsyncCliRunner, require_binary};
 // upstream: util1.c clean_fname() underflow hardening
 #[test]
 fn clean_fname_handles_dotdot_without_crashing() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root = tempfile::tempdir().expect("tempdir");
     let workdir = root.path().join("workdir");
     fs::create_dir_all(workdir.join("mod")).expect("mkdir workdir/mod");

--- a/crates/transfer/tests/uts_delay_updates_atomic.rs
+++ b/crates/transfer/tests/uts_delay_updates_atomic.rs
@@ -42,7 +42,7 @@
 use std::fs;
 use std::path::Path;
 
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries};
 
 /// Trailing-slash form so rsync copies a directory's contents.
 fn slash(p: &Path) -> std::ffi::OsString {
@@ -56,9 +56,7 @@ fn slash(p: &Path) -> std::ffi::OsString {
 // upstream: --delay-updates stages under .~tmp~ then renames at finish
 #[test]
 fn delay_updates_atomic_rename_and_cleanup() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root = tempfile::tempdir().expect("tempdir");
     let from = root.path().join("from");
     let to = root.path().join("to");

--- a/crates/transfer/tests/uts_duplicate_source_names_copied_once.rs
+++ b/crates/transfer/tests/uts_duplicate_source_names_copied_once.rs
@@ -25,16 +25,14 @@
 
 use std::fs;
 
-use test_support::{OcRsyncCliRunner, create_tempdir, require_binary};
+use test_support::{OcRsyncCliRunner, create_tempdir, require_binaries};
 
 /// The same source directory repeated many times on the command line must
 /// still copy each contained file exactly once - both on disk and in the
 /// verbose transfer log.
 #[test]
 fn repeated_source_directory_copies_each_file_exactly_once() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
 
     let tmp = create_tempdir();
     let from = tmp.path().join("from");

--- a/crates/transfer/tests/uts_executability_flag_transfer.rs
+++ b/crates/transfer/tests/uts_executability_flag_transfer.rs
@@ -26,7 +26,9 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use filetime::{FileTime, set_file_mtime};
-use test_support::{LSH_STUB_BIN, LshRunnerStub, OcRsyncCliRunner, create_tempdir, require_binary};
+use test_support::{
+    LSH_STUB_BIN, LshRunnerStub, OcRsyncCliRunner, create_tempdir, require_binaries,
+};
 
 fn mode_of(path: &Path) -> u32 {
     fs::metadata(path).expect("stat file").permissions().mode() & 0o7777
@@ -89,9 +91,7 @@ fn assert_attr_only_outcome(to: &Path) {
 /// executability bits without disturbing the read/write bits.
 #[test]
 fn executability_flag_transfers_only_exec_bits() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
 
     let tmp = create_tempdir();
     let from = tmp.path().join("from");
@@ -205,9 +205,7 @@ fn executability_flag_transfers_only_exec_bits() {
 /// (generator.c:1827).
 #[test]
 fn executability_applies_on_up_to_date_files_over_rsh_push() {
-    if !require_binary("oc-rsync") || !require_binary(LSH_STUB_BIN) {
-        return;
-    }
+    require_binaries!("oc-rsync", LSH_STUB_BIN);
     let stub = LshRunnerStub::locate().expect("lsh-stub located");
 
     let tmp = create_tempdir();
@@ -238,9 +236,7 @@ fn executability_applies_on_up_to_date_files_over_rsh_push() {
 /// 'E' only when `am_sender`); the local receiver must honour its own flag.
 #[test]
 fn executability_applies_on_up_to_date_files_over_rsh_pull() {
-    if !require_binary("oc-rsync") || !require_binary(LSH_STUB_BIN) {
-        return;
-    }
+    require_binaries!("oc-rsync", LSH_STUB_BIN);
     let stub = LshRunnerStub::locate().expect("lsh-stub located");
 
     let tmp = create_tempdir();
@@ -273,9 +269,7 @@ fn executability_applies_on_up_to_date_files_over_rsh_pull() {
 /// full mode under preserve_perms.
 #[test]
 fn executability_is_noop_when_perms_active_over_rsh() {
-    if !require_binary("oc-rsync") || !require_binary(LSH_STUB_BIN) {
-        return;
-    }
+    require_binaries!("oc-rsync", LSH_STUB_BIN);
     let stub = LshRunnerStub::locate().expect("lsh-stub located");
 
     let tmp = create_tempdir();

--- a/crates/transfer/tests/uts_fuzzy_local_basis_reuse.rs
+++ b/crates/transfer/tests/uts_fuzzy_local_basis_reuse.rs
@@ -51,7 +51,7 @@
 use std::fs;
 use std::path::Path;
 
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries};
 
 /// Trailing-slash form so rsync copies a directory's contents.
 fn slash(p: &Path) -> std::ffi::OsString {
@@ -115,9 +115,7 @@ fn seed_fuzzy_pair(root: &Path) -> (std::path::PathBuf, std::path::PathBuf, u64)
 // upstream: generator.c find_fuzzy() basis selection
 #[test]
 fn fuzzy_local_reuses_differently_named_basis() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root = tempfile::tempdir().expect("tempdir");
     let (from, to, size) = seed_fuzzy_pair(root.path());
 
@@ -159,9 +157,7 @@ fn fuzzy_local_reuses_differently_named_basis() {
 // upstream: generator.c - no fuzzy basis is consulted without --fuzzy
 #[test]
 fn without_fuzzy_local_resends_whole_file_as_literal() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root = tempfile::tempdir().expect("tempdir");
     let (from, to, size) = seed_fuzzy_pair(root.path());
 

--- a/crates/transfer/tests/uts_inplace_backup.rs
+++ b/crates/transfer/tests/uts_inplace_backup.rs
@@ -39,7 +39,7 @@ use std::path::Path;
 
 use filetime::{FileTime, set_file_mtime};
 use tempfile::TempDir;
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries};
 
 /// Backdate `path` well before the freshly written source so rsync's
 /// quick-check (matching size + mtime) never short-circuits the transfer.
@@ -71,9 +71,7 @@ fn slash(path: &Path) -> std::ffi::OsString {
 /// backup line.
 #[test]
 fn inplace_backup_copies_original_and_preserves_dest_inode() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
     let from = base.join("from");
@@ -131,9 +129,7 @@ fn inplace_backup_copies_original_and_preserves_dest_inode() {
 /// original.
 #[test]
 fn inplace_whole_file_backup_preserves_dest_inode() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
     let from = base.join("from");
@@ -187,9 +183,7 @@ fn inplace_whole_file_backup_preserves_dest_inode() {
 /// preserved.
 #[test]
 fn inplace_backup_dir_relocates_copy_and_preserves_inode() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
     let from = base.join("from");
@@ -242,9 +236,7 @@ fn inplace_backup_dir_relocates_copy_and_preserves_inode() {
 /// behaviour is specific to `--inplace` and must not leak into the default path.
 #[test]
 fn backup_without_inplace_changes_dest_inode() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
     let from = base.join("from");

--- a/crates/transfer/tests/uts_missing_args.rs
+++ b/crates/transfer/tests/uts_missing_args.rs
@@ -45,7 +45,7 @@ use std::fs;
 use std::path::Path;
 
 use tempfile::TempDir;
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries};
 
 /// Build the shared source/destination fixture used by both legs.
 ///
@@ -85,9 +85,7 @@ fn slash(p: &Path) -> std::ffi::OsString {
 /// exist at the destination, and must not create anything on disk.
 #[test]
 fn ignore_non_existing_dry_run_is_quiet_and_touches_nothing() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root = setup();
     let from = root.path().join("from");
     let to = root.path().join("to");
@@ -126,9 +124,7 @@ fn ignore_non_existing_dry_run_is_quiet_and_touches_nothing() {
 /// directory is dry-missing at the destination.
 #[test]
 fn delete_after_dry_run_still_itemizes_deletion() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root = setup();
     let from = root.path().join("from");
     let to = root.path().join("to");

--- a/crates/transfer/tests/uts_mkpath_create_dest_path.rs
+++ b/crates/transfer/tests/uts_mkpath_create_dest_path.rs
@@ -49,7 +49,7 @@ use std::fs;
 use std::path::Path;
 
 use tempfile::TempDir;
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries};
 
 /// Trailing-slash form of a path (as an `OsString` argument).
 fn slash(path: &Path) -> std::ffi::OsString {
@@ -76,9 +76,7 @@ where
 
 #[test]
 fn mkpath_creates_missing_destination_prefix() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
 

--- a/crates/transfer/tests/uts_multi_source_merge.rs
+++ b/crates/transfer/tests/uts_multi_source_merge.rs
@@ -50,7 +50,7 @@ use std::fs;
 use std::path::Path;
 
 use tempfile::TempDir;
-use test_support::{DirDiff, DirDiffOptions, OcRsyncCliRunner, require_binary};
+use test_support::{DirDiff, DirDiffOptions, OcRsyncCliRunner, require_binaries};
 
 /// Write `contents` to `path`, creating parent directories as needed.
 fn write(path: &Path, contents: &str) {
@@ -116,9 +116,7 @@ fn slash(p: &Path) -> std::ffi::OsString {
 
 #[test]
 fn multiple_sources_merge_into_one_destination() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
     build_sources(base);

--- a/crates/transfer/tests/uts_symlink_ignore_no_links_flag.rs
+++ b/crates/transfer/tests/uts_symlink_ignore_no_links_flag.rs
@@ -22,7 +22,7 @@ use std::fs;
 use std::os::unix::fs::symlink;
 use std::path::Path;
 
-use test_support::{OcRsyncCliRunner, create_tempdir, require_binary};
+use test_support::{OcRsyncCliRunner, create_tempdir, require_binaries};
 
 /// Build the same symlink fixture `rsync.fns`'s `build_symlinks` creates: a
 /// real regular file `referent` plus three symlinks that must all be ignored.
@@ -42,9 +42,7 @@ fn build_symlinks(from: &Path) {
 /// at all" policy.
 #[test]
 fn recursive_copy_without_links_flag_drops_all_symlinks() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
 
     let tmp = create_tempdir();
     let from = tmp.path().join("from");

--- a/crates/transfer/tests/uts_trimslash_source_arg.rs
+++ b/crates/transfer/tests/uts_trimslash_source_arg.rs
@@ -48,7 +48,7 @@ use std::fs;
 use std::path::Path;
 
 use tempfile::TempDir;
-use test_support::{OcRsyncCliRunner, require_binary};
+use test_support::{OcRsyncCliRunner, require_binaries};
 
 /// Build a `src` dir containing a single nested file, so the contents-vs-dir
 /// distinction is observable purely from which directory names appear in dest.
@@ -87,9 +87,7 @@ fn with_slashes(path: &Path, n: usize) -> std::ffi::OsString {
 
 #[test]
 fn trailing_slashes_collapse_to_single_slash_semantics() {
-    if !require_binary("oc-rsync") {
-        return;
-    }
+    require_binaries!("oc-rsync");
     let root: TempDir = tempfile::tempdir().expect("tempdir");
     let base = root.path();
     let src = build_src(base);


### PR DESCRIPTION
## Summary

Upstream-testsuite oracle ports self-skip when the `oc-rsync` workspace binary is not built. The skip line printed by `require_binary` named the probed path but not the test, so a harness log could never show which coverage went missing - a silent skip reads as green coverage that does not exist. The two `running_as_root()` compound gates in `uts_chmod_option.rs` printed nothing at all.

Measured inventory: 27 `require_binary` call sites across 14 `uts_*.rs` files (the tracked estimate said 24), all in `crates/transfer/tests/`. All 27 are converted; the 2 root gates are now loud as well.

## Changes

- `test_support::require_binary` now takes the test name and prints one greppable line per skip: `SKIP <test>: workspace binary '<name>' not built at <path>`.
- New `test_support::require_binaries!` macro is the single gate all uts sites converge on: it probes each named binary, prints the attributed skip line on the first miss, and early-returns so the test stays green (loud, not fatal - cells without the binary keep passing).
- New `test_support::test_name!` macro resolves the fully qualified enclosing-function name at compile time for skip attribution.
- The `running_as_root()` compound gates print `SKIP <test>: requires a non-root user` before returning.
- Unit tests cover the name resolution, the miss predicate, and the macro's early return.

## Sample skip output

With the workspace binary hidden, `cargo nextest run -p transfer -E 'binary(uts_chmod_option)' --no-capture`:

```
SKIP uts_chmod_option::chmod_transfer_root_self_locks_without_owner_execute: workspace binary 'oc-rsync' not built at .../target/debug/oc-rsync
Summary [   0.073s] 5 tests run: 5 passed, 0 skipped
```

With the binary present the same tests run for real: 77 tests across the uts binaries, all passing.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy -p test-support -p transfer --all-targets --all-features --no-deps -- -D warnings` clean.
- `cargo nextest run -p test-support --all-features` (skip helpers): 10 passed.
- `cargo nextest run -p transfer -E 'binary(~uts_)'`: 77 passed with the binary built; the same selection skips loudly per test with it absent.
