### PR TITLE
test(daemon): run auth and module-access daemon tests un-detached

### DIFF
--- a/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
@@ -62,7 +62,7 @@ fn daemon_negotiation_auth_challenge_is_unique_per_session() {
     // release the test's holding listener so the daemon's bind to the same
     // port succeeds (the held listener was only needed to reserve the port).
     drop(held_listener);
-    let handle = spawn_daemon_pending_no_detach(config);
+    let handle = spawn_daemon(config);
 
     let mut challenges = Vec::new();
     for _ in 0..2 {
@@ -154,7 +154,7 @@ fn daemon_negotiation_auth_denies_wrong_password() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -176,11 +176,16 @@ fn daemon_negotiation_auth_denies_wrong_password() {
         .strip_prefix("@RSYNCD: AUTHREQD ")
         .expect("challenge prefix");
 
-    // Compute digest with WRONG password
-    let mut hasher = Md5::new();
-    hasher.update(b"wrongpassword");
-    hasher.update(challenge.as_bytes());
-    let digest = STANDARD_NO_PAD.encode(hasher.finalize());
+    // Compute digest with WRONG password. The greeting offers sha512 first and
+    // upstream's server takes the first client-offered name it supports
+    // (compat.c:354 - `if (best == 1 || am_server) break;`), so the correctly
+    // negotiated digest over the wrong password isolates the password check as
+    // the reason for the refusal.
+    let digest = core::auth::compute_daemon_auth_response(
+        b"wrongpassword",
+        challenge,
+        DaemonAuthDigest::Sha512,
+    );
     let response = format!("alice {digest}\n");
 
     stream
@@ -246,7 +251,7 @@ fn daemon_negotiation_auth_denies_unknown_user() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -268,11 +273,12 @@ fn daemon_negotiation_auth_denies_unknown_user() {
         .strip_prefix("@RSYNCD: AUTHREQD ")
         .expect("challenge prefix");
 
-    // Compute digest with unknown user
-    let mut hasher = Md5::new();
-    hasher.update(b"password");
-    hasher.update(challenge.as_bytes());
-    let digest = STANDARD_NO_PAD.encode(hasher.finalize());
+    // Compute a correctly negotiated digest (sha512 leads the offered list;
+    // upstream's server takes the first client-offered name it supports,
+    // compat.c:354) for an unknown user, so the username lookup is the reason
+    // for the refusal.
+    let digest =
+        core::auth::compute_daemon_auth_response(b"password", challenge, DaemonAuthDigest::Sha512);
     let response = format!("bob {digest}\n");
 
     stream
@@ -329,7 +335,7 @@ fn daemon_negotiation_auth_skipped_for_unprotected_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -403,7 +409,7 @@ fn daemon_negotiation_auth_denies_empty_credentials() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -490,7 +496,7 @@ fn daemon_negotiation_auth_successful_sends_ok() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -512,11 +518,17 @@ fn daemon_negotiation_auth_successful_sends_ok() {
         .strip_prefix("@RSYNCD: AUTHREQD ")
         .expect("challenge prefix");
 
-    // Compute correct digest
-    let mut hasher = Md5::new();
-    hasher.update(b"secretpass");
-    hasher.update(challenge.as_bytes());
-    let digest = STANDARD_NO_PAD.encode(hasher.finalize());
+    // Compute the correct digest. The greeting offers sha512 first and
+    // upstream's server takes the first client-offered name it supports
+    // (compat.c:354 - `if (best == 1 || am_server) break;`), so the exchange
+    // is SHA-512. Verified against rsync 3.4.4: the same greeting and a
+    // sha512 response over `secretpass` + challenge yields `@RSYNCD: OK`,
+    // while an MD5 response is refused with `@ERROR: auth failed`.
+    let digest = core::auth::compute_daemon_auth_response(
+        b"secretpass",
+        challenge,
+        DaemonAuthDigest::Sha512,
+    );
     let response = format!("alice {digest}\n");
 
     stream

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_empty_module_lists_modules.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_empty_module_lists_modules.rs
@@ -29,7 +29,7 @@ fn daemon_negotiation_empty_module_lists_modules() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
@@ -21,7 +21,7 @@ fn daemon_negotiation_error_unknown_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -75,7 +75,7 @@ fn daemon_negotiation_error_empty_module_request() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -136,7 +136,7 @@ fn daemon_negotiation_error_host_denied() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -200,7 +200,7 @@ fn daemon_negotiation_error_refused_options() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -283,7 +283,7 @@ fn daemon_negotiation_error_max_connections_exceeded() {
         ])
         .build();
 
-    let (mut stream1, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream1, handle) = start_daemon(config, port, held_listener);
 
     // First connection should succeed (up to the OK)
     let mut reader1 = BufReader::new(stream1.try_clone().expect("clone"));
@@ -358,7 +358,7 @@ fn daemon_negotiation_error_sanitizes_module_name_in_response() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -412,7 +412,7 @@ fn daemon_negotiation_error_no_exit_after_error() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -467,7 +467,7 @@ fn daemon_negotiation_error_connection_closed_early() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -501,7 +501,7 @@ fn daemon_negotiation_error_invalid_greeting_response() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
@@ -33,7 +33,7 @@ fn daemon_negotiation_error_host_allow_blocks_unlisted() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
@@ -28,7 +28,7 @@ fn daemon_negotiation_module_list_sends_listing_directly() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -91,7 +91,7 @@ fn daemon_negotiation_module_list_respects_listable_flag() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -154,7 +154,7 @@ fn daemon_negotiation_module_list_includes_comments() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();
@@ -197,7 +197,7 @@ fn daemon_negotiation_module_list_empty_when_no_modules() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
@@ -41,7 +41,7 @@ fn run_daemon_accepts_valid_credentials() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
@@ -41,7 +41,7 @@ fn run_daemon_auth_failure_rejects_wrong_credentials() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
@@ -30,7 +30,7 @@ fn run_daemon_denies_module_when_host_not_allowed() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_host_denied_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_host_denied_module.rs
@@ -30,7 +30,7 @@ fn run_daemon_lists_host_denied_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
@@ -20,7 +20,7 @@ fn run_daemon_lists_modules_on_request() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
@@ -27,7 +27,7 @@ fn run_daemon_omits_unlisted_modules_from_listing() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
@@ -45,7 +45,7 @@ fn run_daemon_post_ok_refused_option_uses_multiplexed_error() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Drain the daemon greeting and complete the version handshake.

--- a/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
@@ -25,7 +25,7 @@ fn run_daemon_refuses_disallowed_module_options() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
@@ -32,7 +32,7 @@ fn run_daemon_rejects_push_to_default_read_only_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
@@ -31,7 +31,7 @@ fn run_daemon_rejects_push_to_read_only_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
@@ -24,7 +24,7 @@ fn run_daemon_rejects_unknown_hash_command() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
@@ -41,7 +41,7 @@ fn run_daemon_requests_authentication_for_protected_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon_pending_no_detach(config, port, held_listener);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/tools/ci/check_daemon_no_detach.sh
+++ b/tools/ci/check_daemon_no_detach.sh
@@ -39,7 +39,7 @@ SUPPORT="${TESTS_DIR}/support.rs"
 
 # Lower this when a migration slice converts call sites to the guarded helpers.
 # It must never be raised.
-PENDING_CEILING=110
+PENDING_CEILING=77
 
 violations=0
 


### PR DESCRIPTION
## Summary

Historically the daemon test chunks started their daemon without `--no-detach`: `RuntimeOptions::detach` defaults to true on Unix, `run_daemon()` reached `become_daemon()`, the fork parent - the test process - exited 0, and the harness recorded a pass before a single assertion ran. #6982 added the guarded `start_daemon()`/`spawn_daemon()` helpers (which force `--no-detach`) plus the temporary `*_pending_no_detach` escape hatches and a CI ratchet.

This PR converts the auth and module-access slice to the guarded helpers and triages what the newly-live assertions surface. Transfer/filter/delete chunks remain on the pending helpers for a follow-up slice.

## Chunks converted (17 files, 33 call sites)

Auth (secrets file, auth users, digest exchange):
- `daemon_negotiation_authentication.rs` (6)
- `run_daemon_accepts_valid_credentials.rs` (1)
- `run_daemon_auth_failure_rejects_wrong_credentials.rs` (1)
- `run_daemon_requests_authentication_for_protected_module.rs` (1)
- `run_daemon_rejects_unknown_hash_command.rs` (1)

Module access (hosts allow/deny, listing, read only, refuse options):
- `daemon_negotiation_error_handling.rs` (9)
- `daemon_negotiation_error_host_allow_blocks_unlisted.rs` (1)
- `run_daemon_denies_module_when_host_not_allowed.rs` (1)
- `run_daemon_lists_host_denied_module.rs` (1)
- `run_daemon_lists_modules_on_request.rs` (1)
- `run_daemon_omits_unlisted_modules_from_listing.rs` (1)
- `daemon_negotiation_module_listing.rs` (4)
- `daemon_negotiation_empty_module_lists_modules.rs` (1)
- `run_daemon_rejects_push_to_read_only_module.rs` (1)
- `run_daemon_rejects_push_to_default_read_only_module.rs` (1)
- `run_daemon_refuses_disallowed_module_options.rs` (1)
- `run_daemon_post_ok_refused_option_uses_multiplexed_error.rs` (1)

`daemon_auth_digest_negotiation.rs` already uses the guarded helpers and needed no change. `tools/ci/check_daemon_no_detach.sh` ceiling lowered 110 -> 77.

## Triage

| Test | Verdict | Detail |
|------|---------|--------|
| `daemon_negotiation_auth_successful_sends_ok` | (a) vacuous assertion; test fixed | Computed an MD5 auth digest while its greeting offers `sha512 sha256 sha1 md5 md4`. Upstream's server takes the first client-offered digest it supports (compat.c:354 `if (best == 1 \|\| am_server) break;`), so the exchange is SHA-512 and the MD5 response is correctly refused with `@ERROR: auth failed on module secure`. Verified against rsync 3.4.4 `--daemon --no-detach`: the same greeting plus a base64 (no pad) sha512 digest of password+challenge yields `@RSYNCD: OK`. The test now computes the negotiated sha512 digest via `core::auth::compute_daemon_auth_response`, matching the existing `run_daemon_accepts_valid_credentials` pattern. |
| `daemon_negotiation_auth_denies_wrong_password` | (a) hardened | Passed, but only because its MD5 digest could never match the sha512 negotiation - it could not distinguish a wrong password from a digest-scheme mismatch. Now sends a correctly negotiated sha512 digest over the wrong password so the password check is the reason for the refusal. |
| `daemon_negotiation_auth_denies_unknown_user` | (a) hardened | Same digest-scheme mismatch; now sends a correctly negotiated sha512 digest for the unknown user so the username lookup is the reason for the refusal. |
| remaining 30 tests | pass unchanged | Assertions now execute in the foreground and hold as written. |

No real daemon bugs were exposed by this slice; there are no new `#[ignore]` markers and no daemon source changes.

## Port hygiene

All converted chunks already use `allocate_test_port()` (OS-assigned ephemeral port, listener held and handed to the daemon via `pre_bound_listener`) and readiness polling in `connect_to_daemon()` - no fixed ports, no flat sleeps.

## Validation

- `cargo nextest run -p daemon --all-features -E '<converted chunks>'`: 33/33 passed, run twice, zero retries.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`: clean.
- `tools/ci/check_daemon_no_detach.sh`: no violations, pending 77 (ceiling 77).
