### PR TITLE
fix(protocol): match upstream File list size accounting

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -62,6 +62,7 @@ pub(super) fn convert_server_stats_to_summary(
                 elapsed,
                 transfer_stats.literal_data,
                 transfer_stats.matched_data,
+                transfer_stats.flist_size,
                 transfer_stats.delete_stats,
                 transfer_stats.created_stats,
                 engine::local_copy::FileTypeTotals {

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -40,6 +40,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
                 elapsed,
                 transfer_stats.literal_data,
                 transfer_stats.matched_data,
+                transfer_stats.flist_size,
                 transfer_stats.delete_stats,
                 transfer_stats.created_stats,
                 engine::local_copy::FileTypeTotals {

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -420,6 +420,9 @@ fn replay_batch(
         std::time::Duration::ZERO,
         total_size,
         0,
+        // The --read-batch replay engine decodes the flist from the batch file
+        // without a raw wire counter, so no flist span is measured.
+        0,
         protocol::DeleteStats::new(),
         // The --read-batch replay engine does not reconstruct a per-type
         // ITEM_IS_NEW breakdown, so carry every replayed entry as a created

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -545,6 +545,7 @@ impl LocalCopySummary {
         elapsed: Duration,
         literal_data: u64,
         matched_data: u64,
+        flist_size: u64,
         delete_stats: protocol::DeleteStats,
         created_stats: protocol::CreatedStats,
         file_type_totals: FileTypeTotals,
@@ -587,6 +588,11 @@ impl LocalCopySummary {
             bytes_sent,
             bytes_copied: literal_data,
             matched_bytes: matched_data,
+            // upstream: flist.c:2789 - the pulling client's receiver accumulates
+            // stats.flist_size from its own raw read counter across every
+            // recv_file_list() span; it is never sent over the wire (main.c:445
+            // prints each role's local figure).
+            file_list_size: flist_size,
             total_source_bytes,
             items_deleted: u64::from(delete_stats.total()),
             deleted_dirs: u64::from(delete_stats.dirs),
@@ -662,6 +668,11 @@ impl LocalCopySummary {
             deleted_specials: u64::from(delete_stats.specials),
             total_elapsed: elapsed,
             wall_clock_elapsed: elapsed,
+            // `file_list_size` stays 0 on a push: upstream's client sender
+            // samples stats.total_written around send_file_list (flist.c:2254,
+            // flist.c:2560), but the encoded list is still sitting unflushed in
+            // the 64 KiB iobuf.out (io.c:1382), so the raw counter has not
+            // moved and the client prints `File list size: 0`.
             ..Default::default()
         }
     }
@@ -915,6 +926,7 @@ mod tests {
             Duration::from_secs(5),
             0,
             0,
+            0,
             protocol::DeleteStats::new(),
             protocol::CreatedStats::new(),
             FileTypeTotals::default(),
@@ -929,6 +941,32 @@ mod tests {
         assert_eq!(summary.bytes_sent(), 256);
         assert_eq!(summary.total_source_bytes(), 8192);
         assert_eq!(summary.total_elapsed(), Duration::from_secs(5));
+    }
+
+    /// The receiver-measured flist span must reach the client summary.
+    ///
+    /// WHY: upstream never sends `stats.flist_size` over the wire - the pulling
+    /// client prints its own locally measured span (flist.c:2789, main.c:445).
+    /// Before the fix the remote-pull constructor dropped it, so `--stats`
+    /// printed `File list size: 0` on every remote transfer.
+    #[test]
+    fn from_receiver_stats_maps_flist_size() {
+        let summary = LocalCopySummary::from_receiver_stats(
+            10,
+            5,
+            2000,
+            2048,
+            512,
+            4096,
+            Duration::from_secs(1),
+            0,
+            0,
+            18_821,
+            protocol::DeleteStats::new(),
+            protocol::CreatedStats::new(),
+            FileTypeTotals::default(),
+        );
+        assert_eq!(summary.file_list_size(), 18_821);
     }
 
     /// A remote pull (ssh or daemon) must reconstruct the `--stats` "Number of
@@ -949,6 +987,7 @@ mod tests {
             10,
             100,
             Duration::from_secs(1),
+            0,
             0,
             0,
             protocol::DeleteStats::new(),
@@ -980,6 +1019,7 @@ mod tests {
             Duration::from_secs(2),
             800,
             1200,
+            0,
             protocol::DeleteStats::new(),
             protocol::CreatedStats::new(),
             FileTypeTotals::default(),
@@ -1051,6 +1091,7 @@ mod tests {
             Duration::from_secs(2),
             0,
             0,
+            0,
             delete_stats,
             protocol::CreatedStats::new(),
             FileTypeTotals::default(),
@@ -1088,6 +1129,7 @@ mod tests {
             256,
             8192,
             Duration::from_secs(1),
+            0,
             0,
             0,
             protocol::DeleteStats::new(),

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -906,9 +906,13 @@ pub fn run_server_with_handshake_adopting<W: Write>(
     match config.role {
         ServerRole::Receiver => {
             let mut ctx = ReceiverContext::new(&handshake, config, pipeline);
+            // upstream: flist.c:2615/2789 - recv_file_list() measures its span
+            // against the raw read counter to accumulate stats.flist_size.
+            ctx.set_raw_read_counter(std::sync::Arc::clone(&bytes_received_counter));
             // upstream: io.c:859 - stats.total_written tracking
             let mut counting_writer = writer::CountingWriter::new(&mut writer);
             let mut stats = ctx.run(chained_reader, &mut counting_writer, progress)?;
+            stats.flist_size = ctx.flist_size();
             stats.bytes_sent = counting_writer.bytes_written();
             // upstream: io.c:820 - stats.total_read counts raw bytes read off the
             // socket (mux frames + compressed tokens), below decompression. Source

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -198,6 +198,22 @@ pub struct ReceiverContext {
     /// id lists (upstream: flist.c:2552-2553). Protocol >= 30 uses MSG_IO_ERROR
     /// or SAFE_FILE_LIST instead.
     pub(in crate::receiver) flist_io_error: i32,
+    /// Shared handle on the raw wire byte counter, used to measure the
+    /// file-list spans for `stats.flist_size`.
+    ///
+    /// Upstream snapshots `stats.total_read` (the raw descriptor counter,
+    /// io.c:820) at `recv_file_list()` entry and accumulates the delta on
+    /// return (flist.c:2615, flist.c:2789), so the figure counts raw wire
+    /// bytes - multiplex frame headers included - not decoded entry bytes.
+    /// This handle is the same counter that feeds `bytes_received`.
+    pub(in crate::receiver) raw_read_counter: Option<Arc<std::sync::atomic::AtomicU64>>,
+    /// Accumulated `File list size` in raw wire bytes across every received
+    /// file-list span (initial list plus INC_RECURSE sub-list segments).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2789` - `stats.flist_size += stats.total_read - start_read;`
+    pub(in crate::receiver) flist_size: u64,
     /// Per-operation thresholds for switching between sequential and parallel execution.
     ///
     /// Different operations have different overhead profiles: CPU-bound signature
@@ -451,6 +467,8 @@ impl ReceiverContext {
             hardlink_tracker,
             prior_hlinks: HashMap::new(),
             flist_io_error: 0,
+            raw_read_counter: None,
+            flist_size: 0,
             parallel_thresholds: ParallelThresholds::default(),
             delete_ctx: None,
             pending_del_stats: DeleteStats::new(),
@@ -524,6 +542,45 @@ impl ReceiverContext {
     #[must_use]
     pub fn delete_context(&self) -> Option<Arc<DeleteContext>> {
         self.delete_ctx.as_ref().map(Arc::clone)
+    }
+
+    /// Attaches the raw wire byte counter used to measure file-list spans.
+    ///
+    /// The counter must be the raw transport counter that also feeds
+    /// `bytes_received` (upstream `stats.total_read`, io.c:820). Must be set
+    /// before [`run`](Self::run) for `File list size` to be reported.
+    pub fn set_raw_read_counter(&mut self, counter: Arc<std::sync::atomic::AtomicU64>) {
+        self.raw_read_counter = Some(counter);
+    }
+
+    /// Returns the accumulated `File list size` in raw wire bytes.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2789` - `stats.flist_size += stats.total_read - start_read;`
+    #[must_use]
+    pub fn flist_size(&self) -> u64 {
+        self.flist_size
+    }
+
+    /// Snapshots the raw read counter at the start of a file-list span.
+    ///
+    /// upstream: flist.c:2615 `start_read = stats.total_read;`
+    pub(in crate::receiver) fn flist_span_start(&self) -> u64 {
+        self.raw_read_counter
+            .as_ref()
+            .map_or(0, |c| c.load(Ordering::Relaxed))
+    }
+
+    /// Accumulates the raw bytes read since `start` into `flist_size`.
+    ///
+    /// upstream: flist.c:2789 `stats.flist_size += stats.total_read - start_read;`
+    pub(in crate::receiver) fn flist_span_end(&mut self, start: u64) {
+        if let Some(counter) = &self.raw_read_counter {
+            self.flist_size = self
+                .flist_size
+                .saturating_add(counter.load(Ordering::Relaxed).saturating_sub(start));
+        }
     }
 
     /// Converts a wire NDX value to a flat file list array index.

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -69,17 +69,24 @@ impl ReceiverContext {
         reader: &mut R,
         ndx_codec: &mut NdxCodecEnum,
     ) -> io::Result<FrameKind> {
+        // Snapshot before the ndx read: upstream's raw counter ticks on arrival
+        // (io.c:820), so a segment header or the EOF marker is attributed to an
+        // adjacent recv_file_list span on any real link. The span is kept only
+        // when the frame turns out to be flist traffic; NDX_DONE and per-file
+        // replies are transfer-phase frames upstream never counts.
+        let span_start = self.flist_span_start();
         let ndx = ndx_codec.read_ndx(reader)?;
 
         if ndx == NDX_FLIST_EOF {
             self.flist_eof = true;
+            self.flist_span_end(span_start);
             return Ok(FrameKind::FlistEof);
         }
         if ndx == NDX_DONE {
             return Ok(FrameKind::Done);
         }
         if ndx <= NDX_FLIST_OFFSET {
-            self.receive_one_extra_segment(reader, ndx)?;
+            self.receive_one_extra_segment(reader, ndx, span_start)?;
             return Ok(FrameKind::Segment(NDX_FLIST_OFFSET - ndx));
         }
         Ok(FrameKind::Reply(ndx))

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -31,6 +31,10 @@ impl ReceiverContext {
     /// After the file list entries, this also consumes the UID/GID lists that follow
     /// (unless using incremental recursion). See upstream `recv_id_list()` in uidlist.c.
     pub fn receive_file_list<R: Read + ?Sized>(&mut self, reader: &mut R) -> io::Result<usize> {
+        // upstream: flist.c:2615 - `start_read = stats.total_read;` snapshots the
+        // raw wire counter before any list byte is read; the span (through the id
+        // lists and the pre-30 io_error int) accumulates into stats.flist_size.
+        let span_start = self.flist_span_start();
         let mut flist_reader = self.build_flist_reader();
 
         // Set ndx_start so the reader can distinguish abbreviated vs
@@ -196,6 +200,9 @@ impl ReceiverContext {
         // across recv_file_list() calls - cache the reader to preserve that state.
         self.flist_reader_cache = Some(flist_reader);
 
+        // upstream: flist.c:2789 - `stats.flist_size += stats.total_read - start_read;`
+        self.flist_span_end(span_start);
+
         Ok(count)
     }
 
@@ -234,15 +241,21 @@ impl ReceiverContext {
         let mut total_extra = 0;
 
         loop {
+            // Snapshot before the header ndx: upstream's raw counter ticks on
+            // arrival (io.c:820), so the segment header and EOF marker bytes are
+            // attributed to an adjacent recv_file_list span on any real link;
+            // covering them here reproduces upstream's observable flist_size.
+            let span_start = self.flist_span_start();
             let ndx = ndx_codec.read_ndx(reader)?;
 
             if ndx == NDX_FLIST_EOF {
                 debug_log!(Flist, 2, "received NDX_FLIST_EOF, file list complete");
                 self.flist_eof = true;
+                self.flist_span_end(span_start);
                 break;
             }
 
-            total_extra += self.receive_one_extra_segment(reader, ndx)?;
+            total_extra += self.receive_one_extra_segment(reader, ndx, span_start)?;
         }
 
         debug_log!(
@@ -279,6 +292,7 @@ impl ReceiverContext {
         &mut self,
         reader: &mut R,
         ndx: i32,
+        span_start: u64,
     ) -> io::Result<usize> {
         if ndx > NDX_FLIST_OFFSET {
             return Err(io::Error::new(
@@ -401,6 +415,11 @@ impl ReceiverContext {
             segment_count,
             seg_ndx_start
         );
+
+        // upstream: flist.c:2789 - each sub-list's raw wire bytes accumulate
+        // into stats.flist_size via `+=` on every recv_file_list() call.
+        self.flist_span_end(span_start);
+
         Ok(segment_count)
     }
 

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -111,6 +111,19 @@ pub struct TransferStats {
     /// This is the sum of all file sizes from the received file list,
     /// used to calculate speedup ratio (total_size / bytes_transferred).
     pub total_source_bytes: u64,
+    /// Raw wire bytes occupied by the received file list (`File list size`).
+    ///
+    /// Accumulated as the delta of the raw transport read counter across every
+    /// `recv_file_list` span (initial list plus INC_RECURSE sub-lists), so it
+    /// includes multiplex frame headers, the id lists, and the pre-30 io_error
+    /// int - exactly the raw-descriptor span upstream measures. Never sent over
+    /// the wire; each role prints its own local figure (`main.c:445`).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2615` - `start_read = stats.total_read;`
+    /// - `flist.c:2789` - `stats.flist_size += stats.total_read - start_read;`
+    pub flist_size: u64,
     /// Metadata errors encountered (path, error message).
     pub metadata_errors: Vec<(PathBuf, String)>,
     /// Accumulated I/O error flags from the sender's file list trailer.

--- a/crates/transfer/src/receiver/tests/file_list/flist_size.rs
+++ b/crates/transfer/src/receiver/tests/file_list/flist_size.rs
@@ -1,0 +1,149 @@
+//! `File list size` raw-span accounting on the receiving side.
+//!
+//! Upstream measures `stats.flist_size` as the delta of the raw wire read
+//! counter across every `recv_file_list()` span (`flist.c:2615` snapshots
+//! `stats.total_read`, `flist.c:2789` accumulates the delta). The figure is
+//! never sent over the wire - each role prints its own local number
+//! (`main.c:445`) - so a pulling client that never measures the span prints
+//! `File list size: 0` on every remote transfer. These tests pin the span
+//! measurement against the same raw-counter layering production uses.
+
+use std::io::{Cursor, Read};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use protocol::ProtocolVersion;
+use protocol::flist::{FileEntry, FileListWriter};
+
+use super::super::super::ReceiverContext;
+use super::super::support::{test_config, test_handshake, test_handshake_with_protocol};
+use crate::config::ServerConfig;
+use crate::flags::{NumericIds, ParsedServerFlags};
+use crate::role::ServerRole;
+
+/// Raw-level counting shim mirroring the production `CountingReader`
+/// (upstream: io.c:820 `stats.total_read += n`).
+struct CountingRead<'a> {
+    inner: Cursor<&'a [u8]>,
+    counter: Arc<AtomicU64>,
+}
+
+impl Read for CountingRead<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.counter.fetch_add(n as u64, Ordering::Relaxed);
+        Ok(n)
+    }
+}
+
+/// Encodes entries plus the end marker into a wire buffer.
+fn encode(protocol: ProtocolVersion, entries: &[FileEntry]) -> Vec<u8> {
+    let mut data = Vec::new();
+    let mut writer = FileListWriter::new(protocol);
+    for entry in entries {
+        writer.write_entry(&mut data, entry).unwrap();
+    }
+    writer.write_end(&mut data, None).unwrap();
+    data
+}
+
+/// The measured span must equal the raw bytes the list occupied on the wire.
+///
+/// WHY: upstream's `File list size` is the raw-counter delta across
+/// `recv_file_list()` (flist.c:2615/2789), so the pulling client's printed
+/// value equals the wire bytes consumed for the list. Before the fix the
+/// receiver never measured the span and every remote pull printed
+/// `File list size: 0` while upstream printed the real size.
+#[test]
+fn flist_size_counts_raw_wire_span() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let entries = [
+        FileEntry::new_file("a.txt".into(), 100, 0o644),
+        FileEntry::new_file("b.txt".into(), 50, 0o644),
+        FileEntry::new_file("sub/c.txt".into(), 10, 0o644),
+    ];
+    let data = encode(handshake.protocol, &entries);
+
+    let counter = Arc::new(AtomicU64::new(0));
+    ctx.set_raw_read_counter(Arc::clone(&counter));
+
+    let mut reader = CountingRead {
+        inner: Cursor::new(&data[..]),
+        counter: Arc::clone(&counter),
+    };
+    let count = ctx.receive_file_list(&mut reader).unwrap();
+
+    assert_eq!(count, 3);
+    assert_eq!(
+        ctx.flist_size(),
+        data.len() as u64,
+        "flist_size must equal the raw wire bytes of the list span"
+    );
+}
+
+/// Without an attached raw counter the span is unmeasured and stays 0.
+///
+/// WHY: server-side receivers never print `File list size` (upstream sends
+/// only total_read/total_written/total_size in the stats trailer,
+/// main.c:348-355), so the measurement is opt-in via the counter handle and
+/// its absence must not disturb the read path.
+#[test]
+fn flist_size_zero_without_counter() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let entries = [FileEntry::new_file("a.txt".into(), 100, 0o644)];
+    let data = encode(handshake.protocol, &entries);
+
+    let mut cursor = Cursor::new(&data[..]);
+    let count = ctx.receive_file_list(&mut cursor).unwrap();
+
+    assert_eq!(count, 1);
+    assert_eq!(ctx.flist_size(), 0);
+}
+
+/// The protocol < 30 trailing io_error int is part of the measured span.
+///
+/// WHY: upstream reads the 4-byte io_error trailer inside `recv_file_list()`
+/// (flist.c:2773-2777) before accumulating the span at flist.c:2789, so those
+/// bytes count toward `File list size`.
+#[test]
+fn flist_size_includes_pre30_io_error_int() {
+    let handshake = test_handshake_with_protocol(28);
+    let config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(28u8).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        flags: ParsedServerFlags {
+            numeric_ids: NumericIds::Explicit,
+            ..Default::default()
+        },
+        args: vec![std::ffi::OsString::from(".")],
+        ..Default::default()
+    };
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // Wire: 0x00 end marker + 4-byte LE io_error trailer.
+    let mut wire = vec![0x00u8];
+    wire.extend_from_slice(&0i32.to_le_bytes());
+
+    let counter = Arc::new(AtomicU64::new(0));
+    ctx.set_raw_read_counter(Arc::clone(&counter));
+
+    let mut reader = CountingRead {
+        inner: Cursor::new(&wire[..]),
+        counter: Arc::clone(&counter),
+    };
+    let count = ctx.receive_file_list(&mut reader).unwrap();
+
+    assert_eq!(count, 0);
+    assert_eq!(
+        ctx.flist_size(),
+        wire.len() as u64,
+        "the pre-30 io_error trailer is inside the measured span"
+    );
+}

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -158,6 +158,7 @@ fn transfer_stats_has_incremental_fields() {
         bytes_received: 0,
         bytes_sent: 0,
         total_source_bytes: 0,
+        flist_size: 0,
         metadata_errors: vec![],
         io_error: 0,
         got_xfer_error: false,

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -45,6 +45,7 @@ mod delete_pipeline_hook;
 mod delete_timing;
 mod filter_chain;
 mod filter_recheck;
+mod flist_size;
 #[cfg(feature = "iconv")]
 mod iconv_wire_order;
 mod id_lists;

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -630,6 +630,8 @@ impl ReceiverContext {
             bytes_received,
             bytes_sent: 0,
             total_source_bytes,
+            // upstream: flist.c:2789 - accumulated across recv_file_list spans.
+            flist_size: self.flist_size,
             metadata_errors,
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
                 | self.flist_io_error

--- a/crates/transfer/tests/incremental_transfer.rs
+++ b/crates/transfer/tests/incremental_transfer.rs
@@ -27,6 +27,7 @@ fn transfer_stats_incremental_fields_exist() {
         bytes_received: 1000,
         bytes_sent: 100,
         total_source_bytes: 5000,
+        flist_size: 0,
         metadata_errors: vec![],
         io_error: 0,
         got_xfer_error: false,


### PR DESCRIPTION
## Problem

On remote transfers, `--stats` printed `File list size: 0` on every pull, while upstream 3.4.4 prints the wire size of the received file list.

## Upstream definition

`stats.flist_size` is the delta of the raw descriptor byte counter across each file-list span:

- Receiver: `flist.c:2615` `start_read = stats.total_read;` at `recv_file_list()` entry; `flist.c:2789` `stats.flist_size += stats.total_read - start_read;`. The raw counter ticks on actual reads (`io.c:820`), so the figure includes multiplex frame headers, the id lists, and the pre-30 io_error trailer.
- Sender: `flist.c:2254`/`flist.c:2560` sample `stats.total_written` around `send_file_list()`, but the encoded list is still unflushed in the 64 KiB `iobuf.out` (`io.c:1382`) when the span ends, so a client sender prints `File list size: 0` for any list that fits the buffer.
- The value never crosses the wire: `handle_stats()` (`main.c:325`) sends only total_read/total_written/total_size (+ flist build/xfer times), and `main.c:445` prints each role's local figure.

## Measured divergence (1031-entry mixed tree, upstream 3.4.4 vs oc)

| case | upstream | oc before | oc after |
|---|---|---|---|
| ssh push | 0 | 0 | 0 |
| daemon push | 0 | 0 | 0 |
| ssh pull | 19,475 | 0 | 19,475 |
| daemon pull | 18,600 | 0 | 18,600 |
| ssh pull, 8-entry tree | 154 | 0 | 154 |

Pull rows compare identical wire streams (oc client reading the upstream 3.4.4 server's list); the delta shape before the fix was total absence - the receiving client never measured the span.

## Fix

- Attach the raw read counter (the same one that feeds `bytes_received`) to `ReceiverContext` and accumulate the span delta around the initial list, every INC_RECURSE sub-list (including the segment header and EOF marker, which upstream's arrival-time counter attributes to an adjacent span), and the pre-30 io_error trailer.
- Thread the total through `TransferStats::flist_size` into the client summary for both the ssh and daemon pull paths.
- A push keeps reporting 0, matching upstream's buffered client sender.

`Total bytes sent/received` accounting is untouched.

## Tests

- `flist_size_counts_raw_wire_span`, `flist_size_zero_without_counter`, `flist_size_includes_pre30_io_error_int` (transfer) pin the raw-span measurement.
- `from_receiver_stats_maps_flist_size` (engine) pins the summary plumbing that previously dropped the value.

Verified byte-identical against upstream 3.4.4 over both transports, both directions, small and >1000-entry trees.
