### PR TITLE
fix(transfer): print the root ./ row on the non-incremental ladder

### DIFF
--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -121,6 +121,14 @@ impl ReceiverContext {
     /// the root's metadata (and before child mkdirs bump the root mtime), so the
     /// stat reflects the pre-transfer state - the same pre-mkdir gate the `-i`
     /// root row uses (see `existing_dir_iflags`).
+    ///
+    /// A destination root that is absent pre-transfer is still named: upstream
+    /// "creates" it even under `--dry-run` (`main.c:796-808`; `do_mkdir` is a
+    /// dry-run no-op, syscall.c), `FLAG_DIR_CREATED` then forces `statret = -1`
+    /// (`generator.c:1465-1466`) and `set_file_attrs()` returns 1 for the
+    /// missing dest under dry-run (`rsync.c:498-499`), so the `./` row prints.
+    /// `--list-only` never reaches `get_local_name()`'s mkdir (`main.c:743`),
+    /// so no row is added there.
     pub(in crate::receiver) fn root_verbose_name_emit(&self, dest_dir: &std::path::Path) -> bool {
         if self.dest_root_created {
             return true;
@@ -128,9 +136,15 @@ impl ReceiverContext {
         self.file_list
             .iter()
             .find(|entry| entry.is_dir() && entry.path().as_os_str() == ".")
-            .is_some_and(|entry| {
-                crate::generator::ItemFlags::from_raw(self.existing_dir_iflags(entry, dest_dir))
-                    .has_significant_flags()
+            .is_some_and(|entry| match std::fs::metadata(dest_dir) {
+                Ok(meta) => crate::generator::ItemFlags::from_raw(self.itemize_existing_flags(
+                    entry,
+                    dest_dir,
+                    Some(&meta),
+                    0,
+                ))
+                .has_significant_flags(),
+                Err(_) => !self.config.flags.list_only,
             })
     }
 

--- a/crates/transfer/src/receiver/tests/verbose_dir_names.rs
+++ b/crates/transfer/src/receiver/tests/verbose_dir_names.rs
@@ -85,6 +85,39 @@ fn names_only_created_or_changed_dirs() {
     );
 }
 
+/// A dry run against a missing destination root still names `./`, on both
+/// receiver drivers (this helper is shared; the CI feature matrix runs it with
+/// `incremental-flist` on and off). Upstream "creates" the missing root even
+/// under `-n` (`main.c:796-808`; `do_mkdir` is a dry-run no-op), and
+/// `FLAG_DIR_CREATED` then forces the NAME row (`generator.c:1465-1466`,
+/// `generator.c:1503-1505`; `rsync.c:498-499` returns 1 for the missing dest
+/// under dry-run). `--list-only` never reaches that mkdir (`main.c:743`), so
+/// the root stays silent there.
+#[test]
+fn missing_dest_root_is_named_on_dry_run_but_not_list_only() {
+    let t: i64 = 1_000_000_000;
+    let entries = vec![dir(".", t), dir("sub", t)];
+    let mut c = ctx_with(entries, true);
+    c.config.flags.dry_run = true;
+
+    let parent = tempfile::tempdir().unwrap();
+    let missing = parent.path().join("nonexistent-dest");
+    assert_eq!(
+        c.verbose_dir_name_lines(&missing),
+        vec![(0usize, "./".to_string()), (1usize, "sub/".to_string())],
+        "a dry run against a missing dest root must name ./ first",
+    );
+
+    c.config.flags.dry_run = false;
+    c.config.flags.list_only = true;
+    assert!(
+        !c.verbose_dir_name_lines(&missing)
+            .iter()
+            .any(|(_, name)| name == "./"),
+        "--list-only never creates the dest root, so ./ must stay silent",
+    );
+}
+
 /// With `--times` off, an existing directory reports no time change, so an
 /// unchanged re-sync names nothing (upstream prints no directory lines when
 /// set_file_attrs() makes no change). The absent root is not created here.


### PR DESCRIPTION
## Problem

With a missing destination root, a dry-run pull (`-nav host:src/ dst/`) omitted the leading `./` NAME row that upstream prints:

```
upstream 3.4.4               oc-rsync (before)
receiving incremental...     receiving incremental...
created directory dst        a.txt
./                           sub/b.txt
a.txt                        sub/
sub/
sub/b.txt
```

## Upstream behaviour

- `main.c:796-808` - `get_local_name()` "creates" a missing dest root even under `--dry-run` (`do_mkdir` is a dry-run no-op, syscall.c) and sets `FLAG_DIR_CREATED` on the root `.` entry (main.c:803-805).
- `generator.c:1465-1466` - `FLAG_DIR_CREATED` forces `statret = -1`.
- `generator.c:1503-1505` - the directory NAME row prints when `set_file_attrs()` reports a change; with the dest missing, `sxp` is NULL and `rsync.c:498-499` returns 1 under dry-run, so the `./` row always prints.
- `main.c:743` - `--list-only` returns before the mkdir, so it never names the root.

## Fix

`root_verbose_name_emit()` classified an absent destination root through `existing_dir_iflags()`, whose failed-stat leg is upstream's benign "no change" outcome - correct when comparing an existing directory, wrong for the created/missing root. The absent root is now treated as named, except under `--list-only`.

The helper is shared by both receiver drivers (`run_pipelined` and `run_pipelined_incremental`), so the fix lands identically with the `incremental-flist` feature on and off. Verified end-to-end with the binary built both ways (`-p bin` resolves the feature off; a workspace-unified build resolves it on): both now print the `./` row, and the non-dry-run and dst-exists outputs are unchanged.

## Tests

`missing_dest_root_is_named_on_dry_run_but_not_list_only` in `receiver/tests/verbose_dir_names.rs` fails before the fix and passes after, in both feature configurations; the module is compiled unconditionally, so the CI feature matrix exercises it in the `no-incremental-flist` cell and the default/all-features cells.

## Remaining divergences observed (not addressed here)

- The `created directory <dst>` notice is not printed on remote pulls under plain `-v` (the receiver gates it on the itemize format only) nor under `-n`.
- Dry-run rows are emitted after the summary and dirs after files, instead of upstream's flist-order interleaving before the summary (banner/ordering work is in flight separately).
- `--list-only -v` over remote shell drops the listing table entirely and prints a spurious `sub/` dir row.
