### PR TITLE
fix(protocol): upstream-exact negotiation of unknown algorithm names

### DIFF
--- a/crates/protocol/src/negotiation/capabilities/algorithms.rs
+++ b/crates/protocol/src/negotiation/capabilities/algorithms.rs
@@ -46,6 +46,40 @@ pub(super) fn supported_compressions() -> Vec<&'static str> {
     list
 }
 
+/// Resolves a checksum name to its canonical wire spelling, or `None` when the
+/// name is not a build-supported algorithm.
+///
+/// Mirrors upstream `get_nni_by_name()` (compat.c:223-238): the lookup is
+/// case-insensitive (`strncasecmp`), and an alias entry resolves to its
+/// `main_nni` canonical name (`xxhash` becomes `xxh64`). Unrecognised names
+/// resolve to `None` so callers skip them, exactly as upstream's negotiation
+/// and env-list parsing do - this is what keeps a future name such as
+/// `sha256` from breaking interop.
+pub(super) fn resolve_checksum_name(name: &str) -> Option<&'static str> {
+    let canonical = ChecksumAlgorithm::parse(&name.to_ascii_lowercase())
+        .ok()?
+        .as_str();
+    SUPPORTED_CHECKSUMS
+        .contains(&canonical)
+        .then_some(canonical)
+}
+
+/// Resolves a compression name to its canonical wire spelling, or `None` when
+/// the name is not a build-supported algorithm.
+///
+/// The compression counterpart of [`resolve_checksum_name`]. Feature-gated
+/// codecs (lz4, zstd) absent from this build are treated as unrecognised,
+/// matching upstream's compile-time `valid_compressions_items[]` gating
+/// (compat.c:101-112).
+pub(super) fn resolve_compression_name(name: &str) -> Option<&'static str> {
+    let canonical = CompressionAlgorithm::parse(&name.to_ascii_lowercase())
+        .ok()?
+        .as_str();
+    supported_compressions()
+        .contains(&canonical)
+        .then_some(canonical)
+}
+
 /// Checksum algorithm negotiated between rsync peers.
 ///
 /// Protocol 30+ peers exchange space-separated lists of supported algorithms
@@ -89,15 +123,17 @@ impl ChecksumAlgorithm {
     /// Parses an algorithm from its wire protocol name.
     ///
     /// Accepts "xxhash" as an alias for XXH64, matching upstream rsync's
-    /// `valid_checksums_items` table in `checksum.c` where both "xxh64" and
-    /// "xxhash" map to `CSUM_XXH64`.
+    /// `valid_checksums_items` table (checksum.c:49-65) where both "xxh64" and
+    /// "xxhash" map to `CSUM_XXH64`. No other spellings exist in that table,
+    /// so anything else - including a shortened "xxh" - is unrecognised, just
+    /// as upstream's `get_nni_by_name()` reports.
     pub fn parse(name: &str) -> io::Result<Self> {
         match name {
             "none" => Ok(Self::None),
             "md4" => Ok(Self::MD4),
             "md5" => Ok(Self::MD5),
             "sha1" => Ok(Self::SHA1),
-            "xxh" | "xxh64" | "xxhash" => Ok(Self::XXH64),
+            "xxh64" | "xxhash" => Ok(Self::XXH64),
             "xxh3" => Ok(Self::XXH3),
             "xxh128" => Ok(Self::XXH128),
             _ => Err(io::Error::new(

--- a/crates/protocol/src/negotiation/capabilities/env_list.rs
+++ b/crates/protocol/src/negotiation/capabilities/env_list.rs
@@ -31,9 +31,7 @@
 
 use std::io;
 
-use super::algorithms::{
-    ChecksumAlgorithm, CompressionAlgorithm, SUPPORTED_CHECKSUMS, supported_compressions,
-};
+use super::algorithms::{resolve_checksum_name, resolve_compression_name};
 
 /// Environment variable that overrides the checksum negotiation list.
 const CHECKSUM_LIST_ENV: &str = "RSYNC_CHECKSUM_LIST";
@@ -70,9 +68,9 @@ pub(super) fn checksum_candidates(
 ) -> Option<EnvOverride> {
     if write_batch {
         let forced = if protocol >= 30 { "md5" } else { "md4" };
-        return parse_list(forced, resolve_checksum);
+        return parse_list(forced, resolve_checksum_name);
     }
-    parse_env(CHECKSUM_LIST_ENV, is_server, resolve_checksum)
+    parse_env(CHECKSUM_LIST_ENV, is_server, resolve_checksum_name)
 }
 
 /// Returns the compression candidate override from `RSYNC_COMPRESS_LIST`, or
@@ -83,9 +81,9 @@ pub(super) fn checksum_candidates(
 /// upstream: `compat.c:412-414 getenv_nstr()`.
 pub(super) fn compression_candidates(is_server: bool, write_batch: bool) -> Option<EnvOverride> {
     if write_batch {
-        return parse_list("zlib", resolve_compression);
+        return parse_list("zlib", resolve_compression_name);
     }
-    parse_env(COMPRESS_LIST_ENV, is_server, resolve_compression)
+    parse_env(COMPRESS_LIST_ENV, is_server, resolve_compression_name)
 }
 
 /// Refuses a client-forced `--checksum-choice` whose algorithm is absent from
@@ -112,7 +110,7 @@ pub(super) fn compression_candidates(is_server: bool, write_batch: bool) -> Opti
 /// - `compat.c:426-449 validate_choice_vs_env()` - the refusal check itself.
 /// - `checksum.c:185-186` - the server-only call site.
 pub(super) fn validate_checksum_choice(choice: &str) -> io::Result<()> {
-    validate_choice(CHECKSUM_LIST_ENV, "checksum", choice, resolve_checksum)
+    validate_choice(CHECKSUM_LIST_ENV, "checksum", choice, resolve_checksum_name)
 }
 
 /// Refuses a client-forced `--compress-choice` whose algorithm is absent from
@@ -127,7 +125,12 @@ pub(super) fn validate_checksum_choice(choice: &str) -> io::Result<()> {
 /// - `compat.c:426-449 validate_choice_vs_env()`.
 /// - `compat.c:193-194` - the server-only call site.
 pub(super) fn validate_compress_choice(choice: &str) -> io::Result<()> {
-    validate_choice(COMPRESS_LIST_ENV, "compress", choice, resolve_compression)
+    validate_choice(
+        COMPRESS_LIST_ENV,
+        "compress",
+        choice,
+        resolve_compression_name,
+    )
 }
 
 /// Refuses the forced fallback default checksum on the non-negotiated path when
@@ -147,7 +150,7 @@ pub(super) fn validate_default_checksum(default: &str, is_server: bool) -> io::R
         "checksum",
         default,
         is_server,
-        resolve_checksum,
+        resolve_checksum_name,
     )
 }
 
@@ -164,7 +167,7 @@ pub(super) fn validate_default_compress(default: &str, is_server: bool) -> io::R
         "compress",
         default,
         is_server,
-        resolve_compression,
+        resolve_compression_name,
     )
 }
 
@@ -252,31 +255,6 @@ fn validate_default(
             format!("Failed to negotiate a {kind} choice."),
         )),
     }
-}
-
-/// Resolves a checksum name to its canonical wire spelling, or `None` when the
-/// name is not a build-supported algorithm. Accepts the `xxhash` alias and any
-/// ASCII casing, mirroring upstream's case-insensitive `get_nni_by_name`.
-fn resolve_checksum(name: &str) -> Option<&'static str> {
-    let canonical = ChecksumAlgorithm::parse(&name.to_ascii_lowercase())
-        .ok()?
-        .as_str();
-    SUPPORTED_CHECKSUMS
-        .contains(&canonical)
-        .then_some(canonical)
-}
-
-/// Resolves a compression name to its canonical wire spelling, or `None` when
-/// the name is not a build-supported algorithm. Feature-gated codecs (lz4,
-/// zstd) absent from this build are treated as unrecognised, matching upstream's
-/// compile-time `valid_compressions_items[]` gating.
-fn resolve_compression(name: &str) -> Option<&'static str> {
-    let canonical = CompressionAlgorithm::parse(&name.to_ascii_lowercase())
-        .ok()?
-        .as_str();
-    supported_compressions()
-        .contains(&canonical)
-        .then_some(canonical)
 }
 
 /// Core parser shared by both variables.

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -9,7 +9,8 @@ use crate::nstr::{
 };
 
 use super::algorithms::{
-    ChecksumAlgorithm, CompressionAlgorithm, SUPPORTED_CHECKSUMS, supported_compressions,
+    ChecksumAlgorithm, CompressionAlgorithm, SUPPORTED_CHECKSUMS, resolve_checksum_name,
+    resolve_compression_name, supported_compressions,
 };
 use super::env_list;
 
@@ -113,7 +114,9 @@ pub struct NegotiationResult {
 ///
 /// - Protocol < 30: Not an error, returns default algorithms (MD4, Zlib)
 /// - `do_negotiation=false`: Returns defaults (MD5, Zlib if `-z`) without I/O
-/// - Peer chooses unsupported algorithm: InvalidData error
+/// - No mutual algorithm in the peer's list: `Unsupported` error, matching
+///   upstream's `RERR_UNSUPPORTED` abort (compat.c:406); unknown names inside
+///   the list are skipped, never an error
 /// - I/O errors during send/receive
 ///
 /// # Examples
@@ -419,10 +422,19 @@ pub fn negotiate_capabilities_with_override(
         None => {
             let list = remote_checksum_list.as_deref().unwrap_or("");
             // upstream: compat.c:350 - selection matches remote names against our
-            // local `saw` list, which the env override reorders/restricts.
+            // local `saw` list, which the env override reorders/restricts. With
+            // no override, the default candidates drop `none` on the client
+            // (compat.c:485-486).
+            let default_candidates;
             let candidates: &[&str] = match &checksum_env {
                 Some(env) => &env.candidates,
-                None => SUPPORTED_CHECKSUMS,
+                None => {
+                    default_candidates = default_selection_candidates(
+                        SUPPORTED_CHECKSUMS.iter().copied(),
+                        is_server,
+                    );
+                    &default_candidates
+                }
             };
             choose_checksum_algorithm_in(list, is_server, candidates)?
         }
@@ -435,9 +447,14 @@ pub fn negotiate_capabilities_with_override(
         forced
     } else if let Some(ref list) = remote_compression_list {
         let supported = supported_compressions();
+        let default_candidates;
         let candidates: &[&str] = match &compression_env {
             Some(env) => &env.candidates,
-            None => &supported,
+            None => {
+                default_candidates =
+                    default_selection_candidates(supported.iter().copied(), is_server);
+                &default_candidates
+            }
         };
         choose_compression_algorithm_in(list, is_server, candidates)?
     } else {
@@ -554,20 +571,59 @@ fn resolved_compress_level(compression: CompressionAlgorithm, raw_level: i32) ->
     }
 }
 
+/// Selects the mutual algorithm name from the peer's space-separated list.
+///
+/// Mirrors upstream `parse_negotiate_str()` (compat.c:333-364) token by token:
+///
+/// - Each remote token is resolved via the case-insensitive, alias-aware
+///   lookup (`get_nni_by_name()`, compat.c:223-238); an unrecognised name -
+///   e.g. a future `sha256` from a newer peer - is skipped without error
+///   (compat.c:350 `if (!nni || !nno->saw[nni->num] || ...) continue;`).
+/// - A recognised token must also be in `local` (upstream's `nno->saw`, which
+///   the env override reorders/restricts); the token with the lowest `local`
+///   ordinal wins, matching upstream's `best` tracking.
+/// - The server stops at the first acceptable client choice, the client keeps
+///   scanning for its best own-preference match and stops early only on a
+///   perfect one (compat.c:354 `if (best == 1 || am_server) break;`).
+///
+/// Returns `None` when nothing matched, which callers turn into upstream's
+/// hard `RERR_UNSUPPORTED` failure (compat.c:369-406 `recv_negotiate_str`).
+fn select_from_peer_list<'a>(
+    remote_list: &str,
+    is_server: bool,
+    local: &[&'a str],
+    resolve: impl Fn(&str) -> Option<&'static str>,
+) -> Option<&'a str> {
+    let mut best: Option<usize> = None;
+    for token in remote_list.split_whitespace() {
+        // upstream: compat.c:350 - unknown names are skipped, never an error.
+        let Some(canonical) = resolve(token) else {
+            continue;
+        };
+        let Some(pos) = local.iter().position(|&name| name == canonical) else {
+            continue;
+        };
+        if best.is_none_or(|current| pos < current) {
+            best = Some(pos);
+            // upstream: compat.c:354 - the server stops at the first
+            // acceptable client choice; the client stops only on its own
+            // top preference.
+            if pos == 0 || is_server {
+                break;
+            }
+        }
+    }
+    best.map(|pos| local[pos])
+}
+
 /// Chooses a checksum algorithm using upstream rsync's precedence rules.
 ///
-/// upstream: compat.c:332-363 `parse_negotiate_str()` - both sides converge on
+/// upstream: compat.c:333-364 `parse_negotiate_str()` - both sides converge on
 /// the first entry in the client's list that also appears in the server's list.
 ///
-/// - Server (`is_server=true`): iterates the remote (client's) list, returns the
-///   first entry that appears in our local list. This is the server-side fast path
-///   where the server breaks on first acceptable client choice.
-/// - Client (`is_server=false`): iterates our local list, returns the first entry
-///   that also appears in the remote (server's) list. This finds the best local
-///   preference among mutually supported algorithms.
-///
 /// Returns an error if no common algorithm is found - upstream rsync treats
-/// this as a hard failure (compat.c:383-406 `recv_negotiate_str`).
+/// this as a hard failure (compat.c:383-406 `recv_negotiate_str`, exiting with
+/// `RERR_UNSUPPORTED`).
 ///
 /// This is the default-list convenience wrapper exercised by the test suite;
 /// production callers use [`choose_checksum_algorithm_in`] so the
@@ -577,58 +633,41 @@ pub(super) fn choose_checksum_algorithm(
     remote_list: &str,
     is_server: bool,
 ) -> io::Result<ChecksumAlgorithm> {
-    choose_checksum_algorithm_in(remote_list, is_server, SUPPORTED_CHECKSUMS)
+    choose_checksum_algorithm_in(
+        remote_list,
+        is_server,
+        &default_selection_candidates(SUPPORTED_CHECKSUMS.iter().copied(), is_server),
+    )
 }
 
 /// Chooses a checksum algorithm from an explicit local candidate list.
 ///
 /// Behaves like [`choose_checksum_algorithm`] but takes the ordered local
 /// candidate names as a parameter so the caller can substitute the
-/// `RSYNC_CHECKSUM_LIST` env override (upstream `nno->saw`, compat.c:350). With
-/// the default [`SUPPORTED_CHECKSUMS`] list the behaviour is unchanged.
+/// `RSYNC_CHECKSUM_LIST` env override (upstream `nno->saw`, compat.c:350).
 pub(super) fn choose_checksum_algorithm_in(
     remote_list: &str,
     is_server: bool,
     local: &[&str],
 ) -> io::Result<ChecksumAlgorithm> {
-    let remote_items: Vec<&str> = remote_list.split_whitespace().collect();
-
-    if is_server {
-        // Server: iterate client's (remote) list, first match in our list wins.
-        // upstream: compat.c:353 `if (best == 1 || am_server) break;`
-        for algo in &remote_items {
-            if let Ok(checksum) = ChecksumAlgorithm::parse(algo) {
-                if local.contains(&checksum.as_str()) {
-                    return Ok(checksum);
-                }
-            }
-        }
-    } else {
-        // Client: iterate our local list, first item also in server's (remote)
-        // list wins. This gives client preference order priority.
-        // upstream: compat.c:349-354 - client continues iterating to find the
-        // local item with the best (lowest) position in our own list.
-        for &name in local {
-            if remote_items.contains(&name) {
-                return ChecksumAlgorithm::parse(name)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()));
-            }
-        }
+    match select_from_peer_list(remote_list, is_server, local, resolve_checksum_name) {
+        Some(name) => ChecksumAlgorithm::parse(name)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
+        // upstream: compat.c:387,406 - "Failed to negotiate a %s choice." with
+        // exit_cleanup(RERR_UNSUPPORTED); ErrorKind::Unsupported maps to exit 4.
+        None => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Failed to negotiate a checksum choice.",
+        )),
     }
-
-    // upstream: compat.c:383-406 - failure to negotiate is a hard error
-    Err(io::Error::new(
-        io::ErrorKind::InvalidData,
-        format!("failed to negotiate a common checksum algorithm (remote offers: {remote_list})"),
-    ))
 }
 
 /// Chooses a compression algorithm using upstream rsync's precedence rules.
 ///
-/// Same asymmetric logic as [`choose_checksum_algorithm`] - both sides converge
-/// on the first entry in the client's list that also appears in the server's list.
+/// Same convergence logic as [`choose_checksum_algorithm`] - both sides pick
+/// the first entry in the client's list that also appears in the server's list.
 ///
-/// upstream: compat.c:332-363 `parse_negotiate_str()`
+/// upstream: compat.c:333-364 `parse_negotiate_str()`
 ///
 /// This is the default-list convenience wrapper exercised by the test suite;
 /// production callers use [`choose_compression_algorithm_in`] so the
@@ -639,44 +678,52 @@ pub(super) fn choose_compression_algorithm(
     is_server: bool,
 ) -> io::Result<CompressionAlgorithm> {
     let supported = supported_compressions();
-    choose_compression_algorithm_in(remote_list, is_server, &supported)
+    choose_compression_algorithm_in(
+        remote_list,
+        is_server,
+        &default_selection_candidates(supported.iter().copied(), is_server),
+    )
 }
 
 /// Chooses a compression algorithm from an explicit local candidate list.
 ///
 /// Behaves like [`choose_compression_algorithm`] but takes the ordered local
 /// candidate names as a parameter so the caller can substitute the
-/// `RSYNC_COMPRESS_LIST` env override. With the default
-/// [`supported_compressions`] list the behaviour is unchanged.
+/// `RSYNC_COMPRESS_LIST` env override.
 pub(super) fn choose_compression_algorithm_in(
     remote_list: &str,
     is_server: bool,
     local: &[&str],
 ) -> io::Result<CompressionAlgorithm> {
-    let remote_items: Vec<&str> = remote_list.split_whitespace().collect();
-
-    if is_server {
-        // Server: iterate client's (remote) list, first match in our list wins.
-        for algo in &remote_items {
-            if let Ok(compression) = CompressionAlgorithm::parse(algo) {
-                if local.contains(algo) {
-                    return Ok(compression);
-                }
-            }
-        }
-    } else {
-        // Client: iterate our local list, first item also in server's (remote)
-        // list wins.
-        for &name in local {
-            if remote_items.contains(&name) {
-                return CompressionAlgorithm::parse(name)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()));
-            }
-        }
+    match select_from_peer_list(remote_list, is_server, local, resolve_compression_name) {
+        Some(name) => CompressionAlgorithm::parse(name)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
+        // upstream: compat.c:387,406 recv_negotiate_str - a compression list
+        // with no mutual algorithm is the same hard RERR_UNSUPPORTED failure
+        // as an unmatched checksum list; "none" is never a silent fallback.
+        None => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Failed to negotiate a compress choice.",
+        )),
     }
+}
 
-    // No common algorithm found - use "none"
-    Ok(CompressionAlgorithm::None)
+/// Builds the default local selection candidates for one side.
+///
+/// upstream: compat.c:485-486 `get_default_nno_list()` skips the
+/// zero-numbered entry (`none` for both checksums and compressions) on the
+/// client, so a client can neither advertise nor accept `none` unless the
+/// operator re-enables it through `RSYNC_*_LIST`; the server keeps it. The
+/// `saw` array that `parse_negotiate_str()` consults is populated by that same
+/// loop, so the selection candidates must apply the identical filter.
+fn default_selection_candidates<'a>(
+    names: impl IntoIterator<Item = &'a str>,
+    is_server: bool,
+) -> Vec<&'a str> {
+    names
+        .into_iter()
+        .filter(|&name| is_server || name != "none")
+        .collect()
 }
 
 /// Builds the space-separated algorithm list a peer advertises during

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -28,10 +28,10 @@ fn test_compression_algorithm_roundtrip() {
 }
 
 #[test]
-fn test_xxh_alias() {
-    // "xxh" should parse to XXH64
-    let algo = ChecksumAlgorithm::parse("xxh").unwrap();
-    assert_eq!(algo, ChecksumAlgorithm::XXH64);
+fn test_xxh_is_not_a_valid_name() {
+    // upstream: checksum.c:49-65 valid_checksums_items - only "xxh64" and
+    // "xxhash" name CSUM_XXH64; a bare "xxh" is unrecognised.
+    assert!(ChecksumAlgorithm::parse("xxh").is_err());
 }
 
 #[test]
@@ -1009,9 +1009,10 @@ fn test_lz4_is_advertised_in_preference_order() {
 
 #[test]
 fn test_choose_compression_empty_list() {
-    // Empty list should fall back to None
-    let result = choose_compression_algorithm("", true).unwrap();
-    assert_eq!(result, CompressionAlgorithm::None);
+    // upstream: compat.c:381 `if (len > 0 && parse_negotiate_str(...))` - an
+    // empty list never negotiates and falls into the RERR_UNSUPPORTED abort.
+    let result = choose_compression_algorithm("", true);
+    assert!(result.is_err(), "empty list should be a negotiation error");
 }
 
 #[test]
@@ -1036,14 +1037,14 @@ fn test_daemon_client_handles_empty_capabilities() {
 
     // Empty checksum list from server is a negotiation failure
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
+    assert_eq!(result.unwrap_err().kind(), io::ErrorKind::Unsupported);
 }
 
 #[test]
 fn test_daemon_client_handles_single_algorithm() {
     // Server offers only one checksum and compression option
     let protocol = ProtocolVersion::try_from(31).unwrap();
-    let server_lists = b"\x03md4\x04none";
+    let server_lists = b"\x03md4\x04zlib";
     let mut stdin = &server_lists[..];
     let mut stdout = Vec::new();
 
@@ -1059,9 +1060,34 @@ fn test_daemon_client_handles_single_algorithm() {
     .unwrap();
 
     assert_eq!(result.checksum, ChecksumAlgorithm::MD4);
-    assert_eq!(result.compression, CompressionAlgorithm::None);
+    assert_eq!(result.compression, CompressionAlgorithm::Zlib);
     // Client also sends its lists (bidirectional)
     assert!(!stdout.is_empty());
+}
+
+#[test]
+fn test_client_rejects_none_only_compression_from_server() {
+    // upstream: compat.c:485-486 get_default_nno_list - the client skips the
+    // zero-numbered "none" entry, so its saw[] cannot accept a server list
+    // holding only "none"; recv_negotiate_str aborts with RERR_UNSUPPORTED.
+    let protocol = ProtocolVersion::try_from(31).unwrap();
+    let server_lists = b"\x03md4\x04none";
+    let mut stdin = &server_lists[..];
+    let mut stdout = Vec::new();
+
+    let result = negotiate_capabilities(
+        protocol,
+        &mut stdin,
+        &mut stdout,
+        true,  // do_negotiation
+        true,  // send_compression
+        true,  // is_daemon_mode
+        false, // is_server = false
+    );
+
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert_eq!(err.to_string(), "Failed to negotiate a compress choice.");
 }
 
 #[test]
@@ -2166,10 +2192,10 @@ fn phase5_negotiate_only_unsupported_checksums() {
 
 #[test]
 fn phase5_negotiate_only_unsupported_compressions() {
-    // If client sends only unsupported compressions, fallback to None
+    // upstream: compat.c:383-406 - no common compression is a hard error
     let list = "bzip2 lzma xz brotli";
-    let result = choose_compression_algorithm(list, true).unwrap();
-    assert_eq!(result, CompressionAlgorithm::None);
+    let err = choose_compression_algorithm(list, true).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
 }
 
 #[test]
@@ -2182,8 +2208,11 @@ fn phase5_negotiate_whitespace_only_list() {
         "whitespace-only list should be a negotiation error"
     );
 
-    let compression = choose_compression_algorithm(list, true).unwrap();
-    assert_eq!(compression, CompressionAlgorithm::None);
+    let compression = choose_compression_algorithm(list, true);
+    assert!(
+        compression.is_err(),
+        "whitespace-only list should be a negotiation error"
+    );
 }
 
 #[test]
@@ -2406,13 +2435,15 @@ fn capability_fallback_server_offers_unavailable_compression() {
     assert_eq!(result, CompressionAlgorithm::Zlib);
 }
 
-/// Tests fallback when server offers only unavailable compressions.
+/// Tests that a peer list with only unavailable compressions is a hard error.
 #[test]
 fn capability_fallback_server_only_unavailable_compression() {
+    // upstream: compat.c:383-406 recv_negotiate_str - no mutual compression
+    // aborts with RERR_UNSUPPORTED; there is no silent "none" fallback.
     let remote_list = "brotli lzma xz";
-    let result = choose_compression_algorithm(remote_list, true).unwrap();
-    // Should fall back to None when nothing matches
-    assert_eq!(result, CompressionAlgorithm::None);
+    let err = choose_compression_algorithm(remote_list, true).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert_eq!(err.to_string(), "Failed to negotiate a compress choice.");
 }
 
 /// Tests fallback when server offers only 'none' compression.
@@ -2438,10 +2469,10 @@ fn capability_fallback_unknown_checksum_strings() {
 /// Tests handling of completely unknown compression algorithm names.
 #[test]
 fn capability_fallback_unknown_compression_strings() {
+    // upstream: compat.c:383-406 - all unknown algorithm names is a hard error
     let remote_list = "snappy lzo lzf brotli";
-    let result = choose_compression_algorithm(remote_list, true).unwrap();
-    // Should fall back to None
-    assert_eq!(result, CompressionAlgorithm::None);
+    let err = choose_compression_algorithm(remote_list, true).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
 }
 
 /// Tests mixed known and unknown checksums - unknown first.
@@ -2462,16 +2493,33 @@ fn capability_fallback_mixed_unknown_known_compression() {
     assert_eq!(result, CompressionAlgorithm::ZlibX);
 }
 
-/// Tests handling of malformed algorithm names (typos, case errors).
+/// Tests handling of malformed algorithm names (typos, punctuation).
 #[test]
 fn capability_fallback_malformed_algorithm_names() {
     // upstream: compat.c:383-406 - malformed names with no valid match is a hard error
-    let remote_list = "MD5 Md5 mD5 md-5 md_5 md55 mdv md5!";
+    let remote_list = "md-5 md_5 md55 mdv md5!";
     let result = choose_checksum_algorithm(remote_list, true);
     assert!(
         result.is_err(),
         "all malformed algorithms should be a negotiation error"
     );
+}
+
+/// Tests that name matching is case-insensitive, like upstream's
+/// `get_nni_by_name()` (compat.c:230-236 `strncasecmp`). A peer whose
+/// `RSYNC_CHECKSUM_LIST` carries upper-case names advertises them verbatim
+/// (parse_nni_str keeps a non-alias token's original bytes), and upstream
+/// still negotiates them.
+#[test]
+fn capability_fallback_case_insensitive_names() {
+    for list in ["MD5", "Md5", "mD5"] {
+        for is_server in [true, false] {
+            let result = choose_checksum_algorithm(list, is_server).unwrap();
+            assert_eq!(result, ChecksumAlgorithm::MD5, "list {list:?}");
+        }
+    }
+    let result = choose_compression_algorithm("ZLIB", true).unwrap();
+    assert_eq!(result, CompressionAlgorithm::Zlib);
 }
 
 /// Tests handling of empty algorithm string between spaces.
@@ -2783,18 +2831,81 @@ fn capability_fallback_compression_parse_unknown() {
     assert!(err.to_string().contains("bzip2"));
 }
 
-/// Tests that xxh alias parsing works correctly for fallback.
+/// Tests alias handling in a peer list: "xxhash" resolves to xxh64
+/// (upstream checksum.c:55-56, both names share CSUM_XXH64 and the alias
+/// resolves through `main_nni`), while a bare "xxh" is not in
+/// `valid_checksums_items[]` and is skipped as unknown.
 #[test]
 fn capability_fallback_xxh_alias_in_list() {
-    // "xxh" should be recognized as xxh64
-    let remote_list = "xxh md5";
-    let result = choose_checksum_algorithm(remote_list, true).unwrap();
-    // "xxh" parses to XXH64, whose canonical name "xxh64" is in
-    // SUPPORTED_CHECKSUMS, so it matches before "md5".
-    assert_eq!(result, ChecksumAlgorithm::XXH64);
+    for is_server in [true, false] {
+        let result = choose_checksum_algorithm("xxhash md5", is_server).unwrap();
+        assert_eq!(result, ChecksumAlgorithm::XXH64);
+
+        let result = choose_checksum_algorithm("xxh md5", is_server).unwrap();
+        assert_eq!(result, ChecksumAlgorithm::MD5, "bare xxh must be skipped");
+    }
 }
 
-/// Tests that algorithm names must be exact matches.
+/// Pins forward compatibility with checksum names upstream may add later,
+/// e.g. sha256 as a transfer checksum (proposed upstream PR #1007). A newer
+/// peer advertising such a name must not break negotiation: upstream
+/// `parse_negotiate_str()` skips names `get_nni_by_name()` does not recognise
+/// (compat.c:350) and falls through to the best mutual algorithm.
+#[test]
+fn forward_compat_unknown_sha256_in_peer_list_is_skipped() {
+    for is_server in [true, false] {
+        let result = choose_checksum_algorithm("sha256 xxh128 md5", is_server).unwrap();
+        assert_eq!(result, ChecksumAlgorithm::XXH128, "server={is_server}");
+
+        // A future-name-first list still lands on the best mutual choice.
+        let result = choose_checksum_algorithm("sha512 sha256 md5", is_server).unwrap();
+        assert_eq!(result, ChecksumAlgorithm::MD5, "server={is_server}");
+    }
+}
+
+/// A peer list holding ONLY unknown names fails negotiation with upstream's
+/// hard error - `recv_negotiate_str` prints "Failed to negotiate a checksum
+/// choice." and exits with RERR_UNSUPPORTED (compat.c:387,406; errcode.h:28
+/// `RERR_UNSUPPORTED 4`). There is no silent md5/md4 fallback on the
+/// negotiated path; that fallback only exists for peers that cannot negotiate
+/// at all (compat.c:550-554).
+#[test]
+fn forward_compat_only_unknown_names_hard_error() {
+    for is_server in [true, false] {
+        let err = choose_checksum_algorithm("sha256 sha512 blake3", is_server).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported, "server={is_server}");
+        assert_eq!(err.to_string(), "Failed to negotiate a checksum choice.");
+    }
+}
+
+/// Full negotiation round against a newer peer whose checksum list leads with
+/// a future name: the exchange completes and lands on the best mutual
+/// algorithm without error.
+#[test]
+fn forward_compat_full_negotiation_with_future_peer() {
+    let protocol = ProtocolVersion::try_from(31).unwrap();
+    let mut peer = Vec::new();
+    write_vstring(&mut peer, "sha256 xxh128 xxh3 xxh64 md5 md4 sha1").unwrap();
+    let mut stdin = &peer[..];
+    let mut stdout = Vec::new();
+
+    let result = negotiate_capabilities(
+        protocol,
+        &mut stdin,
+        &mut stdout,
+        true,  // do_negotiation
+        false, // send_compression
+        false, // is_daemon_mode
+        false, // is_server
+    )
+    .unwrap();
+
+    assert_eq!(result.checksum, ChecksumAlgorithm::XXH128);
+}
+
+/// Tests that algorithm names must be whole-token matches. Case variants DO
+/// match (upstream compat.c:233 `strncasecmp`), but prefixes/suffixes do not:
+/// `get_nni_by_name()` requires `nni->name[len] == '\0'`.
 #[test]
 fn capability_fallback_exact_match_required() {
     // These should NOT match any algorithm - upstream compat.c:383-406
@@ -2802,8 +2913,8 @@ fn capability_fallback_exact_match_required() {
     let invalid_names = [
         "md5-hmac",   // suffix
         "prefix-md5", // prefix
-        "MD5",        // uppercase
-        "Md5",        // mixed case
+        "md",         // truncation
+        "xxh",        // truncation of xxh64/xxhash
     ];
 
     for name in invalid_names {
@@ -3319,7 +3430,35 @@ mod env_list_overrides {
         // upstream exits with RERR_UNSUPPORTED here.
         let err =
             choose_checksum_algorithm_in("xxh128 md5 md4", false, &over.candidates).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    // (d'') Forward compatibility: an env list naming a checksum this build
+    // does not know (e.g. sha256, proposed upstream PR #1007) drops the
+    // unknown name and negotiates the surviving mutual choice - upstream
+    // parse_nni_str() drops names get_nni_by_name() rejects (compat.c:295-306),
+    // so `RSYNC_CHECKSUM_LIST="sha256 md5"` behaves exactly like "md5".
+    #[test]
+    fn env_list_with_unknown_sha256_negotiates_survivor() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("sha256 md5"));
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+
+        let over = env_list::checksum_candidates(false, false, 32).unwrap();
+        assert_eq!(over.candidates, vec!["md5"]);
+        assert_eq!(over.advertised, "md5");
+
+        // Full round against a peer advertising the stock upstream list:
+        // negotiation lands on md5 without error.
+        let protocol = ProtocolVersion::try_from(31).unwrap();
+        let peer = test_peer_data(false);
+        let mut stdin = &peer[..];
+        let mut stdout = Vec::new();
+        let result =
+            negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, false, false, false)
+                .unwrap();
+        assert_eq!(result.checksum, ChecksumAlgorithm::MD5);
+        assert_eq!(first_vstring(&stdout), "md5");
     }
 
     // Empty / whitespace-only values are treated as unset (default order).

--- a/crates/protocol/src/version/tests/protocol/v32_compatibility.rs
+++ b/crates/protocol/src/version/tests/protocol/v32_compatibility.rs
@@ -809,7 +809,9 @@ fn v32_checksum_algorithm_parsing() {
     assert!(ChecksumAlgorithm::parse("md5").is_ok());
     assert!(ChecksumAlgorithm::parse("sha1").is_ok());
     assert!(ChecksumAlgorithm::parse("xxh64").is_ok());
-    assert!(ChecksumAlgorithm::parse("xxh").is_ok()); // xxh is alias for xxh64
+    assert!(ChecksumAlgorithm::parse("xxhash").is_ok()); // alias for xxh64
+    // upstream checksum.c:49-65 has no bare "xxh" entry
+    assert!(ChecksumAlgorithm::parse("xxh").is_err());
     assert!(ChecksumAlgorithm::parse("xxh3").is_ok());
     assert!(ChecksumAlgorithm::parse("xxh128").is_ok());
 

--- a/crates/protocol/tests/protocol_v30_compat.rs
+++ b/crates/protocol/tests/protocol_v30_compat.rs
@@ -762,9 +762,10 @@ mod protocol_30_edge_cases {
         let result =
             negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, true, false, true);
 
-        // No valid checksum in the list - negotiation fails
+        // No valid checksum in the list - negotiation fails with upstream's
+        // RERR_UNSUPPORTED semantics (compat.c:406).
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Unsupported);
     }
 
     /// Protocol 30 rejects empty capability lists.
@@ -792,7 +793,7 @@ mod protocol_30_edge_cases {
 
         // Empty checksum list is a negotiation failure per upstream
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Unsupported);
     }
 
     /// Protocol 30 handles truncated capability negotiation.
@@ -1451,9 +1452,10 @@ mod protocol_30_vstring_format {
         let result =
             negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, false, false, true);
 
-        // No valid checksum in the list - negotiation fails
+        // No valid checksum in the list - negotiation fails with upstream's
+        // RERR_UNSUPPORTED semantics (compat.c:406).
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Unsupported);
     }
 }
 

--- a/crates/protocol/tests/protocol_v32_compat.rs
+++ b/crates/protocol/tests/protocol_v32_compat.rs
@@ -424,7 +424,9 @@ mod protocol_32_algorithms {
         assert!(ChecksumAlgorithm::parse("md5").is_ok());
         assert!(ChecksumAlgorithm::parse("sha1").is_ok());
         assert!(ChecksumAlgorithm::parse("xxh64").is_ok());
-        assert!(ChecksumAlgorithm::parse("xxh").is_ok()); // alias for xxh64
+        assert!(ChecksumAlgorithm::parse("xxhash").is_ok()); // alias for xxh64
+        // upstream checksum.c:49-65 has no bare "xxh" entry
+        assert!(ChecksumAlgorithm::parse("xxh").is_err());
         assert!(ChecksumAlgorithm::parse("xxh3").is_ok());
         assert!(ChecksumAlgorithm::parse("xxh128").is_ok());
         assert!(ChecksumAlgorithm::parse("unknown").is_err());

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -142,6 +142,12 @@ Server-to-client flags (unidirectional):
 - Client (`am_server=false`): calls `read_varint(f_in)`
 - No bidirectional exchange
 
+When `CF_VARINT_FLIST_FLAGS` is set, checksum/compression name lists are then
+exchanged per `negotiate_the_strings()`; unknown names in a peer's list are
+skipped (compat.c:350), so future additions stay interoperable. WATCH: upstream
+PR #1007 proposes `sha256` as a negotiable transfer checksum - add it here once
+that merges.
+
 ---
 
 ## Roles


### PR DESCRIPTION
## Summary

Upstream PR #1007 proposes `sha256` as a negotiable transfer checksum. This change verifies and pins that oc-rsync's checksum negotiation treats unknown algorithm names in a peer's list exactly as upstream 3.4.4 does, and fixes the divergences found along the way, so a future upstream release adding new names cannot break interop.

## Upstream semantics (rsync 3.4.4)

- `parse_negotiate_str()` skips any peer token that `get_nni_by_name()` does not recognise (`compat.c:350`) and converges on the client-preference best mutual name; the server stops at the first acceptable client choice (`compat.c:354`).
- `get_nni_by_name()` matches case-insensitively via `strncasecmp` and resolves aliases (`xxhash` -> `xxh64`) through `main_nni` (`compat.c:223-238`, `checksum.c:49-65`).
- A list with no mutual algorithm is a hard failure: `Failed to negotiate a %s choice.` + `exit_cleanup(RERR_UNSUPPORTED)` (`compat.c:387,406`; exit 4). The md5/md4 prefill only applies to peers that cannot negotiate at all (`compat.c:550-554`).
- `get_default_nno_list()` skips the zero-numbered `none` entry on the client (`compat.c:485-486`), so a client cannot accept `none` unless the env list re-enables it.
- Unknown names in `RSYNC_CHECKSUM_LIST`/`RSYNC_COMPRESS_LIST` are dropped by `parse_nni_str()`; an all-unknown value collapses to `INVALID` and fails negotiation (`compat.c:295-306,327-328`).

## Divergences fixed

- Peer tokens were matched case-sensitively and the client path could not resolve the `xxhash` alias; both sides now use the shared case-insensitive, alias-aware resolver.
- The invented bare `xxh` spelling is removed; upstream's table only knows `xxh64`/`xxhash`.
- A checksum list with no mutual algorithm errored with `InvalidData` (exit 12); it now uses `Unsupported` (exit 4) with upstream's wording. A compression list with no mutual algorithm silently fell back to `none`; it is now the same hard exit-4 failure.
- Default client selection candidates now exclude `none`, matching upstream's `saw[]` population.

Unknown names in a peer's list were already skipped gracefully, and env-list unknown-name handling already matched upstream.

## Tests

- New pins: `sha256 xxh128 md5` negotiates xxh128 on both sides; an all-unknown list fails with `Unsupported` and upstream's message; `RSYNC_CHECKSUM_LIST="sha256 md5"` advertises and negotiates `md5`; case-insensitive and alias matching; client rejects a `none`-only compression offer.
- Flipped existing assertions that encoded the pre-fix behaviour (case-sensitive rejection, `xxh` acceptance, silent compression-none fallback, `InvalidData` kinds).
- Live verification against upstream rsync 3.4.4 (banner-confirmed) in both directions: `RSYNC_CHECKSUM_LIST='sha256 md5'` negotiates md5 with identical `--debug=NSTR2` output and exit 0; an all-unknown env list exits 4 on both implementations.

## Docs

One-line watch note in `docs/PROTOCOL.md`: add `sha256` once upstream merges PR #1007.

## Gates

- `cargo fmt --all` clean
- `cargo clippy -p protocol --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p protocol --all-features`: 5962 passed
- `cargo check --workspace --all-features` clean
