### PR TITLE
test: reason strings for bare #[ignore] in matching and rsync_io

### DIFF
--- a/crates/matching/src/index/sparse_match_tests.rs
+++ b/crates/matching/src/index/sparse_match_tests.rs
@@ -177,7 +177,7 @@ fn build_index(basis: &[u8]) -> DeltaSignatureIndex {
 /// Stress runs invoke it via `cargo nextest run --run-ignored only -p
 /// matching -E 'test(sparse_match_100mib_single_overlap)'`.
 #[test]
-#[ignore]
+#[ignore = "100 MiB allocations plus a full-buffer rolling scan exceed the standard nextest budget; opt-in via --run-ignored"]
 fn sparse_match_100mib_single_overlap() {
     let basis = build_basis();
     let target = build_target(&basis);

--- a/crates/matching/tests/sparse_match_fixture.rs
+++ b/crates/matching/tests/sparse_match_fixture.rs
@@ -301,7 +301,7 @@ fn sparse_match_1mb_block4096() {
 /// testing run it explicitly via `cargo nextest run --run-ignored
 /// only`.
 #[test]
-#[ignore]
+#[ignore = "16 MB rolling-hash stress case; opt-in via --run-ignored to keep the default matrix fast"]
 fn sparse_match_16mb_block1024() {
     exercise_matrix(16 * 1024 * 1024, 1024, false);
 }
@@ -309,7 +309,7 @@ fn sparse_match_16mb_block1024() {
 /// 16 MB stress case, block_size = 4096. Same gating rationale as
 /// [`sparse_match_16mb_block1024`].
 #[test]
-#[ignore]
+#[ignore = "16 MB rolling-hash stress case; opt-in via --run-ignored to keep the default matrix fast"]
 fn sparse_match_16mb_block4096() {
     exercise_matrix(16 * 1024 * 1024, 4096, false);
 }

--- a/crates/rsync_io/tests/concurrent_session_validation.rs
+++ b/crates/rsync_io/tests/concurrent_session_validation.rs
@@ -201,7 +201,7 @@ fn all_sessions_complete_at_128() {
 /// exhaust file descriptor limits or cause scheduling stalls on
 /// resource-constrained GitHub Actions runners.
 #[test]
-#[ignore]
+#[ignore = "256 concurrent TCP pairs plus spawn_blocking threads can exhaust fd limits on CI runners"]
 fn all_sessions_complete_at_256() {
     let metrics = run_sessions(256).expect("256 concurrent sessions");
     assert_eq!(
@@ -217,7 +217,7 @@ fn all_sessions_complete_at_256() {
 /// Ignored in CI: same resource constraints as the 256-session test,
 /// amplified. Run locally with `cargo nextest run --run-ignored all`.
 #[test]
-#[ignore]
+#[ignore = "512 concurrent sessions amplify the same fd-exhaustion constraints as the 256 case; run locally with --run-ignored"]
 fn all_sessions_complete_at_512() {
     let metrics = run_sessions(512).expect("512 concurrent sessions");
     assert_eq!(
@@ -269,7 +269,7 @@ fn percentiles_are_monotonic() {
 /// The criterion bench provides meaningful scaling data; this test is for
 /// local validation only.
 #[test]
-#[ignore]
+#[ignore = "timing-based assertions are flaky on shared CI runners; local validation only"]
 fn wall_time_scales_sublinearly() {
     let m16 = run_sessions(16).expect("16 concurrent sessions");
     let m64 = run_sessions(64).expect("64 concurrent sessions");


### PR DESCRIPTION
## What

Convert the six bare `#[ignore]` attributes in the `matching` and `rsync_io` test crates to `#[ignore = "<reason>"]`, lifting the reason from each test's existing adjacent doc comment.

Bare `#[ignore]` prints nothing about why a test is skipped; the `= "reason"` form surfaces it directly in `cargo nextest` / `cargo test` output, so a reader of a skipped-test line knows whether it is a resource-heavy opt-in or a genuine gap.

## Scope

- `crates/matching/tests/sparse_match_fixture.rs` (2) - 16 MB rolling-hash stress cases
- `crates/matching/src/index/sparse_match_tests.rs` (1) - 100 MiB allocation stress case
- `crates/rsync_io/tests/concurrent_session_validation.rs` (3) - 256/512 concurrent-session fd pressure and a timing-based assertion

No test bodies changed, nothing un-ignored, no already-reasoned attribute touched.

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p matching -p rsync_io --all-targets --all-features --no-deps -- -D warnings`: clean
- `cargo nextest run -p matching -p rsync_io --all-features`: 1484 passed, 6 skipped (the reasoned stress/timing cases, correctly not run)
