### PR TITLE
fix(metadata): remove the duplicated attribute on the Windows module

### DIFF
--- a/crates/metadata/src/windows/mod.rs
+++ b/crates/metadata/src/windows/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "windows")]
-
 //! Windows-specific metadata helpers.
 //!
 //! Houses native NTFS metadata facilities that have no upstream rsync


### PR DESCRIPTION
## What

Remove a duplicated `#[cfg(target_os = "windows")]` on the `windows` module, which was a `duplicated_attributes` clippy error under `-D warnings` on the Windows target (invisible to the macOS/Linux clippy cells, which never compile the `windows` module).

The same gate was applied twice:
- `crates/metadata/src/lib.rs:190` — outer `#[cfg(target_os = "windows")]` on `pub mod windows;`
- `crates/metadata/src/windows/mod.rs:1` — redundant inner `#![cfg(target_os = "windows")]`

Deleted the inner one; kept the outer gate at the `mod` declaration (the standard single instance, which also stops the module compiling at all off-Windows). One-line diff, no behavior change, no `#[allow]` waiver.

## Verification

- `cargo clippy -p metadata --all-targets --all-features --no-deps --target x86_64-pc-windows-gnu -- -D warnings`: the `duplicated attribute` error is gone.
- `cargo clippy -p metadata --all-targets --all-features --no-deps -- -D warnings` (unix): clean.
- `cargo fmt --all -- --check`: clean.
