### PR TITLE
style(metadata): fix Windows-only clippy lints in metadata tests

### DIFF
--- a/crates/metadata/src/acl_windows/tests/dacl.rs
+++ b/crates/metadata/src/acl_windows/tests/dacl.rs
@@ -27,8 +27,10 @@ fn reconstruct_acl_fills_base_entries_from_mode() {
 
 #[test]
 fn reconstruct_acl_keeps_existing_entries() {
-    let mut acl = RsyncAcl::default();
-    acl.user_obj = 0o4;
+    let acl = RsyncAcl {
+        user_obj: 0o4,
+        ..Default::default()
+    };
     let restored = reconstruct_acl(&acl, Some(0o777));
     assert_eq!(restored.user_obj, 0o4);
     assert_eq!(restored.group_obj, 0o7);
@@ -37,8 +39,10 @@ fn reconstruct_acl_keeps_existing_entries() {
 
 #[test]
 fn reconstruct_acl_no_mode_passes_through() {
-    let mut acl = RsyncAcl::default();
-    acl.user_obj = 0o7;
+    let acl = RsyncAcl {
+        user_obj: 0o7,
+        ..Default::default()
+    };
     let restored = reconstruct_acl(&acl, None);
     assert_eq!(restored.user_obj, 0o7);
     assert_eq!(restored.group_obj, NO_ENTRY);

--- a/crates/metadata/tests/windows_long_path_metadata.rs
+++ b/crates/metadata/tests/windows_long_path_metadata.rs
@@ -54,7 +54,7 @@ fn build_deep_tree(root: &Path, depth: usize) -> std::io::Result<PathBuf> {
     let mut current = root.to_path_buf();
     for index in 0..depth {
         // 25-character segment: prefix + zero-padded index.
-        let segment = format!("longpath_seg_{:0>10}", index);
+        let segment = format!("longpath_seg_{index:0>10}");
         current.push(segment);
         fs::create_dir(&current)?;
     }

--- a/crates/metadata/tests/windows_reparse_classify_path.rs
+++ b/crates/metadata/tests/windows_reparse_classify_path.rs
@@ -108,7 +108,7 @@ fn missing_path_returns_not_found_error() {
     let err = classify_path(&missing).expect_err("missing path must error");
     assert!(
         err.kind() == std::io::ErrorKind::NotFound
-            || err.raw_os_error().map_or(false, |n| n == 2 || n == 3),
+            || err.raw_os_error().is_some_and(|n| n == 2 || n == 3),
         "expected NotFound for missing path, got {err}"
     );
 }


### PR DESCRIPTION
Fixes three pre-existing clippy lints that only fire on the Windows target in metadata test files (surfaced while resolving the duplicated-attribute error).

- `acl_windows/tests/dacl.rs` — `field_reassign_with_default` (x4): rewrite `let mut acl = RsyncAcl::default(); acl.user_obj = ...;` as struct-init `RsyncAcl { user_obj: ..., ..Default::default() }`.
- `tests/windows_reparse_classify_path.rs` — `map_or(false, ...)` -> `is_some_and(...)`.
- `tests/windows_long_path_metadata.rs` — `uninlined_format_args`: inline the `index` binding.

Behavior-preserving. No `#[allow]`, no `#[ignore]`, no unsafe. Only the three test files are touched.

Verification (Mac, x86_64-pc-windows-gnu target present): windows-gnu clippy and unix clippy both reach `Finished` clean; `cargo-fmt --all -- --check` exit 0.
