### PR TITLE
fix(protocol): emit Server/Client list detail on negotiation failure

### DIFF
--- a/crates/protocol/src/negotiation/capabilities/env_list.rs
+++ b/crates/protocol/src/negotiation/capabilities/env_list.rs
@@ -236,11 +236,12 @@ fn validate_choice(
 /// `recv_negotiate_str` when the env list excludes it.
 ///
 /// A no-op when the variable is unset or the default is a member. On refusal,
-/// emits upstream's `recv_negotiate_str` wording (`compat.c:387` "Failed to
-/// negotiate a %s choice.", where `%s` is the nno `type`, `"checksum"` or
-/// `"compress"`) with [`io::ErrorKind::Unsupported`], which the core exit-code
-/// mapper turns into `RERR_UNSUPPORTED` (exit 4), matching
-/// `exit_cleanup(RERR_UNSUPPORTED)` at `compat.c:406`.
+/// emits upstream's full `recv_negotiate_str` block via
+/// [`super::failure::negotiation_failure`] - the `Failed to negotiate a %s
+/// choice.` line plus the offered Server/Client lists (`compat.c:381-405`) -
+/// with [`io::ErrorKind::Unsupported`], which the core exit-code mapper turns
+/// into `RERR_UNSUPPORTED` (exit 4), matching `exit_cleanup(RERR_UNSUPPORTED)`
+/// at `compat.c:406`. The non-negotiated path prints the lists on both sides.
 fn validate_default(
     key: &str,
     kind: &str,
@@ -248,12 +249,27 @@ fn validate_default(
     is_server: bool,
     resolve: impl Fn(&str) -> Option<&'static str>,
 ) -> io::Result<()> {
-    match env_membership(key, is_server, default, resolve) {
+    // upstream: compat.c:369-406 recv_negotiate_str - the non-negotiated path
+    // prefills `tmpbuf` with the old-style default (compat.c:551-563) and, when
+    // the env-parsed saw list rejects it, prints the offered lists on BOTH
+    // sides (do_negotiated_strings == 0 makes `!am_server || ...` always true).
+    match env_membership(key, is_server, default, &resolve) {
         EnvMembership::Unset | EnvMembership::Present => Ok(()),
-        EnvMembership::Absent => Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            format!("Failed to negotiate a {kind} choice."),
-        )),
+        EnvMembership::Absent => {
+            // Rebuild upstream's full block: the prefilled default IS its
+            // `tmpbuf`, so it is the peer-list line; our env-parsed saw list is
+            // the own-list line. Re-parse (cold error path) to recover it.
+            let candidates = parse_env(key, is_server, resolve)
+                .map(|env| env.candidates)
+                .unwrap_or_default();
+            Err(super::failure::negotiation_failure(
+                kind,
+                is_server,
+                false,
+                default,
+                &candidates,
+            ))
+        }
     }
 }
 

--- a/crates/protocol/src/negotiation/capabilities/failure.rs
+++ b/crates/protocol/src/negotiation/capabilities/failure.rs
@@ -1,0 +1,84 @@
+//! The `recv_negotiate_str()` failure diagnostic (upstream `compat.c:369-406`).
+//!
+//! When a checksum or compression list has no mutually acceptable entry,
+//! upstream prints a fixed block to `FERROR` and aborts with
+//! `RERR_UNSUPPORTED`. This module builds that block byte-for-byte so both the
+//! negotiated selection path ([`super::negotiate`]) and the non-negotiated
+//! env-default check ([`super::env_list`]) share a single implementation.
+
+use std::io;
+
+/// Builds the [`io::Error`] upstream's `recv_negotiate_str()` raises when a
+/// `%s` list yields no mutually acceptable choice (`compat.c:369-406`).
+///
+/// The message text is emitted verbatim as the `FERROR` diagnostic; the core
+/// exit-code mapper turns [`io::ErrorKind::Unsupported`] into
+/// `exit_cleanup(RERR_UNSUPPORTED)` (exit 4, `compat.c:406`).
+///
+/// Upstream prints three lines, but the two list-detail lines are guarded by
+/// `if (!am_server || !do_negotiated_strings)` (`compat.c:382`):
+///
+/// ```text
+/// Failed to negotiate a <kind> choice.
+/// <peer> list: <peer_list>
+/// <self> list:<own list rebuilt from saw>
+/// ```
+///
+/// - `<peer>` is `Client` on the server and `Server` on the client
+///   (`compat.c:384` `am_server ? "Client" : "Server"`); `peer_list` is the
+///   list received from - or, on the non-negotiated path, the default assumed
+///   of - the peer (upstream's `tmpbuf`).
+/// - `<self>` is the opposite label (`compat.c:405`); its list is our own
+///   candidate order with each name space-prefixed (`compat.c:394-402`), or
+///   ` INVALID` when no candidate survived (`compat.c:403-404`).
+///
+/// On the server's negotiated path (`am_server && do_negotiated_strings`) the
+/// two list lines are suppressed, matching upstream, so the server aborts on
+/// the `Failed to negotiate ...` line alone.
+pub(super) fn negotiation_failure(
+    kind: &str,
+    is_server: bool,
+    do_negotiated: bool,
+    peer_list: &str,
+    own_candidates: &[&str],
+) -> io::Error {
+    // upstream: compat.c:381 rprintf(FERROR, "Failed to negotiate a %s choice.\n", ...)
+    let mut msg = format!("Failed to negotiate a {kind} choice.");
+
+    // upstream: compat.c:382 - only `!am_server || !do_negotiated_strings`
+    // prints the offered lists.
+    if !is_server || !do_negotiated {
+        let (peer_label, own_label) = if is_server {
+            ("Client", "Server")
+        } else {
+            ("Server", "Client")
+        };
+
+        // upstream: compat.c:384 rprintf(FERROR, "%s list: %s\n", peer, tmpbuf)
+        msg.push('\n');
+        msg.push_str(peer_label);
+        msg.push_str(" list: ");
+        msg.push_str(peer_list);
+
+        // upstream: compat.c:394-402 - rebuild our own list from the saw
+        // ordinals, each surviving name written with a leading space.
+        let mut own = String::new();
+        for name in own_candidates {
+            own.push(' ');
+            own.push_str(name);
+        }
+        // upstream: compat.c:403-404 - an empty rebuild becomes " INVALID".
+        if own.is_empty() {
+            own.push_str(" INVALID");
+        }
+
+        // upstream: compat.c:405 rprintf(FERROR, "%s list:%s\n", self, tmpbuf) -
+        // no space after the colon; the rebuilt list already leads with one.
+        msg.push('\n');
+        msg.push_str(own_label);
+        msg.push_str(" list:");
+        msg.push_str(&own);
+    }
+
+    io::Error::new(io::ErrorKind::Unsupported, msg)
+}

--- a/crates/protocol/src/negotiation/capabilities/mod.rs
+++ b/crates/protocol/src/negotiation/capabilities/mod.rs
@@ -29,6 +29,7 @@
 
 mod algorithms;
 mod env_list;
+mod failure;
 mod negotiate;
 
 pub use algorithms::{ChecksumAlgorithm, CompressionAlgorithm};

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -653,11 +653,16 @@ pub(super) fn choose_checksum_algorithm_in(
     match select_from_peer_list(remote_list, is_server, local, resolve_checksum_name) {
         Some(name) => ChecksumAlgorithm::parse(name)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
-        // upstream: compat.c:387,406 - "Failed to negotiate a %s choice." with
-        // exit_cleanup(RERR_UNSUPPORTED); ErrorKind::Unsupported maps to exit 4.
-        None => Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "Failed to negotiate a checksum choice.",
+        // upstream: compat.c:381-406 recv_negotiate_str - "Failed to negotiate
+        // a %s choice." plus the offered Server/Client lists, then
+        // exit_cleanup(RERR_UNSUPPORTED). The negotiated path always runs with
+        // do_negotiated_strings set, so pass `true`.
+        None => Err(super::failure::negotiation_failure(
+            "checksum",
+            is_server,
+            true,
+            remote_list,
+            local,
         )),
     }
 }
@@ -698,12 +703,16 @@ pub(super) fn choose_compression_algorithm_in(
     match select_from_peer_list(remote_list, is_server, local, resolve_compression_name) {
         Some(name) => CompressionAlgorithm::parse(name)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
-        // upstream: compat.c:387,406 recv_negotiate_str - a compression list
+        // upstream: compat.c:381-406 recv_negotiate_str - a compression list
         // with no mutual algorithm is the same hard RERR_UNSUPPORTED failure
-        // as an unmatched checksum list; "none" is never a silent fallback.
-        None => Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "Failed to negotiate a compress choice.",
+        // as an unmatched checksum list, with the same Server/Client detail
+        // lines; "none" is never a silent fallback.
+        None => Err(super::failure::negotiation_failure(
+            "compress",
+            is_server,
+            true,
+            remote_list,
+            local,
         )),
     }
 }

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -1087,7 +1087,21 @@ fn test_client_rejects_none_only_compression_from_server() {
 
     let err = result.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
-    assert_eq!(err.to_string(), "Failed to negotiate a compress choice.");
+    // upstream: compat.c:381-405 - the client prints the offered lists. The
+    // headline and the received `Server list:` are deterministic; the rebuilt
+    // `Client list:` order depends on which optional codecs are compiled in, so
+    // assert its presence rather than a feature-dependent tail.
+    let msg = err.to_string();
+    let mut lines = msg.lines();
+    assert_eq!(
+        lines.next().unwrap(),
+        "Failed to negotiate a compress choice."
+    );
+    assert_eq!(lines.next().unwrap(), "Server list: none");
+    assert!(
+        lines.next().unwrap().starts_with("Client list: "),
+        "missing Client list detail line: {msg:?}"
+    );
 }
 
 #[test]
@@ -2874,7 +2888,18 @@ fn forward_compat_only_unknown_names_hard_error() {
     for is_server in [true, false] {
         let err = choose_checksum_algorithm("sha256 sha512 blake3", is_server).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Unsupported, "server={is_server}");
-        assert_eq!(err.to_string(), "Failed to negotiate a checksum choice.");
+        // upstream: compat.c:382 - the offered lists print only on the client;
+        // the server (`am_server && do_negotiated_strings`) aborts on the
+        // headline alone.
+        let expected = if is_server {
+            "Failed to negotiate a checksum choice.".to_string()
+        } else {
+            "Failed to negotiate a checksum choice.\n\
+             Server list: sha256 sha512 blake3\n\
+             Client list: xxh128 xxh3 xxh64 md5 md4 sha1"
+                .to_string()
+        };
+        assert_eq!(err.to_string(), expected, "server={is_server}");
     }
 }
 
@@ -3279,7 +3304,7 @@ mod env_list_overrides {
     use platform::env::EnvGuard;
 
     use super::super::env_list;
-    use super::super::negotiate::{choose_checksum_algorithm_in, read_vstring};
+    use super::super::negotiate::{choose_checksum_algorithm_in, read_vstring, write_vstring};
     use super::*;
 
     /// Serialises env-mutating tests since the process environment is global.
@@ -3427,10 +3452,87 @@ mod env_list_overrides {
         assert_eq!(over.advertised, "INVALID");
 
         // An INVALID list cannot match any remote offer, so selection errors -
-        // upstream exits with RERR_UNSUPPORTED here.
+        // upstream exits with RERR_UNSUPPORTED here. With no surviving own
+        // candidate, upstream rebuilds the `Client list:` as " INVALID"
+        // (compat.c:403-404).
         let err =
             choose_checksum_algorithm_in("xxh128 md5 md4", false, &over.candidates).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        assert_eq!(
+            err.to_string(),
+            "Failed to negotiate a checksum choice.\n\
+             Server list: xxh128 md5 md4\n\
+             Client list: INVALID"
+        );
+    }
+
+    // Disjoint RSYNC_CHECKSUM_LIST on each side: the client offers only md5
+    // while the server offers only md4, so there is no mutual choice. Upstream's
+    // recv_negotiate_str prints the full three-line block on the client and
+    // aborts with RERR_UNSUPPORTED (compat.c:381-406). This is the observable
+    // remainder of the exit-4 negotiation failure.
+    #[test]
+    fn disjoint_checksum_lists_emit_full_failure_block() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5"));
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+
+        // The client's selection candidates come from its env override (md5).
+        let over = env_list::checksum_candidates(false, false, 32).unwrap();
+        assert_eq!(over.candidates, vec!["md5"]);
+
+        // The server advertised only md4 - no mutual algorithm.
+        let err = choose_checksum_algorithm_in("md4", false, &over.candidates).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        assert_eq!(
+            err.to_string(),
+            "Failed to negotiate a checksum choice.\n\
+             Server list: md4\n\
+             Client list: md5"
+        );
+
+        // upstream: compat.c:382 - the server side of the same mismatch keeps
+        // the offered lists to itself (am_server && do_negotiated_strings) and
+        // aborts on the headline alone.
+        let server_err = choose_checksum_algorithm_in("md4", true, &over.candidates).unwrap_err();
+        assert_eq!(
+            server_err.to_string(),
+            "Failed to negotiate a checksum choice."
+        );
+    }
+
+    // The same disjoint-list failure driven through the full `negotiate_the_strings`
+    // wire path: the client advertises its md5-only list, reads the server's
+    // md4-only vstring, finds no match and surfaces upstream's three-line block.
+    #[test]
+    fn disjoint_checksum_lists_fail_through_negotiate() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5"));
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+
+        let protocol = crate::ProtocolVersion::try_from(32).unwrap();
+        let mut server_list = Vec::new();
+        write_vstring(&mut server_list, "md4").unwrap();
+        let mut stdin = &server_list[..];
+        let mut stdout = Vec::new();
+
+        let err = crate::negotiate_capabilities(
+            protocol,
+            &mut stdin,
+            &mut stdout,
+            true,  // do_negotiation
+            false, // send_compression
+            false, // is_daemon_mode (SSH)
+            false, // is_server = client
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        assert_eq!(
+            err.to_string(),
+            "Failed to negotiate a checksum choice.\n\
+             Server list: md4\n\
+             Client list: md5"
+        );
     }
 
     // (d'') Forward compatibility: an env list naming a checksum this build
@@ -3751,16 +3853,31 @@ mod env_list_overrides {
         let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxh3 xxh128"));
         let err = env_list::validate_default_checksum("md5", true).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
-        assert_eq!(err.to_string(), "Failed to negotiate a checksum choice.");
+        // upstream: compat.c:381-405 - the non-negotiated path prints the lists
+        // on both sides; on the server tmpbuf ("md5") is the `Client list:` and
+        // the env-restricted saw is the `Server list:`.
+        assert_eq!(
+            err.to_string(),
+            "Failed to negotiate a checksum choice.\n\
+             Client list: md5\n\
+             Server list: xxh3 xxh128"
+        );
     }
 
     #[test]
     fn validate_default_refuses_compress_when_excluded() {
         let _lock = ENV_LOCK.lock().unwrap();
-        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zstd"));
+        // `zlibx` is always compiled in (unlike the optional zstd/lz4 codecs),
+        // so the rebuilt own-list line is deterministic across feature sets.
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zlibx"));
         let err = env_list::validate_default_compress("zlib", true).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
-        assert_eq!(err.to_string(), "Failed to negotiate a compress choice.");
+        assert_eq!(
+            err.to_string(),
+            "Failed to negotiate a compress choice.\n\
+             Client list: zlib\n\
+             Server list: zlibx"
+        );
     }
 
     /// Drives the non-negotiated branch (`do_negotiation = false`, peer lacks
@@ -3809,7 +3926,12 @@ mod env_list_overrides {
         let _cp = EnvGuard::remove(COMPRESS_ENV);
         let err = negotiate_nonego(true, false).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
-        assert_eq!(err.to_string(), "Failed to negotiate a checksum choice.");
+        assert_eq!(
+            err.to_string(),
+            "Failed to negotiate a checksum choice.\n\
+             Client list: md5\n\
+             Server list: xxh3 xxh128"
+        );
     }
 
     // (f) End-to-end: env includes md5 - the default is returned.
@@ -3828,10 +3950,17 @@ mod env_list_overrides {
     fn nonego_refuses_zlib_default_when_env_excludes_it() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _cs = EnvGuard::remove(CHECKSUM_ENV);
-        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zstd"));
+        // `zlibx` is unconditionally compiled in, keeping the own-list line
+        // deterministic regardless of the optional zstd/lz4 features.
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zlibx"));
         let err = negotiate_nonego(true, true).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
-        assert_eq!(err.to_string(), "Failed to negotiate a compress choice.");
+        assert_eq!(
+            err.to_string(),
+            "Failed to negotiate a compress choice.\n\
+             Client list: zlib\n\
+             Server list: zlibx"
+        );
     }
 
     // (h) End-to-end compress: env includes zlib - the default is returned.


### PR DESCRIPTION
On a checksum/compression negotiation failure, oc printed only the headline (`Failed to negotiate a <kind> choice.`) and omitted upstream's `Server list:` / `Client list:` detail lines. This restores the full block, byte-matching rsync 3.4.4. Folds in #269.

Upstream ground truth (compat.c:381-406, `recv_negotiate_str`): after the headline, upstream prints the peer's list then rebuilds and prints its own (each entry space-prefixed, ` INVALID` when empty). All three lines are gated by `!am_server || !do_negotiated_strings`: on the negotiated path only the client prints the lists; the non-negotiated env-default path prints on both sides. `%s list:%s` has no space after the colon (the rebuilt list already leads with one).

Verified live against upstream 3.4.4 (banner-confirmed) with a disjoint-list split — oc matches byte-for-byte (`cat -A` confirmed the single space after each colon):
- checksum `md4` vs `md5` -> `Server list: md5` / `Client list: md4`
- compress `zlib` vs `zstd` -> `Server list: zstd` / `Client list: zlib`

Changes (all under `protocol/src/negotiation/capabilities/`):
- `failure.rs` (new): single DRY builder with upstream-exact labeling, gating, space-prefix rebuild, and ` INVALID` fallback; returns `Unsupported` (exit 4).
- `negotiate.rs`: negotiated path builds the block via the helper (client-only lists).
- `env_list.rs`: non-negotiated `validate_default` emits the block on both sides.
- `tests.rs`: updated 6 assertions to the multi-line block; added two regression tests (client full block + server headline-only; end-to-end via in-memory pipes).

Gates: fmt 0, clippy -p protocol clean, negotiation nextest 1804 passed / 0 failed.

Note: the server's negotiated-path headline is kept as #7048 set it (it drives exit-4 propagation). Upstream's server prints nothing there; suppressing it is a separate exit-code concern, tracked as a follow-up.
