### PR TITLE
fix(daemon): match upstream connection/auth log bodies

### DIFF
--- a/crates/daemon/src/daemon/sections/auth_helpers.rs
+++ b/crates/daemon/src/daemon/sections/auth_helpers.rs
@@ -56,20 +56,25 @@ fn log_connection(log: &SharedLogSink, host: Option<&str>, peer_addr: SocketAddr
     log_message(log, &message);
 }
 
-fn log_list_request(log: &SharedLogSink, host: Option<&str>, peer_addr: SocketAddr) {
+pub(crate) fn log_list_request(log: &SharedLogSink, host: Option<&str>, peer_addr: SocketAddr) {
     let display = format_host(host, peer_addr.ip());
     let ip = peer_addr.ip();
-    let text = format!("list request from {display} ({ip})");
+    // upstream: clientserver.c:1421 - `module-list request from %s (%s)`
+    let text = format!("module-list request from {display} ({ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
-fn log_module_request(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAddr, module: &str) {
+pub(crate) fn log_module_request(
+    log: &SharedLogSink,
+    host: Option<&str>,
+    peer_ip: IpAddr,
+    module: &str,
+) {
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
-    let text = format!(
-        "module '{module_display}' requested from {display} ({peer_ip})"
-    );
+    // upstream: clientserver.c:742 - `rsync allowed access on module %s from %s (%s)`
+    let text = format!("rsync allowed access on module {module_display} from {display} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
@@ -134,42 +139,47 @@ fn log_module_refused_option(
     log_message(log, &message);
 }
 
-fn log_module_auth_failure(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAddr, module: &str) {
+pub(crate) fn log_module_auth_failure(
+    log: &SharedLogSink,
+    host: Option<&str>,
+    peer_ip: IpAddr,
+    module: &str,
+) {
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
-    let text = format!(
-        "authentication failed for module '{module_display}' from {display} ({peer_ip})"
-    );
+    // upstream: authenticate.c:249 / :335 - `auth failed on module %s from %s (%s)`.
+    // Upstream appends the specific reason (`: invalid challenge response`, or
+    // ` for %s: %s`); the failure reason is not propagated to this emission point,
+    // so only the invariant prefix is reproduced here.
+    let text = format!("auth failed on module {module_display} from {display} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
-fn log_module_auth_success(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAddr, module: &str) {
+pub(crate) fn log_module_denied(
+    log: &SharedLogSink,
+    host: Option<&str>,
+    peer_ip: IpAddr,
+    module: &str,
+) {
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
-    let text = format!(
-        "authentication succeeded for module '{module_display}' from {display} ({peer_ip})"
-    );
+    // upstream: clientserver.c:729 - `rsync denied on module %s from %s (%s)`
+    let text = format!("rsync denied on module {module_display} from {display} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
-fn log_module_denied(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAddr, module: &str) {
+pub(crate) fn log_unknown_module(
+    log: &SharedLogSink,
+    host: Option<&str>,
+    peer_ip: IpAddr,
+    module: &str,
+) {
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
-    let text = format!(
-        "access denied to module '{module_display}' from {display} ({peer_ip})"
-    );
-    let message = rsync_info!(text).with_role(Role::Daemon);
-    log_message(log, &message);
-}
-
-fn log_unknown_module(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAddr, module: &str) {
-    let display = format_host(host, peer_ip);
-    let module_display = sanitize_module_identifier(module);
-    let text = format!(
-        "unknown module '{module_display}' requested from {display} ({peer_ip})"
-    );
+    // upstream: clientserver.c:1434 - `unknown module '%s' tried from %s (%s)`
+    let text = format!("unknown module '{module_display}' tried from {display} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -490,9 +490,10 @@ fn handle_authentication(
             username,
             access_level,
         } => {
-            if let Some(log) = ctx.log_sink {
-                log_module_auth_success(log, ctx.effective_host(), ctx.peer_ip, ctx.request);
-            }
+            // upstream: authenticate.c auth_server() logs nothing on success -
+            // the granted access is observable via the earlier "rsync allowed
+            // access on module" line (clientserver.c:742), so no auth-success
+            // line is emitted here.
             // `@RSYNCD: OK` is deferred to the caller (see the no-auth path
             // above): it is emitted only after chroot + privilege drop succeed.
             Ok(Some((Some(username), access_level)))

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -51,8 +51,13 @@ use crate::daemon::{
     // From sections/greeting.rs
     legacy_daemon_greeting,
     legacy_daemon_greeting_for_protocol,
+    log_list_request,
+    log_module_auth_failure,
     log_module_bandwidth_change,
+    log_module_denied,
     log_module_limit,
+    log_module_request,
+    log_unknown_module,
     module_peer_hostname,
     open_log_sink,
     // From sections/config_helpers.rs
@@ -127,6 +132,7 @@ include!("tests/chunks/cached_legacy_daemon_greeting_matches_per_call_bytes.rs")
 include!("tests/chunks/legacy_daemon_greeting_digest_list_is_protocol_independent.rs");
 include!("tests/chunks/legacy_daemon_greeting_has_single_newline.rs");
 include!("tests/chunks/legacy_daemon_greeting_includes_version_and_digests.rs");
+include!("tests/chunks/log_bodies_match_upstream_wording.rs");
 include!("tests/chunks/log_file_open_failure_returns_message_io.rs");
 include!("tests/chunks/log_module_bandwidth_change_ignores_unchanged.rs");
 include!("tests/chunks/log_module_bandwidth_change_logs_disable.rs");

--- a/crates/daemon/src/tests/chunks/log_bodies_match_upstream_wording.rs
+++ b/crates/daemon/src/tests/chunks/log_bodies_match_upstream_wording.rs
@@ -1,0 +1,59 @@
+/// The daemon's connection and auth log-line bodies must reproduce upstream
+/// rsync's exact `rprintf(FLOG, ...)` format strings byte-for-byte (only the
+/// timestamp/pid prefix, handled by the logging sink, differs).
+///
+/// upstream: clientserver.c:742 / :729 / :1421 / :1434 and authenticate.c:249.
+#[test]
+fn log_bodies_match_upstream_wording() {
+    let dir = tempdir().expect("log dir");
+    let path = dir.path().join("daemon.log");
+    let log = open_log_sink(&path, Brand::Oc).expect("open log");
+
+    let host = Some("client.example");
+    let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 17));
+    let addr = std::net::SocketAddr::new(ip, 873);
+
+    // upstream: clientserver.c:742 - module access granted.
+    log_module_request(&log, host, ip, "docs");
+    // upstream: authenticate.c:249/:335 - auth failure prefix.
+    log_module_auth_failure(&log, host, ip, "docs");
+    // upstream: clientserver.c:729 - access denied by allow/deny rules.
+    log_module_denied(&log, host, ip, "docs");
+    // upstream: clientserver.c:1434 - request for an undefined module.
+    log_unknown_module(&log, host, ip, "docs");
+    // upstream: clientserver.c:1421 - `#list` / empty module request.
+    log_list_request(&log, host, addr);
+
+    drop(log);
+
+    let contents = fs::read_to_string(&path).expect("read log");
+
+    for expected in [
+        "rsync allowed access on module docs from client.example (192.0.2.17)",
+        "auth failed on module docs from client.example (192.0.2.17)",
+        "rsync denied on module docs from client.example (192.0.2.17)",
+        "unknown module 'docs' tried from client.example (192.0.2.17)",
+        "module-list request from client.example (192.0.2.17)",
+    ] {
+        assert!(
+            contents.contains(expected),
+            "missing upstream-exact log body {expected:?} in: {contents:?}"
+        );
+    }
+
+    // Guard against regressing to the previous oc-invented phrasings.
+    // (Note: "list request from" is intentionally omitted - it is a substring
+    // of the correct "module-list request from" wording.)
+    for forbidden in [
+        "module 'docs' requested from",
+        "authentication succeeded for module",
+        "authentication failed for module",
+        "access denied to module",
+        "unknown module 'docs' requested from",
+    ] {
+        assert!(
+            !contents.contains(forbidden),
+            "oc-invented wording {forbidden:?} leaked into: {contents:?}"
+        );
+    }
+}

--- a/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
@@ -99,8 +99,13 @@ fn run_daemon_records_log_file_entries() {
             "log line missing upstream `timestamp [pid] ` prefix (log.c:127): {line:?}"
         );
     }
+    // upstream: clientserver.c:1393 - `connect from %s (%s)`
     assert!(log_contents.contains("connect from"));
     assert!(log_contents.contains("127.0.0.1"));
-    assert!(log_contents.contains("module 'docs'"));
+    // upstream: clientserver.c:742 - `rsync allowed access on module %s from %s (%s)`
+    assert!(
+        log_contents.contains("rsync allowed access on module docs"),
+        "log should record upstream module-access grant: {log_contents:?}"
+    );
 }
 


### PR DESCRIPTION
Fixes the daemon's connection/auth FLOG message bodies to match upstream rsync 3.4.4 byte-for-byte. The timestamp/`[pid]` prefix (#250/#251) is untouched; this is the body-wording remainder. All changes are in `crates/daemon/*`.

Body corrections (each with C citation), in `sections/auth_helpers.rs`:

| before (oc) | after (upstream) | cite |
|---|---|---|
| `module 'X' requested from H (A)` | `rsync allowed access on module X from H (A)` | clientserver.c:742 |
| `list request from H (A)` | `module-list request from H (A)` | clientserver.c:1421 |
| `access denied to module 'X' from H (A)` | `rsync denied on module X from H (A)` | clientserver.c:729 |
| `unknown module 'X' requested from H (A)` | `unknown module 'X' tried from H (A)` | clientserver.c:1434 |
| `authentication failed for module 'X' from H (A)` | `auth failed on module X from H (A)` | authenticate.c:249/335 |
| `authentication succeeded ...` | *removed* — upstream `auth_server()` logs nothing on success; the grant is observable via the cs:742 line | cs:1128-1134 anchor |

Tests: new `tests/chunks/log_bodies_match_upstream_wording.rs` pins each upstream body plus a negative guard against the old oc phrasings; `run_daemon_records_log_file_entries.rs` had encoded the old wording (`module 'docs'`) and is corrected to the cs:742 `rsync allowed access on module docs`.

Gates: fmt 0, clippy -p daemon clean, `test(log)|connect|auth|module_access` nextest 552 passed / 0 failed.

Deferred (documented, out of scope for a body-wording fix): (1) the cs:1128-1134 literal transfer-start line `rsync <on|to> <paths> from <user>@<host> (<addr>)` needs the post-read_args request-path string + role + auth_user, a structural change; (2) the auth-failure reason tail (`: invalid challenge response`) needs a reason threaded through the `Denied` sites; (3) `log_module_limit`'s FLOG body — its `@ERROR` wire payload is already upstream-exact.
