### PR TITLE
test: give bare ignore attributes reason strings

### DIFF
--- a/crates/engine/src/local_copy/tests/execute_min_size.rs
+++ b/crates/engine/src/local_copy/tests/execute_min_size.rs
@@ -390,7 +390,7 @@ fn min_size_prunes_empty_directories_when_enabled() {
 
 #[cfg(unix)]
 #[test]
-#[ignore] // TODO: Symlinks may be filtered by min-size - behavior needs clarification
+#[ignore = "symlinks are currently filtered by --min-size; size-exempt symlink handling not yet implemented"]
 fn min_size_does_not_affect_symlinks() {
     let ctx = test_helpers::setup_copy_test();
 

--- a/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
@@ -6,7 +6,7 @@
 
 
 #[test]
-#[ignore] // TODO: Feature not fully implemented - currently creates directories implicitly
+#[ignore = "--no-implied-dirs not fully implemented; intermediate directories are still created implicitly"]
 fn no_implied_dirs_does_not_create_intermediate_directories() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");

--- a/crates/engine/src/local_copy/tests/list_only.rs
+++ b/crates/engine/src/local_copy/tests/list_only.rs
@@ -478,7 +478,7 @@ fn list_only_with_recursive_shows_nested_structure() {
 }
 
 #[test]
-#[ignore] // TODO: Non-recursive listing with trailing slash behavior needs clarification
+#[ignore = "non-recursive list-only with a trailing-slash source does not yet emit top-level entries"]
 fn list_only_without_recursive_shows_only_top_level() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source");


### PR DESCRIPTION
Gives every bare `#[ignore]` a reason string, per the repo convention that a test must never be silently un-runnable.

A tree-wide scan found exactly three bare `#[ignore]` attributes (the other ignore sites already carry reasons). All three are in the engine local-copy test modules and assert behavior that is genuinely not yet implemented — running them (`--run-ignored`) fails on the missing feature, so un-ignoring would red CI. Each attribute now carries a reason distilled from its existing TODO; no assertion was weakened.

| file:line | reason |
|---|---|
| `engine/src/local_copy/tests/execute_min_size.rs:393` | symlinks are currently filtered by `--min-size`; size-exempt symlink handling not yet implemented |
| `engine/src/local_copy/tests/list_only.rs:481` | non-recursive list-only with a trailing-slash source does not yet emit top-level entries |
| `engine/src/local_copy/tests/execute_no_implied_dirs.rs:9` | `--no-implied-dirs` not fully implemented; intermediate directories are still created implicitly |

Gates: fmt 0, clippy -p engine clean. 3 files, 3 insertions / 3 deletions.
