### PR TITLE
fix(transfer): match upstream Total bytes sent/received accounting on remote

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -183,6 +183,18 @@ pub struct GeneratorContext {
     /// - `main.c:374-383` - `handle_stats()` `else if (write_batch)` arm,
     ///   reached only when `am_sender` and `!am_server`.
     pub(crate) batch_stats_sink: Option<BatchStatsSink>,
+    /// Shared handle on the raw wire byte counter for bytes written to the
+    /// transport, below multiplex framing (upstream `stats.total_written`,
+    /// io.c:859). Sampled at the `handle_stats` point (main.c:979-980) so the
+    /// sender reports raw wire bytes - the count the client sender prints and the
+    /// server sender transmits over the wire - instead of a logical token tally.
+    /// `None` in unit tests, where the logical fallback is used.
+    pub(crate) wire_write_counter: Option<Arc<std::sync::atomic::AtomicU64>>,
+    /// Shared handle on the raw wire byte counter for bytes read from the
+    /// transport (upstream `stats.total_read`, io.c:820). Sampled alongside
+    /// [`Self::wire_write_counter`] at the `handle_stats` point. `None` in unit
+    /// tests, where the logical fallback is used.
+    pub(crate) wire_read_counter: Option<Arc<std::sync::atomic::AtomicU64>>,
 }
 
 /// Handle on the `--write-batch` file, held by a client sender so it can write
@@ -272,7 +284,24 @@ impl GeneratorContext {
             curr_dir: None,
             pipeline,
             batch_stats_sink: None,
+            wire_write_counter: None,
+            wire_read_counter: None,
         }
+    }
+
+    /// Attaches the raw wire byte counters used for `handle_stats()` reporting.
+    ///
+    /// Both counters must wrap the raw transport (below multiplex framing),
+    /// matching upstream's descriptor counters `stats.total_written` (io.c:859)
+    /// and `stats.total_read` (io.c:820). Must be set before [`run`](Self::run)
+    /// for the sender to report raw wire byte totals.
+    pub fn set_wire_counters(
+        &mut self,
+        write_counter: Arc<std::sync::atomic::AtomicU64>,
+        read_counter: Arc<std::sync::atomic::AtomicU64>,
+    ) {
+        self.wire_write_counter = Some(write_counter);
+        self.wire_read_counter = Some(read_counter);
     }
 
     /// Creates a generator context for unit testing with a default pipeline.

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -215,14 +215,41 @@ impl GeneratorContext {
         // --write-batch, writes the same five values straight to batch_fd
         // (main.c:374-383). Both land BEFORE read_final_goodbye tees the goodbye
         // NDX_DONE, which is the order --read-batch parses them back in.
+        //
+        // upstream: main.c:979 io_flush(FULL_FLUSH) then main.c:330-331
+        // handle_stats() caches stats.total_read/total_written (the raw descriptor
+        // counters, io.c:820/859) BEFORE the stats trailer and read_final_goodbye.
+        // Flush buffered transfer output to the transport counter, then snapshot
+        // both raw wire totals here so the trailing stats + goodbye bytes stay
+        // excluded, exactly as upstream's cache-then-write ordering does. Absent
+        // counters (unit tests) fall back to the logical token/byte tallies.
+        writer.flush()?;
+        let total_written = self
+            .wire_write_counter
+            .as_ref()
+            .map_or(transfer_result.bytes_sent, |c| {
+                c.load(std::sync::atomic::Ordering::Relaxed)
+            });
+        let total_read = self
+            .wire_read_counter
+            .as_ref()
+            .map_or(self.timing.total_bytes_read, |c| {
+                c.load(std::sync::atomic::Ordering::Relaxed)
+            });
         let flist_buildtime =
             calculate_duration_ms(self.timing.flist_build_start, self.timing.flist_build_end);
         let flist_xfertime =
             calculate_duration_ms(self.timing.flist_xfer_start, self.timing.flist_xfer_end);
         if !self.config.connection.client_mode {
-            self.send_stats(writer, &transfer_result, flist_buildtime, flist_xfertime)?;
+            self.send_stats(
+                writer,
+                total_read,
+                total_written,
+                flist_buildtime,
+                flist_xfertime,
+            )?;
         } else {
-            self.record_batch_stats(&transfer_result, flist_buildtime, flist_xfertime)?;
+            self.record_batch_stats(total_read, total_written, flist_buildtime, flist_xfertime)?;
         }
 
         let mut ndx_read_codec = transfer_result.ndx_read_codec;
@@ -430,8 +457,12 @@ impl GeneratorContext {
             num_specials: flist_send_stats.num_specials,
             files_transferred: transfer_result.files_transferred,
             transferred_file_size: transfer_result.transferred_file_size,
-            bytes_sent: transfer_result.bytes_sent,
-            bytes_read: self.timing.total_bytes_read,
+            // upstream: main.c:330-331,454-457 - a client sender reports its own
+            // cached raw descriptor counters as "Total bytes sent/received". Use
+            // the raw wire totals snapshotted at the handle_stats point above, not
+            // the logical delta/token tallies.
+            bytes_sent: total_written,
+            bytes_read: total_read,
             matched_data: transfer_result.matched_data,
             literal_data: transfer_result.literal_data,
             total_size: flist_send_stats.total_size,

--- a/crates/transfer/src/generator/transfer/stats.rs
+++ b/crates/transfer/src/generator/transfer/stats.rs
@@ -11,7 +11,7 @@ use std::io::{self, Write};
 
 use protocol::TransferStats;
 
-use super::super::{GeneratorContext, TransferLoopResult};
+use super::super::GeneratorContext;
 
 impl GeneratorContext {
     /// Sends transfer statistics to the client after the transfer loop completes.
@@ -27,7 +27,8 @@ impl GeneratorContext {
     pub(super) fn send_stats<W: Write>(
         &self,
         writer: &mut W,
-        transfer_result: &TransferLoopResult,
+        total_read: u64,
+        total_written: u64,
         flist_buildtime_ms: u64,
         flist_xfertime_ms: u64,
     ) -> io::Result<()> {
@@ -38,12 +39,11 @@ impl GeneratorContext {
         // sub-list, and which would also count directory sizes upstream omits).
         let total_size: u64 = self.flist_send_stats.total_size;
 
-        let stats = TransferStats::with_bytes(
-            self.timing.total_bytes_read,
-            transfer_result.bytes_sent,
-            total_size,
-        )
-        .with_flist_times(flist_buildtime_ms, flist_xfertime_ms);
+        // upstream: main.c:349-350 - handle_stats() writes the sender's cached raw
+        // descriptor counters (total_read, total_written; io.c:820/859) as the
+        // first two varlong30 values, sampled at the caller's handle_stats point.
+        let stats = TransferStats::with_bytes(total_read, total_written, total_size)
+            .with_flist_times(flist_buildtime_ms, flist_xfertime_ms);
 
         stats.write_to(writer, self.protocol)?;
         writer.flush()?;
@@ -69,7 +69,8 @@ impl GeneratorContext {
     /// - `main.c:1345-1347` - `handle_stats(-1)` then `read_final_goodbye()`
     pub(super) fn record_batch_stats(
         &self,
-        transfer_result: &TransferLoopResult,
+        total_read: u64,
+        total_written: u64,
         flist_buildtime_ms: u64,
         flist_xfertime_ms: u64,
     ) -> io::Result<()> {
@@ -77,12 +78,12 @@ impl GeneratorContext {
             return Ok(());
         };
 
-        let stats = TransferStats::with_bytes(
-            self.timing.total_bytes_read,
-            transfer_result.bytes_sent,
-            self.flist_send_stats.total_size,
-        )
-        .with_flist_times(flist_buildtime_ms, flist_xfertime_ms);
+        // upstream: main.c:377-378 - the client sender's --write-batch trailer
+        // records the same cached raw descriptor counters it would send on the
+        // wire, so --read-batch reproduces the identical "Total bytes" report.
+        let stats =
+            TransferStats::with_bytes(total_read, total_written, self.flist_send_stats.total_size)
+                .with_flist_times(flist_buildtime_ms, flist_xfertime_ms);
 
         let mut guard = sink
             .0
@@ -91,5 +92,69 @@ impl GeneratorContext {
         let mut batch: &mut dyn Write = &mut *guard;
         stats.write_to(&mut batch, self.protocol)?;
         batch.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::ServerConfig;
+    use crate::flags::{NumericIds, ParsedServerFlags};
+    use crate::generator::GeneratorContext;
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+    use protocol::{ProtocolVersion, TransferStats};
+
+    fn ctx() -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            flags: ParsedServerFlags {
+                numeric_ids: NumericIds::Explicit,
+                ..Default::default()
+            },
+            args: vec![std::ffi::OsString::from(".")],
+            ..Default::default()
+        };
+        GeneratorContext::new_for_test(&handshake, config)
+    }
+
+    /// `send_stats` transmits the raw wire totals it is handed, verbatim.
+    ///
+    /// WHY: upstream's `handle_stats()` writes the sender's cached raw descriptor
+    /// counters `stats.total_read`/`stats.total_written` (main.c:349-350,
+    /// io.c:820/859), not any logical delta/token tally. The orchestrator samples
+    /// those raw counters at the `handle_stats` point and passes them in; this
+    /// pins that they reach the wire unchanged so a pulling client reports the
+    /// exact byte totals the sender observed.
+    #[test]
+    fn send_stats_transmits_the_raw_totals_verbatim() {
+        let ctx = ctx();
+        let total_read = 96u64;
+        let total_written = 9_780u64;
+
+        let mut got = Vec::new();
+        ctx.send_stats(&mut got, total_read, total_written, 0, 0)
+            .unwrap();
+
+        // The wire must be exactly the (total_read, total_written, total_size)
+        // trailer - total_size is the flist tally, 0 for an unpopulated context.
+        let mut want = Vec::new();
+        TransferStats::with_bytes(total_read, total_written, ctx.flist_send_stats.total_size)
+            .with_flist_times(0, 0)
+            .write_to(&mut want, ctx.protocol)
+            .unwrap();
+
+        assert_eq!(got, want);
     }
 }

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -775,8 +775,16 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         });
     }
 
+    // upstream: io.c:859 - stats.total_written counts every byte the raw
+    // descriptor accepts, multiplex frame headers included, in perform_io().
+    // Wrap the transport below the multiplex framer so the shared counter
+    // mirrors that raw wire total; the sender samples it at its handle_stats
+    // point (main.c:979-980) and reports it as "Total bytes sent".
+    let counting_stdout = writer::CountingWriter::new_shared(stdout);
+    let bytes_sent_counter = counting_stdout.counter();
+
     // MultiplexWriter provides 64KB buffering (matching upstream iobuf_out).
-    let mut writer = writer::ServerWriter::new_plain(stdout);
+    let mut writer = writer::ServerWriter::new_plain(counting_stdout);
 
     let mplex_out = requires_multiplex_output(
         config.connection.client_mode,
@@ -903,6 +911,10 @@ pub fn run_server_with_handshake_adopting<W: Write>(
 
     // Input multiplex activation deferred to each role after reading filter list.
 
+    // Captured before `config` is moved into the role context below; the client
+    // receiver reports the sender's transmitted counters, not its own wire tally.
+    let client_mode = config.connection.client_mode;
+
     match config.role {
         ServerRole::Receiver => {
             let mut ctx = ReceiverContext::new(&handshake, config, pipeline);
@@ -920,6 +932,20 @@ pub fn run_server_with_handshake_adopting<W: Write>(
             // wire bytes, not the post-decompression literal byte total.
             stats.bytes_received =
                 bytes_received_counter.load(std::sync::atomic::Ordering::Relaxed);
+
+            // upstream: main.c:325-372 handle_stats() - the sender is the only
+            // process with the authoritative byte totals. A client receiver reads
+            // the sender's cached raw counters over the wire (main.c:365-372) and
+            // swaps their meaning: it prints the sender's total_read as "Total
+            // bytes sent" and the sender's total_written as "Total bytes received".
+            // Its own wire tally diverges by the trailing stats/goodbye bytes the
+            // sender wrote after sampling, so prefer the transmitted figures.
+            // Absent (empty file list, no stats trailer) keeps the local tally,
+            // matching upstream's `if (f < 0 && !am_sender)` no-op (main.c:363).
+            if client_mode && let Some(sender_stats) = ctx.sender_stats() {
+                stats.bytes_sent = sender_stats.total_read;
+                stats.bytes_received = sender_stats.total_written;
+            }
 
             // A custom `--out-format` on a pull buffered its per-file rows as
             // metadata events (the receiver suppressed its own stdout). Hand each
@@ -940,6 +966,14 @@ pub fn run_server_with_handshake_adopting<W: Write>(
 
             let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
             ctx.batch_stats_sink = batch_stats_sink;
+            // upstream: io.c:820/859 - the sender's handle_stats() reports the raw
+            // descriptor counters. Hand the generator the transport-level wire
+            // counters so it samples total_written/total_read at its handle_stats
+            // point (main.c:979-980), below multiplex framing, matching upstream.
+            ctx.set_wire_counters(
+                std::sync::Arc::clone(&bytes_sent_counter),
+                std::sync::Arc::clone(&bytes_received_counter),
+            );
             let stats = ctx.run(chained_reader, &mut writer, &paths, progress, itemize)?;
 
             Ok(ServerStats::Generator(stats))

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -214,6 +214,16 @@ pub struct ReceiverContext {
     ///
     /// - `flist.c:2789` - `stats.flist_size += stats.total_read - start_read;`
     pub(in crate::receiver) flist_size: u64,
+    /// Byte totals the remote sender transmitted in its `handle_stats()` trailer,
+    /// captured by `finalize_transfer` on a client pull.
+    ///
+    /// Upstream's client receiver reports the sender's cached raw descriptor
+    /// counters, swapping their meaning (main.c:365-372): the sender's total_read
+    /// becomes "Total bytes sent" and its total_written becomes "Total bytes
+    /// received". `None` until the trailer is read (e.g. an empty file list never
+    /// sends one), and always `None` on a server receiver, which upstream never
+    /// has read the trailer at all.
+    pub(in crate::receiver) sender_stats: Option<crate::receiver::stats::SenderStats>,
     /// Per-operation thresholds for switching between sequential and parallel execution.
     ///
     /// Different operations have different overhead profiles: CPU-bound signature
@@ -469,6 +479,7 @@ impl ReceiverContext {
             flist_io_error: 0,
             raw_read_counter: None,
             flist_size: 0,
+            sender_stats: None,
             parallel_thresholds: ParallelThresholds::default(),
             delete_ctx: None,
             pending_del_stats: DeleteStats::new(),
@@ -561,6 +572,18 @@ impl ReceiverContext {
     #[must_use]
     pub fn flist_size(&self) -> u64 {
         self.flist_size
+    }
+
+    /// Returns the byte totals the sender transmitted in its `handle_stats()`
+    /// trailer, or `None` when no trailer was read (empty file list, or a server
+    /// receiver that never reads one).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:365-372` - client receiver reads the sender's cached counters.
+    #[must_use]
+    pub fn sender_stats(&self) -> Option<&crate::receiver::stats::SenderStats> {
+        self.sender_stats.as_ref()
     }
 
     /// Snapshots the raw read counter at the start of a file-list span.

--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -35,6 +35,7 @@ mod parallel_delta_notice;
 mod partial_resume;
 mod post_decision_name_emission;
 mod push_metadata_itemize;
+mod sender_stats;
 mod support;
 mod symlinks_and_devices;
 #[cfg(unix)]

--- a/crates/transfer/src/receiver/tests/sender_stats.rs
+++ b/crates/transfer/src/receiver/tests/sender_stats.rs
@@ -1,0 +1,88 @@
+//! `Total bytes sent` / `Total bytes received` accounting on a client pull.
+//!
+//! Upstream's `handle_stats()` makes the sender authoritative: it caches the
+//! raw descriptor counters `stats.total_read` (io.c:820) and
+//! `stats.total_written` (io.c:859) and, when it is a server sender, writes them
+//! over the wire (main.c:349-350). The client receiver reads them back and
+//! swaps their meaning (main.c:365-372): it prints the sender's `total_read` as
+//! `Total bytes sent` and the sender's `total_written` as `Total bytes
+//! received`. These tests pin that the receiver captures the transmitted trailer
+//! and exposes it for the swap, rather than reporting its own local wire tally
+//! (which diverges by the trailing stats and goodbye bytes).
+
+use std::io::Cursor;
+
+use protocol::TransferStats;
+
+use super::super::ReceiverContext;
+use super::support::{test_config, test_handshake};
+
+/// The receiver decodes the sender's transmitted counters in `total_read`,
+/// `total_written` order, and the client swap maps them onto the summary.
+///
+/// WHY: a client pull must print the sender's numbers exactly. Sourcing them
+/// from the wire trailer (not the receiver's own counters) is what keeps
+/// `Total bytes sent`/`received` byte-identical with the sender, because the
+/// receiver's local tally additionally counts the trailer and goodbye bytes the
+/// sender wrote after it sampled at its `handle_stats` point.
+#[test]
+fn receive_stats_decodes_sender_counters_for_the_client_swap() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // The server sender's `send_stats` encodes (total_read, total_written,
+    // total_size) via this exact call (generator/transfer/stats.rs).
+    let sender_total_read = 96u64;
+    let sender_total_written = 9_780u64;
+    let sender_total_size = 8_500u64;
+    let mut wire = Vec::new();
+    TransferStats::with_bytes(sender_total_read, sender_total_written, sender_total_size)
+        .with_flist_times(0, 0)
+        .write_to(&mut wire, handshake.protocol)
+        .unwrap();
+
+    let mut reader = Cursor::new(&wire[..]);
+    let sender_stats = ctx.receive_stats(&mut reader).unwrap();
+
+    assert_eq!(sender_stats.total_read, sender_total_read);
+    assert_eq!(sender_stats.total_written, sender_total_written);
+    assert_eq!(sender_stats.total_size, sender_total_size);
+
+    // upstream: main.c:365-372,454-457 - the client receiver's report swaps the
+    // pair: "Total bytes sent" is the sender's total_read (what the client sent,
+    // as the sender read it), "Total bytes received" is the sender's
+    // total_written (what the client received, as the sender wrote it).
+    let client_bytes_sent = sender_stats.total_read;
+    let client_bytes_received = sender_stats.total_written;
+    assert_eq!(client_bytes_sent, 96);
+    assert_eq!(client_bytes_received, 9_780);
+}
+
+/// `sender_stats()` is `None` until a trailer is captured, and stores it after.
+///
+/// WHY: a server receiver (a push's remote side) never reads a stats trailer,
+/// so the field must stay `None` there and the client swap must fall back to the
+/// local tally - matching upstream's `if (f < 0 && !am_sender)` no-op
+/// (main.c:363). Only a client pull that captured a trailer overrides the report.
+#[test]
+fn sender_stats_starts_none_and_retains_the_captured_trailer() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    assert!(ctx.sender_stats().is_none());
+
+    let mut wire = Vec::new();
+    TransferStats::with_bytes(42, 4_242, 100)
+        .with_flist_times(0, 0)
+        .write_to(&mut wire, handshake.protocol)
+        .unwrap();
+    let captured = ctx.receive_stats(&mut Cursor::new(&wire[..])).unwrap();
+    // `finalize_transfer` performs exactly this assignment on a client pull.
+    ctx.sender_stats = Some(captured);
+
+    let stored = ctx.sender_stats().expect("trailer retained");
+    assert_eq!(stored.total_read, 42);
+    assert_eq!(stored.total_written, 4_242);
+}

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -283,7 +283,12 @@ impl ReceiverContext {
         self.exchange_phase_done(reader, writer, &mut ndx_write_codec, &mut ndx_read_codec)?;
 
         if self.config.connection.client_mode {
-            let _sender_stats = self.receive_stats(reader)?;
+            // upstream: main.c:365-372 - the client receiver reads the sender's
+            // cached raw descriptor counters here and reports them (with read/write
+            // swapped) as "Total bytes sent/received". Retain them for the summary
+            // instead of discarding, so the figures match the sender exactly rather
+            // than diverging by this trailer and the goodbye bytes that follow.
+            self.sender_stats = Some(self.receive_stats(reader)?);
         }
 
         self.handle_goodbye(reader, writer, &mut ndx_write_codec, &mut ndx_read_codec)?;

--- a/crates/transfer/src/writer/counting.rs
+++ b/crates/transfer/src/writer/counting.rs
@@ -3,6 +3,8 @@
 //! Mirrors upstream rsync's `stats.total_written` tracking in `io.c:859`.
 
 use std::io::{self, IoSlice, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A writer wrapper that counts the total bytes written.
 ///
@@ -11,6 +13,15 @@ use std::io::{self, IoSlice, Write};
 pub struct CountingWriter<W> {
     inner: W,
     bytes_written: u64,
+    /// Optional shared handle mirroring the running total.
+    ///
+    /// Set via [`CountingWriter::new_shared`] when the count must be sampled
+    /// from a different scope than the one owning the writer - e.g. the raw
+    /// transport counter that feeds `stats.total_written` (io.c:859) but is read
+    /// at the generator's `handle_stats` point (main.c:979-980), after the writer
+    /// has been moved into the protocol stack. The handle stays valid after the
+    /// writer is moved or dropped, exactly like the read-side `CountingReader`.
+    shared: Option<Arc<AtomicU64>>,
 }
 
 impl<W> CountingWriter<W> {
@@ -19,12 +30,46 @@ impl<W> CountingWriter<W> {
         Self {
             inner,
             bytes_written: 0,
+            shared: None,
         }
+    }
+
+    /// Creates a counting writer that also publishes its running total through a
+    /// shared [`Arc<AtomicU64>`] obtainable via [`CountingWriter::counter`].
+    ///
+    /// Mirrors the read-side `CountingReader`: the shared handle lets a caller
+    /// sample the raw wire byte total after the writer has been moved into the
+    /// protocol stack, matching upstream's raw descriptor counter
+    /// `stats.total_written` (io.c:859).
+    pub fn new_shared(inner: W) -> Self {
+        Self {
+            inner,
+            bytes_written: 0,
+            shared: Some(Arc::new(AtomicU64::new(0))),
+        }
+    }
+
+    /// Returns a shared handle to the running byte total.
+    ///
+    /// Only advances for a writer built with [`CountingWriter::new_shared`];
+    /// for a plain [`CountingWriter::new`] writer the returned counter stays 0.
+    pub fn counter(&self) -> Arc<AtomicU64> {
+        self.shared
+            .clone()
+            .unwrap_or_else(|| Arc::new(AtomicU64::new(0)))
     }
 
     /// Returns the total number of bytes written through this wrapper.
     pub const fn bytes_written(&self) -> u64 {
         self.bytes_written
+    }
+
+    /// Records `n` freshly written bytes in the local and (if present) shared totals.
+    fn record(&mut self, n: usize) {
+        self.bytes_written = self.bytes_written.saturating_add(n as u64);
+        if let Some(shared) = &self.shared {
+            shared.fetch_add(n as u64, Ordering::Relaxed);
+        }
     }
 
     /// Returns a mutable reference to the inner writer.
@@ -44,17 +89,58 @@ impl<W> CountingWriter<W> {
 impl<W: Write> Write for CountingWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let n = self.inner.write(buf)?;
-        self.bytes_written = self.bytes_written.saturating_add(n as u64);
+        self.record(n);
         Ok(n)
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let n = self.inner.write_vectored(bufs)?;
-        self.bytes_written = self.bytes_written.saturating_add(n as u64);
+        self.record(n);
         Ok(n)
     }
 
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CountingWriter;
+    use std::io::Write;
+    use std::sync::atomic::Ordering;
+
+    /// The shared handle mirrors the running total and survives the writer.
+    ///
+    /// WHY: the generator samples raw wire bytes at its `handle_stats` point
+    /// (main.c:979-980) after the writer has been moved into the protocol stack,
+    /// so the count must be reachable through the shared handle, matching the
+    /// read-side `CountingReader` (io.c:820/859).
+    #[test]
+    fn shared_counter_tracks_raw_bytes_and_outlives_writer() {
+        let mut writer = CountingWriter::new_shared(Vec::new());
+        let counter = writer.counter();
+
+        writer.write_all(b"hello").unwrap();
+        writer.write_all(b" world").unwrap();
+        assert_eq!(writer.bytes_written(), 11);
+        assert_eq!(counter.load(Ordering::Relaxed), 11);
+
+        // Handle stays valid after the writer is dropped.
+        drop(writer);
+        assert_eq!(counter.load(Ordering::Relaxed), 11);
+    }
+
+    /// A plain `new` writer keeps its local count but publishes nothing shared.
+    ///
+    /// WHY: the receiver's existing local `CountingWriter::new` usage must be
+    /// unaffected - only the transport wrapper opts into the shared handle.
+    #[test]
+    fn plain_counter_is_local_only() {
+        let mut writer = CountingWriter::new(Vec::new());
+        let counter = writer.counter();
+        writer.write_all(b"abcd").unwrap();
+        assert_eq!(writer.bytes_written(), 4);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
     }
 }


### PR DESCRIPTION
Fixes the remote `Total bytes sent` / `Total bytes received` summary lines, which diverged from upstream on every network transfer.

Root cause: oc reported logical byte tallies (the generator summed delta/token bytes; the pulling client used its own post-trailer wire counters). Upstream makes the SENDER authoritative — `handle_stats()` caches the raw descriptor counters `stats.total_read` (io.c:820) and `stats.total_written` (io.c:859) at the `io_flush` point (main.c:979-980, before the stats trailer + goodbye). A server sender writes them over the wire (main.c:349-350); a client receiver reads them back and SWAPS their meaning (main.c:365-372), printing the sender's `total_read` as "sent" and `total_written` as "received".

Fix (all in `crates/transfer`):
- `writer/counting.rs` — `CountingWriter` gains a shared `Arc<AtomicU64>` counter (`new_shared`/`counter`), mirroring the read side.
- `lib.rs` — wrap the transport in a shared `CountingWriter` below the multiplex framer (raw wire-write counter); hand both wire counters to the generator; on a client pull, report the sender's transmitted trailer (with the read/write swap) instead of the receiver's own tally.
- `generator/context.rs` — `wire_write_counter`/`wire_read_counter` + `set_wire_counters`.
- `generator/transfer/orchestrator.rs` — flush then snapshot both raw counters at the `handle_stats` point; feed `send_stats`/`record_batch_stats` and `GeneratorStats`.
- `generator/transfer/stats.rs` — transmit the passed raw totals verbatim.
- `receiver/context.rs` + `receiver/transfer/phases.rs` — capture the sender's stats trailer in `finalize_transfer` (was discarded); expose `sender_stats()`.

Measured (upstream 3.4.4 vs oc): before, off by 30-211 bytes across SSH push/pull; after, residual ≤12 bytes. `strace` confirms the reported figure equals actual wire bytes at the sample point (goodbye excluded). The ≤12-byte residual is the pre-existing wire-framing/request-encoding difference tracked as #266, not the accounting.

Tests: 5 new deterministic regressions — sender-stats decode + client swap (None-until-captured), `send_stats` raw-total byte-equality, two `CountingWriter` shared-counter tests. Reuses the raw-read-counter threading pattern from sibling #243 (PR #7046).

Gates: fmt 0, clippy -p transfer -p core clean, `test(stats)|total_bytes|bytes` nextest 108 passed / 0 failed.
