### PR TITLE
fix(cli): render %L hardlink leader on a remote pull

### DIFF
--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -88,26 +88,41 @@ pub(super) fn render_placeholder_value(
         OutFormatPlaceholder::PermissionString => {
             Some(format_out_format_permissions(event.metadata()).into_bytes())
         }
-        OutFormatPlaceholder::SymlinkTarget => match event
-            .metadata()
-            .and_then(ClientEntryMetadata::symlink_target)
-        {
-            Some(target) => {
-                let mut rendered = symlink_target_connector(event).as_bytes().to_vec();
-                rendered.extend_from_slice(&escape_path(target, allow_8bit));
+        OutFormatPlaceholder::SymlinkTarget => {
+            // upstream: log.c:643-646 - `%L` renders the hard-link leader
+            // (`hlink`) before the symlink target: `if (hlink && *hlink) { n =
+            // hlink; " => " }`. A remote pull carries the leader in
+            // `hardlink_leader`; a local copy routes it through the metadata
+            // `symlink_target` slot keyed on the `HardLink` event kind (handled by
+            // `symlink_target_connector` in the else-branch).
+            if let Some(leader) = event.hardlink_leader() {
+                let mut rendered = b" => ".to_vec();
+                rendered.extend_from_slice(&escape_path(leader, allow_8bit));
                 Some(rendered)
+            } else {
+                match event
+                    .metadata()
+                    .and_then(ClientEntryMetadata::symlink_target)
+                {
+                    Some(target) => {
+                        let mut rendered = symlink_target_connector(event).as_bytes().to_vec();
+                        rendered.extend_from_slice(&escape_path(target, allow_8bit));
+                        Some(rendered)
+                    }
+                    // upstream: log.c:648-654 - the `case 'L'` else-branch sets n
+                    // = "" for a non-link/non-hardlink entry. With no width
+                    // modifier upstream breaks with the empty string (matched here
+                    // by returning None); with a width modifier it copies four
+                    // leading spaces then formats the empty string under the width
+                    // specifier, emitting `4 + width` spaces so the empty target
+                    // aligns under the ` -> ` connector column.
+                    None => spec
+                        .format
+                        .width()
+                        .map(|width| vec![b' '; 4 + width.min(MAX_PLACEHOLDER_WIDTH)]),
+                }
             }
-            // upstream: log.c:648-654 - the `case 'L'` else-branch sets n = ""
-            // for a non-link/non-hardlink entry. With no width modifier upstream
-            // breaks with the empty string (matched here by returning None); with
-            // a width modifier it copies four leading spaces then formats the
-            // empty string under the width specifier, emitting `4 + width` spaces
-            // so the empty target aligns under the ` -> ` connector column.
-            None => spec
-                .format
-                .width()
-                .map(|width| vec![b' '; 4 + width.min(MAX_PLACEHOLDER_WIDTH)]),
-        },
+        }
         OutFormatPlaceholder::CurrentTime => Some(format_current_timestamp().into_bytes()),
         // upstream: log.c:570-573 - `case 'U'` renders `uid_ndx ? F_OWNER : 0`,
         // so the numeric uid appears only under `-o`/`--owner`; otherwise `0`.

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1413,9 +1413,56 @@ fn remote_event_with_source_prefix(relative: &str, source_prefix: Option<&str>) 
         is_dir: false,
         is_symlink: false,
         symlink_target: None,
+        hardlink_leader: None,
         is_new: true,
         is_deletion: false,
     })
+}
+
+/// Builds a remote-pull hard-link follower event carrying its group leader's
+/// transfer-relative name, mirroring the receiver's `create_hardlinks` xname
+/// (upstream `hlink.c:232-234`) that a custom `--out-format` collects on a pull.
+fn remote_pull_hardlink_follower(relative: &str, leader: &str) -> ClientEvent {
+    ClientEvent::from_remote_itemize(RemoteItemizeFields {
+        relative_path: PathBuf::from(relative),
+        source_prefix: None,
+        itemize: "hf+++++++++".to_owned(),
+        mode: 0o100_644,
+        size: 4,
+        mtime: 1_700_000_000,
+        mtime_nsec: 0,
+        uid: None,
+        gid: None,
+        is_dir: false,
+        is_symlink: false,
+        symlink_target: None,
+        hardlink_leader: Some(PathBuf::from(leader)),
+        is_new: true,
+        is_deletion: false,
+    })
+}
+
+#[test]
+fn render_percent_l_hardlink_leader_on_remote_pull() {
+    // upstream log.c:643-646 - `%L` renders ` => <hlink>` when a hard-link leader
+    // (`hlink`) is present, before any symlink target. A remote pull has no engine
+    // record, so the receiver's xname rides in `hardlink_leader`; without it `%L`
+    // printed empty for a pulled hard link (#256). Assert the exact ` => ` bytes.
+    let event = remote_pull_hardlink_follower("dir/alias.txt", "dir/leader.txt");
+    assert_eq!(render_format("%L", &event), " => dir/leader.txt\n");
+    // The full default-style template still resolves name then leader.
+    assert_eq!(
+        render_format("%n%L", &event),
+        "dir/alias.txt => dir/leader.txt\n"
+    );
+}
+
+#[test]
+fn render_percent_l_empty_for_remote_pull_regular_file() {
+    // A pulled regular file with no leader and no symlink target renders an empty
+    // `%L` (upstream log.c:650-653 sets n = "" and breaks with no width modifier).
+    let event = remote_event_with_source_prefix("plain.txt", None);
+    assert_eq!(render_format("%L", &event), "\n");
 }
 
 #[test]

--- a/crates/core/src/client/remote/itemize_sink.rs
+++ b/crates/core/src/client/remote/itemize_sink.rs
@@ -63,6 +63,7 @@ impl crate::server::ItemizeCallback for ItemizeEventSink {
                     is_dir: row.is_dir,
                     is_symlink: row.is_symlink,
                     symlink_target: row.symlink_target.map(std::path::Path::to_path_buf),
+                    hardlink_leader: row.hardlink_leader.map(std::path::Path::to_path_buf),
                     is_new: row.is_new,
                     is_deletion: row.is_deletion,
                 }));

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -126,6 +126,15 @@ pub struct ClientEvent {
     /// placeholder (upstream `F_PATHNAME` joined with the name). `None` on a pull
     /// or local copy, where `%f` falls back to [`Self::relative_path`].
     source_prefix: Option<PathBuf>,
+    /// Hard-link group leader's transfer-relative name for a remote-pull
+    /// hard-link follower, carried so `%L` renders the ` => <leader>` suffix.
+    ///
+    /// A local copy already routes its leader through the metadata `symlink_target`
+    /// slot keyed on [`ClientEventKind::HardLink`] (engine `plan/metadata.rs`); a
+    /// remote pull has no engine record, so the receiver's already-computed xname
+    /// (upstream `hlink.c:232-234`) rides here instead. `None` on every path that
+    /// is not a remote-pull hard-link follower.
+    hardlink_leader: Option<PathBuf>,
 }
 
 impl ClientEvent {
@@ -222,6 +231,7 @@ impl ClientEvent {
             is_directory,
             precomputed_itemize: None,
             source_prefix: None,
+            hardlink_leader: None,
         }
     }
 
@@ -248,6 +258,7 @@ impl ClientEvent {
             is_directory: false,
             precomputed_itemize: None,
             source_prefix: None,
+            hardlink_leader: None,
         }
     }
 
@@ -288,6 +299,7 @@ impl ClientEvent {
             is_directory,
             precomputed_itemize: None,
             source_prefix: None,
+            hardlink_leader: None,
         }
     }
 
@@ -326,6 +338,7 @@ impl ClientEvent {
             is_directory: fields.is_dir,
             precomputed_itemize: Some(fields.itemize),
             source_prefix: fields.source_prefix,
+            hardlink_leader: fields.hardlink_leader,
         }
     }
 
@@ -340,6 +353,16 @@ impl ClientEvent {
     #[must_use]
     pub fn source_prefix(&self) -> Option<&Path> {
         self.source_prefix.as_deref()
+    }
+
+    /// Returns the hard-link group leader's transfer-relative name for a
+    /// remote-pull hard-link follower, which `%L` renders as ` => <leader>`
+    /// (upstream `log.c:643-646`). `None` for every other event, including a
+    /// local-copy hard link, whose leader travels through the metadata
+    /// `symlink_target` slot instead.
+    #[must_use]
+    pub fn hardlink_leader(&self) -> Option<&Path> {
+        self.hardlink_leader.as_deref()
     }
 
     /// Returns the action recorded by this event.
@@ -483,6 +506,7 @@ impl ClientEvent {
             is_directory: false,
             precomputed_itemize: None,
             source_prefix: None,
+            hardlink_leader: None,
         }
     }
 
@@ -557,6 +581,7 @@ mod tests {
             is_dir: false,
             is_symlink: false,
             symlink_target: None,
+            hardlink_leader: None,
             is_new: true,
             is_deletion: false,
         });
@@ -589,6 +614,7 @@ mod tests {
             is_dir: false,
             is_symlink: false,
             symlink_target: None,
+            hardlink_leader: None,
             is_new: false,
             is_deletion: true,
         });

--- a/crates/core/src/client/summary/metadata.rs
+++ b/crates/core/src/client/summary/metadata.rs
@@ -78,6 +78,10 @@ pub struct RemoteItemizeFields {
     pub is_symlink: bool,
     /// Symlink target, when the entry is a symlink.
     pub symlink_target: Option<PathBuf>,
+    /// Hard-link group leader's transfer-relative name, when this row is a
+    /// hard-link follower. Renders the `%L` ` => <leader>` suffix on a remote
+    /// pull (upstream `hlink.c:232-234` + `log.c:643-646`); `None` otherwise.
+    pub hardlink_leader: Option<PathBuf>,
     /// Whether the entry is newly created (`ITEM_IS_NEW`).
     pub is_new: bool,
     /// Whether the entry is a deletion.

--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -45,6 +45,9 @@ pub(crate) fn build_itemize_row<'a>(
         is_dir: entry.is_dir(),
         is_symlink: entry.is_symlink(),
         symlink_target: entry.link_target().map(PathBuf::as_path),
+        // The push sender renders a hard-link follower's ` => leader` suffix from
+        // the wire xname in its own itemize path, not through this row builder.
+        hardlink_leader: None,
         is_new: raw & ItemFlags::ITEM_IS_NEW != 0,
         is_deletion: raw & ItemFlags::ITEM_DELETED != 0,
     }

--- a/crates/transfer/src/progress.rs
+++ b/crates/transfer/src/progress.rs
@@ -116,6 +116,12 @@ pub struct ItemizeRow<'a> {
     pub is_symlink: bool,
     /// Symlink target, when the entry is a symlink.
     pub symlink_target: Option<&'a std::path::Path>,
+    /// Hard-link group leader's transfer-relative name, when this row is a
+    /// hard-link follower. Renders the `%L` ` => <leader>` suffix (upstream
+    /// `hlink.c:232-234` passes `realname`; `log.c:643-646` renders ` => hlink`).
+    /// `None` for every non-hard-link row; distinct from `symlink_target`, which
+    /// carries a symlink's ` -> ` target.
+    pub hardlink_leader: Option<&'a std::path::Path>,
     /// Whether the entry is newly created at the destination (`ITEM_IS_NEW`).
     pub is_new: bool,
     /// Whether the row reports a deletion (`ITEM_DELETED`).
@@ -158,6 +164,8 @@ pub struct OwnedItemizeRow {
     pub is_symlink: bool,
     /// Owned copy of [`ItemizeRow::symlink_target`].
     pub symlink_target: Option<std::path::PathBuf>,
+    /// Owned copy of [`ItemizeRow::hardlink_leader`].
+    pub hardlink_leader: Option<std::path::PathBuf>,
     /// See [`ItemizeRow::is_new`].
     pub is_new: bool,
     /// See [`ItemizeRow::is_deletion`].
@@ -182,6 +190,7 @@ impl OwnedItemizeRow {
             is_dir: self.is_dir,
             is_symlink: self.is_symlink,
             symlink_target: self.symlink_target.as_deref(),
+            hardlink_leader: self.hardlink_leader.as_deref(),
             is_new: self.is_new,
             is_deletion: self.is_deletion,
         }

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -422,13 +422,15 @@ impl ReceiverContext {
     /// Builds the owned metadata row for a custom `--out-format` event, applying
     /// the same significance gate and `%i` glyph as [`Self::render_itemize_line`].
     ///
-    /// The receiver-side generator computes iflags locally rather than reading
-    /// them off the wire, so no alternate-basis xname is available; the
-    /// hard-link ` => leader` suffix is owned by the push sender renderer.
+    /// `xname` is the hard-link group leader's transfer-relative name for a
+    /// hard-link follower (upstream `hlink.c:232-234` `realname`); it is carried
+    /// into the row's `hardlink_leader` so the CLI renders the `%L` ` => <leader>`
+    /// suffix (upstream `log.c:643-646`). `None` for every non-follower row.
     fn build_event_row(
         &self,
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
+        xname: Option<&[u8]>,
     ) -> Option<crate::progress::OwnedItemizeRow> {
         let effective_iflags = self.itemize_effective_flags(iflags, entry)?;
         let ctx = self.itemize_context();
@@ -438,11 +440,17 @@ impl ReceiverContext {
             entry,
             is_sender,
             &ctx,
-            None,
+            xname,
         );
         let itemize =
             crate::generator::itemize::format_iflags(&effective_iflags, entry, is_sender, &ctx);
         let raw = effective_iflags.raw();
+        // upstream: log.c:644 gates the ` => hlink` suffix on `hlink && *hlink`,
+        // so an empty xname carries no leader (an already-correct hard-link alias
+        // itemized with the empty string, hlink.c:218-222).
+        let hardlink_leader = xname
+            .filter(|bytes| !bytes.is_empty())
+            .map(bytes_to_path_buf);
         Some(crate::progress::OwnedItemizeRow {
             line,
             itemize,
@@ -460,6 +468,7 @@ impl ReceiverContext {
             is_dir: entry.is_dir(),
             is_symlink: entry.is_symlink(),
             symlink_target: entry.link_target().cloned(),
+            hardlink_leader,
             is_new: raw & crate::generator::ItemFlags::ITEM_IS_NEW != 0,
             is_deletion: raw & crate::generator::ItemFlags::ITEM_DELETED != 0,
         })
@@ -552,7 +561,7 @@ impl ReceiverContext {
         xname: Option<&[u8]>,
     ) -> std::io::Result<()> {
         if self.collect_out_format_events() {
-            self.record_itemize(flist_idx, iflags, entry);
+            self.record_itemize(flist_idx, iflags, entry, xname);
             return Ok(());
         }
         self.emit_itemize(writer, iflags, entry, xname)
@@ -723,7 +732,7 @@ impl ReceiverContext {
         entry: &protocol::flist::FileEntry,
     ) -> std::io::Result<()> {
         if self.defer_itemize || self.collect_out_format_events() {
-            self.record_itemize(flist_idx, iflags, entry);
+            self.record_itemize(flist_idx, iflags, entry, None);
             Ok(())
         } else {
             self.emit_itemize(writer, iflags, entry, None)
@@ -745,6 +754,7 @@ impl ReceiverContext {
         flist_idx: usize,
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
+        xname: Option<&[u8]>,
     ) {
         if !self.config.connection.client_mode {
             return;
@@ -753,7 +763,7 @@ impl ReceiverContext {
         // rendered default string (mutually exclusive - the string path is
         // suppressed so the CLI renders the user's template from these events).
         if self.collect_out_format_events() {
-            if let Some(row) = self.build_event_row(iflags, entry) {
+            if let Some(row) = self.build_event_row(iflags, entry, xname) {
                 self.event_rows
                     .borrow_mut()
                     .entry(flist_idx)
@@ -765,7 +775,7 @@ impl ReceiverContext {
         if !self.should_emit_itemize() {
             return;
         }
-        if let Some(line) = self.render_itemize_line(iflags, entry, None) {
+        if let Some(line) = self.render_itemize_line(iflags, entry, xname) {
             self.itemize_rows
                 .borrow_mut()
                 .entry(flist_idx)
@@ -869,6 +879,23 @@ impl ReceiverContext {
             self.emit_name_line(&line)?;
         }
         Ok(())
+    }
+}
+
+/// Decodes a hard-link leader xname (transfer-relative name bytes) into a
+/// `PathBuf`, preserving raw bytes verbatim on Unix and falling back to a lossy
+/// UTF-8 decode elsewhere. Mirrors the receiver's other byte-to-path decoding
+/// (`dest_root.rs`, `basis.rs`) so a non-UTF-8 leader name survives to the `%L`
+/// renderer under `--8-bit-output`.
+fn bytes_to_path_buf(bytes: &[u8]) -> std::path::PathBuf {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        std::path::PathBuf::from(std::ffi::OsStr::from_bytes(bytes))
+    }
+    #[cfg(not(unix))]
+    {
+        std::path::PathBuf::from(String::from_utf8_lossy(bytes).into_owned())
     }
 }
 

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -215,7 +215,7 @@ fn out_format_collects_events_and_suppresses_string_path() {
     let entry = FileEntry::new_file("docs/readme.txt".into(), 1024, 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
 
-    ctx.record_itemize(3, &iflags, &entry);
+    ctx.record_itemize(3, &iflags, &entry, None);
 
     // String path suppressed; event path populated.
     assert!(ctx.itemize_rows.borrow().is_empty());
@@ -251,7 +251,7 @@ fn out_format_inactive_uses_string_path() {
     let entry = FileEntry::new_file("test.txt".into(), 100, 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
 
-    ctx.record_itemize(0, &iflags, &entry);
+    ctx.record_itemize(0, &iflags, &entry, None);
 
     assert!(ctx.drain_event_rows().is_empty());
     assert_eq!(ctx.itemize_rows.borrow().len(), 1);
@@ -326,6 +326,68 @@ fn out_format_collects_special() {
     // and the `S` special type.
     assert_eq!(row.itemize.len(), 11);
     assert!(row.itemize.starts_with("cS"), "itemize = {:?}", row.itemize);
+}
+
+#[test]
+fn out_format_pull_hardlink_follower_carries_leader() {
+    // upstream: hlink.c:232-234 - create_hardlinks itemizes each follower with the
+    // leader's transfer-relative name (`xname`), which log.c:643-646 renders as the
+    // `%L` ` => <leader>` suffix. On a pull under a custom `--out-format` the row is
+    // collected as an event rather than written as a string; the xname must ride
+    // into `hardlink_leader` so `%L` is not empty (#256). This asserts the receiver
+    // populates that field from the same xname `emit_itemize_indexed` receives.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.info_flags.itemize = false;
+    config.flags.info_flags.out_format_active = true;
+    config.connection.client_mode = true;
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+    let mut writer = MockMsgInfoWriter::new();
+
+    let entry = FileEntry::new_file("dir/alias.txt".into(), 4, 0o644);
+    let iflags = ItemFlags::from_raw(
+        ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_XNAME_FOLLOWS | ItemFlags::ITEM_IS_NEW,
+    );
+
+    ctx.emit_itemize_indexed(&mut writer, 2, &iflags, &entry, Some(b"dir/leader.txt"))
+        .unwrap();
+
+    // String path suppressed; the collected event carries the leader for `%L`.
+    assert!(ctx.itemize_rows.borrow().is_empty());
+    let rows = ctx.drain_event_rows();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.name, std::path::Path::new("dir/alias.txt"));
+    assert_eq!(
+        row.hardlink_leader.as_deref(),
+        Some(std::path::Path::new("dir/leader.txt"))
+    );
+    assert!(row.itemize.starts_with("hf"), "itemize = {:?}", row.itemize);
+}
+
+#[test]
+fn out_format_pull_empty_xname_carries_no_leader() {
+    // upstream: log.c:644 gates the ` => hlink` suffix on `hlink && *hlink`, so an
+    // already-correct hard-link alias itemized with the empty xname (hlink.c:218-222)
+    // carries no leader and `%L` stays empty. An empty xname must not populate
+    // `hardlink_leader`.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.info_flags.itemize = false;
+    config.flags.info_flags.out_format_active = true;
+    config.connection.client_mode = true;
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+    let mut writer = MockMsgInfoWriter::new();
+
+    let entry = FileEntry::new_file("dir/alias.txt".into(), 4, 0o644);
+    let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+
+    ctx.emit_itemize_indexed(&mut writer, 2, &iflags, &entry, Some(b""))
+        .unwrap();
+
+    let rows = ctx.drain_event_rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].hardlink_leader, None);
 }
 
 #[test]

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -587,7 +587,7 @@ impl ReceiverContext {
                 modify_window,
             );
             let iflags = crate::generator::ItemFlags::from_raw(raw);
-            self.record_itemize(idx, &iflags, entry);
+            self.record_itemize(idx, &iflags, entry, None);
             if raw & crate::generator::ItemFlags::ITEM_IS_NEW != 0 {
                 self.record_created(entry.mode());
             }


### PR DESCRIPTION
Fixes a custom `--out-format` with `%L` printing an empty leader for a hard-linked file on a remote PULL.

Root cause: the receiver's `create_hardlinks` pass already computes the group leader's transfer-relative name (xname) and passes it to `emit_itemize_indexed` (receiver/directory/links.rs:936-944). But with a custom `--out-format` active, `emit_itemize_indexed` dropped the xname and rebuilt the row from the flist `FileEntry` alone — whose `link_target()` is empty for a regular hard-linked file — so `%L` rendered nothing.

Upstream ground truth (log.c:643-646): the `%L` hardlink-leader branch takes precedence over the symlink branch and uses the exact bytes `" => "`, gated on `hlink && *hlink` (empty = no suffix).

Fix threads the already-computed xname (no new hardlink-group scan) additively through `record_itemize` -> `build_event_row` into a new `hardlink_leader` field on `ItemizeRow`/`OwnedItemizeRow` -> `RemoteItemizeFields` -> `ClientEvent`; the `%L` renderer checks `hardlink_leader` first (upstream order) then falls through to the unchanged symlink `" -> "` path. Local copy is untouched (its leader still routes through the metadata slot keyed on `ClientEventKind::HardLink`). Empty xname carries no leader, mirroring log.c:644.

Tests (encode upstream log.c %L): CLI `render_percent_l_hardlink_leader_on_remote_pull` asserts exact `" => dir/leader.txt"` and `%n%L` -> `dir/alias.txt => dir/leader.txt`, plus an empty-for-regular-file case; transfer-side xname->hardlink_leader and empty-xname cases.

Gates: fmt 0, clippy -p transfer/-p core/-p cli clean, targeted nextest cli 5 / transfer 7 / core 2 passed.
