### PR TITLE
fix(protocol): drop private capability letter from -e string

### DIFF
--- a/crates/transfer/src/setup/capability.rs
+++ b/crates/transfer/src/setup/capability.rs
@@ -117,31 +117,6 @@ pub(crate) const CAPABILITY_MAPPINGS: &[CapabilityMapping] = &[
     },
 ];
 
-/// Private oc-to-oc capability letter advertised in the `-e.<...>` string when
-/// the consecutive-match extension is opted in.
-///
-/// This letter is NOT an upstream rsync capability. Upstream ignores unknown
-/// capability letters in `client_info` (it only `strchr`s for its own known
-/// set, compat.c:712-732), so advertising it to a stock peer is inert. It is
-/// the wire channel that carries "this oc client opted in": the private
-/// [`CompatibilityFlags::CONSECUTIVE_MATCH`] bit is only ever set when the oc
-/// server sees this letter AND is itself opted in.
-const CONSECUTIVE_MATCH_CHAR: char = 'Z';
-
-/// Returns whether this process opted in to the consecutive-match extension.
-///
-/// The opt-in is a default-off internal switch driven by the
-/// `OC_CONSECUTIVE_MATCH=1` environment variable. It is deliberately NOT a
-/// default-advertised capability: both peers must set it (and both must be oc)
-/// for the negotiation AND to retain
-/// [`CompatibilityFlags::CONSECUTIVE_MATCH`]. Against any upstream rsync, or any
-/// oc peer without the opt-in, the extension stays fully inert and the wire is
-/// byte-identical to upstream.
-#[must_use]
-fn consecutive_match_opt_in() -> bool {
-    std::env::var_os("OC_CONSECUTIVE_MATCH").is_some_and(|value| value == "1" || value == "true")
-}
-
 /// Returns whether the iconv capability ('s' / CF_SYMLINK_ICONV) is
 /// compiled into this build.
 ///
@@ -197,13 +172,6 @@ fn append_capability_chars(buf: &mut String, allow_inc_recurse: bool) {
             continue;
         }
         buf.push(mapping.char);
-    }
-
-    // Private oc extension: advertise the consecutive-match capability letter
-    // only when this process opted in. Upstream peers ignore the unknown
-    // letter, so this is inert against stock rsync.
-    if consecutive_match_opt_in() {
-        buf.push(CONSECUTIVE_MATCH_CHAR);
     }
 }
 
@@ -380,16 +348,6 @@ pub(crate) fn build_compat_flags_from_client_info(
         if own_server_capability || client_info.contains(mapping.char) {
             flags |= mapping.flag;
         }
-    }
-
-    // Private oc extension (CAP_CONSECUTIVE_MATCH): set the bit only when BOTH
-    // sides opted in - the client advertised the letter AND this server process
-    // is itself opted in. This is the negotiation AND that guards the halved
-    // strong-sum length. A stock upstream client never sends the letter, and an
-    // un-opted-in oc server never sets the bit, so the extension is inert unless
-    // both peers are oc and both opted in.
-    if consecutive_match_opt_in() && client_info.contains(CONSECUTIVE_MATCH_CHAR) {
-        flags |= CompatibilityFlags::CONSECUTIVE_MATCH;
     }
 
     flags


### PR DESCRIPTION
Drops the private oc `CONSECUTIVE_MATCH_CHAR` (`'Z'`) letter from the `-e.` capability string so it is byte-identical to upstream 3.4.4 unconditionally (surfaced by the #215/POL-3 audit — the only observable wire divergence gated on an oc opt-in).

Upstream ground truth (options.c:3021-3065 `maybe_add_e_option`): emits `e`, `.`/`<VER>.<SUB>`, optional `i`/`L`/`s`, then unconditionally `f x C I v u` — no trailing private letter. Release yields `-e.iLsfxCIvu` (inc-recurse on) / `-e.LsfxCIvu` (off). oc's `CAPABILITY_MAPPINGS` order already matches; the `'Z'` was appended separately.

Change (`crates/transfer/src/setup/capability.rs`, 42 deletions): remove the `'Z'` const, the `consecutive_match_opt_in()` / `OC_CONSECUTIVE_MATCH` opt-in, the letter emission, and the server-side flag-set that lit `CONSECUTIVE_MATCH` when both peers opted in. The wire advertisement was the SOLE activation path for that private bit, so removing the letter left the whole opt-in unreachable — removed it entirely rather than leave a half-wired feature. `OC_CONSECUTIVE_MATCH` is now referenced nowhere.

The downstream consecutive-match algorithm consumers are left intact but inert (they read the `CONSECUTIVE_MATCH` bit, now never set, so they always take the upstream-identical branch — `needed=1`, no strong-sum halving — and never touch the wire). Fully deleting that self-contained algorithm across matching/transfer/protocol is a larger separate cleanup, filed as a follow-up.

Gates: fmt 0, clippy -p transfer -p protocol clean, transfer capability nextest 29 passed, protocol `test(consecutive)` 33 passed. No golden fixture encoded `'Z'`.
