### PR TITLE
test(fast_io): retry EINTR in zero-copy roundtrip read

### DIFF
--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -1015,6 +1015,9 @@ fn zero_copy_large_payload_roundtrip() {
         match peer.read(&mut buf) {
             Ok(0) => break,
             Ok(n) => received.extend_from_slice(&buf[..n]),
+            // A signal (e.g. SIGCHLD under heavy parallel nextest on musl) can
+            // interrupt the blocking read; EINTR is transient, so retry.
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(e) => panic!("read error: {e}"),
         }
     }


### PR DESCRIPTION
## Problem

`io_uring::tests::zero_copy_large_payload_roundtrip` reads the receiving
socket in a loop that treats every `Err` as fatal:

```rust
Err(e) => panic!("read error: {e}"),
```

Under heavy parallel nextest on musl, a signal (e.g. `SIGCHLD` from a sibling
test's child) can interrupt the blocking `read` with `EINTR` (os error 4),
failing the test spuriously. Observed on the `Linux musl (beta)` cell.

## Fix

Retry the read on `ErrorKind::Interrupted` instead of panicking. `EINTR` is
transient; this matches std's own convention (e.g. `io::copy`,
`Read::read_to_end`) of retrying interrupted reads. No production code path
changes - test-only robustness.
