### PR TITLE
perf(engine): cache CoW probe per directory, drop dead unlink

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -126,7 +126,9 @@ pub(super) fn try_clone(
     }
 
     if fast_io::try_ficlone(source, destination).is_err() {
-        let _ = std::fs::remove_file(destination);
+        // try_ficlone owns cleanup of any destination it created, so there is
+        // nothing to unlink here. On a non-reflink filesystem (ext4) the probe
+        // short-circuits before creating the destination at all.
         return Ok(false);
     }
 

--- a/crates/fast_io/src/platform_copy/cow_detect.rs
+++ b/crates/fast_io/src/platform_copy/cow_detect.rs
@@ -152,19 +152,35 @@ mod imp {
     const ZFS_SUPER_MAGIC: i64 = 0x2FC1_2FC1;
 
     pub(super) fn detect_cow_support(path: &Path) -> io::Result<CowSupport> {
-        let (fs_id, fs_type) = statfs_for_path(path)?;
-        let cache = cache();
-        if let Some(cached) = lookup(cache, fs_id) {
+        // Path fast-path: the fs_id cache still needs a statfs(2) to compute
+        // its key, so on the local-copy hot path it would pay one statfs per
+        // file even when the answer is fixed per mount. Cache by the probed
+        // directory path so repeated files in one directory skip the syscall
+        // entirely - upstream rsync probes the filesystem zero times.
+        if let Some(cached) = lookup_path(path) {
             return Ok(cached);
         }
-        let support = classify(fs_type);
-        insert(cache, fs_id, support);
+        let (fs_id, fs_type) = statfs_for_path(path)?;
+        let cache = cache();
+        let support = match lookup(cache, fs_id) {
+            Some(cached) => cached,
+            None => {
+                let support = classify(fs_type);
+                insert(cache, fs_id, support);
+                support
+            }
+        };
+        insert_path(path, support);
         Ok(support)
     }
 
     pub(super) fn record_probe_outcome(path: &Path, outcome: CowSupport) -> io::Result<()> {
         let (fs_id, _) = statfs_for_path(path)?;
         insert(cache(), fs_id, outcome);
+        // Keep the path cache coherent with a confirming FICLONE probe so a
+        // Probable->No/Yes transition is visible to later files in the same
+        // directory without re-running statfs(2).
+        insert_path(path, outcome);
         Ok(())
     }
 
@@ -195,6 +211,31 @@ mod imp {
         };
         if let Ok(mut guard) = lock.lock() {
             guard.insert(fs_id, support);
+        }
+    }
+
+    // Directory-path cache layered above the fs_id cache: it lets repeated
+    // probes of the same directory return without a statfs(2), which the
+    // fs_id key would otherwise always require.
+    type PathCache = OnceLock<Mutex<HashMap<std::path::PathBuf, CowSupport>>>;
+
+    fn path_cache() -> &'static PathCache {
+        static PATH_CACHE: PathCache = OnceLock::new();
+        PATH_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        &PATH_CACHE
+    }
+
+    fn lookup_path(path: &Path) -> Option<CowSupport> {
+        let guard = path_cache().get()?.lock().ok()?;
+        guard.get(path).copied()
+    }
+
+    fn insert_path(path: &Path, support: CowSupport) {
+        let Some(lock) = path_cache().get() else {
+            return;
+        };
+        if let Ok(mut guard) = lock.lock() {
+            guard.insert(path.to_path_buf(), support);
         }
     }
 

--- a/crates/fast_io/src/platform_copy/dispatch.rs
+++ b/crates/fast_io/src/platform_copy/dispatch.rs
@@ -710,7 +710,8 @@ pub(super) fn try_refs_reflink_impl(_src: &Path, _dst: &Path) -> io::Result<()> 
 ///
 /// Creates the destination file, then attempts a reflink clone from the source.
 /// On success, source and destination share storage blocks (copy-on-write).
-/// On failure, the caller is responsible for cleaning up the destination.
+/// On failure this function removes any destination it created, so the caller
+/// never needs to unlink; the `CowSupport::No` short-circuit creates nothing.
 #[cfg(target_os = "linux")]
 pub(super) fn try_ficlone_impl(src: &Path, dst: &Path) -> io::Result<()> {
     use std::fs::File;
@@ -747,6 +748,13 @@ pub(super) fn try_ficlone_impl(src: &Path, dst: &Path) -> io::Result<()> {
             if matches!(raw, libc::EOPNOTSUPP | libc::EXDEV | libc::EINVAL) {
                 let _ = record_probe_outcome(probe_path, CowSupport::No);
             }
+            // We created `dst` above via File::create; clean up the empty
+            // inode ourselves so the caller never issues an unlink. The
+            // CowSupport::No short-circuit returns before File::create and
+            // therefore leaves nothing to remove - matching upstream rsync,
+            // which does no filesystem-capability probe on the receive path.
+            drop(destination);
+            let _ = std::fs::remove_file(dst);
             Err(io::Error::from_raw_os_error(raw))
         }
     }


### PR DESCRIPTION
## Problem

The local-copy new-file path probed filesystem reflink support with a
`statfs(2)` **per file**. `detect_cow_support` computed its `fs_id` cache
key by calling `statfs` unconditionally, so the "per-mountpoint cache" saved
the classification but still paid one `statfs` for every file — 30000 on a
30k-file tree. It also issued a `remove_file` after every failed clone, which
on a non-reflink filesystem (ext4) is an ENOENT unlink for a destination the
short-circuit never created. Upstream rsync probes the filesystem **zero**
times on the receive path.

## Fix

- Layer a directory-path cache above the `fs_id` cache so repeated files in
  one directory return without a `statfs`. The probe now runs once per
  directory instead of once per file (`record_probe_outcome` keeps both
  layers coherent for the XFS/ZFS `Probable`→confirmed transition).
- Make `try_ficlone` own cleanup of any destination it created, so the caller
  no longer unlinks after every failed clone. The `CowSupport::No`
  short-circuit returns before `File::create`, eliminating the per-file
  ENOENT unlink entirely.

## Measured (x86_64, ext4, 30000×2KB cold, median of 7)

| | statfs/file | unlink/file | small-files median |
|---|---|---|---|
| before | 1 (30000) | 2 (60000) | 2791 ms |
| after  | ~0 (once/dir) | 1 (30000) | **2717 ms** |

Backend selection only — dest tree, `-ai` itemize, stats and exit code are
byte-identical to upstream 3.4.4 (verified) and unchanged from before.
