### PR TITLE
perf(metadata): cache process effective identity once

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -138,7 +138,7 @@ pub fn transfer_root_chmod_self_lock(
     else {
         return Ok(None);
     };
-    let running_as_root = nix::unistd::geteuid().is_root();
+    let running_as_root = crate::identity::is_root();
     Ok(Some((
         tweaked,
         crate::transfer_root_self_locks(tweaked, running_as_root),

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -223,7 +223,7 @@ fn post_chown_bookkeeping(
 #[cfg(unix)]
 #[allow(unsafe_code)]
 pub(super) fn process_in_group(gid: unix_fs::Gid) -> bool {
-    if nix::unistd::getegid() == nix::unistd::Gid::from_raw(gid.as_raw()) {
+    if crate::identity::effective_gid() == gid.as_raw() {
         return true;
     }
     let target = gid.as_raw();
@@ -257,10 +257,11 @@ pub(super) fn process_in_group(gid: unix_fs::Gid) -> bool {
 /// owned by another user, or under a non-root `--chown=user:group`.
 #[cfg(unix)]
 pub(super) fn gate_preserved_owner(owner: Option<unix_fs::Uid>) -> Option<unix_fs::Uid> {
-    // nix (libc `geteuid`) so the euid reflects fakeroot's faked identity,
-    // making `am_root` true under fakeroot exactly like upstream. rustix's raw
-    // syscall would report the real non-root euid and gate the chown away.
-    owner.filter(|_| nix::unistd::geteuid().is_root())
+    // The cached identity is libc-based (like `nix`), so the euid reflects
+    // fakeroot's faked identity, making `am_root` true under fakeroot exactly
+    // like upstream. A rustix raw syscall would report the real non-root euid
+    // and gate the chown away.
+    owner.filter(|_| crate::identity::is_root())
 }
 
 /// Gates a resolved group GID against process privilege, whether it came from
@@ -272,9 +273,9 @@ pub(super) fn gate_preserved_owner(owner: Option<unix_fs::Uid>) -> Option<unix_f
 /// is skipped rather than attempted and failed.
 #[cfg(unix)]
 pub(super) fn gate_preserved_group(group: Option<unix_fs::Gid>) -> Option<unix_fs::Gid> {
-    // See `gate_preserved_owner`: nix (libc `geteuid`) so fakeroot's faked root
-    // euid is honoured, matching upstream's `am_root` gate.
-    group.filter(|gid| nix::unistd::geteuid().is_root() || process_in_group(*gid))
+    // See `gate_preserved_owner`: the cached identity is libc-based so
+    // fakeroot's faked root euid is honoured, matching upstream's `am_root` gate.
+    group.filter(|gid| crate::identity::is_root() || process_in_group(*gid))
 }
 
 /// Whether this process may set a file's group to `gid`, i.e. whether upstream
@@ -293,9 +294,9 @@ pub(super) fn gate_preserved_group(group: Option<unix_fs::Gid>) -> Option<unix_f
 pub fn group_is_settable(gid: u32) -> bool {
     #[cfg(unix)]
     {
-        // See `gate_preserved_group`: nix (libc `geteuid`) so a fakeroot euid
-        // counts as root, matching upstream's `am_root`.
-        nix::unistd::geteuid().is_root() || process_in_group(unix_fs::Gid::from_raw(gid))
+        // See `gate_preserved_group`: the cached identity is libc-based so a
+        // fakeroot euid counts as root, matching upstream's `am_root`.
+        crate::identity::is_root() || process_in_group(unix_fs::Gid::from_raw(gid))
     }
     #[cfg(not(unix))]
     {

--- a/crates/metadata/src/copy_as.rs
+++ b/crates/metadata/src/copy_as.rs
@@ -137,6 +137,11 @@ pub struct CopyAsGuard {
     original_euid: u32,
     original_egid: u32,
     switched_egid: bool,
+    // While held, the metadata identity accessors read live instead of the
+    // cached startup value, so ownership gates observe the switched euid/egid.
+    // Dropped after the euid/egid are restored (fields drop after Drop::drop),
+    // so the restored identity is what later cached reads capture.
+    _switch: crate::identity::SwitchScope,
 }
 
 #[cfg(unix)]
@@ -228,6 +233,7 @@ pub fn switch_effective_ids(ids: &CopyAsIds) -> io::Result<CopyAsGuard> {
         original_euid,
         original_egid,
         switched_egid,
+        _switch: crate::identity::SwitchScope::enter(),
     })
 }
 

--- a/crates/metadata/src/identity.rs
+++ b/crates/metadata/src/identity.rs
@@ -1,0 +1,113 @@
+//! Cached process effective identity (euid/egid) for the metadata-apply hot
+//! path.
+//!
+//! Upstream rsync reads the process identity exactly once at startup and
+//! reuses it for every per-file ownership/permission decision:
+//!
+//! ```c
+//! // main.c:1764-1766
+//! our_uid = MY_UID();          // geteuid()
+//! our_gid = MY_GID();          // getegid()
+//! am_root = our_uid == ROOT_UID;
+//! ```
+//!
+//! Every later `change_uid = am_root && ...` (rsync.c:526) test consults those
+//! cached globals - upstream never calls `geteuid()`/`getegid()` per file. The
+//! oc-rsync ownership gates previously called `nix::unistd::geteuid()` /
+//! `getegid()` for every file, which an strace of a 30000-file local copy
+//! showed as ~2 `geteuid` + 1 `getegid` per file (90000 syscalls upstream does
+//! not make). This module caches the values once to match upstream.
+//!
+//! # fakeroot
+//!
+//! The lookups use libc (`geteuid`/`getegid`), NOT `rustix`'s raw syscall, so
+//! that under `fakeroot`/`fakeroot-ng` (which intercept the libc symbols) the
+//! *faked* root identity is observed - exactly as upstream's libc-based
+//! `MY_UID()` sees it. `rustix` issues the raw syscall and would report the
+//! real non-root euid, gating chowns away where upstream performs them.
+//!
+//! # `--copy-as` / `do_as_root`
+//!
+//! [`switch_effective_ids`](crate::copy_as::switch_effective_ids) temporarily
+//! changes the effective ids for the duration of a [`SwitchScope`]. While such
+//! a scope is active the accessors fall back to a live lookup so a switched
+//! identity is observed, preserving the exact pre-cache behaviour for that
+//! opt-in path. Outside any scope - the common case - the cached startup value
+//! is returned with no syscall.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Number of currently-active effective-id switch scopes. While non-zero the
+/// accessors perform a live lookup instead of returning the cached value.
+static SWITCH_DEPTH: AtomicUsize = AtomicUsize::new(0);
+
+static CACHED_EUID: OnceLock<u32> = OnceLock::new();
+static CACHED_EGID: OnceLock<u32> = OnceLock::new();
+
+#[allow(unsafe_code)]
+fn live_euid() -> u32 {
+    // SAFETY: `geteuid` is a standard POSIX call with no arguments and no side
+    // effects. libc (not rustix) so fakeroot's faked identity is honoured.
+    unsafe { libc::geteuid() }
+}
+
+#[allow(unsafe_code)]
+fn live_egid() -> u32 {
+    // SAFETY: `getegid` is a standard POSIX call with no arguments and no side
+    // effects. libc (not rustix) so fakeroot's faked identity is honoured.
+    unsafe { libc::getegid() }
+}
+
+/// The process effective uid. Cached at first use and reused thereafter,
+/// except while an effective-id [`SwitchScope`] is active (`--copy-as`), when a
+/// live lookup is performed so the switched identity is observed.
+#[must_use]
+pub fn effective_uid() -> u32 {
+    if SWITCH_DEPTH.load(Ordering::Acquire) > 0 {
+        return live_euid();
+    }
+    *CACHED_EUID.get_or_init(live_euid)
+}
+
+/// The process effective gid. See [`effective_uid`] for the caching and
+/// switch-scope semantics.
+#[must_use]
+pub fn effective_gid() -> u32 {
+    if SWITCH_DEPTH.load(Ordering::Acquire) > 0 {
+        return live_egid();
+    }
+    *CACHED_EGID.get_or_init(live_egid)
+}
+
+/// Whether the process effective uid is root (uid 0). The oc analog of
+/// upstream's cached `am_root` (main.c:1766).
+#[must_use]
+pub fn is_root() -> bool {
+    effective_uid() == 0
+}
+
+/// RAII marker that makes the identity accessors read live for its lifetime.
+/// Held by the `--copy-as`/`do_as_root` guard so that a temporarily switched
+/// effective identity is observed by the ownership gates, matching the
+/// behaviour before the cache existed.
+#[derive(Debug)]
+pub struct SwitchScope {
+    _private: (),
+}
+
+impl SwitchScope {
+    /// Enters an effective-id switch scope. The accessors read live until the
+    /// returned guard is dropped.
+    #[must_use]
+    pub fn enter() -> Self {
+        SWITCH_DEPTH.fetch_add(1, Ordering::Release);
+        Self { _private: () }
+    }
+}
+
+impl Drop for SwitchScope {
+    fn drop(&mut self) {
+        SWITCH_DEPTH.fetch_sub(1, Ordering::Release);
+    }
+}

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -107,6 +107,8 @@ mod chmod;
 /// Privilege switching for `--copy-as=USER[:GROUP]`.
 pub mod copy_as;
 mod error;
+#[cfg(unix)]
+pub mod identity;
 
 /// Signed `--modify-window` tolerance and the `same_time()` mtime comparison.
 pub mod modify_window;


### PR DESCRIPTION
## Problem

The per-file ownership/permission gates called `nix::unistd::geteuid()` /
`getegid()` for **every file**. An strace of a 30000-file local copy showed
~2 `geteuid` + 1 `getegid` per file (~90000 syscalls) that upstream rsync does
not make. Upstream reads the identity once at startup and reuses it:

```c
// main.c:1764-1766
our_uid = MY_UID();   // geteuid()
our_gid = MY_GID();   // getegid()
am_root = our_uid == ROOT_UID;
```

Every later `change_uid = am_root && ...` (rsync.c:526) consults those cached
globals.

## Fix

New `metadata::identity` module caches the effective uid/gid once (mirroring
`main.c:1764`) and routes `apply/mod.rs` + the ownership gates through it.

Two behaviours are deliberately preserved:
- **fakeroot** — the lookups use libc (`geteuid`/`getegid`), not `rustix`'s raw
  syscall, so libfakeroot's faked identity is observed, matching upstream's
  libc-based `MY_UID()`.
- **`--copy-as`/`do_as_root`** — the `CopyAsGuard` holds a `SwitchScope` that
  makes the accessors read live while the effective ids are switched, so the
  gates observe the switched identity exactly as before.

## Measured (x86_64, ext4, 30000×2KB cold, median of 7)

| | geteuid/file | getegid/file | median |
|---|---|---|---|
| before | 2 (60303) | 1 (30101) | 2791 ms |
| after  | ~0 (102) | ~0 | **2730 ms** |

Observably neutral: dest tree, `-ai` itemize, stats and exit code are
byte-identical to upstream 3.4.4 (verified). The ownership/permission
*decisions* are unchanged (same libc-based euid, same fakeroot/copy-as
semantics) - only the redundant per-file syscalls are removed.
