### PR TITLE
test: pin client --skip-compress=* never stores -z sender stream

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -274,3 +274,46 @@ fn apply_common_daemon_config(
     }
     server_config.stop_at = config.stop_at();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::SkipCompressList;
+
+    // WHY: `--skip-compress` on a `-z` sender must mirror upstream 3.4.4, where
+    // set_compression()'s per-file suffix lookup is compiled out (`#if 0`, "No
+    // compression algorithms currently allow mid-stream changing of the level.")
+    // and a non-daemon `--skip-compress` is discarded entirely: token.c:182 sets
+    // `f = ""` before building the match list, so the client sender never lowers
+    // its whole-stream deflate level. Even a bare `*` on the client side must NOT
+    // collapse the client sender's zlib stream to store - whole-stream store
+    // (`dont_compress_match_all`) is reachable ONLY through a daemon module's
+    // `dont compress = *` (token.c:206-211, applied server-side in loadparm). If a
+    // future change wired the client's own `--skip-compress=*` into
+    // `dont_compress_match_all`, every `-z --skip-compress=*` push would silently
+    // stop compressing, diverging from upstream's observable wire output. This
+    // pins that a client `-z --skip-compress=*` push keeps compression enabled and
+    // leaves whole-stream store off.
+    #[test]
+    fn client_skip_compress_match_all_never_stores_sender_stream() {
+        let config = ClientConfig::builder()
+            .compress(true)
+            .skip_compress(SkipCompressList::parse("*").expect("`*` parses"))
+            .skip_compress_spec(Some("*".to_owned()))
+            .build();
+
+        let server_config = build_server_config_for_generator(&config, &[], Vec::new())
+            .expect("generator config builds");
+
+        assert!(
+            server_config.flags.compress,
+            "a `-z` push must keep the sender compressing"
+        );
+        assert!(
+            !server_config.connection.dont_compress_match_all,
+            "a client `--skip-compress=*` must not collapse the sender's zlib \
+             stream to store (upstream token.c:182 discards it; whole-stream \
+             store is daemon `dont compress = *` only)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Verifies that `--skip-compress=LIST` (and the built-in default suffix list) is
honored on the `-z` compressing sender exactly as upstream rsync 3.4.4 does, and
adds a focused regression test for the one previously-untested invariant.

## Findings

Reading the upstream C source (`token.c`), the per-file suffix matching in
`set_compression()` is compiled out under `#if 0` ("No compression algorithms
currently allow mid-stream changing of the level."). A single compression stream
spans the whole session, so the level is fixed once at `deflateInit2()`. The
observable effects of the suffix lists in 3.4.4 are therefore:

- **Client `--skip-compress`** is forwarded verbatim to the remote sender on a
  pull (`options.c:2858-2860`), and otherwise discarded for the local sender's
  own match list (`token.c:182` sets `f = ""` for a non-daemon transfer). It
  never switches per-file framing and never lowers the client sender's level.
- **Daemon module `dont compress = *`** is the only live effect: a bare `*`
  collapses the whole zlib stream to store (level 0) at init
  (`token.c:206-211`, `token.c:378`); zstd/lz4 are unaffected (`token.c:748`).

The implementation already mirrors this precisely:

- CLI parses `--skip-compress` and forwards the raw spec on a pull only
  (already covered by tests in `remote/invocation/tests.rs`).
- The `-z` sender frames every file with the negotiated codec; the suffix list
  never switches framing per file (already covered by
  `present_encoder_emits_deflated_framing_not_plain_tokens` and the
  `whole_stream_*` tests in `generator/delta.rs`).
- Whole-stream store is driven solely by `dont_compress_match_all`, set only
  from a daemon module's `dont compress = *`.

No behavior change was required.

## Test

Adds `client_skip_compress_match_all_never_stores_sender_stream`, which builds a
`-z --skip-compress=*` client push config and asserts the generator
(`ServerConfig`) keeps `flags.compress` on and leaves
`connection.dont_compress_match_all` **off**. This pins the `token.c:182`
invariant that a client-supplied `*` never collapses the client sender's own
zlib stream to store (whole-stream store is a daemon-side `dont compress = *`
concern only). Without this guard, wiring a client `--skip-compress=*` into
`dont_compress_match_all` would silently stop every such push from compressing,
diverging from upstream's observable wire output.

## Verification

- `cargo-fmt --all`
- `cargo check -p compress -p transfer -p cli --all-features` - clean
- `cargo nextest run -p core -E 'test(client_skip_compress_match_all_never_stores_sender_stream)'` - 1 passed
