### PR TITLE
refactor: remove inert consecutive-match algorithm

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -224,17 +224,6 @@ fn merge_copy_runs(source: &[u8], mut runs: Vec<CopyRun>, block_len: usize) -> D
 #[derive(Clone, Debug)]
 pub struct DeltaGenerator {
     buffer_len: usize,
-    /// Consecutive-match gating threshold (zsync `seq_matches`).
-    ///
-    /// `1` (default) reproduces upstream's accept-on-first-match behaviour and
-    /// leaves the scan byte-for-byte unchanged. `2` engages the oc-only
-    /// consecutive-match extension: a block match is only trusted (emitted as a
-    /// Copy) when it belongs to a run of at least two consecutive matching
-    /// blocks; a lone match is demoted to a Literal of its own source bytes.
-    /// The threshold is set to `2` only when the mutually negotiated
-    /// `CAP_CONSECUTIVE_MATCH` bit is present, which is also the sole condition
-    /// under which the receiver halves the per-block strong-sum length.
-    consecutive_match_needed: u8,
     /// Enforces upstream's in-place ("updating basis file") monotonicity guard.
     ///
     /// When `true` the scan mirrors `match.c:211` (`updating_basis_file`): a
@@ -260,7 +249,6 @@ impl DeltaGenerator {
     pub const fn new() -> Self {
         Self {
             buffer_len: DEFAULT_BUFFER_LEN,
-            consecutive_match_needed: 1,
             updating_basis_file: false,
             #[cfg(any(test, feature = "bench-internal"))]
             prune_matched: true,
@@ -271,17 +259,6 @@ impl DeltaGenerator {
     #[must_use]
     pub fn with_buffer_len(mut self, buffer_len: usize) -> Self {
         self.buffer_len = buffer_len.max(1);
-        self
-    }
-
-    /// Sets the consecutive-match gating threshold (zsync `seq_matches`).
-    ///
-    /// Values are clamped to `>= 1`. Only `1` (default, upstream-identical) and
-    /// `2` (oc consecutive-match extension) are meaningful; any value `>= 2`
-    /// engages the gated scan.
-    #[must_use]
-    pub fn with_consecutive_match_needed(mut self, needed: u8) -> Self {
-        self.consecutive_match_needed = needed.max(1);
         self
     }
 
@@ -357,9 +334,6 @@ impl DeltaGenerator {
         reader: R,
         index: &DeltaSignatureIndex,
     ) -> io::Result<DeltaScript> {
-        if self.consecutive_match_needed >= 2 {
-            return self.generate_gated(reader, index);
-        }
         #[cfg(any(test, feature = "bench-internal"))]
         let prune_matched = self.prune_matched;
         #[cfg(not(any(test, feature = "bench-internal")))]
@@ -738,200 +712,6 @@ impl DeltaGenerator {
         Ok(DeltaScript::new(tokens, total_bytes, literal_bytes))
     }
 
-    /// Consecutive-match (zsync `seq_matches=2`) gated delta scan.
-    ///
-    /// This path is engaged only when the mutually negotiated
-    /// `CAP_CONSECUTIVE_MATCH` capability is present (both peers are oc and both
-    /// opted in), which is the same condition under which the receiver halves
-    /// the per-block strong-sum length. Halving the strong sum roughly doubles
-    /// the per-block false-alarm probability; requiring a matching neighbour
-    /// before trusting a block restores the effective collision resistance,
-    /// mirroring zsync's `seq_matches` heuristic (`librcksum/rsum.c`).
-    ///
-    /// A run of consecutive matching source blocks is buffered together with
-    /// each block's source bytes. When the run ends:
-    /// - length >= 2: every block is emitted as a `Copy` (trusted).
-    /// - length == 1: the lone block is demoted to a `Literal` of its own
-    ///   source bytes.
-    ///
-    /// Demoting a lone match to a literal is byte-exact regardless of whether
-    /// the match was a genuine block or a halved-checksum false alarm, so
-    /// reconstruction is always correct. As with upstream's short phase-1
-    /// checksums, the receiver's whole-file checksum and phase-2 full-checksum
-    /// redo remain the ultimate backstop against any residual collision.
-    fn generate_gated<R: Read>(
-        &self,
-        mut reader: R,
-        index: &DeltaSignatureIndex,
-    ) -> io::Result<DeltaScript> {
-        let block_len = index.block_length();
-        let mut window = RingBuffer::with_capacity(block_len);
-        let mut pending_literals = Vec::with_capacity(block_len);
-        let mut rolling = RollingChecksum::new();
-        let mut tokens: Vec<DeltaToken> = Vec::new();
-        let mut total_bytes = 0u64;
-        let mut literal_bytes = 0u64;
-
-        let mut matched_blocks = MatchedBlocks::with_block_count(index.block_count());
-        index.reset_consumed();
-
-        let mut buffer = vec![0u8; self.buffer_len.max(block_len)];
-        let mut buffer_pos = 0usize;
-        let mut buffer_len = 0usize;
-
-        // Source cursor (window-start offset), tracked so the in-place guard can
-        // compare each candidate's basis offset against the write position.
-        let mut offset = 0u64;
-
-        // Flushes accumulated literal bytes as a single token, keeping the
-        // total/literal accounting in step. Returns nothing; mutates in place.
-        macro_rules! flush_pending {
-            () => {
-                if !pending_literals.is_empty() {
-                    literal_bytes += pending_literals.len() as u64;
-                    total_bytes += pending_literals.len() as u64;
-                    let filled =
-                        std::mem::replace(&mut pending_literals, Vec::with_capacity(block_len));
-                    tokens.push(DeltaToken::Literal(filled));
-                }
-            };
-        }
-
-        loop {
-            if buffer_pos == buffer_len {
-                buffer_len = reader.read(&mut buffer)?;
-                buffer_pos = 0;
-                if buffer_len == 0 {
-                    break;
-                }
-            }
-
-            let byte = buffer[buffer_pos];
-            buffer_pos += 1;
-
-            let evicted = window.push_back(byte);
-            if let Some(outgoing_byte) = evicted {
-                rolling
-                    .roll(outgoing_byte, byte)
-                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-                pending_literals.push(outgoing_byte);
-                offset += 1;
-            } else {
-                rolling.update_byte(byte);
-            }
-
-            if !window.is_full() {
-                continue;
-            }
-
-            let digest = rolling.digest();
-            let (first, second) = window.as_slices();
-            // upstream: match.c:211 - under --inplace, suppress a candidate whose
-            // basis offset precedes the write cursor so it demotes to a literal.
-            let matched = index
-                .find_match_slices_filtered(digest, first, second, Some(&matched_blocks))
-                .filter(|&idx| self.basis_offset_ok(index, block_len, idx, offset));
-
-            let Some(mut match_idx) = matched else {
-                continue;
-            };
-
-            // A run begins: flush any literals accumulated before it.
-            flush_pending!();
-
-            // Buffer the run of consecutive matching blocks by basis index.
-            // Every block the loop extends spans exactly `block_len` source
-            // bytes (the run only grows on a full next block), so a trusted run
-            // (>= 2) reconstructs from the index alone and never needs a
-            // per-block byte copy. Only a lone match is demoted to a Literal,
-            // and that needs the source bytes - but the window is cleared before
-            // the next block, so the first block's bytes are captured once,
-            // up front. This drops the discarded per-block `Vec` allocation the
-            // trusted path used to make (one copy per matched block).
-            let mut run: Vec<u64> = Vec::new();
-            let mut lone_src: Vec<u8> = Vec::new();
-
-            loop {
-                let basis_idx = index.block(match_idx).index();
-                if run.is_empty() {
-                    let (s1, s2) = window.as_slices();
-                    lone_src.reserve_exact(block_len);
-                    lone_src.extend_from_slice(s1);
-                    lone_src.extend_from_slice(s2);
-                }
-                run.push(basis_idx);
-
-                matched_blocks.mark_matched(match_idx);
-                index.mark_consumed(match_idx as u32);
-
-                window.clear();
-                rolling.reset();
-                // The matched block consumed `block_len` source bytes; advance
-                // the cursor to the next window start for the guard below.
-                offset += block_len as u64;
-
-                let mut filled = 0usize;
-                while filled < block_len {
-                    if buffer_pos == buffer_len {
-                        buffer_len = reader.read(&mut buffer)?;
-                        buffer_pos = 0;
-                        if buffer_len == 0 {
-                            break;
-                        }
-                    }
-                    let take = (buffer_len - buffer_pos).min(block_len - filled);
-                    window.extend_from_slice(&buffer[buffer_pos..buffer_pos + take]);
-                    filled += take;
-                    buffer_pos += take;
-                }
-
-                if filled < block_len {
-                    // EOF before a full next block: the remaining window bytes
-                    // (if any) drain as literals after the run flush.
-                    break;
-                }
-
-                let (f, s) = window.as_slices();
-                rolling.update(f);
-                if !s.is_empty() {
-                    rolling.update(s);
-                }
-                let adj_digest = rolling.digest();
-                let adj = index
-                    .find_match_slices_filtered(adj_digest, f, s, Some(&matched_blocks))
-                    .filter(|&idx| self.basis_offset_ok(index, block_len, idx, offset));
-                match adj {
-                    Some(next_idx) => match_idx = next_idx,
-                    None => break,
-                }
-            }
-
-            // Flush the run: trusted runs (>= 2) become Copy tokens; a lone
-            // match is demoted to a Literal of its own source bytes.
-            if run.len() >= 2 {
-                for idx in run {
-                    total_bytes += block_len as u64;
-                    tokens.push(DeltaToken::Copy {
-                        index: idx,
-                        len: block_len,
-                    });
-                }
-            } else if !run.is_empty() {
-                literal_bytes += lone_src.len() as u64;
-                total_bytes += lone_src.len() as u64;
-                tokens.push(DeltaToken::Literal(lone_src));
-            }
-        }
-
-        // Drain any residual window bytes as literals.
-        while let Some(byte) = window.pop_front() {
-            pending_literals.push(byte);
-        }
-        flush_pending!();
-
-        Ok(DeltaScript::new(tokens, total_bytes, literal_bytes))
-    }
-
     /// Generates a [`DeltaScript`] by scanning `source` in parallel across up
     /// to `max_chunks` overlapping stripes, reassembled into the single-pass
     /// token stream.
@@ -989,15 +769,6 @@ impl DeltaGenerator {
         index: &DeltaSignatureIndex,
         max_chunks: usize,
     ) -> io::Result<DeltaScript> {
-        // The consecutive-match extension needs a single sequential pass to
-        // reason about cross-range block adjacency, so route it through the
-        // gated scan rather than the parallel range split. This path is only
-        // ever taken on the wire sender (never local copy), which already uses
-        // the sequential `generate`, so no parallelism is lost in practice.
-        if self.consecutive_match_needed >= 2 {
-            return self.generate_gated(Cursor::new(source), index);
-        }
-
         // The in-place monotonicity guard (`match.c:211`) compares each match's
         // basis offset against the global source cursor. Parallel stripes only
         // know a stripe-local cursor, so route the guarded scan through the
@@ -1487,154 +1258,6 @@ mod tests {
     }
 
     #[test]
-    fn gated_two_consecutive_blocks_are_both_copied() {
-        // seq_matches=2: a run of two consecutive matching blocks is trusted,
-        // so both are emitted as Copy tokens.
-        let basis: Vec<u8> = (0..10_000).map(|b| (b % 251) as u8).collect();
-        let index = build_index(&basis);
-        let block_len = index.block_length();
-        let input = basis[..2 * block_len].to_vec();
-
-        let generator = DeltaGenerator::new().with_consecutive_match_needed(2);
-        let script = generator.generate(&input[..], &index).expect("script");
-
-        let copies = script
-            .tokens()
-            .iter()
-            .filter(|t| matches!(t, DeltaToken::Copy { .. }))
-            .count();
-        assert_eq!(copies, 2, "both consecutive blocks must be copied");
-        assert_eq!(reconstruct(&basis, &index, &script), input);
-    }
-
-    #[test]
-    fn gated_trusted_run_emits_exact_block_len_copy_tokens() {
-        // Pins the exact Copy token stream for a trusted (>= 2) consecutive run.
-        // The gated flush tracks basis indices and reconstructs each Copy length
-        // from `block_len` instead of materializing (then discarding) every
-        // block's source bytes; this golden locks that the emitted tokens - one
-        // `block_len` Copy per basis block, in order - stay byte-identical to the
-        // materialized baseline, so the wire output cannot silently drift.
-        const BLOCK_LEN: u32 = 512;
-        let basis = pseudo_random(4 * BLOCK_LEN as usize, 0x7eed_1234);
-        let index = build_index_fixed(&basis, BLOCK_LEN);
-        assert!(
-            !index.has_duplicate_blocks(),
-            "run indices are only deterministic on a duplicate-free basis"
-        );
-        let bl = index.block_length();
-        let input = basis[..3 * bl].to_vec();
-
-        let script = DeltaGenerator::new()
-            .with_consecutive_match_needed(2)
-            .generate(&input[..], &index)
-            .expect("script");
-
-        let expected = [
-            DeltaToken::Copy { index: 0, len: bl },
-            DeltaToken::Copy { index: 1, len: bl },
-            DeltaToken::Copy { index: 2, len: bl },
-        ];
-        assert_eq!(
-            script.tokens(),
-            expected.as_slice(),
-            "trusted run must emit one block_len Copy per basis block, in order"
-        );
-        assert_eq!(script.literal_bytes(), 0);
-        assert_eq!(script.total_bytes(), input.len() as u64);
-        assert_eq!(reconstruct(&basis, &index, &script), input);
-    }
-
-    #[test]
-    fn gated_lone_match_is_demoted_to_literal() {
-        // seq_matches=2: a single matching block flanked by non-matching data
-        // has no matching neighbour, so it must NOT be emitted as a Copy - it is
-        // demoted to a Literal and reconstruction stays byte-exact.
-        let basis: Vec<u8> = (0..10_000).map(|b| (b % 251) as u8).collect();
-        let index = build_index(&basis);
-        let block_len = index.block_length();
-
-        // 0xAA never appears in the basis (values are b % 251, and 0xAA=170<251
-        // does appear... use a byte guaranteed absent). basis holds 0..=250, so
-        // 251..=255 are absent; use 0xFF.
-        let filler = vec![0xFFu8; block_len];
-        let mut input = Vec::new();
-        input.extend_from_slice(&filler);
-        input.extend_from_slice(&basis[..block_len]); // exactly one basis block
-        input.extend_from_slice(&filler);
-
-        let generator = DeltaGenerator::new().with_consecutive_match_needed(2);
-        let script = generator.generate(&input[..], &index).expect("script");
-
-        let copies = script
-            .tokens()
-            .iter()
-            .filter(|t| matches!(t, DeltaToken::Copy { .. }))
-            .count();
-        assert_eq!(copies, 0, "a lone match must be demoted to a literal");
-        assert_eq!(reconstruct(&basis, &index, &script), input);
-    }
-
-    #[test]
-    fn gated_default_needed_one_matches_ungated_output() {
-        // Threshold 1 (default) must be byte-for-byte identical to the ungated
-        // generate: the gated path is never entered.
-        let basis: Vec<u8> = (0..10_000).map(|b| (b % 251) as u8).collect();
-        let index = build_index(&basis);
-        let block_len = index.block_length();
-        let mut input = basis[..3 * block_len].to_vec();
-        input.extend_from_slice(b"tail");
-
-        let ungated = DeltaGenerator::new().generate(&input[..], &index).unwrap();
-        let needed_one = DeltaGenerator::new()
-            .with_consecutive_match_needed(1)
-            .generate(&input[..], &index)
-            .unwrap();
-
-        assert_eq!(ungated.tokens().len(), needed_one.tokens().len());
-        assert_eq!(ungated.total_bytes(), needed_one.total_bytes());
-        assert_eq!(ungated.literal_bytes(), needed_one.literal_bytes());
-    }
-
-    #[test]
-    fn gated_reconstructs_modified_source_byte_exact() {
-        // Broad byte-exactness check for the gated scan over a mix of copies,
-        // lone matches and literal regions.
-        let basis = pseudo_random(512 * 1024, 0x00c0_ffee);
-        let index = build_index(&basis);
-        let block_len = index.block_length();
-
-        let mut source = basis.clone();
-        for off in [37usize, 5000, 100_000, source.len() - 40] {
-            source[off] ^= 0xff;
-        }
-        // Splice a lone unmatched region and an isolated single basis block.
-        let mut full = vec![0xFFu8; block_len + 13];
-        full.extend_from_slice(&source);
-        full.extend_from_slice(&basis[block_len..2 * block_len]);
-        full.extend_from_slice(&vec![0xFEu8; block_len + 7]);
-
-        let generator = DeltaGenerator::new().with_consecutive_match_needed(2);
-        let script = generator.generate(&full[..], &index).expect("script");
-        assert_eq!(reconstruct(&basis, &index, &script), full);
-        assert_eq!(script.total_bytes(), full.len() as u64);
-    }
-
-    #[test]
-    fn gated_empty_and_short_inputs() {
-        let basis = vec![0u8; 4096];
-        let index = build_index(&basis);
-        let generator = DeltaGenerator::new().with_consecutive_match_needed(2);
-
-        let empty = generator.generate(&[][..], &index).expect("empty");
-        assert!(empty.tokens().is_empty());
-        assert_eq!(empty.total_bytes(), 0);
-
-        let short = generator.generate(&b"hi"[..], &index).expect("short");
-        assert_eq!(reconstruct(&basis, &index, &short), b"hi");
-    }
-
-    #[test]
     fn generate_chunked_matches_after_prior_pruned_generate() {
         // Regression: the matcher consults the shared `consumed` bitset on
         // every probe. A pruned generate() leaves blocks marked consumed; if
@@ -1859,44 +1482,6 @@ mod tests {
         );
         // Data is still transferred: reconstruction is byte-identical.
         assert_eq!(reconstruct(&basis, &index, &inplace), source);
-    }
-
-    #[test]
-    fn updating_basis_file_guard_holds_in_gated_scan() {
-        // Four distinct full blocks (sliced from one random stream); source runs
-        // [B2,B3] then [B0,B1] so the second run references basis offsets behind
-        // the write cursor.
-        let block_len = 64u32;
-        let bl = block_len as usize;
-        let basis = pseudo_random(4 * bl, 0x4741_5444);
-        let index = build_index_fixed(&basis, block_len);
-
-        let mut source = basis[2 * bl..4 * bl].to_vec();
-        source.extend_from_slice(&basis[0..2 * bl]);
-
-        // Gated scan without the guard trusts the full consecutive run and emits
-        // the backward blocks as Copies - unsafe for an in-place receiver.
-        let unguarded = DeltaGenerator::new()
-            .with_consecutive_match_needed(2)
-            .generate(Cursor::new(&source[..]), &index)
-            .expect("unguarded");
-        assert!(
-            !copies_are_monotonic(&unguarded, bl),
-            "gated scan without the guard must emit the backward Copies"
-        );
-        assert_eq!(reconstruct(&basis, &index, &unguarded), source);
-
-        // With the guard the backward run is suppressed to literals.
-        let guarded = DeltaGenerator::new()
-            .with_consecutive_match_needed(2)
-            .with_updating_basis_file(true)
-            .generate(Cursor::new(&source[..]), &index)
-            .expect("guarded");
-        assert!(
-            copies_are_monotonic(&guarded, bl),
-            "gated inplace scan must never read behind the write cursor"
-        );
-        assert_eq!(reconstruct(&basis, &index, &guarded), source);
     }
 
     #[test]

--- a/crates/protocol/src/compatibility/flags.rs
+++ b/crates/protocol/src/compatibility/flags.rs
@@ -49,24 +49,6 @@ impl CompatibilityFlags {
     /// File-list entries support id0 names (`CF_ID0_NAMES`).
     pub const ID0_NAMES: Self = Self::new(1 << 8);
 
-    /// Private oc-only extension: consecutive-match gating with a halved
-    /// per-block strong checksum (`CAP_CONSECUTIVE_MATCH`).
-    ///
-    /// This is NOT an upstream rsync flag. It occupies a high private bit
-    /// (`0x0200_0000`) deliberately kept out of `Self::KNOWN_MASK`, the
-    /// default-advertised set, and [`Self::ALL_KNOWN`]. compat_flags is a
-    /// varint on the wire (upstream `compat.c:741` `read_varint`), and upstream
-    /// tolerates unknown bits by ignoring them, so this private bit transmits
-    /// harmlessly to a stock peer and is masked away by the negotiation AND
-    /// unless BOTH peers are oc AND both opted in.
-    ///
-    /// Data-integrity invariant: this bit is the sole gate for shrinking the
-    /// per-file strong-sum length (see [`effective_s2length`]). When it is
-    /// absent from the mutually negotiated flags the strong sum stays at full
-    /// length, byte-identical to upstream. It must never be added to
-    /// `KNOWN_MASK` or advertised unconditionally.
-    pub const CONSECUTIVE_MATCH: Self = Self::new(0x0200_0000);
-
     /// Bitfield containing every compatibility flag recognised by this crate.
     pub const ALL_KNOWN: Self = Self::new(Self::KNOWN_MASK);
 
@@ -235,36 +217,6 @@ impl CompatibilityFlags {
             }
             Err(err) => Err(err),
         }
-    }
-}
-
-/// Returns the strong-sum length to use for a file signature given the
-/// mutually negotiated compatibility flags.
-///
-/// This is the single data-integrity choke-point for the consecutive-match
-/// extension (`CAP_CONSECUTIVE_MATCH`). It returns `base_len` unchanged unless
-/// `negotiated` contains [`CompatibilityFlags::CONSECUTIVE_MATCH`], in which
-/// case it returns the halved length (floored at 1). Halving the per-block
-/// strong sum is only safe when the sender simultaneously applies
-/// seq_matches=2 gating, and both behaviours are bound to this exact same
-/// mutual bit.
-///
-/// # Iron invariant
-///
-/// `negotiated` is the result of the negotiation AND (`my_advertised &
-/// peer_advertised`). The private [`CompatibilityFlags::CONSECUTIVE_MATCH`] bit
-/// is only ever set by an oc peer that opted in, so the AND can only retain it
-/// when BOTH peers are oc AND both opted in. Against any upstream rsync (which
-/// never advertises the bit) or any oc peer without the opt-in, the AND clears
-/// the bit and this function returns `base_len` verbatim - byte-identical to
-/// upstream. There is deliberately no other code path that shrinks the
-/// strong-sum length.
-#[must_use]
-pub fn effective_s2length(negotiated: CompatibilityFlags, base_len: u8) -> u8 {
-    if negotiated.contains(CompatibilityFlags::CONSECUTIVE_MATCH) {
-        (base_len / 2).max(1)
-    } else {
-        base_len
     }
 }
 
@@ -743,64 +695,5 @@ mod tests {
         let flags = CompatibilityFlags::INC_RECURSE;
         let cloned = flags;
         assert_eq!(flags, cloned);
-    }
-
-    #[test]
-    fn consecutive_match_is_high_private_bit() {
-        assert_eq!(CompatibilityFlags::CONSECUTIVE_MATCH.bits(), 0x0200_0000);
-    }
-
-    #[test]
-    fn consecutive_match_not_in_known_mask_or_all_known() {
-        // The private extension must never be advertised as a standard flag.
-        assert_eq!(CompatibilityFlags::KNOWN_MASK & 0x0200_0000, 0);
-        assert!(!CompatibilityFlags::ALL_KNOWN.contains(CompatibilityFlags::CONSECUTIVE_MATCH));
-        // Being outside KNOWN_MASK, it reads as an "unknown" (future) bit,
-        // which is exactly how upstream tolerates it.
-        assert!(CompatibilityFlags::CONSECUTIVE_MATCH.has_unknown_bits());
-    }
-
-    #[test]
-    fn consecutive_match_survives_varint_roundtrip() {
-        // A high private bit must round-trip through the varint codec so the
-        // negotiated value the sender reads still carries the capability.
-        let flags = CompatibilityFlags::INC_RECURSE | CompatibilityFlags::CONSECUTIVE_MATCH;
-        let mut encoded = Vec::new();
-        flags.write_to(&mut encoded).unwrap();
-        let decoded = CompatibilityFlags::read_from(&mut encoded.as_slice()).unwrap();
-        assert_eq!(decoded, flags);
-        assert!(decoded.contains(CompatibilityFlags::CONSECUTIVE_MATCH));
-    }
-
-    #[test]
-    fn mutual_and_only_retains_cap_when_both_advertise() {
-        let cap = CompatibilityFlags::CONSECUTIVE_MATCH;
-        // Both advertise -> retained.
-        assert!((cap & cap).contains(cap));
-        // Only one side (peer is upstream, advertises nothing) -> cleared.
-        let peer_upstream = CompatibilityFlags::INC_RECURSE;
-        assert!(!(cap & peer_upstream).contains(cap));
-        assert!(!(peer_upstream & cap).contains(cap));
-    }
-
-    #[test]
-    fn effective_s2length_full_without_cap() {
-        // Iron invariant: no CAP bit -> full length verbatim, for every base.
-        let no_cap = CompatibilityFlags::INC_RECURSE | CompatibilityFlags::SAFE_FILE_LIST;
-        for base in 1u8..=20 {
-            assert_eq!(effective_s2length(no_cap, base), base);
-        }
-        assert_eq!(effective_s2length(CompatibilityFlags::EMPTY, 16), 16);
-    }
-
-    #[test]
-    fn effective_s2length_halved_with_cap() {
-        let with_cap = CompatibilityFlags::INC_RECURSE | CompatibilityFlags::CONSECUTIVE_MATCH;
-        assert_eq!(effective_s2length(with_cap, 16), 8);
-        assert_eq!(effective_s2length(with_cap, 4), 2);
-        assert_eq!(effective_s2length(with_cap, 3), 1);
-        // Never drops below 1 (NonZeroU8 downstream).
-        assert_eq!(effective_s2length(with_cap, 1), 1);
-        assert_eq!(effective_s2length(with_cap, 2), 1);
     }
 }

--- a/crates/protocol/src/compatibility/mod.rs
+++ b/crates/protocol/src/compatibility/mod.rs
@@ -30,7 +30,7 @@ mod flags;
 mod iter;
 mod known;
 
-pub use self::flags::{CompatibilityFlags, effective_s2length};
+pub use self::flags::CompatibilityFlags;
 pub use self::iter::KnownCompatibilityFlagsIter;
 pub use self::known::{KnownCompatibilityFlag, ParseKnownCompatibilityFlagError};
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -160,7 +160,7 @@ pub mod xattr;
 
 pub use compatibility::{
     CompatibilityFlags, KnownCompatibilityFlag, KnownCompatibilityFlagsIter,
-    ParseKnownCompatibilityFlagError, effective_s2length,
+    ParseKnownCompatibilityFlagError,
 };
 pub use envelope::{
     EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, LogCode, LogCodeConversionError,

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -339,13 +339,10 @@ pub fn generate_delta_from_signature<R: Read>(
     source: R,
     config: DeltaGeneratorConfig<'_>,
 ) -> io::Result<DeltaScript> {
-    let needed = consecutive_match_needed(&config);
     let updating_basis_file = config.updating_basis_file;
     let index = build_signature_index(config)?;
 
-    let generator = DeltaGenerator::new()
-        .with_consecutive_match_needed(needed)
-        .with_updating_basis_file(updating_basis_file);
+    let generator = DeltaGenerator::new().with_updating_basis_file(updating_basis_file);
     generator.generate(source, &index).map_err(|e| {
         io::Error::other(format!(
             "delta generation failed: {e} {}{}",
@@ -396,18 +393,10 @@ pub fn generate_delta_from_signature_chunked(
     config: DeltaGeneratorConfig<'_>,
     max_chunks: usize,
 ) -> io::Result<DeltaScript> {
-    // Carry the negotiated consecutive-match threshold onto the parallel path:
-    // when the mutual CAP_CONSECUTIVE_MATCH bit is set the receiver has halved
-    // the strong-sum length, so the sender must apply seq_matches=2 gating here
-    // too. `generate_chunked` routes needed >= 2 through the sequential gated
-    // scan, so the parallel opt-in stays wire-transparent under the bit.
-    let needed = consecutive_match_needed(&config);
     let updating_basis_file = config.updating_basis_file;
     let index = build_signature_index(config)?;
 
-    let generator = DeltaGenerator::new()
-        .with_consecutive_match_needed(needed)
-        .with_updating_basis_file(updating_basis_file);
+    let generator = DeltaGenerator::new().with_updating_basis_file(updating_basis_file);
     let result = if index.has_duplicate_blocks() {
         // Duplicate-content basis: the prune-off parallel scan would diverge
         // from the pruned sequential wire bytes, so keep the sequential path.
@@ -511,26 +500,6 @@ fn build_signature_index(config: DeltaGeneratorConfig<'_>) -> io::Result<DeltaSi
             ),
         )
     })
-}
-
-/// Derives the zsync consecutive-match gating threshold (`seq_matches`) from the
-/// mutually negotiated compat flags.
-///
-/// Returns `2` only when the private `CAP_CONSECUTIVE_MATCH` bit is present -
-/// the exact same condition under which the receiver halved the per-block
-/// strong-sum length carried in `config.strong_sum_length`. The gating
-/// compensates for the shorter, weaker checksum; the two are bound to one
-/// negotiated bit so they can never diverge. Absent the bit (any upstream peer,
-/// or no opt-in) the threshold stays at `1` and the scan is upstream-identical.
-fn consecutive_match_needed(config: &DeltaGeneratorConfig<'_>) -> u8 {
-    if config
-        .compat_flags
-        .is_some_and(|f| f.contains(protocol::CompatibilityFlags::CONSECUTIVE_MATCH))
-    {
-        2
-    } else {
-        1
-    }
 }
 
 /// Computes upstream's per-file `updating_basis_file` flag (`sender.c:337`).

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -108,12 +108,6 @@ pub struct BasisFileConfig<'a> {
     pub checksum_algorithm: engine::signature::SignatureAlgorithm,
     /// When true, skip basis file search entirely (upstream `--whole-file`).
     pub whole_file: bool,
-    /// Mutually negotiated compatibility flags. Only the private
-    /// [`protocol::CompatibilityFlags::CONSECUTIVE_MATCH`] bit is consulted
-    /// here, to decide whether the per-block strong-sum length is halved (see
-    /// [`protocol::effective_s2length`]). `None` (local copy / no negotiation)
-    /// leaves the strong sum at full length, byte-identical to upstream.
-    pub compat_flags: Option<protocol::CompatibilityFlags>,
 }
 
 /// Configuration for generating a signature from a basis file.
@@ -129,8 +123,6 @@ struct SignatureGenerationConfig {
     checksum_length: NonZeroU8,
     /// Algorithm for strong checksums.
     checksum_algorithm: engine::signature::SignatureAlgorithm,
-    /// Mutually negotiated compatibility flags (see [`BasisFileConfig::compat_flags`]).
-    compat_flags: Option<protocol::CompatibilityFlags>,
 }
 
 impl SignatureGenerationConfig {
@@ -140,7 +132,6 @@ impl SignatureGenerationConfig {
             protocol: config.protocol,
             checksum_length: config.checksum_length,
             checksum_algorithm: config.checksum_algorithm,
-            compat_flags: config.compat_flags,
         }
     }
 }
@@ -388,9 +379,7 @@ fn generate_basis_signature(
     // default 16-byte digests (MD5, MD4, XXH3-128) this is a no-op and the
     // SumHead stays byte-identical to upstream; a short digest (XXH64 / XXH3-64 =
     // 8 bytes) bounds s2length so we never write a zero-padded strong sum wider
-    // than the checksum the sender expects. This runs before the private
-    // CAP_CONSECUTIVE_MATCH halving below, mirroring upstream's order (cap in
-    // sum_sizes_sqroot, then any extension).
+    // than the checksum the sender expects.
     // upstream: generator.c:705 sum_sizes_sqroot() `max_s2length`,
     // checksum.c:214 csum_len_for_type().
     let digest_len =
@@ -403,33 +392,6 @@ fn generate_basis_signature(
     let layout = match calculate_signature_layout(params) {
         Ok(layout) => layout,
         Err(_) => return BasisFileResult::EMPTY,
-    };
-
-    // Iron invariant choke-point: the per-block strong-sum length is shrunk
-    // here, and ONLY here, and ONLY when the mutually negotiated compat flags
-    // carry the private CAP_CONSECUTIVE_MATCH bit. That bit can only survive the
-    // negotiation AND when both peers are oc and both opted in, in which case
-    // the sender applies seq_matches=2 gating to compensate for the shorter
-    // checksum. Against any upstream peer, or without the opt-in, the mutual bit
-    // is absent and `effective_s2length` returns the full length verbatim,
-    // yielding a SumHead byte-identical to upstream.
-    let layout = {
-        let base_len = layout.strong_sum_length().get();
-        let negotiated = config
-            .compat_flags
-            .unwrap_or(protocol::CompatibilityFlags::EMPTY);
-        let eff_len = protocol::effective_s2length(negotiated, base_len);
-        if eff_len == base_len {
-            layout
-        } else {
-            let eff_nz = NonZeroU8::new(eff_len).expect("effective_s2length floors at 1");
-            SignatureLayout::from_raw_parts(
-                layout.block_length(),
-                layout.remainder(),
-                layout.block_count(),
-                eff_nz,
-            )
-        }
     };
 
     let parallel = parallel_checksum_enabled();
@@ -951,7 +913,6 @@ mod tests {
             protocol: ProtocolVersion::NEWEST,
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
-            compat_flags: None,
         };
 
         // Production path (windowed BufReader over the basis file).
@@ -1019,7 +980,6 @@ mod tests {
             protocol: ProtocolVersion::NEWEST,
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
-            compat_flags: None,
         };
 
         // Open the basis exactly as the live path does, then let "another
@@ -1086,7 +1046,6 @@ mod tests {
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
-            compat_flags: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1139,7 +1098,6 @@ mod tests {
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
-            compat_flags: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1181,7 +1139,6 @@ mod tests {
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
-            compat_flags: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1257,7 +1214,6 @@ mod tests {
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
-            compat_flags: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1328,7 +1284,6 @@ mod tests {
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
-            compat_flags: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1388,7 +1343,6 @@ mod tests {
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
-            compat_flags: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1448,7 +1402,6 @@ mod tests {
             checksum_algorithm: SignatureAlgorithm::Md4,
             // Not --whole-file: the redo path must still search for a basis.
             whole_file: false,
-            compat_flags: None,
         };
 
         let strong_len = |result: &BasisFileResult| -> u8 {
@@ -1490,73 +1443,6 @@ mod tests {
     }
 
     #[test]
-    fn consecutive_match_cap_halves_strong_sum_length() {
-        use std::io::Write;
-
-        let data: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let path = tmp.path().join("basis.bin");
-        {
-            let mut f = fs::File::create(&path).expect("create");
-            f.write_all(&data).expect("write");
-            f.flush().expect("flush");
-        }
-
-        let strong_len = |cfg: SignatureGenerationConfig| -> u8 {
-            generate_basis_signature(
-                fast_io::open_basis_nofollow(&path).expect("open"),
-                data.len() as u64,
-                path.clone(),
-                protocol::FnameCmpType::Fname,
-                None,
-                cfg,
-            )
-            .signature
-            .as_ref()
-            .expect("signature")
-            .layout()
-            .strong_sum_length()
-            .get()
-        };
-
-        let base = SignatureGenerationConfig {
-            protocol: ProtocolVersion::NEWEST,
-            checksum_length: NonZeroU8::new(16).unwrap(),
-            checksum_algorithm: SignatureAlgorithm::Md4,
-            compat_flags: None,
-        };
-
-        // No flags -> full length (byte-identical to upstream).
-        assert_eq!(strong_len(base), 16);
-
-        // Iron invariant: flags WITHOUT the private CAP bit never shrink it,
-        // even a rich set of standard flags.
-        let no_cap = protocol::CompatibilityFlags::INC_RECURSE
-            | protocol::CompatibilityFlags::SAFE_FILE_LIST
-            | protocol::CompatibilityFlags::CHECKSUM_SEED_FIX;
-        assert_eq!(
-            strong_len(SignatureGenerationConfig {
-                compat_flags: Some(no_cap),
-                ..base
-            }),
-            16
-        );
-
-        // CAP present in the mutual flags -> halved. This is the ONLY input
-        // that shrinks the strong-sum length.
-        let with_cap = protocol::CompatibilityFlags::INC_RECURSE
-            | protocol::CompatibilityFlags::CONSECUTIVE_MATCH;
-        assert_eq!(
-            strong_len(SignatureGenerationConfig {
-                compat_flags: Some(with_cap),
-                ..base
-            }),
-            8,
-            "CAP_CONSECUTIVE_MATCH must halve the strong-sum length"
-        );
-    }
-
-    #[test]
     fn s2length_capped_by_negotiated_digest_length() {
         use std::io::Write;
         use std::num::NonZeroU32;
@@ -1586,7 +1472,6 @@ mod tests {
                 protocol: ProtocolVersion::NEWEST,
                 checksum_length: NonZeroU8::new(phase_len).unwrap(),
                 checksum_algorithm: algo,
-                compat_flags: None,
             };
             let params = SignatureLayoutParams::new(
                 file_size,

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -710,7 +710,6 @@ impl ReceiverContext {
             checksum_length,
             checksum_algorithm,
             whole_file: self.config.flags.whole_file,
-            compat_flags: self.compat_flags,
         }
     }
 

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -288,7 +288,6 @@ impl ReceiverContext {
                         let ref_dirs = &self.config.reference_directories;
                         let partial_dir = self.config.partial_dir.as_deref();
                         let protocol = self.protocol;
-                        let compat_flags = self.compat_flags;
                         let whole_file = self.config.flags.whole_file;
                         let dest_dir = &setup.dest_dir;
                         let checksum_length = setup.checksum_length;
@@ -323,7 +322,6 @@ impl ReceiverContext {
                                         checksum_length,
                                         checksum_algorithm,
                                         whole_file,
-                                        compat_flags,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })
@@ -349,7 +347,6 @@ impl ReceiverContext {
                                         checksum_length,
                                         checksum_algorithm,
                                         whole_file,
-                                        compat_flags,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })
@@ -916,7 +913,6 @@ impl ReceiverContext {
                 checksum_length: setup.checksum_length,
                 checksum_algorithm: setup.checksum_algorithm,
                 whole_file: self.config.flags.whole_file,
-                compat_flags: self.compat_flags,
             };
             let basis = find_basis_file_with_config(&basis_config);
 

--- a/crates/transfer/tests/fuzzy_level2_basis_search.rs
+++ b/crates/transfer/tests/fuzzy_level2_basis_search.rs
@@ -75,7 +75,6 @@ fn fuzzy_level2_finds_basis_in_reference_directory() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
-        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -135,7 +134,6 @@ fn fuzzy_level1_does_not_search_reference_directories() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
-        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -198,7 +196,6 @@ fn fuzzy_level2_selects_best_match_across_reference_dirs() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
-        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -254,7 +251,6 @@ fn fuzzy_level2_generates_valid_signature_from_basis() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
-        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -313,7 +309,6 @@ fn fuzzy_level0_skips_search() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
-        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -362,7 +357,6 @@ fn whole_file_bypasses_fuzzy_search() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: true,
-        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -413,7 +407,6 @@ fn fuzzy_basis_selection_emits_debug_fuzzy_line() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
-        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);

--- a/docs/design/intra-file-parallelism.md
+++ b/docs/design/intra-file-parallelism.md
@@ -670,8 +670,6 @@ search - is **already implemented and shipped** as the opt-in, default-off
   - duplicate-content basis -> pruned sequential scan
     (`crates/transfer/src/generator/delta.rs:411`,
     `index.has_duplicate_blocks()`);
-  - consecutive-match extension (`seq_matches >= 2`) -> sequential gated scan
-    (`crates/matching/src/generator.rs:997`);
   - in-place / `updating_basis_file` (upstream `match.c:211`) -> sequential
     scan that tracks the true global cursor
     (`crates/matching/src/generator.rs:1005`);


### PR DESCRIPTION
## Summary

Removes the inert "consecutive-match" delta algorithm. This was a private,
oc-only extension gated on a `CAP_CONSECUTIVE_MATCH` compatibility bit that
was advertised through an `-e` capability letter. That capability letter has
since been removed for byte-identity with upstream rsync, so nothing ever
sets the `CONSECUTIVE_MATCH` compat bit anymore and every code path guarded
by it is unreachable.

## Why the code was dead

- The `CONSECUTIVE_MATCH` bit (`0x0200_0000`) is deliberately excluded from
  `KNOWN_MASK`/`ALL_KNOWN` and was only ever OR-ed into advertised flags by
  the now-removed capability letter. The only remaining places that set the
  bit were the tests that exercised the algorithm.
- Negotiated flags are the AND of both peers' advertised sets, so with no
  advertiser the bit can never survive negotiation:
  - `effective_s2length()` always returned the full length,
  - the generator's gating threshold was always `1` (upstream behaviour),
  - the receiver's strong-sum halving never triggered.

## What was removed

- **protocol**: the `CompatibilityFlags::CONSECUTIVE_MATCH` constant, the
  `effective_s2length()` strong-sum halving helper, their re-exports, and the
  associated unit tests.
- **matching**: `DeltaGenerator::consecutive_match_needed` field, the
  `with_consecutive_match_needed()` builder, the `>= 2` gating branches in
  `generate` / `generate_chunked`, the entire `generate_gated()` scan, and the
  tests that only exercised the gated path.
- **transfer**: the `consecutive_match_needed()` helper and its call sites in
  the delta generator, and the receiver-side basis strong-sum halving that
  consumed `effective_s2length`.
- **transfer**: the now-unused `BasisFileConfig.compat_flags` field (its sole
  consumer was the halving) and its wiring in `context.rs` and `pipeline.rs`.
- **docs**: the stale fallback bullet in `intra-file-parallelism.md` that
  documented the removed gated-scan routing.

Net: 5 insertions, 687 deletions.

## Behaviour

Pure dead-code removal. Observably neutral - wire bytes, matched/literal
stats, stdout, and exit codes are unchanged, because the gate bit was never
negotiated on any live path. The separate seq-match coalescing / `extend_run`
index feature is untouched.

## Verification

- `cargo-fmt --all` clean.
- `cargo check -p matching -p transfer -p protocol --all-features` compiles
  clean with no warnings.
