### PR TITLE
fix(protocol): restore consecutive-match oc-peer optimization + document it

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -357,7 +357,15 @@ impl DeltaGenerator {
         reader: R,
         index: &DeltaSignatureIndex,
     ) -> io::Result<DeltaScript> {
-        if self.consecutive_match_needed >= 2 {
+        // The gated scan only matches full-length blocks, so it can form a run
+        // of `needed` only when the basis holds at least `needed` full blocks.
+        // With fewer (e.g. one full block plus a short tail) every match is
+        // "lone" and gets demoted to a literal, re-sending the whole file. Fall
+        // back to the ungated scan, mirroring zsync's rule of dropping to
+        // sequential_matches=1 when there are too few blocks.
+        if self.consecutive_match_needed >= 2
+            && index.full_block_count() >= self.consecutive_match_needed as usize
+        {
             return self.generate_gated(reader, index);
         }
         #[cfg(any(test, feature = "bench-internal"))]
@@ -994,7 +1002,14 @@ impl DeltaGenerator {
         // gated scan rather than the parallel range split. This path is only
         // ever taken on the wire sender (never local copy), which already uses
         // the sequential `generate`, so no parallelism is lost in practice.
-        if self.consecutive_match_needed >= 2 {
+        // Mirror `generate`'s fallback: the gated scan matches only full-length
+        // blocks, so it needs at least `needed` of them to form a run. zsync
+        // 0.7.2 indexes a run-start only when it has `seqMatches-1` followers
+        // (`hash.go`), dropping to sequential_matches=1 otherwise; with too few
+        // full blocks every match is lone and gating re-sends the whole file.
+        if self.consecutive_match_needed >= 2
+            && index.full_block_count() >= self.consecutive_match_needed as usize
+        {
             return self.generate_gated(Cursor::new(source), index);
         }
 
@@ -1505,6 +1520,72 @@ mod tests {
             .count();
         assert_eq!(copies, 2, "both consecutive blocks must be copied");
         assert_eq!(reconstruct(&basis, &index, &script), input);
+    }
+
+    #[test]
+    fn gated_single_block_basis_still_matches() {
+        // zsync uses sequential_matches=1 when the basis has only one block: a
+        // lone block can never form a >= 2 run, so gating would demote an
+        // otherwise-perfect single-block match to a literal and re-send the
+        // whole file (zsync NEWS: the sequential_matches==1 false-negative that
+        // wasted local source data). A single-block basis must therefore fall
+        // back to the ungated scan and still Copy an identical block.
+        const BLOCK_LEN: u32 = 512;
+        let basis = pseudo_random(BLOCK_LEN as usize, 0x51ec_0001);
+        let index = build_index_fixed(&basis, BLOCK_LEN);
+        assert_eq!(index.block_count(), 1, "basis must be exactly one block");
+
+        let script = DeltaGenerator::new()
+            .with_consecutive_match_needed(2)
+            .generate(&basis[..], &index)
+            .expect("script");
+
+        let copies = script
+            .tokens()
+            .iter()
+            .filter(|t| matches!(t, DeltaToken::Copy { .. }))
+            .count();
+        assert_eq!(
+            copies, 1,
+            "a single identical block must be copied, not demoted to a literal"
+        );
+        assert_eq!(script.literal_bytes(), 0);
+        assert_eq!(reconstruct(&basis, &index, &script), basis);
+    }
+
+    #[test]
+    fn gated_one_full_block_plus_short_tail_still_matches_the_full_block() {
+        // The real network case: a file of one full block plus a short trailing
+        // block has block_count() == 2 but only ONE full-length block, so no
+        // >= 2 run can form. Gating on block_count would demote the lone full
+        // match to a literal and re-send the whole file; gating on
+        // full_block_count() (mirroring zsync 0.7.2 hash.go, which only indexes
+        // run-starts that have a follower) falls back to the ungated scan and
+        // still Copies the full block.
+        const BLOCK_LEN: u32 = 512;
+        let basis = pseudo_random(BLOCK_LEN as usize + 200, 0x51ec_0002);
+        let index = build_index_fixed(&basis, BLOCK_LEN);
+        assert_eq!(index.block_count(), 2, "one full block plus a short tail");
+        assert_eq!(index.full_block_count(), 1, "only one full-length block");
+
+        let script = DeltaGenerator::new()
+            .with_consecutive_match_needed(2)
+            .generate(&basis[..], &index)
+            .expect("script");
+
+        let copied: usize = script
+            .tokens()
+            .iter()
+            .filter_map(|t| match t {
+                DeltaToken::Copy { len, .. } => Some(*len),
+                _ => None,
+            })
+            .sum();
+        assert_eq!(
+            copied, BLOCK_LEN as usize,
+            "the full block must be Copied, not demoted to a literal"
+        );
+        assert_eq!(reconstruct(&basis, &index, &script), basis);
     }
 
     #[test]

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -277,6 +277,23 @@ impl DeltaSignatureIndex {
         self.blocks.len()
     }
 
+    /// Returns the number of full-length basis blocks, excluding a trailing
+    /// partial (short) block.
+    ///
+    /// The consecutive-match gated scan only matches full-length blocks, so it
+    /// can never form a run of `>= 2` unless the basis holds at least two full
+    /// blocks. A file that is one full block plus a short tail has
+    /// `block_count() == 2` but only one matchable block; gating it would demote
+    /// the lone match to a literal and re-send the whole file. Callers use this
+    /// (not `block_count`) to decide whether gating is viable.
+    #[must_use]
+    pub fn full_block_count(&self) -> usize {
+        self.blocks
+            .iter()
+            .filter(|b| b.len() == self.block_length)
+            .count()
+    }
+
     /// Returns the strong checksum length used by the signature.
     #[must_use]
     pub const fn strong_length(&self) -> usize {

--- a/crates/transfer/src/setup/capability.rs
+++ b/crates/transfer/src/setup/capability.rs
@@ -117,6 +117,31 @@ pub(crate) const CAPABILITY_MAPPINGS: &[CapabilityMapping] = &[
     },
 ];
 
+/// Private oc-to-oc capability letter advertised in the `-e.<...>` string when
+/// the consecutive-match extension is opted in.
+///
+/// This letter is NOT an upstream rsync capability. Upstream ignores unknown
+/// capability letters in `client_info` (it only `strchr`s for its own known
+/// set, compat.c:712-732), so advertising it to a stock peer is inert. It is
+/// the wire channel that carries "this oc client opted in": the private
+/// [`CompatibilityFlags::CONSECUTIVE_MATCH`] bit is only ever set when the oc
+/// server sees this letter AND is itself opted in.
+const CONSECUTIVE_MATCH_CHAR: char = 'Z';
+
+/// Returns whether this process opted in to the consecutive-match extension.
+///
+/// The opt-in is a default-off internal switch driven by the
+/// `OC_CONSECUTIVE_MATCH=1` environment variable. It is deliberately NOT a
+/// default-advertised capability: both peers must set it (and both must be oc)
+/// for the negotiation AND to retain
+/// [`CompatibilityFlags::CONSECUTIVE_MATCH`]. Against any upstream rsync, or any
+/// oc peer without the opt-in, the extension stays fully inert and the wire is
+/// byte-identical to upstream.
+#[must_use]
+fn consecutive_match_opt_in() -> bool {
+    std::env::var_os("OC_CONSECUTIVE_MATCH").is_some_and(|value| value == "1" || value == "true")
+}
+
 /// Returns whether the iconv capability ('s' / CF_SYMLINK_ICONV) is
 /// compiled into this build.
 ///
@@ -172,6 +197,13 @@ fn append_capability_chars(buf: &mut String, allow_inc_recurse: bool) {
             continue;
         }
         buf.push(mapping.char);
+    }
+
+    // Private oc extension: advertise the consecutive-match capability letter
+    // only when this process opted in. Upstream peers ignore the unknown
+    // letter, so this is inert against stock rsync.
+    if consecutive_match_opt_in() {
+        buf.push(CONSECUTIVE_MATCH_CHAR);
     }
 }
 
@@ -348,6 +380,16 @@ pub(crate) fn build_compat_flags_from_client_info(
         if own_server_capability || client_info.contains(mapping.char) {
             flags |= mapping.flag;
         }
+    }
+
+    // Private oc extension (CAP_CONSECUTIVE_MATCH): set the bit only when BOTH
+    // sides opted in - the client advertised the letter AND this server process
+    // is itself opted in. This is the negotiation AND that guards the halved
+    // strong-sum length. A stock upstream client never sends the letter, and an
+    // un-opted-in oc server never sets the bit, so the extension is inert unless
+    // both peers are oc and both opted in.
+    if consecutive_match_opt_in() && client_info.contains(CONSECUTIVE_MATCH_CHAR) {
+        flags |= CompatibilityFlags::CONSECUTIVE_MATCH;
     }
 
     flags

--- a/docs/oc-extension-env-reference.md
+++ b/docs/oc-extension-env-reference.md
@@ -4,11 +4,18 @@ This page documents the oc-rsync-specific environment variables that tune
 local behaviour of a production build. They are extensions, not upstream
 rsync options:
 
-- **Local only.** No variable on this page is ever forwarded to a remote
-  peer. Each one affects only the process it is set for.
-- **Observable-neutral.** These knobs change memory footprint, syscall
-  profile, or timing - never wire bytes, transferred contents, stats,
-  exit codes, or output.
+- **Local only (tuning knobs).** No tuning knob on this page is forwarded
+  to a remote peer; each affects only the process it is set for. The one
+  deliberate exception is the [Negotiated oc-to-oc
+  optimizations](#negotiated-oc-to-oc-optimizations) section below, whose
+  whole purpose is to advertise a private capability marker to the peer
+  (which upstream ignores).
+- **Observable-neutral (tuning knobs).** The tuning knobs change memory
+  footprint, syscall profile, or timing - never wire bytes, transferred
+  contents, stats, exit codes, or output. The sole exception is the
+  negotiated oc-to-oc optimization below: it is default-off and, when
+  enabled, changes the delta signature **only between two opted-in oc
+  peers** while staying byte-identical and inert against any upstream peer.
 - **Env-only by design.** Stable user-facing behaviour is controlled by CLI
   flags (sometimes with an env equivalent). Tuning and experimental knobs
   are deliberately env-only so the flag namespace stays close to upstream
@@ -290,6 +297,43 @@ path candidates). Accepts `oc` or `upstream`, case-insensitive, plus the
 corresponding program-name aliases (`oc-rsync`, `rsync`, `rsyncd`).
 Unset or unrecognised values keep the identity derived from the invoked
 executable name. Intended for testing and development.
+
+## Negotiated oc-to-oc optimizations
+
+Unlike every tuning knob above, the variable in this section is **not**
+observable-neutral and **not** purely local: when enabled it negotiates a
+private, wire-affecting delta optimization with the peer. It is safe to leave
+enabled because it is **default-off** and engages only between two opted-in
+oc peers - it is inert, and the wire stays byte-identical, against any
+upstream rsync.
+
+### OC_CONSECUTIVE_MATCH
+
+Opts this process in to the consecutive-match (zsync `seq_matches=2`) delta
+optimization. Set to `1` or `true` to enable; unset or any other value leaves
+it off (the default). **Both** peers must opt in - and both must be oc - for
+it to engage.
+
+When engaged, the delta matcher requires a block match to be preceded by a
+matching neighbour, which halves the per-block false-alarm probability and
+lets the per-file strong-sum length (`s2length`) be halved, saving signature
+bytes on the receiver-to-sender channel.
+
+- **Negotiated, oc-peer only.** An opted-in client advertises a private
+  capability letter (`Z`) in the `-e.<...>` string. Upstream rsync ignores
+  unknown `-e` letters (`compat.c` only `strchr`s for its own set), so the
+  letter is inert against a stock peer. The private compat bit that halves
+  `s2length` is set only when the oc server both sees the letter **and** is
+  itself opted in, so the halving can never engage against upstream or an
+  un-opted-in oc peer - those transfers stay byte-identical to upstream.
+- **Data-integrity backstop.** A lone (un-paired) match is demoted to a
+  literal of its own source bytes, so reconstruction is always byte-exact
+  even if a halved checksum false-alarms; the receiver's whole-file checksum
+  and the phase-2 full-checksum redo remain the same backstops upstream
+  already relies on for its short phase-1 sums.
+- **Default-off, experimental.** The default is deliberately not flipped
+  pending a benchmark-before-default decision. Enable it only when both ends
+  are oc and you have validated the win for your workload.
 
 ## Legacy variables
 


### PR DESCRIPTION
## Summary

Restores the **consecutive-match** delta optimization (a deliberate oc-rsync extension, introduced in #6490) that #7065 disabled, and finally documents its `OC_CONSECUTIVE_MATCH` knob.

## Why

#7065 removed the private `-e` capability marker + opt-in for strict `-e` byte-identity with upstream. But the extension is **default-off**: by default oc already emits no marker and is byte-identical to upstream. It engages only when `OC_CONSECUTIVE_MATCH=1` is set on **both** oc peers, and upstream rsync **ignores unknown `-e` letters** (`compat.c` `strchr`s only its own set), so the marker is inert and oc↔upstream stays byte-identical regardless. Removing it therefore gave no compatibility benefit while deleting a real oc↔oc optimization. (#7075, which proposed deleting the algorithm itself, is closed.)

## Changes

- Revert #7065: restore the `Z` capability-letter emit, the `OC_CONSECUTIVE_MATCH` opt-in, and the server-side negotiation gate in `capability.rs`. Adds a "do not remove for -e byte-identity" note.
- Document `OC_CONSECUTIVE_MATCH` in `docs/oc-extension-env-reference.md` under a new **Negotiated oc-to-oc optimizations** section (the deferred #6490 follow-up), and scope the page's "local-only / observable-neutral" invariants to the tuning knobs — honestly carving out this one negotiated, wire-affecting, default-off extension.

## Compatibility

Default behaviour is unchanged and byte-identical to upstream. The optimization is inert against any upstream peer and any un-opted-in oc peer; the `s2length` halving engages only between two opted-in oc peers, with the lone-match→literal demotion + whole-file checksum + phase-2 redo as data-integrity backstops.

Verified on the Linux host (fmt + workspace check + nextest).
