### PR TITLE
fix(filters): reject C modifier with no-prefix or side-specifying rules

### DIFF
--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -293,7 +293,15 @@ pub(crate) fn parse_modifiers<'a>(
                 }
                 mods.word_split = true;
             }
-            'C' => mods.cvs_mode = true,
+            // upstream: exclude.c:parse_rule_tok - `C` is invalid when the rule
+            // already set FILTRULE_NO_PREFIXES (a preceding `-`/`+`) or the
+            // prefix binds a side (H/S/P/R), i.e. `prefix_specifies_side`.
+            'C' => {
+                if mods.no_prefixes || prefix_specifies_side {
+                    return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
+                }
+                mods.cvs_mode = true;
+            }
             // upstream: exclude.c:1215-1216 - `/` sets FILTRULE_ABS_PATH.
             '/' => mods.abs_path = true,
             // upstream: exclude.c:1197-1213 - `-`/`+` set FILTRULE_NO_PREFIXES

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -945,6 +945,34 @@ fn parse_rejects_side_modifier_with_word_split_on_side_prefix() {
     assert!(err.message.contains("invalid modifier 's'"));
 }
 
+#[test]
+fn parse_rejects_c_modifier_on_side_specific_prefix() {
+    // upstream: exclude.c:parse_rule_tok - `C` is rejected when the prefix binds
+    // a side (H/S/P/R sets `prefix_specifies_side`), the same incompatibility
+    // that rejects `s`/`r` on those prefixes.
+    for line in ["HC foo", "SC foo", "PC foo", "RC foo"] {
+        let err = parse_rules(line, Path::new("test")).unwrap_err();
+        assert!(
+            err.message.contains("invalid modifier 'C'"),
+            "expected rejection for `{line}`, got `{}`",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn parse_rejects_c_modifier_after_no_prefixes() {
+    // upstream: exclude.c:parse_rule_tok - `C` is rejected once FILTRULE_NO_PREFIXES
+    // is set by a preceding `-`/`+`, mirroring upstream's prefix/no-prefix
+    // incompatibility rather than silently accepting the nonsensical combination.
+    let err = parse_rules(":-C", Path::new("test")).unwrap_err();
+    assert!(
+        err.message.contains("invalid modifier 'C'"),
+        "expected rejection for `:-C`, got `{}`",
+        err.message
+    );
+}
+
 // upstream: exclude.c:1404-1408 - merge / dir-merge with the `C`
 // (CVS-ignore) modifier and an empty pattern defaults to `.cvsignore`.
 #[test]


### PR DESCRIPTION
## Summary

Reject the `C` filter modifier when it is combined with a rule that has already
disabled prefixes (`-`/`+`) or whose action prefix binds a side (`H`/`S`/`P`/`R`).

Upstream `exclude.c:parse_rule_tok` jumps to `invalid` for `C` when
`FILTRULE_NO_PREFIXES` is already set or `prefix_specifies_side` is true, forbidding
nonsensical combinations such as `HC`, `PC`, and `:-C`. oc previously accepted `C`
unconditionally, silently accepting these invalid combinations.

The `'C'` arm now applies the same `mods.no_prefixes || prefix_specifies_side` guard
used by the neighbouring `s`/`r` and `-`/`+` modifiers, returning the shared
`invalid_modifier` error.

## Tests

- `parse_rejects_c_modifier_on_side_specific_prefix` - `HC`/`SC`/`PC`/`RC` rejected as
  invalid modifier `C`, mirroring the existing `s`/`r` side-prefix rejection.
- `parse_rejects_c_modifier_after_no_prefixes` - `:-C` rejected once `-` set
  no-prefixes.
- Existing acceptance tests (bare `C`, `:C`, `.C`) continue to pass, confirming valid
  CVS-ignore usage is unaffected.

Verified on Linux host: `cargo clippy -p filters ... -D warnings` clean and
`cargo nextest run -p filters --all-features` 1426 passed, 0 skipped.
