### PR TITLE
fix(filters): keep '#' tokens in .cvsignore/CVSIGNORE per word_split

### DIFF
--- a/crates/cli/src/frontend/filter_rules/cvs.rs
+++ b/crates/cli/src/frontend/filter_rules/cvs.rs
@@ -98,7 +98,12 @@ where
 {
     for token in tokens {
         let trimmed = token.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        // upstream: exclude.c:parse_filter_file word_split - the CVS ignore
+        // sources are parsed in word_split mode, so line 1514's comment check
+        // (`word_split || (*line != ';' && *line != '#')`) short-circuits: only
+        // empty tokens are skipped. A '#'-prefixed token is a LITERAL exclude of
+        // a file named '#foo', never a comment.
+        if trimmed.is_empty() {
             continue;
         }
 
@@ -188,10 +193,20 @@ mod tests {
     }
 
     #[test]
-    fn append_cvsignore_tokens_skips_hash_comments() {
+    fn append_cvsignore_tokens_hash_is_literal_not_comment() {
+        // upstream: exclude.c:parse_filter_file word_split - CVS ignore sources
+        // parse in word_split mode, so line 1514's `word_split ||` short-circuits
+        // the comment check and '#' is NEVER a comment leader there. A "#foo"
+        // token is a literal exclude of a file named "#foo"; only empty tokens
+        // are dropped. Treating '#' as a comment (as line-parsed filter files do)
+        // would silently drop valid CVS excludes.
         let mut rules = Vec::new();
-        append_cvsignore_tokens(&mut rules, ["*.o", "# comment", "*.a"].iter().copied());
-        assert_eq!(rules.len(), 2);
+        append_cvsignore_tokens(&mut rules, ["*.o", "#foo", "*.a"].iter().copied());
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[0].pattern(), "*.o");
+        assert_eq!(rules[1].kind(), FilterRuleKind::Exclude);
+        assert_eq!(rules[1].pattern(), "#foo");
+        assert_eq!(rules[2].pattern(), "*.a");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

CVS ignore parsing (`$HOME/.cvsignore` and `$CVSIGNORE`) always uses word_split
mode. Upstream `exclude.c:parse_filter_file` line 1514 gates comment handling
with `if (*line && (word_split || (*line != ';' && *line != '#')))`. Because
`word_split` short-circuits, a `#`-prefixed token is NOT a comment in these
sources - `#foo` is a literal exclude rule for a file named `#foo`.

`append_cvsignore_tokens` unconditionally skipped tokens starting with `#`,
silently dropping such patterns and diverging from upstream.

## Fix

Remove the `starts_with('#')` skip in `append_cvsignore_tokens`; keep the
empty-token skip. `#foo` now becomes an exclude token, matching upstream's
word_split parse. Added an upstream cite comment.

The per-directory `.cvsignore` dir-merge path (`allow_comments(false)`) is
separate and unchanged.

## Test

Updated the existing hash-comment test (renamed to
`append_cvsignore_tokens_hash_is_literal_not_comment`) to assert `#foo` becomes
a literal exclude, encoding WHY: CVS ignore sources parse in word_split mode, so
`#` is never a comment leader there.

## Verify

Linux host (172.16.1.74): `cargo clippy -p cli ... -D warnings` clean;
`cargo nextest run -p cli -E 'test(cvsignore)'` = 15 passed.
