### PR TITLE
feat(batch): support --read-batch=- reading from stdin

### DIFF
--- a/crates/batch/src/reader/mod.rs
+++ b/crates/batch/src/reader/mod.rs
@@ -21,7 +21,48 @@ use crate::format::{BatchFlags, BatchHeader};
 use protocol::codec::NdxCodecEnum;
 use protocol::flist::FileListReader;
 use std::fs::File;
-use std::io::{self, BufReader, Read};
+use std::io::{self, BufReader, Cursor, Read, Seek, SeekFrom};
+use std::path::Path;
+
+/// Input source for a batch reader.
+///
+/// A `--read-batch` argument of `-` selects standard input, mirroring upstream
+/// `batch.c:open_batch_files` (`strcmp(batch_name, "-") == 0` opens
+/// `STDIN_FILENO`). Upstream reads the batch fd purely sequentially, but stdin
+/// is not seekable, so the `Stdin` variant buffers the stream into memory:
+/// oc-rsync's compression-codec auto-detection (see [`crate::replay`]) peeks
+/// ahead and restores the position via `Seek`, which the in-memory `Cursor`
+/// supports while a raw stdin fd would not. Both variants are therefore
+/// `Read + Seek`.
+/// upstream: batch.c:open_batch_files
+pub(crate) enum BatchSource {
+    /// A batch file opened from a filesystem path.
+    File(File),
+    /// Standard input buffered into memory (the `--read-batch=-` path).
+    Stdin(Cursor<Vec<u8>>),
+}
+
+impl Read for BatchSource {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::File(f) => f.read(buf),
+            Self::Stdin(c) => c.read(buf),
+        }
+    }
+}
+
+impl Seek for BatchSource {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        match self {
+            Self::File(f) => f.seek(pos),
+            Self::Stdin(c) => c.seek(pos),
+        }
+    }
+}
+
+/// Buffered reader over a [`BatchSource`], the concrete stream type threaded
+/// through header, file-list, delta, and replay decoding.
+pub(crate) type BatchStream = BufReader<BatchSource>;
 
 /// Reader for batch mode operations.
 ///
@@ -30,8 +71,8 @@ use std::io::{self, BufReader, Read};
 pub struct BatchReader {
     /// Configuration for this batch operation.
     config: BatchConfig,
-    /// Reader for the binary batch file.
-    batch_file: Option<BufReader<File>>,
+    /// Reader for the binary batch stream (file or buffered stdin).
+    batch_file: Option<BatchStream>,
     /// The header read from the file.
     header: Option<BatchHeader>,
     /// Accumulated I/O error code from the file list sender.
@@ -62,28 +103,61 @@ pub struct BatchReader {
 
 impl BatchReader {
     /// Create a new batch reader.
+    ///
+    /// A batch path of `-` reads from standard input instead of opening a
+    /// file, mirroring upstream `batch.c:open_batch_files`.
     pub fn new(config: BatchConfig) -> BatchResult<Self> {
-        let batch_path = config.batch_file_path();
-        let file = File::open(batch_path).map_err(|e| {
-            BatchError::Io(io::Error::new(
-                e.kind(),
-                format!(
-                    "Failed to open batch file '{}': {}",
-                    batch_path.display(),
-                    e
-                ),
-            ))
-        })?;
+        let source = Self::open_source(config.batch_file_path())?;
+        Ok(Self::from_source(config, source))
+    }
 
-        Ok(Self {
+    /// Open the batch input source described by `path`.
+    ///
+    /// A path of `-` selects standard input, matching upstream
+    /// `batch.c:open_batch_files` (`strcmp(batch_name, "-") == 0` uses
+    /// `STDIN_FILENO`). stdin is buffered into memory because oc-rsync's
+    /// codec auto-detection seeks the stream; see [`BatchSource`].
+    /// upstream: batch.c:open_batch_files
+    fn open_source(path: &Path) -> BatchResult<BatchSource> {
+        if path.as_os_str() == "-" {
+            let mut buf = Vec::new();
+            io::stdin().lock().read_to_end(&mut buf).map_err(|e| {
+                BatchError::Io(io::Error::new(
+                    e.kind(),
+                    format!("Failed to read batch file from stdin: {e}"),
+                ))
+            })?;
+            Ok(BatchSource::Stdin(Cursor::new(buf)))
+        } else {
+            let file = File::open(path).map_err(|e| {
+                BatchError::Io(io::Error::new(
+                    e.kind(),
+                    format!("Failed to open batch file '{}': {}", path.display(), e),
+                ))
+            })?;
+            Ok(BatchSource::File(file))
+        }
+    }
+
+    /// Construct a reader over an in-memory batch image, exactly as the
+    /// `--read-batch=-` path buffers standard input. Exercises the stdin
+    /// source deterministically without touching the process-wide stdin fd.
+    #[cfg(test)]
+    pub(crate) fn from_stdin_bytes(config: BatchConfig, bytes: Vec<u8>) -> Self {
+        Self::from_source(config, BatchSource::Stdin(Cursor::new(bytes)))
+    }
+
+    /// Build a reader over an already-opened [`BatchSource`].
+    fn from_source(config: BatchConfig, source: BatchSource) -> Self {
+        Self {
             config,
-            batch_file: Some(BufReader::new(file)),
+            batch_file: Some(BufReader::new(source)),
             header: None,
             io_error: 0,
             ndx_codec: None,
             flist_reader: None,
             flist_next_ndx_start: 0,
-        })
+        }
     }
 
     /// Read and validate the batch header.
@@ -208,7 +282,7 @@ impl BatchReader {
     /// example to pass it to protocol-level decoders like `read_delta`.
     ///
     /// Returns `None` if the batch file has not been opened or has been closed.
-    pub fn inner_reader(&mut self) -> Option<&mut BufReader<File>> {
+    pub(crate) fn inner_reader(&mut self) -> Option<&mut BatchStream> {
         self.batch_file.as_mut()
     }
 

--- a/crates/batch/src/reader/tests.rs
+++ b/crates/batch/src/reader/tests.rs
@@ -65,6 +65,63 @@ mod reader_creation_tests {
     }
 }
 
+mod stdin_source_tests {
+    use super::*;
+
+    /// Drain every remaining data byte from a reader after its header is read.
+    fn drain_data(reader: &mut BatchReader) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut buf = [0u8; 64];
+        loop {
+            let n = reader.read_data(&mut buf).unwrap();
+            if n == 0 {
+                break;
+            }
+            out.extend_from_slice(&buf[..n]);
+        }
+        out
+    }
+
+    /// upstream: batch.c:open_batch_files treats a `-` argument as stdin
+    /// (STDIN_FILENO). Replaying a batch from stdin must therefore decode
+    /// byte-for-byte identically to replaying the same batch from a file: the
+    /// input source is the only thing that differs, so any divergence would be
+    /// a bug in the source abstraction, not the wire format.
+    #[test]
+    fn read_batch_dash_reads_from_stdin_like_a_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("dash.batch");
+        create_test_batch(&batch_path);
+        let image = std::fs::read(&batch_path).unwrap();
+
+        let file_config = BatchConfig::new(
+            BatchMode::Read,
+            batch_path.to_string_lossy().to_string(),
+            30,
+        );
+        let mut file_reader = BatchReader::new(file_config).unwrap();
+        let file_flags = file_reader.read_header().unwrap();
+        let file_data = drain_data(&mut file_reader);
+
+        // The `-` path buffers stdin into memory exactly as this constructor
+        // does, so it stands in for `--read-batch=-` without a real stdin fd.
+        let stdin_config = BatchConfig::new(BatchMode::Read, "-".to_owned(), 30);
+        let mut stdin_reader = BatchReader::from_stdin_bytes(stdin_config, image);
+        let stdin_flags = stdin_reader.read_header().unwrap();
+        let stdin_data = drain_data(&mut stdin_reader);
+
+        assert_eq!(
+            stdin_flags.recurse, file_flags.recurse,
+            "stdin batch header must match the file batch header"
+        );
+        assert_eq!(
+            stdin_data, file_data,
+            "stdin batch data must match the file batch data"
+        );
+        assert_eq!(stdin_data, b"test data here");
+    }
+}
+
 mod header_tests {
     use super::*;
 

--- a/crates/batch/src/replay/codec.rs
+++ b/crates/batch/src/replay/codec.rs
@@ -8,10 +8,10 @@
 //! compressed payload to handle both cases correctly.
 
 #[cfg(feature = "zstd")]
-use std::fs::File;
-#[cfg(feature = "zstd")]
-use std::io::{BufReader, Read, Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom};
 
+#[cfg(feature = "zstd")]
+use crate::reader::BatchStream;
 use protocol::wire::CompressedTokenDecoder;
 
 #[cfg(feature = "zstd")]
@@ -92,7 +92,7 @@ pub(super) fn create_compressed_decoder(
 /// upstream: token.c:recv_deflated_token() - DEFLATED_DATA flag = 0x40
 /// zstd spec: frames start with magic 0xFD2FB528 (LE bytes: 28 B5 2F FD)
 #[cfg(feature = "zstd")]
-pub(super) fn detect_compression_codec(reader: &mut BufReader<File>) -> CompressionCodec {
+pub(super) fn detect_compression_codec(reader: &mut BatchStream) -> CompressionCodec {
     let start_pos = match reader.stream_position() {
         Ok(pos) => pos,
         Err(_) => return CompressionCodec::Zlib,
@@ -114,7 +114,7 @@ pub(super) fn detect_compression_codec(reader: &mut BufReader<File>) -> Compress
 ///
 /// Returns `None` if no DEFLATED_DATA block is found before EOF or on error.
 #[cfg(feature = "zstd")]
-fn peek_for_codec(reader: &mut BufReader<File>) -> Option<CompressionCodec> {
+fn peek_for_codec(reader: &mut BatchStream) -> Option<CompressionCodec> {
     // Scan for the first DEFLATED_DATA flag byte. The compressed token stream
     // starts with flag bytes that can be END_FLAG (0x00), TOKEN_LONG (0x20),
     // TOKENRUN_LONG (0x21), DEFLATED_DATA (0x40-0x7F), TOKEN_REL (0x80-0xBF),

--- a/crates/batch/src/replay/dispatch.rs
+++ b/crates/batch/src/replay/dispatch.rs
@@ -11,13 +11,14 @@
 //! - [`apply_file_delta`] applies a decoded delta sequence to a destination
 //!   path, using a temp file + rename for the basis-present path.
 
-use std::fs::{self, File};
-use std::io::{BufReader, Read};
+use std::fs;
+use std::io::Read;
 use std::path::Path;
 
 use protocol::wire::{CompressedToken, CompressedTokenDecoder};
 
 use crate::error::{BatchError, BatchResult};
+use crate::reader::BatchStream;
 
 use super::delta::{apply_delta_ops, block_index_as_i32, write_literals_to_file};
 
@@ -41,10 +42,7 @@ pub(super) const ITEM_TRANSFER: u16 = 1 << 15;
 /// upstream: rsync.c:403-418 - consume optional trailing fields after iflags.
 /// `ITEM_BASIS_TYPE_FOLLOWS` (0x0800): 1 byte fnamecmp_type.
 /// `ITEM_XNAME_FOLLOWS` (0x1000): vstring (1-2 byte length + data).
-pub(super) fn read_iflags_and_skip_meta(
-    stream: &mut BufReader<File>,
-    proto: i32,
-) -> BatchResult<u16> {
+pub(super) fn read_iflags_and_skip_meta(stream: &mut BatchStream, proto: i32) -> BatchResult<u16> {
     let iflags = if proto >= 29 {
         let mut buf = [0u8; 2];
         stream.read_exact(&mut buf).map_err(|e| {
@@ -114,7 +112,7 @@ pub(super) fn read_iflags_and_skip_meta(
 /// [`protocol::wire::SumHead`] applies those same rules, and every copy token
 /// in the body is later resolved through the returned geometry, so a header
 /// that does not match its body is refused instead of guessed at.
-pub(super) fn read_sum_head(stream: &mut BufReader<File>) -> BatchResult<protocol::wire::SumHead> {
+pub(super) fn read_sum_head(stream: &mut BatchStream) -> BatchResult<protocol::wire::SumHead> {
     protocol::wire::SumHead::read(stream).map_err(|e| {
         BatchError::Io(std::io::Error::new(
             e.kind(),
@@ -131,7 +129,7 @@ pub(super) fn read_sum_head(stream: &mut BufReader<File>) -> BatchResult<protoco
 /// default xfer checksum is XXH3-128 or MD5 - both 16 bytes. For protocol
 /// 28-31 it is MD4 or MD5 - also 16 bytes.
 pub(super) fn read_and_discard_file_checksum(
-    stream: &mut BufReader<File>,
+    stream: &mut BatchStream,
     xfer_sum_len: usize,
 ) -> BatchResult<()> {
     let mut checksum_buf = vec![0u8; xfer_sum_len];
@@ -153,7 +151,7 @@ pub(super) fn read_and_discard_file_checksum(
 /// upstream: receiver.c:receive_data() + token.c:see_deflate_token()
 pub(super) fn read_compressed_deltas_streaming(
     decoder: &mut CompressedTokenDecoder,
-    stream: &mut BufReader<File>,
+    stream: &mut BatchStream,
     basis_data: &[u8],
     entry_name: &str,
     sum_head: protocol::wire::SumHead,

--- a/crates/batch/src/replay/tests.rs
+++ b/crates/batch/src/replay/tests.rs
@@ -203,7 +203,9 @@ fn read_iflags_pre_29_synthesises_item_transfer_without_reading() {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().join("stream");
     fs::write(&path, [0xAA, 0xBB]).expect("write stream");
-    let mut stream = std::io::BufReader::new(fs::File::open(&path).expect("open stream"));
+    let mut stream = std::io::BufReader::new(crate::reader::BatchSource::File(
+        fs::File::open(&path).expect("open stream"),
+    ));
 
     for proto in [28, 27, 20] {
         let iflags = super::dispatch::read_iflags_and_skip_meta(&mut stream, proto)
@@ -230,7 +232,9 @@ fn read_iflags_proto_29_reads_shortint() {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().join("stream");
     fs::write(&path, [0x00, 0x80]).expect("write stream");
-    let mut stream = std::io::BufReader::new(fs::File::open(&path).expect("open stream"));
+    let mut stream = std::io::BufReader::new(crate::reader::BatchSource::File(
+        fs::File::open(&path).expect("open stream"),
+    ));
 
     let iflags = super::dispatch::read_iflags_and_skip_meta(&mut stream, 29).expect("read iflags");
     assert_eq!(iflags, 1 << 15);


### PR DESCRIPTION
## Summary

`--read-batch=-` now reads the batch stream from standard input, matching upstream `batch.c:open_batch_files` (`strcmp(batch_name, "-") == 0` opens `STDIN_FILENO`). Previously `BatchReader::new` called `File::open("-")` unconditionally, which failed with a "no such file" error.

## Changes

- Introduce a `BatchSource` input abstraction (`File` or in-memory `Stdin`) behind the `BatchStream` reader type, applying dependency inversion over the input source. Both variants are `Read + Seek`.
- `BatchReader::new` routes a `-` path to `std::io::stdin()` instead of `File::open`.
- Thread the `BatchStream` alias through the codec-detection and per-file dispatch helpers.

## Why buffer stdin

Upstream reads the batch fd purely sequentially, and stdin is not seekable. oc-rsync's compression-codec auto-detection (`replay::codec`) peeks ahead and restores the stream position via `Seek`, which a raw stdin fd cannot provide. The `-` path therefore buffers stdin into an in-memory `Cursor`, preserving both the upstream sequential-read semantics and the seekable codec probe without resorting to a temp file.

## Testing

- New `read_batch_dash_reads_from_stdin_like_a_file` asserts a batch replayed from the buffered-stdin source decodes byte-for-byte identically to the same batch replayed from a file, encoding that `-` means stdin and that the input source is the only difference.
- `cargo clippy -p batch --all-targets --all-features --no-deps -- -D warnings`: clean.
- `cargo nextest run -p batch --all-features`: 229 passed.
