### PR TITLE
fix(receiver): skip delete pass when sender flist had IO errors

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -416,6 +416,16 @@ pub struct ReceiverContext {
     /// [`execute_delayed_deletions`]: Self::execute_delayed_deletions
     pub(in crate::receiver) delayed_delete_victims:
         Vec<crate::receiver::directory::deletion::DeletedEntry>,
+    /// Guards the one-shot "IO error encountered -- skipping file deletion"
+    /// notice so the whole delete pass is skipped exactly once when the sender's
+    /// file list was built after a general I/O error and `--ignore-errors` was
+    /// not given. Mirrors upstream's static `already_warned` in
+    /// `delete_in_dir()`; skipping protects destination files that merely never
+    /// made it into an incomplete file list from being unlinked as extraneous.
+    ///
+    /// upstream: generator.c:298-305 - `delete_in_dir()` returns early (printing
+    /// once) whenever `io_error & IOERR_GENERAL && !ignore_errors`.
+    pub(in crate::receiver) io_error_delete_warning_emitted: bool,
 }
 
 impl ReceiverContext {
@@ -500,6 +510,7 @@ impl ReceiverContext {
             created_stats: std::cell::Cell::new(protocol::stats::CreatedStats::new()),
             got_xfer_error: std::cell::Cell::new(false),
             delayed_delete_victims: Vec::new(),
+            io_error_delete_warning_emitted: false,
         }
     }
 

--- a/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
+++ b/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
@@ -280,6 +280,117 @@ fn late_delete_pass_with_dest_rsync_filter_protects_bak() {
     assert!(dest.join("source.txt").exists(), "listed file must survive");
 }
 
+/// DATA-LOSS GUARD: when the sender reports a general I/O error while scanning
+/// the source (`stats.io_error & IOERR_GENERAL`), its file list may be
+/// incomplete, so a destination file that merely never got listed would be
+/// deleted as "extraneous" - silent data loss. Upstream's `delete_in_dir()`
+/// returns early (printing the notice once) in exactly this case, and only when
+/// `--ignore-errors` was not given. This test pins that the receiver skips the
+/// whole delete pass and keeps the un-listed dest file, emitting the notice once
+/// even across both (early + late) delete-pass sites.
+///
+/// upstream: generator.c:298-305 - `io_error & IOERR_GENERAL && !ignore_errors`.
+#[test]
+fn delete_pass_skipped_when_sender_flist_had_io_error() {
+    use super::super::super::stats::TransferStats;
+    use super::super::super::transfer::DeletePassPhase;
+    use crate::generator::io_error_flags::IOERR_GENERAL;
+    use logging::{DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    init(VerbosityConfig::from_verbose_level(0));
+    let _ = drain_events();
+
+    let handshake = test_handshake();
+
+    // Destination carries an extraneous `stale.txt` that is NOT in the file
+    // list, making it a delete candidate under `--delete`.
+    let build = |dest: &std::path::Path| {
+        std::fs::write(dest.join("stale.txt"), b"extraneous").unwrap();
+        let mut config = test_config();
+        config.flags.delete = true;
+        // --delete-during: immediate early sweep, the mode most exposed to the
+        // incomplete-flist hazard (it deletes before the transfer lands).
+        config.deletion.delete_after = false;
+        config.deletion.late_delete = false;
+        config.args = vec![OsString::from(dest.to_str().unwrap())];
+        config
+    };
+
+    let notice = "IO error encountered -- skipping file deletion";
+    let count_notice = |events: Vec<DiagnosticEvent>| {
+        events
+            .into_iter()
+            .filter(
+                |event| matches!(event, DiagnosticEvent::Info { message, .. } if message == notice),
+            )
+            .count()
+    };
+
+    // Case 1: IOERR_GENERAL set, no --ignore-errors => skip the pass entirely.
+    let guarded_dir = tempfile::TempDir::new().unwrap();
+    let dest = guarded_dir.path();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, build(dest));
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    let mut stats = TransferStats::default();
+    stats.io_error |= IOERR_GENERAL;
+    let mut writer = TestDeletionWriter;
+
+    // Both delete-pass sites run in a real transfer; the guard must fire once.
+    for phase in [DeletePassPhase::Early, DeletePassPhase::Late] {
+        ctx.run_receiver_delete_pass(
+            phase,
+            dest,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+            &mut stats,
+        )
+        .unwrap();
+    }
+    assert!(
+        dest.join("stale.txt").exists(),
+        "an un-listed dest file must survive when the sender's flist had an IO error"
+    );
+    assert_eq!(
+        count_notice(drain_events()),
+        1,
+        "the skip notice must be emitted exactly once across both delete sites"
+    );
+
+    // Case 2: same IO error, but --ignore-errors re-enables deletion and
+    // suppresses the notice - matching upstream, where the flag does both.
+    let ignore_dir = tempfile::TempDir::new().unwrap();
+    let dest = ignore_dir.path();
+    let mut config = build(dest);
+    config.deletion.ignore_errors = true;
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    let mut stats = TransferStats::default();
+    stats.io_error |= IOERR_GENERAL;
+    let mut writer = TestDeletionWriter;
+
+    ctx.run_receiver_delete_pass(
+        DeletePassPhase::Early,
+        dest,
+        #[cfg(unix)]
+        None,
+        &mut writer,
+        &mut stats,
+    )
+    .unwrap();
+    assert!(
+        !dest.join("stale.txt").exists(),
+        "--ignore-errors must let the delete pass proceed despite the IO error"
+    );
+    assert_eq!(
+        count_notice(drain_events()),
+        0,
+        "--ignore-errors must suppress the skip notice"
+    );
+}
+
 /// TIMING CONTRAST: the very same sweep, run while the destination
 /// `.rsync-filter` is NOT yet present (the state at an early, pre-transfer
 /// sweep), deletes the `.bak` files - there is no on-disk merge file to load,

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -273,6 +273,21 @@ impl ReceiverContext {
     where
         W: Write + crate::writer::MsgInfoSender + ?Sized,
     {
+        use crate::generator::io_error_flags::IOERR_GENERAL;
+
+        // upstream: generator.c:298-305 delete_in_dir() - if the sender hit a
+        // general I/O error while scanning the source, its file list may be
+        // incomplete, so deleting dest files that merely never got listed would
+        // lose data. Skip the entire delete pass (both phases) and print the
+        // notice once, unless `--ignore-errors` was given.
+        if stats.io_error & IOERR_GENERAL != 0 && !self.config.deletion.ignore_errors {
+            if !self.io_error_delete_warning_emitted {
+                self.io_error_delete_warning_emitted = true;
+                info_log!(Nonreg, 1, "IO error encountered -- skipping file deletion");
+            }
+            return Ok(());
+        }
+
         // `--delete-delay` (`delete_during == 2`): late_delete without the
         // `delete_after` decision-deferral. Deferrable only on the parallel path.
         let delay = self.config.deletion.late_delete && !self.config.deletion.delete_after;


### PR DESCRIPTION
## Summary

The receiver's destination delete pass did not guard against an incomplete sender file list. Upstream `generator.c:delete_in_dir()` (lines 298-305) returns early - printing `IO error encountered -- skipping file deletion` exactly once - whenever `io_error & IOERR_GENERAL && !ignore_errors`. The rationale is a data-loss protection: if the sender hit a general I/O error while scanning the source, its file list may be incomplete, so deleting destination files that merely never got listed would remove data the user still wants.

The engine local-copy path already implements this guard (`crates/engine/src/local_copy/context_impl/state.rs`). The remote/receiver delete path did not, so a network transfer whose sender reported `IOERR_GENERAL` would still run the full delete sweep and could unlink un-listed destination files.

## Change

- At the top of `run_receiver_delete_pass` (before dispatching to the immediate/collect/execute delete paths), skip the entire pass and emit the upstream notice once when `stats.io_error & IOERR_GENERAL != 0 && !config.deletion.ignore_errors`.
- A one-shot `io_error_delete_warning_emitted` flag on `ReceiverContext` mirrors upstream's static `already_warned`, so the notice prints at most once across both the early and late delete sites.
- `--ignore-errors` keeps the pass running and suppresses the notice, matching upstream where the flag does both.

## Tests

Adds `delete_pass_skipped_when_sender_flist_had_io_error` to the receiver delete-timing module:

- With `IOERR_GENERAL` set and no `--ignore-errors`: an un-listed destination file survives, and the skip notice is emitted exactly once even when both delete-pass sites run.
- With `--ignore-errors`: the delete pass proceeds (the extraneous file is removed) and no notice is emitted.

## Upstream reference

`generator.c:298-305` `delete_in_dir()`.
