### PR TITLE
fix(protocol): reject sum_head s2length wider than negotiated digest

### DIFF
--- a/crates/protocol/src/negotiation/capabilities/algorithms.rs
+++ b/crates/protocol/src/negotiation/capabilities/algorithms.rs
@@ -142,6 +142,26 @@ impl ChecksumAlgorithm {
             )),
         }
     }
+
+    /// Returns the transfer digest width in bytes (`xfer_sum_len`).
+    ///
+    /// This is the number of strong-sum bytes a block signature carries and a
+    /// whole-file checksum spans for the negotiated algorithm. It bounds the
+    /// `s2length` a `sum_head` may advertise: a peer that claims a wider strong
+    /// sum than this would make the reader consume more bytes per block than
+    /// were written, desyncing the signature-block stream.
+    ///
+    /// upstream: checksum.c:214 `csum_len_for_type()` (non-flist form).
+    #[must_use]
+    pub const fn digest_len(self) -> usize {
+        match self {
+            Self::None => 1,
+            Self::MD4 | Self::MD5 => 16,
+            Self::SHA1 => 20,
+            Self::XXH64 | Self::XXH3 => 8,
+            Self::XXH128 => 16,
+        }
+    }
 }
 
 /// Compression algorithm negotiated between rsync peers.

--- a/crates/protocol/src/wire/delta/sum_head.rs
+++ b/crates/protocol/src/wire/delta/sum_head.rs
@@ -204,6 +204,35 @@ impl SumHead {
         Ok(())
     }
 
+    /// Rejects a head whose per-block strong sum is wider than the negotiated
+    /// transfer digest `xfer_sum_len`.
+    ///
+    /// [`check`](Self::check) only bounds `s2length` by the static
+    /// [`MAX_STRONG_SUM_LEN`] ceiling (SHA-1, the widest negotiable digest).
+    /// A peer that negotiated a narrower transfer checksum (XXH64 / XXH3-64 =
+    /// 8 bytes) can still advertise a legal-looking `s2length` up to 20; the
+    /// reader would then consume `4 + s2length` bytes per block while the
+    /// generator only wrote `4 + xfer_sum_len`, desyncing the signature-block
+    /// stream. Gating on the negotiated width closes that gap while leaving a
+    /// well-behaved header - whose `s2length` never exceeds `xfer_sum_len` -
+    /// untouched.
+    ///
+    /// upstream: io.c:read_sum_head - `if (sum->s2length < 0 ||
+    /// sum->s2length > xfer_sum_len) exit_cleanup(RERR_PROTOCOL)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SumHeadError::InvalidStrongSumLength`] when `s2length`
+    /// exceeds `xfer_sum_len`.
+    pub const fn ensure_s2length_within(self, xfer_sum_len: u32) -> Result<Self, SumHeadError> {
+        if self.s2length > xfer_sum_len {
+            return Err(SumHeadError::InvalidStrongSumLength {
+                s2length: self.s2length as i32,
+            });
+        }
+        Ok(self)
+    }
+
     /// Number of basis blocks a match token may reference.
     #[inline]
     #[must_use]
@@ -496,6 +525,35 @@ mod tests {
         assert_eq!(
             SumHead::with_blocks(1, 700, 2, 701),
             Err(SumHeadError::InvalidRemainder { remainder: 701 })
+        );
+    }
+
+    /// A header whose `s2length` exceeds the negotiated transfer digest width
+    /// must be rejected: the block reader would consume `4 + s2length` bytes
+    /// per block while the generator only wrote `4 + xfer_sum_len`, desyncing
+    /// the signature-block stream. A width equal to or below the negotiated
+    /// digest is the only geometry a well-behaved peer emits, so both are
+    /// accepted unchanged.
+    #[test]
+    fn s2length_wider_than_negotiated_digest_is_rejected() {
+        // XXH64 negotiates an 8-byte transfer digest; a header claiming a
+        // 16-byte strong sum passes the static SHA-1 ceiling but must not pass
+        // the negotiated one.
+        let head = SumHead::with_blocks(4, 512, 16, 0).expect("valid geometry");
+        assert_eq!(
+            head.ensure_s2length_within(8),
+            Err(SumHeadError::InvalidStrongSumLength { s2length: 16 })
+        );
+        // s2length == negotiated width is the widest a generator writes.
+        assert_eq!(head.ensure_s2length_within(16), Ok(head));
+        // s2length < negotiated width (e.g. a phase-1 short sum) is accepted.
+        assert_eq!(head.ensure_s2length_within(20), Ok(head));
+
+        let narrow = SumHead::with_blocks(4, 512, 8, 0).expect("valid geometry");
+        assert_eq!(narrow.ensure_s2length_within(8), Ok(narrow));
+        assert_eq!(
+            narrow.ensure_s2length_within(4),
+            Err(SumHeadError::InvalidStrongSumLength { s2length: 8 })
         );
     }
 

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -664,8 +664,16 @@ impl GeneratorContext {
                 continue;
             }
 
-            // upstream: sender.c:120 - receive_sums()
-            let sum_head = SumHead::read(&mut *reader)?;
+            // upstream: sender.c:120 - receive_sums(), which calls
+            // io.c:read_sum_head(). That reader rejects an s2length wider than
+            // the negotiated transfer digest (`xfer_sum_len`): the block loop
+            // below consumes `4 + s2length` bytes per block, so a strong sum
+            // wider than the checksum the generator wrote would desync the
+            // stream. get_checksum_algorithm() yields the negotiated (or
+            // protocol-default) transfer checksum, whose digest_len is upstream's
+            // xfer_sum_len (checksum.c:214 csum_len_for_type()).
+            let xfer_sum_len = self.get_checksum_algorithm().digest_len() as u32;
+            let sum_head = SumHead::read_negotiated(&mut *reader, xfer_sum_len)?;
             self.timing.total_bytes_read += 16;
 
             self.validate_file_index(ndx)?;

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -215,6 +215,32 @@ impl SumHead {
         })
     }
 
+    /// Decodes a sum_head and additionally rejects an `s2length` wider than the
+    /// negotiated transfer digest width `xfer_sum_len`.
+    ///
+    /// [`from_wire_bytes`](Self::from_wire_bytes) bounds `s2length` only by the
+    /// static SHA-1 ceiling; a peer that negotiated a narrower checksum
+    /// (XXH64 / XXH3-64 = 8 bytes) could still advertise a legal-looking 16-byte
+    /// strong sum, making [`read_signature_blocks`] consume `4 + s2length` bytes
+    /// per block while the generator wrote only `4 + xfer_sum_len`, desyncing
+    /// the stream. Gating on the negotiated width closes that gap.
+    ///
+    /// upstream: io.c:read_sum_head - `if (sum->s2length > xfer_sum_len)
+    /// exit_cleanup(RERR_PROTOCOL)`.
+    ///
+    /// [`read_signature_blocks`]: crate::generator::read_signature_blocks
+    fn from_wire_bytes_negotiated(buf: &[u8; 16], xfer_sum_len: u32) -> io::Result<Self> {
+        let head = protocol::wire::SumHead::decode(*buf)
+            .and_then(|head| head.ensure_s2length_within(xfer_sum_len))
+            .map_err(Self::malformed)?;
+        Ok(Self {
+            count: head.count(),
+            blength: head.blength(),
+            s2length: head.s2length(),
+            remainder: head.remainder(),
+        })
+    }
+
     /// Builds a `RERR_PROTOCOL`-mapped error for a malformed sum_head field.
     ///
     /// upstream: io.c:2032-2065 `read_sum_head()` validates every field and
@@ -235,6 +261,21 @@ impl SumHead {
         let mut buf = [0u8; 16];
         reader.read_exact(&mut buf)?;
         Self::from_wire_bytes(&buf)
+    }
+
+    /// Reads a sum_head, rejecting an `s2length` wider than the negotiated
+    /// transfer digest width `xfer_sum_len`.
+    ///
+    /// The signature-block reader that follows consumes `4 + s2length` bytes
+    /// per block, so a header advertising a strong sum wider than the checksum
+    /// the generator actually wrote would desync the stream. This is the read
+    /// used before [`read_signature_blocks`](crate::generator::read_signature_blocks).
+    ///
+    /// upstream: io.c:read_sum_head.
+    pub fn read_negotiated<R: Read>(reader: &mut R, xfer_sum_len: u32) -> io::Result<Self> {
+        let mut buf = [0u8; 16];
+        reader.read_exact(&mut buf)?;
+        Self::from_wire_bytes_negotiated(&buf, xfer_sum_len)
     }
 }
 


### PR DESCRIPTION
## Problem

`read_sum_head` must reject a `sum_head` whose `s2length` exceeds the negotiated transfer digest width (`xfer_sum_len`). Upstream (`io.c:read_sum_head`) enforces `sum->s2length > xfer_sum_len -> RERR_PROTOCOL`.

Our decoder validated `s2length` only against the static ceiling `MAX_STRONG_SUM_LEN` (20 = SHA-1, the widest negotiable digest). A peer that negotiated a narrow transfer checksum (XXH64 / XXH3-64 = 8 bytes) could therefore advertise a legal-looking 16-byte strong sum. The signature-block reader then consumes `4 + s2length` bytes per block while the generator wrote only `4 + xfer_sum_len`, desyncing the delta stream.

## Fix

Thread the negotiated transfer digest width into `sum_head` decoding on the sender's `receive_sums` path:

- `ChecksumAlgorithm::digest_len()` (protocol) mirrors `checksum.c:214 csum_len_for_type()` and yields `xfer_sum_len` for the negotiated algorithm.
- `SumHead::ensure_s2length_within(xfer_sum_len)` (protocol) rejects an over-wide strong sum with the existing `InvalidStrongSumLength` -> `RERR_PROTOCOL` path. The static `MAX_STRONG_SUM_LEN` check in `decode`/`check` stays as defense in depth.
- `SumHead::read_negotiated` (transfer wrapper) reads and enforces it.
- The generator's transfer loop supplies the width via `GeneratorContext::get_checksum_algorithm().digest_len()` before reading the signature blocks.

This only tightens rejection of malformed input. A well-behaved generator caps `s2length` at `MIN(SUM_LENGTH, xfer_sum_len)` (`sum_sizes_sqroot`), so `s2length <= xfer_sum_len` always holds and no wire byte changes. Golden-byte tests are unaffected.

## Tests

Unit test in `sum_head.rs`: a header with `s2length` greater than the negotiated width is rejected, while `s2length == width` and `s2length < width` are accepted, encoding why an over-wide `s2length` desyncs the signature-block stream.

upstream: `io.c:read_sum_head`, `checksum.c:214 csum_len_for_type()`.
