### PR TITLE
fix(cli): correct --ignore-missing-args direction and emit --no-W for inplace+sparse push

### DIFF
--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -682,12 +682,18 @@ impl<'a> RemoteInvocationBuilder<'a> {
             }
         }
 
-        // upstream: options.c:817-818 - missing_args forwarded as long-form.
-        if self.config.ignore_missing_args() {
-            args.push(OsString::from("--ignore-missing-args"));
-        }
+        // upstream: options.c:2866-2871 - "--delete-missing-args needs the
+        // cooperation of both sides, but the sender can handle
+        // --ignore-missing-args by itself." So --delete-missing-args
+        // (missing_args == 2) is ALWAYS forwarded, while --ignore-missing-args
+        // (missing_args == 1) is forwarded only on a PULL (`!am_sender`): a
+        // sender applies the ignore locally and must not steer the remote. The
+        // if/else-if mirrors upstream's mutually-exclusive missing_args state so
+        // the two spellings can never be emitted together.
         if self.config.delete_missing_args() {
             args.push(OsString::from("--delete-missing-args"));
+        } else if self.config.ignore_missing_args() && !am_sender {
+            args.push(OsString::from("--ignore-missing-args"));
         }
 
         // upstream: options.c:2982-2985 - `if (remove_source_files == 1)

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -587,6 +587,17 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // derives inplace from append); the two are mutually exclusive.
         if self.config.inplace() && !self.config.append() {
             args.push(OsString::from("--inplace"));
+            // upstream: options.c:server_options - `else if (inplace) {
+            // --inplace; if (sparse_files && !whole_file && am_sender) --no-W }`.
+            // Works around a bug in older remote receivers where --inplace
+            // --sparse wrongly selected whole-file mode; a PUSH (am_sender)
+            // appends --no-W to force delta transfer there. `whole_file_raw() !=
+            // Some(true)` mirrors upstream `!whole_file`: the compact 'W' letter
+            // is packed only for an explicit whole-file, so its absence is
+            // upstream's resolved `whole_file == 0` for a remote transfer.
+            if am_sender && self.config.sparse() && self.config.whole_file_raw() != Some(true) {
+                args.push(OsString::from("--no-W"));
+            }
         }
 
         // upstream: options.c:2951-2954 server_options() - append_mode is sent

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -801,6 +801,39 @@ fn includes_inplace_long_arg() {
 }
 
 #[test]
+fn ignore_missing_args_is_pull_only_delete_missing_is_both() {
+    // upstream: options.c:2866-2871 - "--delete-missing-args needs the
+    // cooperation of both sides, but the sender can handle
+    // --ignore-missing-args by itself." WHY: forwarding --ignore-missing-args
+    // on a PUSH would steer the remote receiver for a decision the local
+    // sender already makes, so it is emitted only on a PULL (!am_sender);
+    // --delete-missing-args always goes both directions.
+    let ignore = ClientConfig::builder().ignore_missing_args(true).build();
+    let pull = RemoteInvocationBuilder::new(&ignore, RemoteRole::Receiver).build("/path");
+    assert!(
+        pull.iter().any(|a| a == "--ignore-missing-args"),
+        "--ignore-missing-args must be forwarded on a pull: {pull:?}"
+    );
+    let push = RemoteInvocationBuilder::new(&ignore, RemoteRole::Sender).build("/path");
+    assert!(
+        !push.iter().any(|a| a == "--ignore-missing-args"),
+        "--ignore-missing-args must NOT be forwarded on a push: {push:?}"
+    );
+
+    let delete = ClientConfig::builder().delete_missing_args(true).build();
+    let del_pull = RemoteInvocationBuilder::new(&delete, RemoteRole::Receiver).build("/path");
+    let del_push = RemoteInvocationBuilder::new(&delete, RemoteRole::Sender).build("/path");
+    assert!(
+        del_pull.iter().any(|a| a == "--delete-missing-args"),
+        "--delete-missing-args must be forwarded on a pull: {del_pull:?}"
+    );
+    assert!(
+        del_push.iter().any(|a| a == "--delete-missing-args"),
+        "--delete-missing-args must be forwarded on a push: {del_push:?}"
+    );
+}
+
+#[test]
 fn includes_partial_dir_long_arg() {
     let config = ClientConfig::builder()
         .partial_directory(Some(".rsync-partial"))

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -801,6 +801,67 @@ fn includes_inplace_long_arg() {
 }
 
 #[test]
+fn no_w_emitted_for_inplace_sparse_push() {
+    // upstream: options.c:server_options - `else if (inplace) { --inplace; if
+    // (sparse_files && !whole_file && am_sender) --no-W }`. On a PUSH the
+    // remote receiver is an older-rsync workaround target: --inplace --sparse
+    // must be paired with --no-W so the remote does a delta (not whole-file)
+    // transfer. WHY: without --no-W an older remote silently switches to
+    // whole-file mode for --inplace --sparse, defeating the delta the client
+    // asked for.
+    let config = ClientConfig::builder().inplace(true).sparse(true).build();
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+
+    assert!(
+        args.iter().any(|a| a == "--inplace"),
+        "expected --inplace in args: {args:?}"
+    );
+    assert!(
+        args.iter().any(|a| a == "--no-W"),
+        "expected --no-W for inplace+sparse push: {args:?}"
+    );
+}
+
+#[test]
+fn no_w_suppressed_on_pull_and_without_sparse_or_whole_file() {
+    // upstream: options.c:server_options - the --no-W guard is
+    // `sparse_files && !whole_file && am_sender`. Each missing conjunct
+    // suppresses it: a PULL (remote is the sender, !am_sender), no --sparse,
+    // and an explicit --whole-file (`whole_file == 1`) each drop the flag.
+    // WHY: --no-W only patches a receiver-side whole-file bug, so it is
+    // meaningless on a pull, without sparse, or when whole-file is intended.
+
+    // PULL with inplace+sparse: remote is the sender, no --no-W.
+    let pull = ClientConfig::builder().inplace(true).sparse(true).build();
+    let pull_args = RemoteInvocationBuilder::new(&pull, RemoteRole::Receiver).build("/path");
+    assert!(
+        !pull_args.iter().any(|a| a == "--no-W"),
+        "--no-W must not be sent on a pull: {pull_args:?}"
+    );
+
+    // PUSH with inplace but no sparse: no --no-W.
+    let no_sparse = ClientConfig::builder().inplace(true).build();
+    let no_sparse_args =
+        RemoteInvocationBuilder::new(&no_sparse, RemoteRole::Sender).build("/path");
+    assert!(
+        !no_sparse_args.iter().any(|a| a == "--no-W"),
+        "--no-W must not be sent without --sparse: {no_sparse_args:?}"
+    );
+
+    // PUSH with inplace+sparse but explicit --whole-file: no --no-W.
+    let whole = ClientConfig::builder()
+        .inplace(true)
+        .sparse(true)
+        .whole_file_option(Some(true))
+        .build();
+    let whole_args = RemoteInvocationBuilder::new(&whole, RemoteRole::Sender).build("/path");
+    assert!(
+        !whole_args.iter().any(|a| a == "--no-W"),
+        "--no-W must not be sent when whole-file is explicitly requested: {whole_args:?}"
+    );
+}
+
+#[test]
 fn ignore_missing_args_is_pull_only_delete_missing_is_both() {
     // upstream: options.c:2866-2871 - "--delete-missing-args needs the
     // cooperation of both sides, but the sender can handle


### PR DESCRIPTION
## Summary

Corrects two server-argument-forwarding divergences in the SSH `--server`
invocation builder (`crates/core/src/client/remote/invocation/builder.rs`),
each mirroring upstream rsync 3.4.4 `options.c:server_options()`.

### `--ignore-missing-args` is pull-only

Upstream (`options.c:2866-2871`):

```c
/* --delete-missing-args needs the cooperation of both sides, but
 * the sender can handle --ignore-missing-args by itself. */
if (missing_args == 2)
    args[ac++] = "--delete-missing-args";
else if (missing_args == 1 && !am_sender)
    args[ac++] = "--ignore-missing-args";
```

The builder forwarded `--ignore-missing-args` unconditionally and could emit
both spellings together. It is now guarded with `!am_sender` and structured as
a mutually exclusive `if`/`else if` with `--delete-missing-args`, matching
upstream and the already-correct daemon argument path. The stale upstream
citation (`options.c:817-818`) is corrected.

### `--no-W` for `--inplace --sparse` push

Upstream (`options.c:2957-2959`):

```c
} else if (inplace) {
    args[ac++] = "--inplace";
    /* Work around a bug in older rsync versions (on the remote side) for --inplace --sparse */
    if (sparse_files && !whole_file && am_sender)
        args[ac++] = "--no-W";
}
```

The builder sent `--inplace` but never the `--no-W` companion, so a push to an
affected older remote skipped the delta transfer the client requested. `--no-W`
is now emitted under the same guard (`inplace && sparse && !whole_file &&
am_sender`). The compact `W` letter is packed only for an explicit whole-file,
so `whole_file_raw() != Some(true)` mirrors upstream's resolved `!whole_file`.
The server side already parses and applies `--no-W`; no change needed there.

## Tests

Builder-level tests assert:

- `--ignore-missing-args` is forwarded on a pull and NOT on a push, while
  `--delete-missing-args` is forwarded in both directions.
- `--no-W` is emitted for `inplace + sparse + !whole_file + am_sender`, and
  suppressed on a pull, without `--sparse`, and under an explicit
  `--whole-file`.

Each test encodes why the behaviour mirrors upstream `server_options()`.
