### PR TITLE
fix(metadata): honor modify-window in unchanged check and set times before chmod

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -670,13 +670,11 @@ pub fn apply_metadata_with_attrs_flags_and_pre_transfer(
         cached_meta
     };
 
-    permissions::apply_permissions_from_entry(
-        destination,
-        entry,
-        options,
-        cached_meta.as_ref(),
-        pre_transfer_meta.as_ref(),
-    )?;
+    // upstream: rsync.c:632 `set_times()` runs BEFORE rsync.c:658 `do_chmod_at()`,
+    // so timestamps are applied ahead of the permission change. This ordering is
+    // observable (upstream sets the mtime/atime, then the mode) and it also keeps
+    // a read-only target mode from blocking the utimes call that would otherwise
+    // follow it.
 
     // upstream: rsync.c:597 - `if (!(flags & ATTRS_SKIP_MTIME) && !same_mtime(...))`
     if options.times() && !attrs_flags.skip_mtime() {
@@ -698,6 +696,16 @@ pub fn apply_metadata_with_attrs_flags_and_pre_transfer(
     if options.crtimes() && entry.crtime() != 0 && !attrs_flags.skip_crtime() {
         timestamps::apply_crtime_from_entry(destination, entry)?;
     }
+
+    // upstream: rsync.c:658 - `do_chmod_at()` is the last attribute upstream
+    // applies, after times (and after ACLs, which oc applies in the caller).
+    permissions::apply_permissions_from_entry(
+        destination,
+        entry,
+        options,
+        cached_meta.as_ref(),
+        pre_transfer_meta.as_ref(),
+    )?;
 
     Ok(())
 }

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -16,6 +16,7 @@ pub use ownership::group_is_settable;
 mod tests;
 
 use crate::error::MetadataError;
+use crate::modify_window::ModifyWindow;
 use crate::options::{AttrsFlags, MetadataOptions};
 use std::fs;
 #[cfg(unix)]
@@ -290,11 +291,19 @@ pub fn apply_file_metadata_with_fd_if_changed(
 ///   when `unchanged_attrs` would fail (implicit - upstream always calls
 ///   `set_file_attrs` but its internal guards skip every syscall when nothing
 ///   differs)
+///
+/// `modify_window` carries the `--modify-window` tolerance so the mtime leg
+/// matches upstream `mtime_differs()` -> `same_time()` (util1.c:1478) exactly:
+/// the default zero window keeps whole-second equality, a positive window
+/// tolerates that many seconds of drift, and a negative window compares
+/// nanoseconds too. Passing the same `ModifyWindow` the quick-check used keeps
+/// the "content matches" and "attributes match" verdicts consistent.
 #[inline]
 pub fn metadata_unchanged(
     entry: &protocol::flist::FileEntry,
     options: &MetadataOptions,
     cached_meta: &fs::Metadata,
+    modify_window: ModifyWindow,
 ) -> bool {
     #[cfg(unix)]
     {
@@ -335,11 +344,17 @@ pub fn metadata_unchanged(
         }
 
         // upstream: generator.c:492-493 - any_time_differs(sxp, file, fname)
-        // Compare raw seconds + nanoseconds directly instead of constructing
-        // FileTime structs on the hot path.
+        // -> mtime_differs() -> same_time(), so the `--modify-window` tolerance
+        // governs this leg. Pass the sub-second component from both sides; a
+        // negative window compares it (util1.c:1482) while the default zero
+        // window reduces to whole-second equality.
         if options.times()
-            && (cached_meta.mtime() != entry.mtime()
-                || cached_meta.mtime_nsec() as u32 != entry.mtime_nsec())
+            && !modify_window.same_time(
+                cached_meta.mtime(),
+                cached_meta.mtime_nsec() as u32,
+                entry.mtime(),
+                entry.mtime_nsec(),
+            )
         {
             return false;
         }
@@ -357,8 +372,14 @@ pub fn metadata_unchanged(
     {
         if options.times() {
             let current_mtime = filetime::FileTime::from_last_modification_time(cached_meta);
-            let entry_mtime = filetime::FileTime::from_unix_time(entry.mtime(), entry.mtime_nsec());
-            if current_mtime != entry_mtime {
+            // upstream: util1.c:1478 same_time() - apply the `--modify-window`
+            // tolerance rather than an exact FileTime compare.
+            if !modify_window.same_time(
+                current_mtime.unix_seconds(),
+                current_mtime.nanoseconds(),
+                entry.mtime(),
+                entry.mtime_nsec(),
+            ) {
                 return false;
             }
         }

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -721,6 +721,49 @@ fn apply_metadata_from_file_entry_with_timestamps() {
     );
 }
 
+/// upstream: rsync.c:632 `set_times()` runs before rsync.c:658 `do_chmod_at()`,
+/// so timestamps are applied ahead of the (possibly read-only) target mode. This
+/// test drives the full `apply_metadata_with_attrs_flags_and_pre_transfer` path
+/// with both `-p` and `-t` and a read-only target mode: the resulting file must
+/// carry BOTH the requested mtime AND the read-only mode. If the chmod preceded
+/// the time set (the pre-fix order), a mode that forbids owner-write would leave
+/// the mtime unset on any platform that requires write access for utimes - so
+/// the surviving mtime encodes the upstream times-before-chmod ordering.
+#[cfg(unix)]
+#[test]
+fn apply_metadata_sets_times_before_readonly_chmod() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("times-then-chmod.txt");
+    fs::write(&dest, b"data").expect("write dest");
+    // Start writable so the failure mode is solely about the apply ordering.
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o644)).expect("seed dest perms");
+
+    let mut entry = FileEntry::new_file("times-then-chmod.txt".into(), 4, 0o444);
+    entry.set_mtime(1_700_000_000, 123_456_789);
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true);
+    apply_metadata_from_file_entry(&dest, &entry, &opts).expect("apply from entry");
+
+    let dest_meta = fs::metadata(&dest).expect("dest metadata");
+    // The mtime must have been written even though the final mode is read-only.
+    assert_eq!(
+        FileTime::from_last_modification_time(&dest_meta),
+        FileTime::from_unix_time(1_700_000_000, 123_456_789),
+        "mtime must survive: times are set before the read-only chmod"
+    );
+    // And the read-only mode must be the final on-disk state.
+    assert_eq!(
+        current_mode(&dest) & 0o777,
+        0o444,
+        "read-only target mode must be applied after the times"
+    );
+}
+
 #[test]
 fn apply_metadata_from_file_entry_no_times() {
     use protocol::flist::FileEntry;

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1615,7 +1615,7 @@ fn metadata_unchanged_returns_true_when_all_attrs_match() {
         .preserve_group(true);
 
     assert!(
-        metadata_unchanged(&entry, &opts, &meta),
+        metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "should return true when all attributes match"
     );
 }
@@ -1648,7 +1648,7 @@ fn metadata_unchanged_returns_false_on_permission_mismatch() {
         .preserve_group(true);
 
     assert!(
-        !metadata_unchanged(&entry, &opts, &meta),
+        !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "should return false when permissions differ"
     );
 }
@@ -1677,8 +1677,58 @@ fn metadata_unchanged_returns_false_on_mtime_mismatch() {
         .preserve_group(true);
 
     assert!(
-        !metadata_unchanged(&entry, &opts, &meta),
+        !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "should return false when mtime differs"
+    );
+}
+
+/// upstream: generator.c:396 `mtime_differs()` -> util1.c:1478 `same_time()` -
+/// `unchanged_attrs()` must treat two mtimes within `--modify-window` as equal.
+/// Before threading the window, oc compared the mtime exactly, so a
+/// within-window destination was mis-classified as changed and its metadata was
+/// re-applied even though upstream would skip it. The default zero window keeps
+/// the whole-second exact comparison.
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_honors_modify_window() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("window.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let base = meta.mtime();
+
+    let mut entry = FileEntry::new_file("window.txt".into(), 4, meta.mode() & 0o7777);
+    entry.set_uid(meta.uid());
+    entry.set_gid(meta.gid());
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true)
+        .preserve_owner(true)
+        .preserve_group(true);
+
+    // Source mtime 1s newer than the destination: inside a 2s window it is
+    // "the same" (upstream same_time returns 1), so nothing changed.
+    entry.set_mtime(base + 1, 0);
+    assert!(
+        metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::from_secs(2)),
+        "mtime delta (1s) <= window (2s) must be unchanged, mirroring same_time()"
+    );
+    // The default zero window keeps the exact whole-second comparison, so the
+    // same 1s drift is reported as changed.
+    assert!(
+        !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
+        "window 0 must stay exact: a 1s drift is a change"
+    );
+
+    // A drift larger than the window is a change regardless of tolerance.
+    entry.set_mtime(base + 3, 0);
+    assert!(
+        !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::from_secs(2)),
+        "mtime delta (3s) > window (2s) must be changed"
     );
 }
 
@@ -1707,7 +1757,7 @@ fn metadata_unchanged_ignores_perms_when_not_preserved() {
         .preserve_group(true);
 
     assert!(
-        metadata_unchanged(&entry, &opts, &meta),
+        metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "should return true when perms differ but preservation is off"
     );
 }
@@ -1743,7 +1793,7 @@ fn metadata_unchanged_detects_executability_presence_mismatch() {
         .preserve_times(true);
 
     assert!(
-        !metadata_unchanged(&entry, &opts, &meta),
+        !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "executable source vs non-executable dest must force the attr pass"
     );
 
@@ -1753,7 +1803,7 @@ fn metadata_unchanged_detects_executability_presence_mismatch() {
     fs::set_permissions(&dest, fs::Permissions::from_mode(0o755)).expect("chmod dest");
     let meta = fs::metadata(&dest).expect("metadata");
     assert!(
-        !metadata_unchanged(&entry, &opts, &meta),
+        !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "non-executable source vs executable dest must force the attr pass"
     );
 }
@@ -1785,7 +1835,7 @@ fn metadata_unchanged_executability_ignores_matching_presence_and_non_files() {
     let mut entry = FileEntry::new_file("exec-match.txt".into(), 4, 0o700);
     entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
     assert!(
-        metadata_unchanged(&entry, &opts, &meta),
+        metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "matching exec presence must not force the attr pass"
     );
 
@@ -1798,7 +1848,7 @@ fn metadata_unchanged_executability_ignores_matching_presence_and_non_files() {
     let mut dir_entry = FileEntry::new_directory("subdir".into(), 0o755);
     dir_entry.set_mtime(dir_mtime.unix_seconds(), dir_mtime.nanoseconds());
     assert!(
-        metadata_unchanged(&dir_entry, &opts, &dir_meta),
+        metadata_unchanged(&dir_entry, &opts, &dir_meta, crate::ModifyWindow::ZERO),
         "-E never applies to directories"
     );
 }
@@ -1821,7 +1871,7 @@ fn metadata_unchanged_returns_false_when_chmod_would_change_mode() {
     let opts = MetadataOptions::new().with_chmod(Some(chmod));
 
     assert!(
-        !metadata_unchanged(&entry, &opts, &meta),
+        !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "should return false when chmod would change mode"
     );
 }
@@ -1855,7 +1905,7 @@ fn metadata_unchanged_returns_true_when_chmod_is_noop() {
         .with_chmod(Some(chmod));
 
     assert!(
-        metadata_unchanged(&entry, &opts, &meta),
+        metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "should return true when chmod modifier does not change mode"
     );
 }
@@ -1884,7 +1934,7 @@ fn metadata_unchanged_returns_true_when_owner_override_matches() {
         .with_owner_override(Some(meta.uid()));
 
     assert!(
-        metadata_unchanged(&entry, &opts, &meta),
+        metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "should return true when owner override matches current uid"
     );
 }
@@ -1913,7 +1963,7 @@ fn metadata_unchanged_returns_false_when_owner_override_differs() {
         .with_owner_override(Some(meta.uid() + 1));
 
     assert!(
-        !metadata_unchanged(&entry, &opts, &meta),
+        !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "should return false when owner override differs from current uid"
     );
 }
@@ -1942,7 +1992,7 @@ fn metadata_unchanged_returns_true_when_group_override_matches() {
         .with_group_override(Some(meta.gid()));
 
     assert!(
-        metadata_unchanged(&entry, &opts, &meta),
+        metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
         "should return true when group override matches current gid"
     );
 }

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -259,6 +259,7 @@ impl ReceiverContext {
                     &self.config.reference_directories,
                     &crate::receiver::quick_check::NonRegularBasis::Symlink { target },
                     &compare_opts,
+                    self.config.file_selection.modify_window,
                 ) {
                     continue;
                 }

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -145,6 +145,7 @@ impl ReceiverContext {
                         &self.config.reference_directories,
                         &basis,
                         &compare_opts,
+                        self.config.file_selection.modify_window,
                     ) {
                         continue;
                     }

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -303,7 +303,7 @@ fn best_reference_match<'a>(
         // upstream: generator.c:977 - unchanged_attrs() distinguishes level 3
         // (every preserved attr equal) from level 2 (content matches, attrs
         // differ). `metadata_unchanged` is oc's `unchanged_attrs` equivalent.
-        let level = if metadata_unchanged(entry, metadata_opts, &ref_meta) {
+        let level = if metadata_unchanged(entry, metadata_opts, &ref_meta, modify_window) {
             MatchLevel::Exact
         } else {
             MatchLevel::Content
@@ -570,6 +570,7 @@ pub(super) fn try_reference_dest_non(
     reference_directories: &[ReferenceDirectory],
     basis: &NonRegularBasis,
     metadata_opts: &MetadataOptions,
+    modify_window: ModifyWindow,
 ) -> bool {
     if reference_directories.is_empty() {
         return false;
@@ -590,7 +591,7 @@ pub(super) fn try_reference_dest_non(
         }
         // upstream: generator.c:1100 - unchanged_attrs() promotes to match_level
         // 3; `metadata_unchanged` is oc's equivalent.
-        if !metadata_unchanged(entry, metadata_opts, &ref_meta) {
+        if !metadata_unchanged(entry, metadata_opts, &ref_meta, modify_window) {
             return None;
         }
         Some((ref_dir.kind, ref_path))
@@ -1769,6 +1770,7 @@ mod non_regular_alt_dest_tests {
                 target: Path::new("target"),
             },
             &identity_only_opts(),
+            metadata::ModifyWindow::from_secs(0),
         );
 
         assert!(handled, "identical compare-dest symlink must be handled");
@@ -1796,6 +1798,7 @@ mod non_regular_alt_dest_tests {
                 target: Path::new("target"),
             },
             &identity_only_opts(),
+            metadata::ModifyWindow::from_secs(0),
         );
 
         assert!(
@@ -1823,6 +1826,7 @@ mod non_regular_alt_dest_tests {
                 target: Path::new("target"),
             },
             &identity_only_opts(),
+            metadata::ModifyWindow::from_secs(0),
         );
 
         let dest_link = dest.join("link");
@@ -1858,6 +1862,7 @@ mod non_regular_alt_dest_tests {
             &refs(ReferenceDirectoryKind::Link, &basis),
             &NonRegularBasis::Special { is_socket: false },
             &identity_only_opts(),
+            metadata::ModifyWindow::from_secs(0),
         );
 
         let dest_fifo = dest.join("pipe");
@@ -1887,6 +1892,7 @@ mod non_regular_alt_dest_tests {
                 target: Path::new("target"),
             },
             &identity_only_opts(),
+            metadata::ModifyWindow::from_secs(0),
         );
 
         assert!(
@@ -1915,6 +1921,7 @@ mod non_regular_alt_dest_tests {
             &refs(ReferenceDirectoryKind::Compare, &basis),
             &NonRegularBasis::Special { is_socket: true },
             &identity_only_opts(),
+            metadata::ModifyWindow::from_secs(0),
         );
 
         assert!(!handled, "a socket source must not match a fifo basis");
@@ -1950,6 +1957,7 @@ mod non_regular_alt_dest_tests {
                 target: Path::new("target"),
             },
             &opts,
+            metadata::ModifyWindow::from_secs(0),
         );
 
         assert!(
@@ -1981,6 +1989,7 @@ mod non_regular_alt_dest_tests {
             &refs(ReferenceDirectoryKind::Link, &basis),
             &NonRegularBasis::Device { rdev },
             &identity_only_opts(),
+            metadata::ModifyWindow::from_secs(0),
         );
         let dest_dev = dest.join("dev");
         assert!(handled, "identical link-dest device must be handled");
@@ -2003,6 +2012,7 @@ mod non_regular_alt_dest_tests {
                 rdev: metadata::device_word(1, 5),
             },
             &identity_only_opts(),
+            metadata::ModifyWindow::from_secs(0),
         );
         assert!(!handled2, "a differing device rdev must not match");
     }

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -1123,7 +1123,7 @@ impl ReceiverContext {
             } else {
                 " (file change)"
             }
-        } else if !metadata_unchanged(entry, metadata_opts, dest_meta) {
+        } else if !metadata_unchanged(entry, metadata_opts, dest_meta, modify_window) {
             " (attr change)"
         } else {
             " (uptodate)"
@@ -1176,7 +1176,14 @@ impl ReceiverContext {
         // already match. Skip entirely when no preservation flags are active.
         // On a no-change scan this eliminates ownership mapping, permission
         // comparison, and timestamp construction for every file.
-        if needs_metadata_apply && !metadata_unchanged(entry, metadata_opts, stat_meta) {
+        if needs_metadata_apply
+            && !metadata_unchanged(
+                entry,
+                metadata_opts,
+                stat_meta,
+                self.config.file_selection.modify_window,
+            )
+        {
             if let Err(e) = apply_metadata_with_cached_stat(
                 file_path,
                 entry,


### PR DESCRIPTION
Two independent `rsyncd.conf` parsing fidelity fixes for the daemon, each in its own commit.

## 1. Global bare `include` is a P_LOCAL filter default, not file inclusion

Upstream registers `include` as a P_STRING/P_LOCAL filter parameter (daemon-parm.txt `Locals:`, wired through daemon-parm.h in loadparm.c) that every module inherits; file inclusion is spelled `&include` (params.c). oc misrouted a bare global `include` to config-file inclusion, so `include = *.bak` tried to open `*.bak` as a config file instead of seeding each module's include-filter default.

Fix: drop bare `include` from the file-inclusion match arm (keeping `&include`/`&merge`) and add a dedicated `include` handler that populates `module_defaults.include`, mirroring the sibling `exclude` handler. The struct field and finish-time inheritance already existed but were never populated. Stale tests that assumed bare `include` performed file inclusion (recursion detection, module loading) now exercise the `&include` form; a new test locks in that a global `include` seeds the module include-filter default and is inherited by modules that declare none.

## 2. `%ENVVAR%` config tokens expand from the process environment

Upstream `loadparm.c:expand_vars` calls `getenv()` on any `%UPPERCASE%` token in string/path config values, substituting the value when set and leaving the literal `%TOKEN%` in place when unset. oc handled only a fixed set of connection variables (DIFFHOST, MODULE, RSYNC_MODULE_NAME, RSYNC_MODULE_PATH, ADDR) and preserved every other token verbatim, so `path = %HOME%/rsync` never resolved.

Fix: when the built-in lookup misses and the token is a non-empty run of `[A-Z0-9_]`, fall back to `std::env::var()`; substitute if set, otherwise keep the literal token. Tests cover env-backed expansion, unset-token preservation, and the lowercase-token gate, using the crate `EnvGuard` for isolation.

## Verification

- `cargo build --bin oc-rsync`, `cargo clippy -p daemon --all-targets --all-features --no-deps -D warnings`: clean.
- `cargo nextest run -p daemon --all-features`: 1771 passed, 6 skipped.
