### PR TITLE
fix(daemon): honor global include filter default and %ENV% config expansion

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -69,14 +69,14 @@ fn apply_global_directive(
                 },
             ));
         }
-        "include" | "&include" | "&merge" => {
+        "&include" | "&merge" => {
             // upstream: params.c:parse_directives - `&include` and `&merge` both
-            // pull configuration from another file. The historical `include =`
-            // form is retained as a synonym so existing oc-rsync configs keep
-            // working. `&include` runs under a private global scope (`]push`/
-            // `]pop`) so the included file's globals do not leak back, and a
-            // directory target globs `*.conf`; `&merge` shares the current scope
-            // and globs `*.inc`. `apply_include_directive` implements both.
+            // pull configuration from another file. `&include` runs under a
+            // private global scope (`]push`/`]pop`) so the included file's globals
+            // do not leak back, and a directory target globs `*.conf`; `&merge`
+            // shares the current scope and globs `*.inc`. `apply_include_directive`
+            // implements both. A bare `include` (no `&`) is NOT file inclusion -
+            // it is the P_LOCAL `include` filter parameter, handled below.
             apply_include_directive(state, key, value, path, line_number, canonical, stack)?;
         }
         "motdfile" => {
@@ -445,9 +445,16 @@ fn apply_global_directive(
                 state.module_defaults.exclude.push(value.to_owned());
             }
         }
-        // Note: "include" as a P_LOCAL default is not handled here because
-        // our key=value parser already claims "include" for config file
-        // inclusion (upstream uses "&include /path" which doesn't collide).
+        // upstream: daemon-parm.txt `Locals:` `include` is P_STRING/P_LOCAL
+        // (loadparm.c registers it via daemon-parm.h), NOT file inclusion -
+        // upstream reserves `&include` for pulling in another file (params.c).
+        // A bare global `include` therefore seeds every module's include-filter
+        // default, mirroring `exclude` above.
+        "include" => {
+            if !value.is_empty() {
+                state.module_defaults.include.push(value.to_owned());
+            }
+        }
         "filter" => {
             if !value.is_empty() {
                 state.module_defaults.filter.push(value.to_owned());

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -436,8 +436,13 @@ mod config_parsing_tests {
     }
 
 
+    /// A bare global `include` is the P_LOCAL include-filter parameter
+    /// (daemon-parm.txt Locals; loadparm.c via daemon-parm.h), NOT file
+    /// inclusion - upstream reserves `&include` for pulling in another file
+    /// (params.c). So `include = <file>` must be treated as a filter value and
+    /// must NOT load the modules declared in that file.
     #[test]
-    fn parse_include_directive() {
+    fn parse_bare_include_is_filter_default_not_file_inclusion() {
         let dir = TempDir::new().expect("create temp dir");
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
@@ -449,8 +454,9 @@ mod config_parsing_tests {
         let main_file = write_config(&main_config);
 
         let result = parse_config_modules(main_file.path()).expect("parse succeeds");
-        assert_eq!(result.modules.len(), 1);
-        assert_eq!(result.modules[0].name, "included_mod");
+        // The referenced file's `[included_mod]` is NOT pulled in: bare
+        // `include` set a filter default instead of including the file.
+        assert!(result.modules.is_empty());
     }
 
     #[test]
@@ -701,8 +707,10 @@ mod config_parsing_tests {
         let dir = TempDir::new().expect("create temp dir");
         let config_path = dir.path().join("config.conf");
 
-        // Write config that includes itself
-        let content = format!("include = {}\n", config_path.display());
+        // Write a config that includes itself. Recursion detection guards the
+        // file-inclusion directive, which is `&include` (params.c) - a bare
+        // `include` is only a filter default and never opens a file.
+        let content = format!("&include {}\n", config_path.display());
         fs::write(&config_path, &content).expect("write config");
 
         let err = parse_config_modules(&config_path).expect_err("should fail");
@@ -724,11 +732,15 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("must not be empty"));
     }
 
+    /// A bare global `include` is the P_LOCAL include-filter parameter, so an
+    /// empty value is a no-op default (mirroring an empty `exclude`), not an
+    /// error. Empty-value rejection belongs to the file-inclusion directive
+    /// `&include`, covered by `parse_amp_include_empty_value_names_directive`.
     #[test]
-    fn parse_empty_include_errors() {
+    fn parse_empty_bare_include_is_noop() {
         let file = write_config("include = \n");
-        let err = parse_config_modules(file.path()).expect_err("should fail");
-        assert!(err.to_string().contains("must not be empty"));
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(result.modules.is_empty());
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/variable_expansion.rs
+++ b/crates/daemon/src/daemon/sections/variable_expansion.rs
@@ -26,10 +26,14 @@ struct VarExpansionContext<'a> {
 /// - `%RSYNC_MODULE_PATH%` - the module's configured path
 /// - `%ADDR%` - the client's IP address
 /// - `%%` - literal `%`
-/// - Unknown `%FOO%` tokens are left as-is
+/// - Any other all-uppercase `%NAME%` token is looked up in the process
+///   environment (upstream `loadparm.c:expand_vars` calls `getenv`); a set
+///   variable is substituted, an unset one is left as-is
+/// - Any remaining `%FOO%` token is left as-is
 ///
-/// upstream: `loadparm.c` - `lp_string()` calls `alloc_sub_advanced()` which
-/// walks the format string replacing `%`-delimited variable names.
+/// upstream: `loadparm.c:expand_vars()` walks the string and, for every
+/// `%UPPERCASE...%` token, calls `getenv()` on the name between the percents,
+/// substituting the value when set and leaving the raw token unchanged when not.
 fn expand_config_vars(template: &str, ctx: &VarExpansionContext<'_>) -> String {
     let mut result = String::with_capacity(template.len());
     let mut rest = template;
@@ -49,11 +53,14 @@ fn expand_config_vars(template: &str, ctx: &VarExpansionContext<'_>) -> String {
                 let var_name = &rest[..end];
                 match resolve_variable(var_name, ctx) {
                     Some(value) => result.push_str(value),
-                    None => {
-                        result.push('%');
-                        result.push_str(var_name);
-                        result.push('%');
-                    }
+                    None => match env_expansion(var_name) {
+                        Some(value) => result.push_str(&value),
+                        None => {
+                            result.push('%');
+                            result.push_str(var_name);
+                            result.push('%');
+                        }
+                    },
                 }
                 rest = &rest[end + 1..];
             }
@@ -74,8 +81,9 @@ fn find_closing_percent(s: &str) -> Option<usize> {
 
 /// Maps a variable name to its substitution value.
 ///
-/// Returns `None` for unrecognized variable names, which causes the
-/// caller to preserve the original `%NAME%` token verbatim.
+/// Returns `None` for names that are not built-in connection variables; the
+/// caller then falls back to an environment lookup (`env_expansion`) and, only
+/// if that also misses, preserves the original `%NAME%` token verbatim.
 fn resolve_variable<'a>(name: &str, ctx: &VarExpansionContext<'a>) -> Option<&'a str> {
     match name {
         "DIFFHOST" => Some(ctx.client_host),
@@ -84,6 +92,26 @@ fn resolve_variable<'a>(name: &str, ctx: &VarExpansionContext<'a>) -> Option<&'a
         "ADDR" => Some(ctx.client_addr),
         _ => None,
     }
+}
+
+/// Looks up an all-uppercase `%NAME%` token in the process environment.
+///
+/// Returns the environment value when `name` is a non-empty run of
+/// `[A-Z0-9_]` and the variable is set, otherwise `None` so the caller leaves
+/// the literal `%NAME%` token unchanged.
+///
+/// upstream: `loadparm.c:expand_vars` (~185) calls `getenv()` on every
+/// `%UPPERCASE...%` token that is not a built-in name; an unset variable leaves
+/// the raw token in place.
+fn env_expansion(name: &str) -> Option<String> {
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit() || b == b'_')
+    {
+        return None;
+    }
+    std::env::var(name).ok()
 }
 
 /// Applies `%`-variable expansion to all path-type fields of a module definition.
@@ -314,11 +342,48 @@ mod variable_expansion_tests {
 
 
     #[test]
-    fn expand_unknown_variable_preserved() {
+    fn expand_unset_env_variable_preserved() {
+        // upstream: loadparm.c:expand_vars - an all-uppercase token that is not
+        // a built-in name and is unset in the environment leaves the literal
+        // `%TOKEN%` in place (getenv returns NULL, so the raw chars pass
+        // through). WHY: a config author's `%FOO%` must not silently vanish when
+        // FOO is undefined.
+        let _lock = crate::test_env::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::test_env::EnvGuard::remove("OC_RSYNC_TEST_EXPAND_UNSET");
         let ctx = sample_ctx();
         assert_eq!(
-            expand_config_vars("/data/%UNKNOWN%/files", &ctx),
-            "/data/%UNKNOWN%/files"
+            expand_config_vars("/data/%OC_RSYNC_TEST_EXPAND_UNSET%/files", &ctx),
+            "/data/%OC_RSYNC_TEST_EXPAND_UNSET%/files"
+        );
+    }
+
+    #[test]
+    fn expand_env_variable_from_process_environment() {
+        // upstream: loadparm.c:expand_vars (~185) calls getenv() on any
+        // %UPPERCASE% token that is not a built-in name and substitutes the
+        // value when set. WHY: rsyncd.conf paths like `path = %HOME%/rsync` must
+        // resolve against the daemon's environment exactly as upstream does.
+        let _lock = crate::test_env::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::test_env::EnvGuard::set(
+            "OC_RSYNC_TEST_EXPAND_VAR",
+            std::ffi::OsStr::new("/srv/env"),
+        );
+        let ctx = sample_ctx();
+        assert_eq!(
+            expand_config_vars("%OC_RSYNC_TEST_EXPAND_VAR%/rsync", &ctx),
+            "/srv/env/rsync"
+        );
+    }
+
+    #[test]
+    fn expand_lowercase_token_not_env_expanded() {
+        // A non-uppercase token is not an environment variable name and is left
+        // literal even if a same-named var were set, matching upstream's
+        // isUpper() gate in expand_vars.
+        let ctx = sample_ctx();
+        assert_eq!(
+            expand_config_vars("/data/%path%/files", &ctx),
+            "/data/%path%/files"
         );
     }
 

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -311,6 +311,7 @@ include!("tests/chunks/runtime_options_config_pid_file_respects_cli_override.rs"
 include!("tests/chunks/runtime_options_default_enables_reverse_lookup.rs");
 include!("tests/chunks/runtime_options_global_bwlimit_respects_cli_override.rs");
 include!("tests/chunks/runtime_options_global_directives_apply_as_module_defaults.rs");
+include!("tests/chunks/runtime_options_global_include_filter_default_inherited.rs");
 include!(
     "tests/chunks/runtime_options_global_only_directive_after_module_stays_in_module_scope.rs"
 );

--- a/crates/daemon/src/tests/chunks/parse_config_modules_detects_recursive_include.rs
+++ b/crates/daemon/src/tests/chunks/parse_config_modules_detects_recursive_include.rs
@@ -4,14 +4,17 @@ fn parse_config_modules_detects_recursive_include() {
     let first = dir.path().join("first.conf");
     let second = dir.path().join("second.conf");
 
+    // File inclusion is `&include` (params.c); a bare `include` is only a
+    // filter default and never opens a file, so recursion detection must be
+    // exercised through the amp form.
     writeln!(
         File::create(&first).expect("create first"),
-        "include = second.conf\n"
+        "&include second.conf\n"
     )
     .expect("write first");
     writeln!(
         File::create(&second).expect("create second"),
-        "include = first.conf\n"
+        "&include first.conf\n"
     )
     .expect("write second");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_global_include_filter_default_inherited.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_global_include_filter_default_inherited.rs
@@ -1,0 +1,40 @@
+// A bare `include` in the global section is the P_LOCAL `include` filter
+// parameter (daemon-parm.txt `Locals:` `include`, registered via daemon-parm.h
+// in loadparm.c), NOT config-file inclusion - upstream reserves `&include` for
+// pulling in another file (params.c). WHY this matters: misrouting a global
+// `include = *.bak` to file inclusion would try to read `*.bak` as a config
+// file (an error) instead of seeding every module's include-filter default.
+// This test locks in that the value flows to `module_defaults.include` and is
+// inherited by modules that declare no `include` of their own, exactly like
+// the sibling `exclude` default.
+#[test]
+fn runtime_options_global_include_filter_default_inherited() {
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(
+        file,
+        "include = *.bak\n\
+         \n\
+         [alpha]\n\
+         path = /srv/alpha\n\
+         \n\
+         [beta]\n\
+         path = /srv/beta\n\
+         include = *.keep\n"
+    )
+    .expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        file.path().as_os_str().to_os_string(),
+    ])
+    .expect("parse config");
+
+    let modules = options.modules();
+    assert_eq!(modules.len(), 2);
+
+    // alpha declares no include of its own, so it inherits the global default.
+    assert_eq!(modules[0].include(), &["*.bak".to_owned()]);
+    // beta overrides (upstream: STRING params replace, not append), so the
+    // global default is not merged in.
+    assert_eq!(modules[1].include(), &["*.keep".to_owned()]);
+}

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_modules_from_included_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_modules_from_included_config.rs
@@ -8,10 +8,12 @@ fn runtime_options_loads_modules_from_included_config() {
     )
     .expect("write include");
 
+    // File inclusion is `&include` (params.c); a bare `include` sets a filter
+    // default rather than pulling in another config file.
     let main_path = dir.path().join("rsyncd.conf");
     writeln!(
         File::create(&main_path).expect("create config"),
-        "include = modules.conf\n"
+        "&include modules.conf\n"
     )
     .expect("write main config");
 


### PR DESCRIPTION
Two independent `rsyncd.conf` parsing fidelity fixes for the daemon, each in its own commit.

## 1. Global bare `include` is a P_LOCAL filter default, not file inclusion

Upstream registers `include` as a P_STRING/P_LOCAL filter parameter (daemon-parm.txt `Locals:`, wired through daemon-parm.h in loadparm.c) that every module inherits; file inclusion is spelled `&include` (params.c). oc misrouted a bare global `include` to config-file inclusion, so `include = *.bak` tried to open `*.bak` as a config file instead of seeding each module's include-filter default.

Fix: drop bare `include` from the file-inclusion match arm (keeping `&include`/`&merge`) and add a dedicated `include` handler that populates `module_defaults.include`, mirroring the sibling `exclude` handler. The struct field and finish-time inheritance already existed but were never populated. Stale tests that assumed bare `include` performed file inclusion (recursion detection, module loading) now exercise the `&include` form; a new test locks in that a global `include` seeds the module include-filter default and is inherited by modules that declare none.

## 2. `%ENVVAR%` config tokens expand from the process environment

Upstream `loadparm.c:expand_vars` calls `getenv()` on any `%UPPERCASE%` token in string/path config values, substituting the value when set and leaving the literal `%TOKEN%` in place when unset. oc handled only a fixed set of connection variables (DIFFHOST, MODULE, RSYNC_MODULE_NAME, RSYNC_MODULE_PATH, ADDR) and preserved every other token verbatim, so `path = %HOME%/rsync` never resolved.

Fix: when the built-in lookup misses and the token is a non-empty run of `[A-Z0-9_]`, fall back to `std::env::var()`; substitute if set, otherwise keep the literal token. Tests cover env-backed expansion, unset-token preservation, and the lowercase-token gate, using the crate `EnvGuard` for isolation.

## Verification

- `cargo build --bin oc-rsync`, `cargo clippy -p daemon --all-targets --all-features --no-deps -D warnings`: clean.
- `cargo nextest run -p daemon --all-features`: 1771 passed, 6 skipped.
