### PR TITLE
fix(cli): make --old-args a counter to support level 2 arg escaping

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -74,7 +74,11 @@ pub struct ParsedArgs {
     pub protect_args: Option<bool>,
 
     /// `--old-args` / `--no-old-args` - pre-3.0 argument passing.
-    pub old_args: Option<bool>,
+    ///
+    /// Encodes the `old_style_args` level: `None` when unset, `Some(0)` for an
+    /// explicit `--no-old-args`, and `Some(1)`/`Some(2)` for the counted
+    /// `--old-args` (doubled reaches level 2). upstream: options.c:1642.
+    pub old_args: Option<u8>,
 
     /// `--ipv4`, `-4` / `--ipv6`, `-6` - address family preference.
     pub address_mode: AddressMode,

--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -176,7 +176,9 @@ where
     } else {
         env_protect_args_default()
     };
-    let old_args = tri_state_flag_negative_first(&matches, "old-args", "no-old-args");
+    // upstream: options.c:1642 OPT_OLD_ARGS increments `old_style_args`; the
+    // level (1 vs doubled 2) selects how much safe_arg escaping is skipped.
+    let old_args = leveled_flag_pair(&matches, "old-args", "no-old-args");
     let address_mode = if matches.get_flag("ipv4") {
         AddressMode::Ipv4
     } else if matches.get_flag("ipv6") {

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -2235,14 +2235,34 @@ mod old_args_tests {
 
     #[test]
     fn old_args_flag() {
+        // upstream: options.c:1642 OPT_OLD_ARGS - a single `--old-args` sets
+        // `old_style_args` to level 1 (skip filename escaping).
         let parsed = parse_test_args(["--old-args", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.old_args, Some(true));
+        assert_eq!(parsed.old_args, Some(1));
+    }
+
+    #[test]
+    fn old_args_doubled_reaches_level_two() {
+        // upstream: options.c:1646 - a second `--old-args` does `old_style_args++`
+        // to level 2, the state where safe_arg (options.c:2551, `old_style_args
+        // < 2`) drops all remaining escaping. A boolean flag could never reach it.
+        let parsed = parse_test_args(["--old-args", "--old-args", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.old_args, Some(2));
+    }
+
+    #[test]
+    fn old_args_triple_caps_at_level_two() {
+        // Level 2 is the highest state safe_arg distinguishes, so further
+        // repeats saturate rather than overshoot.
+        let parsed = parse_test_args(["--old-args", "--old-args", "--old-args", "src/", "dst/"])
+            .expect("parse");
+        assert_eq!(parsed.old_args, Some(2));
     }
 
     #[test]
     fn no_old_args_flag() {
         let parsed = parse_test_args(["--no-old-args", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.old_args, Some(false));
+        assert_eq!(parsed.old_args, Some(0));
     }
 }
 

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
@@ -79,7 +79,10 @@ pub(super) fn add_network_args(command: ClapCommand) -> ClapCommand {
             Arg::new("old-args")
                 .long("old-args")
                 .help("Use old-style argument handling (pre-3.2.4 behavior).")
-                .action(ArgAction::SetTrue)
+                // upstream: options.c:1642 OPT_OLD_ARGS - each `--old-args`
+                // increments `old_style_args` (level 1 = skip filename escaping,
+                // level 2 = skip all safe_arg escaping), so this is a counter.
+                .action(ArgAction::Count)
                 .overrides_with("no-old-args"),
         )
         .arg(

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -194,7 +194,7 @@ pub(crate) struct ConfigInputs {
     pub(crate) early_input: Option<PathBuf>,
     pub(crate) prefer_aes_gcm: Option<bool>,
     pub(crate) protect_args: Option<bool>,
-    pub(crate) old_args: Option<bool>,
+    pub(crate) old_args: Option<u8>,
     pub(crate) jump_hosts: Option<OsString>,
     pub(crate) batch_config: Option<BatchConfig>,
     pub(crate) no_motd: bool,

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -1118,30 +1118,61 @@ where
     )
 }
 
-/// Resolves the effective `--old-args` setting from the CLI flag and env var.
+/// Resolves the effective `old_style_args` level from the CLI counter and env.
 ///
-/// upstream: options.c:1952-1964 - when `old_style_args` is not explicitly set
-/// (`None`), check `RSYNC_OLD_ARGS` env var. The env var is only honoured when
-/// protect_args is not active (upstream: `protect_args <= 0`). When both
-/// `--old-args` and `--protect-args` are explicitly set, upstream rejects the
-/// combination, but we silently give protect_args precedence (old_args becomes
-/// inactive) since the conflict is validated at the CLI layer.
-fn resolve_old_args(explicit: Option<bool>, protect_args: Option<bool>) -> Option<bool> {
-    if let Some(value) = explicit {
-        return Some(value);
+/// upstream: options.c:1968-1974 - when `old_style_args` is still unset
+/// (`old_style_args < 0`, modelled here as `None`), check `RSYNC_OLD_ARGS` and
+/// set the level with `old_style_args = atoi(arg)`. The env var is only honoured
+/// when protect_args is not active (upstream: `protect_args <= 0`). An explicit
+/// `--old-args`/`--no-old-args` (`Some(level)`) suppresses the env lookup, just
+/// as upstream skips the `< 0` branch once the flag has set the level.
+///
+/// When both `--old-args` and `--protect-args` are explicitly set, upstream
+/// rejects the combination (options.c:1975); we silently give protect_args
+/// precedence since the conflict is validated at the CLI layer.
+fn resolve_old_args(explicit: Option<u8>, protect_args: Option<bool>) -> Option<u8> {
+    if let Some(level) = explicit {
+        return Some(level);
     }
-    // upstream: options.c:1953 - only check env when !am_server && protect_args <= 0
+    // upstream: options.c:1969 - only check env when !am_server && protect_args <= 0
     if protect_args.unwrap_or(false) {
         return None;
     }
     match std::env::var("RSYNC_OLD_ARGS") {
+        // upstream: options.c:1971 old_style_args = atoi(arg). `atoi` reads a
+        // leading integer, so "2"/"2 " -> 2 and non-numeric -> 0. The level is
+        // capped at 2, the highest state safe_arg distinguishes.
         Ok(val) if !val.is_empty() => {
-            // upstream: old_style_args = atoi(arg) - any non-zero value enables
-            let level: i32 = val.parse().unwrap_or(0);
-            if level > 0 { Some(true) } else { None }
+            let level = atoi_leading(&val).clamp(0, 2) as u8;
+            if level > 0 { Some(level) } else { None }
         }
         _ => None,
     }
+}
+
+/// Parses a leading base-10 integer like C's `atoi`, ignoring leading
+/// whitespace and any trailing non-digit suffix. Returns 0 when no digits lead.
+fn atoi_leading(s: &str) -> i32 {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    let mut sign = 1i32;
+    if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
+        if bytes[i] == b'-' {
+            sign = -1;
+        }
+        i += 1;
+    }
+    let mut value = 0i32;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        value = value
+            .saturating_mul(10)
+            .saturating_add((bytes[i] - b'0') as i32);
+        i += 1;
+    }
+    sign * value
 }
 
 /// Returns the explicit checksum seed to record in a batch header, or `None`
@@ -1187,7 +1218,87 @@ fn open_log_file(path: &PathBuf) -> io::Result<File> {
 
 #[cfg(test)]
 mod tests {
-    use super::{derive_batch_seed, explicit_batch_seed};
+    use super::{atoi_leading, derive_batch_seed, explicit_batch_seed, resolve_old_args};
+    use platform::env::EnvGuard;
+    use std::ffi::OsStr;
+    use std::sync::Mutex;
+
+    /// Serialises the `RSYNC_OLD_ARGS` env mutations so the resolver tests never
+    /// race on the process environment even under a threaded test runner.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// `atoi_leading` mirrors C `atoi`: it reads a leading integer and ignores a
+    /// trailing non-digit suffix, which is exactly how upstream parses
+    /// `RSYNC_OLD_ARGS` (options.c:1971 `old_style_args = atoi(arg)`).
+    #[test]
+    fn atoi_leading_matches_c_atoi() {
+        assert_eq!(atoi_leading("2"), 2);
+        assert_eq!(atoi_leading("1"), 1);
+        assert_eq!(atoi_leading("  2"), 2);
+        assert_eq!(atoi_leading("2 "), 2);
+        assert_eq!(atoi_leading("2abc"), 2);
+        assert_eq!(atoi_leading("10"), 10);
+        assert_eq!(atoi_leading("yes"), 0);
+        assert_eq!(atoi_leading(""), 0);
+    }
+
+    /// An explicit `--old-args` counter must flow through unchanged and suppress
+    /// the env lookup, mirroring upstream skipping the `old_style_args < 0`
+    /// branch once the flag has set the level (options.c:1968).
+    #[test]
+    fn explicit_level_passes_through_and_ignores_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set("RSYNC_OLD_ARGS", OsStr::new("2"));
+        assert_eq!(resolve_old_args(Some(2), None), Some(2));
+        assert_eq!(resolve_old_args(Some(1), None), Some(1));
+        // An explicit `--no-old-args` (level 0) wins over the env's level 2.
+        assert_eq!(resolve_old_args(Some(0), None), Some(0));
+    }
+
+    /// upstream: options.c:1971 `old_style_args = atoi(arg)` - `RSYNC_OLD_ARGS=2`
+    /// must reach level 2, the state where safe_arg disables all escaping. This
+    /// is the env path that a boolean model collapsed to level 1, silently
+    /// dropping the option-arg escaping upstream keeps only below level 2.
+    #[test]
+    fn env_sets_the_level_as_an_integer() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        {
+            let _g = EnvGuard::set("RSYNC_OLD_ARGS", OsStr::new("2"));
+            assert_eq!(resolve_old_args(None, None), Some(2));
+        }
+        {
+            let _g = EnvGuard::set("RSYNC_OLD_ARGS", OsStr::new("1"));
+            assert_eq!(resolve_old_args(None, None), Some(1));
+        }
+        {
+            // upstream: atoi("yes") == 0, so a non-numeric value is inactive.
+            let _g = EnvGuard::set("RSYNC_OLD_ARGS", OsStr::new("yes"));
+            assert_eq!(resolve_old_args(None, None), None);
+        }
+        {
+            let _g = EnvGuard::set("RSYNC_OLD_ARGS", OsStr::new(""));
+            assert_eq!(resolve_old_args(None, None), None);
+        }
+    }
+
+    /// upstream: options.c:1969 - the env var is only consulted when
+    /// `protect_args <= 0`. With protect_args active the level stays unset even
+    /// if `RSYNC_OLD_ARGS` is present, since the two options are exclusive.
+    #[test]
+    fn env_ignored_when_protect_args_active() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set("RSYNC_OLD_ARGS", OsStr::new("2"));
+        assert_eq!(resolve_old_args(None, Some(true)), None);
+    }
+
+    /// With no flag and no env the level is unset, so downstream escaping stays
+    /// on (the modern default).
+    #[test]
+    fn unset_when_no_flag_and_no_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::remove("RSYNC_OLD_ARGS");
+        assert_eq!(resolve_old_args(None, None), None);
+    }
 
     /// An explicit non-zero `--checksum-seed=N` must be recorded in the batch
     /// header verbatim so `--read-batch` replays with the identical seed.

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -274,7 +274,7 @@ pub struct ClientConfigBuilder {
     early_input: Option<PathBuf>,
     prefer_aes_gcm: Option<bool>,
     protect_args: Option<bool>,
-    old_args: Option<bool>,
+    old_args: Option<u8>,
     jump_hosts: Option<OsString>,
     batch_config: Option<engine::batch::BatchConfig>,
     files_from: FilesFromSource,
@@ -322,7 +322,9 @@ impl ClientConfigBuilder {
         caps: protocol::CompatibilityFlags,
     ) -> Result<(), ConfigConflict> {
         // upstream: options.c:1974-1977 - --old-args conflicts with --protect-args.
-        if self.old_args == Some(true) && self.protect_args == Some(true) {
+        // Any active level (>= 1) triggers the conflict, matching upstream's
+        // `else if (old_style_args)` truthiness test.
+        if self.old_args.unwrap_or(0) >= 1 && self.protect_args == Some(true) {
             return Err(ConfigConflict {
                 option1: "old-args",
                 option2: "secluded-args",

--- a/crates/core/src/client/config/builder/network.rs
+++ b/crates/core/src/client/config/builder/network.rs
@@ -67,19 +67,19 @@ impl ClientConfigBuilder {
         #[doc(alias = "-s")]
         protect_args: Option<bool>,
 
-        /// Enables or disables old-style argument passing for remote shells.
+        /// Sets the `old_style_args` level for remote shells.
         ///
-        /// When `Some(true)`, filename arguments are not shell-escaped before
-        /// being passed to the remote shell, preserving pre-3.0 behaviour where
-        /// spaces in a remote path are split by `eval` into separate args.
-        /// When `Some(false)`, old-args is explicitly disabled.
-        /// When `None`, the default behavior applies (disabled unless
+        /// `Some(1)` (a single `--old-args`) stops shell-escaping filename
+        /// arguments, preserving pre-3.0 behaviour where spaces in a remote path
+        /// are split by `eval`. `Some(2)` (doubled `--old-args`) additionally
+        /// disables every safe_arg escape. `Some(0)` explicitly disables old-args
+        /// (`--no-old-args`); `None` uses the default (disabled unless
         /// `RSYNC_OLD_ARGS` is set).
         ///
-        /// upstream: options.c - `old_style_args`, `RSYNC_OLD_ARGS`.
+        /// upstream: options.c:1642 OPT_OLD_ARGS, options.c:2551 safe_arg.
         #[doc(alias = "--old-args")]
         #[doc(alias = "--no-old-args")]
-        old_args: Option<bool>,
+        old_args: Option<u8>,
     }
 
     /// Configures the embedded SSH transport options.

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1219,7 +1219,7 @@ fn validate_old_args_with_secluded_args_conflicts() {
     // (`--protect-args`) are mutually exclusive and abort with this exact
     // wording, which differs from the generic "cannot be used with" template:
     // the message names --secluded-args first and ends with a period.
-    let b = builder().old_args(Some(true)).protect_args(Some(true));
+    let b = builder().old_args(Some(1)).protect_args(Some(true));
     let err = b.validate().unwrap_err();
     assert_eq!(err.option1, "old-args");
     assert_eq!(err.option2, "secluded-args");

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -260,10 +260,11 @@ pub struct ClientConfig {
     pub(super) protect_args: Option<bool>,
     /// `--old-args` / `--no-old-args` - pre-3.0 argument passing.
     ///
-    /// When `Some(true)`, filename arguments are passed unescaped to the remote
-    /// shell, allowing space-separated paths to be split by `eval`.
-    /// upstream: options.c - `old_style_args`, `RSYNC_OLD_ARGS` env var.
-    pub(super) old_args: Option<bool>,
+    /// The resolved `old_style_args` level. `Some(1)` passes filename arguments
+    /// unescaped to the remote shell (space-separated paths split by `eval`);
+    /// `Some(2)` disables every safe_arg escape; `Some(0)`/`None` are inactive.
+    /// upstream: options.c:1642 OPT_OLD_ARGS, `RSYNC_OLD_ARGS` env var.
+    pub(super) old_args: Option<u8>,
     pub(super) jump_hosts: Option<OsString>,
     pub(super) batch_config: Option<engine::batch::BatchConfig>,
     pub(super) files_from: FilesFromSource,

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -154,13 +154,15 @@ impl ClientConfig {
     /// shell, preserving the pre-3.0 behaviour where spaces in a remote path
     /// cause `eval` to split them into separate arguments.
     ///
-    /// `Some(false)` explicitly disables old-args. `None` uses the default
-    /// behaviour (disabled unless `RSYNC_OLD_ARGS` is set in the environment).
+    /// Returns the `old_style_args` level: `Some(1)` skips filename escaping,
+    /// `Some(2)` skips every safe_arg escape, `Some(0)` explicitly disables
+    /// old-args, and `None` uses the default (disabled unless `RSYNC_OLD_ARGS`
+    /// is set in the environment).
     ///
-    /// upstream: options.c - `old_style_args`, `RSYNC_OLD_ARGS` env var.
+    /// upstream: options.c:1642 OPT_OLD_ARGS, `RSYNC_OLD_ARGS` env var.
     #[doc(alias = "--old-args")]
     #[doc(alias = "--no-old-args")]
-    pub const fn old_args(&self) -> Option<bool> {
+    pub const fn old_args(&self) -> Option<u8> {
         self.old_args
     }
 

--- a/crates/core/src/client/remote/implied_source.rs
+++ b/crates/core/src/client/remote/implied_source.rs
@@ -30,9 +30,10 @@ pub(crate) fn implied_source_args_for_pull(
     source_paths: &[String],
     files_from_data: Option<&[u8]>,
 ) -> Vec<String> {
-    // upstream: options.c:2513 - old_style_args sets trust_sender_args, so
-    // add_implied_include() returns early and the implied list stays empty.
-    if config.old_args() == Some(true) {
+    // upstream: options.c:2513 - a non-zero old_style_args sets
+    // trust_sender_args, so add_implied_include() returns early and the implied
+    // list stays empty. Any active level (>= 1) qualifies.
+    if config.old_args().unwrap_or(0) >= 1 {
         return Vec::new();
     }
 
@@ -67,7 +68,7 @@ mod tests {
     use super::{files_from_entries, implied_source_args_for_pull};
     use crate::client::config::{ClientConfig, FilesFromSource};
 
-    fn config_with(old_args: Option<bool>, files_from: FilesFromSource) -> ClientConfig {
+    fn config_with(old_args: Option<u8>, files_from: FilesFromSource) -> ClientConfig {
         ClientConfig::builder()
             .old_args(old_args)
             .files_from(files_from)
@@ -86,8 +87,8 @@ mod tests {
 
     #[test]
     fn old_args_disables_the_mechanism() {
-        // upstream: options.c:2513 - old_style_args sets trust_sender_args.
-        let config = config_with(Some(true), FilesFromSource::None);
+        // upstream: options.c:2513 - a non-zero old_style_args sets trust_sender_args.
+        let config = config_with(Some(1), FilesFromSource::None);
         assert!(implied_source_args_for_pull(&config, &["dir".to_owned()], None).is_empty());
     }
 

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -287,10 +287,13 @@ impl<'a> RemoteInvocationBuilder<'a> {
 
         args.push(OsString::from("."));
 
-        // upstream: options.c:2533 safe_arg() - when old_style_args >= 1,
-        // filename arguments (is_filename_arg=true) skip shell escaping so
-        // the remote shell's eval naturally splits space-separated paths.
-        let old_args_active = self.config.old_args().unwrap_or(false);
+        // upstream: options.c:2551 safe_arg() - for a filename arg the escape
+        // gate reduces to `!protect_args && old_style_args == 0`, because the
+        // `(!old_style_args || (!is_filename_arg && ...))` factor is only true at
+        // level 0. So a single `--old-args` (level 1) already stops escaping
+        // filenames, and the doubled level 2 (which upstream's `< 2` gate uses to
+        // also drop option-value escaping) leaves filenames unescaped as well.
+        let old_style_args = self.config.old_args().unwrap_or(0);
 
         // upstream: options.c:2553-2558 escape_leading_tilde is set only when
         // local is NOT the sender (a pull, so the remote paths are the source)
@@ -300,7 +303,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
         let escape_tilde_role = !am_sender && !self.config.trust_sender();
 
         for path in remote_paths {
-            if escape_for_shell && !old_args_active {
+            if escape_for_shell && old_style_args == 0 {
                 // upstream: main.c:622 safe_arg(NULL, *remote_argv++)
                 // upstream: options.c:2555-2557 - escape a leading ~ for a
                 // relative path without a `/./` pivot, or a path with no `/`.
@@ -1204,8 +1207,10 @@ const WILD_CHARS: &str = "*?[]";
 /// - A leading `-` is prefixed with `./` to prevent the remote server from
 ///   interpreting the path as an option.
 ///
-/// This escaping is applied when `protect_args` is not active, matching the
-/// upstream condition `!protect_args && old_style_args < 2`.
+/// This escaping is applied only when `protect_args` is not active and
+/// `old_style_args == 0`; the caller (`build_args_without_program`) evaluates
+/// that gate (upstream `options.c:2551`, where the filename branch reduces to
+/// `!protect_args && old_style_args == 0`) and calls this only when it holds.
 pub(super) fn shell_safe_filename_arg(arg: &str) -> String {
     shell_safe_filename_arg_with_tilde(arg, false)
 }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -3781,6 +3781,52 @@ fn shell_safe_escaping_in_normal_mode() {
     );
 }
 
+#[test]
+fn old_args_level_one_skips_filename_escaping() {
+    // upstream: options.c:2551 safe_arg() - for a filename arg the escape gate
+    // is `!protect_args && old_style_args == 0`, so a single `--old-args`
+    // (level 1) already passes the path through unescaped and the remote
+    // shell's `eval` performs the pre-3.0 word-splitting the user asked for.
+    let config = ClientConfig::builder()
+        .protect_args(None)
+        .old_args(Some(1))
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let secluded = builder.build_secluded(&["/path/A weird)name/"]);
+
+    assert!(
+        secluded
+            .command_line_args
+            .iter()
+            .any(|a| a.to_string_lossy() == "/path/A weird)name/"),
+        "level 1 must leave the path unescaped: {:?}",
+        secluded.command_line_args
+    );
+}
+
+#[test]
+fn old_args_level_two_skips_filename_escaping() {
+    // upstream: options.c:2551 - the doubled `--old-args` (level 2) is the
+    // terminal state where the `old_style_args < 2` gate drops every remaining
+    // safe_arg escape. A boolean flag could never reach it; the doubled counter
+    // must still leave filename args verbatim (never re-escaping at level 2).
+    let config = ClientConfig::builder()
+        .protect_args(None)
+        .old_args(Some(2))
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let secluded = builder.build_secluded(&["/path/A weird)name/"]);
+
+    assert!(
+        secluded
+            .command_line_args
+            .iter()
+            .any(|a| a.to_string_lossy() == "/path/A weird)name/"),
+        "level 2 must leave the path unescaped: {:?}",
+        secluded.command_line_args
+    );
+}
+
 // --usermap / --groupmap forwarding tests
 
 #[cfg(unix)]


### PR DESCRIPTION
## Problem

Upstream `options.c` `OPT_OLD_ARGS` increments an integer `old_style_args`:

- level 1 (`--old-args`): filename args skip `safe_arg` shell-escaping.
- level 2 (doubled `--old-args`, or `RSYNC_OLD_ARGS=2`): `safe_arg` (`options.c:2551`, gate `old_style_args < 2`) disables all remaining escaping.

oc-rsync modelled `--old-args` as `ArgAction::SetTrue` -> `Option<bool>`, so `--old-args --old-args` and `RSYNC_OLD_ARGS=2` both collapsed to `Some(true)` and level 2 was unreachable; the env value was parsed as a boolean instead of an integer level.

## Change

- `--old-args` becomes `ArgAction::Count`, resolved through the existing `leveled_flag_pair` helper into `Option<u8>` (`None` unset, `Some(0)` for `--no-old-args`, `Some(1)`/`Some(2)` for the counted flag, saturating at 2).
- The `u8` level is threaded through the CLI/config plumbing (`ParsedArgs`, `DriveConfig`, `ClientConfigBuilder`, `ClientConfig`).
- `RSYNC_OLD_ARGS` is parsed with C `atoi` semantics (`old_style_args = atoi(arg)`): a leading integer sets the level, non-numeric -> 0/inactive; honoured only when `protect_args <= 0`.
- The filename-escape gate now mirrors upstream's reduced condition for a filename arg (`!protect_args && old_style_args == 0`), so level 1 already leaves filenames unescaped (preserved) and level 2 stays unescaped as well. The conflict check and `trust_sender_args` short-circuit use `level >= 1`, matching upstream's truthiness test.

## Tests

- Parser: single `--old-args` -> level 1, doubled -> level 2, tripled saturates at 2, `--no-old-args` -> level 0.
- `resolve_old_args`/`atoi_leading`: `RSYNC_OLD_ARGS=2` -> level 2, `=1` -> level 1, non-numeric/empty -> inactive, ignored when `protect_args` active, explicit flag suppresses env. Uses the repo `EnvGuard`.
- Invocation builder: level 1 and level 2 both leave a metacharacter path unescaped, encoding why level 2 must fully disable `safe_arg` escaping.

