### PR TITLE
feat(metadata): resolve abbreviated xattr lists against the basis file

### DIFF
--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -1550,7 +1550,8 @@ mod tests {
         let mut list = XattrList::new();
         list.push(XattrEntry::new(test_xattr_name("ro"), b"value".to_vec()));
 
-        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs on read-only file");
+        apply_xattrs_from_list(&file, &list, false, None, None)
+            .expect("apply xattrs on read-only file");
 
         let name = test_xattr_name("ro");
         assert_eq!(

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -404,8 +404,9 @@ pub fn sync_xattrs(
 ///
 /// The function performs a full synchronization:
 /// - Sets each non-abbreviated entry from the list on the destination.
+/// - Resolves each abbreviated entry (checksum-only) against the `basis` file,
+///   applying the basis value when its length and digest match the reference.
 /// - Removes destination xattrs not present in the source list.
-/// - Skips abbreviated entries (checksum-only) that lack full values.
 /// - Respects platform namespace filtering via privilege checks.
 ///
 /// # Arguments
@@ -413,21 +414,31 @@ pub fn sync_xattrs(
 /// * `destination` - Path to apply xattrs to.
 /// * `xattr_list` - Parsed xattr name-value pairs from the wire protocol.
 /// * `follow_symlinks` - Whether to follow symlinks when setting xattrs.
+/// * `basis` - The fnamecmp (basis) file whose existing attributes an
+///   abbreviated entry references. `None` disables resolution, leaving any
+///   abbreviated entry's existing destination value in place (its name is still
+///   protected from the removal sweep, matching upstream's `still_abbrev`).
 /// * `filter` - Optional `x`-modifier filter predicate. When present, a name for
 ///   which it returns `false` is neither applied to the destination nor removed
 ///   from it, mirroring upstream's `saw_xattr_filter` screening.
 ///
 /// # Upstream Reference
 ///
-/// Mirrors `xattrs.c:set_xattr()` - applies received xattr data to destination
-/// files. The `filter` argument mirrors the receive-side screening upstream
-/// performs in `receive_xattr()` (xattrs.c:822, drop an excluded received name)
-/// and `rsync_xal_set()` (xattrs.c:1026, keep an excluded destination name),
-/// both gated on `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)`.
+/// Mirrors `xattrs.c:rsync_xal_set()` - applies received xattr data to
+/// destination files. For an abbreviated entry (`XATTR_ABBREV`, a value longer
+/// than `MAX_FULL_DATUM` carried only as a digest), upstream re-reads the value
+/// from `fnamecmp` via `get_xattr_data()` and confirms the length and
+/// `xattr_sum_nni` digest match before applying it; a mismatch takes the
+/// `still_abbrev` path (xattrs.c:964-1009). The `filter` argument mirrors the
+/// receive-side screening upstream performs in `receive_xattr()` (xattrs.c:822,
+/// drop an excluded received name) and `rsync_xal_set()` (xattrs.c:1026, keep an
+/// excluded destination name), both gated on `name_is_excluded(name,
+/// NAME_IS_XATTR, ALL_FILTERS)`.
 pub fn apply_xattrs_from_list(
     destination: &Path,
     xattr_list: &XattrList,
     follow_symlinks: bool,
+    basis: Option<&Path>,
     filter: Option<&dyn Fn(&str) -> bool>,
 ) -> Result<(), MetadataError> {
     let mut applied_names: HashSet<Vec<u8>> = HashSet::with_capacity(xattr_list.len());
@@ -454,11 +465,6 @@ pub fn apply_xattrs_from_list(
     let _temp_write_perm = TempWritePermission::grant(destination);
 
     for entry in xattr_list.iter() {
-        // Skip abbreviated entries - they only contain a checksum, not the actual value
-        if entry.is_abbreviated() {
-            continue;
-        }
-
         let name_str = entry.name_str();
         if !is_xattr_permitted(&name_str, receiver_user_only()) {
             continue;
@@ -480,6 +486,36 @@ pub fn apply_xattrs_from_list(
         }
 
         let name_bytes = entry.name().to_vec();
+
+        // upstream: xattrs.c:964-1009 rsync_xal_set() - an abbreviated entry
+        // carries only a digest of a value the sender expects the receiver to
+        // already hold on the basis (fnamecmp) file. Resolve the full value
+        // locally by re-reading the basis attribute and confirming its length
+        // and digest match the reference; on a match apply the resolved value.
+        // The name stays in `applied_names` whether or not it resolves, so an
+        // existing destination value survives the removal sweep exactly as
+        // upstream's `still_abbrev` leaves `rxas[i].name` in the kept set.
+        if entry.is_abbreviated() {
+            applied_names.insert(name_bytes.clone());
+            // upstream: get_xattr_data(fnamecmp, name, &len, 1) returning NULL -
+            // a missing basis file or absent attribute - takes the still_abbrev
+            // path (continue), never a fatal error, so a read failure here is
+            // swallowed rather than propagated.
+            if let Some(basis_path) = basis
+                && let Ok(Some(value)) = read_attribute(basis_path, &name_bytes, follow_symlinks)
+                && value.len() == entry.datum_len()
+                // upstream: sum_end()/memcmp against rxas[i].datum+1; oc stores
+                // the bare digest, so compare against `entry.datum()`. The seed
+                // is ignored by the MD5 default (proto 30-32), see
+                // protocol::xattr::wire::compute_xattr_checksum.
+                && protocol::xattr::checksum_matches(entry.datum(), &value, 0)
+            {
+                // upstream: sys_lsetxattr(fname, name, ptr, len). Applying the
+                // resolved basis value is idempotent when destination == basis.
+                write_attribute(destination, &name_bytes, &value, follow_symlinks)?;
+            }
+            continue;
+        }
 
         write_attribute(destination, &name_bytes, entry.datum(), follow_symlinks)?;
         applied_names.insert(name_bytes);
@@ -1462,7 +1498,7 @@ mod tests {
             b"value2".to_vec(),
         ));
 
-        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None, None).expect("apply xattrs");
 
         let attr1 = test_xattr_name("attr1");
         let attr2 = test_xattr_name("attr2");
@@ -1561,7 +1597,7 @@ mod tests {
         // Exclude any name containing "skip" (matches on the local xattr name,
         // which carries the `user.` prefix on Linux and is bare elsewhere).
         let filter = |name: &str| !name.contains("skip");
-        apply_xattrs_from_list(&file, &list, false, Some(&filter)).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None, Some(&filter)).expect("apply xattrs");
 
         // The allowed attr is applied.
         assert_eq!(
@@ -1605,7 +1641,7 @@ mod tests {
         list.push(XattrEntry::new(test_xattr_name("keep"), b"kept".to_vec()));
 
         let filter = |name: &str| !name.contains("skip");
-        apply_xattrs_from_list(&file, &list, false, Some(&filter)).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None, Some(&filter)).expect("apply xattrs");
 
         // Excluded destination attr is preserved.
         assert_eq!(
@@ -1651,7 +1687,7 @@ mod tests {
             b"new_value".to_vec(),
         ));
 
-        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None, None).expect("apply xattrs");
 
         // Stale attr should be removed
         assert!(
@@ -1670,8 +1706,13 @@ mod tests {
         );
     }
 
+    /// Without a basis file an abbreviated entry cannot be resolved, so its
+    /// value is not written - but a full entry in the same list still applies.
+    /// upstream: xattrs.c:970-975 rsync_xal_set() takes the `still_abbrev` path
+    /// when it cannot recover the value; a receiver with no local copy keeps the
+    /// attribute unset rather than writing a checksum as if it were the datum.
     #[test]
-    fn apply_xattrs_from_list_skips_abbreviated_entries() {
+    fn apply_xattrs_from_list_no_basis_leaves_abbreviated_unset() {
         let dir = tempdir().expect("create temp dir");
         let file = dir.path().join("dest.txt");
         fs::write(&file, "content").expect("write file");
@@ -1682,35 +1723,107 @@ mod tests {
         }
 
         let mut list = XattrList::new();
-        // Abbreviated entry - only has checksum, not full value
+        // Abbreviated entry - only carries a checksum, not the full value.
         list.push(XattrEntry::abbreviated(
             test_xattr_name("abbrev"),
             vec![0xAA; 16],
             100,
         ));
-        // Full entry
         list.push(XattrEntry::new(
             test_xattr_name("full"),
             b"full_value".to_vec(),
         ));
 
-        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None, None).expect("apply xattrs");
 
-        // Abbreviated entry should not be set
-        let abbrev = test_xattr_name("abbrev");
         assert!(
-            read_attribute(&file, &abbrev, false)
+            read_attribute(&file, &test_xattr_name("abbrev"), false)
                 .expect("read")
-                .is_none()
+                .is_none(),
+            "an abbreviated value must never be written as its raw checksum"
         );
-
-        // Full entry should be set
-        let full = test_xattr_name("full");
         assert_eq!(
-            read_attribute(&file, &full, false)
+            read_attribute(&file, &test_xattr_name("full"), false)
                 .expect("read")
                 .expect("full"),
             b"full_value"
+        );
+    }
+
+    /// An abbreviated entry references a large value the sender expects the
+    /// receiver to already hold on the basis (fnamecmp) file. The receiver must
+    /// re-read that value and, when its length and digest match the reference,
+    /// apply the full value to the destination - byte-identical to a transfer
+    /// that carried the value in full. Losing this resolution silently drops
+    /// every large (>32-byte) xattr on interop with an upstream sender that
+    /// abbreviates it. upstream: xattrs.c:964-1009 rsync_xal_set().
+    #[test]
+    fn apply_xattrs_from_list_resolves_abbreviated_against_basis() {
+        use protocol::xattr::compute_xattr_checksum;
+
+        let dir = tempdir().expect("create temp dir");
+        let basis = dir.path().join("basis.txt");
+        let dest = dir.path().join("dest.txt");
+        fs::write(&basis, "basis-content").expect("write basis");
+        fs::write(&dest, "dest-content").expect("write dest");
+
+        if !xattrs_supported(&basis) || !xattrs_supported(&dest) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        // A value longer than MAX_FULL_DATUM (32) is what upstream abbreviates.
+        let name = test_xattr_name("large");
+        let value = vec![0x5Au8; 100];
+        write_attribute(&basis, &name, &value, false).expect("seed basis xattr");
+
+        // Build the abbreviated wire entry exactly as the sender would: the
+        // digest is the (unseeded, proto 30-32) MD5 of the full value and
+        // datum_len records the original length.
+        let digest = compute_xattr_checksum(&value, 0).to_vec();
+        let mut list = XattrList::new();
+        list.push(XattrEntry::abbreviated(name.clone(), digest, value.len()));
+
+        apply_xattrs_from_list(&dest, &list, false, Some(&basis), None).expect("apply xattrs");
+
+        // The destination must carry the fully resolved value, identical to a
+        // full-list transfer.
+        assert_eq!(
+            read_attribute(&dest, &name, false)
+                .expect("read")
+                .expect("resolved large xattr"),
+            value
+        );
+    }
+
+    /// A digest that matches no basis value must not be applied: a wrong length
+    /// or a mismatched checksum takes upstream's `still_abbrev` path, leaving the
+    /// destination unchanged rather than copying an unrelated basis value.
+    #[test]
+    fn apply_xattrs_from_list_abbreviated_mismatch_not_applied() {
+        let dir = tempdir().expect("create temp dir");
+        let basis = dir.path().join("basis.txt");
+        let dest = dir.path().join("dest.txt");
+        fs::write(&basis, "basis-content").expect("write basis");
+        fs::write(&dest, "dest-content").expect("write dest");
+
+        if !xattrs_supported(&basis) || !xattrs_supported(&dest) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let name = test_xattr_name("large");
+        // The basis holds a value whose digest will NOT match the reference.
+        write_attribute(&basis, &name, &[0x11u8; 100], false).expect("seed basis xattr");
+
+        let mut list = XattrList::new();
+        list.push(XattrEntry::abbreviated(name.clone(), vec![0xAAu8; 16], 100));
+
+        apply_xattrs_from_list(&dest, &list, false, Some(&basis), None).expect("apply xattrs");
+
+        assert!(
+            read_attribute(&dest, &name, false).expect("read").is_none(),
+            "a digest mismatch must not copy an unrelated basis value"
         );
     }
 
@@ -1730,7 +1843,7 @@ mod tests {
         write_attribute(&file, &attr, b"value", false).expect("write existing");
 
         let list = XattrList::new();
-        apply_xattrs_from_list(&file, &list, false, None).expect("apply empty list");
+        apply_xattrs_from_list(&file, &list, false, None, None).expect("apply empty list");
 
         // All permitted xattrs should be removed
         assert!(read_attribute(&file, &attr, false).expect("read").is_none());
@@ -1756,7 +1869,7 @@ mod tests {
             b"new_value".to_vec(),
         ));
 
-        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None, None).expect("apply xattrs");
 
         assert_eq!(
             read_attribute(&file, &attr, false)
@@ -1780,7 +1893,7 @@ mod tests {
         let mut list = XattrList::new();
         list.push(XattrEntry::new(test_xattr_name("empty_val"), b"".to_vec()));
 
-        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None, None).expect("apply xattrs");
 
         let attr = test_xattr_name("empty_val");
         let value = read_attribute(&file, &attr, false)

--- a/crates/metadata/src/xattr_stub.rs
+++ b/crates/metadata/src/xattr_stub.rs
@@ -74,6 +74,7 @@ pub fn apply_xattrs_from_list(
     _destination: &Path,
     _xattr_list: &XattrList,
     _follow_symlinks: bool,
+    _basis: Option<&Path>,
     _filter: Option<&dyn Fn(&str) -> bool>,
 ) -> Result<(), MetadataError> {
     warn_xattr_unsupported();
@@ -128,7 +129,7 @@ mod tests {
     fn apply_xattrs_from_list_returns_ok() {
         let dst = Path::new("/nonexistent/dst");
         let xattr_list = XattrList::new();
-        let result = apply_xattrs_from_list(dst, &xattr_list, false, None);
+        let result = apply_xattrs_from_list(dst, &xattr_list, false, None, None);
         assert!(result.is_ok());
     }
 
@@ -136,7 +137,7 @@ mod tests {
     fn apply_xattrs_from_list_follow_symlinks_returns_ok() {
         let dst = Path::new("/nonexistent/dst");
         let xattr_list = XattrList::new();
-        let result = apply_xattrs_from_list(dst, &xattr_list, true, None);
+        let result = apply_xattrs_from_list(dst, &xattr_list, true, None, None);
         assert!(result.is_ok());
     }
 }

--- a/crates/metadata/tests/security_selinux_roundtrip.rs
+++ b/crates/metadata/tests/security_selinux_roundtrip.rs
@@ -143,7 +143,7 @@ fn security_selinux_xattr_preserved_via_wire_path() {
         FIXTURE_LABEL.to_vec(),
     ));
 
-    apply_xattrs_from_list(&destination, &list, false, None).expect("apply wire xattrs");
+    apply_xattrs_from_list(&destination, &list, false, None, None).expect("apply wire xattrs");
 
     let landed = xattr::get(&destination, "security.selinux")
         .expect("read dest label")

--- a/crates/metadata/tests/windows_long_path_metadata.rs
+++ b/crates/metadata/tests/windows_long_path_metadata.rs
@@ -108,7 +108,7 @@ fn ads_supported(file: &Path) -> bool {
     let probe_name = b"oc_rsync_longpath_probe".to_vec();
     let mut probe = XattrList::new();
     probe.push(XattrEntry::new(probe_name, b"1".to_vec()));
-    match apply_xattrs_from_list(file, &probe, false, None) {
+    match apply_xattrs_from_list(file, &probe, false, None, None) {
         Ok(()) => true,
         Err(error) => {
             eprintln!("ADS not supported on this volume ({error}); skipping");
@@ -189,7 +189,7 @@ fn long_path_ads_round_trip() {
     let stream_value = b"[ZoneTransfer]\r\nZoneId=3\r\n".to_vec();
     let mut list = XattrList::new();
     list.push(XattrEntry::new(local_name.to_vec(), stream_value.clone()));
-    apply_xattrs_from_list(&file, &list, false, None).expect("apply ADS on long path");
+    apply_xattrs_from_list(&file, &list, false, None, None).expect("apply ADS on long path");
 
     // Read the xattrs back; the boundary path here is
     // `xattr_windows::path_to_wide` feeding `FindFirstStreamW`. The wire

--- a/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
+++ b/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
@@ -122,7 +122,7 @@ fn xattrs_supported(path: &Path) -> bool {
     let mut list = XattrList::new();
     list.push(XattrEntry::new(probe_name, b"1".to_vec()));
 
-    if apply_xattrs_from_list(path, &list, false, None).is_err() {
+    if apply_xattrs_from_list(path, &list, false, None, None).is_err() {
         return false;
     }
 
@@ -130,7 +130,7 @@ fn xattrs_supported(path: &Path) -> bool {
     // Cleanup failure is non-fatal; the test bodies push a fresh full
     // list whose apply step removes any stale entries left behind.
     let cleared = XattrList::new();
-    let _ = apply_xattrs_from_list(path, &cleared, false, None);
+    let _ = apply_xattrs_from_list(path, &cleared, false, None, None);
     true
 }
 
@@ -176,7 +176,7 @@ fn simulated_windows_xattr_dropped_on_linux() {
     list.push(XattrEntry::new(standard_a, b"alpha".to_vec()));
     list.push(XattrEntry::new(standard_b, b"beta".to_vec()));
 
-    apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
+    apply_xattrs_from_list(&file, &list, false, None, None).expect("apply xattrs");
 
     let after = read_back(&file);
 
@@ -247,7 +247,7 @@ fn simulated_windows_xattr_applied_on_windows() {
     // The apply call must succeed regardless of whether the WAS-5
     // dispatch is wired yet; failure here would indicate a regression
     // in the cross-platform xattr backend.
-    apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs on Windows");
+    apply_xattrs_from_list(&file, &list, false, None, None).expect("apply xattrs on Windows");
 
     // Once WAS-5 lands, the DACL is applied via `write_dacl_sddl` and
     // the descriptor can be read back. The returned descriptor must
@@ -283,7 +283,7 @@ fn pure_posix_acl_roundtrip_unaffected_by_reserved_slot() {
         b"second".to_vec(),
     ));
 
-    apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
+    apply_xattrs_from_list(&file, &list, false, None, None).expect("apply xattrs");
 
     let after = read_back(&file);
 

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -47,9 +47,9 @@ pub use prefix::{
     wire_to_local,
 };
 pub use wire::{
-    RecvXattrResult, XattrDefinition, XattrSet, checksum_matches, read_xattr_definitions,
-    recv_xattr, recv_xattr_request, recv_xattr_values, send_sender_xattr_response, send_xattr,
-    send_xattr_request, send_xattr_values,
+    RecvXattrResult, XattrDefinition, XattrSet, checksum_matches, compute_xattr_checksum,
+    read_xattr_definitions, recv_xattr, recv_xattr_request, recv_xattr_values,
+    send_sender_xattr_response, send_xattr, send_xattr_request, send_xattr_values,
 };
 
 /// Maximum size for a full xattr value transmission.

--- a/crates/protocol/src/xattr/wire/encode.rs
+++ b/crates/protocol/src/xattr/wire/encode.rs
@@ -224,10 +224,7 @@ pub fn send_sender_xattr_response<W: Write>(
 /// - `xattrs.c:275-281` - `sum_init(xattr_sum_nni, checksum_seed)` over the datum.
 /// - `checksum.c:588-597` - `sum_init()` `CSUM_MD5` case: `md5_begin()`, no seed.
 /// - `compat.c:824-825` - `xattr_sum_nni` / `xattr_sum_len` fixed to md5 (16 bytes).
-pub(crate) fn compute_xattr_checksum(
-    data: &[u8],
-    checksum_seed: i32,
-) -> [u8; MAX_XATTR_DIGEST_LEN] {
+pub fn compute_xattr_checksum(data: &[u8], checksum_seed: i32) -> [u8; MAX_XATTR_DIGEST_LEN] {
     // upstream: the CSUM_MD5 branch of sum_init() ignores the seed; only the
     // MD4-family branches fold it in. Keep the parameter for signature parity.
     let _ = checksum_seed;

--- a/crates/protocol/src/xattr/wire/mod.rs
+++ b/crates/protocol/src/xattr/wire/mod.rs
@@ -18,7 +18,8 @@ mod tests;
 pub use decode::{
     checksum_matches, read_xattr_definitions, recv_xattr, recv_xattr_request, recv_xattr_values,
 };
-#[cfg(test)]
-pub(crate) use encode::compute_xattr_checksum;
-pub use encode::{send_sender_xattr_response, send_xattr, send_xattr_request, send_xattr_values};
+pub use encode::{
+    compute_xattr_checksum, send_sender_xattr_response, send_xattr, send_xattr_request,
+    send_xattr_values,
+};
 pub use types::{RecvXattrResult, XattrDefinition, XattrSet};

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -60,6 +60,10 @@ pub(super) fn apply_file_metadata(
             begin.xattr_list.as_ref(),
             config.xattr_filter.as_deref(),
             pre_transfer_meta,
+            // upstream: fnamecmp is the pre-transfer destination. Metadata is
+            // applied to the temp file before rename, so the final path still
+            // holds the basis file whose xattrs an abbreviated entry references.
+            &begin.file_path,
         )
     }
 }
@@ -82,6 +86,7 @@ fn apply_metadata_acls_and_xattrs(
     xattr_list: Option<&protocol::xattr::XattrList>,
     xattr_filter: Option<&filters::FilterSet>,
     pre_transfer_meta: Option<std::fs::Metadata>,
+    basis_path: &Path,
 ) -> Option<(PathBuf, String)> {
     let (opts, entry) = match (metadata_opts, file_entry) {
         (Some(o), Some(e)) => (o, e),
@@ -140,7 +145,16 @@ fn apply_metadata_acls_and_xattrs(
     if let Some(xattr_list) = xattr_list {
         let filter = xattr_filter.map(|set| move |name: &str| set.xattr_name_allowed(name));
         let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
-        if let Err(e) = metadata::apply_xattrs_from_list(file_path, xattr_list, true, filter_ref) {
+        // upstream: rsync_xal_set(fname, ..., fnamecmp) resolves an abbreviated
+        // value against the basis file - the pre-transfer destination, which
+        // still holds its old attributes while we stage the temp file.
+        if let Err(e) = metadata::apply_xattrs_from_list(
+            file_path,
+            xattr_list,
+            true,
+            Some(basis_path),
+            filter_ref,
+        ) {
             return Some((file_path.to_path_buf(), e.to_string()));
         }
     }

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -53,19 +53,44 @@ pub(super) fn apply_file_metadata(
         };
         apply_metadata_acls_and_xattrs(
             target_path,
-            file_entry,
-            config.metadata_opts.as_ref(),
-            config.acl_cache.as_deref(),
-            config.acl_id_map.as_deref(),
-            begin.xattr_list.as_ref(),
-            config.xattr_filter.as_deref(),
-            pre_transfer_meta,
-            // upstream: fnamecmp is the pre-transfer destination. Metadata is
-            // applied to the temp file before rename, so the final path still
-            // holds the basis file whose xattrs an abbreviated entry references.
-            &begin.file_path,
+            MetadataApplyInputs {
+                file_entry,
+                metadata_opts: config.metadata_opts.as_ref(),
+                acl_cache: config.acl_cache.as_deref(),
+                acl_id_map: config.acl_id_map.as_deref(),
+                xattr_list: begin.xattr_list.as_ref(),
+                xattr_filter: config.xattr_filter.as_deref(),
+                pre_transfer_meta,
+                // upstream: fnamecmp is the pre-transfer destination. Metadata
+                // is applied to the temp file before rename, so the final path
+                // still holds the basis file whose xattrs an abbreviated entry
+                // references.
+                basis_path: &begin.file_path,
+            },
         )
     }
+}
+
+/// Cohesive inputs for [`apply_metadata_acls_and_xattrs`], sourced from the
+/// receiver's caches and the begin message. Grouped into one struct so the
+/// apply entry point stays within a sensible argument count.
+struct MetadataApplyInputs<'a> {
+    /// Flist entry describing the desired metadata, if resolvable.
+    file_entry: Option<&'a protocol::flist::FileEntry>,
+    /// Permission/ownership/timestamp options.
+    metadata_opts: Option<&'a metadata::MetadataOptions>,
+    /// Cached ACLs to apply after permissions.
+    acl_cache: Option<&'a AclCache>,
+    /// Cross-host id remapper for named ACL entries.
+    acl_id_map: Option<&'a AclIdMapper>,
+    /// Received xattr list to apply last.
+    xattr_list: Option<&'a protocol::xattr::XattrList>,
+    /// `x`-modifier xattr name filter.
+    xattr_filter: Option<&'a filters::FilterSet>,
+    /// Pre-transfer destination stat feeding `dest_mode()`.
+    pre_transfer_meta: Option<std::fs::Metadata>,
+    /// fnamecmp basis file for abbreviated xattr resolution.
+    basis_path: &'a Path,
 }
 
 /// Applies file metadata, ACLs, and xattrs from the receiver's caches.
@@ -79,15 +104,19 @@ pub(super) fn apply_file_metadata(
 /// no metadata/entry is available.
 fn apply_metadata_acls_and_xattrs(
     file_path: &Path,
-    file_entry: Option<&protocol::flist::FileEntry>,
-    metadata_opts: Option<&metadata::MetadataOptions>,
-    acl_cache: Option<&AclCache>,
-    acl_id_map: Option<&AclIdMapper>,
-    xattr_list: Option<&protocol::xattr::XattrList>,
-    xattr_filter: Option<&filters::FilterSet>,
-    pre_transfer_meta: Option<std::fs::Metadata>,
-    basis_path: &Path,
+    inputs: MetadataApplyInputs<'_>,
 ) -> Option<(PathBuf, String)> {
+    let MetadataApplyInputs {
+        file_entry,
+        metadata_opts,
+        acl_cache,
+        acl_id_map,
+        xattr_list,
+        xattr_filter,
+        pre_transfer_meta,
+        basis_path,
+    } = inputs;
+
     let (opts, entry) = match (metadata_opts, file_entry) {
         (Some(o), Some(e)) => (o, e),
         _ => return None,

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -516,9 +516,15 @@ impl ReceiverContext {
                         .as_ref()
                         .map(|set| move |name: &str| set.xattr_name_allowed(name));
                     let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
-                    if let Err(e) =
-                        metadata::apply_xattrs_from_list(&dir_path, xattr_list, true, filter_ref)
-                    {
+                    // upstream: rsync_xal_set resolves an abbreviated value
+                    // against fnamecmp; a directory is its own basis.
+                    if let Err(e) = metadata::apply_xattrs_from_list(
+                        &dir_path,
+                        xattr_list,
+                        true,
+                        Some(&dir_path),
+                        filter_ref,
+                    ) {
                         return Some((dir_path, e.to_string()));
                     }
                 }
@@ -880,8 +886,15 @@ impl ReceiverContext {
                 .xattr_name_filter()
                 .map(|set| move |name: &str| set.xattr_name_allowed(name));
             let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
-            if let Err(e) = metadata::apply_xattrs_from_list(dir_path, xattr_list, true, filter_ref)
-            {
+            // upstream: rsync_xal_set resolves an abbreviated value against
+            // fnamecmp; a directory is its own basis.
+            if let Err(e) = metadata::apply_xattrs_from_list(
+                dir_path,
+                xattr_list,
+                true,
+                Some(dir_path),
+                filter_ref,
+            ) {
                 if self.config.flags.verbose && self.config.connection.client_mode {
                     info_log!(
                         Misc,

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -1208,9 +1208,15 @@ impl ReceiverContext {
                     .xattr_name_filter()
                     .map(|set| move |name: &str| set.xattr_name_allowed(name));
                 let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
-                if let Err(e) =
-                    metadata::apply_xattrs_from_list(file_path, xattr_list, true, filter_ref)
-                {
+                // upstream: rsync_xal_set resolves an abbreviated value against
+                // fnamecmp; the file is its own basis for the in-place case.
+                if let Err(e) = metadata::apply_xattrs_from_list(
+                    file_path,
+                    xattr_list,
+                    true,
+                    Some(file_path),
+                    filter_ref,
+                ) {
                     metadata_errors.push((file_path.to_path_buf(), e.to_string()));
                 }
             }
@@ -1632,7 +1638,7 @@ mod itemize_order_tests {
             b"user.itemize".to_vec(),
             b"v".to_vec(),
         )]);
-        if metadata::apply_xattrs_from_list(&path, &list, true, None).is_err() {
+        if metadata::apply_xattrs_from_list(&path, &list, true, None, None).is_err() {
             // A filesystem without user-namespace xattr support cannot
             // exercise the comparison; skip rather than assert a false pass.
             return;

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -542,9 +542,15 @@ impl ReceiverContext {
                     .xattr_name_filter()
                     .map(|set| move |name: &str| set.xattr_name_allowed(name));
                 let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
-                if let Err(e) =
-                    metadata::apply_xattrs_from_list(&file_path, xattr_list, true, filter_ref)
-                {
+                // upstream: rsync_xal_set resolves an abbreviated value against
+                // fnamecmp; the file is its own basis for the in-place case.
+                if let Err(e) = metadata::apply_xattrs_from_list(
+                    &file_path,
+                    xattr_list,
+                    true,
+                    Some(&file_path),
+                    filter_ref,
+                ) {
                     metadata_errors.push((file_path.clone(), e.to_string()));
                 }
             }


### PR DESCRIPTION
## Problem

An extended attribute value longer than `MAX_FULL_DATUM` (32 bytes) is transmitted *abbreviated*: the sender sends only a digest of a value it expects the receiver to already hold on the basis (fnamecmp) file, rather than resending the full bytes. The receive-side apply path (`apply_xattrs_from_list`) skipped every abbreviated entry outright, so on a transfer from an upstream sender that abbreviated a large xattr the value was silently dropped on the destination.

## Fix

Mirror upstream `xattrs.c:rsync_xal_set()` (lines 964-1009). For an abbreviated entry the receiver now re-reads the referenced attribute from the basis file and, when its length and (unseeded MD5, protocol 30-32) digest match the reference, applies the full value to the destination - byte-identical to a full-list transfer.

- A missing basis file or a mismatched digest takes upstream's `still_abbrev` path: the destination is left unchanged, never written with a raw checksum masquerading as the datum.
- An abbreviated name is retained in the applied set whether or not it resolves, so an existing destination value survives the removal sweep - matching upstream, which keeps `rxas[i].name` in the kept set.

`apply_xattrs_from_list` gains a `basis` parameter. The disk-commit receiver threads the pre-transfer destination path - the true fnamecmp, still intact while the temp file is staged before rename. The in-place and directory apply sites pass the target itself (their own fnamecmp). `compute_xattr_checksum` is made public alongside the already-public `checksum_matches` so a wire-format digest can be constructed directly.

## Scope

Receiver-only. The sender already abbreviates correctly on the wire; the gap was purely that received abbreviations were never resolved. Exotic delta bases (`--fuzzy`, `--link-dest`, `--compare-dest`, `--partial-dir`) are not yet threaded as the resolution source and remain a follow-up; the primary destination basis covers the common case.

## Tests

- `apply_xattrs_from_list_resolves_abbreviated_against_basis` - an abbreviated entry whose digest matches a 100-byte basis value is reconstructed and applied identically to a full-list transfer.
- `apply_xattrs_from_list_abbreviated_mismatch_not_applied` - a non-matching digest is not applied (no unrelated basis value copied).
- `apply_xattrs_from_list_no_basis_leaves_abbreviated_unset` - with no basis the checksum is never written as if it were the value.

All gate on filesystem xattr support with graceful skip. Host verify: `metadata` build + clippy `-D warnings` clean, 614 tests passed / 0 skipped.
