### PR TITLE
fix(transfer): confine and O_NOFOLLOW sender source opens with device guard

### DIFF
--- a/crates/fast_io/src/confined_open.rs
+++ b/crates/fast_io/src/confined_open.rs
@@ -1,0 +1,441 @@
+//! Sender-side confined source open beneath a module root.
+//!
+//! [`open_source_confined`] opens a source file for reading such that the
+//! kernel guarantees resolution cannot escape the module-root directory:
+//! no `..` climb above the root, no absolute-path jump, no symlink whose
+//! target lies outside the root, and no `/proc` magic-link trick. Symlinks
+//! that stay *within* the module root are followed normally, matching the
+//! non-chroot daemon behaviour upstream restored for issue #715.
+//!
+//! This is the sender-side analogue of the receiver's
+//! [`crate::secure_dir::secure_open_dir`] / [`crate::dir_sandbox::DirSandbox`]
+//! confinement. It exists to close the TOCTOU window where an attacker who
+//! controls the module tree swaps a directory component for a symlink
+//! between the file-list scan and the source open, redirecting the read to
+//! a file outside the module.
+//!
+//! # Platform behaviour
+//!
+//! upstream: `syscall.c:secure_relative_open` (called from
+//! `sender.c:secure_relative_open` when `use_secure_symlinks`, i.e. a
+//! non-chroot daemon).
+//!
+//! - Linux 5.6+: `openat2(2)` with
+//!   `RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS` anchored at the module-root
+//!   dirfd. In-tree symlinks are followed; escapes fail with `EXDEV`.
+//! - Older Linux and every other Unix target: a per-component
+//!   `O_NOFOLLOW` walk from the module-root dirfd, mirroring upstream's
+//!   portable fallback. This is stricter than the kernel path - it refuses
+//!   *every* symlink component, in-tree or not - trading function for
+//!   safety exactly as upstream documents.
+//! - Non-Unix: unsupported. The oc daemon (the only caller) is Unix-only,
+//!   so this path is never reached; it returns an `Unsupported` error.
+
+use std::fs::File;
+use std::io;
+use std::path::{Component, Path};
+
+/// Opens `root`/`relative` for reading, confined beneath `root`.
+///
+/// `root` is the operator-trusted module-root directory (an absolute path
+/// from the daemon config); it is opened with normal symlink resolution.
+/// `relative` is the module-relative source path; its resolution is
+/// confined so it cannot escape `root`.
+///
+/// When `noatime` is set the leaf open adds `O_NOATIME` on Linux/Android,
+/// falling back to a plain open if the kernel or filesystem rejects the
+/// flag (`EPERM`/`EACCES`/`EINVAL`/`ENOTSUP`/`EROFS`), matching
+/// [`crate::nofollow_open`] and the source-open helper.
+///
+/// # Errors
+///
+/// - `EINVAL` when `relative` is absolute or contains a `..` component
+///   (front-door validation, mirroring upstream `secure_relative_open`).
+/// - `EXDEV` (Linux `openat2` path) when resolution would escape `root`.
+/// - `ELOOP` (portable fallback) when any component of `relative` is a
+///   symlink.
+/// - `ENOENT` when the file does not exist beneath `root`.
+/// - Any other I/O error from the underlying syscalls, forwarded verbatim.
+///
+/// upstream: sender.c:secure_relative_open
+pub fn open_source_confined(root: &Path, relative: &Path, noatime: bool) -> io::Result<File> {
+    validate_relative(relative)?;
+    imp::open_source_confined(root, relative, noatime)
+}
+
+/// Rejects an absolute `relative` or any `..` component up front with
+/// `EINVAL`, matching upstream `secure_relative_open`'s portable front-door
+/// check (`path_has_dotdot_component`). `.` and normal components are
+/// allowed; the kernel / walk adjudicates the rest.
+fn validate_relative(relative: &Path) -> io::Result<()> {
+    for comp in relative.components() {
+        match comp {
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(io::Error::from_raw_os_error(EINVAL));
+            }
+            Component::CurDir | Component::Normal(_) => {}
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+const EINVAL: i32 = libc::EINVAL;
+
+// On non-Unix the module resolves through the `Unsupported` error path
+// before ever validating, but the constant is still referenced.
+#[cfg(not(unix))]
+const EINVAL: i32 = 22;
+
+#[cfg(unix)]
+mod imp {
+    use super::*;
+    use std::os::fd::AsFd;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    use crate::dir_sandbox::openat;
+
+    pub(super) fn open_source_confined(
+        root: &Path,
+        relative: &Path,
+        noatime: bool,
+    ) -> io::Result<File> {
+        // Open the module root as the anchoring dirfd. The root is an
+        // absolute, operator-trusted path, so a plain open (following any
+        // symlinks in the root itself) matches upstream's
+        // `openat(AT_FDCWD, basedir, O_RDONLY | O_DIRECTORY)`.
+        let root_dir = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
+            .open(root)?;
+
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            if let Some(file) = linux::openat2_confined(root_dir.as_fd(), relative, noatime)? {
+                return Ok(file);
+            }
+        }
+
+        walk_nofollow(root_dir.as_fd(), relative, noatime)
+    }
+
+    /// Portable per-component `O_NOFOLLOW` walk from `root_fd`, mirroring
+    /// the fallback in upstream `secure_relative_open` for platforms
+    /// without kernel `RESOLVE_BENEATH`. Every component - directory and
+    /// leaf - is opened `O_NOFOLLOW`, so any symlink along the path is
+    /// refused with `ELOOP`.
+    fn walk_nofollow(
+        root_fd: std::os::fd::BorrowedFd<'_>,
+        relative: &Path,
+        noatime: bool,
+    ) -> io::Result<File> {
+        let mut components: Vec<&std::ffi::OsStr> = Vec::new();
+        for comp in relative.components() {
+            if let Component::Normal(part) = comp {
+                components.push(part);
+            }
+            // `.` is skipped; `..`, root, and prefix were rejected by
+            // `validate_relative`.
+        }
+
+        let Some((leaf, dirs)) = components.split_last() else {
+            // Empty relative path: nothing to open beneath the root.
+            return Err(io::Error::from_raw_os_error(libc::EINVAL));
+        };
+
+        let dir_flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        let mut current: Option<File> = None;
+        for dir in dirs {
+            let parent = current.as_ref().map_or(root_fd, AsFd::as_fd);
+            let next = openat(parent, dir, dir_flags, 0)?;
+            current = Some(next);
+        }
+
+        let parent = current.as_ref().map_or(root_fd, AsFd::as_fd);
+        open_leaf(parent, leaf, noatime)
+    }
+
+    /// Opens the leaf `O_RDONLY | O_NOFOLLOW`, honouring `--open-noatime`
+    /// with the same graceful fallback the plain source open uses.
+    fn open_leaf(
+        parent: std::os::fd::BorrowedFd<'_>,
+        leaf: &std::ffi::OsStr,
+        noatime: bool,
+    ) -> io::Result<File> {
+        let base = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        if let Some(extra) = noatime_flag(noatime) {
+            match openat(parent, leaf, base | extra, 0) {
+                Ok(file) => return Ok(file),
+                Err(error) if noatime_retryable(&error) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        openat(parent, leaf, base, 0)
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub(super) mod linux {
+        use super::{noatime_flag, noatime_retryable};
+        use std::ffi::CString;
+        use std::fs::File;
+        use std::io;
+        use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd};
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::Path;
+
+        use crate::linux_capabilities::openat2_supported;
+
+        /// Attempts `openat2(RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS)` for
+        /// `relative` beneath `root_fd`.
+        ///
+        /// Returns `Ok(Some(file))` on success, `Ok(None)` when the kernel
+        /// lacks `openat2` (`ENOSYS`, cached by [`openat2_supported`]) so the
+        /// caller falls back to the portable walk, and `Err(_)` for every
+        /// other failure - including the deliberate confinement refusals
+        /// (`EXDEV` for an escape, `ELOOP` for a magic link) the caller must
+        /// surface.
+        pub(super) fn openat2_confined(
+            root_fd: BorrowedFd<'_>,
+            relative: &Path,
+            noatime: bool,
+        ) -> io::Result<Option<File>> {
+            if !openat2_supported() {
+                return Ok(None);
+            }
+
+            let c_rel = CString::new(relative.as_os_str().as_bytes()).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "path contains interior null byte",
+                )
+            })?;
+
+            let base = libc::O_RDONLY | libc::O_CLOEXEC;
+            if let Some(extra) = noatime_flag(noatime) {
+                match raw_openat2(root_fd, &c_rel, base | extra) {
+                    Ok(outcome) => return Ok(outcome),
+                    Err(error) if noatime_retryable(&error) => {}
+                    Err(error) => return Err(error),
+                }
+            }
+            raw_openat2(root_fd, &c_rel, base)
+        }
+
+        /// Issues the raw `openat2(2)` syscall with
+        /// `RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS`.
+        fn raw_openat2(
+            root_fd: BorrowedFd<'_>,
+            c_rel: &CString,
+            flags: i32,
+        ) -> io::Result<Option<File>> {
+            // SAFETY: this block performs three FFI touches, mirroring the
+            // audited pattern in `dir_sandbox::openat2_beneath`:
+            //
+            // 1. `std::mem::zeroed::<open_how>()` - `libc::open_how` is
+            //    `#[non_exhaustive]` and `repr(C)` with integer-only fields;
+            //    an all-zero bit pattern is the documented "no constraint"
+            //    default for every `openat2(2)` knob.
+            // 2. `libc::syscall(SYS_openat2, root_fd, c_rel, &how, size)` -
+            //    `root_fd.as_raw_fd()` is a live borrowed fd that outlives
+            //    the call; `c_rel` is a valid NUL-terminated C string
+            //    borrowed for the call; `how` is fully initialised and its
+            //    address plus `size_of::<open_how>()` are handed to the
+            //    kernel per the syscall ABI. The kernel retains none of the
+            //    pointers past return.
+            // 3. `File::from_raw_fd(raw)` - takes exclusive ownership of the
+            //    fresh `O_CLOEXEC` fd; it is never duplicated, leaked, or
+            //    aliased elsewhere.
+            #[allow(unsafe_code)]
+            let raw = unsafe {
+                let mut how: libc::open_how = std::mem::zeroed();
+                how.flags = flags as u64;
+                how.mode = 0;
+                how.resolve = libc::RESOLVE_BENEATH | libc::RESOLVE_NO_MAGICLINKS;
+
+                libc::syscall(
+                    libc::SYS_openat2,
+                    root_fd.as_raw_fd(),
+                    c_rel.as_ptr(),
+                    &how as *const libc::open_how,
+                    std::mem::size_of::<libc::open_how>(),
+                )
+            };
+
+            if raw >= 0 {
+                // SAFETY: `raw` is a non-negative fd just returned by
+                // `openat2(2)` with `O_CLOEXEC`, owned exclusively here.
+                #[allow(unsafe_code)]
+                let file = unsafe { File::from_raw_fd(raw as libc::c_int) };
+                return Ok(Some(file));
+            }
+
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::ENOSYS) {
+                return Ok(None);
+            }
+            Err(err)
+        }
+    }
+
+    /// Returns `O_NOATIME` when `noatime` is requested on Linux/Android,
+    /// `None` otherwise (the flag is undefined on other targets).
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn noatime_flag(noatime: bool) -> Option<i32> {
+        noatime.then_some(libc::O_NOATIME)
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    fn noatime_flag(_noatime: bool) -> Option<i32> {
+        None
+    }
+
+    /// Whether an `O_NOATIME` open failure should be retried without the
+    /// flag. Mirrors `open_source::try_open_noatime`.
+    fn noatime_retryable(error: &io::Error) -> bool {
+        matches!(
+            error.raw_os_error(),
+            Some(libc::EPERM | libc::EACCES | libc::EINVAL | libc::ENOTSUP | libc::EROFS)
+        )
+    }
+}
+
+#[cfg(not(unix))]
+mod imp {
+    use super::*;
+
+    pub(super) fn open_source_confined(
+        _root: &Path,
+        _relative: &Path,
+        _noatime: bool,
+    ) -> io::Result<File> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "confined source open is Unix-only (the daemon sender is Unix-only)",
+        ))
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use std::os::unix::fs::symlink;
+
+    fn read_to_string(mut file: File) -> String {
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).expect("read");
+        buf
+    }
+
+    #[test]
+    fn opens_regular_file_beneath_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+        std::fs::write(root.join("sub/data"), b"payload").expect("write");
+
+        let file = open_source_confined(&root, Path::new("sub/data"), false).expect("open");
+        assert_eq!(read_to_string(file), "payload");
+    }
+
+    #[test]
+    fn follows_in_tree_directory_symlink_on_kernel_path() {
+        // In-tree symlinks are allowed by the openat2 RESOLVE_BENEATH path
+        // (upstream #715 behaviour). On the portable fallback walk this is
+        // refused with ELOOP; accept either, since the security contract is
+        // "no escape", and the fallback is deliberately stricter.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        std::fs::create_dir(root.join("real")).expect("mkdir real");
+        std::fs::write(root.join("real/data"), b"in-tree").expect("write");
+        symlink("real", root.join("link")).expect("symlink");
+
+        match open_source_confined(&root, Path::new("link/data"), false) {
+            Ok(file) => assert_eq!(read_to_string(file), "in-tree"),
+            Err(error) => {
+                // The portable walk refuses the symlinked directory component:
+                // ELOOP on Linux, ENOTDIR on macOS/BSD (O_DIRECTORY evaluated
+                // before O_NOFOLLOW).
+                let code = error.raw_os_error();
+                assert!(
+                    code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
+                    "fallback walk must refuse the symlink component, got: {error}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn refuses_escape_via_directory_symlink() {
+        // A directory component symlinked to a sibling OUTSIDE the root must
+        // not let the open escape. This is the core TOCTOU defence.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let root = base.join("module");
+        std::fs::create_dir(&root).expect("mkdir module");
+        let outside = base.join("outside");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        std::fs::write(outside.join("secret"), b"do-not-leak").expect("write secret");
+
+        // `<root>/escape` -> the absolute `outside` dir (outside the module).
+        symlink(&outside, root.join("escape")).expect("symlink escape");
+
+        let err = open_source_confined(&root, Path::new("escape/secret"), false)
+            .expect_err("escape must be refused");
+        // openat2 rejects the escape with EXDEV; the portable walk rejects the
+        // symlinked directory component with ELOOP (Linux) or ENOTDIR
+        // (macOS/BSD). Any of the three proves confinement.
+        let code = err.raw_os_error();
+        assert!(
+            code == Some(libc::EXDEV) || code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
+            "expected EXDEV, ELOOP, or ENOTDIR for an escape, got: {err}"
+        );
+    }
+
+    #[test]
+    fn refuses_symlinked_leaf_pointing_outside() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let root = base.join("module");
+        std::fs::create_dir(&root).expect("mkdir module");
+        std::fs::write(base.join("secret"), b"do-not-leak").expect("write secret");
+
+        // Absolute symlink leaf targeting a file outside the module.
+        symlink(base.join("secret"), root.join("leak")).expect("symlink leak");
+
+        let err = open_source_confined(&root, Path::new("leak"), false)
+            .expect_err("symlinked leaf pointing outside must be refused");
+        let code = err.raw_os_error();
+        assert!(
+            code == Some(libc::EXDEV) || code == Some(libc::ELOOP),
+            "expected EXDEV or ELOOP for an outside leaf, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_absolute_relative_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let err = open_source_confined(&root, Path::new("/etc/passwd"), false)
+            .expect_err("absolute relative path must be rejected");
+        assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+    }
+
+    #[test]
+    fn rejects_dotdot_component() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let err = open_source_confined(&root, Path::new("../secret"), false)
+            .expect_err("dotdot component must be rejected");
+        assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+    }
+
+    #[test]
+    fn missing_file_reports_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let err = open_source_confined(&root, Path::new("nope"), false)
+            .expect_err("missing file must fail");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -82,6 +82,12 @@
 
 /// Cached sorting using the Schwartzian transform.
 pub mod cached_sort;
+/// Sender-side confined source open beneath a module root.
+///
+/// Unix-only: mirrors upstream `secure_relative_open` so a non-chroot
+/// daemon sender cannot be redirected outside its module by a swapped
+/// directory symlink (TOCTOU escape).
+pub mod confined_open;
 /// Rootless container / user-namespace detection for SQPOLL gating.
 pub mod container;
 /// Parent-dirfd carrier (`DirSandbox`) for the SEC-1 sandbox.
@@ -347,6 +353,8 @@ pub use traits::{FileReader, FileWriter};
 #[cfg(all(target_os = "macos", feature = "macos-gcd"))]
 pub use gcd::{GcdQueue, GcdReader, GcdWriter};
 
+#[cfg(unix)]
+pub use confined_open::open_source_confined;
 #[cfg(unix)]
 pub use dir_sandbox::{
     AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -912,11 +912,23 @@ impl GeneratorContext {
     /// yields `None` for the fd because its reader owns the descriptor behind an
     /// abstraction; a later zero-copy SERVE gate applies only to the plain-file
     /// case. The fd is purely informational here - the byte stream is identical.
+    ///
+    /// The third tuple element is the effective source length: on the plain-file
+    /// path it is the fstat'd size (with a 0-length device resolved via
+    /// `get_device_size`), preferred over the flist scan-time length exactly as
+    /// upstream `sender.c:404-419` prefers `st.st_size`. The fast path, taken
+    /// only for a non-device regular file that follows symlinks, reports the
+    /// flist length. A device source opened without `--copy-devices` aborts the
+    /// transfer with `RERR_PROTOCOL` (a tagged `ProtocolViolation` error).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:404-419` - `do_fstat` + `IS_DEVICE` guard + `get_device_size`.
     pub(crate) fn open_source_unbuffered(
         &self,
         path: &std::path::Path,
         file_size: u64,
-    ) -> std::io::Result<(Box<dyn std::io::Read>, Option<SourceFd>)> {
+    ) -> std::io::Result<(Box<dyn std::io::Read>, Option<SourceFd>, u64)> {
         // 1 MB threshold: io_uring ring creation has fixed overhead that only
         // pays off for larger reads where batched syscalls reduce total cost.
         const IO_URING_READ_THRESHOLD: u64 = 1024 * 1024;
@@ -940,7 +952,7 @@ impl GeneratorContext {
             #[cfg(target_os = "windows")]
             {
                 if let Ok(r) = fast_io::iocp_reader_from_path(path, fast_io::IocpPolicy::Auto) {
-                    return Ok((Box::new(r), None));
+                    return Ok((Box::new(r), None, file_size));
                 }
                 // Fall through to raw File on IOCP failure.
             }
@@ -951,7 +963,7 @@ impl GeneratorContext {
                     self.config.write.io_uring_policy,
                     self.config.write.io_uring_depth,
                 ) {
-                    Ok(r) => return Ok((Box::new(r), None)),
+                    Ok(r) => return Ok((Box::new(r), None, file_size)),
                     Err(_) => {
                         // Fall through to raw File on io_uring failure
                     }
@@ -959,12 +971,43 @@ impl GeneratorContext {
             }
         }
 
-        let f = self.source_open().open(path)?;
+        let mut f = self.source_open().open(path)?;
+        // upstream: sender.c:404-419 - fstat the opened fd, reject a device
+        // without --copy-devices, and prefer the fstat'd size (resolving a
+        // 0-length device via get_device_size) over the flist scan-time size.
+        let effective_size = self.fstat_source_guard(&mut f)?;
         #[cfg(unix)]
         let src_fd = Some(std::os::fd::AsRawFd::as_raw_fd(&f));
         #[cfg(not(unix))]
         let src_fd = None;
-        Ok((Box::new(f), src_fd))
+        Ok((Box::new(f), src_fd, effective_size))
+    }
+
+    /// Fstats the opened source fd, enforces the sender's device guard, and
+    /// resolves the effective source length.
+    ///
+    /// `File::metadata` performs the `fstat(2)` on the already-open fd using a
+    /// safe std API (no `unsafe` in this crate). A block/char device opened
+    /// without `--copy-devices` aborts the transfer with `RERR_PROTOCOL`; a
+    /// 0-length device with `--copy-devices` has its real size resolved by
+    /// seeking to the end. Every other source reports its fstat length.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:404-419` - `do_fstat` (exit `RERR_FILEIO` on failure),
+    ///   `IS_DEVICE(st.st_mode)` guard (`RERR_PROTOCOL`), and
+    ///   `st.st_size = get_device_size(fd, fname)` for a 0-length device.
+    fn fstat_source_guard(&self, file: &mut std::fs::File) -> std::io::Result<u64> {
+        let metadata = file.metadata()?;
+        #[cfg(unix)]
+        let size = match source_device_guard(&metadata, self.config.flags.copy_devices)? {
+            Some(size) => size,
+            // upstream: sender.c:418 - st.st_size = get_device_size(fd, fname).
+            None => get_device_size(file)?,
+        };
+        #[cfg(not(unix))]
+        let size = metadata.len();
+        Ok(size)
     }
 
     /// Returns the upstream `missing_args` mode for ENOENT handling.
@@ -1071,6 +1114,61 @@ fn join_source_path(base: &Path, name: &Path) -> PathBuf {
     let mut path = base.to_path_buf();
     path.extend(name.components());
     path
+}
+
+/// Applies the sender's device guard to an fstat'd source and reports the
+/// size to use.
+///
+/// Returns `Ok(Some(len))` for a normal source or a non-empty device (use the
+/// fstat length), `Ok(None)` for a 0-length device whose real size must be
+/// resolved with [`get_device_size`], and `Err(_)` (a tagged
+/// [`protocol::ProtocolViolation`]) when a device is opened without
+/// `--copy-devices`.
+///
+/// # Upstream Reference
+///
+/// - `sender.c:405-419` - `if (IS_DEVICE(st.st_mode)) { if (!copy_devices) ...
+///   exit_cleanup(RERR_PROTOCOL); if (st.st_size == 0) st.st_size =
+///   get_device_size(fd, fname); }`.
+#[cfg(unix)]
+fn source_device_guard(
+    metadata: &std::fs::Metadata,
+    copy_devices: bool,
+) -> std::io::Result<Option<u64>> {
+    use std::os::unix::fs::FileTypeExt;
+    let file_type = metadata.file_type();
+    if file_type.is_block_device() || file_type.is_char_device() {
+        if !copy_devices {
+            // upstream: sender.c:407-409 - rprintf(FERROR, "attempt to copy
+            // device contents without --copy-devices\n") + exit_cleanup(RERR_PROTOCOL).
+            return Err(protocol::protocol_violation(format!(
+                "attempt to copy device contents without --copy-devices {}{}",
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::sender()
+            )));
+        }
+        if metadata.len() == 0 {
+            return Ok(None);
+        }
+    }
+    Ok(Some(metadata.len()))
+}
+
+/// Resolves a device's readable size by seeking to its end, then rewinds the
+/// fd so the subsequent read streams from offset 0.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:1550 get_device_size` - `lseek(fd, 0, SEEK_END)` yields the
+///   size; `lseek(fd, 0, SEEK_SET)` rewinds. A seek failure logs and returns
+///   `0` upstream, so the transfer degrades to an empty stream rather than
+///   aborting; the rewind failure is likewise non-fatal.
+#[cfg(unix)]
+fn get_device_size(file: &mut std::fs::File) -> std::io::Result<u64> {
+    use std::io::{Seek, SeekFrom};
+    let size = file.seek(SeekFrom::End(0)).unwrap_or(0);
+    let _ = file.seek(SeekFrom::Start(0));
+    Ok(size)
 }
 
 /// Derives the interned base for a `(full_path, name)` pair such that
@@ -1246,5 +1344,65 @@ mod source_base_windows_tests {
             join_source_path(&base, name),
             PathBuf::from(r"C:\srv\module\foo"),
         );
+    }
+}
+
+#[cfg(all(test, unix))]
+mod device_guard_tests {
+    //! Sender device guard (`sender.c:405-419`): a device source without
+    //! `--copy-devices` must abort with `RERR_PROTOCOL`, a device with
+    //! `--copy-devices` defers to `get_device_size`, and a regular file
+    //! reports its fstat length.
+    use super::source_device_guard;
+
+    /// WHY: without `--copy-devices` upstream refuses to stream device
+    /// contents and `exit_cleanup(RERR_PROTOCOL)`. The guard must surface a
+    /// `ProtocolViolation` so the core mapper returns exit 2, not a silent
+    /// device read.
+    #[test]
+    fn char_device_without_copy_devices_is_refused() {
+        let metadata = std::fs::metadata("/dev/null").expect("/dev/null present");
+        assert!(
+            metadata.file_type_is_device(),
+            "/dev/null must be a character device for this test to mean anything"
+        );
+        let err = source_device_guard(&metadata, false)
+            .expect_err("a device without --copy-devices must abort");
+        assert!(
+            err.get_ref()
+                .is_some_and(|inner| inner.is::<protocol::ProtocolViolation>()),
+            "the device guard must raise a ProtocolViolation (RERR_PROTOCOL), got: {err}"
+        );
+    }
+
+    /// With `--copy-devices` a 0-length device defers size resolution to
+    /// `get_device_size` (upstream `sender.c:418`), signalled by `Ok(None)`.
+    #[test]
+    fn char_device_with_copy_devices_defers_size_resolution() {
+        let metadata = std::fs::metadata("/dev/null").expect("/dev/null present");
+        assert_eq!(source_device_guard(&metadata, true).unwrap(), None);
+    }
+
+    /// A regular file reports its fstat length regardless of `--copy-devices`.
+    #[test]
+    fn regular_file_reports_fstat_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f");
+        std::fs::write(&path, b"12345").unwrap();
+        let metadata = std::fs::metadata(&path).unwrap();
+        assert_eq!(source_device_guard(&metadata, false).unwrap(), Some(5));
+    }
+
+    /// Local extension trait so the test can assert `/dev/null` really is a
+    /// device without importing `FileTypeExt` at module scope.
+    trait FileTypeIsDevice {
+        fn file_type_is_device(&self) -> bool;
+    }
+    impl FileTypeIsDevice for std::fs::Metadata {
+        fn file_type_is_device(&self) -> bool {
+            use std::os::unix::fs::FileTypeExt;
+            let ft = self.file_type();
+            ft.is_block_device() || ft.is_char_device()
+        }
     }
 }

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -597,6 +597,54 @@ impl GeneratorContext {
         join_source_path(&self.source_bases[ndx], self.file_list[ndx].path())
     }
 
+    /// Builds the per-connection source-open policy the sender applies to
+    /// every source file.
+    ///
+    /// Mirrors the branch upstream `sender.c` takes before reading a file:
+    /// a non-chroot daemon (`use_secure_symlinks = am_daemon && !am_chrooted`;
+    /// oc never chroots, so it is simply `is_daemon_connection`) confines the
+    /// open beneath the module root; otherwise `do_open_checklinks` opens with
+    /// `O_NOFOLLOW` unless `--copy-links` / `--copy-unsafe-links` follows the
+    /// symlink.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:1018` - `use_secure_symlinks = am_daemon && !am_chrooted`
+    /// - `sender.c:359-383` - `secure_relative_open` vs `do_open_checklinks`
+    pub(crate) fn source_open(&self) -> open_source::SourceOpen {
+        let confine_root = if self.config.connection.is_daemon_connection {
+            self.config.connection.daemon_module_root.clone()
+        } else {
+            None
+        };
+        let follow_symlinks = self.config.flags.copy_links || self.config.flags.copy_unsafe_links;
+        open_source::SourceOpen::new(
+            confine_root,
+            follow_symlinks,
+            self.config.write.open_noatime,
+        )
+    }
+
+    /// Whether the source open must apply confinement or `O_NOFOLLOW`, which
+    /// the path-based io_uring / IOCP fast readers cannot express (they follow
+    /// symlinks). Only a non-daemon transfer that already follows symlinks
+    /// (`--copy-links` / `--copy-unsafe-links`) may take the fast path.
+    ///
+    /// Non-Unix targets apply no symlink-race defence here (`O_NOFOLLOW` is a
+    /// Unix concept), so the fast path is always available.
+    pub(crate) fn requires_protected_source_open(&self) -> bool {
+        #[cfg(unix)]
+        {
+            let follows = !self.config.connection.is_daemon_connection
+                && (self.config.flags.copy_links || self.config.flags.copy_unsafe_links);
+            !follows
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
+    }
+
     /// Returns the full source path for entry `ndx` for the `%f` out-format
     /// placeholder, mirroring upstream `log.c` `pathjoin(F_PATHNAME(file),
     /// f_name(file))`.
@@ -786,6 +834,7 @@ impl GeneratorContext {
             && file_size >= IO_URING_READ_THRESHOLD
             && self.config.write.io_uring_policy != fast_io::IoUringPolicy::Disabled
             && !self.source_is_copy_device(path)
+            && !self.requires_protected_source_open()
         {
             // Windows gets IOCP where Linux gets io_uring, std elsewhere. The
             // IOCP reader mirrors the disk-commit writer's dispatch: runtime
@@ -814,7 +863,7 @@ impl GeneratorContext {
             }
         }
 
-        let f = open_source::open_source_with_noatime(path, use_noatime)?;
+        let f = self.source_open().open(path)?;
         Ok(Box::new(std::io::BufReader::with_capacity(
             adaptive_buffer_size(file_size),
             f,
@@ -881,6 +930,7 @@ impl GeneratorContext {
             && file_size >= IO_URING_READ_THRESHOLD
             && self.config.write.io_uring_policy != fast_io::IoUringPolicy::Disabled
             && !self.source_is_copy_device(path)
+            && !self.requires_protected_source_open()
         {
             // Windows gets IOCP where Linux gets io_uring, std elsewhere. The
             // IOCP reader mirrors the disk-commit writer's dispatch: runtime
@@ -909,7 +959,7 @@ impl GeneratorContext {
             }
         }
 
-        let f = open_source::open_source_with_noatime(path, use_noatime)?;
+        let f = self.source_open().open(path)?;
         #[cfg(unix)]
         let src_fd = Some(std::os::fd::AsRawFd::as_raw_fd(&f));
         #[cfg(not(unix))]

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -858,7 +858,7 @@ pub(super) fn write_delta_with_compression<W: Write>(
     encoder: Option<&mut CompressedTokenEncoder>,
     is_zlib: bool,
     source_path: &Path,
-    use_noatime: bool,
+    source_open: &super::open_source::SourceOpen,
 ) -> io::Result<()> {
     match encoder {
         Some(encoder) => {
@@ -869,9 +869,7 @@ pub(super) fn write_delta_with_compression<W: Write>(
             let needs_dict_sync =
                 is_zlib && ops.iter().any(|op| matches!(op, DeltaOp::Copy { .. }));
             let mut source_file = if needs_dict_sync {
-                Some(io::BufReader::new(
-                    super::open_source::open_source_with_noatime(source_path, use_noatime)?,
-                ))
+                Some(io::BufReader::new(source_open.open(source_path)?))
             } else {
                 None
             };
@@ -952,7 +950,7 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
     encoder: Option<&mut CompressedTokenEncoder>,
     is_zlib: bool,
     source_path: &Path,
-    use_noatime: bool,
+    source_open: &super::open_source::SourceOpen,
     checksum_algorithm: ChecksumAlgorithm,
     checksum_seed: i32,
     protocol: protocol::ProtocolVersion,
@@ -968,9 +966,7 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
     // A single file handle serves both checksum and dictionary sync.
     let has_copies = ops.iter().any(|op| matches!(op, DeltaOp::Copy { .. }));
     let mut source_file = if has_copies {
-        Some(io::BufReader::new(
-            super::open_source::open_source_with_noatime(source_path, use_noatime)?,
-        ))
+        Some(io::BufReader::new(source_open.open(source_path)?))
     } else {
         None
     };
@@ -1367,7 +1363,7 @@ mod tests {
             None,
             false,
             &source_path,
-            false,
+            &crate::generator::open_source::SourceOpen::new(None, false, false),
             ChecksumAlgorithm::MD5,
             0,
             proto(31),
@@ -1961,7 +1957,7 @@ mod tests {
             None,
             false,
             temp.path(),
-            false,
+            &crate::generator::open_source::SourceOpen::new(None, false, false),
             ChecksumAlgorithm::MD5,
             0,
             proto(31),

--- a/crates/transfer/src/generator/open_source.rs
+++ b/crates/transfer/src/generator/open_source.rs
@@ -1,30 +1,100 @@
-//! Source-file opening with optional `O_NOATIME` propagation.
+//! Source-file opening with the upstream sender's symlink-race defences.
 //!
-//! Mirrors upstream `syscall.c:228 do_open` and `syscall.c:687
-//! do_open_nofollow` (the latter added `O_NOATIME` propagation in
-//! rsync 3.4.2). On Linux/Android, when `--open-noatime` is set the
-//! source file is opened with `OpenOptionsExt::custom_flags(O_NOATIME)`.
-//! Permission failures (`EPERM`, `EACCES`) and filesystems that reject
-//! the flag (`EINVAL`, `ENOTSUP`, `EROFS`) fall back to a plain
-//! `File::open`, matching the local-copy executor's helper.
+//! The sender opens every source file through [`SourceOpen::open`], which
+//! mirrors the branch upstream `sender.c` takes before reading a file:
 //!
-//! On every other target the function is a thin wrapper over
-//! `File::open(path)` because `O_NOATIME` is not defined.
+//! - **Daemon, non-chroot** (`use_secure_symlinks`): the file is opened
+//!   confined beneath the module root via [`fast_io::open_source_confined`],
+//!   so a swapped directory symlink cannot redirect the read outside the
+//!   module (TOCTOU escape). upstream: `sender.c:secure_relative_open`.
+//! - **Everything else** (`do_open_checklinks`): the file is opened with
+//!   `O_NOFOLLOW` on the leaf so a symlinked final component is refused,
+//!   UNLESS `--copy-links` / `--copy-unsafe-links` is set (then the symlink
+//!   is followed with a plain open). upstream: `sender.c:do_open_checklinks`.
+//!
+//! Every open also honours `--open-noatime` (rsync 3.4.2): on Linux/Android
+//! the open adds `O_NOATIME`, falling back to a plain open if the kernel or
+//! filesystem rejects the flag (`EPERM`/`EACCES`/`EINVAL`/`ENOTSUP`/`EROFS`).
+//! upstream: `syscall.c:228 do_open` / `syscall.c:687 do_open_nofollow`.
 
 use std::fs;
 use std::io;
 use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use libc::{EACCES, EINVAL, ENOTSUP, EPERM, EROFS, O_NOATIME};
 
-/// Opens a source file for reading, honouring `--open-noatime`.
+/// The sender's per-connection source-open policy.
 ///
-/// upstream: syscall.c do_open / do_open_nofollow (3.4.2 propagates
-/// `O_NOATIME` through both paths via the `open_noatime` global).
+/// Built once from the transfer config (see
+/// [`GeneratorContext::source_open`](crate::generator::GeneratorContext::source_open))
+/// and shared by every source open so the confinement / `O_NOFOLLOW`
+/// decision lives in exactly one place rather than being duplicated across
+/// the delta, whole-file, and append read paths.
+#[derive(Clone, Debug)]
+pub(crate) struct SourceOpen {
+    /// `Some(module_root)` for a non-chroot daemon sender: opens are
+    /// confined beneath this absolute root. Unused on non-Unix (the daemon
+    /// is Unix-only), hence the `dead_code` allowance there.
+    #[cfg_attr(not(unix), allow(dead_code))]
+    confine_root: Option<PathBuf>,
+    /// Whether to follow a symlinked leaf (`--copy-links` /
+    /// `--copy-unsafe-links`). When false, the leaf is opened `O_NOFOLLOW`.
+    follow_symlinks: bool,
+    /// Whether to propagate `O_NOATIME` (`--open-noatime`).
+    noatime: bool,
+}
+
+impl SourceOpen {
+    /// Builds a policy from its three inputs.
+    pub(crate) fn new(confine_root: Option<PathBuf>, follow_symlinks: bool, noatime: bool) -> Self {
+        Self {
+            confine_root,
+            follow_symlinks,
+            noatime,
+        }
+    }
+
+    /// Opens `path` under this policy.
+    ///
+    /// upstream: sender.c - `secure_relative_open` (daemon, confined) vs
+    /// `do_open_checklinks` (`O_NOFOLLOW` leaf unless copy-links).
+    pub(crate) fn open(&self, path: &Path) -> io::Result<fs::File> {
+        #[cfg(unix)]
+        if let Some(root) = self.confine_root.as_deref() {
+            // upstream: sender.c:secure_relative_open - reconstruct the
+            // module-relative path and open it confined beneath the module
+            // root. oc keeps absolute source paths, so the module-relative
+            // component is the source path with the module root stripped.
+            if let Ok(relative) = path.strip_prefix(root) {
+                return fast_io::open_source_confined(root, relative, self.noatime);
+            }
+            // A source path that is not beneath the module root should never
+            // happen for a legitimate daemon transfer; fail safe by falling
+            // through to the O_NOFOLLOW open rather than following symlinks.
+        }
+
+        if self.follow_symlinks {
+            // upstream: sender.c:do_open_checklinks - copy_links /
+            // copy_unsafe_links follow the symlink via a plain do_open.
+            open_source_with_noatime(path, self.noatime)
+        } else {
+            // upstream: sender.c:do_open_checklinks -> do_open_nofollow.
+            open_source_nofollow(path, self.noatime)
+        }
+    }
+}
+
+/// Opens a source file for reading following symlinks, honouring
+/// `--open-noatime`.
+///
+/// upstream: syscall.c do_open (3.4.2 propagates `O_NOATIME` via the
+/// `open_noatime` global).
 pub(super) fn open_source_with_noatime(path: &Path, use_noatime: bool) -> io::Result<fs::File> {
     if use_noatime {
         if let Some(file) = try_open_noatime(path)? {
@@ -32,6 +102,60 @@ pub(super) fn open_source_with_noatime(path: &Path, use_noatime: bool) -> io::Re
         }
     }
     fs::File::open(path)
+}
+
+/// Opens a source file for reading with `O_NOFOLLOW` on the leaf so a
+/// symlinked final component is refused with `ELOOP`, honouring
+/// `--open-noatime`.
+///
+/// upstream: syscall.c do_open_nofollow - `open(pathname, flags|O_NOFOLLOW)`,
+/// with `O_NOATIME` added when `open_noatime` is set.
+#[cfg(unix)]
+pub(super) fn open_source_nofollow(path: &Path, use_noatime: bool) -> io::Result<fs::File> {
+    let nofollow = libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    if use_noatime {
+        if let Some(extra) = noatime_flag() {
+            let mut options = fs::OpenOptions::new();
+            options.read(true).custom_flags(nofollow | extra);
+            match options.open(path) {
+                Ok(file) => return Ok(file),
+                Err(error) if noatime_retryable(&error) => {}
+                Err(error) => return Err(error),
+            }
+        }
+    }
+    let mut options = fs::OpenOptions::new();
+    options.read(true).custom_flags(nofollow);
+    options.open(path)
+}
+
+/// Non-Unix stub: `O_NOFOLLOW` is a Unix concept, so the leaf-symlink guard
+/// degrades to the plain source open (matching the upstream limitation that
+/// its `do_open_nofollow` guarantee is `O_NOFOLLOW`-platform only).
+#[cfg(not(unix))]
+pub(super) fn open_source_nofollow(path: &Path, use_noatime: bool) -> io::Result<fs::File> {
+    open_source_with_noatime(path, use_noatime)
+}
+
+/// Returns `O_NOATIME` on Linux/Android, `None` on other Unix targets where
+/// the flag is undefined.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn noatime_flag() -> Option<i32> {
+    Some(O_NOATIME)
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+fn noatime_flag() -> Option<i32> {
+    None
+}
+
+/// Whether an `O_NOATIME` open failure should be retried without the flag.
+#[cfg(unix)]
+fn noatime_retryable(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(libc::EPERM | libc::EACCES | libc::EINVAL | libc::ENOTSUP | libc::EROFS)
+    )
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -125,5 +249,103 @@ mod tests {
             before, after,
             "O_NOATIME should preserve atime (before={before}, after={after})"
         );
+    }
+
+    /// A non-daemon default policy (`O_NOFOLLOW`, no confinement) must refuse a
+    /// source whose final component was swapped for a symlink.
+    ///
+    /// WHY: mirrors upstream `sender.c:do_open_checklinks -> do_open_nofollow`,
+    /// which opens the source `O_NOFOLLOW` so a TOCTOU leaf-swap cannot
+    /// redirect the read to an attacker-chosen file. A regression that dropped
+    /// the flag would silently follow the swap and leak the target's contents.
+    #[cfg(unix)]
+    #[test]
+    fn nofollow_policy_refuses_symlinked_leaf() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let secret = dir.path().join("secret");
+        std::fs::write(&secret, b"do-not-leak").unwrap();
+        let leaf = dir.path().join("leaf");
+        symlink(&secret, &leaf).unwrap();
+
+        let policy = SourceOpen::new(None, false, false);
+        let err = policy
+            .open(&leaf)
+            .expect_err("O_NOFOLLOW must refuse a symlinked leaf");
+        assert_eq!(err.raw_os_error(), Some(libc::ELOOP));
+    }
+
+    /// With `--copy-links` / `--copy-unsafe-links` the policy follows the
+    /// symlinked leaf, matching upstream `do_open_checklinks`'s plain `do_open`
+    /// branch.
+    #[cfg(unix)]
+    #[test]
+    fn follow_policy_opens_symlinked_leaf() {
+        use std::io::Read as _;
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::write(&target, b"followed").unwrap();
+        let leaf = dir.path().join("leaf");
+        symlink(&target, &leaf).unwrap();
+
+        let policy = SourceOpen::new(None, true, false);
+        let mut file = policy.open(&leaf).expect("copy-links follows the leaf");
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).unwrap();
+        assert_eq!(buf, "followed");
+    }
+
+    /// A daemon policy confined beneath the module root must refuse an open
+    /// whose directory component is a symlink escaping the module.
+    ///
+    /// WHY: mirrors upstream `sender.c:secure_relative_open`. Without
+    /// confinement a module operator could plant `<module>/escape ->
+    /// /outside` and pull any file the daemon can read.
+    #[cfg(unix)]
+    #[test]
+    fn daemon_confined_policy_refuses_escape() {
+        use std::os::unix::fs::symlink;
+
+        let base = tempfile::tempdir().unwrap();
+        let root = base.path().join("module");
+        std::fs::create_dir(&root).unwrap();
+        let outside = base.path().join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("secret"), b"do-not-leak").unwrap();
+        symlink(&outside, root.join("escape")).unwrap();
+
+        let policy = SourceOpen::new(Some(root.clone()), false, false);
+        // The sender passes the reconstructed absolute source path; the policy
+        // strips the module root and opens the remainder confined.
+        let err = policy
+            .open(&root.join("escape/secret"))
+            .expect_err("confined open must refuse the escape");
+        let code = err.raw_os_error();
+        assert!(
+            code == Some(libc::EXDEV) || code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
+            "expected EXDEV, ELOOP, or ENOTDIR for a confined escape, got: {err}"
+        );
+    }
+
+    /// The confined daemon policy still opens a legitimate in-module file.
+    #[cfg(unix)]
+    #[test]
+    fn daemon_confined_policy_opens_in_module_file() {
+        use std::io::Read as _;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("sub")).unwrap();
+        std::fs::write(root.path().join("sub/data"), b"in-module").unwrap();
+
+        let policy = SourceOpen::new(Some(root.path().to_path_buf()), false, false);
+        let mut file = policy
+            .open(&root.path().join("sub/data"))
+            .expect("in-module source must open");
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).unwrap();
+        assert_eq!(buf, "in-module");
     }
 }

--- a/crates/transfer/src/generator/open_source.rs
+++ b/crates/transfer/src/generator/open_source.rs
@@ -19,9 +19,7 @@
 
 use std::fs;
 use std::io;
-use std::path::Path;
-#[cfg(unix)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2441,7 +2441,7 @@ fn write_delta_with_compression_zlib_dict_sync() {
         Some(&mut encoder),
         true,
         source_file.path(),
-        false,
+        &crate::generator::open_source::SourceOpen::new(None, false, false),
     )
     .unwrap();
 
@@ -2518,7 +2518,7 @@ fn write_delta_with_compression_zlibx_no_dict_sync() {
         Some(&mut encoder),
         false,
         source_file.path(),
-        false,
+        &crate::generator::open_source::SourceOpen::new(None, false, false),
     )
     .unwrap();
 
@@ -2562,7 +2562,7 @@ fn write_delta_with_compression_plain_fallback() {
         None,
         false,
         Path::new("/nonexistent/path"),
-        false,
+        &crate::generator::open_source::SourceOpen::new(None, false, false),
     )
     .unwrap();
 

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -137,8 +137,15 @@ fn should_parallel_delta(file_size: u64, block_length: u32, cores: usize) -> boo
 /// procfs, or a zero-length file on some platforms); the caller treats that as
 /// a signal to fall back to the streaming sequential reader, so wire output is
 /// unaffected.
-fn open_source_mmap(path: &std::path::Path, use_noatime: bool) -> io::Result<fast_io::MmapReader> {
-    let file = super::super::open_source::open_source_with_noatime(path, use_noatime)?;
+fn open_source_mmap(
+    path: &std::path::Path,
+    source_open: &super::super::open_source::SourceOpen,
+) -> io::Result<fast_io::MmapReader> {
+    // The mmap reader wraps the fd opened under the sender's symlink-race
+    // policy (confined / O_NOFOLLOW), so the parallel-delta scan reads the
+    // same protected inode as the sequential path. upstream: sender.c maps
+    // the fd returned by secure_relative_open / do_open_checklinks.
+    let file = source_open.open(path)?;
     fast_io::MmapReader::from_file(file)
 }
 
@@ -679,6 +686,13 @@ impl GeneratorContext {
             let source_path = self.reconstruct_source_path(ndx);
             let source_path_display = source_path.display().to_string();
 
+            // The sender's per-connection source-open policy (confinement for
+            // a non-chroot daemon, O_NOFOLLOW otherwise). Threaded into the
+            // free-function read paths (mmap scan, inline-checksum re-read) so
+            // every open of this source applies the same symlink-race defence.
+            // upstream: sender.c:359-383.
+            let source_open = self.source_open();
+
             // upstream: sender.c:325-341 - when a file arrives again on the redo
             // pass (`file->flags & FLAG_FILE_SENT`), the sender negates
             // append_mode and make_backups so the resend is a full-content
@@ -831,7 +845,7 @@ impl GeneratorContext {
                 let want_parallel = self.config.flags.parallel_delta_scan
                     && should_parallel_delta(file_size, block_length, cores);
                 let source_mmap = if want_parallel {
-                    open_source_mmap(&source_path, self.config.write.open_noatime).ok()
+                    open_source_mmap(&source_path, &source_open).ok()
                 } else {
                     None
                 };
@@ -916,7 +930,6 @@ impl GeneratorContext {
                 )?;
 
                 let checksum_algorithm = self.get_checksum_algorithm();
-                let use_noatime = self.config.write.open_noatime;
                 let wire_ops = script_to_wire_delta(delta_script, block_length);
                 let is_zlib = matches!(
                     negotiated_compression,
@@ -949,7 +962,7 @@ impl GeneratorContext {
                         },
                         is_zlib,
                         &source_path,
-                        use_noatime,
+                        &source_open,
                         checksum_algorithm,
                         self.checksum_seed,
                         self.protocol,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -96,6 +96,19 @@ const fn sent_bytes(counted: u64, diverted: bool) -> u64 {
     if diverted { 0 } else { counted }
 }
 
+/// Whether `error` is a tagged [`protocol::ProtocolViolation`] - an abort that
+/// upstream maps to `exit_cleanup(RERR_PROTOCOL)` - rather than an ordinary
+/// per-file open failure that the sender records with `MSG_NO_SEND` and skips.
+///
+/// Used to route the device-guard abort (`sender.c:407-409`) surfaced by
+/// [`GeneratorContext::open_source_unbuffered`] to a fatal return instead of
+/// [`GeneratorContext::record_open_failure`].
+fn is_protocol_violation(error: &io::Error) -> bool {
+    error
+        .get_ref()
+        .is_some_and(|inner| inner.is::<protocol::ProtocolViolation>())
+}
+
 /// Minimum source size before the opt-in parallel delta scan is considered.
 ///
 /// Below this a single core already scans the file faster than the rayon
@@ -770,10 +783,13 @@ impl GeneratorContext {
                 // upstream: match.c:371-390 - append mode streams only the tail
                 // past the existing prefix; the sum_head's count/blength encode
                 // that flength. No block matching, no signature blocks.
-                let (source, _src_fd): (Box<dyn Read>, Option<_>) = match self
+                let (source, _src_fd, file_size): (Box<dyn Read>, Option<_>, u64) = match self
                     .open_source_unbuffered(&source_path, file_size)
                 {
-                    Ok(pair) => pair,
+                    Ok(triple) => triple,
+                    // upstream: sender.c:407-409 - a device source without
+                    // --copy-devices aborts with exit_cleanup(RERR_PROTOCOL).
+                    Err(e) if is_protocol_violation(&e) => return Err(e),
                     Err(e) => {
                         self.record_open_failure(&mut *writer, wire_ndx, &e, &source_path_display)?;
                         continue;
@@ -985,10 +1001,13 @@ impl GeneratorContext {
                 // Use unbuffered reader: stream_whole_file_transfer manages its
                 // own 256 KB staging buffer with read_exact, so a BufReader would
                 // only add an extra memcpy per byte through its internal buffer.
-                let (source, src_fd): (Box<dyn Read>, Option<_>) = match self
+                let (source, src_fd, file_size): (Box<dyn Read>, Option<_>, u64) = match self
                     .open_source_unbuffered(&source_path, file_size)
                 {
-                    Ok(pair) => pair,
+                    Ok(triple) => triple,
+                    // upstream: sender.c:407-409 - a device source without
+                    // --copy-devices aborts with exit_cleanup(RERR_PROTOCOL).
+                    Err(e) if is_protocol_violation(&e) => return Err(e),
                     Err(e) => {
                         self.record_open_failure(&mut *writer, wire_ndx, &e, &source_path_display)?;
                         continue;


### PR DESCRIPTION
## Summary

Hardens the sender's source-file open path to mirror upstream rsync 3.4.4
`sender.c`, closing one critical and two medium gaps in the same contiguous
upstream code region. No wire bytes change for well-behaved peers; this is
local security plus device-handling correctness.

Every sender source open now flows through one per-connection policy
(`SourceOpen`) instead of the plain `File::open` that was duplicated across the
delta, whole-file, and append read paths.

## Changes

**1. Confined open beneath the module root (critical) - `secure_relative_open`.**
New Unix-only `fast_io::open_source_confined(root, relative, noatime)` opens a
source file so the kernel guarantees resolution cannot escape the module root:
no `..` climb, no absolute jump, no symlink pointing outside, no magic-link
trick. Linux 5.6+ uses `openat2(RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS)`
anchored at the module-root dirfd; older Linux and other Unix fall back to a
per-component `O_NOFOLLOW` walk (stricter, as upstream documents). A non-chroot
daemon sender (`is_daemon_connection`; oc never chroots) opens through this,
closing the TOCTOU where a swapped directory symlink redirects the read outside
the module. The single `unsafe` `openat2` block stays inside `fast_io`;
consumers use the safe API only.

**2. `O_NOFOLLOW` for the non-daemon path (medium) - `do_open_checklinks`.**
Outside the daemon-secure case the leaf is opened `O_NOFOLLOW` so a symlinked
final component is refused, unless `--copy-links` / `--copy-unsafe-links`
follows it with a plain open. The path-based io_uring / IOCP fast readers follow
symlinks and cannot express `O_NOFOLLOW` or confinement, so they are bypassed
whenever a protected open is required; those reads use the protected fd via
memory-map or a buffered reader, matching upstream, which maps the fd returned
by the secure open.

**3. fstat + `IS_DEVICE` guard (medium).** After opening, the sender fstats the
fd (safe `File::metadata`, no `unsafe` in the crate). A block/char device opened
without `--copy-devices` aborts with `RERR_PROTOCOL` ("attempt to copy device
contents without --copy-devices"); a 0-length device with `--copy-devices` has
its real size resolved by seeking to the end (`get_device_size`); and the
fstat'd length is preferred over the flist scan-time size for the stream length.

## Behaviour preservation

The leaf of a regular source is never a symlink in normal operation (the walk
`lstat`s it and sends symlinks as symlinks), so the protected open succeeds
identically for well-behaved transfers - only a mid-transfer symlink swap or a
device swap is refused. `--open-noatime` behaviour is unchanged.

## Tests

- `fast_io::confined_open`: opens in-tree files, follows in-tree symlinks on the
  openat2 path, refuses directory-symlink and leaf-symlink escapes, rejects
  absolute / `..` relative paths.
- `open_source`: policy dispatch - daemon confinement refuses an escape and
  still opens an in-module file; the default policy refuses a symlinked leaf;
  `--copy-links` follows it.
- device guard: `/dev/null` is refused without `--copy-devices`, deferred to
  size resolution with it, and a regular file reports its fstat length.

## Verification

Linux host (x86_64): `cargo build --bin oc-rsync`, `cargo clippy -p transfer
-p fast_io --all-targets --all-features --no-deps -D warnings`, and `cargo
nextest run -p transfer -p fast_io --all-features` - 3569 passed, 4 skipped.

upstream: sender.c:359-419, syscall.c:secure_relative_open / do_open_checklinks
/ do_open_nofollow, flist.c:get_device_size, clientserver.c:1018
