### PR TITLE
fix(metadata): set symlink crtime with FSOPT_NOFOLLOW on macOS

### DIFF
--- a/crates/metadata/src/apply/timestamps.rs
+++ b/crates/metadata/src/apply/timestamps.rs
@@ -705,13 +705,15 @@ fn set_crtime(path: &Path, secs: i64) -> Result<(), MetadataError> {
     // SAFETY: `c_path` is a valid NUL-terminated C string, `attrlist` is
     // zeroed and then configured with valid bitmap values, and `buf` is a
     // repr(C) struct with the exact layout expected by `setattrlist(2)`.
+    // upstream: syscall.c:do_setattrlist_crtime passes FSOPT_NOFOLLOW so a
+    // final-component symlink's own crtime is set, never its target's.
     let ret = unsafe {
         libc::setattrlist(
             c_path.as_ptr(),
             &attrlist as *const _ as *mut _,
             &buf as *const _ as *mut libc::c_void,
             std::mem::size_of::<AttrBuf>(),
-            0,
+            libc::FSOPT_NOFOLLOW,
         )
     };
 
@@ -1029,5 +1031,61 @@ mod crtime_macos_tests {
             let after = std::fs::metadata(path).expect("metadata after");
             assert_eq!(after.ino(), meta.ino());
         }
+    }
+
+    #[test]
+    fn setting_crtime_on_a_symlink_targets_the_link_not_its_target() {
+        // Why: upstream syscall.c:do_setattrlist_crtime passes FSOPT_NOFOLLOW so
+        // that a final-component symlink receives its OWN crtime and the file it
+        // points at is left untouched. Without that flag, setattrlist follows the
+        // link and silently rewrites the target's creation time - a metadata
+        // corruption invisible to a same-second quick check. This test proves the
+        // link is retargeted, not its referent, by driving crtime onto the link
+        // and asserting the target's crtime never moves.
+        use std::os::unix::fs::symlink;
+
+        fn crtime_secs(path: &std::path::Path) -> Option<i64> {
+            std::fs::symlink_metadata(path)
+                .ok()?
+                .created()
+                .ok()?
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()
+                .map(|d| d.as_secs() as i64)
+        }
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let target = dir.path().join("target.txt");
+        let link = dir.path().join("link");
+        std::fs::write(&target, b"payload").expect("write target");
+        symlink(&target, &link).expect("create symlink");
+
+        // A distinct historical value (2000-01-01 UTC) that cannot coincide with
+        // either freshly created crtime, so the quick-check cannot skip the write.
+        let new_secs: i64 = 946_684_800;
+
+        let target_before = crtime_secs(&target);
+        // Filesystems without birthtime support cannot exercise this invariant.
+        let Some(target_before) = target_before else {
+            return;
+        };
+        assert_ne!(
+            target_before, new_secs,
+            "test precondition: target crtime must differ from the value we set"
+        );
+
+        set_crtime(&link, new_secs).expect("set crtime on symlink succeeds");
+
+        let link_after = crtime_secs(&link).expect("link crtime readable after set");
+        let target_after = crtime_secs(&target).expect("target crtime readable after set");
+
+        assert_eq!(
+            link_after, new_secs,
+            "the symlink's own crtime must reflect the value written to it"
+        );
+        assert_eq!(
+            target_after, target_before,
+            "FSOPT_NOFOLLOW must leave the target's crtime unchanged"
+        );
     }
 }


### PR DESCRIPTION
## Problem

On macOS, `set_crtime` in `crates/metadata/src/apply/timestamps.rs` called `setattrlist(2)` with a zero options field. With no flags, `setattrlist` follows a final-component symlink, so setting a symlink's creation time silently rewrote the target file's crtime instead of the link's own - a metadata corruption invisible to a same-second quick check.

Upstream `syscall.c:do_setattrlist_crtime` passes `FSOPT_NOFOLLOW` for exactly this reason: the symlink itself must receive its crtime, never its referent.

## Fix

Pass `libc::FSOPT_NOFOLLOW` as the `setattrlist` options argument so the call does not traverse a final-component symlink, matching upstream byte-for-byte in behaviour. The change is confined to the existing `#[cfg(target_os = "macos")]` gate and the crate's existing FFI unsafe block; non-macOS paths are untouched.

## Test

Added a macOS-gated test that creates a target file and a symlink to it, drives a distinct historical crtime onto the link, and asserts:

- the symlink's own crtime reflects the written value, and
- the target's crtime is left unchanged.

The assertions encode WHY `FSOPT_NOFOLLOW` matters: crtime must apply to the link, not the file it points at. The test degrades gracefully on filesystems without birthtime support.

## Verification

- `cargo-fmt --all` - clean
- `cargo clippy -p metadata --all-targets --all-features --no-deps -- -D warnings` - clean, compiled the macOS cfg
- `cargo build --tests -p metadata` - clean
- `cargo test -p metadata --lib crtime` - 14/14 pass on APFS, including the new symlink test
