### PR TITLE
test(cli): make epoch timestamp format test timezone-independent

### DIFF
--- a/crates/cli/src/frontend/progress/format/list.rs
+++ b/crates/cli/src/frontend/progress/format/list.rs
@@ -110,9 +110,19 @@ mod tests {
     }
 
     #[test]
-    fn format_list_timestamp_epoch_returns_epoch() {
+    fn format_list_timestamp_epoch_renders_epoch_in_local_time() {
+        // Upstream `log.c:timestring()` renders modtimes in local time via
+        // `localtime_r`, so `format_list_timestamp` displays the epoch in the
+        // host timezone rather than a hardcoded UTC string. Deriving the
+        // expected value through the same local-time conversion keeps this
+        // assertion correct on any runner (UTC, UTC+1, America/New_York, ...)
+        // while still proving the `Some` branch formats the supplied instant
+        // instead of falling back to the epoch literal.
+        let expected = crate::frontend::local_time::to_local(SystemTime::UNIX_EPOCH)
+            .format(LIST_TIMESTAMP_FORMAT)
+            .expect("epoch is representable in the local timezone");
         let result = format_list_timestamp(Some(SystemTime::UNIX_EPOCH));
-        assert_eq!(result, "1970/01/01 00:00:00");
+        assert_eq!(result, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`format_list_timestamp` renders modification times in **local time**, mirroring
upstream rsync's `log.c:timestring()` which uses `localtime_r`. The unit test
`format_list_timestamp_epoch_returns_epoch` hardcoded the UTC rendering of the
epoch (`"1970/01/01 00:00:00"`), so it only passed on UTC hosts. On any offset
host (e.g. UTC+1 the epoch renders as `"1970/01/01 01:00:00"`; America/New_York
as `"1969/12/31 19:00:00"`) the assertion failed. CI passed only because the
runners are UTC - a latent timezone-dependent flake.

## Fix

The formatter is correct (local time is the intended, upstream-faithful
behavior), so the test is corrected rather than the production code. The expected
value is now derived through the same local-time conversion the formatter uses,
so the assertion holds on any timezone while still proving the `Some` branch
formats the supplied instant instead of falling back to the epoch literal.

## Verification

Ran on a non-UTC host under two timezones:

- `TZ=America/New_York cargo nextest run -p cli -E 'test(format_list_timestamp)'` - 5 passed
- `TZ=UTC cargo nextest run -p cli -E 'test(format_list_timestamp)'` - 5 passed
- `cargo clippy -p cli --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run -p cli --all-features` - 3726 passed
