### PR TITLE
fix(flist): keep duplicate sender dirs alive with FLAG_DUPLICATE under inc_recurse

### DIFF
--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -165,10 +165,21 @@ impl DualFileList {
     /// that case, leaving the list (and `parallel`) untouched.
     ///
     /// Under INC_RECURSE the pass still runs (upstream's `!am_sender ||
-    /// inc_recurse` branch): each sub-list is cleaned so its numbering matches
-    /// the receiver's identical pass. It reuses
-    /// `resolve_duplicate` for an identical
-    /// keep/drop tie-break.
+    /// inc_recurse` branch). Two rules apply, both mirroring the sender side of
+    /// `flist_sort_and_clean()`:
+    ///
+    /// - **Top-level duplicates are kept alive.** Upstream gates `clear_file()`
+    ///   on `!am_sender` (flist.c:3083-3090), so the sender never removes a
+    ///   duplicate; a repeated top-level source arg (e.g. `rsync -r foo foo
+    ///   dest`) stays on the wire and the receiver tombstones it, keeping both
+    ///   sides' NDX aligned. A duplicate top-level directory is additionally
+    ///   marked FLAG_DUPLICATE (flist.c:3073) so the sub-list scheduler batches
+    ///   the same-named dirs into one sub-list.
+    /// - **Nested duplicates are collapsed.** oc walks the whole tree eagerly, so
+    ///   a repeated source dir yields duplicate *nested* entries that upstream -
+    ///   scanning each physical dir once - never produces. Those are collapsed
+    ///   via [`resolve_duplicate`](super::sort::resolve_duplicate)'s keep/drop
+    ///   tie-break, leaving the wire byte-identical to upstream's single scan.
     ///
     /// # Panics
     ///
@@ -213,6 +224,37 @@ impl DualFileList {
                 if w != r {
                     self.legacy.swap(w, r);
                     parallel.swap(w, r);
+                }
+                r += 1;
+                continue;
+            }
+
+            // upstream: flist.c:3072-3090 - `clear_file()` is gated on
+            // `!am_sender`, so the sender NEVER removes a duplicate; a duplicate
+            // top-level source arg stays alive and the receiver's own clean pass
+            // tombstones it, keeping both sides' NDX aligned. Under INC_RECURSE a
+            // duplicate directory is additionally marked FLAG_DUPLICATE so the
+            // sub-list scheduler batches the same-named dirs into one sub-list
+            // (flist.c:2162-2168). oc walks the whole tree eagerly, so a repeated
+            // source dir also yields duplicate *nested* entries that upstream -
+            // which scans each physical dir once - never produces; those nested
+            // duplicates are collapsed below. Only top-level duplicates (the
+            // genuine repeated source args) are kept, matching upstream's wire
+            // entry count and NDX numbering.
+            let top_level = !self.legacy[r].name().contains('/');
+            if am_sender && top_level {
+                let both_dirs = self.legacy[w].is_dir() && self.legacy[r].is_dir();
+                w += 1;
+                if w != r {
+                    self.legacy.swap(w, r);
+                    parallel.swap(w, r);
+                }
+                // upstream: flist.c:3072-3073 - FLAG_DUPLICATE marks the later
+                // directory (only when both entries are dirs) so
+                // `send_extra_file_list()` batches the duplicate-named dirs into a
+                // single sub-list. The later entry now sits at index `w`.
+                if both_dirs {
+                    self.legacy[w].set_duplicate(true);
                 }
                 r += 1;
                 continue;
@@ -501,30 +543,65 @@ mod tests {
     }
 
     #[test]
-    fn dedup_with_parallel_removes_dup_and_keeps_base_aligned() {
-        // WHY: when a duplicate is dropped (INC_RECURSE sender clean), the
-        // survivor's parallel source_base must travel with it so file_list[i]
-        // still maps to source_bases[i].
+    fn dedup_with_parallel_sender_inc_keeps_top_level_dups_alive() {
+        // WHY: upstream gates clear_file() on !am_sender (flist.c:3083-3090), so
+        // a sender NEVER removes a duplicate - even under INC_RECURSE. A repeated
+        // top-level source arg stays on the wire; the receiver's own clean pass
+        // tombstones it, keeping both sides' NDX numbering aligned. Truncating it
+        // (the old behaviour) made oc send one fewer entry than upstream and
+        // shifted every following NDX, desyncing an upstream receiver.
         let mut list = DualFileList::new();
         list.push(FileEntry::new_file("dup".into(), 0, 0o644));
         list.push(FileEntry::new_file("dup".into(), 0, 0o644));
         list.push(FileEntry::new_file("z".into(), 0, 0o644));
         let mut bases = vec!["first", "second", "zbase"];
         let stats = list.dedup_with_parallel(&mut bases, true, true);
-        assert_eq!(stats.duplicates_removed, 1);
+        assert_eq!(stats.duplicates_removed, 0);
         let names: Vec<&str> = list.iter().map(|e| e.name()).collect();
-        assert_eq!(names, ["dup", "z"]);
-        // The first "dup" survives (keep-first), so its base leads; z stays put.
-        assert_eq!(bases, ["first", "zbase"]);
+        assert_eq!(names, ["dup", "dup", "z"]);
+        // Bases stay aligned 1:1 with the (unremoved) entries.
+        assert_eq!(bases, ["first", "second", "zbase"]);
+        // Plain files are never marked FLAG_DUPLICATE - only dirs, for sub-list
+        // batching (flist.c:3072-3073 sets it inside the both-dirs branch).
+        assert!(!list[1].duplicate());
+    }
+
+    #[test]
+    fn dedup_with_parallel_sender_inc_keeps_top_level_dir_dup_flagged() {
+        // WHY: `rsync -r foo foo dest` under INC_RECURSE. Upstream keeps BOTH
+        // top-level `foo` dirs (clear_file gated on !am_sender) and marks the
+        // later FLAG_DUPLICATE so send_extra_file_list batches them into one
+        // sub-list (flist.c:3073, 2162-2168). oc walks the tree eagerly, so
+        // `foo`'s children appear twice; those NESTED duplicates are collapsed
+        // (upstream scans each physical dir once), but the two top-level `foo`
+        // entries stay - matching upstream's wire entry count and NDX numbering
+        // so an upstream receiver stays in sync.
+        let mut list = DualFileList::new();
+        list.push(FileEntry::new_directory("foo".into(), 0o755));
+        list.push(FileEntry::new_directory("foo".into(), 0o755));
+        list.push(FileEntry::new_file("foo/a".into(), 0, 0o644));
+        list.push(FileEntry::new_file("foo/a".into(), 0, 0o644));
+        let mut bases = vec!["b0", "b1", "b2", "b3"];
+        list.dedup_with_parallel(&mut bases, true, true);
+        let names: Vec<&str> = list.iter().map(|e| e.name()).collect();
+        assert_eq!(names, ["foo", "foo", "foo/a"]);
+        assert!(
+            !list[0].duplicate(),
+            "the earlier survivor is not a duplicate"
+        );
+        assert!(list[1].duplicate(), "the later foo carries FLAG_DUPLICATE");
     }
 
     #[test]
     fn dedup_with_parallel_keeps_directory_over_file() {
-        // WHY: a dir must win over a same-named file "because it might have
-        // contents in the list" (flist.c:3065); its base must travel with it.
+        // WHY: a NESTED same-named dir must win over a same-named file "because
+        // it might have contents in the list" (flist.c:3065); its base must
+        // travel with it. Nested duplicates are oc double-walk artifacts
+        // (upstream scans each physical dir once) and ARE collapsed, unlike the
+        // top-level source-arg dups kept above.
         let mut list = DualFileList::new();
-        list.push(FileEntry::new_file("item".into(), 0, 0o644));
-        list.push(FileEntry::new_directory("item".into(), 0o755));
+        list.push(FileEntry::new_file("sub/item".into(), 0, 0o644));
+        list.push(FileEntry::new_directory("sub/item".into(), 0o755));
         let mut bases = vec!["file_base", "dir_base"];
         let stats = list.dedup_with_parallel(&mut bases, true, true);
         assert_eq!(stats.duplicates_removed, 1);

--- a/crates/protocol/src/flist/entry/accessors.rs
+++ b/crates/protocol/src/flist/entry/accessors.rs
@@ -481,6 +481,33 @@ impl FileEntry {
         }
     }
 
+    /// Returns whether this directory is a sender-side duplicate.
+    ///
+    /// Set on a later same-named directory the sender keeps alive under
+    /// INC_RECURSE. Internal to the file-list build; never encoded on the wire.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:3073` - `file->flags |= FLAG_DUPLICATE` (am_sender branch).
+    #[inline]
+    #[must_use]
+    pub const fn duplicate(&self) -> bool {
+        self.present & super::core::PRESENT_DUPLICATE != 0
+    }
+
+    /// Marks (or clears) this directory as a sender-side duplicate.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:3073` - `file->flags |= FLAG_DUPLICATE` (am_sender branch).
+    pub const fn set_duplicate(&mut self, dup: bool) {
+        if dup {
+            self.present |= super::core::PRESENT_DUPLICATE;
+        } else {
+            self.present &= !super::core::PRESENT_DUPLICATE;
+        }
+    }
+
     /// Returns the hardlink device number (for protocol < 30).
     #[inline]
     pub fn hardlink_dev(&self) -> Option<i64> {

--- a/crates/protocol/src/flist/entry/core.rs
+++ b/crates/protocol/src/flist/entry/core.rs
@@ -35,6 +35,17 @@ pub(super) const PRESENT_HLINKED: u8 = 1 << 4;
 /// when `PRESENT_HLINKED` is also set. Packed here to avoid per-entry
 /// `FileFlags`.
 pub(super) const PRESENT_HLINK_FIRST: u8 = 1 << 5;
+/// Presence bit: this directory is a later duplicate of an earlier same-named
+/// directory kept alive by the sender under INC_RECURSE.
+///
+/// Corresponds to upstream's `FLAG_DUPLICATE` (rsync.h:84, sender-only). A
+/// non-incremental sender never removes duplicates and the receiver tombstones
+/// them, but under INC_RECURSE the sender keeps a duplicate directory alive and
+/// marks it so `send_extra_file_list()` can batch the duplicate-named dirs into
+/// a single sub-list (upstream: flist.c:3073, flist.c:2162-2168). This flag is
+/// internal to the sender's file-list build - it is never encoded on the wire
+/// (the wire encoder reads only `top_dir()`/`content_dir()`).
+pub(super) const PRESENT_DUPLICATE: u8 = 1 << 6;
 
 /// A single entry in the rsync file list.
 ///
@@ -122,7 +133,8 @@ pub struct FileEntry {
     /// `PRESENT_HLINK_FIRST`). These are the only 3 of 24 XMIT wire flags
     /// that survive past decoding - the rest are transient delta-encoding
     /// state recomputed during send.
-    /// Bits 6-7: reserved.
+    /// Bit 6: internal sender-only `PRESENT_DUPLICATE` (never wire-encoded).
+    /// Bit 7: reserved.
     pub(super) present: u8,
 }
 

--- a/crates/transfer/src/generator/file_list/inc_recurse.rs
+++ b/crates/transfer/src/generator/file_list/inc_recurse.rs
@@ -95,7 +95,16 @@ impl GeneratorContext {
             let is_top_level = parent.is_empty() || parent == ".";
 
             if is_top_level {
-                let node_id = if entry.is_dir() && name != "." {
+                // upstream: flist.c:2162-2168 send_extra_file_list() - a
+                // FLAG_DUPLICATE sibling dir is batched into the surviving dir's
+                // sub-list and its FLAG_CONTENT_DIR is cleared so it is never
+                // scanned again. It still occupies a `dir_flist` index on both
+                // peers (the receiver tombstones it but keeps the slot), so it
+                // must be counted in the wire dir_ndx sequence yet own no
+                // sub-list. Give it no node_id (no segment, no tree node) and do
+                // NOT overwrite `dir_map`, so its children stay attached to the
+                // earlier survivor's segment and its own sub-list is empty.
+                let node_id = if entry.is_dir() && name != "." && !entry.duplicate() {
                     let id = node_id_counter;
                     node_id_counter += 1;
                     let tree_handle = tree.add_directory(id, name.to_string(), None);


### PR DESCRIPTION
## Problem

Under INC_RECURSE, a repeated top-level source directory (e.g. `rsync -r foo foo dest/`) was silently collapsed by the sender, so oc emitted one fewer file-list entry than upstream and shifted every following NDX.

Upstream `flist_sort_and_clean()` (flist.c:3016-3104) gates `clear_file()` on `!am_sender`: the sender **never** removes a duplicate. Under INC_RECURSE it only sets `FLAG_DUPLICATE` (rsync.h:84) on the later duplicate directory, keeping it alive so `send_extra_file_list()` (flist.c:2162-2168) can batch the same-named dirs into a single sub-list. The receiver tombstones the duplicate on its own side, keeping both peers' NDX numbering aligned.

oc's sender dedup (`dedup_with_parallel`) instead truncated the duplicate. Measured for `rsync -r foo foo dest` over ssh (source has `foo/a`, `foo/b`, `foo/sub/c`):

| | initial list | Number of files |
|---|---|---|
| upstream 3.4.4 sender | `used=2` | `6 (reg: 3, dir: 3)` |
| oc sender (before) | `used=1` | `5 (reg: 3, dir: 2)` |

## Fix

Mirror upstream's sender semantics while fitting oc's eager-walk model (oc pre-walks the whole tree, so a repeated source dir also yields duplicate *nested* entries that upstream — scanning each physical dir once — never produces):

1. Add an internal `FLAG_DUPLICATE` bit to `FileEntry` (`present` bit 6). Sender-only, never wire-encoded — the wire encoder reads only `top_dir()`/`content_dir()`.
2. `dedup_with_parallel` (sender, INC_RECURSE): keep top-level duplicate source args alive instead of truncating, and mark a duplicate top-level **directory** `FLAG_DUPLICATE`. Nested duplicates (oc double-walk artifacts) are still collapsed, so the wire stays byte-identical to upstream's single scan.
3. Segment classification: a `FLAG_DUPLICATE` top-level dir gets no node/segment and does not overwrite the directory map, so its children attach to the earlier survivor's sub-list (parent dir_ndx of the first dir, mirroring `send_extra_file_list()`) while it still occupies a `dir_flist` index in the wire `dir_ndx` sequence.

The receiver path is unchanged — it already tombstoned the duplicate and handled the batched sub-list correctly.

## Verification (x86_64 Linux, rsync 3.4.4)

- `oc -r foo foo dest` now reports `Number of files: 6 (reg: 3, dir: 3)`; sender initial list `used=2`, sub-lists `used=3`, `used=1` — byte-for-byte the same shape as upstream.
- Cross-binary matrix (oc/upstream sender x oc/upstream receiver, both directions): all exit 0, result trees identical.
- `cargo clippy -p protocol --all-targets --all-features --no-deps -D warnings`: clean.
- `cargo nextest run -p protocol --all-features`: 5974 passed (all golden-byte wire tests green).
- `cargo nextest run -p transfer` (flist/dedup/inc_recurse/build_file_list): 78 passed.

## Scope note

The fix targets non-relative repeated top-level source args (the reachable, documented case). `--relative`/`--files-from` overlapping nested paths remain a separate, pre-existing divergence and are unchanged by this PR.
