### PR TITLE
perf(transfer): truncate to zero for inplace+sparse whole-file writes

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -502,7 +502,18 @@ pub(in crate::local_copy) fn execute_transfer(
     // (`total_size > size_r`), leaving preallocated_len at do_fallocate()'s 0 so the
     // reserved tail is seeked, not punched - don't overwrite it. Otherwise the
     // existing destination extent is already allocated, so an interior zero run must
-    // be punched. A whole-file inplace copy truncates to zero first (0).
+    // be punched.
+    //
+    // The `!whole_file_enabled` guard keeps this to the delta case. A whole-file
+    // inplace copy is upstream's `sparse_files > 0 && whole_file` leg: it starts
+    // the destination empty (`do_ftruncate(fd, 0)`) and keeps `preallocated_len = 0`
+    // so interior zero runs are seeked over as genuine holes rather than punched.
+    // `open_destination_writer` realises that truncation at open time by opening
+    // the inplace destination with `O_TRUNC` whenever there is no delta basis
+    // (`should_truncate = delta_signature.is_none()`, which is exactly the
+    // whole-file case), so preallocated_len must stay 0 here.
+    // upstream: receiver.c:receive_data - `if (sparse_files > 0 && whole_file &&
+    // fd >= 0 && do_ftruncate(fd, 0) == 0) preallocated_len = 0;`
     if preallocated_len == 0 && inplace_enabled && !whole_file_enabled {
         if let Some(existing) = existing_metadata {
             let size_r = existing.len();

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -196,6 +196,88 @@ fn execute_inplace_sparse_punches_hole() {
     );
 }
 
+/// `--inplace --sparse` with `--whole-file` (the local-copy default) rewrites
+/// the whole file from offset 0, so the destination is truncated to zero first
+/// and interior zero runs become genuine holes that are *seeked* over - never
+/// left holding the pre-existing dense basis bytes.
+///
+/// This is upstream's `sparse_files > 0 && whole_file` leg of `receive_data`:
+/// `do_ftruncate(fd, 0)` then `preallocated_len = 0`. oc realises the truncation
+/// by opening the inplace destination with `O_TRUNC` when there is no delta basis
+/// (whole-file), keeping `preallocated_len = 0`. The decisive, syscall-count-free
+/// proof is the hole region: without the zeroing truncate a seek would leave the
+/// old `0xCC` bytes in place, so reading them back as zeros shows the whole-file
+/// rewrite started from an empty file.
+// upstream: receiver.c:receive_data - `if (sparse_files > 0 && whole_file &&
+// fd >= 0 && do_ftruncate(fd, 0) == 0) preallocated_len = 0;`
+#[cfg(unix)]
+#[test]
+fn execute_inplace_sparse_whole_file_seeks_over_stale_basis() {
+    let temp = tempdir().expect("tempdir");
+
+    // Source: 4 KiB data, a 2 MiB zero run (> the 32 KiB sparse threshold), then
+    // 4 KiB data. Written as real bytes so it is a normal (dense) source file.
+    let source = temp.path().join("wf-source.bin");
+    let mut src = Vec::with_capacity(2 * 1024 * 1024 + 8192);
+    src.extend(std::iter::repeat_n(0x11u8, 4096));
+    src.extend(std::iter::repeat_n(0x00u8, 2 * 1024 * 1024));
+    src.extend(std::iter::repeat_n(0x22u8, 4096));
+    fs::write(&source, &src).expect("write source");
+    set_file_mtime(&source, FileTime::from_unix_time(2_000_000, 0)).expect("source mtime");
+
+    // Destination pre-exists as a fully dense file of DIFFERENT bytes (0xCC),
+    // larger than the source, so a missing truncate would leave 0xCC in both the
+    // hole region and past the new EOF.
+    let dest = temp.path().join("wf-dest.bin");
+    fs::write(&dest, vec![0xCCu8; src.len() + 512 * 1024]).expect("write dense destination");
+    // Backdate so rsync's quick-check treats the destination as stale.
+    set_file_mtime(&dest, FileTime::from_unix_time(1_000_000, 0)).expect("destination mtime");
+
+    let plan = LocalCopyPlan::from_operands(&[
+        source.into_os_string(),
+        dest.clone().into_os_string(),
+    ])
+    .expect("plan");
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        // whole_file defaults to true for local copies; set it explicitly to
+        // pin the whole-file rewrite path this optimization targets.
+        LocalCopyOptions::default()
+            .sparse(true)
+            .inplace(true)
+            .whole_file(true),
+    )
+    .expect("inplace sparse whole-file copy succeeds");
+
+    // Length matches the source: the larger pre-existing tail was discarded.
+    let meta = fs::metadata(&dest).expect("dest metadata");
+    assert_eq!(meta.len(), src.len() as u64, "destination truncated to source length");
+
+    // Content is byte-for-byte the source. Critically the 2 MiB middle reads as
+    // zeros, not the pre-existing 0xCC: the whole-file rewrite truncated to zero
+    // so the seeked-over run is a genuine hole, not stale basis data.
+    let readback = fs::read(&dest).expect("read destination");
+    assert_eq!(readback, src, "whole-file inplace sparse content must equal the source");
+    assert!(
+        readback[4096..4096 + 2 * 1024 * 1024].iter().all(|&b| b == 0),
+        "seeked hole must read as zeros, proving the destination was truncated to zero first"
+    );
+
+    // On Linux/ext4 the hole is deallocated, so the file allocates less than its
+    // apparent size (platform-dependent - skipped where st_blocks does not expose
+    // sparse allocation, e.g. macOS/APFS).
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::MetadataExt;
+        assert!(
+            meta.blocks() * 512 < meta.len(),
+            "whole-file sparse rewrite should leave a hole (allocated {}, size {})",
+            meta.blocks() * 512,
+            meta.len(),
+        );
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn execute_with_sparse_enabled_counts_literal_data() {

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -557,6 +557,10 @@ pub(in crate::disk_commit) fn process_whole_file(
     // upstream: receiver.c:319-336 - preallocate the destination before writing
     // when --preallocate is set (see process_file).
     let preallocated_len = maybe_preallocate(&file, config, &begin, basis_len);
+    // upstream: receiver.c:receive_data - a coalesced whole-file rewrite starts
+    // the in-place destination empty so the sparse writer seeks over interior
+    // zero runs instead of punching holes (see truncate_for_whole_file_sparse).
+    let preallocated_len = truncate_for_whole_file_sparse(&file, &begin, preallocated_len);
 
     let mut output = make_writer(
         file,
@@ -881,6 +885,41 @@ fn maybe_preallocate(
             );
             fallback_preallocated_len
         }
+    }
+}
+
+/// Truncates a coalesced whole-file sparse in-place destination to zero and
+/// returns the sparse writer's `preallocated_len`.
+///
+/// The pipelined receiver only emits a `WholeFile` message when the file has no
+/// delta basis (`streaming.rs` gates it on `basis_map.is_none()`), so the entire
+/// content is rewritten from offset 0 - upstream's `whole_file` condition. When
+/// the in-place destination already holds bytes, starting it empty lets the
+/// sparse writer seek over interior zero runs instead of punching holes into the
+/// pre-existing extent that is about to be discarded. The on-disk result is
+/// identical; the truncate just replaces a `PUNCH_HOLE` syscall per zero run with
+/// a cheap seek over never-written space.
+///
+/// A non-zero `preallocated_len` here is exactly the in-place basis length:
+/// [`maybe_preallocate`] returns 0 whenever `--preallocate` reserved the blocks
+/// (those must stay punched, not seeked) and for every non-sparse or non-inplace
+/// target, so `preallocated_len > 0` uniquely identifies upstream's `else if
+/// (inplace_sizing)` branch that the `do_ftruncate(fd, 0)` is nested in. Skipped
+/// in append mode (`append_offset > 0`), which must keep the existing prefix and
+/// which upstream forbids together with `--whole-file` (`options.c:2400`). The
+/// truncate is best-effort: on failure the caller keeps the basis length and
+/// falls back to punching, which is equally correct.
+// upstream: receiver.c:receive_data - `if (sparse_files > 0 && whole_file &&
+// fd >= 0 && do_ftruncate(fd, 0) == 0) preallocated_len = 0;`
+pub(super) fn truncate_for_whole_file_sparse(
+    file: &fs::File,
+    begin: &BeginMessage,
+    preallocated_len: u64,
+) -> u64 {
+    if begin.append_offset == 0 && preallocated_len > 0 && file.set_len(0).is_ok() {
+        0
+    } else {
+        preallocated_len
     }
 }
 

--- a/crates/transfer/src/disk_commit/process/mod.rs
+++ b/crates/transfer/src/disk_commit/process/mod.rs
@@ -39,6 +39,10 @@ use self::commit::{
 #[cfg(all(test, target_os = "macos"))]
 use self::file_ops::make_writer;
 #[cfg(test)]
+use self::file_ops::truncate_for_whole_file_sparse;
+#[cfg(test)]
 use super::config::{BackupConfig, DiskCommitConfig};
 #[cfg(all(test, target_os = "macos"))]
 use super::writer::Writer;
+#[cfg(test)]
+use crate::pipeline::messages::BeginMessage;

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -733,3 +733,92 @@ fn commit_rename_without_sandbox_uses_path_fallback() {
     assert!(final_path.exists());
     assert_eq!(fs::read(&final_path).unwrap(), b"fallback content");
 }
+
+/// Builds a minimal [`BeginMessage`] carrying only the fields
+/// `truncate_for_whole_file_sparse` inspects (`append_offset`).
+fn begin_with_append_offset(path: &Path, append_offset: u64) -> BeginMessage {
+    BeginMessage {
+        file_path: path.to_path_buf(),
+        target_size: 0,
+        file_entry_index: 0,
+        checksum_verifier: None,
+        is_device_target: false,
+        is_inplace: true,
+        append_offset,
+        xattr_list: None,
+    }
+}
+
+/// A coalesced whole-file rewrite of an existing in-place destination must start
+/// the file empty so the sparse writer *seeks* over interior zero runs instead
+/// of issuing a `PUNCH_HOLE` syscall per run into the soon-to-be-discarded basis
+/// extent. Observable proof (no syscall counting): the destination is physically
+/// truncated to zero and the returned `preallocated_len` is 0, which is what
+/// drives the sparse writer down the seek path. upstream: receiver.c:receive_data
+/// `do_ftruncate(fd, 0); preallocated_len = 0`.
+#[test]
+fn truncate_for_whole_file_sparse_zeroes_existing_inplace_destination() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("inplace_basis.bin");
+    fs::write(&path, vec![0xAB_u8; 4096]).unwrap();
+    let file = fs::OpenOptions::new().write(true).open(&path).unwrap();
+
+    // basis_preallocated_len == 4096: the pre-existing in-place basis length that
+    // maybe_preallocate would hand a sparse+inplace whole-file write.
+    let preallocated_len =
+        truncate_for_whole_file_sparse(&file, &begin_with_append_offset(&path, 0), 4096);
+
+    assert_eq!(
+        preallocated_len, 0,
+        "whole-file inplace sparse rewrite must seek over zero runs, so preallocated_len drops to 0"
+    );
+    assert_eq!(
+        file.metadata().unwrap().len(),
+        0,
+        "destination must be truncated to zero before the whole-file rewrite"
+    );
+}
+
+/// Append mode must never truncate: the existing prefix is exactly what the tail
+/// is appended to. Upstream forbids `--append` with `--whole-file`
+/// (options.c:2400), so the `do_ftruncate(fd, 0)` branch is unreachable there;
+/// this guards against it explicitly by keeping the basis length (stale interior
+/// zero runs are punched, never seeked, when the prefix is retained).
+#[test]
+fn truncate_for_whole_file_sparse_preserves_append_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("append_basis.bin");
+    fs::write(&path, vec![0xCD_u8; 4096]).unwrap();
+    let file = fs::OpenOptions::new().write(true).open(&path).unwrap();
+
+    let preallocated_len =
+        truncate_for_whole_file_sparse(&file, &begin_with_append_offset(&path, 1024), 4096);
+
+    assert_eq!(
+        preallocated_len, 4096,
+        "append mode keeps the basis length so stale zero runs are punched, not seeked"
+    );
+    assert_eq!(
+        file.metadata().unwrap().len(),
+        4096,
+        "append prefix must be preserved, never truncated"
+    );
+}
+
+/// A fresh temp/direct target, or any non-sparse / non-inplace write, reaches
+/// this helper with `preallocated_len == 0` (maybe_preallocate returns 0 for all
+/// of those): there is nothing to truncate and the value passes through unchanged
+/// so the seek-vs-punch decision is untouched on paths the optimization does not
+/// apply to.
+#[test]
+fn truncate_for_whole_file_sparse_noop_when_no_basis() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("fresh.bin");
+    let file = fs::File::create(&path).unwrap();
+
+    let preallocated_len =
+        truncate_for_whole_file_sparse(&file, &begin_with_append_offset(&path, 0), 0);
+
+    assert_eq!(preallocated_len, 0);
+    assert_eq!(file.metadata().unwrap().len(), 0);
+}


### PR DESCRIPTION
## Summary

A coalesced whole-file write with `--inplace --sparse` rewrites the entire
destination from offset 0 (the pipelined receiver only emits a `WholeFile`
message when there is no delta basis). Previously the sparse writer kept
`preallocated_len` at the pre-existing file length, so every interior zero run
was deallocated with a `fallocate(PUNCH_HOLE)` syscall.

This mirrors upstream `receiver.c:receive_data`: when `sparse_files > 0 &&
whole_file && fd >= 0`, upstream calls `do_ftruncate(fd, 0)` and sets
`preallocated_len = 0` so zero runs are seeked over as genuine holes instead of
punched. The on-disk result (content plus sparse holes) is identical - only the
per-zero-run syscall is removed.

## Changes

- `transfer`: `process_whole_file` now truncates the in-place destination to
  zero and drops `preallocated_len` to 0 before the rewrite, via a small
  `truncate_for_whole_file_sparse` helper. Append mode is skipped (upstream
  forbids `--append` with `--whole-file`, `options.c:2400`); the final length is
  still set by `finalize_sparse`.
- `engine`: the local-copy path already realises this truncation by opening the
  inplace destination with `O_TRUNC` when there is no delta basis
  (`should_truncate = delta_signature.is_none()`, i.e. the whole-file case).
  Documented that linkage with the explicit upstream `ftruncate(0)` citation.

## Tests

- `transfer`: three unit tests on the helper proving the destination is
  physically truncated to zero and `preallocated_len` becomes 0 for the
  whole-file inplace case, that append mode preserves the prefix, and that
  non-sparse/non-inplace targets are untouched. No syscall-count assertions.
- `engine`: a regression test that does a whole-file inplace sparse rewrite over
  a dense pre-existing destination and asserts the hole region reads back as
  zeros (not the stale basis bytes) - the decisive proof that the file started
  from an empty length.

## Verification

Linux host (x86_64): `cargo build --bin oc-rsync`, `cargo clippy -p transfer -p
engine --all-targets --all-features --no-deps -D warnings` clean, `cargo nextest
run -p transfer -p engine --all-features`: 7492 passed, 29 skipped, 0 failed.
