### PR TITLE
fix(transfer): forward files-from names un-multiplexed at protocol < 31

### DIFF
--- a/crates/protocol/src/version/protocol_version/capabilities.rs
+++ b/crates/protocol/src/version/protocol_version/capabilities.rs
@@ -191,6 +191,25 @@ impl ProtocolVersion {
         self.as_u8() >= 30
     }
 
+    /// Returns `true` when forwarded `--files-from` names ride the socket
+    /// un-multiplexed, i.e. NOT wrapped in `MSG_DATA` frames (protocol < 31).
+    ///
+    /// A receiver with a local `--files-from` list forwards the names to the
+    /// sender while it reads back the incoming file list. Below protocol 31
+    /// upstream temporarily switches the outgoing stream to raw buffered I/O
+    /// (`MPLX_TO_BUFFERED`) for the duration of that forward, so the names are
+    /// sent without multiplex framing; at protocol >= 31 they stay multiplexed.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1230` `start_filesfrom_forwarding` -
+    ///   `if (protocol_version < 31 && OUT_MULTIPLEXED)` switches the output to
+    ///   `MPLX_TO_BUFFERED` before forwarding.
+    #[must_use]
+    pub const fn forwards_files_from_unmultiplexed(self) -> bool {
+        self.as_u8() < 31
+    }
+
     /// Returns `true` if this protocol version uses the extended 3-way goodbye
     /// exchange.
     ///

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -868,8 +868,19 @@ pub fn run_server_with_handshake_adopting<W: Write>(
     // generator reads filenames from the protocol stream.
     if config.connection.client_mode && config.role == ServerRole::Receiver {
         if let Some(data) = config.connection.files_from_data.take() {
-            writer.write_all(&data)?;
-            writer.flush()?;
+            // upstream: io.c:1228 start_filesfrom_forwarding - below protocol 31
+            // the client-receiver forwards its files-from names un-multiplexed
+            // (MPLX_TO_BUFFERED). At protocol 30 the client's output IS
+            // multiplexed (need_messages_from_generator, main.c:1362-1363), so
+            // without this bypass the names would be MSG_DATA-framed while a
+            // real upstream sender reads them raw. At protocol >= 31 they stay
+            // framed; below 30 the stream is already plain so both paths match.
+            if handshake.protocol.forwards_files_from_unmultiplexed() && writer.is_multiplexed() {
+                writer.write_raw(&data)?;
+            } else {
+                writer.write_all(&data)?;
+                writer.flush()?;
+            }
         }
     }
 

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -793,7 +793,7 @@ impl ReceiverContext {
     /// - `main.c:1191-1198` - `start_filesfrom_forwarding(filesfrom_fd)`
     /// - `io.c:370-381` - `forward_filesfrom_data()` core loop
     /// - `options.c:2944-2956` - server-side `--files-from <path>` arg form
-    fn forward_files_from_to_sender<W: io::Write + ?Sized>(
+    fn forward_files_from_to_sender<W: io::Write + crate::writer::MsgInfoSender + ?Sized>(
         &self,
         writer: &mut W,
     ) -> io::Result<()> {
@@ -831,7 +831,17 @@ impl ReceiverContext {
         let from0 = self.config.file_selection.from0;
         let mut staged = Vec::with_capacity(4096);
         protocol::forward_files_from(&mut reader, &mut staged, from0, None)?;
-        writer.write_all(&staged)?;
+
+        // upstream: io.c:1228 start_filesfrom_forwarding - below protocol 31 the
+        // names are forwarded un-multiplexed (MPLX_TO_BUFFERED), so on a
+        // multiplexed server stream we bypass MSG_DATA framing to match the
+        // wire a real upstream sender expects; at protocol >= 31 they stay
+        // framed like any other multiplexed write.
+        if self.protocol.forwards_files_from_unmultiplexed() && writer.is_output_multiplexed() {
+            writer.write_files_from_unframed(&staged)?;
+        } else {
+            writer.write_all(&staged)?;
+        }
         writer.flush()?;
 
         debug_log!(
@@ -1025,5 +1035,153 @@ mod created_directory_notice_tests {
         logging::init(VerbosityConfig::from_verbose_level(1));
         let ctx = server_ctx(false, false);
         assert!(run(&ctx, "dst/").is_empty());
+    }
+}
+
+/// A server-mode receiver forwarding a local `--files-from` list to the sender
+/// must reproduce upstream's `start_filesfrom_forwarding` framing decision: the
+/// names ride the socket un-multiplexed (raw) below protocol 31 and MSG_DATA
+/// framed at protocol >= 31.
+///
+/// upstream: io.c:1230 `if (protocol_version < 31 && OUT_MULTIPLEXED)` switches
+/// the output stream to `MPLX_TO_BUFFERED` for the forwarding window.
+#[cfg(test)]
+mod files_from_forwarding_framing_tests {
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
+    use protocol::ProtocolVersion;
+
+    use crate::config::ServerConfig;
+    use crate::flags::ParsedServerFlags;
+    use crate::handshake::HandshakeResult;
+    use crate::receiver::ReceiverContext;
+    use crate::role::ServerRole;
+    use crate::writer::ServerWriter;
+
+    /// `MSG_DATA` tag byte: `MPLEX_BASE (7) + MSG_DATA (0)` in the header's high
+    /// byte. A framed payload of length `L` is `[L, L>>8, L>>16, 7] ++ payload`.
+    const MSG_DATA_TAG: u8 = 7;
+
+    /// A capturing `Write` sink shared with the caller so the test can inspect
+    /// the exact wire bytes the multiplexed writer emitted.
+    #[derive(Clone, Default)]
+    struct SharedSink(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl SharedSink {
+        fn bytes(&self) -> Vec<u8> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    fn handshake(proto: u8) -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(proto).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    /// Builds a server-mode receiver whose local `--files-from` points at
+    /// `path`, then forwards it through a freshly multiplexed [`ServerWriter`],
+    /// returning the captured wire bytes.
+    fn forward(proto: u8, path: &str) -> Vec<u8> {
+        let mut config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(proto).unwrap(),
+            flags: ParsedServerFlags::default(),
+            ..Default::default()
+        };
+        // Server-side receiver with a real local files-from path (not "-").
+        config.connection.client_mode = false;
+        config.file_selection.files_from_path = Some(path.to_owned());
+
+        let hs = handshake(proto);
+        let ctx = ReceiverContext::new_for_test(&hs, config);
+
+        let sink = SharedSink::default();
+        // Upstream multiplexes the server-receiver's output for protocol >= 23
+        // (start_server -> io_start_multiplex_out); reproduce that here.
+        let mut writer = ServerWriter::new_plain(sink.clone())
+            .activate_multiplex()
+            .expect("activate multiplex");
+        ctx.forward_files_from_to_sender(&mut writer)
+            .expect("forward files-from");
+        sink.bytes()
+    }
+
+    /// Writes a two-name newline-delimited files-from list and returns the raw
+    /// payload the forwarder stages (what upstream would place on the wire).
+    fn write_list(dir: &std::path::Path) -> (String, Vec<u8>) {
+        let path = dir.join("list");
+        std::fs::write(&path, b"alpha\nbeta\n").expect("write list");
+        let mut expected = Vec::new();
+        let file = std::fs::File::open(&path).expect("open list");
+        protocol::forward_files_from(&mut io::BufReader::new(file), &mut expected, false, None)
+            .expect("stage payload");
+        (path.to_string_lossy().into_owned(), expected)
+    }
+
+    /// upstream: io.c:1230 - at protocol 29 (< 31) the forwarded names are sent
+    /// raw, with no `MSG_DATA` framing, so a real upstream sender's `read_line`
+    /// consumes the bytes verbatim.
+    #[test]
+    fn proto29_forwards_names_raw() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (path, expected) = write_list(dir.path());
+        let bytes = forward(29, &path);
+        assert_eq!(
+            bytes, expected,
+            "protocol 29 must forward files-from names un-multiplexed (raw)"
+        );
+    }
+
+    /// upstream: io.c:1230 - at protocol 30 (< 31) the stream is still switched
+    /// to buffered, so the names remain raw even though the server output is
+    /// multiplexed.
+    #[test]
+    fn proto30_forwards_names_raw() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (path, expected) = write_list(dir.path());
+        let bytes = forward(30, &path);
+        assert_eq!(
+            bytes, expected,
+            "protocol 30 must forward files-from names un-multiplexed (raw)"
+        );
+    }
+
+    /// upstream: io.c:1230 - at protocol 31+ the stream stays multiplexed, so
+    /// the forwarded names are wrapped in a single `MSG_DATA` frame.
+    #[test]
+    fn proto31_forwards_names_framed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (path, expected) = write_list(dir.path());
+        let bytes = forward(31, &path);
+
+        assert_ne!(bytes, expected, "protocol 31 must MSG_DATA-frame the names");
+        assert_eq!(
+            bytes.len(),
+            expected.len() + 4,
+            "expected one MSG_DATA header (4 bytes) plus the payload"
+        );
+        let len = u32::from(bytes[0]) | (u32::from(bytes[1]) << 8) | (u32::from(bytes[2]) << 16);
+        assert_eq!(len as usize, expected.len(), "framed length mismatch");
+        assert_eq!(bytes[3], MSG_DATA_TAG, "high byte must be the MSG_DATA tag");
+        assert_eq!(&bytes[4..], expected.as_slice(), "framed payload mismatch");
     }
 }

--- a/crates/transfer/src/writer/counting.rs
+++ b/crates/transfer/src/writer/counting.rs
@@ -80,6 +80,14 @@ impl<W> CountingWriter<W> {
         &mut self.inner
     }
 
+    /// Returns a shared reference to the inner writer.
+    ///
+    /// Used by [`MsgInfoSender`](super::MsgInfoSender) to query multiplex state
+    /// without going through the byte-counting `Write` path.
+    pub(super) fn inner_ref(&self) -> &W {
+        &self.inner
+    }
+
     /// Consumes the wrapper, returning the inner writer.
     pub fn into_inner(self) -> W {
         self.inner

--- a/crates/transfer/src/writer/msg_info.rs
+++ b/crates/transfer/src/writer/msg_info.rs
@@ -157,6 +157,34 @@ pub trait MsgInfoSender {
     ///
     /// - `sender.c:217` - `int f_xfer = write_batch < 0 ? batch_fd : f_out;`
     fn set_batch_route(&mut self, _route: BatchRoute) {}
+
+    /// Returns `true` when ordinary writes are wrapped in `MSG_DATA` multiplex
+    /// frames (i.e. the output stream is multiplexed).
+    ///
+    /// The default is `false`, matching plain writers (e.g. test `Vec<u8>`
+    /// sinks) that never frame their output. Callers forwarding `--files-from`
+    /// names gate on this to reproduce upstream's `OUT_MULTIPLEXED` test.
+    fn is_output_multiplexed(&self) -> bool {
+        false
+    }
+
+    /// Writes forwarded `--files-from` names to the socket bypassing `MSG_DATA`
+    /// framing, mirroring upstream's `MPLX_TO_BUFFERED` switch.
+    ///
+    /// Below protocol 31 a receiver forwards its local files-from names to the
+    /// sender un-multiplexed. On a multiplexed stream that means flushing any
+    /// pending frame, then writing the payload raw, leaving the stream
+    /// multiplexed for subsequent output. Callers gate on
+    /// [`is_output_multiplexed`](Self::is_output_multiplexed); the default is a
+    /// no-op because plain writers never advertise multiplexing and instead
+    /// take the caller's normal `write_all` path.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1228` `start_filesfrom_forwarding` - `io_end_multiplex_out(MPLX_TO_BUFFERED)`.
+    fn write_files_from_unframed(&mut self, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 impl<W: Write> MsgInfoSender for ServerWriter<W> {
@@ -231,6 +259,17 @@ impl<W: Write> MsgInfoSender for ServerWriter<W> {
         // sender unambiguous; the inherent method owns the variant match.
         ServerWriter::set_batch_route(self, route);
     }
+
+    fn is_output_multiplexed(&self) -> bool {
+        self.is_multiplexed()
+    }
+
+    fn write_files_from_unframed(&mut self, data: &[u8]) -> io::Result<()> {
+        // upstream: io.c:1228 start_filesfrom_forwarding switches the stream to
+        // MPLX_TO_BUFFERED; write_raw flushes the pending frame and emits the
+        // payload without MSG_DATA framing, leaving the stream multiplexed.
+        self.write_raw(data)
+    }
 }
 
 impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
@@ -265,6 +304,14 @@ impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
     fn set_batch_route(&mut self, route: BatchRoute) {
         (**self).set_batch_route(route);
     }
+
+    fn is_output_multiplexed(&self) -> bool {
+        (**self).is_output_multiplexed()
+    }
+
+    fn write_files_from_unframed(&mut self, data: &[u8]) -> io::Result<()> {
+        (**self).write_files_from_unframed(data)
+    }
 }
 
 impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
@@ -298,5 +345,13 @@ impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
 
     fn set_batch_route(&mut self, route: BatchRoute) {
         self.inner_ref_mut().set_batch_route(route);
+    }
+
+    fn is_output_multiplexed(&self) -> bool {
+        self.inner_ref().is_output_multiplexed()
+    }
+
+    fn write_files_from_unframed(&mut self, data: &[u8]) -> io::Result<()> {
+        self.inner_ref_mut().write_files_from_unframed(data)
     }
 }


### PR DESCRIPTION
## Summary

A receiver holding a local `--files-from` list forwards the names to the sender while it reads back the incoming file list. Upstream's `start_filesfrom_forwarding` (`io.c:1230`) temporarily switches the outgoing stream to raw buffered I/O (`MPLX_TO_BUFFERED`) below protocol 31, so the names travel **un-multiplexed** (no `MSG_DATA` framing); at protocol >= 31 they stay multiplexed.

oc always wrote the staged names through the ordinary writer, which wraps them in `MSG_DATA` frames whenever output is multiplexed. That diverged from upstream against a real pre-31 peer on two paths:

- **server-receiver** (output multiplexed for protocol >= 23, `main.c:1266` `start_server` -> `io_start_multiplex_out`): protocols **28, 29, 30** framed the names instead of sending them raw.
- **client-receiver** (output multiplexed for protocol >= 30, `main.c:1362-1363` `need_messages_from_generator`): protocol **30** framed them instead of raw.

At protocol 28-29 the client-receiver stream is already plain, so both ends match there; at protocol >= 31 both frame the names.

## Fix

Mirror `MPLX_TO_BUFFERED`: below protocol 31, when the stream is multiplexed, forward the names raw (flush any pending frame, write the payload unframed, and leave the stream multiplexed for subsequent output). At protocol >= 31, or on an already-plain stream, the wire is unchanged.

- New `ProtocolVersion::forwards_files_from_unmultiplexed()` predicate (`protocol_version < 31`), cited to `io.c:1230`.
- Both forwarding sites gate on it: the server-receiver path (`receiver/transfer/setup/context.rs`) via two new `MsgInfoSender` hooks (`is_output_multiplexed` / `write_files_from_unframed`), and the client-receiver path (`lib.rs`) via the concrete `ServerWriter::is_multiplexed` / `write_raw`.

## Tests

`files_from_forwarding_framing_tests` drive `forward_files_from_to_sender` over a capturing multiplexed `ServerWriter` and assert the wire bytes are raw (payload verbatim) at protocol 29 and 30, and a single `MSG_DATA` frame (4-byte header + payload) at protocol 31.

Golden and interop tests remain green.
