### PR TITLE
refactor(rsync_io): make QuicConnector trust source pluggable

### DIFF
--- a/crates/rsync_io/src/quic/mod.rs
+++ b/crates/rsync_io/src/quic/mod.rs
@@ -58,7 +58,8 @@ use std::time::{Duration, Instant};
 use bytes::Bytes;
 use quinn_proto::crypto::rustls::{QuicClientConfig, QuicServerConfig};
 use quinn_proto::{ClientConfig, ConnectionError, Endpoint, EndpointConfig, ServerConfig, VarInt};
-use rustls::RootCertStore;
+pub use rustls::RootCertStore;
+pub use rustls::client::danger::ServerCertVerifier;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 
 use driver::{Role, spawn_io};
@@ -314,25 +315,84 @@ impl std::fmt::Debug for QuicAcceptor {
     }
 }
 
-/// QUIC client: connects to an acceptor whose certificate it pins.
+/// How a [`QuicConnector`] decides whether to trust the server's certificate.
+///
+/// The connector's connect path is identical for every variant - the trust
+/// source only shapes the rustls [`rustls::ClientConfig`] the handshake runs
+/// against. This is the seam the client-verification ladder (policy B) plugs
+/// into: `--quic-ca` supplies [`QuicTrust::Roots`] built from a private CA
+/// bundle, system-root verification supplies [`QuicTrust::Roots`] built from
+/// the platform store, and TOFU `quic_known_hosts` supplies a
+/// [`QuicTrust::Verifier`] that pins the server's SPKI. Tests and the
+/// exact-pin escape hatch use [`QuicTrust::Pinned`].
+///
+/// See `docs/design/quic-transport-policy.md` (Decision B) and
+/// `docs/design/quic-transport-integration.md` (Phase 3).
+pub enum QuicTrust {
+    /// Trust exactly one certificate, verifying the chain against it as the
+    /// sole trust anchor. The zero-dependency escape hatch and the shape the
+    /// loopback tests use.
+    Pinned(CertificateDer<'static>),
+    /// Verify the server's certificate chain against a root store - the
+    /// platform trust store (system-roots default) or a private CA bundle
+    /// supplied via `--quic-ca`.
+    Roots(RootCertStore),
+    /// Delegate the trust decision to a custom rustls verifier, e.g. the TOFU
+    /// SPKI-pinning verifier that backs `quic_known_hosts`.
+    Verifier(Arc<dyn ServerCertVerifier>),
+}
+
+impl std::fmt::Debug for QuicTrust {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pinned(_) => f.write_str("QuicTrust::Pinned(..)"),
+            Self::Roots(_) => f.write_str("QuicTrust::Roots(..)"),
+            Self::Verifier(_) => f.write_str("QuicTrust::Verifier(..)"),
+        }
+    }
+}
+
+/// QUIC client: connects to an acceptor over a trust source it is configured
+/// with (an exact pin, a root store, or a custom verifier - see [`QuicTrust`]).
 pub struct QuicConnector {
     config: ClientConfig,
 }
 
 impl QuicConnector {
     /// Creates a client configuration that trusts exactly
-    /// `server_certificate`.
+    /// `server_certificate`. Convenience wrapper over
+    /// [`QuicConnector::with_trust`] with [`QuicTrust::Pinned`], preserved as
+    /// the exact-pin path used by the loopback tests.
     pub fn new(server_certificate: &CertificateDer<'_>) -> io::Result<Self> {
-        let mut roots = RootCertStore::empty();
-        roots
-            .add(server_certificate.clone().into_owned())
-            .map_err(io_err)?;
+        Self::pinned(server_certificate.clone().into_owned())
+    }
 
-        let mut client_crypto = rustls::ClientConfig::builder_with_provider(ring_provider())
+    /// Creates a connector that trusts exactly `server_certificate`.
+    pub fn pinned(server_certificate: CertificateDer<'static>) -> io::Result<Self> {
+        Self::with_trust(QuicTrust::Pinned(server_certificate))
+    }
+
+    /// Creates a connector whose trust decision is supplied by `trust`.
+    ///
+    /// Every variant produces a TLS 1.3, ALPN-`rsync` client config through
+    /// the one shared builder below; only the verifier stage differs. This is
+    /// the constructor the CA/system-root/TOFU resolution feeds.
+    pub fn with_trust(trust: QuicTrust) -> io::Result<Self> {
+        let builder = rustls::ClientConfig::builder_with_provider(ring_provider())
             .with_protocol_versions(&[&rustls::version::TLS13])
-            .map_err(io_err)?
-            .with_root_certificates(roots)
-            .with_no_client_auth();
+            .map_err(io_err)?;
+        let builder = match trust {
+            QuicTrust::Pinned(certificate) => {
+                let mut roots = RootCertStore::empty();
+                roots.add(certificate).map_err(io_err)?;
+                builder.with_root_certificates(roots)
+            }
+            QuicTrust::Roots(roots) => builder.with_root_certificates(roots),
+            QuicTrust::Verifier(verifier) => builder
+                .dangerous()
+                .with_custom_certificate_verifier(verifier),
+        };
+        let mut client_crypto = builder.with_no_client_auth();
         client_crypto.alpn_protocols = vec![ALPN_RSYNC.to_vec()];
 
         let config = ClientConfig::new(Arc::new(
@@ -517,5 +577,127 @@ impl Write for QuicStream {
 impl std::fmt::Debug for QuicStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QuicStream").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use rustls::DigitallySignedStruct;
+    use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified};
+    use rustls::pki_types::{ServerName, UnixTime};
+    use rustls::{Error as TlsError, SignatureScheme};
+
+    use super::*;
+
+    /// Test-only verifier that accepts any certificate identity while still
+    /// checking handshake signatures against the crypto provider. It stands in
+    /// for the shape a real TOFU/SPKI-pinning verifier (QUIC-5c/5d) will take:
+    /// the trust *decision* is custom, the TLS mechanics are unchanged. Its
+    /// existence proves [`QuicConnector`] can drive an arbitrary
+    /// [`ServerCertVerifier`] through the same `connect` path.
+    #[derive(Debug)]
+    struct AcceptAnyCert {
+        provider: Arc<rustls::crypto::CryptoProvider>,
+    }
+
+    impl ServerCertVerifier for AcceptAnyCert {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName<'_>,
+            _ocsp_response: &[u8],
+            _now: UnixTime,
+        ) -> Result<ServerCertVerified, TlsError> {
+            Ok(ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, TlsError> {
+            rustls::crypto::verify_tls12_signature(
+                message,
+                cert,
+                dss,
+                &self.provider.signature_verification_algorithms,
+            )
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, TlsError> {
+            rustls::crypto::verify_tls13_signature(
+                message,
+                cert,
+                dss,
+                &self.provider.signature_verification_algorithms,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            self.provider
+                .signature_verification_algorithms
+                .supported_schemes()
+        }
+    }
+
+    /// A [`QuicTrust::Roots`] store built from the server certificate yields a
+    /// working connector without touching `connect`. Encodes WHY the trust
+    /// source is pluggable: `--quic-ca` and system-roots verification (policy
+    /// B) both arrive as a `RootCertStore`, and the connector must accept one
+    /// without any change to the pin-based path the loopback tests exercise.
+    #[test]
+    fn roots_trust_source_builds_connector() {
+        let acceptor =
+            QuicAcceptor::bind("127.0.0.1:0".parse().expect("addr")).expect("bind acceptor");
+        let mut roots = RootCertStore::empty();
+        roots
+            .add(acceptor.certificate().clone().into_owned())
+            .expect("add cert");
+        QuicConnector::with_trust(QuicTrust::Roots(roots)).expect("build roots connector");
+    }
+
+    /// A custom [`ServerCertVerifier`] drives a full round trip over the same
+    /// `connect`/`QuicStream` path as the pinned form. Encodes WHY the trust
+    /// source is pluggable: the future TOFU verifier is a `dyn
+    /// ServerCertVerifier`, and swapping the trust decision must not perturb
+    /// the connect path or the byte pipe below it.
+    #[test]
+    fn custom_verifier_trust_source_round_trips() {
+        let acceptor =
+            QuicAcceptor::bind("127.0.0.1:0".parse().expect("addr")).expect("bind acceptor");
+        let addr = acceptor.local_addr().expect("local addr");
+
+        let server = thread::spawn(move || {
+            let mut stream = acceptor.accept().expect("accept");
+            let mut buf = [0u8; 4];
+            stream.read_exact(&mut buf).expect("read");
+            assert_eq!(&buf, b"ping");
+            stream.write_all(b"pong").expect("write");
+            stream.finish().expect("finish");
+        });
+
+        let verifier = Arc::new(AcceptAnyCert {
+            provider: ring_provider(),
+        });
+        let connector = QuicConnector::with_trust(QuicTrust::Verifier(verifier))
+            .expect("build verifier connector");
+        let mut stream = connector.connect(addr, "localhost").expect("connect");
+        stream.write_all(b"ping").expect("write");
+        stream.finish().expect("finish");
+        let mut reply = [0u8; 4];
+        stream.read_exact(&mut reply).expect("read reply");
+        assert_eq!(&reply, b"pong");
+        stream.close();
+
+        server.join().expect("server thread");
     }
 }

--- a/crates/rsync_io/tests/quic_loopback.rs
+++ b/crates/rsync_io/tests/quic_loopback.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use rsync_io::quic::{QuicAcceptor, QuicConnector};
+use rsync_io::quic::{QuicAcceptor, QuicConnector, QuicTrust, RootCertStore};
 
 const PAYLOAD_LEN: usize = 4096;
 /// Prompt-teardown bound: far below any idle timeout, so a pass proves the
@@ -56,6 +56,53 @@ fn round_trip_and_eof() {
     stream.read_exact(&mut received).expect("read reply");
     assert_eq!(received, server_to_client, "server payload corrupted");
     // After the server finishes its send side, the next read is clean EOF.
+    let mut eof = [0u8; 1];
+    assert_eq!(stream.read(&mut eof).expect("read eof"), 0, "expected EOF");
+    stream.close();
+
+    server.join().expect("server thread");
+}
+
+/// The same round trip as `round_trip_and_eof`, but the connector is built
+/// from a [`QuicTrust::Roots`] store instead of an exact pin. Both tests drive
+/// the identical `connect`/`QuicStream` path; passing both proves the trust
+/// source is pluggable - a `RootCertStore` (the shape `--quic-ca` and the
+/// system-roots default deliver) reaches the server without any change to the
+/// connect path, so QUIC-5b/5c/5d can supply CA/system/TOFU trust without
+/// touching the transport.
+#[test]
+fn round_trip_via_roots_trust() {
+    let acceptor =
+        QuicAcceptor::bind("127.0.0.1:0".parse().expect("loopback addr")).expect("bind acceptor");
+    let addr = acceptor.local_addr().expect("local addr");
+
+    let mut roots = RootCertStore::empty();
+    roots
+        .add(acceptor.certificate().clone().into_owned())
+        .expect("add server cert to roots");
+
+    let client_to_server = pattern(0x11);
+    let server_to_client = pattern(0xa7);
+
+    let expected_request = client_to_server.clone();
+    let reply = server_to_client.clone();
+    let server = thread::spawn(move || {
+        let mut stream = acceptor.accept().expect("accept stream");
+        let mut request = vec![0u8; PAYLOAD_LEN];
+        stream.read_exact(&mut request).expect("read request");
+        assert_eq!(request, expected_request, "client payload corrupted");
+        stream.write_all(&reply).expect("write reply");
+        stream.finish().expect("finish reply");
+    });
+
+    let connector = QuicConnector::with_trust(QuicTrust::Roots(roots)).expect("build connector");
+    let mut stream = connector.connect(addr, "localhost").expect("connect");
+    stream.write_all(&client_to_server).expect("write request");
+    stream.finish().expect("finish request");
+
+    let mut received = vec![0u8; PAYLOAD_LEN];
+    stream.read_exact(&mut received).expect("read reply");
+    assert_eq!(received, server_to_client, "server payload corrupted");
     let mut eof = [0u8; 1];
     assert_eq!(stream.read(&mut eof).expect("read eof"), 0, "expected EOF");
     stream.close();


### PR DESCRIPTION
## Summary

Generalizes the feature-gated `QuicConnector` (`crates/rsync_io/src/quic`) so its
trust decision is pluggable instead of hardcoding a single pinned certificate.
This is the seam the client-verification ladder (policy B in
`docs/design/quic-transport-policy.md`) plugs into: `--quic-ca` private CAs,
system-root verification, and TOFU `quic_known_hosts` all feed the same
connector without touching the connect path or the driver.

No CLI flags, no TOFU logic, no daemon wiring here - those are follow-ups. This
change only makes the connector *accept* those trust sources. ALPN `rsync`,
TLS 1.3, the ring provider, `connect()`, `QuicStream`, and the I/O driver are
unchanged. Default builds are unaffected; everything compiles only under
`--features quic`.

## Design

A `QuicTrust` enum captures the three trust shapes, dependency-inverting the
connector on the trust source rather than a concrete cert:

- `Pinned(CertificateDer)` - exact single-cert pin (the prior behaviour; the
  escape hatch and the shape the loopback tests use).
- `Roots(RootCertStore)` - chain verification against a root store (system
  roots default, or a private CA bundle).
- `Verifier(Arc<dyn ServerCertVerifier>)` - a custom rustls verifier (the shape
  a TOFU SPKI-pinning verifier takes).

`QuicConnector::with_trust(trust)` builds the `ClientConfig` through one shared
TLS-1.3/ALPN builder; only the verifier stage differs per variant.
`QuicConnector::pinned(cert)` and the existing `QuicConnector::new(&cert)` are
retained as convenience wrappers over `with_trust(QuicTrust::Pinned(..))`, so
the pin path is byte-for-byte behaviour-preserving.

## Tests

- Existing `quic_loopback` round-trip / half-close / teardown tests still pass
  via the pin path (behaviour unchanged).
- New `round_trip_via_roots_trust` integration test drives a full loopback via
  `QuicTrust::Roots`, proving the connect path is trust-source-agnostic.
- New unit tests: `roots_trust_source_builds_connector` and
  `custom_verifier_trust_source_round_trips` (the latter drives a real round
  trip through a test-only always-accept verifier that still checks handshake
  signatures - the shape the future TOFU verifier takes).

Each test encodes *why* the trust source is pluggable: CA/system/TOFU trust can
be supplied later without changing the transport.

## Verification

- `cargo clippy -p rsync_io --features quic --all-targets --no-deps -- -D warnings`: clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean
- `cargo nextest run -p rsync_io --features quic`: 939 passed, 3 skipped

`rsync_io` remains unsafe-free.
