### PR TITLE
feat(cli): add feature-gated Tcp/Quic transport selector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,12 @@ openssl-vendored = ["checksums/openssl-vendored"]
 # external `ssh` client. Forwards through `core` to `rsync_io/embedded-ssh`.
 embedded-ssh = ["core/embedded-ssh"]
 
+# Native QUIC daemon transport (oc extension, off by default). Forwards through
+# `cli`/`core` to `rsync_io/quic`; only makes the `Transport::Quic` selection
+# representable - no default build is affected. Design:
+# docs/design/quic-transport-policy.md.
+quic = ["cli/quic", "core/quic"]
+
 # ============================================================================
 # Runtime and Debugging Features
 # ============================================================================

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -51,6 +51,14 @@ parallel = ["engine/lazy-metadata", "checksums/parallel"]
 # concurrency benchmark.
 async-daemon = ["daemon/async-daemon"]
 
+# ============================================================================
+# Transport Features
+# ============================================================================
+# Native QUIC daemon transport (oc extension, off by default). Threads the
+# `core` selector through; the `quic://` scheme and `--quic` modifier land in a
+# follow-up. Default builds are unaffected.
+quic = ["core/quic"]
+
 
 [dependencies]
 bandwidth = { path = "../bandwidth" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -97,6 +97,12 @@ async = ["dep:tokio", "engine/async"]
 # var until the CLI flag lands (#1806).
 async-ssh = ["dep:tokio", "rsync_io/async-ssh"]
 
+# Native QUIC daemon transport (oc extension, off by default). Makes the
+# `Transport::Quic` selection representable on a daemon target and pulls in the
+# `rsync_io::quic` primitive it dials in a follow-up. Default builds are
+# unaffected. Design: docs/design/quic-transport-policy.md.
+quic = ["rsync_io/quic"]
+
 # systemd sd-notify integration
 sd-notify = []
 

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -116,7 +116,7 @@ pub use self::error::{
     connection_unexpectedly_closed_error,
 };
 pub use self::module_list::{
-    DaemonAddress, ModuleList, ModuleListEntry, ModuleListOptions, ModuleListRequest,
+    DaemonAddress, ModuleList, ModuleListEntry, ModuleListOptions, ModuleListRequest, Transport,
     run_module_list, run_module_list_with_options, run_module_list_with_password,
     run_module_list_with_password_and_options,
 };

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -9,7 +9,7 @@ use std::net::{SocketAddr, TcpStream};
 use std::time::Duration;
 
 use super::super::{AddressMode, ClientError, TcpFastOpenMode, TransferTimeout};
-use super::DaemonAddress;
+use super::{DaemonAddress, Transport};
 pub(crate) use direct::{connect_direct, resolve_daemon_addresses};
 pub(crate) use program::ConnectProgramConfig;
 use program::ConnectProgramStream;
@@ -246,14 +246,58 @@ pub(crate) fn register_shutdown_wake(
     }))
 }
 
-/// Opens a plain TCP connection to a daemon.
+/// Opens a stream to a daemon, dispatching on the address's [`Transport`].
 ///
-/// Respects `RSYNC_CONNECT_PROG` and `RSYNC_PROXY` environment
-/// variables. `sockopts` (`--sockopts`), when given, is applied to the
-/// connecting socket before `connect(2)` for both the direct and proxied
-/// paths; it has no effect on a connect program, matching upstream (a
-/// connect program bypasses `open_socket_out()` entirely).
+/// This is the single connect-selection point shared by module listing and
+/// daemon transfers. The transport is read off [`DaemonAddress::transport`];
+/// `Transport::Tcp` (the default) establishes a plain TCP connection.
 pub(crate) fn open_daemon_stream(
+    addr: &DaemonAddress,
+    connect_timeout: Option<Duration>,
+    io_timeout: Option<Duration>,
+    address_mode: AddressMode,
+    connect_program: Option<&OsStr>,
+    bind_address: Option<SocketAddr>,
+    tfo: TcpFastOpenMode,
+    sockopts: Option<&OsStr>,
+) -> Result<DaemonStream, ClientError> {
+    // Transport-selection point: the transport rides on `DaemonAddress` from
+    // target parsing. QUIC (feature `quic`, default off) dials via
+    // `rsync_io::quic` in a follow-up; until then every selection establishes
+    // the TCP daemon stream, so the default build is byte-for-byte unchanged.
+    match addr.transport() {
+        Transport::Tcp => open_tcp_daemon_stream(
+            addr,
+            connect_timeout,
+            io_timeout,
+            address_mode,
+            connect_program,
+            bind_address,
+            tfo,
+            sockopts,
+        ),
+        #[cfg(feature = "quic")]
+        Transport::Quic => open_tcp_daemon_stream(
+            addr,
+            connect_timeout,
+            io_timeout,
+            address_mode,
+            connect_program,
+            bind_address,
+            tfo,
+            sockopts,
+        ),
+    }
+}
+
+/// Opens a plain TCP connection to a daemon (the [`Transport::Tcp`] path).
+///
+/// Respects `RSYNC_CONNECT_PROG` and `RSYNC_PROXY` environment variables.
+/// `sockopts` (`--sockopts`), when given, is applied to the connecting socket
+/// before `connect(2)` for both the direct and proxied paths; it has no effect
+/// on a connect program, matching upstream (a connect program bypasses
+/// `open_socket_out()` entirely).
+fn open_tcp_daemon_stream(
     addr: &DaemonAddress,
     connect_timeout: Option<Duration>,
     io_timeout: Option<Duration>,

--- a/crates/core/src/client/module_list/mod.rs
+++ b/crates/core/src/client/module_list/mod.rs
@@ -40,7 +40,7 @@ pub use listing::{
     run_module_list_with_password, run_module_list_with_password_and_options,
 };
 pub use request::{ModuleListOptions, ModuleListRequest};
-pub use types::DaemonAddress;
+pub use types::{DaemonAddress, Transport};
 
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use crate::auth::{DaemonAuthDigest, compute_daemon_auth_response};

--- a/crates/core/src/client/module_list/types.rs
+++ b/crates/core/src/client/module_list/types.rs
@@ -7,15 +7,42 @@ use std::fmt;
 
 use super::super::{ClientError, FEATURE_UNAVAILABLE_EXIT_CODE, daemon_error};
 
+/// Transport carrying the (unmodified) rsync daemon wire protocol.
+///
+/// The variant rides on [`DaemonAddress`] alongside the host and port, so the
+/// selection made when a target is parsed reaches the connect-selection point
+/// (`open_daemon_stream`) unchanged. [`Transport::Tcp`] is the default and the
+/// only variant reachable in a default build, so default behaviour is
+/// preserved byte-for-byte.
+///
+/// [`Transport::Quic`] is an opt-in oc extension - a new way to carry the same
+/// daemon protocol - compiled only under the off-by-default `quic` cargo
+/// feature (design: `docs/design/quic-transport-policy.md`, Decision D). It is
+/// not yet constructed from the CLI; the `quic://` scheme and `--quic` modifier
+/// land in a follow-up.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Transport {
+    /// Plain TCP to the rsync daemon (upstream behaviour, always the default).
+    #[default]
+    Tcp,
+    /// Native QUIC transport (oc extension, `quic` feature only).
+    #[cfg(feature = "quic")]
+    Quic,
+}
+
 /// Target daemon address used for module listing requests.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DaemonAddress {
     pub(crate) host: String,
     pub(crate) port: u16,
+    pub(crate) transport: Transport,
 }
 
 impl DaemonAddress {
     /// Creates a new daemon address from the supplied host and port.
+    ///
+    /// The transport defaults to [`Transport::Tcp`]; use
+    /// [`DaemonAddress::with_transport`] to select another.
     pub fn new(host: String, port: u16) -> Result<Self, ClientError> {
         let trimmed = host.trim();
         if trimmed.is_empty() {
@@ -27,7 +54,21 @@ impl DaemonAddress {
         Ok(Self {
             host: trimmed.to_owned(),
             port,
+            transport: Transport::default(),
         })
+    }
+
+    /// Returns this address with the given [`Transport`] selected.
+    #[must_use]
+    pub fn with_transport(mut self, transport: Transport) -> Self {
+        self.transport = transport;
+        self
+    }
+
+    /// Returns the transport that carries the daemon protocol to this address.
+    #[must_use]
+    pub const fn transport(&self) -> Transport {
+        self.transport
     }
 
     /// Returns the daemon host name or address.
@@ -102,6 +143,41 @@ mod tests {
 
         assert_eq!(a, b);
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn daemon_address_defaults_to_tcp_transport() {
+        // WHY: transport is an explicit, feature-gated selection whose default
+        // must stay TCP so a default build behaves exactly like upstream. Every
+        // existing construction path (rsync://, host::module) flows through
+        // `new`, so this default is what reaches the connect-selection point.
+        let addr = DaemonAddress::new("localhost".to_owned(), 873).expect("address");
+        assert_eq!(addr.transport(), Transport::Tcp);
+    }
+
+    #[test]
+    fn daemon_address_carries_transport_unchanged() {
+        // WHY: the selection made at parse time must reach `open_daemon_stream`
+        // (which reads `transport()`) unchanged - the value rides on the same
+        // struct as host and port.
+        let addr = DaemonAddress::new("localhost".to_owned(), 873)
+            .expect("address")
+            .with_transport(Transport::Tcp);
+        assert_eq!(addr.transport(), Transport::Tcp);
+        assert_eq!(addr.host(), "localhost");
+        assert_eq!(addr.port(), 873);
+    }
+
+    #[cfg(feature = "quic")]
+    #[test]
+    fn daemon_address_can_carry_quic_transport() {
+        // WHY: under the opt-in `quic` feature a QUIC selection must be
+        // representable and carried unchanged, ready for the follow-up that
+        // dials it; it never appears in a default build.
+        let addr = DaemonAddress::new("example.com".to_owned(), 873)
+            .expect("address")
+            .with_transport(Transport::Quic);
+        assert_eq!(addr.transport(), Transport::Quic);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Introduces an explicit `Transport { Tcp, Quic }` selector on a daemon target and threads it through the existing daemon-target config down to the single connect-selection point. This is parse + config plumbing only - no connect logic changes: the connect path still establishes a TCP stream for both values. It makes a future native QUIC transport (an opt-in oc extension) representable and carried without touching default behaviour.

Scope is deliberately narrow: no `--quic` flag and no `quic://` scheme parsing (those land in follow-ups). Design reference: `docs/design/quic-transport-policy.md` (Decision D).

## What changed

- New `pub enum Transport { Tcp, Quic }` beside `DaemonAddress` (`crates/core/src/client/module_list/types.rs`). `Tcp` is `#[default]`; the `Quic` variant is compiled only under the off-by-default `quic` feature.
- `DaemonAddress` gains a `transport` field defaulting to `Tcp`, plus `with_transport()` and a `transport()` getter. It rides on the same struct as host/port, so a selection made at target-parse time reaches the connect-selection point unchanged. Both module-listing and daemon transfers already flow through this type, so nothing new or parallel was introduced.
- `open_daemon_stream` (the one connect-selection point used by both paths) now dispatches on `addr.transport()`; the TCP body was extracted to `open_tcp_daemon_stream`. Both variants currently establish the TCP stream.
- Feature wiring: `quic` on the root package -> `cli` -> `core` -> `rsync_io/quic` (the existing QUIC primitive), mirroring the existing `embedded-ssh` chain.

## Feature-gating

The `Quic` variant is `#[cfg(feature = "quic")]`, so it does not exist at all in a default build - the enum is `Tcp`-only and the `match` in `open_daemon_stream` is exhaustive with a single arm. `Transport` is part of the public API (`core::client::Transport`), so the variant is never flagged as dead code under `--all-features`. When the feature is off, the default build is byte-for-byte unchanged.

## Tests

Encode why transport is an explicit, feature-gated selection with a TCP default that preserves backward compatibility:

- `daemon_address_defaults_to_tcp_transport` - every existing construction path defaults to TCP, so a default build behaves exactly like before.
- `daemon_address_carries_transport_unchanged` - the selection rides on the same struct as host/port and reaches the point `open_daemon_stream` reads unchanged.
- `daemon_address_can_carry_quic_transport` (`#[cfg(feature = "quic")]`) - under the opt-in feature a QUIC selection is representable and carried, ready for the follow-up that dials it.

## Verification

- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` (quic ON): clean.
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings` (quic OFF / default): clean.
- `cargo nextest run -p cli -p core --all-features`: 6437 passed (under `TZ=UTC0`; an unrelated host-timezone-dependent progress-format test is the only thing that varies with the runner's local TZ).
