### PR TITLE
feat(daemon): parse quic cert/key global directives

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -51,6 +51,12 @@ daemon-seccomp = ["dep:seccompiler"]
 # a no-op that still degrades to the plain writer. See
 # docs/design/iouring-send-zc.md for the buffer-lifetime contract.
 daemon-zero-copy = ["fast_io/iouring-send-zc"]
+# QUIC daemon transport (default-off, opt-in oc extension). At this stage the
+# feature only gates parsing and storage of the `quic cert file` / `quic key
+# file` global directives; the listener and certificate loading land under
+# later QUIC build-out tasks. Kept dependency-free so default builds are
+# byte-identical. See docs/design/quic-transport-policy.md (decision A).
+quic = []
 # macOS-only, default-off: source accepted connections in the daemon accept
 # loop from a `kqueue(2)` `EVFILT_READ` readiness wait instead of the portable
 # engines' per-listener `poll(2)` park, giving a single kernel wait over all

--- a/crates/daemon/src/daemon/runtime_options/config.rs
+++ b/crates/daemon/src/daemon/runtime_options/config.rs
@@ -31,6 +31,20 @@ impl RuntimeOptions {
             self.set_config_lock_file(lock_file, &origin)?;
         }
 
+        // QUIC listener identity (oc extension). Directive parsing already
+        // resolved the paths config-relative and rejected any module-scoped use;
+        // a later occurrence overwrites an earlier one, matching the last-wins
+        // policy of the other global path directives. Both-or-neither is
+        // enforced once, after all config sources are merged, in parse_with_brand.
+        #[cfg(feature = "quic")]
+        if let Some((cert, _origin)) = parsed.quic_cert_file {
+            self.quic_cert_file = Some(cert);
+        }
+        #[cfg(feature = "quic")]
+        if let Some((key, _origin)) = parsed.quic_key_file {
+            self.quic_key_file = Some(key);
+        }
+
         if let Some((components, _origin)) = parsed.global_bandwidth_limit
             && !self.bandwidth_limit_configured
         {

--- a/crates/daemon/src/daemon/runtime_options/parsing.rs
+++ b/crates/daemon/src/daemon/runtime_options/parsing.rs
@@ -140,6 +140,31 @@ impl RuntimeOptions {
             options.port = DEFAULT_PORT;
         }
 
+        // QUIC listener identity is a certificate/key pair: the listener needs
+        // both to present an identity, and upstream rsync-ssl keeps
+        // RSYNC_SSL_CERT / RSYNC_SSL_KEY distinct (docs/design/quic-transport-
+        // policy.md, decision A). Enforce both-or-neither once, after CLI, env,
+        // and every config file have merged, so a key split across sources still
+        // validates. Fail loudly rather than silently binding an unexpected
+        // self-signed identity when only half the pair is named.
+        #[cfg(feature = "quic")]
+        match (
+            options.quic_cert_file.is_some(),
+            options.quic_key_file.is_some(),
+        ) {
+            (true, false) => {
+                return Err(config_error(
+                    "'quic cert file' requires 'quic key file' to be set as well".to_owned(),
+                ));
+            }
+            (false, true) => {
+                return Err(config_error(
+                    "'quic key file' requires 'quic cert file' to be set as well".to_owned(),
+                ));
+            }
+            _ => {}
+        }
+
         Ok(options)
     }
 }

--- a/crates/daemon/src/daemon/runtime_options/types.rs
+++ b/crates/daemon/src/daemon/runtime_options/types.rs
@@ -45,6 +45,17 @@ pub(crate) struct RuntimeOptions {
     reverse_lookup_configured: bool,
     lock_file: Option<PathBuf>,
     lock_file_from_config: bool,
+    /// Resolved certificate/key paths the QUIC listener presents, from the
+    /// `quic cert file` / `quic key file` global directives (oc extension).
+    ///
+    /// Per-listener identity, so both are global-only (a module-scoped use is a
+    /// config error). Stored here for the later QUIC listener build-out; the
+    /// listener and certificate loading are not wired at this stage. See
+    /// docs/design/quic-transport-policy.md (decision A).
+    #[cfg(feature = "quic")]
+    quic_cert_file: Option<PathBuf>,
+    #[cfg(feature = "quic")]
+    quic_key_file: Option<PathBuf>,
     global_incoming_chmod: Option<String>,
     global_outgoing_chmod: Option<String>,
     syslog_facility: Option<String>,
@@ -144,6 +155,10 @@ impl Default for RuntimeOptions {
             reverse_lookup_configured: false,
             lock_file: None,
             lock_file_from_config: false,
+            #[cfg(feature = "quic")]
+            quic_cert_file: None,
+            #[cfg(feature = "quic")]
+            quic_key_file: None,
             global_incoming_chmod: None,
             global_outgoing_chmod: None,
             syslog_facility: None,

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -222,6 +222,42 @@ fn apply_global_directive(
             let resolved = resolve_config_relative_path(path, trimmed);
             store_global_directive(&mut state.lock_file, resolved, canonical, line_number);
         }
+        // oc extension (no upstream counterpart - upstream terminates no TLS in
+        // the daemon). `quic cert file` / `quic key file` name the certificate
+        // and private key the QUIC listener presents. They describe the shared
+        // per-listener identity, so they are global-only; a module section that
+        // sets one is rejected in `apply_module_directive`. Path handling mirrors
+        // `pid file` / `lock file` exactly (config-relative resolution, with any
+        // `%` token left verbatim for expansion at listener-bind time).
+        // See docs/design/quic-transport-policy.md (decision A).
+        #[cfg(feature = "quic")]
+        "quiccertfile" => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Err(config_parse_error(
+                    path,
+                    line_number,
+                    "'quic cert file' directive must not be empty",
+                ));
+            }
+
+            let resolved = resolve_config_relative_path(path, trimmed);
+            store_global_directive(&mut state.quic_cert_file, resolved, canonical, line_number);
+        }
+        #[cfg(feature = "quic")]
+        "quickeyfile" => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Err(config_parse_error(
+                    path,
+                    line_number,
+                    "'quic key file' directive must not be empty",
+                ));
+            }
+
+            let resolved = resolve_config_relative_path(path, trimmed);
+            store_global_directive(&mut state.quic_key_file, resolved, canonical, line_number);
+        }
         // upstream: loadparm.c - use chroot is valid in the global section as a
         // default that applies to all modules which do not override it explicitly.
         "usechroot" => {

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
@@ -14,6 +14,12 @@ struct GlobalParseState {
     pid_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
     reverse_lookup: Option<(bool, ConfigDirectiveOrigin)>,
     lock_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
+    /// QUIC listener certificate/key paths from the `quic cert file` /
+    /// `quic key file` global directives (oc extension, feature-gated).
+    #[cfg(feature = "quic")]
+    quic_cert_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
+    #[cfg(feature = "quic")]
+    quic_key_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
     global_bwlimit: Option<(BandwidthLimitComponents, ConfigDirectiveOrigin)>,
     global_secrets_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
     global_incoming_chmod: Option<(String, ConfigDirectiveOrigin)>,
@@ -56,6 +62,10 @@ impl GlobalParseState {
             pid_file: None,
             reverse_lookup: None,
             lock_file: None,
+            #[cfg(feature = "quic")]
+            quic_cert_file: None,
+            #[cfg(feature = "quic")]
+            quic_key_file: None,
             global_bwlimit: None,
             global_secrets_file: None,
             global_incoming_chmod: None,
@@ -130,6 +140,10 @@ impl GlobalParseState {
             pid_file: self.pid_file,
             reverse_lookup: self.reverse_lookup,
             lock_file: self.lock_file,
+            #[cfg(feature = "quic")]
+            quic_cert_file: self.quic_cert_file,
+            #[cfg(feature = "quic")]
+            quic_key_file: self.quic_key_file,
             global_bandwidth_limit: self.global_bwlimit,
             global_secrets_file: self.global_secrets_file,
             global_incoming_chmod: self.global_incoming_chmod,

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -444,6 +444,29 @@ fn apply_module_directive(
                 builder.set_syslog_facility(value.to_owned());
             }
         }
+        // oc extension (docs/design/quic-transport-policy.md, decision A): the
+        // QUIC listener presents one certificate on a socket shared by every
+        // module, so a per-module `quic cert file` / `quic key file` cannot be
+        // honoured. Unlike upstream's P_GLOBAL directives - which loadparm.c
+        // merely reports and ignores in a module section - a misplaced identity
+        // directive is a hard config error: silently dropping it would leave the
+        // operator believing a certificate they named is in force. Reuse the
+        // shared `config_parse_error` surface every other directive uses.
+        #[cfg(feature = "quic")]
+        "quiccertfile" | "quickeyfile" => {
+            let directive = if key == "quiccertfile" {
+                "quic cert file"
+            } else {
+                "quic key file"
+            };
+            return Err(config_parse_error(
+                path,
+                line_number,
+                format!(
+                    "'{directive}' is a global-only directive and cannot appear in a module section"
+                ),
+            ));
+        }
         _ if is_global_only_directive(key) => {
             // upstream: loadparm.c:do_parameter - a known P_GLOBAL parameter
             // that appears inside a module section is reported and ignored,

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -3571,4 +3571,101 @@ mod config_parsing_tests {
 
         assert_eq!(result.motd_lines, vec!["two".to_owned()]);
     }
+
+    // The QUIC listener presents ONE certificate on a UDP socket shared by every
+    // module, so its identity is a property of the listener, not of any module.
+    // These tests pin that: the directives store on the global config, resolve
+    // their paths exactly like the other global path directives, and are refused
+    // inside a module section where a per-module certificate could not be served.
+    #[cfg(feature = "quic")]
+    #[test]
+    fn parse_quic_cert_and_key_files_into_global_config() {
+        let config = format!(
+            "quic cert file = {}\nquic key file = {}\n",
+            abs("/etc/oc-rsync/quic/server.pem"),
+            abs("/etc/oc-rsync/quic/server.key"),
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        let (cert, _) = result.quic_cert_file.expect("quic cert file stored");
+        let (key, _) = result.quic_key_file.expect("quic key file stored");
+        assert_eq!(cert, PathBuf::from(abs("/etc/oc-rsync/quic/server.pem")));
+        assert_eq!(key, PathBuf::from(abs("/etc/oc-rsync/quic/server.key")));
+    }
+
+    // Whitespace between the words is folded, so the spaced directive matches the
+    // same parameter as `pid file` / `secrets file` do - the naming convention the
+    // design note requires (docs/design/quic-transport-policy.md, decision A).
+    #[cfg(feature = "quic")]
+    #[test]
+    fn parse_quic_directives_fold_internal_whitespace() {
+        let config = format!(
+            "quic  cert\tfile = {}\nquic\tkey  file = {}\n",
+            abs("/srv/cert.pem"),
+            abs("/srv/key.pem"),
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        assert!(result.quic_cert_file.is_some());
+        assert!(result.quic_key_file.is_some());
+    }
+
+    // A relative path resolves against the config file's directory, exactly like
+    // `pid file` / `lock file`; the shared `resolve_config_relative_path` is reused.
+    #[cfg(feature = "quic")]
+    #[test]
+    fn parse_quic_cert_file_resolves_relative_to_config_dir() {
+        let dir = TempDir::new().expect("create temp dir");
+        let config_path = dir.path().join("rsyncd.conf");
+        std::fs::write(&config_path, "quic cert file = quic/server.pem\n")
+            .expect("write config");
+
+        let result = parse_config_modules(&config_path).expect("parse succeeds");
+        let (cert, _) = result.quic_cert_file.expect("quic cert file stored");
+        assert_eq!(cert, dir.path().join("quic/server.pem"));
+    }
+
+    #[cfg(feature = "quic")]
+    #[test]
+    fn parse_quic_cert_file_in_module_scope_is_config_error() {
+        let config = format!(
+            "[data]\npath = {}\nquic cert file = {}\n",
+            abs("/srv/data"),
+            abs("/etc/oc-rsync/quic/server.pem"),
+        );
+        let file = write_config(&config);
+        let error = parse_config_modules(file.path())
+            .expect_err("module-scoped quic cert file is a config error");
+        assert!(
+            error.to_string().contains("global-only"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[cfg(feature = "quic")]
+    #[test]
+    fn parse_quic_key_file_in_module_scope_is_config_error() {
+        let config = format!(
+            "[data]\npath = {}\nquic key file = {}\n",
+            abs("/srv/data"),
+            abs("/etc/oc-rsync/quic/server.key"),
+        );
+        let file = write_config(&config);
+        let error = parse_config_modules(file.path())
+            .expect_err("module-scoped quic key file is a config error");
+        assert!(
+            error.to_string().contains("global-only"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[cfg(feature = "quic")]
+    #[test]
+    fn parse_quic_cert_file_empty_value_is_config_error() {
+        let file = write_config("quic cert file =\n");
+        parse_config_modules(file.path())
+            .expect_err("empty quic cert file directive is a config error");
+    }
 }

--- a/crates/daemon/src/daemon/sections/config_parsing/types.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/types.rs
@@ -22,6 +22,14 @@ pub(crate) struct ParsedConfigModules {
     pid_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
     reverse_lookup: Option<(bool, ConfigDirectiveOrigin)>,
     lock_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
+    /// QUIC listener certificate path from the `quic cert file` global
+    /// directive (oc extension, feature-gated). The paired private key lives in
+    /// `quic_key_file`. Identity is per-listener, so both are global-only.
+    #[cfg(feature = "quic")]
+    quic_cert_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
+    /// QUIC listener private-key path from the `quic key file` global directive.
+    #[cfg(feature = "quic")]
+    quic_key_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
     global_bandwidth_limit: Option<(BandwidthLimitComponents, ConfigDirectiveOrigin)>,
     global_secrets_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
     global_incoming_chmod: Option<(String, ConfigDirectiveOrigin)>,

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -380,6 +380,8 @@ include!("tests/chunks/runtime_options_parse_motd_sources.rs");
 include!("tests/chunks/runtime_options_parse_no_bwlimit_argument.rs");
 include!("tests/chunks/runtime_options_parse_pid_file_argument.rs");
 include!("tests/chunks/runtime_options_per_module_max_connections_overrides_global.rs");
+#[cfg(feature = "quic")]
+include!("tests/chunks/runtime_options_quic_cert_key_pairing.rs");
 include!("tests/chunks/runtime_options_reject_duplicate_bwlimit.rs");
 include!("tests/chunks/runtime_options_reject_duplicate_lock_file_argument.rs");
 include!("tests/chunks/runtime_options_reject_duplicate_log_file_argument.rs");

--- a/crates/daemon/src/tests/chunks/runtime_options_quic_cert_key_pairing.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_quic_cert_key_pairing.rs
@@ -1,0 +1,57 @@
+// QUIC listener identity is a certificate/key pair (docs/design/quic-transport-
+// policy.md, decision A): the listener needs both files to present an identity,
+// so naming only one is an incomplete configuration. These tests pin that the
+// merged daemon global config rejects a half-configured pair and accepts a
+// complete one. The paths need not exist - like `pid file` / `lock file`, the
+// directives only resolve and store a path; loading happens at listener build.
+
+#[test]
+fn runtime_options_quic_cert_without_key_is_config_error() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(&config_path, "quic cert file = quic/server.pem\n").expect("write config");
+
+    let error = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect_err("cert without key is a config error");
+    assert!(
+        error.to_string().contains("quic key file"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn runtime_options_quic_key_without_cert_is_config_error() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(&config_path, "quic key file = quic/server.key\n").expect("write config");
+
+    let error = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect_err("key without cert is a config error");
+    assert!(
+        error.to_string().contains("quic cert file"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn runtime_options_quic_cert_and_key_pair_loads() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(
+        &config_path,
+        "quic cert file = quic/server.pem\nquic key file = quic/server.key\n",
+    )
+    .expect("write config");
+
+    RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect("a complete cert/key pair loads");
+}


### PR DESCRIPTION
## Summary

Adds the `quic cert file` and `quic key file` global daemon directives behind
the default-off `quic` cargo feature. They name the certificate and private key
the QUIC listener will present. This change only parses, validates, and stores
the paths; the listener and certificate loading land in later QUIC build-out
work.

Design reference: `docs/design/quic-transport-policy.md` (decision A).

## What changed

- **Reuses the existing global directive dispatch.** The two directives are
  handled in `apply_global_directive` right beside `pid file` / `lock file`:
  whitespace-folded name matching (`quic cert file` -> `quiccertfile`),
  config-relative path resolution via the shared `resolve_config_relative_path`,
  last-wins storage through `store_global_directive`, and the same empty-value
  config error. Any `%` token is left verbatim for expansion at listener-bind
  time, exactly as `pid file` / `lock file` behave today.
- **Stored on the existing config structures.** New feature-gated
  `Option<PathBuf>` slots on `GlobalParseState`, `ParsedConfigModules`, and the
  daemon runtime `RuntimeOptions` - the same journey `pid file` already makes.
  No parallel config path.
- **Global-only.** Server identity is per-listener, not per-module (a module
  cannot present its own certificate on a shared UDP socket), so a module-scoped
  `quic cert file` / `quic key file` is rejected with a config error via the
  shared `config_parse_error` surface.
- **Pair validation.** The certificate and key are a pair; a half-configured
  identity (one set without the other) is rejected once the CLI, environment,
  and every config file have merged.

## Feature gating

`quic` is default-off and dependency-free at this stage, so default builds are
unchanged and the directives compile out entirely. When the feature is off the
directives fall through to the existing unknown-directive warning, matching the
daemon's established convention.

## Tests

Parser-level tests (`config_parsing` suite) and a runtime-options chunk test:
directives parse into the global config, internal whitespace folds like
`pid file`, relative paths resolve against the config directory, module-scope
usage is a config error, an empty value is a config error, and a half-configured
cert/key pair is rejected while a complete pair loads.

## Verification

- `cargo clippy --workspace --all-targets --all-features -D warnings`: clean
- `cargo clippy --workspace --all-targets -D warnings` (feature off): clean
- `cargo nextest run -p daemon --all-features`: 1774 passed, 6 skipped
- `cargo build --bin oc-rsync`: succeeds
