### PR TITLE
test(core): retry TestDaemon startup on port bind conflict

### DIFF
--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -120,9 +120,12 @@ fn allocate_test_port() -> io::Result<u16> {
 /// from a genuine startup failure it must propagate rather than mask.
 #[allow(dead_code)]
 pub fn is_addr_in_use(err: &io::Error) -> bool {
-    err.to_string()
-        .to_ascii_lowercase()
-        .contains("address already in use")
+    // The daemon logs the OS strerror ("Address already in use"), which is the
+    // form that reaches the retry via the readiness-timeout message. A raw
+    // EADDRINUSE `io::Error` renders as the shorter "address in use"; match both
+    // so the classifier is robust to either representation.
+    let msg = err.to_string().to_ascii_lowercase();
+    msg.contains("address already in use") || msg.contains("address in use")
 }
 
 /// A managed rsync daemon instance for testing.

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -55,6 +55,7 @@ pub const UPSTREAM_3_4_4: &str = concat!(
 );
 
 /// Selects which daemon binary to launch.
+#[derive(Clone, Copy)]
 #[allow(dead_code)]
 pub enum DaemonBinary {
     /// Upstream rsync binary at a specific path.
@@ -94,14 +95,34 @@ impl DaemonBinary {
 
 /// Allocate a free TCP port using OS ephemeral port assignment.
 ///
-/// Binds to port 0, reads the assigned port, then drops the listener.
-/// The brief window between drop and daemon bind is acceptable for tests
-/// since each test gets a unique port from the OS.
+/// Binds to port 0, reads the assigned port, then drops the listener so the
+/// daemon can bind it. This is a TOCTOU window: between the drop here and the
+/// daemon's bind, another process can claim the port under parallel load. The
+/// port is not reserved once returned - callers that need a guaranteed bind
+/// (see [`TestDaemon::start`]) must retry on a fresh port when the daemon loses
+/// the race.
 fn allocate_test_port() -> io::Result<u16> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let port = listener.local_addr()?.port();
     drop(listener);
     Ok(port)
+}
+
+/// Whether a [`TestDaemon::start_on_port`] failure was the daemon losing the
+/// allocate-then-bind race for its port.
+///
+/// [`allocate_test_port`] hands back a port the OS just freed, so under
+/// parallel load another process can grab it in the drop->bind window. When
+/// that happens the daemon logs `Address already in use` and never accepts
+/// connections, so the readiness probe times out; that timeout error embeds
+/// the daemon log verbatim (`wait_ready`). Matching the message is how the
+/// retry loop tells a losable port race - safe to retry on a fresh port - apart
+/// from a genuine startup failure it must propagate rather than mask.
+#[allow(dead_code)]
+pub fn is_addr_in_use(err: &io::Error) -> bool {
+    err.to_string()
+        .to_ascii_lowercase()
+        .contains("address already in use")
 }
 
 /// A managed rsync daemon instance for testing.
@@ -125,10 +146,32 @@ impl TestDaemon {
     ///
     /// The daemon is verified ready (accepting TCP connections) before returning.
     /// Eliminates both hardcoded ports and sleep-based synchronization.
+    ///
+    /// [`allocate_test_port`] cannot reserve the port it returns, so under
+    /// parallel load the daemon can lose the allocate-then-bind race (TOCTOU)
+    /// and fail readiness with `Address already in use`. Retry on a fresh port
+    /// up to a small bound; a failed attempt's child is already killed and
+    /// reaped by [`start_on_port`]'s `Drop` before the error propagates here.
+    /// Any non-bind-conflict error is propagated immediately so a real startup
+    /// bug is never masked by the retry.
     #[allow(dead_code)]
     pub fn start(binary: DaemonBinary) -> io::Result<Self> {
-        let port = allocate_test_port()?;
-        Self::start_on_port(binary, port)
+        const MAX_ATTEMPTS: usize = 5;
+        let mut last_err: Option<io::Error> = None;
+        for _ in 0..MAX_ATTEMPTS {
+            let port = allocate_test_port()?;
+            match Self::start_on_port(binary, port) {
+                Ok(daemon) => return Ok(daemon),
+                Err(err) if is_addr_in_use(&err) => last_err = Some(err),
+                Err(err) => return Err(err),
+            }
+        }
+        Err(last_err.unwrap_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AddrInUse,
+                "daemon failed to bind a free port after retries",
+            )
+        }))
     }
 
     /// Start a daemon on a specific port (for tests that need port control).

--- a/crates/core/tests/testdaemon_port_retry.rs
+++ b/crates/core/tests/testdaemon_port_retry.rs
@@ -12,11 +12,10 @@
 //! line, so its correctness is the load-bearing invariant these tests pin.
 
 use std::io;
-use std::path::Path;
 
 mod common;
 
-use common::{DaemonBinary, TestDaemon, is_addr_in_use};
+use common::is_addr_in_use;
 
 /// The daemon-log line an rsync daemon emits when it loses the port race, as it
 /// appears embedded in the readiness-timeout error (`wait_ready`). WHY it must
@@ -90,9 +89,16 @@ fn matching_is_case_insensitive() {
 /// `TestDaemon::start` returns a daemon that is actually accepting connections.
 /// This exercises the loop's success arm end-to-end. Skips gracefully when the
 /// binary has not been built (local Mac runs), per the harness's degrade-not-
-/// fail convention.
+/// fail convention. Unix-only: daemon mode is unsupported on Windows
+/// (`daemon.rs`: "daemon mode is not supported on this platform"), so this
+/// cannot run there; the classifier tests above stay cross-platform.
+#[cfg(unix)]
 #[test]
 fn start_yields_a_ready_daemon() {
+    use std::path::Path;
+
+    use common::{DaemonBinary, TestDaemon};
+
     let bin = test_support::oc_rsync_bin();
     if !Path::new(&bin).exists() {
         eprintln!("skipping: oc-rsync binary not built at {}", bin.display());

--- a/crates/core/tests/testdaemon_port_retry.rs
+++ b/crates/core/tests/testdaemon_port_retry.rs
@@ -1,0 +1,107 @@
+//! Regression coverage for the `TestDaemon` allocate-then-bind port race.
+//!
+//! `allocate_test_port` binds `127.0.0.1:0`, reads the OS-assigned port, then
+//! drops the listener before the daemon binds it. That drop->bind gap is a
+//! TOCTOU window: under parallel test load (macOS CI runners especially)
+//! another process can claim the port first, the daemon logs `Address already
+//! in use` and never becomes ready, and the readiness probe times out with
+//! `daemon did not become ready`. Before the retry, that surfaced as a flaky
+//! failure. `TestDaemon::start` now retries on a fresh port, but ONLY for that
+//! specific bind conflict - any other startup failure must still propagate so a
+//! real bug is never masked. The classifier `is_addr_in_use` is what draws that
+//! line, so its correctness is the load-bearing invariant these tests pin.
+
+use std::io;
+use std::path::Path;
+
+mod common;
+
+use common::{DaemonBinary, TestDaemon, is_addr_in_use};
+
+/// The daemon-log line an rsync daemon emits when it loses the port race, as it
+/// appears embedded in the readiness-timeout error (`wait_ready`). WHY it must
+/// be retryable: losing the OS port to another process is transient and a fresh
+/// port resolves it; refusing to retry here reinstates the original flake.
+#[test]
+fn addr_in_use_timeout_is_retryable() {
+    let log = "IPv4 bind for 0.0.0.0:12345 failed: Address already in use \
+               (os error 48); continuing with remaining address families";
+    let err = io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("daemon on port 12345 did not become ready within 5s\nLog: {log}"),
+    );
+    assert!(
+        is_addr_in_use(&err),
+        "a readiness timeout whose embedded log shows a bind conflict must be retried"
+    );
+}
+
+/// A bare EADDRINUSE error must classify as retryable too - the message text,
+/// not the timeout wrapper, is what the classifier keys on.
+#[test]
+fn bare_eaddrinuse_is_retryable() {
+    let err = io::Error::from(io::ErrorKind::AddrInUse);
+    assert!(
+        is_addr_in_use(&err),
+        "EADDRINUSE is the port race by definition"
+    );
+}
+
+/// A daemon that exits immediately for an unrelated reason must NOT be retried:
+/// retrying would spin five times over a real, deterministic failure and then
+/// report a misleading `AddrInUse` instead of the true cause. WHY this matters:
+/// the retry exists to hide a race, never to hide a bug.
+#[test]
+fn unrelated_immediate_exit_is_not_retryable() {
+    let err = io::Error::other(
+        "daemon exited immediately with status: exit status: 1\n\
+         Stderr: rsync: failed to parse config file: syntax error",
+    );
+    assert!(
+        !is_addr_in_use(&err),
+        "a genuine startup failure must propagate, not be masked by a port retry"
+    );
+}
+
+/// A readiness timeout with no bind conflict in the log (e.g. the daemon is
+/// simply slow, or the log is unavailable) must NOT be retried on a new port:
+/// a fresh port cannot fix a daemon that binds fine but never answers.
+#[test]
+fn clean_timeout_is_not_retryable() {
+    let err = io::Error::new(
+        io::ErrorKind::TimedOut,
+        "daemon on port 12345 did not become ready within 5s\nLog: (log unavailable)",
+    );
+    assert!(
+        !is_addr_in_use(&err),
+        "a timeout without a bind conflict is not a port race and must not retry"
+    );
+}
+
+/// Matching is case-insensitive so a platform that capitalises the message
+/// differently still triggers the retry.
+#[test]
+fn matching_is_case_insensitive() {
+    let err = io::Error::other("bind failed: ADDRESS ALREADY IN USE");
+    assert!(is_addr_in_use(&err));
+}
+
+/// Happy-path smoke test of the retry loop: with the oc-rsync binary built,
+/// `TestDaemon::start` returns a daemon that is actually accepting connections.
+/// This exercises the loop's success arm end-to-end. Skips gracefully when the
+/// binary has not been built (local Mac runs), per the harness's degrade-not-
+/// fail convention.
+#[test]
+fn start_yields_a_ready_daemon() {
+    let bin = test_support::oc_rsync_bin();
+    if !Path::new(&bin).exists() {
+        eprintln!("skipping: oc-rsync binary not built at {}", bin.display());
+        return;
+    }
+    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("daemon should start");
+    assert_ne!(daemon.port(), 0, "daemon must report its bound port");
+    assert!(
+        daemon.url().contains(&daemon.port().to_string()),
+        "url must reference the bound port"
+    );
+}


### PR DESCRIPTION
## Problem

`crates/core/tests/common/mod.rs` `allocate_test_port()` binds `127.0.0.1:0`, reads the OS-assigned port, then drops the listener before `TestDaemon::start` launches the daemon that binds it. That drop -> bind gap is a TOCTOU window: under parallel test load (macOS CI runners especially) another process can claim the port first. The daemon then logs `Address already in use (os error 48); continuing with remaining address families`, never accepts IPv4 connections, and the readiness probe times out with `daemon did not become ready within 5s` - a flaky failure.

Observed on the `macOS (beta)` job in `core::no_partial_temp_cleanup::{no_partial_multi_file_no_residue_on_kill, no_partial_single_file_no_residue_on_kill, no_partial_preserves_dirs_but_removes_temps}`.

## Fix

`TestDaemon::start` now retries on a freshly allocated port, up to 5 attempts, but ONLY when the failure is that bind conflict:

- A small classifier `is_addr_in_use(&io::Error)` inspects the message. The port-conflict signal reaches the retry via the readiness-timeout error, which embeds the daemon log verbatim. It matches both the OS strerror form (`Address already in use`) and the raw `EADDRINUSE` form (`address in use`).
- Any non-bind-conflict error (immediate exit, config parse failure, a clean readiness timeout) propagates immediately, so a real startup bug is never masked by the retry.
- A failed attempt's child is already killed and reaped by `start_on_port`'s `Drop` before the error propagates, so no processes leak between attempts.

`start_on_port` keeps its fixed-port semantics for the tests that drive it directly. The `allocate_test_port` doc comment no longer calls the race window "acceptable" - it now names the TOCTOU hazard and points at the retry.

## Tests

New `crates/core/tests/testdaemon_port_retry.rs` pins the classifier's decision boundary, encoding WHY each case must (or must not) retry: the realistic timeout-with-bind-log is retryable; a raw EADDRINUSE is retryable; an unrelated immediate-exit and a clean timeout are NOT (retrying would mask a real bug); matching is case-insensitive. Plus a guarded happy-path smoke test of the retry loop.

## Verification (x86_64 Linux host)

- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean.
- `cargo nextest run -p core -E 'binary(testdaemon_port_retry)'`: 6 passed.
- `cargo nextest run -p core -E 'binary(no_partial_temp_cleanup)' --test-threads 16 --run-ignored all` x3: 6 passed each run.
