### PR TITLE
fix(transfer): exit RERR_FILEIO on sender fstat failure

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -992,13 +992,25 @@ impl GeneratorContext {
     /// 0-length device with `--copy-devices` has its real size resolved by
     /// seeking to the end. Every other source reports its fstat length.
     ///
+    /// A failed `File::metadata` (the `fstat(2)` on the just-opened fd) is fatal
+    /// and tagged as a [`SenderFstatError`]: upstream aborts the whole transfer
+    /// with `exit_cleanup(RERR_FILEIO)`, never the per-file `MSG_NO_SEND` skip
+    /// used for an *open* failure. The transfer loop routes a tagged error to a
+    /// fatal return, and its [`std::io::ErrorKind::Other`] maps to `RERR_FILEIO`
+    /// (11) via the core exit-code mapper's catch-all.
+    ///
     /// # Upstream Reference
     ///
     /// - `sender.c:404-419` - `do_fstat` (exit `RERR_FILEIO` on failure),
     ///   `IS_DEVICE(st.st_mode)` guard (`RERR_PROTOCOL`), and
     ///   `st.st_size = get_device_size(fd, fname)` for a 0-length device.
     fn fstat_source_guard(&self, file: &mut std::fs::File) -> std::io::Result<u64> {
-        let metadata = file.metadata()?;
+        // upstream: sender.c do_fstat - `if (do_fstat(fd, &st) != 0) { io_error
+        // |= IOERR_GENERAL; rsyserr(FERROR_XFER, errno, "fstat failed"); ...
+        // exit_cleanup(RERR_FILEIO); }`. A do_fstat failure aborts fatally, so
+        // the metadata() error is tagged rather than propagated as a plain open
+        // failure the sender would skip with MSG_NO_SEND.
+        let metadata = file.metadata().map_err(|e| sender_fstat_error(&e))?;
         #[cfg(unix)]
         let size = match source_device_guard(&metadata, self.config.flags.copy_devices)? {
             Some(size) => size,
@@ -1114,6 +1126,54 @@ fn join_source_path(base: &Path, name: &Path) -> PathBuf {
     let mut path = base.to_path_buf();
     path.extend(name.components());
     path
+}
+
+/// Inner marker identifying an [`std::io::Error`] as a fatal sender fstat
+/// failure - the `fstat(2)` on the just-opened source fd itself failing.
+///
+/// Upstream's `send_files` fstats the fd and, on failure, calls
+/// `exit_cleanup(RERR_FILEIO)`: a fatal abort (exit 11), not the per-file
+/// `MSG_NO_SEND` skip used for an *open* failure. oc reaches the same
+/// classification by tagging the `File::metadata` error with this marker so the
+/// transfer loop routes it to a fatal return instead of
+/// [`GeneratorContext::record_open_failure`], while its
+/// [`std::io::ErrorKind::Other`] maps to `RERR_FILEIO` via the core exit-code
+/// mapper's catch-all arm (an untagged errno such as `EACCES` would otherwise
+/// mis-map to `RERR_FILESELECT`).
+///
+/// # Upstream Reference
+///
+/// - `sender.c` `do_fstat` - `if (do_fstat(fd, &st) != 0) { io_error |=
+///   IOERR_GENERAL; rsyserr(FERROR_XFER, errno, "fstat failed"); free_sums(s);
+///   close(fd); exit_cleanup(RERR_FILEIO); }`.
+#[derive(Debug)]
+pub(crate) struct SenderFstatError(String);
+
+impl std::fmt::Display for SenderFstatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SenderFstatError {}
+
+/// Wraps a failed source-fd `fstat` (`File::metadata`) as a fatal `RERR_FILEIO`
+/// abort tagged with [`SenderFstatError`].
+///
+/// The message mirrors upstream's `rsyserr(FERROR_XFER, errno, "fstat failed")`
+/// and carries oc's location + `[sender]` role trailer. The error's
+/// [`std::io::ErrorKind::Other`] pins the exit-code mapping to `RERR_FILEIO`
+/// regardless of the underlying errno.
+///
+/// # Upstream Reference
+///
+/// - `sender.c` `do_fstat` - `exit_cleanup(RERR_FILEIO)` on `do_fstat` failure.
+pub(crate) fn sender_fstat_error(source: &std::io::Error) -> std::io::Error {
+    std::io::Error::other(SenderFstatError(format!(
+        "fstat failed: {source} {}{}",
+        crate::role_trailer::error_location!(),
+        crate::role_trailer::sender()
+    )))
 }
 
 /// Applies the sender's device guard to an fstat'd source and reports the

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -97,6 +97,9 @@ mod transfer;
 
 pub(crate) use self::context::BatchStatsSink;
 pub use self::context::GeneratorContext;
+pub(crate) use self::context::SenderFstatError;
+#[cfg(test)]
+pub(crate) use self::context::sender_fstat_error;
 pub use self::delta::{generate_delta_from_signature, generate_delta_from_signature_chunked};
 pub use self::diagnostics::{
     flush_rate_totals, ndx_convert_totals, prepare_acl_totals, segment_dispatch_totals,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -25,7 +25,8 @@ use super::super::delta::{
 use super::super::item_flags::ItemFlags;
 use super::super::protocol_io::NdxAttrs;
 use super::super::{
-    GeneratorContext, SegmentScheduler, TransferLoopResult, flush_with_count, is_early_close_error,
+    GeneratorContext, SegmentScheduler, SenderFstatError, TransferLoopResult, flush_with_count,
+    is_early_close_error,
 };
 use crate::delta_config::DeltaGeneratorConfig;
 use crate::reader::BufferedInputHint;
@@ -107,6 +108,23 @@ fn is_protocol_violation(error: &io::Error) -> bool {
     error
         .get_ref()
         .is_some_and(|inner| inner.is::<protocol::ProtocolViolation>())
+}
+
+/// Whether `error` is a tagged [`SenderFstatError`] - a failed `fstat(2)` on the
+/// just-opened source fd that upstream aborts with `exit_cleanup(RERR_FILEIO)` -
+/// rather than an ordinary per-file open failure the sender records with
+/// `MSG_NO_SEND` and skips.
+///
+/// Used to route the fstat abort surfaced by
+/// [`GeneratorContext::open_source_unbuffered`] to a fatal return (mapping to
+/// `RERR_FILEIO`, exit 11) instead of [`GeneratorContext::record_open_failure`].
+///
+/// upstream: `sender.c` `do_fstat` - `if (do_fstat(fd, &st) != 0) { ...
+/// exit_cleanup(RERR_FILEIO); }`.
+fn is_sender_fstat_error(error: &io::Error) -> bool {
+    error
+        .get_ref()
+        .is_some_and(|inner| inner.is::<SenderFstatError>())
 }
 
 /// Minimum source size before the opt-in parallel delta scan is considered.
@@ -803,6 +821,10 @@ impl GeneratorContext {
                     // upstream: sender.c:407-409 - a device source without
                     // --copy-devices aborts with exit_cleanup(RERR_PROTOCOL).
                     Err(e) if is_protocol_violation(&e) => return Err(e),
+                    // upstream: sender.c do_fstat - a failed fstat on the opened
+                    // fd aborts fatally with exit_cleanup(RERR_FILEIO), never a
+                    // MSG_NO_SEND skip.
+                    Err(e) if is_sender_fstat_error(&e) => return Err(e),
                     Err(e) => {
                         self.record_open_failure(&mut *writer, wire_ndx, &e, &source_path_display)?;
                         continue;
@@ -1021,6 +1043,10 @@ impl GeneratorContext {
                     // upstream: sender.c:407-409 - a device source without
                     // --copy-devices aborts with exit_cleanup(RERR_PROTOCOL).
                     Err(e) if is_protocol_violation(&e) => return Err(e),
+                    // upstream: sender.c do_fstat - a failed fstat on the opened
+                    // fd aborts fatally with exit_cleanup(RERR_FILEIO), never a
+                    // MSG_NO_SEND skip.
+                    Err(e) if is_sender_fstat_error(&e) => return Err(e),
                     Err(e) => {
                         self.record_open_failure(&mut *writer, wire_ndx, &e, &source_path_display)?;
                         continue;
@@ -1559,6 +1585,73 @@ mod parallel_delta_gate_tests {
     #[test]
     fn min_chunk_floor_is_one_mib() {
         assert_eq!(PARALLEL_DELTA_MIN_CHUNK_BYTES, 1024 * 1024);
+    }
+}
+
+#[cfg(test)]
+mod sender_fstat_error_routing_tests {
+    //! The sender fstats the just-opened source fd; upstream `sender.c`
+    //! `do_fstat` exits `exit_cleanup(RERR_FILEIO)` (exit 11) when that fstat
+    //! fails - a fatal abort, NOT the per-file `MSG_NO_SEND` skip used for an
+    //! *open* failure. These tests pin the classification the transfer loop
+    //! relies on to route the abort fatally with the correct exit code.
+    use super::{is_protocol_violation, is_sender_fstat_error};
+    use crate::generator::sender_fstat_error;
+    use std::io;
+
+    #[test]
+    fn fstat_failure_is_routed_to_a_fatal_return() {
+        // WHY: a regression that dropped the tag would send this error down the
+        // `record_open_failure` skip arm (MSG_NO_SEND, at most exit 23) instead
+        // of aborting - diverging from upstream's fatal RERR_FILEIO exit.
+        let tagged = sender_fstat_error(&io::Error::from_raw_os_error(9)); // EBADF
+        assert!(
+            is_sender_fstat_error(&tagged),
+            "an fstat failure must be recognised so the loop aborts, not skips"
+        );
+    }
+
+    #[test]
+    fn fstat_failure_pins_the_fileio_exit_code() {
+        // WHY: observable exit-code fidelity. The tagged error carries
+        // ErrorKind::Other and no ProtocolViolation tag, which is exactly what
+        // the core exit-code mapper needs to yield RERR_FILEIO (11): the raw
+        // errno alone (e.g. EACCES) would otherwise map to RERR_FILESELECT (3),
+        // and a ProtocolViolation tag would map to RERR_PROTOCOL (2).
+        let tagged = sender_fstat_error(&io::Error::from_raw_os_error(13)); // EACCES
+        assert_eq!(tagged.kind(), io::ErrorKind::Other);
+        assert!(
+            !is_protocol_violation(&tagged),
+            "the fstat abort maps to RERR_FILEIO, never RERR_PROTOCOL"
+        );
+    }
+
+    #[test]
+    fn ordinary_open_failure_is_not_treated_as_an_fstat_abort() {
+        // WHY: an open() failure (vanished/permission) must keep the
+        // MSG_NO_SEND skip semantics; only a genuine fstat failure aborts.
+        let open_err = io::Error::from_raw_os_error(2); // ENOENT
+        assert!(!is_sender_fstat_error(&open_err));
+    }
+
+    #[test]
+    fn device_guard_abort_is_not_treated_as_an_fstat_abort() {
+        // WHY: the device-guard abort (RERR_PROTOCOL) and the fstat abort
+        // (RERR_FILEIO) both return fatally but must stay distinct so each keeps
+        // its own exit code; the classifiers must not cross-detect.
+        let protocol_err = protocol::protocol_violation("attempt to copy device contents");
+        assert!(!is_sender_fstat_error(&protocol_err));
+        assert!(is_protocol_violation(&protocol_err));
+    }
+
+    #[test]
+    fn diagnostic_carries_the_sender_role_trailer() {
+        // WHY: the fatal error surfaces to the client; it must mirror upstream's
+        // "fstat failed" wording and carry oc's [sender] role trailer.
+        let tagged = sender_fstat_error(&io::Error::from_raw_os_error(9));
+        let text = tagged.to_string();
+        assert!(text.contains("fstat failed"), "unexpected message: {text}");
+        assert!(text.contains("[sender"), "missing role trailer: {text}");
     }
 }
 


### PR DESCRIPTION
## Summary

Make the sender's post-open `fstat` failure a fatal `RERR_FILEIO` exit, matching upstream.

Upstream `send_files` fstats the just-opened source fd and, on failure, aborts the whole transfer:

```c
/* map the local file */
if (do_fstat(fd, &st) != 0) {
    io_error |= IOERR_GENERAL;
    rsyserr(FERROR_XFER, errno, "fstat failed");
    free_sums(s);
    close(fd);
    exit_cleanup(RERR_FILEIO);   /* exit 11 - fatal */
}
```

This is distinct from an *open* failure, which the sender records with `MSG_NO_SEND` and skips (at most exit 23).

## Problem

The sender post-open fstat guard propagated a failed `File::metadata()` as an ordinary open failure: it recorded an I/O error, sent `MSG_NO_SEND`, and skipped the file instead of aborting with `RERR_FILEIO`. That is an observable exit-code divergence from upstream (skip/exit 23 vs fatal exit 11). The condition is near-unreachable (fstat on a just-opened fd), but the classification still matters for drop-in fidelity.

## Fix

- Tag a genuine `File::metadata()` (fstat) failure with a `SenderFstatError` marker (`crates/transfer/src/generator/context.rs`).
- The marker carries `ErrorKind::Other`, which pins the core exit-code mapper to `RERR_FILEIO` regardless of the underlying errno (a raw `EACCES` would otherwise mis-map to `RERR_FILESELECT`; a `ProtocolViolation` tag would map to `RERR_PROTOCOL`).
- The transfer loop routes the tagged error to a fatal `return Err(e)` at both `open_source_unbuffered` call sites, instead of `record_open_failure` (`crates/transfer/src/generator/transfer/transfer_loop.rs`).
- The device guard (`RERR_PROTOCOL`) and the normal success path are unchanged.

No `unsafe`, no clippy waivers.

## Tests

New `sender_fstat_error_routing_tests` module encodes the observable-fidelity contract:

- an fstat failure is recognised so the loop aborts rather than skips;
- the tagged error carries `ErrorKind::Other` and no `ProtocolViolation` tag, pinning it to `RERR_FILEIO` (11), never `RERR_FILESELECT` (3) or `RERR_PROTOCOL` (2);
- an ordinary open failure keeps `MSG_NO_SEND` skip semantics;
- the device-guard abort and the fstat abort stay distinct classifiers;
- the diagnostic mirrors upstream's "fstat failed" wording with the `[sender]` role trailer.

## Verification

Local (macOS): `cargo-fmt --all`, `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`, and `cargo build --tests -p transfer --all-features` all clean/zero-warning. The 5 new unit tests pass. Full workspace nextest deferred to CI (Linux host was unavailable; local nextest is not run on macOS).
