### PR TITLE
fix(filters): protect backup-suffix files from --delete under --backup

### DIFF
--- a/crates/core/src/client/config/builder/filters.rs
+++ b/crates/core/src/client/config/builder/filters.rs
@@ -95,4 +95,38 @@ impl ClientConfigBuilder {
         self.filter_rules
             .push(FilterRuleSpec::exclude(pattern).with_perishable(true));
     }
+
+    /// Appends the implicit protect rule that upstream rsync injects to keep
+    /// backup-suffix files out of a `--delete` sweep.
+    ///
+    /// upstream: options.c:2336-2339. When `make_backups && delete_mode &&
+    /// !delete_excluded && !am_server` and no `--backup-dir` is set, rsync
+    /// injects `P *<suffix>` (default suffix `~`) at the tail of the filter
+    /// list via `parse_filter_str(&filter_list, "P *~", rule_template(0), 0)`.
+    /// Backups are written beside the destination as `name<suffix>`, so without
+    /// this rule the very files just saved as backups become extraneous entries
+    /// and are removed by the delete pass. Appended after every CLI rule, it
+    /// carries the lowest precedence, so a user rule matching the same pattern
+    /// still wins under first-match evaluation.
+    ///
+    /// `am_server` is inherently false here: this builder constructs the client
+    /// configuration only. A `--backup-dir` places backups in a separate tree,
+    /// so no protect rule is needed (upstream: options.c:2328-2329). It is not
+    /// marked perishable, mirroring upstream's `rule_template(0)`.
+    pub(super) fn push_backup_protect_filter(&mut self) {
+        if !self.backup || self.backup_dir.is_some() {
+            return;
+        }
+        if !self.delete_mode.is_enabled() || self.delete_excluded {
+            return;
+        }
+        // upstream: options.c:2296-2297 - the effective suffix defaults to `~`
+        // when no `--backup-dir` is set (the only branch reached here).
+        let suffix = self
+            .backup_suffix
+            .as_deref()
+            .map_or_else(|| "~".to_owned(), |s| s.to_string_lossy().into_owned());
+        self.filter_rules
+            .push(FilterRuleSpec::protect(format!("*{suffix}")));
+    }
 }

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -385,6 +385,9 @@ impl ClientConfigBuilder {
         if self.checksum_choice.transfer_is_none() {
             self.whole_file = Some(true);
         }
+        // upstream: options.c:2336-2339 - inject `P *<suffix>` so files saved
+        // as backups beside the destination are protected from the delete pass.
+        self.push_backup_protect_filter();
         // upstream: compat.c:791-797 - append the implicit `--partial-dir`
         // exclude at the tail of the filter list, after every CLI rule.
         self.push_implicit_partial_dir_filter();

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1010,6 +1010,94 @@ fn implicit_partial_dir_filter_skips_absolute_dir() {
     assert!(config.filter_rules().is_empty());
 }
 
+/// upstream: options.c:2336-2339 - `--backup` (no `--backup-dir`) combined with
+/// `--delete` (and without `--delete-excluded`) injects a receiver-side
+/// `P *<suffix>` protect rule. Backups are written beside the destination as
+/// `name~`, so without this rule the delete pass would remove the very files
+/// just saved as backups. WHY this matters: it is the difference between
+/// preserving and destroying user data under `rsync -a --delete --backup`.
+#[test]
+fn backup_with_delete_injects_default_protect_rule() {
+    let config = builder().backup(true).delete(true).build();
+    let rule = config
+        .filter_rules()
+        .last()
+        .expect("backup + delete must inject the protect rule");
+    assert_eq!(rule.kind(), FilterRuleKind::Protect);
+    assert_eq!(rule.pattern(), "*~");
+    // Protect is receiver-side only, matching upstream's `P` rule with no
+    // FILTRULES_SIDES bit set (it governs deletion, never the flist).
+    assert!(!rule.applies_to_sender());
+    assert!(rule.applies_to_receiver());
+    // upstream uses rule_template(0): not perishable.
+    assert!(!rule.is_perishable());
+}
+
+/// upstream: options.c:2337-2338 `"P *%s", backup_suffix` - an explicit
+/// `--suffix` is reflected in the injected protect pattern.
+#[test]
+fn backup_with_delete_uses_explicit_suffix() {
+    let config = builder()
+        .backup(true)
+        .delete(true)
+        .backup_suffix(Some(".bak"))
+        .build();
+    let rule = config
+        .filter_rules()
+        .last()
+        .expect("explicit suffix must inject a matching protect rule");
+    assert_eq!(rule.kind(), FilterRuleKind::Protect);
+    assert_eq!(rule.pattern(), "*.bak");
+}
+
+/// upstream: options.c:2336 guard `!delete_excluded` - `--delete-excluded`
+/// suppresses the protect rule so backup-suffix files remain deletion
+/// candidates. WHY: the guard is what lets `--delete-excluded` reach files the
+/// backup protect rule would otherwise shield.
+#[test]
+fn backup_with_delete_excluded_omits_protect_rule() {
+    let config = builder()
+        .backup(true)
+        .delete(true)
+        .delete_excluded(true)
+        .build();
+    assert!(
+        config
+            .filter_rules()
+            .iter()
+            .all(|rule| rule.kind() != FilterRuleKind::Protect),
+        "--delete-excluded must not inject the backup protect rule"
+    );
+}
+
+/// upstream: options.c:2328-2329 `if (backup_dir) { /* No need for ... a protect
+/// rule. */ }` - a `--backup-dir` stores backups in a separate tree, so no
+/// protect rule is injected.
+#[test]
+fn backup_dir_omits_protect_rule() {
+    let config = builder()
+        .backup_directory(Some("/backups"))
+        .delete(true)
+        .build();
+    assert!(
+        config
+            .filter_rules()
+            .iter()
+            .all(|rule| rule.kind() != FilterRuleKind::Protect),
+        "--backup-dir must not inject the backup protect rule"
+    );
+}
+
+/// upstream: options.c:2336 guard `make_backups && delete_mode` - the protect
+/// rule requires BOTH `--backup` and `--delete`; neither alone injects it.
+#[test]
+fn backup_without_delete_omits_protect_rule() {
+    let config = builder().backup(true).build();
+    assert!(config.filter_rules().is_empty());
+    let config = builder().delete(true).build();
+    assert!(config.filter_rules().is_empty());
+}
+
 /// The implicit rule is appended after every user rule (upstream adds it in
 /// `setup_protocol`, after argument parsing), so it carries the lowest
 /// precedence under first-match evaluation.

--- a/crates/core/tests/client_integration.rs
+++ b/crates/core/tests/client_integration.rs
@@ -139,6 +139,105 @@ fn run_client_copies_with_delete_and_filters() {
     });
 }
 
+/// upstream: options.c:2336-2339 - `rsync -a --delete --backup` (no
+/// `--backup-dir`) injects a `P *~` protect rule so files matching the backup
+/// suffix are NOT candidates for deletion. Backups are written beside the
+/// destination as `name~`; without the protect rule the delete pass would
+/// remove the very files just saved as backups. This exercises the real
+/// local-copy delete path end to end (the same `config.filter_rules()` chain
+/// feeds the remote receiver via `build_wire_format_rules`). WHY this matters:
+/// deleting a pre-existing `*~` here is silent user-data loss plus a wrong
+/// `deleted_files` stat and a spurious `*deleting` line.
+#[test]
+fn backup_with_delete_protects_suffix_files_from_deletion() {
+    run_with_timeout(LOCAL_TIMEOUT, || {
+        let temp = tempdir().expect("tempdir");
+        let source_root = temp.path().join("source");
+        let dest_root = temp.path().join("dest");
+
+        fs::create_dir_all(&source_root).expect("source root");
+        fs::create_dir_all(&dest_root).expect("dest root");
+
+        touch(&source_root.join("keep.txt"), b"keep");
+        // Pre-existing extraneous entries in the destination.
+        touch(&dest_root.join("old.txt~"), b"backup contents");
+        touch(&dest_root.join("gone.txt"), b"obsolete");
+
+        let mut source_arg = source_root.into_os_string();
+        source_arg.push(std::path::MAIN_SEPARATOR.to_string());
+
+        let config = ClientConfig::builder()
+            .transfer_args([source_arg, dest_root.clone().into_os_string()])
+            .recursive(true)
+            .backup(true)
+            .delete(true)
+            .stats(true)
+            .build();
+
+        let summary = run_client(config).expect("run client");
+
+        assert_eq!(fs::read(dest_root.join("keep.txt")).unwrap(), b"keep");
+        assert!(
+            dest_root.join("old.txt~").exists(),
+            "backup-suffix file must survive --delete under --backup"
+        );
+        assert_eq!(
+            fs::read(dest_root.join("old.txt~")).unwrap(),
+            b"backup contents",
+            "protected backup file must be left untouched"
+        );
+        assert!(
+            !dest_root.join("gone.txt").exists(),
+            "a normal extraneous entry is still deleted"
+        );
+        // Only gone.txt is deleted; old.txt~ is protected, so it must not be
+        // counted in the deletion stat.
+        assert_eq!(
+            summary.items_deleted(),
+            1,
+            "protected backup file must be excluded from the deleted-files stat"
+        );
+    });
+}
+
+/// upstream: options.c:2336 guard `!delete_excluded` - `--delete-excluded`
+/// suppresses the backup protect rule, so a pre-existing `*~` again becomes a
+/// deletion candidate. Control for `backup_with_delete_protects_suffix_files_from_deletion`:
+/// proves the survival there is the injected rule, not some unrelated skip.
+#[test]
+fn backup_with_delete_excluded_still_deletes_suffix_files() {
+    run_with_timeout(LOCAL_TIMEOUT, || {
+        let temp = tempdir().expect("tempdir");
+        let source_root = temp.path().join("source");
+        let dest_root = temp.path().join("dest");
+
+        fs::create_dir_all(&source_root).expect("source root");
+        fs::create_dir_all(&dest_root).expect("dest root");
+
+        touch(&source_root.join("keep.txt"), b"keep");
+        touch(&dest_root.join("old.txt~"), b"backup contents");
+
+        let mut source_arg = source_root.into_os_string();
+        source_arg.push(std::path::MAIN_SEPARATOR.to_string());
+
+        let config = ClientConfig::builder()
+            .transfer_args([source_arg, dest_root.clone().into_os_string()])
+            .recursive(true)
+            .backup(true)
+            .delete(true)
+            .delete_excluded(true)
+            .stats(true)
+            .build();
+
+        run_client(config).expect("run client");
+
+        assert!(
+            !dest_root.join("old.txt~").exists(),
+            "--delete-excluded suppresses the protect rule, so the *~ is deleted"
+        );
+    });
+}
+
 #[derive(Default)]
 struct RecordingObserver {
     updates: Vec<(PathBuf, ClientEventKind, bool, Option<u64>, u64)>,


### PR DESCRIPTION
## Problem

Under `rsync -a --delete --backup src/ dest/` (no `--backup-dir`), upstream rsync
keeps a pre-existing extraneous `old.txt~` in the destination, while oc-rsync
deleted it. That is silent user-data loss, a wrong `deleted_files` stat, and a
spurious `*deleting old.txt~` line.

Upstream `options.c:2336-2339`: when
`make_backups && delete_mode && !delete_excluded && !am_server` and no
`--backup-dir` is set, rsync injects a `P *<suffix>` protect rule (default
suffix `~`) into the filter list. Backups are written beside the destination as
`name<suffix>`, so the rule stops the delete pass from removing the very files
just saved as backups. oc-rsync already had the `is_backup_file` backup-before-
delete guard (`delete.c:165`) but never injected this protect rule, so
suffix-matching files stayed deletion candidates.

## Fix

Injected the protect rule at the single filter-list tail where oc already
injects the implicit `--partial-dir` exclude, reusing the same mechanism:

- New `ClientConfigBuilder::push_backup_protect_filter` (in
  `crates/core/src/client/config/builder/filters.rs`), a sibling of the existing
  `push_implicit_partial_dir_filter`. It pushes
  `FilterRuleSpec::protect(format!("*{suffix}"))` when
  `backup && delete_mode.is_enabled() && !delete_excluded` and no `--backup-dir`,
  using the effective suffix (defaults to `~`). Receiver-side, not perishable,
  mirroring upstream `rule_template(0)`.
- Called from `build()` before the partial-dir injection, matching upstream
  ordering (options.c:2336 precedes 2421).

`am_server` is inherently false: this builder constructs the client config only.
The rule flows through the single `config.filter_rules()` source consumed by
every delete path -- `compile_filter_program` (local-copy delete) and
`build_wire_format_rules`/batch serialization (remote receiver), so it is also
transmitted to a remote receiver exactly as upstream transmits its injected
filter_list.

## Tests

- Builder unit tests (`config/builder/tests.rs`): default `*~` protect rule
  injected under backup+delete; explicit `--suffix` reflected as `*.bak`;
  `--delete-excluded`, `--backup-dir`, and backup-or-delete-alone each omit the
  rule.
- End-to-end local-copy tests (`tests/client_integration.rs`): dest `old.txt~`
  survives `--delete --backup` (contents untouched, `items_deleted == 1`, a
  normal extraneous `gone.txt` still deleted); control with `--delete-excluded`
  deletes the `*~` again, proving the survival is the injected rule.

## Verification

Verified locally on macOS (host 172.16.1.74 is down, so host nextest was
skipped -- CI runs the full suite):

- `cargo-fmt --all` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` zero warnings
- `cargo build --tests -p core -p transfer -p engine -p filters --all-features` clean
- Targeted `core` unit + integration tests pass (28 backup builder tests, 2 e2e tests)
