### PR TITLE
feat(cli): parse quic:// scheme and --quic modifier (873/udp, hard-fail)

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -102,6 +102,14 @@ pub struct ParsedArgs {
     /// `--port` - TCP port for daemon connections (default 873).
     pub daemon_port: Option<u16>,
 
+    /// `--quic` - carry the daemon protocol over QUIC (873/udp) instead of TCP.
+    ///
+    /// Upgrades an `rsync://` / `host::` daemon target to the QUIC transport;
+    /// `quic://` targets select it directly. Available only under the `quic`
+    /// feature, so a default build never sees the flag.
+    #[cfg(feature = "quic")]
+    pub quic: bool,
+
     /// `--protocol` - force a specific protocol version (28-32).
     pub protocol: Option<OsString>,
 

--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -165,6 +165,8 @@ where
         .remove_one::<OsString>("connect-program")
         .filter(|value| !value.is_empty());
     let daemon_port = matches.remove_one::<u16>("port");
+    #[cfg(feature = "quic")]
+    let quic = matches.get_flag("quic");
     let remote_options = matches
         .remove_many::<OsString>("remote-option")
         .map(Iterator::collect)
@@ -1189,6 +1191,8 @@ where
         stop_at: stop_at_option,
         out_format,
         daemon_port,
+        #[cfg(feature = "quic")]
+        quic,
         dparam,
         no_iconv,
         executability,

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
@@ -5,7 +5,7 @@ use super::{Arg, ArgAction, ClapCommand, OsStringValueParser};
 
 /// Adds network, remote shell, and connection flags to the command.
 pub(super) fn add_network_args(command: ClapCommand) -> ClapCommand {
-    command
+    let command = command
         .arg(
             Arg::new("rsh")
                 .long("rsh")
@@ -124,5 +124,18 @@ pub(super) fn add_network_args(command: ClapCommand) -> ClapCommand {
                 )
                 .num_args(1)
                 .value_parser(OsStringValueParser::new()),
-        )
+        );
+
+    // The `--quic` modifier (oc extension) upgrades a daemon target to the QUIC
+    // transport; it exists only when the `quic` feature is compiled in, so a
+    // default build rejects it as an unknown argument.
+    #[cfg(feature = "quic")]
+    let command = command.arg(
+        Arg::new("quic")
+            .long("quic")
+            .help("Carry the rsync daemon protocol over QUIC (873/udp); hard-fails if QUIC cannot be established.")
+            .action(ArgAction::SetTrue),
+    );
+
+    command
 }

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -28,6 +28,9 @@ pub(crate) struct ConfigInputs {
     pub(crate) bind_address: Option<core::client::BindAddress>,
     pub(crate) sockopts: Option<OsString>,
     pub(crate) tcp_fastopen: TcpFastOpenMode,
+    /// `--quic` - select the QUIC daemon transport (873/udp).
+    #[cfg(feature = "quic")]
+    pub(crate) quic: bool,
     pub(crate) blocking_io: Option<bool>,
     pub(crate) dry_run: bool,
     pub(crate) list_only: bool,
@@ -326,6 +329,16 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         .mkpath(inputs.mkpath)
         .prune_empty_dirs(inputs.prune_empty_dirs)
         .qsort(inputs.qsort);
+    // `--quic` selects the QUIC daemon transport; without it the default TCP
+    // transport is preserved byte-for-byte (QUIC-8c/8d).
+    #[cfg(feature = "quic")]
+    {
+        builder = builder.daemon_transport(if inputs.quic {
+            core::client::Transport::Quic
+        } else {
+            core::client::Transport::Tcp
+        });
+    }
     // Only override the builder's upstream default when the user supplied
     // `--inc-recursive` or `--no-inc-recursive`. Mirrors upstream
     // `compat.c:720 set_allow_inc_recurse()`.

--- a/crates/cli/src/frontend/execution/drive/module_listing.rs
+++ b/crates/cli/src/frontend/execution/drive/module_listing.rs
@@ -16,6 +16,9 @@ pub(super) struct ModuleListingInputs<'a> {
     pub file_list_operands: &'a [OsString],
     pub remainder: &'a [OsString],
     pub daemon_port: Option<u16>,
+    /// `--quic` - upgrade the daemon listing target to the QUIC transport.
+    #[cfg(feature = "quic")]
+    pub quic: bool,
     pub desired_protocol: Option<ProtocolVersion>,
     pub password_override: Option<Vec<u8>>,
     pub no_motd: bool,
@@ -47,6 +50,8 @@ where
         file_list_operands,
         remainder,
         daemon_port,
+        #[cfg(feature = "quic")]
+        quic,
         desired_protocol,
         password_override,
         no_motd,
@@ -80,6 +85,16 @@ where
 
     let request = if let Some(protocol) = desired_protocol {
         request.with_protocol(protocol)
+    } else {
+        request
+    };
+
+    // `--quic` upgrades an `rsync://` / `host::` listing target to QUIC; a
+    // `quic://` target already carries the transport (QUIC-8c). The QUIC dial
+    // hard-fails with no TCP fallback at the connect-selection point.
+    #[cfg(feature = "quic")]
+    let request = if quic {
+        request.with_transport(core::client::Transport::Quic)
     } else {
         request
     };

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -58,6 +58,8 @@ where
         remote_shell: _,
         connect_program,
         daemon_port,
+        #[cfg(feature = "quic")]
+        quic,
         remote_options,
         rsync_path: _,
         protect_args,
@@ -533,6 +535,8 @@ where
             file_list_operands: &file_list_operands,
             remainder: &remainder,
             daemon_port,
+            #[cfg(feature = "quic")]
+            quic,
             desired_protocol,
             password_override: password_override.clone(),
             no_motd,
@@ -891,6 +895,8 @@ where
         bind_address,
         sockopts: sockopts.clone(),
         tcp_fastopen,
+        #[cfg(feature = "quic")]
+        quic,
         blocking_io,
         dry_run,
         list_only,

--- a/crates/cli/src/frontend/tests/mod.rs
+++ b/crates/cli/src/frontend/tests/mod.rs
@@ -211,6 +211,8 @@ mod parse_args_recognises_port_tests;
 mod parse_args_recognises_preallocate_tests;
 #[path = "parse_args_recognises_prune.rs"]
 mod parse_args_recognises_prune_tests;
+#[path = "parse_args_recognises_quic.rs"]
+mod parse_args_recognises_quic_tests;
 #[path = "parse_args_recognises_recursive.rs"]
 mod parse_args_recognises_recursive_tests;
 #[path = "parse_args_recognises_relative.rs"]

--- a/crates/cli/src/frontend/tests/parse_args_recognises_quic.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_quic.rs
@@ -1,0 +1,54 @@
+use super::common::*;
+use super::*;
+
+#[cfg(feature = "quic")]
+#[test]
+fn parse_args_recognises_quic_flag() {
+    // WHY (QUIC-8c): `--quic` is a recognised modifier under the feature and
+    // sets the flag that upgrades a daemon target to the QUIC transport.
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--quic"),
+        OsString::from("host::module"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(parsed.quic);
+}
+
+#[cfg(feature = "quic")]
+#[test]
+fn parse_args_quic_defaults_off() {
+    // WHY: without `--quic` the daemon transport stays TCP (default behaviour
+    // preserved).
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("host::module"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.quic);
+}
+
+#[cfg(not(feature = "quic"))]
+#[test]
+fn parse_args_does_not_recognise_quic_flag_when_feature_off() {
+    // WHY (QUIC-8d): with the feature compiled out the `--quic` modifier is
+    // absent. The parser therefore never consumes it as a flag - it falls
+    // through to the trailing operand list (where it later fails as a bogus
+    // path), so no code path can select an unbuilt transport.
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--quic"),
+        OsString::from("host::module"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(
+        parsed.remainder.contains(&OsString::from("--quic")),
+        "--quic must not be consumed as a flag when quic is off"
+    );
+}

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -267,6 +267,8 @@ pub struct ClientConfigBuilder {
     bind_address: Option<BindAddress>,
     sockopts: Option<OsString>,
     tcp_fastopen: TcpFastOpenMode,
+    #[cfg(feature = "quic")]
+    daemon_transport: crate::client::Transport,
     blocking_io: Option<bool>,
     iconv: IconvSetting,
     remote_shell: Option<Vec<OsString>>,
@@ -520,6 +522,8 @@ impl ClientConfigBuilder {
             bind_address: self.bind_address,
             sockopts: self.sockopts,
             tcp_fastopen: self.tcp_fastopen,
+            #[cfg(feature = "quic")]
+            daemon_transport: self.daemon_transport,
             blocking_io: self.blocking_io,
             iconv: self.iconv,
             remote_shell: self.remote_shell,

--- a/crates/core/src/client/config/builder/network.rs
+++ b/crates/core/src/client/config/builder/network.rs
@@ -17,6 +17,21 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Selects the transport that carries the daemon protocol.
+    ///
+    /// [`Transport::Quic`](crate::client::Transport::Quic) is chosen by `--quic`
+    /// or a `quic://` target and hard-fails if the QUIC connection cannot be
+    /// established (never falling back to TCP). The default is
+    /// [`Transport::Tcp`](crate::client::Transport::Tcp). Available only under
+    /// the `quic` feature.
+    #[cfg(feature = "quic")]
+    #[must_use]
+    #[doc(alias = "--quic")]
+    pub const fn daemon_transport(mut self, transport: crate::client::Transport) -> Self {
+        self.daemon_transport = transport;
+        self
+    }
+
     /// Configures the TCP Fast Open mode applied to daemon and client sockets.
     ///
     /// `auto` (the default) enables TFO opportunistically on platforms that

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -251,6 +251,11 @@ pub struct ClientConfig {
     pub(super) bind_address: Option<BindAddress>,
     pub(super) sockopts: Option<OsString>,
     pub(super) tcp_fastopen: TcpFastOpenMode,
+    /// Transport carrying the daemon protocol (`--quic` / `quic://`). QUIC is an
+    /// opt-in oc extension compiled only under the `quic` feature; a default
+    /// build always uses TCP, so the field is absent there.
+    #[cfg(feature = "quic")]
+    pub(super) daemon_transport: crate::client::Transport,
     pub(super) blocking_io: Option<bool>,
     pub(super) iconv: IconvSetting,
     pub(super) remote_shell: Option<Vec<OsString>>,
@@ -468,6 +473,8 @@ impl Default for ClientConfig {
             bind_address: None,
             sockopts: None,
             tcp_fastopen: TcpFastOpenMode::Auto,
+            #[cfg(feature = "quic")]
+            daemon_transport: crate::client::Transport::Tcp,
             blocking_io: None,
             iconv: IconvSetting::Unspecified,
             remote_shell: None,

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -9,6 +9,19 @@ impl ClientConfig {
         self.address_mode
     }
 
+    /// Returns the transport that carries the daemon protocol.
+    ///
+    /// [`Transport::Quic`](crate::client::Transport::Quic) is selected by
+    /// `--quic` or a `quic://` target; the default is
+    /// [`Transport::Tcp`](crate::client::Transport::Tcp). Available only under
+    /// the `quic` feature.
+    #[cfg(feature = "quic")]
+    #[must_use]
+    #[doc(alias = "--quic")]
+    pub const fn daemon_transport(&self) -> crate::client::Transport {
+        self.daemon_transport
+    }
+
     /// Returns the configured connect program, if any.
     #[doc(alias = "--connect-program")]
     pub fn connect_program(&self) -> Option<&OsStr> {

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -262,9 +262,9 @@ pub(crate) fn open_daemon_stream(
     sockopts: Option<&OsStr>,
 ) -> Result<DaemonStream, ClientError> {
     // Transport-selection point: the transport rides on `DaemonAddress` from
-    // target parsing. QUIC (feature `quic`, default off) dials via
-    // `rsync_io::quic` in a follow-up; until then every selection establishes
-    // the TCP daemon stream, so the default build is byte-for-byte unchanged.
+    // target parsing. `Transport::Tcp` (the default, and the only variant in a
+    // default build) establishes the plain TCP daemon stream, so default builds
+    // are byte-for-byte unchanged.
     match addr.transport() {
         Transport::Tcp => open_tcp_daemon_stream(
             addr,
@@ -276,18 +276,33 @@ pub(crate) fn open_daemon_stream(
             tfo,
             sockopts,
         ),
+        // QUIC hard-fails here rather than dialing plain TCP: silently falling
+        // back would downgrade an explicitly-requested encrypted transport to
+        // plaintext (a downgrade attack, and a violation of the user's intent).
+        // The QUIC dial itself (`rsync_io::quic`) lands in a follow-up; until
+        // then a QUIC selection exits non-zero and never touches TCP 873
+        // (design: `docs/design/quic-transport-policy.md`, Decision D, "No
+        // silent downgrade").
         #[cfg(feature = "quic")]
-        Transport::Quic => open_tcp_daemon_stream(
-            addr,
-            connect_timeout,
-            io_timeout,
-            address_mode,
-            connect_program,
-            bind_address,
-            tfo,
-            sockopts,
-        ),
+        Transport::Quic => Err(quic_transport_unavailable_error()),
     }
+}
+
+/// Builds the hard-failure error for a QUIC-selected daemon connection.
+///
+/// The QUIC connector is not yet wired (QUIC-5), so any QUIC selection fails
+/// loudly with `RERR_STARTCLIENT` (exit 5). Crucially this is an error, not a
+/// TCP fallback: the selection never silently downgrades to plaintext.
+#[cfg(feature = "quic")]
+fn quic_transport_unavailable_error() -> ClientError {
+    use super::super::CLIENT_SERVER_PROTOCOL_EXIT_CODE;
+    use super::super::daemon_error;
+
+    daemon_error(
+        "QUIC transport was requested but the QUIC connector is not available \
+         in this build; refusing to fall back to plaintext TCP",
+        CLIENT_SERVER_PROTOCOL_EXIT_CODE,
+    )
 }
 
 /// Opens a plain TCP connection to a daemon (the [`Transport::Tcp`] path).
@@ -493,6 +508,43 @@ impl Write for DaemonStream {
         match self {
             Self::Tcp(stream) => stream.flush(),
             Self::Program(stream) => stream.flush(),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "quic"))]
+mod quic_hard_fail_tests {
+    use super::*;
+    use crate::client::AddressMode;
+    use crate::client::TcpFastOpenMode;
+
+    #[test]
+    fn quic_selection_hard_fails_without_tcp_fallback() {
+        // WHY (QUIC-8d): a QUIC-selected daemon connection must exit non-zero
+        // rather than silently dial plaintext TCP. We point the address at a
+        // discard port; if any TCP fallback existed it would attempt a connect,
+        // but the QUIC arm short-circuits to an error before any I/O.
+        let addr = DaemonAddress::new("127.0.0.1".to_owned(), 9)
+            .expect("addr")
+            .with_transport(Transport::Quic);
+
+        let result = open_daemon_stream(
+            &addr,
+            None,
+            None,
+            AddressMode::Default,
+            None,
+            None,
+            TcpFastOpenMode::Auto,
+            None,
+        );
+
+        // `DaemonStream` (the Ok type) is not `Debug`, so match rather than
+        // `expect_err`. upstream RERR_STARTCLIENT (5): the explicit encrypted
+        // transport could not be established and no downgrade is permitted.
+        match result {
+            Ok(_) => panic!("QUIC selection must not fall back to TCP"),
+            Err(err) => assert_eq!(err.exit_code(), 5),
         }
     }
 }

--- a/crates/core/src/client/module_list/request.rs
+++ b/crates/core/src/client/module_list/request.rs
@@ -12,6 +12,8 @@ use protocol::ProtocolVersion;
 use super::super::{AddressMode, ClientError, TcpFastOpenMode};
 use super::parsing::{parse_host_port, split_daemon_host_module, strip_prefix_ignore_ascii_case};
 use super::types::DaemonAddress;
+#[cfg(feature = "quic")]
+use super::types::Transport;
 
 /// Specification describing a daemon module listing request parsed from CLI operands.
 ///
@@ -50,8 +52,18 @@ impl ModuleListRequest {
     fn from_operand(operand: &OsString, default_port: u16) -> Result<Option<Self>, ClientError> {
         let text = operand.to_string_lossy();
 
+        // The `quic://` scheme (oc extension, `quic` feature only) is parsed
+        // exactly beside `rsync://`; it selects the QUIC transport but reuses
+        // the identical authority/module grammar. Recognised only when the
+        // feature is compiled in - a default build treats `quic://...` as an
+        // ordinary (non-daemon) operand, so the scheme is absent when off.
+        #[cfg(feature = "quic")]
+        if let Some(rest) = strip_prefix_ignore_ascii_case(&text, "quic://") {
+            return Self::parse_daemon_url(rest, default_port, Transport::Quic);
+        }
+
         if let Some(rest) = strip_prefix_ignore_ascii_case(&text, "rsync://") {
-            return Self::parse_rsync_url(rest, default_port);
+            return Self::parse_daemon_url(rest, default_port, super::types::Transport::default());
         }
 
         if let Some((host_part, module_part)) = split_daemon_host_module(&text)? {
@@ -65,7 +77,15 @@ impl ModuleListRequest {
         Ok(None)
     }
 
-    fn parse_rsync_url(rest: &str, default_port: u16) -> Result<Option<Self>, ClientError> {
+    /// Parses the authority (`[user@]host[:port]`) of a daemon URL after its
+    /// scheme prefix has been stripped, tagging the resulting address with the
+    /// scheme's [`Transport`]. A non-empty path segment is not a module listing
+    /// (that is a transfer target), so it yields `Ok(None)`.
+    fn parse_daemon_url(
+        rest: &str,
+        default_port: u16,
+        transport: super::types::Transport,
+    ) -> Result<Option<Self>, ClientError> {
         let mut parts = rest.splitn(2, '/');
         let host_port = parts.next().unwrap_or("");
         let remainder = parts.next();
@@ -75,7 +95,10 @@ impl ModuleListRequest {
         }
 
         let target = parse_host_port(host_port, default_port)?;
-        Ok(Some(Self::new(target.address, target.username)))
+        Ok(Some(Self::new(
+            target.address.with_transport(transport),
+            target.username,
+        )))
     }
 
     const fn new(address: DaemonAddress, username: Option<String>) -> Self {
@@ -121,6 +144,20 @@ impl ModuleListRequest {
     #[must_use]
     pub const fn with_protocol(mut self, protocol: ProtocolVersion) -> Self {
         self.protocol = protocol;
+        self
+    }
+
+    /// Returns a new request whose daemon address carries the given transport.
+    ///
+    /// The `--quic` modifier upgrades an otherwise ordinary `rsync://` /
+    /// `host::` daemon target to QUIC without touching its syntax (design:
+    /// `docs/design/quic-transport-policy.md`, Decision D). A `quic://` target
+    /// already carries [`Transport::Quic`] from the scheme, so re-applying it
+    /// is idempotent.
+    #[cfg(feature = "quic")]
+    #[must_use]
+    pub fn with_transport(mut self, transport: Transport) -> Self {
+        self.address = self.address.with_transport(transport);
         self
     }
 }
@@ -284,5 +321,96 @@ impl ModuleListOptions {
 impl Default for ModuleListOptions {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod transport_tests {
+    use super::super::types::Transport;
+    use super::*;
+
+    fn operands(target: &str) -> Vec<OsString> {
+        vec![OsString::from(target)]
+    }
+
+    #[test]
+    fn rsync_scheme_selects_tcp_transport() {
+        // WHY: the default daemon scheme must stay TCP so a default build - and
+        // a `quic`-enabled build that was not asked for QUIC - behaves exactly
+        // like upstream.
+        let request = ModuleListRequest::from_operands(&operands("rsync://host/"))
+            .expect("parse")
+            .expect("daemon target");
+        assert_eq!(request.address().transport(), Transport::Tcp);
+        assert_eq!(request.address().port(), 873);
+    }
+
+    #[test]
+    fn double_colon_selects_tcp_transport() {
+        let request = ModuleListRequest::from_operands(&operands("host::"))
+            .expect("parse")
+            .expect("daemon target");
+        assert_eq!(request.address().transport(), Transport::Tcp);
+    }
+
+    #[cfg(feature = "quic")]
+    #[test]
+    fn quic_scheme_selects_quic_transport_default_port() {
+        // WHY: `quic://` is parsed beside `rsync://` and yields the QUIC
+        // transport with the shared default daemon port 873 (873/udp; policy D).
+        let request = ModuleListRequest::from_operands(&operands("quic://host/"))
+            .expect("parse")
+            .expect("daemon target");
+        assert_eq!(request.address().transport(), Transport::Quic);
+        assert_eq!(request.address().port(), 873);
+    }
+
+    #[cfg(feature = "quic")]
+    #[test]
+    fn quic_scheme_honours_explicit_port() {
+        // WHY: an explicit `:port` in the authority overrides the 873 default,
+        // exactly as it does for `rsync://`.
+        let request = ModuleListRequest::from_operands(&operands("quic://host:1234/"))
+            .expect("parse")
+            .expect("daemon target");
+        assert_eq!(request.address().transport(), Transport::Quic);
+        assert_eq!(request.address().port(), 1234);
+    }
+
+    #[cfg(feature = "quic")]
+    #[test]
+    fn quic_scheme_honours_port_override() {
+        // WHY: `--port` (threaded as the default port) overrides 873 when the
+        // authority omits an explicit port.
+        let request = ModuleListRequest::from_operands_with_port(&operands("quic://host/"), 9999)
+            .expect("parse")
+            .expect("daemon target");
+        assert_eq!(request.address().port(), 9999);
+        assert_eq!(request.address().transport(), Transport::Quic);
+    }
+
+    #[cfg(feature = "quic")]
+    #[test]
+    fn with_transport_upgrades_double_colon_to_quic() {
+        // WHY: the `--quic` modifier upgrades an ordinary `host::` target to
+        // QUIC without changing its syntax (QUIC-8c).
+        let request = ModuleListRequest::from_operands(&operands("host::"))
+            .expect("parse")
+            .expect("daemon target")
+            .with_transport(Transport::Quic);
+        assert_eq!(request.address().transport(), Transport::Quic);
+    }
+
+    #[cfg(not(feature = "quic"))]
+    #[test]
+    fn quic_scheme_absent_when_feature_off() {
+        // WHY: with the feature compiled out the `quic://` scheme must be
+        // absent - not accepted as a daemon target - so no code path can select
+        // an unbuilt transport.
+        let parsed = ModuleListRequest::from_operands(&operands("quic://host/")).expect("parse");
+        assert!(
+            parsed.is_none(),
+            "quic:// must not parse as a daemon target"
+        );
     }
 }

--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -19,6 +19,8 @@ use super::super::super::CLIENT_SERVER_PROTOCOL_EXIT_CODE;
 use super::super::super::error::{
     ClientError, daemon_auth_negotiation_error, daemon_error, socket_error,
 };
+#[cfg(feature = "quic")]
+use super::super::super::module_list::Transport;
 use super::super::super::module_list::{DaemonAddress, load_daemon_password};
 use crate::client::error::invalid_argument_error;
 
@@ -32,22 +34,49 @@ pub(crate) struct DaemonTransferRequest {
 }
 
 impl DaemonTransferRequest {
+    /// Default daemon port, shared by TCP (873/tcp) and QUIC (873/udp); QUIC
+    /// runs over a distinct UDP namespace so the number carries no clash
+    /// (design: `docs/design/quic-transport-policy.md`, Decision D).
+    const DEFAULT_PORT: u16 = 873;
+
     /// Parses an rsync:// URL into a transfer request.
     ///
     /// Format: `rsync://[user@]host[:port]/module/path`
     pub(crate) fn parse_rsync_url(url: &str) -> Result<Self, ClientError> {
-        use super::super::super::module_list::parse_host_port;
-
         let rest = url
             .strip_prefix("rsync://")
             .or_else(|| url.strip_prefix("RSYNC://"))
             .ok_or_else(|| invalid_argument_error(&format!("not an rsync:// URL: {url}"), 1))?;
 
+        Self::from_url_authority(rest, url, "rsync")
+    }
+
+    /// Parses a quic:// URL into a transfer request, tagging the address with
+    /// the QUIC transport (oc extension, `quic` feature only).
+    ///
+    /// Format: `quic://[user@]host[:port]/module/path`. The grammar is
+    /// identical to `rsync://`; only the selected transport differs (QUIC-8b).
+    #[cfg(feature = "quic")]
+    pub(crate) fn parse_quic_url(url: &str) -> Result<Self, ClientError> {
+        let rest = url
+            .strip_prefix("quic://")
+            .or_else(|| url.strip_prefix("QUIC://"))
+            .ok_or_else(|| invalid_argument_error(&format!("not a quic:// URL: {url}"), 1))?;
+
+        Ok(Self::from_url_authority(rest, url, "quic")?.with_transport(Transport::Quic))
+    }
+
+    /// Parses the shared daemon-URL body (`[user@]host[:port]/module/path`)
+    /// after the scheme prefix has been stripped. `scheme` names the origin
+    /// scheme for the "must specify a module" diagnostic.
+    fn from_url_authority(rest: &str, url: &str, scheme: &str) -> Result<Self, ClientError> {
+        use super::super::super::module_list::parse_host_port;
+
         let mut parts = rest.splitn(2, '/');
         let host_port = parts.next().unwrap_or("");
         let path_part = parts.next().unwrap_or("");
 
-        let target = parse_host_port(host_port, 873)?;
+        let target = parse_host_port(host_port, Self::DEFAULT_PORT)?;
 
         let mut path_parts = path_part.splitn(2, '/');
         let module = path_parts.next().unwrap_or("").to_owned();
@@ -55,7 +84,7 @@ impl DaemonTransferRequest {
 
         if module.is_empty() {
             return Err(invalid_argument_error(
-                &format!("rsync:// URL must specify a module: {url}"),
+                &format!("{scheme}:// URL must specify a module: {url}"),
                 1,
             ));
         }
@@ -66,6 +95,16 @@ impl DaemonTransferRequest {
             path: file_path,
             username: target.username,
         })
+    }
+
+    /// Returns this request with its daemon address re-tagged to the given
+    /// transport, used by the `--quic` modifier to upgrade a `rsync://` /
+    /// `host::` target to QUIC (QUIC-8c).
+    #[cfg(feature = "quic")]
+    #[must_use]
+    pub(crate) fn with_transport(mut self, transport: Transport) -> Self {
+        self.address = self.address.with_transport(transport);
+        self
     }
 
     /// Parses a double-colon daemon operand into a transfer request.
@@ -80,7 +119,7 @@ impl DaemonTransferRequest {
             invalid_argument_error(&format!("not a daemon operand: {operand}"), 1)
         })?;
 
-        let target = parse_host_port(host_part, 873)?;
+        let target = parse_host_port(host_part, Self::DEFAULT_PORT)?;
 
         let mut path_parts = module_path.splitn(2, '/');
         let module = path_parts.next().unwrap_or("").to_owned();

--- a/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
@@ -654,3 +654,59 @@ mod handle_at_error_tests {
         assert_eq!(err.exit_code(), CLIENT_SERVER_PROTOCOL_EXIT_CODE);
     }
 }
+
+#[cfg(feature = "quic")]
+mod quic_url_tests {
+    use super::*;
+    use crate::client::module_list::Transport;
+
+    #[test]
+    fn parse_rsync_url_selects_tcp() {
+        // WHY: `rsync://` transfers keep the TCP transport (default behaviour).
+        let request =
+            DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path").expect("parse");
+        assert_eq!(request.address.transport(), Transport::Tcp);
+        assert_eq!(request.address.port(), 873);
+        assert_eq!(request.module, "mod");
+    }
+
+    #[test]
+    fn parse_quic_url_selects_quic_default_port() {
+        // WHY (QUIC-8b): `quic://` is parsed beside `rsync://` and yields the
+        // QUIC transport on the shared default port 873 (873/udp).
+        let request = DaemonTransferRequest::parse_quic_url("quic://host/mod/path").expect("parse");
+        assert_eq!(request.address.transport(), Transport::Quic);
+        assert_eq!(request.address.port(), 873);
+        assert_eq!(request.module, "mod");
+        assert_eq!(request.path, "path");
+    }
+
+    #[test]
+    fn parse_quic_url_honours_explicit_port() {
+        // WHY: an explicit `:port` overrides the 873 default, as for `rsync://`.
+        let request = DaemonTransferRequest::parse_quic_url("quic://host:4321/mod").expect("parse");
+        assert_eq!(request.address.port(), 4321);
+        assert_eq!(request.address.transport(), Transport::Quic);
+    }
+
+    #[test]
+    fn parse_quic_url_requires_module() {
+        // WHY: a module is mandatory, and the diagnostic names the quic scheme.
+        let err = DaemonTransferRequest::parse_quic_url("quic://host/").expect_err("no module");
+        assert!(
+            err.message()
+                .to_string()
+                .contains("quic:// URL must specify a module")
+        );
+    }
+
+    #[test]
+    fn with_transport_upgrades_double_colon_to_quic() {
+        // WHY (QUIC-8c): `--quic` upgrades an ordinary `host::` target to QUIC.
+        let request = DaemonTransferRequest::parse_double_colon("host::mod/path")
+            .expect("parse")
+            .with_transport(Transport::Quic);
+        assert_eq!(request.address.transport(), Transport::Quic);
+        assert_eq!(request.address.port(), 873);
+    }
+}

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -32,6 +32,8 @@ use engine::batch::BatchWriter;
 use super::super::DAEMON_SOCKET_TIMEOUT;
 use super::super::config::ClientConfig;
 use super::super::error::{ClientError, invalid_argument_error, socket_error};
+#[cfg(feature = "quic")]
+use super::super::module_list::Transport;
 use super::super::module_list::{
     RshDaemonSpawn, open_daemon_stream, resolve_connect_timeout, spawn_rsh_daemon_stream,
 };
@@ -42,6 +44,22 @@ use super::invocation::{RemoteRole, TransferSpec, determine_transfer_role};
 
 use connection::{DaemonTransferRequest, perform_daemon_handshake};
 use orchestration::{run_pull_transfer, run_push_transfer, send_daemon_arguments};
+
+/// Returns whether an operand carries a daemon URL scheme.
+///
+/// Always recognises `rsync://` (case-insensitive on the prefix upstream
+/// accepts); `quic://` is recognised only when the `quic` feature is compiled
+/// in, so the scheme is absent from a default build.
+fn is_daemon_url(operand: &str) -> bool {
+    if operand.starts_with("rsync://") || operand.starts_with("RSYNC://") {
+        return true;
+    }
+    #[cfg(feature = "quic")]
+    if operand.starts_with("quic://") || operand.starts_with("QUIC://") {
+        return true;
+    }
+    false
+}
 
 /// Executes a transfer over daemon protocol (rsync://).
 ///
@@ -105,18 +123,38 @@ pub fn run_daemon_transfer(
         .iter()
         .find(|arg| {
             let s = arg.to_string_lossy();
-            s.starts_with("rsync://") || s.starts_with("RSYNC://") || s.contains("::")
+            is_daemon_url(&s) || s.contains("::")
         })
         .ok_or_else(|| invalid_argument_error("no daemon URL or host::module operand found", 1))?;
 
     let daemon_operand_str = daemon_operand.to_string_lossy();
-    let request = if daemon_operand_str.starts_with("rsync://")
+    #[cfg_attr(not(feature = "quic"), allow(unused_mut))]
+    let mut request = if daemon_operand_str.starts_with("rsync://")
         || daemon_operand_str.starts_with("RSYNC://")
     {
         DaemonTransferRequest::parse_rsync_url(&daemon_operand_str)?
     } else {
+        // A `quic://` operand is dispatched to the QUIC parser under the
+        // feature; without it `is_daemon_url` never matches `quic://`, so this
+        // branch only sees `host::module` targets.
+        #[cfg(feature = "quic")]
+        if daemon_operand_str.starts_with("quic://") || daemon_operand_str.starts_with("QUIC://") {
+            DaemonTransferRequest::parse_quic_url(&daemon_operand_str)?
+        } else {
+            DaemonTransferRequest::parse_double_colon(&daemon_operand_str)?
+        }
+        #[cfg(not(feature = "quic"))]
         DaemonTransferRequest::parse_double_colon(&daemon_operand_str)?
     };
+
+    // The `--quic` modifier upgrades an ordinary `rsync://` / `host::` target to
+    // QUIC; a `quic://` target already carries the transport, so this is
+    // idempotent (QUIC-8c). Hard failure with no TCP fallback happens at the
+    // connect-selection point (`open_daemon_stream`), never here.
+    #[cfg(feature = "quic")]
+    if config.daemon_transport() == Transport::Quic {
+        request = request.with_transport(Transport::Quic);
+    }
 
     // upstream: socket.c:274-277 - open_socket_out() bounds connect(2) only when
     // --contimeout is set; --timeout never bounds the connect phase.

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -230,7 +230,18 @@ fn run_client_internal(
     );
 
     let has_daemon_url = config.transfer_args().iter().any(|arg| {
-        arg.to_string_lossy().starts_with("rsync://") || arg.to_string_lossy().contains("::")
+        let s = arg.to_string_lossy();
+        if s.starts_with("rsync://") || s.contains("::") {
+            return true;
+        }
+        // A `quic://` target speaks the same daemon protocol over QUIC, so it
+        // routes to the daemon path (not the SSH path). Recognised only under
+        // the `quic` feature; absent from a default build.
+        #[cfg(feature = "quic")]
+        if s.starts_with("quic://") || s.starts_with("QUIC://") {
+            return true;
+        }
+        false
     });
 
     if has_daemon_url {


### PR DESCRIPTION
## Summary

Wires the already-landed `Transport { Tcp, Quic }` selector (feat/quic-transport-enum, #7103) to the CLI target parser so a daemon transfer can be requested over QUIC. Everything is behind the off-by-default `quic` cargo feature, so a default build is byte-for-byte unchanged and the flag/scheme are absent.

This implements QUIC-8b/8c/8d/8e from `docs/design/quic-transport-integration.md` (Phase 1) and `quic-transport-policy.md` Decision D. Parse + selection only; the actual QUIC dial (QUIC-5) lands in a follow-up.

## What changed

- **QUIC-8b (`quic://` scheme):** parsed exactly beside `rsync://` in both daemon-target parsers - `ModuleListRequest` (listing) and `DaemonTransferRequest` (transfer) - reusing the identical authority/module grammar and tagging the resulting `DaemonAddress` with `Transport::Quic`. Default port 873 (873/udp, a distinct UDP namespace from the TCP daemon per Decision D); an explicit `:port` and `--port` override it.
- **QUIC-8c (`--quic` modifier):** a feature-gated flag that upgrades an ordinary `rsync://` / `host::module` daemon target to QUIC without changing its syntax. Threaded from `ParsedArgs` through `ClientConfig` (transfer path) and `ModuleListingInputs` (listing path) via the existing `DaemonAddress::with_transport` currency.
- **QUIC-8d (hard-fail, no silent downgrade):** the single connect-selection point `open_daemon_stream` returns an error (RERR_STARTCLIENT, exit 5) for a `Transport::Quic` selection instead of dialing plaintext TCP. The daemon-vs-SSH router now recognises `quic://` as a daemon target, so a QUIC target never misroutes to the SSH path. No fallback-to-TCP path exists.
- **Feature gating:** the scheme detection, `--quic` flag, `ClientConfig.daemon_transport` field, and routing predicates are all `#[cfg(feature = "quic")]`. With the feature off, `quic://` is not recognised as a daemon target and `--quic` is not consumed as a flag.

## Integration with the existing `Transport` parser

No parallel path: both the scheme and the flag resolve to the same `DaemonAddress.transport` that `open_daemon_stream` already dispatches on. The `rsync://` parser was generalised into a shared `parse_daemon_url` / `from_url_authority` that takes the scheme's transport, and `quic://` is one more caller of it. The `--quic` upgrade reuses `DaemonAddress::with_transport` via new `with_transport` helpers on the two request types.

## Tests (QUIC-8e)

- Core `request.rs`: rsync/`::` select Tcp; `quic://` selects Quic with default 873; explicit `:port` and `--port` override; `--quic` upgrades `host::`; feature-off `quic://` is not a daemon target.
- Core `connection` (transfer path): `parse_quic_url` default port + port override + module-required diagnostic; `--quic` upgrade of `host::`.
- Core `connect`: QUIC selection hard-fails (exit 5) with no TCP fallback.
- CLI `parse_args_recognises_quic`: `--quic` sets the flag (feature on) / is left as an operand (feature off).

## Verification

The x86_64 Linux host (172.16.1.74) was down (ssh timeout), so host-nextest was skipped; CI covers the full nextest suite. Verified locally on macOS with the pinned 1.88.0 toolchain:

- `cargo fmt --all --check` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean (quic ON)
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings` - clean (quic OFF, default)
- `cargo build --tests -p cli -p core --all-features` - compiles
- New unit tests run green in both feature states (nextest not run locally - hangs on macOS).
