### PR TITLE
feat(rsync_io): QUIC client trust - system roots + TOFU known_hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,6 +772,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,6 +2489,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "openssl-src"
 version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,6 +3150,7 @@ name = "rsync_io"
 version = "0.6.4"
 dependencies = [
  "aes-gcm",
+ "base64",
  "bytes",
  "chacha20poly1305",
  "criterion",
@@ -3148,6 +3165,8 @@ dependencies = [
  "rpassword",
  "russh",
  "rustls",
+ "rustls-native-certs",
+ "sha2 0.10.9",
  "shell-words",
  "tempfile",
  "thiserror",
@@ -3327,6 +3346,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,6 +3416,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,6 +3471,29 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,6 +261,13 @@ bytes = "1.12"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 # Self-signed certificate generation for QUIC loopback tests
 rcgen = { version = "0.14", default-features = false, features = ["crypto", "ring"] }
+# System trust-store loader for the QUIC client verification ladder (policy B,
+# system-roots default). Reads the live platform CA store at runtime, mirroring
+# the openssl/stunnel trust behaviour upstream rsync-ssl relies on - a frozen
+# compiled-in bundle (webpki-roots) would ignore operator-added/corporate CAs.
+rustls-native-certs = "0.8"
+# SHA-256 for the QUIC TOFU known-hosts certificate fingerprint.
+sha2 = { version = "0.10", default-features = false, features = ["std"] }
 # URL parsing for ssh:// URIs
 url = "2"
 # Secure password input from terminal

--- a/crates/rsync_io/Cargo.toml
+++ b/crates/rsync_io/Cargo.toml
@@ -29,6 +29,10 @@ quinn-proto = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 rcgen = { workspace = true, optional = true }
+rustls-native-certs = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
 
 [features]
 default = ["ssh-config-parse"]
@@ -39,7 +43,16 @@ embedded-ssh = ["dep:russh", "dep:url", "dep:rpassword", "dep:is-terminal", "dep
 # exposes one bidirectional stream as blocking `Read`/`Write`. Not wired into
 # any CLI, daemon, or config surface. Concurrency-model decision:
 # docs/design/quic-transport-concurrency-model.md.
-quic = ["dep:quinn-proto", "dep:bytes", "dep:rustls", "dep:rcgen"]
+quic = [
+    "dep:quinn-proto",
+    "dep:bytes",
+    "dep:rustls",
+    "dep:rcgen",
+    "dep:rustls-native-certs",
+    "dep:sha2",
+    "dep:base64",
+    "dep:tempfile",
+]
 # Async SSH transport: opt-in tokio-process backing for `SshConnection`.
 # See `docs/design/async-ssh-transport.md` (#1593) for the staging plan.
 async-ssh = ["dep:tokio"]

--- a/crates/rsync_io/src/quic/mod.rs
+++ b/crates/rsync_io/src/quic/mod.rs
@@ -47,6 +47,7 @@
 //! time and exposes its DER encoding so a connector can pin it.
 
 mod driver;
+mod trust;
 
 use std::collections::VecDeque;
 use std::io::{self, Read, Write};
@@ -63,6 +64,11 @@ pub use rustls::client::danger::ServerCertVerifier;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 
 use driver::{Role, spawn_io};
+
+pub use trust::{
+    Fingerprint, KnownHostsFile, KnownHostsStore, TofuVerifier, TrustPolicy,
+    default_known_hosts_path, resolve, system_roots, tofu, tofu_file,
+};
 
 /// ALPN protocol identifier advertised on every QUIC connection.
 pub const ALPN_RSYNC: &[u8] = b"rsync";

--- a/crates/rsync_io/src/quic/trust.rs
+++ b/crates/rsync_io/src/quic/trust.rs
@@ -1,0 +1,653 @@
+//! Client-side trust backends for the QUIC transport (policy B).
+//!
+//! The bytes inside a QUIC session are the unmodified daemon protocol; this
+//! module only decides *whether to trust the server's certificate*, then hands
+//! the decision to [`QuicConnector`](super::QuicConnector) as a [`QuicTrust`].
+//! Three sources make up the client verification ladder:
+//!
+//! - **System roots** ([`system_roots`], QUIC-5c) - the zero-config default.
+//!   Verifies the server chain against the live platform trust store, the
+//!   openssl/stunnel behaviour upstream `rsync-ssl` relies on when
+//!   `RSYNC_SSL_CA_CERT` is unset.
+//! - **TOFU `quic_known_hosts`** ([`tofu`]/[`TofuVerifier`], QUIC-5d) - the
+//!   self-signed path. On first contact with an authority the server's cert
+//!   fingerprint is pinned into a known-hosts file (mirroring SSH); a changed
+//!   fingerprint for a known authority aborts the handshake loudly. There is no
+//!   blanket insecure escape hatch.
+//! - **Private CA** (a caller-supplied [`RootCertStore`], `--quic-ca`) -
+//!   resolved here only as the highest-precedence [`QuicTrust::Roots`]; the flag
+//!   itself lands with the CLI wiring.
+//!
+//! [`resolve`] selects one source per policy-B precedence so the CLI wiring
+//! (`--quic-ca` > system roots > TOFU) composes these backends without
+//! re-deriving the order. Dependency inversion keeps the TOFU verifier testable:
+//! it pins through a [`KnownHostsStore`] trait, not a hard-wired file, so tests
+//! inject a temp-path store and no network or real trust store is touched.
+//!
+//! See `docs/design/quic-transport-policy.md` (Decision B) and
+//! `docs/design/quic-transport-integration.md` (Phase 3).
+
+use std::fmt;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD_NO_PAD;
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::CryptoProvider;
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, Error as TlsError, RootCertStore, SignatureScheme};
+use sha2::{Digest, Sha256};
+
+use super::{QuicTrust, io_err, ring_provider};
+
+/// SHA-256 fingerprint of a presented server certificate (the whole DER
+/// encoding), the identity a TOFU pin records.
+///
+/// Hashing the certificate DER - rather than the SubjectPublicKeyInfo - is the
+/// `cert SHA-256` option the policy note explicitly allows: the daemon's
+/// zero-config identity is a *persisted* self-signed certificate (policy A), so
+/// the certificate bytes are as stable across restarts as the key would be,
+/// and a whole-certificate digest needs no ASN.1 parser to extract a subfield.
+/// The wire/handshake is untouched either way - this is a local trust check.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Fingerprint([u8; 32]);
+
+impl Fingerprint {
+    /// Computes the fingerprint of `cert`.
+    #[must_use]
+    pub fn of_certificate(cert: &CertificateDer<'_>) -> Self {
+        Self(Sha256::digest(cert.as_ref()).into())
+    }
+
+    /// The `SHA256:<base64>` token stored in `quic_known_hosts` and shown in
+    /// diagnostics, matching the unpadded-base64 form SSH prints for a SHA-256
+    /// key fingerprint.
+    fn token(&self) -> String {
+        format!("SHA256:{}", STANDARD_NO_PAD.encode(self.0))
+    }
+
+    /// Parses a `SHA256:<base64>` token, returning `None` on any malformed
+    /// input so a corrupt line is skipped rather than trusted.
+    fn parse_token(token: &str) -> Option<Self> {
+        let encoded = token.strip_prefix("SHA256:")?;
+        let bytes = STANDARD_NO_PAD.decode(encoded).ok()?;
+        let array: [u8; 32] = bytes.try_into().ok()?;
+        Some(Self(array))
+    }
+}
+
+impl fmt::Display for Fingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.token())
+    }
+}
+
+impl fmt::Debug for Fingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Fingerprint({})", self.token())
+    }
+}
+
+/// Persistent record of the fingerprints pinned per authority - the seam the
+/// TOFU verifier depends on instead of a concrete file.
+///
+/// Inverting this dependency is what makes [`TofuVerifier`] testable offline: a
+/// test injects a store over a temp path (or an in-memory fake) and drives the
+/// pin/accept/reject decisions without a real `~/.config` file or a network.
+pub trait KnownHostsStore: fmt::Debug + Send + Sync {
+    /// Returns the fingerprint pinned for `authority`, or `None` on first
+    /// contact.
+    fn pinned(&self, authority: &str) -> io::Result<Option<Fingerprint>>;
+
+    /// Records `fingerprint` as the pin for `authority`. Called once, on first
+    /// contact; never overwrites a differing pin (that is the caller's abort
+    /// path).
+    fn pin(&self, authority: &str, fingerprint: &Fingerprint) -> io::Result<()>;
+}
+
+/// A `quic_known_hosts` file, one `authority SHA256:<base64>` record per line.
+///
+/// Mirrors SSH `known_hosts`: a per-user trust store keyed by `host:port`,
+/// created `0700`/`0600`, written atomically (temp file in the same directory
+/// then rename) so a concurrent reader never sees a half-written file.
+#[derive(Debug, Clone)]
+pub struct KnownHostsFile {
+    path: PathBuf,
+}
+
+impl KnownHostsFile {
+    /// Binds the store to `path`. The file and its parent directory are created
+    /// lazily on the first [`pin`](KnownHostsStore::pin).
+    #[must_use]
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl KnownHostsStore for KnownHostsFile {
+    fn pinned(&self, authority: &str) -> io::Result<Option<Fingerprint>> {
+        let contents = match fs::read_to_string(&self.path) {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        Ok(contents
+            .lines()
+            .find_map(|line| parse_record(line, authority)))
+    }
+
+    fn pin(&self, authority: &str, fingerprint: &Fingerprint) -> io::Result<()> {
+        if let Some(parent) = self.path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            fs::create_dir_all(parent)?;
+            restrict_dir(parent)?;
+        }
+        let mut contents = match fs::read_to_string(&self.path) {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => String::new(),
+            Err(err) => return Err(err),
+        };
+        if !contents.is_empty() && !contents.ends_with('\n') {
+            contents.push('\n');
+        }
+        contents.push_str(&format!("{authority} {}\n", fingerprint.token()));
+        atomic_write(&self.path, contents.as_bytes())
+    }
+}
+
+/// Parses one `known_hosts` line, returning the fingerprint when it records
+/// `authority`. Blank lines, `#` comments, and malformed tokens are ignored.
+fn parse_record(line: &str, authority: &str) -> Option<Fingerprint> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+    let mut fields = line.split_whitespace();
+    let recorded = fields.next()?;
+    if recorded != authority {
+        return None;
+    }
+    Fingerprint::parse_token(fields.next()?)
+}
+
+/// Writes `bytes` to `path` atomically: a temp file in the same directory,
+/// `0600` on unix, is persisted over the target by rename.
+fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let dir = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(".quic_known_hosts").suffix(".tmp");
+    let mut temp = match dir {
+        Some(dir) => builder.tempfile_in(dir)?,
+        None => builder.tempfile()?,
+    };
+    temp.write_all(bytes)?;
+    temp.flush()?;
+    restrict_file(temp.as_file())?;
+    temp.persist(path).map_err(|err| err.error)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_dir(dir: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn restrict_dir(_dir: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_file(file: &fs::File) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn restrict_file(_file: &fs::File) -> io::Result<()> {
+    Ok(())
+}
+
+/// A rustls [`ServerCertVerifier`] implementing trust-on-first-use.
+///
+/// Keyed by a `host:port` `authority` fixed at construction (rustls hands the
+/// verifier only the certificate and the TLS `ServerName`, not the port, so the
+/// pin key mirrors SSH's `host:port` and comes from the connect target). On
+/// first contact the presented certificate's fingerprint is pinned; afterward
+/// the same authority must present the same fingerprint or the handshake fails.
+/// Handshake-signature verification still runs against the crypto provider, so
+/// a peer must prove possession of the pinned certificate's private key - the
+/// pin alone is not enough.
+pub struct TofuVerifier {
+    authority: String,
+    store: Box<dyn KnownHostsStore>,
+    provider: Arc<CryptoProvider>,
+}
+
+impl TofuVerifier {
+    /// Builds a verifier pinning `authority` through `store`.
+    #[must_use]
+    pub fn new(authority: impl Into<String>, store: Box<dyn KnownHostsStore>) -> Self {
+        Self {
+            authority: authority.into(),
+            store,
+            provider: ring_provider(),
+        }
+    }
+}
+
+impl fmt::Debug for TofuVerifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TofuVerifier")
+            .field("authority", &self.authority)
+            .field("store", &self.store)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ServerCertVerifier for TofuVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, TlsError> {
+        let presented = Fingerprint::of_certificate(end_entity);
+        match self.store.pinned(&self.authority) {
+            Err(err) => Err(TlsError::General(format!(
+                "quic: reading known-hosts for {}: {err}",
+                self.authority
+            ))),
+            Ok(Some(pinned)) if pinned == presented => Ok(ServerCertVerified::assertion()),
+            Ok(Some(pinned)) => {
+                emit_key_changed_warning(&self.authority, &pinned, &presented);
+                Err(TlsError::General(format!(
+                    "quic host key mismatch for {}: pinned {pinned} got {presented}",
+                    self.authority
+                )))
+            }
+            Ok(None) => match self.store.pin(&self.authority, &presented) {
+                Ok(()) => {
+                    emit_pinned_notice(&self.authority, &presented);
+                    Ok(ServerCertVerified::assertion())
+                }
+                Err(err) => Err(TlsError::General(format!(
+                    "quic: pinning host key for {}: {err}",
+                    self.authority
+                ))),
+            },
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+/// Informational first-contact notice (not fatal), matching the policy note.
+fn emit_pinned_notice(authority: &str, fingerprint: &Fingerprint) {
+    let _ = writeln!(
+        io::stderr(),
+        "oc-rsync: quic: pinning new host key for {authority} ({fingerprint}); \
+         add --quic-ca or --quic-known-key to verify out of band"
+    );
+}
+
+/// Loud MITM-shaped warning on a changed key, deliberately echoing SSH's
+/// `REMOTE HOST IDENTIFICATION HAS CHANGED` so operator muscle memory transfers.
+fn emit_key_changed_warning(authority: &str, pinned: &Fingerprint, presented: &Fingerprint) {
+    let _ = writeln!(
+        io::stderr(),
+        "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n\
+         @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @\n\
+         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n\
+         IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\n\
+         Someone could be eavesdropping on you right now (man-in-the-middle attack)!\n\
+         The quic host key for {authority} has changed.\n\
+         Pinned fingerprint: {pinned}\n\
+         Offered fingerprint: {presented}\n\
+         Remove the offending line for {authority} from your quic_known_hosts to proceed."
+    );
+}
+
+/// Builds the system-roots trust source (QUIC-5c): verify the server chain
+/// against the live platform trust store.
+///
+/// This is the zero-config default of the client ladder and the carried-forward
+/// `RSYNC_SSL_CA_CERT`-unset behaviour ("default CA set AND verify"). Errors if
+/// the platform store yields no usable certificate, so a broken trust store
+/// fails loudly rather than silently trusting nothing.
+pub fn system_roots() -> io::Result<QuicTrust> {
+    let loaded = rustls_native_certs::load_native_certs();
+    let mut roots = RootCertStore::empty();
+    let (added, _ignored) = roots.add_parsable_certificates(loaded.certs);
+    if added == 0 {
+        let detail = loaded.errors.first().map_or_else(
+            || "empty platform trust store".to_owned(),
+            ToString::to_string,
+        );
+        return Err(io_err(format!(
+            "no usable certificates in the system trust store: {detail}"
+        )));
+    }
+    Ok(QuicTrust::Roots(roots))
+}
+
+/// Builds a TOFU trust source (QUIC-5d) pinning `authority` through `store`.
+#[must_use]
+pub fn tofu(authority: impl Into<String>, store: Box<dyn KnownHostsStore>) -> QuicTrust {
+    QuicTrust::Verifier(Arc::new(TofuVerifier::new(authority, store)))
+}
+
+/// Builds a TOFU trust source backed by a `quic_known_hosts` file at `path`.
+#[must_use]
+pub fn tofu_file(authority: impl Into<String>, path: PathBuf) -> QuicTrust {
+    tofu(authority, Box::new(KnownHostsFile::new(path)))
+}
+
+/// Default `quic_known_hosts` location: `$XDG_CONFIG_HOME/oc-rsync/` when set,
+/// else the per-user config dir (`~/.config` on unix, `%APPDATA%` on Windows).
+///
+/// Kept inside oc-rsync's own config namespace so it never collides with or
+/// resembles an upstream path. Returns `None` when no home/config dir resolves.
+#[must_use]
+pub fn default_known_hosts_path() -> Option<PathBuf> {
+    const FILE: &str = "quic_known_hosts";
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(xdg).join("oc-rsync").join(FILE));
+    }
+    config_dir().map(|dir| dir.join("oc-rsync").join(FILE))
+}
+
+#[cfg(unix)]
+fn config_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|v| !v.is_empty())
+        .map(|home| PathBuf::from(home).join(".config"))
+}
+
+#[cfg(windows)]
+fn config_dir() -> Option<PathBuf> {
+    std::env::var_os("APPDATA")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn config_dir() -> Option<PathBuf> {
+    None
+}
+
+/// One resolved trust source, in policy-B precedence order.
+///
+/// Constructed by the CLI wiring (a private CA from `--quic-ca`, a TOFU target
+/// from a self-signed endpoint, or the system-roots default) and converted to a
+/// [`QuicTrust`] the connector consumes.
+pub enum TrustPolicy {
+    /// Private CA bundle (`--quic-ca`), already parsed into a root store.
+    PrivateCa(RootCertStore),
+    /// Platform trust store (zero-config default).
+    SystemRoots,
+    /// Trust-on-first-use, keyed by `authority`; `None` uses the default
+    /// `quic_known_hosts` location.
+    Tofu {
+        /// `host:port` the pin is keyed by.
+        authority: String,
+        /// Explicit known-hosts path, or `None` for [`default_known_hosts_path`].
+        known_hosts: Option<PathBuf>,
+    },
+}
+
+impl TrustPolicy {
+    /// Materializes the trust source into a [`QuicTrust`].
+    pub fn into_trust(self) -> io::Result<QuicTrust> {
+        match self {
+            Self::PrivateCa(roots) => Ok(QuicTrust::Roots(roots)),
+            Self::SystemRoots => system_roots(),
+            Self::Tofu {
+                authority,
+                known_hosts,
+            } => {
+                let path = known_hosts
+                    .or_else(default_known_hosts_path)
+                    .ok_or_else(|| {
+                        io_err("cannot resolve a quic_known_hosts path (no HOME/config dir)")
+                    })?;
+                Ok(tofu_file(authority, path))
+            }
+        }
+    }
+}
+
+/// Selects the effective client trust source per policy-B precedence
+/// (`--quic-ca` > system roots > TOFU) and materializes it into a [`QuicTrust`].
+///
+/// An explicit private CA wins; otherwise an explicit TOFU target engages the
+/// self-signed path; otherwise the system-roots default applies. This is the
+/// composition seam for the CLI wiring: it supplies `ca`/`tofu` from the parsed
+/// flags and receives one ready trust source, without re-encoding the order.
+pub fn resolve(
+    ca: Option<RootCertStore>,
+    tofu: Option<(String, Option<PathBuf>)>,
+) -> io::Result<QuicTrust> {
+    let policy = match (ca, tofu) {
+        (Some(roots), _) => TrustPolicy::PrivateCa(roots),
+        (None, Some((authority, known_hosts))) => TrustPolicy::Tofu {
+            authority,
+            known_hosts,
+        },
+        (None, None) => TrustPolicy::SystemRoots,
+    };
+    policy.into_trust()
+}
+
+#[cfg(test)]
+mod tests {
+    use rustls::pki_types::{ServerName, UnixTime};
+
+    use super::super::{QuicConnector, QuicTrust};
+    use super::*;
+
+    const AUTHORITY: &str = "host.example:873";
+
+    /// A fresh self-signed certificate; each call has a distinct key, so two
+    /// certificates yield distinct fingerprints - the "changed host key" case.
+    fn synthetic_cert() -> CertificateDer<'static> {
+        rcgen::generate_simple_self_signed(vec!["host.example".to_owned()])
+            .expect("generate self-signed")
+            .cert
+            .der()
+            .clone()
+    }
+
+    fn store_at(path: &Path) -> Box<dyn KnownHostsStore> {
+        Box::new(KnownHostsFile::new(path.to_path_buf()))
+    }
+
+    fn verify(cert: &CertificateDer<'_>, path: &Path) -> Result<ServerCertVerified, TlsError> {
+        let verifier = TofuVerifier::new(AUTHORITY, store_at(path));
+        verifier.verify_server_cert(
+            cert,
+            &[],
+            &ServerName::try_from("host.example").expect("server name"),
+            &[],
+            UnixTime::now(),
+        )
+    }
+
+    /// The system-roots default (QUIC-5c) must arrive as a `QuicTrust::Roots`
+    /// the existing connector accepts - the whole point is that the platform
+    /// store feeds the unchanged connect path. A trust-store-less environment
+    /// must fail loudly with the documented message, never silently trust
+    /// nothing.
+    #[test]
+    fn system_roots_feeds_the_connector_or_reports_empty() {
+        match system_roots() {
+            Ok(trust) => {
+                assert!(matches!(trust, QuicTrust::Roots(_)));
+                QuicConnector::with_trust(trust).expect("system-roots connector");
+            }
+            Err(err) => assert!(
+                err.to_string().contains("system trust store"),
+                "unexpected error: {err}"
+            ),
+        }
+    }
+
+    /// TOFU end to end: first contact pins the fingerprint and persists it, the
+    /// same certificate is accepted on a later contact, and a changed
+    /// certificate for the known authority is rejected. Encodes WHY: TOFU's
+    /// security property is exactly "pin once, then require the same key" - an
+    /// accept on first sight plus a hard reject on a changed key is what
+    /// distinguishes it from a blanket insecure flag.
+    #[test]
+    fn tofu_pins_then_accepts_same_and_rejects_changed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state").join("quic_known_hosts");
+        let cert = synthetic_cert();
+        let rogue = synthetic_cert();
+        assert_ne!(
+            Fingerprint::of_certificate(&cert),
+            Fingerprint::of_certificate(&rogue),
+            "distinct certs must fingerprint distinctly for this test to mean anything"
+        );
+
+        // First contact: no pin yet, so the cert is accepted and recorded.
+        assert!(!path.exists(), "no known-hosts file before first contact");
+        verify(&cert, &path).expect("first contact pins and accepts");
+        let recorded = std::fs::read_to_string(&path).expect("known-hosts written");
+        assert!(
+            recorded.contains(AUTHORITY) && recorded.contains("SHA256:"),
+            "first contact must persist an authority/fingerprint record: {recorded:?}"
+        );
+
+        // Second contact with the same identity: the pin matches, so accept.
+        verify(&cert, &path).expect("same fingerprint accepted");
+
+        // Changed identity for a known authority: MITM-shaped, must reject.
+        let err = verify(&rogue, &path).expect_err("changed fingerprint must be rejected");
+        assert!(
+            err.to_string().contains("host key mismatch"),
+            "rejection must name the mismatch: {err}"
+        );
+
+        // The reject must not have overwritten the original pin.
+        let after = std::fs::read_to_string(&path).expect("known-hosts still present");
+        assert_eq!(recorded, after, "a rejected key must never repin the host");
+    }
+
+    /// The `quic_known_hosts` file is created with owner-only permissions and a
+    /// `0700` parent, mirroring SSH - a world-readable trust store would let a
+    /// local user tamper with pins.
+    #[cfg(unix)]
+    #[test]
+    fn known_hosts_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let parent = dir.path().join("state");
+        let path = parent.join("quic_known_hosts");
+        let store = KnownHostsFile::new(path.clone());
+        store
+            .pin(AUTHORITY, &Fingerprint::of_certificate(&synthetic_cert()))
+            .expect("pin");
+
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("file meta")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        assert_eq!(
+            std::fs::metadata(&parent)
+                .expect("dir meta")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+    }
+
+    /// The store round-trips a pin: after `pin`, `pinned` returns the same
+    /// fingerprint, and an unknown authority reads back as `None`.
+    #[test]
+    fn store_round_trips_pins() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("quic_known_hosts");
+        let store = KnownHostsFile::new(path);
+        let fp = Fingerprint::of_certificate(&synthetic_cert());
+
+        assert!(store.pinned(AUTHORITY).expect("read empty").is_none());
+        store.pin(AUTHORITY, &fp).expect("pin");
+        assert_eq!(store.pinned(AUTHORITY).expect("read back"), Some(fp));
+        assert!(
+            store
+                .pinned("other:873")
+                .expect("unknown authority")
+                .is_none(),
+            "an unrelated authority must not match"
+        );
+    }
+
+    /// The resolver honours policy-B precedence: an explicit CA outranks a TOFU
+    /// target, and TOFU outranks the system-roots default. Encodes WHY: the CLI
+    /// wiring (#50) relies on this order to compose `--quic-ca`, TOFU, and the
+    /// default without re-deriving it.
+    #[test]
+    fn resolve_precedence_ca_over_tofu() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("quic_known_hosts");
+
+        let tofu_target = Some((AUTHORITY.to_owned(), Some(path.clone())));
+        let trust = resolve(None, tofu_target).expect("tofu resolves");
+        assert!(
+            matches!(trust, QuicTrust::Verifier(_)),
+            "TOFU target -> verifier"
+        );
+
+        let ca = RootCertStore::empty();
+        let both =
+            resolve(Some(ca), Some((AUTHORITY.to_owned(), Some(path)))).expect("ca resolves");
+        assert!(
+            matches!(both, QuicTrust::Roots(_)),
+            "explicit CA outranks TOFU"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements QUIC-5c + QUIC-5d, the client verification ladder from
`docs/design/quic-transport-policy.md` (Decision B), building on the existing
`QuicTrust` enum and `QuicConnector::with_trust` (no parallel path). Everything
is behind the `quic` cargo feature, default-off; `rsync_io` stays unsafe-free.

### QUIC-5c - system roots (default)
`quic::system_roots()` loads the live platform trust store and returns it as
`QuicTrust::Roots`, the zero-config default of the ladder.

Library choice: `rustls-native-certs` over `webpki-roots`. The policy note frames
this source as the "platform CA" / "platform trust store" and the carried-forward
`RSYNC_SSL_CA_CERT`-unset behaviour, i.e. what openssl/stunnel do under upstream
`rsync-ssl`. `rustls-native-certs` reads the live OS store, so operator-added and
corporate CAs are honoured; `webpki-roots` is a frozen compiled-in Mozilla bundle
that would silently ignore them. An empty store fails loudly rather than trusting
nothing.

### QUIC-5d - TOFU `quic_known_hosts`
`TofuVerifier` (a rustls `ServerCertVerifier`) pins the server certificate
SHA-256 on first contact with a `host:port` authority and requires the same
fingerprint afterward; a changed fingerprint aborts the handshake loudly with an
SSH-style `REMOTE HOST IDENTIFICATION HAS CHANGED` warning. Handshake-signature
verification still runs against the crypto provider, so a peer must prove
possession of the pinned certificate's key - the pin alone is not enough. No
blanket insecure flag exists.

- Dependency inversion: the verifier pins through a `KnownHostsStore` trait, not a
  hard-wired file, so it is fully testable offline.
- `KnownHostsFile` mirrors SSH `known_hosts`: `$XDG_CONFIG_HOME/oc-rsync/`
  (or `~/.config`, `%APPDATA%`) location, one `authority SHA256:<base64>` record
  per line, written atomically (temp file + rename) at `0600` under a `0700` dir.
- Fingerprint is the certificate-DER SHA-256 (the "cert SHA-256" option the policy
  note allows); the daemon's persisted self-signed identity (policy A) makes it as
  stable as an SPKI hash, with no ASN.1 parser needed.

### Resolver
`quic::resolve(ca, tofu)` / `TrustPolicy` select one trust source per policy-B
precedence (`--quic-ca` > system roots > TOFU) so the CLI wiring (#50) composes
these backends without re-encoding the order. `--quic-ca` itself is out of scope
here (separate CLI task).

## Tests (offline, no network)
- `system_roots_feeds_the_connector_or_reports_empty` - the system-roots source
  builds a valid `QuicConnector`, or reports the empty-store error loudly.
- `tofu_pins_then_accepts_same_and_rejects_changed` - pins on first contact,
  accepts the same fingerprint, rejects a changed one; a rejected key never repins.
- `known_hosts_file_is_owner_only` - `0600` file under a `0700` parent (unix).
- `store_round_trips_pins`, `resolve_precedence_ca_over_tofu`.

Synthetic rcgen certs + an injected temp known-hosts path; no sockets.

## Local verification (macOS aarch64, host 172.16.1.74 down)
- `cargo-fmt --all` - clean
- `cargo clippy -p rsync_io --features quic --all-targets --no-deps -D warnings` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings` - clean
- `cargo build --tests -p rsync_io --features quic` - clean
- The 5 trust unit tests pass locally (0.17s).

Host nextest was skipped (host outage); CI runs the full suite.
