### PR TITLE
fix(itemize): correct up-to-date hardlink follower itemize (h, gated emission)

### DIFF
--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -596,6 +596,38 @@ mod tests {
         assert_eq!(line, "hf+++++++++ follower\n");
     }
 
+    /// HL-1 (#78): an UP-TO-DATE hardlink follower (destination already links to
+    /// its leader) itemizes with `ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS` and an
+    /// EMPTY xname - exactly what upstream `hlink.c:218-222` passes. Column 0 must
+    /// render `h` (LOCAL_CHANGE + XNAME_FOLLOWS, `log.c:707-708`); with
+    /// `ITEM_IS_NEW` absent and no report flags, the all-dot attribute columns
+    /// collapse to blanks (`log.c:741-750`), and the empty xname suppresses the
+    /// ` => leader` suffix (`log.c:644`). This pins the flags the already-linked
+    /// branch now passes instead of a bare `0`, which rendered a spurious `.`.
+    #[test]
+    fn format_itemize_line_up_to_date_hardlink_follower_renders_h() {
+        let iflags =
+            ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_XNAME_FOLLOWS);
+        let entry = make_file_entry("follower");
+        let line = format_itemize_line(&iflags, &entry, false, &default_ctx(), None);
+
+        // "hf" + 9 blanked attribute columns + " " (%i/%n separator) + name.
+        let mut expected = String::from("hf");
+        expected.push_str(&" ".repeat(9));
+        expected.push(' ');
+        expected.push_str("follower\n");
+        assert_eq!(line, expected);
+        assert_eq!(
+            line.as_bytes()[0],
+            b'h',
+            "column 0 renders the hardlink glyph"
+        );
+        assert!(
+            !line.contains("=>"),
+            "an empty xname suppresses the ` => ` suffix"
+        );
+    }
+
     /// upstream: log.c:716-717 - non-symlink with preserve_mtimes shows lowercase 't'
     #[test]
     fn file_time_with_preserve_mtimes_shows_lowercase_t() {

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -824,11 +824,17 @@ impl ReceiverContext {
                             if link_meta.dev() == leader_meta.dev()
                                 && link_meta.ino() == leader_meta.ino()
                             {
-                                // upstream: hlink.c:218-222 - hardlink already
-                                // correct, metadata only; the itemize xname is
-                                // the empty string, so no ` => ` suffix renders
-                                // (log.c:644 gates on `hlink && *hlink`).
-                                let iflags = ItemFlags::from_raw(0);
+                                // upstream: hlink.c:218-222 - an up-to-date
+                                // hardlink follower itemizes with
+                                // ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS and an
+                                // empty xname. log.c:707-708 renders column 0 as
+                                // 'h' (LOCAL_CHANGE + XNAME_FOLLOWS), and the
+                                // empty xname suppresses the ` => ` suffix
+                                // (log.c:644 / itemize.rs:192 gate on a
+                                // non-empty name).
+                                let iflags = ItemFlags::from_raw(
+                                    ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_XNAME_FOLLOWS,
+                                );
                                 let _ = self.emit_itemize_indexed(
                                     writer,
                                     follower_ndx,

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -627,6 +627,8 @@ impl ReceiverContext {
         &self,
         writer: &mut W,
         ndx_codec: &mut protocol::codec::NdxCodecEnum,
+        dest_dir: &std::path::Path,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
     ) -> std::io::Result<()>
     where
         W: std::io::Write + ?Sized,
@@ -643,14 +645,20 @@ impl ReceiverContext {
             return Ok(());
         }
 
-        // Leader group index -> transfer-relative name, so each follower can name
-        // its leader in the xname the peer renders after "=>".
-        let mut leader_names: std::collections::HashMap<u32, &str> =
+        // The dev/ino up-to-date check is Unix-only; on other platforms every
+        // follower is forwarded, matching the pre-existing behaviour.
+        #[cfg(not(unix))]
+        let _ = dest_dir;
+
+        // Leader group index -> leader entry, so each follower can name its
+        // leader in the xname the peer renders after "=>" and so its destination
+        // path is known for the up-to-date dev/ino check below.
+        let mut leaders: std::collections::HashMap<u32, &protocol::flist::FileEntry> =
             std::collections::HashMap::new();
         for entry in &self.file_list {
             if entry.hlink_first() {
                 if let Some(gnum) = entry.hardlink_idx() {
-                    leader_names.entry(gnum).or_insert_with(|| entry.name());
+                    leaders.entry(gnum).or_insert(entry);
                 }
             }
         }
@@ -663,9 +671,23 @@ impl ReceiverContext {
             let Some(gnum) = entry.hardlink_idx() else {
                 continue;
             };
-            let Some(leader_name) = leader_names.get(&gnum).copied() else {
+            let Some(leader) = leaders.get(&gnum).copied() else {
                 continue;
             };
+            let leader_name = leader.name();
+
+            // upstream: hlink.c:215-227 maybe_hard_link - an up-to-date follower
+            // (destination already shares the leader's dev/ino) itemizes with
+            // ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS and an EMPTY xname. Neither
+            // flag is in SIGNIFICANT_ITEM_FLAGS (rsync.h:258-259) and the xname
+            // is empty, so the generator.c:582 emit gate is false and NOTHING is
+            // written to the wire for it. Only a new follower (statret != 0 or a
+            // dev/ino mismatch, the atomic_create path at hlink.c:230-237)
+            // carries a non-empty xname and crosses the wire with ITEM_IS_NEW.
+            #[cfg(unix)]
+            if self.hardlink_follower_up_to_date(dest_dir, sandbox, entry.path(), leader.path()) {
+                continue;
+            }
 
             let ndx = self.flat_to_wire_ndx(flat_idx);
             ndx_codec.write_ndx(writer, ndx)?;
@@ -692,6 +714,38 @@ impl ReceiverContext {
                 .set(self.hardlink_follower_echoes.get() + emitted);
         }
         Ok(())
+    }
+
+    /// Returns whether the follower's destination already hard-links to its
+    /// leader (destination dev/ino match), mirroring upstream
+    /// `hlink.c:215-217` maybe_hard_link's `statret == 0 && st_dev/st_ino`
+    /// comparison. Such an up-to-date follower is written NOTHING on the wire
+    /// (its itemize xname is empty and its flags are not significant), so the
+    /// caller skips it. A missing follower or leader on disk reads as "not yet
+    /// linked", so the follower is treated as new and forwarded.
+    #[cfg(unix)]
+    fn hardlink_follower_up_to_date(
+        &self,
+        dest_dir: &std::path::Path,
+        sandbox: Option<&fast_io::DirSandbox>,
+        follower_rel: &std::path::Path,
+        leader_rel: &std::path::Path,
+    ) -> bool {
+        use std::os::unix::fs::MetadataExt;
+
+        let follower_path = dest_dir.join(follower_rel);
+        let leader_path = dest_dir.join(leader_rel);
+        // SEC-1.f: route the follower lstat through the sandbox dirfd when the
+        // relative path is a single component, matching create_hardlinks.
+        let Ok(follower_meta) =
+            fast_io::lstat_via_sandbox_or_fallback(sandbox, dest_dir, follower_rel, &follower_path)
+        else {
+            return false;
+        };
+        let Ok(leader_meta) = std::fs::symlink_metadata(&leader_path) else {
+            return false;
+        };
+        follower_meta.dev() == leader_meta.dev() && follower_meta.ino() == leader_meta.ino()
     }
 
     /// Records a metadata-only itemize record a server-mode receiver must

--- a/crates/transfer/src/receiver/tests/hard_links.rs
+++ b/crates/transfer/src/receiver/tests/hard_links.rs
@@ -33,6 +33,26 @@ fn call_create_hardlinks<W: crate::writer::MsgInfoSender + ?Sized>(
         .expect("create_hardlinks must succeed in fixture-controlled tempdirs");
 }
 
+/// `emit_server_hardlink_follower_itemize` took a `dest_dir` plus a
+/// `#[cfg(unix)]` sandbox so it can skip an already-linked follower
+/// (HL-2 / upstream `hlink.c:215-227`). Route every test call through this
+/// cfg-aware shim rather than gating each site.
+fn call_emit_follower_itemize<W: std::io::Write + ?Sized>(
+    ctx: &ReceiverContext,
+    dest: &std::path::Path,
+    buf: &mut W,
+    ndx_codec: &mut protocol::codec::NdxCodecEnum,
+) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        ctx.emit_server_hardlink_follower_itemize(buf, ndx_codec, dest, None)
+    }
+    #[cfg(not(unix))]
+    {
+        ctx.emit_server_hardlink_follower_itemize(buf, ndx_codec, dest)
+    }
+}
+
 #[test]
 fn create_hardlinks_links_follower_to_leader() {
     let temp_dir = tempfile::TempDir::new().unwrap();
@@ -747,9 +767,12 @@ fn server_push_emits_follower_ndx_iflags_and_leader_xname() {
     let ctx = receiver_with_hardlinks(entries);
     let expected_ndx = ctx.flat_to_wire_ndx(1);
 
+    // No on-disk fixture: the follower is not yet linked, so it is a new
+    // follower and must be forwarded (the HL-2 up-to-date gate is inactive).
+    let dest = tempfile::TempDir::new().unwrap();
     let mut buf: Vec<u8> = Vec::new();
     let mut ndx_codec = create_ndx_codec(32);
-    ctx.emit_server_hardlink_follower_itemize(&mut buf, &mut ndx_codec)
+    call_emit_follower_itemize(&ctx, dest.path(), &mut buf, &mut ndx_codec)
         .expect("server-mode follower itemize must serialize");
     assert!(
         !buf.is_empty(),
@@ -814,9 +837,11 @@ fn server_push_emits_one_record_per_follower() {
     let ctx = receiver_with_hardlinks(entries);
     let expected = [ctx.flat_to_wire_ndx(1), ctx.flat_to_wire_ndx(2)];
 
+    // No on-disk fixture: both followers are new and must be forwarded.
+    let dest = tempfile::TempDir::new().unwrap();
     let mut buf: Vec<u8> = Vec::new();
     let mut ndx_codec = create_ndx_codec(32);
-    ctx.emit_server_hardlink_follower_itemize(&mut buf, &mut ndx_codec)
+    call_emit_follower_itemize(&ctx, dest.path(), &mut buf, &mut ndx_codec)
         .expect("server-mode follower itemize must serialize");
     assert_eq!(
         ctx.hardlink_follower_echoes.get(),
@@ -858,9 +883,10 @@ fn pull_receiver_emits_no_follower_wire_record() {
     ];
     let ctx = pull_receiver_with_hardlinks(entries);
 
+    let dest = tempfile::TempDir::new().unwrap();
     let mut buf: Vec<u8> = Vec::new();
     let mut ndx_codec = create_ndx_codec(32);
-    ctx.emit_server_hardlink_follower_itemize(&mut buf, &mut ndx_codec)
+    call_emit_follower_itemize(&ctx, dest.path(), &mut buf, &mut ndx_codec)
         .expect("client-mode call must succeed as a no-op");
     assert!(
         buf.is_empty(),
@@ -882,15 +908,119 @@ fn server_push_without_followers_emits_nothing() {
     let entries = vec![make_hlink_leader("solo.txt", 9, 7)];
     let ctx = receiver_with_hardlinks(entries);
 
+    let dest = tempfile::TempDir::new().unwrap();
     let mut buf: Vec<u8> = Vec::new();
     let mut ndx_codec = create_ndx_codec(32);
-    ctx.emit_server_hardlink_follower_itemize(&mut buf, &mut ndx_codec)
+    call_emit_follower_itemize(&ctx, dest.path(), &mut buf, &mut ndx_codec)
         .expect("no-follower call must succeed");
     assert!(
         buf.is_empty(),
         "a lone leader has no follower rows to forward",
     );
     assert_eq!(ctx.hardlink_follower_echoes.get(), 0);
+}
+
+/// HL-2 (#79, wire): a server-mode push whose destination already hard-links
+/// the follower to its leader (a re-run) must forward NOTHING for that
+/// follower. Upstream `hlink.c:215-227` itemizes an up-to-date follower with
+/// `ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS` and an EMPTY xname; neither flag is
+/// significant (`rsync.h:258-259`), so the `generator.c:582` emit gate is false
+/// and no wire record is written. Emitting one here would make the pushing
+/// client's sender print a spurious `hf...` row on every unchanged re-run.
+#[cfg(unix)]
+#[test]
+fn server_push_skips_up_to_date_follower_on_wire() {
+    use protocol::codec::create_ndx_codec;
+
+    let dest = tempfile::TempDir::new().unwrap();
+    let leader = dest.path().join("leader.txt");
+    let follower = dest.path().join("follower.txt");
+    std::fs::write(&leader, "shared").unwrap();
+    // The destination already links follower -> leader (a prior run did this),
+    // so they share dev/ino and the follower is up-to-date.
+    std::fs::hard_link(&leader, &follower).unwrap();
+
+    let entries = vec![
+        make_hlink_leader("leader.txt", 14, 42),
+        make_hlink_follower("follower.txt", 14, 42),
+    ];
+    let ctx = receiver_with_hardlinks(entries);
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut ndx_codec = create_ndx_codec(32);
+    call_emit_follower_itemize(&ctx, dest.path(), &mut buf, &mut ndx_codec)
+        .expect("up-to-date follower call must succeed");
+    assert!(
+        buf.is_empty(),
+        "an already-linked follower writes no itemize record on the wire",
+    );
+    assert_eq!(
+        ctx.hardlink_follower_echoes.get(),
+        0,
+        "no wire record means the sender emits no echo to drain",
+    );
+}
+
+/// HL-2 companion: a first-time transfer (destination leader present, follower
+/// not yet linked) MUST still forward the follower's itemize record carrying a
+/// non-empty leader xname - the `atomic_create` path at upstream
+/// `hlink.c:230-237`, whose `(xname && *xname)` makes the `generator.c:582`
+/// gate true. This pins that the up-to-date gate narrows emission without
+/// suppressing genuinely new followers.
+#[cfg(unix)]
+#[test]
+fn server_push_emits_new_follower_when_not_yet_linked() {
+    use crate::generator::ItemFlags;
+    use protocol::codec::{NdxCodec, create_ndx_codec};
+
+    let dest = tempfile::TempDir::new().unwrap();
+    // The leader is on disk but the follower is not linked yet (first run).
+    std::fs::write(dest.path().join("leader.txt"), "shared").unwrap();
+
+    let entries = vec![
+        make_hlink_leader("leader.txt", 14, 42),
+        make_hlink_follower("follower.txt", 14, 42),
+    ];
+    let ctx = receiver_with_hardlinks(entries);
+    let expected_ndx = ctx.flat_to_wire_ndx(1);
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut ndx_codec = create_ndx_codec(32);
+    call_emit_follower_itemize(&ctx, dest.path(), &mut buf, &mut ndx_codec)
+        .expect("new follower call must succeed");
+    assert!(
+        !buf.is_empty(),
+        "a not-yet-linked follower must be forwarded so the sender renders its row",
+    );
+    assert_eq!(
+        ctx.hardlink_follower_echoes.get(),
+        1,
+        "the one new follower record produces one echo to drain",
+    );
+
+    let mut cur = std::io::Cursor::new(buf);
+    let mut rd = create_ndx_codec(32);
+    let ndx = rd.read_ndx(&mut cur).expect("follower NDX must decode");
+    assert_eq!(
+        ndx, expected_ndx,
+        "the new follower is itemized under its NDX"
+    );
+    let iflags = ItemFlags::read(&mut cur, 32).expect("iflags must decode");
+    assert!(
+        iflags.raw() & ItemFlags::ITEM_IS_NEW != 0,
+        "a first-time follower carries ITEM_IS_NEW",
+    );
+    let (_ft, xname, _n) = iflags.read_trailing(&mut cur).expect("xname must decode");
+    assert_eq!(
+        xname.as_deref(),
+        Some(b"leader.txt".as_ref()),
+        "the new follower names its leader for the `=> leader.txt` suffix",
+    );
+    assert_eq!(
+        cur.position() as usize,
+        cur.get_ref().len(),
+        "exactly one follower record on the wire",
+    );
 }
 
 /// The peer's sender echoes every non-transfer item back (upstream

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -654,7 +654,19 @@ impl ReceiverContext {
             // pass, which carries no new followers) so a pushing client's
             // sender renders each `hf...` / `=> leader` row.
             if !is_redo_pass {
-                self.emit_server_hardlink_follower_itemize(writer, ndx_write_codec.inner_mut())?;
+                #[cfg(unix)]
+                self.emit_server_hardlink_follower_itemize(
+                    writer,
+                    ndx_write_codec.inner_mut(),
+                    &setup.dest_dir,
+                    setup.sandbox.as_deref(),
+                )?;
+                #[cfg(not(unix))]
+                self.emit_server_hardlink_follower_itemize(
+                    writer,
+                    ndx_write_codec.inner_mut(),
+                    &setup.dest_dir,
+                )?;
             }
 
             let redo_indices = pipelined_receiver.take_redo_indices();

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -586,7 +586,15 @@ impl ReceiverContext {
         // before the phase's NDX_DONE. Emit through the request-phase NDX
         // diff-state so a pushing client's sender renders each `hf...` /
         // `=> leader` row (a no-op in client-mode pull).
-        self.emit_server_hardlink_follower_itemize(writer, ndx_write_codec.inner_mut())?;
+        #[cfg(unix)]
+        self.emit_server_hardlink_follower_itemize(
+            writer,
+            ndx_write_codec.inner_mut(),
+            &dest_dir,
+            sandbox.as_deref(),
+        )?;
+        #[cfg(not(unix))]
+        self.emit_server_hardlink_follower_itemize(writer, ndx_write_codec.inner_mut(), &dest_dir)?;
 
         #[cfg(unix)]
         self.create_hardlinks(&dest_dir, sandbox.as_deref(), writer)?;


### PR DESCRIPTION
## Summary

Fixes two divergences in how an up-to-date hardlink follower (a destination file that already hard-links to its group leader) is itemized versus upstream rsync 3.4.4.

### HL-1 — local itemize render (`-i` column 0)

The already-linked branch in `create_hardlinks` passed empty item flags, so the follower's `-i` row rendered `.` in column 0 instead of `h`. It now passes `ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS` with an empty xname, so:

- column 0 renders `h` (upstream `log.c:707-708`: `LOCAL_CHANGE` + `XNAME_FOLLOWS` → `h`),
- the empty xname keeps the ` => leader` suffix suppressed (`log.c:644`),

matching upstream `hlink.c:218-222`.

### HL-2 — wire emission (server-mode push)

A server-mode push receiver forwarded an itemize record for **every** follower unconditionally (always with `ITEM_IS_NEW`). Upstream's emit gate (`generator.c:582`) writes **nothing** for an up-to-date follower: its xname is empty and `ITEM_LOCAL_CHANGE` / `ITEM_XNAME_FOLLOWS` are excluded from `SIGNIFICANT_ITEM_FLAGS` (`rsync.h:258-259`).

The emission is now gated on a destination `dev`/`ino` check that mirrors `maybe_hard_link` (`hlink.c:215-227`):

- an already-linked follower emits **no** wire record (no spurious `hf...` row on unchanged re-runs, and no sender echo to drain),
- a new / first-time follower still emits its record with `ITEM_IS_NEW` and a non-empty leader xname (the `atomic_create` path, `hlink.c:230-237`).

The check is Unix-only (inode-based); other platforms keep forwarding every follower as before.

## Tests

- `format_itemize_line_up_to_date_hardlink_follower_renders_h` — pins column 0 `h`, blanked attribute columns, and suppressed ` => ` suffix for the up-to-date flags.
- `server_push_skips_up_to_date_follower_on_wire` — a destination already hard-linked emits zero wire records and zero echoes.
- `server_push_emits_new_follower_when_not_yet_linked` — a not-yet-linked follower still emits its `NDX + iflags + leader xname` record with `ITEM_IS_NEW`.
- Existing follower-emission tests routed through a cfg-aware shim that supplies the new `dest_dir` (and Unix sandbox) argument.

## Verification

`cargo build --bin oc-rsync`, `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`, and `cargo nextest run -p transfer --all-features` on an x86_64/aarch64 Linux host.
