### PR TITLE
fix(protocol): model two-part --checksum-choice and forward it on the daemon path

### DIFF
--- a/crates/core/src/client/config/enums/checksum.rs
+++ b/crates/core/src/client/config/enums/checksum.rs
@@ -169,9 +169,28 @@ impl StrongChecksumChoice {
     }
 
     /// Resolves the file checksum algorithm into a [`SignatureAlgorithm`].
+    ///
+    /// upstream: checksum.c:178-189 parse_checksum_choice - `file_sum_nni`
+    /// comes from the second comma component. An `auto` sub-component resolves
+    /// via `parse_csum_name` to the implied checksum, which is md5 at proto>=30
+    /// (checksum.c:118-122), but ONLY when the choice is "set". The fully-auto
+    /// forms (`auto` / `auto,auto`) null `checksum_choice` (options.c:1997-2003)
+    /// and negotiate the strongest mutually supported checksum instead, which
+    /// for a modern local copy is xxh128. Mirror that split: resolve a lone
+    /// `auto` file sub-component to md5 on the suppressed path, and fall back to
+    /// the negotiated xxh128 only when both components are auto.
     #[must_use]
     pub const fn file_signature_algorithm(self) -> SignatureAlgorithm {
-        self.file.to_signature_algorithm()
+        use checksums::strong::Md5Seed;
+        match (self.transfer, self.file) {
+            (StrongChecksumAlgorithm::Auto, StrongChecksumAlgorithm::Auto) => {
+                SignatureAlgorithm::Xxh3_128 { seed: 0 }
+            }
+            (_, StrongChecksumAlgorithm::Auto) => SignatureAlgorithm::Md5 {
+                seed_config: Md5Seed::none(),
+            },
+            (_, file) => file.to_signature_algorithm(),
+        }
     }
 
     /// Renders the selection into the canonical argument form accepted by `--checksum-choice`.
@@ -198,13 +217,26 @@ impl StrongChecksumChoice {
         matches!(self.transfer, StrongChecksumAlgorithm::None)
     }
 
-    /// Returns the transfer algorithm as a protocol-layer override for negotiation.
+    /// Returns the transfer-checksum override that drives protocol 30+
+    /// negotiation, mirroring upstream's send-gate and `auto` resolution.
     ///
-    /// When the transfer algorithm is [`Auto`](StrongChecksumAlgorithm::Auto), returns
-    /// `None` to allow automatic negotiation. Otherwise returns the corresponding
-    /// [`ChecksumAlgorithm`](protocol::ChecksumAlgorithm) to force during negotiation.
+    /// upstream: options.c:1997-2003 nulls `checksum_choice` only when the raw
+    /// string is exactly `auto` or `auto,auto`; any other value stays set and
+    /// suppresses the vstring exchange (compat.c:541 `if (!checksum_choice)`).
+    /// On that suppressed path `parse_checksum_choice` resolves the transfer
+    /// (first) component with `parse_csum_name`, where `auto` becomes the
+    /// implied md5 at proto>=30 (checksum.c:118-122). Returns `None` only for
+    /// the fully-auto choice so the negotiator's `send_checksum` gate
+    /// (`checksum_override.is_none()`) stays true and the exchange picks the
+    /// strongest mutual checksum (xxh128 for a modern peer). Every set choice
+    /// returns `Some`, suppressing the exchange and forcing the resolved
+    /// transfer checksum.
     pub const fn transfer_protocol_override(self) -> Option<protocol::ChecksumAlgorithm> {
-        self.transfer.to_protocol_algorithm()
+        match (self.transfer, self.file) {
+            (StrongChecksumAlgorithm::Auto, StrongChecksumAlgorithm::Auto) => None,
+            (StrongChecksumAlgorithm::Auto, _) => Some(protocol::ChecksumAlgorithm::MD5),
+            (transfer, _) => transfer.to_protocol_algorithm(),
+        }
     }
 }
 
@@ -419,6 +451,73 @@ mod tests {
                     seed_config: checksums::strong::Md5Seed::none(),
                 }
             );
+        }
+
+        // upstream: options.c:1997-2003 + compat.c:541 - "auto,md5" keeps
+        // checksum_choice non-null, so the vstring exchange is SUPPRESSED
+        // (send_checksum = checksum_override.is_none() in negotiate.rs). The
+        // transfer "auto" resolves to implied md5 (checksum.c:118-122) and the
+        // file component is the explicit md5. WHY: returning None here would
+        // re-enable the vstring and desync against an upstream peer that sends
+        // nothing; resolving to xxh128 would compute the wrong whole-file sum.
+        #[test]
+        fn auto_md5_suppresses_negotiation_and_resolves_both_to_md5() {
+            let choice = StrongChecksumChoice::parse("auto,md5").unwrap();
+            assert_eq!(
+                choice.transfer_protocol_override(),
+                Some(protocol::ChecksumAlgorithm::MD5),
+                "auto,md5 must force md5 and suppress the vstring (override.is_some())",
+            );
+            assert_eq!(
+                choice.file_signature_algorithm(),
+                SignatureAlgorithm::Md5 {
+                    seed_config: checksums::strong::Md5Seed::none(),
+                },
+                "auto,md5 file sum is the explicit md5, not xxh128",
+            );
+        }
+
+        // upstream: checksum.c:178-189 - the SECOND component of "md5,auto" is
+        // parsed with parse_csum_name("auto"), which is implied md5 at proto>=30
+        // (checksum.c:118-122), NOT the negotiated xxh128. WHY: the choice is
+        // "set" (checksum_choice non-null), so the file sum follows the
+        // suppressed-path resolution, not the fully-auto negotiated one.
+        #[test]
+        fn md5_auto_resolves_file_component_to_md5() {
+            let choice = StrongChecksumChoice::parse("md5,auto").unwrap();
+            assert_eq!(
+                choice.transfer_protocol_override(),
+                Some(protocol::ChecksumAlgorithm::MD5),
+            );
+            assert_eq!(
+                choice.file_signature_algorithm(),
+                SignatureAlgorithm::Md5 {
+                    seed_config: checksums::strong::Md5Seed::none(),
+                },
+                "a lone auto file sub-component on a set choice resolves to md5, not xxh128",
+            );
+        }
+
+        // upstream: options.c:1997-2003 - ONLY "auto" and "auto,auto" null
+        // checksum_choice, leaving send_checksum true so negotiate_the_strings
+        // exchanges lists and picks the strongest mutual checksum (xxh128 for a
+        // modern local copy). WHY: these two forms must keep override == None,
+        // or the negotiation the transfer relies on never runs.
+        #[test]
+        fn fully_auto_forms_still_negotiate() {
+            for text in ["auto", "auto,auto"] {
+                let choice = StrongChecksumChoice::parse(text).unwrap();
+                assert_eq!(
+                    choice.transfer_protocol_override(),
+                    None,
+                    "{text} must negotiate (override None => send_checksum true)",
+                );
+                assert_eq!(
+                    choice.file_signature_algorithm(),
+                    SignatureAlgorithm::Xxh3_128 { seed: 0 },
+                    "{text} file sum is the negotiated xxh128",
+                );
+            }
         }
     }
 }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -10,7 +10,8 @@ use protocol::ProtocolVersion;
 use transfer::setup::build_capability_string_suffix;
 
 use crate::client::config::{
-    ClientConfig, DeleteMode, IconvSetting, ReferenceDirectoryKind, TransferTimeout,
+    ClientConfig, DeleteMode, IconvSetting, ReferenceDirectoryKind, StrongChecksumAlgorithm,
+    TransferTimeout,
 };
 use crate::client::error::{ClientError, socket_error};
 use crate::client::remote::daemon_transfer::connection::DaemonTransferRequest;
@@ -245,10 +246,20 @@ pub(super) fn build_full_daemon_args(
     // (a PULL), so upstream's `am_sender` corresponds to `!is_sender`.
     let we_are_sender = !is_sender;
 
-    // upstream: options.c:2815-2816
+    // upstream: options.c:2815-2816 server_options() forwards the RAW
+    // --checksum-choice string verbatim - both comma components - gated only on
+    // `checksum_choice` being non-null. That pointer is nulled solely for the
+    // fully-auto forms (options.c:1997-2003), so forward the full choice
+    // whenever it is not fully-auto, mirroring the SSH path (invocation builder)
+    // rather than collapsing to the transfer component alone.
     let checksum_choice = config.checksum_choice();
-    if let Some(override_algo) = checksum_choice.transfer_protocol_override() {
-        args.push(format!("--checksum-choice={}", override_algo.as_str()));
+    if checksum_choice.transfer() != StrongChecksumAlgorithm::Auto
+        || checksum_choice.file() != StrongChecksumAlgorithm::Auto
+    {
+        args.push(format!(
+            "--checksum-choice={}",
+            checksum_choice.to_argument()
+        ));
     }
 
     // upstream: options.c:2612-2731 - single-character flag string (e.g., "-logDtprzc").
@@ -1182,6 +1193,7 @@ pub(super) mod tests {
 mod server_option_fidelity_tests {
     use super::build_full_daemon_args;
     use crate::client::ClientConfig;
+    use crate::client::config::StrongChecksumChoice;
     use crate::client::remote::daemon_transfer::connection::DaemonTransferRequest;
     use protocol::ProtocolVersion;
 
@@ -1700,6 +1712,53 @@ mod server_option_fidelity_tests {
     fn open_noatime_forwarded() {
         let config = ClientConfig::builder().open_noatime(true).build();
         assert!(args(&config, false).iter().any(|a| a == "--open-noatime"));
+    }
+
+    // upstream: options.c:2815-2816 - server_options() forwards the RAW
+    // --checksum-choice string with BOTH comma components. WHY: a daemon
+    // receiver parses the transfer AND file sums from this string
+    // (checksum.c:178-189); dropping the second component - as the old
+    // transfer-only override did - silently desyncs the file-sum algorithm
+    // between client and daemon.
+    #[test]
+    fn daemon_forwards_both_checksum_choice_components() {
+        let config = ClientConfig::builder()
+            .checksum_choice(StrongChecksumChoice::parse("md5,xxh3").unwrap())
+            .build();
+        let pull = args(&config, true);
+        assert!(
+            pull.iter().any(|a| a == "--checksum-choice=md5,xxh3"),
+            "daemon must forward both checksum-choice components: {pull:?}"
+        );
+    }
+
+    // upstream: options.c:1997-2003 - "auto,md5" is NOT nulled (only bare
+    // "auto"/"auto,auto" are), so options.c:2815 forwards the full string. WHY:
+    // the transfer-only override returned None for a leading auto and forwarded
+    // nothing, leaving the daemon to negotiate a checksum the client never
+    // resolved.
+    #[test]
+    fn daemon_forwards_full_string_for_auto_md5() {
+        let config = ClientConfig::builder()
+            .checksum_choice(StrongChecksumChoice::parse("auto,md5").unwrap())
+            .build();
+        let pull = args(&config, true);
+        assert!(
+            pull.iter().any(|a| a == "--checksum-choice=auto,md5"),
+            "daemon must forward the full auto,md5 string: {pull:?}"
+        );
+    }
+
+    // upstream: options.c:1997-2003 + 2815 - the fully-auto forms null
+    // checksum_choice, so nothing is forwarded and the daemon negotiates.
+    #[test]
+    fn daemon_omits_checksum_choice_when_fully_auto() {
+        let config = ClientConfig::builder().build();
+        let pull = args(&config, true);
+        assert!(
+            !pull.iter().any(|a| a.starts_with("--checksum-choice")),
+            "fully-auto must not forward --checksum-choice: {pull:?}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes two `--backup` divergences from upstream rsync 3.4.4 (protocol 32).

### BK-2 — `--backup` (no `--backup-dir`) must imply omit-dir-times

Upstream `options.c:2342-2343` sets `omit_dir_times = -1` when `make_backups && !backup_dir`, so a directory's mtime is never applied (`rsync.c:582-585` adds `ATTRS_SKIP_MTIME` for directories). Previously this implication was only wired into the receiver retouch pass, not the creation-time directory apply nor the local-copy executor, so an empty backed-up directory kept the source mtime instead of its wall-clock mtime.

- Local path: `LocalCopyOptions::omit_dir_times_enabled()` now folds in `backup && backup_dir.is_none()`, so every local consumer (dir metadata apply, touch-up, change detection, reporting) sees the implied value — matching upstream's single global `-1`.
- Receiver path: new `ServerConfig::effective_omit_dir_times()` used by the creation-time apply, the retouch pass (which drops its ad-hoc inline check), and the itemize `keep_time` predicate (`generator.c:513-517`).

The implication stays receiver/local-side only. The sender `-O` letter remains gated on the explicit flag (`options.c:2646`, `omit_dir_times > 0`), so no extra `-O` reaches the wire on a push — the remote receiver re-derives the implication from `-b` exactly as upstream does.

### BK-3 — remote `--backup-dir` subdir attribute inheritance + obstruction removal

The network receiver created `--backup-dir` subdirectories with a bare `create_dir_all`, skipping the destination-directory attribute inheritance and non-directory obstruction removal that the local path already performed (upstream `copy_valid_path`, `backup.c:61-154`, and `validate_backup_dir`, `backup.c:48-53`).

- Extracted a shared `engine::create_backup_dir_parents` helper from the local-copy logic. It ensures the backup root, then walks the relative subtree below it, removing any non-directory obstruction, creating each element, and inheriting the corresponding destination directory's attributes. Directory creation is delegated to an injected `mkdir` closure so the receiver keeps its SEC-1.j sandbox-anchored leaf `mkdir` while the local path uses a plain `create_dir_all`.
- Wired into both disk-commit backup paths (`make_backup`, `make_backup_copy`) via a small `create_backup_path_parents` helper, and into the inline receiver sync path.
- The local executor now delegates to the same helper with no behavior change (guarded by the existing `backup_dir_intermediate_inherits_source_dir_permissions` and `backup_dir_clears_nondir_obstruction` tests).

## Tests

- Engine: `backup_without_backup_dir_omits_directory_mtime` and `backup_dir_preserves_directory_mtime` (empty `e/` dir mtime, local `-a -b` vs `-a -b --backup-dir`).
- Transfer receiver: `make_backup_backup_dir_subdir_inherits_source_mode` (0700 inheritance) and `make_backup_backup_dir_clears_nondir_obstruction` (pre-existing file replaced by dir) on the network commit path.
- Transfer config: `effective_omit_dir_times_*` unit tests pinning the implication and the explicit/`--backup-dir` gating.

## Verification

`cargo build`, `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`, and `cargo nextest run -p transfer -p engine -p cli --all-features` on Linux.
