### PR TITLE
fix(backup): imply omit-dir-times and inherit backup-dir subdir attrs on the remote path

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -221,8 +221,9 @@ pub use local_copy::{
     LocalCopyError, LocalCopyErrorKind, LocalCopyOptions, LocalCopyOptionsBuilder, LocalCopyPlan,
     LocalCopySummary, ReferenceDirectory, ReferenceDirectoryKind, SkipCompressList,
     SkipCompressParseError, SparseDetectStrategy, SparseDetector, SparseReader, SparseRegion,
-    compute_backup_path, trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
-    trace_make_backup_rename, trace_make_backup_symlink,
+    compute_backup_path, create_backup_dir_parents, trace_make_backup_copy,
+    trace_make_backup_device, trace_make_backup_hlink, trace_make_backup_rename,
+    trace_make_backup_symlink,
 };
 
 /// File signature generation for delta transfers.

--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -7,6 +7,7 @@
 
 use std::ffi::{OsStr, OsString};
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::local_copy::LocalCopyError;
@@ -114,12 +115,56 @@ pub(crate) fn create_backup_parents(
             .map_err(|error| LocalCopyError::io("create backup directory", parent, error));
     };
 
-    // Root of the backup tree. Only the relative portion *below* this root is
-    // validated and created element-by-element - mirroring upstream, which
-    // walks `rel = backup_dir_buf + backup_dir_len` (backup.c:67) and never
-    // re-validates the pre-existing path above backup_dir. Walking from the
-    // filesystem root instead would misread symlinked ancestors (e.g. macOS
-    // `/var` -> `/private/var`) as obstructions.
+    // Delegate the `--backup-dir` subtree to the shared helper, using a plain
+    // recursive create for each element (the local path has no receiver
+    // sandbox to anchor against).
+    create_backup_dir_parents(
+        destination_root,
+        backup_dir,
+        parent,
+        metadata_options,
+        |path| fs::create_dir_all(path),
+    )
+    .map_err(|error| LocalCopyError::io("create backup directory", parent, error))
+}
+
+/// Creates the `--backup-dir` parent tree for a backup path, inheriting each
+/// freshly-created subdirectory's attributes from the corresponding
+/// destination directory and clearing any non-directory obstruction.
+///
+/// Mirrors upstream `copy_valid_path` (backup.c:61-154) plus
+/// `validate_backup_dir` (backup.c:48-53): the backup root is ensured first
+/// (backup.c:165 `make_path`), then only the relative portion *below* the root
+/// is validated element-by-element (backup.c:67 walks
+/// `rel = backup_dir_buf + backup_dir_len`, never re-validating the path above
+/// `backup_dir`). Pre-existing directories are skipped (backup.c:102-105
+/// `EEXIST`/`validate_backup_dir`); a non-directory obstruction (including a
+/// symlink) is removed so the element can be recreated as a directory
+/// (backup.c:48-53 `delete_item(...DEL_FOR_BACKUP|DEL_RECURSE)`); and each new
+/// directory inherits the corresponding destination directory's attributes
+/// (backup.c:115-138 `x_stat` + `make_file` + `set_file_attrs`).
+///
+/// Directory creation is delegated to `mkdir` so the network receiver commit
+/// path can anchor the leaf `mkdir` through its destination sandbox dirfd
+/// (SEC-1.j) while the local path uses a plain `create_dir_all`. `mkdir` must
+/// be idempotent for an already-existing directory, matching upstream's
+/// `EEXIST` skip. Shared by the local-copy executor and the network receiver
+/// so a `--backup-dir` subtree gets identical attribute inheritance and
+/// obstruction handling regardless of transport.
+///
+/// Walking from `backup_dir` (rather than the filesystem root) avoids
+/// misreading symlinked ancestors (e.g. macOS `/var` -> `/private/var`) as
+/// obstructions.
+pub fn create_backup_dir_parents<F>(
+    destination_root: &Path,
+    backup_dir: &Path,
+    parent: &Path,
+    metadata_options: &::metadata::MetadataOptions,
+    mut mkdir: F,
+) -> io::Result<()>
+where
+    F: FnMut(&Path) -> io::Result<()>,
+{
     let backup_root = if backup_dir.is_absolute() {
         backup_dir.to_path_buf()
     } else {
@@ -127,15 +172,13 @@ pub(crate) fn create_backup_parents(
     };
 
     // upstream: backup.c:165 make_path(backup_dir_buf, 0) - ensure the backup
-    // directory root exists (with default perms) before validating subdirs.
-    fs::create_dir_all(&backup_root)
-        .map_err(|error| LocalCopyError::io("create backup directory", &backup_root, error))?;
+    // directory root exists before validating subdirs.
+    mkdir(&backup_root)?;
 
     let Ok(rel) = parent.strip_prefix(&backup_root) else {
         // parent is not under backup_root (unexpected path shape); fall back to
         // a plain create so the backup still lands somewhere valid.
-        return fs::create_dir_all(parent)
-            .map_err(|error| LocalCopyError::io("create backup directory", parent, error));
+        return mkdir(parent);
     };
 
     let mut current = backup_root.clone();
@@ -144,36 +187,21 @@ pub(crate) fn create_backup_parents(
         match fs::symlink_metadata(&current) {
             Ok(meta) if meta.is_dir() => continue,
             // upstream: backup.c:48-53 - a non-directory (including a symlink) in
-            // the way is removed so it can be recreated as a directory.
-            Ok(_) => remove_backup_obstruction(&current)?,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(LocalCopyError::io(
-                    "stat backup directory",
-                    current.as_path(),
-                    error,
-                ));
-            }
+            // the way is removed so it can be recreated as a directory. A
+            // non-directory is never a recursive tree, so a plain unlink mirrors
+            // `delete_item` for this case (backup.c:50); `remove_file` drops a
+            // symlink without following it, matching the `lstat`-based check.
+            Ok(_) => fs::remove_file(&current)?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
         }
 
-        fs::create_dir(&current).map_err(|error| {
-            LocalCopyError::io("create backup directory", current.as_path(), error)
-        })?;
+        mkdir(&current)?;
 
         apply_backup_dir_attrs(destination_root, &backup_root, &current, metadata_options);
     }
 
     Ok(())
-}
-
-/// Removes a non-directory that obstructs a backup directory element.
-///
-/// A non-directory is never a recursive tree, so a plain unlink mirrors
-/// upstream's `delete_item` for this case (backup.c:50). `remove_file` also
-/// removes a symlink without following it, matching the `lstat`-based check.
-fn remove_backup_obstruction(path: &Path) -> Result<(), LocalCopyError> {
-    fs::remove_file(path)
-        .map_err(|error| LocalCopyError::io("remove backup directory obstruction", path, error))
 }
 
 /// Copies a freshly-created backup subdirectory's attributes from the

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -12,7 +12,7 @@ mod paths;
 mod preallocate;
 mod sparse;
 
-pub use backup::compute_backup_path;
+pub use backup::{compute_backup_path, create_backup_dir_parents};
 pub(crate) use backup::{copy_entry_to_backup, create_backup_parents};
 pub use backup_trace::{
     trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -27,9 +27,10 @@ pub(crate) use file::{
 };
 pub use file::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,
-    SparseReader, SparseRegion, compute_backup_path, remove_existing_destination,
-    remove_incomplete_destination, trace_make_backup_copy, trace_make_backup_device,
-    trace_make_backup_hlink, trace_make_backup_rename, trace_make_backup_symlink,
+    SparseReader, SparseRegion, compute_backup_path, create_backup_dir_parents,
+    remove_existing_destination, remove_incomplete_destination, trace_make_backup_copy,
+    trace_make_backup_device, trace_make_backup_hlink, trace_make_backup_rename,
+    trace_make_backup_symlink,
 };
 #[cfg(test)]
 pub(crate) use file::{

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -122,9 +122,10 @@ pub(crate) use dir_merge::{
 pub(crate) use executor::*;
 pub use executor::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,
-    SparseReader, SparseRegion, compute_backup_path, remove_existing_destination,
-    remove_incomplete_destination, trace_make_backup_copy, trace_make_backup_device,
-    trace_make_backup_hlink, trace_make_backup_rename, trace_make_backup_symlink,
+    SparseReader, SparseRegion, compute_backup_path, create_backup_dir_parents,
+    remove_existing_destination, remove_incomplete_destination, trace_make_backup_copy,
+    trace_make_backup_device, trace_make_backup_hlink, trace_make_backup_rename,
+    trace_make_backup_symlink,
 };
 
 pub(crate) use hard_links::HardLinkTracker;

--- a/crates/engine/src/local_copy/options/metadata/accessors.rs
+++ b/crates/engine/src/local_copy/options/metadata/accessors.rs
@@ -86,10 +86,19 @@ impl LocalCopyOptions {
         self.preserve_crtimes
     }
 
-    /// Reports whether directory modification times should be skipped during metadata preservation.
+    /// Reports whether directory modification times should be skipped during
+    /// metadata preservation.
+    ///
+    /// A plain `--backup` without `--backup-dir` implies omit-dir-times so a
+    /// directory's mtime is never applied - upstream `options.c:2342-2343`
+    /// (`if (make_backups && !backup_dir) omit_dir_times = -1;`) feeding
+    /// `rsync.c:583` (`ATTRS_SKIP_MTIME` for directories). The implication is
+    /// receiver/local-side only; it is never advertised as the sender `-O`
+    /// letter, which stays gated on the explicit flag (`options.c:2646`,
+    /// `omit_dir_times > 0`).
     #[must_use]
     pub const fn omit_dir_times_enabled(&self) -> bool {
-        self.omit_dir_times
+        self.omit_dir_times || (self.backup && self.backup_dir.is_none())
     }
 
     /// Returns whether symbolic link timestamps should be skipped.

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -2634,3 +2634,91 @@ fn backup_dir_clears_nondir_obstruction() {
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), b"old contents");
 }
+
+/// A plain `--backup` (no `--backup-dir`) implies omit-dir-times, so an empty
+/// directory keeps its wall-clock mtime rather than the source mtime.
+///
+/// upstream: options.c:2342-2343 - `if (make_backups && !backup_dir)
+/// omit_dir_times = -1;` feeds rsync.c:583, which adds `ATTRS_SKIP_MTIME` for
+/// directories. The implication is receiver/local-side only and is never
+/// advertised as the sender `-O` letter (options.c:2646 gates that on
+/// `omit_dir_times > 0`).
+#[cfg(unix)]
+#[test]
+fn backup_without_backup_dir_omits_directory_mtime() {
+    use filetime::{FileTime, set_file_mtime};
+
+    let temp = tempdir().expect("tempdir");
+    let source_root = temp.path().join("source");
+    let empty = source_root.join("e");
+    fs::create_dir_all(&empty).expect("create empty source subdir");
+
+    let dir_mtime = FileTime::from_unix_time(1_600_000_000, 0);
+    set_file_mtime(&empty, dir_mtime).expect("set source subdir mtime");
+
+    let dest_root = temp.path().join("dest");
+    let operands = vec![
+        source_root.clone().into_os_string(),
+        dest_root.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    // `-a -b`: archive (recursive + times) plus a plain `--backup`.
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .times(true)
+        .backup(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let dest_empty = dest_root.join("source").join("e");
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_empty).expect("dest subdir meta"));
+    assert_ne!(
+        dest_mtime, dir_mtime,
+        "a plain --backup must imply omit-dir-times, leaving the empty dir's mtime unpreserved"
+    );
+}
+
+/// With `--backup-dir` the omit-dir-times implication does NOT apply, so the
+/// source directory mtime is preserved as usual.
+///
+/// upstream: options.c:2342 - the implication is gated on `!backup_dir`, so a
+/// `--backup-dir` transfer preserves directory mtimes (generator.c:2271
+/// `need_retouch_dir_times = preserve_mtimes && !omit_dir_times`).
+#[cfg(unix)]
+#[test]
+fn backup_dir_preserves_directory_mtime() {
+    use filetime::{FileTime, set_file_mtime};
+
+    let temp = tempdir().expect("tempdir");
+    let source_root = temp.path().join("source");
+    let empty = source_root.join("e");
+    fs::create_dir_all(&empty).expect("create empty source subdir");
+
+    let dir_mtime = FileTime::from_unix_time(1_600_000_000, 0);
+    set_file_mtime(&empty, dir_mtime).expect("set source subdir mtime");
+
+    let dest_root = temp.path().join("dest");
+    let backup_dir = temp.path().join("bak");
+    let operands = vec![
+        source_root.clone().into_os_string(),
+        dest_root.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .times(true)
+        .with_backup_directory(Some(backup_dir));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let dest_empty = dest_root.join("source").join("e");
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_empty).expect("dest subdir meta"));
+    assert_eq!(
+        dest_mtime, dir_mtime,
+        "with --backup-dir the implication does not apply, so the source dir mtime is preserved"
+    );
+}

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -665,6 +665,27 @@ impl Default for ServerConfig {
 }
 
 impl ServerConfig {
+    /// Reports whether directory modification times should be omitted, folding
+    /// in upstream's implicit `--backup`-without-`--backup-dir` rule.
+    ///
+    /// A plain `--backup` (no `--backup-dir`) implies omit-dir-times so a
+    /// directory's mtime is never applied at creation, and the final retouch
+    /// pass never re-sets it. Receiver-side only; the implication is never
+    /// advertised as the sender `-O` letter (that stays gated on the explicit
+    /// flag).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2342-2343`: `if (make_backups && !backup_dir)
+    ///   omit_dir_times = -1;`
+    /// - `rsync.c:583`: `omit_dir_times && S_ISDIR(...)` adds `ATTRS_SKIP_MTIME`.
+    /// - `generator.c:2271`: `need_retouch_dir_times = preserve_mtimes &&
+    ///   !omit_dir_times`.
+    #[must_use]
+    pub fn effective_omit_dir_times(&self) -> bool {
+        self.flags.omit_dir_times || (self.flags.backup && self.backup_dir.is_none())
+    }
+
     /// Returns the effective backup suffix, matching upstream rsync defaults.
     ///
     /// When `backup_suffix` is explicitly set, returns that value. Otherwise,
@@ -918,6 +939,45 @@ mod tests {
     fn effective_backup_suffix_defaults_to_tilde() {
         let config = ServerConfig::default();
         assert_eq!(config.effective_backup_suffix(), "~");
+    }
+
+    #[test]
+    fn effective_omit_dir_times_implied_by_plain_backup() {
+        // upstream: options.c:2342-2343 - make_backups && !backup_dir => -1.
+        let config = ServerConfig {
+            flags: ParsedServerFlags {
+                backup: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(config.effective_omit_dir_times());
+    }
+
+    #[test]
+    fn effective_omit_dir_times_not_implied_with_backup_dir() {
+        // upstream: options.c:2342 - the implication is gated on `!backup_dir`.
+        let config = ServerConfig {
+            flags: ParsedServerFlags {
+                backup: true,
+                ..Default::default()
+            },
+            backup_dir: Some(".backups".to_owned()),
+            ..Default::default()
+        };
+        assert!(!config.effective_omit_dir_times());
+    }
+
+    #[test]
+    fn effective_omit_dir_times_honors_explicit_flag() {
+        let config = ServerConfig {
+            flags: ParsedServerFlags {
+                omit_dir_times: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(config.effective_omit_dir_times());
     }
 
     #[test]

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -11,8 +11,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use engine::{
-    CleanupManager, compute_backup_path, trace_make_backup_copy, trace_make_backup_hlink,
-    trace_make_backup_rename,
+    CleanupManager, compute_backup_path, create_backup_dir_parents, trace_make_backup_copy,
+    trace_make_backup_hlink, trace_make_backup_rename,
 };
 
 use crate::pipeline::messages::{BackupNotice, BeginMessage};
@@ -650,6 +650,37 @@ fn backup_hardlink_tier(config: &DiskCommitConfig, old_path: &Path, new_path: &P
     }
 }
 
+/// Creates the parent directories of a backup path.
+///
+/// With `--backup-dir`, each freshly-created subdirectory inherits its
+/// corresponding destination directory's attributes and any non-directory
+/// obstruction is removed, mirroring upstream `copy_valid_path`
+/// (backup.c:61-154) via the shared [`create_backup_dir_parents`] helper; the
+/// leaf `mkdir` stays SEC-1.j sandbox-anchored through the injected
+/// [`create_dir_all_sandboxed`]. Without `--backup-dir` the backup lands
+/// alongside the destination, whose parent already exists, so upstream runs no
+/// `copy_valid_path` (backup.c:159) and a plain create suffices.
+fn create_backup_path_parents(
+    parent: &Path,
+    backup_config: &BackupConfig,
+    config: &DiskCommitConfig,
+) -> io::Result<()> {
+    match backup_config.backup_dir.as_deref() {
+        Some(backup_dir) => {
+            let metadata_opts = config.metadata_opts.clone().unwrap_or_default();
+            create_backup_dir_parents(
+                &backup_config.dest_dir,
+                backup_dir,
+                parent,
+                &metadata_opts,
+                |path| create_dir_all_sandboxed(config, path),
+            )
+        }
+        None if parent.exists() => Ok(()),
+        None => create_dir_all_sandboxed(config, parent),
+    }
+}
+
 /// SEC-1.j: create the `--backup-dir` parent, dirfd-anchoring the leaf `mkdir`
 /// against the receiver's destination sandbox when possible.
 ///
@@ -719,9 +750,7 @@ pub(super) fn make_backup(
     );
 
     if let Some(parent) = backup_path.parent() {
-        if !parent.exists() {
-            create_dir_all_sandboxed(config, parent)?;
-        }
+        create_backup_path_parents(parent, backup_config, config)?;
     }
 
     // upstream: backup.c:191-207 - `prefer_rename` is False here (rsync.c:739),
@@ -812,9 +841,7 @@ pub(super) fn make_backup_copy(
     );
 
     if let Some(parent) = backup_path.parent() {
-        if !parent.exists() {
-            create_dir_all_sandboxed(config, parent)?;
-        }
+        create_backup_path_parents(parent, backup_config, config)?;
     }
 
     // upstream: generator.c:1866 copy_file() - duplicate the pre-transfer bytes

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -488,6 +488,116 @@ fn make_backup_missing_file_is_noop() {
     assert!(notice.is_none(), "no notice when nothing was backed up");
 }
 
+/// Verifies the network `--backup-dir` path materialises each new backup
+/// subdirectory with the corresponding destination directory's attributes,
+/// not the umask default.
+///
+/// Before this wiring the network receiver used a bare `create_dir_all`,
+/// skipping the attribute inheritance the local path performs. upstream:
+/// backup.c:115-138 `copy_valid_path` re-`x_stat`s the source-tree dir and
+/// runs `set_file_attrs` on each freshly created backup subdirectory, so
+/// `/bak/sub` mirrors the mode of the destination `sub/` it is displacing.
+#[cfg(unix)]
+#[test]
+fn make_backup_backup_dir_subdir_inherits_source_mode() {
+    use std::ffi::OsString;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let dest_dir = dir.path().join("dst");
+    let sub = dest_dir.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    // The corresponding destination directory carries a restrictive 0700; the
+    // backup subdirectory must inherit *this* mode, proving it is copied from
+    // the destination tree rather than left at the umask default.
+    fs::set_permissions(&sub, fs::Permissions::from_mode(0o700)).unwrap();
+
+    let file_path = sub.join("payload.bin");
+    fs::write(&file_path, b"pre-image").unwrap();
+
+    let backup_dir = dir.path().join("bak");
+    let config = BackupConfig {
+        dest_dir: dest_dir.clone(),
+        backup_dir: Some(backup_dir.clone()),
+        // upstream: options.c:2296-2297 - the default suffix is empty when a
+        // backup directory is set.
+        suffix: OsString::new(),
+    };
+    let disk_config = DiskCommitConfig {
+        metadata_opts: Some(
+            metadata::MetadataOptions::new()
+                .preserve_permissions(true)
+                .preserve_times(true),
+        ),
+        ..DiskCommitConfig::default()
+    };
+
+    make_backup(&file_path, &config, &disk_config)
+        .expect("make_backup succeeds")
+        .expect("notice produced for the backed-up file");
+
+    let backup_sub = backup_dir.join("sub");
+    assert!(backup_sub.is_dir(), "backup subdirectory must be created");
+    let mode = fs::metadata(&backup_sub).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o700,
+        "backup subdir must inherit the destination dir's 0700, got {mode:o}"
+    );
+    assert!(
+        backup_sub.join("payload.bin").exists(),
+        "backup file must be placed under the inherited subdirectory"
+    );
+}
+
+/// Verifies the network `--backup-dir` path removes a non-directory obstruction
+/// (a pre-existing file) sitting where a backup subdirectory must go, then
+/// recreates it as a directory - rather than failing with `NotADirectory`.
+///
+/// upstream: backup.c:48-53 `validate_backup_dir` deletes a non-directory in
+/// the way (`delete_item(...DEL_FOR_BACKUP|DEL_RECURSE)`) so the element can be
+/// recreated as a directory by `copy_valid_path`.
+#[cfg(unix)]
+#[test]
+fn make_backup_backup_dir_clears_nondir_obstruction() {
+    use std::ffi::OsString;
+
+    let dir = tempfile::tempdir().unwrap();
+    let dest_dir = dir.path().join("dst");
+    let sub = dest_dir.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    let file_path = sub.join("payload.bin");
+    fs::write(&file_path, b"pre-image").unwrap();
+
+    let backup_dir = dir.path().join("bak");
+    fs::create_dir_all(&backup_dir).unwrap();
+    // A stale FILE sits exactly where the `sub/` backup directory must go.
+    let obstruction = backup_dir.join("sub");
+    fs::write(&obstruction, b"stale file").unwrap();
+
+    let config = BackupConfig {
+        dest_dir: dest_dir.clone(),
+        backup_dir: Some(backup_dir.clone()),
+        suffix: OsString::new(),
+    };
+    let disk_config = DiskCommitConfig {
+        metadata_opts: Some(metadata::MetadataOptions::new().preserve_permissions(true)),
+        ..DiskCommitConfig::default()
+    };
+
+    make_backup(&file_path, &config, &disk_config)
+        .expect("make_backup must succeed after clearing the obstruction")
+        .expect("notice produced for the backed-up file");
+
+    assert!(
+        obstruction.is_dir(),
+        "the obstructing file must be replaced by a directory"
+    );
+    assert!(
+        obstruction.join("payload.bin").exists(),
+        "backup file must land inside the recreated directory"
+    );
+}
+
 /// Verifies `make_backup_copy` (the `--inplace --backup` path) DUPLICATES the
 /// original to the backup and LEAVES the original in place, unlike `make_backup`
 /// which renames it away. Preserving the original is the whole point: under

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -525,7 +525,7 @@ fn make_backup_backup_dir_subdir_inherits_source_mode() {
     };
     let disk_config = DiskCommitConfig {
         metadata_opts: Some(
-            metadata::MetadataOptions::new()
+            ::metadata::MetadataOptions::new()
                 .preserve_permissions(true)
                 .preserve_times(true),
         ),
@@ -580,7 +580,7 @@ fn make_backup_backup_dir_clears_nondir_obstruction() {
         suffix: OsString::new(),
     };
     let disk_config = DiskCommitConfig {
-        metadata_opts: Some(metadata::MetadataOptions::new().preserve_permissions(true)),
+        metadata_opts: Some(::metadata::MetadataOptions::new().preserve_permissions(true)),
         ..DiskCommitConfig::default()
     };
 

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -418,11 +418,14 @@ impl ReceiverContext {
         // Build owned data for parallel metadata application, skipping failed dirs.
         // upstream: rsync.c:583 - `omit_dir_times && S_ISDIR(...)` adds
         // ATTRS_SKIP_MTIME, so a directory's mtime is never applied under -O.
-        // On a pull the local client IS the receiver and -O rides no wire bit
-        // (options.c:2646-2647 gates 'O' on am_sender), so clear preserve_times
-        // for the directory apply here, mirroring the local executor's
-        // apply_final_directory_metadata.
-        let metadata_opts_clone = if self.config.flags.omit_dir_times {
+        // `effective_omit_dir_times` also folds in the implicit
+        // `--backup`-without-`--backup-dir` rule (options.c:2342-2343), so an
+        // empty backed-up directory keeps its wall-clock mtime rather than the
+        // source mtime. On a pull the local client IS the receiver and -O rides
+        // no wire bit (options.c:2646-2647 gates 'O' on am_sender), so clear
+        // preserve_times for the directory apply here, mirroring the local
+        // executor's apply_final_directory_metadata.
+        let metadata_opts_clone = if self.config.effective_omit_dir_times() {
             metadata_opts.clone().preserve_times(false)
         } else {
             metadata_opts.clone()
@@ -951,11 +954,11 @@ impl ReceiverContext {
         }
 
         // upstream: generator.c:2271 - need_retouch_dir_times =
-        // preserve_mtimes && !omit_dir_times. The backup skip (generator.c:2101)
-        // only concerns the mtime repair (backup file creation moves mtimes).
-        let retouch_times = self.config.flags.times
-            && !self.config.flags.omit_dir_times
-            && !(self.config.flags.backup && self.config.backup_dir.is_none());
+        // preserve_mtimes && !omit_dir_times. `effective_omit_dir_times` folds
+        // in the implicit `--backup`-without-`--backup-dir` rule
+        // (options.c:2342-2343, generator.c:2101), so the same predicate governs
+        // both this retouch pass and the creation-time apply above.
+        let retouch_times = self.config.flags.times && !self.config.effective_omit_dir_times();
 
         // upstream: generator.c:2122 - fix_dir_perms = !am_root && !(mode &
         // S_IWUSR); only meaningful when we preserve perms (otherwise the

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -747,7 +747,7 @@ impl ReceiverContext {
         // reach the receiver's flag set (core sets them on the embedded-SSH and
         // daemon pull paths); an older comment here claimed otherwise.
         let keep_time = self.config.flags.times
-            && !(entry.is_dir() && self.config.flags.omit_dir_times)
+            && !(entry.is_dir() && self.config.effective_omit_dir_times())
             && !(entry.is_symlink() && self.config.flags.omit_link_times);
         let report_time = if keep_time {
             // upstream: generator.c:396-401 - `mtime_differs()` is

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -431,8 +431,24 @@ impl ReceiverContext {
                     std::ffi::OsStr::new(self.config.effective_backup_suffix()),
                 );
                 if let Some(parent) = backup_path.parent() {
-                    if !parent.exists() {
-                        fs::create_dir_all(parent)?;
+                    match self.config.backup_dir.as_ref().map(std::path::Path::new) {
+                        // upstream: backup.c:159,copy_valid_path - with
+                        // --backup-dir each new subdirectory inherits its source
+                        // dir's attrs and any non-directory obstruction is
+                        // cleared before it is recreated as a directory.
+                        Some(backup_dir) => {
+                            engine::create_backup_dir_parents(
+                                &dest_dir,
+                                backup_dir,
+                                parent,
+                                &metadata_opts,
+                                |path| fs::create_dir_all(path),
+                            )?;
+                        }
+                        // Without --backup-dir the parent already exists next to
+                        // the destination; upstream runs no copy_valid_path.
+                        None if parent.exists() => {}
+                        None => fs::create_dir_all(parent)?,
                     }
                 }
                 // SEC-1.j: route the backup rename through the sandbox dirfd


### PR DESCRIPTION
## Summary

Fixes two `--backup` divergences from upstream rsync 3.4.4 (protocol 32).

### BK-2 — `--backup` (no `--backup-dir`) must imply omit-dir-times

Upstream `options.c:2342-2343` sets `omit_dir_times = -1` when `make_backups && !backup_dir`, so a directory's mtime is never applied (`rsync.c:582-585` adds `ATTRS_SKIP_MTIME` for directories). Previously this implication was only wired into the receiver retouch pass, not the creation-time directory apply nor the local-copy executor, so an empty backed-up directory kept the source mtime instead of its wall-clock mtime.

- Local path: `LocalCopyOptions::omit_dir_times_enabled()` now folds in `backup && backup_dir.is_none()`, so every local consumer (dir metadata apply, touch-up, change detection, reporting) sees the implied value — matching upstream's single global `-1`.
- Receiver path: new `ServerConfig::effective_omit_dir_times()` used by the creation-time apply, the retouch pass (which drops its ad-hoc inline check), and the itemize `keep_time` predicate (`generator.c:513-517`).

The implication stays receiver/local-side only. The sender `-O` letter remains gated on the explicit flag (`options.c:2646`, `omit_dir_times > 0`), so no extra `-O` reaches the wire on a push — the remote receiver re-derives the implication from `-b` exactly as upstream does.

### BK-3 — remote `--backup-dir` subdir attribute inheritance + obstruction removal

The network receiver created `--backup-dir` subdirectories with a bare `create_dir_all`, skipping the destination-directory attribute inheritance and non-directory obstruction removal that the local path already performed (upstream `copy_valid_path`, `backup.c:61-154`, and `validate_backup_dir`, `backup.c:48-53`).

- Extracted a shared `engine::create_backup_dir_parents` helper from the local-copy logic. It ensures the backup root, then walks the relative subtree below it, removing any non-directory obstruction, creating each element, and inheriting the corresponding destination directory's attributes. Directory creation is delegated to an injected `mkdir` closure so the receiver keeps its SEC-1.j sandbox-anchored leaf `mkdir` while the local path uses a plain `create_dir_all`.
- Wired into both disk-commit backup paths (`make_backup`, `make_backup_copy`) via a small `create_backup_path_parents` helper, and into the inline receiver sync path.
- The local executor now delegates to the same helper with no behavior change (guarded by the existing `backup_dir_intermediate_inherits_source_dir_permissions` and `backup_dir_clears_nondir_obstruction` tests).

## Tests

- Engine: `backup_without_backup_dir_omits_directory_mtime` and `backup_dir_preserves_directory_mtime` (empty `e/` dir mtime, local `-a -b` vs `-a -b --backup-dir`).
- Transfer receiver: `make_backup_backup_dir_subdir_inherits_source_mode` (0700 inheritance) and `make_backup_backup_dir_clears_nondir_obstruction` (pre-existing file replaced by dir) on the network commit path.
- Transfer config: `effective_omit_dir_times_*` unit tests pinning the implication and the explicit/`--backup-dir` gating.

## Verification

`cargo build`, `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`, and `cargo nextest run -p transfer -p engine -p cli --all-features` on Linux.
