### PR TITLE
docs: document intentional static buffer-pool sizing and env override

### DIFF
--- a/docs/oc-extension-env-reference.md
+++ b/docs/oc-extension-env-reference.md
@@ -40,9 +40,17 @@ commit, and parallel checksum paths (`crates/engine/src/local_copy/buffer_pool/`
 
 Maximum number of buffers the global pool retains. Positive integer.
 Default: the detected hardware parallelism (one buffer per hardware
-thread). Zero, negative, or non-numeric values are ignored.
-Intentionally env-only: the default covers the common case and the knob is
-rarely tuned (`docs/design/cli-tunability-flags.md` section 8).
+thread), each 128 KiB wide, retained under the 32 MiB soft byte budget.
+Zero, negative, or non-numeric values are ignored.
+Because the default already scales with the CPU count, reach for the
+override only under extreme concurrency where the active worker count far
+exceeds `available_parallelism()`, or where a unit of work holds more than
+one buffer at a time - the point where the per-thread cache stops absorbing
+the acquire/return churn. Under-provisioning never blocks or fails an
+acquire; it only raises the allocation rate (a throughput cost, not a
+correctness one). Intentionally env-only: the default covers the common
+case and the knob is rarely tuned (see `docs/user/buffer-pool-tuning.md`
+and `docs/design/cli-tunability-flags.md` section 8).
 
 ### OC_RSYNC_BYTE_BUDGET
 

--- a/docs/user/buffer-pool-tuning.md
+++ b/docs/user/buffer-pool-tuning.md
@@ -43,6 +43,38 @@ outstanding (checked-out) memory. When the cap is reached, acquires block
 until a buffer is returned. This provides backpressure for memory-constrained
 environments.
 
+## Sizing rationale: static, hardware-scaled, no auto-scaling
+
+The default pool size is a static heuristic, not a dynamically tuned
+value. It is deliberately pinned to `std::thread::available_parallelism()`
+buffers, so it already scales with the hardware it runs on: more cores
+yield a larger pool, fewer cores a smaller one, with no runtime feedback
+loop involved. The 32 MiB soft byte budget caps retention on top of that.
+
+This is intentional, and dynamic auto-scaling is deliberately declined:
+
+- **The default is the right heuristic.** One buffer per hardware thread
+  matches the degree of parallelism the engine actually schedules, so the
+  common case needs no tuning.
+- **Under-provisioning is never a correctness or availability problem.**
+  An acquire is satisfied from a per-thread cache (one buffer per thread),
+  then a lock-free central queue, then a fresh allocation on miss. It never
+  blocks and never fails by default. A pool that is too small costs only a
+  higher allocation rate - throughput, not correctness. The per-thread
+  cache absorbs the steady-state acquire/return pattern, so real churn
+  appears only when the worker count far exceeds the CPU count or a unit of
+  work holds more than one buffer at a time.
+- **A grow/shrink feedback loop is not worth its complexity.** Auto-scaling
+  would reintroduce a control-loop that churns pool memory up and down in
+  response to load, for a benefit that has not been quantified against the
+  static default. The static default plus the env-var escape hatch already
+  covers the extreme workloads that would motivate it.
+
+The escape hatch for those extreme cases is `OC_RSYNC_BUFFER_POOL_SIZE`
+(pool size) and `OC_RSYNC_BYTE_BUDGET` / `OC_RSYNC_BUFFER_POOL_MEMORY_CAP`
+(memory bounds); see the environment variables section below and
+`docs/oc-extension-env-reference.md`.
+
 ## Adaptive buffer sizing
 
 The pool selects buffer sizes based on file size to balance memory

--- a/docs/user/buffer-pool-tuning.md
+++ b/docs/user/buffer-pool-tuning.md
@@ -38,10 +38,13 @@ sizing creates large buffers (up to 1 MiB for files >= 256 MiB). Without
 it, a handful of large-file transfers could leave 1 MiB buffers in the
 pool that accumulate past a reasonable memory budget.
 
-The **memory cap** (when configured via `--max-alloc`) is a hard ceiling on
-outstanding (checked-out) memory. When the cap is reached, acquires block
-until a buffer is returned. This provides backpressure for memory-constrained
-environments.
+The **memory cap** (off by default, enabled via
+`OC_RSYNC_BUFFER_POOL_MEMORY_CAP`) is a hard ceiling on outstanding
+(checked-out) memory. When the cap would be exceeded, acquires block until
+a buffer is returned. This provides backpressure for memory-constrained
+environments, and is the only path that can block an acquire. Note that
+`--max-alloc` and `OC_RSYNC_BYTE_BUDGET` set the soft byte budget above,
+not this hard cap.
 
 ## Sizing rationale: static, hardware-scaled, no auto-scaling
 


### PR DESCRIPTION
## Summary

Documents that the engine global buffer-pool sizing is an intentional static, hardware-scaled default with a manual env-var escape hatch, and that dynamic auto-scaling is deliberately declined. Docs-only; no code changes.

## Details

- `docs/oc-extension-env-reference.md` - expands the `OC_RSYNC_BUFFER_POOL_SIZE` entry with the full default (hardware parallelism x 128 KiB under the 32 MiB soft byte budget) and clear guidance on when to reach for the override: extreme concurrency where the active worker count far exceeds `available_parallelism()`, or a unit of work holds more than one buffer at a time. Notes that under-provisioning never blocks or fails an acquire - it only raises the allocation rate.
- `docs/user/buffer-pool-tuning.md` - adds a "Sizing rationale" section stating the sizing is intentionally static and hardware-scaled, that the acquire path (per-thread cache to lock-free queue to allocate-on-miss) makes under-provisioning a throughput cost only, that the env var is the escape hatch, and that a dynamic grow/shrink feedback loop is deliberately declined for an unquantified benefit.

## Verification

Docs-only. Confirmed `git diff` touches only the two markdown files, contains no em-dashes, and renders as valid markdown.
