### PR TITLE
fix(cli): always reject --inplace with --partial-dir (match upstream)

### DIFF
--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -305,22 +305,6 @@ impl ClientConfigBuilder {
     /// - `--append` conflicts with `--whole-file`
     ///   (upstream: options.c:2400 `if (append_mode) { if (whole_file > 0) ... }`)
     pub fn validate(&self) -> Result<(), ConfigConflict> {
-        self.validate_with_capabilities(protocol::CompatibilityFlags::EMPTY)
-    }
-
-    /// Checks for mutually exclusive option combinations, relaxing checks that
-    /// upstream peers negotiate away through capability bits.
-    ///
-    /// Currently `CF_INPLACE_PARTIAL_DIR` (bit 6, introduced at protocol 30)
-    /// permits `--inplace`/`--append` to coexist with `--partial-dir`: the
-    /// receiver writes the in-place output but treats a basis file located in
-    /// `partial_dir` as an inplace target as well.
-    ///
-    /// upstream: compat.c CF_INPLACE_PARTIAL_DIR
-    pub fn validate_with_capabilities(
-        &self,
-        caps: protocol::CompatibilityFlags,
-    ) -> Result<(), ConfigConflict> {
         // upstream: options.c:1974-1977 - --old-args conflicts with --protect-args.
         // Any active level (>= 1) triggers the conflict, matching upstream's
         // `else if (old_style_args)` truthiness test.
@@ -352,13 +336,14 @@ impl ClientConfigBuilder {
                 });
             }
 
-            // upstream: compat.c:777-778 - when CF_INPLACE_PARTIAL_DIR is
-            // negotiated, the receiver enables per-file inplace for basis
-            // files retrieved from the partial directory, allowing the
-            // otherwise-conflicting pair.
-            let inplace_partial_allowed =
-                caps.contains(protocol::CompatibilityFlags::INPLACE_PARTIAL_DIR);
-            if self.partial_dir.is_some() && !inplace_partial_allowed {
+            // upstream: options.c:2424-2432 - `--inplace`/`--append` cannot be
+            // used with `--partial-dir`. Upstream rejects this pair
+            // unconditionally, before any capability negotiation. The
+            // `CF_INPLACE_PARTIAL_DIR` capability (compat.c:777-778,
+            // receiver.c:910) only enables the receiver's internal one_inplace
+            // optimization for a basis file found in the partial directory; it
+            // never relaxes this user-facing option conflict.
+            if self.partial_dir.is_some() {
                 return Err(ConfigConflict {
                     option1: mode,
                     option2: "partial-dir",

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1169,6 +1169,12 @@ fn io_uring_depth_clears_to_none() {
 
 #[test]
 fn validate_inplace_with_partial_dir_conflicts() {
+    // upstream: options.c:2424-2432 - `--inplace` with `--partial-dir` is
+    // rejected unconditionally, before any capability negotiation. The
+    // `CF_INPLACE_PARTIAL_DIR` capability (compat.c:727,778) only enables the
+    // receiver's internal one_inplace optimization for a basis file in the
+    // partial directory; it never relaxes this user-facing option conflict, so
+    // validation must reject the pair regardless of negotiated capabilities.
     let b = builder()
         .inplace(true)
         .partial_directory(Some("/tmp/partial"));
@@ -1265,51 +1271,6 @@ fn validate_partial_dir_without_inplace_ok() {
 fn validate_default_builder_ok() {
     let b = builder();
     assert!(b.validate().is_ok());
-}
-
-// upstream: compat.c CF_INPLACE_PARTIAL_DIR - bit 6, protocol >= 30.
-// When both peers advertise the 'I' capability char, the receiver enables
-// per-file inplace for basis files in the partial directory and the otherwise
-// conflicting --inplace --partial-dir combination is accepted.
-#[test]
-fn validate_with_capabilities_inplace_partial_dir_accepted_when_cap_negotiated() {
-    let b = builder()
-        .inplace(true)
-        .partial_directory(Some("/tmp/partial"));
-    let caps = protocol::CompatibilityFlags::INPLACE_PARTIAL_DIR;
-    assert!(b.validate_with_capabilities(caps).is_ok());
-}
-
-#[test]
-fn validate_with_capabilities_append_partial_dir_accepted_when_cap_negotiated() {
-    let b = builder()
-        .append(true)
-        .partial_directory(Some("/tmp/partial"));
-    let caps = protocol::CompatibilityFlags::INPLACE_PARTIAL_DIR;
-    assert!(b.validate_with_capabilities(caps).is_ok());
-}
-
-#[test]
-fn validate_with_capabilities_inplace_partial_dir_rejected_without_cap() {
-    let b = builder()
-        .inplace(true)
-        .partial_directory(Some("/tmp/partial"));
-    let err = b
-        .validate_with_capabilities(protocol::CompatibilityFlags::EMPTY)
-        .unwrap_err();
-    assert_eq!(err.option1, "inplace");
-    assert_eq!(err.option2, "partial-dir");
-}
-
-#[test]
-fn validate_with_capabilities_delay_updates_conflict_not_relaxed() {
-    // CF_INPLACE_PARTIAL_DIR does not relax --inplace --delay-updates.
-    let b = builder().inplace(true).delay_updates(true);
-    let err = b
-        .validate_with_capabilities(protocol::CompatibilityFlags::INPLACE_PARTIAL_DIR)
-        .unwrap_err();
-    assert_eq!(err.option1, "inplace");
-    assert_eq!(err.option2, "delay-updates");
 }
 
 #[test]

--- a/docs/audits/compatibility-flags-mutual-exclusion-matrix.md
+++ b/docs/audits/compatibility-flags-mutual-exclusion-matrix.md
@@ -241,15 +241,17 @@ Footnote validation sites:
   `options.c:2415-2421`, `keep_partial = 0`). The pair is accepted.
   oc-rsync accepts the pair by absence of any check
   (`crates/core/src/client/config/builder/mod.rs:276-296`).
-- [d] Upstream rejects `--inplace --partial-dir` unless
-  `CF_INPLACE_PARTIAL_DIR` is negotiated. The conflict is detected at
-  `options.c:2406-2414`. oc-rsync now exposes
-  `ClientConfigBuilder::validate_with_capabilities` (see
-  `crates/core/src/client/config/builder/mod.rs`), which permits the
-  pair when the negotiated bitfield contains
-  `CompatibilityFlags::INPLACE_PARTIAL_DIR`. `validate()` keeps the
-  strict default for callers that have not yet seen the negotiated
-  bits, matching upstream's parse-time refusal. Gap G2 is resolved.
+- [d] Upstream rejects `--inplace --partial-dir` unconditionally at
+  parse time, before any capability negotiation
+  (`options.c:2424-2432`, exit 1). `CF_INPLACE_PARTIAL_DIR`
+  (`compat.c:727,778`) does not relax this option conflict; it only
+  enables the receiver's internal `one_inplace` optimization for a
+  basis file located in the partial directory (`receiver.c:910`).
+  oc-rsync mirrors upstream: `ClientConfigBuilder::validate()` rejects
+  the pair unconditionally
+  (`crates/core/src/client/config/builder/mod.rs`), and the negotiated
+  `INPLACE_PARTIAL_DIR` bit drives only the receiver optimization in
+  `crates/transfer` (`config::inplace_partial`), never this validator.
 - [e] Upstream rejects `--inplace --delay-updates` at
   `options.c:2406-2414` (the `partial_dir` message string covers both
   paths because `delay_updates` synthesises a `partial_dir` upstream).
@@ -339,22 +341,26 @@ PR cited in each heading and in the **Status** bullet.
   `crates/cli/tests/option_combinations_flags.rs`
   (`test_checksum_choice_none_parses`).
 
-### G2 - `--inplace --partial-dir` cannot be enabled even when peer advertises `CF_INPLACE_PARTIAL_DIR` (FIXED, PR #4064)
+### G2 - `--inplace --partial-dir` is a user-facing conflict, not a negotiable option (RESOLVED)
 
-- **Upstream behaviour.** `compat.c:777-778` enables `inplace_partial`
-  when both peers negotiate `CF_INPLACE_PARTIAL_DIR` (bit 6,
-  introduced at protocol 30). With that bit set, upstream's
-  `options.c:2406-2414` rejection is bypassed at the receiver and the
-  pair runs successfully.
-- **oc-rsync behaviour.** `ClientConfigBuilder` now exposes
-  `validate_with_capabilities(caps)` alongside the strict default
-  `validate()`. When `caps` contains
-  `CompatibilityFlags::INPLACE_PARTIAL_DIR`, the
-  `--inplace`/`--append` + `--partial-dir` combination is accepted;
-  otherwise the upstream parse-time rejection is preserved.
-- **Status.** FIXED in PR #4064. The strict `validate()`
-  default remains so callers without negotiated capability bits still
-  match upstream's `options.c:2406-2414` behaviour.
+- **Upstream behaviour.** `options.c:2424-2432` rejects
+  `--inplace`/`--append` + `--partial-dir` unconditionally at parse
+  time (exit 1), before any capability exchange.
+  `CF_INPLACE_PARTIAL_DIR` (`compat.c:727,778`, bit 6, protocol 30)
+  does **not** bypass this rejection; it only sets `inplace_partial`,
+  which drives the receiver's internal `one_inplace` optimization for
+  a basis file found in the partial directory (`receiver.c:910`). The
+  option conflict and the wire capability are independent concerns.
+- **oc-rsync behaviour.** `ClientConfigBuilder::validate()` rejects the
+  pair unconditionally, matching upstream's parse-time refusal. The
+  negotiated `INPLACE_PARTIAL_DIR` bit is applied only where upstream
+  applies it - the receiver's `one_inplace` path in `crates/transfer`
+  (`config::inplace_partial`, `transfer_ops`, `generator/delta.rs`) -
+  and never relaxes the option-conflict validator.
+- **Status.** RESOLVED. An earlier capability-gated relaxation in the
+  validator was removed: it would have made oc-rsync silently accept
+  (exit 0) a combination upstream refuses (exit 1) had negotiated
+  capabilities ever been wired into live validation.
 
 ### G3 - `--append --whole-file` accepted instead of rejected (FIXED, PR #4049)
 
@@ -405,7 +411,7 @@ below records the resolving PR for each row:
 | Gap | Summary | Resolving PR |
 |-----|---------|--------------|
 | G1 | `--checksum-choice=none` promotes `whole_file = 1` | #4066 |
-| G2 | `--inplace --partial-dir` gated on `CF_INPLACE_PARTIAL_DIR` | #4064 |
+| G2 | `--inplace --partial-dir` rejected unconditionally (matches upstream parse-time refusal) | #4064 |
 | G3 | `--append --whole-file` rejected at config build time | #4049 |
 | G4 | `--delay-updates` partial_dir promotion centralised in the builder | #4050 |
 


### PR DESCRIPTION
## Summary

Removes a latent observable-fidelity footgun: the client config validator's capability-gated acceptance of `--inplace`/`--append` combined with `--partial-dir`, which upstream rejects unconditionally.

## Upstream truth

- `options.c:2424-2432` rejects the `--inplace`/`--append` + `--partial-dir` pair **unconditionally at parse time** (exit 1), before any capability negotiation.
- `compat.c:727,778` (`CF_INPLACE_PARTIAL_DIR`, bit 6, protocol 30) does **not** relax this option conflict. It only sets `inplace_partial`, which drives the receiver's internal `one_inplace` optimization for a basis file found in the partial directory (`receiver.c:910`).

The option conflict and the wire capability are independent concerns: one is a user-facing parse-time refusal, the other a receiver-side write optimization.

## The bug

`ClientConfigBuilder::validate_with_capabilities` accepted `--inplace --partial-dir` when the passed capabilities contained `INPLACE_PARTIAL_DIR`. It was harmless in practice because the only live caller passes `EMPTY` capabilities, so the combination was still rejected today. But it was a latent break: if negotiated capabilities were ever wired into live validation, oc-rsync would silently accept (exit 0) a combination upstream refuses (exit 1).

## Fix

- Fold `validate_with_capabilities` back into `validate()`, which now rejects the pair unconditionally, matching upstream's parse-time refusal.
- Remove the now-dead `caps` plumbing from this validation path. The `INPLACE_PARTIAL_DIR` capability continues to gate only the receiver `one_inplace` optimization in `crates/transfer` (`config::inplace_partial`, `transfer_ops`, `generator/delta.rs`), which is untouched.
- Replace the obsolete tests that asserted capability-gated acceptance with WHY-encoded coverage on the canonical conflict tests: the pair is rejected unconditionally regardless of negotiated capabilities.
- Correct the mutual-exclusion audit doc, which previously described the removed relaxation as intended behaviour.

## Verification

On a Linux host against this branch:

- `cargo build --bin oc-rsync` - RC 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - RC 0
- `cargo nextest run -p core --all-features -E 'test(inplace) or test(partial_dir) or test(validate)'` - 38 passed, 0 failed
