### PR TITLE
refactor(daemon): extract shared resolve_bind_addresses helper

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -126,51 +126,26 @@ fn serve_connections(
         ));
     }
 
-    // Determine bind addresses based on address_family, dual_stack, and the
-    // `OC_RSYNC_DAEMON_ADDRESS_FAMILY` runtime override (used by CI/test
-    // fixtures to force a specific family without rebuilding the CLI).
+    // Determine bind addresses from address_family, dual_stack, the explicit
+    // `address =` override, and the `OC_RSYNC_DAEMON_ADDRESS_FAMILY` runtime
+    // override. `resolve_bind_addresses` is the single source of truth for
+    // this IP-assignment policy (see its rustdoc for the precedence and the
+    // upstream `open_socket_in` citation), shared so any future datagram
+    // listener binds the identical ordered set.
     //
-    // Default (no flag, no env, no explicit bind address): dual-stack with
-    // IPv6 first, IPv4 second. Mirrors upstream's `default_af_hint = 0`
-    // (AF_UNSPEC) which lets `getaddrinfo(NULL, port, AI_PASSIVE, ...)`
-    // return every available family - on glibc that is `::` then `0.0.0.0`.
-    // `bind_listeners_per_family` walks the list in order, logs a warning
-    // for any per-family bind failure, and only fails the daemon when zero
-    // sockets bound. GitHub Actions Linux runners that have IPv6 partially
-    // configured (where `bind(2)` to `[::]:port` returns `EADDRNOTAVAIL`)
-    // cleanly fall back to the IPv4 listener instead of exiting 10 with a
-    // silent dual-stack misconfiguration.
-    //
-    // upstream: socket.c:402-499 (`open_socket_in`) walks every
-    // getaddrinfo result, binds one socket per family, and only returns
-    // NULL when zero sockets bound.
-    let env_family = read_address_family_env_override();
-    let bind_addresses: Vec<IpAddr> = if bind_address_overridden {
-        vec![bind_address]
-    } else if let Some(env) = env_family {
-        match env {
-            AddressFamilyOverride::Ipv4 => vec![IpAddr::V4(Ipv4Addr::UNSPECIFIED)],
-            AddressFamilyOverride::Ipv6 => vec![IpAddr::V6(Ipv6Addr::UNSPECIFIED)],
-            AddressFamilyOverride::Both => vec![
-                IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            ],
-        }
-    } else if dual_stack {
-        vec![
-            IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-        ]
-    } else {
-        match address_family {
-            Some(AddressFamily::Ipv4) => vec![IpAddr::V4(Ipv4Addr::UNSPECIFIED)],
-            Some(AddressFamily::Ipv6) => vec![IpAddr::V6(Ipv6Addr::UNSPECIFIED)],
-            None => vec![
-                IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            ],
-        }
-    };
+    // `bind_listeners_per_family` then walks the returned list in order, logs
+    // a warning for any per-family bind failure, and only fails the daemon
+    // when zero sockets bound. GitHub Actions Linux runners that have IPv6
+    // partially configured (where `bind(2)` to `[::]:port` returns
+    // `EADDRNOTAVAIL`) cleanly fall back to the IPv4 listener instead of
+    // exiting 10 with a silent dual-stack misconfiguration.
+    let bind_addresses = resolve_bind_addresses(
+        bind_address,
+        bind_address_overridden,
+        address_family,
+        dual_stack,
+        read_address_family_env_override(),
+    );
 
     // upstream: socket.c:set_socket_options() - the `socket options =` /
     // `--sockopts` string is parsed once up front so it can be applied to

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -48,6 +48,64 @@ fn read_address_family_env_override() -> Option<AddressFamilyOverride> {
         .and_then(parse_address_family_env)
 }
 
+/// Resolves the ordered list of wildcard bind addresses for the daemon
+/// listener from the address-family inputs.
+///
+/// This is the single source of truth for the daemon's IP-assignment
+/// policy so the TCP accept loop and any future datagram listener bind the
+/// identical set of addresses in the identical order. The precedence, from
+/// highest to lowest, is:
+///
+/// 1. `bind_address_overridden` - an explicit `address =` / `--address`
+///    was given, so bind exactly that one address.
+/// 2. `env_family` - the `OC_RSYNC_DAEMON_ADDRESS_FAMILY` runtime override
+///    (used by CI/test fixtures to force a family without rebuilding).
+/// 3. `dual_stack` - bind both families, IPv6 first.
+/// 4. `address_family` - the `--ipv4`/`--ipv6` flag, or its absence.
+///
+/// The default (no override, no env, no flag) is dual-stack with IPv6
+/// first, IPv4 second. Mirrors upstream's `default_af_hint = 0` (AF_UNSPEC)
+/// which lets `getaddrinfo(NULL, port, AI_PASSIVE, ...)` return every
+/// available family - on glibc that is `::` then `0.0.0.0`.
+///
+/// upstream: socket.c:402-499 (`open_socket_in`) walks every getaddrinfo
+/// result, binds one socket per family, and only returns NULL when zero
+/// sockets bound.
+fn resolve_bind_addresses(
+    bind_address: IpAddr,
+    bind_address_overridden: bool,
+    address_family: Option<AddressFamily>,
+    dual_stack: bool,
+    env_family: Option<AddressFamilyOverride>,
+) -> Vec<IpAddr> {
+    if bind_address_overridden {
+        vec![bind_address]
+    } else if let Some(env) = env_family {
+        match env {
+            AddressFamilyOverride::Ipv4 => vec![IpAddr::V4(Ipv4Addr::UNSPECIFIED)],
+            AddressFamilyOverride::Ipv6 => vec![IpAddr::V6(Ipv6Addr::UNSPECIFIED)],
+            AddressFamilyOverride::Both => vec![
+                IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            ],
+        }
+    } else if dual_stack {
+        vec![
+            IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        ]
+    } else {
+        match address_family {
+            Some(AddressFamily::Ipv4) => vec![IpAddr::V4(Ipv4Addr::UNSPECIFIED)],
+            Some(AddressFamily::Ipv6) => vec![IpAddr::V6(Ipv6Addr::UNSPECIFIED)],
+            None => vec![
+                IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            ],
+        }
+    }
+}
+
 /// Logs a systemd notification failure if a log sink is available.
 fn log_sd_notify_failure(log: Option<&SharedLogSink>, context: &str, error: &io::Error) {
     if let Some(sink) = log {

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1608,6 +1608,130 @@ fn parse_address_family_env_rejects_unknown() {
     }
 }
 
+// Shorthands for the wildcard addresses `resolve_bind_addresses` returns.
+const V4_ANY: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+const V6_ANY: IpAddr = IpAddr::V6(Ipv6Addr::UNSPECIFIED);
+
+#[test]
+fn resolve_bind_addresses_honours_explicit_override() {
+    // An explicit `address =` / `--address` binds exactly that one address,
+    // regardless of family flags, dual-stack, or the env override.
+    let ipv4: IpAddr = "192.0.2.7".parse().unwrap();
+    assert_eq!(
+        resolve_bind_addresses(ipv4, true, None, false, None),
+        vec![ipv4],
+        "explicit IPv4 override must bind that single address"
+    );
+    let ipv6: IpAddr = "2001:db8::1".parse().unwrap();
+    assert_eq!(
+        resolve_bind_addresses(ipv6, true, None, false, None),
+        vec![ipv6],
+        "explicit IPv6 override must bind that single address"
+    );
+}
+
+#[test]
+fn resolve_bind_addresses_maps_env_override() {
+    // The `OC_RSYNC_DAEMON_ADDRESS_FAMILY` override selects the family list;
+    // `Both` yields IPv6 first, then IPv4.
+    assert_eq!(
+        resolve_bind_addresses(
+            V4_ANY,
+            false,
+            None,
+            false,
+            Some(AddressFamilyOverride::Ipv4)
+        ),
+        vec![V4_ANY],
+        "env Ipv4 must bind a single IPv4 wildcard"
+    );
+    assert_eq!(
+        resolve_bind_addresses(
+            V4_ANY,
+            false,
+            None,
+            false,
+            Some(AddressFamilyOverride::Ipv6)
+        ),
+        vec![V6_ANY],
+        "env Ipv6 must bind a single IPv6 wildcard"
+    );
+    assert_eq!(
+        resolve_bind_addresses(
+            V4_ANY,
+            false,
+            None,
+            false,
+            Some(AddressFamilyOverride::Both)
+        ),
+        vec![V6_ANY, V4_ANY],
+        "env Both must bind IPv6 first, then IPv4"
+    );
+}
+
+#[test]
+fn resolve_bind_addresses_dual_stack_binds_both_ipv6_first() {
+    assert_eq!(
+        resolve_bind_addresses(V4_ANY, false, None, true, None),
+        vec![V6_ANY, V4_ANY],
+        "dual-stack must bind IPv6 first, then IPv4"
+    );
+}
+
+#[test]
+fn resolve_bind_addresses_selects_family_flag() {
+    assert_eq!(
+        resolve_bind_addresses(V4_ANY, false, Some(AddressFamily::Ipv4), false, None),
+        vec![V4_ANY],
+        "--ipv4 must bind a single IPv4 wildcard"
+    );
+    assert_eq!(
+        resolve_bind_addresses(V4_ANY, false, Some(AddressFamily::Ipv6), false, None),
+        vec![V6_ANY],
+        "--ipv6 must bind a single IPv6 wildcard"
+    );
+    assert_eq!(
+        resolve_bind_addresses(V4_ANY, false, None, false, None),
+        vec![V6_ANY, V4_ANY],
+        "default (no flag) must bind dual-stack, IPv6 first"
+    );
+}
+
+#[test]
+fn resolve_bind_addresses_precedence() {
+    // Override wins over env, dual_stack, and family flag.
+    let explicit: IpAddr = "198.51.100.9".parse().unwrap();
+    assert_eq!(
+        resolve_bind_addresses(
+            explicit,
+            true,
+            Some(AddressFamily::Ipv6),
+            true,
+            Some(AddressFamilyOverride::Both)
+        ),
+        vec![explicit],
+        "explicit override must win over env, dual_stack, and family"
+    );
+    // Env wins over dual_stack and family flag.
+    assert_eq!(
+        resolve_bind_addresses(
+            V4_ANY,
+            false,
+            Some(AddressFamily::Ipv6),
+            true,
+            Some(AddressFamilyOverride::Ipv4)
+        ),
+        vec![V4_ANY],
+        "env override must win over dual_stack and family flag"
+    );
+    // Dual-stack wins over the family flag.
+    assert_eq!(
+        resolve_bind_addresses(V4_ANY, false, Some(AddressFamily::Ipv4), true, None),
+        vec![V6_ANY, V4_ANY],
+        "dual_stack must win over the family flag"
+    );
+}
+
 #[test]
 fn warn_per_family_accept_failure_labels_ipv6() {
     // The dual-stack accept loop must produce an identifiable diagnostic


### PR DESCRIPTION
## Summary

Pure refactor, no behavior change. Extracts the daemon's TCP bind-address resolution out of the accept loop into a shared, unit-testable free function so the IP-assignment policy lives in one place.

The accept loop previously computed the ordered `Vec<IpAddr>` of wildcard bind addresses inline from four inputs (explicit `address =` override, the `OC_RSYNC_DAEMON_ADDRESS_FAMILY` env override, `--ipv4`/`--ipv6`, and dual-stack). That logic is now `resolve_bind_addresses(bind_address, bind_address_overridden, address_family, dual_stack, env_family) -> Vec<IpAddr>`, placed in `server_runtime/listener.rs` next to the `AddressFamilyOverride` enum and the env-override reader it consumes. The accept loop calls it with `read_address_family_env_override()`.

Motivation: make the daemon's IP-assignment a single source of truth. A future datagram listener can reuse the identical ordered address set instead of re-deriving (and drifting from) the same policy.

## Byte-identical guarantee

The branch logic was moved verbatim - same precedence, same ordering, same wildcard constants:

1. explicit `address =` override wins -> `[that ip]`
2. else env override -> `Ipv4=[0.0.0.0]`, `Ipv6=[::]`, `Both=[::, 0.0.0.0]`
3. else dual-stack -> `[::, 0.0.0.0]`
4. else family flag -> `Ipv4=[0.0.0.0]`, `Ipv6=[::]`, `None=[::, 0.0.0.0]`

IPv6-first ordering is preserved everywhere both families bind. The upstream citation (`socket.c:402-499` `open_socket_in`, `default_af_hint = 0` / `getaddrinfo` `AI_PASSIVE`) moved with the code into the helper's rustdoc. No wire byte, log line, or bind order changes for any input combination.

## Tests

Added a unit-test table for `resolve_bind_addresses` covering every branch and precedence relationship:

- explicit IPv4 and IPv6 override -> single `[that ip]`
- env `Ipv4`/`Ipv6`/`Both`
- dual-stack -> `[::, 0.0.0.0]`
- family flag `Ipv4`/`Ipv6`/`None`
- precedence: override beats env/dual-stack/family; env beats dual-stack/family; dual-stack beats family

These assert element order (IPv6 first) so they lock the invariant a future datagram listener inherits.

## Verification

On Linux (aarch64), against this branch:

- `cargo build --bin oc-rsync` - RC 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - RC 0
- `cargo nextest run -p daemon --all-features -E 'test(bind_address) or test(resolve_bind)'` - 12 passed
