### PR TITLE
fix(itemize): derive receiver symlink-times from client capability on server-sender

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -195,6 +195,15 @@ pub struct GeneratorContext {
     /// [`Self::wire_write_counter`] at the `handle_stats` point. `None` in unit
     /// tests, where the logical fallback is used.
     pub(crate) wire_read_counter: Option<Arc<std::sync::atomic::AtomicU64>>,
+    /// Whether the RECEIVING peer can set symlink timestamps (upstream's
+    /// `receiver_symlink_times`, compat.c:92). Computed once at construction from
+    /// the receiver's advertised capability - the client's `'L'` letter when we
+    /// are the server, else the negotiated `CF_SYMLINK_TIMES` flag - and consulted
+    /// only by [`Self::itemize_context`] to pick the position-4 `t`/`T` glyph for
+    /// a symlink. Distinct from this process's own platform capability: a Unix
+    /// server-sender must not itemize a symlink time a non-Unix receiver cannot
+    /// apply (upstream compat.c:755-759).
+    pub(crate) receiver_symlink_times: bool,
 }
 
 /// Handle on the `--write-batch` file, held by a client sender so it can write
@@ -260,6 +269,29 @@ impl GeneratorContext {
         let mut config = config;
         config.promote_append_mode_for_protocol(handshake.protocol);
 
+        // upstream: compat.c:755-759 - on the sender, `receiver_symlink_times`
+        // reflects the RECEIVER's capability, not our own platform. When we are
+        // the server the receiver is the client, whose `'L'` letter rides
+        // `client_info` (the `-e` string in `client_args` for daemon mode, or the
+        // compact `flag_string` for SSH mode). When we are a client sender it is
+        // the negotiated `CF_SYMLINK_TIMES` flag. Computed once here so
+        // `itemize_context` renders the position-4 `t`/`T` symlink glyph
+        // correctly even when a non-Unix receiver pulls from this Unix server.
+        let am_server = !config.connection.client_mode;
+        let client_info = if am_server {
+            crate::setup::resolve_server_client_info(
+                handshake.client_args.as_deref(),
+                &config.flag_string,
+            )
+        } else {
+            std::borrow::Cow::Borrowed("")
+        };
+        let receiver_symlink_times = crate::setup::sender_receiver_symlink_times(
+            am_server,
+            &client_info,
+            handshake.compat_flags,
+        );
+
         Self {
             protocol: handshake.protocol,
             config,
@@ -286,6 +318,7 @@ impl GeneratorContext {
             batch_stats_sink: None,
             wire_write_counter: None,
             wire_read_counter: None,
+            receiver_symlink_times,
         }
     }
 
@@ -431,8 +464,9 @@ impl GeneratorContext {
     /// Builds the display context for itemize time-position rendering.
     ///
     /// Captures `preserve_mtimes` (from `--times` flag) and `receiver_symlink_times`
-    /// (from `CF_SYMLINK_TIMES` compat flag) so `format_iflags` can correctly
-    /// distinguish `t` from `T` at position 4.
+    /// (the RECEIVER's advertised symlink-time capability, resolved once in
+    /// [`Self::new`] per upstream compat.c:755-759) so `format_iflags` can
+    /// correctly distinguish `t` from `T` at position 4.
     ///
     /// # Upstream Reference
     ///
@@ -441,9 +475,7 @@ impl GeneratorContext {
     pub(crate) fn itemize_context(&self) -> itemize::ItemizeContext {
         itemize::ItemizeContext {
             preserve_mtimes: self.config.flags.times,
-            receiver_symlink_times: self
-                .compat_flags
-                .is_some_and(|f| f.contains(CompatibilityFlags::SYMLINK_TIMES)),
+            receiver_symlink_times: self.receiver_symlink_times,
         }
     }
 

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -6097,3 +6097,82 @@ fn server_mode_prints_no_sending_banner() {
     logging::init(logging::VerbosityConfig::from_verbose_level(1));
     assert!(!banner_ctx(false, true).should_announce_incremental_flist());
 }
+
+/// Renders the position-4 time glyph of a transferred symlink through a
+/// server-sender's `itemize_context`, so the assertion exercises the real
+/// `GeneratorContext::new` -> `itemize_context` -> `format_iflags` path.
+fn server_sender_symlink_time_glyph(
+    client_args: Option<Vec<String>>,
+    compat_flags: Option<protocol::CompatibilityFlags>,
+) -> char {
+    let mut handshake = test_handshake();
+    handshake.client_args = client_args;
+    handshake.compat_flags = compat_flags;
+
+    let mut config = test_config();
+    // Server (not client): am_server = !client_mode. `--times` is on so the
+    // glyph is t/T rather than a collapsed '.'.
+    config.connection.client_mode = false;
+    config.flags.times = true;
+
+    let ctx = GeneratorContext::new_for_test(&handshake, config);
+
+    let iflags = super::item_flags::ItemFlags::from_raw(
+        super::item_flags::ItemFlags::ITEM_TRANSFER
+            | super::item_flags::ItemFlags::ITEM_REPORT_TIME,
+    );
+    let entry =
+        protocol::flist::FileEntry::new_symlink(PathBuf::from("link"), PathBuf::from("dst"));
+    let row = super::itemize::format_iflags(&iflags, &entry, true, &ctx.itemize_context());
+    // "<L..t......" - position 4 is the time glyph.
+    row.chars().nth(4).unwrap()
+}
+
+/// WHY: upstream compat.c:755-759 derives a server-sender's
+/// `receiver_symlink_times` from the RECEIVER's advertised `'L'` capability
+/// (`strchr(client_info, 'L')`), NOT from the server's own
+/// `CAN_SET_SYMLINK_TIMES` platform capability (which is what the negotiated
+/// `CF_SYMLINK_TIMES` flag reflects on the server side). A Unix server-sender
+/// must therefore itemize a symlink's time as `T` when a receiver that cannot
+/// set symlink times (e.g. a Windows client) omits `'L'` - even though the
+/// server's own `CF_SYMLINK_TIMES` is set. Before the fix the server read the
+/// flag and always showed `t`.
+#[test]
+fn server_sender_symlink_time_follows_receiver_l_capability_not_own_flag() {
+    use protocol::CompatibilityFlags;
+
+    // The server's own capability flag is set (Unix server), yet the receiver
+    // did NOT advertise 'L': the receiver cannot set symlink times, so the glyph
+    // must be 'T'. This is the divergence the fix corrects.
+    let no_l = Some(vec![
+        "--server".to_owned(),
+        "--sender".to_owned(),
+        "-e.sfxCIvu".to_owned(),
+    ]);
+    assert_eq!(
+        server_sender_symlink_time_glyph(no_l, Some(CompatibilityFlags::SYMLINK_TIMES)),
+        'T',
+        "receiver without 'L' must itemize symlink time as 'T', ignoring the server's own CF_SYMLINK_TIMES",
+    );
+
+    // The receiver advertised 'L': it can set symlink times, so the glyph is 't'.
+    let with_l = Some(vec![
+        "--server".to_owned(),
+        "--sender".to_owned(),
+        "-e.LsfxCIvu".to_owned(),
+    ]);
+    assert_eq!(
+        server_sender_symlink_time_glyph(with_l, Some(CompatibilityFlags::SYMLINK_TIMES)),
+        't',
+        "receiver advertising 'L' must itemize symlink time as 't'",
+    );
+
+    // Symmetry check: even when the server's own flag is cleared, a receiver
+    // that advertised 'L' still yields 't' - the value tracks the client letter.
+    let with_l_no_flag = Some(vec!["-e.LsfxCIvu".to_owned()]);
+    assert_eq!(
+        server_sender_symlink_time_glyph(with_l_no_flag, None),
+        't',
+        "server-sender tracks the receiver's 'L', independent of its own flag",
+    );
+}

--- a/crates/transfer/src/setup/capability.rs
+++ b/crates/transfer/src/setup/capability.rs
@@ -409,3 +409,65 @@ pub(crate) fn build_compat_flags_from_client_info(
 pub(crate) fn client_has_pre_release_v_flag(client_info: &str) -> bool {
     client_info.contains('V')
 }
+
+/// Resolves the peer's capability string (`client_info`) on the server side of a
+/// transfer, mirroring the server branch of `build_our_flags`.
+///
+/// In daemon server mode the client's `-e` capabilities ride `client_args`; in
+/// SSH server mode they are embedded in the compact `flag_string`
+/// (`client_info = shell_cmd`, upstream compat.c:163-164). Returns an empty
+/// string when neither carries an `-e.<...>` capability list. Both branches
+/// scan via [`parse_client_info`], so this stays consistent with the flag-build
+/// path even though the two consumers keep separate call sites.
+pub(crate) fn resolve_server_client_info<'a>(
+    client_args: Option<&'a [String]>,
+    flag_string: &str,
+) -> Cow<'a, str> {
+    if let Some(args) = client_args {
+        parse_client_info(args)
+    } else if !flag_string.is_empty() {
+        // Wrap the flag string in a slice so parse_client_info can scan it for
+        // the embedded `-e.xxx` capability chars (matches build_our_flags).
+        let args = [flag_string.to_owned()];
+        Cow::Owned(parse_client_info(&args).into_owned())
+    } else {
+        Cow::Borrowed("")
+    }
+}
+
+/// Derives the sender's `receiver_symlink_times`, mirroring upstream
+/// compat.c:755-759.
+///
+/// The value reflects the RECEIVER's ability to set symlink times, which is not
+/// necessarily this process's own platform capability. When we are the server
+/// the receiver is the client, whose capability is advertised as the `'L'`
+/// letter in `client_info` - so a Unix server-sender must honour a receiver
+/// (e.g. a Windows client) that omits `'L'` and not itemize a symlink time it
+/// cannot apply. When we are a client sender the receiver's capability is the
+/// negotiated `CF_SYMLINK_TIMES` flag. Only the sender consults this (upstream
+/// sets it under `if (am_sender)`); it drives the position-4 `t`/`T` itemize
+/// glyph for symlinks (log.c:713-715).
+///
+/// # Upstream reference
+///
+/// `compat.c:755-759`:
+/// ```c
+/// if (am_sender) {
+///     receiver_symlink_times = am_server
+///         ? strchr(client_info, 'L') != NULL
+///         : !!(compat_flags & CF_SYMLINK_TIMES);
+/// }
+/// ```
+pub(crate) fn sender_receiver_symlink_times(
+    am_server: bool,
+    client_info: &str,
+    compat_flags: Option<CompatibilityFlags>,
+) -> bool {
+    if am_server {
+        // upstream compat.c:756-757 - strchr(client_info, 'L') != NULL
+        client_info.contains('L')
+    } else {
+        // upstream compat.c:758 - !!(compat_flags & CF_SYMLINK_TIMES)
+        compat_flags.is_some_and(|f| f.contains(CompatibilityFlags::SYMLINK_TIMES))
+    }
+}

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -43,6 +43,7 @@ pub(crate) use capability::CAPABILITY_MAPPINGS;
 pub(crate) use capability::{
     build_compat_flags_from_client_info, client_has_pre_release_v_flag, parse_client_info,
 };
+pub(crate) use capability::{resolve_server_client_info, sender_receiver_symlink_times};
 #[cfg(test)]
 pub(crate) use compat::write_compat_flags;
 pub(crate) use protocol::CompatibilityFlags;


### PR DESCRIPTION
## Summary

On the `am_sender && am_server` path, `receiver_symlink_times` must reflect the
**receiver's** advertised capability - the client's `'L'` letter in
`client_info` - not the server's own `CAN_SET_SYMLINK_TIMES` platform
capability. This mirrors upstream `compat.c:755-759`:

```c
if (am_sender) {
    receiver_symlink_times = am_server
        ? strchr(client_info, 'L') != NULL
        : !!(compat_flags & CF_SYMLINK_TIMES);
}
```

## The divergence

oc uniformly derived `receiver_symlink_times` from the negotiated
`CF_SYMLINK_TIMES` compat flag in the sender's `itemize_context`
(`crates/transfer/src/generator/context.rs`). On the server that flag is set
from the server's **own** platform capability, so a Unix server-sender always
itemized position-4 `t`/`T` for symlinks even when the receiver (e.g. a Windows
client that never advertises `'L'`) cannot set symlink times. The result is a
cosmetic itemize mismatch, observable only cross-platform.

## The fix

- Added `sender_receiver_symlink_times()` in `setup/capability.rs` implementing
  the exact upstream ternary, plus `resolve_server_client_info()` which resolves
  `client_info` on the server side the same way `build_our_flags` does (client's
  `-e` from `client_args` in daemon mode, or the compact `flag_string` in SSH
  mode).
- `GeneratorContext` computes `receiver_symlink_times` once in `new()` and
  `itemize_context()` reads that single stored value. The non-server (client
  sender) sub-case still uses `CF_SYMLINK_TIMES`, and the receiver-side
  derivation is untouched.
- Wire bytes are unchanged: this only affects the itemized `t`/`T` glyph
  rendering. Unix-to-Unix transfers are unaffected because a Unix client always
  advertises `'L'`.

## Tests

Added `server_sender_symlink_time_follows_receiver_l_capability_not_own_flag`
beside the generator itemize tests. It drives the real
`GeneratorContext::new` -> `itemize_context` -> `format_iflags` path and asserts
a Unix server-sender renders position-4 `T` when the receiver omits `'L'` (even
with `CF_SYMLINK_TIMES` set), `t` when the receiver advertises `'L'`, and that
the value tracks the client letter independent of the server's own flag.

## Verification (aarch64 Linux)

- `cargo build --bin oc-rsync` - RC 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - RC 0 (full-workspace, as CI runs)
- `cargo nextest run -p protocol -p engine -p transfer --all-features -E 'test(symlink)'` - 414 passed, plus the new test.
