### PR TITLE
fix(partial): keep temp mtime on non-signal verify failure (zero only on abort)

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -225,15 +225,32 @@ pub(super) fn partial_dir_path(file_path: &Path) -> PathBuf {
 /// Errors are logged and silently ignored - partial retention is best-effort.
 /// On failure, the guard's Drop will clean up the temp file.
 ///
+/// `zero_mtime` selects between the two upstream retention paths for plain
+/// `--partial`:
+///
+/// - `true` (signal/abort cleanup): upstream `cleanup.c:174-180` zeros the
+///   modtime (`cleanup_file->modtime = 0`, `tweak_modtime = 1`) so an
+///   interrupted partial stands out in `ls` and is not skipped by `--update`.
+///   Used by the interrupt paths (channel disconnect, `Abort`, `Shutdown`).
+/// - `false` (normal failed-verify keep): upstream `receiver.c:1047` calls
+///   `finish_transfer(..., recv_ok, ...)` with `recv_ok == 0`, which maps to
+///   `ATTRS_SKIP_MTIME` (`rsync.c:748-749`), so the retained stub keeps its
+///   recent temp-creation mtime rather than being reset to the epoch.
+///
+/// `--partial-dir` never zeros the mtime in either case (upstream routes it
+/// through `handle_partial_dir()`, which leaves the timestamp alone).
+///
 /// # Upstream Reference
 ///
 /// - `cleanup.c:105-115` - `handle_partial_dir()` moves temp to partial-dir
-/// - `cleanup.c:130-135` - `keep_partial && got_literal` guard
-/// - `receiver.c:340-345` - `do_rename(partialptr, fname)` for `--partial`
+/// - `cleanup.c:174-180` - signal cleanup zeros modtime for plain `--partial`
+/// - `receiver.c:1047` - normal keep uses `ok_to_set_time = recv_ok` (0 on fail)
+/// - `rsync.c:748-749` - `ok_to_set_time ? ATTRS_ACCURATE_TIME : ATTRS_SKIP_MTIME`
 pub(super) fn retain_partial_file(
     config: &DiskCommitConfig,
     cleanup_guard: &mut TempFileGuard,
     dest_path: &Path,
+    zero_mtime: bool,
 ) {
     match &config.partial_mode {
         PartialMode::None => {}
@@ -244,12 +261,15 @@ pub(super) fn retain_partial_file(
             let temp_path = cleanup_guard.path().to_path_buf();
             match rename_config_sandboxed(config, cleanup_guard.path(), dest_path) {
                 Ok(_) => {
-                    // upstream: cleanup.c:174-178 - stamp modtime=0 on
-                    // retained partial files so --update does not skip them
-                    // as "up to date" on the next run. Only for plain
-                    // --partial, not --partial-dir (upstream uses
-                    // handle_partial_dir() for --partial-dir which does not
-                    // zero the mtime).
+                    // upstream: cleanup.c:174-180 - the signal/abort cleanup
+                    // path stamps modtime=0 on the retained partial so it
+                    // stands out as unfinished in an ls and --update does not
+                    // skip it as "up to date". Only for plain --partial, not
+                    // --partial-dir (handle_partial_dir() leaves the mtime
+                    // alone). The normal failed-verify keep (receiver.c:1047,
+                    // ok_to_set_time=0 -> ATTRS_SKIP_MTIME) does NOT zero it,
+                    // preserving the recent temp-creation mtime - so zero only
+                    // when `zero_mtime` is set (the interrupt paths).
                     //
                     // Use from_unix_time(0, 0) rather than FileTime::zero()
                     // because on Windows, zero() maps to the Windows epoch
@@ -258,15 +278,17 @@ pub(super) fn retain_partial_file(
                     // skipping the stamp. from_unix_time(0, 0) maps to
                     // 1970-01-01 which is a non-zero FILETIME that Windows
                     // will actually apply.
-                    let epoch = filetime::FileTime::from_unix_time(0, 0);
-                    if let Err(e) = filetime::set_file_mtime(dest_path, epoch) {
-                        logging::debug_log!(
-                            Io,
-                            1,
-                            "failed to set mtime=0 on partial file {}: {}",
-                            dest_path.display(),
-                            e
-                        );
+                    if zero_mtime {
+                        let epoch = filetime::FileTime::from_unix_time(0, 0);
+                        if let Err(e) = filetime::set_file_mtime(dest_path, epoch) {
+                            logging::debug_log!(
+                                Io,
+                                1,
+                                "failed to set mtime=0 on partial file {}: {}",
+                                dest_path.display(),
+                                e
+                            );
+                        }
                     }
                     logging::debug_log!(Io, 1, "retained partial file: {}", dest_path.display());
                     CleanupManager::global().unregister_temp_file(&temp_path);

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -154,11 +154,19 @@ fn verify_whole_file_checksum(
 /// destination. The computed digest is still reported so the receiver queues a
 /// redo (phase 1) or logs the error (phase 2).
 ///
+/// The retained stub keeps its recent temp-creation mtime (not the epoch):
+/// upstream `receiver.c:1047` passes `ok_to_set_time = recv_ok`, and a failed
+/// verify has `recv_ok == 0`, which maps to `ATTRS_SKIP_MTIME` (rsync.c:748).
+/// The epoch stamp is reserved for the signal/abort cleanup path (cleanup.c:
+/// 174-180), so `retain_partial_file` is called here with `zero_mtime = false`.
+///
 /// # Upstream Reference
 ///
 /// - `receiver.c:1039-1056` - on `recv_ok == 0` the temp goes to the partial dir
 ///   (`handle_partial_dir(PDIR_CREATE)`) or is unlinked (`do_unlink_at`);
 ///   `finish_transfer()` - the destination rename - is skipped.
+/// - `receiver.c:1047` / `rsync.c:748-749` - `ok_to_set_time = recv_ok` (0 here)
+///   -> `ATTRS_SKIP_MTIME`, so the kept stub retains its temp-creation mtime.
 fn withhold_failed_commit(
     config: &DiskCommitConfig,
     mut cleanup_guard: TempFileGuard,
@@ -166,7 +174,7 @@ fn withhold_failed_commit(
     bytes_written: u64,
     computed_checksum: Option<ComputedChecksum>,
 ) -> CommitResult {
-    retain_partial_file(config, &mut cleanup_guard, &begin.file_path);
+    retain_partial_file(config, &mut cleanup_guard, &begin.file_path, false);
     drop(cleanup_guard);
     CommitResult {
         bytes_written,
@@ -297,7 +305,9 @@ pub(in crate::disk_commit) fn process_file(
                 let _ = output.finish(false, &begin.file_path);
                 // upstream: cleanup.c - retain partial on unexpected disconnect
                 if bytes_written > 0 && needs_rename {
-                    retain_partial_file(config, &mut cleanup_guard, &begin.file_path);
+                    // Interrupt path (cleanup.c:174-180): zero the mtime so an
+                    // aborted partial stands out and --update will not skip it.
+                    retain_partial_file(config, &mut cleanup_guard, &begin.file_path, true);
                 }
                 drop(cleanup_guard);
                 return Err(io::Error::new(
@@ -466,7 +476,9 @@ pub(in crate::disk_commit) fn process_file(
                 // if any data was written, the transfer made progress worth
                 // retaining for later resume.
                 if bytes_written > 0 && needs_rename {
-                    retain_partial_file(config, &mut cleanup_guard, &begin.file_path);
+                    // Interrupt path (cleanup.c:174-180): zero the mtime so an
+                    // aborted partial stands out and --update will not skip it.
+                    retain_partial_file(config, &mut cleanup_guard, &begin.file_path, true);
                 }
                 drop(cleanup_guard);
                 return Err(io::Error::other(reason));
@@ -480,7 +492,9 @@ pub(in crate::disk_commit) fn process_file(
                 let _ = output.finish(false, &begin.file_path);
                 // upstream: cleanup.c - same partial retention on shutdown
                 if bytes_written > 0 && needs_rename {
-                    retain_partial_file(config, &mut cleanup_guard, &begin.file_path);
+                    // Interrupt path (cleanup.c:174-180): zero the mtime so an
+                    // aborted partial stands out and --update will not skip it.
+                    retain_partial_file(config, &mut cleanup_guard, &begin.file_path, true);
                 }
                 drop(cleanup_guard);
                 return Err(io::Error::new(

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2836,6 +2836,81 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
     );
 }
 
+/// WHY: a NON-signal whole-file verify FAILURE that keeps the partial (plain
+/// `--partial`, no `--partial-dir`) must leave the retained stub's recent
+/// temp-creation mtime intact - it must NOT be reset to the epoch. Upstream
+/// separates the two retention paths: the signal/abort cleanup
+/// (`cleanup.c:174-180`) zeros the modtime, but the ordinary failed-verify keep
+/// (`receiver.c:1047`) calls `finish_transfer(..., recv_ok, ...)` with
+/// `recv_ok == 0`, which maps to `ATTRS_SKIP_MTIME` (`rsync.c:748-749`) and so
+/// keeps the temp mtime. Stamping the epoch here (as oc previously did) is an
+/// observable divergence: after a verify failure a `stat` shows 1970 vs
+/// upstream's recent time, visible if the run aborts between the phase-1 failure
+/// and the phase-2 redo, or on a final phase-2 verify failure. The epoch stamp
+/// is asserted separately by the abort/disconnect/shutdown tests above.
+#[test]
+fn verify_failure_keeps_recent_mtime_on_plain_partial() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("verify_fail_partial.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config).unwrap();
+
+    let before = filetime::FileTime::now();
+
+    let data = b"corrupt partial payload";
+    h.file_tx
+        .send(FileMessage::WholeFile {
+            begin: Box::new(BeginMessage {
+                file_path: file_path.clone(),
+                target_size: data.len() as u64,
+                file_entry_index: 0,
+                checksum_verifier: Some(md5_verifier()),
+                is_device_target: false,
+                is_inplace: false,
+                append_offset: 0,
+                xattr_list: None,
+            }),
+            data: data.to_vec(),
+            // Sender's sum is for different bytes: forces a verify mismatch.
+            expected_checksum: expected_md5(b"the good bytes"),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert!(
+        result.computed_checksum.is_some(),
+        "disk thread must still report the computed digest for redo bookkeeping"
+    );
+    assert!(
+        result.delayed_path.is_none(),
+        "a verification failure is never staged for the delay-updates sweep"
+    );
+    assert!(
+        file_path.exists(),
+        "plain --partial must retain the failed-verify stub at the destination"
+    );
+
+    let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    let unix_epoch = filetime::FileTime::from_unix_time(0, 0);
+    assert_ne!(
+        mtime, unix_epoch,
+        "failed-verify keep must NOT reset the stub mtime to the epoch \
+         (receiver.c:1047 ok_to_set_time=0 -> ATTRS_SKIP_MTIME keeps the temp mtime)"
+    );
+    assert!(
+        mtime.unix_seconds() >= before.unix_seconds() - 5,
+        "retained stub must keep a recent temp-creation mtime ({mtime:?}), not an old time"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
 /// Verifies that when a transfer with `delay_updates` is interrupted via
 /// Shutdown after some files have been committed, already-staged files remain
 /// in `.~tmp~/` and are NOT renamed to their final destinations.


### PR DESCRIPTION
## Summary

On a whole-file checksum verify **failure** that keeps the partial under plain `--partial` (no `--partial-dir`), the retained stub was stamped `mtime = epoch (1970)`. Upstream keeps the recent temp-creation mtime on this path and zeros the mtime **only** on the signal/abort cleanup path. After a verify failure a `stat` therefore showed `1970` under oc vs the recent time under upstream - observable if the run aborts between the phase-1 failure and the phase-2 redo, or on a final phase-2 verify failure.

## Upstream truth

Upstream separates the two partial-retention paths for plain `--partial`:

- **`receiver.c:1047`** - the normal failed-verify keep calls `finish_transfer(partialptr, fnametmp, fnamecmp, NULL, file, recv_ok, !partial_dir)`. A verify mismatch has `recv_ok == 0`, and `rsync.c:748-749` maps `ok_to_set_time == 0` to `ATTRS_SKIP_MTIME`, so the retained stub **keeps its temp-creation mtime**.
- **`cleanup.c:174-180`** - only the signal/abort cleanup zeros the modtime (`cleanup_file->modtime = 0`, `tweak_modtime = 1`), and only for plain `--partial` (not `--partial-dir`), so an interrupted partial stands out in `ls` and is not skipped by `--update`.

## Change

`retain_partial_file` now takes a `zero_mtime` flag:

- `withhold_failed_commit` (the non-signal failed-verify keep) passes `false` - the stub keeps its recent temp mtime.
- The interrupt paths (channel disconnect, `Abort`, `Shutdown`) pass `true` - unchanged epoch-stamp behaviour, matching `cleanup.c:174-180`.

`--partial-dir` continues to leave the mtime alone in both cases.

## Tests

- New `verify_failure_keeps_recent_mtime_on_plain_partial` pins the recent-mtime keep on a whole-file verify failure and encodes why (`receiver.c:1047` `ok_to_set_time=0` -> `ATTRS_SKIP_MTIME`).
- The existing abort/disconnect/shutdown tests remain the control, asserting the epoch stamp is still applied on the interrupt paths.

## Verification (Linux aarch64)

- `cargo build --bin oc-rsync` - RC 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run -p transfer --all-features -E 'test(partial) or test(withhold) or test(mtime)'` plus the new test - 109 passed
