### PR TITLE
feat(xattr): request round-trip for unresolved abbreviated entries + exotic-basis resolution

### DIFF
--- a/crates/protocol/src/xattr/diff.rs
+++ b/crates/protocol/src/xattr/diff.rs
@@ -95,11 +95,79 @@ pub fn xattr_diff(sender: &XattrList, receiver: &XattrList, checksum_seed: i32) 
     ri < rec.len()
 }
 
+/// Marks every abbreviated sender entry the receiver cannot satisfy locally as
+/// [`XattrState::Todo`](crate::xattr::XattrState::Todo), returning whether any
+/// were marked.
+///
+/// This is the `find_all` arm of upstream `xattrs.c:xattr_diff()`
+/// (`xattrs.c:547-616`). The generator calls `xattr_diff(file, sxp, 1)` before
+/// itemizing (`generator.c:569`,`generator.c:575`); for every abbreviated value
+/// (`datum_len > MAX_FULL_DATUM`) whose digest does not match the receiver's
+/// on-disk copy it flips `snd_rxa->datum[0]` from `XSTATE_ABBREV` to
+/// `XSTATE_TODO` (`xattrs.c:589-590`). `send_xattr_request()` then transmits
+/// exactly those `num`s to the sender, which replies with the full values.
+///
+/// `sender` is the flist xattr list as received - large values carry only a
+/// digest. `receiver` holds the basis (`fnamecmp`) file's current attributes
+/// with full values (read via `metadata::read_xattrs_for_wire`); pass an empty
+/// list when there is no basis, which lands every abbreviated entry in TODO
+/// exactly as upstream's `rec_cnt == 0` path does for a brand-new file
+/// (`generator.c:575` calls `xattr_diff(file, NULL, 1)`).
+///
+/// Both lists must be sorted by name. Only abbreviated entries are ever marked:
+/// a value carried in full arrived complete in the flist and needs no request,
+/// mirroring upstream which only reaches the `datum[0]` assignment inside the
+/// `snd_rxa->datum_len > MAX_FULL_DATUM` branch.
+#[must_use]
+pub fn mark_xattr_requests(
+    sender: &mut XattrList,
+    receiver: &XattrList,
+    checksum_seed: i32,
+) -> bool {
+    let rec = receiver.entries().to_vec();
+    let mut ri = 0usize;
+    let mut any = false;
+
+    for s in sender.entries_mut() {
+        // upstream: xattrs.c:581 strcmp(snd_rxa->name, rec_rxa->name). Walk the
+        // sorted receiver forward past every name that sorts before this sender
+        // name; what remains either matches or the receiver lacks the name.
+        while ri < rec.len() && rec[ri].name() < s.name() {
+            ri += 1;
+        }
+        let matched = ri < rec.len() && rec[ri].name() == s.name();
+
+        // upstream: xattrs.c:584 - the abbreviation split keys on the sender
+        // entry carrying only a digest, not on length alone (oc keeps a locally
+        // read long value in full, which must not be hashed here).
+        if s.is_abbreviated() {
+            // upstream: xattrs.c:585-587 - an abbreviated value is "same" only
+            // when the names match, the datum lengths agree, and the receiver's
+            // locally computed digest equals the sender's `datum + 1`.
+            let same = matched
+                && s.datum_len() == rec[ri].datum_len()
+                && checksum_matches(s.datum(), rec[ri].datum(), checksum_seed);
+            // upstream: xattrs.c:589-590 - `if (!same && find_all && datum[0]
+            // == XSTATE_ABBREV) datum[0] = XSTATE_TODO`.
+            if !same {
+                s.mark_todo();
+                any = true;
+            }
+        }
+
+        if matched {
+            ri += 1;
+        }
+    }
+
+    any
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::xattr::wire::compute_xattr_checksum;
-    use crate::xattr::{MAX_FULL_DATUM, XattrEntry, XattrList};
+    use crate::xattr::{MAX_FULL_DATUM, XattrEntry, XattrList, XattrState};
 
     fn list(entries: Vec<XattrEntry>) -> XattrList {
         XattrList::with_entries(entries)
@@ -107,6 +175,67 @@ mod tests {
 
     fn full(name: &str, value: &[u8]) -> XattrEntry {
         XattrEntry::new(name.as_bytes().to_vec(), value.to_vec())
+    }
+
+    fn abbrev(name: &str, value: &[u8]) -> XattrEntry {
+        let checksum = compute_xattr_checksum(value, 0).to_vec();
+        XattrEntry::abbreviated(name.as_bytes().to_vec(), checksum, value.len())
+    }
+
+    // upstream: xattrs.c:575 - generator.c:575 calls xattr_diff(file, NULL, 1)
+    // for a brand-new file, so rec_cnt == 0 and every abbreviated sender entry
+    // is not-same and lands in XSTATE_TODO. Without this the receiver never
+    // requests the value and a large xattr on a new file is silently dropped.
+    #[test]
+    fn no_basis_marks_every_abbreviated_entry_todo() {
+        let big = vec![7u8; MAX_FULL_DATUM + 40];
+        let mut sender = list(vec![abbrev("user.big", &big), full("user.small", b"x")]);
+        let any = mark_xattr_requests(&mut sender, &list(vec![]), 0);
+        assert!(any);
+        assert_eq!(sender.entries()[0].state(), XattrState::Todo);
+        // A short value ships in full in the flist, so it is never requested.
+        assert_eq!(sender.entries()[1].state(), XattrState::Done);
+    }
+
+    // upstream: xattrs.c:585-590 - an abbreviated value whose digest matches the
+    // basis stays XSTATE_ABBREV (resolved locally from fnamecmp), never TODO.
+    #[test]
+    fn matching_basis_leaves_abbreviated_entry_unrequested() {
+        let big = vec![7u8; MAX_FULL_DATUM + 40];
+        let mut sender = list(vec![abbrev("user.big", &big)]);
+        let receiver = list(vec![full("user.big", &big)]);
+        let any = mark_xattr_requests(&mut sender, &receiver, 0);
+        assert!(!any);
+        assert_eq!(sender.entries()[0].state(), XattrState::Abbrev);
+    }
+
+    // upstream: xattrs.c:585-590 - a digest mismatch against the basis marks the
+    // entry TODO so the sender is asked for the current value.
+    #[test]
+    fn mismatched_basis_marks_abbreviated_entry_todo() {
+        let sender_val = vec![7u8; MAX_FULL_DATUM + 40];
+        let basis_val = vec![9u8; MAX_FULL_DATUM + 40];
+        let mut sender = list(vec![abbrev("user.big", &sender_val)]);
+        let receiver = list(vec![full("user.big", &basis_val)]);
+        let any = mark_xattr_requests(&mut sender, &receiver, 0);
+        assert!(any);
+        assert_eq!(sender.entries()[0].state(), XattrState::Todo);
+    }
+
+    // upstream: xattrs.c:581 - a name the basis lacks (cmp > 0 / rec exhausted)
+    // is not-same, so an abbreviated value with no basis counterpart is TODO
+    // while an unrelated basis name is skipped without disturbing the walk.
+    #[test]
+    fn partial_basis_marks_only_the_missing_abbreviated_entry() {
+        let a = vec![1u8; MAX_FULL_DATUM + 8];
+        let b = vec![2u8; MAX_FULL_DATUM + 8];
+        let mut sender = list(vec![abbrev("user.a", &a), abbrev("user.b", &b)]);
+        // Basis holds only user.a (identical); user.b is absent.
+        let receiver = list(vec![full("user.a", &a)]);
+        let any = mark_xattr_requests(&mut sender, &receiver, 0);
+        assert!(any);
+        assert_eq!(sender.entries()[0].state(), XattrState::Abbrev);
+        assert_eq!(sender.entries()[1].state(), XattrState::Todo);
     }
 
     #[test]

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -39,7 +39,7 @@ mod prefix;
 mod wire;
 
 pub use cache::XattrCache;
-pub use diff::xattr_diff;
+pub use diff::{mark_xattr_requests, xattr_diff};
 pub use entry::{XattrEntry, XattrState};
 pub use list::XattrList;
 pub use prefix::{

--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -885,6 +885,70 @@ fn sender_response_round_trip_with_todo_entries() {
     assert_eq!(sender_list.entries()[2].state(), XattrState::Done);
 }
 
+/// Golden-byte fidelity for the full abbreviated-xattr request round-trip.
+///
+/// Pins the exact wire bytes upstream emits so an oc<->upstream transfer that
+/// requires the round-trip is byte-identical:
+///
+/// - Generator -> sender request (`send_xattr_request`, `fname == NULL`):
+///   upstream writes `write_varint(f_out, rxa->num - prior_req)` for each
+///   requested entry then `write_byte(f_out, 0)` (`xattrs.c:653`,`xattrs.c:674`).
+///   Requesting the 1st and 3rd entries (0-based 0 and 2, 1-based num 1 and 3)
+///   yields deltas 1 and 2 then the 0 terminator: `[0x01, 0x02, 0x00]`.
+/// - Sender -> receiver response (`send_sender_xattr_response`, sender path):
+///   upstream writes, per TODO entry, `write_varint(num - prior_req)`,
+///   `write_varint(len)`, `write_bigbuf(ptr, len)`, then `write_byte(0)`
+///   (`xattrs.c:653-674`). num 1 with `b"abc"` and num 3 with `b"de"` give
+///   `[0x01,0x03,'a','b','c', 0x02,0x02,'d','e', 0x00]`.
+///
+/// All values are < 0x80 so each varint is a single byte, making the golden
+/// vector exact and protocol-independent (the request/response framing does not
+/// vary across protocol 30-32).
+#[test]
+fn abbreviated_request_response_wire_is_golden() {
+    // Generator -> sender: request entries 0 and 2 (1-based num 1 and 3).
+    let mut req = Vec::new();
+    send_xattr_request(&mut req, &[0, 2]).unwrap();
+    assert_eq!(req, vec![0x01, 0x02, 0x00], "generator request bytes");
+
+    // recv side (sender) parses it back to the same 0-based indices and flags
+    // exactly those entries XSTATE_TODO. upstream: xattrs.c:681 recv_xattr_request.
+    let mut list = XattrList::new();
+    for i in 1..=3u32 {
+        let mut e = XattrEntry::abbreviated(
+            format!("user.a{i}").into_bytes(),
+            vec![0u8; MAX_XATTR_DIGEST_LEN],
+            100,
+        );
+        e.set_num(i);
+        list.push(e);
+    }
+    let indices = recv_xattr_request(&mut Cursor::new(req), &mut list).unwrap();
+    assert_eq!(indices, vec![0, 2]);
+
+    // Sender -> receiver: full values for the two TODO entries, in num order.
+    let mut resp_list = XattrList::new();
+    let mut a = XattrEntry::new(b"user.a1".to_vec(), b"abc".to_vec());
+    a.set_num(1);
+    a.mark_todo();
+    resp_list.push(a);
+    let mut b = XattrEntry::new(b"user.a2".to_vec(), vec![0u8; 10]);
+    b.set_num(2); // not requested: stays out of the response
+    resp_list.push(b);
+    let mut c = XattrEntry::new(b"user.a3".to_vec(), b"de".to_vec());
+    c.set_num(3);
+    c.mark_todo();
+    resp_list.push(c);
+
+    let mut resp = Vec::new();
+    send_sender_xattr_response(&mut resp, &mut resp_list).unwrap();
+    assert_eq!(
+        resp,
+        vec![0x01, 0x03, b'a', b'b', b'c', 0x02, 0x02, b'd', b'e', 0x00],
+        "sender response bytes",
+    );
+}
+
 #[test]
 fn checksum_length_mismatch_returns_false() {
     let value = b"test value";

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -61,11 +61,14 @@ pub(super) fn apply_file_metadata(
                 xattr_list: begin.xattr_list.as_ref(),
                 xattr_filter: config.xattr_filter.as_deref(),
                 pre_transfer_meta,
-                // upstream: fnamecmp is the pre-transfer destination. Metadata
-                // is applied to the temp file before rename, so the final path
-                // still holds the basis file whose xattrs an abbreviated entry
-                // references.
-                basis_path: &begin.file_path,
+                // upstream: xattrs.c:944 rsync_xal_set(fname, ..., fnamecmp) -
+                // an abbreviated entry the generator left unrequested resolves
+                // against the basis (fnamecmp) actually used. `xattr_basis`
+                // carries the --fuzzy / --link-dest / --compare-dest /
+                // --partial-dir basis when it differs from the destination;
+                // absent that (fnamecmp == fname), the pre-transfer destination
+                // still holds the referenced value, so fall back to file_path.
+                basis_path: begin.xattr_basis.as_deref().unwrap_or(&begin.file_path),
             },
         )
     }

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -746,6 +746,7 @@ fn begin_with_append_offset(path: &Path, append_offset: u64) -> BeginMessage {
         is_inplace: true,
         append_offset,
         xattr_list: None,
+        xattr_basis: None,
     }
 }
 

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -184,6 +184,7 @@ fn write_file_with_io_uring_auto_policy() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -228,6 +229,7 @@ fn device_target_inplace_commit_does_not_truncate() {
             is_inplace: true,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx
@@ -344,6 +346,7 @@ fn write_and_commit_file() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -403,6 +406,7 @@ fn inplace_skip_matched_seeks_without_rewriting() {
             is_inplace: true,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -450,6 +454,7 @@ fn abort_cleans_up_temp_file() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -491,6 +496,7 @@ fn multiple_files_sequential() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             })))
             .unwrap();
 
@@ -544,6 +550,7 @@ fn multi_chunk_file() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -582,6 +589,7 @@ fn buffer_recycling() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -629,6 +637,7 @@ fn whole_file_coalesced() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"whole dat".to_vec(),
             expected_checksum: Default::default(),
@@ -675,6 +684,7 @@ fn commit_file_rename_via_io_uring_or_fallback() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -722,6 +732,7 @@ fn commit_file_rename_replaces_existing_via_io_uring_or_fallback() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -769,6 +780,7 @@ fn delay_updates_stages_to_partial_dir() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -838,6 +850,7 @@ fn delay_updates_whole_file_stages_to_partial_dir() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"whole delayed!".to_vec(),
             expected_checksum: Default::default(),
@@ -884,6 +897,7 @@ fn whole_file_commit_via_io_uring_or_fallback() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"whole iouring".to_vec(),
             expected_checksum: Default::default(),
@@ -926,6 +940,7 @@ fn partial_mode_partial_retains_file_on_shutdown() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -972,6 +987,7 @@ fn partial_mode_none_deletes_file_on_shutdown() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1016,6 +1032,7 @@ fn partial_mode_partial_retains_file_on_abort() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1065,6 +1082,7 @@ fn partial_mode_partial_dir_retains_file_in_directory() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1117,6 +1135,7 @@ fn partial_mode_no_retention_without_data() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1158,6 +1177,7 @@ fn partial_mode_channel_disconnect_retains_file() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1203,6 +1223,7 @@ fn partial_mode_relative_partial_dir() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1255,6 +1276,7 @@ fn cleanup_manager_removes_orphaned_temp_files_on_simulated_signal() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1343,6 +1365,7 @@ fn cleanup_manager_unregisters_on_successful_commit() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1404,6 +1427,7 @@ fn cleanup_manager_mixed_committed_and_orphaned_files() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx
@@ -1428,6 +1452,7 @@ fn cleanup_manager_mixed_committed_and_orphaned_files() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx
@@ -1522,6 +1547,7 @@ fn cleanup_manager_whole_file_unregisters_on_commit() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"whole file".to_vec(),
             expected_checksum: Default::default(),
@@ -1572,6 +1598,7 @@ fn cleanup_manager_inplace_skips_registration() {
             is_inplace: true,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx
@@ -1632,6 +1659,7 @@ fn inplace_abort_does_not_delete_existing_destination() {
             is_inplace: true,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1694,6 +1722,7 @@ fn non_inplace_abort_discards_temp_and_leaves_existing_dest() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1770,6 +1799,7 @@ fn partial_dir_abort_mid_stream_moves_to_partial_dir() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1840,6 +1870,7 @@ fn partial_dir_channel_disconnect_moves_to_partial_dir() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1892,6 +1923,7 @@ fn partial_dir_auto_created_on_interrupt() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -1954,6 +1986,7 @@ fn partial_dir_mid_stream_has_intermediate_size() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -2019,6 +2052,7 @@ fn partial_dir_whole_file_success_no_leftover_in_partial_dir() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"complete-dat".to_vec(),
             expected_checksum: Default::default(),
@@ -2262,6 +2296,7 @@ fn delay_updates_disk_thread_e2e_single_file() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -2341,6 +2376,7 @@ fn delay_updates_disk_thread_e2e_multiple_files() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             })))
             .unwrap();
 
@@ -2426,6 +2462,7 @@ fn delay_updates_disk_thread_e2e_whole_file() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"whole file sweep!".to_vec(),
             expected_checksum: Default::default(),
@@ -2481,6 +2518,7 @@ fn delay_updates_disk_thread_e2e_nested_dirs() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx
@@ -2506,6 +2544,7 @@ fn delay_updates_disk_thread_e2e_nested_dirs() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx
@@ -2652,6 +2691,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_shutdown() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -2703,6 +2743,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_abort() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -2757,6 +2798,7 @@ fn partial_mode_partial_dir_does_not_stamp_mtime_zero() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -2812,6 +2854,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -2869,6 +2912,7 @@ fn delay_updates_interrupt_leaves_committed_files_in_staging() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"file1 staged".to_vec(),
             expected_checksum: Default::default(),
@@ -2892,6 +2936,7 @@ fn delay_updates_interrupt_leaves_committed_files_in_staging() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"file2 staged".to_vec(),
             expected_checksum: Default::default(),
@@ -2963,6 +3008,7 @@ fn delay_updates_interrupt_mid_file_retains_prior_staged_files() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"committed".to_vec(),
             expected_checksum: Default::default(),
@@ -2984,6 +3030,7 @@ fn delay_updates_interrupt_mid_file_retains_prior_staged_files() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
 
@@ -3044,6 +3091,7 @@ fn delay_updates_manual_sweep_after_commit_moves_to_final() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"sweep1".to_vec(),
             expected_checksum: Default::default(),
@@ -3064,6 +3112,7 @@ fn delay_updates_manual_sweep_after_commit_moves_to_final() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"sweep2".to_vec(),
             expected_checksum: Default::default(),
@@ -3125,6 +3174,7 @@ fn delay_updates_channel_disconnect_preserves_staged_files() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: b"disconnect data".to_vec(),
             expected_checksum: Default::default(),
@@ -3195,6 +3245,7 @@ fn pipelined_backup_default_suffix_returns_destination_relative_notice() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx
@@ -3265,6 +3316,7 @@ fn pipelined_backup_with_backup_dir_reports_destination_relative_paths() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx
@@ -3340,6 +3392,7 @@ fn inplace_redo_pass_does_not_overwrite_phase1_backup() {
             is_inplace: true,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx
@@ -3412,6 +3465,7 @@ fn whole_file_checksum_mismatch_is_not_committed_to_dest() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: data.to_vec(),
             // Sender's sum for entirely different bytes: forces a mismatch.
@@ -3459,6 +3513,7 @@ fn whole_file_checksum_match_commits_to_dest() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: data.to_vec(),
             expected_checksum: expected_md5(data),
@@ -3497,6 +3552,7 @@ fn chunked_checksum_mismatch_is_not_committed_to_dest() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx.send(FileMessage::Chunk(b"aaa".to_vec())).unwrap();
@@ -3542,6 +3598,7 @@ fn checksum_mismatch_leaves_preexisting_dest_untouched() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: data.to_vec(),
             expected_checksum: expected_md5(b"a different payload"),
@@ -3629,6 +3686,7 @@ fn sparse_streaming_commit_preserves_source_mtime() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx.send(FileMessage::Chunk(payload)).unwrap();
@@ -3678,6 +3736,7 @@ fn sparse_whole_file_commit_preserves_source_mtime() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: payload,
             expected_checksum: Default::default(),
@@ -3724,6 +3783,7 @@ fn non_sparse_commit_preserves_source_mtime() {
             is_inplace: false,
             append_offset: 0,
             xattr_list: None,
+            xattr_basis: None,
         })))
         .unwrap();
     h.file_tx.send(FileMessage::Chunk(payload)).unwrap();

--- a/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
+++ b/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
@@ -38,6 +38,7 @@ fn begin_msg(file_path: std::path::PathBuf, target_size: u64) -> FileMessage {
         is_inplace: false,
         append_offset: 0,
         xattr_list: None,
+        xattr_basis: None,
     }))
 }
 
@@ -52,6 +53,7 @@ fn begin_msg_inplace(file_path: std::path::PathBuf, target_size: u64) -> FileMes
         is_inplace: true,
         append_offset: 0,
         xattr_list: None,
+        xattr_basis: None,
     }))
 }
 

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -127,6 +127,20 @@ pub struct BeginMessage {
     /// Mirrors `xattrs.c:set_xattr()` called from `set_file_attrs()` in
     /// `receiver.c` after file transfer completes.
     pub xattr_list: Option<XattrList>,
+    /// Basis (`fnamecmp`) file whose xattrs an abbreviated entry references.
+    ///
+    /// Carries the exact basis the delta request selected
+    /// (`find_basis_file_with_config`), so an abbreviated value the generator
+    /// left unrequested - because it matched the basis - resolves at apply time
+    /// against that same `--fuzzy` / `--link-dest` / `--compare-dest` /
+    /// `--partial-dir` file rather than only the primary destination. `None`
+    /// falls back to the pre-transfer destination path (`file_path`).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `xattrs.c:944-1009` `rsync_xal_set(fname, ..., fnamecmp, ...)` - the
+    ///   abbreviated resolution re-reads `fnamecmp`, the basis actually used.
+    pub xattr_basis: Option<PathBuf>,
 }
 
 /// Sender's trailing whole-file checksum, carried to the disk thread for

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -621,6 +621,7 @@ mod tests {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             })))
             .unwrap();
 
@@ -966,6 +967,7 @@ mod tests {
                     is_inplace: false,
                     append_offset: 0,
                     xattr_list: None,
+                    xattr_basis: None,
                 }),
                 data: b"test data".to_vec(),
                 expected_checksum: Default::default(),
@@ -1044,6 +1046,7 @@ mod tests {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             })))
             .unwrap();
         pr.file_sender()
@@ -1104,6 +1107,7 @@ mod tests {
                     is_inplace: false,
                     append_offset: 0,
                     xattr_list: None,
+                    xattr_basis: None,
                 }),
                 data: b"next".to_vec(),
                 expected_checksum: Default::default(),
@@ -1167,6 +1171,7 @@ mod tests {
                     is_inplace: false,
                     append_offset: 0,
                     xattr_list: None,
+                    xattr_basis: None,
                 }),
                 data: b"test data".to_vec(),
                 expected_checksum: Default::default(),
@@ -1243,6 +1248,7 @@ mod tests {
                     is_inplace: false,
                     append_offset: 0,
                     xattr_list: None,
+                    xattr_basis: None,
                 }),
                 data: b"test data".to_vec(),
                 expected_checksum: Default::default(),
@@ -1449,6 +1455,7 @@ mod tests {
                     is_inplace: false,
                     append_offset: 0,
                     xattr_list: None,
+                    xattr_basis: None,
                 }),
                 data: b"drop staged".to_vec(),
                 expected_checksum: Default::default(),
@@ -1513,6 +1520,7 @@ mod tests {
                     is_inplace: false,
                     append_offset: 0,
                     xattr_list: None,
+                    xattr_basis: None,
                 }),
                 data: b"shutdown stage".to_vec(),
                 expected_checksum: Default::default(),
@@ -1567,6 +1575,7 @@ mod tests {
                     is_inplace: false,
                     append_offset: 0,
                     xattr_list: None,
+                    xattr_basis: None,
                 }),
                 data: b"e2e staged".to_vec(),
                 expected_checksum: Default::default(),

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -959,7 +959,32 @@ impl ReceiverContext {
         let filter = self
             .xattr_name_filter()
             .map(|set| move |name: &str| set.xattr_name_allowed(name));
-        let opts = metadata::XattrSendOptions {
+        let opts = self.generator_xattr_opts(filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool));
+        let sender = self.resolve_xattr_list(entry).unwrap_or_default();
+        match path {
+            Some(path) => metadata::dest_xattrs_differ(&sender, path, &opts),
+            // upstream: xattrs.c:555-561 - a NULL `sxp` yields `rec_cnt = 0`,
+            // so the count test at :574 already decides the answer.
+            None => protocol::xattr::xattr_diff(
+                &sender,
+                &protocol::xattr::XattrList::default(),
+                self.checksum_seed,
+            ),
+        }
+    }
+
+    /// Builds the generator-side [`metadata::XattrSendOptions`] used to read the
+    /// destination/basis attributes for both the itemize diff and the
+    /// abbreviated-value request round-trip.
+    ///
+    /// Shared by [`Self::dest_xattrs_differ`] and [`Self::build_xattr_request`]
+    /// so both read the destination through the identical namespace/filter
+    /// screen upstream applies in `get_xattr` (`xattrs.c:237-267`).
+    fn generator_xattr_opts<'f>(
+        &self,
+        filter: Option<&'f dyn Fn(&str) -> bool>,
+    ) -> metadata::XattrSendOptions<'f> {
+        metadata::XattrSendOptions {
             role: metadata::XattrRole::Generator,
             follow_symlinks: false,
             // upstream: xattrs.c:237 - `user_only = am_sender ? 0 : !am_root`,
@@ -973,19 +998,66 @@ impl ReceiverContext {
             // the generator keeps rsync.%FOO at either level.
             preserve_xattrs: self.config.flags.xattrs_level,
             fake_super: self.config.fake_super,
-            filter: filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool),
+            filter,
             checksum_seed: self.checksum_seed,
-        };
-        let sender = self.resolve_xattr_list(entry).unwrap_or_default();
-        match path {
-            Some(path) => metadata::dest_xattrs_differ(&sender, path, &opts),
-            // upstream: xattrs.c:555-561 - a NULL `sxp` yields `rec_cnt = 0`,
-            // so the count test at :574 already decides the answer.
-            None => protocol::xattr::xattr_diff(
-                &sender,
-                &protocol::xattr::XattrList::default(),
-                self.checksum_seed,
-            ),
+        }
+    }
+
+    /// Builds the abbreviated-xattr request list for a file about to be
+    /// requested from the sender, marking every large value the local basis
+    /// cannot satisfy as [`XattrState::Todo`](protocol::xattr::XattrState::Todo).
+    ///
+    /// Returns `Some(list)` only when at least one entry needs the round-trip;
+    /// the caller then sends the request via
+    /// [`send_file_request_xattr`](crate::transfer_ops::send_file_request_xattr)
+    /// so the sender replies with the full values. Returns `None` when `-X` is
+    /// off, the file carries no xattrs, or every abbreviated value already
+    /// matches the basis (resolved locally at apply time, exactly as upstream's
+    /// `xattr_diff` returning 0 leaves the entry `XSTATE_ABBREV`).
+    ///
+    /// `basis_path` is the same basis the delta request selected
+    /// (`find_basis_file_with_config`), so the diff honours `--fuzzy`,
+    /// `--link-dest`, `--compare-dest`, and `--partial-dir` bases in upstream's
+    /// priority order. `None` (a brand-new file) compares against an empty list,
+    /// marking every abbreviated entry TODO like `xattr_diff(file, NULL, 1)`
+    /// (`generator.c:575`).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:569`,`generator.c:575` - `xattr_diff(file, sxp, 1)` marks
+    ///   `XSTATE_TODO`; `generator.c:598` `send_xattr_request()` emits them.
+    pub(in crate::receiver) fn build_xattr_request(
+        &self,
+        entry: &FileEntry,
+        basis_path: Option<&Path>,
+    ) -> Option<protocol::xattr::XattrList> {
+        if !self.config.flags.xattrs {
+            return None;
+        }
+        let mut sender = self.resolve_xattr_list(entry)?;
+        // A short-value-only or empty list can never abbreviate, so it never
+        // needs a request; skip the basis read entirely.
+        if !sender.has_abbreviated() {
+            return None;
+        }
+
+        let filter = self
+            .xattr_name_filter()
+            .map(|set| move |name: &str| set.xattr_name_allowed(name));
+        let opts = self.generator_xattr_opts(filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool));
+
+        // upstream: xattrs.c:967 get_xattr_data(fnamecmp, ...) - the diff reads
+        // the basis (fnamecmp) file. A missing basis or a read error yields an
+        // empty list, so every abbreviated entry is not-same and lands in TODO
+        // (the new-file path), never a fatal error.
+        let basis = basis_path
+            .and_then(|p| metadata::read_xattrs_for_wire(p, &opts).ok())
+            .unwrap_or_default();
+
+        if protocol::xattr::mark_xattr_requests(&mut sender, &basis, self.checksum_seed) {
+            Some(sender)
+        } else {
+            None
         }
     }
 

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -26,6 +26,7 @@ use crate::receiver::basis::{BasisFileConfig, find_basis_file_with_config};
 use crate::receiver::{PipelineSetup, ReceiverContext};
 use crate::transfer_ops::{
     RequestConfig, ResponseContext, process_file_response_streaming, send_file_request,
+    send_file_request_xattr,
 };
 
 /// Result type for the pipelined transfer closure:
@@ -404,7 +405,18 @@ impl ReceiverContext {
                                 )?;
                                 continue;
                             }
-                            let pending = send_file_request(
+                            // upstream: generator.c:569,598 - before requesting
+                            // the file the generator diffs the sender's xattrs
+                            // against the basis (fnamecmp) and requests every
+                            // abbreviated value it cannot resolve locally. Use
+                            // the same basis the delta selected so --fuzzy /
+                            // --link-dest / --compare-dest / --partial-dir bases
+                            // drive the resolution in upstream's priority order.
+                            let xattr_request = self.build_xattr_request(
+                                file_entry,
+                                basis_result.basis_path.as_deref(),
+                            );
+                            let pending = send_file_request_xattr(
                                 writer,
                                 &mut ndx_write_codec,
                                 self.flat_to_wire_ndx(file_idx),
@@ -416,6 +428,7 @@ impl ReceiverContext {
                                 file_entry.size(),
                                 base_iflags,
                                 &request_config,
+                                xattr_request.as_ref(),
                             )?;
 
                             pipeline.push(pending);
@@ -442,7 +455,13 @@ impl ReceiverContext {
                                 )?;
                                 continue;
                             }
-                            let pending = send_file_request(
+                            // upstream: generator.c:575,598 - with no basis the
+                            // xattr diff runs against an empty list, so every
+                            // abbreviated value is requested. This keeps a large
+                            // xattr on a new or redo'd file from being dropped
+                            // for lack of a local copy to resolve it against.
+                            let xattr_request = self.build_xattr_request(file_entry, None);
+                            let pending = send_file_request_xattr(
                                 writer,
                                 &mut ndx_write_codec,
                                 self.flat_to_wire_ndx(file_idx),
@@ -454,6 +473,7 @@ impl ReceiverContext {
                                 file_entry.size(),
                                 base_iflags,
                                 &request_config,
+                                xattr_request.as_ref(),
                             )?;
 
                             pipeline.push(pending);

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -133,6 +133,12 @@ pub fn process_file_response_streaming<R: Read>(
         is_inplace: header.use_inplace,
         append_offset: header.append_offset,
         xattr_list,
+        // upstream: xattrs.c:944 rsync_xal_set(fname, ..., fnamecmp, ...) - the
+        // abbreviated-value resolution re-reads the basis actually used, which
+        // for a --fuzzy / --link-dest / --compare-dest / --partial-dir transfer
+        // is not the primary destination. Carry that basis so an entry the
+        // generator left abbreviated (it matched the basis) still resolves.
+        xattr_basis: header.basis_path.clone(),
     });
 
     let mut basis_map = if let Some(ref path) = header.basis_path {


### PR DESCRIPTION
## Summary

Completes the abbreviated-xattr request round-trip and threads exotic bases
into abbreviated-value resolution. Before this change a large extended
attribute (value > `MAX_FULL_DATUM` = 32 bytes) that the sender transmitted
abbreviated was silently dropped whenever the receiver could not resolve it
from the primary destination - most importantly on every brand-new file.

> **WIRE-TOUCHING - please review before merge.** This changes what the
> receiver emits on the request stream (it now sends real xattr requests, not
> just the terminator). Golden-byte and live interop against upstream 3.4.4
> are included below.

## The two gaps

**(1) Request round-trip.** Upstream's generator diffs the sender's xattr list
against the basis (`fnamecmp`) file with `xattr_diff(file, sxp, 1)`
(`xattrs.c:547-616`, `generator.c:569`/`generator.c:575`); every abbreviated
value whose digest does not match the local basis is flipped
`XSTATE_ABBREV -> XSTATE_TODO` and requested via `send_xattr_request()`
(`generator.c:598`, `xattrs.c:623-675`). The sender replies with the full value
(`sender.c:196`, `sender.c:289`) and the receiver stores it in place of the
checksum (`xattrs.c:681-766`).

The sender-response and receiver-apply halves already existed in oc and are
`num`-correct; the missing half was the generator - it never marked entries
TODO and never emitted a request, so the sender never replied. The receiver now
runs the `find_all` diff before requesting each file and sends the request when
a large value cannot be resolved locally. A brand-new file (no basis) requests
every abbreviated value, exactly as upstream's `xattr_diff(file, NULL, 1)`.

**(2) Exotic bases.** The request-time diff and the apply-time resolution now
use the exact basis the delta selected (`find_basis_file_with_config`), so
`--fuzzy`, `--link-dest`, `--compare-dest`, and `--partial-dir` bases drive
abbreviated-value resolution in upstream's priority order - matching
`rsync_xal_set(fname, ..., fnamecmp, ...)` (`xattrs.c:944-1009`), which re-reads
the basis actually used, not only the primary destination. `BeginMessage`
carries that basis to the disk-commit apply; absent it (fnamecmp == fname) the
pre-transfer destination is used as before.

The two gaps are coupled: a large value matching a non-primary basis is left
unrequested by (1), so (2) is required for it to resolve at apply time.

## Changes

- `protocol/src/xattr/diff.rs` - new `mark_xattr_requests()`, the `find_all`
  arm of `xattr_diff()`: marks unresolvable abbreviated entries `Todo`.
- `receiver/transfer/candidates.rs` - `build_xattr_request()` reads the basis
  attributes and marks the request list; shared `generator_xattr_opts()`.
- `receiver/transfer/pipeline.rs` - request sites now emit the xattr request via
  `send_file_request_xattr` when the basis cannot satisfy a large value.
- `pipeline/messages.rs` + `transfer_ops/streaming.rs` +
  `disk_commit/process/metadata.rs` - `BeginMessage.xattr_basis` threads the
  selected basis to the apply path.

No wire bytes change against upstream or an un-abbreviating peer: the request is
emitted only when a large value genuinely needs the round-trip, and the framing
(delta-encoded 1-based `num`s, `0` terminator; response of `num`/len/value pairs
then `0`) is byte-for-byte upstream's.

## Verification (Linux, upstream 3.4.4 reference binary)

- `cargo build --bin oc-rsync` - RC 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - RC 0
- `cargo nextest run -p metadata -p engine -p protocol -p transfer --all-features -E 'test(xattr)'` - 362 passed, 0 failed

**Golden-byte** (`protocol/src/xattr/wire/tests.rs`):
`abbreviated_request_response_wire_is_golden` pins the request bytes
`[01 02 00]` and the sender-response bytes
`[01 03 'a' 'b' 'c' 02 02 'd' 'e' 00]`.

**Unit** (`protocol/src/xattr/diff.rs`): no-basis marks every abbreviated entry
TODO; a matching basis leaves it abbreviated; a mismatch/partial basis marks
only the unsatisfiable entry. Exotic-basis resolution is covered at the metadata
boundary by `apply_xattrs_from_list_resolves_abbreviated_against_basis`.

**Interop vs upstream 3.4.4** (new file, 100-byte `user.big` forcing the
round-trip):

- upstream sender -> oc receiver (pull): `user.big` len 100, values
  byte-identical to the upstream->upstream oracle (`XATTR-VALUES-IDENTICAL`).
- oc sender -> upstream receiver (push): len 100.
- `--fuzzy`, large value matching the fuzzy basis (gap 2): oc len 100, equal to
  the upstream oracle.
