### PR TITLE
fix(transfer): repair master compile — missing xattr_basis in test initializer

### DIFF
--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2917,6 +2917,7 @@ fn verify_failure_keeps_recent_mtime_on_plain_partial() {
                 is_inplace: false,
                 append_offset: 0,
                 xattr_list: None,
+                xattr_basis: None,
             }),
             data: data.to_vec(),
             // Sender's sum is for different bytes: forces a verify mismatch.


### PR DESCRIPTION
Master (ec0f113fb) fails to compile under `--all-targets --all-features`: #7122 added `xattr_basis` to `BeginMessage` but left the `verify_failure_keeps_recent_mtime_on_plain_partial` test initializer (crates/transfer/src/disk_commit/tests.rs) without it (E0063). One-line fix adds `xattr_basis: None`. Confirmed the file's BeginMessage initializers now balance (61=61); no other initializer affected. P0 hotfix to unblock all PR CI.