### PR TITLE
refactor(engine): restore buffer-pool resizer as throughput-governor actuator

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/global.rs
+++ b/crates/engine/src/local_copy/buffer_pool/global.rs
@@ -107,10 +107,10 @@ pub struct GlobalBufferPoolConfig {
 
 /// Default byte budget for pool retention (32 MiB).
 ///
-/// Matches the maximum pooled memory at the central queue's ceiling:
+/// Matches the maximum pooled memory at the adaptive resizer's ceiling:
 /// 256 buffers at 128 KiB each = 32 MiB. This provides a consistent
-/// upper bound on memory the pool retains, including when large-file
-/// transfers use individually larger buffers (adaptive buffer sizing).
+/// upper bound whether the pool grows by count (adaptive resizing) or
+/// by individual buffer size (adaptive buffer sizing for large files).
 ///
 /// Overridden by `--max-alloc`, `OC_RSYNC_BYTE_BUDGET`, or programmatic
 /// configuration via [`GlobalBufferPoolConfig`].

--- a/crates/engine/src/local_copy/buffer_pool/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/mod.rs
@@ -99,6 +99,7 @@ mod guard;
 mod memory_cap;
 mod page_aligned;
 mod pool;
+mod pressure;
 mod thread_local_cache;
 #[cfg(feature = "thread-slab-pool")]
 mod thread_slab;

--- a/crates/engine/src/local_copy/buffer_pool/pool/acquire.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool/acquire.rs
@@ -381,8 +381,9 @@ impl<A: BufferAllocator> BufferPool<A> {
     ///
     /// Uses the lock-free [`ArrayQueue::pop`](crossbeam_queue::ArrayQueue::pop) hot path. The accompanying
     /// `central_count` counter is decremented on success so future returns
-    /// can re-admit buffers up to the soft capacity. Records hit/miss
-    /// statistics for telemetry.
+    /// can re-admit buffers up to the soft capacity. When adaptive resizing
+    /// is enabled, records hit/miss statistics and triggers periodic resize
+    /// evaluations (every 64 operations).
     fn pop_buffer(&self) -> Vec<u8> {
         match self.buffers.pop() {
             Some(buffer) => {
@@ -391,10 +392,18 @@ impl<A: BufferAllocator> BufferPool<A> {
                     budget.release(buffer.capacity());
                 }
                 self.total_hits.fetch_add(1, Ordering::Relaxed);
+                if let Some(pressure) = &self.pressure {
+                    pressure.record_hit();
+                    self.maybe_resize(pressure);
+                }
                 buffer
             }
             None => {
                 self.total_misses.fetch_add(1, Ordering::Relaxed);
+                if let Some(pressure) = &self.pressure {
+                    pressure.record_miss();
+                    self.maybe_resize(pressure);
+                }
                 self.allocator.allocate(self.buffer_size)
             }
         }

--- a/crates/engine/src/local_copy/buffer_pool/pool/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool/mod.rs
@@ -11,6 +11,7 @@
 //!
 //! - [`acquire`] - the acquire/return hot path plus `admit_or_deallocate` and
 //!   `pop_buffer`.
+//! - [`resize`] - adaptive soft-capacity grow/shrink.
 //! - [`memory`] - memory-cap reservation helpers.
 //! - [`stats`] - telemetry snapshot ([`BufferPoolStats`]) and accessors.
 //!
@@ -19,6 +20,7 @@
 
 mod acquire;
 mod memory;
+mod resize;
 mod stats;
 
 use std::sync::atomic::{AtomicU64, AtomicUsize};
@@ -30,6 +32,7 @@ use super::allocator::{BufferAllocator, DefaultAllocator};
 use super::buffer_controller::{AdaptiveBufferController, ControllerConfig};
 use super::byte_budget::ByteBudget;
 use super::memory_cap::MemoryCap;
+use super::pressure::PressureTracker;
 use super::throughput::ThroughputTracker;
 
 pub use stats::BufferPoolStats;
@@ -38,11 +41,12 @@ pub use stats::BufferPoolStats;
 ///
 /// `ArrayQueue` requires a fixed capacity at construction time, so the
 /// queue is sized to the larger of the caller-requested `max_buffers`
-/// and this default. This headroom keeps the queue from having to
-/// reallocate when `max_buffers` is small.
+/// and this default. This headroom allows the adaptive resizer to grow
+/// the soft capacity without having to reallocate the queue.
 ///
-/// At 128 KiB per buffer (`COPY_BUFFER_SIZE`), 256 buffers = 32 MiB of
-/// pooled memory at the queue's maximum fill.
+/// Matches the upper bound enforced by the adaptive resizer (`MAX_CAPACITY`
+/// in `pressure.rs`). At 128 KiB per buffer (`COPY_BUFFER_SIZE`), 256
+/// buffers = 32 MiB of pooled memory at the resizer's maximum soft cap.
 const DEFAULT_QUEUE_CAPACITY: usize = 256;
 
 /// Computes the fixed [`ArrayQueue`] capacity for a given soft maximum.
@@ -130,8 +134,9 @@ pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {
     central_count: AtomicUsize,
     /// Soft maximum number of buffers to retain in the central pool.
     ///
-    /// Read atomically on every return to enforce the soft cap.
-    /// Thread-local cached buffers are not counted against this limit.
+    /// Read atomically on every return to enforce the soft cap and on
+    /// every adaptive-resize evaluation. Thread-local cached buffers are
+    /// not counted against this limit.
     soft_capacity: AtomicUsize,
     /// Size of each buffer in bytes.
     buffer_size: usize,
@@ -156,6 +161,12 @@ pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {
     /// The tracker is only allocated when explicitly enabled via
     /// [`with_throughput_tracking`](Self::with_throughput_tracking).
     throughput: Option<ThroughputTracker>,
+    /// Optional pressure tracker for adaptive pool resizing.
+    ///
+    /// When present, tracks hit/miss rates and periodically adjusts the
+    /// pool's soft capacity to match demand. Enabled via
+    /// [`with_adaptive_resizing`](Self::with_adaptive_resizing).
+    pressure: Option<PressureTracker>,
     /// Optional PID-style buffer-size controller.
     ///
     /// When present, dynamically adjusts the recommended buffer size based
@@ -166,18 +177,28 @@ pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {
     /// [`with_buffer_controller`](Self::with_buffer_controller).
     ///
     /// The controller affects individual buffer sizes (the manipulated
-    /// variable) without touching the pool's slot count.
+    /// variable), while the pressure tracker affects the pool's slot count.
+    /// The two loops observe orthogonal signals and compose without
+    /// interference.
     buffer_controller: Option<AdaptiveBufferController>,
     /// Cumulative count of acquire operations that found a buffer in the
     /// thread-local cache or central pool (no fresh allocation needed).
     ///
+    /// Always active regardless of whether adaptive resizing is enabled.
     /// Uses `Relaxed` ordering since exact precision is not required for
     /// telemetry - small counting errors under concurrent access are
     /// acceptable.
     total_hits: AtomicU64,
     /// Cumulative count of acquire operations that required a fresh
     /// allocation because no pooled buffer was available.
+    ///
+    /// Always active regardless of whether adaptive resizing is enabled.
     total_misses: AtomicU64,
+    /// Cumulative count of pool capacity growth events.
+    ///
+    /// Incremented each time the adaptive resizer increases the soft
+    /// capacity. Always zero when adaptive resizing is not enabled.
+    total_growths: AtomicU64,
 }
 
 impl BufferPool {
@@ -207,9 +228,11 @@ impl BufferPool {
             memory_cap: None,
             byte_budget: None,
             throughput: None,
+            pressure: None,
             buffer_controller: None,
             total_hits: AtomicU64::new(0),
             total_misses: AtomicU64::new(0),
+            total_growths: AtomicU64::new(0),
         }
     }
 
@@ -232,9 +255,11 @@ impl BufferPool {
             memory_cap: None,
             byte_budget: None,
             throughput: None,
+            pressure: None,
             buffer_controller: None,
             total_hits: AtomicU64::new(0),
             total_misses: AtomicU64::new(0),
+            total_growths: AtomicU64::new(0),
         }
     }
 }
@@ -262,9 +287,11 @@ impl<A: BufferAllocator> BufferPool<A> {
             memory_cap: None,
             byte_budget: None,
             throughput: None,
+            pressure: None,
             buffer_controller: None,
             total_hits: AtomicU64::new(0),
             total_misses: AtomicU64::new(0),
+            total_growths: AtomicU64::new(0),
         }
     }
 
@@ -347,6 +374,27 @@ impl<A: BufferAllocator> BufferPool<A> {
         self
     }
 
+    /// Enables adaptive resizing based on allocation pressure.
+    ///
+    /// When enabled, the pool tracks hit/miss rates using atomic counters
+    /// and periodically adjusts its soft capacity:
+    ///
+    /// - **Grow**: When the miss rate exceeds 20% (too many fresh allocations),
+    ///   the capacity is doubled (up to 256).
+    /// - **Shrink**: When pool utilization drops below 30% and miss rate is
+    ///   low, the capacity is halved (down to 2).
+    ///
+    /// Pressure evaluation occurs every 64 acquire operations, amortizing
+    /// the cost. Between checks, only two `Relaxed` atomic increments are
+    /// performed per acquire - negligible overhead on the hot path.
+    ///
+    /// Adaptive resizing is zero-cost when not enabled.
+    #[must_use]
+    pub fn with_adaptive_resizing(mut self) -> Self {
+        self.pressure = Some(PressureTracker::new());
+        self
+    }
+
     /// Enables PID-style buffer-size control based on throughput feedback.
     ///
     /// When enabled, the controller dynamically adjusts the recommended
@@ -356,9 +404,11 @@ impl<A: BufferAllocator> BufferPool<A> {
     /// (the setpoint) using proportional, integral, and derivative terms,
     /// which eliminates steady-state offset and damps overshoot.
     ///
-    /// This feature is orthogonal to throughput tracking (which provides the
-    /// EMA estimate). The controller consumes throughput data and emits a
-    /// buffer-size recommendation without touching pool capacity.
+    /// This feature is orthogonal to adaptive resizing (which adjusts pool
+    /// slot count) and throughput tracking (which provides the EMA estimate).
+    /// The controller consumes throughput data and emits a buffer-size
+    /// recommendation; the existing grow/shrink loop continues to manage
+    /// pool capacity independently.
     ///
     /// Throughput tracking is automatically enabled when a buffer controller
     /// is configured, since the controller requires throughput samples.
@@ -476,9 +526,10 @@ impl<A: BufferAllocator> Drop for BufferPool<A> {
         if std::env::var("OC_RSYNC_BUFFER_POOL_STATS").as_deref() == Ok("1") {
             let stats = self.stats();
             eprintln!(
-                "BufferPool stats: reuses={} allocations={} byte_overflows={} hit_rate={:.1}%",
+                "BufferPool stats: reuses={} allocations={} growths={} byte_overflows={} hit_rate={:.1}%",
                 stats.total_hits,
                 stats.total_misses,
+                stats.total_growths,
                 stats.total_byte_overflows,
                 self.hit_rate() * 100.0,
             );

--- a/crates/engine/src/local_copy/buffer_pool/pool/resize.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool/resize.rs
@@ -1,0 +1,54 @@
+//! Adaptive soft-capacity resizing for [`BufferPool`].
+//!
+//! Drives the pressure-tracker feedback loop: periodically evaluates
+//! hit/miss pressure and grows or shrinks the pool's soft capacity,
+//! deallocating excess buffers on shrink. Capacity updates are atomic
+//! stores and queue mutations are lock-free pops.
+
+use std::sync::atomic::Ordering;
+
+use super::super::allocator::BufferAllocator;
+use super::super::pressure::{PressureTracker, ResizeAction};
+use super::BufferPool;
+
+impl<A: BufferAllocator> BufferPool<A> {
+    /// Evaluates pressure statistics and applies resize if warranted.
+    ///
+    /// Capacity updates are atomic stores; the queue mutations on shrink
+    /// are lock-free [`ArrayQueue::pop`](crossbeam_queue::ArrayQueue::pop) calls.
+    /// Concurrent acquires may observe an intermediate state during shrink (a
+    /// brief window where the queue still holds buffers above the new soft
+    /// cap), but the extras are reclaimed on the next return.
+    pub(super) fn maybe_resize(&self, pressure: &PressureTracker) {
+        if !pressure.should_check() {
+            return;
+        }
+
+        let current_capacity = self.soft_capacity.load(Ordering::Relaxed);
+        let available = self.buffers.len();
+
+        match pressure.evaluate(current_capacity, available) {
+            ResizeAction::Hold => {}
+            ResizeAction::Grow(new_capacity) => {
+                self.soft_capacity.store(new_capacity, Ordering::Relaxed);
+                self.total_growths.fetch_add(1, Ordering::Relaxed);
+            }
+            ResizeAction::Shrink(new_capacity) => {
+                self.soft_capacity.store(new_capacity, Ordering::Relaxed);
+                // Deallocate excess buffers beyond the new capacity.
+                while self.buffers.len() > new_capacity {
+                    match self.buffers.pop() {
+                        Some(buf) => {
+                            self.central_count.fetch_sub(1, Ordering::Relaxed);
+                            if let Some(budget) = &self.byte_budget {
+                                budget.release(buf.capacity());
+                            }
+                            self.allocator.deallocate(buf);
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/engine/src/local_copy/buffer_pool/pool/stats.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool/stats.rs
@@ -26,6 +26,9 @@ impl<A: BufferAllocator> BufferPool<A> {
     ///
     /// Thread-local cached buffers are additional (at most one per thread).
     /// Returns `0` for a zero-capacity pool (never retains buffers).
+    ///
+    /// When adaptive resizing is enabled, this value may change over time
+    /// as the pool adjusts to allocation pressure.
     #[must_use]
     pub fn max_buffers(&self) -> usize {
         self.soft_capacity.load(Ordering::Relaxed)
@@ -87,6 +90,12 @@ impl<A: BufferAllocator> BufferPool<A> {
             .unwrap_or(0)
     }
 
+    /// Returns `true` if adaptive resizing is enabled.
+    #[must_use]
+    pub fn is_adaptive(&self) -> bool {
+        self.pressure.is_some()
+    }
+
     /// Returns the cumulative number of acquire operations that found a
     /// buffer in the thread-local cache or central pool (no fresh
     /// allocation needed).
@@ -122,6 +131,15 @@ impl<A: BufferAllocator> BufferPool<A> {
         self.total_hits() as f64 / total as f64
     }
 
+    /// Returns the cumulative number of pool capacity growth events.
+    ///
+    /// Incremented each time adaptive resizing increases the soft capacity.
+    /// Always zero when adaptive resizing is not enabled.
+    #[must_use]
+    pub fn total_growths(&self) -> u64 {
+        self.total_growths.load(Ordering::Relaxed)
+    }
+
     /// Returns a snapshot of all telemetry counters.
     ///
     /// The returned [`BufferPoolStats`] captures the current values of all
@@ -134,6 +152,7 @@ impl<A: BufferAllocator> BufferPool<A> {
         BufferPoolStats {
             total_hits: self.total_hits(),
             total_misses: self.total_misses(),
+            total_growths: self.total_growths(),
             total_byte_overflows: self.total_byte_overflows(),
         }
     }
@@ -151,6 +170,9 @@ pub struct BufferPoolStats {
     /// Number of acquire operations that required a fresh allocation
     /// because no pooled buffer was available.
     pub total_misses: u64,
+    /// Number of times the adaptive resizer increased the pool's soft
+    /// capacity. Zero when adaptive resizing is not enabled.
+    pub total_growths: u64,
     /// Number of admission rejections due to the byte budget being full
     /// on return. Each rejection means the returning buffer was
     /// deallocated rather than retained. Zero when no byte budget is set.

--- a/crates/engine/src/local_copy/buffer_pool/pressure.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pressure.rs
@@ -1,0 +1,402 @@
+//! Adaptive pool resizing based on allocation pressure.
+//!
+//! Tracks hit/miss rates using atomic counters and periodically adjusts the
+//! pool's soft capacity. A "hit" occurs when a buffer is obtained from the
+//! central pool or thread-local cache. A "miss" occurs when a fresh allocation
+//! is required because no pooled buffer was available.
+//!
+//! # Resize Policy
+//!
+//! - **Grow**: When the miss rate exceeds [`MISS_RATE_GROW_THRESHOLD`] (20%),
+//!   the pool capacity is doubled (up to [`MAX_CAPACITY`]).
+//! - **Shrink**: When utilization drops below [`UTILIZATION_SHRINK_THRESHOLD`]
+//!   (30% of capacity occupied), the pool capacity is halved (down to
+//!   [`MIN_CAPACITY`]).
+//!
+//! # Amortized Checks
+//!
+//! Stats are evaluated every [`CHECK_INTERVAL`] operations (64 by default).
+//! Between checks, only two `Relaxed` atomic increments are performed per
+//! acquire - negligible overhead on the hot path.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Number of acquire operations between resize evaluations.
+///
+/// Chosen to amortize the cost of capacity checks while still reacting
+/// within a few hundred operations. Must be a power of two for efficient
+/// modular arithmetic via bitwise AND.
+const CHECK_INTERVAL: u64 = 64;
+
+/// Miss rate threshold above which the pool grows (20%).
+///
+/// If more than 20% of acquires in the last interval required a fresh
+/// allocation, the pool is undersized.
+const MISS_RATE_GROW_THRESHOLD: f64 = 0.20;
+
+/// Utilization threshold below which the pool shrinks (30%).
+///
+/// If fewer than 30% of pool slots are occupied after a check interval,
+/// the pool is oversized and wasting memory.
+const UTILIZATION_SHRINK_THRESHOLD: f64 = 0.30;
+
+/// Minimum pool capacity after shrinking.
+///
+/// The pool never shrinks below this to avoid degenerate behavior with
+/// very small pools.
+const MIN_CAPACITY: usize = 2;
+
+/// Maximum pool capacity after growing.
+///
+/// Prevents unbounded growth. At 128 KB per buffer (default), 256 buffers
+/// = 32 MB of pooled memory.
+const MAX_CAPACITY: usize = 256;
+
+/// Growth factor applied when the miss rate exceeds the threshold.
+const GROW_FACTOR: usize = 2;
+
+/// Shrink factor applied when utilization drops below the threshold.
+const SHRINK_DIVISOR: usize = 2;
+
+/// Allocation pressure tracker for adaptive pool resizing.
+///
+/// Uses atomic counters to track pool hits (buffer reused from pool) and
+/// misses (fresh allocation required). The counters are reset after each
+/// evaluation to measure pressure within the current interval only.
+///
+/// All operations use `Relaxed` ordering because exact precision is not
+/// required - the resize policy is a heuristic that tolerates small
+/// counting errors under concurrent access.
+#[derive(Debug)]
+pub(super) struct PressureTracker {
+    /// Number of successful pool acquisitions (buffer obtained from pool).
+    hits: AtomicU64,
+    /// Number of pool misses (fresh allocation required).
+    misses: AtomicU64,
+    /// Total acquire operations since last evaluation.
+    ops: AtomicU64,
+}
+
+impl PressureTracker {
+    /// Creates a new pressure tracker with all counters at zero.
+    pub(super) fn new() -> Self {
+        Self {
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            ops: AtomicU64::new(0),
+        }
+    }
+
+    /// Records a pool hit (buffer obtained without fresh allocation).
+    pub(super) fn record_hit(&self) {
+        self.hits.fetch_add(1, Ordering::Relaxed);
+        self.ops.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a pool miss (fresh allocation required).
+    pub(super) fn record_miss(&self) {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        self.ops.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Returns `true` if enough operations have elapsed to warrant a resize
+    /// evaluation.
+    ///
+    /// Uses bitwise AND for efficient modular check (CHECK_INTERVAL is a
+    /// power of two).
+    pub(super) fn should_check(&self) -> bool {
+        let ops = self.ops.load(Ordering::Relaxed);
+        ops > 0 && (ops & (CHECK_INTERVAL - 1)) == 0
+    }
+
+    /// Evaluates the current pressure and returns a resize recommendation.
+    ///
+    /// Resets all counters after evaluation so the next interval starts fresh.
+    ///
+    /// # Arguments
+    ///
+    /// * `current_capacity` - The pool's current soft capacity.
+    /// * `current_available` - Number of buffers currently in the central pool.
+    pub(super) fn evaluate(
+        &self,
+        current_capacity: usize,
+        current_available: usize,
+    ) -> ResizeAction {
+        let hits = self.hits.swap(0, Ordering::Relaxed);
+        let misses = self.misses.swap(0, Ordering::Relaxed);
+        let total = self.ops.swap(0, Ordering::Relaxed);
+
+        if total == 0 {
+            return ResizeAction::Hold;
+        }
+
+        let miss_rate = misses as f64 / total as f64;
+
+        if miss_rate > MISS_RATE_GROW_THRESHOLD {
+            let new_capacity = (current_capacity * GROW_FACTOR).min(MAX_CAPACITY);
+            if new_capacity > current_capacity {
+                return ResizeAction::Grow(new_capacity);
+            }
+            return ResizeAction::Hold;
+        }
+
+        let utilization = if current_capacity > 0 {
+            current_available as f64 / current_capacity as f64
+        } else {
+            0.0
+        };
+
+        // Only shrink when the pool is mostly idle AND the miss rate is low.
+        // The miss-rate gate prevents shrinking when buffers are all checked
+        // out (available = 0, utilization = 0) but demand is high.
+        let _ = hits; // Suppress unused warning; hits contribute to total.
+        if utilization < UTILIZATION_SHRINK_THRESHOLD && miss_rate < MISS_RATE_GROW_THRESHOLD / 2.0
+        {
+            let new_capacity = (current_capacity / SHRINK_DIVISOR).max(MIN_CAPACITY);
+            if new_capacity < current_capacity {
+                return ResizeAction::Shrink(new_capacity);
+            }
+        }
+
+        ResizeAction::Hold
+    }
+
+    /// Returns the current hit count (for diagnostics/testing).
+    #[cfg(test)]
+    pub(super) fn hits(&self) -> u64 {
+        self.hits.load(Ordering::Relaxed)
+    }
+
+    /// Returns the current miss count (for diagnostics/testing).
+    #[cfg(test)]
+    pub(super) fn misses(&self) -> u64 {
+        self.misses.load(Ordering::Relaxed)
+    }
+
+    /// Returns the current operation count (for diagnostics/testing).
+    #[cfg(test)]
+    pub(super) fn ops(&self) -> u64 {
+        self.ops.load(Ordering::Relaxed)
+    }
+}
+
+/// Resize recommendation from pressure evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ResizeAction {
+    /// Keep current capacity.
+    Hold,
+    /// Grow to the specified new capacity.
+    Grow(usize),
+    /// Shrink to the specified new capacity.
+    Shrink(usize),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_tracker_has_zero_counters() {
+        let tracker = PressureTracker::new();
+        assert_eq!(tracker.hits(), 0);
+        assert_eq!(tracker.misses(), 0);
+        assert_eq!(tracker.ops(), 0);
+    }
+
+    #[test]
+    fn record_hit_increments_counters() {
+        let tracker = PressureTracker::new();
+        tracker.record_hit();
+        assert_eq!(tracker.hits(), 1);
+        assert_eq!(tracker.misses(), 0);
+        assert_eq!(tracker.ops(), 1);
+    }
+
+    #[test]
+    fn record_miss_increments_counters() {
+        let tracker = PressureTracker::new();
+        tracker.record_miss();
+        assert_eq!(tracker.hits(), 0);
+        assert_eq!(tracker.misses(), 1);
+        assert_eq!(tracker.ops(), 1);
+    }
+
+    #[test]
+    fn should_check_at_interval_boundary() {
+        let tracker = PressureTracker::new();
+        for i in 1..CHECK_INTERVAL {
+            tracker.record_hit();
+            if i < CHECK_INTERVAL {
+                // Not at boundary yet (except at CHECK_INTERVAL itself).
+            }
+        }
+        assert!(!tracker.should_check());
+        tracker.record_hit();
+        assert!(tracker.should_check());
+    }
+
+    #[test]
+    fn should_check_false_at_zero() {
+        let tracker = PressureTracker::new();
+        assert!(!tracker.should_check());
+    }
+
+    #[test]
+    fn evaluate_hold_with_all_hits() {
+        let tracker = PressureTracker::new();
+        for _ in 0..CHECK_INTERVAL {
+            tracker.record_hit();
+        }
+        // All hits, capacity 8, 6 available (75% utilization) - hold.
+        let action = tracker.evaluate(8, 6);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_grow_with_high_miss_rate() {
+        let tracker = PressureTracker::new();
+        // 30% miss rate (above 20% threshold).
+        for _ in 0..70 {
+            tracker.record_hit();
+        }
+        for _ in 0..30 {
+            tracker.record_miss();
+        }
+        let action = tracker.evaluate(8, 4);
+        assert_eq!(action, ResizeAction::Grow(16));
+    }
+
+    #[test]
+    fn evaluate_grow_capped_at_max() {
+        let tracker = PressureTracker::new();
+        for _ in 0..50 {
+            tracker.record_miss();
+        }
+        let action = tracker.evaluate(MAX_CAPACITY, 0);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_shrink_with_low_utilization() {
+        let tracker = PressureTracker::new();
+        // All hits, low miss rate, low utilization.
+        for _ in 0..CHECK_INTERVAL {
+            tracker.record_hit();
+        }
+        // 16 capacity, 2 available = 12.5% utilization.
+        let action = tracker.evaluate(16, 2);
+        assert_eq!(action, ResizeAction::Shrink(8));
+    }
+
+    #[test]
+    fn evaluate_shrink_capped_at_min() {
+        let tracker = PressureTracker::new();
+        for _ in 0..CHECK_INTERVAL {
+            tracker.record_hit();
+        }
+        let action = tracker.evaluate(MIN_CAPACITY, 0);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_no_shrink_when_miss_rate_moderate() {
+        let tracker = PressureTracker::new();
+        // 15% miss rate - below grow threshold but above shrink guard.
+        for _ in 0..85 {
+            tracker.record_hit();
+        }
+        for _ in 0..15 {
+            tracker.record_miss();
+        }
+        // Low utilization but moderate misses - should hold.
+        let action = tracker.evaluate(16, 2);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_resets_counters() {
+        let tracker = PressureTracker::new();
+        for _ in 0..50 {
+            tracker.record_hit();
+        }
+        let _ = tracker.evaluate(8, 4);
+        assert_eq!(tracker.hits(), 0);
+        assert_eq!(tracker.misses(), 0);
+        assert_eq!(tracker.ops(), 0);
+    }
+
+    #[test]
+    fn evaluate_zero_ops_returns_hold() {
+        let tracker = PressureTracker::new();
+        let action = tracker.evaluate(8, 4);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_zero_capacity_no_panic() {
+        let tracker = PressureTracker::new();
+        for _ in 0..10 {
+            tracker.record_miss();
+        }
+        let action = tracker.evaluate(0, 0);
+        // Cannot grow from 0 (0 * 2 = 0).
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn concurrent_hit_miss_tracking() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let tracker = Arc::new(PressureTracker::new());
+        let thread_count = 8;
+        let iterations = 1000;
+
+        let handles: Vec<_> = (0..thread_count)
+            .map(|id| {
+                let t = Arc::clone(&tracker);
+                thread::spawn(move || {
+                    for _ in 0..iterations {
+                        if id % 2 == 0 {
+                            t.record_hit();
+                        } else {
+                            t.record_miss();
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+
+        let total = tracker.ops();
+        assert_eq!(total, thread_count as u64 * iterations);
+    }
+
+    #[test]
+    fn check_interval_is_power_of_two() {
+        assert!(CHECK_INTERVAL.is_power_of_two());
+    }
+
+    #[test]
+    fn grow_factor_doubles_capacity() {
+        let tracker = PressureTracker::new();
+        for _ in 0..100 {
+            tracker.record_miss();
+        }
+        let action = tracker.evaluate(4, 0);
+        assert_eq!(action, ResizeAction::Grow(8));
+    }
+
+    #[test]
+    fn shrink_halves_capacity() {
+        let tracker = PressureTracker::new();
+        for _ in 0..CHECK_INTERVAL {
+            tracker.record_hit();
+        }
+        let action = tracker.evaluate(32, 4);
+        assert_eq!(action, ResizeAction::Shrink(16));
+    }
+}

--- a/crates/engine/src/local_copy/buffer_pool/tests/adaptive_pool.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests/adaptive_pool.rs
@@ -1,0 +1,308 @@
+//! Adaptive pool-capacity resizing (grow on pressure, shrink when idle).
+
+use super::super::*;
+use super::support::AdaptiveTrackingAllocator;
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+#[test]
+fn adaptive_resizing_disabled_by_default() {
+    let pool = BufferPool::new(4);
+    assert!(!pool.is_adaptive());
+}
+
+#[test]
+fn adaptive_resizing_enabled_via_builder() {
+    let pool = BufferPool::new(4).with_adaptive_resizing();
+    assert!(pool.is_adaptive());
+}
+
+#[test]
+fn adaptive_resizing_with_builder_chain() {
+    let pool = BufferPool::with_buffer_size(4, 1024)
+        .with_memory_cap(8192)
+        .with_adaptive_resizing();
+    assert!(pool.is_adaptive());
+    assert_eq!(pool.memory_cap(), Some(8192));
+    assert_eq!(pool.buffer_size(), 1024);
+}
+
+#[test]
+fn adaptive_pool_grows_under_pressure() {
+    // Start with a tiny pool (capacity 2) and force many misses by
+    // holding all buffers checked out simultaneously.
+    let pool = Arc::new(
+        BufferPool::with_allocator(2, 1024, AdaptiveTrackingAllocator::new())
+            .with_adaptive_resizing(),
+    );
+    let initial_capacity = pool.max_buffers();
+    assert_eq!(initial_capacity, 2);
+
+    // Hold buffers to exhaust the pool, then acquire more to force misses.
+    // Each acquire beyond the pool's capacity triggers a miss. After 64
+    // operations (the check interval), the pool should grow.
+    let mut held = Vec::new();
+    for _ in 0..128 {
+        held.push(BufferPool::acquire_from(Arc::clone(&pool)));
+    }
+
+    // The pool should have grown due to high miss rate.
+    let new_capacity = pool.max_buffers();
+    assert!(
+        new_capacity > initial_capacity,
+        "expected capacity > {initial_capacity}, got {new_capacity}"
+    );
+
+    drop(held);
+}
+
+// The shrink-on-idle integration test below pre-fills the central pool by
+// relying on the single-slot TLS path (one buffer absorbed by TLS, 63
+// routed to the central queue). With the per-thread slab feature on, the
+// slab swallows up to 8 returns per thread before routing to the central
+// queue, which changes the central-queue occupancy and the hit/miss ratio
+// the assertion is calibrated against. Slab-backend equivalents live in
+// `tests/slab.rs`.
+#[cfg(not(feature = "thread-slab-pool"))]
+#[test]
+fn adaptive_pool_shrinks_when_idle() {
+    // Integration test for adaptive pool shrinking through the public API.
+    //
+    // Mathematical analysis of shrink conditions:
+    //   - utilization = available / capacity < 0.30
+    //   - miss_rate = misses / total < 0.10
+    //   - ops >= CHECK_INTERVAL (64)
+    //   - Each fresh thread has cold TLS, so acquire_from calls pop_buffer()
+    //   - TLS buffers are lost on thread exit (not returned to central pool)
+    //
+    // Strategy:
+    // 1. Start at MAX_CAPACITY (256) so pre-fill misses can't cause growth.
+    // 2. Pre-fill: hold 64 buffers, then drop. Main thread's TLS absorbs 1,
+    //    central pool receives 63. Pressure tracker resets at ops=64 (all
+    //    misses, but capacity=MAX_CAPACITY -> Hold -> counters reset to 0).
+    // 3. Spawn 64 fresh threads (cold TLS -> pop_buffer for each):
+    //    - 63 buffers in pool -> 63 HITs, 1 MISS (pool empty for last thread)
+    //    - miss_rate = 1/64 ~ 1.6% < 10% (ok)
+    //    - At op 64: available=0, utilization = 0/256 = 0% < 30% (ok)
+    //    - evaluate() -> Shrink(128)
+    let pool = Arc::new(BufferPool::with_buffer_size(256, 1024).with_adaptive_resizing());
+    assert_eq!(pool.max_buffers(), 256);
+
+    // Phase 1: Pre-fill the central pool.
+    // Acquire 64 buffers simultaneously - all go through pop_buffer (TLS is
+    // empty, pool is empty -> 64 fresh allocations, all MISSes). At ops=64,
+    // maybe_resize fires: miss_rate=100% but capacity=256=MAX_CAPACITY, so
+    // grow is capped -> Hold. Tracker resets to zero.
+    {
+        let bufs: Vec<_> = (0..64)
+            .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+            .collect();
+        drop(bufs);
+        // Drop order: first buffer -> TLS (empty slot), remaining 63 -> central
+        // pool (TLS occupied). Central pool now holds 63 buffers.
+    }
+
+    // Phase 2: 64 fresh threads, each with cold TLS -> pop_buffer on every
+    // acquire. Pool drains from 63 -> 0: 63 HITs + 1 MISS = 1.6% miss rate.
+    // The 64th pop_buffer triggers maybe_resize with available=0, cap=256.
+    let handles: Vec<_> = (0..64)
+        .map(|_| {
+            let pool = Arc::clone(&pool);
+            thread::spawn(move || {
+                let _buf = BufferPool::acquire_from(pool);
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+
+    let new_capacity = pool.max_buffers();
+    assert!(
+        new_capacity < 256,
+        "expected capacity < 256 (shrink), got {new_capacity}"
+    );
+}
+
+#[test]
+fn adaptive_pool_holds_steady_under_balanced_load() {
+    // Pre-fill the pool, then use it at a rate that roughly matches capacity.
+    // The pool should not resize.
+    let pool = Arc::new(BufferPool::with_buffer_size(8, 1024).with_adaptive_resizing());
+
+    // Pre-populate with 8 buffers.
+    let bufs: Vec<_> = (0..8)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    drop(bufs);
+
+    // Acquire and release one at a time - all hits from pool/TLS.
+    for _ in 0..256 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    // Capacity should stay at 8 (balanced utilization).
+    let capacity = pool.max_buffers();
+    assert!(
+        (4..=16).contains(&capacity),
+        "expected capacity near 8, got {capacity}"
+    );
+}
+
+#[test]
+fn adaptive_pool_concurrent_growth() {
+    // Verifies that concurrent allocation pressure grows the pool, without
+    // depending on a race in the resize-check boundary.
+    //
+    // The resize evaluation only fires when a thread observes the shared op
+    // counter at an exact multiple of CHECK_INTERVAL (64). That counter is
+    // sampled with a plain load that races concurrent increments: under
+    // contention every thread can load a value already bumped past 64 by its
+    // peers, so no thread observes the boundary and the pool never resizes.
+    // The old design ran two 64-op concurrent rounds hoping one boundary would
+    // land; under load both could be missed, capacity stayed at 2, and the
+    // assertion flaked.
+    //
+    // Fix: build the miss pressure concurrently (worker threads that are
+    // provably all in-flight via a barrier), keeping the op count strictly
+    // below CHECK_INTERVAL so no check fires mid-phase, then cross the boundary
+    // from a single thread where the counter cannot be raced. The evaluation is
+    // then guaranteed to observe the accumulated high miss rate and grow.
+    const THREADS: usize = 15;
+    const PER_THREAD: usize = 4; // 15 * 4 = 60 ops, below CHECK_INTERVAL (64).
+
+    let pool = Arc::new(BufferPool::with_buffer_size(2, 1024).with_adaptive_resizing());
+    let initial = pool.max_buffers();
+    assert_eq!(initial, 2);
+
+    // Concurrent phase: every worker holds all its buffers simultaneously (the
+    // barrier guarantees all acquisitions are in-flight before any release), so
+    // the capacity-2 pool cannot serve them and every acquire is a genuine
+    // concurrent miss. Total ops (60) stay under CHECK_INTERVAL, so no resize
+    // check fires here and the misses accumulate for the evaluation below.
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let handles: Vec<_> = (0..THREADS)
+        .map(|_| {
+            let pool = Arc::clone(&pool);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let held: Vec<_> = (0..PER_THREAD)
+                    .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+                    .collect();
+                barrier.wait();
+                drop(held);
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+
+    // Boundary-crossing phase: single-threaded acquires push the op counter to
+    // exactly CHECK_INTERVAL. With no concurrent writers the boundary is
+    // observed deterministically, evaluate() sees the accumulated high miss
+    // rate, and the pool grows. If the grow path regresses (threshold, wiring,
+    // or evaluate logic), the counter still crosses the boundary but capacity
+    // stays at 2 and this assertion fails.
+    let _settle: Vec<_> = (0..PER_THREAD)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+
+    let final_cap = pool.max_buffers();
+    assert!(
+        final_cap > initial,
+        "expected capacity > {initial}, got {final_cap}"
+    );
+}
+
+#[test]
+fn adaptive_pool_does_not_grow_without_feature() {
+    // Without adaptive resizing, capacity is fixed.
+    let pool = Arc::new(BufferPool::with_buffer_size(2, 1024));
+
+    let mut held = Vec::new();
+    for _ in 0..128 {
+        held.push(BufferPool::acquire_from(Arc::clone(&pool)));
+    }
+
+    assert_eq!(pool.max_buffers(), 2);
+    drop(held);
+}
+
+#[test]
+fn adaptive_pool_shrink_respects_minimum() {
+    // Pool should never shrink below the minimum (2).
+    let pool = Arc::new(BufferPool::with_buffer_size(4, 1024).with_adaptive_resizing());
+
+    // Light usage to trigger shrink.
+    for _ in 0..512 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    let capacity = pool.max_buffers();
+    assert!(capacity >= 2, "expected capacity >= 2, got {capacity}");
+}
+
+#[test]
+fn adaptive_pool_grow_respects_maximum() {
+    // Pool should never grow beyond 256.
+    let pool = Arc::new(BufferPool::with_buffer_size(128, 1024).with_adaptive_resizing());
+
+    // Force heavy misses by holding many buffers.
+    let mut held = Vec::new();
+    for _ in 0..1024 {
+        held.push(BufferPool::acquire_from(Arc::clone(&pool)));
+    }
+
+    let capacity = pool.max_buffers();
+    assert!(capacity <= 256, "expected capacity <= 256, got {capacity}");
+    drop(held);
+}
+
+#[test]
+fn adaptive_pool_with_custom_allocator() {
+    let pool = Arc::new(
+        BufferPool::with_allocator(2, 512, AdaptiveTrackingAllocator::new())
+            .with_adaptive_resizing(),
+    );
+
+    // Force misses to trigger growth.
+    let held: Vec<_> = (0..128)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+
+    assert!(pool.max_buffers() > 2);
+    assert!(pool.allocator().alloc_count() > 2);
+
+    drop(held);
+}
+
+#[test]
+fn adaptive_pool_deallocates_on_shrink() {
+    let pool = Arc::new(
+        BufferPool::with_allocator(16, 512, AdaptiveTrackingAllocator::new())
+            .with_adaptive_resizing(),
+    );
+
+    // Pre-fill the pool.
+    let bufs: Vec<_> = (0..16)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    drop(bufs);
+
+    let deallocs_before = pool.allocator().dealloc_count();
+
+    // Light usage to trigger shrink. Pool has 16 buffers but low demand.
+    for _ in 0..512 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    // If the pool shrank, it should have deallocated excess buffers.
+    if pool.max_buffers() < 16 {
+        assert!(
+            pool.allocator().dealloc_count() > deallocs_before,
+            "expected deallocations after shrink"
+        );
+    }
+}

--- a/crates/engine/src/local_copy/buffer_pool/tests/controller.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests/controller.rs
@@ -41,8 +41,10 @@ fn buffer_controller_preserves_existing_throughput_tracker() {
 fn buffer_controller_with_builder_chain() {
     let pool = BufferPool::with_buffer_size(4, 1024)
         .with_memory_cap(8192)
+        .with_adaptive_resizing()
         .with_buffer_controller(ControllerConfig::new(50 * 1024 * 1024));
     assert!(pool.has_buffer_controller());
+    assert!(pool.is_adaptive());
     assert_eq!(pool.memory_cap(), Some(8192));
     assert_eq!(pool.buffer_size(), 1024);
 }

--- a/crates/engine/src/local_copy/buffer_pool/tests/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests/mod.rs
@@ -2,12 +2,14 @@
 //!
 //! The pool's behavioural surface is broad (basic ops, adaptive sizing,
 //! contention, TLS cache, byte budget, memory cap, throughput tracker,
-//! buffer controller, telemetry, per-thread slab) so the tests are
-//! partitioned by concern. Each submodule focuses on a single facet to
-//! keep individual files reviewable and below the workspace LoC cap.
+//! buffer controller, adaptive resizing, telemetry, per-thread slab) so
+//! the tests are partitioned by concern. Each submodule focuses on a
+//! single facet to keep individual files reviewable and below the
+//! workspace LoC cap.
 
 mod support;
 
+mod adaptive_pool;
 mod byte_budget;
 mod contention;
 mod controller;

--- a/crates/engine/src/local_copy/buffer_pool/tests/support.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests/support.rs
@@ -41,3 +41,41 @@ impl BufferAllocator for TrackingAllocator {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 }
+
+/// A counting allocator that tracks allocations for adaptive resizing tests.
+#[derive(Debug)]
+pub(super) struct AdaptiveTrackingAllocator {
+    alloc_count: AtomicUsize,
+    dealloc_count: AtomicUsize,
+}
+
+impl AdaptiveTrackingAllocator {
+    pub(super) fn new() -> Self {
+        Self {
+            alloc_count: AtomicUsize::new(0),
+            dealloc_count: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) fn alloc_count(&self) -> usize {
+        self.alloc_count.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(super) fn dealloc_count(&self) -> usize {
+        self.dealloc_count
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+impl BufferAllocator for AdaptiveTrackingAllocator {
+    fn allocate(&self, size: usize) -> Vec<u8> {
+        self.alloc_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        vec![0u8; size]
+    }
+
+    fn deallocate(&self, _buffer: Vec<u8>) {
+        self.dealloc_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}

--- a/crates/engine/src/local_copy/buffer_pool/tests/telemetry.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests/telemetry.rs
@@ -1,4 +1,4 @@
-//! Hit / miss counters and the BufferPoolStats snapshot.
+//! Hit / miss / growth counters and the BufferPoolStats snapshot.
 
 use super::super::*;
 use std::sync::Arc;
@@ -97,6 +97,16 @@ fn telemetry_concurrent_counting() {
 }
 
 #[test]
+fn telemetry_with_adaptive_resizing() {
+    // Telemetry counters work independently of adaptive resizing.
+    let pool = Arc::new(BufferPool::new(4).with_adaptive_resizing());
+    for _ in 0..100 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+    assert_eq!(pool.total_acquires(), 100);
+}
+
+#[test]
 fn telemetry_try_acquire_counts_hits() {
     let pool = BufferPool::with_buffer_size(4, 1024).with_memory_cap(4096);
     // First acquire: miss.
@@ -141,7 +151,46 @@ fn stats_returns_snapshot() {
     assert_eq!(stats.total_acquires(), 2);
     assert_eq!(stats.total_misses, 1);
     assert_eq!(stats.total_hits, 1);
+    assert_eq!(stats.total_growths, 0);
     assert!((stats.hit_rate() - 0.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn stats_growths_zero_without_adaptive() {
+    let pool = Arc::new(BufferPool::new(2));
+    let mut held = Vec::new();
+    for _ in 0..128 {
+        held.push(BufferPool::acquire_from(Arc::clone(&pool)));
+    }
+    assert_eq!(pool.total_growths(), 0);
+    assert_eq!(pool.stats().total_growths, 0);
+    drop(held);
+}
+
+#[test]
+fn stats_growths_incremented_on_adaptive_grow() {
+    let pool = Arc::new(BufferPool::with_buffer_size(2, 1024).with_adaptive_resizing());
+    let initial = pool.max_buffers();
+
+    // Hold many buffers to force misses and trigger growth.
+    let mut held = Vec::new();
+    for _ in 0..128 {
+        held.push(BufferPool::acquire_from(Arc::clone(&pool)));
+    }
+
+    let new_capacity = pool.max_buffers();
+    if new_capacity > initial {
+        assert!(
+            pool.total_growths() >= 1,
+            "expected at least 1 growth event, got {}",
+            pool.total_growths()
+        );
+        assert!(
+            pool.stats().total_growths >= 1,
+            "stats().total_growths should match total_growths()"
+        );
+    }
+    drop(held);
 }
 
 #[test]
@@ -149,6 +198,7 @@ fn stats_hit_rate_empty() {
     let stats = BufferPoolStats {
         total_hits: 0,
         total_misses: 0,
+        total_growths: 0,
         total_byte_overflows: 0,
     };
     assert_eq!(stats.hit_rate(), 0.0);
@@ -160,6 +210,7 @@ fn stats_hit_rate_all_hits() {
     let stats = BufferPoolStats {
         total_hits: 100,
         total_misses: 0,
+        total_growths: 0,
         total_byte_overflows: 0,
     };
     assert!((stats.hit_rate() - 1.0).abs() < f64::EPSILON);
@@ -170,6 +221,7 @@ fn stats_hit_rate_all_misses() {
     let stats = BufferPoolStats {
         total_hits: 0,
         total_misses: 50,
+        total_growths: 0,
         total_byte_overflows: 0,
     };
     assert_eq!(stats.hit_rate(), 0.0);
@@ -181,6 +233,7 @@ fn stats_debug_and_clone() {
     let stats = BufferPoolStats {
         total_hits: 10,
         total_misses: 5,
+        total_growths: 1,
         total_byte_overflows: 2,
     };
     let cloned = stats;
@@ -188,5 +241,6 @@ fn stats_debug_and_clone() {
     let debug = format!("{stats:?}");
     assert!(debug.contains("total_hits"));
     assert!(debug.contains("total_misses"));
+    assert!(debug.contains("total_growths"));
     assert!(debug.contains("total_byte_overflows"));
 }


### PR DESCRIPTION
Reverts #7121. The buffer-pool soft-capacity resizer (`PressureTracker`/`maybe_resize`, `buffer_pool/pool/resize.rs` + `pressure.rs`) was removed as "dead code" (zero production callers), but it is the intentional local actuator that the forthcoming cross-stage throughput governor composes: governor pressure feeds `maybe_resize` (conservative-min with the local `PressureTracker`). Removing it was premature scaffolding loss. Restores the module, the `with_adaptive_resizing` builder, `is_adaptive`, `total_growths`, the re-exports, and its tests exactly. No production behavior change (still test-only until the governor wires it).