### PR TITLE
fix(bandwidth): throttle sender socket writes for --bwlimit (mirror upstream)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4227,6 +4227,7 @@ name = "transfer"
 version = "0.6.4"
 dependencies = [
  "apple-fs",
+ "bandwidth",
  "checksums",
  "compress",
  "criterion",

--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -46,6 +46,13 @@ pub(crate) fn detect_secluded_args_flag(args: &[OsString]) -> bool {
 pub(super) struct ServerLongFlags {
     pub(super) is_sender: bool,
     pub(super) is_receiver: bool,
+    /// Bandwidth limit forwarded by the client as whole KiB per second.
+    ///
+    /// upstream: options.c:2799 - `server_options()` emits `--bwlimit=%d` where
+    /// `%d` is the rate in whole KiB (options.c:1718). Only the sender-role
+    /// server (`--sender`) acts on it; a receiver disables its own throttle
+    /// (main.c:1068). Captured raw here and parsed when building the config.
+    pub(super) bwlimit: Option<String>,
     pub(super) ignore_errors: bool,
     pub(super) fsync: bool,
     pub(super) io_uring_policy: fast_io::IoUringPolicy,
@@ -375,6 +382,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
     let mut flags = ServerLongFlags {
         is_sender: false,
         is_receiver: false,
+        bwlimit: None,
         ignore_errors: false,
         fsync: false,
         io_uring_policy: fast_io::IoUringPolicy::Auto,
@@ -730,6 +738,9 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.max_size = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--max-alloc=") {
         flags.max_alloc = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--bwlimit=") {
+        // upstream: options.c:2799 - client forwards `--bwlimit=%d` in whole KiB.
+        flags.bwlimit = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--stop-at=") {
         flags.stop_at = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--stop-after=") {

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -727,6 +727,25 @@ fn apply_value_flags<Err: Write>(
         }
     }
 
+    // upstream: options.c:2799 - the client forwards `--bwlimit=%d` (whole KiB)
+    // to the server. When this server is the sender (`--sender`), it paces its
+    // own outbound socket writes (io.c:846,861); a receiver ignores it
+    // (main.c:1068). Parse with the `--bwlimit` KiB default suffix and carry the
+    // rate/burst onto the connection so the transfer body installs the limiter.
+    if let Some(bwlimit_str) = &long_flags.bwlimit {
+        match bandwidth::parse_bandwidth_limit(bwlimit_str) {
+            Ok(components) => {
+                if components.rate().is_some() {
+                    config.connection.bwlimit = Some(components);
+                }
+            }
+            Err(e) => {
+                write_server_error(stderr, brand, format!("invalid --bwlimit: {e}"));
+                return Err(1);
+            }
+        }
+    }
+
     if let Some(depth_str) = &long_flags.io_uring_depth {
         match depth_str.parse::<u32>() {
             Ok(parsed) => match fast_io::validate_io_uring_depth(parsed) {

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -171,6 +171,14 @@ pub(crate) fn build_server_config_for_generator(
         ServerConfig::from_flag_string_and_args(ServerRole::Generator, flag_string, args)
             .map_err(|e| invalid_argument_error(&format!("invalid server config: {e}"), 1))?;
 
+    // upstream: io.c:834-862 / main.c:1068 - on an rsync:// push the local
+    // client IS the sender and paces its own outbound socket writes. Carry the
+    // parsed `--bwlimit` rate/burst onto the in-process generator config; the
+    // daemon receiver ignores its forwarded copy (main.c:1068).
+    server_config.connection.bwlimit = config
+        .bandwidth_limit()
+        .map(|limit| limit.into_components());
+
     apply_common_daemon_config(config, &mut server_config, filter_rules);
     server_config.reference_directories = config.reference_directories().to_vec();
     // upstream: --chmod is parsed into `chmod_modes` (options.c:1762) and is

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -670,6 +670,14 @@ fn build_server_config_for_generator(
         ServerConfig::from_flag_string_and_args(ServerRole::Generator, flag_string, args)
             .map_err(|e| invalid_argument_error(&format!("invalid server config: {e}"), 1))?;
 
+    // upstream: io.c:834-862 / main.c:1068 - on a push the local client IS the
+    // sender, so it paces its own outbound socket writes. Carry the parsed
+    // `--bwlimit` rate/burst onto the in-process generator config; the remote
+    // receiver ignores its forwarded copy (main.c:1068).
+    server_config.connection.bwlimit = config
+        .bandwidth_limit()
+        .map(|limit| limit.into_components());
+
     server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -217,6 +217,14 @@ pub(in crate::client::remote) fn build_server_config_for_generator(
         ServerConfig::from_flag_string_and_args(ServerRole::Generator, flag_string, args)
             .map_err(|e| invalid_argument_error(&format!("invalid server config: {e}"), 1))?;
 
+    // upstream: io.c:834-862 / main.c:1068 - on a push the local client IS the
+    // sender and paces its own outbound socket writes. Carry the parsed
+    // `--bwlimit` rate/burst onto the in-process generator config; the remote
+    // receiver ignores its forwarded copy (main.c:1068).
+    server_config.connection.bwlimit = config
+        .bandwidth_limit()
+        .map(|limit| limit.into_components());
+
     // Propagate long-form-only flags that aren't part of the compact flag string.
     // upstream: numeric_ids and delete are --numeric-ids / --delete-* long-form args only.
     server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -306,6 +306,42 @@ fn build_server_config(
             // window once the original CVE-2026-29518 fix landed.
             cfg.connection.is_daemon_connection = true;
 
+            // upstream: options.c:2390-2397 - the daemon sender paces its own
+            // outbound socket writes (io.c:846,861) at the client's forwarded
+            // `--bwlimit` capped by the effective module/global bwlimit.
+            // `ctx.limiter` already holds that daemon-side cap (computed by
+            // apply_module_bandwidth_limit before the transfer), and it is the
+            // SAME limiter that throttles the pre-transfer `@RSYNCD:` text phase
+            // (session_runtime.rs `write_limited`); the bulk phase runs on the
+            // separate `run_server_with_handshake` writer stack, so carrying the
+            // rate here installs one limiter per phase with no double-throttle.
+            // A receiver ignores this (main.c:1068), so it is set unconditionally.
+            {
+                let client_rate = client_args.iter().find_map(|arg| {
+                    arg.strip_prefix("--bwlimit=")
+                        .and_then(|value| parse_bandwidth_limit(value).ok())
+                        .and_then(|components| components.rate())
+                });
+                let daemon_cap = ctx.limiter.as_ref().map(BandwidthLimiter::limit_bytes);
+                let daemon_burst = ctx.limiter.as_ref().and_then(BandwidthLimiter::burst_bytes);
+                // upstream: options.c:2390 `if (daemon_bwlimit && (!bwlimit ||
+                // bwlimit > daemon_bwlimit)) bwlimit = daemon_bwlimit;`
+                let effective = match (client_rate, daemon_cap) {
+                    (Some(client), Some(cap)) => Some(client.min(cap)),
+                    (Some(client), None) => Some(client),
+                    (None, Some(cap)) => Some(cap),
+                    (None, None) => None,
+                };
+                cfg.connection.bwlimit = effective.map(|rate| {
+                    let burst = if daemon_cap == Some(rate) {
+                        daemon_burst
+                    } else {
+                        None
+                    };
+                    BandwidthLimitComponents::new(Some(rate), burst)
+                });
+            }
+
             // upstream: clientserver.c:1120-1121 - `fake super = yes` on the
             // daemon module demotes the receiver's am_root and forces fake-super
             // semantics regardless of whether the client requested --fake-super.

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -21,6 +21,7 @@ engine = { path = "../engine", default-features = false }
 signature = { path = "../signature" }
 filters = { path = "../filters" }
 compress = { path = "../compress" }
+bandwidth = { path = "../bandwidth" }
 logging = { path = "../logging" }
 fast_io = { path = "../fast_io", default-features = false }
 crossbeam-queue = { workspace = true }

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -10,6 +10,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+use bandwidth::BandwidthLimitComponents;
 use compress::zlib::CompressionLevel;
 use metadata::{ChmodModifiers, GroupMapping, ModifyWindow, UserMapping};
 use protocol::FilenameConverter;
@@ -288,6 +289,25 @@ pub struct ConnectionConfig {
     /// [`implied_source_args`]: Self::implied_source_args
     /// [`files_from_data`]: Self::files_from_data
     pub implied_skip_daemon_module: bool,
+    /// Effective `--bwlimit` rate (and optional burst) applied to the sender's
+    /// outbound socket writes.
+    ///
+    /// `Some` only when the local process is the sender (`am_sender`) and a
+    /// non-zero limit is in effect: a client push, an SSH `--server --sender`,
+    /// or a daemon-sender on a pull. The receiver leaves this `None`, mirroring
+    /// upstream `main.c:1068` where the receiver sets `bwlimit_writemax = 0`.
+    /// A `None` value (or a zero rate) is a no-op passthrough on the wire.
+    ///
+    /// The live [`bandwidth::BandwidthLimiter`] is constructed from these
+    /// components at transfer start and installed on the sender's socket writer.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:846,861` - clamp each write to `bwlimit_writemax`, then
+    ///   `sleep_for_bwlimit(n)`.
+    /// - `options.c:2394-2397` - `bwlimit_writemax = bwlimit * 128`, min 512.
+    /// - `main.c:1068` - the receiver disables its own bwlimit.
+    pub bwlimit: Option<BandwidthLimitComponents>,
 }
 
 /// File selection and filtering options for transfer candidates.

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -429,6 +429,32 @@ pub(crate) fn compute_allow_inc_recurse(recursive: bool, qsort: bool, role: Serv
     recursive && !qsort && role == ServerRole::Generator
 }
 
+/// Builds the sender-side bandwidth limiter for this server transfer.
+///
+/// Returns `Some` only when the local role is the sender
+/// ([`ServerRole::Generator`], i.e. an SSH `--server --sender`, a client push,
+/// or a daemon-sender on a pull) and a non-zero `--bwlimit` is in effect. The
+/// receiver always returns `None`: upstream `main.c:1068` sets
+/// `bwlimit_writemax = 0` on the receiver, so it never paces its own writes. A
+/// `None` result makes the sender's socket writer a zero-overhead passthrough.
+///
+/// # Upstream Reference
+///
+/// - `main.c:1068` - the receiver disables its own bwlimit.
+/// - `io.c:846,861` / `options.c:2394-2397` - the sender clamps each write to
+///   `bwlimit_writemax` then `sleep_for_bwlimit(n)`.
+fn sender_bandwidth_limiter(config: &ServerConfig) -> Option<bandwidth::BandwidthLimiter> {
+    if config.role != ServerRole::Generator {
+        return None;
+    }
+    let components = config.connection.bwlimit?;
+    let rate = components.rate()?;
+    Some(bandwidth::BandwidthLimiter::with_burst(
+        rate,
+        components.burst(),
+    ))
+}
+
 /// Executes the native server entry point over standard I/O.
 ///
 /// The implementation performs the protocol handshake before dispatching to the
@@ -775,12 +801,20 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         });
     }
 
+    // upstream: main.c:1068 - only the sender paces its outbound writes; the
+    // receiver sets `bwlimit_writemax = 0`. On this server body that is the
+    // Generator role (SSH `--server --sender`, a client push, or a daemon-sender
+    // on a pull). Install the limiter at the bottom of the writer stack so it
+    // paces the exact wire bytes the descriptor accepts (io.c:846,861), below
+    // the multiplex framer.
+    let throttled_stdout = writer::ThrottlingWriter::new(stdout, sender_bandwidth_limiter(&config));
+
     // upstream: io.c:859 - stats.total_written counts every byte the raw
     // descriptor accepts, multiplex frame headers included, in perform_io().
     // Wrap the transport below the multiplex framer so the shared counter
     // mirrors that raw wire total; the sender samples it at its handle_stats
     // point (main.c:979-980) and reports it as "Total bytes sent".
-    let counting_stdout = writer::CountingWriter::new_shared(stdout);
+    let counting_stdout = writer::CountingWriter::new_shared(throttled_stdout);
     let bytes_sent_counter = counting_stdout.counter();
 
     // MultiplexWriter provides 64KB buffering (matching upstream iobuf_out).

--- a/crates/transfer/src/tests/bwlimit_wiring.rs
+++ b/crates/transfer/src/tests/bwlimit_wiring.rs
@@ -1,0 +1,92 @@
+//! Tests for the sender-role gating of `--bwlimit` on the server transfer body.
+//!
+//! These encode the upstream invariant that only the sender paces its own
+//! outbound socket writes: `main.c:1068` disables the receiver's throttle
+//! (`bwlimit_writemax = 0`), while the sender clamps and sleeps per write
+//! (`io.c:846,861`). The wiring carries the effective rate on
+//! `ConnectionConfig::bwlimit`; [`crate::sender_bandwidth_limiter`] turns it
+//! into a live limiter only for the Generator (sender) role.
+
+use std::num::NonZeroU64;
+
+use bandwidth::BandwidthLimitComponents;
+
+use crate::sender_bandwidth_limiter;
+use crate::{ServerConfig, ServerRole};
+
+fn config_with_bwlimit(
+    role: ServerRole,
+    bwlimit: Option<BandwidthLimitComponents>,
+) -> ServerConfig {
+    let mut config =
+        ServerConfig::from_flag_string_and_args(role, "-logDtpre.iLsfxC".to_owned(), Vec::new())
+            .expect("config parses");
+    config.connection.bwlimit = bwlimit;
+    config
+}
+
+fn components(rate: u64) -> BandwidthLimitComponents {
+    BandwidthLimitComponents::new(NonZeroU64::new(rate), None)
+}
+
+/// The sender (Generator) installs a limiter when a non-zero `--bwlimit` is set.
+///
+/// WHY: the sender must pace its socket writes (upstream `io.c:846,861`), so a
+/// configured rate on the Generator role must materialise a live limiter whose
+/// rate matches - otherwise `--bwlimit` is inert on the network path, the exact
+/// pre-fix bug.
+#[test]
+fn generator_with_bwlimit_builds_limiter() {
+    let config = config_with_bwlimit(ServerRole::Generator, Some(components(64 * 1024)));
+    let limiter = sender_bandwidth_limiter(&config).expect("sender must throttle");
+    assert_eq!(limiter.limit_bytes().get(), 64 * 1024);
+}
+
+/// The receiver never throttles, even when a `--bwlimit` rate is present.
+///
+/// WHY: upstream `main.c:1068` sets `bwlimit_writemax = 0` on the receiver, so
+/// its writes (of ACKs / file-list requests) are never paced. Forwarding a
+/// `--bwlimit` value to a receiver (upstream always forwards it) must remain a
+/// no-op on its writer.
+#[test]
+fn receiver_never_throttles() {
+    let config = config_with_bwlimit(ServerRole::Receiver, Some(components(64 * 1024)));
+    assert!(
+        sender_bandwidth_limiter(&config).is_none(),
+        "receiver must not pace its writes (main.c:1068)"
+    );
+}
+
+/// A generator with no `--bwlimit` (or a zero rate) is a passthrough.
+///
+/// WHY: `--bwlimit=0` means unlimited; the sender's writer must stay a
+/// zero-overhead passthrough so the default network path is unperturbed.
+#[test]
+fn generator_without_bwlimit_is_passthrough() {
+    let none = config_with_bwlimit(ServerRole::Generator, None);
+    assert!(sender_bandwidth_limiter(&none).is_none());
+
+    let zero = config_with_bwlimit(ServerRole::Generator, Some(components(0)));
+    assert!(
+        sender_bandwidth_limiter(&zero).is_none(),
+        "a zero rate is unlimited, not a throttle"
+    );
+}
+
+/// The configured burst is carried into the limiter for the sender.
+///
+/// WHY: the daemon module `bwlimit RATE:BURST` directive and the client's
+/// burst component must reach the live limiter so debt clamping matches the
+/// configured burst, not just the steady-state rate.
+#[test]
+fn generator_preserves_burst() {
+    let comps = BandwidthLimitComponents::new_with_specified(
+        NonZeroU64::new(64 * 1024),
+        NonZeroU64::new(8192),
+        true,
+    );
+    let config = config_with_bwlimit(ServerRole::Generator, Some(comps));
+    let limiter = sender_bandwidth_limiter(&config).expect("sender must throttle");
+    assert_eq!(limiter.limit_bytes().get(), 64 * 1024);
+    assert_eq!(limiter.burst_bytes().map(NonZeroU64::get), Some(8192));
+}

--- a/crates/transfer/src/tests/mod.rs
+++ b/crates/transfer/src/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Tests for server module.
 
 mod allow_inc_recurse;
+mod bwlimit_wiring;
 mod config;
 mod filter_list_gate;
 mod multiplex_protocol_version;

--- a/crates/transfer/src/writer/mod.rs
+++ b/crates/transfer/src/writer/mod.rs
@@ -11,16 +11,19 @@
 //! - `multiplex` - Buffered writer that frames output in `MSG_DATA` multiplex frames.
 //! - `msg_info` - Trait for sending `MSG_INFO` protocol messages through multiplexed streams.
 //! - `counting` - Byte-counting writer wrapper for transfer statistics.
+//! - `throttle` - Bandwidth-limiting writer decorator for the sender socket.
 
 mod counting;
 mod msg_info;
 pub(crate) mod multiplex;
 mod server;
+mod throttle;
 
 pub use self::counting::CountingWriter;
 pub use self::msg_info::MsgInfoSender;
 pub use self::multiplex::BatchRoute;
 pub use self::server::{ServerWriter, shutdown_send_side};
+pub use self::throttle::ThrottlingWriter;
 
 #[cfg(test)]
 mod tests;

--- a/crates/transfer/src/writer/throttle.rs
+++ b/crates/transfer/src/writer/throttle.rs
@@ -1,0 +1,214 @@
+//! Bandwidth-throttling writer decorator for the network sender path.
+//!
+//! Mirrors upstream rsync's socket-write pacing in `io.c:834-862`: the sender's
+//! writer clamps every outbound write to `bwlimit_writemax` bytes
+//! (`options.c:2394-2397`, `bwlimit * 128` floored at 512) and calls
+//! `sleep_for_bwlimit(n)` after each chunk. The receiver never throttles -
+//! `main.c:1068` sets `bwlimit_writemax = 0` once it becomes the receiver - so
+//! callers install a limiter only on a sender-role (`am_sender`) writer.
+//!
+//! Placed at the bottom of the sender's writer stack (below the multiplex
+//! framer and any compression), so it paces the exact wire bytes the raw
+//! descriptor accepts, matching upstream's `perform_io()` write path where the
+//! clamp and sleep sit on the raw `write()` of the outermost output buffer.
+
+use std::io::{self, IoSlice, Write};
+
+use bandwidth::BandwidthLimiter;
+
+/// Writer decorator that paces outbound writes to a bandwidth limit.
+///
+/// When `limiter` is `Some`, every write is split into
+/// [`BandwidthLimiter::write_max_bytes`]-sized chunks and each chunk is
+/// registered with the limiter (which sleeps once the accumulated debt exceeds
+/// the pacing threshold), mirroring the clamp-then-`sleep_for_bwlimit` sequence
+/// in `io.c:846-862`.
+///
+/// When `limiter` is `None` (`--bwlimit=0`, or the receiver role) the decorator
+/// is a zero-overhead passthrough: `write`, `write_vectored`, and `flush`
+/// delegate straight to the inner writer, preserving the un-throttled path's
+/// exact syscall and vectored-batching behaviour.
+pub struct ThrottlingWriter<W> {
+    inner: W,
+    limiter: Option<BandwidthLimiter>,
+}
+
+impl<W: Write> ThrottlingWriter<W> {
+    /// Wraps `inner`, throttling writes when `limiter` is `Some`.
+    pub const fn new(inner: W, limiter: Option<BandwidthLimiter>) -> Self {
+        Self { inner, limiter }
+    }
+
+    /// Consumes the decorator, returning the inner writer.
+    #[allow(dead_code)] // REASON: symmetry with the other writer wrappers; used by tests.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+
+    /// Returns whether a bandwidth limiter is active on this writer.
+    #[allow(dead_code)] // REASON: exercised by tests asserting role-gated wiring.
+    pub const fn is_throttled(&self) -> bool {
+        self.limiter.is_some()
+    }
+}
+
+impl<W: Write> Write for ThrottlingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Destructure so `inner` and `limiter` can be borrowed independently.
+        let Self { inner, limiter } = self;
+        match limiter {
+            // upstream: io.c:846 `if (bwlimit_writemax && len > bwlimit_writemax)
+            // len = bwlimit_writemax;` then io.c:861 `sleep_for_bwlimit(n)`.
+            Some(limiter) => {
+                let max = limiter.write_max_bytes().max(1);
+                for chunk in buf.chunks(max) {
+                    inner.write_all(chunk)?;
+                    let _ = limiter.register(chunk.len());
+                }
+                Ok(buf.len())
+            }
+            None => inner.write(buf),
+        }
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        let Self { inner, limiter } = self;
+        match limiter {
+            Some(limiter) => {
+                let max = limiter.write_max_bytes().max(1);
+                let mut total = 0;
+                for slice in bufs {
+                    for chunk in slice.chunks(max) {
+                        inner.write_all(chunk)?;
+                        let _ = limiter.register(chunk.len());
+                        total += chunk.len();
+                    }
+                }
+                Ok(total)
+            }
+            None => inner.write_vectored(bufs),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroU64;
+    use std::time::Instant;
+
+    /// Records the size of every inner `write` so tests can assert clamping.
+    #[derive(Default)]
+    struct RecordingSink {
+        writes: Vec<usize>,
+        total: usize,
+    }
+
+    impl Write for RecordingSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.writes.push(buf.len());
+            self.total += buf.len();
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn limiter(bytes_per_sec: u64) -> BandwidthLimiter {
+        BandwidthLimiter::new(NonZeroU64::new(bytes_per_sec).expect("non-zero rate"))
+    }
+
+    /// A `None` limiter is a byte-and-syscall-identical passthrough.
+    ///
+    /// WHY: `--bwlimit=0` and the receiver role (`main.c:1068`) must not perturb
+    /// the un-throttled wire path, so a single `write` reaches the inner writer
+    /// whole - no clamping, no sleeping.
+    #[test]
+    fn unlimited_is_passthrough_no_clamp() {
+        let mut writer = ThrottlingWriter::new(RecordingSink::default(), None);
+        let payload = vec![0u8; 1 << 20];
+        let n = writer.write(&payload).expect("write");
+        assert_eq!(n, payload.len());
+        let sink = writer.into_inner();
+        assert_eq!(
+            sink.writes,
+            vec![payload.len()],
+            "no chunking when unlimited"
+        );
+    }
+
+    /// An active limiter clamps each inner write to `write_max_bytes`.
+    ///
+    /// WHY: upstream `io.c:846` caps every socket write to `bwlimit_writemax`
+    /// (`options.c:2395` `bwlimit * 128`), so a single large logical write must
+    /// reach the descriptor as multiple bounded writes, never one oversized one.
+    #[test]
+    fn limited_clamps_each_write_to_write_max() {
+        let lim = limiter(64 * 1024);
+        let write_max = lim.write_max_bytes();
+        let mut writer = ThrottlingWriter::new(RecordingSink::default(), Some(lim));
+        let payload = vec![0u8; write_max * 3 + 7];
+        let n = writer.write(&payload).expect("write");
+        assert_eq!(n, payload.len(), "reports the full logical length");
+        let sink = writer.into_inner();
+        assert_eq!(sink.total, payload.len());
+        assert!(
+            sink.writes.iter().all(|&len| len <= write_max),
+            "every inner write must be clamped to write_max: {:?}",
+            sink.writes
+        );
+        assert!(sink.writes.len() >= 4, "large write split into chunks");
+    }
+
+    /// The limiter paces throughput: sending more than one pacing interval's
+    /// worth of data blocks for a robust lower bound of wall-clock time.
+    ///
+    /// WHY: this is the whole point of `--bwlimit` on the sender - upstream
+    /// `io.c:861 sleep_for_bwlimit(n)` makes the sender wait so the average
+    /// egress rate tracks the configured limit. The bound is deliberately loose
+    /// (a fraction of the ideal sleep) to stay CI-robust while still failing
+    /// closed if the limiter is never invoked (the pre-fix inert behaviour).
+    #[test]
+    fn limited_paces_throughput_lower_bound() {
+        // 64 KiB/s rate, send 2x32 KiB -> ideal steady-state ~1.0 s. The first
+        // pacing interval only fires once accumulated debt exceeds 100 ms
+        // (io.c ONE_SEC/10), so assert a conservative >= 150 ms lower bound.
+        let rate = 64 * 1024;
+        let mut writer = ThrottlingWriter::new(io::sink(), Some(limiter(rate)));
+        let payload = vec![0u8; 32 * 1024];
+        let start = Instant::now();
+        writer.write_all(&payload).expect("write");
+        writer.write_all(&payload).expect("write");
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed.as_millis() >= 150,
+            "bwlimit must pace the sender; elapsed={elapsed:?}"
+        );
+    }
+
+    /// `write_vectored` throttles every slice and reports the full byte count.
+    ///
+    /// WHY: the multiplex framer issues vectored writes (frame header + payload);
+    /// the pacing must cover those bytes too, matching upstream where the clamp
+    /// sits on the single raw descriptor buffer regardless of how it was framed.
+    #[test]
+    fn vectored_writes_are_throttled_and_counted() {
+        let lim = limiter(64 * 1024);
+        let write_max = lim.write_max_bytes();
+        let mut writer = ThrottlingWriter::new(RecordingSink::default(), Some(lim));
+        let a = vec![1u8; write_max + 1];
+        let b = vec![2u8; write_max + 1];
+        let bufs = [IoSlice::new(&a), IoSlice::new(&b)];
+        let n = writer.write_vectored(&bufs).expect("vectored");
+        assert_eq!(n, a.len() + b.len());
+        let sink = writer.into_inner();
+        assert_eq!(sink.total, a.len() + b.len());
+        assert!(sink.writes.iter().all(|&len| len <= write_max));
+    }
+}


### PR DESCRIPTION
## Summary

`--bwlimit` was inert on every network transfer. Only the engine local-copy
path and the daemon's pre-transfer `@RSYNCD:` text handshake throttled; the bulk
network transfer was unthrottled on every role - client push, SSH
`--server --sender`, and the daemon-sender on a pull all streamed at full speed
regardless of `--bwlimit`.

This wires the existing, upstream-faithful `bandwidth::BandwidthLimiter` (token
bucket, `writemax` clamp, `bwlimit * 128` sizing, min-sleep threshold) into the
sender's outbound socket writer, mirroring upstream's `io.c` write path.

## Upstream model

- `io.c:834-862` - the writer paces its own socket writes: clamp each write to
  `bwlimit_writemax`, then `sleep_for_bwlimit(n)`.
- `options.c:2394-2397` - `bwlimit_writemax = bwlimit * 128`, floored at 512.
- `main.c:1068` - the receiver disables its own throttle
  (`bwlimit_writemax = 0`); only the sender paces.
- `options.c:2799` - `--bwlimit=%d` (whole KiB) is forwarded to the server.

## Design

A single `ThrottlingWriter<W>` decorator wraps the sender's raw socket writer at
the bottom of the writer stack (below the multiplex framer and any compression),
so it paces the exact wire bytes the descriptor accepts - matching upstream's
`perform_io()` clamp-then-sleep on the raw output buffer. With a `None` limiter
(`--bwlimit=0` or the receiver role) it is a zero-overhead passthrough:
`write`/`write_vectored`/`flush` delegate straight through, preserving the
un-throttled path's exact syscall and vectored-batching behaviour.

The effective rate/burst is carried on `ConnectionConfig::bwlimit` and turned
into a live limiter by `sender_bandwidth_limiter()` in the one shared server
transfer body (`run_server_with_handshake`), gated on
`role == ServerRole::Generator`. All three sender roles funnel through that body:

1. Client push sender (SSH and `rsync://`) - the generator builders set
   `connection.bwlimit` from the client's parsed `--bwlimit`.
2. SSH `--server --sender` - the server parses the forwarded `--bwlimit=%d`
   (whole KiB) from its argv.
3. Daemon-sender on a pull - `build_server_config` combines the client's
   forwarded `--bwlimit` with the effective module/global cap using upstream's
   precedence (`options.c:2390`).

`SO_MAX_PACING_RATE` remains only as a complementary kernel hint; the userspace
limiter is authoritative.

## No double-throttle on the daemon text phase

The daemon's `write_limited` (session_runtime.rs) throttles ONLY the
pre-transfer `@RSYNCD:` greeting/MOTD/OK text, using the same effective limiter
computed by `apply_module_bandwidth_limit`. The bulk transfer runs on the
separate `run_server_with_handshake` writer stack, which carried no limiter
before this change - so there was never a bulk double-throttle to introduce, and
this change installs exactly one limiter per phase. The daemon-sender wiring
reads that already-computed cap rather than building a second one, keeping the
two phases consistent.

## Tests

- `writer/throttle.rs` - clamp each write to `write_max`; robust wall-clock
  lower-bound proving the sender is paced (fails closed if the limiter is never
  invoked - the pre-fix bug); `write_vectored` throttling; `--bwlimit=0`
  passthrough asserting no clamping.
- `tests/bwlimit_wiring.rs` - role gating: the Generator builds a limiter at the
  configured rate/burst; the Receiver never throttles (`main.c:1068`); an absent
  or zero rate is a passthrough.
