### PR TITLE
feat(daemon): quic port directive (defaults to port, overridable)

### DIFF
--- a/crates/daemon/src/daemon/runtime_options/config.rs
+++ b/crates/daemon/src/daemon/runtime_options/config.rs
@@ -44,6 +44,14 @@ impl RuntimeOptions {
         if let Some((key, _origin)) = parsed.quic_key_file {
             self.quic_key_file = Some(key);
         }
+        // QUIC listener port (oc extension). Unset means the QUIC listener
+        // shares the daemon TCP `port`; a value here overrides that
+        // independently. Directive parsing already coerced a `quic port = 0`
+        // to the well-known rsync port 873, mirroring the TCP `port = 0` path.
+        #[cfg(feature = "quic")]
+        if let Some((port, _origin)) = parsed.quic_port {
+            self.quic_port = Some(port);
+        }
 
         if let Some((components, _origin)) = parsed.global_bandwidth_limit
             && !self.bandwidth_limit_configured

--- a/crates/daemon/src/daemon/runtime_options/quic_identity.rs
+++ b/crates/daemon/src/daemon/runtime_options/quic_identity.rs
@@ -39,4 +39,15 @@ impl RuntimeOptions {
             _ => QuicIdentity::Ephemeral,
         }
     }
+
+    /// Returns the port the QUIC listener binds.
+    ///
+    /// The `quic port` global directive overrides it independently; unset, the
+    /// QUIC listener shares the daemon TCP `port` (873 by default). A configured
+    /// `quic port = 0` was already coerced to 873 at parse time, mirroring the
+    /// TCP `port = 0` path (oc extension - decision on 2026-07-30).
+    #[allow(dead_code)] // REASON: consumed by the QUIC listener build-out (QUIC-6c); exercised by tests now
+    pub(crate) fn effective_quic_port(&self) -> u16 {
+        self.quic_port.unwrap_or(self.port)
+    }
 }

--- a/crates/daemon/src/daemon/runtime_options/types.rs
+++ b/crates/daemon/src/daemon/runtime_options/types.rs
@@ -56,6 +56,15 @@ pub(crate) struct RuntimeOptions {
     quic_cert_file: Option<PathBuf>,
     #[cfg(feature = "quic")]
     quic_key_file: Option<PathBuf>,
+    /// QUIC listener port from the `quic port` global directive (oc extension).
+    ///
+    /// `None` means the QUIC listener shares the daemon TCP `port` (873 by
+    /// default); a value here overrides that independently. A `quic port = 0`
+    /// coerces to the well-known rsync port 873, mirroring the `--port 0` /
+    /// `port = 0` coercion in `parsing.rs`. Global-only, like the QUIC identity
+    /// directives. See docs/design/quic-transport-policy.md.
+    #[cfg(feature = "quic")]
+    quic_port: Option<u16>,
     global_incoming_chmod: Option<String>,
     global_outgoing_chmod: Option<String>,
     syslog_facility: Option<String>,
@@ -159,6 +168,8 @@ impl Default for RuntimeOptions {
             quic_cert_file: None,
             #[cfg(feature = "quic")]
             quic_key_file: None,
+            #[cfg(feature = "quic")]
+            quic_port: None,
             global_incoming_chmod: None,
             global_outgoing_chmod: None,
             syslog_facility: None,

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -258,6 +258,22 @@ fn apply_global_directive(
             let resolved = resolve_config_relative_path(path, trimmed);
             store_global_directive(&mut state.quic_key_file, resolved, canonical, line_number);
         }
+        // oc extension (no upstream counterpart). `quic port` selects the port
+        // the QUIC listener binds; unset, the listener shares the daemon TCP
+        // `port` (873 by default). Value handling mirrors the TCP `port`
+        // directive: `parse_atoi` clamped into the u16 range, then a 0 coerced
+        // to the well-known rsync port 873, matching the `port = 0` / `--port 0`
+        // coercion in parsing.rs (upstream options.c). Global-only like the QUIC
+        // identity directives. See docs/design/quic-transport-policy.md.
+        #[cfg(feature = "quic")]
+        "quicport" => {
+            let mut parsed = parse_atoi(value).clamp(0, i32::from(u16::MAX)) as u16;
+            if parsed == 0 {
+                parsed = DEFAULT_PORT;
+            }
+
+            store_global_directive(&mut state.quic_port, parsed, canonical, line_number);
+        }
         // upstream: loadparm.c - use chroot is valid in the global section as a
         // default that applies to all modules which do not override it explicitly.
         "usechroot" => {

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
@@ -20,6 +20,11 @@ struct GlobalParseState {
     quic_cert_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
     #[cfg(feature = "quic")]
     quic_key_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
+    /// QUIC listener port from the `quic port` global directive (oc extension,
+    /// feature-gated). Unset shares the daemon TCP `port`; a `quic port = 0` is
+    /// coerced to 873 at parse time, mirroring the TCP `port = 0` handling.
+    #[cfg(feature = "quic")]
+    quic_port: Option<(u16, ConfigDirectiveOrigin)>,
     global_bwlimit: Option<(BandwidthLimitComponents, ConfigDirectiveOrigin)>,
     global_secrets_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
     global_incoming_chmod: Option<(String, ConfigDirectiveOrigin)>,
@@ -66,6 +71,8 @@ impl GlobalParseState {
             quic_cert_file: None,
             #[cfg(feature = "quic")]
             quic_key_file: None,
+            #[cfg(feature = "quic")]
+            quic_port: None,
             global_bwlimit: None,
             global_secrets_file: None,
             global_incoming_chmod: None,
@@ -144,6 +151,8 @@ impl GlobalParseState {
             quic_cert_file: self.quic_cert_file,
             #[cfg(feature = "quic")]
             quic_key_file: self.quic_key_file,
+            #[cfg(feature = "quic")]
+            quic_port: self.quic_port,
             global_bandwidth_limit: self.global_bwlimit,
             global_secrets_file: self.global_secrets_file,
             global_incoming_chmod: self.global_incoming_chmod,

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -453,11 +453,11 @@ fn apply_module_directive(
         // operator believing a certificate they named is in force. Reuse the
         // shared `config_parse_error` surface every other directive uses.
         #[cfg(feature = "quic")]
-        "quiccertfile" | "quickeyfile" => {
-            let directive = if key == "quiccertfile" {
-                "quic cert file"
-            } else {
-                "quic key file"
+        "quiccertfile" | "quickeyfile" | "quicport" => {
+            let directive = match key {
+                "quiccertfile" => "quic cert file",
+                "quickeyfile" => "quic key file",
+                _ => "quic port",
             };
             return Err(config_parse_error(
                 path,

--- a/crates/daemon/src/daemon/sections/config_parsing/types.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/types.rs
@@ -30,6 +30,12 @@ pub(crate) struct ParsedConfigModules {
     /// QUIC listener private-key path from the `quic key file` global directive.
     #[cfg(feature = "quic")]
     quic_key_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
+    /// QUIC listener port from the `quic port` global directive (oc extension,
+    /// feature-gated). `None` means the QUIC listener shares the daemon TCP
+    /// `port`; a value overrides it independently. A `quic port = 0` is coerced
+    /// to 873 at parse time, mirroring the TCP `port = 0` handling.
+    #[cfg(feature = "quic")]
+    quic_port: Option<(u16, ConfigDirectiveOrigin)>,
     global_bandwidth_limit: Option<(BandwidthLimitComponents, ConfigDirectiveOrigin)>,
     global_secrets_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
     global_incoming_chmod: Option<(String, ConfigDirectiveOrigin)>,

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -391,6 +391,8 @@ include!("tests/chunks/runtime_options_per_module_max_connections_overrides_glob
 include!("tests/chunks/runtime_options_quic_cert_key_pairing.rs");
 #[cfg(feature = "quic")]
 include!("tests/chunks/runtime_options_quic_identity_resolution.rs");
+#[cfg(feature = "quic")]
+include!("tests/chunks/runtime_options_quic_port_directive.rs");
 include!("tests/chunks/runtime_options_reject_duplicate_bwlimit.rs");
 include!("tests/chunks/runtime_options_reject_duplicate_lock_file_argument.rs");
 include!("tests/chunks/runtime_options_reject_duplicate_log_file_argument.rs");

--- a/crates/daemon/src/tests/chunks/runtime_options_quic_port_directive.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_quic_port_directive.rs
@@ -1,0 +1,98 @@
+// QUIC listener port selection (oc extension). The `quic port` global directive
+// overrides the QUIC bind port independently of the daemon TCP `port`. Unset,
+// the QUIC listener shares the daemon `port` (873 by default). A `quic port = 0`
+// coerces to the well-known rsync port 873, mirroring the TCP `port = 0` path.
+// Decision on 2026-07-30: QUIC binds the SAME port as TCP by default.
+
+#[test]
+fn quic_port_unset_shares_daemon_port() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(&config_path, "# no quic port directive\n").expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect("parse config");
+
+    // With the directive unset the QUIC listener binds the daemon TCP port.
+    assert_eq!(options.effective_quic_port(), options.port);
+    assert_eq!(options.effective_quic_port(), DEFAULT_PORT);
+}
+
+#[test]
+fn quic_port_unset_tracks_overridden_daemon_port() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(&config_path, "port = 9999\n[m]\npath = /srv/m\n").expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect("parse config");
+
+    // A non-default daemon port with no `quic port` still shares it.
+    assert_eq!(options.port, 9999);
+    assert_eq!(options.effective_quic_port(), 9999);
+}
+
+#[test]
+fn quic_port_directive_overrides_daemon_port_independently() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(&config_path, "port = 8022\nquic port = 8873\n").expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect("parse config");
+
+    // `quic port` is independent of the TCP `port`.
+    assert_eq!(options.port, 8022);
+    assert_eq!(options.effective_quic_port(), 8873);
+}
+
+#[test]
+fn quic_port_zero_coerces_to_well_known_rsync_port() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(&config_path, "port = 8022\nquic port = 0\n").expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect("parse config");
+
+    // `quic port = 0` coerces to 873, matching the TCP `port = 0` / `--port 0`
+    // coercion - not the daemon TCP port, and not a kernel-assigned ephemeral.
+    assert_eq!(
+        options.effective_quic_port(),
+        DEFAULT_PORT,
+        "quic port = 0 must coerce to the well-known rsync port 873"
+    );
+}
+
+#[test]
+fn quic_port_in_module_scope_is_config_error() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    // The QUIC listener is shared across modules, so a per-module `quic port`
+    // cannot be honoured and is a hard config error like the QUIC identity
+    // directives, not silently ignored.
+    fs::write(&config_path, "[data]\npath = /srv/data\nquic port = 8873\n").expect("write config");
+
+    let error = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect_err("module-scoped quic port is a config error");
+
+    assert!(
+        error.to_string().contains("quic port"),
+        "error must name the offending directive, got: {error}"
+    );
+}

--- a/crates/daemon/src/tests/chunks/runtime_options_quic_port_directive.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_quic_port_directive.rs
@@ -3,6 +3,11 @@
 // the QUIC listener shares the daemon `port` (873 by default). A `quic port = 0`
 // coerces to the well-known rsync port 873, mirroring the TCP `port = 0` path.
 // Decision on 2026-07-30: QUIC binds the SAME port as TCP by default.
+//
+// These tests read only the crate-visible accessors (`effective_quic_port`,
+// `rsync_port`); the private `port` field and module-private `DEFAULT_PORT` are
+// out of reach from this `tests` submodule, so the well-known port is spelled
+// as the literal 873.
 
 #[test]
 fn quic_port_unset_shares_daemon_port() {
@@ -16,9 +21,8 @@ fn quic_port_unset_shares_daemon_port() {
     ])
     .expect("parse config");
 
-    // With the directive unset the QUIC listener binds the daemon TCP port.
-    assert_eq!(options.effective_quic_port(), options.port);
-    assert_eq!(options.effective_quic_port(), DEFAULT_PORT);
+    // With the directive unset the QUIC listener binds the default daemon port.
+    assert_eq!(options.effective_quic_port(), 873);
 }
 
 #[test]
@@ -33,8 +37,9 @@ fn quic_port_unset_tracks_overridden_daemon_port() {
     ])
     .expect("parse config");
 
-    // A non-default daemon port with no `quic port` still shares it.
-    assert_eq!(options.port, 9999);
+    // A non-default daemon port with no `quic port` still shares it: the
+    // effective QUIC port follows `quic_port.unwrap_or(port)`.
+    assert_eq!(options.rsync_port(), Some(9999));
     assert_eq!(options.effective_quic_port(), 9999);
 }
 
@@ -51,7 +56,7 @@ fn quic_port_directive_overrides_daemon_port_independently() {
     .expect("parse config");
 
     // `quic port` is independent of the TCP `port`.
-    assert_eq!(options.port, 8022);
+    assert_eq!(options.rsync_port(), Some(8022));
     assert_eq!(options.effective_quic_port(), 8873);
 }
 
@@ -71,7 +76,7 @@ fn quic_port_zero_coerces_to_well_known_rsync_port() {
     // coercion - not the daemon TCP port, and not a kernel-assigned ephemeral.
     assert_eq!(
         options.effective_quic_port(),
-        DEFAULT_PORT,
+        873,
         "quic port = 0 must coerce to the well-known rsync port 873"
     );
 }


### PR DESCRIPTION
## Summary

Adds the daemon `quic port` global directive, letting operators pick the port the QUIC listener binds. It is an oc extension (QUIC is oc-only), feature-gated behind `quic`, and inert in default builds.

Per the 2026-07-30 decision, QUIC binds the **same** `port` (873) as the TCP listener by default, and this directive overrides that **independently**:

- Directive unset -> effective QUIC port == the daemon `port`.
- `quic port = 8873` -> QUIC binds 8873 regardless of the TCP `port`.
- `quic port = 0` -> coerces to the well-known rsync port 873, mirroring the TCP `port = 0` / `--port 0` coercion.

## Changes

- `runtime_options/types.rs`: new feature-gated `quic_port: Option<u16>` field, defaulting to `None`.
- `config_parsing/.../dispatch.rs`: parse `quic port`, reusing the TCP `port` value handling (`parse_atoi` clamped to u16, then `0 -> 873`).
- `runtime_options/quic_identity.rs`: `effective_quic_port()` accessor = `quic_port.unwrap_or(port)`.
- `config.rs` / `parse_state.rs` / `config_parsing/types.rs`: thread the value from parse state into runtime options.
- `module_directives.rs`: reject a module-scoped `quic port` as a hard config error, consistent with the per-listener `quic cert file` / `quic key file` directives.

## Tests

New feature-gated chunk `runtime_options_quic_port_directive.rs` (5 tests): default shares the daemon port, tracks an overridden daemon port, overrides independently, `0` coerces to 873, and module-scope use is a config error.

## Verification (x86_64 Linux host)

- `cargo build --bin oc-rsync --features quic`: OK
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean
- `cargo nextest run -p daemon --all-features -E 'test(quic_port) or test(quic) or test(port)'`: 53 passed
