### PR TITLE
feat(engine): throughput-governor telemetry bus (inert observer stage)

### DIFF
--- a/crates/engine/src/concurrent_delta/config.rs
+++ b/crates/engine/src/concurrent_delta/config.rs
@@ -26,6 +26,7 @@
 use std::path::{Path, PathBuf};
 
 use super::spill::policy::SpillPolicy;
+use crate::throughput::SampleSink;
 
 /// Tunable runtime knobs for the concurrent delta pipeline.
 ///
@@ -41,6 +42,16 @@ pub struct ConcurrentDeltaConfig {
     /// [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer)
     /// path; the other [`SpillPolicy`] knobs layer additional policy on top.
     pub spill_policy: SpillPolicy,
+
+    /// Optional throughput-governor telemetry sink.
+    ///
+    /// `None` (the default) leaves the pipeline byte-identical to the
+    /// pre-governor code: the compute workers and reorder drain skip sample
+    /// emission entirely. When `Some`, each instrumented stage publishes a
+    /// [`StageSample`](crate::throughput::StageSample) per unit of work through
+    /// this cheap, clonable handle. Emission only observes; it never alters
+    /// control flow, ordering, or output.
+    pub telemetry_sink: Option<SampleSink>,
 }
 
 impl ConcurrentDeltaConfig {
@@ -58,13 +69,17 @@ impl ConcurrentDeltaConfig {
     pub fn with_spill_threshold(threshold_bytes: u64) -> Self {
         Self {
             spill_policy: SpillPolicy::with_threshold(threshold_bytes),
+            telemetry_sink: None,
         }
     }
 
     /// Returns a configuration that wires through an explicit [`SpillPolicy`].
     #[must_use]
     pub fn with_spill_policy(spill_policy: SpillPolicy) -> Self {
-        Self { spill_policy }
+        Self {
+            spill_policy,
+            telemetry_sink: None,
+        }
     }
 
     /// Sets an explicit on-disk scratch directory for spilled items.
@@ -76,6 +91,18 @@ impl ConcurrentDeltaConfig {
     #[must_use]
     pub fn with_spill_dir(mut self, dir: PathBuf) -> Self {
         self.spill_policy.dir = Some(dir);
+        self
+    }
+
+    /// Attaches a throughput-governor telemetry sink.
+    ///
+    /// With a sink present the compute workers and reorder drain publish
+    /// [`StageSample`](crate::throughput::StageSample)s; without one they emit
+    /// nothing. The sink only observes, so enabling it never changes transfer
+    /// output.
+    #[must_use]
+    pub fn with_telemetry_sink(mut self, sink: SampleSink) -> Self {
+        self.telemetry_sink = Some(sink);
         self
     }
 

--- a/crates/engine/src/concurrent_delta/consumer/loops.rs
+++ b/crates/engine/src/concurrent_delta/consumer/loops.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 use crate::concurrent_delta::reorder::{Metrics as ReorderMetrics, ReorderBuffer};
 use crate::concurrent_delta::spill::{SpillError, SpillableReorderBuffer};
 use crate::concurrent_delta::types::DeltaResult;
+use crate::throughput::{Constraint, SampleSink};
 
 /// Reorder loop for the bare [`ReorderBuffer`] backend (passthrough or
 /// ring-buffer mode). Mirrors the historical control flow: drain ready items
@@ -25,6 +26,7 @@ pub(super) fn run_bare_loop(
     result_tx: &mpsc::Sender<DeltaResult>,
     mut reorder: ReorderBuffer<DeltaResult>,
     metrics: &Arc<Mutex<ReorderMetrics>>,
+    sink: Option<&SampleSink>,
 ) {
     let mut last_drain_at: Option<Instant> = None;
     let publish = |reorder: &ReorderBuffer<DeltaResult>| {
@@ -35,7 +37,7 @@ pub(super) fn run_bare_loop(
 
     for result in stream_rx {
         while reorder.insert(result.sequence(), result.clone()).is_err() {
-            match drain_and_record(&mut reorder, result_tx, &mut last_drain_at) {
+            match drain_and_record(&mut reorder, result_tx, &mut last_drain_at, sink) {
                 DrainOutcome::Disconnected => return,
                 DrainOutcome::Empty => {
                     // Buffer full but next_expected is not buffered.
@@ -50,14 +52,14 @@ pub(super) fn run_bare_loop(
             }
         }
 
-        match drain_and_record(&mut reorder, result_tx, &mut last_drain_at) {
+        match drain_and_record(&mut reorder, result_tx, &mut last_drain_at, sink) {
             DrainOutcome::Disconnected => return,
             DrainOutcome::Empty => {}
             DrainOutcome::Forwarded => publish(&reorder),
         }
     }
 
-    match drain_and_record(&mut reorder, result_tx, &mut last_drain_at) {
+    match drain_and_record(&mut reorder, result_tx, &mut last_drain_at, sink) {
         DrainOutcome::Disconnected => return,
         DrainOutcome::Empty => {}
         DrainOutcome::Forwarded => publish(&reorder),
@@ -85,6 +87,7 @@ pub(super) fn run_spillable_loop(
     mut reorder: SpillableReorderBuffer<DeltaResult>,
     spill_events: &Arc<AtomicU64>,
     spill_activations: &Arc<AtomicU64>,
+    sink: Option<&SampleSink>,
 ) {
     let mut prev_spill = reorder.spill_stats().spill_events;
     let mut prev_activations = reorder.spill_stats().spill_activations;
@@ -164,12 +167,22 @@ pub(super) fn run_spillable_loop(
         publish_spill_events(&reorder, spill_events, &mut prev_spill);
         publish_spill_activations(&reorder, spill_activations, &mut prev_activations);
 
+        let drain_start = Instant::now();
         match reorder.drain_ready() {
             Ok(items) => {
+                let mut bytes = 0u64;
                 for ready in items {
+                    bytes = bytes.saturating_add(ready.bytes_written());
                     if result_tx.send(ready).is_err() {
                         return;
                     }
+                }
+                if bytes > 0 {
+                    // Spillable occupancy lives behind the spill layer's own
+                    // counters (published above); report `0` here since the
+                    // in-memory ring depth is not exposed. The WireWrite rate
+                    // is still the governor's drain-throughput signal.
+                    emit_wire_write(sink, bytes, drain_start);
                 }
             }
             Err(e) => {
@@ -239,6 +252,18 @@ fn publish_spill_activations(
     }
 }
 
+/// Publishes a [`Constraint::WireWrite`] sample for a spillable-loop drain of
+/// `bytes` bytes that began at `drain_start`, with occupancy `0`.
+///
+/// A no-op when `sink` is `None`. Kept separate from [`drain_and_record`]
+/// because the spillable loop drains through the spill layer rather than the
+/// bare ring and has no in-memory occupancy accessor to report.
+fn emit_wire_write(sink: Option<&SampleSink>, bytes: u64, drain_start: Instant) {
+    if let Some(sink) = sink {
+        sink.emit_stage(Constraint::WireWrite, bytes, drain_start.elapsed(), 0);
+    }
+}
+
 /// Outcome of one [`drain_and_record`] call.
 enum DrainOutcome {
     /// No items were ready to drain.
@@ -255,13 +280,25 @@ enum DrainOutcome {
 ///
 /// Bypasses the metrics path on empty drains so the histograms reflect only
 /// the work actually performed by the consumer thread.
+///
+/// When a throughput-governor `sink` is present, each non-empty drain also
+/// publishes a [`Constraint::WireWrite`] sample: the bytes forwarded over the
+/// drain's wall-clock span, tagged with the reorder buffer's residual
+/// occupancy. Occupancy is the drum-detection signal the governor watches - a
+/// persistently full reorder buffer means the consumer, not the workers, is
+/// the constraint. Emission is pure observation and never changes what or when
+/// items are forwarded.
 fn drain_and_record(
     reorder: &mut ReorderBuffer<DeltaResult>,
     result_tx: &mpsc::Sender<DeltaResult>,
     last_drain_at: &mut Option<Instant>,
+    sink: Option<&SampleSink>,
 ) -> DrainOutcome {
+    let drain_start = Instant::now();
     let mut count = 0usize;
+    let mut bytes = 0u64;
     while let Some(ready) = reorder.next_in_order() {
+        bytes = bytes.saturating_add(ready.bytes_written());
         if result_tx.send(ready).is_err() {
             return DrainOutcome::Disconnected;
         }
@@ -276,5 +313,13 @@ fn drain_and_record(
     }
     reorder.record_drain_batch(count);
     *last_drain_at = Some(now);
+    if let Some(sink) = sink {
+        sink.emit_stage(
+            Constraint::WireWrite,
+            bytes,
+            now.saturating_duration_since(drain_start),
+            reorder.buffered_count(),
+        );
+    }
     DrainOutcome::Forwarded
 }

--- a/crates/engine/src/concurrent_delta/consumer/mod.rs
+++ b/crates/engine/src/concurrent_delta/consumer/mod.rs
@@ -205,6 +205,7 @@ impl DeltaConsumer {
             ReorderMode::Bare {
                 capacity: reorder_capacity,
             },
+            None,
         )
     }
 
@@ -219,7 +220,7 @@ impl DeltaConsumer {
     /// when `--delay-updates` is off and files are committed immediately.
     #[must_use]
     pub fn spawn_bypass(rx: WorkQueueReceiver) -> Self {
-        spawn_inner(rx, ReorderMode::Bypass)
+        spawn_inner(rx, ReorderMode::Bypass, None)
     }
 
     /// Spawns background threads honouring a runtime
@@ -245,7 +246,8 @@ impl DeltaConsumer {
         reorder_capacity: usize,
         cfg: ConcurrentDeltaConfig,
     ) -> Self {
-        spawn_inner(rx, ReorderMode::from_config(reorder_capacity, cfg))
+        let sink = cfg.telemetry_sink.clone();
+        spawn_inner(rx, ReorderMode::from_config(reorder_capacity, cfg), sink)
     }
 
     /// Returns a snapshot of consumer-side diagnostic counters.

--- a/crates/engine/src/concurrent_delta/consumer/spawn.rs
+++ b/crates/engine/src/concurrent_delta/consumer/spawn.rs
@@ -16,8 +16,9 @@ use crate::concurrent_delta::config::ConcurrentDeltaConfig;
 use crate::concurrent_delta::reorder::{Metrics as ReorderMetrics, ReorderBuffer};
 use crate::concurrent_delta::spill::{self, SpillableReorderBuffer};
 use crate::concurrent_delta::strategy;
-use crate::concurrent_delta::types::DeltaResult;
+use crate::concurrent_delta::types::{DeltaResult, DeltaWork};
 use crate::concurrent_delta::work_queue::WorkQueueReceiver;
+use crate::throughput::{Constraint, SampleSink};
 
 /// Selects the reorder backend driven by [`spawn_inner`].
 ///
@@ -68,7 +69,19 @@ impl ReorderMode {
 
 /// Spawns the two background threads and returns the assembled
 /// [`DeltaConsumer`] handle. Shared by all public factory methods.
-pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaConsumer {
+///
+/// `sink` is the optional throughput-governor telemetry handle. When `None`
+/// (the default, and always so when the governor is off) neither the compute
+/// workers nor the reorder drain emit samples, so the pipeline runs exactly as
+/// it did before instrumentation. When `Some`, each compute worker publishes a
+/// [`Constraint::Compute`] sample and the reorder drain publishes
+/// [`Constraint::WireWrite`] samples carrying the live reorder-buffer
+/// occupancy. Emission only observes; it never affects ordering or output.
+pub(super) fn spawn_inner(
+    rx: WorkQueueReceiver,
+    mode: ReorderMode,
+    sink: Option<SampleSink>,
+) -> DeltaConsumer {
     let (result_tx, result_rx) = mpsc::channel();
     let spill_events = Arc::new(AtomicU64::new(0));
     let spill_activations = Arc::new(AtomicU64::new(0));
@@ -84,10 +97,16 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
     let (stream_tx, stream_rx) = crossbeam_channel::bounded::<DeltaResult>(stream_capacity);
 
     // Thread 1: runs rayon::scope, streaming results as workers complete.
+    // Each worker times its own delta computation and, when telemetry is on,
+    // publishes a Compute sample - the delta-computation stage boundary.
+    let worker_sink = sink.clone();
     let drain_handle = thread::Builder::new()
         .name("delta-drain".to_string())
         .spawn(move || {
-            rx.drain_parallel_into(|work| strategy::dispatch(&work), stream_tx);
+            rx.drain_parallel_into(
+                move |work| dispatch_with_telemetry(worker_sink.as_ref(), work),
+                stream_tx,
+            );
         })
         .expect("failed to spawn delta-drain thread");
 
@@ -114,7 +133,7 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
         .spawn(move || {
             match backend {
                 ReorderBackend::Bare(buf) => {
-                    run_bare_loop(stream_rx, &result_tx, *buf, &metrics_thread);
+                    run_bare_loop(stream_rx, &result_tx, *buf, &metrics_thread, sink.as_ref());
                 }
                 ReorderBackend::Spillable(buf) => {
                     run_spillable_loop(
@@ -123,6 +142,7 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
                         *buf,
                         &spill_events_thread,
                         &spill_activations_thread,
+                        sink.as_ref(),
                     );
                 }
                 ReorderBackend::Failed(err) => {
@@ -145,6 +165,31 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
         spill_events,
         spill_activations,
         force_inserts,
+    }
+}
+
+/// Dispatches one work item and, when telemetry is enabled, publishes a
+/// [`Constraint::Compute`] sample timing the delta computation.
+///
+/// With `sink` `None` this is exactly `strategy::dispatch(&work)` - no timing,
+/// no branch beyond the null check - so the disabled path is cost-free and
+/// byte-identical. The sample reports the result's `bytes_written` as the work
+/// completed over the measured wall-clock span; `queue_occupancy` is `0`
+/// because per-file compute has no explicit input queue to sample here.
+fn dispatch_with_telemetry(sink: Option<&SampleSink>, work: DeltaWork) -> DeltaResult {
+    match sink {
+        None => strategy::dispatch(&work),
+        Some(sink) => {
+            let start = std::time::Instant::now();
+            let result = strategy::dispatch(&work);
+            sink.emit_stage(
+                Constraint::Compute,
+                result.bytes_written(),
+                start.elapsed(),
+                0,
+            );
+            result
+        }
     }
 }
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -133,6 +133,7 @@ pub mod delete;
 pub mod delta;
 pub mod error;
 pub mod local_copy;
+pub mod throughput;
 pub mod util;
 pub mod walk;
 

--- a/crates/engine/src/throughput/actuator.rs
+++ b/crates/engine/src/throughput/actuator.rs
@@ -1,0 +1,54 @@
+//! Actuator subscription surface for the throughput governor.
+//!
+//! In the drum-buffer-rope design the governor's Strategy phase publishes
+//! tuning signals - buffer-pool pressure, semaphore ceilings, I/O in-flight
+//! depth - that platform actuators consume through this subscription. G2 is
+//! inert: [`ActuatorHandle::inert`] is the only constructor and every query
+//! reports "no action", so subscribing changes nothing. The type exists now so
+//! consumers can wire the subscription and later steps can add real signals
+//! without changing call sites.
+
+/// A subscription to governor actuator signals.
+///
+/// Returned by
+/// [`GovernorHandle::subscribe_actuator`](super::governor::GovernorHandle::subscribe_actuator).
+/// The inert handle answers every query with the "take no action" value, so an
+/// actuator wired to it falls back to its existing static behaviour.
+#[derive(Debug, Clone)]
+pub struct ActuatorHandle {
+    /// Reserved for the shared signal state added when real actuation lands.
+    /// A unit field keeps the struct non-exhaustive in spirit and the
+    /// constructor meaningful without exposing internals.
+    _private: (),
+}
+
+impl ActuatorHandle {
+    /// Constructs the inert handle: no signals, no action.
+    #[must_use]
+    pub fn inert() -> Self {
+        Self { _private: () }
+    }
+
+    /// Whether the governor is currently publishing any actuator signal.
+    ///
+    /// Always `false` in G2. Actuators call this to decide whether to defer to
+    /// governor guidance or keep their static behaviour; a `false` answer keeps
+    /// them exactly as they are today.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inert_handle_reports_no_action() {
+        let handle = ActuatorHandle::inert();
+        assert!(!handle.is_active());
+        // Cloning an inert handle is cheap and stays inert.
+        assert!(!handle.clone().is_active());
+    }
+}

--- a/crates/engine/src/throughput/aggregate.rs
+++ b/crates/engine/src/throughput/aggregate.rs
@@ -1,0 +1,130 @@
+//! Per-stage throughput aggregation for the governor's Sense phase.
+//!
+//! [`StageAggregator`] folds the stream of [`StageSample`]s drained from the
+//! telemetry bus into one exponentially-weighted moving average per
+//! [`Constraint`] stage, using the shared [`Ewma`] primitive so the governor
+//! and the adaptive basis dispatcher smooth identically. In this inert
+//! (G2) step the aggregator is the entire "control loop": it computes a
+//! bytes/second estimate per stage and takes no further action.
+
+use fast_io::ewma::Ewma;
+
+use super::sample::{Constraint, StageSample};
+
+/// Smoothing factor for per-stage throughput averages.
+///
+/// Reuses the α the adaptive basis dispatcher was tuned with
+/// (`fast_io::adaptive_dispatch`, α = 0.2): a fresh sample contributes 20% and
+/// history 80%, which rejects per-file jitter while still tracking a genuine
+/// stage slowdown within a handful of windows. Sharing the constant keeps the
+/// two EWMA consumers from drifting apart.
+pub const STAGE_ALPHA: f64 = 0.2;
+
+/// Folds telemetry samples into a smoothed bytes/second estimate per stage.
+///
+/// One [`Ewma`] per [`Constraint`], indexed by [`Constraint::index`]. A sample
+/// whose rate is undefined (zero duration) is ignored rather than poisoning the
+/// average. The aggregator is single-owner - the governor thread holds it - so
+/// it needs no interior synchronization.
+#[derive(Debug, Clone)]
+pub struct StageAggregator {
+    stages: [Ewma; Constraint::COUNT],
+}
+
+impl StageAggregator {
+    /// Creates an aggregator with every stage unseeded (no samples yet).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            stages: [Ewma::new(STAGE_ALPHA); Constraint::COUNT],
+        }
+    }
+
+    /// Folds one sample into its stage's average and returns the updated
+    /// bytes/second estimate, or `None` when the sample carried no usable rate
+    /// (zero duration) and was skipped.
+    pub fn fold(&mut self, sample: &StageSample) -> Option<f64> {
+        let rate = sample.bytes_per_sec()?;
+        Some(self.stages[sample.stage.index()].update(rate))
+    }
+
+    /// Current smoothed throughput for `stage`, or `None` before any sample
+    /// with a usable rate has been folded in for it.
+    #[must_use]
+    pub fn throughput(&self, stage: Constraint) -> Option<f64> {
+        self.stages[stage.index()].value()
+    }
+}
+
+impl Default for StageAggregator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn sample(stage: Constraint, bytes: u64, millis: u64) -> StageSample {
+        StageSample::new(stage, bytes, Duration::from_millis(millis), 0)
+    }
+
+    #[test]
+    fn first_sample_seeds_stage_rate_exactly() {
+        let mut agg = StageAggregator::new();
+        // 1000 bytes in 1 ms = 1_000_000 bytes/s.
+        let out = agg.fold(&sample(Constraint::Read, 1_000, 1)).expect("rate");
+        assert!((out - 1_000_000.0).abs() < 1e-3, "seed rate {out}");
+        assert_eq!(agg.throughput(Constraint::Read), Some(out));
+    }
+
+    #[test]
+    fn second_sample_blends_per_alpha() {
+        let mut agg = StageAggregator::new();
+        agg.fold(&sample(Constraint::Compute, 1_000, 1)); // 1_000_000 B/s
+        let out = agg
+            .fold(&sample(Constraint::Compute, 2_000, 1)) // 2_000_000 B/s
+            .expect("rate");
+        let expected = STAGE_ALPHA * 2_000_000.0 + (1.0 - STAGE_ALPHA) * 1_000_000.0;
+        assert!(
+            (out - expected).abs() < 1e-3,
+            "blended {out} want {expected}"
+        );
+    }
+
+    #[test]
+    fn stages_are_independent() {
+        let mut agg = StageAggregator::new();
+        agg.fold(&sample(Constraint::Read, 1_000, 1));
+        agg.fold(&sample(Constraint::WireWrite, 500, 1));
+        assert_eq!(agg.throughput(Constraint::Read), Some(1_000_000.0));
+        assert_eq!(agg.throughput(Constraint::WireWrite), Some(500_000.0));
+        assert_eq!(agg.throughput(Constraint::Compute), None);
+    }
+
+    #[test]
+    fn zero_duration_sample_is_skipped() {
+        let mut agg = StageAggregator::new();
+        assert_eq!(agg.fold(&sample(Constraint::Read, 1_000, 0)), None);
+        assert_eq!(
+            agg.throughput(Constraint::Read),
+            None,
+            "skipped sample must not seed the average"
+        );
+    }
+
+    #[test]
+    fn converges_toward_sustained_rate() {
+        let mut agg = StageAggregator::new();
+        // Seed high, then feed a sustained lower rate; the average must track down.
+        agg.fold(&sample(Constraint::Compute, 10_000, 1)); // 10 MB/s
+        for _ in 0..100 {
+            agg.fold(&sample(Constraint::Compute, 1_000, 1)); // 1 MB/s
+        }
+        let v = agg.throughput(Constraint::Compute).expect("seeded");
+        assert!((v - 1_000_000.0).abs() < 1.0, "converged to {v}");
+    }
+}

--- a/crates/engine/src/throughput/bus.rs
+++ b/crates/engine/src/throughput/bus.rs
@@ -1,0 +1,236 @@
+//! Lock-free telemetry bus connecting instrumented stages to the governor.
+//!
+//! The Observer pattern's transport: stages publish [`StageSample`]s through a
+//! cheap [`SampleSink`] handle onto a bounded, lock-free
+//! [`crossbeam_queue::ArrayQueue`]; the governor thread drains them on its own
+//! cadence. The bus is **drop-on-overflow**: if the governor cannot keep up,
+//! excess samples are dropped and counted rather than blocking a producer.
+//! Telemetry must never backpressure the data path - a slow or stalled
+//! governor can only cost accuracy, never throughput.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use crossbeam_queue::ArrayQueue;
+
+use super::sample::{Constraint, StageSample};
+
+/// Capacity of the telemetry ring, in samples.
+///
+/// Sized to buffer a burst of stage completions across one governor poll
+/// window without dropping under normal load. At the pipeline's worker fan-out
+/// (`2 * num_threads` in-flight items) even a 64-thread host completes far
+/// fewer than 4096 files per 250 ms poll, so the steady state never overflows;
+/// the reserve absorbs scheduling jitter. Each [`StageSample`] is a few machine
+/// words, so 4096 slots cost on the order of 128 KiB - negligible against the
+/// transfer's buffer pool. A power of two keeps `ArrayQueue`'s index masking
+/// branch-free.
+pub const DEFAULT_BUS_CAPACITY: usize = 4096;
+
+/// Shared, lock-free ring that carries samples from stages to the governor.
+///
+/// Producers ([`SampleSink`]) push; the governor pops. The queue is
+/// multi-producer/multi-consumer, so any number of worker threads may publish
+/// concurrently with the single governor drain. Overflowed pushes increment
+/// [`TelemetryBus::dropped`] instead of blocking.
+#[derive(Debug)]
+pub struct TelemetryBus {
+    queue: ArrayQueue<StageSample>,
+    dropped: AtomicU64,
+}
+
+impl TelemetryBus {
+    /// Creates a bus with room for `capacity` in-flight samples.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero - a zero-length ring could never hold a
+    /// sample and would drop every observation, which is a configuration
+    /// error rather than a runtime condition.
+    #[must_use]
+    pub fn new(capacity: usize) -> Arc<Self> {
+        assert!(capacity > 0, "telemetry bus capacity must be non-zero");
+        Arc::new(Self {
+            queue: ArrayQueue::new(capacity),
+            dropped: AtomicU64::new(0),
+        })
+    }
+
+    /// Publishes `sample`, dropping and counting it if the ring is full.
+    ///
+    /// Returns `true` when the sample was enqueued and `false` when it was
+    /// dropped. This is the single hot-path operation on the data-path side:
+    /// one lock-free push, and on overflow one relaxed increment.
+    #[inline]
+    pub fn push(&self, sample: StageSample) -> bool {
+        match self.queue.push(sample) {
+            Ok(()) => true,
+            Err(_) => {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+                false
+            }
+        }
+    }
+
+    /// Pops the next queued sample, or `None` when the ring is empty.
+    ///
+    /// Called only by the governor drain thread.
+    #[must_use]
+    pub fn pop(&self) -> Option<StageSample> {
+        self.queue.pop()
+    }
+
+    /// Total samples dropped due to ring overflow since construction.
+    ///
+    /// A non-zero value means the governor fell behind the data path; the
+    /// transfer itself was unaffected because pushes never block.
+    #[must_use]
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Current number of buffered samples awaiting the governor drain.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Whether the ring currently holds no samples.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+}
+
+/// A cheap, clonable producer handle stages hold to publish telemetry.
+///
+/// Cloning is an `Arc` bump; emitting is one [`TelemetryBus::push`]. Stages
+/// keep an `Option<SampleSink>` and skip emission entirely when the governor
+/// is off, so the instrumented path costs nothing beyond a null check in the
+/// disabled configuration.
+#[derive(Debug, Clone)]
+pub struct SampleSink {
+    bus: Arc<TelemetryBus>,
+}
+
+impl SampleSink {
+    /// Wraps a shared bus in a producer handle.
+    #[must_use]
+    pub fn new(bus: Arc<TelemetryBus>) -> Self {
+        Self { bus }
+    }
+
+    /// Publishes `sample`; drops and counts it on overflow.
+    ///
+    /// Returns `true` if enqueued, mirroring [`TelemetryBus::push`]. Callers on
+    /// the data path ignore the return - a dropped sample is by design not an
+    /// error.
+    #[inline]
+    pub fn emit(&self, sample: StageSample) -> bool {
+        self.bus.push(sample)
+    }
+
+    /// Convenience wrapper that builds and emits a [`StageSample`] in one call.
+    ///
+    /// Equivalent to `self.emit(StageSample::new(stage, bytes, duration,
+    /// queue_occupancy))`; keeps instrumentation sites to a single expression.
+    #[inline]
+    pub fn emit_stage(
+        &self,
+        stage: Constraint,
+        bytes: u64,
+        duration: Duration,
+        queue_occupancy: usize,
+    ) -> bool {
+        self.emit(StageSample::new(stage, bytes, duration, queue_occupancy))
+    }
+}
+
+/// Emits a sample through an optional sink, doing nothing when `sink` is
+/// `None`.
+///
+/// The single choke point every instrumentation site funnels through: with the
+/// governor off, callers hold `None` and this compiles to a branch that skips
+/// the push, guaranteeing byte-identical, cost-free behaviour on the disabled
+/// path.
+#[inline]
+pub fn emit_if_enabled(
+    sink: Option<&SampleSink>,
+    stage: Constraint,
+    bytes: u64,
+    duration: Duration,
+    queue_occupancy: usize,
+) {
+    if let Some(sink) = sink {
+        sink.emit_stage(stage, bytes, duration, queue_occupancy);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(bytes: u64) -> StageSample {
+        StageSample::new(Constraint::Compute, bytes, Duration::from_millis(1), 0)
+    }
+
+    #[test]
+    fn push_then_pop_roundtrips_fifo() {
+        let bus = TelemetryBus::new(4);
+        assert!(bus.push(sample(1)));
+        assert!(bus.push(sample(2)));
+        assert_eq!(bus.len(), 2);
+        assert_eq!(bus.pop().map(|s| s.bytes), Some(1));
+        assert_eq!(bus.pop().map(|s| s.bytes), Some(2));
+        assert!(bus.pop().is_none());
+        assert!(bus.is_empty());
+    }
+
+    #[test]
+    fn overflow_drops_are_counted_not_blocked() {
+        let bus = TelemetryBus::new(2);
+        assert!(bus.push(sample(1)));
+        assert!(bus.push(sample(2)));
+        // Ring is full: further pushes drop and count.
+        assert!(!bus.push(sample(3)));
+        assert!(!bus.push(sample(4)));
+        assert_eq!(bus.dropped(), 2);
+        // Draining one slot frees room for a subsequent push.
+        assert_eq!(bus.pop().map(|s| s.bytes), Some(1));
+        assert!(bus.push(sample(5)));
+        assert_eq!(bus.dropped(), 2, "successful push must not count as a drop");
+    }
+
+    #[test]
+    fn sink_is_a_cheap_clone_over_shared_bus() {
+        let bus = TelemetryBus::new(8);
+        let sink_a = SampleSink::new(Arc::clone(&bus));
+        let sink_b = sink_a.clone();
+        sink_a.emit_stage(Constraint::Read, 10, Duration::from_millis(1), 3);
+        sink_b.emit_stage(Constraint::WireWrite, 20, Duration::from_millis(1), 0);
+        assert_eq!(bus.len(), 2, "both clones publish to the same ring");
+    }
+
+    #[test]
+    fn emit_if_enabled_is_noop_when_disabled() {
+        let bus = TelemetryBus::new(4);
+        let sink = SampleSink::new(Arc::clone(&bus));
+        emit_if_enabled(None, Constraint::Read, 100, Duration::from_millis(1), 0);
+        assert!(bus.is_empty(), "None sink must not publish");
+        emit_if_enabled(
+            Some(&sink),
+            Constraint::Read,
+            100,
+            Duration::from_millis(1),
+            0,
+        );
+        assert_eq!(bus.len(), 1, "Some sink publishes exactly once");
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must be non-zero")]
+    fn zero_capacity_panics() {
+        let _ = TelemetryBus::new(0);
+    }
+}

--- a/crates/engine/src/throughput/governor.rs
+++ b/crates/engine/src/throughput/governor.rs
@@ -1,0 +1,502 @@
+//! The throughput [`Governor`] facade: spawn, sense, shut down.
+//!
+//! This is the Mediator/Facade of the drum-buffer-rope design. Stages never
+//! tune each other; they publish telemetry through a [`SampleSink`] and the
+//! single governor owns interpretation. In this inert (G2) step the governor
+//! *only* senses: its dedicated thread drains the telemetry bus and folds
+//! samples into per-stage EWMAs. It takes **no** control action - no buffer
+//! sizing, no rope, no I/O actuation - so enabling it cannot change a single
+//! byte on the wire. Those actuators arrive in later steps behind the same
+//! facade.
+//!
+//! # Threading model
+//!
+//! The governor runs on one dedicated [`std::thread`] - not tokio, not rayon -
+//! because it must observe both the rayon compute pool and the tokio network
+//! edge without living inside either. Shutdown is cooperative: an atomic flag
+//! plus a wake channel let [`GovernorHandle::shutdown`] (and `Drop`) join the
+//! thread promptly on every exit path, including panic unwinding of unrelated
+//! worker threads.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use super::actuator::ActuatorHandle;
+use super::aggregate::StageAggregator;
+use super::bus::{DEFAULT_BUS_CAPACITY, SampleSink, TelemetryBus};
+use super::sample::Constraint;
+
+/// Governor operating mode selected at spawn time.
+///
+/// G2 ships only the inert modes. `Off` is the pre-change static behaviour;
+/// `Observe` senses without acting. Active control modes are added behind this
+/// same enum in later steps, so callers that match on it must remain
+/// exhaustive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernorMode {
+    /// No governor: no thread, no telemetry, byte-identical to the static path.
+    Off,
+    /// Sense only: drain telemetry and maintain per-stage EWMAs, take no action.
+    Observe,
+}
+
+impl GovernorMode {
+    /// Parses the `OC_RSYNC_GOVERNOR` operator knob.
+    ///
+    /// Recognises `on` / `observe` / `1` / `true` (case-insensitive) as
+    /// [`GovernorMode::Observe`]; every other value, including `off`, `0`, the
+    /// empty string, and an absent variable, is [`GovernorMode::Off`]. The
+    /// governor is default-off for now, mirroring the opt-out precedent of
+    /// `OC_RSYNC_ADAPTIVE_BASIS_DISPATCH`.
+    #[must_use]
+    pub fn from_env_value(value: Option<&str>) -> Self {
+        match value.map(|v| v.trim().to_ascii_lowercase()).as_deref() {
+            Some("on" | "observe" | "1" | "true") => GovernorMode::Observe,
+            _ => GovernorMode::Off,
+        }
+    }
+}
+
+/// Environment variable selecting the governor mode.
+pub const GOVERNOR_ENV: &str = "OC_RSYNC_GOVERNOR";
+
+/// Governor poll window.
+///
+/// The sense loop drains the telemetry bus and refreshes the per-stage EWMAs
+/// every 250 ms. The value matches the DBR design's evaluation window: long
+/// enough that a poll folds many per-file samples into a stable estimate and
+/// short enough to notice a genuine constraint shift within a second. Draining
+/// is O(samples queued), so the window bounds governor CPU to a negligible
+/// slice regardless of transfer size.
+pub const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Immutable configuration for [`Governor::spawn`].
+#[derive(Debug, Clone)]
+pub struct GovernorConfig {
+    /// Operating mode.
+    pub mode: GovernorMode,
+    /// Telemetry ring capacity in samples.
+    pub bus_capacity: usize,
+    /// Sense-loop poll window.
+    pub poll_interval: Duration,
+}
+
+impl GovernorConfig {
+    /// Builds a config for `mode` with the default bus capacity and poll window.
+    #[must_use]
+    pub fn new(mode: GovernorMode) -> Self {
+        Self {
+            mode,
+            bus_capacity: DEFAULT_BUS_CAPACITY,
+            poll_interval: POLL_INTERVAL,
+        }
+    }
+
+    /// Builds a config from the `OC_RSYNC_GOVERNOR` environment variable.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let mode = GovernorMode::from_env_value(std::env::var(GOVERNOR_ENV).ok().as_deref());
+        Self::new(mode)
+    }
+}
+
+impl Default for GovernorConfig {
+    /// The default configuration is [`GovernorMode::Off`] - the static,
+    /// byte-identical pipeline.
+    fn default() -> Self {
+        Self::new(GovernorMode::Off)
+    }
+}
+
+/// Sentinel bit pattern for "no throughput estimate yet".
+///
+/// `u64::MAX` is a quiet-NaN bit pattern that [`f64::to_bits`] never produces
+/// for a finite, non-negative rate, so it can flag an unset slot without
+/// colliding with any real value - including a genuine `0.0` stall.
+const RATE_UNSET: u64 = u64::MAX;
+
+/// Lock-free snapshot of per-stage throughput published by the governor thread.
+///
+/// The governor writes each stage's latest smoothed bytes/second here after
+/// every fold; readers (tests, and future actuators) load without blocking the
+/// sense loop. Each slot stores an `f64` rate via its bit pattern, or
+/// [`RATE_UNSET`] before the first usable sample for that stage.
+#[derive(Debug)]
+struct Snapshot {
+    rates: [AtomicU64; Constraint::COUNT],
+}
+
+impl Snapshot {
+    fn new() -> Self {
+        Self {
+            rates: std::array::from_fn(|_| AtomicU64::new(RATE_UNSET)),
+        }
+    }
+
+    fn store(&self, stage: Constraint, rate: f64) {
+        self.rates[stage.index()].store(rate.to_bits(), Ordering::Relaxed);
+    }
+
+    fn load(&self, stage: Constraint) -> Option<f64> {
+        match self.rates[stage.index()].load(Ordering::Relaxed) {
+            RATE_UNSET => None,
+            bits => Some(f64::from_bits(bits)),
+        }
+    }
+}
+
+/// Spawns and owns the throughput governor.
+///
+/// [`Governor::spawn`] is the sole constructor; it returns a
+/// [`GovernorHandle`]. The `Governor` type itself is a namespace for the
+/// constructor and carries no state - all state lives behind the handle so the
+/// facade stays small.
+#[derive(Debug)]
+pub struct Governor;
+
+impl Governor {
+    /// Spawns a governor for `config` and returns its handle.
+    ///
+    /// When `config.mode` is [`GovernorMode::Off`] no thread is spawned and the
+    /// returned handle is inert: [`GovernorHandle::sample_sink`] yields `None`,
+    /// so instrumented stages skip emission and the pipeline behaves exactly as
+    /// it did before the governor existed. When `Observe`, one dedicated thread
+    /// starts draining the telemetry bus.
+    #[must_use]
+    pub fn spawn(config: GovernorConfig) -> GovernorHandle {
+        let bus = TelemetryBus::new(config.bus_capacity);
+        let snapshot = Arc::new(Snapshot::new());
+
+        match config.mode {
+            GovernorMode::Off => GovernorHandle {
+                mode: GovernorMode::Off,
+                bus,
+                snapshot,
+                shutdown: Arc::new(AtomicBool::new(false)),
+                wake: None,
+                thread: None,
+            },
+            GovernorMode::Observe => {
+                let shutdown = Arc::new(AtomicBool::new(false));
+                let (wake_tx, wake_rx) = mpsc::channel::<()>();
+                let poll = config.poll_interval;
+                let bus_thread = Arc::clone(&bus);
+                let snapshot_thread = Arc::clone(&snapshot);
+                let shutdown_thread = Arc::clone(&shutdown);
+                let thread = std::thread::Builder::new()
+                    .name("throughput-governor".to_string())
+                    .spawn(move || {
+                        sense_loop(
+                            &bus_thread,
+                            &snapshot_thread,
+                            &shutdown_thread,
+                            &wake_rx,
+                            poll,
+                        );
+                    })
+                    .expect("failed to spawn throughput-governor thread");
+                GovernorHandle {
+                    mode: GovernorMode::Observe,
+                    bus,
+                    snapshot,
+                    shutdown,
+                    wake: Some(wake_tx),
+                    thread: Some(thread),
+                }
+            }
+        }
+    }
+}
+
+/// The governor sense loop: drain, fold, publish, wait, repeat.
+///
+/// Runs until `shutdown` is set (and a final drain has folded any stragglers).
+/// Each iteration drains every queued sample - keeping the bus shallow so
+/// producers rarely overflow it - folds each into its stage average, and
+/// publishes the refreshed rate to `snapshot`. It then waits up to `poll` for
+/// the next window or an early wake from [`GovernorHandle::shutdown`].
+fn sense_loop(
+    bus: &TelemetryBus,
+    snapshot: &Snapshot,
+    shutdown: &AtomicBool,
+    wake_rx: &mpsc::Receiver<()>,
+    poll: Duration,
+) {
+    let mut aggregator = StageAggregator::new();
+    loop {
+        drain(bus, snapshot, &mut aggregator);
+        if shutdown.load(Ordering::Acquire) {
+            break;
+        }
+        match wake_rx.recv_timeout(poll) {
+            Ok(()) | Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    // Final drain so telemetry emitted between the last poll and shutdown is
+    // still folded into the estimates callers read after joining.
+    drain(bus, snapshot, &mut aggregator);
+}
+
+/// Drains and folds every currently-queued sample.
+fn drain(bus: &TelemetryBus, snapshot: &Snapshot, aggregator: &mut StageAggregator) {
+    while let Some(sample) = bus.pop() {
+        if let Some(rate) = aggregator.fold(&sample) {
+            snapshot.store(sample.stage, rate);
+        }
+    }
+}
+
+/// Handle to a spawned governor: the only public surface after `spawn`.
+///
+/// Exposes the three facade operations the design calls for - [`sample_sink`]
+/// for stages to publish telemetry, [`subscribe_actuator`] for consumers of
+/// tuning signals (a no-op in G2), and [`shutdown`] - plus read-only
+/// introspection ([`throughput`], [`dropped_samples`]) used by tests and later
+/// actuators. Dropping the handle shuts the governor down and joins its thread.
+///
+/// [`sample_sink`]: GovernorHandle::sample_sink
+/// [`subscribe_actuator`]: GovernorHandle::subscribe_actuator
+/// [`shutdown`]: GovernorHandle::shutdown
+/// [`throughput`]: GovernorHandle::throughput
+/// [`dropped_samples`]: GovernorHandle::dropped_samples
+#[derive(Debug)]
+pub struct GovernorHandle {
+    mode: GovernorMode,
+    bus: Arc<TelemetryBus>,
+    snapshot: Arc<Snapshot>,
+    shutdown: Arc<AtomicBool>,
+    wake: Option<mpsc::Sender<()>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl GovernorHandle {
+    /// The mode this governor was spawned in.
+    #[must_use]
+    pub fn mode(&self) -> GovernorMode {
+        self.mode
+    }
+
+    /// A producer handle for stages to publish [`StageSample`]s, or `None` when
+    /// the governor is [`GovernorMode::Off`].
+    ///
+    /// Stages hold the returned `Option<SampleSink>`; a `None` makes every
+    /// emission site a no-op, which is exactly the disabled-path guarantee.
+    /// The sink is a cheap `Arc` clone, safe to hand to every worker thread.
+    ///
+    /// [`StageSample`]: super::sample::StageSample
+    #[must_use]
+    pub fn sample_sink(&self) -> Option<SampleSink> {
+        match self.mode {
+            GovernorMode::Off => None,
+            GovernorMode::Observe => Some(SampleSink::new(Arc::clone(&self.bus))),
+        }
+    }
+
+    /// Subscribes to actuator signals.
+    ///
+    /// In G2 this returns an inert [`ActuatorHandle`] that reports no tuning
+    /// action; the buffer-sizing, rope, and I/O-depth actuators attach to this
+    /// same subscription in later steps. Present now so callers can wire the
+    /// subscription without a later signature change.
+    #[must_use]
+    pub fn subscribe_actuator(&self) -> ActuatorHandle {
+        ActuatorHandle::inert()
+    }
+
+    /// Latest smoothed throughput (bytes/second) for `stage`, or `None` before
+    /// the governor has folded a usable sample for it. Always `None` when the
+    /// governor is off.
+    #[must_use]
+    pub fn throughput(&self, stage: Constraint) -> Option<f64> {
+        self.snapshot.load(stage)
+    }
+
+    /// Total telemetry samples dropped due to bus overflow.
+    ///
+    /// A non-zero count means the governor briefly fell behind the data path;
+    /// the transfer was unaffected because emission never blocks.
+    #[must_use]
+    pub fn dropped_samples(&self) -> u64 {
+        self.bus.dropped()
+    }
+
+    /// Signals shutdown and joins the governor thread.
+    ///
+    /// Idempotent: sets the cooperative flag, wakes the sense loop, and joins.
+    /// Subsequent calls (and the `Drop` path) are no-ops. Off-mode governors
+    /// have no thread and return immediately.
+    ///
+    /// # Panics
+    ///
+    /// Propagates a panic from the governor thread, matching
+    /// [`std::thread::JoinHandle::join`] semantics. The sense loop contains no
+    /// `panic!`, `unwrap`, or `expect`, so this cannot fire in practice.
+    pub fn shutdown(&mut self) {
+        self.stop();
+    }
+
+    /// Internal shutdown shared by [`GovernorHandle::shutdown`] and `Drop`.
+    fn stop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        // Wake the sense loop out of its `recv_timeout` so it observes the flag
+        // immediately rather than after the poll window elapses. Dropping the
+        // sender also disconnects the channel, a second independent wake path.
+        if let Some(wake) = self.wake.take() {
+            let _ = wake.send(());
+            drop(wake);
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for GovernorHandle {
+    /// Guarantees the governor thread is joined on every exit path, including
+    /// unwinding when an unrelated worker thread panics.
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use super::*;
+    use crate::throughput::sample::StageSample;
+
+    fn wait_until<F: Fn() -> bool>(pred: F) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if pred() {
+                return;
+            }
+            std::thread::yield_now();
+        }
+        panic!("condition not met within timeout");
+    }
+
+    #[test]
+    fn from_env_value_defaults_off() {
+        assert_eq!(GovernorMode::from_env_value(None), GovernorMode::Off);
+        assert_eq!(GovernorMode::from_env_value(Some("off")), GovernorMode::Off);
+        assert_eq!(GovernorMode::from_env_value(Some("0")), GovernorMode::Off);
+        assert_eq!(GovernorMode::from_env_value(Some("")), GovernorMode::Off);
+        assert_eq!(
+            GovernorMode::from_env_value(Some("ON")),
+            GovernorMode::Observe
+        );
+        assert_eq!(
+            GovernorMode::from_env_value(Some(" observe ")),
+            GovernorMode::Observe
+        );
+        assert_eq!(
+            GovernorMode::from_env_value(Some("1")),
+            GovernorMode::Observe
+        );
+    }
+
+    #[test]
+    fn off_mode_has_no_sink_and_no_thread() {
+        let mut gov = Governor::spawn(GovernorConfig::new(GovernorMode::Off));
+        assert!(gov.sample_sink().is_none(), "off governor emits nothing");
+        assert!(gov.thread.is_none(), "off governor spawns no thread");
+        assert_eq!(gov.throughput(Constraint::Read), None);
+        gov.shutdown(); // must be a clean no-op
+    }
+
+    #[test]
+    fn observe_mode_folds_samples_into_stage_throughput() {
+        let mut gov = Governor::spawn(GovernorConfig {
+            mode: GovernorMode::Observe,
+            bus_capacity: 64,
+            // Short poll so the loop drains promptly under test.
+            poll_interval: Duration::from_millis(5),
+        });
+        let sink = gov.sample_sink().expect("observe governor exposes a sink");
+        // 4096 bytes in 1 ms = 4_096_000 bytes/s.
+        for _ in 0..8 {
+            sink.emit(StageSample::new(
+                Constraint::Compute,
+                4_096,
+                Duration::from_millis(1),
+                0,
+            ));
+        }
+        wait_until(|| gov.throughput(Constraint::Compute).is_some());
+        let rate = gov.throughput(Constraint::Compute).expect("folded");
+        assert!((rate - 4_096_000.0).abs() < 1.0, "rate {rate}");
+        gov.shutdown();
+    }
+
+    #[test]
+    fn shutdown_joins_cleanly_and_is_idempotent() {
+        let mut gov = Governor::spawn(GovernorConfig::new(GovernorMode::Observe));
+        gov.shutdown();
+        assert!(gov.thread.is_none(), "thread joined and cleared");
+        gov.shutdown(); // second call is a no-op
+    }
+
+    #[test]
+    fn governor_joins_cleanly_despite_worker_panic() {
+        // A data-path worker panicking must not prevent the independent
+        // governor thread from joining. Spawn a governor, then panic an
+        // unrelated worker and catch it, then shut the governor down.
+        let mut gov = Governor::spawn(GovernorConfig::new(GovernorMode::Observe));
+        let sink = gov.sample_sink().expect("sink");
+        let worker = std::thread::spawn(move || {
+            sink.emit(StageSample::new(
+                Constraint::Read,
+                1,
+                Duration::from_millis(1),
+                0,
+            ));
+            panic!("simulated worker panic");
+        });
+        assert!(worker.join().is_err(), "worker did panic");
+        // Governor is unaffected and joins cleanly on shutdown.
+        gov.shutdown();
+        assert!(gov.thread.is_none());
+    }
+
+    #[test]
+    fn drop_shuts_down_without_explicit_shutdown() {
+        let gov = Governor::spawn(GovernorConfig::new(GovernorMode::Observe));
+        // Dropping must join the thread; a leaked thread would keep the process
+        // busy. No assertion beyond "drop does not hang or panic".
+        drop(gov);
+    }
+
+    #[test]
+    fn dropped_samples_counts_bus_overflow() {
+        // Off governor never drains, but we can exercise the counter via a
+        // tiny bus behind an Observe handle whose loop we starve by flooding.
+        let gov = Governor::spawn(GovernorConfig {
+            mode: GovernorMode::Observe,
+            bus_capacity: 1,
+            poll_interval: Duration::from_secs(3600),
+        });
+        let sink = gov.sample_sink().expect("sink");
+        // The loop drains at most one before parking for an hour; flood so the
+        // ring overflows and increments the drop counter deterministically.
+        let mut dropped_seen = false;
+        for _ in 0..10_000 {
+            sink.emit(StageSample::new(
+                Constraint::Read,
+                1,
+                Duration::from_millis(1),
+                0,
+            ));
+            if gov.dropped_samples() > 0 {
+                dropped_seen = true;
+                break;
+            }
+        }
+        assert!(dropped_seen, "expected at least one overflow drop");
+    }
+}

--- a/crates/engine/src/throughput/mod.rs
+++ b/crates/engine/src/throughput/mod.rs
@@ -1,0 +1,51 @@
+//! Drum-buffer-rope throughput governor: telemetry foundation (inert Observer).
+//!
+//! This module is the sensing half of a Theory-of-Constraints throughput
+//! governor for the transfer pipeline. It composes existing building blocks -
+//! the shared [`Ewma`](fast_io::ewma::Ewma) primitive and a lock-free
+//! `crossbeam_queue::ArrayQueue` - into an Observer that watches every pipeline
+//! stage without perturbing it.
+//!
+//! # What this step does (and does not) do
+//!
+//! In this step the governor is **inert**: it senses and nothing more. It has
+//! no control loop that acts, no buffer sizing, no backpressure "rope", and no
+//! I/O actuation. Enabling it therefore cannot change a single byte on the wire
+//! for any protocol version - a property pinned by the differential test in
+//! `tests/throughput_governor_differential.rs`. The actuators (dynamic capacity,
+//! rope, buffer-pool pressure, I/O depth) attach to the same
+//! [`GovernorHandle`] facade in later steps.
+//!
+//! # Pattern composition
+//!
+//! - **Observer** - stages publish [`StageSample`]s through a cheap
+//!   [`SampleSink`] onto the lock-free [`TelemetryBus`] (drop-on-overflow, so
+//!   telemetry never backpressures the data path).
+//! - **Mediator / Facade** - a single [`Governor`] owns interpretation; stages
+//!   never tune each other. [`Governor::spawn`] returns the sole public handle.
+//! - **State** - the [`Constraint`] taxonomy names the stage that can become the
+//!   drum.
+//! - **Adapter (later)** - platform I/O actuators will adapt to governor signals
+//!   through [`ActuatorHandle`] without leaking any `cfg` into this core.
+//!
+//! # Degradation ladder
+//!
+//! `OC_RSYNC_GOVERNOR=off` (the default for now) selects [`GovernorMode::Off`]:
+//! no thread, and [`GovernorHandle::sample_sink`] returns `None` so every
+//! instrumentation site compiles to a skipped branch. The pipeline is then
+//! byte-identical to the pre-governor code. `OC_RSYNC_GOVERNOR=on` selects
+//! [`GovernorMode::Observe`], which senses only.
+
+mod actuator;
+mod aggregate;
+mod bus;
+mod governor;
+mod sample;
+
+pub use actuator::ActuatorHandle;
+pub use aggregate::{STAGE_ALPHA, StageAggregator};
+pub use bus::{DEFAULT_BUS_CAPACITY, SampleSink, TelemetryBus, emit_if_enabled};
+pub use governor::{
+    GOVERNOR_ENV, Governor, GovernorConfig, GovernorHandle, GovernorMode, POLL_INTERVAL,
+};
+pub use sample::{Constraint, StageSample};

--- a/crates/engine/src/throughput/sample.rs
+++ b/crates/engine/src/throughput/sample.rs
@@ -1,0 +1,171 @@
+//! Telemetry sample and constraint-stage taxonomy for the throughput governor.
+//!
+//! A [`StageSample`] is the atom of the Observer half of the drum-buffer-rope
+//! (DBR) governor: each instrumented pipeline stage publishes one sample per
+//! unit of work it completes, and the governor folds those samples into
+//! per-stage throughput estimates. The sample carries only plain data - no
+//! locks, no allocation - so publishing it is a single lock-free queue push.
+
+use std::time::Duration;
+
+/// A pipeline stage that can become the throughput constraint (the DBR "drum").
+///
+/// The governor classifies which stage is the slowest sustained producer of
+/// bytes; that stage is the drum. The variants cover every stage the pipeline
+/// can bottleneck on, ordered from the source of data (`Read`) to its sink
+/// (`Consumer`):
+///
+/// - `Read` - pulling basis/source bytes off disk or the wire.
+/// - `Compute` - rolling/strong checksum and delta application on worker threads.
+/// - `Compress` - token compression (sender-side; instrumented when that path
+///   is tapped in a later step).
+/// - `WireWrite` - emitting reordered results toward the socket or output file.
+/// - `Consumer` - the reorder/commit drain that delivers results in NDX order.
+/// - `Unknown` - no stage has yet accumulated enough samples to classify.
+///
+/// `Unknown` is deliberately last and is never emitted by an instrumented
+/// stage; it is the governor's initial drum designation before any telemetry
+/// arrives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Constraint {
+    /// Reading basis or source bytes (disk or wire).
+    Read,
+    /// Checksum and delta computation on worker threads.
+    Compute,
+    /// Token compression on the sender path.
+    Compress,
+    /// Writing reordered output toward the wire or destination file.
+    WireWrite,
+    /// The reorder/commit drain delivering results in submission order.
+    Consumer,
+    /// No stage classified yet (initial governor state only).
+    Unknown,
+}
+
+impl Constraint {
+    /// Every constraint variant, in declaration order.
+    ///
+    /// Used to size per-stage aggregate arrays and to iterate stages in a
+    /// stable order. Kept in lockstep with the enum by [`Constraint::index`],
+    /// which the aggregate array indexes with.
+    pub const ALL: [Constraint; 6] = [
+        Constraint::Read,
+        Constraint::Compute,
+        Constraint::Compress,
+        Constraint::WireWrite,
+        Constraint::Consumer,
+        Constraint::Unknown,
+    ];
+
+    /// Number of distinct constraint stages.
+    ///
+    /// Equal to `Constraint::ALL.len()`; exposed as a `const` so fixed-size
+    /// per-stage arrays can be declared without referencing the array length
+    /// at a non-const site.
+    pub const COUNT: usize = Self::ALL.len();
+
+    /// Dense array index for this stage in `[0, COUNT)`.
+    ///
+    /// The mapping matches [`Constraint::ALL`] so an array indexed by this
+    /// value can be paired back to its stage by `Constraint::ALL[index]`.
+    #[must_use]
+    pub const fn index(self) -> usize {
+        match self {
+            Constraint::Read => 0,
+            Constraint::Compute => 1,
+            Constraint::Compress => 2,
+            Constraint::WireWrite => 3,
+            Constraint::Consumer => 4,
+            Constraint::Unknown => 5,
+        }
+    }
+}
+
+/// A single throughput observation published by one pipeline stage.
+///
+/// The governor consumes a stream of these and folds each into the owning
+/// stage's exponentially-weighted moving average. All fields are plain values
+/// so a sample can be pushed onto the lock-free telemetry bus without
+/// allocating or blocking the data path.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StageSample {
+    /// The stage that produced this observation.
+    pub stage: Constraint,
+    /// Bytes of useful work completed in this observation window.
+    pub bytes: u64,
+    /// Wall-clock time the stage spent producing `bytes`.
+    pub duration: Duration,
+    /// Depth of the stage's input queue at sampling time.
+    ///
+    /// A high input occupancy paired with a low downstream occupancy is the
+    /// classic constraint signature the governor looks for. For stages without
+    /// an explicit queue (e.g. per-file compute) this is `0`.
+    pub queue_occupancy: usize,
+}
+
+impl StageSample {
+    /// Constructs a sample for `stage` describing `bytes` produced over
+    /// `duration` with the given input `queue_occupancy`.
+    #[must_use]
+    pub const fn new(
+        stage: Constraint,
+        bytes: u64,
+        duration: Duration,
+        queue_occupancy: usize,
+    ) -> Self {
+        Self {
+            stage,
+            bytes,
+            duration,
+            queue_occupancy,
+        }
+    }
+
+    /// Instantaneous throughput in bytes per second for this observation.
+    ///
+    /// Returns `None` when `duration` is zero (no elapsed time yields no
+    /// meaningful rate) so callers never divide by zero. A zero-byte sample
+    /// over a non-zero duration returns `Some(0.0)`, which correctly drags a
+    /// stage's average toward a stall.
+    #[must_use]
+    pub fn bytes_per_sec(&self) -> Option<f64> {
+        let secs = self.duration.as_secs_f64();
+        if secs > 0.0 {
+            Some(self.bytes as f64 / secs)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_is_dense_and_bijective_with_all() {
+        for (i, stage) in Constraint::ALL.iter().enumerate() {
+            assert_eq!(stage.index(), i, "index must match ALL position");
+        }
+        assert_eq!(Constraint::COUNT, 6);
+    }
+
+    #[test]
+    fn bytes_per_sec_computes_rate() {
+        let s = StageSample::new(Constraint::Read, 1_000, Duration::from_millis(500), 0);
+        let rate = s.bytes_per_sec().expect("non-zero duration");
+        assert!((rate - 2_000.0).abs() < 1e-6, "got {rate}");
+    }
+
+    #[test]
+    fn bytes_per_sec_zero_duration_is_none() {
+        let s = StageSample::new(Constraint::Compute, 1_000, Duration::ZERO, 4);
+        assert_eq!(s.bytes_per_sec(), None);
+    }
+
+    #[test]
+    fn zero_bytes_is_a_stall_not_none() {
+        let s = StageSample::new(Constraint::WireWrite, 0, Duration::from_secs(1), 0);
+        assert_eq!(s.bytes_per_sec(), Some(0.0));
+    }
+}

--- a/crates/engine/tests/throughput_governor_differential.rs
+++ b/crates/engine/tests/throughput_governor_differential.rs
@@ -1,0 +1,120 @@
+//! Differential test: the throughput governor is observationally inert.
+//!
+//! Enabling the governor's telemetry sink must not change what the concurrent
+//! delta pipeline delivers - same results, same order, same bytes. This runs
+//! an identical batch of work items through the pipeline twice, once with the
+//! governor off (no sink) and once with an `Observe` governor attached, and
+//! asserts the two output streams are byte-for-byte identical. It is the
+//! host-independent stand-in for the end-to-end "wire-identical governor-on vs
+//! off" guarantee: the instrumentation only reads and publishes, never steers.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use engine::ConcurrentDeltaConfig;
+use engine::concurrent_delta::consumer::DeltaConsumer;
+use engine::concurrent_delta::work_queue;
+use engine::concurrent_delta::{DeltaResult, DeltaWork};
+use engine::throughput::{Constraint, Governor, GovernorConfig, GovernorMode};
+
+/// A comparable projection of a delivered result: everything an observer of the
+/// pipeline can see. If telemetry perturbed the pipeline, one of these fields
+/// would diverge between runs.
+#[derive(Debug, PartialEq, Eq)]
+struct ResultFingerprint {
+    sequence: u64,
+    ndx: u32,
+    bytes_written: u64,
+    success: bool,
+}
+
+fn fingerprint(results: &[DeltaResult]) -> Vec<ResultFingerprint> {
+    results
+        .iter()
+        .map(|r| ResultFingerprint {
+            sequence: r.sequence(),
+            ndx: r.ndx().get(),
+            bytes_written: r.bytes_written(),
+            success: r.is_success(),
+        })
+        .collect()
+}
+
+/// Drives `count` whole-file work items through the pipeline under `cfg` and
+/// returns the delivered results in delivery order.
+fn run_pipeline(count: u32, cfg: ConcurrentDeltaConfig) -> Vec<DeltaResult> {
+    let (tx, rx) = work_queue::bounded_with_capacity(count.max(1) as usize);
+    let producer = std::thread::spawn(move || {
+        for i in 0..count {
+            let work = DeltaWork::whole_file(i, PathBuf::from(format!("/dst/{i}")), 64)
+                .with_sequence(u64::from(i));
+            tx.send(work).expect("send work");
+        }
+    });
+    let consumer = DeltaConsumer::spawn_with_config(rx, 64, cfg);
+    let results: Vec<DeltaResult> = consumer.into_iter().collect();
+    producer.join().expect("producer join");
+    results
+}
+
+#[test]
+fn governor_off_and_on_produce_identical_pipeline_output() {
+    const COUNT: u32 = 256;
+
+    // Baseline: governor off - no telemetry sink at all.
+    let off = run_pipeline(COUNT, ConcurrentDeltaConfig::default());
+
+    // Instrumented: an Observe governor's sink attached to the same pipeline.
+    let mut gov = Governor::spawn(GovernorConfig {
+        mode: GovernorMode::Observe,
+        bus_capacity: 8192,
+        poll_interval: Duration::from_millis(5),
+    });
+    let sink = gov.sample_sink().expect("observe governor exposes a sink");
+    let on = run_pipeline(
+        COUNT,
+        ConcurrentDeltaConfig::default().with_telemetry_sink(sink),
+    );
+
+    assert_eq!(
+        fingerprint(&off),
+        fingerprint(&on),
+        "telemetry must not change pipeline output"
+    );
+
+    // Sanity: the instrumentation actually fired. After shutdown the governor
+    // performs a final drain, so every emitted sample is folded. Compute (from
+    // the workers) and WireWrite (from the reorder drain) must both have a
+    // recorded throughput estimate.
+    gov.shutdown();
+    assert!(
+        gov.throughput(Constraint::Compute).is_some(),
+        "compute stage should have been sampled"
+    );
+    assert!(
+        gov.throughput(Constraint::WireWrite).is_some(),
+        "wire-write stage should have been sampled"
+    );
+}
+
+#[test]
+fn governor_telemetry_survives_empty_transfer() {
+    // An empty batch must not deadlock or emit spurious samples, and the
+    // off/on outputs must both be empty.
+    let off = run_pipeline(0, ConcurrentDeltaConfig::default());
+    assert!(off.is_empty());
+
+    let mut gov = Governor::spawn(GovernorConfig::new(GovernorMode::Observe));
+    let sink = gov.sample_sink().expect("sink");
+    let on = run_pipeline(
+        0,
+        ConcurrentDeltaConfig::default().with_telemetry_sink(sink),
+    );
+    assert!(on.is_empty());
+    gov.shutdown();
+    assert_eq!(
+        gov.dropped_samples(),
+        0,
+        "no work means no dropped telemetry"
+    );
+}


### PR DESCRIPTION
## Summary

Foundation step of the drum-buffer-rope (DBR) throughput governor: an **inert Observer** that senses the transfer pipeline without acting on it. This lands the telemetry infrastructure - a lock-free sample bus, a per-stage EWMA aggregator, and the governor thread/facade - plus stage instrumentation, all **default-off** and **wire-identical** to today.

There is no control action in this change: no buffer sizing, no backpressure rope, no I/O actuation. The governor's control loop is a no-op that only folds samples into per-stage bytes/second estimates. Actuators attach to the same facade in later steps.

## What landed

New module `crates/engine/src/throughput/`:

- **Observer / bus** (`bus.rs`) - stages publish `StageSample { stage, bytes, duration, queue_occupancy }` through a cheap clonable `SampleSink` onto a bounded lock-free `crossbeam_queue::ArrayQueue`. **Drop-on-overflow with a drop counter**: telemetry can never backpressure the data path; a slow governor costs accuracy, never throughput.
- **State** (`sample.rs`) - `Constraint` enum `{ Read, Compute, Compress, WireWrite, Consumer, Unknown }` with a dense index for per-stage arrays.
- **Sense** (`aggregate.rs`) - `StageAggregator` folds samples into one `Ewma` per stage, reusing the shared `Ewma` primitive (α = 0.2) rather than reimplementing it - one smoothing rule across both consumers.
- **Facade / Mediator** (`governor.rs`) - `Governor::spawn(config) -> GovernorHandle` exposing `sample_sink()`, `subscribe_actuator()` (inert no-op for now), and `shutdown()`. The governor runs on **one dedicated `std::thread`** (not tokio, not rayon). Cooperative shutdown via an atomic flag plus a wake channel; the thread joins cleanly on every exit path including `Drop` and unrelated worker-thread panic. Per-stage throughput is published to a lock-free snapshot readers can poll without blocking the sense loop.
- **Adapter seam** (`actuator.rs`) - `ActuatorHandle::inert()`; real signals attach here later with no call-site churn.

Stage instrumentation in the existing `concurrent_delta` receiver pipeline, threaded through an optional `ConcurrentDeltaConfig::telemetry_sink`:

- **Compute** - each rayon worker times its delta computation and emits a sample.
- **WireWrite + reorder-buffer occupancy** - the reorder drain emits per non-empty batch, tagged with live `ReorderBuffer` occupancy (the drum-detection signal).

## Degradation ladder

`OC_RSYNC_GOVERNOR=off` (the default) selects the off mode: no thread, and `sample_sink()` returns `None`, so every instrumentation site is a skipped branch. The pipeline is then byte-identical to the pre-change code. `OC_RSYNC_GOVERNOR=on` senses only.

## Tests

- Bus push/drain FIFO + overflow-drop counting.
- `StageSample` folding into per-stage EWMA yields correct bytes/s (seed, blend, convergence, independence).
- Governor spawn -> shutdown joins cleanly, is idempotent, joins despite a simulated worker panic, and joins on `Drop`.
- **Differential** (`tests/throughput_governor_differential.rs`) - the same work batch through the pipeline governor-off vs governor-on produces byte-identical delivered results (sequence, ndx, bytes, status), with a sanity assertion that instrumentation actually fired.

## Constraints honoured

- NDX ordering untouched (adds no parallelism); no `unwrap()` outside tests; `thiserror`-style crate errors reused (no new fallible surface needed here); rustdoc on every public item with justified constants (bus capacity, α reuse, poll window, NaN sentinel); zero platform `cfg` in the governor core.

## Verification

- `cargo check -p engine --all-features` - clean.
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean.
- `cargo nextest run -p engine --all-features -E 'test(throughput) or test(governor) or test(stage_sample) or test(telemetry)'` - 81 passed.
- `cargo fmt --all -- --check` - clean; placeholder scan clean.

The governor core is platform-neutral (no `cfg`), so these results are representative across the OS matrix.
