### PR TITLE
feat(transfer): receiver local-replay input mode (batch f_in + discard-sink) [batch approach-A step 1]

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -426,6 +426,16 @@ pub struct ReceiverContext {
     /// upstream: generator.c:298-305 - `delete_in_dir()` returns early (printing
     /// once) whenever `io_error & IOERR_GENERAL && !ignore_errors`.
     pub(in crate::receiver) io_error_delete_warning_emitted: bool,
+    /// True when this receiver is applying a recorded batch (`--read-batch`)
+    /// rather than talking to a live peer. Mirrors upstream's `read_batch`
+    /// global as seen by the receiving client: the batch file is fed straight
+    /// in as `f_in` and the generator's `f_out` has no live consumer
+    /// (`main.c:635-651`). The flag gates the `!read_batch` decisions the
+    /// receive path shares with the network path - today only keeping the
+    /// batch `f_in` unmultiplexed (`main.c:1359-1366`). Always `false` on every
+    /// network transfer, so the wire path is byte-identical; set only by
+    /// [`run_local_replay`](Self::run_local_replay).
+    pub(in crate::receiver) local_replay: bool,
 }
 
 impl ReceiverContext {
@@ -511,6 +521,8 @@ impl ReceiverContext {
             got_xfer_error: std::cell::Cell::new(false),
             delayed_delete_victims: Vec::new(),
             io_error_delete_warning_emitted: false,
+            // upstream: read_batch defaults off; the network path never sets it.
+            local_replay: false,
         }
     }
 
@@ -900,8 +912,19 @@ impl ReceiverContext {
     /// **Server mode** (daemon/SSH receiver - `main.c:1185-1186` `do_recv`):
     /// - `if (protocol_version >= 30) io_start_multiplex_in(f_in);`
     /// - Protocol < 30 uses `io_start_buffering_in()` instead (no multiplex).
+    ///
+    /// **Local replay** (`--read-batch`): never. Upstream gates every
+    /// `io_start_multiplex_in(f_in)` on `!read_batch` (`main.c:1359-1366`),
+    /// because the batch file is a raw, one-way recorded stream that was never
+    /// framed. [`local_replay`](Self::local_replay) mirrors that gate so a
+    /// batch-fed `f_in` stays in `Plain` (undemuxed) mode.
     #[must_use]
     pub(crate) const fn should_activate_input_multiplex(&self) -> bool {
+        if self.local_replay {
+            // upstream: main.c:1359 `if (!read_batch)` - the recorded batch
+            // stream is never multiplexed, so keep the reader Plain.
+            return false;
+        }
         if self.config.connection.client_mode {
             // Client mode: >= 23 (upstream main.c:1342-1343)
             self.protocol.supports_multiplex_io()

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -71,6 +71,56 @@ impl ReceiverContext {
         }
     }
 
+    /// Drives the receiver off a pre-recorded batch stream instead of a live
+    /// peer, mirroring upstream's `--read-batch` receive.
+    ///
+    /// Upstream opens the batch file and hands its descriptor to the ordinary
+    /// receiving client as `f_in`, pointing the generator's `f_out` at one end
+    /// of a self-pipe whose read end is never drained (`main.c:635-651`). The
+    /// receiver then reads the recorded file list and delta stream exactly as
+    /// it would off a socket - `do_recv()` is unchanged - while its outbound
+    /// requests and signatures fall into the dead-end pipe. Because the batch
+    /// file was never framed, upstream also skips `io_start_multiplex_in()` for
+    /// it (`main.c:1359-1366`, gated on `!read_batch`).
+    ///
+    /// This is the enabling mechanism for routing `--read-batch` through the
+    /// real receiver rather than the native replay fork. It reproduces both
+    /// halves of that model:
+    ///
+    /// - `batch_input` is wrapped as an undemultiplexed (`Plain`)
+    ///   [`ServerReader`](crate::reader::ServerReader) `f_in`, and the
+    ///   [`local_replay`](Self::local_replay) flag it sets keeps it Plain by
+    ///   suppressing input-multiplex activation.
+    /// - a [`DiscardSink`](crate::writer::DiscardSink) stands in for the
+    ///   generator's consumer-less `f_out`, swallowing every request, signature
+    ///   block, and `MSG_*` frame.
+    ///
+    /// The caller supplies a `ReceiverContext` already primed from the batch
+    /// header - protocol, compat flags, and checksum seed are fed separately -
+    /// so this method owns only the drive. It never touches the network path,
+    /// which leaves `local_replay` at its `false` default and stays
+    /// byte-identical.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:635-651` - `read_batch` sets `f_in = batch_fd` and points
+    ///   `f_out` at a self-pipe with no live consumer.
+    /// - `main.c:1359-1366` - the `!read_batch` gate that leaves the batch
+    ///   `f_in` unmultiplexed.
+    /// - `main.c:1387` - `do_recv(f_in, f_out, local_name)` drives the real
+    ///   receiver over that batch `f_in`.
+    pub fn run_local_replay<R: Read>(
+        &mut self,
+        batch_input: R,
+        progress: Option<&mut dyn crate::TransferProgressCallback>,
+    ) -> io::Result<TransferStats> {
+        // upstream: main.c:1359 `!read_batch` keeps the batch f_in unmultiplexed.
+        self.local_replay = true;
+        let reader = crate::reader::ServerReader::new_plain(batch_input);
+        let mut sink = crate::writer::DiscardSink::new();
+        self.run(reader, &mut sink, progress)
+    }
+
     /// True when this receiver is a *client* that was handed an empty file
     /// list, i.e. every requested source path failed to be listed (missing
     /// source, unreadable directory, everything filtered out).
@@ -526,7 +576,102 @@ pub(in crate::receiver) fn handle_delayed_updates(
 mod tests {
     use super::*;
     use std::fs;
+    use std::io::Cursor;
     use std::path::PathBuf;
+
+    use protocol::ProtocolVersion;
+    use protocol::flist::FileListWriter;
+
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+
+    /// Builds a protocol-32 client-mode receiver context, the shape a
+    /// `--read-batch` client presents to `run_local_replay`.
+    fn replay_client_ctx() -> ReceiverContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let mut config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![std::ffi::OsString::from(".")],
+            ..Default::default()
+        };
+        // upstream: the batch is applied by the receiving *client*, so the
+        // empty-list short-circuit (main.c:1389-1392) is reachable.
+        config.connection.client_mode = true;
+        ReceiverContext::new_for_test(&handshake, config)
+    }
+
+    /// `run_local_replay` drives the real receiver to completion off a plain,
+    /// pre-recorded (Cursor) `f_in` paired with the discard sink - no live peer,
+    /// no multiplex framing - mirroring upstream's `do_recv()` over `batch_fd`.
+    ///
+    /// WHY: this is the whole point of approach A. A recorded batch is a
+    /// one-way stream with nothing to answer the generator's requests; feeding
+    /// it as a Plain `ServerReader` and swallowing the outbound frames in a
+    /// [`DiscardSink`](crate::writer::DiscardSink) must let the ordinary
+    /// receiver run to a clean finish. A trivial empty file list exercises the
+    /// full setup path (Plain f_in, no filter read, flist decode) and returns
+    /// through `finish_empty_client_flist` without touching the disk or the
+    /// wire - so a green result proves the input mode is wired, not that a
+    /// stub returned early.
+    #[test]
+    fn run_local_replay_drives_empty_recorded_stream_to_completion() {
+        let mut ctx = replay_client_ctx();
+
+        // A recorded stream that carries only an (empty) file list - the
+        // minimal complete batch body an upstream `--write-batch` of nothing
+        // would produce.
+        let mut recorded = Vec::new();
+        let writer = FileListWriter::new(ctx.protocol());
+        writer.write_end(&mut recorded, None).unwrap();
+
+        let stats = ctx
+            .run_local_replay(Cursor::new(recorded), None)
+            .expect("empty recorded batch must replay to completion");
+
+        assert_eq!(
+            stats.files_listed, 0,
+            "an empty recorded file list yields no listed files"
+        );
+        assert_eq!(
+            stats.files_transferred, 0,
+            "no delta data is applied for an empty recorded batch"
+        );
+        // The mechanism must have kept the batch f_in unmultiplexed the whole
+        // way through (upstream main.c:1359 `!read_batch`).
+        assert!(!ctx.should_activate_input_multiplex());
+    }
+
+    /// The `local_replay` flag suppresses input-multiplex activation even at a
+    /// protocol that would otherwise demux, and leaves the network default
+    /// untouched.
+    ///
+    /// WHY: upstream gates every `io_start_multiplex_in(f_in)` on `!read_batch`
+    /// (main.c:1359-1366) because the batch file was never framed. Without the
+    /// gate the receiver would try to demux raw batch bytes as `MSG_DATA`
+    /// frames and desync immediately.
+    #[test]
+    fn local_replay_flag_keeps_f_in_plain_at_protocol_32() {
+        let mut ctx = replay_client_ctx();
+        // Default (network) path: proto-32 client activates multiplex.
+        assert!(ctx.should_activate_input_multiplex());
+        ctx.local_replay = true;
+        assert!(
+            !ctx.should_activate_input_multiplex(),
+            "a recorded batch f_in must stay Plain (upstream !read_batch)"
+        );
+    }
 
     /// Verifies the delayed rename sweep moves files from staging paths to
     /// final destinations, matching upstream `receiver.c:422-450`.

--- a/crates/transfer/src/writer/discard.rs
+++ b/crates/transfer/src/writer/discard.rs
@@ -1,0 +1,92 @@
+//! Discard-sink writer for the batch local-replay receiver path.
+
+use std::io::{self, Write};
+
+use super::msg_info::MsgInfoSender;
+
+/// A zero-cost writer that discards every byte and every multiplexed protocol
+/// message the receiver emits.
+///
+/// On a normal network receive the generator's request output - signature
+/// blocks, per-file NDX requests, `MSG_*` frames - flows back to a live sender
+/// that consumes it. When applying a recorded batch there is no such peer:
+/// upstream opens the batch file as the receiver's `f_in` and points the
+/// generator's `f_out` at one end of a self-pipe whose read end
+/// (`batch_gen_fd`) is never drained, so the requests simply go nowhere
+/// (`main.c:635-651`, and the `!read_batch` gate at `main.c:1359-1366` that
+/// leaves that stream unmultiplexed). `DiscardSink` is that dead end - it
+/// swallows the generator's outbound stream without allocating or blocking, so
+/// the real receiver can drive to completion off a one-way pre-recorded input.
+///
+/// Every [`MsgInfoSender`] method uses the trait's default no-op, and the
+/// [`Write`] path reports every byte as accepted so callers never observe a
+/// short write.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DiscardSink;
+
+impl DiscardSink {
+    /// Creates a new discard sink.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Write for DiscardSink {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_all(&mut self, _buf: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// The receiver's outbound protocol messages have no live consumer during a
+/// batch replay, so every frame is dropped via the trait's default no-ops.
+impl MsgInfoSender for DiscardSink {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A discard sink accepts every byte as written and never reports a short
+    /// write, so the receiver's `write_all`/`flush` calls always succeed.
+    #[test]
+    fn write_swallows_all_bytes() {
+        let mut sink = DiscardSink::new();
+        assert_eq!(
+            sink.write(b"signature-block").unwrap(),
+            b"signature-block".len()
+        );
+        sink.write_all(&[0u8; 4096]).unwrap();
+        sink.flush().unwrap();
+    }
+
+    /// Every `MsgInfoSender` emission the generator half makes is a no-op that
+    /// returns `Ok`, so a receiver that itemizes, reports deletions, or acks a
+    /// committed file never fails just because no peer is listening.
+    #[test]
+    fn msg_info_sender_calls_are_noops() {
+        let mut sink = DiscardSink::new();
+        sink.send_msg_info(b"itemize").unwrap();
+        sink.send_msg_error_xfer(b"xfer").unwrap();
+        sink.send_msg_error(b"err").unwrap();
+        sink.send_msg_warning(b"warn").unwrap();
+        sink.send_msg_deleted(b"gone").unwrap();
+        sink.send_msg_success(7).unwrap();
+        assert!(!sink.maybe_send_keepalive().unwrap());
+        sink.write_files_from_unframed(b"names").unwrap();
+        // A batch replay is never multiplexed, so the sink must never claim to
+        // frame its output (mirrors upstream's unmultiplexed batch f_out).
+        assert!(!sink.is_output_multiplexed());
+    }
+}

--- a/crates/transfer/src/writer/mod.rs
+++ b/crates/transfer/src/writer/mod.rs
@@ -12,14 +12,17 @@
 //! - `msg_info` - Trait for sending `MSG_INFO` protocol messages through multiplexed streams.
 //! - `counting` - Byte-counting writer wrapper for transfer statistics.
 //! - `throttle` - Bandwidth-limiting writer decorator for the sender socket.
+//! - `discard` - Dead-end sink for the batch local-replay receiver (no live peer).
 
 mod counting;
+mod discard;
 mod msg_info;
 pub(crate) mod multiplex;
 mod server;
 mod throttle;
 
 pub use self::counting::CountingWriter;
+pub use self::discard::DiscardSink;
 pub use self::msg_info::MsgInfoSender;
 pub use self::multiplex::BatchRoute;
 pub use self::server::{ServerWriter, shutdown_send_side};


### PR DESCRIPTION
## Summary

First step of reunifying batch replay onto the real receiver. This adds the
enabling receiver *input mode* only - it does not yet reroute `--read-batch`
dispatch (a later step) and does not touch the native replay path.

Upstream applies a recorded batch by feeding the batch file straight into the
ordinary receiver as `f_in` and pointing the generator's `f_out` at one end of a
self-pipe whose read end is never drained, so the generator's requests simply go
nowhere (`main.c:635-651`). Because the batch file was never framed, upstream
also skips `io_start_multiplex_in()` for it, gated on `!read_batch`
(`main.c:1359-1366`). `do_recv()` itself is unchanged.

This PR reproduces that model with three small, self-contained pieces:

- **`DiscardSink`** (`writer/discard.rs`) - a zero-cost writer that stands in for
  the consumer-less generator `f_out`. It swallows every byte and every
  `MsgInfoSender` frame (signature blocks, per-file NDX requests, `MSG_*`) via
  the trait's default no-ops, so the receiver can drive to completion off a
  one-way pre-recorded stream with no peer to answer it.
- **`ReceiverContext::run_local_replay`** (`receiver/transfer.rs`) - wraps a
  recorded batch stream as an undemultiplexed (`Plain`) `ServerReader` `f_in` and
  drives the existing `run()` with the discard sink as `f_out`.
- **`local_replay` flag** (`receiver/context.rs`) - gates
  `should_activate_input_multiplex()` off, mirroring upstream's `!read_batch`
  gate so the batch `f_in` stays `Plain`. It defaults `false` on every network
  transfer, so the wire path is byte-identical (an unused-by-default mode).

The caller supplies a `ReceiverContext` already primed from the batch header
(protocol, compat flags, checksum seed) - feeding those is a separate step - so
this PR owns only the drive mechanism and leaves clear seams for the follow-ups.

## Why

A recorded batch is a one-way stream with nothing to consume the generator's
signature/request output. The existing receiver is a bidirectional
request/response driver, so routing a batch through it needs exactly two things:
a `Plain` (undemuxed) `f_in` and a dead-end `f_out`. This PR builds precisely
those, matching upstream's `do_recv()`-over-`batch_fd` model, without altering
any network behaviour.

## Tests

- `DiscardSink` swallows writes (`write`/`write_all`/`flush`) and every
  `MsgInfoSender` call without error, and never advertises multiplexed output.
- `run_local_replay` drives the real receiver to completion on a trivial
  recorded stream (an empty file list) via a `Cursor` `f_in` + discard sink,
  exercising the full setup path with the reader kept `Plain`.
- The `local_replay` gate keeps `f_in` unmultiplexed at protocol 32 while
  leaving the network default (multiplex on) intact.

No interop or wire-format change.

## Upstream references

- `main.c:635-651` - `read_batch` sets `f_in = batch_fd`, `f_out` = self-pipe
  with no live consumer.
- `main.c:1359-1366` - `!read_batch` gate leaves the batch `f_in` unmultiplexed.
- `main.c:1387` - `do_recv(f_in, f_out, local_name)` drives the real receiver.
