### PR TITLE
fix(compress): defer --compress-level=0 to the negotiated codec

### DIFF
--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -96,16 +96,29 @@ fn clamp_level(codec: CompressionAlgorithm, raw: i32) -> CompressLevelArg {
     }
 }
 
-/// Parses `--compress-level=N` and clamps it into `codec`'s range.
+/// Parses `--compress-level=N`, clamping it into `codec`'s range when the codec
+/// is known.
 ///
 /// Any integer is accepted; an out-of-range value is clamped rather than
 /// rejected. Empty or non-numeric input yields a `--compress-level` error.
+///
+/// When `codec` is `None` no `--compress-choice` fixed the algorithm, so the
+/// negotiated codec - and therefore whether level `0` means "off" - is not yet
+/// known. Upstream defers this decision: `init_compression_level()`
+/// (`token.c:55`) runs from `parse_compress_choice(1)` (`compat.c:820`) only
+/// after `negotiate_the_strings()` (`compat.c:809`) has picked the codec, so a
+/// literal `0` disables zlib/zlibx but maps to zstd/lz4's default. Mirror that
+/// by carrying the raw level forward without clamping and never disabling here;
+/// the post-negotiation resolution applies the codec's `off_level`.
 pub(crate) fn parse_compress_level(
     argument: &OsStr,
-    codec: CompressionAlgorithm,
+    codec: Option<CompressionAlgorithm>,
 ) -> Result<CompressLevelArg, Message> {
     parse_raw_level(argument)
-        .map(|raw| clamp_level(codec, raw))
+        .map(|raw| match codec {
+            Some(codec) => clamp_level(codec, raw),
+            None => CompressLevelArg::Level(CompressionLevel::from_signed(raw)),
+        })
         .map_err(CompressionLevelParseError::into_flag_message)
 }
 
@@ -271,13 +284,30 @@ mod tests {
         // maps to the default level, so compression stays on. The clamp is
         // applied against the resolved codec, mirroring upstream exactly.
         assert!(matches!(
-            parse_compress_level(OsStr::new("0"), CompressionAlgorithm::Zlib),
+            parse_compress_level(OsStr::new("0"), Some(CompressionAlgorithm::Zlib)),
             Ok(CompressLevelArg::Disable)
         ));
         #[cfg(feature = "zstd")]
         assert!(matches!(
-            parse_compress_level(OsStr::new("0"), CompressionAlgorithm::Zstd),
+            parse_compress_level(OsStr::new("0"), Some(CompressionAlgorithm::Zstd)),
             Ok(CompressLevelArg::Level(_))
+        ));
+    }
+
+    #[test]
+    fn compress_level_zero_without_codec_defers_off_level() {
+        // upstream: token.c:55 init_compression_level() runs from
+        // parse_compress_choice(1) (compat.c:820) only AFTER
+        // negotiate_the_strings() (compat.c:809). Without --compress-choice the
+        // codec is unknown at parse time, so `--compress-level=0` must NOT
+        // disable compression here - the raw level is carried forward and the
+        // off_level decision is deferred to the negotiated codec. A literal 0
+        // round-trips as CompressionLevel::None (raw 0).
+        assert!(matches!(
+            parse_compress_level(OsStr::new("0"), None),
+            Ok(CompressLevelArg::Level(
+                CompressionLevel::None | CompressionLevel::PreciseSigned(0)
+            ))
         ));
     }
 

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -445,10 +445,16 @@ where
         }
     }
 
-    let codec = compression_algorithm.unwrap_or(CompressionAlgorithm::Zlib);
-
+    // upstream: compat.c:820 parse_compress_choice(1) calls
+    // init_compression_level() (token.c:55) AFTER negotiate_the_strings()
+    // (compat.c:809). When --compress-choice fixed the codec its range is known
+    // now, so clamp against it (level 0 disables zlib/zlibx). Otherwise the
+    // negotiated codec - and whether level 0 means "off" - is unknown until
+    // negotiation, so pass `None`: the raw level is carried forward and the
+    // off_level decision deferred to the post-negotiation resolution in the
+    // transfer layer, matching upstream ordering.
     if !compress_disabled_by_choice && let Some(value) = compress_level {
-        match parse_compress_level(value.as_os_str(), codec) {
+        match parse_compress_level(value.as_os_str(), compression_algorithm) {
             Ok(setting) => compress_level_setting = Some(setting),
             Err(message) => return Err(fail_with_message(message, stderr)),
         }
@@ -667,4 +673,89 @@ where
         log_file_path: log.log_file_path,
         log_file_template: log.log_file_template,
     }))
+}
+
+#[cfg(test)]
+mod compression_defer_tests {
+    use super::*;
+
+    fn parse(
+        compress_flag: bool,
+        no_compress: bool,
+        level: Option<&str>,
+        choice: Option<&str>,
+    ) -> CompressionResult {
+        let mut stderr = MessageSink::new(Vec::<u8>::new());
+        parse_compression_settings(
+            &mut stderr,
+            compress_flag,
+            no_compress,
+            &level.map(OsString::from),
+            &choice.map(OsString::from),
+            &None,
+            &None,
+        )
+        .expect("compression settings parse")
+    }
+
+    /// `-z --compress-level=0` with no `--compress-choice` must NOT disable
+    /// compression at parse time. Upstream defers the off_level decision to the
+    /// negotiated codec: `init_compression_level()` (token.c:76-98) runs from
+    /// `parse_compress_choice(1)` (compat.c:820) only after
+    /// `negotiate_the_strings()` (compat.c:809). Even though the preliminary
+    /// arg-layer estimate collapses level 0 against zlib (`compress_flag =
+    /// false`), the authoritative parse keeps compression on, leaves the codec
+    /// unresolved, and carries the raw level (0) forward for post-negotiation
+    /// resolution.
+    #[test]
+    fn level_zero_without_choice_defers_instead_of_disabling() {
+        let result = parse(false, false, Some("0"), None);
+        assert!(
+            result.compress,
+            "level 0 without a codec must keep compression on until negotiation"
+        );
+        assert!(
+            result.compression_algorithm.is_none(),
+            "no --compress-choice means the codec stays unresolved"
+        );
+        assert!(
+            result.compression_setting.is_enabled(),
+            "the deferred setting is enabled, not disabled"
+        );
+        // Raw level 0 is carried forward (CompressionLevel::None round-trips to 0
+        // via from_signed) so it forwards as --compress-level=0 to the peer.
+        assert!(matches!(
+            result.compression_level_override,
+            Some(CompressionLevel::None | CompressionLevel::PreciseSigned(0))
+        ));
+    }
+
+    /// Control: an explicit `--compress-choice=zstd --compress-level=0` is
+    /// resolved against the known codec at parse time and must stay on at zstd's
+    /// default level (3), never deferred or disabled. upstream: token.c:75-78 -
+    /// zstd maps a literal 0 to `ZSTD_CLEVEL_DEFAULT`.
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn explicit_zstd_level_zero_resolves_to_default() {
+        let result = parse(false, false, Some("0"), Some("zstd"));
+        assert!(result.compress);
+        assert_eq!(
+            result.compression_algorithm,
+            Some(CompressionAlgorithm::Zstd)
+        );
+        assert!(matches!(
+            result.compression_level_override,
+            Some(CompressionLevel::Precise(n)) if n.get() == 3
+        ));
+    }
+
+    /// Control: an explicit `--compress-choice=zlib --compress-level=0` hits
+    /// zlib's off_level (0) at parse time and disables compression - the
+    /// explicit-codec path is unchanged. upstream: token.c:66.
+    #[test]
+    fn explicit_zlib_level_zero_disables() {
+        let result = parse(true, false, Some("0"), Some("zlib"));
+        assert!(!result.compress);
+        assert!(result.compression_setting.is_disabled());
+    }
 }

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -260,6 +260,43 @@ fn compression_level_to_i32(level: compress::zlib::CompressionLevel) -> i32 {
     }
 }
 
+/// Reports whether `--compress-level` turns the negotiated codec off, mirroring
+/// the `do_compression_level == off_level` branch of `init_compression_level()`
+/// (`token.c:76-98`).
+///
+/// Upstream calls `init_compression_level()` from `parse_compress_choice(1)`
+/// (`compat.c:820`), which runs *after* `negotiate_the_strings()`
+/// (`compat.c:809`) has selected the codec. Only then is the meaning of a raw
+/// level known: zlib/zlibx have `off_level == Z_NO_COMPRESSION` (`0`), so a
+/// literal `0` sets `do_compression = CPRES_NONE`; zstd/lz4 have
+/// `off_level == CLVL_NOT_SPECIFIED` and map a literal `0` to their default
+/// level, so they never disable via `--compress-level`.
+///
+/// - `compress_choice_fixed` - true when `--compress-choice` pinned the codec.
+///   Upstream resolves that level against the known codec at parse time, so the
+///   deferred resolution here must leave the explicit-codec path untouched.
+/// - `compression_level` - the raw `do_compression_level`, `CLVL_NOT_SPECIFIED`
+///   when `--compress-level` was not supplied (nothing to resolve).
+///
+/// Returns `true` only when the level lands on the negotiated codec's
+/// `off_level`, i.e. zlib/zlibx at level `0`.
+fn negotiated_level_disables_compression(
+    compress_choice_fixed: bool,
+    compression_level: i32,
+    negotiated: protocol::CompressionAlgorithm,
+) -> bool {
+    if compress_choice_fixed || compression_level == protocol::nstr::CLVL_NOT_SPECIFIED {
+        return false;
+    }
+    // Reuse the single per-codec clamp (`token.c:59-98`): `off_level` is the only
+    // level it maps to "no compression" (`None`), which for the build-supported
+    // codecs is exactly zlib/zlibx at `0`.
+    matches!(
+        negotiated.to_compress_algorithm(),
+        Ok(Some(codec)) if codec.clamp_level(compression_level).is_none()
+    )
+}
+
 /// Reports whether the receiver wants the transfer's filter list on the wire.
 ///
 /// Upstream computes this identical predicate in both `send_filter_list()` (the
@@ -718,6 +755,32 @@ pub fn run_server_with_handshake_adopting<W: Write>(
     handshake.negotiated_algorithms = setup_result.negotiated_algorithms;
     handshake.compat_flags = setup_result.compat_flags;
     handshake.checksum_seed = setup_result.checksum_seed;
+
+    // upstream: compat.c:820 parse_compress_choice(1) -> token.c:55
+    // init_compression_level(), which runs AFTER negotiate_the_strings()
+    // (compat.c:809) and "might turn compression off". When --compress-choice
+    // fixed the codec the level was already resolved against it at CLI parse;
+    // otherwise the meaning of `--compress-level=0` depends on the negotiated
+    // codec's off_level and can only be resolved here. zlib/zlibx have
+    // off_level 0, so a literal 0 sets do_compression = CPRES_NONE and the
+    // sender frames plain tokens; zstd/lz4 have off_level CLVL_NOT_SPECIFIED and
+    // map a literal 0 to their default level, so compression stays on. Only the
+    // off case needs handling: every non-off level already reaches the encoder
+    // correctly through the negotiated codec's own clamp. This runs identically
+    // on both peers (each holds the negotiated codec and the forwarded
+    // do_compression_level, options.c:2755), so the framing decision stays
+    // symmetric.
+    if do_compression
+        && let Some(negotiated) = handshake.negotiated_algorithms.as_mut()
+        && negotiated_level_disables_compression(
+            compress_choice_algo.is_some(),
+            compression_level,
+            negotiated.compression,
+        )
+    {
+        negotiated.compression = protocol::CompressionAlgorithm::None;
+        config.connection.compression_level = None;
+    }
 
     // upstream: compat.c:777-778 - apply CF_INPLACE_PARTIAL_DIR after compat exchange.
     // When the server advertises this flag and a partial directory is configured,

--- a/crates/transfer/src/tests/compress_off_level.rs
+++ b/crates/transfer/src/tests/compress_off_level.rs
@@ -1,0 +1,111 @@
+//! Post-negotiation `init_compression_level()` off_level resolution.
+//!
+//! upstream: `token.c:76-98 init_compression_level()`, called from
+//! `parse_compress_choice(1)` (`compat.c:820`) *after* `negotiate_the_strings()`
+//! (`compat.c:809`). The meaning of `--compress-level=0` is codec-dependent and
+//! therefore only knowable once the codec has been negotiated: zlib/zlibx have
+//! `off_level == Z_NO_COMPRESSION` (`0`) so a literal `0` sets
+//! `do_compression = CPRES_NONE`; zstd/lz4 have `off_level == CLVL_NOT_SPECIFIED`
+//! and map a literal `0` to their default level, so they stay on. These tests
+//! pin that WHY on [`crate::negotiated_level_disables_compression`], the shared
+//! resolver the server transfer applies to the negotiated codec.
+
+use protocol::CompressionAlgorithm;
+use protocol::nstr::CLVL_NOT_SPECIFIED;
+
+use crate::negotiated_level_disables_compression;
+
+/// upstream: token.c:66 - zlib `off_level` is `Z_NO_COMPRESSION` (0), so
+/// `--compress-level=0` against a negotiated zlib peer turns compression off
+/// (`do_compression = CPRES_NONE`) and the sender frames plain tokens.
+#[test]
+fn zlib_level_zero_disables() {
+    assert!(negotiated_level_disables_compression(
+        false,
+        0,
+        CompressionAlgorithm::Zlib
+    ));
+}
+
+/// upstream: token.c:63-66 - zlibx shares zlib's `off_level` of 0.
+#[test]
+fn zlibx_level_zero_disables() {
+    assert!(negotiated_level_disables_compression(
+        false,
+        0,
+        CompressionAlgorithm::ZlibX
+    ));
+}
+
+/// upstream: token.c:75-78 - zstd `off_level` is `CLVL_NOT_SPECIFIED`, and a
+/// literal `0` maps to `ZSTD_CLEVEL_DEFAULT`, so `--compress-level=0` against a
+/// negotiated zstd peer keeps compression on (deflated data at the default
+/// level), never simple tokens.
+#[cfg(feature = "zstd")]
+#[test]
+fn zstd_level_zero_stays_on() {
+    assert!(!negotiated_level_disables_compression(
+        false,
+        0,
+        CompressionAlgorithm::Zstd
+    ));
+}
+
+/// upstream: token.c:82-88 - lz4 forces min/max/def to 0 and never disables via
+/// `--compress-level`.
+#[cfg(feature = "lz4")]
+#[test]
+fn lz4_level_zero_stays_on() {
+    assert!(!negotiated_level_disables_compression(
+        false,
+        0,
+        CompressionAlgorithm::LZ4
+    ));
+}
+
+/// A non-zero zlib level is inside `[min_level, max_level]`, never the
+/// `off_level`, so it stays on. upstream: token.c:96-98 saturates instead of
+/// disabling.
+#[test]
+fn zlib_nonzero_level_stays_on() {
+    assert!(!negotiated_level_disables_compression(
+        false,
+        6,
+        CompressionAlgorithm::Zlib
+    ));
+}
+
+/// When `--compress-level` was not supplied the level is `CLVL_NOT_SPECIFIED`
+/// and resolves to the codec default - never the off_level. upstream: token.c:93
+/// substitutes `def_level` for the sentinel before the off_level check.
+#[test]
+fn unspecified_level_never_disables() {
+    assert!(!negotiated_level_disables_compression(
+        false,
+        CLVL_NOT_SPECIFIED,
+        CompressionAlgorithm::Zlib
+    ));
+}
+
+/// An explicit `--compress-choice` already resolved the level against its known
+/// codec at CLI-parse time, so the deferred resolver must leave that path
+/// untouched even for zlib level 0. upstream: the explicit codec is resolved in
+/// `parse_compress_choice` without deferral.
+#[test]
+fn explicit_choice_zlib_zero_not_redisabled_here() {
+    assert!(!negotiated_level_disables_compression(
+        true,
+        0,
+        CompressionAlgorithm::Zlib
+    ));
+}
+
+/// A negotiated `none` codec has nothing to resolve; it is already off.
+#[test]
+fn negotiated_none_is_not_treated_as_a_level_disable() {
+    assert!(!negotiated_level_disables_compression(
+        false,
+        0,
+        CompressionAlgorithm::None
+    ));
+}

--- a/crates/transfer/src/tests/mod.rs
+++ b/crates/transfer/src/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod allow_inc_recurse;
 mod bwlimit_wiring;
+mod compress_off_level;
 mod config;
 mod filter_list_gate;
 mod multiplex_protocol_version;


### PR DESCRIPTION
## Summary

`-z --compress-level=0` (with no `--compress-choice`) disabled compression at
CLI-parse time. That is wrong: the meaning of level `0` is codec-dependent and
is only knowable after codec negotiation.

Upstream orders this deliberately. `negotiate_the_strings()` (compat.c:809) runs
first; only afterwards does `parse_compress_choice(1)` (compat.c:820) call
`init_compression_level()` (token.c:76-98). There, `off_level` differs per
codec: zlib/zlibx use `Z_NO_COMPRESSION` (0), so a literal `0` turns compression
off (`do_compression = CPRES_NONE`, plain tokens); zstd/lz4 use
`CLVL_NOT_SPECIFIED` and map a literal `0` to their default level, so
compression stays on. So upstream `-z --compress-level=0` against a zstd peer
still compresses at zstd's default level.

oc resolved level `0` at parse time against a hard-coded zlib default
(`compression_algorithm.unwrap_or(Zlib)`), collapsing it to "disabled" before
any negotiation - even when the negotiated codec would be zstd.

## Fix

Mirror upstream ordering:

- `crates/cli/.../execution/compression.rs` - `parse_compress_level` now takes
  `Option<CompressionAlgorithm>`. With an explicit codec it clamps as before
  (zlib level 0 disables); with `None` (no `--compress-choice`) it carries the
  raw level forward without clamping and never disables here.
- `crates/cli/.../execution/drive/options.rs` - pass the optional codec through,
  dropping the zlib fallback. `--compress-level=0` without a choice now keeps
  compression enabled and defers the off_level decision.
- `crates/transfer/src/lib.rs` - after `setup_protocol()` (the negotiation
  point), apply the deferred `init_compression_level()` resolution on both
  peers: when no `--compress-choice` fixed the codec and the level lands on the
  negotiated codec's `off_level` (zlib/zlibx level 0), set the negotiated
  compression to `none` so the sender frames plain tokens. Every non-off level
  already reaches the encoder correctly through the codec's own clamp, so only
  the off case is handled. The per-codec clamp
  (`CompressionAlgorithm::clamp_level`) is reused as the single off_level source.

The explicit `--compress-choice=CODEC --compress-level=0` path is unchanged
(e.g. `zstd` level 0 still resolves to zstd's default level 3).

## Tests

- `compression.rs` - level 0 with no codec defers (raw level carried, not
  disabled).
- `options.rs` - authoritative parse: `-z --compress-level=0` (no choice) keeps
  compression on with the codec unresolved; explicit `zstd` level 0 resolves to
  level 3; explicit `zlib` level 0 still disables.
- `transfer` - `negotiated_level_disables_compression` off_level resolution:
  zlib/zlibx level 0 disable; zstd/lz4 level 0 stay on; non-zero and unspecified
  never disable; explicit-choice and negotiated-`none` untouched.

## References

- token.c:76-98 `init_compression_level()` (per-codec `off_level`).
- compat.c:809 `negotiate_the_strings()` / compat.c:820 `parse_compress_choice(1)`.
- options.c:2755-2758 (`--compress-level=%d` forwarded to the peer, keeping both
  sides symmetric).
