### PR TITLE
feat(quic): client connect path - QuicStream to @RSYNCD handshake + --quic-ca CLI

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -110,6 +110,12 @@ pub struct ParsedArgs {
     #[cfg(feature = "quic")]
     pub quic: bool,
 
+    /// `--quic-ca <PATH>` - verify the QUIC daemon certificate against this PEM
+    /// CA bundle instead of the system trust store (policy B). `None` uses the
+    /// system-roots default. Available only under the `quic` feature.
+    #[cfg(feature = "quic")]
+    pub quic_ca: Option<std::path::PathBuf>,
+
     /// `--protocol` - force a specific protocol version (28-32).
     pub protocol: Option<OsString>,
 

--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -167,6 +167,11 @@ where
     let daemon_port = matches.remove_one::<u16>("port");
     #[cfg(feature = "quic")]
     let quic = matches.get_flag("quic");
+    #[cfg(feature = "quic")]
+    let quic_ca = matches
+        .remove_one::<OsString>("quic-ca")
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from);
     let remote_options = matches
         .remove_many::<OsString>("remote-option")
         .map(Iterator::collect)
@@ -1193,6 +1198,8 @@ where
         daemon_port,
         #[cfg(feature = "quic")]
         quic,
+        #[cfg(feature = "quic")]
+        quic_ca,
         dparam,
         no_iconv,
         executability,

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
@@ -131,12 +131,22 @@ pub(super) fn add_network_args(command: ClapCommand) -> ClapCommand {
     // transport; it exists only when the `quic` feature is compiled in, so a
     // default build rejects it as an unknown argument.
     #[cfg(feature = "quic")]
-    let command = command.arg(
-        Arg::new("quic")
-            .long("quic")
-            .help("Carry the rsync daemon protocol over QUIC (873/udp); hard-fails if QUIC cannot be established.")
-            .action(ArgAction::SetTrue),
-    );
+    let command = command
+        .arg(
+            Arg::new("quic")
+                .long("quic")
+                .help("Carry the rsync daemon protocol over QUIC (873/udp); hard-fails if QUIC cannot be established.")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("quic-ca")
+                .long("quic-ca")
+                .value_name("PATH")
+                .help("Verify the QUIC daemon certificate against the CA bundle in PATH (PEM) instead of the system trust store.")
+                .num_args(1)
+                .action(ArgAction::Set)
+                .value_parser(OsStringValueParser::new()),
+        );
 
     command
 }

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -31,6 +31,10 @@ pub(crate) struct ConfigInputs {
     /// `--quic` - select the QUIC daemon transport (873/udp).
     #[cfg(feature = "quic")]
     pub(crate) quic: bool,
+    /// `--quic-ca <PATH>` - private CA bundle for verifying the QUIC daemon
+    /// certificate; `None` uses the system-roots default.
+    #[cfg(feature = "quic")]
+    pub(crate) quic_ca: Option<PathBuf>,
     pub(crate) blocking_io: Option<bool>,
     pub(crate) dry_run: bool,
     pub(crate) list_only: bool,
@@ -338,6 +342,9 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         } else {
             core::client::Transport::Tcp
         });
+        // `--quic-ca` selects a private CA bundle for QUIC certificate
+        // verification; `None` keeps the system-roots default.
+        builder = builder.quic_ca(inputs.quic_ca);
     }
     // Only override the builder's upstream default when the user supplied
     // `--inc-recursive` or `--no-inc-recursive`. Mirrors upstream

--- a/crates/cli/src/frontend/execution/drive/module_listing.rs
+++ b/crates/cli/src/frontend/execution/drive/module_listing.rs
@@ -19,6 +19,10 @@ pub(super) struct ModuleListingInputs<'a> {
     /// `--quic` - upgrade the daemon listing target to the QUIC transport.
     #[cfg(feature = "quic")]
     pub quic: bool,
+    /// `--quic-ca <PATH>` - private CA bundle for verifying the QUIC daemon
+    /// certificate; `None` uses the system-roots default.
+    #[cfg(feature = "quic")]
+    pub quic_ca: Option<&'a std::path::Path>,
     pub desired_protocol: Option<ProtocolVersion>,
     pub password_override: Option<Vec<u8>>,
     pub no_motd: bool,
@@ -52,6 +56,8 @@ where
         daemon_port,
         #[cfg(feature = "quic")]
         quic,
+        #[cfg(feature = "quic")]
+        quic_ca,
         desired_protocol,
         password_override,
         no_motd,
@@ -105,7 +111,8 @@ where
     // malformed spec is ignored, matching the transfer path's lenient handling.
     let remote_shell_args = remote_shell.and_then(|spec| ssh::parse_remote_shell(spec).ok());
 
-    let list_options = ModuleListOptions::default()
+    #[cfg_attr(not(feature = "quic"), allow(unused_mut))]
+    let mut list_options = ModuleListOptions::default()
         .suppress_motd(no_motd)
         .with_address_mode(address_mode)
         .with_bind_address(bind_address.map(|addr| addr.socket()))
@@ -115,6 +122,10 @@ where
         .with_sockopts(sockopts.cloned())
         .with_tcp_fastopen(tcp_fastopen)
         .with_blocking_io(blocking_io);
+    #[cfg(feature = "quic")]
+    {
+        list_options = list_options.with_quic_ca(quic_ca.map(std::path::Path::to_path_buf));
+    }
 
     match run_module_list_with_password_and_options(
         request,

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -60,6 +60,8 @@ where
         daemon_port,
         #[cfg(feature = "quic")]
         quic,
+        #[cfg(feature = "quic")]
+        quic_ca,
         remote_options,
         rsync_path: _,
         protect_args,
@@ -537,6 +539,8 @@ where
             daemon_port,
             #[cfg(feature = "quic")]
             quic,
+            #[cfg(feature = "quic")]
+            quic_ca: quic_ca.as_deref(),
             desired_protocol,
             password_override: password_override.clone(),
             no_motd,
@@ -897,6 +901,8 @@ where
         tcp_fastopen,
         #[cfg(feature = "quic")]
         quic,
+        #[cfg(feature = "quic")]
+        quic_ca,
         blocking_io,
         dry_run,
         list_only,

--- a/crates/cli/src/frontend/tests/parse_args_recognises_quic.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_quic.rs
@@ -19,6 +19,41 @@ fn parse_args_recognises_quic_flag() {
 
 #[cfg(feature = "quic")]
 #[test]
+fn parse_args_recognises_quic_ca_flag() {
+    // WHY (#50): `--quic-ca <PATH>` is a recognised value flag under the feature
+    // and threads the private CA bundle path through to the QUIC trust ladder.
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--quic-ca"),
+        OsString::from("/etc/oc-rsync/ca.pem"),
+        OsString::from("quic://host/module"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(
+        parsed.quic_ca.as_deref(),
+        Some(std::path::Path::new("/etc/oc-rsync/ca.pem"))
+    );
+}
+
+#[cfg(feature = "quic")]
+#[test]
+fn parse_args_quic_ca_defaults_none() {
+    // WHY: without `--quic-ca` the QUIC trust source stays the system-roots
+    // default (no private CA bundle).
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("host::module"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(parsed.quic_ca.is_none());
+}
+
+#[cfg(feature = "quic")]
+#[test]
 fn parse_args_quic_defaults_off() {
     // WHY: without `--quic` the daemon transport stays TCP (default behaviour
     // preserved).

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -269,6 +269,8 @@ pub struct ClientConfigBuilder {
     tcp_fastopen: TcpFastOpenMode,
     #[cfg(feature = "quic")]
     daemon_transport: crate::client::Transport,
+    #[cfg(feature = "quic")]
+    quic_ca: Option<PathBuf>,
     blocking_io: Option<bool>,
     iconv: IconvSetting,
     remote_shell: Option<Vec<OsString>>,
@@ -512,6 +514,8 @@ impl ClientConfigBuilder {
             tcp_fastopen: self.tcp_fastopen,
             #[cfg(feature = "quic")]
             daemon_transport: self.daemon_transport,
+            #[cfg(feature = "quic")]
+            quic_ca: self.quic_ca,
             blocking_io: self.blocking_io,
             iconv: self.iconv,
             remote_shell: self.remote_shell,

--- a/crates/core/src/client/config/builder/network.rs
+++ b/crates/core/src/client/config/builder/network.rs
@@ -32,6 +32,20 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Sets the `--quic-ca` private CA bundle used to verify the daemon's QUIC
+    /// certificate.
+    ///
+    /// `None` (the default) verifies against the platform trust store
+    /// (system-roots). A supplied PEM bundle replaces the platform store for
+    /// the QUIC handshake (policy B). Available only under the `quic` feature.
+    #[cfg(feature = "quic")]
+    #[must_use]
+    #[doc(alias = "--quic-ca")]
+    pub fn quic_ca(mut self, path: Option<PathBuf>) -> Self {
+        self.quic_ca = path;
+        self
+    }
+
     /// Configures the TCP Fast Open mode applied to daemon and client sockets.
     ///
     /// `auto` (the default) enables TFO opportunistically on platforms that

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -256,6 +256,11 @@ pub struct ClientConfig {
     /// build always uses TCP, so the field is absent there.
     #[cfg(feature = "quic")]
     pub(super) daemon_transport: crate::client::Transport,
+    /// `--quic-ca <PATH>` - private CA PEM bundle used to verify the daemon's
+    /// QUIC certificate (policy B). `None` uses the system-roots default. Only
+    /// present under the `quic` feature.
+    #[cfg(feature = "quic")]
+    pub(super) quic_ca: Option<PathBuf>,
     pub(super) blocking_io: Option<bool>,
     pub(super) iconv: IconvSetting,
     pub(super) remote_shell: Option<Vec<OsString>>,
@@ -475,6 +480,8 @@ impl Default for ClientConfig {
             tcp_fastopen: TcpFastOpenMode::Auto,
             #[cfg(feature = "quic")]
             daemon_transport: crate::client::Transport::Tcp,
+            #[cfg(feature = "quic")]
+            quic_ca: None,
             blocking_io: None,
             iconv: IconvSetting::Unspecified,
             remote_shell: None,

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -22,6 +22,18 @@ impl ClientConfig {
         self.daemon_transport
     }
 
+    /// Returns the `--quic-ca` private CA bundle path, if one was supplied.
+    ///
+    /// When present it verifies the daemon's QUIC certificate against this PEM
+    /// bundle instead of the platform trust store (policy B). Available only
+    /// under the `quic` feature.
+    #[cfg(feature = "quic")]
+    #[must_use]
+    #[doc(alias = "--quic-ca")]
+    pub fn quic_ca(&self) -> Option<&std::path::Path> {
+        self.quic_ca.as_deref()
+    }
+
     /// Returns the configured connect program, if any.
     #[doc(alias = "--connect-program")]
     pub fn connect_program(&self) -> Option<&OsStr> {

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -29,6 +29,9 @@ pub(crate) enum DaemonStreamReader {
     Program(program::ProgramReader),
     #[cfg(not(unix))]
     Program(std::process::ChildStdout),
+    /// QUIC bidirectional stream read handle (blocking `Read`).
+    #[cfg(feature = "quic")]
+    Quic(rsync_io::quic::QuicStream),
 }
 
 impl Read for DaemonStreamReader {
@@ -36,6 +39,8 @@ impl Read for DaemonStreamReader {
         match self {
             Self::Tcp(stream) => stream.read(buf),
             Self::Program(reader) => reader.read(buf),
+            #[cfg(feature = "quic")]
+            Self::Quic(stream) => stream.read(buf),
         }
     }
 }
@@ -48,6 +53,8 @@ impl DaemonStreamReader {
         match self {
             Self::Tcp(stream) => stream.try_clone().ok(),
             Self::Program(_) => None,
+            #[cfg(feature = "quic")]
+            Self::Quic(_) => None,
         }
     }
 }
@@ -150,6 +157,9 @@ pub(crate) enum DaemonStreamWriter {
     Program(program::ProgramWriter),
     #[cfg(not(unix))]
     Program(std::process::ChildStdin),
+    /// QUIC bidirectional stream write handle (blocking `Write`).
+    #[cfg(feature = "quic")]
+    Quic(rsync_io::quic::QuicStream),
 }
 
 impl Write for DaemonStreamWriter {
@@ -157,6 +167,8 @@ impl Write for DaemonStreamWriter {
         match self {
             Self::Tcp(writer) => writer.write(buf),
             Self::Program(writer) => writer.write(buf),
+            #[cfg(feature = "quic")]
+            Self::Quic(writer) => writer.write(buf),
         }
     }
 
@@ -164,6 +176,8 @@ impl Write for DaemonStreamWriter {
         match self {
             Self::Tcp(writer) => writer.write_vectored(bufs),
             Self::Program(writer) => writer.write_vectored(bufs),
+            #[cfg(feature = "quic")]
+            Self::Quic(writer) => writer.write_vectored(bufs),
         }
     }
 
@@ -171,6 +185,8 @@ impl Write for DaemonStreamWriter {
         match self {
             Self::Tcp(writer) => writer.flush(),
             Self::Program(writer) => writer.flush(),
+            #[cfg(feature = "quic")]
+            Self::Quic(writer) => writer.flush(),
         }
     }
 }
@@ -183,6 +199,8 @@ impl DaemonStreamWriter {
         match self {
             Self::Tcp(writer) => writer.stream.try_clone().ok(),
             Self::Program(_) => None,
+            #[cfg(feature = "quic")]
+            Self::Quic(_) => None,
         }
     }
 }
@@ -246,21 +264,55 @@ pub(crate) fn register_shutdown_wake(
     }))
 }
 
+/// The connect-phase and per-I/O timeouts for a daemon connection.
+///
+/// Bundles the two timeouts that always travel together: `connect` bounds
+/// `connect(2)` (only when `--contimeout` is set) and `io` is applied as the
+/// established stream's read/write timeout.
+#[derive(Clone, Copy)]
+pub(crate) struct DaemonConnectTimeouts {
+    /// Connect-phase bound (`--contimeout`), or `None` to leave it unbounded.
+    pub(crate) connect: Option<Duration>,
+    /// Per-I/O timeout applied to the established stream.
+    pub(crate) io: Option<Duration>,
+}
+
+/// Client-side QUIC dial parameters carried to the connect-selection point.
+///
+/// Holds the trust-source inputs the QUIC ladder needs: the `--quic-ca` private
+/// CA bundle path (when supplied) selects [`QuicTrust::Roots`](rsync_io::quic::QuicTrust);
+/// otherwise the system-roots default applies. The struct is empty (a
+/// zero-sized value) and never read when the `quic` feature is disabled, so it
+/// threads through the shared connect signature without a cfg on the parameter
+/// itself.
+#[derive(Clone, Default)]
+pub(crate) struct QuicDialParams {
+    /// `--quic-ca <PATH>`: a PEM CA bundle that replaces the platform trust
+    /// store for verifying the daemon's certificate.
+    #[cfg(feature = "quic")]
+    pub(crate) ca: Option<std::path::PathBuf>,
+}
+
 /// Opens a stream to a daemon, dispatching on the address's [`Transport`].
 ///
 /// This is the single connect-selection point shared by module listing and
 /// daemon transfers. The transport is read off [`DaemonAddress::transport`];
-/// `Transport::Tcp` (the default) establishes a plain TCP connection.
+/// `Transport::Tcp` (the default) establishes a plain TCP connection, while
+/// `Transport::Quic` dials the same daemon protocol over QUIC.
 pub(crate) fn open_daemon_stream(
     addr: &DaemonAddress,
-    connect_timeout: Option<Duration>,
-    io_timeout: Option<Duration>,
+    timeouts: DaemonConnectTimeouts,
     address_mode: AddressMode,
     connect_program: Option<&OsStr>,
     bind_address: Option<SocketAddr>,
     tfo: TcpFastOpenMode,
     sockopts: Option<&OsStr>,
+    quic: &QuicDialParams,
 ) -> Result<DaemonStream, ClientError> {
+    // The QUIC dial params are consumed only by the `Transport::Quic` arm, which
+    // is compiled out in a default (non-`quic`) build.
+    #[cfg(not(feature = "quic"))]
+    let _ = quic;
     // Transport-selection point: the transport rides on `DaemonAddress` from
     // target parsing. `Transport::Tcp` (the default, and the only variant in a
     // default build) establishes the plain TCP daemon stream, so default builds
@@ -268,39 +320,94 @@ pub(crate) fn open_daemon_stream(
     match addr.transport() {
         Transport::Tcp => open_tcp_daemon_stream(
             addr,
-            connect_timeout,
-            io_timeout,
+            timeouts.connect,
+            timeouts.io,
             address_mode,
             connect_program,
             bind_address,
             tfo,
             sockopts,
         ),
-        // QUIC hard-fails here rather than dialing plain TCP: silently falling
-        // back would downgrade an explicitly-requested encrypted transport to
-        // plaintext (a downgrade attack, and a violation of the user's intent).
-        // The QUIC dial itself (`rsync_io::quic`) lands in a follow-up; until
-        // then a QUIC selection exits non-zero and never touches TCP 873
+        // QUIC dials over UDP and hands the resulting blocking stream to the
+        // same `@RSYNCD` handshake TCP uses; the daemon-protocol bytes after the
+        // QUIC handshake are unchanged (the QUIC-7 wire-identity invariant). A
+        // failed dial hard-fails and never silently downgrades to plaintext TCP
         // (design: `docs/design/quic-transport-policy.md`, Decision D, "No
         // silent downgrade").
         #[cfg(feature = "quic")]
-        Transport::Quic => Err(quic_transport_unavailable_error()),
+        Transport::Quic => open_quic_daemon_stream(addr, address_mode, quic),
     }
 }
 
-/// Builds the hard-failure error for a QUIC-selected daemon connection.
+/// Opens a QUIC connection to a daemon (the [`Transport::Quic`] path).
 ///
-/// The QUIC connector is not yet wired (QUIC-5), so any QUIC selection fails
-/// loudly with `RERR_STARTCLIENT` (exit 5). Crucially this is an error, not a
-/// TCP fallback: the selection never silently downgrades to plaintext.
+/// Resolves the client trust source through the QUIC verification ladder
+/// (`--quic-ca` private CA > system-roots default; the TOFU backend is wired in
+/// `rsync_io::quic` and engaged by a follow-up opt-in), builds the connector
+/// with ALPN `rsync`, resolves the daemon host to `host:port` candidates
+/// (873/udp default), and dials the first that succeeds. The peer certificate
+/// is validated against the `quic://` authority (`addr.host()`) as the TLS
+/// server name.
+///
+/// Any dial or handshake failure - unreachable endpoint, certificate rejection,
+/// or ALPN mismatch - maps to `RERR_STARTCLIENT` (exit 5). This is an interim
+/// mapping; the full quinn-proto error -> exit-code schema is a separate task
+/// (#57). Crucially it is an error, never a TCP fallback.
 #[cfg(feature = "quic")]
-fn quic_transport_unavailable_error() -> ClientError {
+fn open_quic_daemon_stream(
+    addr: &DaemonAddress,
+    address_mode: AddressMode,
+    quic: &QuicDialParams,
+) -> Result<DaemonStream, ClientError> {
+    use rsync_io::quic::{QuicConnector, load_private_ca, resolve};
+
+    // Trust ladder (policy B): `--quic-ca` selects a private CA bundle;
+    // otherwise the system-roots default applies. The `resolve(ca, tofu)` seam
+    // keeps the TOFU precedence slot in place (tofu = None here).
+    let ca = match &quic.ca {
+        Some(path) => {
+            Some(load_private_ca(path).map_err(|error| quic_dial_error(addr, &error.to_string()))?)
+        }
+        None => None,
+    };
+    let trust = resolve(ca, None).map_err(|error| quic_dial_error(addr, &error.to_string()))?;
+    let connector = QuicConnector::with_trust(trust)
+        .map_err(|error| quic_dial_error(addr, &error.to_string()))?;
+
+    let candidates = resolve_daemon_addresses(addr, address_mode)?;
+    let server_name = addr.host();
+    let mut last_error: Option<io::Error> = None;
+    for candidate in candidates {
+        match connector.connect(candidate, server_name) {
+            Ok(stream) => return Ok(DaemonStream::quic(stream)),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    let error = last_error
+        .expect("resolve_daemon_addresses guarantees at least one candidate")
+        .to_string();
+    Err(quic_dial_error(addr, &error))
+}
+
+/// Maps a QUIC dial/handshake failure to a [`ClientError`] with exit code
+/// `RERR_STARTCLIENT` (5).
+///
+/// Interim classifier: every failure - connection loss, certificate rejection,
+/// and ALPN mismatch (`no application protocol`) - maps to 5, matching the
+/// policy that an explicitly-requested encrypted transport that cannot be
+/// established fails loudly rather than downgrading. The full quinn-proto error
+/// taxonomy (distinguishing e.g. handshake-timeout from cert-reject) is #57;
+/// this leaves the message informative and the exit code stable.
+#[cfg(feature = "quic")]
+fn quic_dial_error(addr: &DaemonAddress, detail: &str) -> ClientError {
     use super::super::CLIENT_SERVER_PROTOCOL_EXIT_CODE;
     use super::super::daemon_error;
 
     daemon_error(
-        "QUIC transport was requested but the QUIC connector is not available \
-         in this build; refusing to fall back to plaintext TCP",
+        format!(
+            "QUIC connection to {} failed: {detail}; refusing to fall back to plaintext TCP",
+            addr.socket_addr_display()
+        ),
         CLIENT_SERVER_PROTOCOL_EXIT_CODE,
     )
 }
@@ -380,11 +487,19 @@ pub(crate) enum DaemonStream {
     Tcp(TcpStream),
     /// Connection via an external connect program.
     Program(ConnectProgramStream),
+    /// Native QUIC connection carrying the daemon protocol (oc extension).
+    #[cfg(feature = "quic")]
+    Quic(rsync_io::quic::QuicStream),
 }
 
 impl DaemonStream {
     const fn tcp(stream: TcpStream) -> Self {
         Self::Tcp(stream)
+    }
+
+    #[cfg(feature = "quic")]
+    const fn quic(stream: rsync_io::quic::QuicStream) -> Self {
+        Self::Quic(stream)
     }
 
     fn program(stream: ConnectProgramStream) -> Self {
@@ -411,6 +526,8 @@ impl DaemonStream {
         match self {
             Self::Tcp(stream) => Some(stream),
             Self::Program(_) => None,
+            #[cfg(feature = "quic")]
+            Self::Quic(_) => None,
         }
     }
 
@@ -442,6 +559,20 @@ impl DaemonStream {
                     DaemonStreamReader::Program(parts.reader),
                     DaemonStreamWriter::Program(parts.writer),
                     DaemonStreamGuard::Child(parts.child),
+                ))
+            }
+            // The QUIC read and write handles are cheap clones over one
+            // bidirectional stream; the guard owns the teardown so those
+            // handles drop cheaply while the last written bytes are still
+            // flushed (finish + close) before the connection ends - the QUIC
+            // analogue of a TCP socket flushing its send buffer on close.
+            #[cfg(feature = "quic")]
+            Self::Quic(stream) => {
+                let guard = stream.shutdown_guard();
+                Ok((
+                    DaemonStreamReader::Quic(stream.try_clone()),
+                    DaemonStreamWriter::Quic(stream),
+                    DaemonStreamGuard::Quic(guard),
                 ))
             }
         }
@@ -476,13 +607,26 @@ pub(crate) enum DaemonStreamGuard {
     None,
     /// Owns a connect program child process.
     Child(std::process::Child),
+    /// Owns the QUIC connection teardown (flush + FIN + graceful close on drop).
+    #[cfg(feature = "quic")]
+    Quic(rsync_io::quic::QuicShutdown),
 }
 
 impl Drop for DaemonStreamGuard {
     fn drop(&mut self) {
-        if let Self::Child(child) = self {
-            let _ = child.kill();
-            let _ = child.wait();
+        match self {
+            Self::None => {}
+            Self::Child(child) => {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            // The QUIC teardown (flush + FIN + graceful close) runs when the
+            // held `QuicShutdown` drops right after this body; nothing to do
+            // here beyond keeping ownership until now.
+            #[cfg(feature = "quic")]
+            Self::Quic(guard) => {
+                let _ = guard;
+            }
         }
     }
 }
@@ -492,6 +636,8 @@ impl Read for DaemonStream {
         match self {
             Self::Tcp(stream) => stream.read(buf),
             Self::Program(stream) => stream.read(buf),
+            #[cfg(feature = "quic")]
+            Self::Quic(stream) => stream.read(buf),
         }
     }
 }
@@ -501,6 +647,8 @@ impl Write for DaemonStream {
         match self {
             Self::Tcp(stream) => stream.write(buf),
             Self::Program(stream) => stream.write(buf),
+            #[cfg(feature = "quic")]
+            Self::Quic(stream) => stream.write(buf),
         }
     }
 
@@ -508,44 +656,167 @@ impl Write for DaemonStream {
         match self {
             Self::Tcp(stream) => stream.flush(),
             Self::Program(stream) => stream.flush(),
+            #[cfg(feature = "quic")]
+            Self::Quic(stream) => stream.flush(),
         }
     }
 }
 
 #[cfg(all(test, feature = "quic"))]
-mod quic_hard_fail_tests {
+mod quic_connect_tests {
+    use std::io::{Read, Write};
+    use std::path::PathBuf;
+    use std::thread;
+
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD;
+    use rsync_io::quic::QuicAcceptor;
+    use tempfile::TempDir;
+
     use super::*;
-    use crate::client::AddressMode;
-    use crate::client::TcpFastOpenMode;
+    use crate::client::{AddressMode, TcpFastOpenMode};
 
-    #[test]
-    fn quic_selection_hard_fails_without_tcp_fallback() {
-        // WHY (QUIC-8d): a QUIC-selected daemon connection must exit non-zero
-        // rather than silently dial plaintext TCP. We point the address at a
-        // discard port; if any TCP fallback existed it would attempt a connect,
-        // but the QUIC arm short-circuits to an error before any I/O.
-        let addr = DaemonAddress::new("127.0.0.1".to_owned(), 9)
+    /// PEM-encodes a certificate DER and writes it to a `--quic-ca` bundle file,
+    /// returning the temp dir (kept alive) and the file path.
+    fn write_ca_pem(cert_der: &[u8]) -> (TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ca.pem");
+        let mut pem = String::from("-----BEGIN CERTIFICATE-----\n");
+        for chunk in STANDARD.encode(cert_der).as_bytes().chunks(64) {
+            pem.push_str(std::str::from_utf8(chunk).expect("base64 is ascii"));
+            pem.push('\n');
+        }
+        pem.push_str("-----END CERTIFICATE-----\n");
+        std::fs::write(&path, pem).expect("write ca pem");
+        (dir, path)
+    }
+
+    /// Builds a QUIC daemon address for a loopback acceptor. Uses `localhost`
+    /// (the acceptor cert's SAN) as the host so rustls hostname verification
+    /// passes, with `Ipv4` mode so it resolves to the `127.0.0.1` the acceptor
+    /// bound.
+    fn quic_addr(port: u16) -> DaemonAddress {
+        DaemonAddress::new("localhost".to_owned(), port)
             .expect("addr")
-            .with_transport(Transport::Quic);
+            .with_transport(Transport::Quic)
+    }
 
-        let result = open_daemon_stream(
-            &addr,
+    fn dial(addr: &DaemonAddress, ca: Option<PathBuf>) -> Result<DaemonStream, ClientError> {
+        let quic = QuicDialParams { ca };
+        open_daemon_stream(
+            addr,
+            DaemonConnectTimeouts {
+                connect: None,
+                io: None,
+            },
+            AddressMode::Ipv4,
             None,
             None,
-            AddressMode::Default,
+            TcpFastOpenMode::Off,
             None,
-            None,
-            TcpFastOpenMode::Auto,
-            None,
-        );
+            &quic,
+        )
+    }
 
-        // `DaemonStream` (the Ok type) is not `Debug`, so match rather than
-        // `expect_err`. upstream RERR_STARTCLIENT (5): the explicit encrypted
-        // transport could not be established and no downgrade is permitted.
-        match result {
-            Ok(_) => panic!("QUIC selection must not fall back to TCP"),
+    /// End to end over the loopback fixture: `--quic-ca` (the acceptor's
+    /// self-signed cert, used as its own trust anchor) is accepted, the dial
+    /// yields a `DaemonStream`, and that stream is a byte-transparent
+    /// `Read`+`Write` drop-in - the server reads exactly what the client wrote
+    /// and vice versa, with no framing added by the transport. This is the
+    /// QUIC-7 wire-identity invariant at the transport boundary: whatever the
+    /// `@RSYNCD` handshake writes reaches the peer unchanged.
+    #[test]
+    fn quic_ca_trust_path_dials_and_is_byte_transparent() {
+        let acceptor =
+            QuicAcceptor::bind("127.0.0.1:0".parse().expect("addr")).expect("bind acceptor");
+        let port = acceptor.local_addr().expect("local addr").port();
+        let (_dir, ca_path) = write_ca_pem(acceptor.certificate().as_ref());
+
+        // The bytes a real @RSYNCD handshake would put on the wire first.
+        let request = b"@RSYNCD: 32.0\nmodule\n".to_vec();
+        let reply = b"@RSYNCD: 32.0\n@RSYNCD: OK\n".to_vec();
+
+        let expected_request = request.clone();
+        let server_reply = reply.clone();
+        let server = thread::spawn(move || {
+            let mut stream = acceptor.accept().expect("accept");
+            let mut got = vec![0u8; expected_request.len()];
+            stream.read_exact(&mut got).expect("server read");
+            assert_eq!(got, expected_request, "transport must not alter the bytes");
+            stream.write_all(&server_reply).expect("server write");
+            stream.finish().expect("server finish");
+        });
+
+        let addr = quic_addr(port);
+        let stream =
+            dial(&addr, Some(ca_path)).expect("quic dial succeeds with matching --quic-ca");
+        let (reader, mut writer, guard) = stream.split().expect("split");
+        let mut reader = reader;
+
+        writer.write_all(&request).expect("client write");
+        writer.flush().expect("client flush");
+
+        let mut got_reply = vec![0u8; reply.len()];
+        reader.read_exact(&mut got_reply).expect("client read");
+        assert_eq!(got_reply, reply, "reply must arrive byte-identical");
+
+        drop(writer);
+        drop(reader);
+        drop(guard);
+        server.join().expect("server thread");
+    }
+
+    /// An unrelated certificate offered as `--quic-ca` must reject the peer and
+    /// hard-fail with `RERR_STARTCLIENT` (5) - never a `DaemonStream`, never a
+    /// TCP fallback. Proves the CA bundle is actually used to verify the peer.
+    #[test]
+    fn quic_unrelated_ca_is_rejected_and_hard_fails() {
+        let acceptor =
+            QuicAcceptor::bind("127.0.0.1:0".parse().expect("addr")).expect("bind acceptor");
+        let port = acceptor.local_addr().expect("local addr").port();
+
+        // A second acceptor yields a distinct self-signed cert unrelated to the
+        // one the first acceptor will present.
+        let other =
+            QuicAcceptor::bind("127.0.0.1:0".parse().expect("addr")).expect("bind other acceptor");
+        let (_dir, wrong_ca) = write_ca_pem(other.certificate().as_ref());
+
+        // Keep the target acceptor draining so the handshake reaches (and fails)
+        // certificate verification rather than stalling.
+        let server = thread::spawn(move || {
+            let _ = acceptor.accept();
+        });
+
+        let addr = quic_addr(port);
+        match dial(&addr, Some(wrong_ca)) {
+            Ok(_) => panic!("an unrelated --quic-ca must not authenticate the peer"),
+            Err(err) => assert_eq!(err.exit_code(), 5, "cert reject -> RERR_STARTCLIENT"),
+        }
+        drop(server);
+    }
+
+    /// A missing `--quic-ca` bundle fails loudly at trust resolution with exit 5
+    /// (no dial attempted, no TCP fallback).
+    #[test]
+    fn quic_missing_ca_bundle_hard_fails() {
+        let addr = quic_addr(1);
+        let missing = PathBuf::from("/nonexistent/oc-rsync-quic-ca.pem");
+        match dial(&addr, Some(missing)) {
+            Ok(_) => panic!("a missing --quic-ca bundle must not connect"),
             Err(err) => assert_eq!(err.exit_code(), 5),
         }
+    }
+
+    /// The interim dial-error classifier maps every QUIC failure - including an
+    /// ALPN mismatch (`no application protocol`) - to `RERR_STARTCLIENT` (5),
+    /// per policy. The full quinn-proto error taxonomy is #57.
+    #[test]
+    fn quic_alpn_mismatch_maps_to_startclient() {
+        let addr = quic_addr(873);
+        let err = quic_dial_error(&addr, "peer doesn't support any known protocol");
+        assert_eq!(err.exit_code(), 5);
+        let refused = quic_dial_error(&addr, "aborted by peer: the cryptographic handshake failed");
+        assert_eq!(refused.exit_code(), 5);
     }
 }
 

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -31,7 +31,8 @@ use super::auth::{
     normalize_motd_payload, send_daemon_auth_credentials,
 };
 use super::connect::{
-    RshDaemonSpawn, open_daemon_stream, resolve_connect_timeout, spawn_rsh_daemon_stream,
+    DaemonConnectTimeouts, QuicDialParams, RshDaemonSpawn, open_daemon_stream,
+    resolve_connect_timeout, spawn_rsh_daemon_stream,
 };
 use super::errors::{legacy_daemon_error_payload, map_daemon_handshake_error, read_trimmed_line};
 use super::request::ModuleListOptions;
@@ -215,15 +216,22 @@ pub fn run_module_list_with_password_and_options(
             address_mode,
         })?
     } else {
+        let quic_dial = QuicDialParams {
+            #[cfg(feature = "quic")]
+            ca: options.quic_ca().map(std::path::Path::to_path_buf),
+        };
         open_daemon_stream(
             addr,
-            connect_duration,
-            effective_timeout,
+            DaemonConnectTimeouts {
+                connect: connect_duration,
+                io: effective_timeout,
+            },
             address_mode,
             options.connect_program(),
             options.bind_address(),
             options.tcp_fastopen(),
             options.sockopts(),
+            &quic_dial,
         )?
     };
 

--- a/crates/core/src/client/module_list/mod.rs
+++ b/crates/core/src/client/module_list/mod.rs
@@ -50,11 +50,11 @@ pub(super) use auth::{
 };
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use connect::{
-    ConnectProgramConfig, DaemonStream, DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter,
-    ProxyConfig, ProxyCredentials, RshDaemonSpawn, build_io_timeout_reapply, connect_direct,
-    connect_via_proxy, establish_proxy_tunnel, open_daemon_stream, parse_proxy_spec,
-    register_shutdown_wake, resolve_connect_timeout, resolve_daemon_addresses,
-    spawn_rsh_daemon_stream,
+    ConnectProgramConfig, DaemonConnectTimeouts, DaemonStream, DaemonStreamGuard,
+    DaemonStreamReader, DaemonStreamWriter, ProxyConfig, ProxyCredentials, QuicDialParams,
+    RshDaemonSpawn, build_io_timeout_reapply, connect_direct, connect_via_proxy,
+    establish_proxy_tunnel, open_daemon_stream, parse_proxy_spec, register_shutdown_wake,
+    resolve_connect_timeout, resolve_daemon_addresses, spawn_rsh_daemon_stream,
 };
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use errors::map_daemon_handshake_error;

--- a/crates/core/src/client/module_list/request.rs
+++ b/crates/core/src/client/module_list/request.rs
@@ -174,6 +174,11 @@ pub struct ModuleListOptions {
     blocking_io: Option<bool>,
     remote_shell: Option<Vec<OsString>>,
     rsync_path: Option<OsString>,
+    /// `--quic-ca <PATH>` private CA bundle for verifying a QUIC daemon's
+    /// certificate (policy B). `None` uses the system-roots default. Only
+    /// present under the `quic` feature.
+    #[cfg(feature = "quic")]
+    quic_ca: Option<std::path::PathBuf>,
 }
 
 impl ModuleListOptions {
@@ -190,7 +195,28 @@ impl ModuleListOptions {
             blocking_io: None,
             remote_shell: None,
             rsync_path: None,
+            #[cfg(feature = "quic")]
+            quic_ca: None,
         }
+    }
+
+    /// Supplies the `--quic-ca` private CA bundle path for QUIC listings.
+    ///
+    /// `None` (the default) verifies the daemon's QUIC certificate against the
+    /// platform trust store. Available only under the `quic` feature.
+    #[cfg(feature = "quic")]
+    #[must_use]
+    #[doc(alias = "--quic-ca")]
+    pub fn with_quic_ca(mut self, path: Option<std::path::PathBuf>) -> Self {
+        self.quic_ca = path;
+        self
+    }
+
+    /// Returns the configured `--quic-ca` private CA bundle path, if any.
+    #[cfg(feature = "quic")]
+    #[must_use]
+    pub fn quic_ca(&self) -> Option<&std::path::Path> {
+        self.quic_ca.as_deref()
     }
 
     /// Returns a new configuration that suppresses daemon MOTD lines.

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -35,7 +35,8 @@ use super::super::error::{ClientError, invalid_argument_error, socket_error};
 #[cfg(feature = "quic")]
 use super::super::module_list::Transport;
 use super::super::module_list::{
-    RshDaemonSpawn, open_daemon_stream, resolve_connect_timeout, spawn_rsh_daemon_stream,
+    DaemonConnectTimeouts, QuicDialParams, RshDaemonSpawn, open_daemon_stream,
+    resolve_connect_timeout, spawn_rsh_daemon_stream,
 };
 use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
@@ -160,15 +161,24 @@ pub fn run_daemon_transfer(
     // --contimeout is set; --timeout never bounds the connect phase.
     let connect_duration = resolve_connect_timeout(config.connect_timeout());
     let handshake_io_timeout = config.timeout().effective(DAEMON_SOCKET_TIMEOUT);
+    // QUIC trust inputs (`--quic-ca`); inert/empty when the transport is TCP or
+    // the `quic` feature is off.
+    let quic_dial = QuicDialParams {
+        #[cfg(feature = "quic")]
+        ca: config.quic_ca().map(std::path::Path::to_path_buf),
+    };
     let stream = open_daemon_stream(
         &request.address,
-        connect_duration,
-        handshake_io_timeout,
+        DaemonConnectTimeouts {
+            connect: connect_duration,
+            io: handshake_io_timeout,
+        },
         config.address_mode(),
         config.connect_program(),
         config.bind_address().map(|b| b.socket()),
         config.tcp_fastopen(),
         config.sockopts(),
+        &quic_dial,
     )?;
 
     // upstream: socket.c:279-280 - set_socket_options(s, sockopts) is applied

--- a/crates/rsync_io/src/quic/mod.rs
+++ b/crates/rsync_io/src/quic/mod.rs
@@ -470,6 +470,35 @@ impl QuicStream {
         }
     }
 
+    /// Returns a second handle to the same bidirectional stream.
+    ///
+    /// Reads touch only the receive path and writes only the send path, so an
+    /// independent read handle and write handle over one clone pair never
+    /// contend beyond the shared lock. This is what lets a caller split the
+    /// stream into a blocking [`Read`] half and a blocking [`Write`] half - the
+    /// shape the daemon `@RSYNCD` handshake needs - without cloning a socket.
+    #[must_use]
+    pub fn try_clone(&self) -> QuicStream {
+        QuicStream {
+            io: Arc::clone(&self.io),
+        }
+    }
+
+    /// Builds a teardown guard for this connection.
+    ///
+    /// Dropping the guard finishes the send stream (flushing every buffered
+    /// byte and its FIN, then blocking until the peer acknowledges it or the
+    /// connection ends) and then closes the connection gracefully. This is the
+    /// QUIC analogue of a TCP socket flushing its send buffer as it closes:
+    /// hold the guard for the lifetime of a transfer and let it drop last, so
+    /// no trailing bytes are truncated by an abrupt close.
+    #[must_use]
+    pub fn shutdown_guard(&self) -> QuicShutdown {
+        QuicShutdown {
+            io: Arc::clone(&self.io),
+        }
+    }
+
     /// Gracefully closes the connection (application error code 0) and blocks
     /// until it has drained and the driver thread exited.
     pub fn close(self) {
@@ -584,6 +613,51 @@ impl Write for QuicStream {
 impl std::fmt::Debug for QuicStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QuicStream").finish_non_exhaustive()
+    }
+}
+
+/// Connection teardown guard produced by [`QuicStream::shutdown_guard`].
+///
+/// On drop it flushes the send stream and FIN, blocks until the peer has
+/// acknowledged them (or the connection ended), then closes the connection
+/// gracefully and joins the driver thread. Keeping teardown in one guard - held
+/// alongside independent read/write handles cloned from the same stream - gives
+/// those handles simple `Drop`s (a reference-count decrement) while still
+/// guaranteeing the last written bytes reach the peer before the close, exactly
+/// as a TCP socket flushes its send buffer on close.
+pub struct QuicShutdown {
+    io: Arc<Io>,
+}
+
+impl Drop for QuicShutdown {
+    fn drop(&mut self) {
+        let shared = &self.io.shared;
+        // Flush + FIN, then wait for the delivery barrier: every queued byte is
+        // drained to the send stream and acknowledged, or the connection ended.
+        {
+            let mut st = shared.lock();
+            st.send_fin = true;
+            self.io.signal(&mut st);
+            while !st.send_finished && st.terminal.is_none() && !st.drained {
+                st = shared.wait(st);
+            }
+        }
+        // Graceful close (application error code 0); wait until it has drained.
+        {
+            let mut st = shared.lock();
+            st.close_requested = true;
+            self.io.signal(&mut st);
+            while !st.drained {
+                st = shared.wait(st);
+            }
+        }
+        self.io.join();
+    }
+}
+
+impl std::fmt::Debug for QuicShutdown {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QuicShutdown").finish_non_exhaustive()
     }
 }
 

--- a/crates/rsync_io/src/quic/trust.rs
+++ b/crates/rsync_io/src/quic/trust.rs
@@ -560,6 +560,19 @@ mod tests {
         Box::new(KnownHostsFile::new(path.to_path_buf()))
     }
 
+    /// PEM-encodes a certificate DER (`-----BEGIN CERTIFICATE-----` framing,
+    /// standard base64 wrapped at 64 columns).
+    fn cert_to_pem(der: &CertificateDer<'_>) -> String {
+        use base64::engine::general_purpose::STANDARD;
+        let mut pem = String::from("-----BEGIN CERTIFICATE-----\n");
+        for chunk in STANDARD.encode(der.as_ref()).as_bytes().chunks(64) {
+            pem.push_str(std::str::from_utf8(chunk).expect("base64 is ascii"));
+            pem.push('\n');
+        }
+        pem.push_str("-----END CERTIFICATE-----\n");
+        pem
+    }
+
     fn verify(cert: &CertificateDer<'_>, path: &Path) -> Result<ServerCertVerified, TlsError> {
         let verifier = TofuVerifier::new(AUTHORITY, store_at(path));
         verifier.verify_server_cert(
@@ -684,6 +697,38 @@ mod tests {
                 .expect("unknown authority")
                 .is_none(),
             "an unrelated authority must not match"
+        );
+    }
+
+    /// `load_private_ca` parses a PEM bundle into a usable root store the
+    /// connector accepts, and fails loudly on a missing file or one with no
+    /// certificate - a mistyped or empty `--quic-ca` must never silently
+    /// degrade trust.
+    #[test]
+    fn load_private_ca_reads_pem_and_rejects_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let issued =
+            rcgen::generate_simple_self_signed(vec!["ca.example".to_owned()]).expect("gen cert");
+        let pem_path = dir.path().join("ca.pem");
+        std::fs::write(&pem_path, cert_to_pem(issued.cert.der())).expect("write pem");
+
+        let roots = load_private_ca(&pem_path).expect("load ca bundle");
+        assert!(!roots.is_empty(), "the bundle must yield a trust anchor");
+        super::super::QuicConnector::with_trust(QuicTrust::Roots(roots))
+            .expect("connector accepts the loaded CA");
+
+        let missing = dir.path().join("does-not-exist.pem");
+        assert!(
+            load_private_ca(&missing).is_err(),
+            "missing file must error"
+        );
+
+        let empty = dir.path().join("empty.pem");
+        std::fs::write(&empty, b"not a certificate\n").expect("write empty");
+        assert!(
+            load_private_ca(&empty).is_err(),
+            "a bundle with no certificate must error"
         );
     }
 

--- a/crates/rsync_io/tests/quic_loopback.rs
+++ b/crates/rsync_io/tests/quic_loopback.rs
@@ -110,6 +110,64 @@ fn round_trip_via_roots_trust() {
     server.join().expect("server thread");
 }
 
+/// Split handles plus a teardown guard: a read handle (`try_clone`) and a
+/// write handle over one stream carry a full request/reply round trip, and the
+/// [`QuicShutdown`](rsync_io::quic) guard flushes the last write (finish + FIN)
+/// and closes the connection on drop. This is the shape the daemon `@RSYNCD`
+/// handshake needs - an independent blocking `Read` half and `Write` half whose
+/// simple drops never truncate the tail because the guard owns the flush.
+#[test]
+fn split_handles_round_trip_and_guard_flushes_on_drop() {
+    let acceptor =
+        QuicAcceptor::bind("127.0.0.1:0".parse().expect("loopback addr")).expect("bind acceptor");
+    let addr = acceptor.local_addr().expect("local addr");
+    let cert = acceptor.certificate().clone().into_owned();
+
+    let request = pattern(0x42);
+    let reply = pattern(0x24);
+
+    let expected_request = request.clone();
+    let server_reply = reply.clone();
+    let server = thread::spawn(move || {
+        let mut stream = acceptor.accept().expect("accept stream");
+        let mut got = vec![0u8; PAYLOAD_LEN];
+        stream.read_exact(&mut got).expect("read request");
+        assert_eq!(got, expected_request, "request corrupted");
+        stream.write_all(&server_reply).expect("write reply");
+        stream.finish().expect("finish reply");
+        // After the client's write handle is dropped and the guard drops, the
+        // client's FIN must arrive - proving the guard drives the flush + FIN
+        // even though the write handle was never explicitly finished.
+        let mut trailing = Vec::new();
+        stream
+            .read_to_end(&mut trailing)
+            .expect("read to client FIN");
+        assert!(trailing.is_empty(), "client sent no trailing bytes");
+    });
+
+    let connector = QuicConnector::new(&cert).expect("build connector");
+    let stream = connector.connect(addr, "localhost").expect("connect");
+
+    let guard = stream.shutdown_guard();
+    let mut read_half = stream.try_clone();
+    let mut write_half = stream;
+
+    write_half.write_all(&request).expect("write request");
+    // Drop the write handle WITHOUT finishing: the guard owns the flush + FIN.
+    drop(write_half);
+
+    let mut received = vec![0u8; PAYLOAD_LEN];
+    read_half.read_exact(&mut received).expect("read reply");
+    assert_eq!(received, reply, "reply corrupted");
+
+    drop(read_half);
+    // Dropping the guard finishes the send stream (delivering the FIN the
+    // server's read_to_end is waiting for) and closes the connection.
+    drop(guard);
+
+    server.join().expect("server thread");
+}
+
 /// Half-close semantics: after the client sends FIN, its read side keeps
 /// working - the server reads to EOF, then streams a multi-chunk reply the
 /// client receives intact.


### PR DESCRIPTION
## Summary

Wires the client QUIC connect path so a `quic://` target (or `--quic` on an
`rsync://` / `host::` target) actually **dials over QUIC** and then runs the
**normal `@RSYNCD` daemon handshake and session driver unchanged** - a blocking
`QuicStream` is substituted for the `TcpStream`. The daemon-protocol bytes after
the QUIC handshake are byte-identical to a TCP daemon session (**QUIC-7
wire-identity invariant**). QUIC is an oc-only extension behind the off-by-default
`quic` feature; default builds are unchanged.

This replaces the previous hard-fail stub at the shared connect-selection point
with the real dial.

## What changed

- **`open_daemon_stream`** gains a `Transport::Quic` arm (`open_quic_daemon_stream`):
  resolves trust, builds the ALPN-`rsync` `QuicConnector`, resolves the daemon
  host to `host:port` candidates (873/udp default), and dials the first that
  succeeds. The peer cert is validated against the `quic://` authority
  (`addr.host()`) as the TLS server name. The two timeouts were bundled into a
  small `DaemonConnectTimeouts` to keep the shared signature within the arg-count
  budget.
- **`DaemonStream` / `DaemonStreamReader` / `DaemonStreamWriter` / `DaemonStreamGuard`**
  gain feature-gated `Quic` variants. `split()` hands out cheap `try_clone`d
  read/write handles; the **guard owns teardown** (flush + FIN + graceful close),
  so the handles drop cheaply while the last written bytes are still delivered -
  the QUIC analogue of a TCP socket flushing its send buffer on close.
- **`rsync_io::quic`** gains `load_private_ca` (PEM bundle -> `RootCertStore`),
  `QuicStream::try_clone`, and the `QuicShutdown` teardown guard.
- **`--quic-ca <PATH>`** (feature-gated) is added and threaded through
  `ParsedArgs` -> `ClientConfig` (transfer path) and `ModuleListOptions` (listing
  path) to both `open_daemon_stream` call sites. It finally gives
  `load_private_ca` a live consumer.

## Trust ladder (precedence decision - please read)

Per the #7109 design and `docs/design/quic-transport-policy.md` (Decision B),
precedence is **PrivateCa > TOFU > SystemRoots**. This PR wires the two ends that
have a live trigger today:

- `--quic-ca <PATH>` present -> **PrivateCa** (`resolve(Some(roots), None)`).
- otherwise -> **SystemRoots** (the documented zero-config default,
  `resolve(None, None)`).

**Scope decision surfaced loudly:** the **TOFU** slot is left as the `resolve(ca,
tofu)` seam with `tofu = None` for now - the `quic_known_hosts` backend is fully
wired and unit-tested in `rsync_io::quic`, but it has **no CLI trigger yet**. I
deliberately did **not** invent a `--quic-known-hosts` surface the task didn't
scope (simplicity-first). Consequence worth noting for reviewers: because the
daemon's default cert is ephemeral self-signed (#7113), a zero-config `quic://`
to a default daemon will be rejected by system-roots until either `--quic-ca` is
supplied or a follow-up wires the TOFU opt-in as the self-signed default. That
follow-up is the natural next step.

## Error mapping (interim - seam for #57)

Every dial/handshake failure - unreachable endpoint, certificate rejection, and
ALPN mismatch (`no application protocol`) - maps to **`RERR_STARTCLIENT` (exit
5)**, with an informative message. There is **no silent TCP fallback**: a
requested-but-failed QUIC connection errors, never downgrades to plaintext. The
full quinn-proto error -> exit-code taxonomy is left as a seam for **#57**.

## Tests

- `rsync_io`: `load_private_ca` parses a PEM bundle and rejects missing/empty
  files; `split_handles_round_trip_and_guard_flushes_on_drop` proves the
  try_clone read/write handles round-trip and the guard drives flush+FIN on drop.
- `core` (`quic_connect_tests`, against the `quic_loopback` acceptor fixture):
  `--quic-ca` (the acceptor's self-signed cert used as its own anchor) dials and
  the stream is a **byte-transparent** `Read`+`Write` drop-in (QUIC-7); an
  unrelated `--quic-ca` is **rejected -> exit 5**; a missing bundle -> exit 5;
  the dial-error classifier maps an ALPN mismatch -> exit 5.
- `cli`: `--quic-ca <PATH>` parses into `ParsedArgs.quic_ca`; absent it defaults
  to `None`.

All feature-gated behind `quic`; default builds compile and behave unchanged.

## Verification

- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` -> clean
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings` (default, no quic) -> clean
- `cargo fmt --all --check` -> clean
- `cargo nextest run -p rsync_io -p core -p cli --all-features -E 'test(quic)'` -> 24 passed
- `cargo build --bin oc-rsync --features quic` -> RC 0; `--quic-ca` is a recognized flag and hard-fails exit 5 with no TCP fallback.
