### PR TITLE
feat(engine): DBR governor control loop + rope (CapacitySource::Dynamic, off by default)

### DIFF
--- a/crates/engine/src/throughput/aggregate.rs
+++ b/crates/engine/src/throughput/aggregate.rs
@@ -9,6 +9,7 @@
 
 use fast_io::ewma::Ewma;
 
+use super::drum::{StageSignal, StageSignals};
 use super::sample::{Constraint, StageSample};
 
 /// Smoothing factor for per-stage throughput averages.
@@ -20,15 +21,29 @@ use super::sample::{Constraint, StageSample};
 /// two EWMA consumers from drifting apart.
 pub const STAGE_ALPHA: f64 = 0.2;
 
-/// Folds telemetry samples into a smoothed bytes/second estimate per stage.
+/// Folds telemetry samples into a smoothed bytes/second estimate per stage and
+/// tracks each stage's input-queue occupancy for drum identification.
 ///
 /// One [`Ewma`] per [`Constraint`], indexed by [`Constraint::index`]. A sample
 /// whose rate is undefined (zero duration) is ignored rather than poisoning the
-/// average. The aggregator is single-owner - the governor thread holds it - so
-/// it needs no interior synchronization.
+/// average, but its occupancy is still recorded. The aggregator is single-owner
+/// - the governor thread holds it - so it needs no interior synchronization.
+///
+/// Occupancy arrives as an absolute queue depth, but stages have different
+/// capacities, so the aggregator normalizes each stage against its own observed
+/// high-water mark. This self-calibrates without any external capacity hint: a
+/// stage whose input sits at its highest-ever depth reads `1.0`; an empty one
+/// reads `0.0`. Drum identification only compares a stage's normalized input
+/// against its normalized output, so the shared, self-relative scale is exactly
+/// what the constraint signature needs.
 #[derive(Debug, Clone)]
 pub struct StageAggregator {
     stages: [Ewma; Constraint::COUNT],
+    /// Most recent input-queue occupancy observed for each stage.
+    occupancy: [usize; Constraint::COUNT],
+    /// Highest input-queue occupancy ever observed for each stage, the
+    /// normalization denominator.
+    occupancy_high_water: [usize; Constraint::COUNT],
 }
 
 impl StageAggregator {
@@ -37,15 +52,25 @@ impl StageAggregator {
     pub fn new() -> Self {
         Self {
             stages: [Ewma::new(STAGE_ALPHA); Constraint::COUNT],
+            occupancy: [0; Constraint::COUNT],
+            occupancy_high_water: [0; Constraint::COUNT],
         }
     }
 
     /// Folds one sample into its stage's average and returns the updated
     /// bytes/second estimate, or `None` when the sample carried no usable rate
     /// (zero duration) and was skipped.
+    ///
+    /// The sample's input-queue occupancy is recorded regardless of whether the
+    /// rate was usable, so a zero-duration sample still updates the drum signal.
     pub fn fold(&mut self, sample: &StageSample) -> Option<f64> {
+        let idx = sample.stage.index();
+        self.occupancy[idx] = sample.queue_occupancy;
+        if sample.queue_occupancy > self.occupancy_high_water[idx] {
+            self.occupancy_high_water[idx] = sample.queue_occupancy;
+        }
         let rate = sample.bytes_per_sec()?;
-        Some(self.stages[sample.stage.index()].update(rate))
+        Some(self.stages[idx].update(rate))
     }
 
     /// Current smoothed throughput for `stage`, or `None` before any sample
@@ -53,6 +78,50 @@ impl StageAggregator {
     #[must_use]
     pub fn throughput(&self, stage: Constraint) -> Option<f64> {
         self.stages[stage.index()].value()
+    }
+
+    /// Normalized input-queue occupancy for `stage` in `[0.0, 1.0]`.
+    ///
+    /// The latest observed depth divided by the stage's high-water mark; `0.0`
+    /// before any occupancy has been seen (high-water still zero).
+    #[must_use]
+    pub fn input_occupancy(&self, stage: Constraint) -> f64 {
+        let idx = stage.index();
+        let high = self.occupancy_high_water[idx];
+        if high == 0 {
+            0.0
+        } else {
+            self.occupancy[idx] as f64 / high as f64
+        }
+    }
+
+    /// Builds the per-stage [`StageSignals`] snapshot the drum identifier reads.
+    ///
+    /// Each real stage's signal carries its smoothed rate and normalized input
+    /// occupancy; a second pass fills each stage's output occupancy from its
+    /// [`successor`](Constraint::successor)'s input occupancy, so a stage backed
+    /// up at its own input while its downstream neighbour is empty reads as the
+    /// classic constraint.
+    #[must_use]
+    pub fn stage_signals(&self) -> StageSignals {
+        let mut signals = StageSignals::new();
+        for stage in Constraint::REAL {
+            signals.set(
+                stage,
+                StageSignal {
+                    rate: self.throughput(stage),
+                    input_occupancy: self.input_occupancy(stage),
+                    output_occupancy: 0.0,
+                },
+            );
+        }
+        for stage in Constraint::REAL {
+            if let Some(successor) = stage.successor() {
+                let downstream_input = signals.get(successor).input_occupancy;
+                signals.set_output_occupancy(stage, downstream_input);
+            }
+        }
+        signals
     }
 }
 
@@ -70,6 +139,10 @@ mod tests {
 
     fn sample(stage: Constraint, bytes: u64, millis: u64) -> StageSample {
         StageSample::new(stage, bytes, Duration::from_millis(millis), 0)
+    }
+
+    fn sample_occ(stage: Constraint, bytes: u64, millis: u64, occ: usize) -> StageSample {
+        StageSample::new(stage, bytes, Duration::from_millis(millis), occ)
     }
 
     #[test]
@@ -114,6 +187,46 @@ mod tests {
             None,
             "skipped sample must not seed the average"
         );
+    }
+
+    #[test]
+    fn occupancy_normalizes_against_stage_high_water() {
+        let mut agg = StageAggregator::new();
+        assert_eq!(agg.input_occupancy(Constraint::WireWrite), 0.0);
+        // First occupancy seeds the high-water mark: reads full.
+        agg.fold(&sample_occ(Constraint::WireWrite, 1_000, 1, 8));
+        assert!((agg.input_occupancy(Constraint::WireWrite) - 1.0).abs() < 1e-12);
+        // A lower depth reads as a fraction of the high-water mark.
+        agg.fold(&sample_occ(Constraint::WireWrite, 1_000, 1, 2));
+        assert!((agg.input_occupancy(Constraint::WireWrite) - 0.25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn zero_duration_sample_still_records_occupancy() {
+        let mut agg = StageAggregator::new();
+        // Rate is skipped (zero duration) but occupancy must still register.
+        assert_eq!(
+            agg.fold(&sample_occ(Constraint::WireWrite, 1_000, 0, 4)),
+            None
+        );
+        assert!((agg.input_occupancy(Constraint::WireWrite) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn stage_signals_fills_output_from_successor_input() {
+        let mut agg = StageAggregator::new();
+        // Compute busy at input, WireWrite (its successor) idle at input.
+        agg.fold(&sample_occ(Constraint::Compute, 2_000, 1, 10));
+        agg.fold(&sample_occ(Constraint::WireWrite, 2_000, 1, 10)); // seed WW high-water
+        agg.fold(&sample_occ(Constraint::WireWrite, 2_000, 1, 0)); // now empty
+        let signals = agg.stage_signals();
+        let compute = signals.get(Constraint::Compute);
+        assert!(compute.rate.is_some());
+        assert!((compute.input_occupancy - 1.0).abs() < 1e-12);
+        // Compute's output occupancy mirrors WireWrite's (empty) input.
+        assert!((compute.output_occupancy - 0.0).abs() < 1e-12);
+        // The terminal Consumer stage has no successor: output stays 0.
+        assert_eq!(signals.get(Constraint::Consumer).output_occupancy, 0.0);
     }
 
     #[test]

--- a/crates/engine/src/throughput/drum.rs
+++ b/crates/engine/src/throughput/drum.rs
@@ -1,0 +1,480 @@
+//! Drum identification with hysteresis for the throughput governor.
+//!
+//! The "drum" in a Theory-of-Constraints drum-buffer-rope pipeline is the
+//! single stage that paces the whole system - the constraint. This module turns
+//! a snapshot of per-stage telemetry into a drum designation and debounces it so
+//! transient noise cannot make the designation flap.
+//!
+//! # Constraint signature
+//!
+//! A stage is the constraint when work piles up at *its* input while its
+//! downstream neighbour stays starved: the stage cannot consume its backlog fast
+//! enough, yet nothing downstream is holding it back. Formally, [`classify`]
+//! nominates the stage that
+//!
+//! - has a throughput estimate (an unsampled stage cannot be the drum), and
+//! - shows **high input** occupancy ([`HIGH_OCCUPANCY`] or more), and
+//! - shows **low output** occupancy ([`LOW_OCCUPANCY`] or less),
+//!
+//! breaking ties by the **lowest sustained bytes/second** - the slowest such
+//! stage is the true pace-setter. When no stage matches the signature the
+//! candidate is [`Constraint::Unknown`]: the pipeline is balanced or
+//! under-observed and there is no drum to protect.
+//!
+//! # Hysteresis
+//!
+//! Occupancy and rate estimates jitter window to window. If the governor re-sized
+//! buffers every time the instantaneous candidate changed it would chase noise
+//! and oscillate. [`DrumIdentifier`] therefore commits a new drum only after
+//! [`HYSTERESIS_WINDOWS`] consecutive evaluation windows agree on the same
+//! challenger; a single window that re-affirms the incumbent clears any pending
+//! challenge. This is the State pattern element of the governor: an explicit,
+//! debounced transition between drum designations.
+
+use super::sample::Constraint;
+
+/// Input-queue occupancy fraction at or above which a stage's input is "full".
+///
+/// Occupancy is normalized to `[0.0, 1.0]` (see
+/// [`StageAggregator::stage_signals`](super::aggregate::StageAggregator::stage_signals)),
+/// so this is three-quarters full. Chosen well above the midpoint so a stage is
+/// only flagged as backlogged when its input is genuinely saturated, not merely
+/// busy; paired with [`LOW_OCCUPANCY`] it leaves a wide neutral band that keeps
+/// balanced pipelines out of any drum designation.
+pub const HIGH_OCCUPANCY: f64 = 0.75;
+
+/// Output-queue occupancy fraction at or below which a stage's output is "empty".
+///
+/// One-quarter full: the downstream neighbour is drinking from a nearly dry
+/// queue, so this stage is not being throttled from below. The gap to
+/// [`HIGH_OCCUPANCY`] is the neutral band that suppresses drum flapping when
+/// every stage sits near the middle.
+pub const LOW_OCCUPANCY: f64 = 0.25;
+
+/// Consecutive agreeing evaluation windows required to commit a drum change.
+///
+/// At the governor's 250 ms poll window (see
+/// [`POLL_INTERVAL`](super::governor::POLL_INTERVAL)) three windows is ~750 ms
+/// of sustained agreement - long enough to reject a one- or two-window blip from
+/// scheduling jitter or a single slow file, short enough to react to a genuine
+/// constraint shift inside a second. It mirrors the seq-matches debounce used
+/// elsewhere in the pipeline: require a run, not a single sample, before acting.
+pub const HYSTERESIS_WINDOWS: u8 = 3;
+
+/// One stage's telemetry for a single evaluation window.
+///
+/// All occupancies are normalized to `[0.0, 1.0]`. `rate` is the smoothed
+/// bytes/second estimate, or `None` when the stage has not been sampled yet.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StageSignal {
+    /// Smoothed throughput in bytes/second, or `None` if unsampled.
+    pub rate: Option<f64>,
+    /// Normalized input-queue occupancy in `[0.0, 1.0]`.
+    pub input_occupancy: f64,
+    /// Normalized output-queue occupancy in `[0.0, 1.0]` (the successor stage's
+    /// input occupancy).
+    pub output_occupancy: f64,
+}
+
+impl StageSignal {
+    /// An unsampled, idle stage: no rate, empty queues.
+    #[must_use]
+    pub const fn unsampled() -> Self {
+        Self {
+            rate: None,
+            input_occupancy: 0.0,
+            output_occupancy: 0.0,
+        }
+    }
+
+    /// Whether this stage matches the constraint signature: sampled, input at or
+    /// above [`HIGH_OCCUPANCY`], output at or below [`LOW_OCCUPANCY`].
+    #[must_use]
+    fn is_constraint_candidate(&self) -> bool {
+        self.rate.is_some()
+            && self.input_occupancy >= HIGH_OCCUPANCY
+            && self.output_occupancy <= LOW_OCCUPANCY
+    }
+}
+
+/// Per-stage telemetry snapshot for one evaluation window.
+///
+/// Indexed by [`Constraint::index`]; the [`Constraint::Unknown`] slot is present
+/// for a dense array but never classified.
+#[derive(Debug, Clone, Copy)]
+pub struct StageSignals {
+    signals: [StageSignal; Constraint::COUNT],
+}
+
+impl Default for StageSignals {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StageSignals {
+    /// Builds a snapshot with every stage unsampled and idle.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            signals: [StageSignal::unsampled(); Constraint::COUNT],
+        }
+    }
+
+    /// Returns the signal recorded for `stage`.
+    #[must_use]
+    pub fn get(&self, stage: Constraint) -> StageSignal {
+        self.signals[stage.index()]
+    }
+
+    /// Overwrites the signal for `stage`.
+    pub fn set(&mut self, stage: Constraint, signal: StageSignal) {
+        self.signals[stage.index()] = signal;
+    }
+
+    /// Sets `stage`'s output occupancy without disturbing its other fields.
+    pub fn set_output_occupancy(&mut self, stage: Constraint, output_occupancy: f64) {
+        self.signals[stage.index()].output_occupancy = output_occupancy;
+    }
+}
+
+/// Classifies the instantaneous constraint stage from one window's signals.
+///
+/// Returns the slowest stage matching the constraint signature (see the
+/// [module docs](self)), or [`Constraint::Unknown`] when none match. Pure and
+/// side-effect free so it can be exhaustively truth-tabled; [`DrumIdentifier`]
+/// layers hysteresis on top.
+#[must_use]
+pub fn classify(signals: &StageSignals) -> Constraint {
+    let mut drum: Option<(Constraint, f64)> = None;
+    for stage in Constraint::REAL {
+        let signal = signals.get(stage);
+        if !signal.is_constraint_candidate() {
+            continue;
+        }
+        // `is_constraint_candidate` guarantees `rate` is `Some`.
+        let rate = signal.rate.unwrap_or(f64::INFINITY);
+        match drum {
+            Some((_, best)) if rate >= best => {}
+            _ => drum = Some((stage, rate)),
+        }
+    }
+    drum.map_or(Constraint::Unknown, |(stage, _)| stage)
+}
+
+/// Debounced drum designation: the State element of the governor.
+///
+/// Feed one [`observe`](Self::observe) per evaluation window; the committed
+/// [`current`](Self::current) drum changes only after [`windows`](Self::new)
+/// consecutive windows agree on a new challenger.
+#[derive(Debug, Clone)]
+pub struct DrumIdentifier {
+    /// The committed drum designation.
+    current: Constraint,
+    /// The challenger accumulating consecutive agreeing windows.
+    pending: Constraint,
+    /// How many consecutive windows `pending` has held.
+    streak: u8,
+    /// Consecutive agreeing windows required to commit a change.
+    windows: u8,
+}
+
+impl Default for DrumIdentifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DrumIdentifier {
+    /// Creates an identifier seeded at [`Constraint::Unknown`] using the default
+    /// [`HYSTERESIS_WINDOWS`] debounce.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_windows(HYSTERESIS_WINDOWS)
+    }
+
+    /// Creates an identifier with an explicit hysteresis window count.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `windows` is zero: a change would then commit with no agreeing
+    /// windows, defeating the debounce. One or more is required.
+    #[must_use]
+    pub fn with_windows(windows: u8) -> Self {
+        assert!(windows >= 1, "hysteresis window count must be >= 1");
+        Self {
+            current: Constraint::Unknown,
+            pending: Constraint::Unknown,
+            streak: 0,
+            windows,
+        }
+    }
+
+    /// The committed drum designation.
+    #[must_use]
+    pub fn current(&self) -> Constraint {
+        self.current
+    }
+
+    /// Folds one window's `signals` into the designation and returns the
+    /// committed drum after this window.
+    pub fn observe(&mut self, signals: &StageSignals) -> Constraint {
+        self.observe_candidate(classify(signals))
+    }
+
+    /// Folds one already-classified `candidate` into the designation.
+    ///
+    /// Split from [`observe`](Self::observe) so the hysteresis state machine can
+    /// be tested independently of [`classify`]. A candidate equal to the
+    /// incumbent re-affirms it and clears any pending challenge; a different
+    /// candidate must repeat for [`windows`](Self::with_windows) consecutive
+    /// calls before it is committed.
+    pub fn observe_candidate(&mut self, candidate: Constraint) -> Constraint {
+        if candidate == self.current {
+            // Incumbent re-affirmed: abandon any in-progress challenge.
+            self.pending = self.current;
+            self.streak = 0;
+            return self.current;
+        }
+        if candidate == self.pending {
+            self.streak = self.streak.saturating_add(1);
+        } else {
+            self.pending = candidate;
+            self.streak = 1;
+        }
+        if self.streak >= self.windows {
+            self.current = self.pending;
+            self.streak = 0;
+        }
+        self.current
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a one-stage snapshot for truth-table cases.
+    fn signals_with(stage: Constraint, signal: StageSignal) -> StageSignals {
+        let mut s = StageSignals::new();
+        s.set(stage, signal);
+        s
+    }
+
+    fn sig(rate: Option<f64>, input: f64, output: f64) -> StageSignal {
+        StageSignal {
+            rate,
+            input_occupancy: input,
+            output_occupancy: output,
+        }
+    }
+
+    // --- classify: constraint-signature truth table --------------------------
+
+    #[test]
+    fn classify_full_input_empty_output_is_the_drum() {
+        // high input, low output, sampled -> constraint.
+        let s = signals_with(Constraint::Compute, sig(Some(1.0e6), 0.9, 0.1));
+        assert_eq!(classify(&s), Constraint::Compute);
+    }
+
+    #[test]
+    fn classify_requires_a_rate_estimate() {
+        // Same occupancy signature but unsampled -> not a candidate.
+        let s = signals_with(Constraint::Compute, sig(None, 0.9, 0.1));
+        assert_eq!(classify(&s), Constraint::Unknown);
+    }
+
+    #[test]
+    fn classify_high_input_but_high_output_is_a_victim_not_the_drum() {
+        // Backed up at input AND output: throttled from downstream, not the
+        // constraint itself.
+        let s = signals_with(Constraint::WireWrite, sig(Some(1.0e6), 0.9, 0.9));
+        assert_eq!(classify(&s), Constraint::Unknown);
+    }
+
+    #[test]
+    fn classify_low_input_is_never_the_drum() {
+        // Nothing piling up at the input: not starved-downstream constraint.
+        let s = signals_with(Constraint::Read, sig(Some(1.0e6), 0.1, 0.0));
+        assert_eq!(classify(&s), Constraint::Unknown);
+    }
+
+    #[test]
+    fn classify_threshold_boundaries_are_inclusive() {
+        // Exactly at the thresholds must qualify (>= / <=).
+        let s = signals_with(
+            Constraint::Compress,
+            sig(Some(5.0e5), HIGH_OCCUPANCY, LOW_OCCUPANCY),
+        );
+        assert_eq!(classify(&s), Constraint::Compress);
+
+        // A hair under HIGH input, or a hair over LOW output, disqualifies.
+        let under_input = signals_with(
+            Constraint::Compress,
+            sig(Some(5.0e5), HIGH_OCCUPANCY - 1e-9, LOW_OCCUPANCY),
+        );
+        assert_eq!(classify(&under_input), Constraint::Unknown);
+        let over_output = signals_with(
+            Constraint::Compress,
+            sig(Some(5.0e5), HIGH_OCCUPANCY, LOW_OCCUPANCY + 1e-9),
+        );
+        assert_eq!(classify(&over_output), Constraint::Unknown);
+    }
+
+    #[test]
+    fn classify_breaks_ties_by_slowest_stage() {
+        // Two stages match the signature; the slower (lower bytes/s) is the
+        // pace-setter.
+        let mut s = StageSignals::new();
+        s.set(Constraint::Read, sig(Some(9.0e6), 0.8, 0.1));
+        s.set(Constraint::WireWrite, sig(Some(1.0e6), 0.8, 0.1));
+        assert_eq!(classify(&s), Constraint::WireWrite);
+
+        // Reverse the rates: now Read is the slower one.
+        let mut s2 = StageSignals::new();
+        s2.set(Constraint::Read, sig(Some(1.0e6), 0.8, 0.1));
+        s2.set(Constraint::WireWrite, sig(Some(9.0e6), 0.8, 0.1));
+        assert_eq!(classify(&s2), Constraint::Read);
+    }
+
+    #[test]
+    fn classify_first_match_wins_on_exact_rate_tie() {
+        // Equal rates: the earlier pipeline stage (Read before WireWrite) keeps
+        // the designation because a strictly-lower rate is required to displace.
+        let mut s = StageSignals::new();
+        s.set(Constraint::Read, sig(Some(1.0e6), 0.8, 0.1));
+        s.set(Constraint::WireWrite, sig(Some(1.0e6), 0.8, 0.1));
+        assert_eq!(classify(&s), Constraint::Read);
+    }
+
+    #[test]
+    fn classify_empty_snapshot_is_unknown() {
+        assert_eq!(classify(&StageSignals::new()), Constraint::Unknown);
+    }
+
+    #[test]
+    fn classify_never_nominates_unknown_slot() {
+        // Even a fully-loaded Unknown slot is ignored: REAL excludes it.
+        let s = signals_with(Constraint::Unknown, sig(Some(1.0), 1.0, 0.0));
+        assert_eq!(classify(&s), Constraint::Unknown);
+    }
+
+    // --- hysteresis: debounced transitions -----------------------------------
+
+    #[test]
+    fn drum_holds_until_n_windows_agree() {
+        let mut drum = DrumIdentifier::with_windows(3);
+        assert_eq!(drum.current(), Constraint::Unknown);
+        // Two agreeing windows: still no commit.
+        assert_eq!(
+            drum.observe_candidate(Constraint::Compute),
+            Constraint::Unknown
+        );
+        assert_eq!(
+            drum.observe_candidate(Constraint::Compute),
+            Constraint::Unknown
+        );
+        // Third consecutive window commits.
+        assert_eq!(
+            drum.observe_candidate(Constraint::Compute),
+            Constraint::Compute
+        );
+    }
+
+    #[test]
+    fn interrupted_streak_resets_and_does_not_commit() {
+        let mut drum = DrumIdentifier::with_windows(3);
+        drum.observe_candidate(Constraint::Compute); // streak 1
+        drum.observe_candidate(Constraint::Compute); // streak 2
+        // A different candidate breaks the run before the 3rd agreeing window.
+        drum.observe_candidate(Constraint::WireWrite); // streak 1 for WireWrite
+        assert_eq!(drum.current(), Constraint::Unknown);
+        // Compute must start over: two more are not enough.
+        drum.observe_candidate(Constraint::Compute);
+        drum.observe_candidate(Constraint::Compute);
+        assert_eq!(drum.current(), Constraint::Unknown);
+        drum.observe_candidate(Constraint::Compute);
+        assert_eq!(drum.current(), Constraint::Compute);
+    }
+
+    #[test]
+    fn incumbent_reaffirmation_clears_a_pending_challenger() {
+        let mut drum = DrumIdentifier::with_windows(3);
+        // Commit Compute first.
+        for _ in 0..3 {
+            drum.observe_candidate(Constraint::Compute);
+        }
+        assert_eq!(drum.current(), Constraint::Compute);
+        // A challenger appears twice...
+        drum.observe_candidate(Constraint::WireWrite);
+        drum.observe_candidate(Constraint::WireWrite);
+        // ...then the incumbent re-affirms, wiping the challenge.
+        drum.observe_candidate(Constraint::Compute);
+        assert_eq!(drum.current(), Constraint::Compute);
+        // The challenger must restart from scratch.
+        drum.observe_candidate(Constraint::WireWrite);
+        drum.observe_candidate(Constraint::WireWrite);
+        assert_eq!(drum.current(), Constraint::Compute);
+        drum.observe_candidate(Constraint::WireWrite);
+        assert_eq!(drum.current(), Constraint::WireWrite);
+    }
+
+    #[test]
+    fn windows_one_commits_immediately() {
+        let mut drum = DrumIdentifier::with_windows(1);
+        assert_eq!(
+            drum.observe_candidate(Constraint::Read),
+            Constraint::Read,
+            "a single window commits when hysteresis is 1"
+        );
+    }
+
+    #[test]
+    fn observe_folds_classification_through_hysteresis() {
+        let mut drum = DrumIdentifier::with_windows(2);
+        let s = {
+            let mut s = StageSignals::new();
+            s.set(Constraint::WireWrite, sig(Some(1.0e6), 0.9, 0.1));
+            s
+        };
+        assert_eq!(drum.observe(&s), Constraint::Unknown, "first window pends");
+        assert_eq!(
+            drum.observe(&s),
+            Constraint::WireWrite,
+            "second agreeing window commits"
+        );
+    }
+
+    #[test]
+    fn default_uses_three_window_hysteresis() {
+        let mut drum = DrumIdentifier::new();
+        for _ in 0..HYSTERESIS_WINDOWS - 1 {
+            assert_eq!(
+                drum.observe_candidate(Constraint::Compute),
+                Constraint::Unknown
+            );
+        }
+        assert_eq!(
+            drum.observe_candidate(Constraint::Compute),
+            Constraint::Compute
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "hysteresis window count must be >= 1")]
+    fn zero_windows_panics() {
+        let _ = DrumIdentifier::with_windows(0);
+    }
+
+    #[test]
+    fn set_output_occupancy_preserves_other_fields() {
+        let mut s = StageSignals::new();
+        s.set(Constraint::Read, sig(Some(2.0e6), 0.8, 0.0));
+        s.set_output_occupancy(Constraint::Read, 0.4);
+        let out = s.get(Constraint::Read);
+        assert_eq!(out.rate, Some(2.0e6));
+        assert!((out.input_occupancy - 0.8).abs() < 1e-12);
+        assert!((out.output_occupancy - 0.4).abs() < 1e-12);
+    }
+}

--- a/crates/engine/src/throughput/governor.rs
+++ b/crates/engine/src/throughput/governor.rs
@@ -19,7 +19,7 @@
 //! worker threads.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -27,6 +27,7 @@ use std::time::Duration;
 use super::actuator::ActuatorHandle;
 use super::aggregate::StageAggregator;
 use super::bus::{DEFAULT_BUS_CAPACITY, SampleSink, TelemetryBus};
+use super::drum::DrumIdentifier;
 use super::sample::Constraint;
 
 /// Governor operating mode selected at spawn time.
@@ -127,12 +128,15 @@ const RATE_UNSET: u64 = u64::MAX;
 #[derive(Debug)]
 struct Snapshot {
     rates: [AtomicU64; Constraint::COUNT],
+    /// Latest committed drum designation, stored as a [`Constraint::index`].
+    drum: AtomicU8,
 }
 
 impl Snapshot {
     fn new() -> Self {
         Self {
             rates: std::array::from_fn(|_| AtomicU64::new(RATE_UNSET)),
+            drum: AtomicU8::new(Constraint::Unknown.index() as u8),
         }
     }
 
@@ -145,6 +149,14 @@ impl Snapshot {
             RATE_UNSET => None,
             bits => Some(f64::from_bits(bits)),
         }
+    }
+
+    fn store_drum(&self, drum: Constraint) {
+        self.drum.store(drum.index() as u8, Ordering::Relaxed);
+    }
+
+    fn load_drum(&self) -> Constraint {
+        Constraint::from_index(self.drum.load(Ordering::Relaxed) as usize)
     }
 }
 
@@ -211,13 +223,19 @@ impl Governor {
     }
 }
 
-/// The governor sense loop: drain, fold, publish, wait, repeat.
+/// The governor sense loop: drain, fold, identify the drum, publish, wait,
+/// repeat.
 ///
 /// Runs until `shutdown` is set (and a final drain has folded any stragglers).
 /// Each iteration drains every queued sample - keeping the bus shallow so
-/// producers rarely overflow it - folds each into its stage average, and
-/// publishes the refreshed rate to `snapshot`. It then waits up to `poll` for
-/// the next window or an early wake from [`GovernorHandle::shutdown`].
+/// producers rarely overflow it - folds each into its stage average, publishes
+/// the refreshed rate to `snapshot`, then runs one drum-identification window
+/// over the folded signals and publishes the debounced drum. It waits up to
+/// `poll` for the next window or an early wake from [`GovernorHandle::shutdown`].
+///
+/// Drum identification is pure observation: it reads the aggregated telemetry
+/// and stores a designation for callers to read. In this step it drives no
+/// actuator, so the sensing remains byte-neutral on the data path.
 fn sense_loop(
     bus: &TelemetryBus,
     snapshot: &Snapshot,
@@ -226,8 +244,10 @@ fn sense_loop(
     poll: Duration,
 ) {
     let mut aggregator = StageAggregator::new();
+    let mut drum = DrumIdentifier::new();
     loop {
         drain(bus, snapshot, &mut aggregator);
+        identify_drum(snapshot, &aggregator, &mut drum);
         if shutdown.load(Ordering::Acquire) {
             break;
         }
@@ -239,6 +259,7 @@ fn sense_loop(
     // Final drain so telemetry emitted between the last poll and shutdown is
     // still folded into the estimates callers read after joining.
     drain(bus, snapshot, &mut aggregator);
+    identify_drum(snapshot, &aggregator, &mut drum);
 }
 
 /// Drains and folds every currently-queued sample.
@@ -248,6 +269,13 @@ fn drain(bus: &TelemetryBus, snapshot: &Snapshot, aggregator: &mut StageAggregat
             snapshot.store(sample.stage, rate);
         }
     }
+}
+
+/// Runs one drum-identification evaluation window over the aggregated signals
+/// and publishes the debounced designation.
+fn identify_drum(snapshot: &Snapshot, aggregator: &StageAggregator, drum: &mut DrumIdentifier) {
+    let designation = drum.observe(&aggregator.stage_signals());
+    snapshot.store_drum(designation);
 }
 
 /// Handle to a spawned governor: the only public surface after `spawn`.
@@ -313,6 +341,19 @@ impl GovernorHandle {
     #[must_use]
     pub fn throughput(&self, stage: Constraint) -> Option<f64> {
         self.snapshot.load(stage)
+    }
+
+    /// The governor's current drum designation - the identified constraint
+    /// stage.
+    ///
+    /// [`Constraint::Unknown`] until the sense loop has run enough
+    /// [hysteresis](super::drum::HYSTERESIS_WINDOWS) windows to commit a drum,
+    /// and always [`Constraint::Unknown`] when the governor is off (no sense
+    /// loop runs). The designation is debounced, so it reflects a sustained
+    /// constraint rather than a single noisy window.
+    #[must_use]
+    pub fn drum(&self) -> Constraint {
+        self.snapshot.load_drum()
     }
 
     /// Total telemetry samples dropped due to bus overflow.
@@ -432,6 +473,50 @@ mod tests {
         let rate = gov.throughput(Constraint::Compute).expect("folded");
         assert!((rate - 4_096_000.0).abs() < 1.0, "rate {rate}");
         gov.shutdown();
+    }
+
+    #[test]
+    fn off_mode_drum_is_unknown() {
+        let gov = Governor::spawn(GovernorConfig::new(GovernorMode::Off));
+        assert_eq!(
+            gov.drum(),
+            Constraint::Unknown,
+            "off governor names no drum"
+        );
+    }
+
+    #[test]
+    fn sense_loop_identifies_a_sustained_drum() {
+        // WireWrite is sampled with a full input queue while its downstream
+        // (Consumer) is never sampled - the classic constraint signature. After
+        // enough hysteresis windows the governor must commit it as the drum.
+        let mut gov = Governor::spawn(GovernorConfig {
+            mode: GovernorMode::Observe,
+            bus_capacity: 256,
+            poll_interval: Duration::from_millis(2),
+        });
+        let sink = gov.sample_sink().expect("sink");
+        // Emit continuously so successive poll windows keep classifying
+        // WireWrite as the candidate until hysteresis commits it.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            sink.emit(StageSample::new(
+                Constraint::WireWrite,
+                4_096,
+                Duration::from_millis(1),
+                8, // full input queue -> high normalized occupancy
+            ));
+            if gov.drum() == Constraint::WireWrite {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "drum never committed to WireWrite"
+            );
+            std::thread::yield_now();
+        }
+        gov.shutdown();
+        assert_eq!(gov.drum(), Constraint::WireWrite);
     }
 
     #[test]

--- a/crates/engine/src/throughput/mod.rs
+++ b/crates/engine/src/throughput/mod.rs
@@ -8,12 +8,23 @@
 //!
 //! # What this step does (and does not) do
 //!
-//! In this step the governor is **inert**: it senses and nothing more. It has
-//! no control loop that acts, no buffer sizing, no backpressure "rope", and no
-//! I/O actuation. Enabling it therefore cannot change a single byte on the wire
-//! for any protocol version - a property pinned by the differential test in
-//! `tests/throughput_governor_differential.rs`. The actuators (dynamic capacity,
-//! rope, buffer-pool pressure, I/O depth) attach to the same
+//! The governor **senses and identifies the drum**: its dedicated thread folds
+//! per-stage telemetry into EWMAs and runs a debounced [`DrumIdentifier`] over
+//! them every window, publishing the current constraint stage through
+//! [`GovernorHandle::drum`]. Identification is pure observation - it stores a
+//! designation and drives no actuator on the data path - so enabling the
+//! governor still cannot change a single byte on the wire for any protocol
+//! version, a property pinned by the differential test in
+//! `tests/throughput_governor_differential.rs`.
+//!
+//! The **rope** ([`Rope`]) is the first actuator: it sizes the concurrent-delta
+//! work queue's [`AdaptiveSemaphore`](crate::concurrent_delta::work_queue::AdaptiveSemaphore)
+//! ceiling to the drum's service time, memory-bounded and clamped to a
+//! configured range. It is **opt-in**: a caller constructs it over a dynamic
+//! queue and drives it from a governor handle. Nothing wires it into the default
+//! transfer path, which keeps the static [`CapacitySource::Fixed`](crate::concurrent_delta::work_queue)
+//! bound, so the default build stays byte-identical to the pre-governor code.
+//! The remaining actuators (buffer-pool pressure, I/O depth) attach to the same
 //! [`GovernorHandle`] facade in later steps.
 //!
 //! # Pattern composition
@@ -23,10 +34,11 @@
 //!   telemetry never backpressures the data path).
 //! - **Mediator / Facade** - a single [`Governor`] owns interpretation; stages
 //!   never tune each other. [`Governor::spawn`] returns the sole public handle.
-//! - **State** - the [`Constraint`] taxonomy names the stage that can become the
-//!   drum.
-//! - **Adapter (later)** - platform I/O actuators will adapt to governor signals
-//!   through [`ActuatorHandle`] without leaking any `cfg` into this core.
+//! - **State** - [`DrumIdentifier`] debounces the [`Constraint`] designation,
+//!   committing a new drum only after several consecutive windows agree.
+//! - **Adapter** - the [`Rope`] actuator adapts the drum signal to an admission
+//!   ceiling; further platform I/O actuators attach through [`ActuatorHandle`]
+//!   without leaking any `cfg` into this core.
 //!
 //! # Degradation ladder
 //!
@@ -34,18 +46,29 @@
 //! no thread, and [`GovernorHandle::sample_sink`] returns `None` so every
 //! instrumentation site compiles to a skipped branch. The pipeline is then
 //! byte-identical to the pre-governor code. `OC_RSYNC_GOVERNOR=on` selects
-//! [`GovernorMode::Observe`], which senses only.
+//! [`GovernorMode::Observe`], which senses and identifies the drum but engages
+//! no actuator unless one is explicitly attached.
 
 mod actuator;
 mod aggregate;
 mod bus;
+mod drum;
 mod governor;
+mod rope;
 mod sample;
 
 pub use actuator::ActuatorHandle;
 pub use aggregate::{STAGE_ALPHA, StageAggregator};
 pub use bus::{DEFAULT_BUS_CAPACITY, SampleSink, TelemetryBus, emit_if_enabled};
+pub use drum::{
+    DrumIdentifier, HIGH_OCCUPANCY, HYSTERESIS_WINDOWS, LOW_OCCUPANCY, StageSignal, StageSignals,
+    classify,
+};
 pub use governor::{
     GOVERNOR_ENV, Governor, GovernorConfig, GovernorHandle, GovernorMode, POLL_INTERVAL,
+};
+pub use rope::{
+    DEFAULT_MEM_BUDGET_BYTES, DEFAULT_SAFETY_FACTOR, Rope, RopeConfig, RopeConfigError,
+    permit_weight_bytes,
 };
 pub use sample::{Constraint, StageSample};

--- a/crates/engine/src/throughput/rope.rs
+++ b/crates/engine/src/throughput/rope.rs
@@ -1,0 +1,526 @@
+//! The rope: admission sizing that paces the pipeline to the drum.
+//!
+//! In a drum-buffer-rope pipeline the *rope* ties upstream admission to the
+//! drum's pace so the producer can never run further ahead than the buffer in
+//! front of the constraint can absorb. Here the rope is realized as the ceiling
+//! of the [`AdaptiveSemaphore`] that gates the concurrent-delta
+//! [`work_queue`](crate::concurrent_delta::work_queue): the semaphore already
+//! releases one permit per drained item (see `PermitGuard`), so the only thing
+//! left to close the loop is *how high* to set the ceiling. [`Rope`] computes
+//! that ceiling from the drum's measured service time and resizes the semaphore.
+//!
+//! # Sizing law
+//!
+//! The buffer in front of the drum must hold enough in-flight work to keep the
+//! drum fed across one control window even if the producer stalls. Over a
+//! protection window `W` the drum consumes `rate * W` bytes; at a per-item
+//! footprint of `unit` bytes that is `rate * W / unit` items. Multiplying by a
+//! safety factor gives the target admission ceiling:
+//!
+//! ```text
+//! target = ceil(safety * rate_bytes_per_sec * W_secs / unit_bytes)
+//! ```
+//!
+//! The result is then **memory-bounded** - a permit for a 1 GiB file reserves
+//! far more resident memory than one for a 4 KiB file, so the ceiling is capped
+//! at `mem_budget / weight(unit)` where `weight` mirrors the file-size buffer
+//! tiers - and finally clamped to the configured `[min, max]`. Every returned
+//! ceiling is therefore in `[min, max]` by construction.
+//!
+//! This is the DBR counterpart to the block-rate
+//! [`AdaptiveQueueController`](crate::concurrent_delta::work_queue::AdaptiveQueueController):
+//! that one reacts to *admission contention*, this one sizes from *drum service
+//! time*. Both only move the ceiling within `[min, max]` and never reorder or
+//! revoke in-flight work, so both preserve the single-producer / multi-consumer
+//! ordering contract.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::concurrent_delta::work_queue::{AdaptiveSemaphore, MAX_CAPACITY};
+
+use super::governor::{GovernorHandle, POLL_INTERVAL};
+use super::sample::Constraint;
+
+/// Default multiple of the drum's per-window demand to keep buffered.
+///
+/// A factor of two keeps roughly two control windows of work in flight ahead of
+/// the drum, so a single stalled producer window cannot starve it before the
+/// next resize. Larger factors buffer more slack (and memory) for burstier
+/// producers; two is the conservative default that matches the historical
+/// `2 * thread_count` static bound's intent of "one spare item per worker".
+pub const DEFAULT_SAFETY_FACTOR: f64 = 2.0;
+
+/// Default resident-memory budget for in-flight admission, in bytes.
+///
+/// 256 MiB caps the worst-case footprint of everything the rope admits at once.
+/// It bounds the ceiling for large-file transfers (where each permit reserves a
+/// megabyte-class buffer) while leaving small-file transfers - whose per-permit
+/// weight is a few kilobytes - free to reach the configured `max`. Operators who
+/// need a tighter or looser bound override it via [`RopeConfig::mem_budget`].
+pub const DEFAULT_MEM_BUDGET_BYTES: u64 = 256 * 1024 * 1024;
+
+// Per-permit memory weight tiers.
+//
+// Mirrors `transfer::adaptive_buffer::adaptive_buffer_size`: the engine crate
+// does not depend on `transfer`, so the tier boundaries are duplicated here with
+// this reference so the two stay in lockstep. A permit's memory weight is the
+// buffer the transfer would allocate for a file of that size.
+
+/// Files smaller than this (64 KiB) reserve the small buffer.
+const SMALL_FILE_THRESHOLD: u64 = 64 * 1024;
+/// Files smaller than this (1 MiB) reserve the medium buffer.
+const MEDIUM_FILE_THRESHOLD: u64 = 1024 * 1024;
+/// Files smaller than this (10 MiB) reserve the large buffer.
+const HUGE_FILE_THRESHOLD: u64 = 10 * 1024 * 1024;
+
+/// Weight of a permit for a small file (4 KiB buffer).
+const SMALL_WEIGHT: u64 = 4 * 1024;
+/// Weight of a permit for a medium file (64 KiB buffer).
+const MEDIUM_WEIGHT: u64 = 64 * 1024;
+/// Weight of a permit for a large file (256 KiB buffer).
+const LARGE_WEIGHT: u64 = 256 * 1024;
+/// Weight of a permit for a huge file (1 MiB buffer).
+const HUGE_WEIGHT: u64 = 1024 * 1024;
+
+/// Returns the resident-memory weight of one admission permit for a work unit of
+/// `unit_bytes`, mirroring the transfer crate's file-size buffer tiers.
+///
+/// Never returns zero, so it is always a safe divisor when computing the
+/// memory-bounded ceiling.
+#[must_use]
+pub const fn permit_weight_bytes(unit_bytes: u64) -> u64 {
+    if unit_bytes < SMALL_FILE_THRESHOLD {
+        SMALL_WEIGHT
+    } else if unit_bytes < MEDIUM_FILE_THRESHOLD {
+        MEDIUM_WEIGHT
+    } else if unit_bytes < HUGE_FILE_THRESHOLD {
+        LARGE_WEIGHT
+    } else {
+        HUGE_WEIGHT
+    }
+}
+
+/// Error returned when a [`RopeConfig`] is internally inconsistent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RopeConfigError {
+    /// `min` was zero; at least one permit is required for liveness.
+    MinTooLow,
+    /// `min` exceeded `max`.
+    MinAboveMax {
+        /// The requested minimum ceiling.
+        min: usize,
+        /// The requested maximum ceiling.
+        max: usize,
+    },
+    /// `max` exceeded the semaphore's hard [`MAX_CAPACITY`].
+    MaxTooHigh {
+        /// The requested maximum ceiling.
+        max: usize,
+    },
+    /// `safety_factor` was not a finite, strictly-positive number.
+    BadSafetyFactor,
+    /// `mem_budget` was zero, which would forbid every admission.
+    ZeroMemBudget,
+}
+
+impl std::fmt::Display for RopeConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RopeConfigError::MinTooLow => f.write_str("rope min ceiling must be at least 1"),
+            RopeConfigError::MinAboveMax { min, max } => {
+                write!(f, "rope min ceiling {min} exceeds max {max}")
+            }
+            RopeConfigError::MaxTooHigh { max } => {
+                write!(
+                    f,
+                    "rope max ceiling {max} exceeds the semaphore limit {MAX_CAPACITY}"
+                )
+            }
+            RopeConfigError::BadSafetyFactor => {
+                f.write_str("rope safety factor must be finite and positive")
+            }
+            RopeConfigError::ZeroMemBudget => f.write_str("rope memory budget must be non-zero"),
+        }
+    }
+}
+
+impl std::error::Error for RopeConfigError {}
+
+/// Immutable sizing policy for a [`Rope`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RopeConfig {
+    /// Lowest admission ceiling the rope may set (liveness floor, `>= 1`).
+    min: usize,
+    /// Highest admission ceiling the rope may set.
+    max: usize,
+    /// Multiple of per-window drum demand to keep buffered.
+    safety_factor: f64,
+    /// Control window the ceiling must keep the drum fed across.
+    protection_window: Duration,
+    /// Resident-memory cap on total in-flight admission, in bytes.
+    mem_budget: u64,
+}
+
+impl RopeConfig {
+    /// Builds a config for the `[min, max]` ceiling range with default safety
+    /// factor, protection window ([`POLL_INTERVAL`]), and memory budget.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RopeConfigError`] when the range is inconsistent (`min == 0`,
+    /// `min > max`, or `max > MAX_CAPACITY`).
+    pub fn new(min: usize, max: usize) -> Result<Self, RopeConfigError> {
+        Self::validated(
+            min,
+            max,
+            DEFAULT_SAFETY_FACTOR,
+            POLL_INTERVAL,
+            DEFAULT_MEM_BUDGET_BYTES,
+        )
+    }
+
+    fn validated(
+        min: usize,
+        max: usize,
+        safety_factor: f64,
+        protection_window: Duration,
+        mem_budget: u64,
+    ) -> Result<Self, RopeConfigError> {
+        if min < 1 {
+            return Err(RopeConfigError::MinTooLow);
+        }
+        if min > max {
+            return Err(RopeConfigError::MinAboveMax { min, max });
+        }
+        if max > MAX_CAPACITY {
+            return Err(RopeConfigError::MaxTooHigh { max });
+        }
+        if !safety_factor.is_finite() || safety_factor <= 0.0 {
+            return Err(RopeConfigError::BadSafetyFactor);
+        }
+        if mem_budget == 0 {
+            return Err(RopeConfigError::ZeroMemBudget);
+        }
+        Ok(Self {
+            min,
+            max,
+            safety_factor,
+            protection_window,
+            mem_budget,
+        })
+    }
+
+    /// Overrides the safety factor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RopeConfigError::BadSafetyFactor`] if `factor` is not finite
+    /// and positive.
+    pub fn with_safety_factor(mut self, factor: f64) -> Result<Self, RopeConfigError> {
+        if !factor.is_finite() || factor <= 0.0 {
+            return Err(RopeConfigError::BadSafetyFactor);
+        }
+        self.safety_factor = factor;
+        Ok(self)
+    }
+
+    /// Overrides the protection window.
+    #[must_use]
+    pub fn with_protection_window(mut self, window: Duration) -> Self {
+        self.protection_window = window;
+        self
+    }
+
+    /// Overrides the resident-memory budget.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RopeConfigError::ZeroMemBudget`] if `bytes` is zero.
+    pub fn with_mem_budget(mut self, bytes: u64) -> Result<Self, RopeConfigError> {
+        if bytes == 0 {
+            return Err(RopeConfigError::ZeroMemBudget);
+        }
+        self.mem_budget = bytes;
+        Ok(self)
+    }
+
+    /// The configured minimum ceiling.
+    #[must_use]
+    pub fn min(&self) -> usize {
+        self.min
+    }
+
+    /// The configured maximum ceiling.
+    #[must_use]
+    pub fn max(&self) -> usize {
+        self.max
+    }
+
+    /// The memory-bounded maximum ceiling for a work unit of `unit_bytes`.
+    ///
+    /// This is `min(max, mem_budget / weight(unit))`, never dropping below
+    /// [`min`](Self::min) so the pipeline always stays live even under a tiny
+    /// budget.
+    #[must_use]
+    fn mem_bounded_max(&self, unit_bytes: u64) -> usize {
+        let weight = permit_weight_bytes(unit_bytes);
+        // weight is always >= SMALL_WEIGHT > 0, so this division is safe.
+        let by_mem = (self.mem_budget / weight).max(1);
+        let by_mem = usize::try_from(by_mem).unwrap_or(usize::MAX);
+        by_mem.min(self.max).max(self.min)
+    }
+
+    /// Computes the target ceiling for a drum with the given rate and work-unit
+    /// footprint. The result is always in `[min, max]`.
+    #[must_use]
+    fn target_ceiling(&self, drum_rate_bps: f64, unit_bytes: u64) -> usize {
+        let effective_max = self.mem_bounded_max(unit_bytes);
+        // Without a usable rate estimate, stay at the conservative floor.
+        if !drum_rate_bps.is_finite() || drum_rate_bps <= 0.0 {
+            return self.min;
+        }
+        // A zero-size work unit still costs one slot; treat it as one byte so the
+        // demand computation cannot divide by zero.
+        let unit = unit_bytes.max(1) as f64;
+        let window = self.protection_window.as_secs_f64();
+        let demand_items = self.safety_factor * drum_rate_bps * window / unit;
+        // Round up so a fractional item still reserves a whole permit; guard the
+        // f64 -> usize cast against overflow and NaN.
+        let target = demand_items.ceil();
+        let target = if target.is_finite() && target >= 1.0 {
+            target.min(usize::MAX as f64) as usize
+        } else {
+            self.min
+        };
+        target.clamp(self.min, effective_max)
+    }
+}
+
+/// The rope actuator: sizes an [`AdaptiveSemaphore`]'s ceiling to the drum's
+/// pace.
+///
+/// Holds a shared handle to the queue's admission semaphore. Call
+/// [`actuate`](Self::actuate) (or [`actuate_from`](Self::actuate_from)) once per
+/// governor evaluation window to move the ceiling; the semaphore's own
+/// acquire/release protocol (permits returned at drain time) does the rest.
+#[derive(Debug, Clone)]
+pub struct Rope {
+    semaphore: Arc<AdaptiveSemaphore>,
+    config: RopeConfig,
+}
+
+impl Rope {
+    /// Attaches a rope to `semaphore` with sizing policy `config`.
+    ///
+    /// The semaphore's current ceiling is left untouched until the first
+    /// [`actuate`](Self::actuate); callers typically construct the semaphore via
+    /// [`bounded_dynamic`](crate::concurrent_delta::work_queue::bounded_dynamic)
+    /// with the same `[min, max]`.
+    #[must_use]
+    pub fn new(semaphore: Arc<AdaptiveSemaphore>, config: RopeConfig) -> Self {
+        Self { semaphore, config }
+    }
+
+    /// The sizing policy in force.
+    #[must_use]
+    pub fn config(&self) -> &RopeConfig {
+        &self.config
+    }
+
+    /// The target ceiling for a drum of `drum_rate_bps` and `unit_bytes` per
+    /// item, without applying it. Always in `[min, max]`.
+    #[must_use]
+    pub fn target_ceiling(&self, drum_rate_bps: f64, unit_bytes: u64) -> usize {
+        self.config.target_ceiling(drum_rate_bps, unit_bytes)
+    }
+
+    /// Resizes the semaphore to the target ceiling for the given drum signal and
+    /// returns the applied ceiling.
+    ///
+    /// The target is clamped into `[min, max]`, which the semaphore validated at
+    /// construction, so the resize is infallible; on the impossible out-of-range
+    /// error the ceiling is left unchanged and the current value returned.
+    pub fn actuate(&self, drum_rate_bps: f64, unit_bytes: u64) -> usize {
+        let target = self.target_ceiling(drum_rate_bps, unit_bytes);
+        match self.semaphore.resize(target) {
+            Ok(()) => target,
+            Err(_) => self.semaphore.current_cap(),
+        }
+    }
+
+    /// Drives the ceiling from a live [`GovernorHandle`]: reads the current drum
+    /// and its throughput and resizes accordingly.
+    ///
+    /// Holds the current ceiling unchanged (returning it) when the governor has
+    /// not yet identified a drum ([`Constraint::Unknown`]) or has no throughput
+    /// estimate for it - there is nothing to size against yet.
+    pub fn actuate_from(&self, governor: &GovernorHandle, unit_bytes: u64) -> usize {
+        let drum = governor.drum();
+        if drum == Constraint::Unknown {
+            return self.semaphore.current_cap();
+        }
+        match governor.throughput(drum) {
+            Some(rate) => self.actuate(rate, unit_bytes),
+            None => self.semaphore.current_cap(),
+        }
+    }
+
+    /// The semaphore's current ceiling.
+    #[must_use]
+    pub fn current_ceiling(&self) -> usize {
+        self.semaphore.current_cap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::concurrent_delta::work_queue::bounded_dynamic;
+
+    fn cfg(min: usize, max: usize) -> RopeConfig {
+        RopeConfig::new(min, max).expect("valid range")
+    }
+
+    fn rope(min: usize, max: usize) -> Rope {
+        let dq = bounded_dynamic(min, min, max).expect("dynamic queue");
+        Rope::new(dq.semaphore, cfg(min, max))
+    }
+
+    // --- config validation ---------------------------------------------------
+
+    #[test]
+    fn config_rejects_inconsistent_ranges() {
+        assert_eq!(RopeConfig::new(0, 4), Err(RopeConfigError::MinTooLow));
+        assert_eq!(
+            RopeConfig::new(8, 4),
+            Err(RopeConfigError::MinAboveMax { min: 8, max: 4 })
+        );
+        assert_eq!(
+            RopeConfig::new(1, MAX_CAPACITY + 1),
+            Err(RopeConfigError::MaxTooHigh {
+                max: MAX_CAPACITY + 1
+            })
+        );
+    }
+
+    #[test]
+    fn config_rejects_bad_safety_and_budget() {
+        assert_eq!(
+            cfg(1, 4).with_safety_factor(0.0),
+            Err(RopeConfigError::BadSafetyFactor)
+        );
+        assert_eq!(
+            cfg(1, 4).with_safety_factor(f64::NAN),
+            Err(RopeConfigError::BadSafetyFactor)
+        );
+        assert_eq!(
+            cfg(1, 4).with_mem_budget(0),
+            Err(RopeConfigError::ZeroMemBudget)
+        );
+    }
+
+    // --- permit weight -------------------------------------------------------
+
+    #[test]
+    fn permit_weight_follows_file_size_tiers() {
+        assert_eq!(permit_weight_bytes(0), SMALL_WEIGHT);
+        assert_eq!(permit_weight_bytes(SMALL_FILE_THRESHOLD - 1), SMALL_WEIGHT);
+        assert_eq!(permit_weight_bytes(SMALL_FILE_THRESHOLD), MEDIUM_WEIGHT);
+        assert_eq!(permit_weight_bytes(MEDIUM_FILE_THRESHOLD), LARGE_WEIGHT);
+        assert_eq!(permit_weight_bytes(HUGE_FILE_THRESHOLD), HUGE_WEIGHT);
+        assert_eq!(permit_weight_bytes(u64::MAX), HUGE_WEIGHT);
+    }
+
+    // --- ceiling sizing ------------------------------------------------------
+
+    #[test]
+    fn no_rate_estimate_sizes_to_min() {
+        let r = rope(2, 64);
+        assert_eq!(r.target_ceiling(0.0, 4096), 2);
+        assert_eq!(r.target_ceiling(-1.0, 4096), 2);
+        assert_eq!(r.target_ceiling(f64::NAN, 4096), 2);
+        assert_eq!(r.target_ceiling(f64::INFINITY, 4096), 2);
+    }
+
+    #[test]
+    fn faster_drum_demands_a_higher_ceiling() {
+        // 4 KiB units, 0.25 s window, safety 2. At 1 MB/s: 2*1e6*0.25/4096 ~= 122
+        // -> clamped to max. At 40 KB/s: 2*4e4*0.25/4096 ~= 4.88 -> ceil 5.
+        let r = rope(2, 256);
+        let slow = r.target_ceiling(40_000.0, 4096);
+        let fast = r.target_ceiling(1_000_000.0, 4096);
+        assert_eq!(slow, 5, "slow drum needs a shallow buffer, got {slow}");
+        assert!(
+            fast > slow,
+            "faster drum must demand more, {fast} vs {slow}"
+        );
+    }
+
+    #[test]
+    fn ceiling_is_always_within_min_max() {
+        let r = rope(3, 40);
+        for &rate in &[1.0, 1e3, 1e6, 1e9, 1e15, f64::MAX] {
+            for &unit in &[0u64, 1, 4096, 1 << 20, 1 << 30, u64::MAX] {
+                let c = r.target_ceiling(rate, unit);
+                assert!(
+                    (3..=40).contains(&c),
+                    "ceiling {c} out of [3,40] for rate={rate} unit={unit}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn memory_budget_caps_large_file_ceiling() {
+        // A 4 MiB memory budget with 1 MiB-per-permit huge files allows only 4
+        // permits even though max is 1000 and the rate demands far more.
+        let dq = bounded_dynamic(1, 1, 1000).unwrap();
+        let config = cfg(1, 1000).with_mem_budget(4 * 1024 * 1024).unwrap();
+        let r = Rope::new(dq.semaphore, config);
+        let huge = r.target_ceiling(1e12, HUGE_FILE_THRESHOLD);
+        assert_eq!(
+            huge, 4,
+            "memory budget must cap huge-file admission, got {huge}"
+        );
+        // Small files under the same budget are not memory-constrained.
+        let small = r.target_ceiling(1e12, 1024);
+        assert_eq!(small, 1000, "small files can reach max, got {small}");
+    }
+
+    #[test]
+    fn zero_size_unit_does_not_divide_by_zero() {
+        let r = rope(1, 64);
+        let c = r.target_ceiling(1e6, 0);
+        assert!((1..=64).contains(&c), "zero-size unit gave {c}");
+    }
+
+    // --- actuation -----------------------------------------------------------
+
+    #[test]
+    fn actuate_moves_the_semaphore_ceiling() {
+        let dq = bounded_dynamic(2, 2, 256).unwrap();
+        let sem = Arc::clone(&dq.semaphore);
+        let r = Rope::new(dq.semaphore, cfg(2, 256));
+        let applied = r.actuate(1_000_000.0, 4096);
+        assert_eq!(applied, sem.current_cap());
+        assert!(applied > 2, "a fast drum should grow the ceiling");
+        // A stalled estimate pulls the ceiling back to the floor.
+        let floored = r.actuate(0.0, 4096);
+        assert_eq!(floored, 2);
+        assert_eq!(sem.current_cap(), 2);
+    }
+
+    #[test]
+    fn actuate_from_holds_without_a_drum() {
+        use crate::throughput::{Governor, GovernorConfig, GovernorMode};
+        let dq = bounded_dynamic(4, 2, 64).unwrap();
+        let sem = Arc::clone(&dq.semaphore);
+        let r = Rope::new(dq.semaphore, cfg(2, 64));
+        let mut gov = Governor::spawn(GovernorConfig::new(GovernorMode::Observe));
+        // No telemetry emitted: drum stays Unknown, ceiling held.
+        assert_eq!(r.actuate_from(&gov, 4096), 4);
+        assert_eq!(sem.current_cap(), 4);
+        gov.shutdown();
+    }
+}

--- a/crates/engine/src/throughput/sample.rs
+++ b/crates/engine/src/throughput/sample.rs
@@ -57,12 +57,63 @@ impl Constraint {
         Constraint::Unknown,
     ];
 
+    /// Every schedulable pipeline stage, in data-flow order, excluding
+    /// [`Constraint::Unknown`].
+    ///
+    /// `Unknown` is the governor's initial, unclassified drum designation and
+    /// is never a real pipeline stage, so drum identification iterates this
+    /// list rather than [`Constraint::ALL`]. The order matches the physical
+    /// pipeline (`Read → Compute → Compress → WireWrite → Consumer`) so
+    /// [`Constraint::successor`] can walk it.
+    pub const REAL: [Constraint; 5] = [
+        Constraint::Read,
+        Constraint::Compute,
+        Constraint::Compress,
+        Constraint::WireWrite,
+        Constraint::Consumer,
+    ];
+
     /// Number of distinct constraint stages.
     ///
     /// Equal to `Constraint::ALL.len()`; exposed as a `const` so fixed-size
     /// per-stage arrays can be declared without referencing the array length
     /// at a non-const site.
     pub const COUNT: usize = Self::ALL.len();
+
+    /// The stage immediately downstream of `self` in the transfer pipeline, or
+    /// `None` for the terminal [`Constraint::Consumer`] and the non-stage
+    /// [`Constraint::Unknown`].
+    ///
+    /// Drum identification uses this to read a stage's *output* queue occupancy:
+    /// the successor's input queue is, by construction, this stage's output.
+    /// A stage that is piling work at its own input while its successor's input
+    /// stays empty is the classic Theory-of-Constraints bottleneck signature.
+    #[must_use]
+    pub const fn successor(self) -> Option<Constraint> {
+        match self {
+            Constraint::Read => Some(Constraint::Compute),
+            Constraint::Compute => Some(Constraint::Compress),
+            Constraint::Compress => Some(Constraint::WireWrite),
+            Constraint::WireWrite => Some(Constraint::Consumer),
+            Constraint::Consumer | Constraint::Unknown => None,
+        }
+    }
+
+    /// Reconstructs a stage from its dense [`index`](Constraint::index).
+    ///
+    /// Returns [`Constraint::Unknown`] for any value outside `[0, COUNT)`, so a
+    /// round-trip through an atomic `u8` slot can never yield an invalid stage.
+    #[must_use]
+    pub const fn from_index(index: usize) -> Constraint {
+        match index {
+            0 => Constraint::Read,
+            1 => Constraint::Compute,
+            2 => Constraint::Compress,
+            3 => Constraint::WireWrite,
+            4 => Constraint::Consumer,
+            _ => Constraint::Unknown,
+        }
+    }
 
     /// Dense array index for this stage in `[0, COUNT)`.
     ///
@@ -148,6 +199,45 @@ mod tests {
             assert_eq!(stage.index(), i, "index must match ALL position");
         }
         assert_eq!(Constraint::COUNT, 6);
+    }
+
+    #[test]
+    fn real_stages_exclude_unknown_and_stay_in_flow_order() {
+        assert_eq!(Constraint::REAL.len(), Constraint::COUNT - 1);
+        assert!(!Constraint::REAL.contains(&Constraint::Unknown));
+        // REAL is a prefix of ALL (declaration/data-flow order).
+        for (i, stage) in Constraint::REAL.iter().enumerate() {
+            assert_eq!(*stage, Constraint::ALL[i]);
+        }
+    }
+
+    #[test]
+    fn successor_walks_the_pipeline_to_a_terminal() {
+        assert_eq!(Constraint::Read.successor(), Some(Constraint::Compute));
+        assert_eq!(Constraint::Compute.successor(), Some(Constraint::Compress));
+        assert_eq!(
+            Constraint::Compress.successor(),
+            Some(Constraint::WireWrite)
+        );
+        assert_eq!(
+            Constraint::WireWrite.successor(),
+            Some(Constraint::Consumer)
+        );
+        assert_eq!(Constraint::Consumer.successor(), None);
+        assert_eq!(Constraint::Unknown.successor(), None);
+    }
+
+    #[test]
+    fn from_index_round_trips_and_saturates_to_unknown() {
+        for stage in Constraint::ALL {
+            assert_eq!(Constraint::from_index(stage.index()), stage);
+        }
+        // Out-of-range indices collapse to Unknown rather than panic.
+        assert_eq!(
+            Constraint::from_index(Constraint::COUNT),
+            Constraint::Unknown
+        );
+        assert_eq!(Constraint::from_index(usize::MAX), Constraint::Unknown);
     }
 
     #[test]

--- a/crates/engine/tests/throughput_rope.rs
+++ b/crates/engine/tests/throughput_rope.rs
@@ -1,0 +1,222 @@
+//! Property and concurrency tests for the drum-buffer-rope admission actuator.
+//!
+//! These pin the two safety contracts the rope must never break:
+//!
+//! 1. **Bounded ceiling.** For any drum rate and any work-unit footprint the
+//!    computed admission ceiling stays inside the configured `[min, max]`. A
+//!    controller arithmetic slip can never push the semaphore out of range.
+//! 2. **Balanced permits.** Driving the rope's resizes concurrently with a live
+//!    producer/consumer transfer never leaks or double-returns an admission
+//!    permit: at quiescence every item has been delivered and the semaphore's
+//!    in-flight count is exactly zero, whatever the resize interleaving.
+//!
+//! A third test proves the rope gates *admission only, not ordering*: a transfer
+//! driven through a rope-resized dynamic queue delivers byte-for-byte the same
+//! result stream as the static fixed-capacity queue.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use engine::ConcurrentDeltaConfig;
+use engine::concurrent_delta::consumer::DeltaConsumer;
+use engine::concurrent_delta::work_queue::{self, bounded_dynamic};
+use engine::concurrent_delta::{DeltaResult, DeltaWork};
+use engine::throughput::{Rope, RopeConfig};
+
+use proptest::prelude::*;
+
+/// A comparable projection of a delivered result - everything an observer can
+/// see. Divergence here would mean the rope perturbed the transfer.
+#[derive(Debug, PartialEq, Eq)]
+struct ResultFingerprint {
+    sequence: u64,
+    ndx: u32,
+    bytes_written: u64,
+    success: bool,
+}
+
+fn fingerprint(results: &[DeltaResult]) -> Vec<ResultFingerprint> {
+    results
+        .iter()
+        .map(|r| ResultFingerprint {
+            sequence: r.sequence(),
+            ndx: r.ndx().get(),
+            bytes_written: r.bytes_written(),
+            success: r.is_success(),
+        })
+        .collect()
+}
+
+// --- property 1: ceiling always in [min, max] -------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn ceiling_stays_within_configured_bounds(
+        min in 1usize..=64,
+        span in 0usize..=512,
+        rate in prop::num::f64::ANY,
+        unit in 0u64..=(4u64 << 30),
+    ) {
+        let max = min + span;
+        let dq = bounded_dynamic(min, min, max).expect("dynamic queue");
+        let config = RopeConfig::new(min, max).expect("valid range");
+        let rope = Rope::new(dq.semaphore, config);
+
+        let ceiling = rope.target_ceiling(rate, unit);
+        prop_assert!(
+            (min..=max).contains(&ceiling),
+            "ceiling {ceiling} escaped [{min}, {max}] for rate={rate} unit={unit}"
+        );
+    }
+}
+
+// --- property 2: permits acquired == released at quiescence ------------------
+
+/// Runs `count` items through a rope-resized dynamic queue while a background
+/// thread hammers the ceiling with pseudo-random resizes, then asserts the
+/// admission semaphore is fully drained (in_flight == 0) and every item was
+/// delivered exactly once, in order.
+fn run_dynamic_with_resizes(count: u32, min: usize, max: usize) -> Vec<DeltaResult> {
+    let dq = bounded_dynamic(min, min, max).expect("dynamic queue");
+    let sender = dq.sender;
+    let receiver = dq.receiver;
+    let semaphore = Arc::clone(&dq.semaphore);
+
+    let config = RopeConfig::new(min, max).expect("valid range");
+    let rope = Rope::new(Arc::clone(&semaphore), config);
+
+    // Background resizer: drive the rope across a spread of synthetic drum rates
+    // so the ceiling grows and shrinks continuously while work is in flight.
+    let stop = Arc::new(AtomicBool::new(false));
+    let resizer_stop = Arc::clone(&stop);
+    let resizer = std::thread::spawn(move || {
+        let mut i: u64 = 0;
+        while !resizer_stop.load(Ordering::Relaxed) {
+            // Sweep rate across several orders of magnitude and unit size across
+            // the buffer tiers, exercising both grow and shrink paths.
+            let rate = 10f64.powi((i % 9) as i32);
+            let unit = 1u64 << ((i % 24) as u32);
+            rope.actuate(rate, unit);
+            i += 1;
+            std::thread::yield_now();
+        }
+    });
+
+    let producer = std::thread::spawn(move || {
+        for i in 0..count {
+            let work = DeltaWork::whole_file(i, PathBuf::from(format!("/dst/{i}")), 64)
+                .with_sequence(u64::from(i));
+            sender.send(work).expect("send work");
+        }
+        // Dropping the sender closes the queue so the consumer can finish.
+    });
+
+    let consumer = DeltaConsumer::spawn_with_config(receiver, 64, ConcurrentDeltaConfig::default());
+    let results: Vec<DeltaResult> = consumer.into_iter().collect();
+    producer.join().expect("producer join");
+    stop.store(true, Ordering::Relaxed);
+    resizer.join().expect("resizer join");
+
+    // Quiescence: every admitted permit was returned at drain time.
+    assert_eq!(
+        semaphore.in_flight(),
+        0,
+        "admission permits leaked: in_flight should be zero at quiescence"
+    );
+    results
+}
+
+#[test]
+fn permits_balance_under_concurrent_resizes() {
+    for &(count, min, max) in &[(256u32, 1usize, 8usize), (512, 2, 16), (1000, 4, 64)] {
+        let results = run_dynamic_with_resizes(count, min, max);
+        assert_eq!(
+            results.len(),
+            count as usize,
+            "every item must be delivered"
+        );
+        // Delivered strictly in submission order (the reorder buffer restores it).
+        for (i, r) in results.iter().enumerate() {
+            assert_eq!(r.sequence(), i as u64, "out-of-order delivery at {i}");
+        }
+    }
+}
+
+// --- property 3: the rope gates admission, not ordering ----------------------
+
+/// Baseline transfer through the static fixed-capacity queue - "today's"
+/// behaviour.
+fn run_fixed(count: u32) -> Vec<DeltaResult> {
+    let (tx, rx) = work_queue::bounded_with_capacity(count.max(1) as usize);
+    let producer = std::thread::spawn(move || {
+        for i in 0..count {
+            let work = DeltaWork::whole_file(i, PathBuf::from(format!("/dst/{i}")), 64)
+                .with_sequence(u64::from(i));
+            tx.send(work).expect("send work");
+        }
+    });
+    let consumer = DeltaConsumer::spawn_with_config(rx, 64, ConcurrentDeltaConfig::default());
+    let results: Vec<DeltaResult> = consumer.into_iter().collect();
+    producer.join().expect("producer join");
+    results
+}
+
+#[test]
+fn rope_resized_output_matches_fixed_output() {
+    const COUNT: u32 = 400;
+    let baseline = run_fixed(COUNT);
+    let roped = run_dynamic_with_resizes(COUNT, 2, 16);
+    assert_eq!(
+        fingerprint(&baseline),
+        fingerprint(&roped),
+        "the rope gates admission only; it must not change what or in what order results are delivered"
+    );
+}
+
+#[test]
+fn rope_actuate_from_governor_drives_the_ceiling() {
+    use engine::throughput::{Constraint, Governor, GovernorConfig, GovernorMode, StageSample};
+
+    // Stand up a dynamic queue + rope + observing governor, feed the governor a
+    // sustained WireWrite-constraint signal, and confirm the rope moves the
+    // ceiling off its floor once the drum is identified.
+    let dq = bounded_dynamic(2, 2, 128).expect("dynamic queue");
+    let semaphore = Arc::clone(&dq.semaphore);
+    let rope = Rope::new(Arc::clone(&semaphore), RopeConfig::new(2, 128).unwrap());
+
+    let mut gov = Governor::spawn(GovernorConfig {
+        mode: GovernorMode::Observe,
+        bus_capacity: 256,
+        poll_interval: Duration::from_millis(2),
+    });
+    let sink = gov.sample_sink().expect("sink");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        sink.emit(StageSample::new(
+            Constraint::WireWrite,
+            1_000_000,
+            Duration::from_millis(1),
+            8,
+        ));
+        if gov.drum() == Constraint::WireWrite {
+            break;
+        }
+        assert!(std::time::Instant::now() < deadline, "drum never committed");
+        std::thread::yield_now();
+    }
+
+    // A fast WireWrite drum with 4 KiB units demands well above the floor.
+    let applied = rope.actuate_from(&gov, 4096);
+    assert!(
+        applied > 2,
+        "rope should grow the ceiling for a fast drum, got {applied}"
+    );
+    assert_eq!(applied, semaphore.current_cap());
+    assert!(applied <= 128, "ceiling must respect the configured max");
+    gov.shutdown();
+}


### PR DESCRIPTION
## DBR-G1: governor control loop + rope

Builds on the merged telemetry foundation (`crates/engine/src/throughput/`). This step adds the control loop that identifies the constraint stage (the drum) and the rope actuator that sizes admission to it. The default is unchanged and byte-identical.

### Drum identification (State + hysteresis)

The governor's sense loop now folds per-stage telemetry into a debounced constraint designation each 250 ms window:

- A stage is a **drum candidate** when it has a throughput estimate, its **input** queue occupancy is high (>= 0.75 normalized) and its **output** queue occupancy is low (<= 0.25) - the classic Theory-of-Constraints signature (backed up at the input, not throttled from downstream). Ties break by **lowest sustained bytes/second** - the slowest such stage sets the pace.
- **Hysteresis:** the designation commits only after `HYSTERESIS_WINDOWS = 3` consecutive windows agree on the same challenger; a single window re-affirming the incumbent clears a pending challenge. This rejects one- and two-window blips from scheduling jitter. All constants carry rustdoc justifications tied to the poll window.
- Occupancy is normalized per stage against its own observed high-water mark, so identification needs no external capacity hint. Output occupancy of a stage is read from its pipeline successor's input.

Exposed through `GovernorHandle::drum()`. `classify` (pure) and the hysteresis state machine are split so each is exhaustively unit-tested.

### Rope (`CapacitySource::Dynamic` sizing)

`Rope` sizes the concurrent-delta work queue's `AdaptiveSemaphore` ceiling so in-flight work covers the drum's service time x safety factor:

```
target = ceil(safety * drum_bytes_per_sec * window_secs / unit_bytes)
```

then **memory-bounds** it (each permit is weighted by its expected buffer footprint, mirroring the file-size buffer tiers - a 1 GiB-file permit is not a 4 KiB-file permit) and clamps to `[min, max]`. Drain-time permit release is already handled by the existing `PermitGuard` / iterator paths, so the rope only supplies the sizing law - the DBR counterpart to the block-rate AIMD controller, driven by drum service time. `Rope::actuate_from(&governor, unit_bytes)` closes the loop from a live governor handle.

### Degradation: default off / Fixed = byte-identical

- The default work queue stays `CapacitySource::Fixed` (static 2x bound) and the governor stays off. `OC_RSYNC_GOVERNOR=off` selects the no-thread, no-sink path.
- Drum identification is pure observation (it stores a designation, drives no actuator on the data path); the rope is opt-in and is **not** wired into the default transfer path.
- **No wire / no NDX change:** the rope gates admission (how many items in flight), never ordering. The existing `ReorderBuffer` drain is untouched, so results are still delivered in strict submission order.

### Tests (host-independent)

- **Drum truth table:** every constraint signature (full-input/empty-output drum, high-input-high-output victim, unsampled stage, low-input, inclusive threshold boundaries, slowest-stage tie-break) plus the hysteresis boundaries (no commit at N-1 windows, commit at N, interrupted-streak reset, incumbent re-affirmation).
- **Property:** for any drum rate and work-unit footprint the ceiling stays within `[min, max]`.
- **Concurrency:** permits acquired == released at quiescence - a live producer/consumer transfer with a background thread hammering rope resizes ends with `in_flight == 0` and every item delivered in order, under any interleaving.
- **Differential:** a rope-resized dynamic-queue transfer delivers byte-for-byte the same result stream as the static fixed-capacity queue (the rope gates admission, not ordering). The existing governor off-vs-observe differential still holds.
- **Shutdown:** governor thread joins cleanly under a simulated worker panic.

### Verification

- `cargo build --bin oc-rsync`: success.
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean.
- `cargo nextest run -p engine --all-features -E 'test(governor) or test(rope) or test(capacity) or test(drum) or test(throughput) ...'`: 145 passed.
- `cargo fmt --all --check`: clean.
