### PR TITLE
feat(daemon): bind QUIC/UDP listener alongside TCP (mirror TCP bind pipeline)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,7 @@ dependencies = [
  "nix",
  "platform",
  "protocol",
+ "rsync_io",
  "sd-notify",
  "seccompiler",
  "socket2",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -51,14 +51,16 @@ daemon-seccomp = ["dep:seccompiler"]
 # a no-op that still degrades to the plain writer. See
 # docs/design/iouring-send-zc.md for the buffer-lifetime contract.
 daemon-zero-copy = ["fast_io/iouring-send-zc"]
-# QUIC daemon transport (default-off, opt-in oc extension). At this stage the
-# feature gates parsing and storage of the `quic cert file` / `quic key file`
-# global directives and resolving the listener identity (operator-supplied files
-# vs. an ephemeral in-memory self-signed cert generated at bind time); the
-# listener itself lands under later QUIC build-out tasks. Kept dependency-free so
-# default builds are byte-identical. See docs/design/quic-transport-policy.md
-# (decision A).
-quic = []
+# QUIC daemon transport (default-off, opt-in oc extension). Gates parsing and
+# storage of the `quic cert file` / `quic key file` / `quic port` global
+# directives, resolving the listener identity (operator-supplied files vs. an
+# ephemeral in-memory self-signed cert generated at bind time), and binding the
+# UDP/QUIC listener alongside the TCP one via `rsync_io`'s `QuicAcceptor`. The
+# accept()->session handoff lands under a later QUIC build-out task; this stage
+# holds the bound acceptors ready for it. Pulls `rsync_io` (with its `quic`
+# feature) only when enabled, so default builds stay dependency-free and
+# byte-identical. See docs/design/quic-transport-policy.md (decision A).
+quic = ["dep:rsync_io", "rsync_io/quic"]
 # macOS-only, default-off: source accepted connections in the daemon accept
 # loop from a `kqueue(2)` `EVFILT_READ` readiness wait instead of the portable
 # engines' per-listener `poll(2)` park, giving a single kernel wait over all
@@ -79,6 +81,8 @@ platform = { path = "../platform" }
 protocol = { path = "../protocol" }
 logging = { path = "../logging" }
 logging-sink = { path = "../logging-sink" }
+# Pulled only by the `quic` feature for `QuicAcceptor` (the UDP/QUIC listener).
+rsync_io = { path = "../rsync_io", default-features = false, optional = true }
 fs2 = "0.4"
 socket2 = { workspace = true, features = ["all"] }
 tempfile = { workspace = true }

--- a/crates/daemon/src/daemon/runtime_options/quic_identity.rs
+++ b/crates/daemon/src/daemon/runtime_options/quic_identity.rs
@@ -40,6 +40,21 @@ impl RuntimeOptions {
         }
     }
 
+    /// Reports whether the daemon should bind a UDP/QUIC listener.
+    ///
+    /// The dedicated `quic = yes` enable directive from
+    /// docs/design/quic-transport-policy.md (Decision, daemon-side config) is
+    /// not yet parsed, so this interim predicate treats QUIC as enabled when
+    /// the operator configured any QUIC directive: a certificate path, a key
+    /// path, or an explicit `quic port`. A daemon with no QUIC directives never
+    /// opens the UDP socket, so a default `--all-features` build stays
+    /// TCP-only and byte-identical. When the enable directive lands, this is
+    /// the single seam to consult it instead.
+    #[allow(dead_code)] // REASON: consumed by the QUIC listener wiring (QUIC-6c); exercised by tests now
+    pub(crate) fn quic_listener_enabled(&self) -> bool {
+        self.quic_cert_file.is_some() || self.quic_key_file.is_some() || self.quic_port.is_some()
+    }
+
     /// Returns the port the QUIC listener binds.
     ///
     /// The `quic port` global directive overrides it independently; unset, the

--- a/crates/daemon/src/daemon/sections/server_runtime.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime.rs
@@ -22,6 +22,12 @@ include!("server_runtime/accept_engine.rs");
 
 include!("server_runtime/accept_loop.rs");
 
+// QUIC/UDP listener binding (oc extension). Unix-only daemon; gated so default
+// and non-quic builds are byte-identical. Bound alongside the TCP listeners in
+// `serve_connections`; the accept()->session handoff lands under QUIC task #55.
+#[cfg(all(unix, feature = "quic"))]
+include!("server_runtime/quic_listener.rs");
+
 #[cfg(test)]
 #[path = "server_runtime/tests.rs"]
 mod server_runtime_tests;

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -38,6 +38,16 @@ fn serve_connections(
     let acceptor_threads = options.acceptor_threads();
     let socket_options_str = options.socket_options().map(str::to_string);
     let tcp_fastopen_mode = options.tcp_fastopen();
+
+    // Capture the QUIC listener inputs before `options` is destructured. The
+    // UDP/QUIC listener binds the same resolved address set as TCP but only
+    // when QUIC is configured; unconfigured (the default, even under
+    // `--all-features`) leaves this `None` and no UDP socket is opened.
+    #[cfg(all(unix, feature = "quic"))]
+    let quic_bind = options
+        .quic_listener_enabled()
+        .then(|| (options.effective_quic_port(), options.resolve_quic_identity()));
+
     let RuntimeOptions {
         bind_address,
         port,
@@ -216,6 +226,42 @@ fn serve_connections(
             }
         }
     }
+
+    // QUIC/UDP listener (oc extension): bind it alongside the TCP listeners,
+    // over the identical `resolve_bind_addresses` set, while CAP_NET_BIND_SERVICE
+    // is still held (the default port 873 is privileged). The bound acceptors
+    // are held for the whole daemon lifetime; the accept()->session handoff
+    // lands under QUIC task #55, so for now they simply keep the UDP sockets
+    // reserved next to the TCP ones.
+    #[cfg(all(unix, feature = "quic"))]
+    let _quic_acceptors: Vec<QuicAcceptor> = if let Some((quic_port, quic_identity)) = &quic_bind {
+        match bind_quic_listeners_per_family(
+            &bind_addresses,
+            *quic_port,
+            quic_identity,
+            log_sink.as_ref(),
+        ) {
+            Ok(acceptors) => {
+                if let Some(log) = log_sink.as_ref() {
+                    let addrs: Vec<String> = acceptors
+                        .iter()
+                        .filter_map(|a| a.local_addr().ok())
+                        .map(|a| a.to_string())
+                        .collect();
+                    let text = format!("QUIC listener bound on {}", addrs.join(" and "));
+                    let message = rsync_info!(text).with_role(Role::Daemon);
+                    log_message(log, &message);
+                }
+                acceptors
+            }
+            Err(error) => {
+                let requested_addr = SocketAddr::new(bind_addresses[0], *quic_port);
+                return Err(bind_error(requested_addr, error));
+            }
+        }
+    } else {
+        Vec::new()
+    };
 
     // LSM-CAP.2: CAP_NET_BIND_SERVICE is no longer needed once the listener
     // has bound. Drop it from effective, permitted, and bounding sets so a

--- a/crates/daemon/src/daemon/sections/server_runtime/quic_listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/quic_listener.rs
@@ -1,0 +1,106 @@
+// QUIC/UDP listener binding (oc extension, feature `quic`, Unix-only daemon).
+//
+// This is the datagram sibling of the TCP `bind_listeners_per_family` pipeline
+// in `listener.rs`. It reuses the identical `resolve_bind_addresses` policy so
+// the QUIC listener binds the same ordered, dual-stack set of addresses as the
+// TCP one, and mirrors the per-family tolerance: a dual-stack startup that
+// loses one family (e.g. an IPv6-degraded CI runner) still comes up on the
+// survivor, and only a total bind failure is fatal.
+//
+// Scope: bind and hold the acceptors. Driving `accept()` -> `QuicStream` ->
+// session is the next QUIC task (#55); `serve_connections` keeps the returned
+// acceptors alive for it. See docs/design/quic-transport-policy.md.
+
+use rsync_io::quic::{QuicAcceptor, QuicServerIdentity};
+
+/// Maps the daemon's resolved [`QuicIdentity`] onto the transport-layer
+/// [`QuicServerIdentity`] the acceptor consumes.
+///
+/// The two enums live in different layers on purpose: [`QuicIdentity`] is the
+/// daemon's config-time decision (which directives the operator set), while
+/// [`QuicServerIdentity`] is what `rsync_io` needs to materialize a
+/// certificate at bind time.
+fn quic_server_identity(identity: &QuicIdentity) -> QuicServerIdentity {
+    match identity {
+        QuicIdentity::Ephemeral => QuicServerIdentity::Ephemeral,
+        QuicIdentity::Files { cert, key } => QuicServerIdentity::PemFiles {
+            cert: cert.clone(),
+            key: key.clone(),
+        },
+    }
+}
+
+/// Builds one bound UDP socket for the QUIC listener at `addr`.
+///
+/// Uses `socket2` so the IPv6 socket can set `IPV6_V6ONLY`, exactly as the TCP
+/// listener does in `bind_with_backlog`: in dual-stack mode the daemon binds a
+/// separate `[::]` and `0.0.0.0` socket, and without v6-only isolation the
+/// IPv6 wildcard would also claim IPv4 traffic and the paired IPv4 bind would
+/// fail with `EADDRINUSE`. `SO_REUSEADDR` mirrors the TCP path so a restart can
+/// rebind without waiting out the previous socket.
+fn bind_quic_socket(addr: SocketAddr) -> io::Result<std::net::UdpSocket> {
+    let domain = if addr.is_ipv4() {
+        socket2::Domain::IPV4
+    } else {
+        socket2::Domain::IPV6
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?;
+    socket.set_reuse_address(true)?;
+    if addr.is_ipv6() {
+        socket.set_only_v6(true)?;
+    }
+    socket.bind(&addr.into())?;
+    Ok(socket.into())
+}
+
+/// Binds one QUIC/UDP acceptor per entry in `bind_addresses`, tolerating
+/// per-family failures while at least one family binds.
+///
+/// The datagram counterpart of [`bind_listeners_per_family`]: it walks the same
+/// `resolve_bind_addresses` list in the same order, warns via
+/// [`warn_per_family_bind_failure`] when a family fails in dual-stack mode, and
+/// only returns `Err` when every family failed (callers map that to a
+/// `DaemonError`). `quic_port` is the resolved `effective_quic_port()`.
+///
+/// The returned acceptors are bound but idle; the accept loop that turns each
+/// into a session lands under QUIC task #55.
+fn bind_quic_listeners_per_family(
+    bind_addresses: &[IpAddr],
+    quic_port: u16,
+    identity: &QuicIdentity,
+    log_sink: Option<&SharedLogSink>,
+) -> Result<Vec<QuicAcceptor>, io::Error> {
+    let server_identity = quic_server_identity(identity);
+    let dual_stack = bind_addresses.len() > 1;
+    let mut acceptors = Vec::with_capacity(bind_addresses.len());
+    let mut last_error: Option<io::Error> = None;
+
+    for addr in bind_addresses {
+        let requested_addr = SocketAddr::new(*addr, quic_port);
+        let result = bind_quic_socket(requested_addr)
+            .and_then(|socket| QuicAcceptor::from_socket(socket, &server_identity));
+        match result {
+            Ok(acceptor) => acceptors.push(acceptor),
+            Err(error) => {
+                if dual_stack {
+                    warn_per_family_bind_failure(log_sink, requested_addr, &error);
+                    last_error = Some(error);
+                    continue;
+                }
+                return Err(error);
+            }
+        }
+    }
+
+    if acceptors.is_empty() {
+        let error = last_error.unwrap_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AddrNotAvailable,
+                "no addresses available to bind the QUIC listener",
+            )
+        });
+        return Err(error);
+    }
+
+    Ok(acceptors)
+}

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -2283,3 +2283,89 @@ fn kqueue_engine_delivers_queued_connection_without_sleep_floor() {
     engine.shutdown();
     drop(client);
 }
+
+// QUIC/UDP listener binding (QUIC-6c). The datagram sibling of the TCP
+// `bind_listeners_per_family` pipeline: it reuses `resolve_bind_addresses` and
+// mirrors the per-family tolerance. These tests pin dual-stack binding, the
+// IPv6->IPv4 fallback, single-family error propagation, the effective-port
+// wiring, and the identity mapping. Unix-only, feature-gated - the module they
+// exercise only compiles under `cfg(all(unix, feature = "quic"))`.
+#[cfg(all(unix, feature = "quic"))]
+#[test]
+fn quic_server_identity_maps_both_variants() {
+    assert_eq!(
+        quic_server_identity(&QuicIdentity::Ephemeral),
+        rsync_io::quic::QuicServerIdentity::Ephemeral,
+    );
+    let cert = std::path::PathBuf::from("/etc/oc-rsync/quic/server.pem");
+    let key = std::path::PathBuf::from("/etc/oc-rsync/quic/server.key");
+    assert_eq!(
+        quic_server_identity(&QuicIdentity::Files {
+            cert: cert.clone(),
+            key: key.clone(),
+        }),
+        rsync_io::quic::QuicServerIdentity::PemFiles { cert, key },
+    );
+}
+
+#[cfg(all(unix, feature = "quic"))]
+#[test]
+fn bind_quic_listeners_binds_dual_stack_loopback() {
+    // The same resolved dual-stack list TCP uses (IPv6 first, IPv4 second)
+    // yields one QUIC acceptor per family. Loopback addresses on port 0
+    // keep the test hermetic - no privileged port, no shared-port race.
+    let bind_addresses = vec![
+        IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+    ];
+
+    let acceptors =
+        bind_quic_listeners_per_family(&bind_addresses, 0, &QuicIdentity::Ephemeral, None)
+            .expect("dual-stack QUIC bind");
+
+    assert_eq!(acceptors.len(), 2, "both families must bind a QUIC listener");
+    let bound: Vec<SocketAddr> = acceptors
+        .iter()
+        .map(|a| a.local_addr().expect("local addr"))
+        .collect();
+    assert!(bound[0].is_ipv6(), "first acceptor must be IPv6");
+    assert!(bound[1].is_ipv4(), "second acceptor must be IPv4");
+    assert!(
+        bound.iter().all(|a| a.port() != 0),
+        "the kernel must assign an ephemeral UDP port to each acceptor"
+    );
+}
+
+#[cfg(all(unix, feature = "quic"))]
+#[test]
+fn bind_quic_listeners_falls_back_from_ipv6_to_ipv4() {
+    // Mirror the TCP per-family tolerance: an unreachable IPv6 documentation
+    // address (RFC 3849 2001:db8::/32) fails to bind, the helper warns and
+    // continues, and the reachable IPv4 loopback still produces a working
+    // acceptor instead of failing the whole daemon.
+    let unreachable_v6 = IpAddr::V6(std::net::Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1));
+    let reachable_v4 = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+    let bind_addresses = vec![unreachable_v6, reachable_v4];
+
+    let acceptors =
+        bind_quic_listeners_per_family(&bind_addresses, 0, &QuicIdentity::Ephemeral, None)
+            .expect("IPv4 fallback must bind when IPv6 is unreachable");
+
+    assert_eq!(acceptors.len(), 1, "only the reachable IPv4 family binds");
+    let bound = acceptors[0].local_addr().expect("local addr");
+    assert!(bound.is_ipv4(), "fallback acceptor must be IPv4, got {bound}");
+}
+
+#[cfg(all(unix, feature = "quic"))]
+#[test]
+fn bind_quic_listeners_single_family_propagates_error() {
+    // With only one configured address there is no family to fall back to, so a
+    // bind failure propagates verbatim - matching the TCP path and the
+    // non-dual-stack branch of the loop.
+    let bind_addresses = vec![IpAddr::V6(std::net::Ipv6Addr::new(
+        0x2001, 0x0db8, 0, 0, 0, 0, 0, 1,
+    ))];
+
+    bind_quic_listeners_per_family(&bind_addresses, 0, &QuicIdentity::Ephemeral, None)
+        .expect_err("the single unreachable address must fail the QUIC bind");
+}

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -393,6 +393,8 @@ include!("tests/chunks/runtime_options_quic_cert_key_pairing.rs");
 include!("tests/chunks/runtime_options_quic_identity_resolution.rs");
 #[cfg(feature = "quic")]
 include!("tests/chunks/runtime_options_quic_port_directive.rs");
+#[cfg(feature = "quic")]
+include!("tests/chunks/runtime_options_quic_listener_enabled.rs");
 include!("tests/chunks/runtime_options_reject_duplicate_bwlimit.rs");
 include!("tests/chunks/runtime_options_reject_duplicate_lock_file_argument.rs");
 include!("tests/chunks/runtime_options_reject_duplicate_log_file_argument.rs");

--- a/crates/daemon/src/tests/chunks/runtime_options_quic_listener_enabled.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_quic_listener_enabled.rs
@@ -1,0 +1,68 @@
+// QUIC listener enablement (QUIC-6c). The daemon opens a UDP/QUIC listener only
+// when QUIC is configured. Until the dedicated `quic = yes` enable directive
+// lands, "configured" means any QUIC directive is present: a cert path, a key
+// path, or an explicit `quic port`. A config with no QUIC directives leaves the
+// listener off so a default `--all-features` daemon stays TCP-only.
+
+#[test]
+fn quic_listener_disabled_without_directives() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(&config_path, "# no quic directives\n").expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect("parse config");
+
+    assert!(
+        !options.quic_listener_enabled(),
+        "a daemon with no QUIC directives must not open a QUIC listener"
+    );
+}
+
+#[test]
+fn quic_listener_enabled_by_cert_key_directives() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(
+        &config_path,
+        "quic cert file = server.pem\nquic key file = server.key\n",
+    )
+    .expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect("parse config");
+
+    assert!(
+        options.quic_listener_enabled(),
+        "configured cert/key directives must enable the QUIC listener"
+    );
+}
+
+#[test]
+fn quic_listener_enabled_by_port_directive() {
+    let dir = tempdir().expect("config dir");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(&config_path, "quic port = 8873\n").expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        config_path.as_os_str().to_os_string(),
+    ])
+    .expect("parse config");
+
+    assert!(
+        options.quic_listener_enabled(),
+        "an explicit `quic port` must enable the QUIC listener"
+    );
+    assert_eq!(
+        options.effective_quic_port(),
+        8873,
+        "the QUIC listener must bind the configured port"
+    );
+}

--- a/crates/rsync_io/src/quic/mod.rs
+++ b/crates/rsync_io/src/quic/mod.rs
@@ -52,6 +52,7 @@ mod trust;
 use std::collections::VecDeque;
 use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
+use std::path::PathBuf;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -61,6 +62,7 @@ use quinn_proto::crypto::rustls::{QuicClientConfig, QuicServerConfig};
 use quinn_proto::{ClientConfig, ConnectionError, Endpoint, EndpointConfig, ServerConfig, VarInt};
 pub use rustls::RootCertStore;
 pub use rustls::client::danger::ServerCertVerifier;
+use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 
 use driver::{Role, spawn_io};
@@ -249,6 +251,75 @@ fn wait_stream(io: &Arc<Io>) -> io::Result<QuicStream> {
     }
 }
 
+/// The TLS identity a [`QuicAcceptor`] presents to connecting clients.
+///
+/// Mirrors the daemon's Decision A (docs/design/quic-transport-policy.md): an
+/// operator either supplies a certificate/key pair on disk, or the listener
+/// mints a fresh in-memory self-signed certificate at bind time that is never
+/// persisted and rotates on every restart.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum QuicServerIdentity {
+    /// Generate a fresh self-signed certificate valid for `localhost` in
+    /// memory at bind time. Nothing is written to disk and the identity
+    /// changes on every bind.
+    Ephemeral,
+    /// Load the PEM-encoded certificate chain and private key from the given
+    /// paths. The chain's first certificate is the leaf presented for pinning.
+    PemFiles {
+        /// Path to the PEM certificate chain (leaf first).
+        cert: PathBuf,
+        /// Path to the PEM private key (PKCS#8, PKCS#1, or SEC1).
+        key: PathBuf,
+    },
+}
+
+impl QuicServerIdentity {
+    /// Materializes the leaf certificate, the full chain, and the private key
+    /// for this identity.
+    ///
+    /// For [`QuicServerIdentity::Ephemeral`] this generates a self-signed
+    /// certificate via `rcgen`. For [`QuicServerIdentity::PemFiles`] it reads
+    /// and parses the operator-supplied PEM files, surfacing an
+    /// [`io::Error`] when a file is missing, unreadable, or contains no
+    /// certificate.
+    fn materialize(
+        &self,
+    ) -> io::Result<(
+        CertificateDer<'static>,
+        Vec<CertificateDer<'static>>,
+        PrivateKeyDer<'static>,
+    )> {
+        match self {
+            Self::Ephemeral => {
+                let issued = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])
+                    .map_err(io_err)?;
+                let certificate = issued.cert.der().clone();
+                let key = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(
+                    issued.signing_key.serialize_der(),
+                ));
+                Ok((certificate.clone(), vec![certificate], key))
+            }
+            Self::PemFiles { cert, key } => {
+                let chain: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(cert)
+                    .map_err(io_err)?
+                    .collect::<Result<_, _>>()
+                    .map_err(io_err)?;
+                let leaf = chain
+                    .first()
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("no certificate found in {}", cert.display()),
+                        )
+                    })?
+                    .clone();
+                let key = PrivateKeyDer::from_pem_file(key).map_err(io_err)?;
+                Ok((leaf, chain, key))
+            }
+        }
+    }
+}
+
 /// QUIC listener: binds a UDP socket, generates a self-signed certificate,
 /// and accepts one blocking stream for its single incoming connection.
 pub struct QuicAcceptor {
@@ -260,17 +331,34 @@ pub struct QuicAcceptor {
 impl QuicAcceptor {
     /// Binds a QUIC server endpoint on `addr` with a fresh self-signed
     /// certificate valid for `localhost`.
+    ///
+    /// Convenience wrapper over [`QuicAcceptor::from_socket`] that binds a
+    /// plain [`UdpSocket`] to `addr` and presents an ephemeral in-memory
+    /// certificate. Callers that need dual-stack isolation
+    /// (`IPV6_V6ONLY`) or an operator-supplied certificate build the socket
+    /// themselves and call [`QuicAcceptor::from_socket`].
     pub fn bind(addr: SocketAddr) -> io::Result<Self> {
-        let issued =
-            rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).map_err(io_err)?;
-        let certificate = issued.cert.der().clone();
-        let key = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(issued.signing_key.serialize_der()));
+        let socket = UdpSocket::bind(addr)?;
+        Self::from_socket(socket, &QuicServerIdentity::Ephemeral)
+    }
+
+    /// Wraps an already-bound `socket` in a QUIC server endpoint presenting
+    /// the certificate selected by `identity`.
+    ///
+    /// The caller owns the UDP socket, so it also owns every socket option
+    /// that must be set before `bind(2)` - notably `IPV6_V6ONLY`, which the
+    /// daemon sets on its IPv6 listener so a dual-stack QUIC bind does not
+    /// collide with the paired IPv4 socket (mirrors the TCP listener's
+    /// `set_only_v6(true)`). This crate deliberately keeps that policy in the
+    /// caller so it stays identical to the TCP path.
+    pub fn from_socket(socket: UdpSocket, identity: &QuicServerIdentity) -> io::Result<Self> {
+        let (certificate, chain, key) = identity.materialize()?;
 
         let mut server_crypto = rustls::ServerConfig::builder_with_provider(ring_provider())
             .with_protocol_versions(&[&rustls::version::TLS13])
             .map_err(io_err)?
             .with_no_client_auth()
-            .with_single_cert(vec![certificate.clone()], key)
+            .with_single_cert(chain, key)
             .map_err(io_err)?;
         server_crypto.alpn_protocols = vec![ALPN_RSYNC.to_vec()];
 
@@ -278,7 +366,6 @@ impl QuicAcceptor {
             QuicServerConfig::try_from(server_crypto).map_err(io_err)?,
         ));
 
-        let socket = UdpSocket::bind(addr)?;
         let local = socket.local_addr()?;
         // allow_mtud = false: a std UdpSocket cannot set the don't-fragment
         // bit, so MTU discovery probes could be silently fragmented.
@@ -705,5 +792,116 @@ mod tests {
         stream.close();
 
         server.join().expect("server thread");
+    }
+
+    /// Drives one `ping`/`pong` round trip against `acceptor`, pinning the
+    /// client to `cert`. Proves the acceptor's presented certificate is the
+    /// one under test and the byte pipe works end to end.
+    fn round_trip_pinned(acceptor: QuicAcceptor, cert: CertificateDer<'static>) {
+        let addr = acceptor.local_addr().expect("local addr");
+        let server = thread::spawn(move || {
+            let mut stream = acceptor.accept().expect("accept");
+            let mut buf = [0u8; 4];
+            stream.read_exact(&mut buf).expect("read");
+            assert_eq!(&buf, b"ping");
+            stream.write_all(b"pong").expect("write");
+            stream.finish().expect("finish");
+        });
+
+        let connector = QuicConnector::new(&cert).expect("build connector");
+        let mut stream = connector.connect(addr, "localhost").expect("connect");
+        stream.write_all(b"ping").expect("write");
+        stream.finish().expect("finish");
+        let mut reply = [0u8; 4];
+        stream.read_exact(&mut reply).expect("read reply");
+        assert_eq!(&reply, b"pong");
+        stream.close();
+        server.join().expect("server thread");
+    }
+
+    /// `from_socket` with an ephemeral identity binds a caller-owned UDP socket
+    /// and serves a round trip - the identity-parameterized path is
+    /// behaviorally identical to the historical `bind` helper.
+    #[test]
+    fn from_socket_ephemeral_binds_and_round_trips() {
+        let socket = UdpSocket::bind("127.0.0.1:0").expect("udp bind");
+        let acceptor = QuicAcceptor::from_socket(socket, &QuicServerIdentity::Ephemeral)
+            .expect("bind ephemeral");
+        let cert = acceptor.certificate().clone().into_owned();
+        round_trip_pinned(acceptor, cert);
+    }
+
+    /// Wraps DER bytes in a PEM block. The workspace builds `rcgen` without its
+    /// `pem` feature, so the test encodes the block itself: base64 (64-column
+    /// wrapped) between the standard `-----BEGIN/END <label>-----` markers.
+    fn der_to_pem(label: &str, der: &[u8]) -> String {
+        use base64::Engine as _;
+        let body = base64::engine::general_purpose::STANDARD.encode(der);
+        let mut out = format!("-----BEGIN {label}-----\n");
+        for chunk in body.as_bytes().chunks(64) {
+            out.push_str(std::str::from_utf8(chunk).expect("base64 is ascii"));
+            out.push('\n');
+        }
+        out.push_str(&format!("-----END {label}-----\n"));
+        out
+    }
+
+    /// `from_socket` with a `PemFiles` identity presents the operator-supplied
+    /// certificate verbatim: the listener's leaf cert equals the one on disk
+    /// and a client pinned to it completes a round trip. Encodes WHY Files
+    /// identity matters - the daemon `quic cert file` / `quic key file`
+    /// directives must yield a stable, on-disk identity, not a fresh ephemeral
+    /// one.
+    #[test]
+    fn from_socket_pem_files_presents_configured_cert() {
+        let issued = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])
+            .expect("generate cert");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        std::fs::write(
+            &cert_path,
+            der_to_pem("CERTIFICATE", issued.cert.der().as_ref()),
+        )
+        .expect("write cert pem");
+        std::fs::write(
+            &key_path,
+            der_to_pem("PRIVATE KEY", &issued.signing_key.serialize_der()),
+        )
+        .expect("write key pem");
+        let expected = issued.cert.der().clone();
+
+        let socket = UdpSocket::bind("127.0.0.1:0").expect("udp bind");
+        let acceptor = QuicAcceptor::from_socket(
+            socket,
+            &QuicServerIdentity::PemFiles {
+                cert: cert_path,
+                key: key_path,
+            },
+        )
+        .expect("bind pem files");
+        assert_eq!(
+            acceptor.certificate(),
+            &expected,
+            "listener must present the configured leaf certificate"
+        );
+        round_trip_pinned(acceptor, expected);
+    }
+
+    /// A `PemFiles` identity pointing at a missing certificate surfaces the
+    /// file error instead of silently falling back to an ephemeral identity.
+    #[test]
+    fn from_socket_pem_files_missing_cert_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = UdpSocket::bind("127.0.0.1:0").expect("udp bind");
+        let err = QuicAcceptor::from_socket(
+            socket,
+            &QuicServerIdentity::PemFiles {
+                cert: dir.path().join("absent-cert.pem"),
+                key: dir.path().join("absent-key.pem"),
+            },
+        )
+        .expect_err("a missing certificate file must fail the bind");
+        let _ = err;
     }
 }


### PR DESCRIPTION
## Summary

Binds the daemon's QUIC/UDP listener alongside the existing TCP listener,
mirroring the TCP bind pipeline. This is the listener-binding step; the
`accept()` -> session handoff is a separate follow-up (a clear seam is left:
the bound acceptors are held ready for it).

## What changed

- **`rsync_io`**: `QuicAcceptor::from_socket(UdpSocket, &QuicServerIdentity)`.
  The caller owns the UDP socket (and its socket options), and the new
  `QuicServerIdentity` selects the presented certificate: `Ephemeral` mints a
  fresh in-memory self-signed cert at bind time (the prior behaviour), or
  `PemFiles { cert, key }` loads an operator-supplied PEM certificate chain and
  private key verbatim. `QuicAcceptor::bind` is unchanged - it now delegates to
  `from_socket` with `Ephemeral`.
- **`daemon`** (`bind_quic_listeners_per_family`): the datagram sibling of
  `bind_listeners_per_family`. It reuses the same `resolve_bind_addresses`
  helper, so QUIC binds the identical dual-stack, IPv6-first ordered set as TCP,
  and applies the same per-family tolerance - a warning-and-continue when one
  family fails, an error only when zero families bind. The IPv6 UDP socket sets
  `IPV6_V6ONLY` (via `socket2`, matching the TCP listener's `set_only_v6`) so the
  paired v4/v6 sockets do not collide.
- The resolved `QuicIdentity` (cert/key files vs. ephemeral) is mapped onto
  `QuicServerIdentity` and threaded into the acceptor. The bound acceptors are
  held next to the TCP listeners for the whole daemon lifetime; driving accepted
  QUIC streams into sessions is the next step.
- Wired into the accept setup while `CAP_NET_BIND_SERVICE` is still held (the
  default port 873 is privileged), and only when QUIC is configured. Until the
  dedicated `quic = yes` enable directive lands, "configured" means any QUIC
  directive is present (`quic_listener_enabled()`); that accessor is the single
  seam to consult the enable directive later.

## Scope / safety

- Feature-gated behind `quic` and Unix-only. Default and non-`quic` builds pull
  no new dependencies and are byte-identical; a daemon with no QUIC directives
  never opens a UDP socket, even under `--all-features`.

## Tests

- `rsync_io`: `from_socket` binds and round-trips with both `Ephemeral` and
  `PemFiles` identities; the `PemFiles` listener presents the on-disk leaf
  certificate; a missing cert file fails the bind (no silent ephemeral
  fallback).
- `daemon`: dual-stack loopback binds one acceptor per family; the IPv6->IPv4
  per-family fallback; single-family error propagation; the identity mapping for
  both variants; and `quic_listener_enabled` / effective-port resolution.

## Verification (x86_64 Linux)

- `cargo build --bin oc-rsync` (default): pass
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean
- default (no-quic) clippy on `daemon` + `rsync_io`: clean
- `cargo nextest run -p daemon --all-features -E 'test(quic) or test(bind) or test(listener)'`: 69 passed
- `cargo fmt --all -- --check`: clean
