### PR TITLE
feat(transfer): feed batch header (protocol/seed/compat) into local-replay receiver setup [batch approach-A step 2]

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -526,6 +526,94 @@ impl ReceiverContext {
         }
     }
 
+    /// Builds a receiver context primed to replay a recorded batch file,
+    /// seeding its negotiated protocol state from the batch header instead of a
+    /// live handshake.
+    ///
+    /// Upstream's `--read-batch` never negotiates with a peer: `setup_protocol()`
+    /// reads the recorded protocol version, compat flags, and checksum seed back
+    /// from the batch fd - the same three values `start_write_batch()` teed at
+    /// capture - and pins them for the whole replay. This constructor mirrors
+    /// that by translating the already-parsed `BatchHeader`
+    /// into the negotiated state [`new`](Self::new) expects, reusing the batch
+    /// reader's single header parse as the one source of truth.
+    ///
+    /// The returned context drives via
+    /// [`run_local_replay`](Self::run_local_replay): its basis/signature
+    /// computation reuses the batch's `checksum_seed`, its file-list decode uses
+    /// the pinned protocol and compat flags, and nothing is negotiated on any
+    /// wire.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`io::ErrorKind::InvalidData`](std::io::ErrorKind::InvalidData)
+    /// when the header carries a protocol version outside the supported range,
+    /// or an FSM error if the initial pipeline transition is rejected.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `compat.c:604,740` - under `read_batch`, `setup_protocol()` reads
+    ///   `remote_protocol` and `compat_flags` from the batch fd rather than
+    ///   exchanging them with a peer.
+    /// - `io.c:2521-2524` - `start_write_batch()` wrote those same values
+    ///   (protocol, compat varint for proto >= 30, checksum seed) into the
+    ///   header at capture.
+    pub fn for_batch_replay(
+        header: &engine::batch::BatchHeader,
+        config: ServerConfig,
+    ) -> std::io::Result<Self> {
+        // upstream: compat.c:604 remote_protocol = read_int(f_in) - the batch
+        // pins the protocol it was recorded under; reject anything the wire
+        // types cannot represent or the negotiator does not support.
+        let protocol = u8::try_from(header.protocol_version)
+            .ok()
+            .and_then(|raw| ProtocolVersion::try_from(raw).ok())
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "batch header carries unsupported protocol version {}",
+                        header.protocol_version
+                    ),
+                )
+            })?;
+
+        // upstream: compat.c:740 compat_flags = read_varint(f_in) - recorded
+        // only for protocol >= 30, which is exactly when the header carries the
+        // varint (io.c:2522-2523). `None` below 30 leaves compat state absent,
+        // matching a legacy negotiation.
+        let compat_flags = header
+            .compat_flags
+            .map(|bits| CompatibilityFlags::from_bits(bits as u32));
+
+        let handshake = HandshakeResult {
+            protocol,
+            buffered: Vec::new(),
+            // The batch already carries the recorded compat exchange; replay
+            // exchanges nothing.
+            compat_exchanged: true,
+            client_args: None,
+            io_timeout: None,
+            // Algorithm negotiation is a live-peer exchange with no recorded
+            // form; the seed alone pins the checksum family
+            // (get_checksum_algorithm falls back to the protocol default).
+            negotiated_algorithms: None,
+            compat_flags,
+            // upstream: io.c:2524 write_int(batch_fd, checksum_seed) - the seed
+            // the basis/signature checksums must reuse on replay.
+            checksum_seed: header.checksum_seed,
+        };
+
+        // Mirror the network receiver's FSM position at construction: the
+        // handshake is complete, so advance to FilterExchange (lib.rs:713-716).
+        let mut pipeline = TransferPipeline::new(crate::role::ServerRole::Receiver);
+        pipeline
+            .advance_to(crate::transfer_state::TransferPhase::FilterExchange)
+            .map_err(crate::fsm_error)?;
+
+        Ok(Self::new(&handshake, config, pipeline))
+    }
+
     /// Creates a receiver context for unit testing with a default pipeline.
     ///
     /// The pipeline is initialized at `FilterExchange`, matching the state

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -673,6 +673,159 @@ mod tests {
         );
     }
 
+    /// Builds a client-mode receiver `ServerConfig` at `proto`, the shape a
+    /// `--read-batch` client hands to [`ReceiverContext::for_batch_replay`].
+    fn replay_config(proto: u8) -> ServerConfig {
+        let mut config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(proto).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![std::ffi::OsString::from(".")],
+            ..Default::default()
+        };
+        config.connection.client_mode = true;
+        config
+    }
+
+    /// [`for_batch_replay`](ReceiverContext::for_batch_replay) pins the
+    /// receiver's negotiated state from the batch header's protocol, checksum
+    /// seed, and compat varint - not from a live handshake.
+    ///
+    /// WHY: this is the A2 seam. Upstream's `--read-batch` skips negotiation and
+    /// reads the recorded protocol/compat/seed back from the batch fd
+    /// (`compat.c` `setup_protocol()` under `read_batch`; the values
+    /// `io.c:2521-2524` teed at capture). The replay receiver must run against
+    /// the SAME protocol/seed/compat the batch was recorded under or its
+    /// file-list decode and basis checksums desync. The header is round-tripped
+    /// through the batch reader's own [`BatchHeader::read_from`] so the parse is
+    /// the single source of truth, then asserted on the built context: the seed
+    /// lands in the field every basis/signature site reads
+    /// (context.rs `build_flist_reader` / `build_basis_file_config`), the
+    /// protocol is pinned, and each compat bit is applied.
+    #[test]
+    fn for_batch_replay_pins_protocol_seed_and_compat_from_header() {
+        use engine::batch::BatchHeader;
+        use protocol::CompatibilityFlags;
+
+        // A proto-32 batch recorded with two compat bits and a distinctive seed.
+        let bits =
+            CompatibilityFlags::INC_RECURSE.bits() | CompatibilityFlags::SYMLINK_TIMES.bits();
+        let seed = 0x0BAD_F00D_u32 as i32;
+        let mut written = BatchHeader::new(32, seed);
+        written.compat_flags = Some(bits as i32);
+
+        // Recorded, then parsed by the batch reader (the one source of truth).
+        let mut recorded = Vec::new();
+        written.write_to(&mut recorded).unwrap();
+        let header = BatchHeader::read_from(&mut Cursor::new(recorded)).unwrap();
+
+        let ctx = ReceiverContext::for_batch_replay(&header, replay_config(32))
+            .expect("a supported batch header must build a replay context");
+
+        assert_eq!(
+            ctx.protocol(),
+            ProtocolVersion::try_from(32u8).unwrap(),
+            "the header's protocol version must pin the receiver's protocol"
+        );
+        assert_eq!(
+            ctx.checksum_seed, seed,
+            "the header's checksum seed must seed the receiver's basis checksums"
+        );
+        let compat = ctx
+            .compat_flags()
+            .expect("proto >= 30 records a compat varint");
+        assert!(
+            compat.contains(CompatibilityFlags::INC_RECURSE)
+                && compat.contains(CompatibilityFlags::SYMLINK_TIMES),
+            "every recorded compat bit must be applied to the replay receiver"
+        );
+    }
+
+    /// A batch recorded below protocol 30 carries no compat varint, so the
+    /// replay receiver's compat state is absent - never a phantom zero.
+    ///
+    /// WHY: upstream writes the compat varint only for protocol >= 30
+    /// (`io.c:2522-2523`), and [`BatchHeader::read_from`] mirrors that by
+    /// reading it only then. `for_batch_replay` must carry that `None` through
+    /// (leaving `compat_flags()` `None`, exactly as a legacy live negotiation
+    /// would) while still pinning the recorded protocol and seed.
+    #[test]
+    fn for_batch_replay_below_protocol_30_has_no_compat() {
+        use engine::batch::BatchHeader;
+
+        let seed = 0x0051_5EED_i32;
+        let written = BatchHeader::new(29, seed);
+        assert!(
+            written.compat_flags.is_none(),
+            "a proto-29 header records no compat varint"
+        );
+
+        let mut recorded = Vec::new();
+        written.write_to(&mut recorded).unwrap();
+        let header = BatchHeader::read_from(&mut Cursor::new(recorded)).unwrap();
+
+        let ctx = ReceiverContext::for_batch_replay(&header, replay_config(29))
+            .expect("a proto-29 batch header must build a replay context");
+
+        assert_eq!(ctx.protocol(), ProtocolVersion::try_from(29u8).unwrap());
+        assert_eq!(ctx.checksum_seed, seed);
+        assert!(
+            ctx.compat_flags().is_none(),
+            "no compat varint below proto 30 must leave compat state absent"
+        );
+    }
+
+    /// A context built by `for_batch_replay` drives the real receiver to a clean
+    /// finish off the recorded stream, proving the header-seeded protocol
+    /// actually feeds a live receive - not just the accessors.
+    ///
+    /// WHY: A2 is only wired if the seeded state survives all the way through a
+    /// real drive. The header is parsed off the front of the recorded stream and
+    /// the remaining bytes (an empty file list, the minimal complete batch body)
+    /// stream straight into [`run_local_replay`](ReceiverContext::run_local_replay)
+    /// as `f_in` - exactly the A3 shape, one parse feeding both the setup and the
+    /// drive. A green empty-list finish through `finish_empty_client_flist`
+    /// confirms the pinned protocol decoded the recorded flist, unmultiplexed.
+    #[test]
+    fn for_batch_replay_drives_recorded_stream_to_completion() {
+        use engine::batch::BatchHeader;
+
+        let seed = 0x1234_5678_i32;
+        let written = BatchHeader::new(32, seed);
+
+        // Header followed by an empty recorded file list, in one stream.
+        let mut recorded = Vec::new();
+        written.write_to(&mut recorded).unwrap();
+        FileListWriter::new(ProtocolVersion::try_from(32u8).unwrap())
+            .write_end(&mut recorded, None)
+            .unwrap();
+
+        // The batch reader consumes the header; the same cursor then feeds the
+        // flist body to the receiver.
+        let mut cursor = Cursor::new(recorded);
+        let header = BatchHeader::read_from(&mut cursor).unwrap();
+        let mut ctx = ReceiverContext::for_batch_replay(&header, replay_config(32))
+            .expect("a supported batch header must build a replay context");
+
+        assert_eq!(ctx.checksum_seed, seed, "the seed must be pinned pre-drive");
+
+        let stats = ctx
+            .run_local_replay(cursor, None)
+            .expect("the header-seeded receiver must replay to completion");
+
+        assert_eq!(stats.files_listed, 0);
+        assert_eq!(stats.files_transferred, 0);
+        assert_eq!(
+            ctx.protocol(),
+            ProtocolVersion::try_from(32u8).unwrap(),
+            "the pinned protocol must survive the drive"
+        );
+        assert!(
+            !ctx.should_activate_input_multiplex(),
+            "a header-seeded batch f_in must stay Plain (upstream !read_batch)"
+        );
+    }
+
     /// Verifies the delayed rename sweep moves files from staging paths to
     /// final destinations, matching upstream `receiver.c:422-450`.
     #[test]


### PR DESCRIPTION
## Summary

Step 2 of routing `--read-batch` through the real receiver (approach A). Builds on the merged step 1 (#7139), which added the receiver's `run_local_replay` input mode (`DiscardSink` + `local_replay` flag). This step feeds the batch's pinned negotiated state into receiver setup so the local generator runs against the SAME protocol, checksum seed, and compat flags the batch was recorded under.

Adds `ReceiverContext::for_batch_replay(header, config)`, which seeds the receiver's negotiated state from an already-parsed batch header instead of a live handshake:

- **protocol** pinned from `header.protocol_version` (rejected as `InvalidData` if outside the supported range),
- **compat flags** applied from the header's varint (present only for protocol >= 30, `None` below it),
- **checksum seed** carried from `header.checksum_seed` into the field every basis/signature site reads.

The constructor translates the batch reader's single `BatchHeader` parse into a `HandshakeResult` and hands it to the ordinary receiver setup, so a subsequent `run_local_replay` drives basis/signature computation under the exact protocol/seed/compat the batch pins. The batch reader's header parse stays the one source of truth (no re-parsing).

## Upstream reference

On `--read-batch`, upstream does not negotiate with a live peer: `setup_protocol()` reads the recorded protocol version, compat flags, and checksum seed back from the batch fd rather than exchanging them (`compat.c:604,740`). Those are the same three values `start_write_batch()` teed into the header at capture (`io.c:2521-2524`). This constructor mirrors that read-batch setup path.

## Scope / what this does NOT do

- **No dispatch reroute.** `replay_batch` still calls the native replay engine; wiring `for_batch_replay` + `run_local_replay` into the dispatch is the next step. The seam is construction-only.
- **No network-path change.** The new constructor is only reachable from the batch-replay path; the wire path is byte-identical (`local_replay` stays `false` on every network transfer).

## Tests

Unit-level, driven with a `Cursor` over a synthetic header + flist round-tripped through the batch reader's own `BatchHeader::read_from` (the source of truth):

- `for_batch_replay_pins_protocol_seed_and_compat_from_header` - proto 32 with two compat bits and a distinctive seed; asserts protocol pinned, seed pinned, each compat bit applied.
- `for_batch_replay_below_protocol_30_has_no_compat` - proto 29 records no compat varint; asserts compat state stays absent while protocol and seed are still pinned.
- `for_batch_replay_drives_recorded_stream_to_completion` - header parsed off the front of the stream, remaining flist body fed straight into `run_local_replay`; the header-seeded receiver replays an empty list to a clean finish, unmultiplexed.

Verified on x86_64 Linux: `cargo build --bin oc-rsync` (RC 0), `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` (RC 0), and the targeted `transfer` + `batch` nextest set (replay / local_replay / header) green.
