### PR TITLE
feat(engine): DBR-G7 feed governor pressure into buffer-pool maybe_resize (conservative-min)

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/pool/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool/mod.rs
@@ -34,6 +34,7 @@ use super::byte_budget::ByteBudget;
 use super::memory_cap::MemoryCap;
 use super::pressure::PressureTracker;
 use super::throughput::ThroughputTracker;
+use crate::throughput::ActuatorHandle;
 
 pub use stats::BufferPoolStats;
 
@@ -181,6 +182,15 @@ pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {
     /// The two loops observe orthogonal signals and compose without
     /// interference.
     buffer_controller: Option<AdaptiveBufferController>,
+    /// Optional subscription to the throughput governor's buffer-pool ceiling.
+    ///
+    /// When present and the governor has published a ceiling, adaptive resizing
+    /// composes it with the local [`PressureTracker`] via conservative-min: the
+    /// pool never grows more aggressively than the governor permits. `None` (the
+    /// default) leaves resizing on local pressure alone, byte-identical to the
+    /// pre-governor path. Wired via
+    /// [`with_governor_actuator`](Self::with_governor_actuator).
+    governor: Option<ActuatorHandle>,
     /// Cumulative count of acquire operations that found a buffer in the
     /// thread-local cache or central pool (no fresh allocation needed).
     ///
@@ -230,6 +240,7 @@ impl BufferPool {
             throughput: None,
             pressure: None,
             buffer_controller: None,
+            governor: None,
             total_hits: AtomicU64::new(0),
             total_misses: AtomicU64::new(0),
             total_growths: AtomicU64::new(0),
@@ -257,6 +268,7 @@ impl BufferPool {
             throughput: None,
             pressure: None,
             buffer_controller: None,
+            governor: None,
             total_hits: AtomicU64::new(0),
             total_misses: AtomicU64::new(0),
             total_growths: AtomicU64::new(0),
@@ -289,6 +301,7 @@ impl<A: BufferAllocator> BufferPool<A> {
             throughput: None,
             pressure: None,
             buffer_controller: None,
+            governor: None,
             total_hits: AtomicU64::new(0),
             total_misses: AtomicU64::new(0),
             total_growths: AtomicU64::new(0),
@@ -392,6 +405,27 @@ impl<A: BufferAllocator> BufferPool<A> {
     #[must_use]
     pub fn with_adaptive_resizing(mut self) -> Self {
         self.pressure = Some(PressureTracker::new());
+        self
+    }
+
+    /// Subscribes adaptive resizing to the throughput governor's buffer-pool
+    /// ceiling.
+    ///
+    /// Once subscribed, [`maybe_resize`](Self::maybe_resize) composes the
+    /// governor's published ceiling with the local [`PressureTracker`] via
+    /// conservative-min: the pool grows to `min(local_target, governor_ceiling)`
+    /// and so never grows more aggressively than the governor permits. When the
+    /// governor publishes no ceiling - always the case for an inert
+    /// ([`GovernorMode::Off`](crate::throughput::GovernorMode)) handle - resizing
+    /// falls back to local pressure alone, byte-identical to the unsubscribed
+    /// path.
+    ///
+    /// Independent of [`with_adaptive_resizing`](Self::with_adaptive_resizing):
+    /// the ceiling only takes effect once adaptive resizing is also enabled,
+    /// since it is the local resizer that reads it.
+    #[must_use]
+    pub fn with_governor_actuator(mut self, actuator: ActuatorHandle) -> Self {
+        self.governor = Some(actuator);
         self
     }
 

--- a/crates/engine/src/local_copy/buffer_pool/pool/resize.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool/resize.rs
@@ -4,6 +4,15 @@
 //! hit/miss pressure and grows or shrinks the pool's soft capacity,
 //! deallocating excess buffers on shrink. Capacity updates are atomic
 //! stores and queue mutations are lock-free pops.
+//!
+//! When a throughput-governor actuator is subscribed
+//! ([`with_governor_actuator`](BufferPool::with_governor_actuator)), the local
+//! grow target is composed with the governor's published ceiling via
+//! **conservative-min** before it is applied: the pool grows to
+//! `min(local_target, governor_ceiling)` and so never grows more aggressively
+//! than either the local pressure tracker or the governor wants. The two
+//! sources are folded into a single [`ResizeAction`] before any atomic store,
+//! so each evaluation still performs at most one resize.
 
 use std::sync::atomic::Ordering;
 
@@ -13,6 +22,12 @@ use super::BufferPool;
 
 impl<A: BufferAllocator> BufferPool<A> {
     /// Evaluates pressure statistics and applies resize if warranted.
+    ///
+    /// The local [`PressureTracker`] recommendation is composed with the
+    /// governor's buffer-pool ceiling by
+    /// [`compose_with_governor`](Self::compose_with_governor) into a single
+    /// action, so a subscribed governor and the local tracker never each apply
+    /// their own resize in one pass.
     ///
     /// Capacity updates are atomic stores; the queue mutations on shrink
     /// are lock-free [`ArrayQueue::pop`](crossbeam_queue::ArrayQueue::pop) calls.
@@ -27,7 +42,8 @@ impl<A: BufferAllocator> BufferPool<A> {
         let current_capacity = self.soft_capacity.load(Ordering::Relaxed);
         let available = self.buffers.len();
 
-        match pressure.evaluate(current_capacity, available) {
+        let local = pressure.evaluate(current_capacity, available);
+        match self.compose_with_governor(local, current_capacity) {
             ResizeAction::Hold => {}
             ResizeAction::Grow(new_capacity) => {
                 self.soft_capacity.store(new_capacity, Ordering::Relaxed);
@@ -50,5 +66,41 @@ impl<A: BufferAllocator> BufferPool<A> {
                 }
             }
         }
+    }
+
+    /// Composes the local resize recommendation with the governor's published
+    /// buffer-pool ceiling via conservative-min.
+    ///
+    /// With no subscribed actuator, or when the governor publishes no ceiling,
+    /// the local action passes through unchanged - the byte-identical
+    /// pre-governor behaviour. Otherwise the ceiling only restrains growth: a
+    /// local [`Grow`](ResizeAction::Grow) target is capped at the ceiling
+    /// (`min(target, ceiling)`) and demoted to [`Hold`](ResizeAction::Hold) if
+    /// that leaves nothing above the current capacity, so the governor can never
+    /// push the pool larger than local demand nor force an extra shrink beyond
+    /// what the local tracker already wants.
+    fn compose_with_governor(&self, local: ResizeAction, current_capacity: usize) -> ResizeAction {
+        let Some(ceiling) = self.governor_ceiling() else {
+            return local;
+        };
+        match local {
+            ResizeAction::Grow(target) => {
+                let capped = target.min(ceiling).max(current_capacity);
+                if capped > current_capacity {
+                    ResizeAction::Grow(capped)
+                } else {
+                    ResizeAction::Hold
+                }
+            }
+            other => other,
+        }
+    }
+
+    /// The governor's current buffer-pool ceiling, or `None` when no actuator is
+    /// subscribed or none is published.
+    fn governor_ceiling(&self) -> Option<usize> {
+        self.governor
+            .as_ref()
+            .and_then(|actuator| actuator.buffer_pool_ceiling())
     }
 }

--- a/crates/engine/src/local_copy/buffer_pool/pool/resize.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool/resize.rs
@@ -79,7 +79,11 @@ impl<A: BufferAllocator> BufferPool<A> {
     /// that leaves nothing above the current capacity, so the governor can never
     /// push the pool larger than local demand nor force an extra shrink beyond
     /// what the local tracker already wants.
-    fn compose_with_governor(&self, local: ResizeAction, current_capacity: usize) -> ResizeAction {
+    pub(in super::super) fn compose_with_governor(
+        &self,
+        local: ResizeAction,
+        current_capacity: usize,
+    ) -> ResizeAction {
         let Some(ceiling) = self.governor_ceiling() else {
             return local;
         };

--- a/crates/engine/src/local_copy/buffer_pool/tests/governor_actuator.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests/governor_actuator.rs
@@ -1,0 +1,236 @@
+//! Composition of adaptive resizing with the throughput-governor ceiling.
+//!
+//! The buffer pool subscribes to the governor's buffer-pool actuator signal and
+//! folds it with the local pressure tracker via conservative-min. These tests
+//! pin the composition truth table, the byte-identical governor-off fallback,
+//! the single-action ("no double-resize") guarantee, and grow/shrink under
+//! concurrent acquire/release.
+
+use super::super::pressure::ResizeAction;
+use super::super::*;
+use crate::throughput::{Governor, GovernorConfig, GovernorHandle, GovernorMode};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+/// An Observe governor with a ceiling published, plus the pool subscribed to it.
+fn pool_with_ceiling(start_cap: usize, ceiling: usize) -> (BufferPool, GovernorHandle) {
+    let gov = Governor::spawn(GovernorConfig::new(GovernorMode::Observe));
+    gov.publish_buffer_pool_ceiling(Some(ceiling));
+    let pool = BufferPool::new(start_cap)
+        .with_adaptive_resizing()
+        .with_governor_actuator(gov.subscribe_actuator());
+    (pool, gov)
+}
+
+// --- composition truth table (pure, deterministic) --------------------------
+
+#[test]
+fn no_actuator_passes_local_action_through_unchanged() {
+    let pool = BufferPool::new(2).with_adaptive_resizing();
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Grow(64), 2),
+        ResizeAction::Grow(64)
+    );
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Shrink(2), 8),
+        ResizeAction::Shrink(2)
+    );
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Hold, 4),
+        ResizeAction::Hold
+    );
+}
+
+#[test]
+fn inert_governor_handle_is_local_only() {
+    // An Off governor hands out an inert actuator: composition must be identical
+    // to having no actuator at all - the byte-identical disabled path.
+    let gov = Governor::spawn(GovernorConfig::new(GovernorMode::Off));
+    let pool = BufferPool::new(2)
+        .with_adaptive_resizing()
+        .with_governor_actuator(gov.subscribe_actuator());
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Grow(64), 2),
+        ResizeAction::Grow(64)
+    );
+}
+
+#[test]
+fn active_handle_without_a_published_ceiling_is_local_only() {
+    // Subscribed to an Observe governor, but nothing published yet.
+    let gov = Governor::spawn(GovernorConfig::new(GovernorMode::Observe));
+    let pool = BufferPool::new(2)
+        .with_adaptive_resizing()
+        .with_governor_actuator(gov.subscribe_actuator());
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Grow(64), 2),
+        ResizeAction::Grow(64)
+    );
+}
+
+#[test]
+fn conservative_min_caps_local_grow_at_the_ceiling() {
+    // Governor wants X=8, local wants Y=64 -> min is 8.
+    let (pool, gov) = pool_with_ceiling(2, 8);
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Grow(64), 2),
+        ResizeAction::Grow(8)
+    );
+    drop(pool);
+    drop(gov);
+}
+
+#[test]
+fn conservative_min_keeps_local_grow_when_local_is_smaller() {
+    // Governor ceiling X=64, local wants Y=4 -> min is 4 (local wins).
+    let (pool, gov) = pool_with_ceiling(2, 64);
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Grow(4), 2),
+        ResizeAction::Grow(4)
+    );
+    drop(pool);
+    drop(gov);
+}
+
+#[test]
+fn ceiling_at_or_below_current_demotes_grow_to_hold() {
+    // Ceiling below the current capacity must not force a shrink: the grow is
+    // simply demoted to Hold.
+    let (pool, gov) = pool_with_ceiling(4, 2);
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Grow(8), 4),
+        ResizeAction::Hold
+    );
+    drop(pool);
+    drop(gov);
+}
+
+#[test]
+fn governor_never_alters_shrink_or_hold() {
+    // The ceiling restrains growth only; local shrink and hold pass through.
+    let (pool, gov) = pool_with_ceiling(8, 2);
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Shrink(4), 8),
+        ResizeAction::Shrink(4)
+    );
+    assert_eq!(
+        pool.compose_with_governor(ResizeAction::Hold, 8),
+        ResizeAction::Hold
+    );
+    drop(pool);
+    drop(gov);
+}
+
+// --- end-to-end through the acquire path ------------------------------------
+
+#[test]
+fn adaptive_grow_is_bounded_by_the_governor_ceiling() {
+    // Cap starts at 2; local pressure alone would double repeatedly, but the
+    // governor caps the pool at 4. Force sustained misses by holding buffers.
+    let (pool, gov) = pool_with_ceiling(2, 4);
+    let pool = Arc::new(pool);
+    let mut held = Vec::new();
+    for _ in 0..256 {
+        held.push(BufferPool::acquire_from(Arc::clone(&pool)));
+    }
+    let cap = pool.max_buffers();
+    assert!(cap > 2, "expected some growth, got {cap}");
+    assert!(cap <= 4, "governor ceiling must bound growth, got {cap}");
+    drop(held);
+    drop(gov);
+}
+
+#[test]
+fn single_evaluation_applies_one_capped_action_not_two() {
+    // Exactly one check interval (64 acquires, all misses) must grow the pool to
+    // min(local_double, ceiling) in a single step - never to the local double
+    // first and then a second corrective resize. Local would double 2 -> 4; the
+    // ceiling of 3 clamps the single applied action to 3.
+    let (pool, gov) = pool_with_ceiling(2, 3);
+    let pool = Arc::new(pool);
+    let held: Vec<_> = (0..64)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    assert_eq!(
+        pool.max_buffers(),
+        3,
+        "one evaluation must land exactly on the composed min"
+    );
+    drop(held);
+    drop(gov);
+}
+
+#[test]
+fn grow_and_shrink_under_concurrent_acquire_release_stays_within_bounds() {
+    // Hammer the pool from many threads with the governor active. The soft
+    // capacity must never escape [MIN, ceiling] regardless of interleaving, and
+    // no acquire/return may panic.
+    const CEILING: usize = 8;
+    let (pool, gov) = pool_with_ceiling(2, CEILING);
+    let pool = Arc::new(pool);
+    let threads = 8;
+    let barrier = Arc::new(Barrier::new(threads));
+
+    let handles: Vec<_> = (0..threads)
+        .map(|_| {
+            let pool = Arc::clone(&pool);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for i in 0..2000 {
+                    if i % 3 == 0 {
+                        // Briefly hold several buffers to spike misses (grow).
+                        let bufs: Vec<_> = (0..4)
+                            .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+                            .collect();
+                        drop(bufs);
+                    } else {
+                        // Acquire/release one at a time (hits -> idle -> shrink).
+                        let _b = BufferPool::acquire_from(Arc::clone(&pool));
+                    }
+                    let cap = pool.max_buffers();
+                    assert!(
+                        (1..=CEILING).contains(&cap),
+                        "capacity {cap} escaped [1, {CEILING}]"
+                    );
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("worker thread panicked");
+    }
+    let cap = pool.max_buffers();
+    assert!(
+        (1..=CEILING).contains(&cap),
+        "final capacity {cap} escaped [1, {CEILING}]"
+    );
+    drop(gov);
+}
+
+#[test]
+fn lowering_the_ceiling_stops_further_growth() {
+    // Grow to the initial ceiling, then lower it; subsequent evaluations must
+    // not push past the new, tighter bound.
+    let (pool, gov) = pool_with_ceiling(2, 8);
+    let pool = Arc::new(pool);
+    let warm: Vec<_> = (0..128)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    drop(warm);
+    let grown = pool.max_buffers();
+    assert!(grown > 2, "expected growth toward 8, got {grown}");
+
+    gov.publish_buffer_pool_ceiling(Some(grown));
+    let held: Vec<_> = (0..256)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    assert!(
+        pool.max_buffers() <= grown,
+        "tightened ceiling must halt growth, got {}",
+        pool.max_buffers()
+    );
+    drop(held);
+    drop(gov);
+}

--- a/crates/engine/src/local_copy/buffer_pool/tests/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests/mod.rs
@@ -11,9 +11,9 @@ mod support;
 
 mod adaptive_pool;
 mod byte_budget;
-mod governor_actuator;
 mod contention;
 mod controller;
+mod governor_actuator;
 mod memory_cap;
 mod pool_basic;
 mod telemetry;

--- a/crates/engine/src/local_copy/buffer_pool/tests/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests/mod.rs
@@ -11,6 +11,7 @@ mod support;
 
 mod adaptive_pool;
 mod byte_budget;
+mod governor_actuator;
 mod contention;
 mod controller;
 mod memory_cap;

--- a/crates/engine/src/throughput/actuator.rs
+++ b/crates/engine/src/throughput/actuator.rs
@@ -2,41 +2,121 @@
 //!
 //! In the drum-buffer-rope design the governor's Strategy phase publishes
 //! tuning signals - buffer-pool pressure, semaphore ceilings, I/O in-flight
-//! depth - that platform actuators consume through this subscription. G2 is
-//! inert: [`ActuatorHandle::inert`] is the only constructor and every query
-//! reports "no action", so subscribing changes nothing. The type exists now so
-//! consumers can wire the subscription and later steps can add real signals
-//! without changing call sites.
+//! depth - that platform actuators consume through this subscription. This
+//! module carries the **buffer-pool pressure** signal: the governor publishes a
+//! soft-capacity ceiling and the buffer pool reads it through an
+//! [`ActuatorHandle`], composing it with its local pressure tracker
+//! (conservative-min) in
+//! [`maybe_resize`](crate::local_copy::buffer_pool). The governor never touches
+//! the pool directly - it only publishes into the shared signal (Mediator).
+//!
+//! The default build stays byte-identical to the pre-governor code: an
+//! [`ActuatorHandle::inert`] handle (the one a
+//! [`GovernorMode::Off`](super::GovernorMode) governor hands out) publishes no
+//! ceiling, so every subscriber falls back to its existing static behaviour.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Sentinel meaning "the governor publishes no buffer-pool ceiling".
+///
+/// A soft capacity of zero is never a valid pool size (the adaptive resizer
+/// floors at `MIN_CAPACITY = 2`), so zero unambiguously flags an unset signal
+/// without colliding with any ceiling a producer could legitimately publish.
+const NO_CEILING: usize = 0;
+
+/// Shared buffer-pool ceiling published by the governor and read by the pool.
+///
+/// A single lock-free `AtomicUsize` behind an `Arc`: the governor thread stores
+/// the current recommendation and every actuator subscription loads it without
+/// blocking the sense loop. Cloning an [`ActuatorHandle`] shares this cell, so a
+/// ceiling published once is visible to every subscriber.
+#[derive(Debug)]
+pub(super) struct BufferCeiling(AtomicUsize);
+
+impl BufferCeiling {
+    /// Creates a shared, initially-unpublished ceiling signal.
+    pub(super) fn new() -> Arc<Self> {
+        Arc::new(Self(AtomicUsize::new(NO_CEILING)))
+    }
+
+    /// Publishes a new buffer-pool soft-capacity ceiling, or clears it.
+    ///
+    /// `None` (or a `Some(0)`, which would be an invalid pool size) clears the
+    /// signal so subscribers revert to local-only pressure. Uses `Relaxed`
+    /// ordering: the ceiling is a heuristic hint and a subscriber reading a
+    /// momentarily stale value only defers one resize decision by a window.
+    pub(super) fn publish(&self, ceiling: Option<usize>) {
+        let value = ceiling.filter(|&c| c != NO_CEILING).unwrap_or(NO_CEILING);
+        self.0.store(value, Ordering::Relaxed);
+    }
+
+    /// Loads the current ceiling, or `None` when none is published.
+    fn load(&self) -> Option<usize> {
+        match self.0.load(Ordering::Relaxed) {
+            NO_CEILING => None,
+            value => Some(value),
+        }
+    }
+}
 
 /// A subscription to governor actuator signals.
 ///
 /// Returned by
 /// [`GovernorHandle::subscribe_actuator`](super::governor::GovernorHandle::subscribe_actuator).
-/// The inert handle answers every query with the "take no action" value, so an
-/// actuator wired to it falls back to its existing static behaviour.
+/// An [`inert`](Self::inert) handle - the one an
+/// [`GovernorMode::Off`](super::GovernorMode) governor hands out - carries no
+/// signal, so an actuator wired to it falls back to its existing static
+/// behaviour. An active handle carries the shared buffer-pool ceiling the
+/// governor publishes.
 #[derive(Debug, Clone)]
 pub struct ActuatorHandle {
-    /// Reserved for the shared signal state added when real actuation lands.
-    /// A unit field keeps the struct non-exhaustive in spirit and the
-    /// constructor meaningful without exposing internals.
-    _private: (),
+    /// Shared buffer-pool ceiling, or `None` for an inert handle. The `Arc` is
+    /// shared with the governor (the writer) and every clone of this handle.
+    buffer_ceiling: Option<Arc<BufferCeiling>>,
 }
 
 impl ActuatorHandle {
-    /// Constructs the inert handle: no signals, no action.
+    /// Constructs the inert handle: no signal, no action.
     #[must_use]
     pub fn inert() -> Self {
-        Self { _private: () }
+        Self {
+            buffer_ceiling: None,
+        }
     }
 
-    /// Whether the governor is currently publishing any actuator signal.
+    /// Constructs an active handle backed by a shared buffer-pool ceiling.
     ///
-    /// Always `false` in G2. Actuators call this to decide whether to defer to
-    /// governor guidance or keep their static behaviour; a `false` answer keeps
-    /// them exactly as they are today.
+    /// Only [`GovernorHandle::subscribe_actuator`](super::governor::GovernorHandle::subscribe_actuator)
+    /// calls this, handing every subscriber a clone of the governor's own
+    /// signal cell.
+    pub(super) fn active(buffer_ceiling: Arc<BufferCeiling>) -> Self {
+        Self {
+            buffer_ceiling: Some(buffer_ceiling),
+        }
+    }
+
+    /// Whether the governor is currently publishing a buffer-pool ceiling.
+    ///
+    /// `false` for an inert handle and for an active handle before the governor
+    /// has published any ceiling. Actuators can call this to decide whether to
+    /// defer to governor guidance; a `false` answer keeps them exactly as they
+    /// are today.
     #[must_use]
     pub fn is_active(&self) -> bool {
-        false
+        self.buffer_pool_ceiling().is_some()
+    }
+
+    /// The governor's current buffer-pool soft-capacity ceiling, or `None`.
+    ///
+    /// `None` means "no governor guidance" - either an inert handle or an active
+    /// one with nothing published yet - and the buffer pool then resizes on its
+    /// local pressure alone. A `Some(ceiling)` is an upper bound the pool
+    /// composes with its local grow target via conservative-min: it never grows
+    /// more aggressively than this ceiling permits.
+    #[must_use]
+    pub fn buffer_pool_ceiling(&self) -> Option<usize> {
+        self.buffer_ceiling.as_ref().and_then(|c| c.load())
     }
 }
 
@@ -48,7 +128,42 @@ mod tests {
     fn inert_handle_reports_no_action() {
         let handle = ActuatorHandle::inert();
         assert!(!handle.is_active());
+        assert_eq!(handle.buffer_pool_ceiling(), None);
         // Cloning an inert handle is cheap and stays inert.
         assert!(!handle.clone().is_active());
+    }
+
+    #[test]
+    fn active_handle_is_inert_until_a_ceiling_is_published() {
+        let signal = BufferCeiling::new();
+        let handle = ActuatorHandle::active(Arc::clone(&signal));
+        // Wired but unpublished: still no guidance.
+        assert!(!handle.is_active());
+        assert_eq!(handle.buffer_pool_ceiling(), None);
+
+        signal.publish(Some(16));
+        assert!(handle.is_active());
+        assert_eq!(handle.buffer_pool_ceiling(), Some(16));
+    }
+
+    #[test]
+    fn published_ceiling_is_visible_across_clones() {
+        let signal = BufferCeiling::new();
+        let handle = ActuatorHandle::active(Arc::clone(&signal));
+        let clone = handle.clone();
+        signal.publish(Some(32));
+        assert_eq!(clone.buffer_pool_ceiling(), Some(32));
+    }
+
+    #[test]
+    fn publishing_none_or_zero_clears_the_signal() {
+        let signal = BufferCeiling::new();
+        let handle = ActuatorHandle::active(Arc::clone(&signal));
+        signal.publish(Some(8));
+        assert_eq!(handle.buffer_pool_ceiling(), Some(8));
+        signal.publish(None);
+        assert_eq!(handle.buffer_pool_ceiling(), None);
+        signal.publish(Some(0));
+        assert_eq!(handle.buffer_pool_ceiling(), None);
     }
 }

--- a/crates/engine/src/throughput/governor.rs
+++ b/crates/engine/src/throughput/governor.rs
@@ -24,7 +24,7 @@ use std::sync::mpsc::{self, RecvTimeoutError};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use super::actuator::ActuatorHandle;
+use super::actuator::{ActuatorHandle, BufferCeiling};
 use super::aggregate::StageAggregator;
 use super::bus::{DEFAULT_BUS_CAPACITY, SampleSink, TelemetryBus};
 use super::drum::DrumIdentifier;
@@ -181,12 +181,14 @@ impl Governor {
     pub fn spawn(config: GovernorConfig) -> GovernorHandle {
         let bus = TelemetryBus::new(config.bus_capacity);
         let snapshot = Arc::new(Snapshot::new());
+        let buffer_ceiling = BufferCeiling::new();
 
         match config.mode {
             GovernorMode::Off => GovernorHandle {
                 mode: GovernorMode::Off,
                 bus,
                 snapshot,
+                buffer_ceiling,
                 shutdown: Arc::new(AtomicBool::new(false)),
                 wake: None,
                 thread: None,
@@ -214,6 +216,7 @@ impl Governor {
                     mode: GovernorMode::Observe,
                     bus,
                     snapshot,
+                    buffer_ceiling,
                     shutdown,
                     wake: Some(wake_tx),
                     thread: Some(thread),
@@ -296,6 +299,8 @@ pub struct GovernorHandle {
     mode: GovernorMode,
     bus: Arc<TelemetryBus>,
     snapshot: Arc<Snapshot>,
+    /// Buffer-pool ceiling the governor publishes to buffer-pool actuators.
+    buffer_ceiling: Arc<BufferCeiling>,
     shutdown: Arc<AtomicBool>,
     wake: Option<mpsc::Sender<()>>,
     thread: Option<JoinHandle<()>>,
@@ -326,13 +331,35 @@ impl GovernorHandle {
 
     /// Subscribes to actuator signals.
     ///
-    /// In G2 this returns an inert [`ActuatorHandle`] that reports no tuning
-    /// action; the buffer-sizing, rope, and I/O-depth actuators attach to this
-    /// same subscription in later steps. Present now so callers can wire the
-    /// subscription without a later signature change.
+    /// An [`GovernorMode::Off`] governor hands out an inert
+    /// [`ActuatorHandle`] that reports no tuning action, so a subscribed
+    /// actuator keeps its static behaviour and the build stays byte-identical.
+    /// An [`GovernorMode::Observe`] governor hands out a handle backed by the
+    /// shared buffer-pool ceiling, so [`publish_buffer_pool_ceiling`] becomes
+    /// visible to every subscriber. The rope and I/O-depth actuators attach to
+    /// this same subscription in later steps.
+    ///
+    /// [`publish_buffer_pool_ceiling`]: GovernorHandle::publish_buffer_pool_ceiling
     #[must_use]
     pub fn subscribe_actuator(&self) -> ActuatorHandle {
-        ActuatorHandle::inert()
+        match self.mode {
+            GovernorMode::Off => ActuatorHandle::inert(),
+            GovernorMode::Observe => ActuatorHandle::active(Arc::clone(&self.buffer_ceiling)),
+        }
+    }
+
+    /// Publishes a buffer-pool soft-capacity ceiling to every subscribed
+    /// actuator, or clears it with `None`.
+    ///
+    /// The ceiling is an upper bound: a subscribed buffer pool composes it with
+    /// its local pressure tracker via conservative-min, so it can only restrain
+    /// growth, never force the pool larger than local demand wants. A `None`
+    /// clears the signal and reverts subscribers to local-only pressure.
+    ///
+    /// A no-op on an [`GovernorMode::Off`] governor, whose subscribers are inert
+    /// and never read the signal - the disabled path stays byte-identical.
+    pub fn publish_buffer_pool_ceiling(&self, ceiling: Option<usize>) {
+        self.buffer_ceiling.publish(ceiling);
     }
 
     /// Latest smoothed throughput (bytes/second) for `stage`, or `None` before
@@ -472,6 +499,36 @@ mod tests {
         wait_until(|| gov.throughput(Constraint::Compute).is_some());
         let rate = gov.throughput(Constraint::Compute).expect("folded");
         assert!((rate - 4_096_000.0).abs() < 1.0, "rate {rate}");
+        gov.shutdown();
+    }
+
+    #[test]
+    fn off_mode_subscribe_is_inert_and_publish_is_a_noop() {
+        let gov = Governor::spawn(GovernorConfig::new(GovernorMode::Off));
+        let actuator = gov.subscribe_actuator();
+        assert!(!actuator.is_active());
+        // Publishing on an off governor changes nothing an inert subscriber sees.
+        gov.publish_buffer_pool_ceiling(Some(64));
+        assert_eq!(actuator.buffer_pool_ceiling(), None);
+    }
+
+    #[test]
+    fn observe_mode_publishes_ceiling_to_subscribers() {
+        let mut gov = Governor::spawn(GovernorConfig::new(GovernorMode::Observe));
+        let actuator = gov.subscribe_actuator();
+        // Wired but unpublished: no guidance yet.
+        assert!(!actuator.is_active());
+        assert_eq!(actuator.buffer_pool_ceiling(), None);
+
+        gov.publish_buffer_pool_ceiling(Some(24));
+        assert!(actuator.is_active());
+        assert_eq!(actuator.buffer_pool_ceiling(), Some(24));
+
+        // A late subscriber sees the already-published ceiling.
+        assert_eq!(gov.subscribe_actuator().buffer_pool_ceiling(), Some(24));
+
+        gov.publish_buffer_pool_ceiling(None);
+        assert_eq!(actuator.buffer_pool_ceiling(), None);
         gov.shutdown();
     }
 


### PR DESCRIPTION
## Summary

DBR-G7: subscribe the buffer pool's adaptive resizer to the throughput
governor's buffer-pool pressure signal. `maybe_resize` now composes the local
`PressureTracker` recommendation with the governor's published soft-capacity
ceiling via **conservative-min**: the pool grows to
`min(local_target, governor_ceiling)` and never grows more aggressively than
either source wants. The two signals are folded into a single `ResizeAction`
before any atomic store, so one evaluation still applies at most one resize (no
double-resize).

Builds on DBR-G1 (governor control loop + rope) and the restored buffer-pool
resizer (`maybe_resize` + `PressureTracker`).

## Design

- The governor publishes a buffer-pool ceiling through its actuator
  subscription (`ActuatorHandle`), backed by a shared lock-free atomic. It never
  touches pool internals directly - the pool reads the signal (Mediator).
- `ActuatorHandle::inert()` (handed out by an `Off` governor) publishes nothing,
  so `buffer_pool_ceiling()` returns `None` and the pool resizes on local
  pressure alone.
- The pool subscribes opt-in via `BufferPool::with_governor_actuator`. No
  production transfer wires it yet, matching the incremental gap-by-gap
  delivery; the default build is byte-identical to the pre-governor path.

Composition semantics (`compose_with_governor`): the ceiling restrains growth
only. A local `Grow(t)` is capped at `min(t, ceiling)` and demoted to `Hold`
when that leaves nothing above the current capacity, so the governor can neither
inflate the pool beyond local demand nor force an extra shrink beyond what the
local tracker already wants. `Shrink` and `Hold` pass through unchanged.

## Default off = unchanged

With no subscribed actuator (the default) or an inert handle, the local action
passes through untouched. The existing observational-inertness differential test
is unaffected: this change adds no wire-path behaviour and is not wired into any
transfer.

## Tests

New `governor_actuator` suite plus governor/actuator unit tests cover:

- conservative-min truth table (governor X vs local Y -> min; local-smaller
  wins; ceiling <= current demotes to Hold; shrink/hold untouched);
- governor-off / inert / active-but-unpublished paths == local-only;
- end-to-end grow bounded by the ceiling through the acquire path;
- single-evaluation single capped action (no double-resize);
- grow/shrink under 8-thread concurrent acquire/release staying within
  `[MIN, ceiling]`;
- lowering the ceiling halts further growth;
- signal publish/clear visibility across handle clones and late subscribers.

## Verification (x86_64 Linux)

- `cargo build --bin oc-rsync` - RC 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - RC 0
- `cargo nextest run -p engine --all-features -E 'test(buffer_pool) or test(maybe_resize) or test(pressure) or test(governor) or test(actuator)'` - 342 passed
- `cargo fmt --all -- --check` - RC 0
