### PR TITLE
fix(cli): mirror upstream popt arg-arity when parsing server args (fixes -e value leak #7153)

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -892,7 +892,10 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--existing"
             | "--ignore-non-existing"
             | "--delay-updates"
-            | "--partial-dir"
+            // NOTE: bare `--partial-dir` is POPT_ARG_STRING (value in the next
+            // argv slot) and is handled by `is_two_arg_server_long_flag`, which
+            // the operand parser consults first. Only the joined
+            // `--partial-dir=VALUE` form is matched here (via `starts_with`).
             | "--backup"
             | "--mkpath"
             | "--no-mkpath"
@@ -951,8 +954,52 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--only-write-batch=")
 }
 
+// popt argument-arity model for server-mode option tokens.
+//
+// Upstream rsync runs the SAME popt parser (`options.c` `long_options[]`) on
+// both the client and the server. Each option entry declares its arity:
+// `POPT_ARG_NONE` (boolean) or `POPT_ARG_STRING`/`POPT_ARG_INT`
+// (value-bearing). popt binds a value-bearing option's value from either the
+// same token (`--flag=v`, `-e.xxx`) or the FOLLOWING argv token
+// (`--flag v`, `-e` `.xxx`) automatically, so the value never lands in the
+// operand list. oc has no per-letter popt table - it bundles the short
+// transfer letters into one compact flag string - but the same arity rule
+// still applies: a value-bearing option whose value was emitted as a separate
+// argv slot must consume that slot, or the value leaks into `positional_args`
+// as a stray destination path. That is the recurring positional-leak class
+// (#6569, #6587, #6880, #7153). The two arms are
+// `is_two_arg_server_long_flag` (long `POPT_ARG_STRING` options) and
+// `compact_flag_string_expects_split_value` (the short `-e`).
+
+/// Short options that carry a value (popt `POPT_ARG_STRING`) and can appear as
+/// the final letter of oc's compact flag string.
+///
+/// Only `-e` qualifies. `maybe_add_e_option()` (options.c:3021) appends the
+/// `e.<caps>` capability suffix as the LAST bytes of `argstr`, and `-e` is
+/// `POPT_ARG_STRING` (options.c:823). In the joined form the `.`-payload rides
+/// inside the same token, so the compact string ends in a capability letter
+/// (never a bare `e`); only when the exec line is re-tokenized by a remote
+/// shell does the value split off, leaving the compact string ending in `e`.
+const VALUE_BEARING_COMPACT_SHORT_FLAGS: &[u8] = b"e";
+
+/// Returns `true` when the compact flag string ends in a value-bearing short
+/// option whose value was split into the following argv token.
+///
+/// See [`VALUE_BEARING_COMPACT_SHORT_FLAGS`]. In the joined form the capability
+/// suffix (`e.<caps>`, options.c:2728) rides inside the token and the string
+/// ends in a capability letter, so this returns `false` and the existing
+/// joined path is untouched. It returns `true` only for the split form
+/// (`-vve` with the `.<caps>` value as a separate token), mirroring popt
+/// binding `-e`'s `POPT_ARG_STRING` value from the next argv element.
+pub(super) fn compact_flag_string_expects_split_value(flag_string: &str) -> bool {
+    flag_string
+        .as_bytes()
+        .last()
+        .is_some_and(|byte| VALUE_BEARING_COMPACT_SHORT_FLAGS.contains(byte))
+}
+
 /// Returns `true` when the argument is a bare server-mode long flag whose
-/// value is supplied as the next positional argument.
+/// value is supplied as the next argv slot (popt `POPT_ARG_STRING` arity).
 ///
 /// Upstream `options.c::server_options()` emits a handful of path-bearing
 /// long flags as two argv slots: the flag name and the value, joined later
@@ -963,13 +1010,19 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
 /// lands the source files under `$HOME/--copy-dest/` instead of creating
 /// the dest root at `/path/to/`.
 ///
-/// `--partial-dir` is handled separately in `parse_server_long_flags`
-/// because it predates this helper and keeps its own `idx += 1` branch.
-/// All other split-form path flags route through this predicate.
+/// This is the long-option arm of the arity model documented above; the
+/// operand parser consults it BEFORE [`is_known_server_long_flag`] so the
+/// value slot is consumed rather than the flag name alone. `--partial-dir`
+/// is included here (also `POPT_ARG_STRING`), replacing its former one-off
+/// `idx += 2` special case in the operand parser. The structured
+/// `parse_server_long_flags` pass keeps its own explicit `--partial-dir` arm
+/// (it stores the value), which matches before this predicate is consulted.
 ///
 /// # Upstream Reference
 ///
+/// - `options.c:823` - `-e`/`--rsh` is `POPT_ARG_STRING` (the short arm).
 /// - `options.c:2807-2808` - `--backup-dir`
+/// - `options.c:2886-2890` - `--partial-dir`
 /// - `options.c:2926-2927` - `--temp-dir`
 /// - `options.c:2939-2940` - `--copy-dest` / `--link-dest` / `--compare-dest`
 ///   (via `alt_dest_opt(0)`)
@@ -983,5 +1036,6 @@ pub(super) fn is_two_arg_server_long_flag(arg: &str) -> bool {
             | "--backup-dir"
             | "--temp-dir"
             | "--files-from"
+            | "--partial-dir"
     )
 }

--- a/crates/cli/src/frontend/server/parse.rs
+++ b/crates/cli/src/frontend/server/parse.rs
@@ -3,7 +3,9 @@
 use std::ffi::{OsStr, OsString};
 use std::time::SystemTime;
 
-use super::flags::{is_known_server_long_flag, is_two_arg_server_long_flag};
+use super::flags::{
+    compact_flag_string_expects_split_value, is_known_server_long_flag, is_two_arg_server_long_flag,
+};
 
 /// Parses the flag string and positional arguments from server-mode argument list.
 ///
@@ -11,13 +13,20 @@ use super::flags::{is_known_server_long_flag, is_two_arg_server_long_flag};
 /// a known long flag) and positional arguments (everything after the flag string
 /// and optional `.` separator).
 ///
-/// Upstream `options.c::server_options()` emits a few path-bearing long flags
-/// (`--copy-dest`, `--link-dest`, `--compare-dest`, `--files-from`,
-/// `--backup-dir`, `--partial-dir`, `--temp-dir`) as two argv slots via
-/// `safe_arg("", value)`. This parser recognises the bare flag and skips the
-/// following value slot so the path never lands in `positional_args` as a
-/// stray destination. See [`is_two_arg_server_long_flag`] for the upstream
-/// emission sites.
+/// This mirrors popt's argument-arity model (upstream runs the same
+/// `options.c` `long_options[]` popt parser on the server): a value-bearing
+/// option's value is bound whether it travels inside the same token or in the
+/// FOLLOWING argv token, so it never lands in `positional_args`. Two arms:
+///
+/// - Long `POPT_ARG_STRING` flags (`--copy-dest`, `--link-dest`,
+///   `--compare-dest`, `--files-from`, `--backup-dir`, `--partial-dir`,
+///   `--temp-dir`) that `server_options()` emits as two argv slots via
+///   `safe_arg("", value)` - recognised by [`is_two_arg_server_long_flag`],
+///   whose following value slot is skipped.
+/// - The short `-e` (`POPT_ARG_STRING`, options.c:823) whose `.`-capability
+///   value can split off the compact flag string when a remote shell
+///   re-tokenizes the joined exec line - rebound by
+///   [`compact_flag_string_expects_split_value`].
 pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, Vec<OsString>) {
     let mut flag_string = String::new();
     let mut positional_args = Vec::new();
@@ -28,38 +37,45 @@ pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, V
         let arg = &args[idx];
         let arg_str = arg.to_string_lossy();
 
-        if is_known_server_long_flag(&arg_str) {
-            // upstream: options.c:2886-2890 - `--partial-dir` is emitted as
-            // TWO separate argv entries by server_options(), so the value
-            // that immediately follows must also be skipped here. Without
-            // this, the partial-dir VALUE leaks into the positional list and
-            // becomes a destination-path argument.
-            if arg_str == "--partial-dir" {
-                idx += 2;
-                continue;
-            }
-            idx += 1;
+        // popt value-in-next-token arity: long `POPT_ARG_STRING` options that
+        // server_options() emits as two argv slots (`--copy-dest`,
+        // `--link-dest`, `--compare-dest`, `--files-from`, `--backup-dir`,
+        // `--temp-dir`, `--partial-dir`). Checked BEFORE
+        // `is_known_server_long_flag` so the following value slot is consumed
+        // too, not just the flag name. Without this, `--copy-dest /alt . dest/`
+        // lands `/alt` in positional_args[0] and `dest/` in positional_args[1],
+        // so the receiver mkdir's the alt-dest basis (already exists) instead
+        // of the actual destination root. The joined `--flag=value` form rides
+        // in one token and is handled by `is_known_server_long_flag` below.
+        if is_two_arg_server_long_flag(&arg_str) {
+            idx += 2;
             continue;
         }
 
-        // upstream: options.c::server_options() emits path-bearing long
-        // flags (`--copy-dest`, `--link-dest`, `--compare-dest`,
-        // `--files-from`, `--backup-dir`, `--temp-dir`) as `--flag VALUE`
-        // (two argv slots). The `--flag=value` joined form is handled by
-        // `is_known_server_long_flag` above; the split form is consumed
-        // here so the value does not surface as a positional destination
-        // path. Without this, `--copy-dest /alt . dest/` lands `/alt` in
-        // positional_args[0] and `dest/` in positional_args[1], so the
-        // receiver mkdir's the alt-dest basis (already exists) instead of
-        // the actual destination root.
-        if is_two_arg_server_long_flag(&arg_str) {
-            idx += 2;
+        if is_known_server_long_flag(&arg_str) {
+            idx += 1;
             continue;
         }
 
         if !found_flags && arg_str.starts_with('-') {
             flag_string = arg_str.into_owned();
             found_flags = true;
+            // popt value-in-next-token arity for the short `-e`
+            // (`POPT_ARG_STRING`, options.c:823). When a remote shell
+            // re-tokenized the joined `-...e.<caps>` exec line, `-e`'s
+            // capability value became a separate argv token. Rebind it onto
+            // the compact flag string so it is consumed as the `-e` value
+            // (never a positional) and the downstream `ParsedServerFlags::parse`
+            // reads the `.`-capability letters exactly as it does for the
+            // never-split joined form - fixing both the path leak and the lost
+            // compat negotiation in one place. See
+            // `compact_flag_string_expects_split_value`.
+            if compact_flag_string_expects_split_value(&flag_string) {
+                if let Some(value) = args.get(idx + 1) {
+                    flag_string.push_str(&value.to_string_lossy());
+                    idx += 1;
+                }
+            }
             idx += 1;
             continue;
         }

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -2149,3 +2149,419 @@ fn parse_server_args_skips_task291_long_flags() {
         "task #291 long flags must not leak into positional args: {pos_args:?}",
     );
 }
+
+// ===========================================================================
+// popt arg-arity model: split `-e` capability value (issue #7153) and the
+// client-emit -> server-decode round-trip guard.
+//
+// Upstream runs the SAME popt parser (`options.c` `long_options[]`) on the
+// server; `-e`/`--rsh` is POPT_ARG_STRING (options.c:823), so popt binds its
+// capability value whether it arrives inside the compact flag string
+// (`-...e.<caps>`, the joined form the oc client emits) or as the FOLLOWING
+// argv token (the split form a remote shell - e.g. Windows OpenSSH - produces
+// when it re-tokenizes the exec line). Either way the value is consumed and
+// never surfaces as a positional path. Before the fix the split form leaked
+// the `.<caps>` token into `positional_args` (push wrote to `.<caps>/...`; a
+// sender exited 23 on `link_stat ".<caps>"`) AND lost compat negotiation
+// (the `-e` value never reached `ParsedServerFlags`).
+// ===========================================================================
+
+use core::client::ClientConfig;
+use core::client::remote::{RemoteInvocationBuilder, RemoteRole};
+use core::server::{ParsedServerFlags, ServerConfig, ServerRole};
+
+/// Decodes a server argv (program name already stripped) exactly as
+/// `run.rs` does: extract the compact flag string + operands, then decode the
+/// flag string into structured `ParsedServerFlags`.
+fn decode_server_argv(
+    argv: &[OsString],
+    role: ServerRole,
+) -> (String, Vec<OsString>, ParsedServerFlags) {
+    let (flag_string, operands) = parse_server_flag_string_and_args(argv);
+    let config =
+        ServerConfig::from_flag_string_and_args(role, flag_string.clone(), operands.clone())
+            .expect("server flag string must decode");
+    (flag_string, operands, config.flags)
+}
+
+/// Splits a joined compact flag string token (`-...e.<caps>`) into the two
+/// tokens a remote shell produces when it re-tokenizes the exec line: the
+/// transfer-letter run ending in `e`, and the `.<caps>` capability value.
+/// Returns `None` when the token carries no `e.<caps>` suffix (protocol < 30).
+fn split_capability_token(argv: &[OsString]) -> Option<Vec<OsString>> {
+    let idx = argv.iter().position(|a| {
+        let s = a.to_string_lossy();
+        s.starts_with('-') && !s.starts_with("--") && s.contains("e.")
+    })?;
+    let token = argv[idx].to_string_lossy().into_owned();
+    let cut = token.find("e.")? + 1; // keep `e` on the left, `.` starts the value
+    let (head, value) = token.split_at(cut);
+    let mut split = argv.to_vec();
+    split.splice(idx..=idx, [OsString::from(head), OsString::from(value)]);
+    Some(split)
+}
+
+/// Regression #7153 (push): the split `.<caps>` capability token must be bound
+/// to `-e`, not leaked as a destination path, and the caps must still parse.
+#[test]
+fn parse_server_split_e_value_push_no_leak() {
+    // A remote shell delivered `-vve.isfxCIvu` as two tokens: `-vve` `.isfxCIvu`.
+    let split = vec![
+        OsString::from("--server"),
+        OsString::from("-vve"),
+        OsString::from(".isfxCIvu"),
+        OsString::from("."),
+        OsString::from("dst"),
+    ];
+    let (flag_string, operands, flags) = decode_server_argv(&split, ServerRole::Receiver);
+
+    // popt binds the `.<caps>` value onto `-e`; the reconstructed flag string
+    // is byte-identical to the never-split joined form.
+    assert_eq!(flag_string, "-vve.isfxCIvu");
+    assert_eq!(
+        operands,
+        vec![OsString::from("dst")],
+        "the `.<caps>` value must never leak into operands: {operands:?}",
+    );
+
+    // Compat negotiation is NOT silently lost: the capability letters parse
+    // exactly as they do for the joined delivery.
+    let joined = vec![
+        OsString::from("--server"),
+        OsString::from("-vve.isfxCIvu"),
+        OsString::from("."),
+        OsString::from("dst"),
+    ];
+    let (_, _, joined_flags) = decode_server_argv(&joined, ServerRole::Receiver);
+    assert_eq!(
+        flags, joined_flags,
+        "split delivery must decode to the same caps as the joined form",
+    );
+    assert!(flags.rsh, "`e` must set rsh");
+    assert!(
+        flags.info_flags.flist,
+        "`f` capability must parse from split value"
+    );
+}
+
+/// Regression #7153 (pull): same as above with `--sender` present. Without the
+/// fix the sender parsed `.sfxCIvu` as a source operand and exited 23 on
+/// `link_stat ".sfxCIvu"`.
+#[test]
+fn parse_server_split_e_value_pull_no_leak() {
+    let split = vec![
+        OsString::from("--server"),
+        OsString::from("--sender"),
+        OsString::from("-logDtpre"),
+        OsString::from(".sfxCIvu"),
+        OsString::from("."),
+        OsString::from("src"),
+    ];
+    let (flag_string, operands, flags) = decode_server_argv(&split, ServerRole::Generator);
+
+    assert_eq!(flag_string, "-logDtpre.sfxCIvu");
+    assert_eq!(
+        operands,
+        vec![OsString::from("src")],
+        "the `.<caps>` value must never leak into operands on a pull: {operands:?}",
+    );
+    assert!(flags.rsh);
+    assert!(flags.info_flags.flist);
+    assert!(
+        flags.info_flags.stats,
+        "`s` capability must parse from split value"
+    );
+}
+
+/// The joined form must stay byte-identical: a compact flag string that ends
+/// in a capability letter (never a bare `e`) must NOT consume the following
+/// `.` separator as a value.
+#[test]
+fn parse_server_joined_e_value_unchanged() {
+    let joined = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpre.iLsfxCIvu"),
+        OsString::from("."),
+        OsString::from("dst"),
+    ];
+    let (flag_string, operands, flags) = decode_server_argv(&joined, ServerRole::Receiver);
+    assert_eq!(flag_string, "-logDtpre.iLsfxCIvu");
+    assert_eq!(operands, vec![OsString::from("dst")]);
+    assert!(flags.info_flags.itemize, "`i` (inc_recurse) must parse");
+}
+
+/// A bare compact flag string with no capability suffix and a following `.`
+/// separator (protocol < 30 shape) must leave the `.` as the separator, not
+/// bind it: only a string ending in a value-bearing short letter binds.
+#[test]
+fn parse_server_no_suffix_does_not_bind_dot_separator() {
+    let argv = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("."),
+        OsString::from("dst"),
+    ];
+    let (flag_string, operands) = parse_server_flag_string_and_args(&argv);
+    assert_eq!(flag_string, "-logDtpr");
+    assert_eq!(operands, vec![OsString::from("dst")]);
+    assert!(!super::flags::compact_flag_string_expects_split_value(
+        "-logDtpr"
+    ));
+    assert!(super::flags::compact_flag_string_expects_split_value(
+        "-vve"
+    ));
+}
+
+/// Golden table over every delivery shape: joined, split, `-e` as the final
+/// cluster letter binding the next token, `--sender`, `--` handling, and
+/// secluded-args (`-s`). Each row asserts the reconstructed flag string, the
+/// operands, and that the joined and split deliveries decode identically.
+#[test]
+fn parse_server_arg_arity_golden_table() {
+    struct Case {
+        name: &'static str,
+        argv: Vec<OsString>,
+        role: ServerRole,
+        expect_flags: &'static str,
+        expect_operands: Vec<OsString>,
+    }
+    let os = |s: &str| OsString::from(s);
+    let cases = vec![
+        Case {
+            name: "joined push -e.LsfxCIvu",
+            argv: vec![os("--server"), os("-e.LsfxCIvu"), os("."), os("dst")],
+            role: ServerRole::Receiver,
+            expect_flags: "-e.LsfxCIvu",
+            expect_operands: vec![os("dst")],
+        },
+        Case {
+            name: "joined push -vve.iLsfxCIvu",
+            argv: vec![os("--server"), os("-vve.iLsfxCIvu"), os("."), os("dst")],
+            role: ServerRole::Receiver,
+            expect_flags: "-vve.iLsfxCIvu",
+            expect_operands: vec![os("dst")],
+        },
+        Case {
+            name: "joined pull -logDtpre.iLsfxC",
+            argv: vec![
+                os("--server"),
+                os("--sender"),
+                os("-logDtpre.iLsfxC"),
+                os("."),
+                os("src"),
+            ],
+            role: ServerRole::Generator,
+            expect_flags: "-logDtpre.iLsfxC",
+            expect_operands: vec![os("src")],
+        },
+        Case {
+            name: "split push -vve + .iLsfxCIvu",
+            argv: vec![
+                os("--server"),
+                os("-vve"),
+                os(".iLsfxCIvu"),
+                os("."),
+                os("dst"),
+            ],
+            role: ServerRole::Receiver,
+            expect_flags: "-vve.iLsfxCIvu",
+            expect_operands: vec![os("dst")],
+        },
+        Case {
+            name: "-e final cluster letter binds next token",
+            argv: vec![
+                os("--server"),
+                os("-logDtpre"),
+                os(".iLsfxCIvu"),
+                os("."),
+                os("dst"),
+            ],
+            role: ServerRole::Receiver,
+            expect_flags: "-logDtpre.iLsfxCIvu",
+            expect_operands: vec![os("dst")],
+        },
+        Case {
+            name: "secluded-args -s packed, split -e",
+            argv: vec![
+                os("--server"),
+                os("-svve"),
+                os(".iLsfxCIvu"),
+                os("."),
+                os("dst"),
+            ],
+            role: ServerRole::Receiver,
+            expect_flags: "-svve.iLsfxCIvu",
+            expect_operands: vec![os("dst")],
+        },
+    ];
+
+    for case in cases {
+        let (flag_string, operands, _) = decode_server_argv(&case.argv, case.role);
+        assert_eq!(
+            flag_string, case.expect_flags,
+            "flag string for `{}`",
+            case.name
+        );
+        assert_eq!(
+            operands, case.expect_operands,
+            "operands for `{}`",
+            case.name
+        );
+    }
+}
+
+/// Round-trip guard: the client's real server-command builder must agree with
+/// the server parser's arity model for every option set in the matrix. Building
+/// the argv, then splitting its capability token the way a remote shell would,
+/// must decode to the SAME flags and operands as the joined delivery - so emit
+/// and decode can never silently diverge again (the recurring positional-leak
+/// class: #6569, #6587, #6880, #7153).
+#[test]
+fn client_build_to_server_parse_round_trip() {
+    // Representative matrix: role (push/pull), verbosity, links/recursive,
+    // secluded-args, and protocol (>=30 emits the `e.<caps>` suffix, 29 does
+    // not). Each entry configures the real ClientConfig used to spawn a remote.
+    let matrix: Vec<(RemoteRole, ClientConfig)> = vec![
+        (RemoteRole::Sender, ClientConfig::builder().build()),
+        (RemoteRole::Receiver, ClientConfig::builder().build()),
+        (
+            RemoteRole::Sender,
+            ClientConfig::builder()
+                .verbosity(2)
+                .links(true)
+                .recursive(true)
+                .build(),
+        ),
+        (
+            RemoteRole::Receiver,
+            ClientConfig::builder().verbosity(1).recursive(true).build(),
+        ),
+        (
+            RemoteRole::Sender,
+            ClientConfig::builder()
+                .protect_args(Some(true))
+                .recursive(true)
+                .build(),
+        ),
+        (
+            RemoteRole::Sender,
+            ClientConfig::builder()
+                .protocol_version(Some(protocol::ProtocolVersion::V29))
+                .recursive(true)
+                .build(),
+        ),
+    ];
+
+    for (role, config) in &matrix {
+        let full = RemoteInvocationBuilder::new(config, *role).build("dest");
+        // run.rs feeds the parser everything after the program name.
+        let joined_argv: Vec<OsString> = full[1..].to_vec();
+
+        // Map the client's role to the peer server's role.
+        let server_role = match role {
+            RemoteRole::Sender => ServerRole::Receiver, // push: peer receives
+            // pull: peer sends. Proxy never occurs in this matrix; the arm
+            // only satisfies exhaustiveness.
+            RemoteRole::Receiver | RemoteRole::Proxy => ServerRole::Generator,
+        };
+
+        let (joined_flags_str, joined_ops, joined_flags) =
+            decode_server_argv(&joined_argv, server_role);
+        assert_eq!(
+            joined_ops,
+            vec![OsString::from("dest")],
+            "joined operands must be exactly the destination for {role:?}",
+        );
+
+        // Simulate a remote shell splitting the `-...e.<caps>` token. When
+        // there is no suffix (protocol 29) there is nothing to split.
+        if let Some(split_argv) = split_capability_token(&joined_argv) {
+            let (split_flags_str, split_ops, split_flags) =
+                decode_server_argv(&split_argv, server_role);
+            assert_eq!(
+                split_flags_str, joined_flags_str,
+                "split delivery must reconstruct the joined flag string for {role:?}",
+            );
+            assert_eq!(
+                split_ops, joined_ops,
+                "split delivery must not leak the `.<caps>` value into operands for {role:?}",
+            );
+            assert_eq!(
+                split_flags, joined_flags,
+                "split delivery must decode to the same caps as joined for {role:?}",
+            );
+        } else {
+            // Protocol 29: no capability suffix, flag string ends in a
+            // transfer letter, and the parser must not bind the `.` separator.
+            assert!(
+                !joined_flags_str.ends_with('e'),
+                "protocol 29 flag string must not end in a bare `e`: {joined_flags_str}",
+            );
+        }
+    }
+}
+
+/// Property-style guard over a representative generated space: for every
+/// transfer-letter bundle and optional `.`-capability payload, delivered both
+/// joined and split, NO capability letter and no `-e` value ever lands in the
+/// operand list, and the two deliveries decode identically.
+#[test]
+fn no_capability_letter_leaks_into_operands() {
+    let letter_bundles = ["-r", "-logDtpr", "-vvlogDtpr", "-slogDtpr", "-a"];
+    let cap_payloads = ["", ".iLsfxCIvu", ".LsfxCIvu", ".sfxCIvu", ".iLsfxCIvuZ"];
+
+    for bundle in letter_bundles {
+        for cap in cap_payloads {
+            // The client always emits `e` immediately before the `.<caps>`
+            // suffix (maybe_add_e_option), so a non-empty cap implies a
+            // trailing `-e`.
+            let joined_flags = if cap.is_empty() {
+                bundle.to_string()
+            } else {
+                format!("{bundle}e{cap}")
+            };
+
+            let joined_argv = vec![
+                OsString::from("--server"),
+                OsString::from(joined_flags.clone()),
+                OsString::from("."),
+                OsString::from("dst"),
+            ];
+            let (joined_str, joined_ops) = parse_server_flag_string_and_args(&joined_argv);
+            assert_eq!(joined_str, joined_flags);
+            assert_eq!(joined_ops, vec![OsString::from("dst")]);
+
+            if cap.is_empty() {
+                continue;
+            }
+
+            // Split delivery: `<bundle>e` then `.<caps>`.
+            let split_argv = vec![
+                OsString::from("--server"),
+                OsString::from(format!("{bundle}e")),
+                OsString::from(cap),
+                OsString::from("."),
+                OsString::from("dst"),
+            ];
+            let (split_str, split_ops) = parse_server_flag_string_and_args(&split_argv);
+            assert_eq!(
+                split_str, joined_flags,
+                "split `{bundle}e` `{cap}` must reconstruct the joined flag string",
+            );
+            assert_eq!(
+                split_ops,
+                vec![OsString::from("dst")],
+                "no capability letter may leak into operands for `{bundle}e` `{cap}`",
+            );
+            // No operand may contain a capability character or a leading dot
+            // payload.
+            for op in &split_ops {
+                let s = op.to_string_lossy();
+                assert!(
+                    !s.starts_with('.') || s == ".",
+                    "operand looks like a `.<caps>` leak: {s}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7153: on a remote push/pull the server-mode argument parser could leak the `-e` capability value (`.<caps>`) into the positional operand list, corrupting the destination path and silently dropping compat negotiation.

Upstream rsync runs the **same popt parser** (`options.c` `long_options[]`) on both the client and the server. Each option declares its arity: `POPT_ARG_NONE` (boolean) or `POPT_ARG_STRING`/`POPT_ARG_INT` (value-bearing). `-e`/`--rsh` is `POPT_ARG_STRING` (options.c:823), so popt binds its value whether it arrives **inside** the same token or in the **following** argv token, and the value never lands in the operand list.

The oc client emits the capability string joined onto the compact flag string (`-...e.<caps>`, via `maybe_add_e_option`, options.c:2728/3021), which already worked. But when a remote shell re-tokenizes the exec line - notably **Windows OpenSSH** - the joined token splits into two argv slots (`-vve` then `.iLsfxCIvu`). oc's server parser was a string heuristic with **no arity model** for `-e`, so:

- the split `.<caps>` value fell through into `positional_args` - a push then wrote to `.<caps>/...`, and a sender exited 23 on `link_stat ".<caps>"`; and
- because the `.` payload never reached `ParsedServerFlags`, compat negotiation (inc_recurse / varint / flist-safety / checksum negotiation) was silently lost.

This is the latest instance of a recurring positional-leak class (#6569, #6587, #6880).

## Fix

Generalize the existing two-arg long-flag handling into **one popt-style arg-arity model** with two arms, both of which consume the option's value so it can never become an operand:

- `is_two_arg_server_long_flag` - long `POPT_ARG_STRING` options `server_options()` emits as two argv slots (`--copy-dest`, `--link-dest`, `--compare-dest`, `--files-from`, `--backup-dir`, `--temp-dir`, and now `--partial-dir`, folding away its former one-off special case). Consulted **before** `is_known_server_long_flag`.
- `compact_flag_string_expects_split_value` - the short `-e` terminating the compact flag string. When the compact string ends in a bare `e` (only possible when the `.<caps>` value split off - the joined form always ends in a capability letter), the following token is rebound onto the flag string, reconstructing exactly the already-working joined shape before decoding.

The **joined form is byte-identical** and every currently-passing case is unchanged (golden/interop safe); only the split delivery is repaired. The single existing decode path (`ParsedServerFlags::parse`) then reads the `.`-capability letters unchanged, so both the path leak and the lost negotiation are fixed in one place. Not Windows-specific - the fix is general.

## Tests (Tier B)

These fail on `master` (they exercise the split delivery the old parser mishandled) and pass here:

1. **Regression #7153** - split push (`-vve` `.isfxCIvu`) and split pull (`--sender ... -logDtpre` `.sfxCIvu`): operands are exactly `[dst]`/`[src]` (no leaked `.<caps>`), and the caps parse identically to the joined form.
2. **Golden table** `(server_argv) -> (flag_string, operands, caps)` across every shape: joined `-e.LsfxCIvu`, joined `-vve.iLsfxCIvu`, joined `-logDtpre.iLsfxC`, split `-vve`+`.iLsfxCIvu`, `-e` as the final cluster letter binding the next token, `--sender`, and secluded-args (`-s`).
3. **Round-trip guard** - builds the server argv with the real client server-command builder (`RemoteInvocationBuilder`) across an option matrix (role, verbosity, links/recursive, secluded-args, protocol 29 vs >=30), splits the capability token the way a remote shell would, and asserts the split decode matches the joined decode. This ties the arity model to the client emitter so emit and decode can never silently diverge again.
4. **Generative no-leak guard** - for every transfer-letter bundle x optional `.`-capability payload, in both joined and split delivery, no capability letter or `-e` value ever appears in the operands.

## Verification

Verified on an x86_64 Linux host (toolchain pinned to 1.88.0):

- `cargo fmt --all -- --check` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run -p cli -p transfer -p core --all-features` (server/parse/flag/arity/round-trip/leak filter) - 2680 passed, 0 failed
- `cargo build --bin oc-rsync` - clean
- `cargo check --locked --workspace --target x86_64-pc-windows-gnu` - clean (full workspace incl. C deps; validates the OsString/path handling on Windows, the platform behind this bug)

The change is pure `std` string/`OsString` handling with no `#[cfg]`, platform, or C code, so Windows-MSVC and Linux-musl portability follow from the native-gnu and windows-gnu results; those two targets are exercised by the required CI Windows and Linux-musl checks (they need MSVC / musl C cross-toolchains not present on the dev host).
