### PR TITLE
fix(cli): byte-faithful path escaping on non-Unix (-8 parity) + render-path tests

### DIFF
--- a/crates/cli/src/frontend/escape.rs
+++ b/crates/cli/src/frontend/escape.rs
@@ -142,12 +142,12 @@ fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> Vec<u8> {
 /// WTF-8 bytes are not exposed by stable std. For every well-formed Unicode
 /// path, `to_str()` yields the exact UTF-8 bytes with no substitution, so
 /// escaping them stays byte-faithful and mirrors upstream. Only a path that is
-/// ill-formed UTF-16 - a lone surrogate, which cannot round-trip through `&str`
-/// - falls back to `to_string_lossy()`, replacing the surrogate with U+FFFD.
-/// That single lossy case is a documented platform limitation, not an
-/// accidental transcode of otherwise-representable filenames: stable std offers
-/// no API to recover the raw WTF-8 bytes, so full byte-fidelity for lone
-/// surrogates is unreachable on Windows today.
+/// ill-formed UTF-16 (a lone surrogate, which cannot round-trip through `&str`)
+/// falls back to `to_string_lossy()`, replacing the surrogate with U+FFFD. That
+/// single lossy case is a documented platform limitation, not an accidental
+/// transcode of otherwise-representable filenames: stable std offers no API to
+/// recover the raw WTF-8 bytes, so full byte-fidelity for lone surrogates is
+/// unreachable on Windows today.
 pub(crate) fn escape_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
     #[cfg(unix)]
     {

--- a/crates/cli/src/frontend/escape.rs
+++ b/crates/cli/src/frontend/escape.rs
@@ -134,10 +134,20 @@ fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> Vec<u8> {
 /// Escapes a path for display output, returning raw bytes.
 ///
 /// On Unix, operates on the raw bytes of the path to faithfully represent
-/// non-UTF-8 filenames. On other platforms, falls back to `to_string_lossy()`
-/// before escaping. The bytes are meant to be written directly to a byte sink
-/// (stdout/stderr); interpolating them through a `String` would replace lone
-/// invalid bytes with U+FFFD, diverging from upstream `filtered_fwrite`.
+/// non-UTF-8 filenames: a lone invalid byte such as `0x80` reaches the escape
+/// layer verbatim, matching upstream `filtered_fwrite` (log.c:224-245), which
+/// copies filename bytes to the output fd unmodified.
+///
+/// On non-Unix hosts (chiefly Windows) a path is an `OsStr` whose internal
+/// WTF-8 bytes are not exposed by stable std. For every well-formed Unicode
+/// path, `to_str()` yields the exact UTF-8 bytes with no substitution, so
+/// escaping them stays byte-faithful and mirrors upstream. Only a path that is
+/// ill-formed UTF-16 - a lone surrogate, which cannot round-trip through `&str`
+/// - falls back to `to_string_lossy()`, replacing the surrogate with U+FFFD.
+/// That single lossy case is a documented platform limitation, not an
+/// accidental transcode of otherwise-representable filenames: stable std offers
+/// no API to recover the raw WTF-8 bytes, so full byte-fidelity for lone
+/// surrogates is unreachable on Windows today.
 pub(crate) fn escape_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
     #[cfg(unix)]
     {
@@ -146,8 +156,10 @@ pub(crate) fn escape_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
     }
     #[cfg(not(unix))]
     {
-        let lossy = path.to_string_lossy();
-        escape_for_output(lossy.as_bytes(), allow_8bit)
+        match path.as_os_str().to_str() {
+            Some(valid) => escape_for_output(valid.as_bytes(), allow_8bit),
+            None => escape_for_output(path.to_string_lossy().as_bytes(), allow_8bit),
+        }
     }
 }
 
@@ -340,6 +352,65 @@ mod tests {
     fn escape_path_with_directory_separator() {
         let path = Path::new("foo/bar/baz.txt");
         assert_eq!(escape_path(path, false), b"foo/bar/baz.txt".to_vec());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn escape_path_non_utf8_bytes_survive_under_8bit() {
+        // WHY: a lone 0x80 is invalid UTF-8. `escape_path` must not route the
+        // path through a `String` (which would replace it with U+FFFD): under
+        // `-8` the raw byte passes verbatim to the byte sink, matching upstream
+        // `filtered_fwrite`, which copies filename bytes unmodified
+        // (log.c:224-245). This is the round-trip that `--8-bit-output` parity
+        // depends on.
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        let path = Path::new(OsStr::from_bytes(b"a\x80b"));
+        let out = escape_path(path, true);
+        assert_eq!(out, b"a\x80b".to_vec());
+        // Exactly three bytes reach the sink - no U+FFFD (ef bf bd) expansion.
+        assert_eq!(out.len(), 3);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn escape_path_non_utf8_byte_octal_escaped_in_default_mode() {
+        // WHY: default mode (use_isprint=1) octal-escapes the raw high byte
+        // rather than lossily transcoding it, so the escape is reversible.
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        let path = Path::new(OsStr::from_bytes(b"a\x80b"));
+        assert_eq!(escape_path(path, false), b"a\\#200b".to_vec());
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn escape_path_valid_unicode_is_byte_faithful() {
+        // WHY: `to_str()` yields exact UTF-8 for a well-formed path, so `-8`
+        // keeps the original bytes (no U+FFFD), matching upstream
+        // `filtered_fwrite` byte-for-byte. `café` is bytes 63 61 66 c3 a9.
+        let path = Path::new("caf\u{e9}");
+        assert_eq!(escape_path(path, true), b"caf\xc3\xa9".to_vec());
+        assert_eq!(escape_path(path, false), b"caf\\#303\\#251".to_vec());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn escape_path_lone_surrogate_pins_documented_limitation() {
+        // Pinned behavior: a lone UTF-16 surrogate is ill-formed and cannot
+        // round-trip through `&str`, so `to_str()` returns None and the path
+        // falls back to `to_string_lossy()`, replacing the surrogate with
+        // U+FFFD (ef bf bd). Stable std exposes no API to recover the raw WTF-8
+        // bytes, so full byte-fidelity is unreachable here; this asserts the
+        // fallback is deliberate, not an accidental transcode of a
+        // representable filename.
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+        // 'a', lone high surrogate 0xD800, 'b'.
+        let os = OsString::from_wide(&[0x0061, 0xD800, 0x0062]);
+        let path = Path::new(&os);
+        // Under -8 the U+FFFD bytes (all high) pass through raw.
+        assert_eq!(escape_path(path, true), b"a\xef\xbf\xbdb".to_vec());
     }
 
     // -- escape_str --

--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -221,9 +221,9 @@ fn transfer_byte_count(event: &ClientEvent, is_sender: bool, want_checksum: bool
 /// Pure and platform-independent so it is unit-testable on every host;
 /// [`escape_render_path`] invokes it only under `cfg(windows)`, where `\` is the
 /// native separator. A naive rewrite of every backslash would corrupt the
-/// leading `\` of a `\#ooo` escape - a non-ASCII name such as `café`, escaped to
-/// `caf\#303\#251` in the default (non-`-8`) mode, would become `caf/#303/#251`
-/// - so the leading backslash of a `\#` + three-digit sequence is preserved.
+/// leading `\` of a `\#ooo` escape (a non-ASCII name such as `café`, escaped to
+/// `caf\#303\#251` in the default non-`-8` mode, would become `caf/#303/#251`),
+/// so the leading backslash of a `\#` + three-digit sequence is preserved.
 ///
 /// upstream: rsync stores filenames with `/` separators before logging
 /// (flist.c), so `filtered_fwrite` never sees a `\` separator; oc-rsync retains

--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -215,6 +215,49 @@ fn transfer_byte_count(event: &ClientEvent, is_sender: bool, want_checksum: bool
     }
 }
 
+/// Rewrites Windows path separators (`\`) to POSIX `/` in already-escaped
+/// render bytes, leaving `\#ooo` octal escape sequences intact.
+///
+/// Pure and platform-independent so it is unit-testable on every host;
+/// [`escape_render_path`] invokes it only under `cfg(windows)`, where `\` is the
+/// native separator. A naive rewrite of every backslash would corrupt the
+/// leading `\` of a `\#ooo` escape - a non-ASCII name such as `café`, escaped to
+/// `caf\#303\#251` in the default (non-`-8`) mode, would become `caf/#303/#251`
+/// - so the leading backslash of a `\#` + three-digit sequence is preserved.
+///
+/// upstream: rsync stores filenames with `/` separators before logging
+/// (flist.c), so `filtered_fwrite` never sees a `\` separator; oc-rsync retains
+/// the platform-native separator in storage and normalizes only here, at the
+/// render boundary.
+#[cfg(any(windows, test))]
+fn normalize_render_separators(escaped: &[u8]) -> Vec<u8> {
+    let len = escaped.len();
+    let mut out = Vec::with_capacity(len);
+    let mut i = 0;
+    while i < len {
+        let byte = escaped[i];
+        if byte == b'\\' {
+            // A `\#ddd` escape sequence keeps its backslash; a bare separator
+            // backslash becomes `/`. Mirrors the escape guard in escape.rs.
+            if i + 4 < len
+                && escaped[i + 1] == b'#'
+                && escaped[i + 2].is_ascii_digit()
+                && escaped[i + 3].is_ascii_digit()
+                && escaped[i + 4].is_ascii_digit()
+            {
+                out.extend_from_slice(&escaped[i..i + 5]);
+                i += 5;
+                continue;
+            }
+            out.push(b'/');
+        } else {
+            out.push(byte);
+        }
+        i += 1;
+    }
+    out
+}
+
 /// Escapes a path to raw output bytes, normalizing Windows separators.
 ///
 /// upstream: flist.c / log.c - itemize and out-format paths use POSIX
@@ -223,16 +266,13 @@ fn transfer_byte_count(event: &ClientEvent, is_sender: bool, want_checksum: bool
 fn escape_render_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
     let rendered = escape_path(path, allow_8bit);
     #[cfg(windows)]
-    let rendered = {
-        let mut bytes = rendered;
-        for byte in bytes.iter_mut() {
-            if *byte == b'\\' {
-                *byte = b'/';
-            }
-        }
-        bytes
-    };
-    rendered
+    {
+        normalize_render_separators(&rendered)
+    }
+    #[cfg(not(windows))]
+    {
+        rendered
+    }
 }
 
 /// Renders `%n`: the transfer-relative name, with a trailing slash for a
@@ -361,5 +401,49 @@ mod tests {
     #[test]
     fn format_out_format_mtime_none() {
         assert_eq!(format_out_format_mtime(None), "1970/01/01-00:00:00");
+    }
+
+    // -- normalize_render_separators (pure, tested on all platforms) --
+
+    #[test]
+    fn normalize_render_separators_rewrites_backslashes() {
+        // WHY: upstream logs POSIX `/` separators regardless of host (flist.c
+        // stores `/` before logging); the Windows render path must present
+        // `a\b\c` as `a/b/c`.
+        assert_eq!(normalize_render_separators(b"a\\b\\c"), b"a/b/c".to_vec());
+    }
+
+    #[test]
+    fn normalize_render_separators_preserves_octal_escapes() {
+        // WHY: `café` in the default (non-`-8`) mode escapes to `caf\#303\#251`.
+        // A naive backslash rewrite would corrupt it to `caf/#303/#251`; the
+        // `\#ooo` escape backslash is not a separator and must survive so `%n`
+        // stays byte-faithful to upstream `filtered_fwrite`.
+        assert_eq!(
+            normalize_render_separators(b"caf\\#303\\#251"),
+            b"caf\\#303\\#251".to_vec()
+        );
+    }
+
+    #[test]
+    fn normalize_render_separators_mixed_sep_and_escape() {
+        // Real separators become `/` while an embedded octal escape is kept.
+        assert_eq!(
+            normalize_render_separators(b"dir\\caf\\#303\\#251"),
+            b"dir/caf\\#303\\#251".to_vec()
+        );
+    }
+
+    #[test]
+    fn normalize_render_separators_trailing_backslash_is_separator() {
+        // A backslash with fewer than the 4 trailing bytes of an escape
+        // sequence is a bare separator and is rewritten.
+        assert_eq!(normalize_render_separators(b"a\\"), b"a/".to_vec());
+        assert_eq!(normalize_render_separators(b"a\\#12"), b"a/#12".to_vec());
+    }
+
+    #[test]
+    fn normalize_render_separators_noop_without_backslash() {
+        assert_eq!(normalize_render_separators(b"a/b/c"), b"a/b/c".to_vec());
     }
 }

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1489,6 +1489,47 @@ fn render_percent_f_falls_back_to_relative_without_source_prefix() {
     assert_eq!(render_format("%f", &event), "docs/afile.txt\n");
 }
 
+#[cfg(windows)]
+#[test]
+fn render_percent_n_normalizes_windows_separators_file() {
+    // WHY: upstream logs POSIX `/` separators regardless of host (flist.c stores
+    // `/` before logging), so a Windows-native `a\b\c` file renders as `a/b/c`.
+    let event = ClientEvent::for_test(
+        PathBuf::from(r"a\b\c"),
+        ClientEventKind::DataCopied,
+        true,
+        Some(ClientEvent::test_metadata(ClientEntryKind::File)),
+        LocalCopyChangeSet::new(),
+    );
+    assert_eq!(render_format("%n", &event), "a/b/c\n");
+}
+
+#[cfg(windows)]
+#[test]
+fn render_percent_n_normalizes_windows_separators_dir_single_trailing_slash() {
+    // A Windows-native directory renders normalized with exactly one trailing
+    // slash - separator normalization must not add a second.
+    let event = ClientEvent::for_test(
+        PathBuf::from(r"a\b\c"),
+        ClientEventKind::DirectoryCreated,
+        true,
+        Some(ClientEvent::test_metadata(ClientEntryKind::Directory)),
+        LocalCopyChangeSet::new(),
+    );
+    assert_eq!(render_format("%n", &event), "a/b/c/\n");
+}
+
+#[cfg(windows)]
+#[test]
+fn render_percent_f_leading_slash_strip_runs_after_normalization() {
+    // WHY: `%f` strips a single leading `/`. On Windows the source prefix arrives
+    // with `\` separators; normalization turns the leading `\` into `/`, then the
+    // strip removes it. Order matters - the strip must run on the normalized
+    // bytes, or a leading `\` would survive and diverge from upstream's `/`-form.
+    let event = remote_event_with_source_prefix("afile.txt", Some(r"\abs\docs\afile.txt"));
+    assert_eq!(render_format("%f", &event), "abs/docs/afile.txt\n");
+}
+
 #[test]
 fn render_percent_l_shows_file_length() {
     let event = make_event(


### PR DESCRIPTION
## Summary

Fixes a silent byte-fidelity loss in filename escaping on non-Unix hosts that
defeated `--8-bit-output` (`-8`) parity, and adds the missing test coverage for
the render-path separator normalization.

Upstream `filtered_fwrite` (log.c:224-245) escapes raw filename **bytes** and
copies non-escaped bytes to the output fd verbatim - it never lossily
transcodes. On Unix, `escape_path` already mirrors this by operating on the raw
`OsStr` bytes, so a lone invalid byte (e.g. `0x80`) survives under `-8`. On
non-Unix, `escape_path` was calling `path.to_string_lossy()` first, replacing
every non-UTF-8 / lone-surrogate sequence with U+FFFD **before** escaping -
diverging from upstream.

## Changes

- **`escape_path` (non-Unix)**: try `OsStr::to_str()` first. For every
  well-formed Unicode path this yields the exact UTF-8 bytes with no
  substitution, so escaping stays byte-faithful and matches upstream. Only an
  ill-formed path (a lone UTF-16 surrogate, which cannot round-trip through
  `&str`) falls back to `to_string_lossy()`. The lossy fallback is now explicit
  and documented rather than an accidental blanket conversion.
- **`escape_render_path` separator normalization** factored into a pure,
  platform-independent `normalize_render_separators` fn taking the escaped
  bytes, unit-tested on all platforms. The previous inline Windows rewrite
  naively replaced **every** backslash, which would corrupt the leading `\` of a
  `\#ooo` octal escape (a non-ASCII name like `café`, escaped to `caf\#303\#251`
  in default mode, would become `caf/#303/#251`). The pure fn preserves `\#ooo`
  sequences and rewrites only genuine separators.

## Tests

- `escape_path` on a non-UTF-8 Unix path (`OsStr::from_bytes(b"a\x80b")`)
  returns the raw byte under `-8` (exact bytes, no U+FFFD, length asserted) and
  the octal `\#200` escape in default mode.
- non-Unix counterpart pinning valid-Unicode byte-fidelity (`café` -> exact
  `c3 a9`), and a Windows-only test pinning the documented lone-surrogate
  fallback to U+FFFD.
- `normalize_render_separators`: separators rewritten, `\#ooo` escapes
  preserved, mixed input, trailing/partial backslash, and no-op cases - on all
  platforms.
- Windows-only `%n`/`%f` integration: `a\b\c` renders `a/b/c` (file) and
  `a/b/c/` (dir, exactly one trailing slash); `%f` leading-slash strip runs
  **after** normalization (`\abs\docs\afile.txt` -> `abs/docs/afile.txt`).

## Windows byte-fidelity limitation (surfaced)

Full byte-fidelity for a **lone UTF-16 surrogate** is unreachable on Windows
today: stable std exposes no API to recover an `OsStr`'s raw WTF-8 bytes, so
such a path must fall back to U+FFFD. This is now pinned by a test and documented
as a deliberate platform limitation rather than an accidental transcode. Every
well-formed Unicode path (the overwhelming common case, including all valid
UTF-8 filenames) is byte-faithful.

Reference: upstream `rsync-3.4.4/log.c` `filtered_fwrite`.
