### PR TITLE
fix(engine): robust EXDEV + reparse-hardened local-copy commit (parity with transfer)

### DIFF
--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -108,6 +108,121 @@ pub fn remove_incomplete_destination(destination: &Path) {
     }
 }
 
+/// Creates the staging temp file with `create_new` semantics, reparse-point
+/// hardened on Windows.
+///
+/// On Windows the create routes through `fast_io::create_new_no_follow`
+/// (`CREATE_NEW` + `FILE_FLAG_OPEN_REPARSE_POINT`, the analog of `O_EXCL |
+/// O_NOFOLLOW`), so a symlink/junction pre-planted at the temp leaf is opened as
+/// the reparse point itself (and `CREATE_NEW` fails) rather than traversed,
+/// closing the CVE-2024-12747 residual on the temp-create side. This mirrors the
+/// transfer receiver's `temp_guard::try_create_new`. On every other platform it
+/// is the plain `create_new` open the local-copy guard has always used.
+fn create_new_temp(path: &Path) -> io::Result<fs::File> {
+    #[cfg(windows)]
+    {
+        fast_io::create_new_no_follow(path)
+    }
+    #[cfg(not(windows))]
+    {
+        fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+    }
+}
+
+/// Renames the staging temp onto the destination, reparse-point hardened on
+/// Windows and io_uring-accelerated on Linux.
+///
+/// On Windows the rename routes through `fast_io::rename_no_follow`, which
+/// validates and pins the destination parent as a real directory (not a
+/// junction/mount-point swap) and renames the temp file by handle, so a
+/// concurrent reparse-point swap on the commit parent between temp-create and
+/// rename cannot redirect the committed file outside the destination tree
+/// (CVE-2024-12747 residual). This mirrors the transfer disk-commit
+/// `temp_guard::commit_rename_no_follow`. On other platforms it prefers an
+/// `IORING_OP_RENAMEAT` SQE, falling back to `std::fs::rename`.
+///
+/// `replace_existing` is always `true`: upstream `do_rename` overwrites the
+/// destination, matching `std::fs::rename`'s replace semantics.
+fn hardened_rename(temp_path: &Path, final_path: &Path) -> io::Result<()> {
+    // Test-only fault injection: force the EXDEV boundary so the copy+remove
+    // fallback runs deterministically on a single filesystem (and on Windows CI,
+    // where a real second volume is unavailable).
+    #[cfg(test)]
+    if force_exdev_active() {
+        return Err(simulated_cross_device_error());
+    }
+    #[cfg(windows)]
+    {
+        fast_io::rename_no_follow(temp_path, final_path, true)
+    }
+    #[cfg(not(windows))]
+    {
+        if let Some(result) = fast_io::try_rename_via_io_uring(temp_path, final_path) {
+            result
+        } else {
+            fs::rename(temp_path, final_path)
+        }
+    }
+}
+
+// Test-only fault injection for the commit rename boundary. A thread-local flag
+// (nextest runs each test in its own process, and the guard is thread-scoped
+// regardless) makes `hardened_rename` report a cross-device error, driving the
+// EXDEV copy+remove fallback without a real second filesystem. Mirrors the
+// transfer disk-commit `ForceExdev` harness so both commit paths are exercised
+// identically.
+#[cfg(test)]
+thread_local! {
+    static FORCE_EXDEV: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+fn force_exdev_active() -> bool {
+    FORCE_EXDEV.with(std::cell::Cell::get)
+}
+
+/// Builds an error [`fast_io::is_cross_device`] recognizes on the current
+/// platform: `EXDEV` (errno 18) on Unix, `ERROR_NOT_SAME_DEVICE` (17) on
+/// Windows.
+#[cfg(test)]
+fn simulated_cross_device_error() -> io::Error {
+    #[cfg(unix)]
+    {
+        io::Error::from_raw_os_error(libc::EXDEV)
+    }
+    #[cfg(windows)]
+    {
+        io::Error::from_raw_os_error(17)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        io::Error::other("simulated cross-device")
+    }
+}
+
+/// Test-only RAII guard that forces [`hardened_rename`] onto the cross-device
+/// path for its lifetime, exercising the copy+remove fallback.
+#[cfg(test)]
+struct ForceExdev;
+
+#[cfg(test)]
+impl ForceExdev {
+    fn new() -> Self {
+        FORCE_EXDEV.with(|c| c.set(true));
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for ForceExdev {
+    fn drop(&mut self) {
+        FORCE_EXDEV.with(|c| c.set(false));
+    }
+}
+
 /// Finalization strategy for destination writes.
 ///
 /// Named temp files use rename; anonymous temp files use `linkat(2)`.
@@ -212,11 +327,7 @@ impl DestinationWriteGuard {
         // partial only appears at its final resting place on interrupt/success.
         loop {
             let temp_path = temp_name_with_suffix(destination, temp_dir, &temp_suffix());
-            match fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&temp_path)
-            {
+            match create_new_temp(&temp_path) {
                 Ok(file) => {
                     let final_path = destination.to_path_buf();
                     // Only --partial/--partial-dir temps need the abort-path
@@ -379,28 +490,23 @@ impl DestinationWriteGuard {
     ///
     /// upstream: `util1.c:robust_rename()` - retry up to 4 times on `ETXTBSY`.
     /// Returns `true` when commit used a cross-device copy instead of rename.
+    ///
+    /// The rename dispatch and the EXDEV detection share the transfer
+    /// disk-commit path's robust primitives: on Windows the commit routes
+    /// through `fast_io::rename_no_follow` (handle-anchored, reparse-point
+    /// hardened - CVE-2024-12747 residual) and the cross-device fallback is
+    /// keyed on [`fast_io::is_cross_device`] (raw `ERROR_NOT_SAME_DEVICE` = 17
+    /// on Windows / `EXDEV` on Unix), the single source of truth. This closes
+    /// the #7153-class divergence where this guard and the transfer commit
+    /// hardened the same operation differently.
     fn commit_named_temp_file(&self, temp_path: PathBuf) -> Result<bool, LocalCopyError> {
         let mut tries = 4u32;
         loop {
-            let rename_result = if let Some(result) =
-                fast_io::try_rename_via_io_uring(&temp_path, &self.final_path)
-            {
-                result
-            } else {
-                fs::rename(&temp_path, &self.final_path)
-            };
-            match rename_result {
+            match hardened_rename(&temp_path, &self.final_path) {
                 Ok(()) => return Ok(false),
                 Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
                     remove_existing_destination(&self.final_path)?;
-                    let retry_result = if let Some(result) =
-                        fast_io::try_rename_via_io_uring(&temp_path, &self.final_path)
-                    {
-                        result
-                    } else {
-                        fs::rename(&temp_path, &self.final_path)
-                    };
-                    retry_result.map_err(|rename_error| {
+                    hardened_rename(&temp_path, &self.final_path).map_err(|rename_error| {
                         LocalCopyError::io(self.finalise_action(), temp_path.clone(), rename_error)
                     })?;
                     return Ok(false);
@@ -417,7 +523,7 @@ impl DestinationWriteGuard {
                 // existing destination before creating a fresh file. Without
                 // this unlink, fs::copy fails with EACCES when the existing
                 // destination has restrictive permissions (e.g. mode 440).
-                Err(error) if error.kind() == io::ErrorKind::CrossesDevices => {
+                Err(error) if fast_io::is_cross_device(&error) => {
                     remove_existing_destination(&self.final_path)?;
                     fs::copy(&temp_path, &self.final_path).map_err(|copy_error| {
                         LocalCopyError::io(
@@ -784,6 +890,103 @@ mod tests {
         assert!(staging.is_file());
 
         guard.discard();
+    }
+
+    /// #7153-class one-source-of-truth: the engine local-copy commit must share
+    /// the transfer disk-commit's EXDEV fallback. A cross-device rename (a
+    /// `--temp-dir` on a different mount) reports `EXDEV` on Unix and
+    /// `ERROR_NOT_SAME_DEVICE` (17) on Windows; both must fall back to
+    /// copy+remove (upstream `util1.c:robust_rename()`) and report the commit as
+    /// cross-device so the caller invalidates its temp-inode fd. `ForceExdev`
+    /// injects the boundary without a real second filesystem, so this runs on
+    /// the Windows engine CI job too (where errno 17 is what std would surface).
+    #[test]
+    fn commit_falls_back_to_copy_remove_on_cross_device_rename() {
+        let temp = tempdir().expect("tempdir");
+        let dest = temp.path().join("final.txt");
+        // Pre-existing destination with restrictive perms exercises the
+        // remove-before-copy that upstream's unlink_and_reopen performs.
+        fs::write(&dest, b"old content").expect("seed dest");
+
+        let (guard, mut file) =
+            DestinationWriteGuard::new(&dest, false, None, None).expect("guard");
+        file.write_all(b"cross device payload").expect("write");
+        drop(file);
+        let staging = guard.staging_path().to_path_buf();
+
+        let cross = {
+            let _force = ForceExdev::new();
+            guard
+                .commit()
+                .expect("commit must succeed via copy+remove fallback")
+        };
+
+        assert!(
+            cross,
+            "a cross-device commit must report cross_device=true so the caller \
+             invalidates the temp-inode fd"
+        );
+        assert!(dest.exists(), "destination must exist after the fallback");
+        assert!(
+            !staging.exists(),
+            "the temp file must be removed after copy"
+        );
+        assert_eq!(
+            fs::read(&dest).expect("read dest"),
+            b"cross device payload",
+            "the fallback must land the exact staged content"
+        );
+    }
+
+    /// CVE-2024-12747 residual: a junction swapped onto the destination parent
+    /// between temp-create and commit must not redirect the committed file into
+    /// an attacker-controlled tree. The engine guard now anchors the commit
+    /// rename through `fast_io::rename_no_follow` (the same primitive the
+    /// transfer disk-commit path uses), which validates and pins the destination
+    /// parent as a real directory and refuses a reparse point. Junctions are
+    /// created without privilege, so this runs on unprivileged Windows CI; if
+    /// even the junction fallback is unavailable the test skips.
+    #[cfg(windows)]
+    #[test]
+    fn commit_refuses_reparse_point_destination_parent() {
+        let root = tempdir().expect("tempdir");
+        let real_dest = root.path().join("real_dest");
+        let attacker = root.path().join("attacker");
+        fs::create_dir(&real_dest).expect("real_dest");
+        fs::create_dir(&attacker).expect("attacker");
+        fs::write(attacker.join("keep.txt"), b"keep").expect("sentinel");
+
+        let dest = real_dest.join("victim.bin");
+        let (guard, mut file) =
+            DestinationWriteGuard::new(&dest, false, None, None).expect("guard");
+        file.write_all(b"loot").expect("write");
+        drop(file);
+
+        // Swap: move the real destination aside and plant a junction at its path
+        // pointing at the attacker tree.
+        let aside = root.path().join("real_dest.aside");
+        fs::rename(&real_dest, &aside).expect("move aside");
+        match fast_io::create_directory_symlink_or_junction(&attacker, &real_dest) {
+            Ok(_) => {}
+            Err(err) => {
+                eprintln!("skipping: cannot create reparse point ({err})");
+                return;
+            }
+        }
+
+        let result = guard.commit();
+        assert!(
+            result.is_err(),
+            "commit must refuse a reparse-point destination parent"
+        );
+        assert!(
+            !attacker.join("victim.bin").exists(),
+            "attacker tree must never receive the committed file"
+        );
+        assert!(
+            attacker.join("keep.txt").exists(),
+            "attacker sentinel must be untouched"
+        );
     }
 
     #[test]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -435,6 +435,7 @@ pub use temp_file_strategy::WindowsTempFileStrategy;
 pub use temp_file_strategy::{
     DefaultTempFileStrategy, NamedTempFileStrategy, TempFileHandle, TempFileKind, TempFileStrategy,
 };
+pub use win_atomic_commit::is_cross_device;
 #[cfg(windows)]
 pub use win_atomic_commit::{create_new_no_follow, rename_no_follow};
 pub use win_path::to_extended_path;

--- a/crates/fast_io/src/win_atomic_commit.rs
+++ b/crates/fast_io/src/win_atomic_commit.rs
@@ -30,6 +30,184 @@
 //! All Win32 FFI lives here in `fast_io` (a permitted-unsafe crate); the
 //! `transfer` receiver calls the safe functions.
 
+/// Extended-length (`\\?\`) path conversion shared by the no-follow commit
+/// primitives.
+///
+/// The handle-based opens in [`imp`] all go through `OpenOptions::open`, which
+/// applies std's `maybe_verbatim` internally, so they already accept paths over
+/// the legacy 260-char `MAX_PATH`. The one Win32 call that receives a raw path
+/// string is `SetFileInformationByHandle(FileRenameInfo)` in
+/// [`imp::set_rename_info`]: its `FILE_RENAME_INFO::FileName` is passed straight
+/// to the kernel with no long-path awareness, so a deep destination fails with
+/// `ERROR_FILENAME_EXCED_RANGE` (206). [`to_verbatim_wide`] converts an
+/// already-absolute, already-normalized destination path into the `\\?\`
+/// verbatim form the way std does, restoring the long-path behaviour the prior
+/// `std::fs::rename` commit path had.
+#[cfg_attr(not(windows), allow(dead_code))]
+mod verbatim {
+    // UTF-16 code units used to detect and build verbatim paths. All are ASCII,
+    // so casting the byte literal to `u16` is exact.
+    const SEP: u16 = b'\\' as u16;
+    const ALT_SEP: u16 = b'/' as u16;
+    const QUERY: u16 = b'?' as u16;
+    const COLON: u16 = b':' as u16;
+
+    // `\\?\`
+    const VERBATIM_PREFIX: [u16; 4] = [SEP, SEP, QUERY, SEP];
+    // `\??\` (the NT-namespace form std also leaves untouched)
+    const NT_PREFIX: [u16; 4] = [SEP, QUERY, QUERY, SEP];
+    // `\\?\UNC\`
+    const UNC_VERBATIM_PREFIX: [u16; 8] = [
+        SEP,
+        SEP,
+        QUERY,
+        SEP,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        SEP,
+    ];
+
+    /// True for an ASCII drive letter (`A`-`Z` / `a`-`z`) as a UTF-16 unit.
+    fn is_drive_letter(c: u16) -> bool {
+        (b'A' as u16..=b'Z' as u16).contains(&c) || (b'a' as u16..=b'z' as u16).contains(&c)
+    }
+
+    /// Returns the extended-length (`\\?\`) verbatim form of a UTF-16 Windows
+    /// path, or the input unchanged when it is already verbatim/NT-prefixed or
+    /// is not fully qualified.
+    ///
+    /// Operates on a UTF-16 code-unit slice (as std's `maybe_verbatim` does) so
+    /// it is unit-testable on every platform even though it is only used on
+    /// Windows. The commit path only ever hands this a fully-qualified,
+    /// already-normalized destination, so - unlike std - it does not resolve
+    /// `.`/`..` via `GetFullPathNameW`; it only rewrites the prefix:
+    ///
+    /// - Already `\\?\` or `\??\`: returned untouched.
+    /// - Drive-absolute (`X:\...` or `X:/...`): becomes `\\?\X:\...` with
+    ///   forward slashes normalized to backslashes.
+    /// - UNC (`\\server\...` or `//server/...`): becomes `\\?\UNC\server\...`.
+    /// - Anything else (relative, drive-relative like `X:foo`): returned
+    ///   untouched - a verbatim path must be fully qualified, and such paths
+    ///   never exceed `MAX_PATH` on the commit path.
+    pub(super) fn to_verbatim_wide(path: &[u16]) -> Vec<u16> {
+        if path.starts_with(&VERBATIM_PREFIX) || path.starts_with(&NT_PREFIX) {
+            return path.to_vec();
+        }
+
+        // Drive-absolute: `X:\...` / `X:/...`.
+        if path.len() >= 3
+            && is_drive_letter(path[0])
+            && path[1] == COLON
+            && (path[2] == SEP || path[2] == ALT_SEP)
+        {
+            let mut out = Vec::with_capacity(VERBATIM_PREFIX.len() + path.len());
+            out.extend_from_slice(&VERBATIM_PREFIX);
+            out.extend(path.iter().map(|&c| if c == ALT_SEP { SEP } else { c }));
+            return out;
+        }
+
+        // UNC: `\\server\...` / `//server/...`. Drop the leading two separators;
+        // the `\\?\UNC\` prefix supplies them.
+        if path.len() >= 2
+            && (path[0] == SEP || path[0] == ALT_SEP)
+            && (path[1] == SEP || path[1] == ALT_SEP)
+        {
+            let mut out = Vec::with_capacity(UNC_VERBATIM_PREFIX.len() + path.len());
+            out.extend_from_slice(&UNC_VERBATIM_PREFIX);
+            out.extend(
+                path[2..]
+                    .iter()
+                    .map(|&c| if c == ALT_SEP { SEP } else { c }),
+            );
+            return out;
+        }
+
+        path.to_vec()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        /// Encodes an ASCII string as a UTF-16 vector, the wire form Win32 sees.
+        fn w(s: &str) -> Vec<u16> {
+            s.encode_utf16().collect()
+        }
+
+        /// A deep drive-absolute path (>260 UTF-16 units) gains the `\\?\`
+        /// prefix - the exact fix for the `ERROR_FILENAME_EXCED_RANGE` commit.
+        #[test]
+        fn long_absolute_path_gains_verbatim_prefix() {
+            let deep = format!("C:\\{}\\file.bin", "d0000000".repeat(40));
+            assert!(deep.len() > 260, "fixture must exceed MAX_PATH");
+            let got = to_verbatim_wide(&w(&deep));
+            assert_eq!(got, w(&format!("\\\\?\\{deep}")));
+        }
+
+        /// A short drive-absolute path is still prefixed (correctness does not
+        /// depend on length; the raw rename would otherwise stay short-only).
+        #[test]
+        fn short_absolute_path_gains_verbatim_prefix() {
+            assert_eq!(
+                to_verbatim_wide(&w(r"C:\dir\file.bin")),
+                w(r"\\?\C:\dir\file.bin")
+            );
+        }
+
+        /// Forward slashes in a drive-absolute path are normalized to
+        /// backslashes: the verbatim namespace does no separator translation.
+        #[test]
+        fn forward_slashes_normalized_to_backslashes() {
+            assert_eq!(
+                to_verbatim_wide(&w("C:/dir/sub/file.bin")),
+                w(r"\\?\C:\dir\sub\file.bin")
+            );
+        }
+
+        /// A UNC path maps to the `\\?\UNC\` form with the leading `\\` dropped.
+        #[test]
+        fn unc_path_maps_to_unc_verbatim() {
+            assert_eq!(
+                to_verbatim_wide(&w(r"\\server\share\dir\file.bin")),
+                w(r"\\?\UNC\server\share\dir\file.bin")
+            );
+        }
+
+        /// An already-verbatim path is returned untouched (idempotent), so a
+        /// double conversion cannot corrupt the prefix.
+        #[test]
+        fn already_verbatim_is_unchanged() {
+            let p = w(r"\\?\C:\dir\file.bin");
+            assert_eq!(to_verbatim_wide(&p), p);
+        }
+
+        /// An NT-namespace (`\??\`) path is likewise left untouched.
+        #[test]
+        fn nt_prefixed_is_unchanged() {
+            let p = w(r"\??\C:\dir\file.bin");
+            assert_eq!(to_verbatim_wide(&p), p);
+        }
+
+        /// A relative path is not fully qualified, so it is returned unchanged
+        /// (no prefix, no slash rewrite) - such paths never exceed MAX_PATH on
+        /// the commit path.
+        #[test]
+        fn relative_path_is_unchanged() {
+            let p = w(r"dir\file.bin");
+            assert_eq!(to_verbatim_wide(&p), p);
+        }
+
+        /// A drive-relative path (`X:foo`, no separator after the colon) is also
+        /// left unchanged - prefixing it would change its meaning.
+        #[test]
+        fn drive_relative_path_is_unchanged() {
+            let p = w("C:file.bin");
+            assert_eq!(to_verbatim_wide(&p), p);
+        }
+    }
+}
+
 #[cfg(windows)]
 mod imp {
     use std::ffi::OsStr;
@@ -201,13 +379,17 @@ mod imp {
     ///
     /// `RootDirectory` is `NULL` (the only form the Win32
     /// `SetFileInformationByHandle` accepts) and `FileName` is the complete
-    /// destination path. `FILE_RENAME_INFO` is a variable-length struct whose
-    /// trailing `FileName[1]` field is a flexible array; the buffer is
-    /// allocated as a `Vec<u64>` so it is large enough for the path and aligned
-    /// to the struct's 8-byte (HANDLE) alignment. `FileNameLength` is the path
-    /// length in bytes (not UTF-16 code units).
+    /// destination path, converted to its `\\?\` verbatim form
+    /// ([`super::verbatim::to_verbatim_wide`]) because this raw Win32 call is
+    /// not long-path aware - without the prefix a destination deeper than 260
+    /// characters fails with `ERROR_FILENAME_EXCED_RANGE`. `FILE_RENAME_INFO` is
+    /// a variable-length struct whose trailing `FileName[1]` field is a flexible
+    /// array; the buffer is allocated as a `Vec<u64>` so it is large enough for
+    /// the path and aligned to the struct's 8-byte (HANDLE) alignment.
+    /// `FileNameLength` is the path length in bytes (not UTF-16 code units).
     fn set_rename_info(src: &File, dest_name: &OsStr, replace_existing: bool) -> io::Result<()> {
-        let name: Vec<u16> = dest_name.encode_wide().collect();
+        let name =
+            super::verbatim::to_verbatim_wide(&dest_name.encode_wide().collect::<Vec<u16>>());
         let name_bytes = name.len() * size_of::<u16>();
         // size_of::<FILE_RENAME_INFO>() already includes the 2-byte FileName[1]
         // stub, so header + name_bytes slightly over-allocates - harmless.

--- a/crates/fast_io/src/win_atomic_commit.rs
+++ b/crates/fast_io/src/win_atomic_commit.rs
@@ -357,3 +357,33 @@ mod imp {
 
 #[cfg(windows)]
 pub use imp::{create_new_no_follow, rename_no_follow};
+
+/// Returns `true` when an I/O error represents a cross-device link (`EXDEV`).
+///
+/// This is the single source of truth for the EXDEV detection every
+/// temp->destination commit path shares. A temp file staged in a `--temp-dir`
+/// (or partial dir) that lives on a different filesystem than the destination
+/// cannot be `rename(2)`d across the mount, so the commit falls back to
+/// copy+remove (upstream `util1.c:robust_rename()`).
+///
+/// The check is keyed on the raw OS error number rather than
+/// [`std::io::ErrorKind::CrossesDevices`] so it stays robust across std
+/// releases and is byte-identical on both sides of the commit divergence it
+/// unifies (the engine local-copy guard and the transfer disk-commit path):
+///
+/// - Unix: `raw_os_error() == libc::EXDEV` (errno 18).
+/// - Windows: `raw_os_error() == 17` (`ERROR_NOT_SAME_DEVICE`).
+///
+/// Every other platform reports `false`, so callers surface the original error.
+#[must_use]
+pub fn is_cross_device(error: &std::io::Error) -> bool {
+    match error.raw_os_error() {
+        #[cfg(unix)]
+        Some(code) => code == libc::EXDEV,
+        #[cfg(windows)]
+        Some(code) => code == 17, // ERROR_NOT_SAME_DEVICE
+        #[cfg(not(any(unix, windows)))]
+        Some(_) => false,
+        None => false,
+    }
+}

--- a/crates/fast_io/src/win_atomic_commit.rs
+++ b/crates/fast_io/src/win_atomic_commit.rs
@@ -218,6 +218,8 @@ mod imp {
     use std::os::windows::fs::OpenOptionsExt;
     use std::os::windows::io::AsRawHandle;
     use std::path::Path;
+    use std::thread::sleep;
+    use std::time::Duration;
 
     use windows_sys::Win32::Foundation::HANDLE;
     use windows_sys::Win32::Storage::FileSystem::{
@@ -285,6 +287,19 @@ mod imp {
     /// `replace_existing` maps to `FILE_RENAME_INFO::ReplaceIfExists` (upstream
     /// `do_rename` overwrites the destination).
     ///
+    /// The pin in step 1 omits `FILE_SHARE_DELETE`, which also means two commits
+    /// racing to the *same* destination momentarily lock each other out: while
+    /// one holds its pin, the other's replace can fail with
+    /// `ERROR_SHARING_VIOLATION` (32) or `ERROR_ACCESS_DENIED` (5). That
+    /// contention is transient - the pin drops the instant the other commit
+    /// returns - so [`is_transient_rename_contention`] gates a bounded retry
+    /// loop (`MAX_RETRY_ATTEMPTS` attempts, ~1 s cap) that re-opens and
+    /// re-validates the parent on every attempt, preserving the anti-swap
+    /// invariant across retries. oc-specific robustness: upstream rsync never
+    /// commits two temp files to one destination concurrently, so this only
+    /// races in the engine's parallel `DestinationWriteGuard` path, never on the
+    /// wire.
+    ///
     /// # Errors
     ///
     /// - [`io::ErrorKind::InvalidInput`] if `dest_path` lacks a parent
@@ -294,7 +309,8 @@ mod imp {
     ///   (upstream `util1.c:robust_rename()`).
     /// - Any underlying open, validation, or rename failure. A reparse-point
     ///   swap detected in step 1 or 2 surfaces as an error, so the commit fails
-    ///   safe rather than following the redirect.
+    ///   safe rather than following the redirect. Transient same-destination
+    ///   contention that outlasts the retry budget surfaces as the last error.
     pub fn rename_no_follow(
         temp_path: &Path,
         dest_path: &Path,
@@ -307,6 +323,45 @@ mod imp {
             )
         })?;
 
+        // Bounded retry on transient same-destination contention. Each attempt
+        // re-opens and re-validates the parent, so the reparse-swap rejection
+        // still fires on every attempt (never hoisted out of the loop); the
+        // fixed 20 ms backoff caps total waiting at ~1 s.
+        let mut attempt: u32 = 0;
+        loop {
+            match try_rename_no_follow_once(temp_path, dest_dir, dest_path, replace_existing) {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    attempt += 1;
+                    let transient = err
+                        .raw_os_error()
+                        .is_some_and(super::is_transient_rename_contention);
+                    if transient && attempt < MAX_RETRY_ATTEMPTS {
+                        sleep(RETRY_BACKOFF);
+                        continue;
+                    }
+                    return Err(err);
+                }
+            }
+        }
+    }
+
+    /// Retry ceiling for [`rename_no_follow`]'s transient-contention loop.
+    /// `MAX_RETRY_ATTEMPTS * RETRY_BACKOFF` bounds the total wait at ~1 s.
+    const MAX_RETRY_ATTEMPTS: u32 = 50;
+    /// Fixed backoff between contention retries.
+    const RETRY_BACKOFF: Duration = Duration::from_millis(20);
+
+    /// One attempt of the anchored, reparse-hardened commit rename. Splitting
+    /// this out lets [`rename_no_follow`] retry the whole open+validate+rename
+    /// sequence on transient same-destination contention while re-running the
+    /// reparse-point checks on every attempt.
+    fn try_rename_no_follow_once(
+        temp_path: &Path,
+        dest_dir: &Path,
+        dest_path: &Path,
+        replace_existing: bool,
+    ) -> io::Result<()> {
         // (1) Open, validate, and pin the destination parent. The missing
         // FILE_SHARE_DELETE keeps the directory from being renamed/removed/
         // replaced (swapped for a junction) while this handle is held across
@@ -567,5 +622,48 @@ pub fn is_cross_device(error: &std::io::Error) -> bool {
         #[cfg(not(any(unix, windows)))]
         Some(_) => false,
         None => false,
+    }
+}
+
+/// True for the transient Win32 error numbers a concurrent commit to the *same*
+/// destination produces while another committer briefly holds the no-follow pin
+/// on the destination parent.
+///
+/// [`imp::rename_no_follow`] pins that parent without `FILE_SHARE_DELETE` (the
+/// reparse-swap hardening), so a second committer racing to replace the same
+/// destination can be denied for the moment the pin is held:
+///
+/// - `ERROR_SHARING_VIOLATION` (32)
+/// - `ERROR_ACCESS_DENIED` (5)
+///
+/// Both clear as soon as the other committer's handle drops, so the commit
+/// retries. Every other error number is terminal and must surface unchanged -
+/// notably `ERROR_NOT_SAME_DEVICE` (17, EXDEV) so the caller falls back to
+/// copy+remove, `ERROR_FILENAME_EXCED_RANGE` (206), and `ERROR_FILE_NOT_FOUND`
+/// (2).
+///
+/// oc-specific robustness: upstream rsync never commits two temp files to one
+/// destination concurrently, so this races only in the engine's parallel
+/// `DestinationWriteGuard` path, never on the wire.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn is_transient_rename_contention(raw_os_error: i32) -> bool {
+    // ERROR_ACCESS_DENIED = 5, ERROR_SHARING_VIOLATION = 32.
+    matches!(raw_os_error, 5 | 32)
+}
+
+#[cfg(test)]
+mod contention_tests {
+    use super::is_transient_rename_contention;
+
+    /// The two transient contention codes retry; unrelated codes - including
+    /// EXDEV (17), which must fall back to copy+remove - stay terminal.
+    #[test]
+    fn only_sharing_and_access_denied_are_transient() {
+        assert!(is_transient_rename_contention(32)); // ERROR_SHARING_VIOLATION
+        assert!(is_transient_rename_contention(5)); // ERROR_ACCESS_DENIED
+        assert!(!is_transient_rename_contention(2)); // ERROR_FILE_NOT_FOUND
+        assert!(!is_transient_rename_contention(17)); // ERROR_NOT_SAME_DEVICE (EXDEV)
+        assert!(!is_transient_rename_contention(206)); // ERROR_FILENAME_EXCED_RANGE
+        assert!(!is_transient_rename_contention(0));
     }
 }

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -460,18 +460,12 @@ pub(super) fn rename_config_sandboxed(
 
 /// Returns `true` when an I/O error represents a cross-device link (EXDEV).
 ///
-/// On Unix, `raw_os_error() == libc::EXDEV` (errno 18). On Windows,
-/// `ERROR_NOT_SAME_DEVICE` (error 17) is the equivalent.
+/// Forwards to [`fast_io::is_cross_device`], the single source of truth shared
+/// with the engine local-copy commit guard and [`crate::temp_guard`]. On Unix
+/// this is `raw_os_error() == libc::EXDEV` (errno 18); on Windows
+/// `ERROR_NOT_SAME_DEVICE` (error 17).
 pub(super) fn is_cross_device(e: &io::Error) -> bool {
-    match e.raw_os_error() {
-        #[cfg(unix)]
-        Some(code) => code == libc::EXDEV,
-        #[cfg(windows)]
-        Some(code) => code == 17, // ERROR_NOT_SAME_DEVICE
-        #[cfg(not(any(unix, windows)))]
-        Some(_) => false,
-        None => false,
-    }
+    fast_io::is_cross_device(e)
 }
 
 /// Moves an existing destination file to its backup path, falling back to a

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -551,16 +551,11 @@ pub fn partial_dir_fname(dest_path: &Path, partial_dir: &Path) -> Option<PathBuf
 }
 
 /// Returns `true` when an I/O error represents a cross-device link (EXDEV).
+///
+/// Forwards to [`fast_io::is_cross_device`], the single source of truth shared
+/// with the engine local-copy commit guard and the disk-commit path.
 fn is_cross_device_error(e: &io::Error) -> bool {
-    match e.raw_os_error() {
-        #[cfg(unix)]
-        Some(code) => code == libc::EXDEV,
-        #[cfg(windows)]
-        Some(code) => code == 17, // ERROR_NOT_SAME_DEVICE
-        #[cfg(not(any(unix, windows)))]
-        Some(_) => false,
-        None => false,
-    }
+    fast_io::is_cross_device(e)
 }
 
 /// Commits a temp file to its final destination on Windows with a


### PR DESCRIPTION
## Problem

The temp->destination commit was implemented twice, and the two copies hardened the same operation differently:

- **Robust (transfer disk-commit):** `crates/transfer/src/temp_guard.rs` and `crates/transfer/src/disk_commit/process/commit.rs` detect the cross-device fallback via `raw_os_error()` (`EXDEV` on Unix, `ERROR_NOT_SAME_DEVICE = 17` on Windows) and commit through the reparse-anchored `fast_io::rename_no_follow` / `fast_io::create_new_no_follow` primitives (`crates/fast_io/src/win_atomic_commit.rs`), closing the CVE-2024-12747 junction-swap residual.
- **Fragile (engine local-copy):** `crates/engine/src/local_copy/executor/file/guard.rs` detected the cross-device case via `io::ErrorKind::CrossesDevices` and committed with a plain `fs::rename`, staging with a plain `fs::OpenOptions::create_new`. That path was **not** reparse-hardened on Windows: a junction/mount-point swapped onto the destination parent between temp-create and rename could redirect the committed file outside the destination tree, and the temp-create could be redirected through a pre-planted reparse point.

This is a GH-7153-class divergence: one upstream rule (`util1.c:robust_rename()` EXDEV copy+remove, plus the receiver's no-follow temp semantics) implemented two inconsistent ways.

## Change

Unify the engine commit guard with the transfer path around shared primitives:

- Add `fast_io::is_cross_device` as the **single source of truth** for the EXDEV / errno-17 detection. The two duplicated detectors in `transfer` (`is_cross_device`, `is_cross_device_error`) now forward to it.
- Engine `commit_named_temp_file` now keys its cross-device fallback on `fast_io::is_cross_device` instead of `ErrorKind::CrossesDevices`, and the commit rename routes through `fast_io::rename_no_follow` on Windows (handle-anchored, destination-parent validated as a real directory). The temp-create routes through `fast_io::create_new_no_follow` on Windows.
- Unix behaviour is unchanged: the io_uring / `fs::rename` fast path is preserved, and the EXDEV copy+remove fallback keeps its remove-before-copy step so a restrictive-permission (e.g. mode 440) existing destination is still replaced. `cross_device == true` is still returned so the caller invalidates its temp-inode fd.

## Tests

- `commit_falls_back_to_copy_remove_on_cross_device_rename` - an injected cross-device rename (thread-local fault injection mirroring the transfer `ForceExdev` harness) forces the copy+remove fallback, asserting the destination holds the exact staged content and the commit reports `cross_device == true`. Runs on the Windows engine CI job too (errno 17 is what std surfaces there).
- `commit_refuses_reparse_point_destination_parent` (Windows) - a junction swapped onto the destination parent is refused; the attacker tree never receives the committed file and its sentinel is untouched.

## Verification (x86_64 Linux, 1.88.0, isolated worktree, CARGO_BUILD_JOBS=4)

- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - RC 0
- `cargo check --locked --workspace --target x86_64-pc-windows-gnu` - RC 0
- `cargo check --locked --workspace --target x86_64-unknown-linux-musl` - RC 0
- `cargo nextest run -p engine --all-features -E 'test(commit) or test(atomic) or test(rename) or test(cross_device) or test(guard)'` - 98 passed
- `cargo build --locked --bin oc-rsync` - RC 0
- `cargo-fmt --all -- --check` - clean

## Follow-up

Full extraction of a single shared commit routine was intentionally not done: the engine EXDEV branch removes an existing restrictive-permission destination before `fs::copy` (matching upstream `unlink_and_reopen`), which the leaner transfer commit does not, and engine cannot depend on `transfer` (the dependency runs `transfer -> engine`). The shared piece that could be unified without regressing that behaviour - the errno detector - now lives once in `fast_io`. A later pass could hoist the anchored-rename + EXDEV-fallback loop into `fast_io` and have both callers parameterise the pre-copy unlink.

