### PR TITLE
fix(cli): stop --bwlimit=/--block-size server-arg positional leaks + round-trip guard

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -912,6 +912,15 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--compare-dest=")
         || arg.starts_with("--copy-dest=")
         || arg.starts_with("--link-dest=")
+        // upstream: options.c:2807-2808 / 2926-2927 - server_options() emits
+        // `--backup-dir` / `--temp-dir` as SPLIT two-arg slots (`--flag` +
+        // safe_arg), recognised by is_two_arg_server_long_flag. oc's own
+        // forwarder (invocation/builder.rs) emits the JOINED `--flag=value`
+        // form; recognise it here too, exactly like the alt-dest flags above,
+        // so the joined value is not mistaken for a positional destination
+        // path (same allow-list-drift class as --compare/copy/link-dest).
+        || arg.starts_with("--backup-dir=")
+        || arg.starts_with("--temp-dir=")
         || arg.starts_with("--modify-window=")
         // upstream: options.c:2874 - a negative modify_window arrives as the
         // short `-@%d` token (e.g. `-@-1`) after the compact flag string, so it
@@ -923,6 +932,11 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--stop-at=")
         || arg.starts_with("--stop-after=")
         || arg.starts_with("--files-from=")
+        // upstream: options.c:2799-2800 - server_options() emits `--bwlimit=%d`
+        // (whole KiB) as a JOINED long flag. Recognise it so the value is not
+        // mistaken for a positional destination path; a separate pass captures
+        // the numeric value into ServerLongFlags::bwlimit.
+        || arg.starts_with("--bwlimit=")
         || arg.starts_with("--max-delete=")
         // upstream: options.c:2812-2813 / 2912-2913 / 2915-2916 / 2859-2860 -
         // server_options() emits these as joined `--flag=value` via safe_arg().

--- a/crates/cli/src/frontend/server/mod.rs
+++ b/crates/cli/src/frontend/server/mod.rs
@@ -13,6 +13,9 @@ mod run;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod roundtrip_tests;
+
 pub(crate) use daemon::{
     daemon_mode_arguments, run_daemon_mode, run_server_daemon_mode, server_daemon_mode_requested,
     server_mode_requested,

--- a/crates/cli/src/frontend/server/roundtrip_tests.rs
+++ b/crates/cli/src/frontend/server/roundtrip_tests.rs
@@ -1,0 +1,179 @@
+//! Round-trip guard against server-arg allow-list drift.
+//!
+//! `is_known_server_long_flag` is a hand-maintained allow-list. When a
+//! value-bearing flag the client actually emits is missing from it,
+//! `parse_server_flag_string_and_args` cannot tell the flag's operand from a
+//! transfer path, so the `--opt=val` (or `-Xval`) token falls through into
+//! `positional_args` and becomes a spurious source/destination path - silently
+//! corrupting the transfer.
+//!
+//! This has bitten repeatedly: the `--bwlimit=` / `--block-size` leaks these
+//! tests were added for, `-e` (#7153), and earlier #6569 / #6587. Asserting one
+//! flag at a time never catches the NEXT drift. Instead, this module builds the
+//! real server argv with [`RemoteInvocationBuilder`] for a representative matrix
+//! of client configs and both transfer roles, feeds it through the production
+//! parser, and asserts that `positional_args` holds ONLY the genuine transfer
+//! paths - zero leaked option tokens - while the forwarded values are still
+//! captured. Any future emitter/allow-list divergence fails here.
+//!
+//! (`RemoteInvocationBuilder` lives in the `core` crate; the parser functions
+//! are the `pub(super)` production entry points used by `run.rs`.)
+
+use std::ffi::OsString;
+use std::num::{NonZeroU32, NonZeroU64};
+
+use core::client::remote::invocation::{RemoteInvocationBuilder, RemoteRole};
+use core::client::{BandwidthLimit, ClientConfig, TransferTimeout};
+
+use super::flags::parse_server_long_flags;
+use super::parse::parse_server_flag_string_and_args;
+
+/// Builds the server argv exactly as the SSH transport would, then returns the
+/// slice the server actually parses: production `run.rs` drops the arg0 program
+/// name (`&args[1..]`) before handing the tail to the parser.
+fn server_argv(config: &ClientConfig, role: RemoteRole, paths: &[&str]) -> Vec<OsString> {
+    RemoteInvocationBuilder::new(config, role).build_with_paths(paths)
+}
+
+/// Core invariant: after parsing, `positional_args` must equal exactly the
+/// transfer paths - no token may start with `-`, which is the signature of an
+/// allow-list miss leaking an option into the path list.
+fn assert_no_positional_leak(config: &ClientConfig, role: RemoteRole, paths: &[&str]) {
+    let built = server_argv(config, role, paths);
+    let (flag_string, positional) = parse_server_flag_string_and_args(&built[1..]);
+
+    assert!(
+        flag_string.starts_with('-') && !flag_string.starts_with("--"),
+        "expected a compact flag string, got {flag_string:?} in {built:?}"
+    );
+
+    for token in &positional {
+        let text = token.to_string_lossy();
+        assert!(
+            !text.starts_with('-'),
+            "leaked option token `{text}` in positional_args - \
+             is_known_server_long_flag drifted from the emitter: {built:?}"
+        );
+    }
+
+    let got: Vec<String> = positional
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    let want: Vec<String> = paths.iter().map(|p| (*p).to_owned()).collect();
+    assert_eq!(
+        got, want,
+        "positional_args must be exactly the transfer paths: {built:?}"
+    );
+}
+
+#[test]
+fn bwlimit_does_not_leak_and_is_captured() {
+    // upstream: options.c:2799-2800 - `--bwlimit=%d` (whole KiB), emitted
+    // unconditionally (both roles). The parser must recognise the joined form
+    // AND capture its value.
+    let config = ClientConfig::builder()
+        .bandwidth_limit(Some(BandwidthLimit::from_bytes_per_second(
+            NonZeroU64::new(4 * 1024 * 1024).unwrap(),
+        )))
+        .build();
+
+    for role in [RemoteRole::Sender, RemoteRole::Receiver] {
+        assert_no_positional_leak(&config, role, &["/remote/path"]);
+        let built = server_argv(&config, role, &["/remote/path"]);
+        assert!(
+            built
+                .iter()
+                .any(|a| a.to_string_lossy().starts_with("--bwlimit=")),
+            "bwlimit must forward on {role:?}: {built:?}"
+        );
+        let long = parse_server_long_flags(&built[1..]);
+        assert!(
+            long.bwlimit.is_some(),
+            "server parser must capture the forwarded bwlimit on {role:?}: {built:?}"
+        );
+    }
+}
+
+#[test]
+fn block_size_emits_short_b_and_does_not_leak() {
+    // upstream: options.c:2788 - `-B%u` short spelling. The old non-upstream
+    // long `--block-size=` form leaked because is_known only knows `-B<digits>`.
+    let config = ClientConfig::builder()
+        .block_size_override(Some(NonZeroU32::new(131072).unwrap()))
+        .build();
+
+    for role in [RemoteRole::Sender, RemoteRole::Receiver] {
+        assert_no_positional_leak(&config, role, &["/remote/path"]);
+        let built = server_argv(&config, role, &["/remote/path"]);
+        assert!(
+            built.iter().any(|a| a == "-B131072"),
+            "block_size must forward as upstream `-B131072` on {role:?}: {built:?}"
+        );
+        assert!(
+            !built
+                .iter()
+                .any(|a| a.to_string_lossy().starts_with("--block-size")),
+            "the non-upstream long --block-size spelling must be gone: {built:?}"
+        );
+        let long = parse_server_long_flags(&built[1..]);
+        assert_eq!(
+            long.block_size.as_deref(),
+            Some("131072"),
+            "server parser must capture the -B value on {role:?}: {built:?}"
+        );
+    }
+}
+
+#[test]
+fn temp_dir_and_backup_dir_joined_forms_do_not_leak() {
+    // upstream emits these SPLIT (options.c:2807-2808 / 2926-2927); oc's own
+    // forwarder emits the JOINED `--flag=value`. Both must be recognised. These
+    // are am_sender (PUSH) only, so exercise the Sender role.
+    let config = ClientConfig::builder()
+        .temp_directory(Some("/var/tmp/oc-spill"))
+        .backup(true)
+        .backup_directory(Some("/srv/backups"))
+        .backup_suffix(Some(".orig"))
+        .build();
+
+    assert_no_positional_leak(&config, RemoteRole::Sender, &["/remote/dest"]);
+
+    let built = server_argv(&config, RemoteRole::Sender, &["/remote/dest"]);
+    assert!(
+        built.iter().any(|a| a == "--temp-dir=/var/tmp/oc-spill"),
+        "temp-dir must forward joined: {built:?}"
+    );
+    assert!(
+        built.iter().any(|a| a == "--backup-dir=/srv/backups"),
+        "backup-dir must forward joined: {built:?}"
+    );
+}
+
+#[test]
+fn broad_flag_mix_never_leaks_positionals() {
+    // A single config that lights up the value-bearing, leak-prone flags at once
+    // (the boolean flags fold into the compact string and cannot become
+    // positionals). `-e.<caps>` is embedded in the compact flag string of every
+    // invocation, so the #7153 `-e` class is covered here too.
+    let config = ClientConfig::builder()
+        .bandwidth_limit(Some(BandwidthLimit::from_bytes_per_second(
+            NonZeroU64::new(8 * 1024 * 1024).unwrap(),
+        )))
+        .block_size_override(Some(NonZeroU32::new(65536).unwrap()))
+        .temp_directory(Some("/tmp/oc"))
+        .backup(true)
+        .backup_directory(Some("/bak"))
+        .backup_suffix(Some("~"))
+        .compare_destination("/cmp")
+        .link_destination("/lnk")
+        .copy_destination("/cpy")
+        .timeout(TransferTimeout::Seconds(NonZeroU64::new(300).unwrap()))
+        .build();
+
+    // Sender (PUSH): dest-refs, temp-dir, backup-dir all emit here. Single path.
+    assert_no_positional_leak(&config, RemoteRole::Sender, &["/remote/dest"]);
+    // Receiver (PULL): bwlimit/block-size/timeout still emit. Multi-path exercises
+    // the `.` separator and back-to-back paths.
+    assert_no_positional_leak(&config, RemoteRole::Receiver, &["/remote/a", "/remote/b"]);
+}

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -520,8 +520,14 @@ impl<'a> RemoteInvocationBuilder<'a> {
             )));
         }
 
+        // upstream: options.c:2788 - block_size is forwarded as the SHORT
+        // `-B%u` token (e.g. `-B131072`), not a long `--block-size=` flag.
+        // Emitting the upstream spelling keeps the wire byte-identical and is
+        // recognised by the server parser's `-B<digits>` guard; the long form
+        // is absent from is_known_server_long_flag and would otherwise leak
+        // into the positional path list on an oc-to-oc SSH transfer.
         if let Some(bs) = self.config.block_size_override() {
-            args.push(OsString::from(format!("--block-size={}", bs.get())));
+            args.push(OsString::from(format!("-B{}", bs.get())));
         }
 
         if let TransferTimeout::Seconds(secs) = self.config.timeout() {

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2581,15 +2581,22 @@ fn includes_new_compress_for_explicit_zlibx() {
 }
 
 #[test]
-fn includes_block_size_long_arg() {
+fn includes_block_size_short_arg() {
     use std::num::NonZeroU32;
     let config = ClientConfig::builder()
         .block_size_override(Some(NonZeroU32::new(8192).unwrap()))
         .build();
     let args = build_sender_args(&config);
+    // upstream: options.c:2788 - block_size forwards as the SHORT `-B%u` token,
+    // never a long `--block-size=` flag (which the server parser would leak as
+    // a positional destination path).
     assert!(
-        args.iter().any(|a| a == "--block-size=8192"),
-        "expected --block-size=8192 in args: {args:?}"
+        args.iter().any(|a| a == "-B8192"),
+        "expected -B8192 in args: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a.starts_with("--block-size")),
+        "must not emit the non-upstream long --block-size spelling: {args:?}"
     );
 }
 
@@ -3069,8 +3076,10 @@ fn omits_block_size_when_none() {
     let config = ClientConfig::builder().build();
     let args = build_sender_args(&config);
     assert!(
-        !args.iter().any(|a| a.starts_with("--block-size=")),
-        "should not emit --block-size= when none: {args:?}"
+        !args
+            .iter()
+            .any(|a| a.starts_with("-B") || a.starts_with("--block-size")),
+        "should not emit a block-size token when none: {args:?}"
     );
 }
 
@@ -3344,7 +3353,6 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--min-size=100",
         "--modify-window=1",
         "--compress-level=9",
-        "--block-size=4096",
         "--timeout=60",
         "--inplace",
         "--copy-unsafe-links",
@@ -3366,6 +3374,16 @@ fn all_flags_enabled_produces_valid_invocation() {
             "all-flags test: missing {expected} in args: {args:?}"
         );
     }
+
+    // upstream: options.c:2788 - block_size forwards as the SHORT `-B%u` token.
+    assert!(
+        args.iter().any(|a| a == "-B4096"),
+        "all-flags test: missing -B4096 in args: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a.starts_with("--block-size")),
+        "all-flags test: must not emit the non-upstream long --block-size spelling: {args:?}"
+    );
 
     // upstream: `--munge-links` is absent from server_options() entirely - it is
     // applied locally where the symlink is written (options.c:2254, gated on


### PR DESCRIPTION
## Problem

The server-mode operand scanner (`parse_server_flag_string_and_args`) walks the
`--server` argv and skips value-bearing long flags using the hand-maintained
`is_known_server_long_flag` allow-list. Anything not on that list that starts a
new token is treated as a transfer path. Two flags the client actually forwards
were missing, so their operands leaked into `positional_args` as spurious
source/destination paths and corrupted the transfer:

- **`--bwlimit=`** - `server_options()` emits `--bwlimit=%d` (whole KiB) as a
  joined long flag (`options.c:2799-2800`), which oc mirrors exactly. But
  `is_known_server_long_flag` had no `--bwlimit=` arm, so `--bwlimit=1024`
  became a positional path. This breaks **upstream->oc** and **oc->oc** SSH
  transfers whenever a bandwidth limit is set.
- **`--temp-dir=` / `--backup-dir=`** - upstream emits these split
  (`--flag` + value, `options.c:2807-2808` / `2926-2927`), already handled by
  `is_two_arg_server_long_flag`. oc's own forwarder emits the joined
  `--flag=value` form, which had no allow-list arm - the same drift class as the
  alt-dest flags, which already carry both a joined `is_known` arm and a split
  `is_two_arg` arm. **oc->oc** leak.

Separately, the SSH invocation builder emitted a **non-upstream long**
`--block-size={N}`. Upstream forwards the short `-B%u` token
(`options.c:2788`), and the server parser already recognises it via its
`-B<digits>` guard. The long spelling had no allow-list arm, so `--block-size=`
leaked on **oc->oc** SSH.

These are all the same allow-list-drift class as GH-7153 (which closed only the
`-e` value-arg parse), #6569, and #6587.

## Fix

- Parser-side: add `--bwlimit=`, `--temp-dir=`, `--backup-dir=` arms to
  `is_known_server_long_flag` (the emit already matches upstream for these).
- Emit-side: change the SSH invocation builder to forward `-B{N}` instead of
  `--block-size={N}`, byte-identical to upstream (`options.c:2788`) and already
  parseable by the existing `-B<digits>` guard. Removes the wire divergence.

A full re-scan of every builder emission against the allow-list found only these
missing arms; `--suffix=`, `--usermap=`, `--groupmap=`, `--skip-compress=`, the
alt-dest flags, and the rest were already covered.

## Durable guard

New `crates/cli/src/frontend/server/roundtrip_tests.rs`: for a representative
matrix of client configs and both transfer roles, it builds the real server
argv with `RemoteInvocationBuilder`, feeds it through the production parser, and
asserts `positional_args` holds **only** the genuine transfer paths (zero leaked
`--opt=val` / `-Xval` tokens) while the forwarded values stay captured. It
covers `--bwlimit`, `-B`, `--temp-dir=`, `--backup-dir=`, the embedded `-e.<caps>`
string, and a broad mix. This catches the whole allow-list-drift class instead
of one flag at a time; reverting any of the arms makes it fail with the exact
leaked token.

## Verification (x86_64 Linux)

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` RC0
- `cargo check --locked --workspace --target x86_64-pc-windows-gnu` RC0
- `cargo check --locked --workspace --target x86_64-unknown-linux-musl` RC0
- `cargo nextest run -p cli -p core -p transfer --all-features -E 'test(server) or test(bwlimit) or test(block_size) or test(roundtrip) or test(invocation)'` - 836 passed, 0 failed
- `cargo build --bin oc-rsync` RC0

## Note (out of scope)

The daemon-transfer arg builder
(`daemon_transfer/orchestration/arguments.rs`) still emits the joined
`--block-size=` spelling. That path uses the separate daemon `client_args`
parser (not this SSH server parser), which accepts the joined form, and upstream
recognises `--block-size` in its popt table - so it is a cosmetic wire
divergence, not a leak. A follow-up can align it to `-B` for full wire fidelity.

