### PR TITLE
fix(test-support): anchor profile-dir on the build/ landmark (fixes macOS-nightly)

### DIFF
--- a/crates/test-support/build.rs
+++ b/crates/test-support/build.rs
@@ -4,11 +4,14 @@
 //! package that declares the `oc-rsync` `[[bin]]`, so `env!` is a hard compile
 //! error in every other package. `OUT_DIR`, by contrast, is given to every
 //! build script, and Cargo lays it out as
-//! `<target-dir>/[<triple>/]<profile>/build/<pkg>-<hash>/out`. Its fourth
-//! ancestor is therefore the exact profile directory that the current Cargo
-//! invocation links workspace binaries into - including custom profiles,
-//! cross-compilation triples, and relocated target directories such as
-//! `cargo llvm-cov`'s.
+//! `<target-dir>/[<triple>/]<profile>/build/<pkg>-<hash>/out`. The `build`
+//! directory Cargo puts build-script output under sits directly inside the
+//! profile directory, so that profile directory - the exact directory the
+//! current Cargo invocation links workspace binaries into, including custom
+//! profiles, cross-compilation triples, and relocated target directories such
+//! as `cargo llvm-cov`'s - is the parent of the nearest `build` ancestor. We
+//! anchor on that landmark rather than a fixed ancestor count, which a deeper
+//! OUT_DIR nesting on newer Cargo toolchains would silently break.
 //!
 //! Emitting that one directory gives dependent crates a Cargo-provided,
 //! compile-time anchor, replacing hand-rolled `target/{debug,release,dist}`
@@ -22,10 +25,26 @@ fn main() {
     let out_dir = PathBuf::from(
         std::env::var_os("OUT_DIR").expect("OUT_DIR is always set for build scripts"),
     );
+    // Cargo lays OUT_DIR out as `<profile>/build/<pkg>-<hash>/out`, but the
+    // exact depth between `out` and `build` is not contractual: newer Cargo
+    // toolchains nest it one level deeper, which silently broke a hard-coded
+    // `ancestors().nth(3)` - it then resolved to `<profile>/build`, so every
+    // workspace binary was sought under the build-script output directory and
+    // never found (observed on a newer nightly macOS runner). Anchor on the one
+    // stable landmark instead: Cargo always writes build-script output into a
+    // `build` directory that sits directly inside the profile directory, so the
+    // profile directory is that `build` directory's parent - correct regardless
+    // of any intervening nesting.
     let profile_dir = out_dir
         .ancestors()
-        .nth(3)
-        .unwrap_or_else(|| panic!("unexpected OUT_DIR layout: {}", out_dir.display()));
+        .find(|ancestor| ancestor.file_name().is_some_and(|name| name == "build"))
+        .and_then(std::path::Path::parent)
+        .unwrap_or_else(|| {
+            panic!(
+                "unexpected OUT_DIR layout (no `build` ancestor): {}",
+                out_dir.display()
+            )
+        });
 
     println!(
         "cargo:rustc-env=OC_RSYNC_TARGET_PROFILE_DIR={}",


### PR DESCRIPTION
## Root cause

The recurring **macOS (nightly)** CI failure is **not** a copy_dest / clonefile / content-divergence issue (as previously assumed). Three tests in `crates/cli/tests/inc_recurse_capability_gate.rs` — which spawn the built `oc-rsync` binary — panicked at `test-support/src/bin_path.rs:52`:

```
oc-rsync binary missing at .../target/debug/build/oc-rsync;
refusing to fall back to a stale build
```

The path is wrong: binaries live at `target/debug/oc-rsync`, not under `target/debug/**build**/` (Cargo's build-script output dir). `test-support/build.rs` derived `OC_RSYNC_TARGET_PROFILE_DIR` from `OUT_DIR` with a hard-coded `ancestors().nth(3)`, assuming `OUT_DIR == <profile>/build/<pkg>-<hash>/out`. A newer Cargo toolchain (the macOS nightly runner) nests `OUT_DIR` one level deeper, so `nth(3)` resolved to `<profile>/build` — hence the bad path and the panic. Other runners (stable, older nightly) use the classic layout, so they passed.

## Fix

Anchor the profile-dir derivation on a stable landmark instead of a fixed ancestor count: Cargo always writes build-script output into a `build` directory that sits **directly inside** the profile directory, so the profile dir is the nearest `build` ancestor's parent — correct for the classic layout, the deeper nesting, cross-compilation triples, and custom profiles alike.

## Validation

Verified the derivation against representative `OUT_DIR` layouts:

| layout | fix | old `nth(3)` |
|---|---|---|
| classic `.../debug/build/<pkg>/out` | `.../debug` ✓ | `.../debug` ✓ |
| deeper-nightly `.../debug/build/<pkg>/out/extra` | `.../debug` ✓ | `.../debug/build` ✗ (the bug) |
| triple `.../<triple>/debug/build/<pkg>/out` | `.../<triple>/debug` ✓ | `.../<triple>/debug` ✓ |
| release | `.../release` ✓ | `.../release` ✓ |

The fix produces the correct profile dir for every layout, including the deeper one the old code got wrong. The macOS-nightly cell on this PR exercises the real newer-Cargo layout.
