### PR TITLE
fix(metadata): Windows metadata_unchanged must compare the read-only bit

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -274,6 +274,25 @@ pub fn apply_file_metadata_with_fd_if_changed(
     Ok(())
 }
 
+/// Returns `true` when the destination's Windows read-only attribute differs
+/// from what the sender's mode requires, so the quick-check must treat the file
+/// as changed and let the apply path re-stamp the bit.
+///
+/// Windows preserves only the read-only attribute; the apply path
+/// ([`permissions::set_permissions_like`] and `apply_permissions_from_entry`)
+/// derives it from the POSIX owner-write bit, so a mode with `0o200` clear is
+/// read-only. This collapses upstream's full-mode `perms_differ()`
+/// (generator.c:418) to a single read-only-bit compare, mirroring the Unix
+/// arm's permission leg. Kept as a pure, platform-independent helper so it is
+/// unit-testable on Linux even though it only gates the `cfg(not(unix))` path.
+// upstream: generator.c:418 perms_differ() - the mode compare behind
+// unchanged_attrs()'s `if perms_differ(...)` leg.
+#[cfg(any(not(unix), test))]
+pub(crate) fn windows_readonly_differs(entry_permissions: u32, current_readonly: bool) -> bool {
+    let required_readonly = entry_permissions & 0o200 == 0;
+    required_readonly != current_readonly
+}
+
 /// Fast check whether all metadata attributes already match the destination.
 ///
 /// Mirrors upstream `generator.c:468 unchanged_attrs()` - a pure in-memory
@@ -370,6 +389,19 @@ pub fn metadata_unchanged(
 
     #[cfg(not(unix))]
     {
+        // upstream: generator.c:494-495 perms_differ(). Windows preserves only
+        // the read-only attribute, so the full-mode compare collapses to a
+        // single read-only-bit compare (`windows_readonly_differs`). The apply
+        // path (permissions::set_permissions_like /
+        // apply_permissions_from_entry) re-stamps this bit under --perms, so the
+        // quick-check must gate on it or a file differing ONLY in the read-only
+        // attribute is judged unchanged and the update is silently skipped.
+        if options.permissions()
+            && windows_readonly_differs(entry.permissions(), cached_meta.permissions().readonly())
+        {
+            return false;
+        }
+
         if options.times() {
             let current_mtime = filetime::FileTime::from_last_modification_time(cached_meta);
             // upstream: util1.c:1478 same_time() - apply the `--modify-window`

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1775,6 +1775,85 @@ fn metadata_unchanged_honors_modify_window() {
     );
 }
 
+/// WHY: On Windows the only permission bit the apply path preserves is the
+/// read-only attribute, derived from the sender's owner-write bit (0o200).
+/// `windows_readonly_differs` is the pure compare that the `cfg(not(unix))`
+/// quick-check gates on; if it were wrong (or absent) a dest differing ONLY in
+/// the read-only attribute would be judged unchanged and never re-stamped. This
+/// runs on Linux to lock the mapping (0o200 clear == read-only) independent of
+/// any Windows filesystem, mirroring upstream `perms_differ()` (generator.c:418).
+#[test]
+fn windows_readonly_differs_maps_owner_write_bit() {
+    // Sender mode is writable (0o644): a read-only dest differs, a writable
+    // dest matches.
+    assert!(
+        crate::apply::windows_readonly_differs(0o644, true),
+        "writable source vs read-only dest must differ"
+    );
+    assert!(
+        !crate::apply::windows_readonly_differs(0o644, false),
+        "writable source vs writable dest must match"
+    );
+
+    // Sender mode is read-only (0o444, 0o200 clear): a writable dest differs, a
+    // read-only dest matches.
+    assert!(
+        crate::apply::windows_readonly_differs(0o444, false),
+        "read-only source vs writable dest must differ"
+    );
+    assert!(
+        !crate::apply::windows_readonly_differs(0o444, true),
+        "read-only source vs read-only dest must match"
+    );
+}
+
+/// WHY: `set_permissions_like` / `apply_permissions_from_entry` re-stamp the
+/// Windows read-only attribute under `--perms`, so the quick-check must report
+/// a file that differs ONLY in that attribute as changed - otherwise the update
+/// is silently skipped. Runs in the Windows CI job for the metadata crate.
+#[cfg(windows)]
+#[test]
+fn metadata_unchanged_detects_readonly_difference() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("ro.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    // Destination is writable on disk.
+    let meta = fs::metadata(&dest).expect("metadata");
+    assert!(!meta.permissions().readonly(), "dest starts writable");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    // Sender entry carries a read-only mode (owner-write bit 0o200 cleared);
+    // every other preserved attribute matches the destination.
+    let mut entry = FileEntry::new_file("ro.txt".into(), 4, 0o444);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true);
+
+    assert!(
+        !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
+        "a read-only-only difference must be reported as changed"
+    );
+
+    // Applying the entry must re-stamp the read-only attribute.
+    apply_metadata_from_file_entry(&dest, &entry, &opts).expect("apply from entry");
+    let applied = fs::metadata(&dest).expect("re-stat");
+    assert!(
+        applied.permissions().readonly(),
+        "read-only attribute must be applied to the destination"
+    );
+
+    // Now the destination matches: the quick-check reports unchanged.
+    assert!(
+        metadata_unchanged(&entry, &opts, &applied, crate::ModifyWindow::ZERO),
+        "matching read-only attribute must be reported as unchanged"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn metadata_unchanged_ignores_perms_when_not_preserved() {


### PR DESCRIPTION
## Problem

`metadata_unchanged` (`crates/metadata/src/apply/mod.rs`) is the in-memory
quick-check that lets the receiver skip the metadata-application chain when every
preserved attribute already matches the destination. The `cfg(not(unix))`
(Windows) arm compared mtime, atime, chmod presence and owner/group overrides -
but never the read-only attribute.

The apply path *does* preserve that attribute: `set_permissions_like` copies
`metadata.permissions().readonly()` onto the destination, and
`apply_permissions_from_entry` re-stamps it under `--perms`
(`readonly = entry.permissions() & 0o200 == 0`). So a destination differing ONLY
in the read-only attribute was judged "unchanged" and the read-only update was
silently skipped.

The Unix arm has no such hole: it runs a full `perms_differ()`-style mode compare
(`generator.c:418`) gated on `--perms`.

## Fix

Add a pure, platform-independent helper `windows_readonly_differs(entry_permissions,
current_readonly)` that maps the sender's owner-write bit (`0o200` clear ==
read-only) to the Windows read-only attribute - the single bit the apply path
honors. The Windows quick-check now gates its permission leg on this helper, so a
read-only-only difference marks the file changed and the bit is re-applied. This
mirrors the Unix arm's permission leg and upstream `perms_differ()`
(`generator.c:418`), which `unchanged_attrs()` (`generator.c:468`) evaluates
before declaring a file unchanged.

Behavior for every currently-compared attribute is unchanged.

## Tests

- `windows_readonly_differs_maps_owner_write_bit` - pure compare, runs on Linux,
  locks the mapping (writable vs read-only source against writable/read-only
  dest) independent of any Windows filesystem.
- `metadata_unchanged_detects_readonly_difference` (Windows CI job) - a
  destination differing only in the read-only attribute is reported changed, the
  apply path re-stamps the attribute, and a matching attribute is then reported
  unchanged. Encodes WHY: the apply path preserves this bit under `--perms`, so
  the quick-check must gate on it.

## Verification (x86_64 Linux)

- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo check --locked --workspace --target x86_64-pc-windows-gnu` - clean
- `cargo check --locked --workspace --target x86_64-unknown-linux-musl` - clean
- `cargo nextest run -p metadata --all-features -E 'test(metadata_unchanged) or test(readonly) or test(permission) or test(quick)'` - 31 passed
- `cargo fmt --all -- --check` - clean
