### PR TITLE
fix(cli): reject --rsh combined with an ssh:// URL operand (mutually exclusive transports)

### DIFF
--- a/crates/cli/tests/mutually_exclusive_options.rs
+++ b/crates/cli/tests/mutually_exclusive_options.rs
@@ -283,6 +283,29 @@ fn test_old_args_and_secluded_args_rejected() {
 }
 
 #[test]
+fn test_rsh_and_ssh_url_operand_rejected() {
+    // oc-specific: `-e ssh` requests the external system ssh, but an `ssh://`
+    // URL operand selects the built-in SSH client, which ignores --rsh. The
+    // two pick mutually exclusive transports; historically `ssh://` silently
+    // won and --rsh was dropped, running a transport the user did not ask for.
+    // The conflict surfaces at config-build time as RERR_SYNTAX (exit 1).
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let code = cli::run(
+        ["oc-rsync", "-e", "ssh", "ssh://host/path", "dest"],
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(code, 1, "expected RERR_SYNTAX (exit code 1)");
+    let stderr_text = String::from_utf8_lossy(&stderr);
+    assert!(
+        stderr_text.contains("--rsh/-e cannot be combined with an ssh:// URL operand"),
+        "stderr should explain the transport conflict, got: {stderr_text}"
+    );
+}
+
+#[test]
 fn test_append_and_no_whole_file_accepted() {
     // The companion `--no-whole-file` form must remain accepted.
     let result = parse_args(["oc-rsync", "--append", "--no-whole-file", "src", "dest"]);

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -11,12 +11,31 @@ use std::time::SystemTime;
 pub struct ConfigConflict {
     /// The first conflicting option (e.g. `--inplace`).
     pub option1: &'static str,
-    /// The second conflicting option (e.g. `--partial-dir`).
+    /// The second conflicting option (e.g. `--partial-dir`), or a sentinel such
+    /// as [`SSH_URL_OPERAND`] when the conflict is against an operand rather
+    /// than a second option.
     pub option2: &'static str,
 }
 
+/// Sentinel [`ConfigConflict::option2`] value marking the `--rsh`/`ssh://`-URL
+/// transport-selection conflict. Its second half is a URL operand, not an
+/// option, so [`ConfigConflict`]'s `Display` gives it a bespoke message rather
+/// than the generic "--X cannot be used with --Y" phrasing.
+const SSH_URL_OPERAND: &str = "ssh-url-operand";
+
 impl fmt::Display for ConfigConflict {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // oc-specific: an explicit --rsh/-e selects the external system ssh
+        // binary, which is honoured only for `host:path` operands; an `ssh://`
+        // URL instead selects the built-in SSH client, which ignores --rsh.
+        // The two are contradictory, so the message names the operand rather
+        // than a second option. No upstream analogue: upstream has no ssh://.
+        if matches!((self.option1, self.option2), ("rsh", SSH_URL_OPERAND)) {
+            return write!(
+                f,
+                "--rsh/-e cannot be combined with an ssh:// URL operand (ssh:// uses the built-in SSH client); use host:path for an external ssh, or drop --rsh"
+            );
+        }
         // upstream: options.c:1977 - the secluded/old-args conflict has a
         // dedicated phrasing (and operand order) distinct from the generic
         // "--X cannot be used with --Y" template used for other conflicts.
@@ -308,7 +327,31 @@ impl ClientConfigBuilder {
     ///   (upstream: `--append` sets `inplace = 1`, then the `inplace && partial_dir` check fires)
     /// - `--append` conflicts with `--whole-file`
     ///   (upstream: options.c:2400 `if (append_mode) { if (whole_file > 0) ... }`)
+    /// - `--rsh`/`-e` conflicts with an `ssh://` URL operand (oc-specific: the
+    ///   URL scheme selects the built-in SSH client, which ignores `--rsh`)
     pub fn validate(&self) -> Result<(), ConfigConflict> {
+        // oc-specific: an explicit --rsh/-e (or RSYNC_RSH) selects the external
+        // system ssh binary, which is consulted only for `host:path` operands.
+        // An `ssh://` URL operand instead dispatches to the built-in SSH
+        // client, which never spawns an external shell and so silently drops
+        // --rsh. The two select mutually exclusive transports, so reject the
+        // combination up front instead of dropping --rsh without warning. This
+        // has no direct upstream analogue - upstream rsync has no `ssh://`
+        // scheme. The check is unconditional (not gated on `embedded-ssh`)
+        // because the combination is contradictory regardless of build
+        // features.
+        if self.remote_shell.is_some()
+            && self
+                .transfer_args
+                .iter()
+                .any(|arg| arg.to_string_lossy().starts_with("ssh://"))
+        {
+            return Err(ConfigConflict {
+                option1: "rsh",
+                option2: SSH_URL_OPERAND,
+            });
+        }
+
         // upstream: options.c:1974-1977 - --old-args conflicts with --protect-args.
         // Any active level (>= 1) triggers the conflict, matching upstream's
         // `else if (old_style_args)` truthiness test.

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1362,6 +1362,55 @@ fn validate_default_builder_ok() {
 }
 
 #[test]
+fn validate_rsh_with_ssh_url_operand_conflicts() {
+    // oc-specific: `-e ssh` selects the external system ssh binary, but an
+    // `ssh://` URL operand dispatches to the built-in SSH client, which never
+    // consults --rsh. Silently dropping --rsh would run a different transport
+    // than the user asked for, so the pair must be rejected as RERR_SYNTAX.
+    let b = builder()
+        .set_remote_shell(["ssh"])
+        .transfer_args(["ssh://host/path", "dest"]);
+    let err = b.validate().unwrap_err();
+    assert_eq!(err.option1, "rsh");
+    assert_eq!(err.option2, "ssh-url-operand");
+}
+
+#[test]
+fn validate_rsh_with_host_path_operand_ok() {
+    // A `host:path` operand is exactly the case where --rsh is honoured (it
+    // spawns the external ssh), so it must not trip the ssh:// conflict.
+    let b = builder()
+        .set_remote_shell(["ssh"])
+        .transfer_args(["host:path", "dest"]);
+    assert!(b.validate().is_ok());
+}
+
+#[test]
+fn validate_ssh_url_without_rsh_ok() {
+    // An `ssh://` operand on its own is the normal built-in-SSH path. With no
+    // explicit --rsh (remote_shell = None) there is nothing to conflict with,
+    // so the default/unset shell must not trip the check.
+    let b = builder().transfer_args(["ssh://host/path", "dest"]);
+    assert!(b.validate().is_ok());
+}
+
+#[test]
+fn validate_rsh_ssh_url_conflict_message() {
+    // The message names the operand, not a second option, and points the user
+    // at the two ways to resolve it (host:path, or dropping --rsh).
+    let b = builder()
+        .set_remote_shell(["ssh"])
+        .transfer_args(["ssh://host/path", "dest"]);
+    let err = b.validate().unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "--rsh/-e cannot be combined with an ssh:// URL operand \
+         (ssh:// uses the built-in SSH client); use host:path for an \
+         external ssh, or drop --rsh"
+    );
+}
+
+#[test]
 fn compare_destination_adds_directory() {
     let config = builder().compare_destination("/tmp/compare").build();
     assert_eq!(config.reference_directories().len(), 1);


### PR DESCRIPTION
## Problem

oc-rsync selects its SSH transport by operand scheme:

- `host:path` spawns the external system `ssh` (and honors `-e`/`--rsh`).
- `ssh://host/path` uses the built-in (russh) client, whose connection
  parameters come from the URL and `~/.ssh`.

These are two mutually exclusive selectors, but they were not enforced.
When an explicit `-e`/`--rsh` (or `RSYNC_RSH`) was combined with an `ssh://`
URL operand, the `ssh://` scheme won unconditionally and the `-e` value was
**silently discarded** — no error, no warning. A user who asked for a
specific external ssh command got the built-in client instead, with no
indication their request was dropped.

## Fix

Treat the combination as a hard conflict, mirroring how upstream rsync's
`options.c` rejects contradictory options (`RERR_SYNTAX`, exit 1). The check
lives in `ClientConfigBuilder::validate()` next to the existing
`--inplace`/`--append`/`--old-args` conflicts, so it uses the same
`ConfigConflict` → exit-1 path the CLI already wires up.

An explicit remote shell is only meaningful for the external-ssh
(`host:path`) transport; keying the check on an explicitly-set remote shell
means a normal `ssh://` transfer (no `-e`) is never falsely rejected.

Error message:

```
--rsh/-e cannot be combined with an ssh:// URL operand (ssh:// uses the built-in SSH client); use host:path for an external ssh, or drop --rsh
```

## Tests

- `crates/core/src/client/config/builder/tests.rs`:
  - `validate_rsh_with_ssh_url_operand_conflicts`
  - `validate_rsh_with_host_path_operand_ok`
  - `validate_ssh_url_without_rsh_ok`
  - `validate_rsh_ssh_url_conflict_message`
- `crates/cli/tests/mutually_exclusive_options.rs`:
  - `test_rsh_and_ssh_url_operand_rejected` (end-to-end: exit 1 + message on stderr)
