### PR TITLE
fix(batch): pin batch replay compression to upstream codec (drop non-upstream zstd auto-detect)

### DIFF
--- a/crates/batch/Cargo.toml
+++ b/crates/batch/Cargo.toml
@@ -9,7 +9,10 @@ description = "Batch mode support for offline rsync transfer workflows"
 repository.workspace = true
 
 [features]
-# Compression algorithm features forwarded from protocol crate.
+# Enables protocol's zstd codec. Batch replay itself never decodes zstd -
+# upstream pins batch compression to zlib (compat.c:417-418) - so this only
+# lets the test suite construct a zstd-framed batch body to prove replay
+# refuses to auto-detect it.
 zstd = ["protocol/zstd"]
 
 [dependencies]

--- a/crates/batch/README.md
+++ b/crates/batch/README.md
@@ -29,4 +29,6 @@ recording a transfer to a file and replaying it later on a different machine.
 
 ## Features
 
-- `zstd` - forwarded to `protocol` for zstd-compressed batch streams
+- `zstd` - enables `protocol`'s zstd codec so the test suite can build a
+  zstd-framed batch body. Batch replay is pinned to zlib (upstream
+  compat.c:417-418) and never decodes zstd; this feature adds no replay support.

--- a/crates/batch/src/replay/codec.rs
+++ b/crates/batch/src/replay/codec.rs
@@ -1,207 +1,33 @@
-//! Compression codec detection and decoder construction for batch replay.
+//! Zlib decoder construction for the compressed batch token stream.
 //!
-//! Upstream rsync write-batch forces `compress_choice = "zlib"` (compat.c:413-414),
-//! so batch files from upstream always contain zlib-compressed data. However,
-//! upstream rsync 3.4.1+ with SUPPORT_ZSTD can auto-negotiate zstd for live
-//! transfers, and a hypothetical or patched upstream could produce batch files
-//! with zstd-compressed tokens. This module detects the actual codec from the
-//! compressed payload to handle both cases correctly.
+//! upstream: compat.c:417-418 getenv_nstr() - when `write_batch` is set the
+//! negotiated compression list is forced to "zlib", so a batch file's token
+//! stream is ALWAYS zlib-compressed (never zstd or lz4). Batch replay therefore
+//! pins the codec to zlib; it never sniffs the compressed payload to pick a
+//! codec.
 
-#[cfg(feature = "zstd")]
-use std::io::{Read, Seek, SeekFrom};
-
-#[cfg(feature = "zstd")]
-use crate::reader::BatchStream;
 use protocol::wire::CompressedTokenDecoder;
 
-#[cfg(feature = "zstd")]
-use crate::error::BatchError;
-use crate::error::BatchResult;
-
-/// Compression codec used in a batch file's compressed token stream.
+/// Builds the zlib [`CompressedTokenDecoder`] used for compressed batch replay.
 ///
-/// Upstream rsync write-batch forces `compress_choice = "zlib"` (compat.c:413-414),
-/// so batch files from upstream always contain zlib-compressed data. However,
-/// upstream rsync 3.4.1+ with SUPPORT_ZSTD can auto-negotiate zstd for live
-/// transfers, and a hypothetical or patched upstream could produce batch files
-/// with zstd-compressed tokens. oc-rsync detects the actual codec from the
-/// compressed payload to handle both cases correctly.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum CompressionCodec {
-    /// Zlib/DEFLATE - the upstream default for batch files.
-    /// upstream: compat.c:194-195 - batch read defaults to CPRES_ZLIB
-    Zlib,
-    /// Zstd - possible if the batch was written by a patched upstream or
-    /// future rsync version that allows zstd in batch mode.
-    #[cfg(feature = "zstd")]
-    Zstd,
-}
-
-/// Creates a `CompressedTokenDecoder` for batch replay.
+/// The codec is fixed at construction - upstream pins batch compression to
+/// zlib, so replay never inspects the payload to choose an algorithm.
 ///
-/// Selects the appropriate decoder based on the detected compression codec.
-/// Upstream rsync write-batch forces zlib (compat.c:413-414), and read-batch
-/// defaults to CPRES_ZLIB (compat.c:194-195). oc-rsync extends this by
-/// auto-detecting the codec from the compressed payload, allowing it to
-/// read batch files regardless of which algorithm was used during recording.
+/// upstream: compat.c:417-418 getenv_nstr() forces `write_batch` transfers to
+/// negotiate "zlib"; compat.c:195 - read-batch defaults `do_compression` to
+/// CPRES_ZLIB.
 ///
-/// For zlib: sets zlibx=false so `see_token()` feeds matched block data
-/// into the inflate dictionary. Without this, inflate fails with "invalid
-/// distance too far back".
+/// Sets `zlibx=false` so `see_token()` feeds matched block data into the
+/// inflate dictionary. Without this, inflate fails with "invalid distance too
+/// far back". `protocol_version` gates that dictionary advance to match the
+/// sender that produced the batch.
 ///
-/// For zstd: `see_token()` is a noop - no dictionary synchronization needed.
-///
-/// upstream: compat.c:194-195 - batch read defaults to CPRES_ZLIB
-/// upstream: token.c:see_deflate_token() - feeds block data into inflate dictionary
-pub(super) fn create_compressed_decoder(
-    codec: CompressionCodec,
-    protocol_version: u32,
-) -> BatchResult<CompressedTokenDecoder> {
-    match codec {
-        CompressionCodec::Zlib => {
-            let mut decoder = CompressedTokenDecoder::new();
-            // Batch was recorded at this protocol version; gate see_token's
-            // dictionary advance to match the sender that produced the batch.
-            // upstream: token.c:710 see_deflate_token() `buf += blklen`.
-            decoder.set_protocol_version(protocol_version);
-            decoder.set_zlibx(false);
-            Ok(decoder)
-        }
-        #[cfg(feature = "zstd")]
-        CompressionCodec::Zstd => CompressedTokenDecoder::new_zstd().map_err(|e| {
-            BatchError::Io(std::io::Error::new(
-                e.kind(),
-                format!("failed to create zstd decoder for batch replay: {e}"),
-            ))
-        }),
-    }
-}
-
-/// Detects the compression codec from the batch stream by peeking at compressed data.
-///
-/// Upstream rsync write-batch always uses zlib (compat.c:413-414), but a
-/// patched or future upstream could produce zstd-compressed batch files.
-/// This function peeks at the first DEFLATED_DATA block in the stream,
-/// checks for the zstd magic number (`0xFD2FB528` LE), and returns the
-/// detected codec. The stream position is restored after peeking.
-///
-/// The function scans forward from the current position looking for a byte
-/// with the DEFLATED_DATA flag (upper 2 bits = 0x40). It reads the 2-byte
-/// header to get the payload length, then checks the first 4 bytes of the
-/// payload for the zstd frame magic. The stream is then seeked back to
-/// the original position.
-///
-/// If the stream contains no DEFLATED_DATA blocks before EOF, or if an
-/// I/O error occurs during peeking, falls back to zlib (the upstream default).
-///
-/// upstream: token.c:recv_deflated_token() - DEFLATED_DATA flag = 0x40
-/// zstd spec: frames start with magic 0xFD2FB528 (LE bytes: 28 B5 2F FD)
-#[cfg(feature = "zstd")]
-pub(super) fn detect_compression_codec(reader: &mut BatchStream) -> CompressionCodec {
-    let start_pos = match reader.stream_position() {
-        Ok(pos) => pos,
-        Err(_) => return CompressionCodec::Zlib,
-    };
-
-    let result = peek_for_codec(reader);
-
-    // Always restore stream position regardless of detection result.
-    let _ = reader.seek(SeekFrom::Start(start_pos));
-
-    result.unwrap_or(CompressionCodec::Zlib)
-}
-
-/// Inner peek logic for codec detection, separated for clean error handling.
-///
-/// Scans the stream byte-by-byte looking for a DEFLATED_DATA header (flag
-/// byte with upper 2 bits = 0x40). Once found, reads the payload length
-/// from the 2-byte header and checks the first 4 bytes for the zstd magic.
-///
-/// Returns `None` if no DEFLATED_DATA block is found before EOF or on error.
-#[cfg(feature = "zstd")]
-fn peek_for_codec(reader: &mut BatchStream) -> Option<CompressionCodec> {
-    // Scan for the first DEFLATED_DATA flag byte. The compressed token stream
-    // starts with flag bytes that can be END_FLAG (0x00), TOKEN_LONG (0x20),
-    // TOKENRUN_LONG (0x21), DEFLATED_DATA (0x40-0x7F), TOKEN_REL (0x80-0xBF),
-    // or TOKENRUN_REL (0xC0-0xFF). We need to find a DEFLATED_DATA byte.
-    //
-    // Limit scan to 64KB to avoid reading the entire batch file.
-    const SCAN_LIMIT: usize = 65536;
-    let mut scanned = 0;
-
-    while scanned < SCAN_LIMIT {
-        let mut byte = [0u8; 1];
-        if reader.read_exact(&mut byte).is_err() {
-            return None;
-        }
-        scanned += 1;
-
-        let flag = byte[0];
-
-        // Check if this byte has the DEFLATED_DATA pattern (upper 2 bits = 01)
-        if (flag & 0xC0) == 0x40 {
-            // Read the second byte of the DEFLATED_DATA header
-            let high = (flag & 0x3F) as usize;
-            let mut low_buf = [0u8; 1];
-            if reader.read_exact(&mut low_buf).is_err() {
-                return None;
-            }
-            let len = (high << 8) | (low_buf[0] as usize);
-
-            if len < 4 {
-                // Payload too short to contain zstd magic - assume zlib.
-                return Some(CompressionCodec::Zlib);
-            }
-
-            // Read the first 4 bytes of the compressed payload
-            let mut magic_buf = [0u8; 4];
-            if reader.read_exact(&mut magic_buf).is_err() {
-                return None;
-            }
-
-            // Zstd frame magic: 0xFD2FB528 stored as LE bytes [0x28, 0xB5, 0x2F, 0xFD]
-            #[cfg(feature = "zstd")]
-            if magic_buf == [0x28, 0xB5, 0x2F, 0xFD] {
-                return Some(CompressionCodec::Zstd);
-            }
-
-            return Some(CompressionCodec::Zlib);
-        }
-
-        // Skip over known flag types to avoid false DEFLATED_DATA matches.
-        // TOKEN_LONG: 4-byte token follows
-        if flag == 0x20 {
-            let mut skip = [0u8; 4];
-            if reader.read_exact(&mut skip).is_err() {
-                return None;
-            }
-            scanned += 4;
-            continue;
-        }
-        // TOKENRUN_LONG: 4-byte token + 2-byte run count
-        if flag == 0x21 {
-            let mut skip = [0u8; 6];
-            if reader.read_exact(&mut skip).is_err() {
-                return None;
-            }
-            scanned += 6;
-            continue;
-        }
-        // TOKEN_REL (0x80-0xBF): no additional data
-        if flag & 0xC0 == 0x80 {
-            continue;
-        }
-        // TOKENRUN_REL (0xC0-0xFF): 2-byte run count follows
-        if flag & 0xC0 == 0xC0 {
-            let mut skip = [0u8; 2];
-            if reader.read_exact(&mut skip).is_err() {
-                return None;
-            }
-            scanned += 2;
-            continue;
-        }
-        // END_FLAG (0x00) or other: continue scanning
-    }
-
-    None
+/// upstream: token.c:710 see_deflate_token() `if (protocol_version >= 31) buf += blklen;`
+pub(super) fn create_compressed_decoder(protocol_version: u32) -> CompressedTokenDecoder {
+    let mut decoder = CompressedTokenDecoder::new();
+    // Batch was recorded at this protocol version; gate see_token's dictionary
+    // advance to match the sender that produced the batch.
+    decoder.set_protocol_version(protocol_version);
+    decoder.set_zlibx(false);
+    decoder
 }

--- a/crates/batch/src/replay/delta_phase.rs
+++ b/crates/batch/src/replay/delta_phase.rs
@@ -20,9 +20,7 @@ use crate::format::BatchFlags;
 use crate::reader::BatchReader;
 
 use super::ReplayResult;
-#[cfg(feature = "zstd")]
-use super::codec::detect_compression_codec;
-use super::codec::{CompressionCodec, create_compressed_decoder};
+use super::codec::create_compressed_decoder;
 use super::delta::default_xfer_sum_len;
 use super::dispatch::{
     ITEM_TRANSFER, apply_file_delta, read_and_discard_file_checksum,
@@ -42,7 +40,7 @@ pub(super) fn apply_delta_phase(
     verbosity: i32,
 ) -> BatchResult<()> {
     let proto = reader.config().protocol_version;
-    let mut codec_state = CodecState::new(flags, proto as u32)?;
+    let mut codec_state = CodecState::new(flags, proto as u32);
     let mut flist_segments = init_flist_segments(reader, entries.len())?;
     let mut ndx_codec = reader
         .take_ndx_codec()
@@ -106,90 +104,28 @@ pub(super) fn apply_delta_phase(
 /// Tracks compression-codec state across the NDX loop iterations.
 struct CodecState {
     decoder: Option<protocol::wire::CompressedTokenDecoder>,
-    /// Currently detected codec. `None` means the batch is uncompressed.
-    /// Only read when the `zstd` feature is enabled; without `zstd` the
-    /// codec is always [`CompressionCodec::Zlib`] and detection is a no-op.
-    #[cfg(feature = "zstd")]
-    detected: Option<CompressionCodec>,
     /// True when the active codec is CPRES_ZLIB, requiring `see_token()`
     /// dictionary sync between block-match tokens.
     cpres_zlib: bool,
-    /// Negotiated protocol version of the recorded batch, retained so a late
-    /// zstd fallback rebuilds its decoder with the same value. Only the zstd
-    /// auto-detection path reads it; without that feature the codec is always
-    /// zlib and the version is applied at construction.
-    #[cfg(feature = "zstd")]
-    protocol_version: u32,
 }
 
 impl CodecState {
-    fn new(flags: &BatchFlags, protocol_version: u32) -> BatchResult<Self> {
+    fn new(flags: &BatchFlags, protocol_version: u32) -> Self {
         // upstream: batch.c:check_batch_flags() - when the batch stream flags
         // include do_compression (bit 8), the token data in the batch file
         // uses compressed format (DEFLATED_DATA headers).
         //
-        // Upstream always forces CPRES_ZLIB for batch reads (compat.c:194-195),
-        // so we start with a zlib decoder. However, if zlib decompression
-        // fails on the first token, we fall back to zstd. This auto-detection
-        // handles both standard upstream batch files (always zlib) and
-        // hypothetical zstd-compressed batch files from patched or future
-        // upstream versions.
-        let decoder = if flags.do_compression {
-            Some(create_compressed_decoder(
-                CompressionCodec::Zlib,
-                protocol_version,
-            )?)
-        } else {
-            None
-        };
-        let cpres_zlib = flags.do_compression;
-        Ok(Self {
+        // upstream: compat.c:417-418 getenv_nstr() forces `write_batch` to
+        // negotiate "zlib", and compat.c:195 defaults read-batch to CPRES_ZLIB,
+        // so a batch token stream is ALWAYS zlib. Replay pins the codec to zlib
+        // and never sniffs the payload to pick a different one.
+        let decoder = flags
+            .do_compression
+            .then(|| create_compressed_decoder(protocol_version));
+        Self {
             decoder,
-            #[cfg(feature = "zstd")]
-            detected: if flags.do_compression {
-                Some(CompressionCodec::Zlib)
-            } else {
-                None
-            },
-            cpres_zlib,
-            #[cfg(feature = "zstd")]
-            protocol_version,
-        })
-    }
-
-    /// Run codec auto-detection at most once. If detection finds zstd, build
-    /// a fresh zstd decoder so the next read uses the right inflate context.
-    #[cfg(feature = "zstd")]
-    fn detect_once(&mut self, reader: &mut BatchReader) -> BatchResult<()> {
-        let was_zlib = self.detected == Some(CompressionCodec::Zlib);
-        let Some(decoder) = self.decoder.as_mut() else {
-            return Ok(());
-        };
-        if !was_zlib || decoder.initialized() {
-            return Ok(());
+            cpres_zlib: flags.do_compression,
         }
-        let stream = reader
-            .inner_reader()
-            .ok_or_else(|| BatchError::Io(std::io::Error::other("batch file not open")))?;
-        let actual_codec = detect_compression_codec(stream);
-        if actual_codec != CompressionCodec::Zlib {
-            self.detected = Some(actual_codec);
-            self.cpres_zlib = false;
-            // Replace the zlib decoder with a fresh zstd one. Subsequent
-            // files reuse this decoder across iterations.
-            self.decoder = Some(create_compressed_decoder(
-                CompressionCodec::Zstd,
-                self.protocol_version,
-            )?);
-        }
-        Ok(())
-    }
-
-    /// Without `zstd`, codec detection is a no-op: the active codec is always
-    /// CPRES_ZLIB and there is nothing to swap.
-    #[cfg(not(feature = "zstd"))]
-    fn detect_once(&mut self, _reader: &mut BatchReader) -> BatchResult<()> {
-        Ok(())
     }
 }
 
@@ -290,10 +226,6 @@ fn process_file_ndx(
     // A non-regular dest never has a usable basis (and must not be opened as
     // one).
     let basis_exists = is_regular && dest_path.exists();
-
-    // Auto-detect compression codec on the first compressed file before
-    // building delta operations. Detection runs once per batch.
-    codec_state.detect_once(reader)?;
 
     let delta_ops = read_delta_tokens(
         reader,

--- a/crates/batch/src/replay/mod.rs
+++ b/crates/batch/src/replay/mod.rs
@@ -22,8 +22,8 @@
 //!
 //! # Submodules
 //!
-//! - `codec` - compression codec detection (`zlib` vs `zstd`) and decoder
-//!   construction.
+//! - `codec` - zlib decoder construction for the compressed batch token
+//!   stream (upstream pins batch compression to zlib).
 //! - `delta` - low-level delta-application primitives (`apply_delta_ops`,
 //!   `write_literals_to_file`).
 //! - `dispatch` - per-file helpers used by the main loop: iflags decoding,

--- a/crates/batch/src/replay/tests.rs
+++ b/crates/batch/src/replay/tests.rs
@@ -7,7 +7,7 @@
 use std::fs;
 use tempfile::TempDir;
 
-use super::codec::{CompressionCodec, create_compressed_decoder};
+use super::codec::create_compressed_decoder;
 use super::delta::{apply_delta_ops, write_literals_to_file};
 
 /// Builds the geometry a batch would have advertised for these tests.
@@ -154,39 +154,17 @@ fn write_literals_ignores_copy_ops() {
     assert_eq!(result, b"datamore");
 }
 
+/// The batch replay codec is pinned to zlib: `create_compressed_decoder`
+/// builds a zlib decoder regardless of payload, matching upstream which forces
+/// `write_batch` compression to "zlib" (compat.c:417-418). There is no codec
+/// parameter and no payload sniffing, so a zstd stream can never be selected.
 #[test]
-fn compressed_decoder_created_for_zlib() {
-    let decoder = create_compressed_decoder(CompressionCodec::Zlib, 31).unwrap();
+fn compressed_decoder_created_is_zlib() {
+    let decoder = create_compressed_decoder(31);
     assert!(
         !decoder.initialized(),
         "fresh zlib decoder should not be initialized"
     );
-}
-
-#[cfg(feature = "zstd")]
-#[test]
-fn compressed_decoder_created_for_zstd() {
-    let decoder = create_compressed_decoder(CompressionCodec::Zstd, 31).unwrap();
-    assert!(
-        !decoder.initialized(),
-        "fresh zstd decoder should not be initialized"
-    );
-}
-
-/// When the detected codec is zlib, dictionary sync (`see_token`)
-/// must be active. Matches upstream CPRES_ZLIB behavior.
-#[test]
-fn cpres_zlib_true_for_zlib_codec() {
-    let codec = CompressionCodec::Zlib;
-    assert!(Some(codec) == Some(CompressionCodec::Zlib));
-}
-
-/// Zstd's `see_token()` is a noop, so the dictionary-sync path does not apply.
-#[cfg(feature = "zstd")]
-#[test]
-fn cpres_zlib_false_for_zstd_codec() {
-    let codec = CompressionCodec::Zstd;
-    assert!(Some(codec) != Some(CompressionCodec::Zlib));
 }
 
 /// A pre-29 batch stream carries no iflags word, so the replay loop must

--- a/crates/batch/src/tests.rs
+++ b/crates/batch/src/tests.rs
@@ -1205,18 +1205,19 @@ mod integration {
         assert_eq!(content, file_data);
     }
 
-    /// Verifies replay of a batch file with zstd-compressed delta tokens.
+    /// A batch body whose DEFLATED_DATA payload is a real zstd frame (magic
+    /// 0xFD2FB528) must NOT be auto-detected and decoded as zstd on replay.
     ///
-    /// This tests the auto-detection path: when a batch file's compressed
-    /// payload contains zstd frames (magic 0xFD2FB528), oc-rsync detects
-    /// the codec and creates a zstd decoder instead of the default zlib.
-    ///
-    /// Upstream rsync write-batch always forces zlib (compat.c:413-414),
-    /// so this scenario only arises from a patched or future upstream.
-    /// oc-rsync handles it correctly via compressed payload auto-detection.
+    /// Upstream forces `write_batch` compression to "zlib" (compat.c:417-418),
+    /// so a batch token stream is ALWAYS zlib; the codec is pinned, never
+    /// sniffed from the payload. A zstd frame is therefore fed to the zlib
+    /// inflater, which rejects it - replay fails rather than silently switching
+    /// codecs. If the non-upstream magic-byte auto-detect were reintroduced,
+    /// this replay would succeed and the assertion below would fail, guarding
+    /// the removed divergence.
     #[cfg(feature = "zstd")]
     #[test]
-    fn test_replay_zstd_compressed_batch() {
+    fn test_replay_zstd_magic_payload_not_autodetected() {
         use protocol::flist::{FileEntry, FileListWriter};
         use protocol::wire::CompressedTokenEncoder;
 
@@ -1304,145 +1305,20 @@ mod integration {
             protocol_version,
         );
 
-        let result = crate::replay::replay(&read_config, &dest_dir, 0).unwrap();
-
-        assert_eq!(result.file_count, 2); // 1 dir + 1 file
-        assert!(dest_dir.join("zstd_test.txt").exists());
-
-        let content = fs::read(dest_dir.join("zstd_test.txt")).unwrap();
-        assert_eq!(content, file_data);
-    }
-
-    /// Verifies replay of a zstd-compressed batch with block matches.
-    ///
-    /// Unlike CPRES_ZLIB, zstd does not need dictionary synchronization
-    /// (see_token is a noop). This test exercises the code path where
-    /// the detected codec is zstd and cpres_zlib is false, ensuring
-    /// block matches work without dictionary sync.
-    #[cfg(feature = "zstd")]
-    #[test]
-    fn test_replay_zstd_compressed_delta_with_block_matches() {
-        use protocol::flist::{FileEntry, FileListWriter};
-        use protocol::wire::CompressedTokenEncoder;
-
-        let temp_dir = TempDir::new().unwrap();
-        let batch_path = temp_dir.path().join("replay_delta_zstd.batch");
-        let dest_dir = temp_dir.path().join("dest");
-        fs::create_dir_all(&dest_dir).unwrap();
-
-        let protocol_version = 32;
-
-        // Create basis file at destination
-        let basis_data = vec![b'Z'; 2000];
-        fs::write(dest_dir.join("data.bin"), &basis_data).unwrap();
-
-        let patch = b"ZSTD_PATCHED_DATA";
-        let output_size = 700 + 700 + patch.len() + 600;
-
-        let write_config = BatchConfig::new(
-            BatchMode::Write,
-            batch_path.to_string_lossy().to_string(),
-            protocol_version,
-        )
-        .with_checksum_seed(42);
-
-        let mut writer = BatchWriter::new(write_config).unwrap();
-        let flags = BatchFlags {
-            recurse: true,
-            do_compression: true,
-            ..Default::default()
-        };
-        writer.write_header(flags).unwrap();
-
-        let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
-        let mut flist_writer = FileListWriter::new(protocol);
-        let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
-        dir_entry.set_mtime(1_700_000_000, 0);
-        let mut buf = Vec::new();
-        flist_writer.write_entry(&mut buf, &dir_entry).unwrap();
-        writer.write_data(&buf).unwrap();
-        let mut file_entry = FileEntry::new_file("data.bin".into(), output_size as u64, 0o644);
-        file_entry.set_mtime(1_700_000_001, 0);
-        buf.clear();
-        flist_writer.write_entry(&mut buf, &file_entry).unwrap();
-        writer.write_data(&buf).unwrap();
-        let mut end_buf = Vec::new();
-        flist_writer.write_end(&mut end_buf, None).unwrap();
-        writer.write_data(&end_buf).unwrap();
-
-        // NDX-framed delta with zstd-compressed block matches and literals
-        {
-            use protocol::codec::{NdxCodec, NdxCodecEnum};
-
-            let mut ndx_codec = NdxCodecEnum::new(protocol_version as u8);
-            let mut ndx_buf = Vec::new();
-
-            ndx_codec.write_ndx(&mut ndx_buf, 1).unwrap();
-            writer.write_data(&ndx_buf).unwrap();
-
-            writer.write_data(&0x8000u16.to_le_bytes()).unwrap();
-
-            let block_length: i32 = 700;
-            let block_count: i32 = 3;
-            let remainder: i32 = 600;
-            let s2length: i32 = 16;
-            writer.write_data(&block_count.to_le_bytes()).unwrap();
-            writer.write_data(&block_length.to_le_bytes()).unwrap();
-            writer.write_data(&s2length.to_le_bytes()).unwrap();
-            writer.write_data(&remainder.to_le_bytes()).unwrap();
-
-            // Zstd encoder - see_token is noop, no dictionary sync needed
-            let mut token_buf = Vec::new();
-            let mut encoder = CompressedTokenEncoder::new_zstd(3, None).unwrap();
-
-            // Block 0: copy from basis
-            encoder.send_block_match(&mut token_buf, 0).unwrap();
-            encoder.see_token(&basis_data[0..700]).unwrap(); // noop for zstd
-
-            // Block 1: copy from basis
-            encoder.send_block_match(&mut token_buf, 1).unwrap();
-            encoder.see_token(&basis_data[700..1400]).unwrap(); // noop for zstd
-
-            // Literal patch
-            encoder.send_literal(&mut token_buf, patch).unwrap();
-
-            // Block 2: copy from basis (remainder)
-            encoder.send_block_match(&mut token_buf, 2).unwrap();
-            encoder.see_token(&basis_data[1400..2000]).unwrap(); // noop for zstd
-
-            encoder.finish(&mut token_buf).unwrap();
-            writer.write_data(&token_buf).unwrap();
-            writer.write_data(&[0u8; 16]).unwrap();
-
-            // NDX_DONE phase 1 -> phase 2
-            ndx_buf.clear();
-            ndx_codec.write_ndx_done(&mut ndx_buf).unwrap();
-            writer.write_data(&ndx_buf).unwrap();
-
-            // NDX_DONE phase 2 -> end
-            ndx_buf.clear();
-            ndx_codec.write_ndx_done(&mut ndx_buf).unwrap();
-            writer.write_data(&ndx_buf).unwrap();
-        }
-
-        writer.finalize().unwrap();
-        let read_config = BatchConfig::new(
-            BatchMode::Read,
-            batch_path.to_string_lossy().to_string(),
-            protocol_version,
+        // The pinned zlib inflater rejects the zstd frame; replay must fail
+        // rather than auto-switch to a zstd decoder. A successful replay here
+        // would mean the removed magic-byte auto-detect had come back.
+        let err = crate::replay::replay(&read_config, &dest_dir, 0)
+            .expect_err("zstd-framed batch body must not be auto-detected as zstd");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("delta token") || msg.contains("delta operations"),
+            "expected a delta-token decode failure, got: {msg}"
         );
-
-        let result = crate::replay::replay(&read_config, &dest_dir, 0).unwrap();
-
-        assert_eq!(result.file_count, 2);
-        assert!(dest_dir.join("data.bin").exists());
-
-        let content = fs::read(dest_dir.join("data.bin")).unwrap();
-        assert_eq!(content.len(), output_size);
-        assert_eq!(&content[0..700], &basis_data[0..700]);
-        assert_eq!(&content[700..1400], &basis_data[700..1400]);
-        assert_eq!(&content[1400..1400 + patch.len()], patch);
-        assert_eq!(&content[1400 + patch.len()..], &basis_data[1400..2000]);
+        assert!(
+            !dest_dir.join("zstd_test.txt").exists(),
+            "no file should be materialised from a rejected zstd payload"
+        );
     }
 
     /// Verifies that compressed batch replay correctly resets the decoder


### PR DESCRIPTION
## Summary

Upstream rsync pins batch-file compression to zlib. `getenv_nstr()` forces
the negotiated compression list to `"zlib"` whenever `write_batch` is set
(`compat.c:417-418`), and read-batch defaults `do_compression` to
`CPRES_ZLIB` (`compat.c:195`). A batch token stream is therefore always
zlib-compressed - never zstd or lz4.

oc had added a non-upstream magic-byte auto-detect on `--read-batch`
replay: it peeked the compressed payload for the zstd frame magic
(`0xFD2FB528`) and, on a match, swapped the zlib decoder for a zstd one.
This is a divergence with no upstream counterpart - upstream selects the
codec deterministically from the recorded compat/negotiation state, it
does not sniff the payload.

## Changes

- Remove the payload sniffing (`detect_compression_codec` /
  `peek_for_codec`) and the `CompressionCodec` enum from the batch replay
  codec module.
- Remove the once-per-batch zstd decoder-swap path (`CodecState::detect_once`).
- `create_compressed_decoder` now always builds the zlib decoder; the codec
  is fixed at construction, mirroring upstream `batch.c` semantics, with the
  upstream `compat.c` reference cited in the module and function docs.
- Narrow the batch `zstd` feature to its remaining (test-only) purpose and
  document it as adding no replay support.

## Tests

- New regression test: a batch body whose `DEFLATED_DATA` payload is a real
  zstd frame is NOT auto-detected as zstd on replay - the pinned zlib
  inflater rejects it and replay fails. If the auto-detect were
  reintroduced the replay would succeed and this test would fail.
- Existing zlib compressed-replay tests (single- and multi-file decoder
  reset) continue to pass, confirming the pinned zlib path is unchanged.

## Verification (x86_64 Linux, --locked)

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo check --workspace --target x86_64-pc-windows-gnu`
- `cargo check --workspace --target x86_64-unknown-linux-musl`
- `cargo nextest run -p batch --all-features` (107 passed)
- `cargo build --bin oc-rsync`
