### PR TITLE
fix(protocol): preserve raw bytes for non-UTF-8/backslash --files-from paths

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -1743,7 +1743,11 @@ mod files_from_forwarding_tests {
         let filenames = protocol::read_files_from_stream(&mut reader, None).unwrap();
         assert_eq!(
             filenames,
-            vec!["file1.txt", "file2.txt", "subdir/file3.txt"]
+            vec![
+                b"file1.txt".to_vec(),
+                b"file2.txt".to_vec(),
+                b"subdir/file3.txt".to_vec()
+            ]
         );
     }
 
@@ -1762,7 +1766,7 @@ mod files_from_forwarding_tests {
 
         let mut reader = Cursor::new(&data);
         let filenames = protocol::read_files_from_stream(&mut reader, None).unwrap();
-        assert_eq!(filenames, vec!["alpha.txt", "beta.txt"]);
+        assert_eq!(filenames, vec![b"alpha.txt".to_vec(), b"beta.txt".to_vec()]);
     }
 
     #[test]
@@ -1828,7 +1832,10 @@ mod files_from_forwarding_tests {
 
         let mut reader = Cursor::new(&data);
         let filenames = protocol::read_files_from_stream(&mut reader, None).unwrap();
-        assert_eq!(filenames, vec!["file1.txt", "file2.txt"]);
+        assert_eq!(
+            filenames,
+            vec![b"file1.txt".to_vec(), b"file2.txt".to_vec()]
+        );
     }
 
     #[test]

--- a/crates/protocol/src/files_from.rs
+++ b/crates/protocol/src/files_from.rs
@@ -139,16 +139,20 @@ fn write_filesfrom_entry<W: Write>(
 
 /// Reads NUL-separated filenames from a remote source (wire protocol).
 ///
-/// Returns a vector of filenames. The stream is terminated by a double-NUL
-/// sentinel (an empty filename after a NUL). Empty strings between NULs
-/// are skipped.
+/// Returns each filename as a raw byte vector. The stream is terminated by a
+/// double-NUL sentinel (an empty filename after a NUL). Empty entries between
+/// NULs are skipped.
+///
+/// Names are carried as raw bytes, never UTF-8-validated, mirroring upstream
+/// rsync which handles filenames as `char*` byte strings. A non-UTF-8 name
+/// (a legal filename on Unix) therefore round-trips intact instead of being
+/// silently dropped.
 ///
 /// When `iconv` is `Some`, each NUL-separated entry is transcoded with
-/// [`FilenameConverter::remote_to_local`] before being decoded into a
-/// `String`, mirroring upstream `read_line(RL_CONVERT)`'s
-/// `iconvbufs(ic_recv, ...)` call. When `iconv` is `None`, wire bytes are
-/// decoded verbatim - equivalent to upstream's `ic_recv == (iconv_t)-1`
-/// case.
+/// [`FilenameConverter::remote_to_local`], mirroring upstream
+/// `read_line(RL_CONVERT)`'s `iconvbufs(ic_recv, ...)` call. When `iconv` is
+/// `None`, wire bytes are forwarded verbatim - equivalent to upstream's
+/// `ic_recv == (iconv_t)-1` case.
 ///
 /// This is used by the sender process to receive the file list from the
 /// client when `--files-from=-` was passed (stdin/socket forwarding).
@@ -162,7 +166,7 @@ fn write_filesfrom_entry<W: Write>(
 pub fn read_files_from_stream<R: Read>(
     reader: &mut R,
     iconv: Option<&FilenameConverter>,
-) -> io::Result<Vec<String>> {
+) -> io::Result<Vec<Vec<u8>>> {
     read_files_from_stream_inner(reader, iconv, None)
 }
 
@@ -193,7 +197,7 @@ pub fn read_files_from_stream_with_deadline<R: Read>(
     reader: &mut R,
     iconv: Option<&FilenameConverter>,
     deadline: std::time::Duration,
-) -> io::Result<Vec<String>> {
+) -> io::Result<Vec<Vec<u8>>> {
     read_files_from_stream_inner(reader, iconv, Some(deadline))
 }
 
@@ -201,7 +205,7 @@ fn read_files_from_stream_inner<R: Read>(
     reader: &mut R,
     iconv: Option<&FilenameConverter>,
     deadline: Option<std::time::Duration>,
-) -> io::Result<Vec<String>> {
+) -> io::Result<Vec<Vec<u8>>> {
     let mut filenames = Vec::new();
     let mut current = Vec::new();
     let start = deadline.map(|_| std::time::Instant::now());
@@ -245,13 +249,13 @@ fn read_files_from_stream_inner<R: Read>(
     Ok(filenames)
 }
 
-/// Decodes a single wire entry into a `String`, applying iconv when configured.
+/// Pushes a single wire entry as raw bytes, applying iconv when configured.
 ///
-/// Non-UTF-8 results are silently dropped to preserve the existing String-based
-/// representation. Upstream's `ICB_INCLUDE_BAD` flag (pass through bad bytes)
-/// is honored only at the iconv layer; the final UTF-8 check is a downstream
-/// limitation of the `Vec<String>` API.
-fn push_decoded_filename(out: &mut Vec<String>, raw: &[u8], iconv: Option<&FilenameConverter>) {
+/// The name is kept as raw bytes and never UTF-8-validated, so a non-UTF-8
+/// filename (legal on Unix) is preserved verbatim rather than silently
+/// dropped. Empty entries are skipped, matching the double-NUL / collapsed-run
+/// handling upstream applies to filenames.
+fn push_decoded_filename(out: &mut Vec<Vec<u8>>, raw: &[u8], iconv: Option<&FilenameConverter>) {
     let bytes: Cow<'_, [u8]> = match iconv {
         Some(converter) => match converter.remote_to_local(raw) {
             Ok(cow) => cow,
@@ -260,10 +264,8 @@ fn push_decoded_filename(out: &mut Vec<String>, raw: &[u8], iconv: Option<&Filen
         },
         None => Cow::Borrowed(raw),
     };
-    if let Ok(s) = std::str::from_utf8(&bytes)
-        && !s.is_empty()
-    {
-        out.push(s.to_owned());
+    if !bytes.is_empty() {
+        out.push(bytes.into_owned());
     }
 }
 
@@ -356,7 +358,43 @@ mod tests {
 
         let files = read_files_from_stream(&mut reader, None).unwrap();
 
-        assert_eq!(files, vec!["file1.txt", "file2.txt", "file3.txt"]);
+        assert_eq!(
+            files,
+            vec![
+                b"file1.txt".to_vec(),
+                b"file2.txt".to_vec(),
+                b"file3.txt".to_vec()
+            ]
+        );
+    }
+
+    #[test]
+    fn read_preserves_non_utf8_entry() {
+        // A non-UTF-8 filename (0xFF byte) is a legal name on Unix. Upstream
+        // carries filenames as raw char* bytes and never UTF-8-validates, so
+        // the sender must receive the exact bytes rather than silently drop
+        // the entry (which corrupts the file list and aborts the transfer).
+        let input = b"foo\xffbar.txt\0plain.txt\0\0";
+        let mut reader = Cursor::new(input);
+
+        let files = read_files_from_stream(&mut reader, None).unwrap();
+
+        assert_eq!(
+            files,
+            vec![b"foo\xffbar.txt".to_vec(), b"plain.txt".to_vec()]
+        );
+    }
+
+    #[test]
+    fn read_preserves_backslash_entry() {
+        // A backslash is a literal filename byte on Unix, not an escape, and
+        // must survive the wire read verbatim.
+        let input = b"back\\slash.txt\0\0";
+        let mut reader = Cursor::new(input);
+
+        let files = read_files_from_stream(&mut reader, None).unwrap();
+
+        assert_eq!(files, vec![b"back\\slash.txt".to_vec()]);
     }
 
     #[test]
@@ -376,7 +414,7 @@ mod tests {
 
         let files = read_files_from_stream(&mut reader, None).unwrap();
 
-        assert_eq!(files, vec!["only.txt"]);
+        assert_eq!(files, vec![b"only.txt".to_vec()]);
     }
 
     #[test]
@@ -386,7 +424,7 @@ mod tests {
 
         let files = read_files_from_stream(&mut reader, None).unwrap();
 
-        assert_eq!(files, vec!["partial.txt"]);
+        assert_eq!(files, vec![b"partial.txt".to_vec()]);
     }
 
     #[test]
@@ -400,7 +438,14 @@ mod tests {
         let mut wire_reader = Cursor::new(&wire);
         let files = read_files_from_stream(&mut wire_reader, None).unwrap();
 
-        assert_eq!(files, vec!["alpha.txt", "beta.txt", "gamma.txt"]);
+        assert_eq!(
+            files,
+            vec![
+                b"alpha.txt".to_vec(),
+                b"beta.txt".to_vec(),
+                b"gamma.txt".to_vec()
+            ]
+        );
     }
 
     #[test]
@@ -414,7 +459,14 @@ mod tests {
         let mut wire_reader = Cursor::new(&wire);
         let files = read_files_from_stream(&mut wire_reader, None).unwrap();
 
-        assert_eq!(files, vec!["one.txt", "two.txt", "three.txt"]);
+        assert_eq!(
+            files,
+            vec![
+                b"one.txt".to_vec(),
+                b"two.txt".to_vec(),
+                b"three.txt".to_vec()
+            ]
+        );
     }
 
     #[cfg(feature = "iconv")]
@@ -466,7 +518,10 @@ mod tests {
 
         let files = read_files_from_stream(&mut Cursor::new(wire), Some(&converter)).unwrap();
 
-        assert_eq!(files, vec!["café", "naïve"]);
+        assert_eq!(
+            files,
+            vec!["café".as_bytes().to_vec(), "naïve".as_bytes().to_vec()]
+        );
     }
 
     #[cfg(feature = "iconv")]
@@ -490,6 +545,9 @@ mod tests {
         .unwrap();
 
         let files = read_files_from_stream(&mut Cursor::new(&wire), Some(&reader_iconv)).unwrap();
-        assert_eq!(files, vec!["café", "naïve"]);
+        assert_eq!(
+            files,
+            vec!["café".as_bytes().to_vec(), "naïve".as_bytes().to_vec()]
+        );
     }
 }

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -72,9 +72,55 @@ pub struct FilesFromEntry {
 /// anchor with content after it, mirroring upstream's `implied_dot_dir`
 /// detection at `flist.c:2368` (`*fn == '.' && fn[1] == '/' && fn[2]`). The
 /// third-byte requirement excludes a bare `.` or `./`.
-fn has_leading_dot_anchor(name: &str) -> bool {
-    let b = name.as_bytes();
-    b.len() > 2 && b[0] == b'.' && b[1] == b'/'
+fn has_leading_dot_anchor(name: &[u8]) -> bool {
+    name.len() > 2 && name[0] == b'.' && name[1] == b'/'
+}
+
+/// Joins a raw byte component onto `path`, preserving non-UTF-8 bytes.
+///
+/// `--files-from` names are raw byte strings (upstream carries them as
+/// `char*`), so a non-UTF-8 filename - legal on Unix - must reach the
+/// filesystem intact. On Unix the bytes become an `OsStr` directly; on other
+/// targets (Windows uses UTF-16 `OsString`s, and no `std` API turns arbitrary
+/// bytes into one losslessly) the bytes are interpreted as UTF-8, which is
+/// exact for valid UTF-8 names.
+#[cfg(unix)]
+fn push_bytes(path: &mut PathBuf, bytes: &[u8]) {
+    use std::os::unix::ffi::OsStrExt;
+    path.push(std::ffi::OsStr::from_bytes(bytes));
+}
+
+#[cfg(not(unix))]
+fn push_bytes(path: &mut PathBuf, bytes: &[u8]) {
+    path.push(String::from_utf8_lossy(bytes).as_ref());
+}
+
+/// Joins a raw byte component onto a clone of `base`, returning the new path.
+fn join_bytes(base: &Path, bytes: &[u8]) -> PathBuf {
+    let mut out = base.to_path_buf();
+    push_bytes(&mut out, bytes);
+    out
+}
+
+/// Strips all trailing `/` bytes (byte-slice `trim_end_matches('/')`).
+fn trim_end_slashes(mut s: &[u8]) -> &[u8] {
+    while let [rest @ .., b'/'] = s {
+        s = rest;
+    }
+    s
+}
+
+/// Strips all leading `/` bytes (byte-slice `trim_start_matches('/')`).
+fn trim_start_slashes(mut s: &[u8]) -> &[u8] {
+    while let [b'/', rest @ ..] = s {
+        s = rest;
+    }
+    s
+}
+
+/// Returns the index of the first occurrence of `needle` in `haystack`.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
 }
 
 /// Splits a sanitized `--files-from` entry on its first `/./` anchor.
@@ -107,7 +153,7 @@ fn has_leading_dot_anchor(name: &str) -> bool {
 /// The `/./` anchor is relative-only and is not honoured under `--no-relative`.
 pub(super) fn split_files_from_entry(
     base_dir: &Path,
-    sanitized: &str,
+    sanitized: &[u8],
     raw_trailing_slash: bool,
     relative_paths: bool,
 ) -> FilesFromEntry {
@@ -116,7 +162,7 @@ pub(super) fn split_files_from_entry(
     // leading path component: the walk base absorbs the parent directory and
     // the transmitted name is the trailing basename. No implied parent dirs.
     if !relative_paths {
-        let trimmed = sanitized.trim_end_matches('/');
+        let trimmed = trim_end_slashes(sanitized);
         if raw_trailing_slash {
             // upstream: flist.c:2312-2322 - a trailing `/` turns `X/` into the
             // DOTDIR `X/.`; the strrchr split then makes the WHOLE directory the
@@ -127,7 +173,7 @@ pub(super) fn split_files_from_entry(
             let base = if trimmed.is_empty() {
                 base_dir.to_path_buf()
             } else {
-                base_dir.join(trimmed)
+                join_bytes(base_dir, trimmed)
             };
             return FilesFromEntry {
                 base: base.clone(),
@@ -138,19 +184,19 @@ pub(super) fn split_files_from_entry(
                 implied_dot: false,
             };
         }
-        let (head, fname) = match trimmed.rsplit_once('/') {
-            Some((head, fname)) => (head, fname),
-            None => ("", trimmed),
+        let (head, fname) = match trimmed.iter().rposition(|&b| b == b'/') {
+            Some(i) => (&trimmed[..i], &trimmed[i + 1..]),
+            None => (b"".as_slice(), trimmed),
         };
         let base = if head.is_empty() {
             base_dir.to_path_buf()
         } else {
-            base_dir.join(head)
+            join_bytes(base_dir, head)
         };
         let path = if fname.is_empty() {
             base.clone()
         } else {
-            base.join(fname)
+            join_bytes(&base, fname)
         };
         return FilesFromEntry {
             base,
@@ -162,21 +208,21 @@ pub(super) fn split_files_from_entry(
     }
 
     // Anchored form: prefix `/./` suffix.
-    if let Some(anchor) = sanitized.find("/./") {
+    if let Some(anchor) = find_subslice(sanitized, b"/./") {
         let (head, tail) = sanitized.split_at(anchor);
         // upstream: flist.c:2321 - skip the `/./` separator and any redundant
         // leading slashes on the suffix so `dir/./subdir` and `dir/././subdir`
         // both collapse to a relative name of `subdir`.
-        let rest = tail[3..].trim_start_matches('/');
+        let rest = trim_start_slashes(&tail[3..]);
         let base = if head.is_empty() {
             base_dir.to_path_buf()
         } else {
-            base_dir.join(head)
+            join_bytes(base_dir, head)
         };
         let path = if rest.is_empty() {
             base.clone()
         } else {
-            base.join(rest)
+            join_bytes(&base, rest)
         };
         // An empty suffix (e.g. `from/./`) is upstream's DOTDIR_NAME case,
         // which always recurses. Otherwise honour the raw trailing slash.
@@ -194,9 +240,9 @@ pub(super) fn split_files_from_entry(
 
     // Trailing-anchor form: prefix `/.` (sanitize stripped the trailing slash
     // upstream would have left). Treat it identically to `prefix/./`.
-    if let Some(head) = sanitized.strip_suffix("/.") {
+    if let Some(head) = sanitized.strip_suffix(b"/.") {
         if !head.is_empty() {
-            let base = base_dir.join(head);
+            let base = join_bytes(base_dir, head);
             return FilesFromEntry {
                 base: base.clone(),
                 path: base,
@@ -210,7 +256,7 @@ pub(super) fn split_files_from_entry(
 
     FilesFromEntry {
         base: base_dir.to_path_buf(),
-        path: base_dir.join(sanitized),
+        path: join_bytes(base_dir, sanitized),
         recurse: raw_trailing_slash,
         // No `/./` split: the whole sanitized name is the transmitted `fn`.
         implied_dot: has_leading_dot_anchor(sanitized),
@@ -352,13 +398,15 @@ impl GeneratorContext {
             // Always sanitize files_from entries to prevent directory traversal.
             // This collapses ".." components and strips leading "/" to confine
             // paths within the transfer root. `SP_KEEP_DOT_DIRS` preserves the
-            // `/./` anchor so the split below mirrors upstream exactly.
-            let sanitized = crate::sanitize_path::sanitize_path_keep_dot_dirs(name);
+            // `/./` anchor so the split below mirrors upstream exactly. The
+            // byte variant keeps non-UTF-8 names intact (upstream carries the
+            // name as raw `char*`).
+            let sanitized = crate::sanitize_path::sanitize_path_keep_dot_dirs_bytes(name);
             // upstream: flist.c:2329 - a raw trailing slash flags the entry
             // as SLASH_ENDING_NAME, which forces recursion even when global
             // `-r` is off. Capture it from the original (pre-sanitisation)
             // line so the split can propagate the flag.
-            let raw_trailing_slash = name.ends_with('/');
+            let raw_trailing_slash = name.last() == Some(&b'/');
             resolved.push(split_files_from_entry(
                 &base_dir,
                 &sanitized,
@@ -699,7 +747,7 @@ fn append_cvsignore_tokens(rules: &mut Vec<FilterRule>, source: &str, perishable
 ///
 /// - `main.c:675-679` - `open(files_from, O_RDONLY)` for local file
 /// - `flist.c:2297` - `read_line(filesfrom_fd, ...)` reads lines
-pub(super) fn read_files_from_local_path(path: &str, from0: bool) -> io::Result<Vec<String>> {
+pub(super) fn read_files_from_local_path(path: &str, from0: bool) -> io::Result<Vec<Vec<u8>>> {
     let file = std::fs::File::open(path)?;
     let mut reader = io::BufReader::new(file);
 
@@ -714,29 +762,33 @@ pub(super) fn read_files_from_local_path(path: &str, from0: bool) -> io::Result<
         // strips leading '#'/';' comment lines even with NUL delimiters. A
         // local file open is not "reading remotely", so comments are stripped.
         let mut filenames = protocol::read_files_from_stream(&mut reader, None)?;
-        filenames.retain(|name| !name.starts_with('#') && !name.starts_with(';'));
+        filenames.retain(|name| !name.starts_with(b"#") && !name.starts_with(b";"));
         Ok(filenames)
     } else {
-        // Line-delimited: read lines, skip comments and empty lines.
+        // Line-delimited: read lines as raw bytes so non-UTF-8 names survive
+        // (upstream carries filenames as `char*`), skipping comments and empty
+        // lines.
         let mut filenames = Vec::new();
-        let mut line = String::new();
+        let mut line: Vec<u8> = Vec::new();
         loop {
             line.clear();
-            let n = io::BufRead::read_line(&mut reader, &mut line)?;
+            let n = io::BufRead::read_until(&mut reader, b'\n', &mut line)?;
             if n == 0 {
                 break;
             }
-            let trimmed = line.trim_end_matches(['\n', '\r']);
-            if trimmed.is_empty() {
+            while matches!(line.last(), Some(b'\n' | b'\r')) {
+                line.pop();
+            }
+            if line.is_empty() {
                 continue;
             }
             // upstream: io.c:1276 - RL_DUMP_COMMENTS strips leading '#'/';'
             // comment lines for local files (flist.c:2249, reading_remotely
             // false), regardless of eol_nulls.
-            if trimmed.starts_with('#') || trimmed.starts_with(';') {
+            if matches!(line.first(), Some(b'#' | b';')) {
                 continue;
             }
-            filenames.push(trimmed.to_owned());
+            filenames.push(line.clone());
         }
         Ok(filenames)
     }
@@ -830,7 +882,7 @@ mod tests {
     #[test]
     fn split_files_from_entry_without_anchor_inherits_base() {
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "dir/file.txt", false, true);
+        let split = split_files_from_entry(&base, b"dir/file.txt", false, true);
         assert_eq!(split.base, PathBuf::from("/src"));
         assert_eq!(split.path, PathBuf::from("/src/dir/file.txt"));
         assert!(!split.recurse);
@@ -845,7 +897,7 @@ mod tests {
         // no implied `sub` directory. An upstream receiver rejects an
         // unrequested intermediate `sub` with exit 4.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "sub/file", false, false);
+        let split = split_files_from_entry(&base, b"sub/file", false, false);
         assert_eq!(split.base, PathBuf::from("/src/sub"));
         assert_eq!(split.path, PathBuf::from("/src/sub/file"));
         assert_eq!(
@@ -855,7 +907,7 @@ mod tests {
         assert!(!split.recurse);
 
         // Deeper nesting still flattens to the trailing basename (last `/`).
-        let deep = split_files_from_entry(&base, "a/b/c/file", false, false);
+        let deep = split_files_from_entry(&base, b"a/b/c/file", false, false);
         assert_eq!(deep.base, PathBuf::from("/src/a/b/c"));
         assert_eq!(
             deep.path.strip_prefix(&deep.base).unwrap(),
@@ -863,13 +915,13 @@ mod tests {
         );
 
         // A top-level entry keeps the source argument as its base.
-        let top = split_files_from_entry(&base, "file", false, false);
+        let top = split_files_from_entry(&base, b"file", false, false);
         assert_eq!(top.base, PathBuf::from("/src"));
         assert_eq!(top.path, PathBuf::from("/src/file"));
 
         // The `/./` anchor is relative-only; under --no-relative it is a
         // literal component and the split still takes the last `/`.
-        let anchored = split_files_from_entry(&base, "from/./dir/file", false, false);
+        let anchored = split_files_from_entry(&base, b"from/./dir/file", false, false);
         assert_eq!(anchored.base, PathBuf::from("/src/from/./dir"));
         assert_eq!(
             anchored.path.strip_prefix(&anchored.base).unwrap(),
@@ -879,14 +931,14 @@ mod tests {
         // A trailing slash names a directory whose contents flatten into the
         // transfer root: base is the whole dir, path == base (transmit `.`),
         // and recursion is forced (upstream DOTDIR / SLASH_ENDING_NAME).
-        let dir = split_files_from_entry(&base, "sub", true, false);
+        let dir = split_files_from_entry(&base, b"sub", true, false);
         assert_eq!(dir.base, PathBuf::from("/src/sub"));
         assert_eq!(dir.path, PathBuf::from("/src/sub"));
         assert!(dir.recurse);
 
         // A plain directory entry (no trailing slash) keeps the parent as base,
         // transmits the basename, and is NOT recursed (files-from clears `-r`).
-        let plain_dir = split_files_from_entry(&base, "sub", false, false);
+        let plain_dir = split_files_from_entry(&base, b"sub", false, false);
         assert_eq!(plain_dir.base, PathBuf::from("/src"));
         assert_eq!(plain_dir.path, PathBuf::from("/src/sub"));
         assert!(!plain_dir.recurse);
@@ -899,7 +951,7 @@ mod tests {
         // `dir/subdir`. Otherwise upstream's `implied_filter_list` check
         // (flist.c:1026) rejects `from/dir/subdir` as "unrequested".
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "from/./dir/subdir", false, true);
+        let split = split_files_from_entry(&base, b"from/./dir/subdir", false, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));
         assert_eq!(split.path, PathBuf::from("/src/from/dir/subdir"));
         assert!(!split.recurse);
@@ -913,7 +965,7 @@ mod tests {
         // anchor directory itself, with the relative name collapsing to `.`,
         // and is always recursed into.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "from/./", true, true);
+        let split = split_files_from_entry(&base, b"from/./", true, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));
         assert_eq!(split.path, PathBuf::from("/src/from"));
         assert!(split.recurse);
@@ -926,8 +978,8 @@ mod tests {
         // upstream preserves. Without trailing-dot handling, the split would
         // miss the anchor and emit a `from/` directory entry instead of
         // promoting `from` to the walk base.
-        let sanitized = crate::sanitize_path::sanitize_path_keep_dot_dirs("from/./");
-        assert_eq!(sanitized, "from/.");
+        let sanitized = crate::sanitize_path::sanitize_path_keep_dot_dirs_bytes(b"from/./");
+        assert_eq!(sanitized, b"from/.");
         let base = PathBuf::from("/src");
         let split = split_files_from_entry(&base, &sanitized, true, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));
@@ -942,7 +994,7 @@ mod tests {
         // the named directory even though `--files-from` clears the global
         // `-r` flag.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "from/./dir/subdir/subsubdir2", true, true);
+        let split = split_files_from_entry(&base, b"from/./dir/subdir/subsubdir2", true, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));
         assert_eq!(split.path, PathBuf::from("/src/from/dir/subdir/subsubdir2"));
         assert!(split.recurse);
@@ -952,7 +1004,7 @@ mod tests {
     fn split_files_from_entry_collapses_redundant_separator_slashes() {
         // `dir/././sub` should behave like `dir/./sub`: head is `dir`, rest is `sub`.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "dir/././sub", false, true);
+        let split = split_files_from_entry(&base, b"dir/././sub", false, true);
         assert_eq!(split.base, PathBuf::from("/src/dir"));
         // The second `./` is part of `rest` and joins as `./sub`; PathBuf
         // join keeps it as a no-op fs component.
@@ -975,7 +1027,7 @@ mod tests {
         // upstream: flist.c:2368 - `implied_dot_dir` only trips on a leading
         // `./`; a plain relative name never emits the transfer-root `.`.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "dir/file.txt", false, true);
+        let split = split_files_from_entry(&base, b"dir/file.txt", false, true);
         assert!(!split.implied_dot);
     }
 
@@ -985,7 +1037,7 @@ mod tests {
         // leading `./foo` files-from line (no embedded `/./`) marks the entry
         // so `--relative` mode emits a single FLAG_IMPLIED_DIR root `.`.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "./foo/bar", false, true);
+        let split = split_files_from_entry(&base, b"./foo/bar", false, true);
         assert!(split.implied_dot);
     }
 
@@ -993,8 +1045,8 @@ mod tests {
     fn split_files_from_entry_bare_dot_forms_are_not_implied_dot() {
         // A bare `.` or `./` (upstream `fn[2]` is NUL) never sets the flag.
         let base = PathBuf::from("/src");
-        assert!(!split_files_from_entry(&base, ".", false, true).implied_dot);
-        assert!(!split_files_from_entry(&base, "./", true, true).implied_dot);
+        assert!(!split_files_from_entry(&base, b".", false, true).implied_dot);
+        assert!(!split_files_from_entry(&base, b"./", true, true).implied_dot);
     }
 
     #[test]
@@ -1003,7 +1055,33 @@ mod tests {
         // suffix; `dir/././sub` leaves `rest == "./sub"`, which still trips
         // `implied_dot_dir`.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "dir/././sub", false, true);
+        let split = split_files_from_entry(&base, b"dir/././sub", false, true);
         assert!(split.implied_dot);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn split_files_from_entry_preserves_non_utf8_bytes() {
+        // A non-UTF-8 filename (0xFF byte) and a literal backslash are legal
+        // Unix names. The split must carry every byte into the resolved path
+        // verbatim - upstream treats the name as raw `char*`.
+        use std::os::unix::ffi::OsStrExt;
+        let base = PathBuf::from("/src");
+
+        let split = split_files_from_entry(&base, b"foo\xffbar.txt", false, true);
+        assert_eq!(split.path.as_os_str().as_bytes(), b"/src/foo\xffbar.txt");
+        assert_eq!(split.base.as_os_str().as_bytes(), b"/src");
+
+        let bs = split_files_from_entry(&base, b"back\\slash.txt", false, true);
+        assert_eq!(bs.path.as_os_str().as_bytes(), b"/src/back\\slash.txt");
+
+        // Non-UTF-8 bytes inside an anchored entry: `dir\xff/./file\xfe`
+        // promotes `dir\xff` to the base and transmits `file\xfe`.
+        let anchored = split_files_from_entry(&base, b"dir\xff/./file\xfe", false, true);
+        assert_eq!(anchored.base.as_os_str().as_bytes(), b"/src/dir\xff");
+        assert_eq!(
+            anchored.path.as_os_str().as_bytes(),
+            b"/src/dir\xff/file\xfe"
+        );
     }
 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3982,7 +3982,7 @@ mod files_from {
 
             // Build the entry through the real non-relative split so the walk
             // base absorbs `sub` and the wire name flattens to `file`.
-            let entry = super::filters::split_files_from_entry(&src, "sub/file", false, false);
+            let entry = super::filters::split_files_from_entry(&src, b"sub/file", false, false);
             ctx.build_file_list_with_base(&src, &[entry]).unwrap();
 
             ctx.file_list()
@@ -4402,7 +4402,10 @@ mod files_from {
         let result =
             super::super::filters::read_files_from_local_path(&list_file.to_string_lossy(), false)
                 .unwrap();
-        assert_eq!(result, vec!["a.txt", "b.txt", "c.txt"]);
+        assert_eq!(
+            result,
+            vec![b"a.txt".to_vec(), b"b.txt".to_vec(), b"c.txt".to_vec()]
+        );
     }
 
     #[test]
@@ -4414,7 +4417,7 @@ mod files_from {
         let result =
             super::super::filters::read_files_from_local_path(&list_file.to_string_lossy(), true)
                 .unwrap();
-        assert_eq!(result, vec!["x.txt", "y.txt"]);
+        assert_eq!(result, vec![b"x.txt".to_vec(), b"y.txt".to_vec()]);
     }
 
     #[test]
@@ -4429,7 +4432,7 @@ mod files_from {
         let result =
             super::super::filters::read_files_from_local_path(&list_file.to_string_lossy(), true)
                 .unwrap();
-        assert_eq!(result, vec!["x.txt", "y.txt"]);
+        assert_eq!(result, vec![b"x.txt".to_vec(), b"y.txt".to_vec()]);
     }
 
     #[test]
@@ -4441,7 +4444,7 @@ mod files_from {
         let result =
             super::super::filters::read_files_from_local_path(&list_file.to_string_lossy(), false)
                 .unwrap();
-        assert_eq!(result, vec!["file.txt", "other.txt"]);
+        assert_eq!(result, vec![b"file.txt".to_vec(), b"other.txt".to_vec()]);
     }
 }
 

--- a/crates/transfer/src/sanitize_path.rs
+++ b/crates/transfer/src/sanitize_path.rs
@@ -47,16 +47,51 @@ pub fn sanitize_path_keep_dot_dirs(path: &str) -> String {
     sanitize_path_with_depth(path, 0, true)
 }
 
+/// Byte-exact variant of [`sanitize_path_keep_dot_dirs`].
+///
+/// Used for `--files-from` entries whose names may not be valid UTF-8. A
+/// filename is a raw byte string on Unix (upstream carries it as `char*`),
+/// so the sanitizer must preserve every non-separator byte verbatim rather
+/// than route through `String`, which would drop non-UTF-8 names. The
+/// traversal-guard logic is identical to the `&str` path - both delegate to
+/// [`sanitize_path_bytes`], which only ever inspects the ASCII `/` and `.`
+/// bytes.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:2299` - `sanitize_path(fbuf, fbuf, "", 0, SP_KEEP_DOT_DIRS)`
+pub fn sanitize_path_keep_dot_dirs_bytes(path: &[u8]) -> Vec<u8> {
+    sanitize_path_bytes(path, 0, true)
+}
+
 /// Core sanitization with configurable depth budget and dot-dir handling.
 ///
 /// - `depth`: number of leading `..` segments allowed (0 for daemon mode)
 /// - `keep_dot_dirs`: when true, preserves leading `./` (SP_KEEP_DOT_DIRS)
 ///
+/// The `&str` input is valid UTF-8 and [`sanitize_path_bytes`] only rewrites
+/// ASCII separators/dot components, so the result is always valid UTF-8.
+///
 /// # Upstream Reference
 ///
 /// - `util1.c:1035-1108`
-fn sanitize_path_with_depth(path: &str, mut depth: i32, keep_dot_dirs: bool) -> String {
-    let bytes = path.as_bytes();
+fn sanitize_path_with_depth(path: &str, depth: i32, keep_dot_dirs: bool) -> String {
+    let out = sanitize_path_bytes(path.as_bytes(), depth, keep_dot_dirs);
+    String::from_utf8(out).unwrap_or_else(|_| ".".to_string())
+}
+
+/// Byte-level core of [`sanitize_path_with_depth`].
+///
+/// Operates purely on the raw bytes, inspecting only the ASCII `/` (0x2F)
+/// separator and `.` (0x2E) dot bytes; every other byte is copied through
+/// verbatim, so non-UTF-8 filenames survive intact. This is the single
+/// implementation of the traversal guard - the `&str` and `&[u8]` public
+/// entry points both delegate here so the security behaviour cannot diverge.
+///
+/// # Upstream Reference
+///
+/// - `util1.c:1035-1108`
+fn sanitize_path_bytes(bytes: &[u8], mut depth: i32, keep_dot_dirs: bool) -> Vec<u8> {
     let mut p = 0usize;
 
     // upstream: util1.c:1051 - strip leading slash (absolute -> relative)
@@ -131,11 +166,10 @@ fn sanitize_path_with_depth(path: &str, mut depth: i32, keep_dot_dirs: bool) -> 
     }
 
     if result.is_empty() {
-        ".".to_string()
+        // upstream: util1.c:1103 - an empty result becomes ".".
+        b".".to_vec()
     } else {
-        // SAFETY: input is &str (valid UTF-8), and we only manipulate ASCII
-        // path separators and dot components, preserving UTF-8 validity.
-        String::from_utf8(result).unwrap_or_else(|_| ".".to_string())
+        result
     }
 }
 
@@ -370,6 +404,79 @@ mod tests {
         assert_eq!(
             sanitize_path_keep_dot_dirs("./a/../../etc/passwd"),
             "etc/passwd"
+        );
+    }
+
+    // --- Byte-level entry point: preservation + traversal guard parity ---
+    //
+    // `--files-from` names may be non-UTF-8 (a legal Unix filename), so the
+    // sender sanitizes them through `sanitize_path_keep_dot_dirs_bytes`. These
+    // tests pin two invariants: (1) non-separator bytes (including 0xFF and a
+    // literal backslash) round-trip verbatim, and (2) the traversal guard is
+    // byte-identical to the `&str` path - `../` and absolute escapes are still
+    // collapsed even when the surviving component carries non-UTF-8 bytes.
+
+    #[test]
+    fn bytes_preserves_non_utf8_component() {
+        assert_eq!(
+            sanitize_path_keep_dot_dirs_bytes(b"foo\xffbar.txt"),
+            b"foo\xffbar.txt".to_vec()
+        );
+    }
+
+    #[test]
+    fn bytes_preserves_backslash_component() {
+        // A backslash is an ordinary filename byte on Unix, not a separator.
+        assert_eq!(
+            sanitize_path_keep_dot_dirs_bytes(b"back\\slash.txt"),
+            b"back\\slash.txt".to_vec()
+        );
+    }
+
+    #[test]
+    fn bytes_matches_str_path_for_ascii() {
+        // Same input, both entry points: identical bytes out.
+        let ascii = "a/./b/../c";
+        assert_eq!(
+            sanitize_path_keep_dot_dirs_bytes(ascii.as_bytes()),
+            sanitize_path_keep_dot_dirs(ascii).into_bytes()
+        );
+    }
+
+    #[test]
+    fn bytes_dotdot_traversal_blocked_with_non_utf8() {
+        // `../` escape is collapsed to the root even though the retained
+        // component (`\xff\xfe`) is not valid UTF-8. The guard must not be
+        // weakened for non-UTF-8 input.
+        assert_eq!(
+            sanitize_path_keep_dot_dirs_bytes(b"../../\xff\xfe/passwd"),
+            b"\xff\xfe/passwd".to_vec()
+        );
+    }
+
+    #[test]
+    fn bytes_absolute_traversal_stripped_with_non_utf8() {
+        // Leading `/` is stripped (absolute -> relative) with a non-UTF-8 tail.
+        assert_eq!(
+            sanitize_path_keep_dot_dirs_bytes(b"/\xff\xfe/secret"),
+            b"\xff\xfe/secret".to_vec()
+        );
+    }
+
+    #[test]
+    fn bytes_interior_dotdot_collapses_non_utf8_component() {
+        // `a/b/../c` collapses `b`, preserving the non-UTF-8 bytes in `a`/`c`.
+        assert_eq!(
+            sanitize_path_keep_dot_dirs_bytes(b"\xffa/b/../\xfec"),
+            b"\xffa/\xfec".to_vec()
+        );
+    }
+
+    #[test]
+    fn bytes_deep_dotdot_cannot_escape_root_non_utf8() {
+        assert_eq!(
+            sanitize_path_keep_dot_dirs_bytes(b"a/../../../../\xff/shadow"),
+            b"\xff/shadow".to_vec()
         );
     }
 }

--- a/crates/transfer/src/tests/config.rs
+++ b/crates/transfer/src/tests/config.rs
@@ -210,5 +210,12 @@ fn files_from_data_roundtrip_with_protocol_wire_format() {
     let data = cfg.connection.files_from_data.take().unwrap();
     let mut wire_reader = Cursor::new(&data);
     let filenames = protocol::read_files_from_stream(&mut wire_reader, None).unwrap();
-    assert_eq!(filenames, vec!["alpha.txt", "beta.txt", "gamma/delta.txt"]);
+    assert_eq!(
+        filenames,
+        vec![
+            b"alpha.txt".to_vec(),
+            b"beta.txt".to_vec(),
+            b"gamma/delta.txt".to_vec()
+        ]
+    );
 }

--- a/crates/transfer/tests/files_from_lsh_repeated.rs
+++ b/crates/transfer/tests/files_from_lsh_repeated.rs
@@ -88,11 +88,11 @@ fn forwarded_round_trip_repeats_cleanly() {
         assert_eq!(
             names,
             vec![
-                "from/./",
-                "from/./dir/subdir",
-                "from/./dir/subdir/subsubdir",
-                "from/./dir/subdir/subsubdir2/",
-                "from/./dir/subdir/foobar.baz",
+                b"from/./".to_vec(),
+                b"from/./dir/subdir".to_vec(),
+                b"from/./dir/subdir/subsubdir".to_vec(),
+                b"from/./dir/subdir/subsubdir2/".to_vec(),
+                b"from/./dir/subdir/foobar.baz".to_vec(),
             ],
             "iteration {iteration} parsed filenames diverged"
         );


### PR DESCRIPTION
## Problem

On the sender side of a network transfer, a forwarded (or locally-read) `--files-from` list was decoded through `String`: `read_files_from_stream` ran each NUL-separated name through a `str::from_utf8` check and **silently dropped** any name that was not valid UTF-8. A non-UTF-8 filename is legal on Unix, and upstream rsync carries filenames as raw `char*` bytes, so the entry simply disappeared from the sender's file list.

Measured on Linux (oc built from this branch's base vs `/usr/bin/rsync` 3.4.4), a `--files-from` list containing `foo\xffbar.txt` + `plain.txt`:

- **oc↔oc SSH pull (before):** only `plain.txt` transferred; `foo\xffbar.txt` vanished with no error.
- **oc client → upstream server SSH pull (before):** transfer aborted (`connection unexpectedly closed`).
- **upstream↔upstream (oracle):** both files transferred, bytes intact.

## Fix

Carry `--files-from` names as raw bytes end to end on the sender side, mirroring upstream's byte-exact `char*` handling:

- `protocol::read_files_from_stream` / `read_files_from_stream_with_deadline` now return `Vec<Vec<u8>>` and no longer UTF-8-validate (upstream `flist.c:2297 read_line`, `io.c forward_filesfrom_data`).
- The generator's local-file reader reads raw lines; the entry splitter (`split_files_from_entry`) and `sanitize_path_keep_dot_dirs` operate on bytes. Components reach the filesystem via `OsStr::from_bytes` on Unix; non-Unix targets interpret bytes as UTF-8 (exact for valid UTF-8 names, preserved as `OsString`).

## Security invariant preserved

`sanitize_path` already worked purely on the ASCII `/` and `.` bytes, so the `&str` and new `&[u8]` entry points delegate to one shared implementation - the traversal guard is byte-identical. New tests prove `../` and absolute-path escapes are still collapsed when the surviving component carries non-UTF-8 bytes.

## Verification (Linux x86_64)

- `cargo fmt --all -- --check`, `cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings`: clean.
- `cargo check` for `x86_64-pc-windows-gnu` and `x86_64-unknown-linux-musl`: clean.
- `cargo nextest` across protocol/transfer/core (files_from / from0 / sanitize / traversal / byte / split): 354 passed.
- End-to-end after the fix: oc↔oc, oc→upstream, and upstream↔upstream all land `foo\xffbar.txt` + `plain.txt` with byte-identical names (`666f6fff6261722e747874`, `706c61696e2e747874`).
