### PR TITLE
fix(engine): emit -R implied parent dirs in local-copy itemize/stats/verbose

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -222,6 +222,14 @@ pub(crate) struct CopyContext<'a> {
     /// path's same-filesystem gate. `None` means verified but device not yet
     /// resolved.
     verified_parents: HashMap<PathBuf, Option<u64>>,
+    /// Relative paths of implied parent directories already surfaced as flist
+    /// entries during this transfer (`--relative`). Upstream's
+    /// `send_implied_dirs()` (flist.c:1937) relies on `lastpath` plus
+    /// `flist_sort_and_clean()` deduplication so each implied ancestor appears
+    /// once even when several source args share a prefix; this set reproduces
+    /// that single-emission guarantee for the local-copy itemize/stats/verbose
+    /// stream, which never builds a shared sorted flist.
+    emitted_implied_dirs: HashSet<PathBuf>,
     /// Protocol flist encoder for batch mode.
     ///
     /// When batch mode is active, file entries are encoded using the protocol

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -119,6 +119,21 @@ impl<'a> CopyContext<'a> {
         }
     }
 
+    /// Marks `relative` as an implied parent directory surfaced during this
+    /// transfer and reports whether it is the first sighting. Returns `true`
+    /// when the caller should emit the directory's flist entry (itemize row,
+    /// `--stats` counters, verbose line), `false` when an earlier source arg
+    /// already surfaced the same ancestor.
+    ///
+    /// upstream: flist.c:1937 `send_implied_dirs()` dedups shared ancestors via
+    /// its `lastpath` cache and the later `flist_sort_and_clean()` pass so each
+    /// implied directory appears once even when several `--relative` operands
+    /// share a prefix. The local-copy executor never builds a shared sorted
+    /// flist, so this set enforces the same one-entry-per-ancestor guarantee.
+    pub(super) fn mark_implied_dir_emitted(&mut self, relative: &Path) -> bool {
+        self.emitted_implied_dirs.insert(relative.to_path_buf())
+    }
+
     /// Consumes the context and returns the final [`CopyOutcome`].
     pub(super) fn into_outcome(self) -> CopyOutcome {
         CopyOutcome {

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -165,6 +165,7 @@ impl<'a> CopyContext<'a> {
             delete_io_error: false,
             multi_source: false,
             verified_parents: HashMap::new(),
+            emitted_implied_dirs: HashSet::new(),
             batch_flist_writer,
             batch_delta_buf,
             batch_delta_entries: Vec::new(),

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -257,7 +257,9 @@ fn copy_directory_recursive_inner(
         // when the destination already exists (test line 74-79) while `-vv`
         // surfaces it as `.d ./`.
         if destination_missing {
-            context.summary_mut().mark_destination_root_created();
+            // The recursive root frame (relative == None) is the transfer-root
+            // "." flist entry of a copy-contents transfer, so it counts.
+            context.summary_mut().mark_destination_root_created(true);
         }
         Some((
             std::path::PathBuf::from("."),

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -9,9 +9,9 @@ use logging::{debug_log, info_log};
 
 use crate::local_copy::overrides::device_identifier;
 use crate::local_copy::{
-    CopyContext, CopyOutcome, LocalCopyAction, LocalCopyArgumentError, LocalCopyError,
-    LocalCopyExecution, LocalCopyOptions, LocalCopyPlan, LocalCopyRecord, LocalCopyRecordHandler,
-    SourceSpec,
+    CopyContext, CopyOutcome, LocalCopyAction, LocalCopyArgumentError, LocalCopyChangeSet,
+    LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyOptions, LocalCopyPlan,
+    LocalCopyRecord, LocalCopyRecordHandler, SourceSpec,
 };
 
 use super::super::file::remove_existing_destination;
@@ -167,8 +167,19 @@ pub(crate) fn copy_sources(
                 )?;
             }
 
+            // upstream: main.c:803-808 prints `created directory <dest>` for the
+            // pre-flight mkdir and, when the flist carries a "." top entry (a
+            // non-relative copy-contents transfer), counts it as a created dir.
+            // Under `--relative` the destination root is the mkpath target,
+            // announced by the same notice yet absent from the flist, so it must
+            // not inflate the created-dir count - a `./`-anchored operand's "."
+            // is accounted for by `emit_relative_implied_parents`. Set the
+            // notice flag either way; count only for non-relative transfers.
             if destination_root_created {
-                context.summary_mut().mark_destination_root_created();
+                let count_root = !context.relative_paths_enabled();
+                context
+                    .summary_mut()
+                    .mark_destination_root_created(count_root);
             }
 
             let destination_behaves_like_directory =
@@ -183,6 +194,7 @@ pub(crate) fn copy_sources(
                     destination_path,
                     destination_behaves_like_directory,
                     multiple_sources,
+                    destination_root_created,
                 );
                 if let Err(error) = result {
                     if error.is_vanished_error() {
@@ -319,6 +331,7 @@ fn process_single_source(
     destination_path: &Path,
     destination_behaves_like_directory: bool,
     multiple_sources: bool,
+    destination_root_created: bool,
 ) -> Result<(), LocalCopyError> {
     // Directory copy handlers set the correct offset before recursing.
     context.set_safety_depth_offset(0);
@@ -444,6 +457,20 @@ fn process_single_source(
         ));
     }
 
+    // upstream: flist.c:2456-2472 - send_file_list() calls send_implied_dirs()
+    // for each `--relative` operand *before* send_file_name() emits the operand
+    // itself, so the implied parent directories precede the operand's row in the
+    // itemize / verbose / stats stream. Surface those ancestor rows here, ahead
+    // of the leaf's own record, mirroring that ordering.
+    emit_relative_implied_parents(
+        context,
+        source,
+        source_path,
+        destination_path,
+        relative_root.as_deref(),
+        destination_root_created,
+    )?;
+
     if file_type.is_dir() {
         if source.copy_contents() {
             handle_directory_contents_copy(
@@ -480,6 +507,189 @@ fn process_single_source(
     )?;
 
     context.enforce_timeout()?;
+    Ok(())
+}
+
+/// Surfaces the implied parent directories along a `--relative` source's path
+/// as flist entries so the local-copy itemize (`-i`), `--stats` counters, and
+/// verbose (`-v`) listing match upstream. Only the ancestors *above* the leaf
+/// are recorded here; the leaf's own row is emitted by the file/directory
+/// handler. The directories themselves are still physically materialized by
+/// `prepare_parent_directory` during the leaf's copy - this pass records them.
+///
+/// upstream: flist.c:1937 `send_implied_dirs()` emits one `FLAG_IMPLIED_DIR`
+/// entry per ancestor component (`flist.c:1989-1998`), bypassing the filter
+/// chain (`flist.c:1950`) and deduplicating shared ancestors across operands;
+/// the receiver then itemizes each as `cd+++++++++ <dir>/` and counts it under
+/// the created-dir stats. `--no-implied-dirs` clears `implied_dirs`
+/// (`flist.c:2468`), suppressing the whole set - mirrored by the guard below.
+fn emit_relative_implied_parents(
+    context: &mut CopyContext,
+    source: &SourceSpec,
+    source_path: &Path,
+    destination_path: &Path,
+    relative_root: Option<&Path>,
+    destination_root_created: bool,
+) -> Result<(), LocalCopyError> {
+    if !context.relative_paths_enabled() {
+        return Ok(());
+    }
+    let Some(relative) = relative_root else {
+        return Ok(());
+    };
+
+    // upstream: flist.c:2258 - a protocol >= 30 sender (which a local transfer
+    // always is, being a proto-32 sender/receiver pair) forces `implied_dirs = 1`
+    // so the flagged implied parents are always placed in the shared flist and
+    // counted toward "Number of files (dir: N)". `--no-implied-dirs` only tells
+    // the receiver not to apply the source dir's attributes, which suppresses
+    // the itemize row and the created-dir tally - not the flist entry itself.
+    let itemize = context.implied_dirs_enabled();
+
+    // Dot-dir transfer root ".": upstream flist.c:2368+2417-2419 injects a
+    // synthetic "." entry into the flist only for an operand that *begins* with
+    // `./` (`implied_dot_dir`), so it counts toward "Number of files". A dot in
+    // the middle of the path (e.g. `src/./sub`) reroots the relative path but
+    // adds no "." entry. `dot_dir_anchor()` returns "." exactly for the leading
+    // form (its prefix-skip is zero). The receiver never itemizes the
+    // pre-existing destination root and end-of-run touch-up leaves it unchanged,
+    // so the entry stays count-only (no verbose/itemize row, no created-dir bump
+    // - the latter is owned by `mark_destination_root_created` when the root is
+    // freshly made).
+    if source.dot_dir_anchor().as_deref() == Some(Path::new(".")) {
+        let dot = PathBuf::from(".");
+        if context.mark_implied_dir_emitted(&dot) {
+            context.record_file_list_entry(non_empty_path(dot.as_path()));
+            context.summary_mut().record_directory_total();
+
+            // The leading-dot "." maps to the destination transfer root. When
+            // that root is freshly created this run, upstream itemizes it
+            // `cd+++++++++ ./` and counts it as a created dir (main.c:803-808);
+            // a pre-existing root stays count-only (unchanged, suppressed under
+            // -i). `--no-implied-dirs` (itemize == false) drops both. In dry-run
+            // the mkdir is elided, so "would create" is inferred from the root's
+            // absence on disk. The itemize row snapshots the source anchor dir,
+            // which exists in both modes (the destination may not yet).
+            let root_created = destination_root_created
+                || (context.mode().is_dry_run() && !destination_path.exists());
+            if root_created
+                && itemize
+                && let Some(anchor) = source.dot_dir_anchor()
+                && let Ok(meta) = fs::symlink_metadata(&anchor)
+                && meta.file_type().is_dir()
+            {
+                context.summary_mut().record_directory();
+                let snapshot = LocalCopyMetadata::from_metadata(&meta, None);
+                let snapshot_len = snapshot.len();
+                context.record(
+                    LocalCopyRecord::new(
+                        dot.clone(),
+                        LocalCopyAction::DirectoryCreated,
+                        0,
+                        Some(snapshot_len),
+                        Duration::default(),
+                        Some(snapshot),
+                    )
+                    .with_creation(true),
+                );
+            }
+        }
+    }
+
+    let components: Vec<&std::ffi::OsStr> = relative.iter().collect();
+    let parent_count = components.len().saturating_sub(1);
+    if parent_count == 0 {
+        return Ok(());
+    }
+
+    let Some(source_root) = strip_path_suffix(source_path, relative) else {
+        return Ok(());
+    };
+    let destination_root = strip_path_suffix(destination_path, relative)
+        .unwrap_or_else(|| destination_path.to_path_buf());
+
+    let metadata_options = context.metadata_options();
+    let omit_dir_times = context.omit_dir_times_enabled();
+    let modify_window = context.options().modify_window();
+
+    let mut accumulated = PathBuf::new();
+    for component in &components[..parent_count] {
+        accumulated.push(component);
+
+        // Emit each ancestor once per transfer (upstream dedups via lastpath +
+        // flist_sort_and_clean); a later operand sharing this prefix must not
+        // re-list it.
+        if !context.mark_implied_dir_emitted(&accumulated) {
+            continue;
+        }
+
+        let source_dir = source_root.join(&accumulated);
+        // Best-effort, matching send_implied_dirs()'s tolerance for an ancestor
+        // that vanished or is not a directory: skip it silently.
+        let source_meta = match fs::symlink_metadata(&source_dir) {
+            Ok(meta) if meta.file_type().is_dir() => meta,
+            _ => continue,
+        };
+        let destination_dir = destination_root.join(&accumulated);
+        let existing_meta = match fs::symlink_metadata(&destination_dir) {
+            Ok(meta) if meta.file_type().is_dir() => Some(meta),
+            _ => None,
+        };
+
+        let relative_path = accumulated.clone();
+
+        // upstream: flist.c:2258 - implied dirs always join the shared flist, so
+        // each counts toward "Number of files (dir: N)" even under
+        // --no-implied-dirs.
+        context.record_file_list_entry(non_empty_path(relative_path.as_path()));
+        context.summary_mut().record_directory_total();
+
+        // --no-implied-dirs (itemize == false): the receiver applies no source
+        // attributes, so there is no itemize/verbose row and no created-dir
+        // bump - the flist count above is the only observable effect.
+        if !itemize {
+            continue;
+        }
+
+        let snapshot = LocalCopyMetadata::from_metadata(&source_meta, None);
+        let snapshot_len = snapshot.len();
+
+        let record = if let Some(existing) = existing_meta.as_ref() {
+            // Pre-existing ancestor: no ITEM_IS_NEW; itemize against the basis so
+            // an unchanged dir stays an all-dot `.d` row (shown only under -vv).
+            let change_set = LocalCopyChangeSet::for_existing_directory(
+                &source_meta,
+                existing,
+                &metadata_options,
+                omit_dir_times,
+                false,
+                false,
+                modify_window,
+            );
+            LocalCopyRecord::new(
+                relative_path,
+                LocalCopyAction::MetadataReused,
+                0,
+                Some(snapshot_len),
+                Duration::default(),
+                Some(snapshot),
+            )
+            .with_change_set(change_set)
+        } else {
+            context.summary_mut().record_directory();
+            LocalCopyRecord::new(
+                relative_path,
+                LocalCopyAction::DirectoryCreated,
+                0,
+                Some(snapshot_len),
+                Duration::default(),
+                Some(snapshot),
+            )
+            .with_creation(true)
+        };
+        context.record(record);
+    }
+
     Ok(())
 }
 

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -515,14 +515,27 @@ impl LocalCopySummary {
         self.destination_root_created
     }
 
-    pub(in crate::local_copy) const fn mark_destination_root_created(&mut self) {
-        // upstream: receiver.c:731-746 - the pre-flight mkdir of the
-        // destination root sets ITEM_IS_NEW on the synthesized "." entry, so
-        // `stats.created_files++` and `stats.created_dirs++` count it. Bump the
-        // created-directory tally exactly once (guarded by the flag, which both
-        // call sites also set) so `--stats` "Number of created files" includes
-        // the destination root - dir:2 for a fresh recursive copy, not dir:1.
-        if !self.destination_root_created {
+    /// Records that the transfer materialised the destination root directory,
+    /// which drives the `created directory %s` notice. `count_created` also
+    /// bumps the created-directory tally when the root is a real "." flist
+    /// entry.
+    ///
+    /// upstream: receiver.c:731-746 - the pre-flight mkdir of the destination
+    /// root sets ITEM_IS_NEW on the synthesized "." entry, so
+    /// `stats.created_files++`/`stats.created_dirs++` count it - but ONLY when
+    /// the flist actually carries that "." entry (a non-relative copy-contents
+    /// transfer). Under `--relative` the destination root is the
+    /// `get_local_name()` mkpath target, printed via the same notice yet absent
+    /// from the flist, so it must not inflate the created-dir count; a
+    /// `./`-anchored operand's "." is accounted for separately by
+    /// `emit_relative_implied_parents`. The flag (and thus the notice) is set
+    /// regardless; the count bump is gated on `count_created` and fires at most
+    /// once.
+    pub(in crate::local_copy) const fn mark_destination_root_created(
+        &mut self,
+        count_created: bool,
+    ) {
+        if !self.destination_root_created && count_created {
             self.directories_created = self.directories_created.saturating_add(1);
         }
         self.destination_root_created = true;

--- a/crates/engine/tests/relative_implied_parent_records.rs
+++ b/crates/engine/tests/relative_implied_parent_records.rs
@@ -1,0 +1,150 @@
+//! Regression coverage for `-R` implied parent directories in the local-copy
+//! itemize / `--stats` stream.
+//!
+//! Upstream `flist.c::send_implied_dirs()` injects one flagged directory entry
+//! per ancestor of a `--relative` operand into the shared flist, *before* the
+//! operand's own entry. The receiver then itemizes each as `cd+++++++++ <dir>/`
+//! and counts it under `stats.num_dirs` / `stats.created_dirs`. A local copy
+//! must surface the same ancestor rows and tallies; before this fix oc's
+//! local-copy executor materialised the directories on disk but never recorded
+//! them, so `-R a/b/c.txt` reported only the file.
+//!
+//! `--no-implied-dirs` clears `implied_dirs`, which suppresses the receiver's
+//! attribute application (hence the itemize row and the created-dir bump) but,
+//! at protocol >= 30 (which a local transfer always is), still ships the
+//! ancestors in the flist - so they keep counting toward "Number of files".
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:1937 send_implied_dirs()` - one `FLAG_IMPLIED_DIR` entry per ancestor.
+//! - `flist.c:2258` - `protocol_version >= 30` forces `implied_dirs = 1` for the flist.
+//! - `main.c:387-411 output_itemized_counts()` - the `dir:` breakdown.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
+
+use engine::local_copy::{
+    LocalCopyAction, LocalCopyExecution, LocalCopyOptions, LocalCopyPlan, LocalCopyRecord,
+};
+use tempfile::tempdir;
+
+/// Builds `<from>/./a/b/c.txt` (a `/./`-anchored `-R` operand rooted at
+/// `<from>`) and returns `(operands, from, to)`. The dot anchor sits after
+/// `from`, so the relative chain is `a/b/c.txt` and the implied ancestors are
+/// `a` and `a/b` - with no synthetic `.` transfer-root entry.
+fn relative_tree() -> (Vec<OsString>, PathBuf, PathBuf, tempfile::TempDir) {
+    let temp = tempdir().expect("tempdir");
+    let from = temp.path().join("from");
+    let to = temp.path().join("to");
+    let leaf_dir = from.join("a").join("b");
+    fs::create_dir_all(&leaf_dir).expect("create source tree");
+    fs::create_dir_all(&to).expect("create destination root");
+    fs::write(leaf_dir.join("c.txt"), b"payload").expect("write leaf file");
+
+    let mut operand = from.clone();
+    operand.push(".");
+    operand.push("a");
+    operand.push("b");
+    operand.push("c.txt");
+
+    let operands = vec![operand.into_os_string(), to.clone().into_os_string()];
+    (operands, from, to, temp)
+}
+
+fn is_created_dir(record: &LocalCopyRecord) -> bool {
+    record.was_created() && matches!(record.action(), LocalCopyAction::DirectoryCreated)
+}
+
+/// `-R a/b/c.txt` surfaces the implied ancestors `a` and `a/b` as created
+/// directory records, ordered ahead of the file, and counts both in the
+/// directory tallies - matching `send_implied_dirs()` + upstream `--stats`.
+#[test]
+fn relative_implied_parents_are_itemized_and_counted() {
+    let (operands, _from, to, _temp) = relative_tree();
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .collect_events(true);
+
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("relative copy succeeds");
+
+    // The physical tree is still correct.
+    assert!(to.join("a").join("b").join("c.txt").is_file());
+
+    let records = report.records();
+    let dir_paths: Vec<PathBuf> = records
+        .iter()
+        .filter(|r| is_created_dir(r))
+        .map(|r| r.relative_path().to_path_buf())
+        .collect();
+    assert_eq!(
+        dir_paths,
+        vec![PathBuf::from("a"), PathBuf::from("a/b")],
+        "both implied ancestors must be itemized as created dirs, shallowest first"
+    );
+
+    // Ancestors precede the leaf file in the record stream (send_implied_dirs
+    // runs before send_file_name).
+    let first_file = records
+        .iter()
+        .position(|r| matches!(r.action(), LocalCopyAction::DataCopied))
+        .expect("leaf file record present");
+    let last_dir = records
+        .iter()
+        .rposition(is_created_dir)
+        .expect("implied dir records present");
+    assert!(
+        last_dir < first_file,
+        "implied parent rows must appear before the transferred file row"
+    );
+
+    // `--stats` counts both ancestors (created and total); the leaf is the only
+    // regular file, and there is no synthetic `.` root for a mid-path dot.
+    let summary = report.summary();
+    assert_eq!(summary.directories_created(), 2, "created dirs: a, a/b");
+    assert_eq!(summary.directories_total(), 2, "total dirs: a, a/b");
+}
+
+/// `--no-implied-dirs` drops the ancestor itemize rows and the created-dir
+/// bump, but the ancestors still ship in the flist (protocol >= 30), so they
+/// keep counting toward "Number of files" (`directories_total`).
+#[test]
+fn no_implied_dirs_suppresses_rows_but_still_counts_ancestors() {
+    let (operands, _from, to, _temp) = relative_tree();
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .implied_dirs(false)
+        .collect_events(true);
+
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("relative copy succeeds");
+
+    assert!(to.join("a").join("b").join("c.txt").is_file());
+
+    let records = report.records();
+    assert!(
+        !records.iter().any(is_created_dir),
+        "--no-implied-dirs must not itemize the implied ancestors"
+    );
+
+    let summary = report.summary();
+    assert_eq!(
+        summary.directories_created(),
+        0,
+        "--no-implied-dirs applies no source attrs, so no created-dir bump"
+    );
+    assert_eq!(
+        summary.directories_total(),
+        2,
+        "ancestors still ship in the flist at protocol >= 30, so they count"
+    );
+}


### PR DESCRIPTION
## Problem

A local `--relative` (`-R`) copy materialised the implied parent directories on
disk but never recorded them, so the ancestors were absent from the itemize
(`-i`), `--stats` counts, and verbose (`-v`) listing.

Measured against upstream rsync 3.4.4 (`rsync -aiR --stats src/sub/b.txt dst/`):

```
# upstream                       # oc-rsync (before)
cd+++++++++ src/                 >f+++++++++ src/sub/b.txt
cd+++++++++ src/sub/             Number of created files: 1 (reg: 1)
>f+++++++++ src/sub/b.txt
Number of created files: 3 (reg: 1, dir: 2)
```

The directories were created correctly on disk; only the observable output
(itemize + stats + verbose) diverged. The remote/wire path already emitted these
via the generator (`send_implied_dirs` parity in the flist builder) - this gap
was in the local-copy executor alone, so there is no wire change here.

## Fix

Mirror upstream `flist.c:send_implied_dirs()` in the local-copy executor: before
handling each `-R` operand, surface every ancestor component as a flist entry
(itemized `cd+++++++++ <dir>/`, counted under created/total dirs), deduplicated
across operands. A leading `./`-anchored operand's synthetic `.` transfer-root
entry (`implied_dot_dir`, `flist.c:2417-2419`) is accounted for as well.

At protocol >= 30 - which a local transfer always is - the sender forces the
flagged implied dirs into the flist (`flist.c:2258`), so `--no-implied-dirs`
still counts the ancestors toward "Number of files" while suppressing their
itemize row and created-dir bump. The `created directory <dest>` notice is
decoupled from the created-dir tally so a `--relative` destination root is
announced without inflating the count.

## Regression gate

Non-`-R` transfers are untouched: the destination-root counter keeps its prior
behaviour for non-relative copies, and the new emission is gated on
`relative_paths`. Verified fmt/clippy/windows-gnu/musl and the full `engine`,
`cli`, and `core` test suites on x86_64 Linux, plus an interop-oracle diff vs
upstream rsync 3.4.4 across file / deep / dir / leading-dot / mid-dot /
`--no-implied-dirs` / dry-run at `-i`, `-v`, `-vv`, and `--stats`, on both fresh
and pre-existing destinations - all match upstream byte-for-byte.

## Tests

`crates/engine/tests/relative_implied_parent_records.rs` asserts the implied
ancestors are itemized as created dirs ahead of the file and counted in the
directory tallies, and that `--no-implied-dirs` drops the rows/created-bump yet
still counts the ancestors in the flist total.
