### PR TITLE
fix(filters): match non-wild patterns literally so backslash --files-from names transfer

### DIFF
--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -75,6 +75,27 @@ impl CompiledRule {
         );
 
         let (anchored, directory_only, core_pattern) = normalise_pattern(&pattern);
+
+        // upstream: exclude.c:236 add_rule() - FILTRULE_WILD is set only when
+        // the pattern contains a wildcard metacharacter (`*`, `?`, `[`). A
+        // non-wild rule is matched with a literal comparison (exclude.c:967-978
+        // litmatch_array / strcmp), where a backslash is an ordinary filename
+        // byte, NOT an escape. oc matches every rule with wildmatch(), which
+        // treats `\` as an escape, so a literal backslash in a non-wild pattern
+        // (e.g. a `back\slash.txt` --files-from name) would otherwise fail to
+        // match its own file - on a pull the receiver then aborts with
+        // "rejecting unrequested file-list name" (flist.c:1026). Escape each `\`
+        // to `\\` for non-wild patterns so wildmatch reproduces upstream's
+        // literal comparison. Wild patterns keep `\` as an escape, matching
+        // upstream's wildmatch_array path.
+        let has_glob_wildcard =
+            core_pattern.contains('*') || core_pattern.contains('?') || core_pattern.contains('[');
+        let core_pattern = if !has_glob_wildcard && core_pattern.contains('\\') {
+            std::borrow::Cow::Owned(core_pattern.replace('\\', "\\\\"))
+        } else {
+            core_pattern
+        };
+
         // upstream: exclude.c:903-960 rule_matches() - an unanchored pattern
         // that already begins with `**` is matched with slash_handling = -1
         // (try after every slash) by wildmatch_array (lib/wildmatch.c:316).
@@ -125,8 +146,6 @@ impl CompiledRule {
         // `CompiledRule` is shared across them and upstream's rule_matches()
         // returns "no match" for FILTRULE_DIRECTORY non-dir candidates
         // regardless of which call site dispatched the query.
-        let has_glob_wildcard =
-            core_pattern.contains('*') || core_pattern.contains('?') || core_pattern.contains('[');
         let slash_anchored = pattern.starts_with('/');
         // Directory-only unanchored wildcard gate: the user wrote `foo/*/`
         // (or any dir-only wildcard without a leading `/`). Upstream never
@@ -264,6 +283,37 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.perishable);
+    }
+
+    /// A non-wild pattern carrying a literal backslash must match the file
+    /// whose name contains that backslash. upstream: exclude.c:236 only sets
+    /// FILTRULE_WILD for `*?[`, so `back\slash.txt` is matched with a literal
+    /// strcmp (exclude.c:967-978) where `\` is an ordinary byte. oc matches via
+    /// wildmatch(), which treats `\` as an escape, so the literal backslash had
+    /// to be escaped at compile time to reproduce upstream's literal match.
+    #[test]
+    fn non_wild_literal_backslash_matches_its_own_name() {
+        use crate::FilterRule;
+        use std::path::Path;
+
+        let compiled = CompiledRule::new(FilterRule::exclude("back\\slash.txt")).unwrap();
+        assert!(compiled.matches(Path::new("back\\slash.txt"), false, true));
+        // The escape must not make it match the escaped-away spelling.
+        assert!(!compiled.matches(Path::new("backslash.txt"), false, true));
+    }
+
+    /// A wild pattern keeps `\` as a wildmatch escape (upstream sets
+    /// FILTRULE_WILD, matching via wildmatch_array). `a\*b` matches the literal
+    /// `a*b`, NOT an arbitrary `a<anything>b`, so the backslash is not
+    /// double-escaped by the non-wild fixup.
+    #[test]
+    fn wild_pattern_backslash_stays_an_escape() {
+        use crate::FilterRule;
+        use std::path::Path;
+
+        let compiled = CompiledRule::new(FilterRule::exclude("a\\*b")).unwrap();
+        assert!(compiled.matches(Path::new("a*b"), false, true));
+        assert!(!compiled.matches(Path::new("axyzb"), false, true));
     }
 
     /// Verifies that `--include '*/'` does NOT generate descendant matchers.

--- a/crates/filters/src/implied.rs
+++ b/crates/filters/src/implied.rs
@@ -469,6 +469,28 @@ mod tests {
     }
 
     #[test]
+    fn backslash_name_round_trips_as_literal() {
+        // A valid filename containing a literal backslash (an ordinary byte on
+        // Unix) must be admitted by its own implied-include rule. upstream
+        // records `back\slash.txt` as a NON-wild rule (no `*?[`) and matches it
+        // with a literal strcmp (exclude.c:967-978), so the `\` stays literal.
+        // Regression: oc's wildmatch treated `\s` as an escape, so the receiver
+        // rejected the sender's own name as "unrequested file-list name",
+        // aborting an oc<->oc SSH --files-from pull.
+        let opts = ImpliedIncludeOptions {
+            relative: true,
+            dirs: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["back\\slash.txt", "plain.txt"]).unwrap();
+        assert!(covers(&implied, "back\\slash.txt", false));
+        assert!(covers(&implied, "plain.txt", false));
+        // The literal-backslash rule stays anchored: it must not admit an
+        // unrelated injected name (CVE-2022-29154 teeth preserved).
+        assert!(!covers(&implied, "evil", false));
+    }
+
+    #[test]
     fn escape_live_brackets_escapes_only_live_brackets() {
         assert_eq!(escape_live_brackets("a[b").as_deref(), Some("a\\[b"));
         assert_eq!(

--- a/crates/filters/tests/edge_cases.rs
+++ b/crates/filters/tests/edge_cases.rs
@@ -213,13 +213,24 @@ fn escaped_brackets() {
     assert!(set.allows(Path::new("array0"), false));
 }
 
-/// Verifies escaped backslash is literal.
+/// Verifies a non-wild backslash pattern matches literally, byte for byte.
+///
+/// The pattern `path\\file` (two literal backslash bytes) has no `*?[`, so
+/// upstream sets no FILTRULE_WILD and matches it with a literal comparison
+/// (exclude.c:967-978 litmatch_array): the backslashes are ordinary bytes, NOT
+/// escapes. Verified against rsync 3.4.4 (`- path\\file` excludes the file named
+/// `path\\file` and leaves `path\file` untouched). A pattern is only de-escaped
+/// on the wildmatch path, which non-wild rules never take.
 #[test]
 fn escaped_backslash() {
     let set = FilterSet::from_rules([FilterRule::exclude("path\\\\file")]).unwrap();
 
-    // Literal backslash
-    assert!(!set.allows(Path::new("path\\file"), false));
+    // Two literal backslashes match the two-backslash name.
+    assert!(!set.allows(Path::new("path\\\\file"), false));
+
+    // They must NOT collapse to a single-backslash name (that would be the
+    // wildmatch de-escape upstream applies only to wild rules).
+    assert!(set.allows(Path::new("path\\file"), false));
 }
 
 /// Verifies path with multiple dots.


### PR DESCRIPTION
## Summary

A valid filename containing a backslash (an ordinary byte on Unix) listed in a
`--files-from` set aborted an oc-to-oc SSH pull. The receiver rejected the
sender's own name with `ERROR: rejecting unrequested file-list name: back\slash.txt`
(exit 4), and the remote sender then died with `multiplexed frame truncated`.
The sender error is a downstream effect of the receiver tearing down the
connection: an oc sender feeding an upstream receiver transfers the same name
fine, and only the oc receiver aborts (even against an upstream sender).

## Root cause

Every filter pattern was matched with `wildmatch()`, which treats `\` as an
escape. Upstream sets `FILTRULE_WILD` only for patterns containing `*`, `?`, or
`[` (`exclude.c:236`) and matches every other (non-wild) pattern with a literal
comparison (`exclude.c:967-978`, `litmatch_array` / `strcmp`), where `\` is an
ordinary byte.

The receiver records one implied-include rule per requested name
(`add_implied_include`, `exclude.c:379`) and rejects any received name not
covered by it (`recv_file_entry`, `flist.c:1026` - the CVE-2022-29154 guard).
For `back\slash.txt` that rule is non-wild, so oc's `wildmatch` de-escaped `\s`
to `s`, the rule stopped matching its own file, and the guard fired.

## Fix

Escape each backslash to `\\` when compiling a non-wild pattern so `wildmatch`
reproduces upstream's literal comparison; wild patterns keep `\` as an escape
(upstream's `wildmatch_array` path). One change in the shared `CompiledRule`
compiler, so it corrects the implied-include recheck, the server-filter
recheck, and user filter rules uniformly.

Verified against rsync 3.4.4 on Linux: a `- path\\file` rule excludes the file
named `path\\file` and leaves `path\file` untouched, confirming a non-wild
backslash is literal and never de-escaped.

## Interop proof (x86_64 Linux, `/usr/bin/rsync` = 3.4.4)

`--files-from` list with `back\slash.txt` + `plain.txt`, SSH pull:

| direction | before | after |
|-----------|--------|-------|
| oc receiver <- oc sender | exit 4, name rejected | exit 0, byte-identical |
| oc receiver <- upstream sender | exit 12, connection closed | exit 0, byte-identical |
| upstream receiver <- oc sender | exit 0 | exit 0 |
| upstream <-> upstream | exit 0 | exit 0 |

## Tests

- `filters::implied` regression: a literal-backslash `--files-from` name is
  covered by its own implied-include rule and still rejects an injected name.
- `filters::compiled` regressions: a non-wild backslash pattern matches its own
  name; a wild pattern keeps `\` as a wildmatch escape.
- Corrected the existing `escaped_backslash` edge-case test, which encoded the
  old de-escaping behavior, to upstream's literal (non-de-escaping) semantics.
