### PR TITLE
fix(cli): match upstream -vv output ordering and per-file total: line

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -10,14 +10,14 @@ use core::{
     },
     message::Message,
 };
-use logging::{InfoFlag, LogCode, info_gte};
+use logging::{DebugFlag, InfoFlag, LogCode, debug_gte, info_gte};
 use logging_sink::{MessageSink, logfile::LogFileWriter};
 
 use crate::frontend::{
     out_format::{OutFormat, OutFormatContext},
     progress::{
-        LiveProgress, NameOutputLevel, ProgressMode, ProgressOutputConfig, StderrMode,
-        emit_transfer_summary,
+        DeltaTransmissionState, DeltaTransmissionSummary, LiveProgress, NameOutputLevel,
+        ProgressMode, ProgressOutputConfig, StderrMode, emit_transfer_summary,
     },
 };
 
@@ -152,6 +152,31 @@ where
     // the collected events - still gets the banner from this deferred path.
     let emit_flist_banner =
         config.recursive() && info_gte(InfoFlag::Flist, 1) && !config.is_pull() && !is_sender;
+    // A pure-local copy (no remote operand): `is_local_sender()` reports false
+    // for the local `local_server` case and `is_pull()` is false, so their
+    // conjunction uniquely identifies the in-process local-copy path whose
+    // generator/sender diagnostics oc renders post-hoc.
+    let is_local_transfer = !config.is_pull() && !is_sender;
+    // upstream: main.c:650-653 forces whole_file=1 for a local transfer unless
+    // the user passed --[no-]whole-file; the local-copy default is therefore
+    // whole-file. This decides the `delta-transmission` wording and gates the
+    // `total:` line (whose zero match counts are only provable in whole-file
+    // mode).
+    let whole_file = config.whole_file();
+    // upstream: generator.c:2291-2294 + match.c:439-446 - the delta-transmission
+    // notice fires at DEBUG_GTE(FLIST, 1) and the match_report `total:` line at
+    // DEBUG_GTE(DELTASUM, 1); both first activate at -vv and honour --debug
+    // overrides. Only wire them for the local-copy path (see #170); network
+    // transfers emit them live from the generator/sender.
+    let delta_state = if whole_file {
+        DeltaTransmissionState::Disabled
+    } else {
+        DeltaTransmissionState::Enabled
+    };
+    let delta_notice = DeltaTransmissionSummary {
+        notice: (is_local_transfer && debug_gte(DebugFlag::Flist, 1)).then_some(delta_state),
+        emit_total: is_local_transfer && whole_file && debug_gte(DebugFlag::Deltasum, 1),
+    };
     // Capture the preserve-links state before `config` is consumed so the
     // `--list-only` renderer knows whether to append the ` -> <target>` arrow
     // to symlink rows (upstream: generator.c:1183 gates it on preserve_links).
@@ -218,6 +243,7 @@ where
                     human_readable_mode,
                     suppress_updated_only_totals,
                     emit_flist_banner,
+                    delta_notice,
                     show_copy_method,
                     show_atimes,
                     show_crtimes,
@@ -395,6 +421,10 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         human_readable_mode,
         false,
         false,
+        // The delta-transmission notice and match_report `total:` line are
+        // stdout-only diagnostics (upstream FINFO); the log file is fed from the
+        // FLOG queue above, so suppress them here.
+        DeltaTransmissionSummary::default(),
         // The `Copy method` line is a stdout-only `--info=copy` nicety; keep it
         // out of the log file.
         false,

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -21,4 +21,6 @@ pub(crate) use self::mode::ProgressMode;
 pub use self::mode::{NameOutputLevel, ProgressSetting, StderrMode}; // Changed to pub for test_utils
 #[cfg(test)]
 pub(crate) use self::render::emit_list_only;
-pub(crate) use self::render::emit_transfer_summary;
+pub(crate) use self::render::{
+    DeltaTransmissionState, DeltaTransmissionSummary, emit_transfer_summary,
+};

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -53,6 +53,50 @@ use super::mode::{NameOutputLevel, ProgressMode};
 use crate::{OutFormat, OutFormatContext, emit_out_format};
 use logging::{InfoFlag, info_gte};
 
+/// Which `delta-transmission %s` notice the generator would print.
+///
+/// upstream: generator.c:2291-2294 - the generator emits this line once at
+/// `DEBUG_GTE(FLIST, 1)` (first active at `-vv`), before the per-file generate
+/// loop. `whole_file` (the local-copy default) reports `Disabled`; an explicit
+/// `--no-whole-file` reports `Enabled`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum DeltaTransmissionState {
+    /// `delta-transmission disabled for local transfer or --whole-file`.
+    Disabled,
+    /// `delta-transmission enabled`.
+    Enabled,
+}
+
+impl DeltaTransmissionState {
+    /// The exact `%s` substituted into upstream's `delta-transmission %s` line.
+    const fn text(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled for local transfer or --whole-file",
+            Self::Enabled => "enabled",
+        }
+    }
+}
+
+/// The two generator/sender diagnostics that bracket the per-file name list on
+/// a verbose (`-vv`) local transfer, threaded in so `emit_transfer_summary`
+/// renders them at their upstream positions rather than dead-last through the
+/// deferred diagnostic flush.
+///
+/// Both are `None`/`false` for network transfers and for verbosity below the
+/// gating debug level, leaving remote-path output untouched.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct DeltaTransmissionSummary {
+    /// The `delta-transmission %s` notice printed after the `created directory`
+    /// notice and before the name list. `Some` only at `DEBUG_GTE(FLIST, 1)` on
+    /// a local transfer. upstream: generator.c:2291-2294.
+    pub notice: Option<DeltaTransmissionState>,
+    /// Whether to print the `match_report()` `total:` line after the name list.
+    /// `true` only at `DEBUG_GTE(DELTASUM, 1)` on a whole-file local transfer,
+    /// where every match count is provably zero and `data` is the literal bytes
+    /// copied (read from the summary). upstream: match.c:439-446.
+    pub emit_total: bool,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_transfer_summary(
     summary: &ClientSummary,
@@ -72,6 +116,7 @@ pub(crate) fn emit_transfer_summary(
     human_readable_mode: HumanReadableMode,
     suppress_updated_only_totals: bool,
     emit_flist_banner: bool,
+    delta_notice: DeltaTransmissionSummary,
     show_copy_method: bool,
     show_atimes: bool,
     show_crtimes: bool,
@@ -161,6 +206,16 @@ pub(crate) fn emit_transfer_summary(
         writer.write_all(b"\n")?;
     }
 
+    // upstream: generator.c:2290-2295 - the generator prints the
+    // delta-transmission status once at DEBUG_GTE(FLIST, 1) (first active at
+    // -vv), after the receiver's `created directory` notice and before the
+    // per-file generate loop. On a local transfer oc renders the name list
+    // post-hoc here, so emit the notice at the same position rather than
+    // dead-last through the deferred diagnostic flush.
+    if let Some(state) = delta_notice.notice {
+        writeln!(writer, "delta-transmission {}", state.text())?;
+    }
+
     let formatted_rendered = if let Some(format) = out_format {
         if events.is_empty() {
             false
@@ -211,6 +266,20 @@ pub(crate) fn emit_transfer_summary(
             human_readable_mode,
             eight_bit_output,
             writer,
+        )?;
+    }
+
+    // upstream: match.c:439-446 match_report() - the sender prints the
+    // cumulative match totals once at DEBUG_GTE(DELTASUM, 1) (first active at
+    // -vv) after send_files() finishes and before output_summary(). On a
+    // whole-file local transfer no block matching runs, so matches, hash_hits
+    // and false_alarms are all zero; `data` is the literal bytes copied, which
+    // upstream renders with big_num() (plain digits, no separator: inums.h:19).
+    if delta_notice.emit_total {
+        writeln!(
+            writer,
+            "total: matches=0  hash_hits=0  false_alarms=0 data={}",
+            summary.bytes_copied()
         )?;
     }
 
@@ -1419,12 +1488,13 @@ mod tests {
             NameOutputLevel::Disabled,
             false, // name_overridden
             HumanReadableMode::Grouped,
-            false, // suppress_updated_only_totals
-            false, // emit_flist_banner
-            false, // show_copy_method
-            false, // show_atimes
-            false, // show_crtimes
-            false, // eight_bit_output
+            false,                               // suppress_updated_only_totals
+            false,                               // emit_flist_banner
+            DeltaTransmissionSummary::default(), // delta_notice
+            false,                               // show_copy_method
+            false,                               // show_atimes
+            false,                               // show_crtimes
+            false,                               // eight_bit_output
             &mut out,
         )
         .expect("emit_transfer_summary writes to an in-memory buffer");

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -202,7 +202,8 @@ fn out_format_current_time_follows_upstream_format() {
 #[test]
 fn out_format_suppresses_verbose_listing_in_summary() {
     use super::super::super::{
-        NameOutputLevel, ProgressSetting, emit_transfer_summary, parse_out_format,
+        DeltaTransmissionSummary, NameOutputLevel, ProgressSetting, emit_transfer_summary,
+        parse_out_format,
     };
     use core::client::{ClientConfig, HumanReadableMode};
 
@@ -239,11 +240,12 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,
         HumanReadableMode::Grouped,
         false,
-        false, // emit_flist_banner
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
-        false, // eight_bit_output
+        false,                               // emit_flist_banner
+        DeltaTransmissionSummary::default(), // delta_notice
+        false,                               // show_copy_method
+        false,                               // show_atimes
+        false,                               // show_crtimes
+        false,                               // eight_bit_output
         &mut with_out_format,
     )
     .expect("render with out-format");
@@ -264,11 +266,12 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,
         HumanReadableMode::Grouped,
         false,
-        false, // emit_flist_banner
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
-        false, // eight_bit_output
+        false,                               // emit_flist_banner
+        DeltaTransmissionSummary::default(), // delta_notice
+        false,                               // show_copy_method
+        false,                               // show_atimes
+        false,                               // show_crtimes
+        false,                               // eight_bit_output
         &mut without_out_format,
     )
     .expect("render without out-format");

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -71,11 +71,12 @@ fn render_stats_at_level(
         false,
         human_readable,
         false,
-        false, // emit_flist_banner
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
-        false, // eight_bit_output
+        false,                               // emit_flist_banner
+        DeltaTransmissionSummary::default(), // delta_notice
+        false,                               // show_copy_method
+        false,                               // show_atimes
+        false,                               // show_crtimes
+        false,                               // eight_bit_output
         &mut rendered,
     )
     .expect("render stats");
@@ -99,11 +100,12 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         false,
         HumanReadableMode::Grouped,
         false,
-        true,  // emit_flist_banner
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
-        false, // eight_bit_output
+        true,                                // emit_flist_banner
+        DeltaTransmissionSummary::default(), // delta_notice
+        false,                               // show_copy_method
+        false,                               // show_atimes
+        false,                               // show_crtimes
+        false,                               // eight_bit_output
         &mut rendered,
     )
     .expect("render verbose");
@@ -143,11 +145,12 @@ fn info_name_only_suppresses_stats_footer() {
         false,
         HumanReadableMode::Grouped,
         false,
-        false, // emit_flist_banner
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
-        false, // eight_bit_output
+        false,                               // emit_flist_banner
+        DeltaTransmissionSummary::default(), // delta_notice
+        false,                               // show_copy_method
+        false,                               // show_atimes
+        false,                               // show_crtimes
+        false,                               // eight_bit_output
         &mut rendered,
     )
     .expect("render");
@@ -540,11 +543,12 @@ fn parity_totals_only_without_stats_flag() {
         false,
         HumanReadableMode::Grouped,
         false,
-        true,  // emit_flist_banner
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
-        false, // eight_bit_output
+        true,                                // emit_flist_banner
+        DeltaTransmissionSummary::default(), // delta_notice
+        false,                               // show_copy_method
+        false,                               // show_atimes
+        false,                               // show_crtimes
+        false,                               // eight_bit_output
         &mut rendered,
     )
     .expect("render");
@@ -811,11 +815,12 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         false,
         HumanReadableMode::Grouped,
         false,
-        true,  // emit_flist_banner
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
-        false, // eight_bit_output
+        true,                                // emit_flist_banner
+        DeltaTransmissionSummary::default(), // delta_notice
+        false,                               // show_copy_method
+        false,                               // show_atimes
+        false,                               // show_crtimes
+        false,                               // eight_bit_output
         &mut rendered,
     )
     .expect("render");

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -55,11 +55,12 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         false,
         HumanReadableMode::DecimalUnits,
         false,
-        false, // emit_flist_banner (list_only path)
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
-        false, // eight_bit_output
+        false,                               // emit_flist_banner (list_only path)
+        DeltaTransmissionSummary::default(), // delta_notice
+        false,                               // show_copy_method
+        false,                               // show_atimes
+        false,                               // show_crtimes
+        false,                               // eight_bit_output
         &mut rendered,
     )
     .expect("render summary");
@@ -91,11 +92,12 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         false,
         HumanReadableMode::DecimalUnits,
         false,
-        true,  // emit_flist_banner
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
-        false, // eight_bit_output
+        true,                                // emit_flist_banner
+        DeltaTransmissionSummary::default(), // delta_notice
+        false,                               // show_copy_method
+        false,                               // show_atimes
+        false,                               // show_crtimes
+        false,                               // eight_bit_output
         &mut rendered,
     )
     .expect("render summary");
@@ -136,6 +138,7 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         HumanReadableMode::Grouped,
         false,
         false, // emit_flist_banner (out_format path: starts_with assertion)
+        DeltaTransmissionSummary::default(), // delta_notice
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -375,6 +375,75 @@ fn level_2_includes_summary_totals() {
     );
 }
 
+/// Pins the ordering of the two generator/sender diagnostics that bracket the
+/// per-file name list on a `-vv` local transfer, matching upstream rsync 3.4.4:
+///
+/// ```text
+/// sending incremental file list
+/// delta-transmission disabled for local transfer or --whole-file
+/// <name list>
+/// total: matches=0  hash_hits=0  false_alarms=0 data=<literal bytes>
+///
+/// sent ... bytes  received ... bytes  ...
+/// ```
+///
+/// upstream: generator.c:2291-2294 prints the delta-transmission notice at
+/// `DEBUG_GTE(FLIST, 1)` before the generate loop; match.c:439-446
+/// `match_report()` prints the `total:` line at `DEBUG_GTE(DELTASUM, 1)` after
+/// `send_files()` and before `output_summary()`. Both first activate at `-vv`.
+/// Fails before the fix, which emitted the notice dead-last (after the summary)
+/// and omitted the `total:` line entirely.
+#[test]
+fn level_2_local_brackets_name_list_with_delta_and_total() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source = tmp.path().join("src");
+    let destination = tmp.path().join("dst");
+    std::fs::create_dir(&source).expect("mkdir src");
+    // Deterministic literal-byte total: 6 + 11 = 17 bytes copied whole-file.
+    std::fs::write(source.join("a.txt"), b"hello\n").expect("write a");
+    std::fs::write(source.join("b.txt"), b"worldworld\n").expect("write b");
+
+    let mut src_arg = source.clone().into_os_string();
+    src_arg.push("/");
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-a"),
+        OsString::from("-vv"),
+        src_arg,
+        destination.into_os_string(),
+    ]);
+
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rendered = String::from_utf8(stdout).expect("utf8");
+
+    let delta = rendered
+        .find("delta-transmission disabled for local transfer or --whole-file")
+        .unwrap_or_else(|| panic!("missing delta-transmission notice, got: {rendered:?}"));
+    let total = rendered
+        .find("total: matches=0  hash_hits=0  false_alarms=0 data=17")
+        .unwrap_or_else(|| panic!("missing or malformed total: line, got: {rendered:?}"));
+    let first_name = rendered
+        .find("a.txt")
+        .unwrap_or_else(|| panic!("missing name list, got: {rendered:?}"));
+    let last_name = rendered
+        .rfind("b.txt")
+        .unwrap_or_else(|| panic!("missing name list, got: {rendered:?}"));
+    let sent = rendered
+        .find("\nsent ")
+        .unwrap_or_else(|| panic!("missing summary trailer, got: {rendered:?}"));
+
+    assert!(
+        delta < first_name,
+        "delta-transmission notice must precede the name list, got: {rendered:?}"
+    );
+    assert!(
+        last_name < total && total < sent,
+        "total: line must follow the name list and precede the summary trailer, got: {rendered:?}"
+    );
+}
+
 /// Verifies that -vvv produces output that is at least as verbose as -vv.
 /// It should still contain the descriptor prefix and totals.
 #[test]

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use logging::{debug_log, info_log};
+use logging::info_log;
 
 use crate::local_copy::overrides::device_identifier;
 use crate::local_copy::{
@@ -69,19 +69,11 @@ pub(crate) fn copy_sources(
     context.set_multi_source(plan.sources().len() > 1);
 
     // upstream: generator.c:2290-2295 - the generator prints the
-    // delta-transmission status once, gated on DEBUG_GTE(FLIST, 1) (first
-    // active at -vv). Local copies default to whole-file mode; delta is
-    // used only when --no-whole-file is explicitly set.
-    debug_log!(
-        Flist,
-        1,
-        "delta-transmission {}",
-        if context.options().whole_file_enabled() {
-            "disabled for local transfer or --whole-file"
-        } else {
-            "enabled"
-        }
-    );
+    // delta-transmission status once at DEBUG_GTE(FLIST, 1) (first active at
+    // -vv), before the per-file generate loop. A local copy renders its name
+    // list post-hoc in the CLI, so that notice is emitted there (in
+    // `emit_transfer_summary`) to keep it ahead of the list rather than
+    // dead-last through the deferred diagnostic flush.
 
     let result = {
         let context = &mut context;


### PR DESCRIPTION
## Problem

On a **local** transfer at `-vv`, oc-rsync's stdout diverged from upstream rsync 3.4.4 in two ways (stdout only, no wire change):

1. The `delta-transmission disabled for local transfer or --whole-file` notice printed **after** the summary trailer instead of **before** the name list.
2. The per-file `total: matches=0  hash_hits=0  false_alarms=0 data=N` line was **missing entirely**.

### Measured (fresh directory dest, `-a -vv`)

```
# upstream                                   # oc (before)
sending incremental file list                sending incremental file list
created directory DST                        created directory DST
delta-transmission disabled for local ...    ./
./                                           a.txt
a.txt                                        b.txt
b.txt
total: matches=0  hash_hits=0 ... data=47    sent 47 bytes  received 0 bytes ...
                                             total size is 47  speedup is 1.00
sent 212 bytes  received 152 bytes ...       delta-transmission disabled for local ...
total size is 47  speedup is 0.13
```

The notice landed dead-last, after the summary, and the `total:` line was absent.

## Upstream reference

- `generator.c:2291-2294` prints the delta-transmission notice at `DEBUG_GTE(FLIST, 1)` **before** the generate loop.
- `match.c:439-446` `match_report()` prints the totals at `DEBUG_GTE(DELTASUM, 1)` **after** `send_files()` and before `output_summary()`.
- Both first activate at `-vv`. `data` uses `big_num()` (plain digits, no separator: `inums.h:19`).

## Fix

oc renders a local copy's name list post-hoc in `emit_transfer_summary`, so both diagnostics are now rendered there at their upstream positions: the notice between the `created directory` line and the name list, the totals between the name list and the summary trailer. The buffered Flist debug emission in the local-copy engine (which flushed dead-last) is removed.

For a whole-file local transfer (the default) no block matching runs, so the match counts are provably zero and `data` is the literal bytes copied (`summary.bytes_copied()`, the value oc already reports as `--stats` "Literal data"). The lines are gated to local transfers via `DEBUG_GTE(FLIST/DELTASUM, 1)` (honouring `--debug` overrides); network paths are untouched.

### After

Local `-vv` now byte-matches upstream ordering + the `total:` line for fresh, existing/up-to-date, single-file, and directory transfers. The remaining `sent/received` byte-count difference is a separate, pre-existing local-copy stats-accounting divergence, out of scope here.

## Scope note

The `total:` line is emitted only in whole-file mode (the local default), where the zero match counts are provably correct. An explicit `--no-whole-file` local transfer runs oc's delta path, whose literal/matched accounting already diverges from upstream independently and which does not track upstream's match/hash/false-alarm counts; emitting fabricated counts there would be wrong, so it is deliberately left for that separate delta-accounting work.

## Tests

- `level_2_local_brackets_name_list_with_delta_and_total` (cli/verbose): drives a real `-a -vv` local directory transfer and pins the ordering (notice before the name list; `total: ... data=17` after the name list and before the summary). Fails before the fix (notice was last, `total:` absent).
