### PR TITLE
refactor(daemon): emit @ERROR lines through a typed formatter with round-trip test

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -69,8 +69,11 @@ use crate::{
     systemd,
 };
 
+mod at_error;
 mod help;
 pub(crate) mod tracing_stream;
+
+pub(crate) use self::at_error::AtError;
 
 /// Concurrent session tracking for the daemon accept loop.
 #[cfg(feature = "concurrent-sessions")]
@@ -724,11 +727,11 @@ fn refuse_async_connection_at_capacity(
     limit: Option<usize>,
 ) {
     let limit = limit.unwrap_or(0);
-    let payload = format!(
-        "{}\n",
-        MODULE_MAX_CONNECTIONS_PAYLOAD.replace("{limit}", &limit.to_string())
-    );
-    let _ = stream.write_all(payload.as_bytes());
+    let payload = AtError::MaxConnections {
+        limit: limit as i64,
+    }
+    .to_wire();
+    let _ = stream.write_all(&payload);
     let _ = stream.flush();
 }
 

--- a/crates/daemon/src/daemon/async_session/session.rs
+++ b/crates/daemon/src/daemon/async_session/session.rs
@@ -203,10 +203,11 @@ pub(super) async fn handle_async_session(
     // handling lives in the sync `legacy_session` path.
     // upstream: clientserver.c:381-385 - the client treats `@ERROR` as fatal
     // and returns before reading further, so no `@RSYNCD: EXIT` follows.
-    let error_msg = "@ERROR: daemon functionality limited in async mode\n";
-    writer.write_all(error_msg.as_bytes()).await?;
+    let error_wire =
+        crate::daemon::AtError::message("daemon functionality limited in async mode").to_wire();
+    writer.write_all(&error_wire).await?;
     writer.flush().await?;
-    bytes_sent += error_msg.len() as u64;
+    bytes_sent += error_wire.len() as u64;
 
     #[cfg(feature = "concurrent-sessions")]
     {

--- a/crates/daemon/src/daemon/at_error.rs
+++ b/crates/daemon/src/daemon/at_error.rs
@@ -1,0 +1,292 @@
+//! Typed formatter for the daemon's pre-handshake `@ERROR:` protocol lines.
+//!
+//! Upstream rsync emits every daemon refusal in the ASCII negotiation phase as
+//! `io_printf(f_out, "@ERROR: <msg>\n")` and then closes the socket; the client
+//! treats a line beginning with `@ERROR` as fatal
+//! (upstream: clientserver.c:381-385). Historically each refusal site in this
+//! crate built that wire line with an ad-hoc `format!("@ERROR: ...")` and a
+//! separate `\n`, so the `@ERROR: ` prefix and the terminating newline were
+//! spelled out in a dozen places with no single point that guaranteed the exact
+//! bytes.
+//!
+//! [`AtError`] is that single point. Each variant maps to one upstream message;
+//! the message wording stays single-sourced in the `*_PAYLOAD` constants in the
+//! parent module (which the upstream-wording pin tests guard), while this type
+//! owns the `@ERROR: ` prefix and the trailing `\n`. The inverse is the client's
+//! own parse path (`protocol::parse_legacy_error_message`), so the round-trip is
+//! testable end to end.
+//!
+//! Out of scope: the read-only / write-only module rejections
+//! (`ERROR: module is ...`, no `@`) and the incomplete-build placeholder, which
+//! travel inside multiplexed `MSG_ERROR` frames without a trailing newline
+//! rather than as raw negotiation-phase lines.
+
+use std::borrow::Cow;
+
+use super::{
+    ACCESS_DENIED_PAYLOAD, AUTH_FAILED_PAYLOAD, CHDIR_FAILED_PAYLOAD, CHROOT_FAILED_PAYLOAD,
+    INVALID_GID_PAYLOAD, INVALID_UID_PAYLOAD, MODULE_LOCK_ERROR_PAYLOAD,
+    MODULE_MAX_CONNECTIONS_PAYLOAD, PROTOCOL_STARTUP_ERROR_PAYLOAD, SETGID_FAILED_PAYLOAD,
+    SETGROUPS_FAILED_PAYLOAD, SETUID_FAILED_PAYLOAD, UNKNOWN_COMMAND_PAYLOAD,
+    UNKNOWN_MODULE_PAYLOAD, UNSUPPORTED_AUTH_DIGEST_PAYLOAD,
+};
+
+/// The literal prefix every `@ERROR:` negotiation line carries.
+///
+/// upstream: clientserver.c - the format string is always `"@ERROR: %s\n"`.
+pub(crate) const AT_ERROR_PREFIX: &str = "@ERROR: ";
+
+/// A daemon `@ERROR:` refusal line, rendered to the wire as
+/// `@ERROR: <message>\n` and parsed back with [`AtError::parse`].
+///
+/// Variants carry only the dynamic operands; the fixed wording is taken from
+/// the upstream-cited `*_PAYLOAD` constants so there is exactly one source of
+/// truth for both the text (the constants) and the framing (this type).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AtError {
+    /// upstream: clientserver.c:180-184 - the client's first line is not a
+    /// version banner (`@ERROR: protocol startup error`).
+    ProtocolStartupError,
+    /// upstream: clientserver.c:732 - requested module does not exist, and the
+    /// non-listable masking of an access-denied module
+    /// (`@ERROR: Unknown module '<name>'`).
+    UnknownModule(String),
+    /// upstream: clientserver.c:1429 - a `#`-prefixed request that is neither
+    /// `#list` nor `#early_input=` (`@ERROR: Unknown command '<line>'`).
+    UnknownCommand(String),
+    /// upstream: clientserver.c:735-736 - host denied access to a listable
+    /// module (`@ERROR: access denied to <module> from <host> (<addr>)`).
+    AccessDenied {
+        /// Module name, sanitized for display.
+        module: String,
+        /// Reverse-resolved peer hostname, or the address when unavailable.
+        host: String,
+        /// Peer address in string form.
+        addr: String,
+    },
+    /// upstream: clientserver.c:764 - authentication failed on a protected
+    /// module (`@ERROR: auth failed on module <name>`).
+    AuthFailed {
+        /// Module name, sanitized for display.
+        module: String,
+    },
+    /// upstream: compat.c:872-874 - none of the client's daemon-auth digests is
+    /// supported here (`@ERROR: your client does not support ...: <list>`).
+    UnsupportedAuthDigest {
+        /// This build's advertised daemon-auth digest list.
+        digests: String,
+    },
+    /// upstream: clientserver.c:754 - a module reached its connection cap
+    /// (`@ERROR: max connections (<n>) reached -- try again later`). The count
+    /// is rendered verbatim so a negative `max connections` keeps its sign.
+    MaxConnections {
+        /// The configured limit, rendered with upstream's `%d`.
+        limit: i64,
+    },
+    /// upstream: clientserver.c:750 - opening the module lock file failed
+    /// (`@ERROR: failed to open lock file`).
+    ModuleLockError,
+    /// upstream: clientserver.c:985 - chroot failed during module setup.
+    ChrootFailed,
+    /// upstream: clientserver.c:649 - chdir failed during module setup.
+    ChdirFailed,
+    /// upstream: clientserver.c:1053 - setuid failed after chroot.
+    SetuidFailed,
+    /// upstream: clientserver.c:1024 - setgid failed after chroot.
+    SetgidFailed,
+    /// upstream: clientserver.c:1031 - setgroups failed after chroot.
+    SetgroupsFailed,
+    /// upstream: clientserver.c:785 - a module uid NAME failed to resolve
+    /// (`@ERROR: invalid uid <name>`).
+    InvalidUid(String),
+    /// upstream: clientserver.c:658 - a module gid NAME failed to resolve
+    /// (`@ERROR: invalid gid <name>`).
+    InvalidGid(String),
+    /// A refusal whose body is composed at the call site (client-omitted
+    /// greeting tokens, refused options, per-session setup failures that carry
+    /// an OS error string). The body is stored WITHOUT the `@ERROR: ` prefix;
+    /// [`AtError`] prepends it exactly once.
+    Message(String),
+}
+
+impl AtError {
+    /// Builds a [`AtError::Message`] from an already-composed body, stripping a
+    /// redundant leading `@ERROR: ` if the caller passed a full line.
+    pub(crate) fn message(body: impl Into<String>) -> Self {
+        let body = body.into();
+        match body.strip_prefix(AT_ERROR_PREFIX) {
+            Some(rest) => Self::Message(rest.to_owned()),
+            None => Self::Message(body),
+        }
+    }
+
+    /// Renders the full `@ERROR: <message>` line, without a trailing newline.
+    ///
+    /// Fixed-wording variants borrow their `*_PAYLOAD` constant directly, so the
+    /// emitted bytes are identical to the constant the pin tests guard.
+    pub(crate) fn line(&self) -> Cow<'static, str> {
+        match self {
+            Self::ProtocolStartupError => Cow::Borrowed(PROTOCOL_STARTUP_ERROR_PAYLOAD),
+            Self::ModuleLockError => Cow::Borrowed(MODULE_LOCK_ERROR_PAYLOAD),
+            Self::ChrootFailed => Cow::Borrowed(CHROOT_FAILED_PAYLOAD),
+            Self::ChdirFailed => Cow::Borrowed(CHDIR_FAILED_PAYLOAD),
+            Self::SetuidFailed => Cow::Borrowed(SETUID_FAILED_PAYLOAD),
+            Self::SetgidFailed => Cow::Borrowed(SETGID_FAILED_PAYLOAD),
+            Self::SetgroupsFailed => Cow::Borrowed(SETGROUPS_FAILED_PAYLOAD),
+            Self::UnknownModule(module) => {
+                Cow::Owned(UNKNOWN_MODULE_PAYLOAD.replace("{module}", module))
+            }
+            Self::UnknownCommand(command) => {
+                Cow::Owned(UNKNOWN_COMMAND_PAYLOAD.replace("{command}", command))
+            }
+            Self::AccessDenied { module, host, addr } => Cow::Owned(
+                ACCESS_DENIED_PAYLOAD
+                    .replace("{module}", module)
+                    .replace("{host}", host)
+                    .replace("{addr}", addr),
+            ),
+            Self::AuthFailed { module } => {
+                Cow::Owned(AUTH_FAILED_PAYLOAD.replace("{module}", module))
+            }
+            Self::UnsupportedAuthDigest { digests } => {
+                Cow::Owned(UNSUPPORTED_AUTH_DIGEST_PAYLOAD.replace("{digests}", digests))
+            }
+            Self::MaxConnections { limit } => {
+                Cow::Owned(MODULE_MAX_CONNECTIONS_PAYLOAD.replace("{limit}", &limit.to_string()))
+            }
+            Self::InvalidUid(name) => Cow::Owned(INVALID_UID_PAYLOAD.replace("{uid}", name)),
+            Self::InvalidGid(name) => Cow::Owned(INVALID_GID_PAYLOAD.replace("{gid}", name)),
+            Self::Message(body) => Cow::Owned(format!("{AT_ERROR_PREFIX}{body}")),
+        }
+    }
+
+    /// Renders the exact wire bytes: `@ERROR: <message>\n`.
+    ///
+    /// upstream: every `io_printf(f_out, "@ERROR: ...\n")` emits the message
+    /// followed by a single newline and nothing more.
+    pub(crate) fn to_wire(&self) -> Vec<u8> {
+        let mut bytes = self.line().into_owned().into_bytes();
+        bytes.push(b'\n');
+        bytes
+    }
+}
+
+impl std::fmt::Display for AtError {
+    /// Formats the `@ERROR:` line without the trailing newline, so the value can
+    /// be logged or asserted on directly. Use [`AtError::to_wire`] for the bytes
+    /// sent to the client.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.line())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use protocol::parse_legacy_error_message;
+
+    /// Every upstream `@ERROR:` variant paired with the exact message body the
+    /// client must recover, per clientserver.c / compat.c.
+    fn upstream_variants() -> Vec<(AtError, &'static str)> {
+        vec![
+            (AtError::ProtocolStartupError, "protocol startup error"),
+            (
+                AtError::UnknownModule("secret".to_owned()),
+                "Unknown module 'secret'",
+            ),
+            (
+                AtError::UnknownCommand("#bogus".to_owned()),
+                "Unknown command '#bogus'",
+            ),
+            (
+                AtError::AccessDenied {
+                    module: "public".to_owned(),
+                    host: "myhost".to_owned(),
+                    addr: "10.0.0.1".to_owned(),
+                },
+                "access denied to public from myhost (10.0.0.1)",
+            ),
+            (
+                AtError::AuthFailed {
+                    module: "protected".to_owned(),
+                },
+                "auth failed on module protected",
+            ),
+            (
+                AtError::UnsupportedAuthDigest {
+                    digests: "md5 md4".to_owned(),
+                },
+                "your client does not support one of our daemon-auth checksums: md5 md4",
+            ),
+            (
+                AtError::MaxConnections { limit: 2 },
+                "max connections (2) reached -- try again later",
+            ),
+            (AtError::ModuleLockError, "failed to open lock file"),
+            (AtError::ChrootFailed, "chroot failed"),
+            (AtError::ChdirFailed, "chdir failed"),
+            (AtError::SetuidFailed, "setuid failed"),
+            (AtError::SetgidFailed, "setgid failed"),
+            (AtError::SetgroupsFailed, "setgroups failed"),
+            (
+                AtError::InvalidUid("nobody".to_owned()),
+                "invalid uid nobody",
+            ),
+            (
+                AtError::InvalidGid("nobody".to_owned()),
+                "invalid gid nobody",
+            ),
+            (
+                AtError::message("your client omitted the subprotocol value: @RSYNCD: 32"),
+                "your client omitted the subprotocol value: @RSYNCD: 32",
+            ),
+        ]
+    }
+
+    /// Golden + round-trip: each variant renders the exact upstream
+    /// `@ERROR: <body>\n` bytes, and feeding those bytes back through the
+    /// client's parse path recovers the original body verbatim. This pins that
+    /// the formatter and the parser are true inverses, so a refusal the daemon
+    /// emits is always one the client decodes to the same message.
+    #[test]
+    fn every_variant_formats_and_parses_back() {
+        for (at, body) in upstream_variants() {
+            let expected_line = format!("@ERROR: {body}");
+            assert_eq!(at.line(), expected_line, "line mismatch for {at:?}");
+            assert_eq!(at.to_string(), expected_line, "Display mismatch for {at:?}");
+
+            let wire = at.to_wire();
+            assert_eq!(
+                wire,
+                format!("{expected_line}\n").into_bytes(),
+                "wire bytes mismatch for {at:?}"
+            );
+            assert_eq!(wire.last(), Some(&b'\n'), "must end with a single newline");
+            assert_ne!(
+                wire.get(wire.len().wrapping_sub(2)),
+                Some(&b'\n'),
+                "must not double-terminate"
+            );
+
+            let line = std::str::from_utf8(&wire).expect("utf8");
+            // Parse via the client's @ERROR parse path.
+            let recovered = parse_legacy_error_message(line).expect("client parses @ERROR line");
+            assert_eq!(recovered, body, "round-trip lost the body for {at:?}");
+        }
+    }
+
+    /// `message()` never double-prefixes when a caller hands it a full line.
+    #[test]
+    fn message_strips_redundant_prefix() {
+        let from_body = AtError::message("invalid daemon param: bad");
+        let from_line = AtError::message("@ERROR: invalid daemon param: bad");
+        assert_eq!(from_body, from_line);
+        assert_eq!(from_body.line(), "@ERROR: invalid daemon param: bad");
+    }
+
+    /// A non-`@ERROR` line is not decoded as one by the client's parse path.
+    #[test]
+    fn parse_rejects_non_error_lines() {
+        assert_eq!(parse_legacy_error_message("@RSYNCD: OK"), None);
+    }
+}

--- a/crates/daemon/src/daemon/sections/greeting.rs
+++ b/crates/daemon/src/daemon/sections/greeting.rs
@@ -72,7 +72,7 @@ pub(crate) fn cached_legacy_daemon_greeting() -> &'static [u8] {
 /// The presence gates themselves live in [`missing_greeting_token`] so the
 /// daemon (`am_client == 0`) and the client (`am_client == 1`) enforce the exact
 /// same upstream thresholds; only the diagnostic wording differs by role.
-pub(crate) fn reject_malformed_client_greeting(line: &str) -> Option<String> {
+pub(crate) fn reject_malformed_client_greeting(line: &str) -> Option<AtError> {
     // upstream: clientserver.c:180-184 - `if (sscanf(buf, "@RSYNCD: %d.%d", ...)
     // < 1)` the daemon answers `@ERROR: protocol startup error`. The client's
     // first line must be a version banner, so a bare module name, an empty
@@ -80,14 +80,14 @@ pub(crate) fn reject_malformed_client_greeting(line: &str) -> Option<String> {
     // module name. A banner that parses but omits a required token falls through
     // to the token check below, which is upstream's later, distinct refusal.
     if !is_version_banner(line) {
-        return Some(PROTOCOL_STARTUP_ERROR_PAYLOAD.to_owned());
+        return Some(AtError::ProtocolStartupError);
     }
 
     let token = missing_greeting_token(line)?;
-    Some(format!(
-        "@ERROR: your client omitted the {}: {line}",
+    Some(AtError::message(format!(
+        "your client omitted the {}: {line}",
         token.description()
-    ))
+    )))
 }
 
 /// Reads one line from `reader`, stripping trailing `\r` and `\n`.
@@ -158,7 +158,9 @@ mod greeting_validation_tests {
             "@RSYNCD: OK",
         ] {
             assert_eq!(
-                reject_malformed_client_greeting(not_a_banner).as_deref(),
+                reject_malformed_client_greeting(not_a_banner)
+                    .map(|e| e.to_string())
+                    .as_deref(),
                 Some("@ERROR: protocol startup error"),
                 "not a version banner: {not_a_banner:?}"
             );
@@ -167,7 +169,9 @@ mod greeting_validation_tests {
         // Parses as a banner (protocol number present), so the refusal is the
         // token diagnostic, not the startup error.
         assert_eq!(
-            reject_malformed_client_greeting("@RSYNCD: 32").as_deref(),
+            reject_malformed_client_greeting("@RSYNCD: 32")
+                .map(|e| e.to_string())
+                .as_deref(),
             Some("@ERROR: your client omitted the subprotocol value: @RSYNCD: 32"),
         );
     }
@@ -178,11 +182,15 @@ mod greeting_validation_tests {
     #[test]
     fn rejects_greeting_missing_subprotocol() {
         assert_eq!(
-            reject_malformed_client_greeting("@RSYNCD: 32").as_deref(),
+            reject_malformed_client_greeting("@RSYNCD: 32")
+                .map(|e| e.to_string())
+                .as_deref(),
             Some("@ERROR: your client omitted the subprotocol value: @RSYNCD: 32"),
         );
         assert_eq!(
-            reject_malformed_client_greeting("@RSYNCD: 30").as_deref(),
+            reject_malformed_client_greeting("@RSYNCD: 30")
+                .map(|e| e.to_string())
+                .as_deref(),
             Some("@ERROR: your client omitted the subprotocol value: @RSYNCD: 30"),
         );
     }
@@ -192,7 +200,9 @@ mod greeting_validation_tests {
     #[test]
     fn rejects_greeting_missing_digest_list() {
         assert_eq!(
-            reject_malformed_client_greeting("@RSYNCD: 32.0").as_deref(),
+            reject_malformed_client_greeting("@RSYNCD: 32.0")
+                .map(|e| e.to_string())
+                .as_deref(),
             Some("@ERROR: your client omitted the digest name list: @RSYNCD: 32.0"),
         );
     }
@@ -202,7 +212,9 @@ mod greeting_validation_tests {
     #[test]
     fn protocol_31_requires_subprotocol_not_digest() {
         assert_eq!(
-            reject_malformed_client_greeting("@RSYNCD: 31").as_deref(),
+            reject_malformed_client_greeting("@RSYNCD: 31")
+                .map(|e| e.to_string())
+                .as_deref(),
             Some("@ERROR: your client omitted the subprotocol value: @RSYNCD: 31"),
         );
         assert_eq!(reject_malformed_client_greeting("@RSYNCD: 31.0"), None);

--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -94,9 +94,10 @@ fn perform_module_authentication(
     ) {
         Ok(digest) => digest,
         Err(_) => {
-            let payload = UNSUPPORTED_AUTH_DIGEST_PAYLOAD
-                .replace("{digests}", &supported_daemon_digest_list());
-            send_error(reader.get_mut(), limiter, &payload)?;
+            let error = AtError::UnsupportedAuthDigest {
+                digests: supported_daemon_digest_list(),
+            };
+            send_error(reader.get_mut(), limiter, &error)?;
             return Ok(AuthenticationStatus::DigestUnsupported);
         }
     };
@@ -293,7 +294,8 @@ fn send_auth_failed(
     module: &ModuleDefinition,
     limiter: &mut Option<BandwidthLimiter>,
 ) -> io::Result<()> {
-    let module_display = sanitize_module_identifier(&module.name);
-    let payload = AUTH_FAILED_PAYLOAD.replace("{module}", module_display.as_ref());
-    send_error(stream, limiter, &payload)
+    let error = AtError::AuthFailed {
+        module: sanitize_module_identifier(&module.name).into_owned(),
+    };
+    send_error(stream, limiter, &error)
 }

--- a/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
@@ -208,8 +208,8 @@ fn read_and_log_client_args(
     let phase1_args = match read_client_arguments(ctx.reader, negotiated_protocol) {
         Ok(args) => args,
         Err(err) => {
-            let payload = format!("@ERROR: failed to read client arguments: {err}");
-            send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+            let error = AtError::message(format!("failed to read client arguments: {err}"));
+            send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
             return Ok(None);
         }
     };
@@ -249,8 +249,8 @@ fn read_and_log_client_args(
         match protocol::secluded_args::recv_secluded_args(ctx.reader, None) {
             Ok(full_args) => merge_secluded_args(phase1_args, full_args),
             Err(err) => {
-                let payload = format!("@ERROR: failed to read secluded args: {err}");
-                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                let error = AtError::message(format!("failed to read secluded args: {err}"));
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 return Ok(None);
             }
         }

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -166,9 +166,8 @@ fn build_server_config(
         match resolve_receiver_dest(std::path::Path::new(&module.path), client_args, &module.name) {
             Some(dest) => vec![OsString::from(dest.as_os_str())],
             None => {
-                let payload =
-                    "@ERROR: requested path resolves outside module root".to_owned();
-                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                let error = AtError::message("requested path resolves outside module root");
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 return Ok(None);
             }
         }
@@ -179,9 +178,8 @@ fn build_server_config(
                 .map(|p| OsString::from(p.as_os_str()))
                 .collect(),
             None => {
-                let payload =
-                    "@ERROR: requested path resolves outside module root".to_owned();
-                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                let error = AtError::message("requested path resolves outside module root");
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 return Ok(None);
             }
         }
@@ -214,9 +212,9 @@ fn build_server_config(
                     let message = rsync_warning!(text).with_role(Role::Daemon);
                     log_message(log, &message);
                 }
-                let payload =
-                    format!("@ERROR: {offender}: unrecognized option (in daemon mode)");
-                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                let error =
+                    AtError::message(format!("{offender}: unrecognized option (in daemon mode)"));
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 return Ok(None);
             }
 
@@ -354,12 +352,8 @@ fn build_server_config(
                     cfg.daemon_outgoing_chmod = outgoing;
                 }
                 Err(err) => {
-                    let payload = format!("@ERROR: {err}");
-                    send_error(
-                        ctx.reader.get_mut(),
-                        ctx.limiter,
-                        &payload,
-                    )?;
+                    let error = AtError::message(err.to_string());
+                    send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                     return Ok(None);
                 }
             }
@@ -379,8 +373,8 @@ fn build_server_config(
             Ok(Some(cfg))
         }
         Err(err) => {
-            let payload = format!("@ERROR: failed to configure server: {err}");
-            send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+            let error = AtError::message(format!("failed to configure server: {err}"));
+            send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
             Ok(None)
         }
     }

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -80,9 +80,9 @@ impl<'a> ModuleRequestContext<'a> {
 fn send_error(
     stream: &mut DaemonStream,
     limiter: &mut Option<BandwidthLimiter>,
-    payload: &str,
+    error: &AtError,
 ) -> io::Result<()> {
-    write_limited(stream, limiter, payload.as_bytes())?;
+    write_limited(stream, limiter, error.line().as_bytes())?;
     write_limited(stream, limiter, b"\n")?;
     stream.flush()
 }
@@ -133,18 +133,19 @@ fn deny_module(
     limiter: &mut Option<BandwidthLimiter>,
 ) -> io::Result<()> {
     let module_display = sanitize_module_identifier(&module.name);
-    let payload = if !module.listable {
+    let error = if !module.listable {
         // upstream: clientserver.c:730 - hide module existence for non-listable modules.
-        UNKNOWN_MODULE_PAYLOAD.replace("{module}", module_display.as_ref())
+        AtError::UnknownModule(module_display.into_owned())
     } else {
         let addr_str = peer_ip.to_string();
         let host_display = host.unwrap_or(&addr_str);
-        ACCESS_DENIED_PAYLOAD
-            .replace("{module}", module_display.as_ref())
-            .replace("{host}", host_display)
-            .replace("{addr}", &addr_str)
+        AtError::AccessDenied {
+            module: module_display.into_owned(),
+            host: host_display.to_owned(),
+            addr: addr_str,
+        }
     };
-    send_error(stream, limiter, &payload)
+    send_error(stream, limiter, &error)
 }
 
 /// Sends the "@RSYNCD: OK" acknowledgment to the client.
@@ -171,8 +172,13 @@ fn handle_max_connections_exceeded(
     module: &ModuleRuntime,
     limit: i32,
 ) -> io::Result<()> {
-    let payload = MODULE_MAX_CONNECTIONS_PAYLOAD.replace("{limit}", &limit.to_string());
-    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+    send_error(
+        ctx.reader.get_mut(),
+        ctx.limiter,
+        &AtError::MaxConnections {
+            limit: i64::from(limit),
+        },
+    )?;
     if let Some(log) = ctx.log_sink {
         let current = module
             .active_connections
@@ -193,11 +199,7 @@ fn handle_max_connections_exceeded(
 ///
 /// Sends an error message and logs the lock failure.
 fn handle_lock_error(ctx: &mut ModuleRequestContext<'_>, error: &io::Error) -> io::Result<()> {
-    send_error(
-        ctx.reader.get_mut(),
-        ctx.limiter,
-        MODULE_LOCK_ERROR_PAYLOAD,
-    )?;
+    send_error(ctx.reader.get_mut(), ctx.limiter, &AtError::ModuleLockError)?;
     if let Some(log) = ctx.log_sink {
         log_module_lock_error(log, ctx.effective_host(), ctx.peer_ip, ctx.request, error);
     }
@@ -210,8 +212,8 @@ fn handle_lock_error(ctx: &mut ModuleRequestContext<'_>, error: &io::Error) -> i
 /// Used when refused-options are detected from `OPTION` directives sent before
 /// `@RSYNCD: OK`; at this point the client still reads raw text.
 fn handle_refused_option(ctx: &mut ModuleRequestContext<'_>, refused: &str) -> io::Result<()> {
-    let payload = format!("@ERROR: The server is configured to refuse {refused}");
-    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+    let error = AtError::message(format!("The server is configured to refuse {refused}"));
+    send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
     if let Some(log) = ctx.log_sink {
         log_module_refused_option(log, ctx.effective_host(), ctx.peer_ip, ctx.request, refused);
     }
@@ -246,11 +248,11 @@ fn handle_refused_option_post_handshake(
     client_args: &[String],
 ) -> io::Result<()> {
     finalize_post_ok_protocol_for_error(ctx, protocol_version, client_args)?;
-    let payload = format!("@ERROR: The server is configured to refuse {refused}");
+    let error = AtError::message(format!("The server is configured to refuse {refused}"));
     send_multiplexed_error_and_exit(
         ctx.reader.get_mut(),
         ctx.limiter,
-        &payload,
+        &error.line(),
         FEATURE_UNAVAILABLE_EXIT_CODE,
     )?;
     if let Some(log) = ctx.log_sink {
@@ -512,14 +514,13 @@ fn handle_unknown_module(
     session_peer_host: Option<&str>,
     log_sink: Option<&SharedLogSink>,
 ) -> io::Result<()> {
-    let module_display = sanitize_module_identifier(request);
-    let payload = UNKNOWN_MODULE_PAYLOAD.replace("{module}", module_display.as_ref());
+    let error = AtError::UnknownModule(sanitize_module_identifier(request).into_owned());
 
     if let Some(log) = log_sink {
         log_unknown_module(log, session_peer_host, peer_ip, request);
     }
 
-    send_error(stream, limiter, &payload)
+    send_error(stream, limiter, &error)
 }
 
 /// Handles a denied module access.

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -96,8 +96,8 @@ fn process_approved_module(
             match apply_daemon_param_overrides(options, &mut definition) {
                 Ok(()) => {}
                 Err(err) => {
-                    let payload = format!("@ERROR: invalid daemon param: {err}");
-                    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                    let error = AtError::message(format!("invalid daemon param: {err}"));
+                    send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                     return Ok(());
                 }
             }
@@ -163,8 +163,8 @@ fn process_approved_module(
                     }
                 }
                 Ok(Err(error_msg)) => {
-                    let payload = format!("@ERROR: {error_msg}");
-                    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                    let error = AtError::message(error_msg.to_string());
+                    send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                     // upstream: clientserver.c:945-949 - early exec runs after
                     // the post-xfer-exec fork point, so its failure is a
                     // child exit the waiting parent still observes.
@@ -180,11 +180,11 @@ fn process_approved_module(
                     return Ok(());
                 }
                 Err(err) => {
-                    let payload = format!(
-                        "@ERROR: failed to run early exec command for module '{}': {err}",
+                    let error = AtError::message(format!(
+                        "failed to run early exec command for module '{}': {err}",
                         ctx.request
-                    );
-                    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                    ));
+                    send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                     let host_owned = ctx.effective_host().map(str::to_owned);
                     run_post_xfer_finalizer(
                         ctx,
@@ -240,7 +240,7 @@ fn process_approved_module(
             send_error(
                 ctx.reader.get_mut(),
                 ctx.limiter,
-                "@ERROR: daemon security issue -- contact admin",
+                &AtError::message("daemon security issue -- contact admin"),
             )?;
             let host_owned = ctx.effective_host().map(str::to_owned);
             run_post_xfer_finalizer(
@@ -418,8 +418,8 @@ fn process_approved_module(
         match NameConverter::spawn(&expanded) {
             Ok(nc) => Some(install_name_converter(nc)),
             Err(err) => {
-                let payload = format!("@ERROR: name-converter exec failed: {err}");
-                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                let error = AtError::message(format!("name-converter exec failed: {err}"));
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 // upstream: clientserver.c:965-970 - the name-converter spawn
                 // runs after the post-xfer-exec fork point, so its failure
                 // is a child exit the waiting parent still observes.
@@ -486,8 +486,8 @@ fn process_approved_module(
     match build_daemon_filter_rules(module) {
         Ok(rules) => config.daemon_filter_rules = rules,
         Err(err) => {
-            let payload = format!("@ERROR: failed to load module filter rules: {err}");
-            send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+            let error = AtError::message(format!("failed to load module filter rules: {err}"));
+            send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
             let host_owned = ctx.effective_host().map(str::to_owned);
             run_post_xfer_finalizer(
                 ctx,
@@ -638,8 +638,8 @@ fn process_approved_module(
                     write_limited(ctx.reader.get_mut(), ctx.limiter, err.stdout.as_bytes())?;
                     write_limited(ctx.reader.get_mut(), ctx.limiter, b"\n")?;
                 }
-                let payload = format!("@ERROR: {}", err.message);
-                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                let error = AtError::message(err.message.clone());
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 if let Some(log) = ctx.log_sink {
                     let message = rsync_error!(1, err.message).with_role(Role::Daemon);
                     log_message(log, &message);
@@ -662,8 +662,8 @@ fn process_approved_module(
                     "failed to run pre-xfer exec command for module '{}': {io_err}",
                     ctx.request
                 );
-                let payload = format!("@ERROR: {error_msg}");
-                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                let error = AtError::message(error_msg.clone());
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 if let Some(log) = ctx.log_sink {
                     let message = rsync_error!(1, error_msg).with_role(Role::Daemon);
                     log_message(log, &message);

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -66,12 +66,12 @@ fn apply_privilege_restrictions_with_upstream_errors(
                 // upstream: clientserver.c:985 - `@ERROR: chroot failed\n`
                 // upstream: clientserver.c:649 - `@ERROR: chdir failed\n`
                 let text = err.to_string();
-                let payload = if text.contains("chdir") {
-                    CHDIR_FAILED_PAYLOAD
+                let error = if text.contains("chdir") {
+                    AtError::ChdirFailed
                 } else {
-                    CHROOT_FAILED_PAYLOAD
+                    AtError::ChrootFailed
                 };
-                send_error(ctx.reader.get_mut(), ctx.limiter, payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 let host_owned = ctx.effective_host().map(str::to_owned);
                 run_post_xfer_finalizer(
                     ctx,
@@ -100,10 +100,10 @@ fn apply_privilege_restrictions_with_upstream_errors(
                 // upstream: clientserver.c:784-786 (uid) / 657-659 (gid). This
                 // lookup runs before the post-xfer-exec fork point (908), so
                 // no `post-xfer exec` hook fires here.
-                let (flog, payload) = err.upstream_reply();
+                let (flog, error) = err.upstream_reply();
                 let message = rsync_error!(1, flog).with_role(Role::Daemon);
                 log_message(log_sink, &message);
-                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 return Ok(None);
             }
         };
@@ -113,14 +113,14 @@ fn apply_privilege_restrictions_with_upstream_errors(
                 // Distinguish upstream error messages based on the error text.
                 // upstream: clientserver.c:1024/1031/1053
                 let text = err.to_string();
-                let payload = if text.contains("setgroups") {
-                    SETGROUPS_FAILED_PAYLOAD
+                let error = if text.contains("setgroups") {
+                    AtError::SetgroupsFailed
                 } else if text.contains("setuid") {
-                    SETUID_FAILED_PAYLOAD
+                    AtError::SetuidFailed
                 } else {
-                    SETGID_FAILED_PAYLOAD
+                    AtError::SetgidFailed
                 };
-                send_error(ctx.reader.get_mut(), ctx.limiter, payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 let host_owned = ctx.effective_host().map(str::to_owned);
                 run_post_xfer_finalizer(
                     ctx,
@@ -181,12 +181,12 @@ fn validate_module_path(
         return Ok(true);
     }
 
-    let payload = format!(
-        "@ERROR: module '{}' path does not exist: {}",
+    let error = AtError::message(format!(
+        "module '{}' path does not exist: {}",
         sanitize_module_identifier(ctx.request),
         module.path.display()
-    );
-    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+    ));
+    send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
 
     if let Some(log) = ctx.log_sink {
         let text = format!(

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -192,8 +192,8 @@ fn setup_transfer_streams(
     let read_stream = match tcp.try_clone() {
         Ok(s) => s,
         Err(err) => {
-            let payload = format!("@ERROR: failed to clone stream: {err}");
-            send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+            let error = AtError::message(format!("failed to clone stream: {err}"));
+            send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
             return Ok(None);
         }
     };

--- a/crates/daemon/src/daemon/sections/privilege.rs
+++ b/crates/daemon/src/daemon/sections/privilege.rs
@@ -224,19 +224,19 @@ impl DropResolutionError {
     /// upstream: clientserver.c:784-786 (`Invalid uid %s` / `@ERROR: invalid
     /// uid %s`) and clientserver.c:657-658 (`Invalid gid %s` / `@ERROR: invalid
     /// gid %s`).
-    fn upstream_reply(&self) -> (String, String) {
+    fn upstream_reply(&self) -> (String, AtError) {
         match self {
             Self::InvalidUid(name) => (
                 format!("Invalid uid {name}"),
-                INVALID_UID_PAYLOAD.replace("{uid}", name),
+                AtError::InvalidUid(name.clone()),
             ),
             Self::InvalidGid(name) => (
                 format!("Invalid gid {name}"),
-                INVALID_GID_PAYLOAD.replace("{gid}", name),
+                AtError::InvalidGid(name.clone()),
             ),
             Self::GroupEnumeration(err) => (
                 format!("group enumeration failed: {err}"),
-                SETUID_FAILED_PAYLOAD.to_owned(),
+                AtError::SetuidFailed,
             ),
         }
     }
@@ -611,19 +611,21 @@ mod privilege_tests {
     /// Pins both strings so they can never be merged again.
     #[test]
     fn drop_resolution_error_maps_to_upstream_invalid_strings() {
-        let (flog, payload) = DropResolutionError::InvalidUid("nobody".to_owned()).upstream_reply();
+        let (flog, error) = DropResolutionError::InvalidUid("nobody".to_owned()).upstream_reply();
         assert_eq!(flog, "Invalid uid nobody");
-        assert_eq!(payload, "@ERROR: invalid uid nobody");
+        assert_eq!(error.line(), "@ERROR: invalid uid nobody");
         assert_ne!(
-            payload, SETUID_FAILED_PAYLOAD,
+            error.line(),
+            SETUID_FAILED_PAYLOAD,
             "resolution failure must not reuse the setuid syscall string"
         );
 
-        let (flog, payload) = DropResolutionError::InvalidGid("nobody".to_owned()).upstream_reply();
+        let (flog, error) = DropResolutionError::InvalidGid("nobody".to_owned()).upstream_reply();
         assert_eq!(flog, "Invalid gid nobody");
-        assert_eq!(payload, "@ERROR: invalid gid nobody");
+        assert_eq!(error.line(), "@ERROR: invalid gid nobody");
         assert_ne!(
-            payload, SETGID_FAILED_PAYLOAD,
+            error.line(),
+            SETGID_FAILED_PAYLOAD,
             "resolution failure must not reuse the setgid syscall string"
         );
     }
@@ -650,10 +652,10 @@ mod privilege_tests {
             ..Default::default()
         };
         let err = resolve_drop_target(&module, true).expect_err("missing nobody must fail");
-        let (flog, payload) = err.upstream_reply();
-        assert_eq!(payload, "@ERROR: invalid uid nobody");
+        let (flog, error) = err.upstream_reply();
+        assert_eq!(error.line(), "@ERROR: invalid uid nobody");
         assert_eq!(flog, "Invalid uid nobody");
-        assert_ne!(payload, SETUID_FAILED_PAYLOAD);
+        assert_ne!(error.line(), SETUID_FAILED_PAYLOAD);
     }
 
     /// WHY: upstream clientserver.c:831 - an EXPLICIT `use chroot = yes` has no

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -132,8 +132,11 @@ fn refuse_if_at_capacity(
 
     // Mirror upstream wording exactly. The trailing newline is part of the
     // protocol-framed `@ERROR:` reply (`io_printf` writes the literal `\n`).
-    let payload = format!("{}\n", MODULE_MAX_CONNECTIONS_PAYLOAD.replace("{limit}", &limit.to_string()));
-    if let Err(error) = stream.write_all(payload.as_bytes())
+    let payload = AtError::MaxConnections {
+        limit: limit as i64,
+    }
+    .to_wire();
+    if let Err(error) = stream.write_all(&payload)
         && let Some(log) = state.log_sink.as_ref()
     {
         let text =

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -318,9 +318,9 @@ fn handle_legacy_session(
         // applies; the refusal is a fatal pre-OK @ERROR line, after which the
         // client returns and the socket closes.
         if negotiated_protocol.is_none()
-            && let Some(payload) = reject_malformed_client_greeting(&line)
+            && let Some(error) = reject_malformed_client_greeting(&line)
         {
-            write_limited(reader.get_mut(), &mut limiter, payload.as_bytes())?;
+            write_limited(reader.get_mut(), &mut limiter, error.line().as_bytes())?;
             write_limited(reader.get_mut(), &mut limiter, b"\n")?;
             reader.get_mut().flush()?;
             // FSM: -> Closing after the fatal @ERROR refusal.
@@ -415,9 +415,8 @@ fn handle_legacy_session(
         // the raw line including the leading `#` - which is distinct from the
         // unknown-module response reserved for a bad module name. The client
         // treats `@ERROR` as fatal and closes without reading further.
-        let command_display = sanitize_module_identifier(&request);
-        let payload = UNKNOWN_COMMAND_PAYLOAD.replace("{command}", command_display.as_ref());
-        send_error(reader.get_mut(), &mut limiter, &payload)?;
+        let error = AtError::UnknownCommand(sanitize_module_identifier(&request).into_owned());
+        send_error(reader.get_mut(), &mut limiter, &error)?;
         // FSM: -> Closing after rejecting the unknown command.
         _ = conn_state
             .transition(ConnectionState::Closing)

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -958,7 +958,7 @@ fn refuse_emits_at_error_raw_pre_handshake() {
     send_error(
         &mut stream,
         &mut limiter,
-        "@ERROR: The server is configured to refuse --delete",
+        &AtError::message("The server is configured to refuse --delete"),
     )
     .expect("send pre-handshake error");
 


### PR DESCRIPTION
## Summary

Every daemon refusal in the ASCII negotiation phase is an `@ERROR: <msg>\n` line the client treats as fatal (upstream: `clientserver.c:381-385`). The `@ERROR: ` prefix and the terminating newline were previously spelled out at every emit site with an ad-hoc `format!("@ERROR: ...")` plus a separate `\n`, so no single point guaranteed the exact bytes.

This introduces `AtError`, a typed formatter that owns the framing, and routes every negotiation-phase emit site through it.

## What changed

- New `crates/daemon/src/daemon/at_error.rs`: an `AtError` enum whose variants each map to one upstream refusal. Fixed-wording variants borrow the single-sourced `*_PAYLOAD` constants; dynamic variants carry only their operands. `to_wire()` renders the exact `@ERROR: <msg>\n` bytes and `Display` renders the newline-free line for logging/assertions. A freeform `Message` variant covers call-site-composed bodies (refused options, omitted greeting tokens, per-session OS error strings) and strips a redundant leading `@ERROR: ` so the prefix is applied exactly once.
- `send_error` now takes `&AtError` instead of a pre-formatted `&str`, so the sink is the single place that appends the newline.
- Routed all remaining hand-built sites through the formatter: the two raw-socket max-connections paths (sync accept loop + async refusal) and the async-session refusal that previously wrote `"@ERROR: ...\n"` by hand.

## Fidelity

The emitted bytes are unchanged and remain byte-identical to upstream. The wording pin test (`daemon_error_payloads_match_upstream_wording`) and the max-connections golden-byte test (`daemon_max_connections_wire_bytes_match_upstream`) still pass unmodified.

## Round-trip coverage

Adds `every_variant_formats_and_parses_back`: for each variant it asserts the golden `@ERROR: <body>\n` bytes, that the line ends in exactly one newline, and that feeding the bytes back through the client parse path (`protocol::parse_legacy_error_message`) recovers the original body verbatim - pinning the formatter and parser as true inverses.

## Out of scope

The multiplexed `ERROR: module is ...` rejections and the incomplete-build handshake placeholder travel inside `MSG_ERROR` frames without a trailing newline, so they are intentionally not routed through this line formatter.

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean
- `cargo check --target x86_64-pc-windows-gnu -p daemon --all-features`: clean
- `cargo check --target x86_64-unknown-linux-musl -p daemon --all-features`: clean
- `cargo nextest run -p daemon --all-features`: 351 targeted tests pass (error/at_error/greeting/handshake/auth/max-connections/refuse); round-trip + golden gate tests pass
- `cargo build --bin oc-rsync --all-features`: builds
