### PR TITLE
fix(cli): return a clear error for ssh:// URLs when embedded-ssh is not compiled in

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -552,6 +552,31 @@ pub(crate) fn daemon_listing_unavailable_error(reason: &str) -> ClientError {
     daemon_error(detail, FEATURE_UNAVAILABLE_EXIT_CODE)
 }
 
+/// Reports that an `ssh://` operand was given but the built-in SSH client was
+/// not compiled into this build, so the transfer has no transport.
+///
+/// Without the `embedded-ssh` feature the `ssh://` scheme has no handler: the
+/// subprocess ssh path parses `ssh://user@host/path` as a `host:path` spec with
+/// host `ssh`, producing a confusing "could not resolve hostname ssh". This
+/// surfaces the real cause with an actionable remedy instead. The exit code
+/// matches the other feature-unavailable diagnostics ([`ExitCode::Syntax`], via
+/// [`FEATURE_UNAVAILABLE_EXIT_CODE`]).
+///
+/// oc-specific: upstream rsync has no `ssh://` operand scheme.
+///
+/// Only compiled when `embedded-ssh` is absent - that is the sole configuration
+/// in which an `ssh://` operand has no transport and this diagnostic fires.
+#[cfg(not(feature = "embedded-ssh"))]
+#[cold]
+pub(crate) fn ssh_url_requires_embedded_ssh() -> ClientError {
+    daemon_error(
+        "ssh:// URLs require the built-in SSH client, which is not compiled \
+         into this build (rebuild with the 'embedded-ssh' feature). For the \
+         standard SSH transport, use a host:path source with -e ssh instead.",
+        FEATURE_UNAVAILABLE_EXIT_CODE,
+    )
+}
+
 /// Enables idiomatic error conversion using the `?` operator.
 ///
 /// # Examples
@@ -1119,6 +1144,18 @@ mod tests {
             let msg = error.to_string();
             assert!(msg.contains("daemon refused module listing"));
             assert!(!msg.contains("listing: "));
+        }
+
+        #[cfg(not(feature = "embedded-ssh"))]
+        #[test]
+        fn ssh_url_requires_embedded_ssh_is_actionable() {
+            let error = ssh_url_requires_embedded_ssh();
+
+            assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
+            let msg = error.to_string();
+            assert!(msg.contains("ssh:// URLs require the built-in SSH client"));
+            assert!(msg.contains("embedded-ssh"));
+            assert!(msg.contains("-e ssh"));
         }
 
         #[test]

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -46,15 +46,6 @@ use super::ssh_transfer::convert_server_stats_to_summary;
 use crate::exit_code::ExitCode;
 use crate::server::{ServerConfig, ServerRole, TransferProgressCallback, TransferProgressEvent};
 
-/// Checks whether an operand is an `ssh://` URL suitable for embedded transport.
-///
-/// Returns `true` for operands starting with `ssh://`, which distinguishes
-/// embedded SSH transfers from standard `host:path` SSH operands that use
-/// the system SSH binary.
-pub(crate) fn is_ssh_url(operand: &str) -> bool {
-    operand.starts_with("ssh://")
-}
-
 /// Executes a transfer over the embedded SSH transport.
 ///
 /// Entry point for `ssh://` URL transfers when the `embedded-ssh` feature is
@@ -719,13 +710,6 @@ fn build_server_config_for_generator(
 mod tests {
     use super::*;
 
-    #[test]
-    fn is_ssh_url_detects_ssh_scheme() {
-        assert!(is_ssh_url("ssh://host/path"));
-        assert!(is_ssh_url("ssh://user@host/path"));
-        assert!(is_ssh_url("ssh://user:pass@host:2222/path"));
-    }
-
     /// The embedded (russh) pull receiver must carry the alt-dest reference
     /// directories onto its ServerConfig, exactly like the subprocess ssh and
     /// daemon receiver builders. On a pull the args are never forwarded to the
@@ -1128,14 +1112,6 @@ mod tests {
             build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
-    }
-
-    #[test]
-    fn is_ssh_url_rejects_non_ssh() {
-        assert!(!is_ssh_url("rsync://host/module"));
-        assert!(!is_ssh_url("host:path"));
-        assert!(!is_ssh_url("host::module"));
-        assert!(!is_ssh_url("/local/path"));
     }
 
     #[test]

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -49,8 +49,6 @@ pub use async_ssh_transport::{
 };
 pub use daemon_transfer::{run_daemon_over_remote_shell, run_daemon_transfer};
 #[cfg(feature = "embedded-ssh")]
-pub(crate) use embedded_ssh_transfer::is_ssh_url;
-#[cfg(feature = "embedded-ssh")]
 pub use embedded_ssh_transfer::run_embedded_ssh_transfer;
 pub use invocation::{
     RemoteInvocationBuilder, RemoteOperands, RemoteRole, SecludedInvocation, TransferSpec,
@@ -61,6 +59,20 @@ pub use ssh_transfer::run_ssh_transfer;
 use rsync_io::ssh::SshAddressFamily;
 
 use super::config::AddressMode;
+
+/// Checks whether an operand is an `ssh://` URL.
+///
+/// Returns `true` for operands beginning with `ssh://`, the scheme that selects
+/// the built-in (russh) SSH transport rather than the `host:path` subprocess
+/// ssh path. Compiled into every build - not gated on `embedded-ssh` - so the
+/// dispatcher can recognise the scheme even when that feature is absent and
+/// reject it with a clear diagnostic instead of misparsing it as a `host:path`
+/// spec with host `ssh`.
+///
+/// oc-specific: upstream rsync has no `ssh://` operand scheme.
+pub(crate) fn is_ssh_url(operand: &str) -> bool {
+    operand.starts_with("ssh://")
+}
 
 /// Maps the negotiated [`AddressMode`] onto the SSH `-4`/`-6` hint shared by
 /// every `do_cmd()`-equivalent SSH spawn (single-host and remote-to-remote).
@@ -78,5 +90,27 @@ pub(in crate::client::remote) const fn ssh_address_family(
         AddressMode::Default => None,
         AddressMode::Ipv4 => Some(SshAddressFamily::V4),
         AddressMode::Ipv6 => Some(SshAddressFamily::V6),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_ssh_url;
+
+    /// The `ssh://` detector is the single source of truth for the scheme that
+    /// selects the embedded transport, so it must recognise the scheme (with or
+    /// without user/port) and reject every other operand shape - `host:path`,
+    /// daemon modules, `rsync://`, `quic://`, and plain local paths.
+    #[test]
+    fn is_ssh_url_matches_only_ssh_scheme() {
+        assert!(is_ssh_url("ssh://host/path"));
+        assert!(is_ssh_url("ssh://user@host/path"));
+        assert!(is_ssh_url("ssh://user:pass@host:2222/path"));
+
+        assert!(!is_ssh_url("host:path"));
+        assert!(!is_ssh_url("host::module"));
+        assert!(!is_ssh_url("rsync://host/module"));
+        assert!(!is_ssh_url("quic://host/module"));
+        assert!(!is_ssh_url("/local/path"));
     }
 }

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -298,6 +298,24 @@ fn run_client_internal(
             }
         }
 
+        // With the embedded SSH client absent, an ssh:// operand would otherwise
+        // fall through to the subprocess ssh path below, which parses
+        // ssh://user@host/path as a host:path spec with host "ssh" and fails
+        // with a confusing "could not resolve hostname ssh". Fail fast with an
+        // actionable diagnostic instead.
+        // oc-specific: upstream rsync has no ssh:// operand scheme.
+        #[cfg(not(feature = "embedded-ssh"))]
+        {
+            let has_ssh_url = config
+                .transfer_args()
+                .iter()
+                .any(|arg| remote::is_ssh_url(&arg.to_string_lossy()));
+
+            if has_ssh_url {
+                return Err(super::error::ssh_url_requires_embedded_ssh());
+            }
+        }
+
         // upstream parity: SSH transfers stay on the spawned-process path by
         // default. The async transport (#1805) is gated behind the
         // `async-ssh` cargo feature and only activated when the
@@ -1085,6 +1103,33 @@ mod run_client_tests {
 
     use super::run_client;
     use crate::client::config::{ClientConfig, FilterRuleSpec};
+
+    /// Without the embedded SSH client compiled in, an `ssh://` operand has no
+    /// transport. It must fail fast with the feature-unavailable exit code and
+    /// an actionable message, never fall through to the subprocess ssh path
+    /// where `ssh://user@host/path` misparses as host `ssh` and yields the
+    /// confusing "could not resolve hostname ssh".
+    #[cfg(not(feature = "embedded-ssh"))]
+    #[test]
+    fn run_client_rejects_ssh_url_without_embedded_ssh() {
+        use crate::client::error::FEATURE_UNAVAILABLE_EXIT_CODE;
+
+        let error = run_client(
+            ClientConfig::builder()
+                .transfer_args([
+                    std::ffi::OsString::from("ssh://user@localhost/src"),
+                    std::ffi::OsString::from("/tmp/oc-ssh-url-dest"),
+                ])
+                .build(),
+        )
+        .expect_err("ssh:// without embedded-ssh must error");
+
+        assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
+        let msg = error.to_string();
+        assert!(msg.contains("ssh:// URLs require the built-in SSH client"));
+        assert!(msg.contains("embedded-ssh"));
+        assert!(msg.contains("-e ssh"));
+    }
 
     #[test]
     fn run_client_update_skips_newer_destination() {


### PR DESCRIPTION
## Problem

oc-rsync has two SSH transports selected by operand scheme:

- `host:path` (optionally with `-e ssh`) uses the classic subprocess `ssh`.
- `ssh://user@host/path` uses the built-in russh client, which is compiled in
  only when the `embedded-ssh` cargo feature is enabled.

When `embedded-ssh` is not compiled in, the `#[cfg(feature = "embedded-ssh")]`
dispatch block in `run_client_internal` disappears and an `ssh://` operand falls
through to the subprocess `ssh` path. That path parses `ssh://user@host/path`
as a `host:path` spec with host `ssh`, so the transfer dies with a confusing
`ssh: Could not resolve hostname ssh`, giving the user no hint that the real
issue is a missing feature.

## Fix

- Ungate the trivial `ssh://` scheme detector (`is_ssh_url`) and move it to an
  always-compiled location (`client/remote/mod.rs`) so it is a single source of
  truth available regardless of the feature. The embedded module and the
  dispatcher both use it.
- In `run_client_internal`, add a `#[cfg(not(feature = "embedded-ssh"))]` arm
  right after the embedded-ssh dispatch block: if any transfer operand is an
  `ssh://` URL, return a clear, actionable error instead of falling through to
  the subprocess ssh path.
- Add `ssh_url_requires_embedded_ssh()` beside the other feature-unavailable
  error constructors.

Error text:

> ssh:// URLs require the built-in SSH client, which is not compiled into this
> build (rebuild with the embedded-ssh feature). For the standard SSH
> transport, use a host:path source with -e ssh instead.

### Exit code

`FEATURE_UNAVAILABLE_EXIT_CODE` (`ExitCode::Syntax` = 1), matching the other
feature-unavailable diagnostics in `client/error.rs`. This is a
build-configuration/usage error surfaced before any transport is attempted, so
the syntax/usage code is the consistent choice.

### Scope

Default builds (embedded-ssh on) are unchanged: `ssh://` still routes to the
embedded russh transport. The new arm and its error constructor are compiled
only in no-embedded-ssh builds, where they are the sole path an `ssh://`
operand can take.

`is_ssh_url` and this whole scheme are an oc-specific extension; upstream rsync
has no `ssh://` operand scheme.

## Tests

- `is_ssh_url_matches_only_ssh_scheme` (always compiled): positive `ssh://`
  cases plus `host:path`, daemon module, `rsync://`, `quic://`, and local-path
  negatives.
- `run_client_rejects_ssh_url_without_embedded_ssh` (`cfg(not(embedded-ssh))`):
  dispatching a transfer with an `ssh://` operand returns the new error with the
  feature-unavailable exit code and expected message.
- `ssh_url_requires_embedded_ssh_is_actionable` (`cfg(not(embedded-ssh))`):
  message + exit-code contract for the constructor.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings`
- `cargo nextest run -p core --all-features` (embedded-ssh on) and
  `cargo nextest run -p core` (embedded-ssh off) for the new tests
- `cargo check --locked --workspace` for `x86_64-pc-windows-gnu` and
  `x86_64-unknown-linux-musl`
- Manual proof with a no-embedded-ssh binary:
  `oc-rsync -av ssh://user@localhost/tmp/x /tmp/y` prints the clear error and
  exits 1 (no "could not resolve hostname ssh").
