### PR TITLE
fix(engine): stop over-counting the destination root as a created dir in --stats (non-relative)

### DIFF
--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -159,16 +159,23 @@ pub(crate) fn copy_sources(
                 )?;
             }
 
-            // upstream: main.c:803-808 prints `created directory <dest>` for the
-            // pre-flight mkdir and, when the flist carries a "." top entry (a
-            // non-relative copy-contents transfer), counts it as a created dir.
-            // Under `--relative` the destination root is the mkpath target,
-            // announced by the same notice yet absent from the flist, so it must
-            // not inflate the created-dir count - a `./`-anchored operand's "."
-            // is accounted for by `emit_relative_implied_parents`. Set the
-            // notice flag either way; count only for non-relative transfers.
+            // upstream: main.c:802-808 - the pre-flight mkdir always prints
+            // `created directory <dest>`, but only sets FLAG_DIR_CREATED on the
+            // flist top entry (and thus counts the root as a created dir) when
+            // that entry's basename is "." - i.e. a copy-contents transfer whose
+            // implied root maps to the destination. A single-file or
+            // no-trailing-slash directory source has a NAMED top entry
+            // ("a.txt"/"src"), so upstream emits the notice yet never counts the
+            // destination root; the named entries are counted on their own.
+            // Under `--relative` the root is the mkpath target, absent from the
+            // flist, counted instead by `emit_relative_implied_parents`; a
+            // `./`-anchored operand's "." is accounted for there too. Set the
+            // notice flag either way; count the root only for a non-relative
+            // copy-contents "." top entry (multiple sources keep their tally).
             if destination_root_created {
-                let count_root = !context.relative_paths_enabled();
+                let count_root = !context.relative_paths_enabled()
+                    && (multiple_sources
+                        || plan.sources().first().is_some_and(|s| s.copy_contents()));
                 context
                     .summary_mut()
                     .mark_destination_root_created(count_root);

--- a/crates/engine/tests/created_dir_root_stats.rs
+++ b/crates/engine/tests/created_dir_root_stats.rs
@@ -1,0 +1,126 @@
+//! Regression coverage for the `--stats` "created dirs" tally of the
+//! destination root on a fresh, non-relative transfer.
+//!
+//! Upstream `main.c:802-808` (`get_local_name`) pre-flight-mkdirs the
+//! destination root and unconditionally prints `created directory <dest>`, but
+//! only flags the flist top entry `FLAG_DIR_CREATED` - and thus counts the root
+//! toward `stats.created_dirs` (receiver.c:733-738) - when that entry's basename
+//! is `"."`:
+//!
+//! ```c
+//! if (flist->high >= flist->low
+//!  && strcmp(flist->files[flist->low]->basename, ".") == 0)
+//!     flist->files[0]->flags |= FLAG_DIR_CREATED;
+//! ```
+//!
+//! The top entry is `"."` only for a copy-contents transfer (a trailing-slash or
+//! dot-dir source whose implied root maps onto the destination). A single-file
+//! source (`src/a.txt`) or a no-trailing-slash directory source (`src`) has a
+//! NAMED top entry (`a.txt` / `src`), so upstream emits the notice yet never
+//! counts the destination root itself; the named entries are counted on their
+//! own. These tests pin that distinction so oc does not over-count the root.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use tempfile::tempdir;
+
+/// Builds a source tree
+///
+/// ```text
+/// src/
+///   a.txt
+///   sub1/b.txt
+///   sub2/c.txt
+/// ```
+///
+/// and returns `(src_dir, dest_root, tempdir)`. `dest_root` does NOT exist yet,
+/// so every transfer below runs against a fresh destination.
+fn source_tree() -> (PathBuf, PathBuf, tempfile::TempDir) {
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src");
+    fs::create_dir_all(src.join("sub1")).expect("sub1");
+    fs::create_dir_all(src.join("sub2")).expect("sub2");
+    fs::write(src.join("a.txt"), b"a").expect("a.txt");
+    fs::write(src.join("sub1").join("b.txt"), b"b").expect("b.txt");
+    fs::write(src.join("sub2").join("c.txt"), b"c").expect("c.txt");
+    let dest = temp.path().join("dst");
+    (src, dest, temp)
+}
+
+fn recursive_options() -> LocalCopyOptions {
+    LocalCopyOptions::default()
+        .recursive(true)
+        .collect_events(true)
+}
+
+fn created_dirs(operands: &[OsString], dest: &Path) -> u64 {
+    let plan = LocalCopyPlan::from_operands(operands).expect("plan");
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, recursive_options())
+        .expect("copy succeeds");
+    assert!(dest.exists(), "destination root materialised");
+    report.summary().directories_created()
+}
+
+/// `-a src/a.txt dst/` (single file, non-relative, fresh dest): upstream mkdirs
+/// and announces `dst` but the flist top entry is the file `a.txt`, not `"."`,
+/// so `FLAG_DIR_CREATED` is never set and the created-dir tally stays 0. oc must
+/// not inflate it by counting the pre-flight mkdir of the destination root.
+#[test]
+fn single_file_non_relative_does_not_count_destination_root() {
+    let (src, dest, _temp) = source_tree();
+    let operands = vec![
+        src.join("a.txt").into_os_string(),
+        format!("{}/", dest.display()).into(),
+    ];
+    assert_eq!(
+        created_dirs(&operands, &dest),
+        0,
+        "a named single-file top entry never sets FLAG_DIR_CREATED on the root"
+    );
+    assert!(dest.join("a.txt").is_file());
+}
+
+/// `-a src dst/` (directory, no trailing slash, non-relative, fresh dest): the
+/// flist top entry is the NAMED directory `src`, not `"."`, so upstream counts
+/// `src` and its two subdirs (3) but NOT the pre-flight `dst` root. Before the
+/// fix oc reported 4 (the extra being the wrongly-counted `dst` root).
+#[test]
+fn no_trailing_slash_dir_does_not_count_destination_root() {
+    let (src, dest, _temp) = source_tree();
+    let operands = vec![
+        src.clone().into_os_string(),
+        format!("{}/", dest.display()).into(),
+    ];
+    assert_eq!(
+        created_dirs(&operands, &dest),
+        3,
+        "counts src + sub1 + sub2; the dst root is announced but not counted"
+    );
+    assert!(dest.join("src").join("sub1").join("b.txt").is_file());
+}
+
+/// Control: `-a src/ dst/` (copy-contents, non-relative, fresh dest). Here the
+/// flist top entry IS the synthetic `"."` root that maps onto `dst`, so upstream
+/// DOES set `FLAG_DIR_CREATED` and counts the root alongside the two subdirs
+/// (3). This is the case the fix must leave unchanged - the root count is
+/// legitimate only when the top entry is `"."`.
+#[test]
+fn copy_contents_still_counts_destination_root() {
+    let (src, dest, _temp) = source_tree();
+    let operands = vec![
+        format!("{}/", src.display()).into(),
+        format!("{}/", dest.display()).into(),
+    ];
+    assert_eq!(
+        created_dirs(&operands, &dest),
+        3,
+        "the \".\" top entry maps to dst, so the root counts with sub1 + sub2"
+    );
+    assert!(dest.join("sub1").join("b.txt").is_file());
+}


### PR DESCRIPTION
## Summary

`--stats` over-counted "created dirs" by one for a fresh destination when the
source was a single non-relative file or a directory operand with no trailing
slash. Measured against rsync 3.4.4:

| case (fresh dest) | upstream created dir: | oc before | oc after |
|---|---|---|---|
| `-a src/a.txt dst/` (single file) | 0 | 1 | 0 |
| `-a src dst/` (dir, no slash) | 3 | 4 | 3 |
| `-a src/ dst/` (copy-contents, control) | 3 | 3 | 3 |
| `-a -R src/a.txt dst/` (relative, control) | 3 | 3 | 3 |

## Root cause

`copy_sources` (crates/engine/src/local_copy/executor/sources/orchestration.rs)
counted the pre-flight destination-root mkdir as a created dir for *any*
non-relative transfer (`count_root = !relative_paths_enabled()`).

Upstream `get_local_name` (main.c:802-808) always prints
`created directory <dest>` for the mkdir, but only sets `FLAG_DIR_CREATED` on
the flist top entry - and thus counts the root toward `stats.created_dirs`
(receiver.c:733-738 via `ITEM_IS_NEW`) - when that entry basename is `"."`:

```c
if (flist->high >= flist->low
 && strcmp(flist->files[flist->low]->basename, ".") == 0)
    flist->files[0]->flags |= FLAG_DIR_CREATED;
```

The top entry is `"."` only for a copy-contents transfer (trailing-slash or
dot-dir source). A single-file (`a.txt`) or no-trailing-slash directory (`src`)
source has a NAMED top entry, so upstream emits the notice yet never counts the
destination root; the named entries are counted on their own.

## Fix

Gate the root count on a non-relative copy-contents `"."` top entry. The
`created directory` notice, the `--relative` implied-parent accounting, the
copy-contents control, and multiple-source tallies are unchanged.

## Tests

`crates/engine/tests/created_dir_root_stats.rs` pins the created-dir tally
against the upstream-derived counts for the single-file and no-trailing-slash
cases, plus a copy-contents control that must still count the root. The two
regression tests fail before the fix (1 vs 0, 4 vs 3).

## Verification (x86_64 Linux)

- `cargo fmt --all --check`, `cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings`
- `cargo check` for `x86_64-pc-windows-gnu` and `x86_64-unknown-linux-musl`
- `cargo nextest run -p engine` (72 stats/created/relative tests) and `-p cli` (581 tests)
- Interop oracle vs `/usr/bin/rsync` 3.4.4: all four cases above match after the fix
