### PR TITLE
fix(cli): preserve raw bytes through the SSH operand pipeline

### DIFF
--- a/crates/cli/src/frontend/server/roundtrip_tests.rs
+++ b/crates/cli/src/frontend/server/roundtrip_tests.rs
@@ -32,7 +32,8 @@ use super::parse::parse_server_flag_string_and_args;
 /// slice the server actually parses: production `run.rs` drops the arg0 program
 /// name (`&args[1..]`) before handing the tail to the parser.
 fn server_argv(config: &ClientConfig, role: RemoteRole, paths: &[&str]) -> Vec<OsString> {
-    RemoteInvocationBuilder::new(config, role).build_with_paths(paths)
+    let os_paths: Vec<&std::ffi::OsStr> = paths.iter().map(|p| std::ffi::OsStr::new(*p)).collect();
+    RemoteInvocationBuilder::new(config, role).build_with_paths(&os_paths)
 }
 
 /// Core invariant: after parsing, `positional_args` must equal exactly the

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -2453,7 +2453,7 @@ fn client_build_to_server_parse_round_trip() {
     ];
 
     for (role, config) in &matrix {
-        let full = RemoteInvocationBuilder::new(config, *role).build("dest");
+        let full = RemoteInvocationBuilder::new(config, *role).build(std::ffi::OsStr::new("dest"));
         // run.rs feeds the parser everything after the program name.
         let joined_argv: Vec<OsString> = full[1..].to_vec();
 

--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -41,7 +41,7 @@
 //! pulls in `rsync_io/async-ssh` and `dep:tokio`). Default builds remain
 //! on the synchronous transport.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io;
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
@@ -164,7 +164,8 @@ pub fn run_async_ssh_transfer(
             remote_sources,
             local_dest,
         } => {
-            let plan = build_plan(config, RemoteRole::Receiver, "", Some(&remote_sources))?;
+            let plan =
+                build_plan(config, RemoteRole::Receiver, OsStr::new(""), Some(&remote_sources))?;
             let mut server_config = build_pull_server_config(config, &[local_dest])?;
             // upstream: main.c:1525,1549 / io.c:427,464 / flist.c:1026 - record
             // each requested source path (or local --files-from entry) as an
@@ -188,14 +189,14 @@ pub fn run_async_ssh_transfer(
 struct AsyncSpawnPlan {
     remote: String,
     invocation_args: Vec<OsString>,
-    stdin_args: Vec<String>,
+    stdin_args: Vec<OsString>,
     config: SshConnectConfig,
 }
 
 fn build_plan(
     config: &ClientConfig,
     role: RemoteRole,
-    single_dest: &str,
+    single_dest: &OsStr,
     pull_sources: Option<&RemoteOperands>,
 ) -> Result<AsyncSpawnPlan, ClientError> {
     let (invocation_args, host, user, _port, stdin_args) = if let Some(sources) = pull_sources {
@@ -227,7 +228,7 @@ fn build_plan(
 
 fn build_pull_server_config(
     config: &ClientConfig,
-    local_paths: &[String],
+    local_paths: &[OsString],
 ) -> Result<ServerConfig, ClientError> {
     let mut server_config = build_server_config_for_receiver(config, local_paths)?;
     server_config.connection.client_mode = true;
@@ -241,7 +242,7 @@ fn build_pull_server_config(
 
 fn build_push_server_config(
     config: &ClientConfig,
-    local_paths: &[String],
+    local_paths: &[OsString],
 ) -> Result<ServerConfig, ClientError> {
     let mut server_config = build_server_config_for_generator(config, local_paths)?;
     server_config.connection.client_mode = true;
@@ -305,9 +306,9 @@ fn run_async_session(
         // Done here on the async side because AsyncSshTransport owns
         // stdin until we hand it to the pump below.
         if !stdin_args.is_empty() {
-            let arg_refs: Vec<&str> = stdin_args.iter().map(String::as_str).collect();
-            protocol::cmd::trace_protected_args(&arg_refs);
-            let payload = encode_secluded_args(&arg_refs, iconv_converter.as_ref());
+            protocol::cmd::trace_protected_args(&stdin_args);
+            let arg_bytes: Vec<&[u8]> = stdin_args.iter().map(|a| os_str_bytes(a)).collect();
+            let payload = encode_secluded_args(&arg_bytes, iconv_converter.as_ref());
             async_writer.write_all(&payload).await.map_err(|e| {
                 invalid_argument_error(
                     &format!("failed to send secluded args: {e}"),
@@ -463,23 +464,40 @@ fn transport_split(
 /// upstream: rsync.c:283-320 send_protected_args() / iconvbufs(ic_send)
 /// uses `ICB_INCLUDE_BAD`: invalid bytes are passed through verbatim.
 /// We use lossy conversion which replaces unconvertible bytes with `?`.
-fn encode_secluded_args(
-    args: &[&str],
+fn encode_secluded_args<A: AsRef<[u8]>>(
+    args: &[A],
     iconv: Option<&protocol::iconv::FilenameConverter>,
 ) -> Vec<u8> {
     let mut payload = Vec::new();
     for arg in args {
+        let bytes = arg.as_ref();
         match iconv {
             Some(converter) => {
-                let outcome = converter.local_to_remote_lossy(arg.as_bytes());
+                let outcome = converter.local_to_remote_lossy(bytes);
                 payload.extend_from_slice(&outcome.output);
             }
-            None => payload.extend_from_slice(arg.as_bytes()),
+            None => payload.extend_from_slice(bytes),
         }
         payload.push(0);
     }
     payload.push(0);
     payload
+}
+
+/// Returns the raw bytes backing an `OsStr` for null-separated stdin
+/// transmission. Unix exposes the verbatim filesystem bytes; other targets
+/// expose the WTF-8 encoding, exact for the Unicode operands they carry.
+#[inline]
+fn os_str_bytes(name: &OsStr) -> &[u8] {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        name.as_bytes()
+    }
+    #[cfg(not(unix))]
+    {
+        name.as_encoded_bytes()
+    }
 }
 
 /// Sync `Read` adapter over a `std::sync::mpsc::Receiver<Vec<u8>>`.
@@ -679,7 +697,7 @@ mod tests {
                 std::num::NonZeroU64::new(37).unwrap(),
             ))
             .build();
-        let plan = build_plan(&config, RemoteRole::Sender, "host:/data", None)
+        let plan = build_plan(&config, RemoteRole::Sender, OsStr::new("host:/data"), None)
             .expect("build_plan should succeed for a simple remote dest");
         assert_eq!(
             plan.config.io_timeout,
@@ -694,7 +712,7 @@ mod tests {
         // must preserve the watchdog's default-off behavior, matching the
         // pre-wiring contract for transfers that never opt into a timeout.
         let config = crate::client::config::ClientConfigBuilder::default().build();
-        let plan = build_plan(&config, RemoteRole::Sender, "host:/data", None)
+        let plan = build_plan(&config, RemoteRole::Sender, OsStr::new("host:/data"), None)
             .expect("build_plan should succeed for a simple remote dest");
         assert_eq!(plan.config.io_timeout, None);
     }

--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -164,8 +164,12 @@ pub fn run_async_ssh_transfer(
             remote_sources,
             local_dest,
         } => {
-            let plan =
-                build_plan(config, RemoteRole::Receiver, OsStr::new(""), Some(&remote_sources))?;
+            let plan = build_plan(
+                config,
+                RemoteRole::Receiver,
+                OsStr::new(""),
+                Some(&remote_sources),
+            )?;
             let mut server_config = build_pull_server_config(config, &[local_dest])?;
             // upstream: main.c:1525,1549 / io.c:427,464 / flist.c:1026 - record
             // each requested source path (or local --files-from entry) as an
@@ -736,7 +740,7 @@ mod tests {
 
     #[test]
     fn encode_secluded_args_empty_only_terminator() {
-        let payload = encode_secluded_args(&[], None);
+        let payload = encode_secluded_args::<&[u8]>(&[], None);
         assert_eq!(payload, vec![0u8]);
     }
 

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -108,9 +108,15 @@ pub fn run_daemon_transfer(
 
     let transfer_spec = determine_transfer_role(sources, destination)?;
     let role = transfer_spec.role();
-    let local_paths = match &transfer_spec {
-        TransferSpec::Push { local_sources, .. } => local_sources.clone(),
-        TransferSpec::Pull { local_dest, .. } => vec![local_dest.clone()],
+    // The daemon orchestration carries local operands as `String`; a lossy view
+    // is intentional here and unchanged by the byte-faithful SSH operand work.
+    // Raw-byte local-path fidelity for the daemon path is tracked separately.
+    let local_paths: Vec<String> = match &transfer_spec {
+        TransferSpec::Push { local_sources, .. } => local_sources
+            .iter()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect(),
+        TransferSpec::Pull { local_dest, .. } => vec![local_dest.to_string_lossy().into_owned()],
         TransferSpec::Proxy { .. } => {
             return Err(invalid_argument_error(
                 "remote-to-remote transfers via rsync daemon are not supported",
@@ -334,9 +340,15 @@ pub fn run_daemon_over_remote_shell(
 
     let transfer_spec = determine_transfer_role(sources, destination)?;
     let role = transfer_spec.role();
-    let local_paths = match &transfer_spec {
-        TransferSpec::Push { local_sources, .. } => local_sources.clone(),
-        TransferSpec::Pull { local_dest, .. } => vec![local_dest.clone()],
+    // The daemon orchestration carries local operands as `String`; a lossy view
+    // is intentional here and unchanged by the byte-faithful SSH operand work.
+    // Raw-byte local-path fidelity for the daemon path is tracked separately.
+    let local_paths: Vec<String> = match &transfer_spec {
+        TransferSpec::Push { local_sources, .. } => local_sources
+            .iter()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect(),
+        TransferSpec::Pull { local_dest, .. } => vec![local_dest.to_string_lossy().into_owned()],
         TransferSpec::Proxy { .. } => {
             return Err(invalid_argument_error(
                 "remote-to-remote transfers via daemon-over-remote-shell are not supported",

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -108,14 +108,18 @@ pub fn run_embedded_ssh_transfer(
 /// Executes a push transfer (local -> remote) via embedded SSH.
 fn run_embedded_push(
     config: &ClientConfig,
-    remote_dest: &str,
-    local_sources: &[String],
+    remote_dest: &OsStr,
+    local_sources: &[OsString],
     observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
-    let (ssh_config, remote_path) = parse_ssh_url(remote_dest, config)?;
+    // The embedded transport only handles `ssh://` operands (see the dispatch
+    // in `run/mod.rs`), whose URL grammar is ASCII/percent-encoded, so the
+    // lossy view is exact here. Raw-byte remote paths ride the `host:path`
+    // subprocess path (`ssh_transfer`) instead.
+    let (ssh_config, remote_path) = parse_ssh_url(&remote_dest.to_string_lossy(), config)?;
     let invocation_builder = RemoteInvocationBuilder::new(config, RemoteRole::Sender);
-    let secluded = invocation_builder.build_secluded(&[&remote_path]);
+    let secluded = invocation_builder.build_secluded(&[OsStr::new(&remote_path)]);
 
     let mut server_config = build_server_config_for_generator(config, local_sources)?;
     server_config.connection.client_mode = true;
@@ -141,12 +145,12 @@ fn run_embedded_push(
 fn run_embedded_pull(
     config: &ClientConfig,
     remote_sources: &RemoteOperands,
-    local_dest: &str,
+    local_dest: &OsStr,
     observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let (ssh_config, paths) = parse_remote_operands_urls(remote_sources, config)?;
-    let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+    let path_refs: Vec<&OsStr> = paths.iter().map(OsStr::new).collect();
     let invocation_builder = RemoteInvocationBuilder::new(config, RemoteRole::Receiver);
     let secluded = invocation_builder.build_secluded(&path_refs);
 
@@ -210,7 +214,7 @@ fn parse_remote_operands_urls(
 ) -> Result<(SshConfig, Vec<String>), ClientError> {
     match operands {
         RemoteOperands::Single(url) => {
-            let (ssh_config, path) = parse_ssh_url(url, config)?;
+            let (ssh_config, path) = parse_ssh_url(&url.to_string_lossy(), config)?;
             Ok((ssh_config, vec![path]))
         }
         RemoteOperands::Multiple(urls) => {
@@ -218,7 +222,7 @@ fn parse_remote_operands_urls(
             let mut paths = Vec::with_capacity(urls.len());
 
             for url in urls {
-                let (cfg, path) = parse_ssh_url(url, config)?;
+                let (cfg, path) = parse_ssh_url(&url.to_string_lossy(), config)?;
                 if let Some(ref existing) = ssh_config {
                     let existing: &SshConfig = existing;
                     if cfg.host != existing.host
@@ -321,7 +325,7 @@ fn apply_cli_overrides(ssh_config: &mut SshConfig, config: &ClientConfig) {
 fn run_transfer_over_embedded_ssh(
     ssh_config: SshConfig,
     invocation_args: &[OsString],
-    stdin_args: &[String],
+    stdin_args: &[OsString],
     server_config: ServerConfig,
     observer: Option<&mut dyn ClientProgressObserver>,
     batch_ctx: Option<super::batch_support::BatchContext>,
@@ -333,7 +337,9 @@ fn run_transfer_over_embedded_ssh(
     } else {
         let mut data = Vec::new();
         for arg in stdin_args {
-            data.extend_from_slice(arg.as_bytes());
+            // as_encoded_bytes is the raw filesystem bytes on Unix (a no-op
+            // conversion) so a non-UTF-8 remote path ships verbatim.
+            data.extend_from_slice(arg.as_encoded_bytes());
             data.push(0);
         }
         data.push(0);

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -19,7 +19,7 @@
 //! - `main.c:do_cmd()` - SSH fork/exec and pipe setup (replaced by russh)
 //! - `main.c:client_run()` - Role dispatch after SSH connection
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io::BufReader;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -488,10 +488,10 @@ impl TransferProgressCallback for ServerProgressAdapter<'_> {
 /// Builds server configuration for receiver role (pull transfer).
 fn build_server_config_for_receiver(
     config: &ClientConfig,
-    local_paths: &[String],
+    local_paths: &[OsString],
 ) -> Result<ServerConfig, ClientError> {
     let flag_string = flags::build_server_flag_string(config);
-    let args: Vec<OsString> = local_paths.iter().map(OsString::from).collect();
+    let args: Vec<OsString> = local_paths.to_vec();
 
     let mut server_config =
         ServerConfig::from_flag_string_and_args(ServerRole::Receiver, flag_string, args)
@@ -658,10 +658,10 @@ fn build_server_config_for_receiver(
 /// from a recursive walk of the source operand.
 fn build_server_config_for_generator(
     config: &ClientConfig,
-    local_paths: &[String],
+    local_paths: &[OsString],
 ) -> Result<ServerConfig, ClientError> {
     let flag_string = flags::build_server_flag_string(config);
-    let args: Vec<OsString> = local_paths.iter().map(OsString::from).collect();
+    let args: Vec<OsString> = local_paths.to_vec();
 
     let mut server_config =
         ServerConfig::from_flag_string_and_args(ServerRole::Generator, flag_string, args)
@@ -732,7 +732,7 @@ mod tests {
             .link_destination("/prev")
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.reference_directories.len(), 2);
         assert_eq!(
@@ -766,7 +766,7 @@ mod tests {
             .backup_suffix(Some(".old"))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.backup);
         assert_eq!(server_config.backup_dir.as_deref(), Some("/bak"));
@@ -779,7 +779,7 @@ mod tests {
     fn embedded_receiver_config_without_backup_has_no_backup_dir() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.backup);
         assert!(server_config.backup_dir.is_none());
@@ -795,7 +795,7 @@ mod tests {
     fn embedded_receiver_config_propagates_ignore_existing() {
         let config = ClientConfig::builder().ignore_existing(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.file_selection.ignore_existing);
     }
@@ -805,7 +805,7 @@ mod tests {
     fn embedded_receiver_config_without_ignore_existing_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.file_selection.ignore_existing);
     }
@@ -823,7 +823,7 @@ mod tests {
             .chmod(Some(modifiers.clone()))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.chmod.as_ref(), Some(&modifiers));
     }
@@ -834,7 +834,7 @@ mod tests {
     fn embedded_receiver_config_without_chmod_has_none() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.chmod.is_none());
     }
@@ -849,7 +849,7 @@ mod tests {
     fn embedded_receiver_config_propagates_list_only() {
         let config = ClientConfig::builder().list_only(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.list_only);
     }
@@ -864,7 +864,7 @@ mod tests {
     fn embedded_receiver_config_propagates_delay_updates() {
         let config = ClientConfig::builder().delay_updates(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.write.delay_updates);
     }
@@ -881,7 +881,7 @@ mod tests {
             .user_mapping(Some(mapping.clone()))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.user_mapping.as_ref(), Some(&mapping));
     }
@@ -895,7 +895,7 @@ mod tests {
             .group_mapping(Some(mapping.clone()))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.group_mapping.as_ref(), Some(&mapping));
     }
@@ -907,7 +907,7 @@ mod tests {
     fn embedded_receiver_config_propagates_fsync() {
         let config = ClientConfig::builder().fsync(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.write.fsync);
     }
@@ -919,7 +919,7 @@ mod tests {
     fn embedded_receiver_config_propagates_write_devices() {
         let config = ClientConfig::builder().write_devices(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.write.write_devices);
     }
@@ -930,7 +930,7 @@ mod tests {
     fn embedded_receiver_config_propagates_keep_dirlinks() {
         let config = ClientConfig::builder().keep_dirlinks(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.keep_dirlinks);
     }
@@ -942,7 +942,7 @@ mod tests {
     fn embedded_receiver_config_propagates_fuzzy_level() {
         let config = ClientConfig::builder().fuzzy_level(2).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.flags.fuzzy_level, 2);
     }
@@ -958,7 +958,7 @@ mod tests {
             .temp_directory(Some("/var/tmp/rsync"))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(
             server_config.temp_dir.as_deref(),
@@ -971,7 +971,7 @@ mod tests {
     fn embedded_receiver_config_without_temp_dir_stays_none() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.temp_dir.is_none());
     }
@@ -986,7 +986,7 @@ mod tests {
     fn embedded_receiver_config_propagates_omit_dir_times() {
         let config = ClientConfig::builder().omit_dir_times(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.omit_dir_times);
     }
@@ -996,7 +996,7 @@ mod tests {
     fn embedded_receiver_config_without_omit_dir_times_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.omit_dir_times);
     }
@@ -1009,7 +1009,7 @@ mod tests {
     fn embedded_receiver_config_propagates_omit_link_times() {
         let config = ClientConfig::builder().omit_link_times(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.omit_link_times);
     }
@@ -1019,7 +1019,7 @@ mod tests {
     fn embedded_receiver_config_without_omit_link_times_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.omit_link_times);
     }
@@ -1032,7 +1032,7 @@ mod tests {
     fn embedded_receiver_config_propagates_preserve_executability() {
         let config = ClientConfig::builder().executability(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.preserve_executability);
     }
@@ -1042,7 +1042,7 @@ mod tests {
     fn embedded_receiver_config_without_preserve_executability_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.preserve_executability);
     }
@@ -1057,7 +1057,7 @@ mod tests {
     fn embedded_receiver_config_propagates_mkpath() {
         let config = ClientConfig::builder().mkpath(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.mkpath);
     }
@@ -1068,7 +1068,7 @@ mod tests {
     fn embedded_receiver_config_without_mkpath_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.mkpath);
     }
@@ -1079,7 +1079,7 @@ mod tests {
     fn embedded_receiver_config_without_receiver_only_flags_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.list_only);
         assert!(!server_config.write.delay_updates);
@@ -1104,7 +1104,7 @@ mod tests {
             .chmod(Some(modifiers.clone()))
             .build();
         let server_config =
-            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")]).unwrap();
 
         assert_eq!(server_config.chmod.as_ref(), Some(&modifiers));
     }
@@ -1115,7 +1115,7 @@ mod tests {
     fn embedded_generator_config_without_chmod_has_none() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")]).unwrap();
 
         assert!(server_config.chmod.is_none());
     }
@@ -1343,7 +1343,7 @@ mod tests {
     #[test]
     fn parse_remote_operands_single() {
         let config = ClientConfig::builder().build();
-        let operands = RemoteOperands::Single("ssh://user@host/~/data".to_owned());
+        let operands = RemoteOperands::Single(OsString::from("ssh://user@host/~/data"));
         let (ssh_config, paths) = parse_remote_operands_urls(&operands, &config).unwrap();
         assert_eq!(ssh_config.host, "host");
         assert_eq!(paths, vec!["~/data"]);
@@ -1353,8 +1353,8 @@ mod tests {
     fn parse_remote_operands_multiple_same_host() {
         let config = ClientConfig::builder().build();
         let operands = RemoteOperands::Multiple(vec![
-            "ssh://user@host/~/file1".to_owned(),
-            "ssh://user@host/~/file2".to_owned(),
+            OsString::from("ssh://user@host/~/file1"),
+            OsString::from("ssh://user@host/~/file2"),
         ]);
         let (ssh_config, paths) = parse_remote_operands_urls(&operands, &config).unwrap();
         assert_eq!(ssh_config.host, "host");
@@ -1365,8 +1365,8 @@ mod tests {
     fn parse_remote_operands_multiple_different_hosts_fails() {
         let config = ClientConfig::builder().build();
         let operands = RemoteOperands::Multiple(vec![
-            "ssh://user@host1/~/file1".to_owned(),
-            "ssh://user@host2/~/file2".to_owned(),
+            OsString::from("ssh://user@host1/~/file1"),
+            OsString::from("ssh://user@host2/~/file2"),
         ]);
         let result = parse_remote_operands_urls(&operands, &config);
         assert!(result.is_err());

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -9,7 +9,7 @@
 //! - `options.c:server_options()` - Server argument generation
 //! - `options.c:parse_arguments()` - Server-side argument parsing
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::time::SystemTime;
 
 use super::super::super::config::{
@@ -83,7 +83,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// The first element is the rsync binary name (either from `--rsync-path`
     /// or "rsync" by default), followed by "--server", optional role flags,
     /// the compact flag string, ".", and the remote path(s).
-    pub fn build(&self, remote_path: &str) -> Vec<OsString> {
+    pub fn build(&self, remote_path: &OsStr) -> Vec<OsString> {
         self.build_with_paths(&[remote_path])
     }
 
@@ -91,7 +91,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
     ///
     /// This is used for pull operations with multiple remote sources from the same host.
     /// Filename arguments are shell-escaped for safe eval by the remote shell.
-    pub fn build_with_paths(&self, remote_paths: &[&str]) -> Vec<OsString> {
+    pub fn build_with_paths(&self, remote_paths: &[&OsStr]) -> Vec<OsString> {
         let mut args = Vec::new();
 
         if let Some(rsync_path) = self.config.rsync_path() {
@@ -123,7 +123,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// even under `--secluded-args`; only the arguments emitted after the
     /// `protect_args && !local_server` NULL cutoff (`options.c:2745-2746`)
     /// are deferred to `send_protected_args()` (`rsync.c:283-320`).
-    pub fn build_secluded(self, remote_paths: &[&str]) -> SecludedInvocation {
+    pub fn build_secluded(self, remote_paths: &[&OsStr]) -> SecludedInvocation {
         if !self.config.protect_args().unwrap_or(false) {
             return SecludedInvocation {
                 command_line_args: self.build_with_paths(remote_paths),
@@ -148,9 +148,10 @@ impl<'a> RemoteInvocationBuilder<'a> {
     }
 
     /// Builds the tail portion for stdin transmission in secluded-args mode:
-    /// the long-form options, `.`, and the remote paths as `String` values
+    /// the long-form options, `.`, and the remote paths as `OsString` values
     /// suitable for null-separated transmission. No shell escaping is
-    /// applied because stdin args are null-separated, not eval'd.
+    /// applied because stdin args are null-separated, not eval'd. Paths keep
+    /// their raw bytes so a non-UTF-8 remote path ships verbatim.
     ///
     /// # Upstream Reference
     ///
@@ -161,16 +162,14 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// arg0 so the receiver's `read_args()`/`parse_arguments()` can skip
     /// argv[0] the same way it would for a real command line; the
     /// server-side reader (`frontend/server/run.rs`) discards this element.
-    fn build_tail_args_for_stdin(&self, remote_paths: &[&str]) -> Vec<String> {
+    fn build_tail_args_for_stdin(&self, remote_paths: &[&OsStr]) -> Vec<OsString> {
         let mut args = vec![OsString::from("rsync")];
         self.append_long_form_args(&mut args);
         args.push(OsString::from("."));
         for path in remote_paths {
-            args.push(OsString::from(*path));
+            args.push((*path).to_os_string());
         }
-        args.into_iter()
-            .map(|a| a.to_string_lossy().into_owned())
-            .collect()
+        args
     }
 
     /// Builds the protected head of the server invocation: `--server`,
@@ -276,7 +275,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// `lsh.sh`) does not misinterpret special characters in filenames.
     fn build_args_without_program(
         &self,
-        remote_paths: &[&str],
+        remote_paths: &[&OsStr],
         escape_for_shell: bool,
     ) -> Vec<OsString> {
         let mut args = self.build_head_args();
@@ -307,17 +306,20 @@ impl<'a> RemoteInvocationBuilder<'a> {
                 // upstream: main.c:622 safe_arg(NULL, *remote_argv++)
                 // upstream: options.c:2555-2557 - escape a leading ~ for a
                 // relative path without a `/./` pivot, or a path with no `/`.
+                // The `/`-based shape tests are pure ASCII, so a lossy view is
+                // sufficient here and never touches the escaped bytes below.
+                let shape = path.to_string_lossy();
                 let escape_tilde = escape_tilde_role
-                    && ((self.config.relative_paths() && !path.contains("/./"))
-                        || !path.contains('/'));
+                    && ((self.config.relative_paths() && !shape.contains("/./"))
+                        || !shape.contains('/'));
                 let escaped = if escape_tilde {
                     shell_safe_filename_arg_with_tilde(path, true)
                 } else {
                     shell_safe_filename_arg(path)
                 };
-                args.push(OsString::from(escaped));
+                args.push(escaped);
             } else {
-                args.push(OsString::from(*path));
+                args.push((*path).to_os_string());
             }
         }
 
@@ -1234,7 +1236,7 @@ const WILD_CHARS: &str = "*?[]";
 /// `old_style_args == 0`; the caller (`build_args_without_program`) evaluates
 /// that gate (upstream `options.c:2551`, where the filename branch reduces to
 /// `!protect_args && old_style_args == 0`) and calls this only when it holds.
-pub(super) fn shell_safe_filename_arg(arg: &str) -> String {
+pub(super) fn shell_safe_filename_arg(arg: &OsStr) -> OsString {
     shell_safe_filename_arg_with_tilde(arg, false)
 }
 
@@ -1248,7 +1250,64 @@ pub(super) fn shell_safe_filename_arg(arg: &str) -> String {
 /// `escape_leading_tilde` flag is set only on a pull (`!am_sender`) for an
 /// untrusted sender and a relative/no-slash path; the caller computes that
 /// gate and passes the result here.
-pub(super) fn shell_safe_filename_arg_with_tilde(arg: &str, escape_leading_tilde: bool) -> String {
+pub(super) fn shell_safe_filename_arg_with_tilde(arg: &OsStr, escape_leading_tilde: bool) -> OsString {
+    // On Unix the escape runs over raw bytes so a non-UTF-8 remote path (a legal
+    // filename, carried by rsync as raw `char*`) survives verbatim; every
+    // metacharacter in SHELL_CHARS/WILD_CHARS is ASCII, so byte-level membership
+    // is exact and non-ASCII bytes pass through untouched. Other targets keep
+    // the char-based escape over the lossy string: their operands originate from
+    // Unicode argv, so no arbitrary-byte fidelity is lost.
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+        OsString::from_vec(escape_shell_bytes(arg.as_bytes(), escape_leading_tilde))
+    }
+    #[cfg(not(unix))]
+    {
+        OsString::from(escape_shell_str(&arg.to_string_lossy(), escape_leading_tilde))
+    }
+}
+
+/// Byte-level shell escape used on Unix (see [`shell_safe_filename_arg_with_tilde`]).
+#[cfg(unix)]
+fn escape_shell_bytes(arg: &[u8], escape_leading_tilde: bool) -> Vec<u8> {
+    let shell = SHELL_CHARS.as_bytes();
+    let wild = WILD_CHARS.as_bytes();
+    let leading_dash = arg.first() == Some(&b'-');
+    let leading_tilde = escape_leading_tilde && arg.first() == Some(&b'~');
+    let needs_escaping = leading_dash || leading_tilde || arg.iter().any(|b| shell.contains(b));
+    if !needs_escaping {
+        return arg.to_vec();
+    }
+
+    let mut out = Vec::with_capacity(arg.len() + 16);
+    if leading_dash {
+        out.extend_from_slice(b"./");
+    } else if leading_tilde {
+        // upstream: options.c:2581 - a single backslash before a leading ~.
+        out.push(b'\\');
+    }
+
+    for (i, &b) in arg.iter().enumerate() {
+        if b == b'\\' {
+            // upstream: backslash is only escaped when the next character is
+            // NOT a wildcard (preserving intentional wildcard escapes).
+            let next = arg.get(i + 1).copied().unwrap_or(0);
+            if !wild.contains(&next) {
+                out.push(b'\\');
+            }
+        } else if shell.contains(&b) {
+            out.push(b'\\');
+        }
+        out.push(b);
+    }
+
+    out
+}
+
+/// Char-level shell escape used on non-Unix targets, over the lossy operand.
+#[cfg(not(unix))]
+fn escape_shell_str(arg: &str, escape_leading_tilde: bool) -> String {
     let leading_dash = arg.starts_with('-');
     let leading_tilde = escape_leading_tilde && arg.starts_with('~');
     let needs_escaping =
@@ -1269,8 +1328,6 @@ pub(super) fn shell_safe_filename_arg_with_tilde(arg: &str, escape_leading_tilde
     let chars: Vec<char> = arg.chars().collect();
     for (i, &ch) in chars.iter().enumerate() {
         if ch == '\\' {
-            // upstream: backslash is only escaped when the next character is
-            // NOT a wildcard (preserving intentional wildcard escapes).
             let next = chars.get(i + 1).copied().unwrap_or('\0');
             if !WILD_CHARS.contains(next) {
                 out.push('\\');

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -1250,7 +1250,10 @@ pub(super) fn shell_safe_filename_arg(arg: &OsStr) -> OsString {
 /// `escape_leading_tilde` flag is set only on a pull (`!am_sender`) for an
 /// untrusted sender and a relative/no-slash path; the caller computes that
 /// gate and passes the result here.
-pub(super) fn shell_safe_filename_arg_with_tilde(arg: &OsStr, escape_leading_tilde: bool) -> OsString {
+pub(super) fn shell_safe_filename_arg_with_tilde(
+    arg: &OsStr,
+    escape_leading_tilde: bool,
+) -> OsString {
     // On Unix the escape runs over raw bytes so a non-UTF-8 remote path (a legal
     // filename, carried by rsync as raw `char*`) survives verbatim; every
     // metacharacter in SHELL_CHARS/WILD_CHARS is ASCII, so byte-level membership
@@ -1264,7 +1267,10 @@ pub(super) fn shell_safe_filename_arg_with_tilde(arg: &OsStr, escape_leading_til
     }
     #[cfg(not(unix))]
     {
-        OsString::from(escape_shell_str(&arg.to_string_lossy(), escape_leading_tilde))
+        OsString::from(escape_shell_str(
+            &arg.to_string_lossy(),
+            escape_leading_tilde,
+        ))
     }
 }
 

--- a/crates/core/src/client/remote/invocation/mod.rs
+++ b/crates/core/src/client/remote/invocation/mod.rs
@@ -64,15 +64,20 @@ pub(super) struct RemoteOperandParsed {
 /// For push operations (local -> remote), there's always a single remote destination.
 /// For pull operations (remote -> local), there can be multiple remote sources from
 /// the same host.
+///
+/// Operands are held as [`OsString`] so a non-UTF-8 remote path (a legal Unix
+/// filename, carried by rsync as raw `char*`) survives verbatim to the
+/// remote-shell command line. upstream: `main.c:do_cmd()` forwards the raw
+/// `remote_argv` bytes through `safe_arg()` without transcoding.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RemoteOperands {
     /// Single remote operand (for push or single-source pull).
-    Single(String),
+    Single(OsString),
 
     /// Multiple remote operands (for multi-source pull).
     ///
     /// All operands must be from the same host with the same user and port.
-    Multiple(Vec<String>),
+    Multiple(Vec<OsString>),
 }
 
 /// Full specification of a transfer, capturing both endpoints and their types.
@@ -86,9 +91,9 @@ pub enum TransferSpec {
     /// The local process acts as generator/sender.
     Push {
         /// Local file paths to send.
-        local_sources: Vec<String>,
+        local_sources: Vec<OsString>,
         /// Remote destination operand (e.g., "user@host:/path").
-        remote_dest: String,
+        remote_dest: OsString,
     },
 
     /// Pull transfer: remote sources -> local destination.
@@ -98,7 +103,7 @@ pub enum TransferSpec {
         /// Remote source operand(s) (e.g., "user@host:/path").
         remote_sources: RemoteOperands,
         /// Local destination path.
-        local_dest: String,
+        local_dest: OsString,
     },
 
     /// Proxy transfer: remote sources -> remote destination (via local).
@@ -108,7 +113,7 @@ pub enum TransferSpec {
         /// Remote source operand(s) (e.g., "user@src:/path").
         remote_sources: RemoteOperands,
         /// Remote destination operand (e.g., "user@dst:/path").
-        remote_dest: String,
+        remote_dest: OsString,
     },
 }
 
@@ -139,6 +144,7 @@ pub struct SecludedInvocation {
     pub command_line_args: Vec<OsString>,
     /// Arguments to send over stdin (non-empty only when secluded-args is
     /// active): the deferred long-form tail, `.`, and the path arguments.
-    /// Each string is sent null-separated with an empty-string terminator.
-    pub stdin_args: Vec<String>,
+    /// Each argument is sent null-separated with an empty-string terminator.
+    /// Held as [`OsString`] so a non-UTF-8 remote path survives verbatim.
+    pub stdin_args: Vec<OsString>,
 }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1,6 +1,6 @@
 //! Tests for remote invocation builder and transfer role detection.
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::time::SystemTime;
 
 use compress::algorithm::CompressionAlgorithm;
@@ -23,7 +23,7 @@ fn builds_receiver_invocation_with_sender_flag() {
     // overflow on the next decode.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     assert_eq!(args[0], "rsync");
     assert_eq!(args[1], "--server");
@@ -46,7 +46,7 @@ fn builds_sender_invocation_no_sender_flag() {
     // flag string, producing one argument like `-re.iLsfxCIvu`.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     assert_eq!(args[0], "rsync");
     assert_eq!(args[1], "--server");
@@ -69,7 +69,7 @@ fn ssh_sender_includes_inc_recurse_capability_by_default() {
     // upstream: the capability string is embedded in the compact flag string.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     // Capability string is now embedded in the compact flag string, not separate.
     let flag_str = args[2].to_string_lossy();
@@ -92,7 +92,7 @@ fn ssh_sender_omits_inc_recurse_when_no_inc_recursive_set() {
     // upstream: capability string is embedded in the compact flag string.
     let config = ClientConfig::builder().inc_recursive_send(false).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     let flag_str = args[2].to_string_lossy();
     assert!(
@@ -131,7 +131,7 @@ fn ssh_sender_omits_inc_recurse_without_recursion_or_under_qsort() {
         ("--qsort", ClientConfig::builder().qsort(true).build()),
     ] {
         let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-        let args = builder.build("/remote/path");
+        let args = builder.build(std::ffi::OsStr::new("/remote/path"));
         let flag_str = args[2].to_string_lossy();
         let caps_portion = flag_str.split("e.").nth(1).expect("e. separator");
         assert!(
@@ -154,7 +154,7 @@ fn ssh_receiver_omits_inc_recurse_capability_by_default() {
     // local side's actual ability to honor CF_INC_RECURSE.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     // Pull: args[3] is the flag string (after --server, --sender)
     let flag_str = args[3].to_string_lossy();
@@ -176,7 +176,7 @@ fn ssh_receiver_omits_inc_recurse_when_no_inc_recursive_set() {
     // upstream: capability string is embedded in the compact flag string.
     let config = ClientConfig::builder().inc_recursive_send(false).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     // Pull: args[3] is the flag string (after --server, --sender)
     let flag_str = args[3].to_string_lossy();
@@ -195,7 +195,7 @@ fn ssh_receiver_omits_inc_recurse_when_no_inc_recursive_set() {
 fn includes_recursive_flag_when_enabled() {
     let config = ClientConfig::builder().recursive(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     // Push layout: rsync --server -flags . /path
     let flags = args[2].to_string_lossy();
@@ -212,7 +212,7 @@ fn includes_multiple_preservation_flags() {
         .build();
 
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('t'), "expected 't' in flags: {flags}");
@@ -225,7 +225,7 @@ fn includes_multiple_preservation_flags() {
 fn includes_compress_flag() {
     let config = ClientConfig::builder().compress(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('z'), "expected 'z' in flags: {flags}");
@@ -241,7 +241,8 @@ fn omits_compress_flag_for_zstd() {
         .compress(true)
         .compression_algorithm(compress::algorithm::CompressionAlgorithm::Zstd)
         .build();
-    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     let flags = args[2].to_string_lossy();
     assert!(!flags.contains('z'), "must not pack 'z' for zstd: {flags}");
 }
@@ -255,7 +256,8 @@ fn omits_compress_flag_for_zlibx() {
         .compression_algorithm(compress::algorithm::CompressionAlgorithm::Zlib)
         .compress_choice_name(Some("zlibx".to_owned()))
         .build();
-    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     let flags = args[2].to_string_lossy();
     assert!(!flags.contains('z'), "must not pack 'z' for zlibx: {flags}");
 }
@@ -270,7 +272,7 @@ fn includes_log_format_for_itemize() {
         .out_format_forwards_i(true)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let args_str: Vec<_> = args
         .iter()
@@ -302,7 +304,7 @@ fn includes_ii_log_format_for_itemize_unchanged() {
         .out_format_forwards_i(true)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let args_str: Vec<_> = args
         .iter()
@@ -322,7 +324,7 @@ fn includes_ii_log_format_for_itemize_unchanged() {
 fn omits_log_format_when_itemize_disabled() {
     let config = ClientConfig::builder().itemize_changes(false).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let args_str: Vec<_> = args
         .iter()
@@ -370,7 +372,7 @@ fn detects_pull_when_source_remote() {
             assert_eq!(local_dest, "local.txt");
             assert_eq!(
                 remote_sources,
-                RemoteOperands::Single("user@host:/remote.txt".to_owned())
+                RemoteOperands::Single(OsString::from("user@host:/remote.txt"))
             );
         }
         _ => panic!("Expected Pull transfer"),
@@ -411,7 +413,7 @@ fn detects_proxy_when_both_remote() {
         } => {
             assert_eq!(
                 remote_sources,
-                RemoteOperands::Single("host1:/file".to_owned())
+                RemoteOperands::Single(OsString::from("host1:/file"))
             );
             assert_eq!(remote_dest, "host2:/file");
         }
@@ -455,7 +457,10 @@ fn accepts_multiple_remote_sources_same_host() {
             assert_eq!(local_dest, "dest/");
             assert_eq!(
                 remote_sources,
-                RemoteOperands::Multiple(vec!["host:/file1".to_owned(), "host:/file2".to_owned()])
+                RemoteOperands::Multiple(vec![
+                    OsString::from("host:/file1"),
+                    OsString::from("host:/file2")
+                ])
             );
         }
         _ => panic!("Expected Pull transfer"),
@@ -478,7 +483,7 @@ fn rejects_multiple_remote_sources_different_hosts() {
 fn includes_ignore_errors_flag_when_set() {
     let config = ClientConfig::builder().ignore_errors(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--ignore-errors"),
@@ -490,7 +495,7 @@ fn includes_ignore_errors_flag_when_set() {
 fn omits_ignore_errors_flag_when_not_set() {
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         !args.iter().any(|a| a == "--ignore-errors"),
@@ -507,13 +512,15 @@ fn omits_ignore_errors_flag_when_not_set() {
 fn fsync_forwarded_on_push_only() {
     let config = ClientConfig::builder().fsync(true).build();
 
-    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         push.iter().any(|a| a == "--fsync"),
         "push must forward --fsync: {push:?}"
     );
 
-    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !pull.iter().any(|a| a == "--fsync"),
         "pull must not forward --fsync to the remote sender: {pull:?}"
@@ -524,7 +531,7 @@ fn fsync_forwarded_on_push_only() {
 fn omits_fsync_flag_when_not_set() {
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         !args.iter().any(|a| a == "--fsync"),
@@ -629,7 +636,7 @@ fn remote_invocation_only_sends_upstream_compatible_args() {
 
     for role in [RemoteRole::Sender, RemoteRole::Receiver] {
         let builder = RemoteInvocationBuilder::new(&config, role);
-        let args = builder.build("/path");
+        let args = builder.build(std::ffi::OsStr::new("/path"));
 
         for arg in &args {
             let s = arg.to_string_lossy();
@@ -661,7 +668,7 @@ fn remote_invocation_only_sends_upstream_compatible_args() {
 fn includes_delete_before_long_arg() {
     let config = ClientConfig::builder().delete_before(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--delete-before"),
@@ -673,7 +680,7 @@ fn includes_delete_before_long_arg() {
 fn includes_delete_after_long_arg() {
     let config = ClientConfig::builder().delete_after(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--delete-after"),
@@ -685,7 +692,7 @@ fn includes_delete_after_long_arg() {
 fn includes_delete_excluded_long_arg() {
     let config = ClientConfig::builder().delete_excluded(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--delete-excluded"),
@@ -714,7 +721,7 @@ fn config_with_batch_mode(mode: engine::batch::BatchMode) -> ClientConfig {
 fn only_write_batch_sender_emits_placeholder_arg() {
     let config = config_with_batch_mode(engine::batch::BatchMode::OnlyWrite);
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--only-write-batch=X"),
@@ -729,7 +736,7 @@ fn only_write_batch_sender_emits_placeholder_arg() {
 fn only_write_batch_is_not_forwarded_on_a_pull() {
     let config = config_with_batch_mode(engine::batch::BatchMode::OnlyWrite);
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         !args.iter().any(|a| a == "--only-write-batch=X"),
@@ -744,7 +751,7 @@ fn only_write_batch_is_not_forwarded_on_a_pull() {
 fn plain_write_batch_sender_emits_no_placeholder_arg() {
     let config = config_with_batch_mode(engine::batch::BatchMode::Write);
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         !args
@@ -761,7 +768,7 @@ fn includes_timeout_long_arg() {
         .timeout(TransferTimeout::Seconds(NonZeroU64::new(30).unwrap()))
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--timeout=30"),
@@ -779,7 +786,7 @@ fn includes_bwlimit_long_arg() {
         )))
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter()
@@ -792,7 +799,7 @@ fn includes_bwlimit_long_arg() {
 fn includes_inplace_long_arg() {
     let config = ClientConfig::builder().inplace(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--inplace"),
@@ -810,7 +817,8 @@ fn no_w_emitted_for_inplace_sparse_push() {
     // whole-file mode for --inplace --sparse, defeating the delta the client
     // asked for.
     let config = ClientConfig::builder().inplace(true).sparse(true).build();
-    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--inplace"),
@@ -833,7 +841,8 @@ fn no_w_suppressed_on_pull_and_without_sparse_or_whole_file() {
 
     // PULL with inplace+sparse: remote is the sender, no --no-W.
     let pull = ClientConfig::builder().inplace(true).sparse(true).build();
-    let pull_args = RemoteInvocationBuilder::new(&pull, RemoteRole::Receiver).build("/path");
+    let pull_args = RemoteInvocationBuilder::new(&pull, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !pull_args.iter().any(|a| a == "--no-W"),
         "--no-W must not be sent on a pull: {pull_args:?}"
@@ -841,8 +850,8 @@ fn no_w_suppressed_on_pull_and_without_sparse_or_whole_file() {
 
     // PUSH with inplace but no sparse: no --no-W.
     let no_sparse = ClientConfig::builder().inplace(true).build();
-    let no_sparse_args =
-        RemoteInvocationBuilder::new(&no_sparse, RemoteRole::Sender).build("/path");
+    let no_sparse_args = RemoteInvocationBuilder::new(&no_sparse, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !no_sparse_args.iter().any(|a| a == "--no-W"),
         "--no-W must not be sent without --sparse: {no_sparse_args:?}"
@@ -854,7 +863,8 @@ fn no_w_suppressed_on_pull_and_without_sparse_or_whole_file() {
         .sparse(true)
         .whole_file_option(Some(true))
         .build();
-    let whole_args = RemoteInvocationBuilder::new(&whole, RemoteRole::Sender).build("/path");
+    let whole_args = RemoteInvocationBuilder::new(&whole, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !whole_args.iter().any(|a| a == "--no-W"),
         "--no-W must not be sent when whole-file is explicitly requested: {whole_args:?}"
@@ -870,20 +880,24 @@ fn ignore_missing_args_is_pull_only_delete_missing_is_both() {
     // sender already makes, so it is emitted only on a PULL (!am_sender);
     // --delete-missing-args always goes both directions.
     let ignore = ClientConfig::builder().ignore_missing_args(true).build();
-    let pull = RemoteInvocationBuilder::new(&ignore, RemoteRole::Receiver).build("/path");
+    let pull = RemoteInvocationBuilder::new(&ignore, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         pull.iter().any(|a| a == "--ignore-missing-args"),
         "--ignore-missing-args must be forwarded on a pull: {pull:?}"
     );
-    let push = RemoteInvocationBuilder::new(&ignore, RemoteRole::Sender).build("/path");
+    let push = RemoteInvocationBuilder::new(&ignore, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !push.iter().any(|a| a == "--ignore-missing-args"),
         "--ignore-missing-args must NOT be forwarded on a push: {push:?}"
     );
 
     let delete = ClientConfig::builder().delete_missing_args(true).build();
-    let del_pull = RemoteInvocationBuilder::new(&delete, RemoteRole::Receiver).build("/path");
-    let del_push = RemoteInvocationBuilder::new(&delete, RemoteRole::Sender).build("/path");
+    let del_pull = RemoteInvocationBuilder::new(&delete, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/path"));
+    let del_push = RemoteInvocationBuilder::new(&delete, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         del_pull.iter().any(|a| a == "--delete-missing-args"),
         "--delete-missing-args must be forwarded on a pull: {del_pull:?}"
@@ -900,7 +914,7 @@ fn includes_partial_dir_long_arg() {
         .partial_directory(Some(".rsync-partial"))
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter()
@@ -915,7 +929,7 @@ fn includes_checksum_choice_long_arg() {
     let choice = StrongChecksumChoice::parse("md5").unwrap();
     let config = ClientConfig::builder().checksum_choice(choice).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter()
@@ -938,7 +952,7 @@ fn includes_copy_links_flag() {
 fn includes_keep_dirlinks_flag() {
     let config = ClientConfig::builder().keep_dirlinks(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('K'), "expected 'K' in flags: {flags}");
@@ -948,7 +962,7 @@ fn includes_keep_dirlinks_flag() {
 fn includes_executability_flag() {
     let config = ClientConfig::builder().executability(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('E'), "expected 'E' in flags: {flags}");
@@ -962,7 +976,7 @@ fn executability_suppressed_when_permissions_set() {
         .executability(true)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('p'), "expected 'p' in flags: {flags}");
@@ -976,7 +990,7 @@ fn executability_suppressed_when_permissions_set() {
 fn includes_fuzzy_flag() {
     let config = ClientConfig::builder().fuzzy(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('y'), "expected 'y' in flags: {flags}");
@@ -986,7 +1000,7 @@ fn includes_fuzzy_flag() {
 fn includes_double_fuzzy_flag() {
     let config = ClientConfig::builder().fuzzy_level(2).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let flags = args[2].to_string_lossy();
     assert!(flags.contains("yy"), "expected 'yy' in flags: {flags}");
@@ -996,7 +1010,7 @@ fn includes_double_fuzzy_flag() {
 fn includes_prune_empty_dirs_flag() {
     let config = ClientConfig::builder().prune_empty_dirs(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('m'), "expected 'm' in flags: {flags}");
@@ -1006,7 +1020,7 @@ fn includes_prune_empty_dirs_flag() {
 fn includes_verbosity_flags() {
     let config = ClientConfig::builder().verbosity(3).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     // Count 'v' only in the transfer-flag portion, excluding the embedded
     // capability suffix (which contains its own 'v' in e.g. `e.iLsfxCIvu`).
@@ -1024,7 +1038,7 @@ fn includes_backup_related_args() {
         .backup_suffix(Some(".bak"))
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
     let string_args: Vec<String> = args
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
@@ -1057,7 +1071,7 @@ fn includes_backup_related_args() {
 fn includes_link_dest_via_reference_directories() {
     let config = ClientConfig::builder().link_destination("/prev").build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter()
@@ -1079,7 +1093,7 @@ fn reference_directories_not_forwarded_on_pull() {
         .compare_destination("/cmp")
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         !args.iter().any(|a| {
@@ -1104,13 +1118,15 @@ fn forwards_write_devices_to_remote_receiver_only() {
     // receiver (RemoteRole::Sender) but never a remote sender (a PULL).
     let config = ClientConfig::builder().write_devices(true).build();
 
-    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         push.iter().any(|a| a == "--write-devices"),
         "expected --write-devices forwarded on a push: {push:?}"
     );
 
-    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !pull.iter().any(|a| a == "--write-devices"),
         "did not expect --write-devices forwarded on a pull: {pull:?}"
@@ -1124,13 +1140,15 @@ fn forwards_copy_devices_to_remote_sender_only() {
     // sender (RemoteRole::Receiver) but never a remote receiver (a PUSH).
     let config = ClientConfig::builder().copy_devices(true).build();
 
-    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         pull.iter().any(|a| a == "--copy-devices"),
         "expected --copy-devices forwarded on a pull: {pull:?}"
     );
 
-    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !push.iter().any(|a| a == "--copy-devices"),
         "did not expect --copy-devices forwarded on a push: {push:?}"
@@ -1141,7 +1159,7 @@ fn forwards_copy_devices_to_remote_sender_only() {
 fn includes_delay_updates_long_arg() {
     let config = ClientConfig::builder().delay_updates(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--delay-updates"),
@@ -1158,7 +1176,8 @@ fn partial_dir_not_forwarded_on_pull_receiver() {
     let config = ClientConfig::builder()
         .partial_directory(Some(".rsync-partial"))
         .build();
-    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !args
             .iter()
@@ -1173,7 +1192,8 @@ fn delay_updates_not_forwarded_on_pull_receiver() {
     // `partial_dir && am_sender` block. On a pull the receiver applies it
     // locally and must not forward it to the remote sender.
     let config = ClientConfig::builder().delay_updates(true).build();
-    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !args.iter().any(|a| a == "--delay-updates"),
         "--delay-updates must not be forwarded on a pull (receiver): {args:?}"
@@ -1185,7 +1205,8 @@ fn inplace_suppressed_when_append_mode() {
     // upstream: options.c:2951-2956 - `if (append_mode) {...} else if (inplace)`.
     // append_mode takes precedence, so --inplace must not accompany --append.
     let config = ClientConfig::builder().inplace(true).append(true).build();
-    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
     assert!(
         !args.iter().any(|a| a == "--inplace"),
         "--inplace must be suppressed when --append is set: {args:?}"
@@ -1200,7 +1221,7 @@ fn inplace_suppressed_when_append_mode() {
 fn includes_remove_source_files_long_arg() {
     let config = ClientConfig::builder().remove_source_files(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--remove-source-files"),
@@ -1217,7 +1238,7 @@ fn forwards_deprecated_remove_sent_files_spelling() {
         .remove_sent_files(true)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--remove-sent-files"),
@@ -1238,7 +1259,7 @@ fn forwards_log_format_o_when_out_format_has_operation() {
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args: Vec<_> = builder
-        .build("/path")
+        .build(std::ffi::OsStr::new("/path"))
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
@@ -1258,7 +1279,7 @@ fn omits_log_format_o_on_pull() {
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args: Vec<_> = builder
-        .build("/path")
+        .build(std::ffi::OsStr::new("/path"))
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
@@ -1276,7 +1297,7 @@ fn forwards_log_format_placeholder_when_not_verbose() {
     let config = ClientConfig::builder().out_format_placeholder(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args: Vec<_> = builder
-        .build("/path")
+        .build(std::ffi::OsStr::new("/path"))
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
@@ -1297,7 +1318,7 @@ fn omits_log_format_placeholder_when_verbose() {
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args: Vec<_> = builder
-        .build("/path")
+        .build(std::ffi::OsStr::new("/path"))
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
@@ -1322,7 +1343,7 @@ fn out_format_without_i_forwards_o_not_i_even_with_dash_i() {
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args: Vec<_> = builder
-        .build("/path")
+        .build(std::ffi::OsStr::new("/path"))
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
@@ -1345,7 +1366,7 @@ fn explicit_out_format_with_i_forwards_log_format_i() {
     let config = ClientConfig::builder().out_format_forwards_i(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args: Vec<_> = builder
-        .build("/path")
+        .build(std::ffi::OsStr::new("/path"))
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
@@ -1360,7 +1381,7 @@ fn explicit_out_format_with_i_forwards_log_format_i() {
 fn includes_size_only_long_arg() {
     let config = ClientConfig::builder().size_only(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--size-only"),
@@ -1378,7 +1399,7 @@ fn includes_no_implied_dirs_when_disabled() {
         .implied_dirs(false)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         args.iter().any(|a| a == "--no-implied-dirs"),
@@ -1390,7 +1411,7 @@ fn includes_no_implied_dirs_when_disabled() {
 fn omits_no_implied_dirs_when_default() {
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         !args.iter().any(|a| a == "--no-implied-dirs"),
@@ -1408,7 +1429,7 @@ fn omits_no_implied_dirs_when_disabled_without_relative_paths() {
     let config = ClientConfig::builder().implied_dirs(false).build();
     assert!(!config.relative_paths());
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     assert!(
         !args.iter().any(|a| a == "--no-implied-dirs"),
@@ -1420,7 +1441,7 @@ fn omits_no_implied_dirs_when_disabled_without_relative_paths() {
 fn includes_dry_run_flag() {
     let config = ClientConfig::builder().dry_run(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
+    let args = builder.build(std::ffi::OsStr::new("/path"));
 
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('n'), "expected 'n' in flags: {flags}");
@@ -1430,7 +1451,7 @@ fn includes_dry_run_flag() {
 fn secluded_invocation_disabled_returns_normal_args() {
     let config = ClientConfig::builder().protect_args(None).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let secluded = builder.build_secluded(&["/path"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/path")]);
 
     assert!(
         secluded.stdin_args.is_empty(),
@@ -1453,7 +1474,7 @@ fn secluded_invocation_enabled_keeps_flags_and_capability_on_command_line() {
     // send_protected_args()).
     let config = ClientConfig::builder().protect_args(Some(true)).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let secluded = builder.build_secluded(&["/path/to/files"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/path/to/files")]);
 
     let cmd_strs: Vec<String> = secluded
         .command_line_args
@@ -1496,10 +1517,10 @@ fn secluded_invocation_enabled_keeps_flags_and_capability_on_command_line() {
         "stdin_args should contain the '.' separator"
     );
     assert!(
-        !secluded
-            .stdin_args
-            .iter()
-            .any(|a| a.starts_with('-') && a.contains('s') && a.len() > 2),
+        !secluded.stdin_args.iter().any(|a| {
+            let a = a.to_string_lossy();
+            a.starts_with('-') && a.contains('s') && a.len() > 2
+        }),
         "the compact flag string must not be duplicated over stdin: {:?}",
         secluded.stdin_args
     );
@@ -1509,7 +1530,7 @@ fn secluded_invocation_enabled_keeps_flags_and_capability_on_command_line() {
 fn secluded_invocation_pull_includes_sender_flag() {
     let config = ClientConfig::builder().protect_args(Some(true)).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let secluded = builder.build_secluded(&["/remote/src"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/remote/src")]);
 
     let cmd_strs: Vec<String> = secluded
         .command_line_args
@@ -1546,13 +1567,13 @@ fn secluded_invocation_stdin_args_omit_flag_string_and_defer_long_form() {
         .ignore_errors(true)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let secluded = builder.build_secluded(&["/data"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/data")]);
 
     assert!(
-        !secluded
-            .stdin_args
-            .iter()
-            .any(|a| a.starts_with('-') && !a.starts_with("--") && a.len() > 1),
+        !secluded.stdin_args.iter().any(|a| {
+            let a = a.to_string_lossy();
+            a.starts_with('-') && !a.starts_with("--") && a.len() > 1
+        }),
         "stdin_args must not contain the compact flag string: {:?}",
         secluded.stdin_args
     );
@@ -1579,7 +1600,7 @@ fn secluded_invocation_stdin_args_omit_flag_string_and_defer_long_form() {
 fn secluded_invocation_explicitly_disabled_returns_normal() {
     let config = ClientConfig::builder().protect_args(Some(false)).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let secluded = builder.build_secluded(&["/path"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/path")]);
 
     assert!(
         secluded.stdin_args.is_empty(),
@@ -1610,7 +1631,7 @@ fn secluded_invocation_locks_cmdline_and_stdin_sequence() {
         .inc_recursive_send(false)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let secluded = builder.build_secluded(&["/data"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/data")]);
 
     let cmd_strs: Vec<String> = secluded
         .command_line_args
@@ -1635,10 +1656,10 @@ fn secluded_invocation_locks_cmdline_and_stdin_sequence() {
     assert_eq!(
         secluded.stdin_args,
         vec![
-            "rsync".to_owned(),
-            "--ignore-errors".to_owned(),
-            ".".to_owned(),
-            "/data".to_owned(),
+            OsString::from("rsync"),
+            OsString::from("--ignore-errors"),
+            OsString::from("."),
+            OsString::from("/data"),
         ],
         "stdin must hold exactly the synthetic arg0, the deferred \
          long-form tail, the '.' separator, and the path"
@@ -1655,7 +1676,7 @@ fn secluded_invocation_locks_cmdline_and_stdin_sequence() {
 fn build_sender_args(config: &ClientConfig) -> Vec<String> {
     let builder = RemoteInvocationBuilder::new(config, RemoteRole::Sender);
     builder
-        .build("/path")
+        .build(std::ffi::OsStr::new("/path"))
         .into_iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect()
@@ -1702,7 +1723,7 @@ fn sender_flag_string(config: &ClientConfig) -> String {
 fn build_receiver_args(config: &ClientConfig) -> Vec<String> {
     let builder = RemoteInvocationBuilder::new(config, RemoteRole::Receiver);
     builder
-        .build("/path")
+        .build(std::ffi::OsStr::new("/path"))
         .into_iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect()
@@ -2900,7 +2921,11 @@ fn build_with_multiple_paths() {
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args: Vec<String> = builder
-        .build_with_paths(&["/src1", "/src2", "/src3"])
+        .build_with_paths(&[
+            std::ffi::OsStr::new("/src1"),
+            std::ffi::OsStr::new("/src2"),
+            std::ffi::OsStr::new("/src3"),
+        ])
         .into_iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
@@ -3447,56 +3472,58 @@ fn all_flags_enabled_produces_valid_invocation() {
 
 #[test]
 fn local_absolute_path_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new("/tmp/foo")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new("/tmp/foo")));
 }
 
 #[test]
 fn local_relative_path_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new("./relative/path")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new("./relative/path")));
 }
 
 #[test]
 fn local_bare_filename_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new("file.txt")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new("file.txt")));
 }
 
 #[test]
 fn local_path_with_colon_after_slash_is_not_remote() {
     // Colon appears after a slash, so the before-colon part contains '/'.
     // upstream: main.c - only treat as remote if no slash before colon.
-    assert!(!operand_is_remote(OsStr::new("/foo:bar")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new("/foo:bar")));
 }
 
 #[test]
 fn local_path_with_colon_after_backslash_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new("dir\\sub:file")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new("dir\\sub:file")));
 }
 
 #[test]
 fn local_path_nested_colon_after_slash_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new("/a/b/c:d")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new("/a/b/c:d")));
 }
 
 #[test]
 fn local_dot_path_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new(".")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new(".")));
 }
 
 #[test]
 fn local_parent_path_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new("..")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new("..")));
 }
 
 #[cfg(windows)]
 #[test]
 fn windows_drive_letter_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new("C:\\Windows\\path")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new(
+        "C:\\Windows\\path"
+    )));
 }
 
 #[cfg(windows)]
 #[test]
 fn windows_drive_letter_forward_slash_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new("D:/Users/test")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new("D:/Users/test")));
 }
 
 #[cfg(not(windows))]
@@ -3504,82 +3531,92 @@ fn windows_drive_letter_forward_slash_is_not_remote() {
 fn single_letter_colon_on_unix_is_remote() {
     // On Unix, "C:" looks like host:path with empty path - treated as remote.
     // Only Windows has the drive letter exemption.
-    assert!(operand_is_remote(OsStr::new("C:")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("C:")));
 }
 
 #[test]
 fn rsync_url_is_remote() {
-    assert!(operand_is_remote(OsStr::new("rsync://host/module/path")));
+    assert!(operand_is_remote(std::ffi::OsStr::new(
+        "rsync://host/module/path"
+    )));
 }
 
 #[test]
 fn rsync_url_with_user_is_remote() {
-    assert!(operand_is_remote(OsStr::new("rsync://user@host/module")));
+    assert!(operand_is_remote(std::ffi::OsStr::new(
+        "rsync://user@host/module"
+    )));
 }
 
 #[test]
 fn rsync_url_bare_host_is_remote() {
-    assert!(operand_is_remote(OsStr::new("rsync://host")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("rsync://host")));
 }
 
 #[test]
 fn ssh_url_is_remote() {
-    assert!(operand_is_remote(OsStr::new("ssh://host/path")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("ssh://host/path")));
 }
 
 #[test]
 fn ssh_url_with_user_is_remote() {
-    assert!(operand_is_remote(OsStr::new("ssh://user@host/path")));
+    assert!(operand_is_remote(std::ffi::OsStr::new(
+        "ssh://user@host/path"
+    )));
 }
 
 #[test]
 fn ssh_url_with_port_is_remote() {
-    assert!(operand_is_remote(OsStr::new("ssh://user@host:22/path")));
+    assert!(operand_is_remote(std::ffi::OsStr::new(
+        "ssh://user@host:22/path"
+    )));
 }
 
 #[test]
 fn ssh_url_bare_host_is_remote() {
-    assert!(operand_is_remote(OsStr::new("ssh://host")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("ssh://host")));
 }
 
 #[test]
 fn host_colon_path_is_remote() {
-    assert!(operand_is_remote(OsStr::new("host:path")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("host:path")));
 }
 
 #[test]
 fn user_at_host_colon_path_is_remote() {
-    assert!(operand_is_remote(OsStr::new("user@host:path")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("user@host:path")));
 }
 
 #[test]
 fn host_colon_empty_path_is_remote() {
-    assert!(operand_is_remote(OsStr::new("host:")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("host:")));
 }
 
 #[test]
 fn ip_colon_path_is_remote() {
-    assert!(operand_is_remote(OsStr::new("192.168.1.1:/data")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("192.168.1.1:/data")));
 }
 
 #[test]
 fn host_double_colon_module_is_remote() {
-    assert!(operand_is_remote(OsStr::new("host::module")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("host::module")));
 }
 
 #[test]
 fn user_at_host_double_colon_module_is_remote() {
-    assert!(operand_is_remote(OsStr::new("user@host::module")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("user@host::module")));
 }
 
 #[test]
 fn host_double_colon_module_path_is_remote() {
-    assert!(operand_is_remote(OsStr::new("host::module/subdir")));
+    assert!(operand_is_remote(std::ffi::OsStr::new(
+        "host::module/subdir"
+    )));
 }
 
 #[test]
 fn empty_string_is_not_remote() {
-    assert!(!operand_is_remote(OsStr::new("")));
+    assert!(!operand_is_remote(std::ffi::OsStr::new("")));
 }
 
 #[test]
@@ -3587,13 +3624,13 @@ fn http_url_is_not_classified_as_ssh() {
     // "http://foo" has a colon, but the before-colon part ("http") contains
     // no '/' or '\', so it is treated as host:path (remote).
     // This matches upstream rsync behavior - http:// is not special-cased.
-    assert!(operand_is_remote(OsStr::new("http://foo")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("http://foo")));
 }
 
 #[test]
 fn ftp_url_is_not_special_cased() {
     // Same as http:// - upstream rsync treats any host:path as remote.
-    assert!(operand_is_remote(OsStr::new("ftp://foo")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("ftp://foo")));
 }
 
 #[test]
@@ -3601,26 +3638,26 @@ fn uppercase_ssh_url_is_not_recognized() {
     // Only lowercase "ssh://" triggers the URL check. Uppercase "SSH://"
     // falls through to the colon-based check where "SSH" has no '/' or '\'
     // before the colon, so it is treated as host:path (remote) anyway.
-    assert!(operand_is_remote(OsStr::new("SSH://host/path")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("SSH://host/path")));
 }
 
 #[test]
 fn uppercase_rsync_url_is_not_recognized_as_url() {
     // "RSYNC://host" - "RSYNC" has no slash before colon, treated as remote.
-    assert!(operand_is_remote(OsStr::new("RSYNC://host")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("RSYNC://host")));
 }
 
 #[test]
 fn path_with_only_colons_double_is_remote() {
     // "::" contains double-colon, so it is treated as remote daemon syntax.
-    assert!(operand_is_remote(OsStr::new("::")));
+    assert!(operand_is_remote(std::ffi::OsStr::new("::")));
 }
 
 #[test]
 fn path_with_single_colon_only_is_remote() {
     // ":" has a colon with empty before and after parts. Empty before has no
     // '/' or '\', so it falls through to remote classification.
-    assert!(operand_is_remote(OsStr::new(":")));
+    assert!(operand_is_remote(std::ffi::OsStr::new(":")));
 }
 
 #[test]
@@ -3686,7 +3723,7 @@ fn daemon_double_colon_to_local_is_pull() {
 fn iconv_unspecified_omits_iconv_arg() {
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         !args
             .iter()
@@ -3701,7 +3738,7 @@ fn iconv_disabled_omits_iconv_arg() {
         .iconv(IconvSetting::Disabled)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         !args
             .iter()
@@ -3716,7 +3753,7 @@ fn iconv_locale_default_forwards_dot() {
         .iconv(IconvSetting::LocaleDefault)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         args.iter().any(|a| a == "--iconv=."),
         "LocaleDefault must forward --iconv=.: {args:?}"
@@ -3735,7 +3772,7 @@ fn iconv_explicit_pair_forwards_only_remote_half() {
         })
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         args.iter().any(|a| a == "--iconv=ISO-8859-1"),
         "Explicit pair must forward only the remote half: {args:?}"
@@ -3757,7 +3794,7 @@ fn iconv_explicit_single_forwards_whole_spec() {
         })
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         args.iter().any(|a| a == "--iconv=UTF-8"),
         "Explicit single must forward the whole spec: {args:?}"
@@ -3771,53 +3808,93 @@ fn iconv_explicit_single_forwards_whole_spec() {
 
 use super::builder::{shell_safe_filename_arg, shell_safe_filename_arg_with_tilde};
 
+/// `&str` test wrappers around the byte-native escape helpers.
+fn shell_safe(arg: &str) -> OsString {
+    shell_safe_filename_arg(std::ffi::OsStr::new(arg))
+}
+fn shell_safe_tilde(arg: &str, escape_leading_tilde: bool) -> OsString {
+    shell_safe_filename_arg_with_tilde(std::ffi::OsStr::new(arg), escape_leading_tilde)
+}
+
 #[test]
 fn shell_safe_simple_path_unchanged() {
-    assert_eq!(shell_safe_filename_arg("/simple/path"), "/simple/path");
+    assert_eq!(shell_safe("/simple/path"), "/simple/path");
+}
+
+/// A non-UTF-8 operand round-trips byte-identically through
+/// `determine_transfer_role` -> `shell_safe_filename_arg`: the raw path byte
+/// (`0xFF`, a legal Unix filename byte rsync carries as `char*`) survives, and
+/// the ASCII shell metacharacter beside it is still escaped. Fails pre-fix,
+/// where the operand was lossily decoded to U+FFFD before escaping ran.
+#[cfg(unix)]
+#[test]
+fn shell_safe_preserves_non_utf8_operand_bytes() {
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    // Operand `host:/a<FF>b)c` as it arrives from argv.
+    let mut operand = b"host:/a".to_vec();
+    operand.push(0xFF);
+    operand.extend_from_slice(b"b)c");
+    let sources = [OsString::from_vec(operand)];
+    let dest = OsString::from("/local/dest");
+
+    let spec = determine_transfer_role(&sources, &dest).unwrap();
+    let TransferSpec::Pull { remote_sources, .. } = spec else {
+        panic!("expected a pull");
+    };
+    let RemoteOperands::Single(operand) = remote_sources else {
+        panic!("expected a single source");
+    };
+
+    let parsed = rsync_io::ssh::parse_ssh_operand(&operand).unwrap();
+    let escaped = shell_safe_filename_arg(parsed.path());
+
+    // `)` is escaped; the raw 0xFF byte is preserved verbatim.
+    let mut expected = b"/a".to_vec();
+    expected.push(0xFF);
+    expected.extend_from_slice(b"b\\)c");
+    assert_eq!(escaped.as_bytes(), &expected[..]);
 }
 
 #[test]
 fn shell_safe_escapes_parentheses() {
     // upstream: SHELL_CHARS includes '(' and ')'
     assert_eq!(
-        shell_safe_filename_arg("/dir/A weird)name/file"),
+        shell_safe("/dir/A weird)name/file"),
         "/dir/A\\ weird\\)name/file"
     );
 }
 
 #[test]
 fn shell_safe_escapes_spaces() {
-    assert_eq!(
-        shell_safe_filename_arg("/dir/has space/file"),
-        "/dir/has\\ space/file"
-    );
+    assert_eq!(shell_safe("/dir/has space/file"), "/dir/has\\ space/file");
 }
 
 #[test]
 fn shell_safe_escapes_shell_metacharacters() {
-    assert_eq!(shell_safe_filename_arg("a&b"), "a\\&b");
-    assert_eq!(shell_safe_filename_arg("a;b"), "a\\;b");
-    assert_eq!(shell_safe_filename_arg("a|b"), "a\\|b");
-    assert_eq!(shell_safe_filename_arg("a<b"), "a\\<b");
-    assert_eq!(shell_safe_filename_arg("a>b"), "a\\>b");
-    assert_eq!(shell_safe_filename_arg("a{b}"), "a\\{b\\}");
-    assert_eq!(shell_safe_filename_arg("a\"b"), "a\\\"b");
-    assert_eq!(shell_safe_filename_arg("a'b"), "a\\'b");
-    assert_eq!(shell_safe_filename_arg("a`b"), "a\\`b");
-    assert_eq!(shell_safe_filename_arg("a#b"), "a\\#b");
-    assert_eq!(shell_safe_filename_arg("a$b"), "a\\$b");
-    assert_eq!(shell_safe_filename_arg("a!b"), "a\\!b");
+    assert_eq!(shell_safe("a&b"), "a\\&b");
+    assert_eq!(shell_safe("a;b"), "a\\;b");
+    assert_eq!(shell_safe("a|b"), "a\\|b");
+    assert_eq!(shell_safe("a<b"), "a\\<b");
+    assert_eq!(shell_safe("a>b"), "a\\>b");
+    assert_eq!(shell_safe("a{b}"), "a\\{b\\}");
+    assert_eq!(shell_safe("a\"b"), "a\\\"b");
+    assert_eq!(shell_safe("a'b"), "a\\'b");
+    assert_eq!(shell_safe("a`b"), "a\\`b");
+    assert_eq!(shell_safe("a#b"), "a\\#b");
+    assert_eq!(shell_safe("a$b"), "a\\$b");
+    assert_eq!(shell_safe("a!b"), "a\\!b");
 }
 
 #[test]
 fn shell_safe_escapes_tab() {
-    assert_eq!(shell_safe_filename_arg("a\tb"), "a\\\tb");
+    assert_eq!(shell_safe("a\tb"), "a\\\tb");
 }
 
 #[test]
 fn shell_safe_leading_dash_gets_dot_slash() {
     // upstream: safe_arg prepends "./" to prevent option interpretation
-    assert_eq!(shell_safe_filename_arg("-file"), "./-file");
+    assert_eq!(shell_safe("-file"), "./-file");
 }
 
 #[test]
@@ -3825,8 +3902,8 @@ fn shell_safe_leading_tilde_unescaped_when_not_requested() {
     // The plain wrapper - and a push, where escape_leading_tilde is false -
     // leaves a leading ~ untouched, matching upstream which lets the remote
     // expand ~ on the destination.
-    assert_eq!(shell_safe_filename_arg("~foo"), "~foo");
-    assert_eq!(shell_safe_filename_arg_with_tilde("~foo", false), "~foo");
+    assert_eq!(shell_safe("~foo"), "~foo");
+    assert_eq!(shell_safe_tilde("~foo", false), "~foo");
 }
 
 #[test]
@@ -3834,29 +3911,29 @@ fn shell_safe_leading_tilde_escaped_when_requested() {
     // upstream: options.c:2553-2558 / :2581 - on a pull the leading ~ of a
     // bare-name source path is backslash-escaped to \~foo so the remote shell
     // does not tilde-expand a path literally named ~foo.
-    assert_eq!(shell_safe_filename_arg_with_tilde("~foo", true), "\\~foo");
+    assert_eq!(shell_safe_tilde("~foo", true), "\\~foo");
 }
 
 #[test]
 fn shell_safe_tilde_escape_only_affects_leading_tilde() {
     // A ~ that is not the first character is ordinary (not a SHELL_CHARS
     // member) and is left as-is even when tilde escaping is requested.
-    assert_eq!(shell_safe_filename_arg_with_tilde("a~b", true), "a~b");
+    assert_eq!(shell_safe_tilde("a~b", true), "a~b");
 }
 
 #[test]
 fn shell_safe_backslash_not_before_wildcard_is_escaped() {
     // upstream: backslash is escaped unless followed by a wildcard char
-    assert_eq!(shell_safe_filename_arg("a\\b"), "a\\\\b");
+    assert_eq!(shell_safe("a\\b"), "a\\\\b");
 }
 
 #[test]
 fn shell_safe_backslash_before_wildcard_is_preserved() {
     // upstream: backslash before wildcard chars (*?[]) is NOT escaped
-    assert_eq!(shell_safe_filename_arg("a\\*b"), "a\\*b");
-    assert_eq!(shell_safe_filename_arg("a\\?b"), "a\\?b");
-    assert_eq!(shell_safe_filename_arg("a\\[b"), "a\\[b");
-    assert_eq!(shell_safe_filename_arg("a\\]b"), "a\\]b");
+    assert_eq!(shell_safe("a\\*b"), "a\\*b");
+    assert_eq!(shell_safe("a\\?b"), "a\\?b");
+    assert_eq!(shell_safe("a\\[b"), "a\\[b");
+    assert_eq!(shell_safe("a\\]b"), "a\\]b");
 }
 
 #[test]
@@ -3864,7 +3941,7 @@ fn shell_safe_no_escaping_in_secluded_mode() {
     // When protect_args is active, stdin_args should NOT be shell-escaped
     let config = ClientConfig::builder().protect_args(Some(true)).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let secluded = builder.build_secluded(&["/path/A weird)name/"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/path/A weird)name/")]);
 
     assert!(
         secluded
@@ -3881,7 +3958,7 @@ fn shell_safe_escaping_in_normal_mode() {
     // When protect_args is off, command_line_args should have escaped paths
     let config = ClientConfig::builder().protect_args(None).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let secluded = builder.build_secluded(&["/path/A weird)name/"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/path/A weird)name/")]);
 
     assert!(
         secluded
@@ -3904,7 +3981,7 @@ fn old_args_level_one_skips_filename_escaping() {
         .old_args(Some(1))
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let secluded = builder.build_secluded(&["/path/A weird)name/"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/path/A weird)name/")]);
 
     assert!(
         secluded
@@ -3927,7 +4004,7 @@ fn old_args_level_two_skips_filename_escaping() {
         .old_args(Some(2))
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let secluded = builder.build_secluded(&["/path/A weird)name/"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/path/A weird)name/")]);
 
     assert!(
         secluded
@@ -4055,13 +4132,13 @@ fn stop_at_forwarded_in_secluded_mode() {
         .protect_args(Some(true))
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let secluded = builder.build_secluded(&["/path"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/path")]);
 
     assert!(
         secluded
             .stdin_args
             .iter()
-            .any(|a| a.starts_with("--stop-at=")),
+            .any(|a| a.to_string_lossy().starts_with("--stop-at=")),
         "secluded stdin_args should contain --stop-at=: {:?}",
         secluded.stdin_args
     );
@@ -4254,7 +4331,7 @@ fn remote_options_included_in_secluded_stdin_args() {
         .remote_options(vec!["--bwlimit=500"])
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let secluded = builder.build_secluded(&["/data"]);
+    let secluded = builder.build_secluded(&[std::ffi::OsStr::new("/data")]);
 
     assert!(
         secluded.stdin_args.iter().any(|a| a == "--bwlimit=500"),
@@ -4301,7 +4378,7 @@ fn push_with_local_files_from_omits_remote_arg() {
         .build();
     // RemoteRole::Sender == local is sender (push).
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/remote/dest");
+    let args = builder.build(std::ffi::OsStr::new("/remote/dest"));
 
     assert!(
         !args.iter().any(|a| {
@@ -4328,7 +4405,7 @@ fn push_with_stdin_files_from_omits_remote_arg() {
         .from0(true)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/remote/dest");
+    let args = builder.build(std::ffi::OsStr::new("/remote/dest"));
 
     assert!(
         !args.iter().any(|a| {
@@ -4350,7 +4427,7 @@ fn push_with_remote_files_from_forwards_path() {
         .files_from(FilesFromSource::RemoteFile("/remote/list.txt".to_owned()))
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/remote/dest");
+    let args = builder.build(std::ffi::OsStr::new("/remote/dest"));
 
     assert!(
         args.iter()
@@ -4372,7 +4449,7 @@ fn pull_with_local_files_from_sends_files_from_stdin_to_remote() {
         .build();
     // RemoteRole::Receiver == local is receiver (pull).
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/source");
+    let args = builder.build(std::ffi::OsStr::new("/remote/source"));
 
     assert!(
         args.iter().any(|a| a == "--files-from=-"),
@@ -4399,7 +4476,7 @@ fn pull_with_files_from_no_relative_forwards_no_relative_and_omits_r() {
         .relative_paths(false)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/source");
+    let args = builder.build(std::ffi::OsStr::new("/remote/source"));
 
     assert!(
         args.iter().any(|a| a == "--no-relative"),
@@ -4425,7 +4502,7 @@ fn pull_with_files_from_relative_packs_r_and_omits_no_relative() {
         .relative_paths(true)
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/source");
+    let args = builder.build(std::ffi::OsStr::new("/remote/source"));
 
     assert!(
         !args.iter().any(|a| a == "--no-relative"),
@@ -4448,7 +4525,7 @@ fn pull_with_remote_files_from_forwards_path() {
         .files_from(FilesFromSource::RemoteFile("/remote/list.txt".to_owned()))
         .build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/source");
+    let args = builder.build(std::ffi::OsStr::new("/remote/source"));
 
     assert!(
         args.iter()
@@ -4464,14 +4541,15 @@ fn ssh_forwards_use_qsort_when_set() {
     let config = ClientConfig::builder().qsort(true).build();
     for role in [RemoteRole::Sender, RemoteRole::Receiver] {
         let builder = RemoteInvocationBuilder::new(&config, role);
-        let args = builder.build("/remote/path");
+        let args = builder.build(std::ffi::OsStr::new("/remote/path"));
         assert!(
             args.iter().any(|a| a == "--use-qsort"),
             "qsort must forward --use-qsort ({role:?}): {args:?}"
         );
     }
     let off = ClientConfig::builder().build();
-    let args = RemoteInvocationBuilder::new(&off, RemoteRole::Sender).build("/remote/path");
+    let args = RemoteInvocationBuilder::new(&off, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(!args.iter().any(|a| a == "--use-qsort"));
 }
 
@@ -4481,19 +4559,22 @@ fn ssh_forwards_use_qsort_when_set() {
 #[test]
 fn ssh_forwards_super_on_push_only() {
     let config = ClientConfig::builder().super_user(true).build();
-    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/remote/path");
+    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         push.iter().any(|a| a == "--super"),
         "push must forward --super: {push:?}"
     );
-    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/remote/path");
+    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         !pull.iter().any(|a| a == "--super"),
         "pull must not forward --super: {pull:?}"
     );
     // Not requested: never forwarded.
     let off = ClientConfig::builder().build();
-    let args = RemoteInvocationBuilder::new(&off, RemoteRole::Sender).build("/remote/path");
+    let args = RemoteInvocationBuilder::new(&off, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(!args.iter().any(|a| a == "--super"));
 }
 
@@ -4503,18 +4584,21 @@ fn ssh_forwards_super_on_push_only() {
 #[test]
 fn ssh_forwards_stats_on_push_only() {
     let config = ClientConfig::builder().stats(true).build();
-    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/remote/path");
+    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         push.iter().any(|a| a == "--stats"),
         "push must forward --stats: {push:?}"
     );
-    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/remote/path");
+    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         !pull.iter().any(|a| a == "--stats"),
         "pull must not forward --stats: {pull:?}"
     );
     let off = ClientConfig::builder().build();
-    let args = RemoteInvocationBuilder::new(&off, RemoteRole::Sender).build("/remote/path");
+    let args = RemoteInvocationBuilder::new(&off, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(!args.iter().any(|a| a == "--stats"));
 }
 
@@ -4529,12 +4613,14 @@ fn ssh_forwards_info_and_debug_when_set() {
         .info_flags([OsString::from("del1")])
         .debug_flags([OsString::from("send1")])
         .build();
-    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/remote/path");
+    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         push.iter().any(|a| a == "--info=del"),
         "push must forward receiver-side --info=del: {push:?}"
     );
-    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/remote/path");
+    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         pull.iter().any(|a| a == "--debug=send"),
         "pull must forward sender-side --debug=send: {pull:?}"
@@ -4542,7 +4628,8 @@ fn ssh_forwards_info_and_debug_when_set() {
 
     // Nothing set: no --info / --debug argument at all.
     let off = ClientConfig::builder().build();
-    let args = RemoteInvocationBuilder::new(&off, RemoteRole::Sender).build("/remote/path");
+    let args = RemoteInvocationBuilder::new(&off, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/remote/path"));
     assert!(
         !args
             .iter()
@@ -5048,7 +5135,7 @@ mod oc_flag_forwarding {
 
     fn build_args(config: &ClientConfig, role: RemoteRole) -> Vec<String> {
         RemoteInvocationBuilder::new(config, role)
-            .build("/remote/path")
+            .build(std::ffi::OsStr::new("/remote/path"))
             .into_iter()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect()

--- a/crates/core/src/client/remote/invocation/transfer_role.rs
+++ b/crates/core/src/client/remote/invocation/transfer_role.rs
@@ -167,20 +167,18 @@ pub fn determine_transfer_role(
 
             validate_same_host(&parsed_sources)?;
 
+            // Preserve the operand bytes verbatim (a non-UTF-8 remote path is a
+            // legal Unix filename); host/user validation above already ran on a
+            // lossy copy, which is fine because those components are ASCII.
             let remote_sources = if sources.len() > 1 {
-                RemoteOperands::Multiple(
-                    sources
-                        .iter()
-                        .map(|s| s.to_string_lossy().to_string())
-                        .collect(),
-                )
+                RemoteOperands::Multiple(sources.to_vec())
             } else {
-                RemoteOperands::Single(sources[0].to_string_lossy().to_string())
+                RemoteOperands::Single(sources[0].clone())
             };
 
             Ok(TransferSpec::Proxy {
                 remote_sources,
-                remote_dest: destination.to_string_lossy().to_string(),
+                remote_dest: destination.clone(),
             })
         }
         (false, false) => Err(invalid_argument_error("no remote operand found", 1)),
@@ -200,17 +198,15 @@ pub fn determine_transfer_role(
 
             validate_same_host(&parsed_sources)?;
 
-            let local_dest = destination.to_string_lossy().to_string();
+            let local_dest = destination.clone();
 
+            // Preserve the operand bytes verbatim (a non-UTF-8 remote path is a
+            // legal Unix filename); host/user validation above already ran on a
+            // lossy copy, which is fine because those components are ASCII.
             let remote_sources = if sources.len() > 1 {
-                RemoteOperands::Multiple(
-                    sources
-                        .iter()
-                        .map(|s| s.to_string_lossy().to_string())
-                        .collect(),
-                )
+                RemoteOperands::Multiple(sources.to_vec())
             } else {
-                RemoteOperands::Single(sources[0].to_string_lossy().to_string())
+                RemoteOperands::Single(sources[0].clone())
             };
 
             Ok(TransferSpec::Pull {
@@ -218,16 +214,9 @@ pub fn determine_transfer_role(
                 local_dest,
             })
         }
-        (false, true) => {
-            let local_sources: Vec<String> = sources
-                .iter()
-                .map(|s| s.to_string_lossy().to_string())
-                .collect();
-
-            Ok(TransferSpec::Push {
-                local_sources,
-                remote_dest: destination.to_string_lossy().to_string(),
-            })
-        }
+        (false, true) => Ok(TransferSpec::Push {
+            local_sources: sources.to_vec(),
+            remote_dest: destination.clone(),
+        }),
     }
 }

--- a/crates/core/src/client/remote/remote_to_remote.rs
+++ b/crates/core/src/client/remote/remote_to_remote.rs
@@ -53,7 +53,7 @@ use crate::exit_code::ExitCode;
 ///
 /// Returned by `parse_source_operands` to encapsulate all connection details
 /// extracted from remote source operand(s).
-type SourceConnectionInfo = (String, Option<String>, Option<u16>, Vec<String>);
+type SourceConnectionInfo = (String, Option<String>, Option<u16>, Vec<OsString>);
 
 /// Statistics from a proxy transfer.
 #[derive(Debug, Default)]
@@ -80,7 +80,7 @@ struct ProxyStats {
 pub fn run_remote_to_remote_transfer(
     config: &ClientConfig,
     remote_sources: RemoteOperands,
-    remote_dest: String,
+    remote_dest: OsString,
 ) -> Result<ClientSummary, ClientError> {
     let (source_host, source_user, source_port, source_paths) =
         parse_source_operands(&remote_sources)?;
@@ -107,26 +107,26 @@ pub fn run_remote_to_remote_transfer(
 /// Parses source operand(s) and extracts connection info.
 fn parse_source_operands(operands: &RemoteOperands) -> Result<SourceConnectionInfo, ClientError> {
     match operands {
-        RemoteOperands::Single(operand_str) => {
-            let operand = parse_ssh_operand(OsStr::new(operand_str))
+        RemoteOperands::Single(operand) => {
+            let parsed = parse_ssh_operand(operand)
                 .map_err(|e| invalid_argument_error(&format!("invalid source operand: {e}"), 1))?;
             Ok((
-                operand.host().to_owned(),
-                operand.user().map(String::from),
-                operand.port(),
-                vec![operand.path().to_owned()],
+                parsed.host().to_owned(),
+                parsed.user().map(String::from),
+                parsed.port(),
+                vec![parsed.path().to_os_string()],
             ))
         }
-        RemoteOperands::Multiple(operand_strs) => {
-            let first = parse_ssh_operand(OsStr::new(&operand_strs[0]))
+        RemoteOperands::Multiple(operands) => {
+            let first = parse_ssh_operand(&operands[0])
                 .map_err(|e| invalid_argument_error(&format!("invalid source operand: {e}"), 1))?;
 
-            let mut paths = Vec::with_capacity(operand_strs.len());
-            for operand_str in operand_strs {
-                let operand = parse_ssh_operand(OsStr::new(operand_str)).map_err(|e| {
+            let mut paths = Vec::with_capacity(operands.len());
+            for operand in operands {
+                let parsed = parse_ssh_operand(operand).map_err(|e| {
                     invalid_argument_error(&format!("invalid source operand: {e}"), 1)
                 })?;
-                paths.push(operand.path().to_owned());
+                paths.push(parsed.path().to_os_string());
             }
 
             Ok((
@@ -141,31 +141,31 @@ fn parse_source_operands(operands: &RemoteOperands) -> Result<SourceConnectionIn
 
 /// Parses the destination operand and extracts connection info.
 fn parse_dest_operand(
-    operand_str: &str,
-) -> Result<(String, Option<String>, Option<u16>, String), ClientError> {
-    let operand = parse_ssh_operand(OsStr::new(operand_str))
+    operand: &OsStr,
+) -> Result<(String, Option<String>, Option<u16>, OsString), ClientError> {
+    let parsed = parse_ssh_operand(operand)
         .map_err(|e| invalid_argument_error(&format!("invalid destination operand: {e}"), 1))?;
     Ok((
-        operand.host().to_owned(),
-        operand.user().map(String::from),
-        operand.port(),
-        operand.path().to_owned(),
+        parsed.host().to_owned(),
+        parsed.user().map(String::from),
+        parsed.port(),
+        parsed.path().to_os_string(),
     ))
 }
 
 /// Builds the rsync invocation for the source (sender) side.
-fn build_source_invocation(config: &ClientConfig, paths: &[String]) -> Vec<OsString> {
+fn build_source_invocation(config: &ClientConfig, paths: &[OsString]) -> Vec<OsString> {
     let builder = RemoteInvocationBuilder::new(config, RemoteRole::Sender);
     if paths.len() == 1 {
         builder.build(&paths[0])
     } else {
-        let path_refs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+        let path_refs: Vec<&OsStr> = paths.iter().map(OsString::as_os_str).collect();
         builder.build_with_paths(&path_refs)
     }
 }
 
 /// Builds the rsync invocation for the destination (receiver) side.
-fn build_dest_invocation(config: &ClientConfig, path: &str) -> Vec<OsString> {
+fn build_dest_invocation(config: &ClientConfig, path: &OsStr) -> Vec<OsString> {
     let builder = RemoteInvocationBuilder::new(config, RemoteRole::Receiver);
     builder.build(path)
 }

--- a/crates/core/src/client/remote/remote_to_remote.rs
+++ b/crates/core/src/client/remote/remote_to_remote.rs
@@ -447,30 +447,34 @@ mod tests {
 
     #[test]
     fn parse_single_source_operand() {
-        let operands = RemoteOperands::Single("user@host:/path/to/file".to_string());
+        let operands = RemoteOperands::Single(OsString::from("user@host:/path/to/file"));
         let (host, user, port, paths) = parse_source_operands(&operands).unwrap();
         assert_eq!(host, "host");
         assert_eq!(user, Some("user".to_string()));
         assert_eq!(port, None);
-        assert_eq!(paths, vec!["/path/to/file"]);
+        assert_eq!(paths, vec![OsString::from("/path/to/file")]);
     }
 
     #[test]
     fn parse_multiple_source_operands() {
         let operands = RemoteOperands::Multiple(vec![
-            "user@host:/path/one".to_string(),
-            "user@host:/path/two".to_string(),
+            OsString::from("user@host:/path/one"),
+            OsString::from("user@host:/path/two"),
         ]);
         let (host, user, port, paths) = parse_source_operands(&operands).unwrap();
         assert_eq!(host, "host");
         assert_eq!(user, Some("user".to_string()));
         assert_eq!(port, None);
-        assert_eq!(paths, vec!["/path/one", "/path/two"]);
+        assert_eq!(
+            paths,
+            vec![OsString::from("/path/one"), OsString::from("/path/two")]
+        );
     }
 
     #[test]
     fn parse_dest_operand_basic() {
-        let (host, user, port, path) = parse_dest_operand("root@server:/backup").unwrap();
+        let (host, user, port, path) =
+            parse_dest_operand(std::ffi::OsStr::new("root@server:/backup")).unwrap();
         assert_eq!(host, "server");
         assert_eq!(user, Some("root".to_string()));
         assert_eq!(port, None);

--- a/crates/core/src/client/remote/ssh_transfer/connection.rs
+++ b/crates/core/src/client/remote/ssh_transfer/connection.rs
@@ -5,7 +5,7 @@
 //! secluded args over stdin when active (upstream:
 //! `rsync.c:283-320 send_protected_args()`).
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::time::Duration;
 
 use rsync_io::ssh::{SshCommand, SshConnection};
@@ -13,6 +13,23 @@ use rsync_io::ssh::{SshCommand, SshConnection};
 use super::super::super::config::ClientConfig;
 use super::super::super::error::{ClientError, invalid_argument_error};
 use super::super::ssh_address_family;
+
+/// Returns the raw bytes backing an `OsStr` for null-separated stdin
+/// transmission. On Unix this is the verbatim filesystem bytes
+/// (`OsStrExt::as_bytes`); other targets expose the WTF-8 encoding
+/// (`as_encoded_bytes`), which is exact for the Unicode operands they carry.
+#[inline]
+fn os_str_bytes(name: &OsStr) -> &[u8] {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        name.as_bytes()
+    }
+    #[cfg(not(unix))]
+    {
+        name.as_encoded_bytes()
+    }
+}
 
 /// Builds and spawns an SSH connection with the remote rsync invocation.
 ///
@@ -25,7 +42,7 @@ pub(super) fn build_ssh_connection(
     port: Option<u16>,
     invocation_args: &[OsString],
     config: &ClientConfig,
-    stdin_args: &[String],
+    stdin_args: &[OsString],
 ) -> Result<SshConnection, ClientError> {
     let mut ssh = SshCommand::new(host);
 
@@ -90,12 +107,13 @@ pub(super) fn build_ssh_connection(
     // applying iconvbufs(ic_send, ...) to each arg when iconv is configured
     // (compat.c:799-806 filesfrom_convert / protect-args iconv gating).
     if !stdin_args.is_empty() {
-        let arg_refs: Vec<&str> = stdin_args.iter().map(String::as_str).collect();
         // upstream: rsync.c:296-297 - DEBUG_GTE(CMD, 1) emits
         // `print_child_argv("protected args:", args + i + 1)` right before the
-        // per-arg `iconvbufs(ic_send, ...)` loop. `arg_refs` is the same
-        // payload we are about to ship over stdin.
-        protocol::cmd::trace_protected_args(&arg_refs);
+        // per-arg `iconvbufs(ic_send, ...)` loop. `stdin_args` is the same
+        // payload we are about to ship over stdin, carried as raw bytes so a
+        // non-UTF-8 remote path survives verbatim.
+        protocol::cmd::trace_protected_args(stdin_args);
+        let arg_bytes: Vec<&[u8]> = stdin_args.iter().map(|a| os_str_bytes(a)).collect();
         let iconv_converter = if config.protect_args().unwrap_or(false) {
             config.iconv().resolve_converter()
         } else {
@@ -103,7 +121,7 @@ pub(super) fn build_ssh_connection(
         };
         protocol::secluded_args::send_secluded_args(
             &mut connection,
-            &arg_refs,
+            &arg_bytes,
             iconv_converter.as_ref(),
         )
         .map_err(|e| {

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -5,6 +5,7 @@
 //! server over the SSH pipes and reaps the remote child. This mirrors the flow
 //! in upstream `main.c:do_cmd()` / `main.c:client_run()`.
 
+use std::ffi::OsString;
 use std::io::BufReader;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -156,7 +157,7 @@ pub fn run_ssh_transfer(
 fn run_pull_transfer(
     config: &ClientConfig,
     connection: SshConnection,
-    local_paths: &[String],
+    local_paths: &[OsString],
     source_paths: &[String],
     observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
@@ -229,7 +230,7 @@ fn run_pull_transfer(
 fn run_push_transfer(
     config: &ClientConfig,
     connection: SshConnection,
-    local_paths: &[String],
+    local_paths: &[OsString],
     observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
@@ -280,7 +281,7 @@ fn run_push_transfer(
 fn run_proxy_transfer(
     config: &ClientConfig,
     remote_sources: RemoteOperands,
-    remote_dest: String,
+    remote_dest: OsString,
     _observer: Option<&mut dyn ClientProgressObserver>,
 ) -> Result<ClientSummary, ClientError> {
     use super::super::remote_to_remote::run_remote_to_remote_transfer;

--- a/crates/core/src/client/remote/ssh_transfer/mod.rs
+++ b/crates/core/src/client/remote/ssh_transfer/mod.rs
@@ -49,6 +49,7 @@ pub(super) use server_config::{
 mod tests {
     use super::*;
     use connection::{should_warn_double_compression, warn_double_compression_once};
+    use std::ffi::OsString;
 
     use super::super::super::config::ClientConfig;
     use crate::server::ServerRole;
@@ -57,7 +58,7 @@ mod tests {
     fn builds_receiver_server_config() {
         let config = ClientConfig::builder().recursive(true).times(true).build();
 
-        let result = build_server_config_for_receiver(&config, &["dest/".to_owned()]);
+        let result = build_server_config_for_receiver(&config, &[OsString::from("dest/")]);
         assert!(result.is_ok());
 
         let server_config = result.unwrap();
@@ -79,7 +80,7 @@ mod tests {
             .prune_empty_dirs(true)
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest/".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest/")]).unwrap();
         assert!(server_config.flags.prune_empty_dirs);
     }
 
@@ -87,7 +88,7 @@ mod tests {
     fn receiver_server_config_prune_empty_dirs_default_false() {
         let config = ClientConfig::builder().recursive(true).times(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest/".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest/")]).unwrap();
         assert!(!server_config.flags.prune_empty_dirs);
     }
 
@@ -97,7 +98,7 @@ mod tests {
 
         let result = build_server_config_for_generator(
             &config,
-            &["file1.txt".to_owned(), "file2.txt".to_owned()],
+            &[OsString::from("file1.txt"), OsString::from("file2.txt")],
         );
         assert!(result.is_ok());
 
@@ -126,8 +127,9 @@ mod tests {
             .files_from(FilesFromSource::LocalFile(list_path.clone()))
             .build();
 
-        let server_config = build_server_config_for_generator(&config, &["/tmp/source".to_owned()])
-            .expect("generator config builds");
+        let server_config =
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")])
+                .expect("generator config builds");
 
         assert_eq!(
             server_config.file_selection.files_from_path.as_deref(),
@@ -150,8 +152,9 @@ mod tests {
             .from0(true)
             .build();
 
-        let server_config = build_server_config_for_generator(&config, &["/tmp/source".to_owned()])
-            .expect("generator config builds");
+        let server_config =
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")])
+                .expect("generator config builds");
 
         assert_eq!(
             server_config.file_selection.files_from_path.as_deref(),
@@ -172,8 +175,9 @@ mod tests {
             .files_from(FilesFromSource::RemoteFile("/remote/list.txt".to_owned()))
             .build();
 
-        let server_config = build_server_config_for_generator(&config, &["/tmp/source".to_owned()])
-            .expect("generator config builds");
+        let server_config =
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")])
+                .expect("generator config builds");
 
         assert_eq!(
             server_config.file_selection.files_from_path.as_deref(),
@@ -190,8 +194,9 @@ mod tests {
     fn generator_config_leaves_files_from_path_unset_when_disabled() {
         let config = ClientConfig::builder().recursive(true).build();
 
-        let server_config = build_server_config_for_generator(&config, &["/tmp/source".to_owned()])
-            .expect("generator config builds");
+        let server_config =
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")])
+                .expect("generator config builds");
 
         assert!(
             server_config.file_selection.files_from_path.is_none(),

--- a/crates/core/src/client/remote/ssh_transfer/parse.rs
+++ b/crates/core/src/client/remote/ssh_transfer/parse.rs
@@ -16,23 +16,24 @@ use super::super::invocation::{RemoteInvocationBuilder, RemoteOperands, RemoteRo
 ///
 /// Used by `parse_single_remote` and `parse_remote_operands` to return parsed
 /// remote connection information along with the rsync invocation arguments.
-/// The final `Vec<String>` contains arguments to send over stdin when
-/// secluded-args is active (empty when disabled).
+/// The final `Vec<OsString>` contains arguments to send over stdin when
+/// secluded-args is active (empty when disabled); it is `OsString` so a
+/// non-UTF-8 remote path ships verbatim.
 pub(super) type SshInvocationResult = (
     Vec<OsString>,
     String,
     Option<String>,
     Option<u16>,
-    Vec<String>,
+    Vec<OsString>,
 );
 
 /// Parses a single remote operand and builds the invocation args.
 pub(in crate::client::remote) fn parse_single_remote(
-    operand_str: &str,
+    operand: &OsStr,
     config: &ClientConfig,
     role: RemoteRole,
 ) -> Result<SshInvocationResult, ClientError> {
-    let operand = parse_ssh_operand(OsStr::new(operand_str))
+    let operand = parse_ssh_operand(operand)
         .map_err(|e| invalid_argument_error(&format!("invalid remote operand: {e}"), 1))?;
 
     let invocation_builder = RemoteInvocationBuilder::new(config, role);
@@ -54,21 +55,21 @@ pub(in crate::client::remote) fn parse_remote_operands(
     role: RemoteRole,
 ) -> Result<SshInvocationResult, ClientError> {
     match remote_operands {
-        RemoteOperands::Single(operand_str) => parse_single_remote(operand_str, config, role),
-        RemoteOperands::Multiple(operand_strs) => {
-            let first_operand = parse_ssh_operand(OsStr::new(&operand_strs[0]))
+        RemoteOperands::Single(operand) => parse_single_remote(operand, config, role),
+        RemoteOperands::Multiple(operands) => {
+            let first_operand = parse_ssh_operand(&operands[0])
                 .map_err(|e| invalid_argument_error(&format!("invalid remote operand: {e}"), 1))?;
 
-            let mut paths = Vec::new();
-            for operand_str in operand_strs {
-                let operand = parse_ssh_operand(OsStr::new(operand_str)).map_err(|e| {
+            let mut paths: Vec<OsString> = Vec::new();
+            for operand in operands {
+                let parsed = parse_ssh_operand(operand).map_err(|e| {
                     invalid_argument_error(&format!("invalid remote operand: {e}"), 1)
                 })?;
-                paths.push(operand.path().to_owned());
+                paths.push(parsed.path().to_os_string());
             }
 
             let invocation_builder = RemoteInvocationBuilder::new(config, role);
-            let path_refs: Vec<&str> = paths.iter().map(|s| s.as_ref()).collect();
+            let path_refs: Vec<&OsStr> = paths.iter().map(OsString::as_os_str).collect();
             let secluded = invocation_builder.build_secluded(&path_refs);
 
             Ok((
@@ -91,15 +92,19 @@ pub(in crate::client::remote) fn parse_remote_operands(
 pub(in crate::client::remote) fn remote_operand_source_paths(
     operands: &RemoteOperands,
 ) -> Result<Vec<String>, ClientError> {
-    let operand_strs: &[String] = match operands {
+    let operand_list: &[OsString] = match operands {
         RemoteOperands::Single(operand) => std::slice::from_ref(operand),
         RemoteOperands::Multiple(operands) => operands.as_slice(),
     };
-    operand_strs
+    // These feed the receiver-side implied-include check (CVE-2022-29154),
+    // which matches against the `String`-typed filter machinery; a lossy view
+    // is intentional here and independent of the byte-faithful operand that
+    // `parse_remote_operands` ships to the remote sender.
+    operand_list
         .iter()
         .map(|operand| {
-            parse_ssh_operand(OsStr::new(operand))
-                .map(|parsed| parsed.path().to_owned())
+            parse_ssh_operand(operand)
+                .map(|parsed| parsed.path().to_string_lossy().into_owned())
                 .map_err(|e| invalid_argument_error(&format!("invalid remote operand: {e}"), 1))
         })
         .collect()

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -314,7 +314,7 @@ mod tests {
     fn generator_config_carries_only_write_batch() {
         let config = config_with_batch_mode(engine::batch::BatchMode::OnlyWrite);
         let server_config =
-            build_server_config_for_generator(&config, &["src".to_owned()]).unwrap();
+            build_server_config_for_generator(&config, &[OsString::from("src")]).unwrap();
         assert!(server_config.flags.only_write_batch);
     }
 
@@ -325,7 +325,7 @@ mod tests {
     fn generator_config_leaves_plain_write_batch_on_the_wire() {
         let config = config_with_batch_mode(engine::batch::BatchMode::Write);
         let server_config =
-            build_server_config_for_generator(&config, &["src".to_owned()]).unwrap();
+            build_server_config_for_generator(&config, &[OsString::from("src")]).unwrap();
         assert!(!server_config.flags.only_write_batch);
     }
 
@@ -344,7 +344,7 @@ mod tests {
             .link_destination("/prev")
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.reference_directories.len(), 2);
         assert_eq!(
@@ -378,7 +378,7 @@ mod tests {
     fn receiver_config_without_alt_dest_has_no_reference_directories() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
         assert!(server_config.reference_directories.is_empty());
     }
 
@@ -397,7 +397,7 @@ mod tests {
             .backup_suffix(Some(".old"))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.backup);
         assert_eq!(server_config.backup_dir.as_deref(), Some("/bak"));
@@ -410,7 +410,7 @@ mod tests {
     fn receiver_config_without_backup_has_no_backup_dir() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.backup);
         assert!(server_config.backup_dir.is_none());
@@ -427,7 +427,7 @@ mod tests {
     fn receiver_config_propagates_ignore_existing() {
         let config = ClientConfig::builder().ignore_existing(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.file_selection.ignore_existing);
     }
@@ -438,7 +438,7 @@ mod tests {
     fn receiver_config_without_ignore_existing_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.file_selection.ignore_existing);
     }
@@ -457,7 +457,7 @@ mod tests {
             .chmod(Some(modifiers.clone()))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.chmod.as_ref(), Some(&modifiers));
     }
@@ -468,7 +468,7 @@ mod tests {
     fn receiver_config_without_chmod_has_none() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.chmod.is_none());
     }
@@ -487,7 +487,7 @@ mod tests {
             .user_mapping(Some(mapping.clone()))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.user_mapping.as_ref(), Some(&mapping));
     }
@@ -501,7 +501,7 @@ mod tests {
             .group_mapping(Some(mapping.clone()))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.group_mapping.as_ref(), Some(&mapping));
     }
@@ -511,7 +511,7 @@ mod tests {
     fn receiver_config_without_id_maps_has_none() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.user_mapping.is_none());
         assert!(server_config.group_mapping.is_none());
@@ -526,7 +526,7 @@ mod tests {
     fn receiver_config_propagates_fsync() {
         let config = ClientConfig::builder().fsync(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.write.fsync);
     }
@@ -538,7 +538,7 @@ mod tests {
     fn receiver_config_propagates_write_devices() {
         let config = ClientConfig::builder().write_devices(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.write.write_devices);
     }
@@ -550,11 +550,11 @@ mod tests {
     #[test]
     fn receiver_config_propagates_out_format_forwards_i() {
         let with_i = ClientConfig::builder().out_format_forwards_i(true).build();
-        let sc = build_server_config_for_receiver(&with_i, &["dest".to_owned()]).unwrap();
+        let sc = build_server_config_for_receiver(&with_i, &[OsString::from("dest")]).unwrap();
         assert!(sc.flags.info_flags.out_format_forwards_i);
 
         let without = ClientConfig::builder().out_format_forwards_i(false).build();
-        let sc = build_server_config_for_receiver(&without, &["dest".to_owned()]).unwrap();
+        let sc = build_server_config_for_receiver(&without, &[OsString::from("dest")]).unwrap();
         assert!(!sc.flags.info_flags.out_format_forwards_i);
     }
 
@@ -565,7 +565,7 @@ mod tests {
     fn receiver_config_propagates_keep_dirlinks() {
         let config = ClientConfig::builder().keep_dirlinks(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.keep_dirlinks);
     }
@@ -577,7 +577,7 @@ mod tests {
     fn receiver_config_propagates_fuzzy_level() {
         let config = ClientConfig::builder().fuzzy_level(2).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(server_config.flags.fuzzy_level, 2);
     }
@@ -592,7 +592,7 @@ mod tests {
     fn receiver_config_propagates_delay_updates() {
         let config = ClientConfig::builder().delay_updates(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.write.delay_updates);
     }
@@ -606,7 +606,7 @@ mod tests {
     fn receiver_config_propagates_list_only() {
         let config = ClientConfig::builder().list_only(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.list_only);
     }
@@ -618,7 +618,7 @@ mod tests {
     fn receiver_config_without_receiver_only_flags_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.write.fsync);
         assert!(!server_config.write.write_devices);
@@ -640,7 +640,7 @@ mod tests {
             .temp_directory(Some("/var/tmp/rsync"))
             .build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert_eq!(
             server_config.temp_dir.as_deref(),
@@ -654,7 +654,7 @@ mod tests {
     fn receiver_config_without_temp_dir_stays_none() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.temp_dir.is_none());
     }
@@ -669,7 +669,7 @@ mod tests {
     fn receiver_config_propagates_omit_dir_times() {
         let config = ClientConfig::builder().omit_dir_times(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.omit_dir_times);
     }
@@ -680,7 +680,7 @@ mod tests {
     fn receiver_config_without_omit_dir_times_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.omit_dir_times);
     }
@@ -695,7 +695,7 @@ mod tests {
     fn receiver_config_propagates_omit_link_times() {
         let config = ClientConfig::builder().omit_link_times(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.omit_link_times);
     }
@@ -706,7 +706,7 @@ mod tests {
     fn receiver_config_without_omit_link_times_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.omit_link_times);
     }
@@ -721,7 +721,7 @@ mod tests {
     fn receiver_config_propagates_preserve_executability() {
         let config = ClientConfig::builder().executability(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.preserve_executability);
     }
@@ -731,7 +731,7 @@ mod tests {
     fn receiver_config_without_preserve_executability_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.preserve_executability);
     }
@@ -747,7 +747,7 @@ mod tests {
     fn receiver_config_propagates_mkpath() {
         let config = ClientConfig::builder().mkpath(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.flags.mkpath);
     }
@@ -758,7 +758,7 @@ mod tests {
     fn receiver_config_without_mkpath_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.flags.mkpath);
     }
@@ -772,7 +772,7 @@ mod tests {
     fn receiver_config_propagates_fake_super() {
         let config = ClientConfig::builder().fake_super(true).build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(server_config.fake_super);
     }
@@ -782,7 +782,7 @@ mod tests {
     fn receiver_config_without_fake_super_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+            build_server_config_for_receiver(&config, &[OsString::from("dest")]).unwrap();
 
         assert!(!server_config.fake_super);
     }
@@ -800,7 +800,7 @@ mod tests {
             .chmod(Some(modifiers.clone()))
             .build();
         let server_config =
-            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")]).unwrap();
 
         assert_eq!(server_config.chmod.as_ref(), Some(&modifiers));
     }
@@ -811,7 +811,7 @@ mod tests {
     fn generator_config_without_chmod_has_none() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")]).unwrap();
 
         assert!(server_config.chmod.is_none());
     }
@@ -826,7 +826,7 @@ mod tests {
     fn generator_config_propagates_fake_super() {
         let config = ClientConfig::builder().fake_super(true).build();
         let server_config =
-            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")]).unwrap();
 
         assert!(server_config.fake_super);
     }
@@ -836,7 +836,7 @@ mod tests {
     fn generator_config_without_fake_super_stays_clear() {
         let config = ClientConfig::builder().build();
         let server_config =
-            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+            build_server_config_for_generator(&config, &[OsString::from("/tmp/source")]).unwrap();
 
         assert!(!server_config.fake_super);
     }

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -15,10 +15,10 @@ use crate::server::{ServerConfig, ServerRole};
 /// Builds server configuration for receiver role (pull transfer).
 pub(in crate::client::remote) fn build_server_config_for_receiver(
     config: &ClientConfig,
-    local_paths: &[String],
+    local_paths: &[OsString],
 ) -> Result<ServerConfig, ClientError> {
     let flag_string = flags::build_server_flag_string(config);
-    let args: Vec<OsString> = local_paths.iter().map(OsString::from).collect();
+    let args: Vec<OsString> = local_paths.to_vec();
 
     let mut server_config =
         ServerConfig::from_flag_string_and_args(ServerRole::Receiver, flag_string, args)
@@ -208,10 +208,10 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
 ///   wires `filesfrom_fd = f_in` so the remote forwards bytes via the wire.
 pub(in crate::client::remote) fn build_server_config_for_generator(
     config: &ClientConfig,
-    local_paths: &[String],
+    local_paths: &[OsString],
 ) -> Result<ServerConfig, ClientError> {
     let flag_string = flags::build_server_flag_string(config);
-    let args: Vec<OsString> = local_paths.iter().map(OsString::from).collect();
+    let args: Vec<OsString> = local_paths.to_vec();
 
     let mut server_config =
         ServerConfig::from_flag_string_and_args(ServerRole::Generator, flag_string, args)

--- a/crates/protocol/src/secluded_args.rs
+++ b/crates/protocol/src/secluded_args.rs
@@ -56,16 +56,21 @@ use crate::iconv::FilenameConverter;
 /// When `iconv` is `None`, bytes are forwarded verbatim - equivalent to
 /// upstream's `ic_send == (iconv_t)-1` case.
 ///
+/// Arguments are accepted as any byte-slice-convertible type (`&str`,
+/// `&[u8]`, `Vec<u8>`, ...) so a caller holding raw operand bytes - a remote
+/// path that is not valid UTF-8, which rsync carries as raw `char*` - can ship
+/// them verbatim without a lossy `String` round-trip.
+///
 /// # Upstream Reference
 ///
 /// Mirrors `send_protected_args()` in upstream `rsync.c:283-320`.
-pub fn send_secluded_args<W: Write>(
+pub fn send_secluded_args<W: Write, A: AsRef<[u8]>>(
     writer: &mut W,
-    args: &[&str],
+    args: &[A],
     iconv: Option<&FilenameConverter>,
 ) -> io::Result<()> {
     for arg in args {
-        write_secluded_arg(writer, arg.as_bytes(), iconv)?;
+        write_secluded_arg(writer, arg.as_ref(), iconv)?;
     }
     // Empty string terminator
     writer.write_all(b"\0")?;

--- a/crates/rsync_io/src/ssh/operand.rs
+++ b/crates/rsync_io/src/ssh/operand.rs
@@ -3,7 +3,7 @@
 //! This module provides utilities to parse remote operand strings (e.g.,
 //! `user@host:path`, `[::1]:path`) into structured components for SSH invocation.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 
 use thiserror::Error;
 
@@ -19,20 +19,30 @@ use thiserror::Error;
 /// let parsed = parse_ssh_operand(operand).unwrap();
 /// assert_eq!(parsed.user(), Some("user"));
 /// assert_eq!(parsed.host(), "example.com");
-/// assert_eq!(parsed.path(), "/path/to/file");
+/// assert_eq!(parsed.path(), OsStr::new("/path/to/file"));
 /// ```
+///
+/// The `path` is retained as an [`OsString`] so a non-UTF-8 remote path (a
+/// legal filename on Unix, which rsync carries as raw `char*`) survives verbatim
+/// on its way to the remote-shell command line. The `user`/`host` components
+/// remain `String`: they are validated as text and never carry arbitrary bytes.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RemoteOperand {
     user: Option<String>,
     host: String,
     port: Option<u16>,
-    path: String,
+    path: OsString,
 }
 
 impl RemoteOperand {
     /// Creates a new remote operand with the specified components.
     #[must_use]
-    pub const fn new(user: Option<String>, host: String, port: Option<u16>, path: String) -> Self {
+    pub const fn new(
+        user: Option<String>,
+        host: String,
+        port: Option<u16>,
+        path: OsString,
+    ) -> Self {
         Self {
             user,
             host,
@@ -57,9 +67,12 @@ impl RemoteOperand {
         self.port
     }
 
-    /// Returns the remote path component.
+    /// Returns the remote path component as raw bytes.
+    ///
+    /// The value round-trips the operand's post-colon bytes verbatim, so a
+    /// non-UTF-8 remote path is preserved for the remote-shell command line.
     #[must_use]
-    pub fn path(&self) -> &str {
+    pub fn path(&self) -> &OsStr {
         &self.path
     }
 }
@@ -108,7 +121,7 @@ pub enum RemoteOperandParseError {
 /// let operand = OsStr::new("example.com:/remote/path");
 /// let parsed = parse_ssh_operand(operand).unwrap();
 /// assert_eq!(parsed.host(), "example.com");
-/// assert_eq!(parsed.path(), "/remote/path");
+/// assert_eq!(parsed.path(), OsStr::new("/remote/path"));
 /// ```
 pub fn parse_ssh_operand(operand: &OsStr) -> Result<RemoteOperand, RemoteOperandParseError> {
     if operand.is_empty() {
@@ -126,6 +139,19 @@ pub fn parse_ssh_operand(operand: &OsStr) -> Result<RemoteOperand, RemoteOperand
     if host.is_empty() {
         return Err(RemoteOperandParseError::InvalidFormat);
     }
+
+    // Recover the post-colon path as raw bytes. `path` is always a trailing
+    // suffix of the lossy `text` (every extractor returns `&text[colon + 1..]`),
+    // and the operand prefix up to and including the colon is pure ASCII
+    // (`user@host:` / `[ipv6]:`). Because that prefix contains no non-UTF-8
+    // bytes, its lossy length equals its raw byte length, so
+    // `text.len() - path.len()` is a valid byte offset into the raw operand -
+    // the lossy expansion of any non-UTF-8 path byte appears identically in
+    // both `text` and `path` and therefore cancels. See upstream
+    // options.c:check_for_hostspec(), which returns `path + 1` into the raw
+    // `char*` arg without transcoding.
+    let path_start = text.len() - path.len();
+    let raw_path = raw_path_suffix(operand, path_start);
 
     // An empty path after the colon (e.g. `localhost:`) is valid: upstream
     // rsync interprets it as the remote user's home directory.
@@ -146,8 +172,34 @@ pub fn parse_ssh_operand(operand: &OsStr) -> Result<RemoteOperand, RemoteOperand
         host: host.to_owned(),
         // Port is carried via the `-e ssh -p N` option, not the operand.
         port: None,
-        path: path.to_owned(),
+        path: raw_path,
     })
+}
+
+/// Reconstructs the raw post-colon path bytes at `path_start` within `operand`.
+///
+/// On Unix the operand's bytes are sliced verbatim (`OsStrExt::as_bytes`), so a
+/// non-UTF-8 filename survives byte-for-byte. On Windows the wide units are
+/// sliced (`encode_wide` / `OsStringExt::from_wide`), preserving unpaired
+/// surrogates. `path_start` is a byte offset into the (all-ASCII) prefix, which
+/// equals the wide-unit offset there. On other targets, which cannot expose the
+/// underlying bytes safely, the lossy operand slice is used as a fallback.
+fn raw_path_suffix(operand: &OsStr, path_start: usize) -> OsString {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+        OsString::from_vec(operand.as_bytes()[path_start..].to_vec())
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+        let wide: Vec<u16> = operand.encode_wide().collect();
+        OsString::from_wide(&wide[path_start..])
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        OsString::from(operand.to_string_lossy()[path_start..].to_owned())
+    }
 }
 
 /// Rejects a hostname or user component that begins with `-`.
@@ -223,7 +275,7 @@ mod tests {
         assert_eq!(result.user(), None);
         assert_eq!(result.host(), "example.com");
         assert_eq!(result.port(), None);
-        assert_eq!(result.path(), "/remote/path");
+        assert_eq!(result.path(), OsStr::new("/remote/path"));
     }
 
     #[test]
@@ -234,7 +286,7 @@ mod tests {
         assert_eq!(result.user(), Some("alice"));
         assert_eq!(result.host(), "example.com");
         assert_eq!(result.port(), None);
-        assert_eq!(result.path(), "/home/alice/file.txt");
+        assert_eq!(result.path(), OsStr::new("/home/alice/file.txt"));
     }
 
     #[test]
@@ -245,7 +297,7 @@ mod tests {
         assert_eq!(result.user(), None);
         assert_eq!(result.host(), "::1");
         assert_eq!(result.port(), None);
-        assert_eq!(result.path(), "/path");
+        assert_eq!(result.path(), OsStr::new("/path"));
     }
 
     #[test]
@@ -256,7 +308,7 @@ mod tests {
         assert_eq!(result.user(), Some("bob"));
         assert_eq!(result.host(), "2001:db8::1");
         assert_eq!(result.port(), None);
-        assert_eq!(result.path(), "/remote/dir/");
+        assert_eq!(result.path(), OsStr::new("/remote/dir/"));
     }
 
     #[test]
@@ -266,7 +318,7 @@ mod tests {
 
         assert_eq!(result.user(), None);
         assert_eq!(result.host(), "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
-        assert_eq!(result.path(), "/data");
+        assert_eq!(result.path(), OsStr::new("/data"));
     }
 
     #[test]
@@ -276,7 +328,7 @@ mod tests {
 
         assert_eq!(result.user(), Some("user"));
         assert_eq!(result.host(), "::ffff:127.0.0.1");
-        assert_eq!(result.path(), "/tmp/file");
+        assert_eq!(result.path(), OsStr::new("/tmp/file"));
     }
 
     #[test]
@@ -285,7 +337,7 @@ mod tests {
         let result = parse_ssh_operand(operand).unwrap();
 
         assert_eq!(result.host(), "host");
-        assert_eq!(result.path(), "relative/path");
+        assert_eq!(result.path(), OsStr::new("relative/path"));
     }
 
     #[test]
@@ -294,7 +346,7 @@ mod tests {
         let result = parse_ssh_operand(operand).unwrap();
 
         assert_eq!(result.host(), "host");
-        assert_eq!(result.path(), "/path/with:colon/in:name");
+        assert_eq!(result.path(), OsStr::new("/path/with:colon/in:name"));
     }
 
     #[test]
@@ -304,7 +356,7 @@ mod tests {
 
         assert_eq!(result.user(), Some("user"));
         assert_eq!(result.host(), "host");
-        assert_eq!(result.path(), "/path/with@symbol");
+        assert_eq!(result.path(), OsStr::new("/path/with@symbol"));
     }
 
     #[test]
@@ -313,7 +365,7 @@ mod tests {
         let result = parse_ssh_operand(operand).unwrap();
 
         assert_eq!(result.host(), "files.example.co.uk");
-        assert_eq!(result.path(), "/backup/data");
+        assert_eq!(result.path(), OsStr::new("/backup/data"));
     }
 
     #[test]
@@ -322,7 +374,7 @@ mod tests {
         let result = parse_ssh_operand(operand).unwrap();
 
         assert_eq!(result.host(), "backup-server");
-        assert_eq!(result.path(), "/data");
+        assert_eq!(result.path(), OsStr::new("/data"));
     }
 
     #[test]
@@ -331,7 +383,7 @@ mod tests {
         let result = parse_ssh_operand(operand).unwrap();
 
         assert_eq!(result.host(), "192.168.1.100");
-        assert_eq!(result.path(), "/files");
+        assert_eq!(result.path(), OsStr::new("/files"));
     }
 
     #[test]
@@ -341,7 +393,7 @@ mod tests {
 
         assert_eq!(result.user(), Some("admin"));
         assert_eq!(result.host(), "10.0.0.1");
-        assert_eq!(result.path(), "/etc/config");
+        assert_eq!(result.path(), OsStr::new("/etc/config"));
     }
 
     #[test]
@@ -378,7 +430,7 @@ mod tests {
         let result = parse_ssh_operand(operand).unwrap();
 
         assert_eq!(result.host(), "host");
-        assert_eq!(result.path(), "");
+        assert_eq!(result.path(), OsStr::new(""));
     }
 
     #[test]
@@ -387,7 +439,7 @@ mod tests {
         let result = parse_ssh_operand(operand).unwrap();
 
         assert_eq!(result.host(), "::1");
-        assert_eq!(result.path(), "");
+        assert_eq!(result.path(), OsStr::new(""));
     }
 
     #[test]
@@ -397,7 +449,7 @@ mod tests {
 
         assert_eq!(result.user(), Some("alice"));
         assert_eq!(result.host(), "example.com");
-        assert_eq!(result.path(), "");
+        assert_eq!(result.path(), OsStr::new(""));
     }
 
     #[test]
@@ -430,13 +482,13 @@ mod tests {
             Some("user".to_owned()),
             "example.com".to_owned(),
             Some(2222),
-            "/path".to_owned(),
+            OsString::from("/path"),
         );
 
         assert_eq!(operand.user(), Some("user"));
         assert_eq!(operand.host(), "example.com");
         assert_eq!(operand.port(), Some(2222));
-        assert_eq!(operand.path(), "/path");
+        assert_eq!(operand.path(), OsStr::new("/path"));
     }
 
     #[test]
@@ -518,5 +570,32 @@ mod tests {
             result,
             Err(RemoteOperandParseError::LeadingDash("-bad".to_owned()))
         );
+    }
+
+    /// A non-UTF-8 path byte (`0xFF`, a legal Unix filename byte that rsync
+    /// carries as raw `char*`) must survive the split verbatim rather than
+    /// collapsing to U+FFFD. Guards the shell-operand pipeline: the remote
+    /// sender/receiver must see the exact bytes the user typed, or it opens the
+    /// wrong file. upstream: options.c:check_for_hostspec() slices the raw arg.
+    #[cfg(unix)]
+    #[test]
+    fn preserves_non_utf8_path_bytes() {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        // `alice@host:/dir/a<FF>b)c` - non-UTF-8 byte plus a shell metacharacter.
+        let mut raw = b"alice@host:/dir/a".to_vec();
+        raw.push(0xFF);
+        raw.extend_from_slice(b"b)c");
+        let operand = std::ffi::OsString::from_vec(raw);
+
+        let parsed = parse_ssh_operand(&operand).unwrap();
+
+        assert_eq!(parsed.user(), Some("alice"));
+        assert_eq!(parsed.host(), "host");
+
+        let mut expected = b"/dir/a".to_vec();
+        expected.push(0xFF);
+        expected.extend_from_slice(b"b)c");
+        assert_eq!(parsed.path().as_bytes(), &expected[..]);
     }
 }

--- a/tests/ssh_transport.rs
+++ b/tests/ssh_transport.rs
@@ -310,7 +310,7 @@ fn test_transfer_role_detection() {
             assert_eq!(local_dest, "local.txt");
             assert_eq!(
                 remote_sources,
-                RemoteOperands::Single("host:remote.txt".to_string())
+                RemoteOperands::Single(OsString::from("host:remote.txt"))
             );
         }
         _ => panic!("Expected Pull transfer"),
@@ -366,7 +366,7 @@ fn test_remote_invocation_builder() {
         .build();
 
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     assert_eq!(args[0].to_string_lossy(), "rsync");
     assert_eq!(args[1].to_string_lossy(), "--server");
@@ -389,7 +389,7 @@ fn test_remote_invocation_builder() {
 
     // Test receiver (pull) invocation — SHOULD have --sender flag
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     assert_eq!(args[0].to_string_lossy(), "rsync");
     assert_eq!(args[1].to_string_lossy(), "--server");
@@ -447,7 +447,7 @@ fn test_remote_invocation_with_custom_rsync_path() {
 
     // Build invocation for sender (push) role — no --sender flag
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     // First argument should be the custom rsync path, not "rsync"
     assert_eq!(args[0].to_string_lossy(), "/usr/local/bin/rsync");
@@ -468,7 +468,7 @@ fn test_remote_invocation_with_default_rsync_path() {
 
     // Build invocation for sender role
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/remote/path");
+    let args = builder.build(std::ffi::OsStr::new("/remote/path"));
 
     // First argument should be default "rsync"
     assert_eq!(args[0].to_string_lossy(), "rsync");
@@ -499,9 +499,9 @@ fn test_multiple_sources_same_host() {
             assert_eq!(
                 remote_sources,
                 RemoteOperands::Multiple(vec![
-                    "host:/file1".to_string(),
-                    "host:/file2".to_string(),
-                    "host:/dir/file3".to_string(),
+                    OsString::from("host:/file1"),
+                    OsString::from("host:/file2"),
+                    OsString::from("host:/dir/file3"),
                 ])
             );
         }
@@ -532,8 +532,8 @@ fn test_multiple_sources_with_user_same_host() {
             assert_eq!(
                 remote_sources,
                 RemoteOperands::Multiple(vec![
-                    "user@host:/file1".to_string(),
-                    "user@host:/file2".to_string(),
+                    OsString::from("user@host:/file1"),
+                    OsString::from("user@host:/file2"),
                 ])
             );
         }
@@ -628,7 +628,7 @@ fn test_single_remote_source_returns_single_variant() {
             assert_eq!(local_dest, "local/");
             assert_eq!(
                 remote_sources,
-                RemoteOperands::Single("host:/single/file".to_string())
+                RemoteOperands::Single(OsString::from("host:/single/file"))
             );
         }
         _ => panic!("Expected Pull transfer"),
@@ -642,7 +642,11 @@ fn test_remote_invocation_with_multiple_paths() {
 
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build_with_paths(&["/path1", "/path2", "/path3"]);
+    let args = builder.build_with_paths(&[
+        std::ffi::OsStr::new("/path1"),
+        std::ffi::OsStr::new("/path2"),
+        std::ffi::OsStr::new("/path3"),
+    ]);
 
     assert_eq!(args[0].to_string_lossy(), "rsync");
     assert_eq!(args[1].to_string_lossy(), "--server");


### PR DESCRIPTION
## Problem

An SSH `host:path` operand carrying non-UTF-8 bytes was corrupted before it
ever reached the wire. `determine_transfer_role` stored the operand as a
`String` via `to_string_lossy()`, so a byte like `0xFF` became U+FFFD
(EF BF BD) four stages before `shell_safe_filename_arg` ran. Upstream rsync
carries operands as raw `char*` end to end (`main.c` `safe_arg` over
`remote_argv`) and never UTF-8-validates them, so a filename with arbitrary
bytes round-trips faithfully; oc silently mangled it.

## Fix

Thread the SSH operand as raw bytes through the whole pipeline instead of a
lossy `String`, so the exact bytes the user passed reach the spawned `ssh`
argv and the secluded-args stdin stream. The only behavioural edit is
rewriting `shell_safe_filename_arg` to escape on bytes; everything else is
mechanical `String` -> `OsString`/`&[u8]` type threading. Host/user tokens
stay validated `String`; only the post-colon path is byte-faithful. The
colon split is done at the ASCII-`:` byte boundary.

Files threaded:

- `rsync_io/ssh/operand.rs`: `RemoteOperand.path` `String` -> `OsString`;
  `parse_ssh_operand` recovers the path via raw `as_bytes()` on unix /
  `encode_wide` on Windows.
- `protocol/secluded_args.rs`: `send_secluded_args` generic over
  `AsRef<[u8]>` (existing `&str`/daemon callers unchanged; SSH passes bytes).
- `core/client/remote/invocation/{mod,transfer_role,builder}.rs`:
  `TransferSpec` / `RemoteOperands` / `SecludedInvocation.stdin_args` ->
  `OsString`/`Vec<OsString>`; `shell_safe_filename_arg(&OsStr) -> OsString`
  escapes on bytes on unix with a char fallback on non-unix.
- `core/client/remote/{ssh_transfer/*, embedded_ssh_transfer,
  async_ssh_transport, remote_to_remote, daemon_transfer}.rs`: threaded
  `OsString`; stdin ships raw bytes.

## Scope

Deliberately limited to the `host:path` external-SSH operand path. Two
adjacent subsystems keep their current boundary behaviour (no regression)
and are tracked as separate follow-ups:

- The `rsync://` daemon operand path (String-deep daemon orchestration).
- The receiver-side implied-include guard (CVE-2022-29154) in the filters
  subsystem.

The embedded `ssh://` URL path stays `String`: its byte fidelity is bounded
by URL percent-encoding, which is orthogonal (noted in code).

## Tests

- Unit: an operand round-trips byte-identically through
  `determine_transfer_role` -> `shell_safe_filename_arg` (`0xFF` preserved,
  `)` escaped); fails before the fix.
- The SSH invocation tests are threaded onto `OsString` operands.
