### PR TITLE
fix(engine): emit -vv delta match_report total: line in local copy

### DIFF
--- a/crates/engine/src/delta/mod.rs
+++ b/crates/engine/src/delta/mod.rs
@@ -22,7 +22,8 @@
 /// - [`generate_delta`] is the high-level convenience wrapper around
 ///   [`DeltaGenerator`].
 pub use matching::{
-    DeltaGenerator, DeltaScript, DeltaSignatureIndex, DeltaToken, apply_delta, generate_delta,
+    DeltaGenerator, DeltaScript, DeltaSignatureIndex, DeltaToken, ProbeCounters, apply_delta,
+    generate_delta,
 };
 
 /// Signature-layout primitives mirroring upstream `generator.c:sum_sizes_sqroot()`.

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -42,7 +42,7 @@ use super::{
     trace_make_backup_hlink, trace_make_backup_rename, trace_make_backup_symlink,
     write_sparse_chunk,
 };
-use crate::delta::DeltaSignatureIndex;
+use crate::delta::{DeltaSignatureIndex, ProbeCounters};
 use crate::signature::SignatureBlock;
 use ::metadata::{
     MetadataOptions, apply_file_metadata_with_options, apply_symlink_metadata_with_options,
@@ -57,7 +57,7 @@ use compress::algorithm::CompressionAlgorithm;
 use compress::strategy::adaptive_level::AdaptiveLevelController;
 use compress::zlib::CompressionLevel;
 use filters::FilterRule;
-use logging::info_log;
+use logging::{debug_log, info_log};
 use protocol::flist::FileListWriter;
 
 use super::overrides::{backup_rename, create_hard_link};
@@ -294,6 +294,15 @@ pub(crate) struct CopyContext<'a> {
     /// Adaptive compression level controller that adjusts compression level
     /// between files based on observed compression ratios.
     adaptive_level: Option<AdaptiveLevelController>,
+    /// Cumulative delta-matcher diagnostics for the `-vv` `total:` line,
+    /// accumulated across every file the local-copy delta path processes and
+    /// emitted once at end-of-run by [`CopyContext::emit_delta_match_report`].
+    ///
+    /// upstream: match.c:433-436 folds each file's `matches`/`hash_hits`/
+    /// `false_alarms` into `total_*`; match_report() (match.c:439) prints them
+    /// once. The local-copy executor has no forked sender, so it keeps the same
+    /// running totals here.
+    delta_match_report: DeltaMatchReport,
 }
 
 /// Path and type context for metadata finalization.
@@ -378,6 +387,24 @@ impl<'a> FinalizeMetadataParams<'a> {
         self.pre_transfer_meta = pre_transfer_meta;
         self
     }
+}
+
+/// Cumulative delta-match diagnostics reproduced on the `-vv` `total:` line.
+///
+/// upstream: `match.c:433-436` folds each file's per-file `matches`,
+/// `hash_hits`, and `false_alarms` into `total_*`, and `match_report()`
+/// (`match.c:439-448`) prints them once at end-of-run alongside
+/// `stats.literal_data`. The local-copy executor has no forked sender running
+/// `match_sums()`, so it accumulates the same figures directly. `matches` and
+/// the literal-byte total match upstream exactly; `hash_hits`/`false_alarms`
+/// are oc-native (bithash-prefilter positives and the subset that fails the
+/// exact verify) and do not reproduce upstream's `SUM2HASH`-collision counts -
+/// see [`crate::delta::ProbeCounters`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct DeltaMatchReport {
+    matches: u64,
+    hash_hits: u64,
+    false_alarms: u64,
 }
 
 /// Byte-level statistics from a single file copy (literal and optional

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -112,6 +112,12 @@ impl<'a> CopyContext<'a> {
         let mut compressed_progress = 0u64;
         let mut total_bytes = 0u64;
         let mut literal_bytes = 0u64;
+        // upstream: match.c:365-368 match_sums() zeroes the per-file counters;
+        // the loop tallies confirmed matches inline and hash_hits/false_alarms
+        // through the counted probe, folded into the run totals at the end for
+        // the `-vv` `total:` line (match.c:439 match_report()).
+        let mut probe = ProbeCounters::default();
+        let mut file_matches = 0u64;
         let mut sparse_state = SparseWriteState::default();
         sparse_state.set_preallocated_len(preallocated_len);
         let mut window: VecDeque<u8> = VecDeque::with_capacity(index.block_length());
@@ -168,7 +174,10 @@ impl<'a> CopyContext<'a> {
             }
 
             let digest = rolling.digest();
-            if let Some(block_index) = index.find_match_window(digest, &window, &mut scratch) {
+            if let Some(block_index) =
+                index.find_match_window_counted(digest, &window, &mut scratch, &mut probe)
+            {
+                file_matches += 1;
                 if !pending_literals.is_empty() {
                     let flushed_len = pending_literals.len();
                     if inplace_mode {
@@ -297,6 +306,11 @@ impl<'a> CopyContext<'a> {
             index.find_tail_match_window(digest, &window, &mut scratch)
         };
         if let Some(block_index) = tail_matched_block {
+            // A matched trailing partial block is one confirmed match, and its
+            // bucket lookup is one hash hit. upstream: match.c hash_search()
+            // counts the shrunk-window tail probe the same as any other.
+            file_matches += 1;
+            probe.hash_hits += 1;
             if !pending_literals.is_empty() {
                 let flushed_len = pending_literals.len();
                 if inplace_mode {
@@ -449,6 +463,11 @@ impl<'a> CopyContext<'a> {
                 )
             })?;
         }
+
+        // upstream: match.c:433-436 folds the per-file counters into the run
+        // totals after match_sums() returns; do the same for the end-of-run
+        // `-vv` `total:` line.
+        self.record_delta_match_stats(file_matches, probe.hash_hits, probe.false_alarms);
 
         let outcome = if let Some(encoder) = compressor {
             let compressed_total = encoder.finish().map_err(|error| {

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -1,4 +1,50 @@
 impl<'a> CopyContext<'a> {
+    /// Folds one delta-scanned file's match diagnostics into the cumulative
+    /// totals for the end-of-run `-vv` `total:` line.
+    ///
+    /// upstream: match.c:433-436 - `total_matches += matches` etc. after each
+    /// file's `match_sums()`.
+    pub(in crate::local_copy) fn record_delta_match_stats(
+        &mut self,
+        matches: u64,
+        hash_hits: u64,
+        false_alarms: u64,
+    ) {
+        self.delta_match_report.matches = self.delta_match_report.matches.saturating_add(matches);
+        self.delta_match_report.hash_hits =
+            self.delta_match_report.hash_hits.saturating_add(hash_hits);
+        self.delta_match_report.false_alarms = self
+            .delta_match_report
+            .false_alarms
+            .saturating_add(false_alarms);
+    }
+
+    /// Emits upstream's `match_report()` `total:` line once at end-of-run.
+    ///
+    /// upstream: match.c:439-448 match_report() prints
+    /// `total: matches=%d  hash_hits=%d  false_alarms=%d data=%s` gated on
+    /// `DEBUG_GTE(DELTASUM, 1)` (first active at `-vv`), where `data` is the
+    /// cumulative literal-byte count (`stats.literal_data`, plain `big_num`, no
+    /// grouping). A whole-file local copy still emits the line with
+    /// `matches=0` and `data` equal to the total literal bytes, exactly as
+    /// upstream's forked sender does. `matches` and `data` match upstream
+    /// exactly; `hash_hits`/`false_alarms` are oc-native (bithash-prefilter
+    /// positives and the subset that fails the exact verify) and are not
+    /// expected to equal upstream's `SUM2HASH`-collision counts (see
+    /// [`crate::delta::ProbeCounters`]).
+    pub(in crate::local_copy) fn emit_delta_match_report(&self) {
+        let report = &self.delta_match_report;
+        debug_log!(
+            Deltasum,
+            1,
+            "total: matches={}  hash_hits={}  false_alarms={} data={}",
+            report.matches,
+            report.hash_hits,
+            report.false_alarms,
+            self.summary.bytes_copied()
+        );
+    }
+
     /// Records a skip event for a non-regular file (e.g. socket, unknown type).
     ///
     /// Emits an `--info=NONREG` notice mirroring upstream rsync 3.4.1

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -178,6 +178,7 @@ impl<'a> CopyContext<'a> {
             batch_token_encoder,
             readdir_buf: Vec::new(),
             adaptive_level,
+            delta_match_report: DeltaMatchReport::default(),
         }
     }
 

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -306,6 +306,10 @@ pub(crate) fn copy_sources(
             context
                 .summary_mut()
                 .record_wall_clock_elapsed(Duration::from_secs(elapsed_secs));
+            // upstream: sender.c:491 calls match_report() once at the end of
+            // send_files(); mirror that end-of-run emission for the local copy
+            // so `-vv` prints the delta `total:` line (match.c:439).
+            context.emit_delta_match_report();
             Ok(context.into_outcome())
         }
         Err(error) => {

--- a/crates/engine/src/local_copy/tests/execute_delta.rs
+++ b/crates/engine/src/local_copy/tests/execute_delta.rs
@@ -47,6 +47,103 @@ fn execute_delta_copy_reuses_existing_blocks() {
     assert_eq!(fs::read(&dest_path).expect("read destination"), updated);
 }
 
+/// GUARD (#185/#186): the local `--no-whole-file` delta summary must split a
+/// transferred file into literal + matched bytes exactly as upstream's
+/// `stats.literal_data` (match.c:436) and `stats.matched_data` (match.c:121),
+/// which together always cover the whole file. #185 MEASURED these already
+/// match upstream on a local delta copy (Literal 65,536 / Matched 983,040), so
+/// this test is a regression guard, not a fix: a future matcher change that
+/// mis-splits the file (e.g. losing the prefix match and inflating literal)
+/// must fail here rather than silently diverge from upstream stats.
+#[test]
+fn delta_summary_literal_matched_partition_matches_upstream() {
+    let temp = tempdir().expect("tempdir");
+    let source_root = temp.path().join("source");
+    let target_root = temp.path().join("target");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(&target_root).expect("create target root");
+
+    let source_path = source_root.join("file.bin");
+    let dest_path = target_root.join("file.bin");
+
+    // Basis = 700 A + 700 B; updated source = 700 A + 700 C. The leading 700-byte
+    // block is reusable; the trailing 700 bytes changed, so upstream matches the
+    // prefix and sends the suffix as literal data.
+    let prefix = vec![b'A'; 700];
+    let mut initial = prefix.clone();
+    initial.extend(std::iter::repeat_n(b'B', 700));
+    fs::write(&dest_path, &initial).expect("write basis");
+    set_file_mtime(&dest_path, FileTime::from_unix_time(1, 0)).expect("backdate basis");
+
+    let mut updated = prefix.clone();
+    updated.extend(std::iter::repeat_n(b'C', 700));
+    fs::write(&source_path, &updated).expect("write source");
+    set_file_mtime(&source_path, FileTime::from_unix_time(2, 0)).expect("bump source mtime");
+
+    let operands = vec![
+        source_path.into_os_string(),
+        dest_path.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().whole_file(false),
+        )
+        .expect("delta copy succeeds");
+
+    assert_eq!(
+        summary.bytes_copied(),
+        700,
+        "literal data = the changed 700-byte suffix"
+    );
+    assert_eq!(
+        summary.matched_bytes(),
+        700,
+        "matched data = the reused 700-byte prefix block"
+    );
+    assert_eq!(
+        summary.bytes_copied() + summary.matched_bytes(),
+        updated.len() as u64,
+        "literal + matched must cover the whole transferred file, exactly as \
+         upstream's stats.literal_data + stats.matched_data do"
+    );
+    assert_eq!(fs::read(&dest_path).expect("read dest"), updated);
+}
+
+/// GUARD (#186): a whole-file local copy reports every byte as literal and none
+/// matched - upstream's sender matches against an empty basis, so the entire
+/// file is `stats.literal_data`. Pins the other end of the literal/matched
+/// partition so whole-file accounting cannot silently regress either.
+#[test]
+fn whole_file_summary_is_all_literal_none_matched() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("whole.bin");
+    let dest = temp.path().join("dest.bin");
+    let payload = vec![b'Z'; 4096];
+    fs::write(&source, &payload).expect("write source");
+
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().whole_file(true),
+        )
+        .expect("whole-file copy succeeds");
+
+    assert_eq!(
+        summary.bytes_copied(),
+        payload.len() as u64,
+        "whole-file copy counts every byte as literal data"
+    );
+    assert_eq!(
+        summary.matched_bytes(),
+        0,
+        "a fresh destination matches nothing"
+    );
+}
+
 #[test]
 fn execute_with_report_dry_run_records_file_event() {
     use std::fs;

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -72,6 +72,30 @@ const NEXT_MATCH_NONE: u32 = u32::MAX;
 /// upstream-rsync-style fast-path rejection before the bucket walk, and the
 /// bithash prefilter (ZSO-1) rejects the bulk of post-tag misses before the
 /// chain probe.
+/// Per-run tally of the delta matcher's probe diagnostics, mirroring the two
+/// counters upstream reports on the `-vv` `total:` line.
+///
+/// Semantics are oc-native. Upstream (`match.c:202`) increments `hash_hits`
+/// once per source offset whose `SUM2HASH` bucket is non-empty, and
+/// (`match.c:239`) `false_alarms` once per candidate whose weak sum matches but
+/// whose strong sum does not. oc has no such hashed-bucket table: instead
+/// `hash_hits` counts positives of the zsync bithash prefilter (the coarse gate
+/// analogous to a bucket hit) and `false_alarms` counts bithash positives that
+/// then fail the exact rolling-sum + strong-sum verify. Because upstream's
+/// counts are inflated by `SUM2HASH` collisions that oc's structure does not
+/// have, the two numbers are NOT expected to equal the upstream oracle; they
+/// carry genuine signal about oc's own bithash false-positive rate. `matches`
+/// and the `data` byte total on the same line DO match upstream exactly.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ProbeCounters {
+    /// Source offsets that passed the bithash prefilter (the coarse gate; some
+    /// will still fail the exact verify and count as false alarms).
+    pub hash_hits: u64,
+    /// Bithash positives that produced no confirmed match (exact rolling-sum or
+    /// strong-sum verify rejected them).
+    pub false_alarms: u64,
+}
+
 #[derive(Debug)]
 pub struct DeltaSignatureIndex {
     block_length: usize,
@@ -559,6 +583,21 @@ impl DeltaSignatureIndex {
         window: &[u8],
         matched: Option<&MatchedBlocks>,
     ) -> Option<usize> {
+        self.probe_bytes(digest, window, matched, None)
+    }
+
+    /// Shared probe core for [`Self::find_match_bytes_filtered`] and the
+    /// counted [`Self::find_match_window_counted`]. When `counters` is `Some`,
+    /// tallies upstream-style `hash_hits`/`false_alarms` (see [`ProbeCounters`])
+    /// as a side effect; the returned match index is identical either way.
+    #[inline]
+    fn probe_bytes(
+        &self,
+        digest: RollingDigest,
+        window: &[u8],
+        matched: Option<&MatchedBlocks>,
+        mut counters: Option<&mut ProbeCounters>,
+    ) -> Option<usize> {
         if window.len() != self.block_length {
             return None;
         }
@@ -569,11 +608,21 @@ impl DeltaSignatureIndex {
             return None;
         }
 
-        // zsync-style bithash prefilter: rejects ~7/8 of post-tag misses
-        // using both sum halves before the hash-table probe. One-sided, so
-        // never produces a false negative.
+        // zsync-style bithash prefilter: rejects ~7/8 of post-tag misses using
+        // both sum halves before the hash-table probe. One-sided (no false
+        // negatives) but it does admit false positives. A positive here is oc's
+        // analogue of upstream's coarse hash-bucket hit (match.c:202
+        // `hash_hits++`): it still has to pass the exact rolling-sum + strong-sum
+        // verify below, and a positive that fails that verify is a false alarm
+        // (match.c:239). oc counts bithash positives rather than upstream's
+        // SUM2HASH bucket hits, so these two diagnostics are oc-native and do
+        // not reproduce upstream's collision-inflated values - see
+        // [`ProbeCounters`].
         if !self.bithash.contains(digest.value()) {
             return None;
+        }
+        if let Some(counters) = counters.as_mut() {
+            counters.hash_hits += 1;
         }
 
         let strong = self.algorithm.compute_truncated(window, self.strong_length);
@@ -593,6 +642,12 @@ impl DeltaSignatureIndex {
             if strong.as_slice() == block.strong() {
                 return Some(index);
             }
+        }
+        // A bithash positive that produced no confirmed match: the exact
+        // rolling-sum / strong-sum verify rejected it. upstream: match.c:239
+        // `false_alarms++`.
+        if let Some(counters) = counters.as_mut() {
+            counters.false_alarms += 1;
         }
         None
     }
@@ -769,6 +824,30 @@ impl DeltaSignatureIndex {
         scratch.extend_from_slice(front);
         scratch.extend_from_slice(back);
         self.find_match_bytes(digest, scratch.as_slice())
+    }
+
+    /// [`Self::find_match_window`] that also tallies upstream-style
+    /// `hash_hits`/`false_alarms` into `counters` for the `-vv` `total:` line.
+    ///
+    /// upstream: `match.c:180-244 hash_search()` maintains the same two counters
+    /// while scanning a file; the local-copy delta loop calls this in place of
+    /// the uncounted probe so it can reproduce `match_report()` (`match.c:439`).
+    pub fn find_match_window_counted(
+        &self,
+        digest: RollingDigest,
+        window: &VecDeque<u8>,
+        scratch: &mut Vec<u8>,
+        counters: &mut ProbeCounters,
+    ) -> Option<usize> {
+        if window.len() != self.block_length {
+            return None;
+        }
+
+        scratch.clear();
+        let (front, back) = window.as_slices();
+        scratch.extend_from_slice(front);
+        scratch.extend_from_slice(back);
+        self.probe_bytes(digest, scratch.as_slice(), None, Some(counters))
     }
 
     /// Attempts to match a short trailing [`VecDeque`] window against a basis

--- a/crates/matching/src/index/tests.rs
+++ b/crates/matching/src/index/tests.rs
@@ -75,6 +75,46 @@ fn find_match_window_handles_split_buffers() {
 }
 
 #[test]
+fn find_match_window_counted_tallies_probe_diagnostics() {
+    let data = vec![b'a'; 2048];
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature = generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4)
+        .expect("signature");
+    let index =
+        DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
+
+    let digest = index.block(0).rolling();
+    let mut window = VecDeque::with_capacity(index.block_length());
+    let mut scratch = Vec::with_capacity(index.block_length());
+    for &byte in &data[..index.block_length()] {
+        window.push_back(byte);
+    }
+
+    // A matching full-length window is exactly one bithash-prefilter positive
+    // that then confirms (no false alarm), and the counted probe returns the
+    // same index the uncounted path would. Two probes accumulate (the probe
+    // does not consume the block).
+    let mut counters = ProbeCounters::default();
+    assert_eq!(
+        index.find_match_window_counted(digest, &window, &mut scratch, &mut counters),
+        Some(0)
+    );
+    assert_eq!(counters.hash_hits, 1, "one bithash-prefilter positive");
+    assert_eq!(counters.false_alarms, 0, "exact verify confirmed the match");
+    index
+        .find_match_window_counted(digest, &window, &mut scratch, &mut counters)
+        .expect("second match");
+    assert_eq!(counters.hash_hits, 2, "counters accumulate across probes");
+    assert_eq!(counters.false_alarms, 0);
+}
+
+#[test]
 fn delta_signature_index_block_length() {
     let data = vec![b'a'; 2048];
     let params = SignatureLayoutParams::new(

--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -36,7 +36,7 @@ pub use fuzzy::{
 };
 pub use generator::{DeltaGenerator, generate_delta};
 pub use index::{
-    DeltaSignatureIndex, HASH_KEY_BITS, HashtableRole, MatchedBlocks, trace_hashtable_created,
-    trace_hashtable_destroyed, trace_hashtable_growing,
+    DeltaSignatureIndex, HASH_KEY_BITS, HashtableRole, MatchedBlocks, ProbeCounters,
+    trace_hashtable_created, trace_hashtable_destroyed, trace_hashtable_growing,
 };
 pub use script::{DeltaScript, DeltaToken, apply_delta};


### PR DESCRIPTION
## Summary

A local copy prints delta stats but omitted upstream's `match_report()` line. Upstream's forked sender emits it once at the end of `send_files()` (`sender.c:491` -> `match.c:439-448`) when `DEBUG_GTE(DELTASUM, 1)` (first active at `-vv`):

```
total: matches=%d  hash_hits=%d  false_alarms=%d data=%s
```

The local-copy executor bypasses the forked sender, so the line was missing entirely. This reproduces it from the executor's own delta accounting.

## What changed

- `matching`: a counted probe (`find_match_window_counted` + shared `probe_bytes`) tallies `hash_hits`/`false_alarms` (new `ProbeCounters`) alongside the match lookup. The uncounted hot path is unchanged.
- `engine` local-copy delta loop counts confirmed matches and folds per-file `matches`/`hash_hits`/`false_alarms` into a run total (`DeltaMatchReport`), emitted once at end-of-run via `debug_log!(Deltasum, 1, ...)` with `data` = cumulative literal bytes. A whole-file copy emits it with `matches=0`, exactly as upstream does.

Nothing about `Total bytes sent`/`received` or the trailer changes here (that is a separate, held decision). This line is stdout/stderr only for a local copy - no wire or golden-byte impact.

## Fidelity (measured vs rsync 3.4.4, x86_64)

`matches` and `data` match upstream exactly. `hash_hits`/`false_alarms` are oc-native diagnostics: `hash_hits` counts bithash-prefilter positives and `false_alarms` the subset that then fails the exact rolling-sum/strong-sum verify. They carry genuine signal about oc's bithash false-positive rate but do NOT reproduce upstream's `SUM2HASH`-collision counts (structurally impossible, and pointless for a `-vv` debug line). The invariant `hash_hits == matches + false_alarms` holds.

| case | upstream | oc |
|---|---|---|
| delta, random 1 MiB basis + 64 KiB change | `total: matches=960  hash_hits=1958  false_alarms=0 data=65536` | `total: matches=960  hash_hits=8238  false_alarms=7278 data=65536` |
| whole-file, fresh dest | `total: matches=0  hash_hits=0  false_alarms=0 data=1048576` | identical |
| `-v` (not `-vv`) | no `total:` line | no `total:` line |

An interop test comparing this line to the oracle should assert `matches == oracle`, `data == oracle`, `hash_hits >= matches`, and `false_alarms >= 0` - not `hash_hits`/`false_alarms` equality.

## Tests

- `matching`: unit test for the counted probe (`hash_hits`/`false_alarms`/return value + accumulation).
- `engine`: guard tests pinning the literal/matched byte partition of the local delta and whole-file summary (the counts measured to already match upstream), so they cannot silently regress.

## Verification (x86_64 Linux, isolated clone off origin/master)

- `cargo fmt --all --check`; `cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings`
- `cargo check` for `x86_64-pc-windows-gnu` and `x86_64-unknown-linux-musl`
- `cargo nextest run -p matching -p engine` (651 delta/stats/probe tests, incl. the 3 new)
- Interop oracle vs `/usr/bin/rsync` 3.4.4 for the cases above
