### PR TITLE
fix(engine): sort multi-source operands in local copy to match upstream itemize order

### DIFF
--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -1,11 +1,13 @@
 //! Top-level source processing orchestration and deferred operation flushing.
 
+use std::cmp::Ordering;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use logging::info_log;
+use protocol::flist::{FileEntry, compare_file_entries};
 
 use crate::local_copy::overrides::device_identifier;
 use crate::local_copy::{
@@ -35,6 +37,67 @@ fn whole_unix_seconds() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|since_epoch| since_epoch.as_secs())
         .unwrap_or(0)
+}
+
+/// Returns the operands in the order the local-copy executor should process
+/// them so multi-operand itemize / `--list-only` output matches upstream.
+///
+/// upstream: flist.c:2544 flist_sort_and_clean() sorts the COMBINED
+/// multi-source file list with f_name_cmp before the generator itemizes it, so
+/// top-level operands are emitted in name order, not command-line order. oc's
+/// per-directory walk already emits each operand's subtree in f_name_cmp order,
+/// and a directory sorts contiguously with its own contents (no top-level
+/// sibling can slot between a directory and its children), so reproducing
+/// upstream's global order only requires ordering the operands themselves with
+/// the same comparator the network generator applies to its flist
+/// (`protocol::flist::compare_file_entries`, transfer `generator/file_list`).
+///
+/// Scope: applied only when every operand contributes a single NAMED top-level
+/// entry - a non-`--relative` transfer with no trailing-slash / copy-contents
+/// operand. A copy-contents operand merges its CONTENTS into the destination,
+/// which upstream interleaves across operands by content name; that cannot be
+/// reproduced by ordering the operands, so those transfers keep command-line
+/// order. `--relative` operands carry implied parent directories whose ordering
+/// is handled during emission, so they are left untouched. Reordering is a
+/// pure output-ordering change: the destination result is byte-identical, the
+/// `--delete` keep-set is order-independent, and dir creation simply follows
+/// the same sorted order upstream uses.
+fn ordered_operands(sources: &[SourceSpec], relative_paths: bool) -> Vec<&SourceSpec> {
+    let mut ordered: Vec<&SourceSpec> = sources.iter().collect();
+    let reorderable = sources.len() > 1
+        && !relative_paths
+        && sources.iter().all(|source| !source.copy_contents());
+    if reorderable {
+        ordered.sort_by(|a, b| compare_operand_names(a, b));
+    }
+    ordered
+}
+
+/// Compares two named operands with the flist sort comparator upstream applies
+/// to top-level entries: directories compare as `name/` and a file sorts before
+/// a same-prefixed directory, exactly as `compare_file_entries` orders the
+/// generator's flist.
+fn compare_operand_names(a: &SourceSpec, b: &SourceSpec) -> Ordering {
+    compare_file_entries(&operand_sort_entry(a), &operand_sort_entry(b))
+}
+
+/// Models an operand as a top-level flist entry (its destination basename plus
+/// its on-disk directory-ness) purely for ordering.
+///
+/// link_stat (lstat) semantics: a directory operand is a directory; a symlink
+/// operand is not (upstream keeps the symlink's own name in the flist). An
+/// operand that has vanished or cannot be stat'd is ordered as a file;
+/// `process_single_source` reports its `link_stat` failure downstream.
+fn operand_sort_entry(source: &SourceSpec) -> FileEntry {
+    let name = source
+        .path()
+        .file_name()
+        .map_or_else(|| source.path().to_path_buf(), PathBuf::from);
+    if fs::symlink_metadata(source.path()).is_ok_and(|meta| meta.is_dir()) {
+        FileEntry::new_directory(name, 0o755)
+    } else {
+        FileEntry::new_file(name, 0, 0o644)
+    }
 }
 
 /// Entry point for copying all sources to the destination.
@@ -178,7 +241,7 @@ pub(crate) fn copy_sources(
                 destination_state.is_dir || plan.destination_spec().force_directory();
 
             let mut first_io_error: Option<LocalCopyError> = None;
-            for source in plan.sources() {
+            for source in ordered_operands(plan.sources(), context.relative_paths_enabled()) {
                 let result = process_single_source(
                     context,
                     plan,

--- a/crates/engine/tests/multi_source_operand_order.rs
+++ b/crates/engine/tests/multi_source_operand_order.rs
@@ -1,0 +1,243 @@
+//! Regression coverage: a LOCAL multi-source copy visits its operands in
+//! upstream `f_name_cmp` order, not command-line order, so the itemize /
+//! `--list-only` / `-v` stdout stream matches a real upstream 3.4.4 transfer.
+//!
+//! # Why this matters (observable stdout-fidelity contract)
+//!
+//! Upstream `send_file_list()` (flist.c:2227) accumulates every source operand
+//! into ONE file list and sorts it globally with `f_name_cmp`
+//! (`flist_sort_and_clean`, flist.c:2544) before the generator itemizes it, so
+//! top-level operands are emitted in name order regardless of the order they
+//! were given on the command line. oc's local-copy executor walks each
+//! operand's subtree already in `f_name_cmp` order but, before this fix, visited
+//! the operands themselves in argument order - so `oc-rsync -ai f_mango
+//! f_cherry f_apple f_banana dst/` itemized `mango, cherry, apple, banana`
+//! where upstream prints `apple, banana, cherry, mango`. The files landed
+//! correctly either way (a copy is a copy); only the observable order diverged,
+//! which the project's output-fidelity contract forbids.
+//!
+//! The expected orders below are the ones a real upstream rsync 3.4.4 prints
+//! for the identical command (verified against the reference binary). These
+//! tests FAIL before the operand-sort fix (they would see argument order).
+//!
+//! Scope (matches the fix): the reorder applies only to NAMED operands (each
+//! contributes a single top-level entry) in a non-`--relative` transfer.
+//! Trailing-slash / copy-contents operands merge their CONTENTS into the
+//! destination, which upstream interleaves across operands by content name -
+//! unreproducible by operand ordering - so they are left in argument order and
+//! covered separately. `--relative` operands are likewise left untouched here.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use engine::local_copy::{
+    LocalCopyAction, LocalCopyExecution, LocalCopyOptions, LocalCopyPlan, LocalCopyRecord,
+};
+use tempfile::{TempDir, tempdir};
+
+/// Relative paths of the records that represent an emitted flist entry
+/// (a created directory or a copied regular file), in stream order.
+fn emitted_entry_order(records: &[LocalCopyRecord]) -> Vec<String> {
+    records
+        .iter()
+        .filter(|record| {
+            matches!(
+                record.action(),
+                LocalCopyAction::DataCopied | LocalCopyAction::DirectoryCreated
+            )
+        })
+        .map(|record| record.relative_path().to_string_lossy().into_owned())
+        .collect()
+}
+
+fn apply(operands: &[OsString], options: LocalCopyOptions) -> engine::local_copy::LocalCopyReport {
+    let plan = LocalCopyPlan::from_operands(operands).expect("plan builds");
+    plan.execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds")
+}
+
+/// Four single-file operands supplied in an order that is deliberately NOT
+/// their sorted order. Upstream itemizes them sorted (`apple, banana, cherry,
+/// mango`); before the fix oc emitted argument order (`mango, cherry, apple,
+/// banana`).
+#[test]
+fn multi_file_operands_are_itemized_in_sorted_order() {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+
+    // Command-line order: mango, cherry, apple, banana.
+    let names = ["mango", "cherry", "apple", "banana"];
+    let mut operands: Vec<OsString> = Vec::new();
+    for name in names {
+        let path = temp.path().join(name);
+        fs::write(&path, name.as_bytes()).expect("write source file");
+        operands.push(path.into_os_string());
+    }
+    operands.push(dst.clone().into_os_string());
+
+    let report = apply(&operands, LocalCopyOptions::default().collect_events(true));
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["apple", "banana", "cherry", "mango"],
+        "multi-file operands must itemize in f_name_cmp order (upstream 3.4.4), \
+         not command-line order",
+    );
+
+    // Regression: every file still lands with correct content.
+    for name in names {
+        assert_eq!(
+            fs::read(dst.join(name)).expect("dst file exists"),
+            name.as_bytes(),
+            "content for {name} must be copied intact",
+        );
+    }
+}
+
+/// Builds two NAMED directory operands whose sorted order is the reverse of the
+/// command-line order, with contents chosen so a naive "sort by content" would
+/// give a different answer than "sort the operands": `zdir` holds the
+/// low-sorting file, `adir` holds the high-sorting file. Upstream orders the
+/// operands (`adir` before `zdir`) and keeps each subtree contiguous.
+fn two_named_dirs() -> (Vec<OsString>, PathBuf, TempDir) {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+    for (dir, file) in [("zdir", "aaa"), ("adir", "zzz")] {
+        let dpath = temp.path().join(dir);
+        fs::create_dir_all(&dpath).expect("create source dir");
+        fs::write(dpath.join(file), file.as_bytes()).expect("write file");
+    }
+    // Command-line order: zdir then adir.
+    let operands = vec![
+        temp.path().join("zdir").into_os_string(),
+        temp.path().join("adir").into_os_string(),
+        dst.clone().into_os_string(),
+    ];
+    (operands, dst, temp)
+}
+
+/// Named directory operands are ordered by `f_name_cmp`, and each operand's
+/// subtree stays contiguous with it - exactly upstream's `adir/, adir/zzz,
+/// zdir/, zdir/aaa`. Proves the reorder keys on the OPERAND name (not on the
+/// contents): `adir` sorts first even though it holds the higher-sorting file.
+#[test]
+fn multi_dir_operands_order_by_operand_name_with_contiguous_subtrees() {
+    let (operands, dst, _temp) = two_named_dirs();
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default().recursive(true).collect_events(true),
+    );
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["adir", "adir/zzz", "zdir", "zdir/aaa"],
+        "named directory operands must sort by operand name with each subtree \
+         contiguous, matching upstream's global flist sort",
+    );
+
+    // Regression: both trees land intact.
+    assert_eq!(fs::read(dst.join("adir/zzz")).unwrap(), b"zzz");
+    assert_eq!(fs::read(dst.join("zdir/aaa")).unwrap(), b"aaa");
+}
+
+/// A single operand is never reordered (nothing to sort) and its own subtree
+/// stays in `f_name_cmp` order - guarding against the sort touching the common
+/// single-source path.
+#[test]
+fn single_directory_source_subtree_stays_sorted() {
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&src).expect("create src");
+    fs::create_dir_all(&dst).expect("create dst");
+    for name in ["zebra", "mango", "apple", "delta"] {
+        fs::write(src.join(name), name.as_bytes()).expect("write");
+    }
+    // Trailing slash: copy the directory's CONTENTS into dst.
+    let operands = vec![
+        format!("{}/", src.display()).into(),
+        dst.clone().into_os_string(),
+    ];
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default().recursive(true).collect_events(true),
+    );
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["apple", "delta", "mango", "zebra"],
+        "a single source's contents stay in f_name_cmp order",
+    );
+}
+
+/// `--relative` operands are intentionally NOT reordered by this fix (their
+/// implied-parent emission ordering is handled separately), so a `-R`
+/// multi-source copy keeps command-line operand order. This pins the scope
+/// boundary: the fix must leave `-R` behaviour exactly as it was.
+#[test]
+fn relative_operands_are_left_in_command_line_order() {
+    let (operands, _dst, _temp) = two_named_dirs();
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .relative_paths(true)
+            .collect_events(true),
+    );
+
+    let order = emitted_entry_order(report.records());
+    let zdir = order.iter().position(|p| p == "zdir");
+    let adir = order.iter().position(|p| p == "adir");
+    assert!(
+        matches!((zdir, adir), (Some(z), Some(a)) if z < a),
+        "under --relative the operands keep command-line order (zdir before \
+         adir); reordering -R is out of scope for this fix. Order was {order:?}",
+    );
+}
+
+/// The operand sort is a pure output-ordering change: reordering the operands
+/// must never change WHICH files land on disk. A copy of the same two dirs in
+/// either command-line order produces byte-identical destinations.
+#[test]
+fn reordering_does_not_change_destination_contents() {
+    let (operands, dst, _temp) = two_named_dirs();
+    apply(
+        &operands,
+        LocalCopyOptions::default().recursive(true),
+    );
+
+    fn snapshot(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+        let mut out = Vec::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            for entry in fs::read_dir(&dir).expect("read_dir") {
+                let path = entry.expect("entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else {
+                    let rel = path.strip_prefix(root).unwrap().to_path_buf();
+                    out.push((rel, fs::read(&path).expect("read")));
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    assert_eq!(
+        snapshot(&dst),
+        vec![
+            (PathBuf::from("adir/zzz"), b"zzz".to_vec()),
+            (PathBuf::from("zdir/aaa"), b"aaa".to_vec()),
+        ],
+        "destination contents are independent of operand visit order",
+    );
+}

--- a/crates/engine/tests/multi_source_operand_order.rs
+++ b/crates/engine/tests/multi_source_operand_order.rs
@@ -193,9 +193,11 @@ fn relative_operands_are_left_in_command_line_order() {
             .collect_events(true),
     );
 
+    // Absolute operands under --relative record their full path-minus-root, so
+    // match the operand leaf by suffix rather than by a bare name.
     let order = emitted_entry_order(report.records());
-    let zdir = order.iter().position(|p| p == "zdir");
-    let adir = order.iter().position(|p| p == "adir");
+    let zdir = order.iter().position(|p| p.ends_with("zdir"));
+    let adir = order.iter().position(|p| p.ends_with("adir"));
     assert!(
         matches!((zdir, adir), (Some(z), Some(a)) if z < a),
         "under --relative the operands keep command-line order (zdir before \
@@ -209,10 +211,7 @@ fn relative_operands_are_left_in_command_line_order() {
 #[test]
 fn reordering_does_not_change_destination_contents() {
     let (operands, dst, _temp) = two_named_dirs();
-    apply(
-        &operands,
-        LocalCopyOptions::default().recursive(true),
-    );
+    apply(&operands, LocalCopyOptions::default().recursive(true));
 
     fn snapshot(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
         let mut out = Vec::new();

--- a/crates/engine/tests/multi_source_operand_order.rs
+++ b/crates/engine/tests/multi_source_operand_order.rs
@@ -244,3 +244,63 @@ fn reordering_does_not_change_destination_contents() {
         "destination contents are independent of operand visit order",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Known divergences NOT addressed by the operand sort, pinned as ignored specs
+// so they stay tracked rather than silently masked. Each encodes upstream's
+// exact behaviour and is ready to un-ignore when its dedicated follow-up lands.
+// ---------------------------------------------------------------------------
+
+/// KNOWN DIVERGENCE (tracked, ignored): copy-contents (trailing-slash) sources
+/// merging into one destination. Upstream flattens every operand's CONTENTS
+/// into one flist and sorts globally, interleaving files across operands by
+/// content name (`aaa, mmm, zzz` below); oc processes each operand's contents
+/// contiguously (`aaa, zzz, mmm`). Ordering the operands cannot reproduce a
+/// cross-operand interleave, so this needs a local-copy flist-collect refactor
+/// and is deliberately out of scope for the named-operand sort. Un-ignore when
+/// that refactor lands.
+#[test]
+#[ignore = "known divergence: copy-contents multi-source content interleave \
+            needs a local-copy flist-collect refactor (separate follow-up)"]
+fn copy_contents_multi_source_interleave_matches_upstream() {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+    fs::create_dir_all(temp.path().join("asrc")).unwrap();
+    fs::create_dir_all(temp.path().join("zsrc")).unwrap();
+    for f in ["aaa", "zzz"] {
+        fs::write(temp.path().join("asrc").join(f), f.as_bytes()).unwrap();
+    }
+    fs::write(temp.path().join("zsrc").join("mmm"), b"mmm").unwrap();
+
+    // Both sources are copy-contents (trailing slash), given asrc then zsrc.
+    let operands = vec![
+        format!("{}/", temp.path().join("asrc").display()).into(),
+        format!("{}/", temp.path().join("zsrc").display()).into(),
+        dst.clone().into_os_string(),
+    ];
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .collect_events(true),
+    );
+
+    // Upstream 3.4.4 interleaves by content name across the two operands.
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["aaa", "mmm", "zzz"],
+        "copy-contents sources must interleave globally by content name",
+    );
+}
+
+// KNOWN DIVERGENCE (tracked, not tested here): multi-source `--delete` timing.
+// With copy-contents directory sources under `--delete`, upstream removes an
+// extraneous destination entry BEFORE it transfers the sources (the `*deleting`
+// row precedes the `>f` rows), whereas oc runs its delete pass at the end so the
+// deletion trails the transfers. The operand sort deliberately does not move the
+// delete pass (the deletion keep-set is order-independent, so results are
+// unchanged). This timing is a separate investigate-and-fix follow-up; it is
+// noted here rather than tested because it only arises with copy-contents
+// sources, which are themselves out of scope above.

--- a/crates/engine/tests/multi_source_operand_order.rs
+++ b/crates/engine/tests/multi_source_operand_order.rs
@@ -131,7 +131,9 @@ fn multi_dir_operands_order_by_operand_name_with_contiguous_subtrees() {
 
     let report = apply(
         &operands,
-        LocalCopyOptions::default().recursive(true).collect_events(true),
+        LocalCopyOptions::default()
+            .recursive(true)
+            .collect_events(true),
     );
 
     assert_eq!(
@@ -167,7 +169,9 @@ fn single_directory_source_subtree_stays_sorted() {
 
     let report = apply(
         &operands,
-        LocalCopyOptions::default().recursive(true).collect_events(true),
+        LocalCopyOptions::default()
+            .recursive(true)
+            .collect_events(true),
     );
 
     assert_eq!(


### PR DESCRIPTION
## What

A local copy with multiple source operands itemized them in command-line
order, while upstream rsync emits them in `f_name_cmp` order. Upstream
`send_file_list()` (flist.c:2227) gathers every operand into one file list and
sorts it globally with `flist_sort_and_clean()` (flist.c:2544, comparator
`f_name_cmp` flist.c:3252) before the generator itemizes it, so top-level
operands appear in name order regardless of argument order.

Measured divergence (vs upstream 3.4.4):

```
oc-rsync -ai f_mango f_cherry f_apple f_banana dst/
  upstream: apple, banana, cherry, mango
  oc (before): mango, cherry, apple, banana
```

The files always landed correctly; only the observable `-i` / `-v` /
`--list-only` order diverged, which the output-fidelity contract forbids.

## Fix

The local-copy executor walks each operand's subtree already in `f_name_cmp`
order and keeps each subtree contiguous, and no top-level sibling can sort
between a directory and its own contents. So reproducing upstream's global
order only requires ordering the operands themselves with the same comparator
the network generator applies to its flist
(`protocol::flist::compare_file_entries`). `ordered_operands()` sorts the
operand list before the processing loop in
`crates/engine/src/local_copy/executor/sources/orchestration.rs`.

The reorder is a pure output-ordering change: the destination result is
byte-identical, the `--delete` keep-set is order-independent (identical
deletions), and directory creation simply follows the same sorted order
upstream uses.

## Scope

Applied only when every operand contributes a single NAMED top-level entry: a
non-`--relative` transfer with no trailing-slash / copy-contents operand.
Deliberately left untouched (tracked separately):

- Copy-contents (trailing-slash) operands merging into one destination.
  Upstream interleaves their CONTENTS across operands by content name, which
  cannot be reproduced by ordering operands (it needs a local-copy
  flist-collect). Reordering such operands could also break cases that happen
  to be correct, so a trailing-slash operand disables the reorder.
- `--relative` / `-R` operands carry implied parent directories whose ordering
  is handled during emission; their multi-source order is a separate, same-class
  divergence not addressed here.

## Verification (isolated clone, x86_64 Linux, vs upstream rsync 3.4.4)

- Multi-file and multi-dir `-ai`: order now byte-matches upstream.
- `--delete` multi-source: destination listing identical to upstream; deletions
  unchanged.
- Content/attrs: `diff -r` clean; `rsync -aHin src dst` dry-run empty.
- Single-source and `-R` behaviour unchanged.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean.
- `cargo check -p engine --all-features --lib --tests` for `x86_64-pc-windows-gnu` and `x86_64-unknown-linux-musl`: clean (pre-existing bench cross-compile failures are unrelated and present on the base branch).
- `cargo nextest run -p engine --all-features`: 5014 passed.
- `cargo nextest run -p cli --all-features`: 3763 passed.
- New test `multi_source_operand_order` (5 cases): passes, and FAILS on the base source (arg order) - proving it pins the divergence.
- `cargo build --bin oc-rsync`: ok.

## Test

`crates/engine/tests/multi_source_operand_order.rs` pins the itemize order to
upstream's for multi-file and multi-dir named operands (keyed on operand name,
not contents), asserts single-source and `--relative` order are unchanged, and
asserts the destination contents are independent of operand visit order.
