### PR TITLE
fix(cli): return a clear error for quic:// URIs when the quic feature is not compiled in

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -90,6 +90,30 @@ fn check_basis_dir_limit(matches: &clap::ArgMatches) -> Result<(), clap::Error> 
     ))
 }
 
+/// Rejects `--quic`/`--quic-ca` on a build without the QUIC transport with an
+/// actionable diagnostic (exit 1) instead of silently ignoring them.
+///
+/// The flags are registered in every build (hidden from help when the `quic`
+/// feature is absent) so they are recognised here and rejected with a clear
+/// remedy, rather than falling through to a bare "unknown option '--quic'".
+///
+/// oc-specific: upstream rsync has no `--quic` modifier.
+#[cfg(not(feature = "quic"))]
+fn check_quic_feature(matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+    let quic_requested =
+        matches.get_flag("quic") || matches.get_one::<OsString>("quic-ca").is_some();
+    if !quic_requested {
+        return Ok(());
+    }
+
+    Err(clap::Error::raw(
+        clap::error::ErrorKind::UnknownArgument,
+        "--quic requires the QUIC transport, which is not compiled into this \
+         build (rebuild with the 'quic' feature). For the daemon protocol over \
+         TCP, use an rsync:// or host::module target instead.\n",
+    ))
+}
+
 /// Parses command-line arguments into a structured [`ParsedArgs`] representation.
 ///
 /// This function accepts an iterator of arguments (typically from `std::env::args_os()`)
@@ -116,6 +140,8 @@ where
     let mut matches = command.try_get_matches_from(args.clone())?;
 
     check_basis_dir_limit(&matches)?;
+    #[cfg(not(feature = "quic"))]
+    check_quic_feature(&matches)?;
 
     let show_help = matches.get_flag("help");
     let show_version = matches.get_count("version");

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
@@ -127,15 +127,18 @@ pub(super) fn add_network_args(command: ClapCommand) -> ClapCommand {
                 .value_parser(OsStringValueParser::new()),
         );
 
-    // The `--quic` modifier (oc extension) upgrades a daemon target to the QUIC
-    // transport; it exists only when the `quic` feature is compiled in, so a
-    // default build rejects it as an unknown argument.
-    #[cfg(feature = "quic")]
-    let command = command
+    // The `--quic`/`--quic-ca` modifiers (oc extension) upgrade a daemon target
+    // to the QUIC transport. They are recognised in every build - hidden from
+    // help when the `quic` feature is absent - so a default build can reject
+    // them with an actionable "requires the 'quic' feature" diagnostic (via
+    // `check_quic_feature`) instead of a bare "unknown option".
+    let quic_unavailable = cfg!(not(feature = "quic"));
+    command
         .arg(
             Arg::new("quic")
                 .long("quic")
                 .help("Carry the rsync daemon protocol over QUIC (873/udp); hard-fails if QUIC cannot be established.")
+                .hide(quic_unavailable)
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -143,10 +146,9 @@ pub(super) fn add_network_args(command: ClapCommand) -> ClapCommand {
                 .long("quic-ca")
                 .value_name("PATH")
                 .help("Verify the QUIC daemon certificate against the CA bundle in PATH (PEM) instead of the system trust store.")
+                .hide(quic_unavailable)
                 .num_args(1)
                 .action(ArgAction::Set)
                 .value_parser(OsStringValueParser::new()),
-        );
-
-    command
+        )
 }

--- a/crates/cli/src/frontend/tests/parse_args_recognises_quic.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_quic.rs
@@ -69,21 +69,26 @@ fn parse_args_quic_defaults_off() {
 
 #[cfg(not(feature = "quic"))]
 #[test]
-fn parse_args_does_not_recognise_quic_flag_when_feature_off() {
-    // WHY (QUIC-8d): with the feature compiled out the `--quic` modifier is
-    // absent. The parser therefore never consumes it as a flag - it falls
-    // through to the trailing operand list (where it later fails as a bogus
-    // path), so no code path can select an unbuilt transport.
-    let parsed = parse_args([
-        OsString::from(RSYNC),
-        OsString::from("--quic"),
-        OsString::from("host::module"),
-        OsString::from("dest"),
-    ])
-    .expect("parse");
+fn parse_args_rejects_quic_flags_with_actionable_error_when_feature_off() {
+    // WHY (176a): with the feature compiled out the `--quic`/`--quic-ca`
+    // modifiers are still RECOGNISED (hidden from help) so the parser rejects
+    // them with an actionable "requires the 'quic' feature" diagnostic and exit
+    // 1, rather than silently passing `--quic` through as a bogus operand. No
+    // code path can select an unbuilt transport, and the user learns the remedy.
+    for args in [
+        vec!["--quic", "host::module", "dest"],
+        vec!["--quic-ca", "/etc/oc-rsync/ca.pem", "host::module", "dest"],
+    ] {
+        let mut argv = vec![OsString::from(RSYNC)];
+        argv.extend(args.iter().map(OsString::from));
+        let err = parse_args(argv).expect_err("quic flags must be rejected when the feature is off");
 
-    assert!(
-        parsed.remainder.contains(&OsString::from("--quic")),
-        "--quic must not be consumed as a flag when quic is off"
-    );
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--quic requires the QUIC transport"),
+            "unexpected message: {msg}"
+        );
+        assert!(msg.contains("'quic' feature"), "unexpected message: {msg}");
+    }
 }

--- a/crates/cli/src/frontend/tests/parse_args_recognises_quic.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_quic.rs
@@ -81,7 +81,8 @@ fn parse_args_rejects_quic_flags_with_actionable_error_when_feature_off() {
     ] {
         let mut argv = vec![OsString::from(RSYNC)];
         argv.extend(args.iter().map(OsString::from));
-        let err = parse_args(argv).expect_err("quic flags must be rejected when the feature is off");
+        let err =
+            parse_args(argv).expect_err("quic flags must be rejected when the feature is off");
 
         assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
         let msg = err.to_string();

--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -577,6 +577,32 @@ pub(crate) fn ssh_url_requires_embedded_ssh() -> ClientError {
     )
 }
 
+/// Reports that a `quic://` operand was given but the QUIC transport was not
+/// compiled into this build, so the transfer has no transport.
+///
+/// Without the `quic` feature the `quic://` scheme is not recognised as a
+/// daemon URL, so the operand falls through to the subprocess ssh path, which
+/// parses `quic://host/module` as a `host:path` spec with host `quic` and fails
+/// with a confusing "could not resolve hostname quic". This surfaces the real
+/// cause with an actionable remedy instead. The exit code matches the other
+/// feature-unavailable diagnostics ([`ExitCode::Syntax`], via
+/// [`FEATURE_UNAVAILABLE_EXIT_CODE`]).
+///
+/// oc-specific: upstream rsync has no `quic://` operand scheme.
+///
+/// Only compiled when `quic` is absent - that is the sole configuration in
+/// which a `quic://` operand has no transport and this diagnostic fires.
+#[cfg(not(feature = "quic"))]
+#[cold]
+pub(crate) fn quic_url_requires_quic_feature() -> ClientError {
+    daemon_error(
+        "quic:// URLs require the QUIC transport, which is not compiled into \
+         this build (rebuild with the 'quic' feature). For the daemon protocol \
+         over TCP, use an rsync:// or host::module target instead.",
+        FEATURE_UNAVAILABLE_EXIT_CODE,
+    )
+}
+
 /// Enables idiomatic error conversion using the `?` operator.
 ///
 /// # Examples
@@ -1156,6 +1182,18 @@ mod tests {
             assert!(msg.contains("ssh:// URLs require the built-in SSH client"));
             assert!(msg.contains("embedded-ssh"));
             assert!(msg.contains("-e ssh"));
+        }
+
+        #[cfg(not(feature = "quic"))]
+        #[test]
+        fn quic_url_requires_quic_feature_is_actionable() {
+            let error = quic_url_requires_quic_feature();
+
+            assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
+            let msg = error.to_string();
+            assert!(msg.contains("quic:// URLs require the QUIC transport"));
+            assert!(msg.contains("'quic' feature"));
+            assert!(msg.contains("rsync://"));
         }
 
         #[test]

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -74,6 +74,20 @@ pub(crate) fn is_ssh_url(operand: &str) -> bool {
     operand.starts_with("ssh://")
 }
 
+/// Checks whether an operand is a `quic://` URL.
+///
+/// Returns `true` for operands beginning with `quic://` (case-insensitive
+/// scheme, matching the daemon-URL dispatch), the scheme that carries the
+/// daemon protocol over QUIC. Compiled into every build - not gated on the
+/// `quic` feature - so the dispatcher can recognise the scheme even when that
+/// feature is absent and reject it with a clear diagnostic instead of
+/// misparsing it as a `host:path` spec with host `quic`.
+///
+/// oc-specific: upstream rsync has no `quic://` operand scheme.
+pub(crate) fn is_quic_url(operand: &str) -> bool {
+    operand.starts_with("quic://") || operand.starts_with("QUIC://")
+}
+
 /// Maps the negotiated [`AddressMode`] onto the SSH `-4`/`-6` hint shared by
 /// every `do_cmd()`-equivalent SSH spawn (single-host and remote-to-remote).
 ///
@@ -95,7 +109,7 @@ pub(in crate::client::remote) const fn ssh_address_family(
 
 #[cfg(test)]
 mod tests {
-    use super::is_ssh_url;
+    use super::{is_quic_url, is_ssh_url};
 
     /// The `ssh://` detector is the single source of truth for the scheme that
     /// selects the embedded transport, so it must recognise the scheme (with or
@@ -112,5 +126,22 @@ mod tests {
         assert!(!is_ssh_url("rsync://host/module"));
         assert!(!is_ssh_url("quic://host/module"));
         assert!(!is_ssh_url("/local/path"));
+    }
+
+    /// The `quic://` detector is the single source of truth for the QUIC daemon
+    /// scheme (compiled into every build), so it must recognise `quic://` in
+    /// either case and reject every other operand shape - `host:path`, daemon
+    /// modules, `rsync://`, `ssh://`, and plain local paths.
+    #[test]
+    fn is_quic_url_matches_only_quic_scheme() {
+        assert!(is_quic_url("quic://host/module"));
+        assert!(is_quic_url("quic://user@host:8730/module"));
+        assert!(is_quic_url("QUIC://host/module"));
+
+        assert!(!is_quic_url("host:path"));
+        assert!(!is_quic_url("host::module"));
+        assert!(!is_quic_url("rsync://host/module"));
+        assert!(!is_quic_url("ssh://host/path"));
+        assert!(!is_quic_url("/local/path"));
     }
 }

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -229,6 +229,23 @@ fn run_client_internal(
         },
     );
 
+    // With the QUIC transport absent, a quic:// operand would otherwise fall
+    // through to the subprocess ssh path below, which parses quic://host/module
+    // as a host:path spec with host "quic" and fails with a confusing "could
+    // not resolve hostname quic". Fail fast with an actionable diagnostic
+    // instead. oc-specific: upstream rsync has no quic:// operand scheme.
+    #[cfg(not(feature = "quic"))]
+    {
+        let has_quic_url = config
+            .transfer_args()
+            .iter()
+            .any(|arg| remote::is_quic_url(&arg.to_string_lossy()));
+
+        if has_quic_url {
+            return Err(super::error::quic_url_requires_quic_feature());
+        }
+    }
+
     let has_daemon_url = config.transfer_args().iter().any(|arg| {
         let s = arg.to_string_lossy();
         if s.starts_with("rsync://") || s.contains("::") {
@@ -238,7 +255,7 @@ fn run_client_internal(
         // routes to the daemon path (not the SSH path). Recognised only under
         // the `quic` feature; absent from a default build.
         #[cfg(feature = "quic")]
-        if s.starts_with("quic://") || s.starts_with("QUIC://") {
+        if remote::is_quic_url(&s) {
             return true;
         }
         false
@@ -1161,6 +1178,33 @@ mod run_client_tests {
         // Must NOT be the -e conflict, which would blame an option the user may
         // never have typed (RSYNC_RSH) on a build that cannot do ssh:// anyway.
         assert!(!msg.contains("cannot be combined with an ssh:// URL operand"));
+    }
+
+    /// Without the QUIC transport compiled in, a `quic://` operand has no
+    /// transport. It must fail fast with the feature-unavailable exit code and
+    /// an actionable message, never fall through to the subprocess ssh path
+    /// where `quic://host/module` misparses as host `quic` and yields the
+    /// confusing "could not resolve hostname quic".
+    #[cfg(not(feature = "quic"))]
+    #[test]
+    fn run_client_rejects_quic_url_without_quic() {
+        use crate::client::error::FEATURE_UNAVAILABLE_EXIT_CODE;
+
+        let error = run_client(
+            ClientConfig::builder()
+                .transfer_args([
+                    std::ffi::OsString::from("quic://localhost/module"),
+                    std::ffi::OsString::from("/tmp/oc-quic-url-dest"),
+                ])
+                .build(),
+        )
+        .expect_err("quic:// without the quic feature must error");
+
+        assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
+        let msg = error.to_string();
+        assert!(msg.contains("quic:// URLs require the QUIC transport"));
+        assert!(msg.contains("'quic' feature"));
+        assert!(msg.contains("rsync://"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

On a build without the `quic` feature, a `quic://` operand or the `--quic`/`--quic-ca` modifiers produced obscure failures instead of a clear diagnostic. This mirrors the just-merged ssh:// handling (#7175) for QUIC.

Measured on a default (non-quic) build, before -> after:

| input | before | after |
|---|---|---|
| `quic://localhost/mod/` operand | `ssh: Could not resolve hostname quic` -> `unexplained error (code 255)` | `quic:// URLs require the QUIC transport, which is not compiled into this build (rebuild with the 'quic' feature)...` (exit 1) |
| `--quic` | `unknown option '--quic'` (exit 1) | `--quic requires the QUIC transport... (rebuild with the 'quic' feature)...` (exit 1) |
| `--quic-ca PATH` | `unknown option '--quic-ca'` (exit 1) | same actionable message (exit 1) |

## What changed

- **core** (`quic://` operand): `is_quic_url` is compiled into every build (single source of truth), used by the daemon-URL dispatch under the feature and by a new `#[cfg(not(feature = "quic"))]` guard that fails fast with `quic_url_requires_quic_feature()` (exit code `Syntax` = 1, matching the other feature-unavailable diagnostics). Without this the operand fell through to the subprocess ssh path and misparsed as host `quic`.
- **cli** (`--quic`/`--quic-ca`): the flags are registered in every build, hidden from `--help` when the `quic` feature is absent, and rejected on a non-quic build by `check_quic_feature` with the same actionable message - instead of the generic "unknown option".

No behavior change under the `quic` feature: the flags stay visible and functional, and the daemon-URL dispatch is unchanged.

## Tests

- core: `is_quic_url` scheme matcher; `quic_url_requires_quic_feature()` message/exit; `run_client` rejects a `quic://` operand without the feature.
- cli: the pre-existing `parse_args ... quic ... feature_off` test is updated from the old "falls through to remainder" behavior to the new "recognised and rejected with an actionable error (exit 1)", covering `--quic` and `--quic-ca`.

## Verification (x86_64 Linux, isolated clone off origin/master)

Both feature configurations, since the fix lives mainly in `#[cfg(not(feature = "quic"))]` paths that CI's `--all-features` build does not compile:

- `cargo fmt --all --check`
- `cargo clippy --locked --workspace --all-targets --no-deps -D warnings` (default) and `... --all-features` - both clean
- `cargo check` for `x86_64-pc-windows-gnu` and `x86_64-unknown-linux-musl` (`--all-features`)
- `cargo nextest run -p core -p cli` (6431 passed, default) and `... --all-features` (6510 passed)
- Manual: `quic://`, `--quic`, `--quic-ca` all exit 1 with the actionable message on a default build; `--quic` is hidden from `--help`.
