### PR TITLE
fix(filters): re-derive CVS C-modifier implied flags on wire decode

### DIFF
--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -449,7 +449,20 @@ fn parse_wire_rule_modern(
                 pattern_start += 1;
             }
             'C' => {
+                // upstream: exclude.c:1248-1255 parse_rule_tok() case 'C' sets
+                // FILTRULE_NO_PREFIXES | FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT
+                // | FILTRULE_CVS_IGNORE together, so a `C` rule carries all the
+                // flags it implies. Re-derive them here so a `:C` dir-merge from
+                // an upstream peer keeps its no-inherit/word-split/no-prefixes
+                // semantics (the receiver gates DirMergeConfig::with_inherit on
+                // no_inherit). The serializer collapses these back to a bare `C`
+                // (get_rule_prefix emits only `C` and suppresses the implied
+                // flags, exclude.c:1548-1561), so re-encoding a decoded `:C`
+                // stays `:C` - no double-application.
                 rule.cvs_exclude = true;
+                rule.no_inherit = true;
+                rule.word_split = true;
+                rule.no_prefixes = true;
                 pattern_start += 1;
             }
             'n' => {

--- a/crates/protocol/tests/filter_rule_wire_roundtrip.rs
+++ b/crates/protocol/tests/filter_rule_wire_roundtrip.rs
@@ -556,62 +556,55 @@ fn risk_normalizes_to_receiver_side_include() {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// CVS `C` modifier: the serializer emits ONLY `C` and suppresses the flags it
+// CVS `C` modifier. The serializer emits ONLY `C` and suppresses the flags it
 // implies (no-inherit/word-split/no-prefixes), matching upstream
-// get_rule_prefix() (exclude.c:1548-1561). Upstream's parser, however,
-// RE-DERIVES those implied flags from `C` (parse_rule_tok case 'C',
-// exclude.c:1248-1254), whereas oc's wire parser sets only `cvs_exclude` and
-// leaves the implied flags unset. This is therefore NOT a self-inverse for a
-// realistic CVS dir-merge: the implied flags are lost on decode. Pinned here as
-// the current behavior; flagged to the lead as an asymmetry-vs-upstream finding
-// for a separate fix (the wire parser should re-derive the implied flags on `C`
-// to match parse_rule_tok).
+// get_rule_prefix() (exclude.c:1548-1561). The PARSER re-derives those implied
+// flags from `C`, mirroring upstream parse_rule_tok case 'C'
+// (exclude.c:1248-1255 sets NO_PREFIXES|WORD_SPLIT|NO_INHERIT|CVS_IGNORE). The
+// two halves compose into a stable WIRE fixpoint: `:C` decodes to the full
+// implied flag set and re-encodes back to `:C`.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn cvs_dir_merge_serializes_only_c_and_parser_does_not_re_derive_implied_flags() {
+fn cvs_dir_merge_c_modifier_re_derives_implied_flags_matching_upstream() {
     let protocol = proto(32);
+    // A realistic CVS dir-merge carries the flags `C` implies on the send side.
     let cvs = FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
         pattern: ".cvsignore".to_owned(),
         cvs_exclude: true,
-        // The flags `C` implies upstream; oc sets them on the send-side rule.
         no_inherit: true,
         word_split: true,
         no_prefixes: true,
         ..FilterRuleWireFormat::default()
     };
 
-    let (payload, decoded) = encode_payload_and_decode(&cvs, protocol);
-    // Serializer collapses the implied flags to a single `C`, matching upstream.
-    assert_eq!(payload, b":C .cvsignore");
-    assert!(decoded.cvs_exclude, "the `C` bit survives");
-    // Asymmetry: oc's parser does NOT re-add the flags `C` implies (upstream
-    // parse_rule_tok would). Pinned so the divergence is visible and any future
-    // fix updates this assertion deliberately.
-    assert!(
-        !decoded.no_inherit,
-        "implied no-inherit is NOT re-derived (finding)"
-    );
-    assert!(
-        !decoded.word_split,
-        "implied word-split is NOT re-derived (finding)"
-    );
-    assert!(
-        !decoded.no_prefixes,
-        "implied no-prefixes is NOT re-derived (finding)"
-    );
+    // Serializer collapses the implied flags to a single `C`, and the parser
+    // re-derives them, so this full-implied rule is a true struct fixpoint.
+    assert_roundtrips_to_self(cvs, protocol, b":C .cvsignore");
 
-    // A rule carrying ONLY the `C` bit (no implied flags) IS a clean fixpoint,
-    // so the oc<->oc wire is self-consistent even though it diverges from an
-    // upstream peer's re-derivation.
+    // A rule carrying ONLY the `C` bit still serializes to `:C`, and decoding it
+    // re-derives the flags `C` implies - exactly what an UPSTREAM peer's `:C`
+    // means. So the struct gains the implied flags (it is NOT a struct fixpoint),
+    // but the WIRE bytes are a fixpoint: `:C` -> full-implied -> `:C`.
     let bare_cvs = FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
         pattern: ".cvsignore".to_owned(),
         cvs_exclude: true,
         ..FilterRuleWireFormat::default()
     };
-    assert_roundtrips_to_self(bare_cvs, protocol, b":C .cvsignore");
+    let (payload, decoded) = encode_payload_and_decode(&bare_cvs, protocol);
+    assert_eq!(payload, b":C .cvsignore");
+    assert!(decoded.cvs_exclude, "the `C` bit survives");
+    assert!(decoded.no_inherit, "no-inherit is re-derived from `C`");
+    assert!(decoded.word_split, "word-split is re-derived from `C`");
+    assert!(decoded.no_prefixes, "no-prefixes is re-derived from `C`");
+
+    // Re-encoding the decoded rule reproduces the same `:C` bytes (the
+    // serializer suppresses the implied flags again - no double-application).
+    let (payload2, decoded2) = encode_payload_and_decode(&decoded, protocol);
+    assert_eq!(payload2, b":C .cvsignore");
+    assert_eq!(decoded2, decoded, "`:C` is a wire fixpoint");
 }
 
 #[test]

--- a/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
+++ b/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
@@ -179,4 +179,38 @@ mod tests {
         assert_eq!(merge_configs.len(), 1);
         assert_eq!(merge_configs[0].filename(), ".rsync-filter");
     }
+
+    /// End-to-end: a `:C` dir-merge as an UPSTREAM peer emits it must yield a
+    /// non-inheriting per-directory merge config on the receiver. Upstream's
+    /// `parse_rule_tok` case `C` sets NO_INHERIT (exclude.c:1248-1255), and this
+    /// receiver gates `DirMergeConfig::with_inherit(false)` on `wire_rule.no_inherit`.
+    /// Before the wire parser re-derived the `C`-implied flags, `no_inherit` came
+    /// back unset and the config inherited into subdirectories - dropping the CVS
+    /// no-inherit semantics for a real upstream `:C`. Decode the raw `:C` bytes
+    /// (exercising the parser) and confirm the built config does not inherit.
+    #[test]
+    fn upstream_colon_c_dir_merge_yields_non_inheriting_config() {
+        let protocol = protocol::ProtocolVersion::from_supported(32).unwrap();
+        // Wire record an upstream peer emits for a CVS per-directory merge.
+        let payload: &[u8] = b":C .cvsignore";
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(payload.len() as i32).to_le_bytes());
+        buf.extend_from_slice(payload);
+        buf.extend_from_slice(&0i32.to_le_bytes());
+
+        let wire = protocol::filters::read_filter_list(&mut &buf[..], protocol)
+            .expect("`:C` record decodes");
+        assert_eq!(wire.len(), 1);
+        assert!(wire[0].cvs_exclude, "`C` bit decoded");
+        assert!(wire[0].no_inherit, "`C` re-derives no-inherit on decode");
+
+        let (_set, merge_configs) =
+            parse_wire_filters_for_receiver(&wire).expect("dir-merge rule parses");
+        assert_eq!(merge_configs.len(), 1);
+        assert_eq!(merge_configs[0].filename(), ".cvsignore");
+        assert!(
+            !merge_configs[0].inherits(),
+            "an upstream `:C` merge must NOT inherit into subdirectories",
+        );
+    }
 }


### PR DESCRIPTION
## What

The filter-list wire PARSER did not re-derive the flags the `C` modifier
implies. Upstream `parse_rule_tok()` (exclude.c:1248-1255, confirmed in the
3.4.4 source) sets, for `case 'C'`:

```
FILTRULE_NO_PREFIXES | FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT | FILTRULE_CVS_IGNORE
```

oc's `parse_wire_rule_modern()` set only `cvs_exclude`, leaving `no_inherit`,
`word_split`, and `no_prefixes` unset. Because the SERIALIZER already collapses
those implied flags to a bare `C` (`get_rule_prefix()` emits only `C`,
exclude.c:1548-1561), an oc-to-oc bare-`C` round-trip was a symmetric fixpoint
and the gap stayed hidden. Against a real UPSTREAM peer it was not: a `:C`
per-directory CVS merge decodes with `no_inherit` unset, and the receiver gates
`DirMergeConfig::with_inherit(false)` on `wire_rule.no_inherit`, so the merged
CVS rules were wrongly inherited into subdirectories.

## Fix

`parse_wire_rule_modern()` now sets all four flags on `C`, mirroring
`parse_rule_tok`. The serializer is unchanged: encoding a decoded `:C`
suppresses the implied flags again, so `:C` -> full-implied -> `:C` is a stable
wire fixpoint with no double-application.

Before/after decode of the wire record `:C .cvsignore`:

```
before: cvs_exclude=true, no_inherit=false, word_split=false, no_prefixes=false
after:  cvs_exclude=true, no_inherit=true,  word_split=true,  no_prefixes=true
```

## Tests

- `crates/transfer/.../wire_filters.rs`:
  `upstream_colon_c_dir_merge_yields_non_inheriting_config` decodes the raw
  `:C .cvsignore` bytes an upstream peer emits and asserts the resulting
  `DirMergeConfig` does NOT inherit. Fails pre-fix ("`C` re-derives no-inherit
  on decode").
- `crates/protocol/tests/filter_rule_wire_roundtrip.rs`: the existing CVS-`C`
  test is updated from pinning the old divergence to asserting the corrected
  behaviour - `:C` decodes to the full implied flag set (a struct fixpoint) and
  re-encodes to `:C` (a wire fixpoint). Fails pre-fix on the round-trip
  equality. The golden `:C` byte tests are unchanged (the serializer is
  untouched).

## Verification (isolated clone off origin/master, x86_64 Linux)

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean.
- `cargo check -p protocol -p transfer --all-features --lib --tests` for `x86_64-pc-windows-gnu` and `x86_64-unknown-linux-musl`: clean.
- `cargo nextest run -p protocol -p transfer --all-features`: 8673 passed.
- `cargo build --bin oc-rsync`: ok.
- Both new/updated assertions confirmed to FAIL on the pre-fix parser and pass after.
