### PR TITLE
docs(cli): document ssh:// and quic:// access methods in --help (feature-gated)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,10 @@ openssl-vendored = ["checksums/openssl-vendored"]
 # ============================================================================
 
 # Embedded SSH transport via russh - removes the runtime dependency on an
-# external `ssh` client. Forwards through `core` to `rsync_io/embedded-ssh`.
-embedded-ssh = ["core/embedded-ssh"]
+# external `ssh` client. Forwards through `core` to `rsync_io/embedded-ssh`, and
+# through `cli` so `--help` advertises the built-in `ssh://` client only when it
+# is compiled in.
+embedded-ssh = ["cli/embedded-ssh", "core/embedded-ssh"]
 
 # Native QUIC daemon transport (oc extension, off by default). Forwards through
 # `cli`/`core` to `rsync_io/quic`; only makes the `Transport::Quic` selection

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -69,6 +69,7 @@ async-daemon = ["daemon/async-daemon"]
 quic = ["core/quic"]
 
 
+
 [dependencies]
 bandwidth = { path = "../bandwidth" }
 clap = { workspace = true }

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -7,7 +7,7 @@ use core::branding::{build_revision, rust_version};
 pub(super) fn help_text(program_name: ProgramName) -> String {
     let program = program_name.as_str();
 
-    format!(
+    let mut help = format!(
         concat!(
             "{program} v{version} revision #{revision}\n",
             "Usage: {program} [-h] [-V] [--daemon] [-n] [-a] [-S] [-z] [-e COMMAND] [--delete] [--bwlimit=RATE] SOURCE... DEST\n",
@@ -250,13 +250,36 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "    Security / daemon:\n",
             "      --password-command=COMMAND  Alternative to --password-file and the RSYNC_PASSWORD environment variable (both honored); use when the daemon password must come from a command.\n",
             "\n",
-            "SOURCE may be local paths or remote references (USER@HOST:PATH or\n",
-            "rsync://HOST/MODULE/PATH). When multiple sources are supplied, DEST\n",
-            "must name a directory. Metadata preservation covers permissions,\n",
-            "timestamps, and optional ownership metadata.\n",
+            "Access methods for SOURCE and DEST:\n",
+            "      [USER@]HOST:PATH  Connect via a remote shell (-e/--rsh, default ssh).\n",
+            "      [USER@]HOST::MODULE[/PATH]  Connect to an rsync daemon.\n",
+            "      rsync://[USER@]HOST[:PORT]/MODULE[/PATH]  Connect to an rsync daemon.\n",
         ),
         program = program,
         version = rust_version(),
         revision = build_revision(),
-    )
+    );
+
+    // The ssh:// and quic:// schemes are oc-rsync extensions compiled in only
+    // under their respective cargo features. cfg! yields a compile-time bool, so
+    // each line appears only in a build that actually understands the scheme.
+    if cfg!(feature = "embedded-ssh") {
+        help.push_str(
+            "      ssh://[USER@]HOST[:PORT]/PATH  oc-rsync extension: builtin SSH client.\n",
+        );
+    }
+    if cfg!(feature = "quic") {
+        help.push_str(
+            "      quic://[USER@]HOST[:PORT]/MODULE[/PATH]  oc-rsync extension: QUIC transport.\n",
+        );
+    }
+
+    help.push_str(concat!(
+        "\n",
+        "Local paths are also accepted. When multiple sources are supplied,\n",
+        "DEST must name a directory. Metadata preservation covers permissions,\n",
+        "timestamps, and optional ownership metadata.\n",
+    ));
+
+    help
 }

--- a/crates/cli/src/frontend/tests/help.rs
+++ b/crates/cli/src/frontend/tests/help.rs
@@ -263,6 +263,50 @@ fn regrouping_preserves_the_full_option_set() {
     );
 }
 
+#[test]
+fn access_methods_block_lists_all_connection_forms_feature_gated() {
+    // WHY: --help must tell a user every way to name a SOURCE/DEST. The upstream
+    // forms (remote shell, host::module, rsync://) are always available, so they
+    // are unconditional. ssh:// and quic:// are oc-rsync extensions that only
+    // work when their cargo feature is compiled in; advertising them in a build
+    // that cannot honor them would be a lie. The assertions therefore track the
+    // feature set this test is compiled under (cfg!), never a fixed snapshot.
+    let help = render_help(ProgramName::OcRsync);
+
+    assert!(help.contains("Access methods for SOURCE and DEST:"));
+    assert!(
+        help.contains("[USER@]HOST:PATH  Connect via a remote shell"),
+        "remote-shell access method missing"
+    );
+    assert!(
+        help.contains("[USER@]HOST::MODULE[/PATH]  Connect to an rsync daemon."),
+        "host::module daemon access method missing"
+    );
+    assert!(
+        help.contains("rsync://[USER@]HOST[:PORT]/MODULE[/PATH]  Connect to an rsync daemon."),
+        "rsync:// daemon access method missing"
+    );
+
+    let has_ssh = help.contains("ssh://[USER@]HOST[:PORT]/PATH  oc-rsync extension");
+    assert_eq!(
+        has_ssh,
+        cfg!(feature = "embedded-ssh"),
+        "ssh:// access method must appear iff the embedded-ssh feature is compiled in"
+    );
+
+    let has_quic = help.contains("quic://[USER@]HOST[:PORT]/MODULE[/PATH]  oc-rsync extension");
+    assert_eq!(
+        has_quic,
+        cfg!(feature = "quic"),
+        "quic:// access method must appear iff the quic feature is compiled in"
+    );
+
+    assert!(
+        help.contains("When multiple sources are supplied,\nDEST must name a directory."),
+        "multi-source DEST-must-be-a-directory note missing"
+    );
+}
+
 fn collect_options(text: &str) -> BTreeSet<String> {
     let mut tokens = BTreeSet::new();
     let mut chars = text.chars().peekable();


### PR DESCRIPTION
## Summary

The `--help` access-methods trailer only documented two of the connection
forms oc-rsync accepts:

```
SOURCE may be local paths or remote references (USER@HOST:PATH or
rsync://HOST/MODULE/PATH). When multiple sources are supplied, DEST
must name a directory. ...
```

It omitted the `host::MODULE` daemon shorthand and the two oc-rsync transport
extensions (`ssh://`, `quic://`), which previously surfaced only inside
individual `--ssh-*` / `--aes` flag descriptions.

This restructures the trailer into an explicit "Access methods" block that
enumerates every connection form. The two oc-rsync extensions are
feature-gated so a line appears only in a build that can actually honor the
scheme.

## After (default features: embedded-ssh on, quic off)

```
Access methods for SOURCE and DEST:
      [USER@]HOST:PATH  Connect via a remote shell (-e/--rsh, default ssh).
      [USER@]HOST::MODULE[/PATH]  Connect to an rsync daemon.
      rsync://[USER@]HOST[:PORT]/MODULE[/PATH]  Connect to an rsync daemon.
      ssh://[USER@]HOST[:PORT]/PATH  oc-rsync extension: builtin SSH client.

Local paths are also accepted. When multiple sources are supplied,
DEST must name a directory. Metadata preservation covers permissions,
timestamps, and optional ownership metadata.
```

## After (`--all-features`: embedded-ssh + quic on)

Same block plus:

```
      quic://[USER@]HOST[:PORT]/MODULE[/PATH]  oc-rsync extension: QUIC transport.
```

A build with neither feature (`cargo build -p cli` with no default features)
shows only the three unconditional upstream forms.

## Feature-gating

The block is built by pushing lines onto a `String`; `cfg!(feature = "...")`
yields a compile-time bool, so each extension line is emitted only when its
feature is active. The `cli` crate already had a `quic` feature; this adds a
matching `embedded-ssh = ["core/embedded-ssh"]` feature (mirroring the `quic`
pattern) and forwards it from the workspace-root `embedded-ssh` feature so
`cfg!(feature = "embedded-ssh")` is meaningful inside `cli`. No default build
changes: `core/embedded-ssh` is already active under the shipping binary's
default features; the new forwarding only threads the selector into `cli`.

Help text only. No wire, protocol, or transfer-behavior change.

## Tests

The help snapshot test compares `--help` output against `render_help(...)`
(same code path), so it stays correct under any feature set. A new
`access_methods_block_lists_all_connection_forms_feature_gated` test asserts
the three unconditional forms are always present and that `ssh://` / `quic://`
appear iff `cfg!(feature = "embedded-ssh")` / `cfg!(feature = "quic")`, so it
passes under both default and `--all-features`.
