### PR TITLE
fix(daemon): resolve Windows local-group membership for @group auth

### DIFF
--- a/crates/daemon/src/daemon/module_state/auth.rs
+++ b/crates/daemon/src/daemon/module_state/auth.rs
@@ -69,10 +69,12 @@ pub(crate) trait GroupMembership {
 /// Production [`GroupMembership`] backed by the host group database.
 ///
 /// Resolves the user's uid and enumerates its full group set via
-/// `metadata::id_lookup::groups_for_user` (`getpwnam` + `getgrouplist` +
-/// `getgrgid`). On platforms without a POSIX group database the set is empty,
-/// so no `@group` token can match - matching upstream, which compiles the
-/// `@group` branch only when `HAVE_GETGROUPLIST` is defined.
+/// `metadata::id_lookup::groups_for_user`. On Unix this is `getpwnam` +
+/// `getgrouplist` + `getgrgid`; on Windows it is `NetUserGetLocalGroups`
+/// (local groups the account belongs to, including indirect membership). On a
+/// platform with neither database the set is empty, so no `@group` token can
+/// match - matching upstream, which compiles the `@group` branch only when
+/// `HAVE_GETGROUPLIST` is defined.
 ///
 /// upstream: authenticate.c:283-295 `auth_server()` resolves the authenticating
 /// user's groups with `getallgroups()` and `wildmatch`es each against `tok+1`.
@@ -80,11 +82,11 @@ pub(crate) struct SystemGroupMembership;
 
 impl GroupMembership for SystemGroupMembership {
     fn groups_of(&self, user: &str) -> Vec<String> {
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             metadata::id_lookup::groups_for_user(user).unwrap_or_default()
         }
-        #[cfg(not(unix))]
+        #[cfg(not(any(unix, windows)))]
         {
             let _ = user;
             Vec::new()
@@ -277,5 +279,98 @@ mod tests {
         let list = entries(&["alice", "team*", "@staff"]);
         let groups = MockGroups(HashMap::from([("carol", vec!["staff"])]));
         assert!(authorize_auth_user(&list, "intruder", &groups).is_none());
+    }
+
+    /// On Windows, `auth users = @group` must admit a real member of a local
+    /// group and reject a non-member. This exercises the production
+    /// [`SystemGroupMembership`] against live `NetUserGetLocalGroups`
+    /// resolution, guarding against a regression to the old empty-`Vec` stub
+    /// that made every `@group` token dead on Windows.
+    ///
+    /// WHY the real resolver, not [`MockGroups`]: the mock proves the matching
+    /// loop; only the system resolver proves the platform lookup actually
+    /// returns the account's groups. The test provisions a throwaway local
+    /// group containing the current user with `net localgroup`. Creating or
+    /// populating a local group needs Administrator rights, so when the CI
+    /// account lacks them the provisioning step fails and the test skips with a
+    /// printed reason - it never passes silently.
+    #[cfg(windows)]
+    #[test]
+    fn windows_group_token_admits_real_member() {
+        use std::process::Command;
+
+        let group = format!("ocrsync_test_grp_{}", std::process::id());
+        let Ok(user) = std::env::var("USERNAME") else {
+            eprintln!(
+                "SKIP windows_group_token_admits_real_member: USERNAME is not set, cannot identify the current account"
+            );
+            return;
+        };
+
+        let delete = |g: &str| {
+            let _ = Command::new("net")
+                .args(["localgroup", g, "/delete"])
+                .status();
+        };
+
+        // Provision: create the group. Denied without admin rights - skip.
+        match Command::new("net")
+            .args(["localgroup", &group, "/add"])
+            .status()
+        {
+            Ok(status) if status.success() => {}
+            Ok(status) => {
+                eprintln!(
+                    "SKIP windows_group_token_admits_real_member: cannot create local group (net localgroup /add exit {:?})",
+                    status.code()
+                );
+                return;
+            }
+            Err(err) => {
+                eprintln!(
+                    "SKIP windows_group_token_admits_real_member: net.exe unavailable: {err}"
+                );
+                return;
+            }
+        }
+
+        // Populate: add the current user. May also be denied - skip after
+        // cleaning up the group we just created.
+        let added = Command::new("net")
+            .args(["localgroup", &group, &user, "/add"])
+            .status();
+        if !matches!(added, Ok(ref status) if status.success()) {
+            delete(&group);
+            eprintln!(
+                "SKIP windows_group_token_admits_real_member: cannot add user to local group (exit {:?})",
+                added.ok().and_then(|status| status.code())
+            );
+            return;
+        }
+
+        let token = format!("@{group}");
+        let list = entries(&[token.as_str()]);
+        let groups = SystemGroupMembership;
+
+        let member = authorize_auth_user(&list, &user, &groups);
+        let non_member = authorize_auth_user(&list, "definitely_not_a_member_zzzz", &groups);
+
+        // Clean up before asserting so a failed assertion cannot leak the group.
+        delete(&group);
+
+        let member =
+            member.expect("a real member of the local group must be admitted by the @group token");
+        assert!(
+            member
+                .group
+                .as_deref()
+                .is_some_and(|name| name.eq_ignore_ascii_case(&group)),
+            "the concrete matched group name must be reported, got {:?}",
+            member.group
+        );
+        assert!(
+            non_member.is_none(),
+            "a non-member must not be admitted by the @group token"
+        );
     }
 }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -48,6 +48,7 @@ apple-fs = { path = "../apple-fs" }
 fast_io = { path = "../fast_io", default-features = false }
 windows = { workspace = true, features = [
     "Win32_Foundation",
+    "Win32_NetworkManagement_NetManagement",
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",

--- a/crates/metadata/src/id_lookup/mod.rs
+++ b/crates/metadata/src/id_lookup/mod.rs
@@ -29,6 +29,8 @@ mod name_cache;
 mod nss;
 #[cfg(not(unix))]
 mod nss_stub;
+#[cfg(windows)]
+mod nss_win;
 
 #[cfg(unix)]
 pub use cache::{map_gid, map_uid};
@@ -43,6 +45,8 @@ pub use nss::{
 pub use nss_stub::{
     lookup_group_by_name, lookup_group_name, lookup_user_by_name, lookup_user_name,
 };
+#[cfg(windows)]
+pub use nss_win::groups_for_user;
 
 /// Maps a remote UID to a local UID.
 ///

--- a/crates/metadata/src/id_lookup/nss_win.rs
+++ b/crates/metadata/src/id_lookup/nss_win.rs
@@ -1,0 +1,87 @@
+//! Windows local-group membership for `auth users = @group`.
+//!
+//! POSIX resolves the authenticating user's group set with `getgrouplist`
+//! (see `nss.rs`). Windows has no POSIX group database, so this module
+//! enumerates the local groups an account belongs to via
+//! `NetUserGetLocalGroups`. The direction matches the Unix path - the *user's*
+//! groups, not the members of one named group - so a wildcard token like
+//! `@admin*` can be matched against every group the user is in, mirroring
+//! upstream `authenticate.c auth_server()`, which admits a client that is a
+//! member of the named group.
+
+use std::io;
+
+/// Returns the names of every local group the named user belongs to, including
+/// membership inherited through global groups.
+///
+/// Enumerates membership with `NetUserGetLocalGroups` at info level 0
+/// (`LOCALGROUP_USERS_INFO_0`) and passes `LG_INCLUDE_INDIRECT`, so a user who
+/// belongs to a global group that is itself a member of a local group is still
+/// reported. An account name that does not resolve yields an empty list rather
+/// than an error, matching the Unix path (a missing passwd entry is treated as
+/// "no groups") and upstream's `user_to_uid()` failure handling.
+///
+/// The username is passed to the API verbatim; both a bare `user` and a
+/// qualified `DOMAIN\user` form are accepted by the local lookup.
+///
+/// upstream: authenticate.c:283-295 `auth_server()` resolves the user's groups
+/// and `wildmatch`es each against the `@group` token.
+#[allow(unsafe_code)]
+pub fn groups_for_user(username: &str) -> Result<Vec<String>, io::Error> {
+    use windows::Win32::NetworkManagement::NetManagement::{
+        LG_INCLUDE_INDIRECT, LOCALGROUP_USERS_INFO_0, MAX_PREFERRED_LENGTH, NetApiBufferFree,
+        NetUserGetLocalGroups,
+    };
+    use windows::core::PCWSTR;
+
+    let user_wide: Vec<u16> = username.encode_utf16().chain(std::iter::once(0)).collect();
+
+    let mut buf_ptr: *mut u8 = std::ptr::null_mut();
+    let mut entries_read: u32 = 0;
+    let mut total_entries: u32 = 0;
+
+    // SAFETY: `user_wide` is a NUL-terminated UTF-16 string; every out-parameter
+    // pointer is valid for this stack frame. On success the call allocates
+    // `buf_ptr`, which is released below with NetApiBufferFree.
+    let status = unsafe {
+        NetUserGetLocalGroups(
+            PCWSTR::null(),
+            PCWSTR(user_wide.as_ptr()),
+            0,
+            LG_INCLUDE_INDIRECT,
+            &mut buf_ptr,
+            MAX_PREFERRED_LENGTH,
+            &mut entries_read,
+            &mut total_entries,
+        )
+    };
+
+    // NERR_UserNotFound (2221) and ERROR_NO_SUCH_USER (1317): an unknown account
+    // has no groups, mirroring the Unix empty-list path rather than erroring.
+    if status == 2221 || status == 1317 {
+        return Ok(Vec::new());
+    }
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+
+    let mut names = Vec::new();
+    if !buf_ptr.is_null() && entries_read > 0 {
+        // SAFETY: on success `buf_ptr` addresses `entries_read` contiguous
+        // LOCALGROUP_USERS_INFO_0 structs allocated by the call above.
+        let infos: &[LOCALGROUP_USERS_INFO_0] =
+            unsafe { std::slice::from_raw_parts(buf_ptr.cast(), entries_read as usize) };
+        for info in infos {
+            // SAFETY: `lgrui0_name` is a NUL-terminated PWSTR owned by the
+            // NetApi buffer and valid until it is freed below.
+            if let Ok(name) = unsafe { info.lgrui0_name.to_string() } {
+                names.push(name);
+            }
+        }
+    }
+    if !buf_ptr.is_null() {
+        // SAFETY: the buffer was allocated by NetUserGetLocalGroups.
+        let _ = unsafe { NetApiBufferFree(Some(buf_ptr.cast())) };
+    }
+    Ok(names)
+}


### PR DESCRIPTION
## Problem

The rsync daemon's `auth users = @groupname` directive admits any member of the
named local group. On Windows the group-membership lookup was a stub returning
an empty list, so `@group` auth never matched -- a Windows daemon could not use
group-based auth at all.

## Fix

Resolve real Windows local-group membership. The lookup uses the Windows
`NetworkManagement` APIs via the safe `windows` crate and lives in the
`metadata` crate (`crates/metadata/src/id_lookup/nss_win.rs`), which is the
home for platform id/group lookups and is permitted to contain the required
FFI. The `daemon` crate calls a safe public API and stays unsafe-free, per the
workspace unsafe-code policy.

- `metadata`: new `id_lookup::nss_win::groups_for_user(username)` returning the
  local groups a user belongs to; wired into the id-lookup module. Adds the
  `windows` crate dependency (Windows-only).
- `daemon`: the `@group` auth check calls the metadata API on Windows instead
  of the empty-Vec stub; the POSIX path is unchanged.

Mirrors upstream `access.c` semantics: a member of the named local group is
admitted.

## Tests

A `cfg(windows)` test asserts `auth users = @group` admits a member and rejects
a non-member, degrading gracefully (skip-with-reason) where the CI account
cannot provision a local group. The behavior test runs on CI's Windows job; the
Windows and musl (POSIX-unchanged) targets both compile clean.
