### PR TITLE
fix(engine): order -R multi-source operands to match upstream itemize

### DIFF
--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -52,52 +52,79 @@ fn whole_unix_seconds() -> u64 {
 /// the same comparator the network generator applies to its flist
 /// (`protocol::flist::compare_file_entries`, transfer `generator/file_list`).
 ///
-/// Scope: applied only when every operand contributes a single NAMED top-level
-/// entry - a non-`--relative` transfer with no trailing-slash / copy-contents
-/// operand. A copy-contents operand merges its CONTENTS into the destination,
-/// which upstream interleaves across operands by content name; that cannot be
-/// reproduced by ordering the operands, so those transfers keep command-line
-/// order. `--relative` operands carry implied parent directories whose ordering
-/// is handled during emission, so they are left untouched. Reordering is a
-/// pure output-ordering change: the destination result is byte-identical, the
-/// `--delete` keep-set is order-independent, and dir creation simply follows
-/// the same sorted order upstream uses.
+/// Scope: applied whenever every operand contributes a NAMED top-level subtree,
+/// i.e. no operand is a trailing-slash / copy-contents operand. A copy-contents
+/// operand merges its CONTENTS into the destination, which upstream interleaves
+/// across operands by content name; that cannot be reproduced by ordering the
+/// operands, so those transfers keep command-line order (handled in #212).
+///
+/// Both the plain and `--relative` (`-R`) cases reduce to the same rule because
+/// upstream sorts the whole flist globally: a directory operand's subtree is
+/// emitted contiguously and name-sorted within, and two operands whose paths
+/// diverge sort as whole blocks, so ordering the operands by the exact key
+/// upstream would give their flist rows reproduces the global order. The only
+/// key difference is what that row is named - see `operand_sort_entry`.
+/// Reordering is a pure output-ordering change: the destination result is
+/// byte-identical, the `--delete` keep-set is order-independent, and dir
+/// creation simply follows the same sorted order upstream uses.
 fn ordered_operands(sources: &[SourceSpec], relative_paths: bool) -> Vec<&SourceSpec> {
     let mut ordered: Vec<&SourceSpec> = sources.iter().collect();
-    let reorderable = sources.len() > 1
-        && !relative_paths
-        && sources.iter().all(|source| !source.copy_contents());
+    let reorderable = sources.len() > 1 && sources.iter().all(|source| !source.copy_contents());
     if reorderable {
-        ordered.sort_by(|a, b| compare_operand_names(a, b));
+        ordered.sort_by(|a, b| compare_operand_names(a, b, relative_paths));
     }
     ordered
 }
 
-/// Compares two named operands with the flist sort comparator upstream applies
-/// to top-level entries: directories compare as `name/` and a file sorts before
-/// a same-prefixed directory, exactly as `compare_file_entries` orders the
+/// Compares two operands with the flist sort comparator upstream applies to its
+/// top-level entries: directories compare as `name/` and a file sorts before a
+/// same-prefixed directory, exactly as `compare_file_entries` orders the
 /// generator's flist.
-fn compare_operand_names(a: &SourceSpec, b: &SourceSpec) -> Ordering {
-    compare_file_entries(&operand_sort_entry(a), &operand_sort_entry(b))
+fn compare_operand_names(a: &SourceSpec, b: &SourceSpec, relative_paths: bool) -> Ordering {
+    compare_file_entries(
+        &operand_sort_entry(a, relative_paths),
+        &operand_sort_entry(b, relative_paths),
+    )
 }
 
-/// Models an operand as a top-level flist entry (its destination basename plus
-/// its on-disk directory-ness) purely for ordering.
+/// Models an operand as the top-level flist entry upstream would emit for it
+/// (its flist name plus on-disk directory-ness) purely for ordering.
+///
+/// The flist name depends on `--relative`: without it, only the destination
+/// basename lands in the flist (`flist.c:2479` send_file_name uses the operand
+/// tail), so the basename is the sort key. Under `-R` the operand keeps its
+/// full relative path (`flist.c:2463` send_implied_dirs + the leaf), so the
+/// whole relative path is the key - `a/y` must sort before `b/x` regardless of
+/// command-line order, and `b/w` before `b/x` even sharing the `b/` prefix.
 ///
 /// link_stat (lstat) semantics: a directory operand is a directory; a symlink
 /// operand is not (upstream keeps the symlink's own name in the flist). An
 /// operand that has vanished or cannot be stat'd is ordered as a file;
 /// `process_single_source` reports its `link_stat` failure downstream.
-fn operand_sort_entry(source: &SourceSpec) -> FileEntry {
-    let name = source
-        .path()
-        .file_name()
-        .map_or_else(|| source.path().to_path_buf(), PathBuf::from);
+fn operand_sort_entry(source: &SourceSpec, relative_paths: bool) -> FileEntry {
+    let name = if relative_paths {
+        source
+            .relative_root()
+            .filter(|path| !path.as_os_str().is_empty())
+            .unwrap_or_else(|| operand_basename(source))
+    } else {
+        operand_basename(source)
+    };
     if fs::symlink_metadata(source.path()).is_ok_and(|meta| meta.is_dir()) {
         FileEntry::new_directory(name, 0o755)
     } else {
         FileEntry::new_file(name, 0, 0o644)
     }
+}
+
+/// Returns the operand's destination basename - the flist name for a
+/// non-`--relative` transfer, and the fallback when a `--relative` operand has
+/// no distinct relative path (e.g. a bare `.`).
+fn operand_basename(source: &SourceSpec) -> PathBuf {
+    source
+        .path()
+        .file_name()
+        .map_or_else(|| source.path().to_path_buf(), PathBuf::from)
 }
 
 /// Entry point for copying all sources to the destination.

--- a/crates/engine/tests/multi_source_operand_order.rs
+++ b/crates/engine/tests/multi_source_operand_order.rs
@@ -20,12 +20,14 @@
 //! for the identical command (verified against the reference binary). These
 //! tests FAIL before the operand-sort fix (they would see argument order).
 //!
-//! Scope (matches the fix): the reorder applies only to NAMED operands (each
-//! contributes a single top-level entry) in a non-`--relative` transfer.
+//! Scope (matches the fix): the reorder applies to every NAMED operand - both
+//! the plain case (each operand contributes its destination basename) and the
+//! `--relative` (`-R`) case (each operand keeps its full relative path), keyed
+//! on the exact name upstream's global flist sort would give the operand's row.
 //! Trailing-slash / copy-contents operands merge their CONTENTS into the
 //! destination, which upstream interleaves across operands by content name -
 //! unreproducible by operand ordering - so they are left in argument order and
-//! covered separately. `--relative` operands are likewise left untouched here.
+//! covered separately (#212).
 
 #![cfg(unix)]
 
@@ -57,6 +59,16 @@ fn apply(operands: &[OsString], options: LocalCopyOptions) -> engine::local_copy
     let plan = LocalCopyPlan::from_operands(operands).expect("plan builds");
     plan.execute_with_report(LocalCopyExecution::Apply, options)
         .expect("local copy succeeds")
+}
+
+/// Builds a `--relative` operand that reroots at `tail` via a `/./` marker, so
+/// the recorded relative path is exactly `tail` (independent of the temp dir's
+/// absolute prefix). Mirrors how `rsync -R ./tail` anchors the relative root.
+fn dot_rerooted(root: &Path, tail: &str) -> OsString {
+    let mut path = root.to_path_buf();
+    path.push(".");
+    path.push(tail);
+    path.into_os_string()
 }
 
 /// Four single-file operands supplied in an order that is deliberately NOT
@@ -181,12 +193,14 @@ fn single_directory_source_subtree_stays_sorted() {
     );
 }
 
-/// `--relative` operands are intentionally NOT reordered by this fix (their
-/// implied-parent emission ordering is handled separately), so a `-R`
-/// multi-source copy keeps command-line operand order. This pins the scope
-/// boundary: the fix must leave `-R` behaviour exactly as it was.
+/// Under `--relative` (`-R`) the operand keeps its FULL relative path in the
+/// flist, so upstream's global `f_name_cmp` sort orders the operands by that
+/// whole path. `two_named_dirs` supplies `zdir` then `adir` (absolute operands,
+/// so each records its path-minus-root); `adir` sorts before `zdir`, and each
+/// subtree stays contiguous. This is the `-R` counterpart of the named-operand
+/// sort above and pins that the fix now reorders `-R` too.
 #[test]
-fn relative_operands_are_left_in_command_line_order() {
+fn relative_operands_are_ordered_by_full_relative_path() {
     let (operands, _dst, _temp) = two_named_dirs();
 
     let report = apply(
@@ -197,15 +211,89 @@ fn relative_operands_are_left_in_command_line_order() {
             .collect_events(true),
     );
 
-    // Absolute operands under --relative record their full path-minus-root, so
-    // match the operand leaf by suffix rather than by a bare name.
     let order = emitted_entry_order(report.records());
-    let zdir = order.iter().position(|p| p.ends_with("zdir"));
     let adir = order.iter().position(|p| p.ends_with("adir"));
+    let zdir = order.iter().position(|p| p.ends_with("zdir"));
     assert!(
-        matches!((zdir, adir), (Some(z), Some(a)) if z < a),
-        "under --relative the operands keep command-line order (zdir before \
-         adir); reordering -R is out of scope for this fix. Order was {order:?}",
+        matches!((adir, zdir), (Some(a), Some(z)) if a < z),
+        "under --relative the operands sort by full relative path (adir before \
+         zdir), matching upstream's global flist sort. Order was {order:?}",
+    );
+}
+
+/// `-R` multi-source operands with DISTINCT relative prefixes, supplied in
+/// reverse-sorted command-line order (`b/x` before `a/y`), must itemize in
+/// upstream's global `f_name_cmp` order with each implied-parent chain and leaf
+/// contiguous. The `/./` marker reroots each operand so the recorded relative
+/// paths are exactly `a/y`, `b/x`. Expected order is the one upstream rsync
+/// 3.4.4 prints for `rsync -aiR ./b/x ./a/y dst/` (verified against the
+/// reference binary): `a, a/y, a/y/f3, b, b/x, b/x/f1`.
+#[test]
+fn relative_multi_source_distinct_prefixes_match_upstream_order() {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+    for (dir, file) in [("b/x", "f1"), ("a/y", "f3")] {
+        let dpath = temp.path().join(dir);
+        fs::create_dir_all(&dpath).expect("create source dir");
+        fs::write(dpath.join(file), file.as_bytes()).expect("write file");
+    }
+    // Command-line order b/x then a/y; `/./` reroots to the bare relative path.
+    let operands = vec![
+        dot_rerooted(temp.path(), "b/x"),
+        dot_rerooted(temp.path(), "a/y"),
+        dst.clone().into_os_string(),
+    ];
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .relative_paths(true)
+            .collect_events(true),
+    );
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["a", "a/y", "a/y/f3", "b", "b/x", "b/x/f1"],
+        "-R operands with distinct prefixes must itemize in upstream's global \
+         f_name_cmp order, not command-line order",
+    );
+}
+
+/// `-R` multi-source operands SHARING a prefix, supplied reversed (`b/x` before
+/// `b/w`), must still sort by the full relative path so `b/w` precedes `b/x`
+/// under the shared `b/` parent - matching `rsync -aiR ./b/x ./b/w dst/`
+/// (upstream 3.4.4): `b, b/w, b/w/f2, b/x, b/x/f1`.
+#[test]
+fn relative_multi_source_shared_prefix_match_upstream_order() {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+    for (dir, file) in [("b/x", "f1"), ("b/w", "f2")] {
+        let dpath = temp.path().join(dir);
+        fs::create_dir_all(&dpath).expect("create source dir");
+        fs::write(dpath.join(file), file.as_bytes()).expect("write file");
+    }
+    let operands = vec![
+        dot_rerooted(temp.path(), "b/x"),
+        dot_rerooted(temp.path(), "b/w"),
+        dst.clone().into_os_string(),
+    ];
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .relative_paths(true)
+            .collect_events(true),
+    );
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["b", "b/w", "b/w/f2", "b/x", "b/x/f1"],
+        "-R operands sharing a prefix must sort by the full relative path \
+         (b/w before b/x), matching upstream's global flist sort",
     );
 }
 


### PR DESCRIPTION
## Problem

With `--relative` (`-R`), a multi-source local copy visited its operands in
command-line order, while upstream rsync emits them in name order. Upstream's
`send_file_list()` accumulates every source operand into one file list and
sorts it globally with `f_name_cmp` (`flist_sort_and_clean`, flist.c:2544)
before the generator itemizes it, so top-level operands appear sorted
regardless of the order given on the command line.

An earlier change sorted multi-source operands for non-relative transfers but
deliberately gated out `-R`, because the relative case also emits implied
parent directories. As a result:

```
# rsync 3.4.4 (reference)          # oc-rsync (before)
$ rsync -aiR -n b/x a/y dst/       $ oc-rsync -aiR -n b/x a/y dst/
a/                                 b/
a/y/                               b/x/
a/y/f3                             b/x/f1
a/y/g                              a/
b/                                 a/y/
b/x/                               a/y/f3
b/x/f1                             a/y/g
```

The files land identically either way; only the observable itemize / verbose /
`--list-only` order diverged, which the output-fidelity contract forbids.

## Fix

Extend the operand sort to the `-R` case. A directory operand's subtree is
emitted contiguously and name-sorted within, and two operands whose relative
paths diverge sort as whole blocks, so ordering the operands by the exact key
upstream would give their flist row reproduces the global sort. The only
difference from the non-relative case is what that row is named:

- without `--relative`: the destination basename (`flist.c` send_file_name
  keeps the operand tail);
- under `-R`: the operand's full relative path (`send_implied_dirs` + the
  leaf), so `a/y` sorts before `b/x`, and `b/w` before `b/x` under a shared
  `b/` prefix.

The reorder is a pure output-ordering change: destinations are byte-identical,
the `--delete` keep-set is order-independent, and directory creation follows
the same sorted order upstream uses.

## Scope

Copy-contents (trailing-slash) operands still keep command-line order. Their
cross-operand content interleave cannot be reproduced by ordering the operands
and needs a separate local-copy flist-collect refactor (tracked separately). A
pre-existing, unrelated divergence remains when one operand is a strict
ancestor directory of another (`-aR a a/y`): the descendant operand's subtree
is listed twice; that is a dedup issue, not an ordering one, and is out of
scope here.

## Tests

`crates/engine/tests/multi_source_operand_order.rs`:

- `relative_multi_source_distinct_prefixes_match_upstream_order` - `-aR b/x
  a/y` itemizes `a, a/y, a/y/f3, b, b/x, b/x/f1` (the exact upstream 3.4.4
  order), failing before the fix.
- `relative_multi_source_shared_prefix_match_upstream_order` - shared-prefix
  operands sort `b/w` before `b/x`.
- `relative_operands_are_ordered_by_full_relative_path` - replaces the old
  scope-boundary test that pinned command-line order.

The existing non-relative operand-sort tests are unchanged and stay green.

## Verification

Against a real rsync 3.4.4 on Linux x86_64: `-aiR -n` multi-source itemize
with distinct prefixes and with a shared prefix now match the reference binary
byte-for-byte (both previously in argument order). `cargo fmt --check`;
`clippy --workspace --all-targets --all-features -D warnings` and default
features, both clean; `cargo check` for `x86_64-pc-windows-gnu` and
`x86_64-unknown-linux-musl` (lib+bins+tests); `nextest -p engine -p cli` on
default features (8699) and `--all-features` (8784), all passing.
