### PR TITLE
test(engine): pin Windows NTFS sparse data-parity and --one-file-system boundary

### DIFF
--- a/crates/engine/src/local_copy/tests/execute_one_file_system.rs
+++ b/crates/engine/src/local_copy/tests/execute_one_file_system.rs
@@ -1000,3 +1000,58 @@ fn one_file_system_delete_preserves_mount_nested_in_doomed_dir() {
     // and its contents were not.
     assert!(summary.items_deleted() >= 2, "same-device extras were deleted");
 }
+
+/// On Windows, `--one-file-system` cannot consult a POSIX `st_dev` (std's
+/// `volume_serial_number` accessor is still unstable), so the traversal
+/// boundary is derived from the path prefix: the drive letter, or the
+/// server+share of a UNC path. This pins that documented boundary - the value
+/// the planner compares to decide `SkipMountPoint` - so it cannot silently
+/// regress into, say, a constant that makes every entry look same-device (never
+/// stopping) or different-device (always stopping).
+///
+/// Limitation deliberately NOT asserted here: a directory junction or volume
+/// mount point nested under one drive letter keeps that drive's prefix, so the
+/// native Windows path cannot detect a real volume crossing the way Cygwin's
+/// `st_dev` does. This test pins only the drive-letter / UNC-share boundary
+/// that IS implemented.
+#[cfg(windows)]
+#[test]
+fn one_file_system_windows_boundary_is_drive_letter_and_unc_share() {
+    use crate::local_copy::overrides::device_identifier;
+
+    // device_identifier ignores its metadata argument on Windows (it parses the
+    // path prefix), but the signature still requires one; any real metadata
+    // handle works and the compared paths themselves need not exist.
+    let temp = tempdir().expect("tempdir");
+    let probe = temp.path().join("probe");
+    fs::write(&probe, b"x").expect("write probe");
+    let md = fs::metadata(&probe).expect("probe metadata");
+
+    let dev = |p: &str| device_identifier(Path::new(p), &md).expect("windows device id");
+
+    // Same drive letter -> same device id -> traversal continues into the dir.
+    assert_eq!(
+        dev(r"C:\root\alpha"),
+        dev(r"C:\root\alpha\beta\gamma"),
+        "paths sharing a drive letter must resolve to one device"
+    );
+
+    // Different drive letter -> different device id -> traversal stops.
+    assert_ne!(
+        dev(r"C:\root\alpha"),
+        dev(r"D:\root\alpha"),
+        "a different drive letter is a different filesystem boundary"
+    );
+
+    // UNC: same server+share is one filesystem; a different share is not.
+    assert_eq!(
+        dev(r"\\server\share\a"),
+        dev(r"\\server\share\b\c"),
+        "one UNC share is one filesystem"
+    );
+    assert_ne!(
+        dev(r"\\server\share1\a"),
+        dev(r"\\server\share2\a"),
+        "different UNC shares are different filesystems"
+    );
+}

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -2019,3 +2019,71 @@ fn execute_with_sparse_enabled_marks_ntfs_sparse() {
     );
 }
 
+
+/// A `--sparse` transfer must write byte-identical DATA on Windows/NTFS. NTFS
+/// may not deallocate the hole the way Linux does (a dense fallback is allowed),
+/// but the observable file CONTENT must equal a plain dense copy of the same
+/// source. This pins data-parity independent of block allocation: sparse mode
+/// changes only *how* zero runs are stored, never *what* bytes are read back.
+/// The assertion compares content directly (a content-hash equality), never
+/// `st_blocks` / allocation.
+#[cfg(windows)]
+#[test]
+fn execute_sparse_ntfs_data_matches_dense_copy() {
+    use std::io::{Seek, SeekFrom};
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("holed.bin");
+    let mut source_file = fs::File::create(&source).expect("create source");
+    source_file.write_all(b"HEAD").expect("write leading data");
+    source_file
+        .seek(SeekFrom::Start(3 * 1024 * 1024))
+        .expect("seek past a large zero run");
+    source_file.write_all(b"TAIL").expect("write trailing data");
+    source_file
+        .set_len(5 * 1024 * 1024)
+        .expect("extend with trailing zeros");
+    drop(source_file);
+
+    let dense_dest = temp.path().join("dense.bin");
+    let sparse_dest = temp.path().join("sparse.bin");
+
+    LocalCopyPlan::from_operands(&[
+        source.clone().into_os_string(),
+        dense_dest.clone().into_os_string(),
+    ])
+    .expect("plan dense")
+    .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
+    .expect("dense copy succeeds");
+
+    LocalCopyPlan::from_operands(&[
+        source.clone().into_os_string(),
+        sparse_dest.clone().into_os_string(),
+    ])
+    .expect("plan sparse")
+    .execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().sparse(true),
+    )
+    .expect("sparse copy succeeds");
+
+    let source_bytes = fs::read(&source).expect("read source");
+    let dense_bytes = fs::read(&dense_dest).expect("read dense copy");
+    let sparse_bytes = fs::read(&sparse_dest).expect("read sparse copy");
+
+    // Data-parity is the invariant, not allocation: the sparse copy must be
+    // byte-for-byte identical to both the source and the dense copy.
+    assert_eq!(
+        sparse_bytes.len(),
+        source_bytes.len(),
+        "sparse copy length must match the source"
+    );
+    assert_eq!(
+        dense_bytes, sparse_bytes,
+        "sparse copy DATA must be identical to the dense copy on NTFS"
+    );
+    assert_eq!(
+        sparse_bytes, source_bytes,
+        "sparse copy DATA must be identical to the source on NTFS"
+    );
+}


### PR DESCRIPTION
## Summary

Adds two `#[cfg(windows)]` regression tests that pin observable Windows
filesystem-write behaviours so they cannot silently regress. Test-only; no
production code changes.

### NTFS `--sparse` data parity

`crates/engine/src/local_copy/tests/execute_sparse.rs` gains
`execute_sparse_ntfs_data_matches_dense_copy`. It copies a holed source both
densely (default) and with `--sparse`, then asserts the two destinations are
byte-for-byte identical to each other and to the source. NTFS may fall back to
a dense layout when it cannot deallocate the hole; the invariant pinned is data
parity independent of block allocation - `--sparse` changes only how zero runs
are stored, never the bytes read back. The comparison is on file content (a
content-hash equality), never `st_blocks`. This complements the existing
`execute_with_sparse_enabled_marks_ntfs_sparse`, which checks the sparse
attribute but has no dense comparand.

### `--one-file-system` Windows boundary

`crates/engine/src/local_copy/tests/execute_one_file_system.rs` gains
`one_file_system_windows_boundary_is_drive_letter_and_unc_share`. On Windows the
traversal boundary is derived from the path prefix - the drive letter, or the
server+share of a UNC path - because the standard library `volume_serial_number`
accessor is still unstable. The test pins that documented boundary (the value
the planner compares to decide whether to stop descending): the same drive
letter resolves to one device, while a different drive letter or a different UNC
share resolves to a different device. The pre-existing override-based tests in
this file already exercise the end-to-end skip decision on the Windows planner
arm; this adds the missing coverage of the real path-prefix derivation.

The test also documents, but deliberately does not assert, the known
limitation: a directory junction or volume mount point nested under one drive
letter keeps that drive prefix, so the native Windows path cannot detect a real
volume crossing the way a POSIX `st_dev` does.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo check -p engine --all-features --lib --tests --target x86_64-pc-windows-gnu` - RC 0 (compiles the new `#[cfg(windows)]` tests; matches what the Windows CI job builds via `nextest -p engine`)
- `cargo check -p engine --all-features --lib --tests --target x86_64-unknown-linux-musl` - RC 0, no warnings (gated tests leak no unused imports)
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo build --locked -p bin --bin oc-rsync` - RC 0

Both new tests are `#[cfg(windows)]` and run on the Windows CI job; there is no
host-runnable Linux part.
