### PR TITLE
fix(engine): drop non-upstream per-file debug lines from verbose local copy

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -138,13 +138,6 @@ pub(super) fn try_clone(
 
     let start = Instant::now();
     debug_log!(
-        Send,
-        1,
-        "cloned {}: {} bytes (CoW)",
-        record_path.display(),
-        file_size
-    );
-    debug_log!(
         Clone,
         1,
         "CoW clone succeeded: dst={} ({} bytes)",

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -18,8 +18,6 @@ use std::fs;
 use std::path::Path;
 use std::time::Instant;
 
-use logging::debug_log;
-
 use ::metadata::MetadataOptions;
 
 use crate::local_copy::{
@@ -133,13 +131,6 @@ pub(super) fn try_clone(
     }
 
     let start = Instant::now();
-    debug_log!(
-        Send,
-        1,
-        "cloned {}: {} bytes (FICLONE)",
-        record_path.display(),
-        file_size
-    );
 
     context.capture_batch_whole_file(source, file_size)?;
     context.finalize_batch_file_delta(source)?;

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -552,18 +552,6 @@ pub(in crate::local_copy) fn execute_transfer(
     };
 
     let start = Instant::now();
-    debug_log!(
-        Send,
-        1,
-        "sending {}: {} bytes{}",
-        record_path.display(),
-        file_size,
-        if delta_signature.is_some() {
-            " (delta)"
-        } else {
-            ""
-        }
-    );
 
     // When a backup RENAME moved the basis file (non-inplace --backup) or a
     // fuzzy basis is used, point the delta transfer at that separate location so
@@ -666,14 +654,6 @@ pub(in crate::local_copy) fn execute_transfer(
     context.record_hard_link(metadata, hard_link_path);
 
     let elapsed = start.elapsed();
-    debug_log!(
-        Deltasum,
-        2,
-        "transferred {}: {} literal bytes in {:.3}s",
-        record_path.display(),
-        outcome.literal_bytes(),
-        elapsed.as_secs_f64()
-    );
 
     // EMA throughput sample feeds dynamic buffer sizing.
     if context.use_buffer_pool() {

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
@@ -10,8 +10,6 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
-use logging::debug_log;
-
 use ::metadata::MetadataOptions;
 
 #[cfg(all(any(unix, windows), feature = "acl"))]
@@ -113,7 +111,6 @@ pub(super) fn try_skip_up_to_date(
         existing,
         flags,
         mode,
-        "already up-to-date",
     )?;
 
     Ok(true)
@@ -138,15 +135,7 @@ pub(super) fn record_metadata_only_skip(
     flags: &TransferFlags,
     #[allow(unused_variables)] // REASON: used on unix with feature "xattr"
     mode: LocalCopyExecution,
-    reason: &str,
 ) -> Result<(), LocalCopyError> {
-    debug_log!(
-        Deltasum,
-        2,
-        "skipping {}: {}",
-        record_path.display(),
-        reason
-    );
     // upstream: rsync.c:672-676 - rprintf(FCLIENT, "%s is uptodate\n", fname)
     // at INFO_GTE(NAME, 2) when a quick-check or content-equal path reuses
     // the existing destination instead of transferring. The CLI renders this

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -18,8 +18,6 @@ use std::fs;
 use std::path::Path;
 use std::time::Instant;
 
-use logging::debug_log;
-
 use metadata::MetadataOptions;
 
 use crate::local_copy::{
@@ -118,13 +116,6 @@ pub(super) fn try_copy(
     };
 
     let start = Instant::now();
-    debug_log!(
-        Send,
-        1,
-        "wincopy {}: {} bytes",
-        record_path.display(),
-        file_size
-    );
 
     context.capture_batch_whole_file(source, file_size)?;
     context.finalize_batch_file_delta(source)?;

--- a/crates/engine/tests/verbose_local_copy_no_debug_leak.rs
+++ b/crates/engine/tests/verbose_local_copy_no_debug_leak.rs
@@ -1,0 +1,113 @@
+//! Guards that the local-copy executor emits no non-upstream per-file debug
+//! lines into the `-v`/`-vv`/`-vvv` verbose stream.
+//!
+//! Upstream rsync has no analog in its verbose stream for oc's former per-file
+//! `"sending <f>: N bytes"`, `"transferred <f>: N literal bytes in Ss"`,
+//! `"cloned <f>: N bytes (CoW)"`/`(FICLONE)`, `"wincopy <f>: N bytes"`, or
+//! `"skipping <f>: already up-to-date"` diagnostics. They were emitted through
+//! the `DEBUG_GTE(SEND)` / `DEBUG_GTE(DELTASUM)` categories and, being buffered,
+//! flushed after the summary trailer - so they both leaked non-upstream text and
+//! landed in the wrong position. They must never appear again.
+//!
+//! This drives a real fresh copy and an up-to-date rerun at maximal SEND /
+//! DELTASUM / FLIST debug verbosity and asserts none of those shapes surface.
+
+use std::fs;
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use logging::{DiagnosticEvent, VerbosityConfig, drain_events, init};
+use tempfile::tempdir;
+
+/// Every diagnostic message emitted since the last drain.
+fn drained_messages() -> Vec<String> {
+    drain_events()
+        .into_iter()
+        .map(|event| match event {
+            DiagnosticEvent::Debug { message, .. } | DiagnosticEvent::Info { message, .. } => {
+                message
+            }
+        })
+        .collect()
+}
+
+/// Recognises the exact shapes of the removed non-upstream debug lines. A match
+/// means one leaked back into the verbose stream.
+fn is_removed_line(message: &str) -> bool {
+    message.contains("literal bytes in")                    // "transferred <f>: N literal bytes in Ss"
+        || message.contains("bytes (CoW)")                  // clonefile.rs
+        || message.contains("bytes (FICLONE)")              // ficlone.rs
+        || message.starts_with("wincopy ")                  // wincopy.rs
+        || (message.starts_with("skipping ") && message.contains(": ")) // record_metadata_only_skip
+        || (message.starts_with("sending ")
+            && message.contains(": ")
+            && message.contains(" bytes")) // "sending <f>: N bytes"
+}
+
+fn assert_no_leak(context: &str) {
+    let leaked: Vec<String> = drained_messages()
+        .into_iter()
+        .filter(|message| is_removed_line(message))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "non-upstream per-file debug line leaked during {context}: {leaked:?}"
+    );
+}
+
+/// Raise every debug category the removed lines used well above their emit
+/// thresholds (SEND >= 1, DELTASUM >= 2), so a regression that reinstates any
+/// line is guaranteed to be drained here.
+fn max_debug_config() -> VerbosityConfig {
+    let mut config = VerbosityConfig::default();
+    config.debug.send = 3;
+    config.debug.deltasum = 3;
+    config.debug.flist = 3;
+    config
+}
+
+fn copy(operands: &[std::ffi::OsString], what: &str) {
+    let plan = LocalCopyPlan::from_operands(operands).expect("plan");
+    plan.execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
+        .unwrap_or_else(|error| panic!("{what} copy failed: {error}"));
+}
+
+#[test]
+fn local_copy_emits_no_nonupstream_perfile_debug_lines() {
+    init(max_debug_config());
+    let _ = drain_events();
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::write(source.join("a.txt"), b"hello").expect("write a.txt");
+    fs::write(source.join("b.txt"), b"world!!").expect("write b.txt");
+
+    let operands = vec![
+        source.clone().into_os_string(),
+        dest.clone().into_os_string(),
+    ];
+
+    // Fresh copy: exercises the whole-file transfer path (mod.rs) and, where the
+    // filesystem supports it, the reflink/CoW fast paths (ficlone/clonefile).
+    copy(&operands, "fresh");
+    assert!(
+        dest.join("source/a.txt").exists(),
+        "fresh copy must write a.txt"
+    );
+    assert_no_leak("fresh copy");
+
+    // Align each destination mtime to its source so the rerun's quick-check
+    // (size + mtime) treats every file as up-to-date and skips it through
+    // record_metadata_only_skip - the path that carried the former
+    // "skipping <f>: already up-to-date" debug line.
+    for name in ["a.txt", "b.txt"] {
+        let src_meta = fs::metadata(source.join(name)).expect("source metadata");
+        let mtime = filetime::FileTime::from_last_modification_time(&src_meta);
+        filetime::set_file_mtime(dest.join("source").join(name), mtime).expect("align mtime");
+    }
+
+    // Up-to-date rerun: the quick-check now skips every file.
+    copy(&operands, "rerun");
+    assert_no_leak("up-to-date rerun");
+}


### PR DESCRIPTION
## Summary

The local-copy executor emitted six per-file diagnostics into the
`-v`/`-vv`/`-vvv` verbose stream that upstream rsync has no analog for. They
were buffered in the thread-local diagnostic queue and flushed *after* the
transfer summary, so they both leaked non-upstream text and printed after the
`sent … / total size is … / speedup …` trailer:

| Line | Site | Category |
| --- | --- | --- |
| `sending <f>: N bytes` | `execute/mod.rs` | DEBUG SEND |
| `transferred <f>: N literal bytes in Ss` | `execute/mod.rs` | DEBUG DELTASUM |
| `skipping <f>: already up-to-date` | `execute/skip.rs` | DEBUG DELTASUM |
| `cloned <f>: N bytes (CoW)` | `execute/clonefile.rs` (macOS) | DEBUG SEND |
| `cloned <f>: N bytes (FICLONE)` | `execute/ficlone.rs` (Linux) | DEBUG SEND |
| `wincopy <f>: N bytes` | `execute/wincopy.rs` (Windows) | DEBUG SEND |

Removing them lets the verbose local-copy stream match upstream: the per-file
name list, the delta-transmission notice and the summary trailer keep their
upstream positions with none of these trailing debug lines.

The two reflink lines have no upstream notion, so they are dropped outright
rather than gated behind a debug flag. Removing the skip line also retires the
now-unused `reason` parameter of `record_metadata_only_skip` and the now-unused
`logging::debug_log` imports in `skip`/`ficlone`/`wincopy`.

## Before / after (`rsync -vv -a src/ dst/`, fresh)

Upstream reference output:

```
sending incremental file list
created directory dst
delta-transmission disabled for local transfer or --whole-file
./
a.txt
b.txt
sub/
sub/c.txt
total: matches=0  hash_hits=0  false_alarms=0 data=11
sent 291 bytes  received 180 bytes  942.00 bytes/sec
total size is 11  speedup is 0.02
```

Before this change the same run appended, after the trailer:

```
delta-transmission disabled for local transfer or --whole-file
sending a.txt: 5 bytes
transferred a.txt: 5 literal bytes in 0.000s
…
```

After this change the per-file name list, delta-transmission notice and trailer
match upstream with none of those trailing lines.

## Test

Adds `crates/engine/tests/verbose_local_copy_no_debug_leak.rs`, which drives a
fresh copy and an up-to-date rerun at maximal SEND/DELTASUM/FLIST verbosity and
asserts none of the removed shapes are emitted.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo nextest run -p engine` (new test + existing debug-emission tests) and
  `-p cli` (3763 passed)
- `cargo check -p engine --all-features --target x86_64-pc-windows-gnu` and
  `--target x86_64-unknown-linux-musl` (no warnings; the reflink/wincopy sites
  are cfg-platform)
