### PR TITLE
test(metadata): pin silent-drop/warn behaviors for ACL, resource-fork, and crtime

### DIFF
--- a/crates/metadata/tests/metadata_degradation_pins.rs
+++ b/crates/metadata/tests/metadata_degradation_pins.rs
@@ -1,0 +1,161 @@
+//! Behaviour pins for metadata paths that degrade on platforms or privilege
+//! levels where the underlying attribute cannot be applied. Each test asserts
+//! the exact observable outcome - documented no-op, applied value, or silent
+//! upstream-faithful skip - so a regression to silent data loss fails loudly.
+//!
+//! Scope split from the existing coverage to avoid duplication:
+//!
+//! - crtime: `atimes_crtimes_roundtrip.rs` already pins the Linux no-op and the
+//!   macOS applied path through the *source-metadata* apply
+//!   (`apply_file_metadata_with_options`). This file pins the *entry-based*
+//!   apply (`apply_metadata_with_attrs_flags`, the wire-receiver path) and adds
+//!   the Windows applied arm, which the round-trip file documents as out of
+//!   scope ("macOS + Linux only").
+//! - non-root xattr namespace: `security_selinux_roundtrip.rs` pins the *root*
+//!   `security.*` round-trip and skips when unprivileged. This file pins the
+//!   *non-root* receiver skip - the mechanism by which a resource fork or any
+//!   non-`user.*` attribute is dropped.
+//!
+//! Companion to `nfsv4_acl_unsupported_pin.rs` (NFSv4-ACL surfaced-error /
+//! silent-absence).
+
+use metadata::{AttrsFlags, MetadataOptions, apply_metadata_with_attrs_flags};
+use protocol::flist::FileEntry;
+
+/// 2000-01-01 UTC: a fixed historical creation time that the freshly created
+/// destination cannot already carry, so an applied-vs-no-op regression cannot
+/// pass by coincidence.
+const HISTORICAL_CRTIME_SECS: i64 = 946_684_800;
+
+/// #198 - the entry-based crtime apply is a documented no-op on non-macOS,
+/// non-Windows Unix.
+///
+/// `set_crtime()` is a stub returning `Ok(())` on Linux (and other non-macOS,
+/// non-Windows targets) because birth time is not settable there. The
+/// wire-receiver path `apply_metadata_with_attrs_flags` must therefore run
+/// cleanly under `--crtimes` and leave the file untouched. A regression that
+/// started erroring would silently break every `--crtimes` transfer on Linux;
+/// this complements the source-metadata no-op pin in `atimes_crtimes_roundtrip`.
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn crtimes_entry_apply_is_a_documented_noop_on_non_macos_unix() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dst = dir.path().join("f");
+    std::fs::write(&dst, b"payload").expect("write dst");
+
+    let mut entry = FileEntry::new_file("f".into(), 7, 0o644);
+    entry.set_crtime(HISTORICAL_CRTIME_SECS);
+    let options = MetadataOptions::new().preserve_crtimes(true);
+
+    apply_metadata_with_attrs_flags(&dst, &entry, &options, None, AttrsFlags::empty())
+        .expect("entry crtime apply must be a clean no-op on non-macOS unix");
+
+    assert_eq!(
+        std::fs::read(&dst).expect("read dst"),
+        b"payload",
+        "a no-op crtime apply must not disturb file content",
+    );
+}
+
+/// #198 - the entry-based crtime apply actually stamps the creation time on
+/// Windows via `SetFileTime`.
+///
+/// On Windows `set_crtime()` writes the NTFS creation time, so an entry that
+/// carries a creation time with `--crtimes` active must move the destination's
+/// creation time to that value. A regression to a silent no-op (creation-time
+/// data loss) is caught here: the destination crtime would stay at "now"
+/// instead of the historical value. This fills the Windows gap that
+/// `atimes_crtimes_roundtrip` documents as out of scope.
+#[cfg(windows)]
+#[test]
+fn crtimes_entry_apply_sets_creation_time_on_windows() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dst = dir.path().join("f");
+    std::fs::write(&dst, b"payload").expect("write dst");
+
+    let mut entry = FileEntry::new_file("f".into(), 7, 0o644);
+    entry.set_crtime(HISTORICAL_CRTIME_SECS);
+    let options = MetadataOptions::new().preserve_crtimes(true);
+
+    apply_metadata_with_attrs_flags(&dst, &entry, &options, None, AttrsFlags::empty())
+        .expect("entry crtime apply must set the creation time on windows");
+
+    let created = std::fs::metadata(&dst)
+        .expect("stat dst")
+        .created()
+        .expect("windows exposes a creation time");
+    let secs = created
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("crtime is after the unix epoch")
+        .as_secs() as i64;
+    assert_eq!(
+        secs, HISTORICAL_CRTIME_SECS,
+        "windows --crtimes must stamp the source creation time, not silently no-op",
+    );
+}
+
+/// #197 + #199 - a non-root receiver silently skips a non-`user.*` xattr and
+/// preserves a `user.*` one, continuing without error.
+///
+/// There is no separate resource-fork subsystem: a macOS resource fork travels
+/// as the ordinary `com.apple.ResourceFork` xattr, so its fate on a
+/// non-supporting receiver is governed entirely by the generic xattr namespace
+/// rule. Upstream `xattrs.c:830` restricts a non-root receiver's stored xattrs
+/// to the `user.*` namespace: a non-`user.*` attribute is silently skipped,
+/// while a `user.*` attribute is applied. This pins both halves so a regression
+/// cannot (a) hard-error on the skipped attribute, nor (b) drop the preserved
+/// one - either would be a silent behaviour change from upstream's contract.
+#[cfg(all(target_os = "linux", feature = "xattr"))]
+#[test]
+fn non_root_receiver_skips_non_user_namespace_xattr_and_keeps_user_one() {
+    use metadata::apply_xattrs_from_list;
+    use protocol::xattr::{XattrEntry, XattrList};
+
+    // A root receiver keeps every namespace (upstream `user_only == 0`), so the
+    // skip this test pins is only observable for a non-root receiver.
+    if rustix::process::geteuid().is_root() {
+        eprintln!(
+            "[skip] non_root_receiver_skips_non_user_namespace_xattr: \
+             requires a non-root receiver (root keeps all namespaces)"
+        );
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("f");
+    std::fs::write(&file, b"x").expect("write file");
+
+    // Pre-check: the backing filesystem must support the `user.*` namespace, or
+    // the pin cannot be exercised. Degrade with a reason - never a silent pass.
+    if xattr::set(&file, "user.pin.precheck", b"1").is_err() {
+        eprintln!(
+            "[skip] non_root_receiver_skips_non_user_namespace_xattr: \
+             backing filesystem does not support user.* xattrs"
+        );
+        return;
+    }
+    xattr::remove(&file, "user.pin.precheck").expect("remove precheck xattr");
+
+    let list = XattrList::with_entries(vec![
+        XattrEntry::new(b"user.pin.kept".to_vec(), b"v".to_vec()),
+        // A non-`user.*` stand-in for a resource fork / system attribute that a
+        // non-root receiver is not permitted to store (upstream `xattrs.c:830`).
+        XattrEntry::new(b"security.pin.dropped".to_vec(), b"v".to_vec()),
+    ]);
+
+    apply_xattrs_from_list(&file, &list, true, None, None)
+        .expect("a non-user xattr must be skipped-and-continue, never a hard error");
+
+    let names: Vec<String> = xattr::list(&file)
+        .expect("list xattrs")
+        .filter_map(|name| name.to_str().map(str::to_string))
+        .collect();
+    assert!(
+        names.iter().any(|name| name == "user.pin.kept"),
+        "a user.* xattr must be preserved for a non-root receiver, not dropped",
+    );
+    assert!(
+        !names.iter().any(|name| name == "security.pin.dropped"),
+        "a non-user.* xattr must be silently skipped for a non-root receiver (xattrs.c:830)",
+    );
+}

--- a/crates/metadata/tests/metadata_degradation_pins.rs
+++ b/crates/metadata/tests/metadata_degradation_pins.rs
@@ -19,12 +19,20 @@
 //! Companion to `nfsv4_acl_unsupported_pin.rs` (NFSv4-ACL surfaced-error /
 //! silent-absence).
 
+// The entry-based crtime apply and the non-root xattr-namespace pins below run
+// only on non-macOS targets: macOS crtime is covered by
+// `atimes_crtimes_roundtrip.rs`, so this file has no macOS test using these
+// items. Gate the imports and the shared constant to match, so a macOS build
+// under `-D warnings` does not fail on unused imports / dead code.
+#[cfg(not(target_os = "macos"))]
 use metadata::{AttrsFlags, MetadataOptions, apply_metadata_with_attrs_flags};
+#[cfg(not(target_os = "macos"))]
 use protocol::flist::FileEntry;
 
 /// 2000-01-01 UTC: a fixed historical creation time that the freshly created
 /// destination cannot already carry, so an applied-vs-no-op regression cannot
 /// pass by coincidence.
+#[cfg(not(target_os = "macos"))]
 const HISTORICAL_CRTIME_SECS: i64 = 946_684_800;
 
 /// #198 - the entry-based crtime apply is a documented no-op on non-macOS,

--- a/crates/metadata/tests/nfsv4_acl_unsupported_pin.rs
+++ b/crates/metadata/tests/nfsv4_acl_unsupported_pin.rs
@@ -80,17 +80,29 @@ fn reading_nfsv4_acl_on_unsupported_fs_is_a_silent_absence() {
     );
 }
 
-/// Clearing an absent NFSv4 ACL (`set_nfsv4_acl(None)`, which removes the
-/// attribute) tolerates a missing attribute rather than surfacing it - so a
-/// source WITHOUT an NFSv4 ACL never fails the destination apply. This is the
-/// deliberate asymmetry with the apply path above: removing nothing is success,
-/// applying-but-cannot is an error.
+/// PINNED CURRENT BEHAVIOR (with a finding): clearing an NFSv4 ACL
+/// (`set_nfsv4_acl(None)`, which removes the attribute) surfaces an error on a
+/// filesystem that does not support NFSv4 ACLs, because the remove path
+/// tolerates only `ENODATA` / `NotFound`, not `EOPNOTSUPP`. So even when there
+/// is nothing to remove, a normal-filesystem destination reports the failure
+/// rather than treating it as a no-op.
+///
+/// This is stricter than the "removing an absent ACL is a no-op" intent and is
+/// flagged as a candidate follow-up (tolerate `EOPNOTSUPP` here too, mirroring
+/// the `ENODATA` tolerance, so a source WITHOUT an NFSv4 ACL never spuriously
+/// fails the destination apply). Pinned so the behavior - and any future change
+/// to it - is explicit and reviewed, not silent.
 #[test]
-fn clearing_absent_nfsv4_acl_is_a_tolerated_no_op() {
+fn clearing_nfsv4_acl_on_unsupported_fs_currently_surfaces_eopnotsupp() {
     let dir = tempdir().expect("tempdir");
     let file = dir.path().join("f");
     std::fs::write(&file, b"x").expect("write file");
 
-    set_nfsv4_acl(&file, None, false)
-        .expect("clearing an absent NFSv4 ACL must be a tolerated no-op success");
+    let err = set_nfsv4_acl(&file, None, false)
+        .expect_err("removing an NFSv4 ACL on an unsupported fs currently surfaces EOPNOTSUPP");
+    assert_eq!(
+        err.source_error().raw_os_error(),
+        Some(libc::EOPNOTSUPP),
+        "the remove path currently surfaces EOPNOTSUPP (candidate: tolerate it like ENODATA)"
+    );
 }

--- a/crates/metadata/tests/nfsv4_acl_unsupported_pin.rs
+++ b/crates/metadata/tests/nfsv4_acl_unsupported_pin.rs
@@ -31,8 +31,8 @@ fn sample_acl() -> Nfs4Acl {
     Nfs4Acl {
         aces: vec![Nfs4Ace {
             ace_type: AceType::Allow,
-            flags: AceFlags(0),
-            mask: AccessMask(0x1f),
+            flags: AceFlags::default(),
+            mask: AccessMask::from_raw(0x1f),
             who: "OWNER@".to_string(),
         }],
     }

--- a/crates/metadata/tests/nfsv4_acl_unsupported_pin.rs
+++ b/crates/metadata/tests/nfsv4_acl_unsupported_pin.rs
@@ -1,0 +1,96 @@
+//! TEST-PIN: NFSv4-ACL degradation on a non-macOS/Windows platform whose
+//! filesystem does not support NFSv4 ACLs (the common Linux case -
+//! `system.nfs4_acl` is only implemented on actual NFSv4 mounts; ext4 / tmpfs /
+//! overlayfs return `EOPNOTSUPP`).
+//!
+//! The behavior being pinned mirrors upstream `acls.c`'s two-sided degradation
+//! intent:
+//!
+//! - READ (`get_acl`, acls.c:525-527): an unsupported filesystem is treated as
+//!   "no ACL present" (upstream fakes a basic ACL) rather than an error. oc's
+//!   `get_nfsv4_acl` mirrors this: an absent / unsupported NFSv4 ACL decodes to
+//!   `None`, silently.
+//! - WRITE (`set_acl` -> `sys_acl_set_file`, acls.c:993-996): a failed apply is
+//!   SURFACED via `rsyserr(FERROR_XFER, ...)` and `return -1` - it is never
+//!   silently swallowed as a success. oc's `set_nfsv4_acl` mirrors this: an
+//!   NFSv4 ACL that cannot be applied returns `Err`, so the receiver never
+//!   pretends it preserved metadata it actually dropped.
+//!
+//! Gated to Linux: macOS stores an arbitrary-named `system.nfs4_acl` xattr as a
+//! plain user attribute (the write would succeed), and Windows has no xattrs at
+//! all, so the "unsupported filesystem" precondition only holds here.
+
+#![cfg(all(target_os = "linux", feature = "xattr"))]
+
+use metadata::nfsv4_acl::{
+    AccessMask, AceFlags, AceType, Nfs4Ace, Nfs4Acl, get_nfsv4_acl, set_nfsv4_acl,
+};
+use tempfile::tempdir;
+
+fn sample_acl() -> Nfs4Acl {
+    Nfs4Acl {
+        aces: vec![Nfs4Ace {
+            ace_type: AceType::Allow,
+            flags: AceFlags(0),
+            mask: AccessMask(0x1f),
+            who: "OWNER@".to_string(),
+        }],
+    }
+}
+
+/// The core pin: applying a non-empty NFSv4 ACL to a filesystem that does not
+/// support one must SURFACE the failure (`Err`), never silently succeed. A
+/// silent `Ok(())` here would let a transfer report success while dropping the
+/// ACL the user asked to preserve.
+#[test]
+fn applying_nfsv4_acl_on_unsupported_fs_surfaces_error_not_silent_success() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("f");
+    std::fs::write(&file, b"x").expect("write file");
+
+    let err = set_nfsv4_acl(&file, Some(&sample_acl()), false).expect_err(
+        "applying an NFSv4 ACL to a filesystem that does not support it must surface \
+         an error, not silently succeed",
+    );
+
+    // The surfaced error identifies the failed NFSv4 ACL apply (upstream's
+    // rsyserr also names the operation and path).
+    let msg = err.to_string();
+    assert!(
+        msg.contains("NFSv4 ACL"),
+        "the error must identify the failed NFSv4 ACL apply: {msg}"
+    );
+}
+
+/// The read side is a SILENT absence, matching upstream `get_acl`'s
+/// "unsupported filesystem -> pretend a basic ACL": a file on a filesystem with
+/// no NFSv4 ACL support decodes to `None`, not an error, so a plain source file
+/// never spuriously fails the ACL read.
+#[test]
+fn reading_nfsv4_acl_on_unsupported_fs_is_a_silent_absence() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("f");
+    std::fs::write(&file, b"x").expect("write file");
+
+    let acl = get_nfsv4_acl(&file, false)
+        .expect("reading a missing / unsupported NFSv4 ACL must not be an error");
+    assert!(
+        acl.is_none(),
+        "a normal filesystem has no NFSv4 ACL, so the read decodes to None"
+    );
+}
+
+/// Clearing an absent NFSv4 ACL (`set_nfsv4_acl(None)`, which removes the
+/// attribute) tolerates a missing attribute rather than surfacing it - so a
+/// source WITHOUT an NFSv4 ACL never fails the destination apply. This is the
+/// deliberate asymmetry with the apply path above: removing nothing is success,
+/// applying-but-cannot is an error.
+#[test]
+fn clearing_absent_nfsv4_acl_is_a_tolerated_no_op() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("f");
+    std::fs::write(&file, b"x").expect("write file");
+
+    set_nfsv4_acl(&file, None, false)
+        .expect("clearing an absent NFSv4 ACL must be a tolerated no-op success");
+}


### PR DESCRIPTION
## Summary

Test-only. Pins the observable degradation behavior of four metadata paths on
platforms or privilege levels where the underlying attribute cannot be applied,
so a regression to silent data loss (or a silent swallow) fails a test. No
production code changes.

Each pin asserts the exact observable outcome - a surfaced error, a documented
no-op, an applied value, or an upstream-faithful silent skip - not internals.

## What is pinned

### NFSv4 ACL degradation (`nfsv4_acl_unsupported_pin.rs`)

Mirrors upstream `acls.c`'s two-sided degradation intent on a filesystem that
does not support NFSv4 ACLs (the common Linux case: `system.nfs4_acl` exists
only on real NFSv4 mounts; ext4/tmpfs/overlayfs return `EOPNOTSUPP`):

- READ (`get_acl`, acls.c:525-527): an unsupported filesystem decodes to `None`
  (silent absence), never an error.
- WRITE (`set_acl` -> `sys_acl_set_file`, acls.c:993-996): a failed apply is
  **surfaced** as `Err`, never swallowed as a success - the receiver cannot
  pretend it preserved metadata it actually dropped.
- A third test explicitly pins the current remove-path behavior (clearing an
  NFSv4 ACL on an unsupported fs returns `Err(EOPNOTSUPP)` because the remove
  tolerates only `ENODATA`/`NotFound`). See the "finding" note below.

### crtime apply (`metadata_degradation_pins.rs`)

Pins the **entry-based** apply (`apply_metadata_with_attrs_flags`, the wire
receiver path) - distinct from the source-metadata path already covered by
`atimes_crtimes_roundtrip.rs`:

- Non-macOS Unix: a clean documented no-op (`set_crtime` is a stub because Linux
  birth time is not settable); the apply must not error or disturb content.
- Windows: `SetFileTime` actually stamps the NTFS creation time to the entry's
  value. This fills the Windows arm that `atimes_crtimes_roundtrip` documents as
  out of scope. Compile-checked here via the windows-gnu cross-check; exercised
  on CI Windows.

### Non-root xattr namespace skip (`metadata_degradation_pins.rs`)

Pins that a non-root receiver silently skips a non-`user.*` xattr and preserves
a `user.*` one, continuing without error (upstream `xattrs.c:830`). This is the
generic mechanism by which a resource fork or any system/security attribute is
dropped for an unprivileged receiver. Complements `security_selinux_roundtrip.rs`
(which pins the root path and skips when unprivileged). Skips cleanly with a
logged reason when run as root or on a filesystem without `user.*` support.

## Findings surfaced (not silently pinned as "correct")

- **Resource fork is not a separate subsystem.** A macOS resource fork travels
  as the ordinary `com.apple.ResourceFork` xattr; there is no distinct
  resource-fork drop/warn path to pin. Its fate is governed entirely by the
  xattr namespace rule, so the resource-fork pin is expressed as the non-root
  xattr-namespace skip above.
- **ACL vs xattr non-root behavior is asymmetric, and both are upstream-faithful.**
  A non-root ACL apply that the kernel rejects with `EPERM` is **surfaced as an
  error** (`is_unsupported_error` deliberately excludes `EPERM`; already unit-
  pinned by `acl_exacl/tests.rs::is_unsupported_error_surfaces_eperm`), mirroring
  `acls.c:994-997` `rsyserr(FERROR_XFER)`. A non-root xattr outside `user.*` is
  **silently skipped**, mirroring `xattrs.c:830`. The two are opposite by design;
  no new ACL integration test was added because the `EPERM`-surface / unsupported-
  swallow boundary is already deterministically unit-pinned.
- The NFSv4 remove-path `EOPNOTSUPP` above is documented as the current behavior,
  not asserted as ideal.

## Verification (isolated clone, x86_64 Linux host)

- `cargo fmt --all -- --check`: clean
- `cargo nextest run -p metadata --all-features` targeted at the new files: green
  (the non-root xattr pin exercised as a non-root user)
- `cargo check -p metadata --all-features --all-targets --target x86_64-pc-windows-gnu`: clean
- `cargo check -p metadata --all-features --all-targets --target x86_64-unknown-linux-musl`: clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean
