### PR TITLE
fix(transfer): honor -C cvs-exclude on server decode for pull transfers

### DIFF
--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -397,6 +397,21 @@ pub struct ParsedServerFlags {
     /// byte-identical output on arbitrary inputs.
     pub parallel_delta_scan: bool,
 
+    /// Apply the built-in CVS-ignore rule set (`C` flag, `--cvs-exclude`).
+    ///
+    /// Sender-side in effect. Upstream `options.c:2709-2710` packs `'C'` into
+    /// the compact string whenever `cvs_exclude` is set, on both a push and a
+    /// pull. On a **pull** the remote server is the sender and the CVS rules
+    /// are NOT transmitted over the wire (`exclude.c:1652` gates the send on
+    /// `am_sender`, which the pulling client is not); instead the server must
+    /// re-derive them locally, exactly as upstream `recv_filter_list()` does
+    /// when `am_sender` (`exclude.c:1689-1695`, appending `:C` then `-C` after
+    /// the received rules). Without decoding `C` here the server-sender ran
+    /// with `cvs_exclude` off and transferred `CVS/`, `*.o`, `.cvsignore`
+    /// matches that upstream skips. On a **push** the client sends the CVS
+    /// rules over the wire, so the flag rides along but adds nothing extra.
+    pub cvs_exclude: bool,
+
     /// Info flags after the first `.` separator.
     pub info_flags: InfoFlags,
 }
@@ -624,6 +639,21 @@ impl ParsedServerFlags {
             // upstream: options.c:764 - fuzzy_basis++ for each 'y'
             b'y' => self.fuzzy_level = self.fuzzy_level.saturating_add(1),
             b'm' => self.prune_empty_dirs = true,
+            // upstream: options.c:2709-2710 - `if (cvs_exclude) argstr = 'C'`.
+            // A pulling client forwards `C` so the server-sender re-derives the
+            // CVS-ignore rules itself (they are not sent on a pull); the
+            // generator wires this into its filter chain via
+            // `receive_filter_list_if_server`.
+            b'C' => self.cvs_exclude = true,
+            // Deliberately NOT stored here (each still falls through):
+            //  - `s` (options.c:2623, `--secluded-args`) is detected by the
+            //    dedicated `detect_secluded_args_flag` scan in the CLI server
+            //    entry, which switches argv reading to the protected stream;
+            //    routing it through this struct would be redundant.
+            //  - `q` (options.c:2629, `--quiet`, sent only when
+            //    `quiet && msgs2stderr`) suppresses the sender's own progress
+            //    chatter; oc has no such server-side chatter to gate, so it is
+            //    cosmetic with no observable effect to reproduce.
             // Unknown flags are ignored for forward compatibility.
             _ => {}
         }
@@ -1059,5 +1089,48 @@ mod tests {
         let _ = flags.clear_unsupported_features();
         assert!(flags.recursive, "recursive should be preserved");
         assert!(flags.compress, "compress should be preserved");
+    }
+
+    /// A pulling client packs `C` into the compact string (upstream
+    /// `options.c:2709`) so the server-sender re-derives the CVS excludes.
+    /// Before this arm the byte fell through to `_ => {}` and
+    /// `--cvs-exclude` was silently ignored on a pull from an oc server.
+    #[test]
+    fn parses_cvs_exclude_flag() {
+        let flags = ParsedServerFlags::parse("-rltC").unwrap();
+        assert!(flags.cvs_exclude);
+        assert!(flags.recursive);
+        // The real pull flag string carries `C` right before the `.` section.
+        let packed = ParsedServerFlags::parse("-logDtprCe.iLsfxC").unwrap();
+        assert!(packed.cvs_exclude);
+    }
+
+    #[test]
+    fn cvs_exclude_off_by_default() {
+        assert!(!ParsedServerFlags::parse("-rlt").unwrap().cvs_exclude);
+    }
+
+    /// The `s` (secluded-args) and `q` (quiet) letters are intentionally not
+    /// stored on this struct - `s` is handled by the CLI server's dedicated
+    /// secluded-args detection and `q` is cosmetic. Decoding them here must
+    /// stay a no-op: they must not accidentally set an unrelated flag, and the
+    /// surrounding real flags must still parse.
+    #[test]
+    fn secluded_and_quiet_letters_are_inert_here() {
+        let flags = ParsedServerFlags::parse("-sqrlt").unwrap();
+        assert!(flags.recursive);
+        assert!(flags.links);
+        assert!(flags.times);
+        assert!(!flags.cvs_exclude);
+        // No transfer flag is spuriously toggled by `s`/`q`.
+        assert_eq!(
+            flags,
+            ParsedServerFlags {
+                recursive: true,
+                links: true,
+                times: true,
+                ..ParsedServerFlags::default()
+            }
+        );
     }
 }

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -24,6 +24,7 @@ use filters::{DirMergeConfig, FilterChain, cvs_exclusion_rules};
 use logging::info_log;
 use protocol::filters::{FilterRuleWireFormat, RuleType, read_filter_list};
 
+use crate::role::ServerRole;
 use crate::role_trailer::error_location;
 
 use super::GeneratorContext;
@@ -300,7 +301,7 @@ impl GeneratorContext {
         // upstream: clientserver.c:rsync_module() - daemon_filter_list is applied
         // on top of client filters. Daemon rules take precedence (prepended).
         let daemon_rules = &self.config.daemon_filter_rules;
-        let combined = if daemon_rules.is_empty() {
+        let mut combined = if daemon_rules.is_empty() {
             wire_rules
         } else if wire_rules.is_empty() {
             daemon_rules.clone()
@@ -309,6 +310,22 @@ impl GeneratorContext {
             combined.extend(wire_rules);
             combined
         };
+
+        // upstream: exclude.c:1689-1695 recv_filter_list() - once the client's
+        // rules are read, a server that IS the sender (a pull; upstream's
+        // `am_sender`) re-derives the CVS-ignore rules locally, because a
+        // pulling client does NOT transmit them (`exclude.c:1652` sends them
+        // only when the client is itself the sender). Append the per-directory
+        // `.cvsignore` merge (`:C`) and then the built-in CVS exclude set
+        // (`-C`), in that order, after the received rules so they take the same
+        // lowest precedence upstream gives them. `ServerRole::Generator` is
+        // oc's `am_sender` server. Without this a `-C` pull from an oc server
+        // transferred exactly the CVS-ignored files (`CVS/`, `*.o`, entries
+        // named by `.cvsignore`) the client asked to skip.
+        if self.config.flags.cvs_exclude && self.config.role == ServerRole::Generator {
+            combined.push(cvs_dir_merge_wire_rule());
+            combined.push(cvs_exclude_wire_rule());
+        }
 
         if !combined.is_empty() {
             let (filter_set, merge_configs) = self.parse_received_filters(&combined)?;
@@ -576,6 +593,34 @@ fn is_order_bearing(rule: &FilterRule) -> bool {
 /// from the pattern body, while the `filters` crate expects them embedded in
 /// the pattern string. This restores them so downstream rule compilation
 /// observes the user's original intent.
+/// Builds the synthetic `:C` wire rule - a per-directory `.cvsignore` merge
+/// carrying the CVS defaults - that a server-sender appends when the pulling
+/// client requested `--cvs-exclude`. The empty pattern defaults to
+/// `.cvsignore` in `wire_rule_to_dir_merge_config`.
+///
+/// upstream: exclude.c:1689 recv_filter_list() `parse_filter_str(":C")`.
+fn cvs_dir_merge_wire_rule() -> FilterRuleWireFormat {
+    FilterRuleWireFormat {
+        rule_type: RuleType::DirMerge,
+        cvs_exclude: true,
+        ..FilterRuleWireFormat::default()
+    }
+}
+
+/// Builds the synthetic `-C` wire rule - the built-in CVS exclude set. The
+/// empty pattern with `cvs_exclude` triggers the `get_cvs_excludes()`
+/// expansion (static defaults + `$HOME/.cvsignore` + `$CVSIGNORE`) in
+/// `parse_received_filters`.
+///
+/// upstream: exclude.c:1691 recv_filter_list() `parse_filter_str("-C")`.
+fn cvs_exclude_wire_rule() -> FilterRuleWireFormat {
+    FilterRuleWireFormat {
+        rule_type: RuleType::Exclude,
+        cvs_exclude: true,
+        ..FilterRuleWireFormat::default()
+    }
+}
+
 fn reconstruct_pattern(wire_rule: &FilterRuleWireFormat) -> String {
     let mut pattern = String::with_capacity(wire_rule.pattern.len() + 2);
     if wire_rule.anchored && !wire_rule.pattern.starts_with('/') {

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -16,7 +16,7 @@ use crate::delta_apply::ChecksumVerifier;
 use crate::handshake::HandshakeResult;
 use crate::receiver::SumHead;
 use engine::delta::{DeltaScript, DeltaToken};
-use protocol::filters::FilterRuleWireFormat;
+use protocol::filters::{FilterRuleWireFormat, write_filter_list};
 use protocol::wire::{CompressedTokenEncoder, DeltaOp};
 use protocol::{ChecksumAlgorithm, CompressionAlgorithm, NegotiationResult, ProtocolVersion};
 use std::ffi::OsString;
@@ -6177,5 +6177,89 @@ fn server_sender_symlink_time_follows_receiver_l_capability_not_own_flag() {
         server_sender_symlink_time_glyph(with_l_no_flag, None),
         't',
         "server-sender tracks the receiver's 'L', independent of its own flag",
+    );
+}
+
+// -- server-sender CVS-exclude injection (compact `C`, upstream recv_filter_list) --
+
+/// Builds an empty client filter list on the wire at protocol 28 (raw, not
+/// multiplexed) so `receive_filter_list_if_server` reads zero client rules and
+/// then applies only whatever the server injects.
+fn empty_client_filter_list_v28() -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_filter_list(&mut buf, &[], ProtocolVersion::try_from(28u8).unwrap())
+        .expect("encode empty filter list");
+    buf
+}
+
+/// A server-side config at protocol 28 with the given role and `cvs_exclude`
+/// state, in server mode (not client_mode) so the server filter-receive path
+/// runs.
+fn cvs_server_config(role: ServerRole, cvs_exclude: bool) -> ServerConfig {
+    let mut config = test_config();
+    config.role = role;
+    config.protocol = ProtocolVersion::try_from(28u8).unwrap();
+    config.flag_string = "-logDtprC".to_owned();
+    config.flags.cvs_exclude = cvs_exclude;
+    config.connection.client_mode = false;
+    config
+}
+
+fn receive_empty_list(config: ServerConfig) -> GeneratorContext {
+    let handshake = test_handshake_with_protocol(28);
+    let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+    let buf = empty_client_filter_list_v28();
+    ctx.receive_filter_list_if_server(&mut Cursor::new(buf))
+        .expect("server filter receive");
+    ctx
+}
+
+/// A pull (`ServerRole::Generator` = upstream `am_sender`) with `--cvs-exclude`
+/// forwarded as the compact `C` must re-derive the built-in CVS excludes even
+/// though the pulling client sends NO filter rules over the wire. Before the
+/// fix the server dropped `C`, so `*.o` and `CVS/` were transferred instead of
+/// skipped.
+///
+/// upstream: exclude.c:1689-1695 recv_filter_list() appends `:C` then `-C` when
+/// `am_sender`; the `-C` set includes the `*.o` / `CVS` defaults.
+#[test]
+fn server_sender_cvs_exclude_injects_default_excludes() {
+    let ctx = receive_empty_list(cvs_server_config(ServerRole::Generator, true));
+    assert!(
+        !ctx.filter_chain.allows(Path::new("foo.o"), false),
+        "*.o must be excluded by the injected CVS defaults on a -C pull",
+    );
+    assert!(
+        !ctx.filter_chain.allows(Path::new("CVS"), true),
+        "CVS/ must be excluded by the injected CVS defaults on a -C pull",
+    );
+    assert!(
+        ctx.filter_chain.allows(Path::new("keep.txt"), false),
+        "a non-CVS file must still transfer",
+    );
+}
+
+/// The injection is gated on `cvs_exclude`: a pull WITHOUT `-C` must not grow
+/// any CVS excludes (guards against unconditionally adding them).
+#[test]
+fn server_sender_without_cvs_exclude_transfers_everything() {
+    let ctx = receive_empty_list(cvs_server_config(ServerRole::Generator, false));
+    assert!(
+        ctx.filter_chain.allows(Path::new("foo.o"), false),
+        "without -C the server must not synthesize CVS excludes",
+    );
+}
+
+/// The injection is gated on the sender role: on a PUSH the server is the
+/// receiver (`ServerRole::Receiver`), and upstream transmits the CVS rules over
+/// the wire instead of re-deriving them locally (exclude.c:1652 / :1695 gate on
+/// `am_sender`). So a `-C` push server must NOT inject them a second time.
+#[test]
+fn server_receiver_does_not_inject_cvs_excludes() {
+    let ctx = receive_empty_list(cvs_server_config(ServerRole::Receiver, true));
+    assert!(
+        ctx.filter_chain.allows(Path::new("foo.o"), false),
+        "a server-receiver (push) must rely on the wire-transmitted CVS rules, \
+         not inject its own",
     );
 }


### PR DESCRIPTION
## Problem

The compact server flag string packs `C` whenever `--cvs-exclude` is active
(upstream `options.c:2709`). oc's client forwards it, but the server flag
parser (`ParsedServerFlags::parse_transfer_flag`) had no arm for `C`, so the
byte fell through to `_ => {}` and was silently dropped.

On a **pull**, the remote oc server is the sender, and the pulling client does
NOT transmit the CVS rules over the wire (`exclude.c:1652` gates that send on
`am_sender`, which the pulling client is not). Upstream's server re-derives the
CVS rules locally in `recv_filter_list()`. With `C` dropped, oc's server never
did, so `--cvs-exclude` was silently ineffective and the server transferred
exactly the files upstream skips.

Measured against rsync 3.4.4 over ssh (`-aiR`-style `-aC` pull), before the fix:

```
upstream lands:  .cvsignore  keep.txt  sub/data.txt
oc lands:        .cvsignore  keep.txt  sub/data.txt  CVS/Entries  foo.o  skipme.log  sub/bar.o
```

`CVS/`, `*.o`, and files matched by a directory's `.cvsignore` all leaked.

## Fix

Decode `C` into a new `cvs_exclude` field, and wire it into the server's
`receive_filter_list_if_server`: when the server is the sender
(`ServerRole::Generator` = upstream `am_sender`), re-derive the CVS rules after
the client's received rules, mirroring `recv_filter_list()`
(`exclude.c:1689-1695`) - append the `:C` per-directory `.cvsignore` merge and
then the `-C` built-in exclude set (static defaults + `$HOME/.cvsignore` +
`$CVSIGNORE`), in that order and at the same lowest precedence. Both synthetic
rules flow through the existing filter-rule expansion (`parse_received_filters`
already expands a `cvs_exclude` Exclude rule with an empty pattern into
`get_cvs_excludes()` and a `cvs_exclude` DirMerge into a `.cvsignore` merge).

A **push** is unaffected: the client-sender applies CVS excludes locally AND
transmits the rules over the wire, so the server (receiver) must not inject
them a second time - the injection is gated on the sender role.

### Audit of the other unhandled letters

- `s` (`--secluded-args`, `options.c:2623`) is already handled by the CLI
  server's dedicated `detect_secluded_args_flag` scan, which switches argv
  reading to the protected stream. Routing it through `ParsedServerFlags` would
  be redundant; documented as an intentional no-op.
- `q` (`--quiet`, `options.c:2629`, sent only when `quiet && msgs2stderr`)
  suppresses the sender's own progress chatter, which oc does not emit on the
  server side; cosmetic, documented as an intentional no-op.

(`b`/backup and `O`/`J` omit-times were already handled.)

## Tests

`crates/transfer/src/flags.rs`:
- `parses_cvs_exclude_flag` / `cvs_exclude_off_by_default` - the decode.
- `secluded_and_quiet_letters_are_inert_here` - `s`/`q` toggle nothing.

`crates/transfer/src/generator/tests.rs` (drive `receive_filter_list_if_server`
with an empty client list at protocol 28):
- `server_sender_cvs_exclude_injects_default_excludes` - a `-C` pull excludes
  `*.o` and `CVS/` while keeping a normal file. Fails before the fix.
- `server_sender_without_cvs_exclude_transfers_everything` - gated on `-C`.
- `server_receiver_does_not_inject_cvs_excludes` - gated on the sender role
  (a push relies on the wire-transmitted rules).

## Verification

Against rsync 3.4.4 on Linux x86_64: an oc<->oc `-aC` pull over ssh now lands
the same files as the upstream oracle (`CVS/`, `*.o`, and `.cvsignore` matches
all excluded), and a `-aC` push is unchanged. `cargo fmt --check` clean;
`clippy --workspace --all-targets --all-features -D warnings` and default
features, both rc 0; `cargo check` for `x86_64-pc-windows-gnu` and
`x86_64-unknown-linux-musl` (lib+bins+tests), both rc 0; `nextest -p transfer
--all-features`, 2666 passing.
