### PR TITLE
fix(protocol): preserve raw bytes for non-UTF-8 filter-rule wire patterns

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -298,7 +298,7 @@ pub(crate) fn build_wire_format_rules(
                 let (pattern, anchored, directory_only) = split_pattern_modifiers(spec.pattern());
                 wire_rules.push(FilterRuleWireFormat {
                     rule_type: RuleType::Exclude,
-                    pattern,
+                    pattern: pattern.into(),
                     anchored,
                     directory_only,
                     // upstream: 'e' flag = FILTRULE_EXCLUDE_SELF.
@@ -317,7 +317,7 @@ pub(crate) fn build_wire_format_rules(
         let (pattern, anchored, directory_only) = split_pattern_modifiers(spec.pattern());
         let mut wire_rule = FilterRuleWireFormat {
             rule_type,
-            pattern,
+            pattern: pattern.into(),
             anchored,
             directory_only,
             xattr_only: spec.is_xattr_only(),

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1602,7 +1602,7 @@ mod module_access_tests {
         let rule = build_pattern_rule("foo/", false);
         assert!(rule.anchored); // has embedded '/'
         assert!(!rule.directory_only); // cleared by DIR2WILD3
-        assert!(rule.pattern.ends_with("/***"));
+        assert!(rule.pattern.to_string_lossy().ends_with("/***"));
     }
 
     #[test]

--- a/crates/protocol/src/filters/prefix.rs
+++ b/crates/protocol/src/filters/prefix.rs
@@ -68,8 +68,11 @@ fn build_old_prefix(rule: &FilterRuleWireFormat) -> Option<String> {
     // upstream: exclude.c:1538 - only emit "- " when the pattern would otherwise
     // be ambiguous with another prefix; else send the bare pattern (legal_len = 0).
     if matches!(rule.rule_type, RuleType::Exclude) {
-        let pat = &rule.pattern;
-        let needs_prefix = (pat.starts_with("- ") || pat.starts_with("+ "))
+        // `as_encoded_bytes()` preserves ASCII bytes verbatim on every platform,
+        // so probing the ASCII `"- "`/`"+ "` prefixes on the raw bytes is sound
+        // even for a non-UTF-8 pattern body.
+        let pat = rule.pattern.as_encoded_bytes();
+        let needs_prefix = (pat.starts_with(b"- ") || pat.starts_with(b"+ "))
             || matches!(
                 rule.rule_type,
                 RuleType::Protect | RuleType::Risk | RuleType::Merge | RuleType::Clear
@@ -232,7 +235,7 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(32).unwrap();
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".rules".to_owned(),
+            pattern: ".rules".into(),
             anchored: true,
             ..FilterRuleWireFormat::default()
         };
@@ -268,7 +271,7 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(32).unwrap();
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".cvsignore".to_owned(),
+            pattern: ".cvsignore".into(),
             cvs_exclude: true,
             no_inherit: true,
             word_split: true,
@@ -391,7 +394,7 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(32).unwrap();
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::Protect,
-            pattern: "important".to_owned(),
+            pattern: "important".into(),
             receiver_side: true,
             ..FilterRuleWireFormat::default()
         };
@@ -407,7 +410,7 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(32).unwrap();
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::Risk,
-            pattern: "scratch".to_owned(),
+            pattern: "scratch".into(),
             receiver_side: true,
             ..FilterRuleWireFormat::default()
         };

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -1,6 +1,7 @@
 //! Wire format encoding and decoding for filter rules.
 
 use crate::ProtocolVersion;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, Read, Write};
 
 /// Rule type prefix character.
@@ -65,8 +66,17 @@ impl RuleType {
 pub struct FilterRuleWireFormat {
     /// Rule type (Include/Exclude/Clear/etc.).
     pub rule_type: RuleType,
-    /// Glob pattern.
-    pub pattern: String,
+    /// Glob pattern, stored as raw bytes.
+    ///
+    /// Upstream carries filter patterns as a raw `char *` end-to-end
+    /// (`exclude.c:219` allocates `rule->pattern = new_array(char, ...)`;
+    /// `exclude.c:1638` writes it verbatim with `write_buf`; `exclude.c:1685`
+    /// reads it back into a `char[]` with `read_sbuf`) and never validates the
+    /// bytes as UTF-8. Storing an [`OsString`] rather than a `String` lets a
+    /// pattern containing non-UTF-8 bytes round-trip through the wire
+    /// serialize/parse pair byte-for-byte, matching upstream. For a valid-UTF-8
+    /// pattern the on-wire bytes are unchanged.
+    pub pattern: OsString,
     /// Anchored pattern (`/` modifier).
     pub anchored: bool,
     /// Directory-only pattern (trailing `/`).
@@ -117,10 +127,10 @@ pub struct FilterRuleWireFormat {
 
 impl FilterRuleWireFormat {
     /// Creates a simple exclude rule with default modifiers.
-    pub const fn exclude(pattern: String) -> Self {
+    pub fn exclude(pattern: impl Into<OsString>) -> Self {
         Self {
             rule_type: RuleType::Exclude,
-            pattern,
+            pattern: pattern.into(),
             anchored: false,
             directory_only: false,
             no_inherit: false,
@@ -139,10 +149,10 @@ impl FilterRuleWireFormat {
     }
 
     /// Creates a simple include rule with default modifiers.
-    pub const fn include(pattern: String) -> Self {
+    pub fn include(pattern: impl Into<OsString>) -> Self {
         Self {
             rule_type: RuleType::Include,
-            pattern,
+            pattern: pattern.into(),
             anchored: false,
             directory_only: false,
             no_inherit: false,
@@ -202,6 +212,41 @@ fn read_i32_le(reader: &mut dyn Read) -> io::Result<i32> {
 /// which writes 4 bytes as a little-endian int32.
 fn write_i32_le(writer: &mut dyn Write, value: i32) -> io::Result<()> {
     writer.write_all(&value.to_le_bytes())
+}
+
+/// Returns the raw wire bytes of a filter pattern.
+///
+/// On unix the pattern bytes are the `OsStr` bytes verbatim, so any byte
+/// sequence (including non-UTF-8) round-trips unchanged. On other platforms
+/// `OsStr` is not byte-addressable, so we fall back to the UTF-8 encoding,
+/// which is lossless for the valid-UTF-8 patterns those platforms produce.
+#[cfg(unix)]
+fn pattern_to_wire_bytes(pattern: &OsStr) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    pattern.as_bytes().to_vec()
+}
+
+/// Non-unix twin of [`pattern_to_wire_bytes`].
+#[cfg(not(unix))]
+fn pattern_to_wire_bytes(pattern: &OsStr) -> Vec<u8> {
+    pattern.to_string_lossy().into_owned().into_bytes()
+}
+
+/// Reconstructs a filter pattern from its raw wire bytes.
+///
+/// The inverse of [`pattern_to_wire_bytes`]: on unix it wraps the bytes as an
+/// `OsString` without any UTF-8 check, so a non-UTF-8 pattern survives
+/// verbatim.
+#[cfg(unix)]
+fn wire_bytes_to_pattern(bytes: &[u8]) -> OsString {
+    use std::os::unix::ffi::OsStrExt;
+    OsStr::from_bytes(bytes).to_os_string()
+}
+
+/// Non-unix twin of [`wire_bytes_to_pattern`].
+#[cfg(not(unix))]
+fn wire_bytes_to_pattern(bytes: &[u8]) -> OsString {
+    OsString::from(String::from_utf8_lossy(bytes).into_owned())
 }
 
 /// Reads filter list from wire format.
@@ -325,6 +370,12 @@ pub fn write_filter_list<W: Write>(
 /// or `"!"`. No modifier characters are parsed. This matches upstream
 /// `exclude.c:1119-1133` where `XFLG_OLD_PREFIXES` restricts parsing to
 /// these three forms.
+///
+/// The rule-type prefix and every modifier byte are ASCII, so parsing scans
+/// the leading bytes directly and treats the remaining bytes as the raw
+/// pattern body. The pattern is never validated as UTF-8: upstream carries it
+/// as a raw `char *` (`exclude.c:1685` `read_sbuf` into a `char[]`), so a
+/// non-UTF-8 pattern is preserved verbatim rather than rejected.
 fn parse_wire_rule(buf: &[u8], protocol: ProtocolVersion) -> io::Result<FilterRuleWireFormat> {
     if buf.is_empty() {
         return Err(io::Error::new(
@@ -333,19 +384,12 @@ fn parse_wire_rule(buf: &[u8], protocol: ProtocolVersion) -> io::Result<FilterRu
         ));
     }
 
-    let text = std::str::from_utf8(buf).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("invalid UTF-8 in filter rule: {e}"),
-        )
-    })?;
-
     // upstream: exclude.c:1675 - protocol < 29 uses XFLG_OLD_PREFIXES
     if protocol.uses_old_prefixes() {
-        return parse_wire_rule_old_prefix(text);
+        return parse_wire_rule_old_prefix(buf);
     }
 
-    parse_wire_rule_modern(text, protocol)
+    parse_wire_rule_modern(buf, protocol)
 }
 
 /// Parses a wire rule using old-style prefix rules (protocol < 29).
@@ -372,28 +416,31 @@ fn parse_wire_rule(buf: &[u8], protocol: ProtocolVersion) -> io::Result<FilterRu
 /// Returns `InvalidData` when a prefix is followed by an empty pattern,
 /// mirroring upstream's "unexpected end of filter rule" `RERR_SYNTAX` exit
 /// (exclude.c:1324-1327).
-fn parse_wire_rule_old_prefix(text: &str) -> io::Result<FilterRuleWireFormat> {
-    if text == "!" {
+fn parse_wire_rule_old_prefix(buf: &[u8]) -> io::Result<FilterRuleWireFormat> {
+    if buf == b"!" {
         return Ok(FilterRuleWireFormat {
             rule_type: RuleType::Clear,
             ..FilterRuleWireFormat::default()
         });
     }
 
-    let (rule_type, pattern_text) = if let Some(pat) = text.strip_prefix("- ") {
+    let (rule_type, pattern_bytes) = if let Some(pat) = buf.strip_prefix(b"- ".as_slice()) {
         (RuleType::Exclude, pat)
-    } else if let Some(pat) = text.strip_prefix("+ ") {
+    } else if let Some(pat) = buf.strip_prefix(b"+ ".as_slice()) {
         (RuleType::Include, pat)
     } else {
-        (RuleType::Exclude, text)
+        (RuleType::Exclude, buf)
     };
 
-    if pattern_text.is_empty() {
+    if pattern_bytes.is_empty() {
         // upstream: exclude.c:1324-1327 exits RERR_SYNTAX on a rule that
         // ends right after its prefix.
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("unexpected end of filter rule: {text:?}"),
+            format!(
+                "unexpected end of filter rule: {:?}",
+                String::from_utf8_lossy(buf)
+            ),
         ));
     }
 
@@ -402,11 +449,11 @@ fn parse_wire_rule_old_prefix(text: &str) -> io::Result<FilterRuleWireFormat> {
         ..FilterRuleWireFormat::default()
     };
 
-    if let Some(stripped) = pattern_text.strip_suffix('/') {
+    if let Some(stripped) = pattern_bytes.strip_suffix(b"/".as_slice()) {
         rule.directory_only = true;
-        stripped.clone_into(&mut rule.pattern);
+        rule.pattern = wire_bytes_to_pattern(stripped);
     } else {
-        pattern_text.clone_into(&mut rule.pattern);
+        rule.pattern = wire_bytes_to_pattern(pattern_bytes);
     }
 
     Ok(rule)
@@ -417,18 +464,19 @@ fn parse_wire_rule_old_prefix(text: &str) -> io::Result<FilterRuleWireFormat> {
 /// Supports full modifier parsing including `/`, `!`, `C`, `n`, `w`, `e`,
 /// `x`, `s`, `r`, `p` flags.
 fn parse_wire_rule_modern(
-    text: &str,
+    buf: &[u8],
     protocol: ProtocolVersion,
 ) -> io::Result<FilterRuleWireFormat> {
-    let mut chars = text.chars();
-    let first = chars
-        .next()
+    // The rule-type prefix is always a single ASCII byte, so decode it as a
+    // char without validating the rest of the buffer as UTF-8.
+    let first = *buf
+        .first()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "empty filter rule"))?;
 
-    let rule_type = RuleType::from_prefix_char(first).ok_or_else(|| {
+    let rule_type = RuleType::from_prefix_char(first as char).ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("invalid rule type prefix: '{first}'"),
+            format!("invalid rule type prefix: '{}'", first as char),
         )
     })?;
 
@@ -438,17 +486,19 @@ fn parse_wire_rule_modern(
     };
 
     let mut pattern_start = 1;
-    for (i, c) in chars.enumerate() {
+    // Every modifier byte is ASCII; scan them directly and stop at the first
+    // non-modifier byte, which begins the (possibly non-UTF-8) pattern body.
+    for (i, &c) in buf[1..].iter().enumerate() {
         match c {
-            '/' if i == 0 => {
+            b'/' if i == 0 => {
                 rule.anchored = true;
                 pattern_start += 1;
             }
-            '!' => {
+            b'!' => {
                 rule.negate = true;
                 pattern_start += 1;
             }
-            'C' => {
+            b'C' => {
                 // upstream: exclude.c:1248-1255 parse_rule_tok() case 'C' sets
                 // FILTRULE_NO_PREFIXES | FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT
                 // | FILTRULE_CVS_IGNORE together, so a `C` rule carries all the
@@ -465,19 +515,19 @@ fn parse_wire_rule_modern(
                 rule.no_prefixes = true;
                 pattern_start += 1;
             }
-            'n' => {
+            b'n' => {
                 rule.no_inherit = true;
                 pattern_start += 1;
             }
-            'w' => {
+            b'w' => {
                 rule.word_split = true;
                 pattern_start += 1;
             }
-            'e' => {
+            b'e' => {
                 rule.exclude_from_merge = true;
                 pattern_start += 1;
             }
-            'x' => {
+            b'x' => {
                 rule.xattr_only = true;
                 pattern_start += 1;
             }
@@ -486,28 +536,28 @@ fn parse_wire_rule_modern(
             // Acceptance is gated on Merge/DirMerge to mirror upstream's
             // FILTRULE_MERGE_FILE precondition; on other rule types these
             // characters fall through to `_` and terminate modifier parsing.
-            '-' if matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) => {
+            b'-' if matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) => {
                 rule.no_prefixes = true;
                 pattern_start += 1;
             }
-            '+' if matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) => {
+            b'+' if matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) => {
                 rule.no_prefixes = true;
                 rule.no_prefixes_include = true;
                 pattern_start += 1;
             }
-            's' if protocol.supports_sender_receiver_modifiers() => {
+            b's' if protocol.supports_sender_receiver_modifiers() => {
                 rule.sender_side = true;
                 pattern_start += 1;
             }
-            'r' if protocol.supports_sender_receiver_modifiers() => {
+            b'r' if protocol.supports_sender_receiver_modifiers() => {
                 rule.receiver_side = true;
                 pattern_start += 1;
             }
-            'p' if protocol.supports_perishable_modifier() => {
+            b'p' if protocol.supports_perishable_modifier() => {
                 rule.perishable = true;
                 pattern_start += 1;
             }
-            ' ' => {
+            b' ' => {
                 // Trailing space terminates the modifier section per upstream
                 // exclude.c parser.
                 pattern_start += 1;
@@ -517,7 +567,7 @@ fn parse_wire_rule_modern(
         }
     }
 
-    let mut pattern_text = &text[pattern_start..];
+    let mut pattern_bytes = &buf[pattern_start..];
 
     // Non-merge rules encode the anchor as a leading `/` in the pattern body
     // (upstream keeps it in ent->pattern with FILTRULE_ABS_PATH unset). Fold it
@@ -528,18 +578,18 @@ fn parse_wire_rule_modern(
     // the `/` prefix modifier in the loop above.
     if !rule.anchored
         && !matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge)
-        && pattern_text.len() > 1
-        && pattern_text.starts_with('/')
+        && pattern_bytes.len() > 1
+        && pattern_bytes.first() == Some(&b'/')
     {
         rule.anchored = true;
-        pattern_text = &pattern_text[1..];
+        pattern_bytes = &pattern_bytes[1..];
     }
 
-    if let Some(stripped) = pattern_text.strip_suffix('/') {
+    if let Some(stripped) = pattern_bytes.strip_suffix(b"/".as_slice()) {
         rule.directory_only = true;
-        stripped.clone_into(&mut rule.pattern);
+        rule.pattern = wire_bytes_to_pattern(stripped);
     } else {
-        pattern_text.clone_into(&mut rule.pattern);
+        rule.pattern = wire_bytes_to_pattern(pattern_bytes);
     }
 
     Ok(rule)
@@ -563,6 +613,7 @@ fn serialize_rule(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -> io:
         )
     })?;
     let mut bytes = prefix.into_bytes();
+    let pattern_bytes = pattern_to_wire_bytes(&rule.pattern);
     // Non-merge anchored rules carry the anchor as a leading `/` in the pattern
     // body, mirroring upstream whose command-line `- /foo` keeps the slash in
     // ent->pattern with FILTRULE_ABS_PATH unset (exclude.c:200-208). The `/`
@@ -572,11 +623,11 @@ fn serialize_rule(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -> io:
     // parse_wire_rule_modern() (server) fold the leading `/` into `anchored`.
     if rule.anchored
         && !matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge)
-        && !rule.pattern.starts_with('/')
+        && pattern_bytes.first() != Some(&b'/')
     {
         bytes.push(b'/');
     }
-    bytes.extend_from_slice(rule.pattern.as_bytes());
+    bytes.extend_from_slice(&pattern_bytes);
 
     if rule.directory_only {
         bytes.push(b'/');
@@ -809,7 +860,7 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(32).unwrap();
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".excl".to_owned(),
+            pattern: ".excl".into(),
             no_prefixes: true,
             ..FilterRuleWireFormat::default()
         };
@@ -838,7 +889,7 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(32).unwrap();
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".incl".to_owned(),
+            pattern: ".incl".into(),
             no_prefixes: true,
             no_prefixes_include: true,
             ..FilterRuleWireFormat::default()
@@ -892,6 +943,45 @@ mod tests {
         let mut buf = Vec::new();
         let result = write_filter_list(&mut buf, &[rule], protocol_v28);
         assert!(result.is_err());
+    }
+
+    /// A filter rule whose pattern contains a non-UTF-8 byte must round-trip
+    /// through the wire serialize/parse pair byte-for-byte. Upstream carries the
+    /// pattern as a raw `char *` and never validates it as UTF-8
+    /// (`exclude.c:1638` `write_buf(f_out, ent->pattern, len)` on send,
+    /// `exclude.c:1685` `read_sbuf(f_in, line, len)` into a `char[]` on recv),
+    /// so a `0xFF` byte survives verbatim. Before the pattern became byte-based
+    /// the reader rejected such a record as `InvalidData` (the pinned rejection
+    /// is retired by this round-trip). The 0xFF byte cannot live in a `String`,
+    /// so this case is unix-only where `OsStr` is byte-addressable.
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_pattern_roundtrips_byte_for_byte() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        let pattern = OsStr::from_bytes(b"log\xff.txt").to_os_string();
+        let rule = FilterRuleWireFormat::exclude(pattern);
+
+        let mut buf = Vec::new();
+        write_filter_list(&mut buf, std::slice::from_ref(&rule), protocol).unwrap();
+
+        // Wire bytes: 4-byte LE length + "- " prefix + the raw pattern bytes
+        // (0xFF emitted verbatim) + the 4-byte LE zero terminator.
+        let payload = b"- log\xff.txt";
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&(payload.len() as i32).to_le_bytes());
+        expected.extend_from_slice(payload);
+        expected.extend_from_slice(&0i32.to_le_bytes());
+        assert_eq!(
+            buf, expected,
+            "0xFF pattern byte must reach the wire verbatim"
+        );
+
+        // Decode(encode(rule)) == rule, byte-for-byte on the pattern.
+        let parsed = read_filter_list(&mut &buf[..], protocol).unwrap();
+        assert_eq!(parsed, vec![rule]);
+        assert_eq!(parsed[0].pattern.as_bytes(), b"log\xff.txt");
     }
 
     /// Proves the async twin decodes byte-for-byte identically to the blocking

--- a/crates/protocol/tests/adversarial_stream_corpus.rs
+++ b/crates/protocol/tests/adversarial_stream_corpus.rs
@@ -556,21 +556,31 @@ fn filter_list_oversized_length_truncates_to_eof() {
     assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
 }
 
+#[cfg(unix)]
 #[test]
-fn filter_list_invalid_utf8_rejected() {
-    // Bug it catches: a rule body with non-UTF-8 bytes must surface as
-    // InvalidData (upstream rsync expects UTF-8 filter rules). A regression
-    // in `parse_wire_rule` once accepted them silently and corrupted the
-    // pattern downstream.
+fn filter_list_non_utf8_pattern_preserved() {
+    // Bug it catches: a rule body with non-UTF-8 bytes must be preserved
+    // verbatim, not rejected. Upstream carries the pattern as a raw `char *`
+    // and never validates UTF-8 (exclude.c:1685 `read_sbuf(f_in, line, len)`
+    // into a `char[]`), so a `0xFF` byte round-trips. This retires the earlier
+    // pinned `InvalidData` rejection, which wrongly refused a byte sequence
+    // upstream accepts.
+    use std::os::unix::ffi::OsStrExt;
     let mut bytes = Vec::new();
-    bytes.extend_from_slice(&3_i32.to_le_bytes());
-    bytes.extend_from_slice(&[0xFF, 0xFE, 0xFD]);
+    let body = b"- log\xff.txt";
+    bytes.extend_from_slice(&(body.len() as i32).to_le_bytes());
+    bytes.extend_from_slice(body);
     bytes.extend_from_slice(&0_i32.to_le_bytes());
     let mut cursor = Cursor::new(&bytes[..]);
     let protocol = ProtocolVersion::from_supported(32).expect("v32 supported");
-    let err = read_filter_list(&mut cursor, protocol)
-        .expect_err("invalid UTF-8 rule must surface InvalidData");
-    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    let rules = read_filter_list(&mut cursor, protocol)
+        .expect("non-UTF-8 filter pattern must be accepted, not rejected");
+    assert_eq!(rules.len(), 1);
+    assert_eq!(
+        rules[0].pattern.as_bytes(),
+        b"log\xff.txt",
+        "the non-UTF-8 pattern bytes must survive the wire decode verbatim"
+    );
 }
 
 #[test]

--- a/crates/protocol/tests/filter_colon_c_lsh_wire_byte.rs
+++ b/crates/protocol/tests/filter_colon_c_lsh_wire_byte.rs
@@ -32,7 +32,7 @@ fn colon_c_bare_modifier_emits_cvsignore_default_over_lsh() {
     let protocol = ProtocolVersion::from_supported(32).unwrap();
     let rule = FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
-        pattern: ".cvsignore".to_owned(),
+        pattern: ".cvsignore".into(),
         cvs_exclude: true,
         ..FilterRuleWireFormat::default()
     };
@@ -72,7 +72,7 @@ fn colon_c_bare_modifier_wire_format_stable_at_v29() {
     let protocol = ProtocolVersion::from_supported(29).unwrap();
     let rule = FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
-        pattern: ".cvsignore".to_owned(),
+        pattern: ".cvsignore".into(),
         cvs_exclude: true,
         ..FilterRuleWireFormat::default()
     };

--- a/crates/protocol/tests/filter_legal_len_parity.rs
+++ b/crates/protocol/tests/filter_legal_len_parity.rs
@@ -25,7 +25,7 @@ fn proto(v: u8) -> ProtocolVersion {
 fn dir_merge_rule(pattern: &str) -> FilterRuleWireFormat {
     FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
-        pattern: pattern.to_owned(),
+        pattern: pattern.into(),
         ..FilterRuleWireFormat::default()
     }
 }

--- a/crates/protocol/tests/filter_rule_wire_roundtrip.rs
+++ b/crates/protocol/tests/filter_rule_wire_roundtrip.rs
@@ -288,7 +288,7 @@ fn merge_rule_roundtrips() {
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::Merge,
-            pattern: "merge.rules".to_owned(),
+            pattern: "merge.rules".into(),
             ..FilterRuleWireFormat::default()
         },
         proto(32),
@@ -301,7 +301,7 @@ fn dir_merge_rule_roundtrips() {
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".rsync-filter".to_owned(),
+            pattern: ".rsync-filter".into(),
             ..FilterRuleWireFormat::default()
         },
         proto(32),
@@ -317,7 +317,7 @@ fn dir_merge_anchored_emits_slash_modifier_and_roundtrips() {
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".rules".to_owned(),
+            pattern: ".rules".into(),
             anchored: true,
             ..FilterRuleWireFormat::default()
         },
@@ -332,7 +332,7 @@ fn dir_merge_no_inherit_roundtrips() {
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".f".to_owned(),
+            pattern: ".f".into(),
             no_inherit: true,
             ..FilterRuleWireFormat::default()
         },
@@ -347,7 +347,7 @@ fn dir_merge_word_split_roundtrips() {
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".f".to_owned(),
+            pattern: ".f".into(),
             word_split: true,
             ..FilterRuleWireFormat::default()
         },
@@ -362,7 +362,7 @@ fn dir_merge_exclude_self_roundtrips() {
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".f".to_owned(),
+            pattern: ".f".into(),
             exclude_from_merge: true,
             ..FilterRuleWireFormat::default()
         },
@@ -379,7 +379,7 @@ fn dir_merge_no_prefixes_minus_roundtrips() {
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".excl".to_owned(),
+            pattern: ".excl".into(),
             no_prefixes: true,
             ..FilterRuleWireFormat::default()
         },
@@ -395,7 +395,7 @@ fn dir_merge_no_prefixes_plus_roundtrips() {
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".incl".to_owned(),
+            pattern: ".incl".into(),
             no_prefixes: true,
             no_prefixes_include: true,
             ..FilterRuleWireFormat::default()
@@ -413,7 +413,7 @@ fn dir_merge_all_merge_modifiers_roundtrip() {
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".rules".to_owned(),
+            pattern: ".rules".into(),
             anchored: true,
             no_inherit: true,
             word_split: true,
@@ -460,7 +460,7 @@ fn heterogeneous_rule_list_roundtrips_in_order() {
         FilterRuleWireFormat::exclude("secret".to_owned()).with_anchored(true),
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".rsync-filter".to_owned(),
+            pattern: ".rsync-filter".into(),
             ..FilterRuleWireFormat::default()
         },
         FilterRuleWireFormat {
@@ -499,7 +499,7 @@ fn protect_normalizes_to_receiver_side_exclude() {
     let protocol = proto(32);
     let protect = FilterRuleWireFormat {
         rule_type: RuleType::Protect,
-        pattern: "protected".to_owned(),
+        pattern: "protected".into(),
         receiver_side: true,
         ..FilterRuleWireFormat::default()
     };
@@ -530,7 +530,7 @@ fn risk_normalizes_to_receiver_side_include() {
     let protocol = proto(32);
     let risk = FilterRuleWireFormat {
         rule_type: RuleType::Risk,
-        pattern: "scratch".to_owned(),
+        pattern: "scratch".into(),
         receiver_side: true,
         ..FilterRuleWireFormat::default()
     };
@@ -571,7 +571,7 @@ fn cvs_dir_merge_c_modifier_re_derives_implied_flags_matching_upstream() {
     // A realistic CVS dir-merge carries the flags `C` implies on the send side.
     let cvs = FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
-        pattern: ".cvsignore".to_owned(),
+        pattern: ".cvsignore".into(),
         cvs_exclude: true,
         no_inherit: true,
         word_split: true,
@@ -589,7 +589,7 @@ fn cvs_dir_merge_c_modifier_re_derives_implied_flags_matching_upstream() {
     // but the WIRE bytes are a fixpoint: `:C` -> full-implied -> `:C`.
     let bare_cvs = FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
-        pattern: ".cvsignore".to_owned(),
+        pattern: ".cvsignore".into(),
         cvs_exclude: true,
         ..FilterRuleWireFormat::default()
     };
@@ -607,19 +607,29 @@ fn cvs_dir_merge_c_modifier_re_derives_implied_flags_matching_upstream() {
     assert_eq!(decoded2, decoded, "`:C` is a wire fixpoint");
 }
 
+// Upstream carries filter patterns as a raw `char *` and never validates them
+// as UTF-8 (exclude.c:1685 `read_sbuf(f_in, line, len)` into a `char[]`), so a
+// non-UTF-8 pattern must decode to its raw bytes rather than being rejected.
+// This retires the earlier pinned `InvalidData` rejection. The 0xFF byte cannot
+// live in a `String`, so this case is unix-only where `OsStr` is byte-addressable.
+#[cfg(unix)]
 #[test]
-fn non_utf8_wire_record_is_rejected_not_silently_decoded() {
+fn non_utf8_wire_record_decodes_to_raw_bytes() {
+    use std::os::unix::ffi::OsStrExt;
+
     let protocol = proto(32);
 
     // Hand-build a well-framed record whose payload (`- \xff`) is a valid
-    // prefix followed by an invalid UTF-8 byte, then the zero terminator.
+    // prefix followed by a non-UTF-8 byte, then the zero terminator.
     let mut buf = Vec::new();
     let payload: &[u8] = b"- \xff";
     buf.extend_from_slice(&(payload.len() as i32).to_le_bytes());
     buf.extend_from_slice(payload);
     buf.extend_from_slice(&0i32.to_le_bytes());
 
-    let err = read_filter_list(&mut &buf[..], protocol)
-        .expect_err("a non-UTF-8 filter record must be rejected, not decoded lossily");
-    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    let rules = read_filter_list(&mut &buf[..], protocol)
+        .expect("a non-UTF-8 filter record must decode to raw bytes, not be rejected");
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].rule_type, RuleType::Exclude);
+    assert_eq!(rules[0].pattern.as_bytes(), b"\xff");
 }

--- a/crates/protocol/tests/mdf_2_1_dir_only_unanchored_wire.rs
+++ b/crates/protocol/tests/mdf_2_1_dir_only_unanchored_wire.rs
@@ -37,13 +37,13 @@ fn dir_only_corpus() -> [FilterRuleWireFormat; 2] {
     [
         FilterRuleWireFormat {
             rule_type: RuleType::Exclude,
-            pattern: "foo/*".to_owned(),
+            pattern: "foo/*".into(),
             directory_only: true,
             ..FilterRuleWireFormat::default()
         },
         FilterRuleWireFormat {
             rule_type: RuleType::Include,
-            pattern: "foo/s?b".to_owned(),
+            pattern: "foo/s?b".into(),
             directory_only: true,
             ..FilterRuleWireFormat::default()
         },
@@ -93,7 +93,7 @@ fn dir_only_unanchored_emits_no_descendant_companion() {
             "every rule must carry FILTRULE_DIRECTORY, not be a descendant companion",
         );
         assert!(
-            !rule.pattern.contains("**"),
+            !rule.pattern.to_string_lossy().contains("**"),
             "no rule pattern should carry a `/**` descendant suffix",
         );
     }

--- a/crates/protocol/tests/mdf_2_2_delete_excluded_sender_side_wire.rs
+++ b/crates/protocol/tests/mdf_2_2_delete_excluded_sender_side_wire.rs
@@ -37,7 +37,7 @@ fn delete_excluded_merge_exclude_wire_emits_sender_side_prefix() {
     let protocol = ProtocolVersion::from_supported(32).unwrap();
     let rule = FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
-        pattern: "*.tmp".to_owned(),
+        pattern: "*.tmp".into(),
         sender_side: true,
         ..FilterRuleWireFormat::default()
     };
@@ -78,7 +78,7 @@ fn merge_exclude_without_delete_excluded_emits_bare_prefix() {
     let protocol = ProtocolVersion::from_supported(32).unwrap();
     let rule = FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
-        pattern: "*.tmp".to_owned(),
+        pattern: "*.tmp".into(),
         ..FilterRuleWireFormat::default()
     };
 
@@ -105,7 +105,7 @@ fn delete_excluded_does_not_flip_include_rule_wire_format() {
     let protocol = ProtocolVersion::from_supported(32).unwrap();
     let rule = FilterRuleWireFormat {
         rule_type: RuleType::Include,
-        pattern: "*.keep".to_owned(),
+        pattern: "*.keep".into(),
         ..FilterRuleWireFormat::default()
     };
 
@@ -136,7 +136,7 @@ fn explicit_receiver_side_rule_unaffected_by_delete_excluded() {
     let protocol = ProtocolVersion::from_supported(32).unwrap();
     let rule = FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
-        pattern: "*.tmp".to_owned(),
+        pattern: "*.tmp".into(),
         receiver_side: true,
         ..FilterRuleWireFormat::default()
     };

--- a/crates/protocol/tests/mdf_2_3_no_double_star_prefix_wire.rs
+++ b/crates/protocol/tests/mdf_2_3_no_double_star_prefix_wire.rs
@@ -36,17 +36,17 @@ fn double_star_corpus() -> [FilterRuleWireFormat; 3] {
     [
         FilterRuleWireFormat {
             rule_type: RuleType::Exclude,
-            pattern: "foo/**/bar".to_owned(),
+            pattern: "foo/**/bar".into(),
             ..FilterRuleWireFormat::default()
         },
         FilterRuleWireFormat {
             rule_type: RuleType::Exclude,
-            pattern: "**/baz".to_owned(),
+            pattern: "**/baz".into(),
             ..FilterRuleWireFormat::default()
         },
         FilterRuleWireFormat {
             rule_type: RuleType::Exclude,
-            pattern: "bar".to_owned(),
+            pattern: "bar".into(),
             ..FilterRuleWireFormat::default()
         },
     ]
@@ -93,9 +93,10 @@ fn double_star_patterns_emit_no_prefix_companion() {
         // A `**/foo/**/bar` companion would be detectable as a rule that
         // both starts with `**/` AND contains an interior `**`. No such
         // rule must appear in the parsed list.
-        let starts_with_double_star_slash = rule.pattern.starts_with("**/");
-        let has_interior_double_star = rule
-            .pattern
+        // The pattern is UTF-8 in this corpus; decode lossily to probe it.
+        let pat = rule.pattern.to_string_lossy();
+        let starts_with_double_star_slash = pat.starts_with("**/");
+        let has_interior_double_star = pat
             .strip_prefix("**/")
             .map(|rest| rest.contains("**"))
             .unwrap_or(false);

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -577,11 +577,15 @@ fn is_order_bearing(rule: &FilterRule) -> bool {
 /// the pattern string. This restores them so downstream rule compilation
 /// observes the user's original intent.
 fn reconstruct_pattern(wire_rule: &FilterRuleWireFormat) -> String {
-    let mut pattern = String::with_capacity(wire_rule.pattern.len() + 2);
-    if wire_rule.anchored && !wire_rule.pattern.starts_with('/') {
+    // The sender's local FilterChain compiles patterns via wildmatch (&str),
+    // so a non-UTF-8 wire pattern is decoded lossily here. The wire pattern
+    // itself remains byte-faithful; only this rule-compilation input is lossy.
+    let body = wire_rule.pattern.to_string_lossy();
+    let mut pattern = String::with_capacity(body.len() + 2);
+    if wire_rule.anchored && !body.starts_with('/') {
         pattern.push('/');
     }
-    pattern.push_str(&wire_rule.pattern);
+    pattern.push_str(&body);
     if wire_rule.directory_only && !pattern.ends_with('/') {
         pattern.push('/');
     }
@@ -614,10 +618,14 @@ fn wire_rule_to_dir_merge_config(
     // resulting `DirMergeConfig` would have an empty filename, which causes
     // `enter_directory()` to look up the directory itself instead of any
     // `.cvsignore` it contains, dropping CVS-style ignores entirely.
-    let pattern: &str = if wire_rule.cvs_exclude && wire_rule.pattern.is_empty() {
+    // The merge filename feeds `Path`/`DirMergeConfig`, which are `str`-based,
+    // so a non-UTF-8 wire pattern is decoded lossily here. The wire pattern is
+    // byte-faithful; only this local dir-merge config boundary is lossy.
+    let lossy = wire_rule.pattern.to_string_lossy();
+    let pattern: &str = if wire_rule.cvs_exclude && lossy.is_empty() {
         ".cvsignore"
     } else {
-        wire_rule.pattern.as_str()
+        lossy.as_ref()
     };
 
     // upstream: exclude.c - a leading '/' on the merge filename means the
@@ -802,7 +810,7 @@ mod tests {
     fn make_dir_merge_wire_rule(pattern: &str) -> FilterRuleWireFormat {
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: pattern.to_owned(),
+            pattern: pattern.into(),
             ..FilterRuleWireFormat::default()
         }
     }

--- a/crates/transfer/src/receiver/pipeline_setup.rs
+++ b/crates/transfer/src/receiver/pipeline_setup.rs
@@ -116,11 +116,15 @@ pub(in crate::receiver) fn compile_daemon_filter_set(
     let filter_rules: Vec<FilterRule> = rules
         .iter()
         .filter_map(|wire_rule| {
+            // FilterRule compiles patterns via wildmatch (String-backed), so a
+            // non-UTF-8 wire pattern is decoded lossily for the local match set.
+            // The wire pattern stays byte-faithful; only this boundary is lossy.
+            let pat = wire_rule.pattern.to_string_lossy();
             let mut rule = match wire_rule.rule_type {
-                RuleType::Include => FilterRule::include(&wire_rule.pattern),
-                RuleType::Exclude => FilterRule::exclude(&wire_rule.pattern),
-                RuleType::Protect => FilterRule::protect(&wire_rule.pattern),
-                RuleType::Risk => FilterRule::risk(&wire_rule.pattern),
+                RuleType::Include => FilterRule::include(pat),
+                RuleType::Exclude => FilterRule::exclude(pat),
+                RuleType::Protect => FilterRule::protect(pat),
+                RuleType::Risk => FilterRule::risk(pat),
                 RuleType::Clear | RuleType::DirMerge | RuleType::Merge => return None,
             };
 

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
@@ -22,7 +22,7 @@ fn daemon_filter_set_built_from_config_rules() {
     let mut config = test_config();
     config.daemon_filter_rules = vec![FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
-        pattern: "*.tmp".to_string(),
+        pattern: "*.tmp".into(),
         ..FilterRuleWireFormat::default()
     }];
     let ctx = ReceiverContext::new_for_test(&handshake, config);
@@ -54,12 +54,12 @@ fn daemon_filter_set_include_and_exclude() {
     config.daemon_filter_rules = vec![
         FilterRuleWireFormat {
             rule_type: RuleType::Include,
-            pattern: "*.rs".to_string(),
+            pattern: "*.rs".into(),
             ..FilterRuleWireFormat::default()
         },
         FilterRuleWireFormat {
             rule_type: RuleType::Exclude,
-            pattern: "*".to_string(),
+            pattern: "*".into(),
             ..FilterRuleWireFormat::default()
         },
     ];
@@ -86,7 +86,7 @@ fn daemon_filter_set_anchored_pattern() {
     let mut config = test_config();
     config.daemon_filter_rules = vec![FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
-        pattern: "/secret".to_string(),
+        pattern: "/secret".into(),
         anchored: true,
         ..FilterRuleWireFormat::default()
     }];
@@ -118,7 +118,7 @@ fn daemon_filter_rules_prepended_to_receiver_deletion_chain() {
     let mut config = test_config();
     config.daemon_filter_rules = vec![FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
-        pattern: "secret_*".to_string(),
+        pattern: "secret_*".into(),
         ..FilterRuleWireFormat::default()
     }];
     let ctx = ReceiverContext::new_for_test(&handshake, config);
@@ -149,7 +149,7 @@ fn refused_directory_swallows_its_contents_without_a_second_report() {
     let mut config = test_config();
     config.daemon_filter_rules = vec![FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
-        pattern: "*.secret".to_string(),
+        pattern: "*.secret".into(),
         ..FilterRuleWireFormat::default()
     }];
     let ctx = ReceiverContext::new_for_test(&handshake, config);

--- a/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
@@ -277,7 +277,7 @@ fn client_pull_populates_filter_chain_from_cli_rules() {
     config.connection.client_mode = true;
     config.connection.filter_rules = vec![FilterRuleWireFormat {
         rule_type: RuleType::Protect,
-        pattern: "emptyprot".to_owned(),
+        pattern: "emptyprot".into(),
         ..FilterRuleWireFormat::default()
     }];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);

--- a/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
+++ b/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
@@ -41,11 +41,16 @@ pub(in crate::receiver) fn parse_wire_filters_for_receiver(
         // applied below via `anchor_to_root()`.
         // upstream: exclude.c:get_rule_prefix() - directory-only is a trailing
         // slash on the pattern body.
-        let pattern: Cow<'_, str> = if wire_rule.directory_only && !wire_rule.pattern.ends_with('/')
-        {
-            Cow::Owned(format!("{}/", wire_rule.pattern))
+        // The `filters` crate compiles patterns into `wildmatch`, which operates
+        // on `&str`, so a non-UTF-8 wire pattern is decoded lossily here for the
+        // local match set. The wire pattern itself stays byte-faithful (it is an
+        // `OsString`); only this receiver-side rule-compilation boundary is
+        // lossy, mirroring the fact that the whole `filters` model is `String`.
+        let lossy = wire_rule.pattern.to_string_lossy();
+        let pattern: Cow<'_, str> = if wire_rule.directory_only && !lossy.ends_with('/') {
+            Cow::Owned(format!("{lossy}/"))
         } else {
-            Cow::Borrowed(wire_rule.pattern.as_str())
+            lossy.clone()
         };
         let mut rule = match wire_rule.rule_type {
             RuleType::Include => FilterRule::include(pattern.as_ref()),
@@ -74,11 +79,7 @@ pub(in crate::receiver) fn parse_wire_filters_for_receiver(
                 // encoder emits the anchor as a `/` modifier with a bare pattern,
                 // so this is a no-op for the oc<->oc wire and only normalises the
                 // `/`-in-body form a real upstream client sends.
-                let filename = wire_rule
-                    .pattern
-                    .rsplit('/')
-                    .next()
-                    .unwrap_or(wire_rule.pattern.as_str());
+                let filename = lossy.rsplit('/').next().unwrap_or(lossy.as_ref());
                 let mut config = DirMergeConfig::new(filename);
                 if wire_rule.no_inherit {
                     config = config.with_inherit(false);
@@ -143,7 +144,7 @@ mod tests {
     fn dir_merge_wire_pattern_yields_basename_filename() {
         let wire = vec![FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: "/.rsync-filter".to_string(),
+            pattern: "/.rsync-filter".into(),
             ..FilterRuleWireFormat::default()
         }];
 
@@ -168,7 +169,7 @@ mod tests {
     fn dir_merge_bare_pattern_is_unchanged() {
         let wire = vec![FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
-            pattern: ".rsync-filter".to_string(),
+            pattern: ".rsync-filter".into(),
             anchored: true,
             ..FilterRuleWireFormat::default()
         }];

--- a/crates/transfer/src/tests/filter_list_gate.rs
+++ b/crates/transfer/src/tests/filter_list_gate.rs
@@ -239,7 +239,7 @@ fn explicitly_sided_no_prefix_merge_uses_side_check() {
 fn cvs_origin_exclude_local_on_pull_transmitted_on_push() {
     let rule = FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
-        pattern: "*.o".to_owned(),
+        pattern: "*.o".into(),
         cvs_origin: true,
         ..FilterRuleWireFormat::default()
     };
@@ -274,7 +274,7 @@ fn cvs_origin_exclude_local_on_pull_transmitted_on_push() {
 fn cvs_origin_dir_merge_gated_on_protocol_29() {
     let rule = FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
-        pattern: ".cvsignore".to_owned(),
+        pattern: ".cvsignore".into(),
         cvs_exclude: true,
         cvs_origin: true,
         ..FilterRuleWireFormat::default()
@@ -323,7 +323,7 @@ fn cvs_origin_dir_merge_gated_on_protocol_29() {
 fn manual_dir_merge_without_cvs_origin_not_gated() {
     let rule = FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
-        pattern: ".cvsignore".to_owned(),
+        pattern: ".cvsignore".into(),
         cvs_exclude: true,
         cvs_origin: false,
         ..FilterRuleWireFormat::default()


### PR DESCRIPTION
## Summary

The filter-rule wire pattern was carried as a `String`, so the wire reader rejected any record whose pattern contained a non-UTF-8 byte with `InvalidData`. Upstream carries filter patterns as a raw `char *` end-to-end and never validates them as UTF-8, so such a pattern could not round-trip.

This changes `FilterRuleWireFormat.pattern` from `String` to `OsString` and threads the byte-faithful type through the serialize/parse pair. A filter pattern containing a byte like `0xFF` now round-trips through the wire encode/decode verbatim.

## Upstream behaviour

Filter patterns are raw bytes end-to-end, never UTF-8-validated:

- `exclude.c:219` - `rule->pattern = new_array(char, pre_len + pat_len + suf_len + 1)`, filled with `memcpy`/`strlcpy`.
- `exclude.c:1638` - send: `write_buf(f_out, ent->pattern, len)` writes the raw pattern bytes (`len = strlen(ent->pattern)`).
- `exclude.c:1685` - recv: `read_sbuf(f_in, line, len)` reads into a `char[]`, then `parse_filter_str` operates on `char *`.

## What changed

- `FilterRuleWireFormat.pattern`: `String` -> `OsString`.
- `parse_wire_rule` no longer runs `std::str::from_utf8` on the record. The rule-type prefix and every modifier byte are ASCII, so the modern/old-prefix parsers scan the leading bytes directly and take the remaining bytes as the raw pattern body.
- `serialize_rule` emits the pattern bytes verbatim. On unix the pattern maps to `OsStr` bytes; on other platforms it falls back to UTF-8 (lossless for the valid-UTF-8 patterns they produce).
- The on-wire encoding of a valid-UTF-8 pattern is byte-identical to before; only the in-memory type changes.

## Downstream boundary (surfaced)

The receiver/generator rule-compilation paths (`filters` crate + `wildmatch`) are `String`/`&str`-based. They now decode the wire pattern lossily (`to_string_lossy`) for the local match set. This is not a regression - a non-UTF-8 pattern was previously rejected outright, so the match path never saw one. The wire representation itself stays byte-faithful; making the whole `filters` model byte-based is a separate, broader change.

## Tests

- New round-trip test: a `0xFF` pattern survives `decode(encode(rule))` byte-for-byte (`crates/protocol/src/filters/wire.rs`, and a wire-level twin in `filter_rule_wire_roundtrip.rs` / `adversarial_stream_corpus.rs`).
- The pinned `InvalidData` rejection tests for the non-UTF-8 case are retired in favour of byte-preservation assertions.
- All existing UTF-8 golden-byte filter tests remain unchanged and green.

## Verification (x86_64 Linux host)

- `cargo fmt --all -- --check` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo check --target x86_64-pc-windows-gnu` / `x86_64-unknown-linux-musl` - clean
- `cargo nextest run -p protocol -p filters --all-features` - 7445 passed
- Targeted `transfer`/`core`/`daemon` filter tests - 289 passed
- `cargo build --bin oc-rsync --all-features` - success
