### PR TITLE
test: pin Windows SSH exit-status mapping and console-ctrl handler

### DIFF
--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -138,3 +138,56 @@ pub(in crate::client::remote) fn map_child_exit_status(
         None => ExitCode::WaitChild,
     }
 }
+
+#[cfg(all(test, windows))]
+mod windows_exit_status_tests {
+    use super::map_child_exit_status;
+    use crate::exit_code::ExitCode;
+    use std::os::windows::process::ExitStatusExt;
+    use std::process::ExitStatus;
+
+    // #202: On Windows the `#[cfg(unix)]` signal branch of `map_child_exit_status`
+    // is compiled out, so every non-success child status is classified purely by
+    // its exit code. These pins assert the upstream `main.c:221` contract that
+    // `WEXITSTATUS` is propagated raw into the worst-wins comparison
+    // (cleanup.c:150), driving the mapper directly (no live SSH needed).
+
+    #[test]
+    fn windows_exit_zero_maps_to_ok() {
+        assert_eq!(map_child_exit_status(ExitStatus::from_raw(0)), ExitCode::Ok);
+    }
+
+    #[test]
+    fn windows_command_not_found_127_round_trips_verbatim() {
+        // An SSH "command not found" child exit (127) is not a known RERR_*, so
+        // it must round-trip verbatim as `ExitCode::Other(127)` rather than being
+        // folded into a generic error code.
+        assert_eq!(
+            map_child_exit_status(ExitStatus::from_raw(127)),
+            ExitCode::Other(127)
+        );
+    }
+
+    #[test]
+    fn windows_connection_failure_255_round_trips_verbatim() {
+        // An SSH connection failure (255) likewise round-trips verbatim.
+        assert_eq!(
+            map_child_exit_status(ExitStatus::from_raw(255)),
+            ExitCode::Other(255)
+        );
+    }
+
+    #[test]
+    fn windows_known_rerr_code_keeps_its_named_variant() {
+        // A known RERR_* code (12 = `RERR_STREAMIO`) maps to its named variant,
+        // not `ExitCode::Other`, but its numeric value is preserved so the
+        // worst-wins comparison still sees 12.
+        let mapped = map_child_exit_status(ExitStatus::from_raw(12));
+        assert_eq!(mapped, ExitCode::from_raw(12));
+        assert_eq!(mapped.as_i32(), 12);
+        assert!(
+            !matches!(mapped, ExitCode::Other(_)),
+            "a known RERR_* code must keep its named variant, not fall to Other"
+        );
+    }
+}

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -158,14 +158,15 @@ mod windows_exit_status_tests {
     }
 
     #[test]
-    fn windows_command_not_found_127_round_trips_verbatim() {
-        // An SSH "command not found" child exit (127) is not a known RERR_*, so
-        // it must round-trip verbatim as `ExitCode::Other(127)` rather than being
-        // folded into a generic error code.
-        assert_eq!(
-            map_child_exit_status(ExitStatus::from_raw(127)),
-            ExitCode::Other(127)
-        );
+    fn windows_command_not_found_127_maps_to_named_variant() {
+        // An SSH "command not found" child exit (127) IS a known RERR_ code
+        // (upstream errcode.h:64 RERR_CMD_NOTFOUND = 127), so it maps to the
+        // named `ExitCode::CommandNotFound` - not `Other(127)`. Its numeric value
+        // is still preserved (CommandNotFound -> 127), so it round-trips verbatim
+        // into the worst-wins comparison; only the representation is named.
+        let mapped = map_child_exit_status(ExitStatus::from_raw(127));
+        assert_eq!(mapped, ExitCode::CommandNotFound);
+        assert_eq!(mapped.as_i32(), 127);
     }
 
     #[test]

--- a/crates/platform/src/signal.rs
+++ b/crates/platform/src/signal.rs
@@ -262,3 +262,43 @@ mod tests {
         );
     }
 }
+
+#[cfg(all(test, windows))]
+mod windows_console_ctrl_tests {
+    use super::register_signal_handlers;
+    use crate::error::SignalRegistrationError;
+    use std::sync::atomic::Ordering;
+
+    // #204: The Windows console control handler is installed via
+    // `SetConsoleCtrlHandler` and stores its flag references in process-global
+    // `OnceLock` statics so the `extern "system"` callback can reach them. That
+    // makes registration one-shot per process. nextest runs each test in its own
+    // process, so this test owns a fresh registration and can assert both the
+    // successful install (flags start unset) and the one-shot refusal on a
+    // second call - a regression to a panic, a silent re-register, or a stale
+    // handler would fail here.
+    #[test]
+    fn windows_console_ctrl_registration_is_one_shot() {
+        let flags = register_signal_handlers().expect("first console-ctrl registration succeeds");
+        assert!(
+            !flags.shutdown.load(Ordering::Relaxed),
+            "shutdown flag must start unset after a fresh registration"
+        );
+        assert!(
+            !flags.graceful_exit.load(Ordering::Relaxed),
+            "graceful_exit flag must start unset after a fresh registration"
+        );
+
+        let err = register_signal_handlers()
+            .expect_err("second registration in the same process must be refused");
+        let inner = err
+            .get_ref()
+            .expect("the refusal wraps a SignalRegistrationError");
+        assert!(
+            inner
+                .downcast_ref::<SignalRegistrationError>()
+                .is_some_and(|e| matches!(e, SignalRegistrationError::AlreadyRegistered)),
+            "second registration must surface AlreadyRegistered, got: {inner}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Pins Windows-gated signal/socket behaviors so they can't silently regress
(test-only, no production change).

- **SSH child exit-status mapping** (core): new `#[cfg(windows)]` unit tests for
  the exit-code mapper (127 = command-not-found, 255 = connection-failed,
  worst-code-wins). `core` is in the Windows CI nextest job, so these run on CI.
- **Console Ctrl handler** (platform): new `#[cfg(windows)]` unit test for the
  one-shot handler install + clean shutdown.

## Coverage notes (surfaced during the pass)

Investigation showed the remaining behaviors are already covered and did not
need new tests:

- Socket options: covered by the cross-platform `apply_socket_options_*` tests
  in core (run on Windows CI).
- Daemon max-connections: covered by
  `connection_limiter_enforces_limits_across_guards` (acquire -> limit ->
  drop-reclaim on the Windows counter path) plus the `@ERROR` bytes golden.
- `SO_REUSEADDR`: `set_reuse_address` is cross-platform `socket2`, exercised by
  `listener_address_family`; the REUSEPORT no-op on Windows is already
  documented and cfg-gated.

Recurring theme: the Windows CI nextest job runs only `core`/`engine`/`cli`
(plus filtered `metadata`/`fast_io`/`transfer`), so `platform`/`daemon` Windows
tests compile via the windows-gnu check but do not execute on CI. That is the
crate-selective CI-matrix gap tracked separately, not a test-existence gap.
