### PR TITLE
chore(deps): bump zlib-rs to 0.6.7 (set_level use-after-free fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5006,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"


### PR DESCRIPTION
## What

Bump `zlib-rs` 0.6.6 -> 0.6.7 in `Cargo.lock`.

## Why

zlib-rs v0.6.7 fixes a **use-after-free in `set_level`** (upstream PR #552) -
a memory-safety/soundness bug. oc-rsync reaches `set_level` through the
`-z`/`--compress-level` deflate path when built with the opt-in `zlib-rs`
backend (`flate2/zlib-rs`; default backend is miniz_oxide). The `zlib-rs`
feature is exercised in CI and selectable by users, so the fixed version is
worth pinning even though it is not the default backend.

Lockfile-only change (patch bump of a transitive dependency via `flate2`); no
source or behavior change.
