### PR TITLE
docs(fast_io,transfer): correct io_uring feature-comment perf claims

### DIFF
--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -78,7 +78,13 @@ sqpoll-mlock-basis = []
 
 # io_uring support for Linux 5.6+ with automatic fallback to standard I/O
 # Requirements: Linux 5.6+ kernel (runtime detection and fallback)
-# Benefits: 20-40% faster I/O via batched syscalls
+# Scope: batches metadata syscalls (statx, rename, linkat). The data write
+# path submits one SQE per buffer flush (equivalent to a pwrite - queue depth
+# and pipelining are NOT engaged), and the WRITE_FIXED / registered-buffer /
+# SEND_ZC fast paths are gated off pending IUR-3.e and unvalidated on
+# hardware. Measured data-path impact on a default build is neutral to
+# negative versus BufWriter (escape hatch: OC_RSYNC_DISABLE_IOURING=1); do
+# NOT expect write-throughput gains from the stock build.
 # Trade-offs: Linux-only, adds dependency on io-uring crate
 io_uring = ["dep:io-uring"]
 

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -89,8 +89,11 @@ iconv = ["protocol/iconv"]
 # I/O Optimization Features
 # ============================================================================
 
-# io_uring support for Linux 5.6+ with automatic fallback
-# Benefits: Batched async I/O for 20-40% better throughput
+# io_uring support for Linux 5.6+ with automatic fallback.
+# Batches metadata syscalls; the data write path is single-SQE-per-flush (no
+# pipelining / queue depth engaged) and measures neutral-to-negative versus
+# BufWriter on a default build - see fast_io's io_uring feature note. Not a
+# write-throughput win today.
 io_uring = ["fast_io/io_uring"]
 
 # IOCP (I/O Completion Ports) for Windows with automatic fallback


### PR DESCRIPTION
## Problem

Two Cargo feature-description comments advertise an io_uring write-throughput
gain the default build does not deliver:

- `crates/fast_io/Cargo.toml`: `Benefits: 20-40% faster I/O via batched syscalls`
- `crates/transfer/Cargo.toml`: `Benefits: Batched async I/O for 20-40% better throughput`

What the default `io_uring` write path actually does: `IoUringWriter::flush_buffer`
calls `submit_write_batch(ring, fd, &buffer[..len], .., buffer_size, ..)` with
`len <= buffer_size`, so `submit_write_batch` computes
`n_chunks = div_ceil(len, buffer_size).min(sq_entries) = 1` - one SQE, one
`submit_and_wait(1)`, one CQE. That is a `pwrite(2)` with a ring around it: no
queue depth, no pipelining, no overlap. The writer's own module doc says the
fast paths are off: "fixed-file registration and registered buffers ... are
recorded as unavailable on every writer ... IUR-3.e re-introduces them." The
`WRITE_FIXED` / registered-buffer / `SEND_ZC` uplift paths are gated off and,
by the project's own decision docs, unvalidated on hardware.

Measured reality (prior benchmarking, recorded in project notes): io_uring
provides no throughput win in any exercised mode on the data path and is
1.05-2.6x slower where the deeper paths are engaged - hence the
`OC_RSYNC_DISABLE_IOURING=1` escape hatch. So "20-40% faster" is not merely
unvalidated, it is contradicted by measurement, which conflicts with the
project rule of never advertising untested capabilities.

## Fix

Rewrite both feature comments to state what the feature actually does today:
metadata-syscall batching (statx/rename/linkat) is the real benefit; the data
write path is single-SQE-per-flush and measures neutral-to-negative versus
`BufWriter` on a stock build. No code or build-graph change - comments only.
