### PR TITLE
fix(ssh): honor IdentityAgent on the embedded ssh:// path

### DIFF
--- a/crates/rsync_io/src/ssh/embedded/auth.rs
+++ b/crates/rsync_io/src/ssh/embedded/auth.rs
@@ -33,24 +33,63 @@ fn effective_username(config: &SshConfig) -> Result<String, SshError> {
     })
 }
 
+/// Which SSH agent a resolved `IdentityAgent` value selects.
+///
+/// Mirrors OpenSSH's special-casing in `readconf.c`: the literal
+/// `SSH_AUTH_SOCK` means "use the environment variable", `none` disables the
+/// agent, and any other value is a Unix-domain socket path.
+#[cfg(unix)]
+#[derive(Debug, PartialEq, Eq)]
+enum AgentSource<'a> {
+    /// `IdentityAgent none` - agent authentication is disabled.
+    Disabled,
+    /// No directive or the literal `SSH_AUTH_SOCK` - use `$SSH_AUTH_SOCK`.
+    Env,
+    /// An explicit Unix-domain socket path.
+    Socket(&'a str),
+}
+
+/// Classifies an `IdentityAgent` value into the agent source to connect to.
+#[cfg(unix)]
+fn classify_identity_agent(identity_agent: Option<&str>) -> AgentSource<'_> {
+    match identity_agent {
+        Some(value) if value.eq_ignore_ascii_case("none") => AgentSource::Disabled,
+        Some("SSH_AUTH_SOCK") => AgentSource::Env,
+        Some(path) => AgentSource::Socket(path),
+        None => AgentSource::Env,
+    }
+}
+
 /// Try authentication via the SSH agent.
 ///
-/// Connects to the agent using `SSH_AUTH_SOCK`, enumerates all identities, and
+/// Connects to the agent selected by `identity_agent` (an `IdentityAgent`
+/// directive or `SSH_AUTH_SOCK` when unset), enumerates all identities, and
 /// signs each via `authenticate_publickey_with()` until one succeeds. Returns
-/// `Ok(true)` on success, `Ok(false)` when the agent is unavailable or no
-/// identity works.
+/// `Ok(true)` on success, `Ok(false)` when the agent is disabled, unavailable,
+/// or no identity works.
 ///
 /// `russh::keys::agent::client::AgentClient::connect_env` is gated to
 /// `cfg(unix)` upstream (Pageant / named-pipe support is a separate Windows
 /// path we have not validated). On non-Unix targets this method short-circuits
 /// to `Ok(false)` so the caller falls through to identity-file and password
-/// auth.
+/// auth; `IdentityAgent` is therefore honoured only on Unix.
 #[cfg(unix)]
 async fn try_agent_auth(
     session: &mut russh::client::Handle<SshClientHandler>,
     username: &str,
+    identity_agent: Option<&str>,
 ) -> Result<bool, SshError> {
-    let mut agent = match russh::keys::agent::client::AgentClient::connect_env().await {
+    use russh::keys::agent::client::AgentClient;
+
+    let connect = match classify_identity_agent(identity_agent) {
+        AgentSource::Disabled => {
+            logging::debug_log!(Io, 1, "IdentityAgent=none: SSH agent disabled");
+            return Ok(false);
+        }
+        AgentSource::Env => AgentClient::connect_env().await,
+        AgentSource::Socket(path) => AgentClient::connect_uds(path).await,
+    };
+    let mut agent = match connect {
         Ok(agent) => agent,
         Err(e) => {
             logging::debug_log!(Io, 1, "SSH agent unavailable: {}", e);
@@ -93,6 +132,7 @@ async fn try_agent_auth(
 async fn try_agent_auth(
     _session: &mut russh::client::Handle<SshClientHandler>,
     _username: &str,
+    _identity_agent: Option<&str>,
 ) -> Result<bool, SshError> {
     logging::debug_log!(Io, 1, "SSH agent auth is not supported on this platform");
     Ok(false)
@@ -263,7 +303,8 @@ async fn try_password_auth(
 /// Authenticate an SSH session using all available methods.
 ///
 /// Tries methods in OpenSSH order:
-/// 1. SSH agent (if `config.use_agent` is true and `SSH_AUTH_SOCK` is set)
+/// 1. SSH agent (if `config.use_agent` is true; `config.identity_agent`
+///    selects the socket, defaulting to `SSH_AUTH_SOCK`)
 /// 2. Identity files (each file in `config.identity_files`)
 /// 3. Password (URL-embedded or interactive prompt)
 ///
@@ -277,7 +318,7 @@ pub async fn authenticate(
     let mut tried = Vec::new();
 
     if config.use_agent {
-        if try_agent_auth(session, &username).await? {
+        if try_agent_auth(session, &username, config.identity_agent.as_deref()).await? {
             return Ok(());
         }
         tried.push("agent");
@@ -304,6 +345,44 @@ pub async fn authenticate(
 mod tests {
     use super::*;
     use is_terminal::IsTerminal;
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_identity_agent_defaults_to_env() {
+        // No directive means the agent comes from $SSH_AUTH_SOCK, preserving
+        // the pre-IdentityAgent behaviour.
+        assert_eq!(classify_identity_agent(None), AgentSource::Env);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_identity_agent_literal_sock_uses_env() {
+        // OpenSSH treats the literal token SSH_AUTH_SOCK as "use the env var",
+        // not as a filesystem path named SSH_AUTH_SOCK.
+        assert_eq!(
+            classify_identity_agent(Some("SSH_AUTH_SOCK")),
+            AgentSource::Env
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_identity_agent_none_disables() {
+        // IdentityAgent none must switch the agent off, not connect to a socket
+        // literally named "none".
+        assert_eq!(classify_identity_agent(Some("none")), AgentSource::Disabled);
+        assert_eq!(classify_identity_agent(Some("None")), AgentSource::Disabled);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_identity_agent_path_is_socket() {
+        // Any other value is a socket path the agent connects to via connect_uds.
+        assert_eq!(
+            classify_identity_agent(Some("/run/agent.sock")),
+            AgentSource::Socket("/run/agent.sock")
+        );
+    }
 
     #[test]
     fn has_controlling_terminal_does_not_panic() {
@@ -624,6 +703,7 @@ mod tests {
             password: None,
             identity_files: Vec::new(),
             use_agent: false,
+            identity_agent: None,
             ciphers: None,
             connect_timeout: std::time::Duration::from_secs(5),
             keepalive_interval: None,

--- a/crates/rsync_io/src/ssh/embedded/config.rs
+++ b/crates/rsync_io/src/ssh/embedded/config.rs
@@ -68,6 +68,12 @@ pub struct SshConfig {
     pub identity_files: Vec<PathBuf>,
     /// Whether to attempt authentication via an SSH agent.
     pub use_agent: bool,
+    /// Explicit SSH agent socket from an `IdentityAgent` directive. `None`
+    /// uses `SSH_AUTH_SOCK`. The literal `"SSH_AUTH_SOCK"` forces the
+    /// environment variable; `"none"` disables agent authentication; any
+    /// other value is treated as a Unix-domain socket path. Honoured only on
+    /// Unix, where the embedded transport supports agent auth.
+    pub identity_agent: Option<String>,
     /// Cipher preference list. `None` uses hardware-detected defaults.
     pub ciphers: Option<Vec<String>>,
     /// TCP connect timeout.
@@ -127,6 +133,7 @@ impl Default for SshConfig {
             password: None,
             identity_files: default_identity_files(),
             use_agent: true,
+            identity_agent: None,
             ciphers: None,
             connect_timeout: Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS),
             keepalive_interval: Some(Duration::from_secs(DEFAULT_KEEPALIVE_INTERVAL_SECS)),
@@ -172,6 +179,12 @@ impl SshConfig {
     /// Sets whether to attempt SSH agent authentication.
     pub fn use_agent(&mut self, use_agent: bool) -> &mut Self {
         self.use_agent = use_agent;
+        self
+    }
+
+    /// Sets the `IdentityAgent` socket. Pass `None` to use `SSH_AUTH_SOCK`.
+    pub fn identity_agent(&mut self, identity_agent: Option<String>) -> &mut Self {
+        self.identity_agent = identity_agent;
         self
     }
 
@@ -269,6 +282,11 @@ impl SshConfig {
             if !self.identity_files.contains(ident) {
                 self.identity_files.push(ident.clone());
             }
+        }
+        if self.identity_agent.is_none()
+            && let Some(ref agent) = resolved.identity_agent
+        {
+            self.identity_agent = Some(agent.clone());
         }
     }
 
@@ -849,5 +867,41 @@ mod tests {
             defaults.strict_host_key_checking
         );
         assert_eq!(cfg.ip_preference, defaults.ip_preference);
+    }
+
+    #[test]
+    fn default_identity_agent_is_none() {
+        let cfg = SshConfig::default();
+        assert!(cfg.identity_agent.is_none());
+    }
+
+    #[test]
+    fn builder_identity_agent() {
+        let mut cfg = SshConfig::default();
+        cfg.identity_agent(Some("/run/agent.sock".to_owned()));
+        assert_eq!(cfg.identity_agent.as_deref(), Some("/run/agent.sock"));
+    }
+
+    #[test]
+    fn identity_agent_from_config_is_applied() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config");
+        std::fs::write(&path, "Host example\n  IdentityAgent /run/custom.sock\n")
+            .expect("write config");
+        let mut cfg = SshConfig::default();
+        cfg.apply_ssh_config_from(&path, "example");
+        assert_eq!(cfg.identity_agent.as_deref(), Some("/run/custom.sock"));
+    }
+
+    #[test]
+    fn explicit_identity_agent_wins_over_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config");
+        std::fs::write(&path, "Host example\n  IdentityAgent /run/from-file.sock\n")
+            .expect("write config");
+        let mut cfg = SshConfig::default();
+        cfg.identity_agent(Some("/run/explicit.sock".to_owned()));
+        cfg.apply_ssh_config_from(&path, "example");
+        assert_eq!(cfg.identity_agent.as_deref(), Some("/run/explicit.sock"));
     }
 }


### PR DESCRIPTION
## Summary

The embedded russh transport (`ssh://` URLs) parsed the `IdentityAgent`
ssh_config keyword into `ResolvedHost`, but `merge_resolved_host` never carried
it into the runtime config, so a specified agent socket was silently dropped.
This wires the directive through instead of leaving it parse-but-drop.

`russh` 0.62 can connect to an explicit agent socket via
`AgentClient::connect_uds`, so honoring the directive is achievable and honest:

- Add `SshConfig::identity_agent`, populated from `~/.ssh/config` (an explicit
  or URL-supplied value still wins) and passed to the agent auth step.
- `classify_identity_agent` mirrors OpenSSH `readconf.c` semantics: the literal
  `SSH_AUTH_SOCK` uses the environment variable, `none` disables agent auth, and
  any other value is a Unix-domain socket path connected via `connect_uds`.
- Honored on Unix only, matching the existing agent-auth platform gating (the
  non-Unix path already short-circuits agent auth to a no-op).

The system-ssh `host:path` route already honors `IdentityAgent` through the
delegated `ssh` binary; this closes the equivalent gap on the embedded route.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo nextest run -p rsync_io --all-features` (agent/identity_agent tests, 13 passed)
- `cargo check --target x86_64-pc-windows-gnu -p rsync_io --all-features`

New tests pin the behavior: the classifier decisions (env default, literal
`SSH_AUTH_SOCK`, `none` disables, path becomes a socket), config-file merge, and
explicit-value-wins precedence.
