### PR TITLE
test: guard --bwlimit hoisting after operands over ssh

### DIFF
--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -678,4 +678,47 @@ mod tests {
     fn hoist_leaves_bare_dash_as_operand() {
         assert_eq!(hoist(&["rsync", "-", "dst/"]), vec!["rsync", "-", "dst/"]);
     }
+
+    #[test]
+    fn hoist_bwlimit_after_operands_uses_real_command() {
+        // Regression: `--bwlimit` supplied AFTER the source/destination operands
+        // must be recognised against the real option registry and hoisted ahead
+        // of the operands so clap consumes it client-side. Without hoisting, the
+        // operand `args` (allow_hyphen_values + trailing_var_arg) swallows it as
+        // a path, and the leaked `--bwlimit=10000` reaches the remote sender as a
+        // bogus file name (`link_stat "--bwlimit=10000" failed`). Both the
+        // attached and space-separated spellings must hoist. Guards the coupling
+        // between `classify_long_options` and the actual `--bwlimit` Arg, which
+        // the synthetic `hoist_command` above does not cover.
+        let command = crate::frontend::command_builder::clap_command("rsync");
+        let equals = hoist_options_before_operands(
+            &command,
+            ["rsync", "host:src/", "dst/", "--bwlimit=10000"]
+                .into_iter()
+                .map(OsString::from)
+                .collect(),
+        );
+        assert_eq!(
+            equals,
+            ["rsync", "--bwlimit=10000", "host:src/", "dst/"]
+                .into_iter()
+                .map(OsString::from)
+                .collect::<Vec<_>>()
+        );
+
+        let spaced = hoist_options_before_operands(
+            &command,
+            ["rsync", "host:src/", "dst/", "--bwlimit", "10000"]
+                .into_iter()
+                .map(OsString::from)
+                .collect(),
+        );
+        assert_eq!(
+            spaced,
+            ["rsync", "--bwlimit", "10000", "host:src/", "dst/"]
+                .into_iter()
+                .map(OsString::from)
+                .collect::<Vec<_>>()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

A field report claimed `oc-rsync --bwlimit=10000 host:src dst` over ssh failed with
`[sender] link_stat "--bwlimit=10000" failed: No such file`, i.e. `--bwlimit` being
forwarded to the remote sender as a path operand instead of an option.

I could not reproduce this on current master. Measured on x86_64 Linux with a debug build:

- Local parsing: `--bwlimit=10000` and `--bwlimit 10000`, in every operand position
  (leading, trailing, interleaved), parse client-side. No file named `--bwlimit=10000`
  is ever stat'd.
- Remote (ssh) push/pull: the forwarded server argv is
  `rsync --server --sender -e.LsfxCIvu --bwlimit=10000 . <path>` - `--bwlimit` is emitted
  as an option ahead of the `.`/path operands, never as a path.
- End-to-end oc-to-oc ssh loop and oc-client to upstream rsync 3.4.4 server both transfer
  successfully with `--bwlimit` supplied after the operands.

The behaviour is correct and matches upstream: `server_options()` (options.c:2799) forwards
`--bwlimit=%d` (whole KiB) to the server. The trailing-operand case works because
`hoist_options_before_operands` permutes recognised options ahead of the operands before
clap parses them (the operand `args` uses `allow_hyphen_values` + `trailing_var_arg`, which
would otherwise swallow a trailing `--bwlimit` as a path). The original report was most
likely produced by a stale binary predating that preprocessor.

## Change

No production change - the code is already correct. This adds one regression test that
exercises the reported scenario against the real option registry (`clap_command`), not the
synthetic `hoist_command` the existing hoist tests use. It locks in the coupling between
`classify_long_options` and the actual `--bwlimit` Arg: `--bwlimit=N` and `--bwlimit N`
placed after `host:src/ dst/` must be hoisted ahead of the operands so they are consumed as
options and never leak to the remote sender as a bogus path.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo nextest run -p cli --all-features -E 'test(hoist)'` - 8 passed
