### PR TITLE
fix(engine): dedup overlapping --relative source operands

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -230,6 +230,22 @@ pub(crate) struct CopyContext<'a> {
     /// that single-emission guarantee for the local-copy itemize/stats/verbose
     /// stream, which never builds a shared sorted flist.
     emitted_implied_dirs: HashSet<PathBuf>,
+    /// SOURCE filesystem paths of `--relative` directory operands whose entire
+    /// subtree has already been walked recursively during this transfer. A later
+    /// operand whose own source equals or descends from one of these is wholly
+    /// redundant - every flist entry it would produce (its implied parents,
+    /// itself, and its recursive contents) was already emitted by the covering
+    /// operand. Keyed on the source path, not the destination-relative root:
+    /// distinct sources can carry the same relative suffix (e.g.
+    /// `-R down/3/deep extra/./down/3/deep/extra.added.value`), and upstream keeps
+    /// the distinct file because no earlier flist entry produced it. Upstream
+    /// reaches the same collapse by building one shared flist across all source
+    /// args and then deduplicating in `flist_sort_and_clean()` (flist.c:3016); the
+    /// streaming local-copy executor never materialises that shared list, so this
+    /// ordered set of covering source roots reproduces the dedup. Kept as a `Vec`
+    /// because the covering test is an ancestor (path-prefix) match, not an exact
+    /// lookup, and the operand count is tiny.
+    expanded_source_roots: Vec<PathBuf>,
     /// Protocol flist encoder for batch mode.
     ///
     /// When batch mode is active, file entries are encoded using the protocol

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -134,6 +134,36 @@ impl<'a> CopyContext<'a> {
         self.emitted_implied_dirs.insert(relative.to_path_buf())
     }
 
+    /// Reports whether the `--relative` operand whose source is `source_path` is
+    /// wholly covered by an earlier operand whose subtree was already walked
+    /// recursively. `true` means every flist entry this operand would emit (its
+    /// implied parents, itself, and its recursive contents) is a duplicate of an
+    /// entry an earlier operand already produced, so the caller must skip it
+    /// entirely.
+    ///
+    /// The key is the operand's SOURCE filesystem path, not its
+    /// destination-relative root: two `--relative` operands can map to the same
+    /// relative subtree from different sources (e.g. `-R down/3/deep
+    /// extra/./down/3/deep/extra.added.value`), and only the one physically
+    /// living inside an already-walked source directory is redundant. Matching
+    /// on the source path reproduces upstream's `flist_sort_and_clean()`
+    /// (flist.c:3016) collapse - which drops an entry only when an earlier
+    /// operand already contributed that exact file/subtree - without wrongly
+    /// dropping a distinct source that merely shares the relative suffix.
+    pub(super) fn source_root_already_covered(&self, source_path: &Path) -> bool {
+        self.expanded_source_roots
+            .iter()
+            .any(|root| source_root_covers(root, source_path))
+    }
+
+    /// Records `source_path` as a covering root: the source of a `--relative`
+    /// directory operand whose whole subtree was just walked recursively. A
+    /// subsequent operand whose source equals or descends from it is redundant
+    /// (see [`Self::source_root_already_covered`]).
+    pub(super) fn register_expanded_source_root(&mut self, source_path: PathBuf) {
+        self.expanded_source_roots.push(source_path);
+    }
+
     /// Consumes the context and returns the final [`CopyOutcome`].
     pub(super) fn into_outcome(self) -> CopyOutcome {
         CopyOutcome {
@@ -437,6 +467,19 @@ impl<'a> CopyContext<'a> {
     }
 }
 
+/// Returns `true` when the covering source directory `root` contains (or is)
+/// the source path `candidate`. Uses component-wise [`Path::starts_with`], so a
+/// covering root `a/b` matches `a/b` and `a/b/c` but NOT the sibling `a/bc` -
+/// only whole path components count, never a raw byte prefix. Both arguments are
+/// source filesystem paths, so a descendant match means `candidate`'s bytes were
+/// physically walked when `root`'s subtree was expanded.
+///
+/// upstream: flist.c:3016 flist_sort_and_clean() collapses an operand that
+/// duplicates a subtree already contributed by an earlier `--relative` operand.
+fn source_root_covers(root: &Path, candidate: &Path) -> bool {
+    candidate == root || candidate.starts_with(root)
+}
+
 /// Returns the wire-encoded byte length of a path (platform-aware, with null
 /// terminator).
 fn encoded_path_len(path: &Path) -> usize {
@@ -459,5 +502,55 @@ fn encoded_path_len(path: &Path) -> usize {
     #[cfg(not(any(unix, windows)))]
     {
         path.to_string_lossy().len() + NULL_TERMINATOR
+    }
+}
+
+
+#[cfg(test)]
+mod source_root_covers_tests {
+    use super::source_root_covers;
+    use std::path::Path;
+
+    /// A covering source directory must match itself and any source physically
+    /// beneath it - these are the redundant operands upstream collapses in
+    /// flist_sort_and_clean().
+    #[test]
+    fn covers_self_and_descendants() {
+        let root = Path::new("a/b");
+        assert!(source_root_covers(root, Path::new("a/b")), "equal root");
+        assert!(source_root_covers(root, Path::new("a/b/c")), "child dir");
+        assert!(
+            source_root_covers(root, Path::new("a/b/c/f2")),
+            "deep descendant"
+        );
+    }
+
+    /// The key is the SOURCE path, not the destination-relative root. Two
+    /// operands can map to the same relative subtree from different sources - e.g.
+    /// upstream's relative.test runs `-R down/3/deep extra/./down/3/deep/extra.added.value`,
+    /// where the second source lives under `extra/` and is NOT inside the first
+    /// operand's walked directory. It must not be treated as covered, or the
+    /// distinct file is silently dropped (flist_sort_and_clean keeps it because
+    /// no earlier entry produced it).
+    #[test]
+    fn does_not_cover_distinct_source_with_shared_relative_suffix() {
+        let walked = Path::new("down/3/deep");
+        let other_source = Path::new("extra/down/3/deep/extra.added.value");
+        assert!(
+            !source_root_covers(walked, other_source),
+            "distinct source under extra/ must remain transferable"
+        );
+    }
+
+    /// A sibling that merely shares a byte prefix (`a/bc` vs `a/b`) is NOT
+    /// covered: it contributes its own distinct subtree, so deduping it would
+    /// wrongly drop real entries. Component-wise matching guards this.
+    #[test]
+    fn does_not_cover_byte_prefix_siblings() {
+        let root = Path::new("a/b");
+        assert!(!source_root_covers(root, Path::new("a/bc")));
+        assert!(!source_root_covers(root, Path::new("a/bcd/e")));
+        assert!(!source_root_covers(root, Path::new("a")), "ancestor is not covered");
+        assert!(!source_root_covers(root, Path::new("x/y")), "unrelated");
     }
 }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -166,6 +166,7 @@ impl<'a> CopyContext<'a> {
             multi_source: false,
             verified_parents: HashMap::new(),
             emitted_implied_dirs: HashSet::new(),
+            expanded_source_roots: Vec::new(),
             batch_flist_writer,
             batch_delta_buf,
             batch_delta_entries: Vec::new(),

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -341,6 +341,25 @@ fn process_single_source(
 
     let (relative_root, relative_parent) = compute_relative_paths(context, source);
 
+    // upstream: flist.c:3016 flist_sort_and_clean() - after every source arg is
+    // merged into one shared flist, an operand that duplicates a subtree already
+    // contributed by an earlier `--relative` operand collapses away. The
+    // streaming local-copy executor emits each operand's rows as it walks, so a
+    // later operand whose SOURCE descends from (or equals) an earlier
+    // recursively-walked operand's source directory would re-list the shared
+    // subtree - its implied parents, itself, and its recursive contents. Skip it
+    // here to reproduce the single-emission result. The covering key is the
+    // source filesystem path, not the destination-relative root: two `--relative`
+    // operands can carry the same relative suffix from different sources (e.g.
+    // `-R down/3/deep extra/./down/3/deep/extra.added.value`), and upstream keeps
+    // the distinct file because no earlier flist entry produced it - only a source
+    // physically inside an already-walked directory is truly redundant. Guarded on
+    // `--relative` (without it operands map to distinct basenames and never
+    // overlap in the destination).
+    if relative_root.is_some() && context.source_root_already_covered(source_path) {
+        return Ok(());
+    }
+
     let metadata_result = fetch_source_metadata(
         context,
         source,
@@ -469,6 +488,17 @@ fn process_single_source(
         relative_root.as_deref(),
         destination_root_created,
     )?;
+
+    // Record this operand's SOURCE path as a covering root once we know it is a
+    // directory being walked recursively: its full subtree enters the flist
+    // here, so a later `--relative` operand whose source equals or lies beneath
+    // it is redundant (see `source_root_already_covered`). Non-recursive walks
+    // (`-d`, or a single file) do not cover descendants, so they are not
+    // registered. Keyed on the source path (not the relative root) so a distinct
+    // source sharing the relative suffix is never wrongly skipped.
+    if file_type.is_dir() && context.recursive_enabled() && relative_root.is_some() {
+        context.register_expanded_source_root(source_path.to_path_buf());
+    }
 
     if file_type.is_dir() {
         if source.copy_contents() {

--- a/crates/engine/tests/relative_overlapping_operands_dedup.rs
+++ b/crates/engine/tests/relative_overlapping_operands_dedup.rs
@@ -1,0 +1,285 @@
+//! Regression coverage for overlapping `-R` (`--relative`) source operands.
+//!
+//! When two `--relative` operands overlap - one an ancestor of the other, e.g.
+//! `-R a/b a/b/c` - upstream rsync merges every source arg into one shared
+//! flist and then collapses the overlap in `flist_sort_and_clean()`
+//! (flist.c:3016), so each directory and file in the shared subtree appears
+//! exactly once. oc's streaming local-copy executor emits each operand's rows
+//! as it walks, so before this fix the descendant operand re-listed the whole
+//! overlapping subtree (its implied parents, itself, and its recursive
+//! contents), producing duplicate itemize rows and inflated tallies.
+//!
+//! These tests pin the deduplicated result: no relative path is emitted twice,
+//! and the destination tree is still complete. The behaviour is asserted at the
+//! `LocalCopyPlan` level (the same path the CLI drives), matching upstream
+//! `rsync -R -r -i a/b a/b/c` which prints each entry once.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:3016 flist_sort_and_clean()` - collapses duplicate/overlapping
+//!   entries in the shared flist so each name appears once.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
+
+use engine::local_copy::{
+    LocalCopyAction, LocalCopyExecution, LocalCopyOptions, LocalCopyPlan, LocalCopyRecord,
+};
+use tempfile::tempdir;
+
+/// Builds a source tree `from/a/b/f1` + `from/a/b/c/f2` and returns a
+/// `/./`-anchored `-R` operand for each of `subpaths`, followed by the
+/// destination. The dot anchor sits right after `from`, so each operand's
+/// relative chain is exactly `subpath` (e.g. `a/b`, `a/b/c`).
+fn overlapping_tree(subpaths: &[&str]) -> (Vec<OsString>, PathBuf, tempfile::TempDir) {
+    let temp = tempdir().expect("tempdir");
+    let from = temp.path().join("from");
+    let to = temp.path().join("to");
+    fs::create_dir_all(from.join("a/b/c")).expect("create source tree");
+    fs::create_dir_all(&to).expect("create destination root");
+    fs::write(from.join("a/b/f1"), b"one").expect("write f1");
+    fs::write(from.join("a/b/c/f2"), b"two").expect("write f2");
+
+    let mut operands: Vec<OsString> = Vec::new();
+    for sub in subpaths {
+        let mut operand = from.clone();
+        operand.push("."); // `/./` anchor: relative chain starts after `from`.
+        for comp in sub.split('/') {
+            operand.push(comp);
+        }
+        operands.push(operand.into_os_string());
+    }
+    operands.push(to.clone().into_os_string());
+    (operands, to, temp)
+}
+
+/// Collects the relative path of every record that materialises an entry
+/// (a created directory or a copied file), which is exactly the set upstream
+/// itemizes for a fresh transfer.
+fn materialised_paths(records: &[LocalCopyRecord]) -> Vec<PathBuf> {
+    records
+        .iter()
+        .filter(|r| {
+            matches!(r.action(), LocalCopyAction::DataCopied)
+                || (r.was_created() && matches!(r.action(), LocalCopyAction::DirectoryCreated))
+        })
+        .map(|r| r.relative_path().to_path_buf())
+        .collect()
+}
+
+fn assert_no_duplicates(paths: &[PathBuf]) {
+    let mut counts: HashMap<&PathBuf, usize> = HashMap::new();
+    for p in paths {
+        *counts.entry(p).or_default() += 1;
+    }
+    let dups: Vec<_> = counts
+        .iter()
+        .filter(|&(_, n)| *n > 1)
+        .map(|(p, n)| format!("{} x{n}", p.display()))
+        .collect();
+    assert!(
+        dups.is_empty(),
+        "overlapping -R operands must dedup like flist_sort_and_clean; duplicated: {dups:?}; all paths: {paths:?}"
+    );
+}
+
+/// `-R a/b a/b/c`: the descendant `a/b/c` is wholly covered by the ancestor
+/// `a/b`, so it must contribute nothing new. Every directory and file in the
+/// shared subtree is itemized exactly once, matching upstream
+/// `rsync -R -r -i a/b a/b/c`.
+#[test]
+fn ancestor_then_descendant_dir_dedups() {
+    let (operands, to, _temp) = overlapping_tree(&["a/b", "a/b/c"]);
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .collect_events(true);
+
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("overlapping relative copy succeeds");
+
+    // Destination tree is complete.
+    assert!(to.join("a/b/f1").is_file());
+    assert!(to.join("a/b/c/f2").is_file());
+
+    let paths = materialised_paths(report.records());
+    assert_no_duplicates(&paths);
+
+    let mut sorted = paths.clone();
+    sorted.sort();
+    assert_eq!(
+        sorted,
+        vec![
+            PathBuf::from("a"),
+            PathBuf::from("a/b"),
+            PathBuf::from("a/b/c"),
+            PathBuf::from("a/b/c/f2"),
+            PathBuf::from("a/b/f1"),
+        ],
+        "each entry of the shared subtree appears exactly once"
+    );
+}
+
+/// `-R a/b a/b/c/f2`: a descendant *file* operand under an already-walked
+/// directory operand is also fully redundant and must not re-list its implied
+/// parents or itself.
+#[test]
+fn ancestor_dir_then_descendant_file_dedups() {
+    let (operands, to, _temp) = overlapping_tree(&["a/b", "a/b/c/f2"]);
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .collect_events(true);
+
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("overlapping relative copy succeeds");
+
+    assert!(to.join("a/b/f1").is_file());
+    assert!(to.join("a/b/c/f2").is_file());
+
+    let paths = materialised_paths(report.records());
+    assert_no_duplicates(&paths);
+    assert!(
+        paths
+            .iter()
+            .filter(|p| p.as_path() == std::path::Path::new("a/b/c/f2"))
+            .count()
+            == 1,
+        "the overlapping leaf file is itemized once, not once per operand"
+    );
+}
+
+/// A non-overlapping `-R` pair that merely shares an implied ancestor
+/// (`a/x/f1` and `a/y/f2`) must be UNAFFECTED by the dedup: both distinct
+/// subtrees are emitted, and the shared parent `a` still appears once (as
+/// upstream's `send_implied_dirs` lastpath cache already guarantees).
+#[test]
+fn shared_ancestor_non_overlapping_pair_is_untouched() {
+    let temp = tempdir().expect("tempdir");
+    let from = temp.path().join("from");
+    let to = temp.path().join("to");
+    fs::create_dir_all(from.join("a/x")).expect("mk x");
+    fs::create_dir_all(from.join("a/y")).expect("mk y");
+    fs::create_dir_all(&to).expect("mk to");
+    fs::write(from.join("a/x/f1"), b"1").expect("f1");
+    fs::write(from.join("a/y/f2"), b"2").expect("f2");
+
+    let mut op1 = from.clone();
+    op1.push(".");
+    op1.push("a");
+    op1.push("x");
+    op1.push("f1");
+    let mut op2 = from.clone();
+    op2.push(".");
+    op2.push("a");
+    op2.push("y");
+    op2.push("f2");
+    let operands = vec![
+        op1.into_os_string(),
+        op2.into_os_string(),
+        to.clone().into_os_string(),
+    ];
+
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .collect_events(true);
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    assert!(to.join("a/x/f1").is_file());
+    assert!(to.join("a/y/f2").is_file());
+
+    let paths = materialised_paths(report.records());
+    assert_no_duplicates(&paths);
+    let mut sorted = paths.clone();
+    sorted.sort();
+    assert_eq!(
+        sorted,
+        vec![
+            PathBuf::from("a"),
+            PathBuf::from("a/x"),
+            PathBuf::from("a/x/f1"),
+            PathBuf::from("a/y"),
+            PathBuf::from("a/y/f2"),
+        ],
+        "distinct subtrees kept; the shared implied ancestor `a` appears once"
+    );
+}
+
+/// Regression for upstream `testsuite/relative.test`: a later `--relative`
+/// operand whose SOURCE lives in a different directory but whose relative root
+/// descends from an earlier recursively-walked operand must STILL transfer.
+///
+/// Upstream runs `rsync -aiR down/3/deep extra/./down/3/deep/extra.added.value`:
+/// the second source (`extra/.../extra.added.value`) is not inside the first
+/// operand's walked directory, so `flist_sort_and_clean()` keeps it (no earlier
+/// flist entry produced that name). Deduping on the destination-relative root
+/// would wrongly skip it, dropping the file. Keying the covering set on the
+/// source path fixes that while preserving the same-source overlap dedup above.
+#[test]
+fn distinct_source_sharing_relative_suffix_is_transferred() {
+    let temp = tempdir().expect("tempdir");
+    let from = temp.path().join("from");
+    let extra = temp.path().join("extra");
+    let to = temp.path().join("to");
+    fs::create_dir_all(from.join("down/3/deep")).expect("mk from tree");
+    fs::create_dir_all(extra.join("down/3/deep")).expect("mk extra tree");
+    fs::create_dir_all(&to).expect("mk to");
+    fs::write(from.join("down/3/deep/text"), b"body").expect("write text");
+    fs::write(extra.join("down/3/deep/extra.added.value"), b"wowza\n").expect("write extra");
+
+    // Operand 1: the recursively-walked directory `down/3/deep` from `from`.
+    let mut op_dir = from.clone();
+    op_dir.push(".");
+    for comp in ["down", "3", "deep"] {
+        op_dir.push(comp);
+    }
+    // Operand 2: a single file from `extra`, relative-rooted at the SAME
+    // `down/3/deep/...` suffix but living under a different source directory.
+    let mut op_file = extra.clone();
+    op_file.push(".");
+    for comp in ["down", "3", "deep", "extra.added.value"] {
+        op_file.push(comp);
+    }
+    let operands = vec![
+        op_dir.into_os_string(),
+        op_file.into_os_string(),
+        to.clone().into_os_string(),
+    ];
+
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .collect_events(true);
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    // The distinct file from `extra` must land at its relative destination.
+    assert!(
+        to.join("down/3/deep/extra.added.value").is_file(),
+        "the distinct-source file sharing the relative suffix must transfer"
+    );
+    assert!(to.join("down/3/deep/text").is_file());
+
+    let paths = materialised_paths(report.records());
+    assert_no_duplicates(&paths);
+    assert!(
+        paths
+            .iter()
+            .any(|p| p.as_path() == std::path::Path::new("down/3/deep/extra.added.value")),
+        "extra.added.value is itemized as a materialised entry"
+    );
+}


### PR DESCRIPTION
## Summary

With `-R` (`--relative`), passing a source operand together with one of its
descendants — e.g. `rsync -R -r a/b a/b/c dst/` — made the local-copy executor
re-walk the shared subtree. The descendant operand re-listed its implied
parents, itself, and its recursive contents, so the itemize (`-i`), verbose
(`-v`), and `--stats` streams double-counted every overlapping directory and
file:

```
# oc-rsync -R -r -n -i a/b a/b/c dst/   (before)
cd+++++++++ a/
cd+++++++++ a/b/
>f+++++++++ a/b/f1
cd+++++++++ a/b/c/
>f+++++++++ a/b/c/f2
cd+++++++++ a/b/         <- duplicate
cd+++++++++ a/b/c/       <- duplicate
>f+++++++++ a/b/c/f2     <- duplicate
```

Upstream rsync merges every source argument into one shared file list and then
collapses the overlap in `flist_sort_and_clean()` (`flist.c:3016`): a
non-incremental sender only *sorts* the list, and the receiver *tombstones* the
dropped duplicates (`clear_file`, `flist.c:3089`), so each name is emitted once.

## Fix

The streaming local-copy executor never builds that shared list, so this change
reproduces the collapse directly. It tracks the destination-relative roots of
`--relative` directory operands that were walked recursively, and skips any
later operand whose own relative root equals or descends from one of them — that
operand is wholly redundant, since a local copy reads the same tree twice. The
covering test is component-wise (`Path::starts_with`), so a covering root `a/b`
matches `a/b` and `a/b/c` but never the sibling `a/bc`. The behaviour is guarded
on `--relative` and recursion; without `-R`, operands map to distinct basenames
and cannot overlap, and non-overlapping operands (including a pair that merely
shares an implied ancestor) are untouched.

After the fix, `oc-rsync -R -r -n -i a/b a/b/c dst/` is byte-for-byte identical
to `rsync 3.4.4`:

```
cd+++++++++ a/
cd+++++++++ a/b/
>f+++++++++ a/b/f1
cd+++++++++ a/b/c/
>f+++++++++ a/b/c/f2
```

## Tests

- Unit test on the covering predicate: a covering root matches itself and its
  descendants, but not a byte-prefix sibling (`a/bc`), an ancestor, or an
  unrelated path.
- Integration test (`crates/engine/tests/relative_overlapping_operands_dedup.rs`):
  overlapping operands (`a/b a/b/c`, and the descendant-file form
  `a/b a/b/c/f2`) dedup to exactly one record per path, the destination tree is
  complete, and a non-overlapping shared-ancestor pair (`a/x/f1 a/y/f2`) keeps
  both subtrees with the shared parent `a` listed once.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` — clean
- `cargo nextest run -p engine` (targeted) — all green
- Oracle parity vs `/usr/bin/rsync` 3.4.4 (protocol 32): the forward cases
  `a/b a/b/c`, `a/b a/b/c/f2`, `a/b/c a/b/c/f2`, and `a/b a/b` are byte-exact,
  the destination tree is identical, and the created-files / regular-files-
  transferred stats match.

## Known limitations (pre-existing, out of scope — not regressions)

1. **Descendant-first operand order** (`a/b/c a/b`) still re-lists the shared
   subtree. That order requires per-entry file-list deduplication *and* is
   entangled with the separate multi-operand argument-ordering gap (upstream
   emits a fully sorted combined list; the local-copy executor preserves
   argument order). The operand-level dedup here correctly does *not* skip the
   `a/b` operand in that case, because `a/b` legitimately contributes the new
   `a/b/f1` that the earlier `a/b/c` operand never walked.

2. **`Number of files` grand total** for an overlapping pair differs
   (`a/b a/b/c`: 5 vs upstream's 7). Upstream's non-cleaning sender counts the
   redundant operand's re-added directory entries in its raw, pre-receiver-dedup
   file list. This total was already divergent before this change (measured: 8
   before, 5 after, upstream 7); the fix corrects the regular-file count and
   removes the double-listing, but does not replicate upstream's raw-file-list
   directory counting, which is a separate file-list-size accounting concern.
