### PR TITLE
fix(delete): render -v deletions as "deleting %n" before the summary

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -469,10 +469,25 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         NameOutputLevel::UpdatedAndUnchanged
     ));
 
+    // upstream: log.c:870 log_delete() prints "deleting %n" whenever
+    // INFO_GTE(DEL, 1), independent of -v. `--info=del` (level >= 1) raises DEL
+    // without raising verbosity, so `collect_events()` - which only fires on
+    // verbosity/progress/list_only - would leave the engine without the
+    // EntryDeleted events the CLI renders, dropping the deletion lines. Force
+    // collection when DEL was explicitly requested. `info_flags_list` carries
+    // the resolved `del{level}` token (options.c info_words[] order).
+    let info_del_requested = inputs.info_flags_list.iter().any(|token| {
+        token
+            .to_str()
+            .and_then(|value| value.strip_prefix("del"))
+            .and_then(|level| level.parse::<u8>().ok())
+            .is_some_and(|level| level >= 1)
+    });
     let force_event_collection = inputs.itemize_changes
         || inputs.out_format_template.is_some()
         || inputs.log_file_template.is_some()
-        || !matches!(inputs.name_level, NameOutputLevel::Disabled);
+        || !matches!(inputs.name_level, NameOutputLevel::Disabled)
+        || info_del_requested;
 
     builder = builder.files_from(inputs.files_from).from0(inputs.from0);
 

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -925,7 +925,18 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
     eight_bit_output: bool,
     stdout: &mut W,
 ) -> io::Result<()> {
-    if matches!(name_level, NameOutputLevel::Disabled) && (verbosity == 0 || name_overridden) {
+    // upstream: log.c:870 log_delete() prints "deleting %n" whenever
+    // INFO_GTE(DEL, 1), independent of the NAME level that gates the per-file
+    // listing. `--info=del` leaves NAME disabled at verbosity 0, so this
+    // short-circuit must fall through when DEL-gated deletions are queued -
+    // otherwise the deletion lines below are never rendered.
+    let has_deletions = events
+        .iter()
+        .any(|event| matches!(event.kind(), ClientEventKind::EntryDeleted));
+    if matches!(name_level, NameOutputLevel::Disabled)
+        && (verbosity == 0 || name_overridden)
+        && !(has_deletions && info_gte(InfoFlag::Del, 1))
+    {
         return Ok(());
     }
 

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -242,12 +242,20 @@ pub(crate) fn emit_transfer_summary(
     // name listing so `--progress` (info=name1, verbosity 0) does not re-print
     // the whole list - mirroring the `!progress_rendered` guard already applied
     // to the verbosity>0 branch above.
+    // upstream: log_delete() (log.c:870) prints deletions whenever
+    // INFO_GTE(DEL, 1), independent of the NAME level that gates the per-file
+    // listing. -v raises both, but `--info=del1` alone raises only DEL, so the
+    // verbose listing must still run to surface the "deleting" lines.
+    let has_deletions = events
+        .iter()
+        .any(|event| matches!(event.kind(), ClientEventKind::EntryDeleted));
     let emit_verbose_listing = out_format.is_none()
         && !events.is_empty()
         && ((verbosity > 0
             && (!name_overridden || name_enabled)
             && (!progress_rendered || verbosity > 1))
-            || (verbosity == 0 && name_enabled && !progress_rendered));
+            || (verbosity == 0 && name_enabled && !progress_rendered)
+            || (has_deletions && info_gte(InfoFlag::Del, 1) && !progress_rendered));
 
     if formatted_rendered && (emit_verbose_listing || stats_on || verbosity > 0) {
         writeln!(writer)?;
@@ -947,6 +955,26 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
 
     for event in ordered_events {
         let kind = event.kind();
+        // upstream: log.c:870-874 log_delete() prints "deleting %n" gated on
+        // INFO_GTE(DEL, 1), which -v raises to 1 (options.c:251). The deletion
+        // notice is DEL-gated and independent of the NAME level that governs the
+        // per-file listing, so render it here - ahead of the transfer summary -
+        // rather than via info_log! (whose events drain after the summary and so
+        // misorder the line). f_name() appends a trailing slash for a directory
+        // (log.c:639-640); EntryDeleted rows carry the directory bit set by the
+        // engine cleanup pass.
+        if matches!(kind, ClientEventKind::EntryDeleted) {
+            if info_gte(InfoFlag::Del, 1) {
+                let mut line = b"deleting ".to_vec();
+                line.extend_from_slice(&escape_path(event.relative_path(), eight_bit_output));
+                if event.is_directory() {
+                    line.push(b'/');
+                }
+                stdout.write_all(&line)?;
+                stdout.write_all(b"\n")?;
+            }
+            continue;
+        }
         let include_for_name = event_matches_name_level(event, name_level);
 
         if verbosity == 0 {

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -976,11 +976,24 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
         // engine cleanup pass.
         if matches!(kind, ClientEventKind::EntryDeleted) {
             if info_gte(InfoFlag::Del, 1) {
-                let mut line = b"deleting ".to_vec();
-                line.extend_from_slice(&escape_path(event.relative_path(), eight_bit_output));
-                if event.is_directory() {
-                    line.push(b'/');
+                let mut name = escape_path(event.relative_path(), eight_bit_output);
+                // upstream: flist.c f_name() emits POSIX forward-slash
+                // separators regardless of host OS. The stored relative path
+                // keeps the platform-native separator, so normalize Windows
+                // backslashes at the rendering boundary - mirroring
+                // `verbose_listing_name` - so `deleting %n` matches upstream
+                // and the other verbose rows on every platform.
+                #[cfg(windows)]
+                for byte in name.iter_mut() {
+                    if *byte == b'\\' {
+                        *byte = b'/';
+                    }
                 }
+                if event.is_directory() {
+                    name.push(b'/');
+                }
+                let mut line = b"deleting ".to_vec();
+                line.extend_from_slice(&name);
                 stdout.write_all(&line)?;
                 stdout.write_all(b"\n")?;
             }

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -1569,3 +1569,121 @@ fn verbose_directory_listing_has_trailing_slash_and_root_row() {
         "expected the file row `sub/file.txt`, got: {rendered:?}"
     );
 }
+
+/// Regression: `-v --delete` on a local copy must render deletions as upstream
+/// does - a `deleting <path>` line (trailing slash for a directory) emitted at
+/// the generator's delete-pass position, BEFORE the transfer summary. The
+/// pre-fix engine leaked a bare filename in the verbose listing while routing
+/// the real `deleting` line through `info_log!`, whose events drain AFTER the
+/// summary (misordered) - so the output showed both a bare name and a trailing
+/// duplicate. Encodes the ordering + text contract, not merely presence.
+///
+/// upstream: delete.c:180 log_delete() -> log.c:873 fmt "deleting %n".
+#[test]
+fn verbose_delete_renders_deleting_before_summary_no_bare_leak() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("src");
+    let dest_dir = tmp.path().join("dst");
+    fs::create_dir_all(&source_dir).expect("mkdir source");
+    fs::create_dir_all(&dest_dir).expect("mkdir dest");
+
+    // A file that already matches keeps the transfer side quiet; the deletions
+    // are what we assert on.
+    fs::write(source_dir.join("keep.txt"), b"keep").expect("write src keep");
+    fs::write(dest_dir.join("keep.txt"), b"keep").expect("write dst keep");
+    // Extraneous entries that must be deleted: a plain file and a non-empty
+    // directory (its child is deleted first, then the directory itself).
+    fs::write(dest_dir.join("extra.txt"), b"stale").expect("write extra");
+    fs::create_dir_all(dest_dir.join("staledir")).expect("mkdir staledir");
+    fs::write(dest_dir.join("staledir/gone.txt"), b"gone").expect("write gone");
+
+    // Backdate every entry so the quick-check skips the matching keep.txt and
+    // no spurious transfer row appears.
+    let epoch = filetime::FileTime::from_unix_time(1_000_000_000, 0);
+    for path in [
+        source_dir.join("keep.txt"),
+        dest_dir.join("keep.txt"),
+        dest_dir.join("extra.txt"),
+        dest_dir.join("staledir"),
+        dest_dir.join("staledir/gone.txt"),
+    ] {
+        filetime::set_file_mtime(&path, epoch).expect("backdate");
+    }
+
+    let mut source_operand = source_dir.into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-rv"),
+        OsString::from("--delete"),
+        source_operand,
+        dest_dir.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rendered = String::from_utf8(stdout).expect("utf8");
+    let lines: Vec<&str> = rendered.lines().collect();
+
+    // (text) every deletion is rendered with the `deleting ` prefix; the
+    // directory carries a trailing slash (f_name), the file does not.
+    assert!(
+        rendered.contains("deleting staledir/gone.txt\n"),
+        "missing `deleting staledir/gone.txt`, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("deleting staledir/\n"),
+        "directory deletion must carry a trailing slash, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("deleting extra.txt\n"),
+        "missing `deleting extra.txt`, got: {rendered:?}"
+    );
+
+    // (no bare-name leak) the verbose listing must never emit a deleted entry as
+    // a bare filename - only the `deleting ` form is upstream-legal.
+    for bare in ["extra.txt", "staledir", "staledir/gone.txt"] {
+        assert!(
+            !lines.contains(&bare),
+            "bare deleted name `{bare}` leaked into verbose output, got: {rendered:?}"
+        );
+    }
+
+    // (order) child precedes its parent directory in the delete pass.
+    let idx_child = rendered
+        .find("deleting staledir/gone.txt")
+        .expect("child deletion present");
+    let idx_dir = rendered
+        .find("deleting staledir/\n")
+        .expect("dir deletion present");
+    assert!(
+        idx_child < idx_dir,
+        "child must be deleted before its parent directory, got: {rendered:?}"
+    );
+
+    // (order) every `deleting` line precedes the transfer summary - upstream
+    // deletes during the generator pass, ahead of `sent ... bytes`.
+    let summary_pos = rendered
+        .find("\nsent ")
+        .or_else(|| rendered.strip_prefix("sent ").map(|_| 0))
+        .expect("summary line present");
+    let last_delete = rendered
+        .rfind("deleting ")
+        .expect("at least one deletion present");
+    assert!(
+        last_delete < summary_pos,
+        "all `deleting` lines must precede the summary, got: {rendered:?}"
+    );
+
+    assert!(
+        !dest_dir.join("extra.txt").exists(),
+        "extra.txt should have been deleted"
+    );
+    assert!(
+        !dest_dir.join("staledir").exists(),
+        "staledir should have been deleted"
+    );
+}

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -641,10 +641,8 @@ fn delete_leaf(
     // leaving it non-empty. Upstream `delete_dir_contents` reports this as the
     // benign `DR_NOT_EMPTY` (delete.c:117): print the notice, keep the
     // directory, do not flag an I/O error or count a deletion. The rmdir must
-    // therefore run before the "deleting" line so the line is only emitted for a
-    // directory that is actually removed. Files keep the print-before-unlink
-    // order (the backup already renamed them; the unlink cannot leave a
-    // survivor).
+    // therefore run before the deletion is recorded so the `*deleting` event is
+    // only emitted for a directory that is actually removed.
     if is_dir {
         if !context.mode().is_dry_run() {
             match RealDeleteFs.rmdir(path) {
@@ -670,30 +668,22 @@ fn delete_leaf(
                 }
             }
         }
-        if !context.options().is_itemize_active() {
-            info_log!(Del, 1, "deleting {}/", entry_relative.display());
-        }
-    } else {
-        if !context.options().is_itemize_active() {
-            info_log!(Del, 1, "deleting {}", entry_relative.display());
-        }
-        if !context.mode().is_dry_run() {
-            let fs = RealDeleteFs;
-            let result = if file_type.is_symlink() {
-                fs.unlink_symlink(path)
-            } else {
-                fs.unlink_file(path)
-            };
-            if let Err(error) = result {
-                // A vanished entry is a benign no-op (upstream ENOENT path); any
-                // other failure surfaces so the exit code reflects it.
-                if error.kind() != io::ErrorKind::NotFound {
-                    return Err(LocalCopyError::io(
-                        "delete extraneous destination entry",
-                        path.to_path_buf(),
-                        error,
-                    ));
-                }
+    } else if !context.mode().is_dry_run() {
+        let fs = RealDeleteFs;
+        let result = if file_type.is_symlink() {
+            fs.unlink_symlink(path)
+        } else {
+            fs.unlink_file(path)
+        };
+        if let Err(error) = result {
+            // A vanished entry is a benign no-op (upstream ENOENT path); any
+            // other failure surfaces so the exit code reflects it.
+            if error.kind() != io::ErrorKind::NotFound {
+                return Err(LocalCopyError::io(
+                    "delete extraneous destination entry",
+                    path.to_path_buf(),
+                    error,
+                ));
             }
         }
     }
@@ -984,18 +974,6 @@ fn apply_delete_side_effects(
                 true,
             )?;
         }
-        // upstream: log.c:log_delete emits exactly ONE line - the itemize
-        // format when stdout_format_has_o_or_i, otherwise "deleting %n".
-        // Suppress the plain line when itemize is active so only the
-        // `*deleting` record renders; f_name appends a trailing slash for
-        // directories and never inserts the word "directory".
-        if !context.options().is_itemize_active() {
-            if is_dir {
-                info_log!(Del, 1, "deleting {}/", entry_relative.display());
-            } else {
-                info_log!(Del, 1, "deleting {}", entry_relative.display());
-            }
-        }
         context.summary_mut().record_deletion(file_type);
         context.record(
             LocalCopyRecord::new(
@@ -1065,16 +1043,6 @@ pub(crate) fn record_directory_subtree(
         let is_dir = file_type.is_dir();
         if is_dir {
             record_directory_subtree(context, path_buf, relative_buf)?;
-        }
-        // upstream: log.c:log_delete emits one line; suppress the plain
-        // "deleting %n" when itemize is active. f_name appends a trailing
-        // slash for dirs and never inserts the word "directory".
-        if !context.options().is_itemize_active() {
-            if is_dir {
-                info_log!(Del, 1, "deleting {}/", relative_buf.display());
-            } else {
-                info_log!(Del, 1, "deleting {}", relative_buf.display());
-            }
         }
         context.summary_mut().record_deletion(file_type);
         context.record(


### PR DESCRIPTION
## Summary

On a local `--delete` copy under `-v` (verbose, without `-i`/itemize), extraneous-entry deletions rendered incorrectly in two ways:

- **Bare-name leak** - the verbose listing printed the deleted entry as a bare filename (`extra.txt`) at the delete-pass position.
- **Misordered `deleting` line** - the real `deleting <path>` line was routed through `info_log!`, whose events drain *after* the transfer summary, so it printed below `sent ... bytes` instead of during the delete pass.

Result (before): a bare name before the summary **and** a duplicate `deleting` line after it.

## Upstream reference

`log_delete()` (`log.c:870-874`) prints a single `deleting %n` line, gated on `INFO_GTE(DEL, 1)`, emitted during the generator's delete pass ahead of the final stats. `-v` raises `DEL` to 1 (`options.c:251`). `f_name()` appends a trailing slash for a directory (`log.c:639-640`).

## Fix

- Render `EntryDeleted` events through the verbose event stream (`emit_verbose`) as `deleting <path>` (trailing slash for a directory), gated on the `DEL` info level independently of the `NAME` level that governs the per-file listing. This places the line at the delete-pass position, ahead of the summary.
- Drop the redundant `info_log!(Del, 1, "deleting ...")` calls in the local-copy cleanup paths, which were the source of the after-summary duplicate.
- Extend the verbose-listing gate so deletions still surface when only `DEL` is raised (e.g. `--info=del1` without `-v`).

The log-file deletion output is unaffected: it is rendered from the event records via the out-format renderer, not from these diagnostic events.

## Verification

- New regression test `verbose_delete_renders_deleting_before_summary_no_bare_leak` asserts the deletion text, trailing-slash on directories, child-before-parent order, that every `deleting` line precedes the summary, and that no bare name leaks. It fails on the pre-fix code and passes after.
- Oracle parity: `oc-rsync -rv --delete` output matches upstream rsync 3.4.4 byte-for-byte on the deletion lines and their order.
- `cargo fmt --all -- --check`, `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`, and the targeted `cli`/`engine` delete/verbose/itemize suites (844 tests) all pass.

Before:
```
sending incremental file list
staledir/gone.txt
staledir
extra.txt

sent 0 bytes  received 0 bytes  0.00 bytes/sec
total size is 6  speedup is 0.00
deleting staledir/gone.txt
deleting staledir/
deleting extra.txt
```

After (matches upstream):
```
sending incremental file list
deleting staledir/gone.txt
deleting staledir/
deleting extra.txt

sent 0 bytes  received 0 bytes  0.00 bytes/sec
total size is 6  speedup is 0.00
```
