### PR TITLE
fix(engine): honor --one-file-system across Windows volume boundaries

### DIFF
--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -169,44 +169,13 @@ pub(super) fn device_identifier(path: &Path, metadata: &fs::Metadata) -> Option<
 
     #[cfg(windows)]
     {
-        use std::borrow::Cow;
-        use std::hash::{Hash, Hasher};
-        use std::path::{Component, Prefix};
-
-        fn normalize_path<'a>(path: &'a Path) -> Cow<'a, Path> {
-            if path.is_absolute() {
-                Cow::Borrowed(path)
-            } else {
-                std::env::current_dir()
-                    .map(|cwd| Cow::Owned(cwd.join(path)))
-                    .unwrap_or_else(|_| Cow::Borrowed(path))
-            }
-        }
-
-        fn device_from_components(path: &Path) -> Option<u64> {
-            let mut components = path.components();
-            match components.next()? {
-                Component::Prefix(prefix) => match prefix.kind() {
-                    Prefix::Disk(letter) | Prefix::VerbatimDisk(letter) => Some(letter as u64),
-                    Prefix::UNC(server, share) | Prefix::VerbatimUNC(server, share) => {
-                        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                        server.hash(&mut hasher);
-                        share.hash(&mut hasher);
-                        Some(hasher.finish())
-                    }
-                    _ => None,
-                },
-                _ => None,
-            }
-        }
-
-        let absolute = normalize_path(path);
-        // The standard library's `MetadataExt::volume_serial_number` accessor is currently
-        // unstable on Windows, so fall back to deriving the device identifier from the path
-        // components instead.
+        // Native Windows has no POSIX st_dev. Use the volume serial number
+        // (GetFileInformationByHandle) as the stable per-volume identity so a
+        // junction or a volume mounted at a directory is detected as a
+        // filesystem boundary - a drive-letter path prefix cannot see it.
+        // upstream: flist.c `st.st_dev != filesystem_dev` mount-point check.
         let _ = metadata;
-
-        device_from_components(absolute.as_ref())
+        fast_io::same_fs::volume_id(path)
     }
 
     #[cfg(not(any(unix, windows)))]

--- a/crates/engine/src/local_copy/tests/execute_one_file_system.rs
+++ b/crates/engine/src/local_copy/tests/execute_one_file_system.rs
@@ -1001,57 +1001,60 @@ fn one_file_system_delete_preserves_mount_nested_in_doomed_dir() {
     assert!(summary.items_deleted() >= 2, "same-device extras were deleted");
 }
 
-/// On Windows, `--one-file-system` cannot consult a POSIX `st_dev` (std's
-/// `volume_serial_number` accessor is still unstable), so the traversal
-/// boundary is derived from the path prefix: the drive letter, or the
-/// server+share of a UNC path. This pins that documented boundary - the value
-/// the planner compares to decide `SkipMountPoint` - so it cannot silently
-/// regress into, say, a constant that makes every entry look same-device (never
-/// stopping) or different-device (always stopping).
+/// On Windows, `--one-file-system` cannot consult a POSIX `st_dev` (Windows has
+/// no such field), so `device_identifier` stands in the volume serial number
+/// from `GetFileInformationByHandle` (`fast_io::same_fs::volume_id`) as the
+/// per-volume identity the planner compares to decide `SkipMountPoint`. This
+/// pins the three properties that boundary check relies on, using only real
+/// paths under a temp dir so it never depends on a runner-specific second drive
+/// letter or UNC share:
 ///
-/// Limitation deliberately NOT asserted here: a directory junction or volume
-/// mount point nested under one drive letter keeps that drive's prefix, so the
-/// native Windows path cannot detect a real volume crossing the way Cygwin's
-/// `st_dev` does. This test pins only the drive-letter / UNC-share boundary
-/// that IS implemented.
+/// - a real path resolves to a `Some` id (not a stub that returns `None`, which
+///   would silently disable the boundary check);
+/// - a file, its parent directory, and a nested subdirectory - always one
+///   volume - resolve to the same id, so a same-volume descent is never
+///   mistaken for a filesystem crossing;
+/// - an unresolvable path resolves to `None`, so the planner treats the device
+///   as unknown and does not spuriously skip the entry.
+///
+/// The complementary "different volume -> different id -> stop" half of the
+/// semantic is pinned platform-agnostically by
+/// `walk::walkdir_impl::tests::boundary_decision_is_pure_and_platform_agnostic`,
+/// which drives the pure `crosses_filesystem_boundary` decision on synthetic
+/// ids (a real second volume is not available on CI runners). Using the volume
+/// serial - not a drive-letter path prefix - is deliberate: it detects a
+/// junction or a volume mounted at a directory, a boundary a prefix cannot see.
 #[cfg(windows)]
 #[test]
-fn one_file_system_windows_boundary_is_drive_letter_and_unc_share() {
+fn one_file_system_windows_boundary_uses_volume_serial_identity() {
     use crate::local_copy::overrides::device_identifier;
 
-    // device_identifier ignores its metadata argument on Windows (it parses the
-    // path prefix), but the signature still requires one; any real metadata
-    // handle works and the compared paths themselves need not exist.
     let temp = tempdir().expect("tempdir");
-    let probe = temp.path().join("probe");
-    fs::write(&probe, b"x").expect("write probe");
-    let md = fs::metadata(&probe).expect("probe metadata");
+    let dir = temp.path().join("root");
+    let nested = dir.join("alpha").join("beta");
+    fs::create_dir_all(&nested).expect("create nested");
+    let file = dir.join("probe");
+    fs::write(&file, b"x").expect("write probe");
 
-    let dev = |p: &str| device_identifier(Path::new(p), &md).expect("windows device id");
+    // device_identifier ignores its metadata argument on Windows (it resolves
+    // the path's volume serial), but the signature still requires one.
+    let md = fs::metadata(&file).expect("probe metadata");
+    let dev = |p: &Path| device_identifier(p, &md);
 
-    // Same drive letter -> same device id -> traversal continues into the dir.
+    // A real path resolves to a concrete volume identity.
+    let dir_id = dev(&dir).expect("an existing dir resolves a volume id");
+
+    // A file, its parent directory, and a nested subdirectory all live on one
+    // volume, so they must share that identity - a same-volume descent must
+    // never look like a filesystem crossing.
+    assert_eq!(dev(&file), Some(dir_id), "a file shares its dir's volume");
+    assert_eq!(dev(&nested), Some(dir_id), "a nested dir shares the volume");
+
+    // An unresolvable path yields None, so the planner leaves the boundary
+    // check disabled rather than spuriously skipping the entry.
     assert_eq!(
-        dev(r"C:\root\alpha"),
-        dev(r"C:\root\alpha\beta\gamma"),
-        "paths sharing a drive letter must resolve to one device"
-    );
-
-    // Different drive letter -> different device id -> traversal stops.
-    assert_ne!(
-        dev(r"C:\root\alpha"),
-        dev(r"D:\root\alpha"),
-        "a different drive letter is a different filesystem boundary"
-    );
-
-    // UNC: same server+share is one filesystem; a different share is not.
-    assert_eq!(
-        dev(r"\\server\share\a"),
-        dev(r"\\server\share\b\c"),
-        "one UNC share is one filesystem"
-    );
-    assert_ne!(
-        dev(r"\\server\share1\a"),
-        dev(r"\\server\share2\a"),
-        "different UNC shares are different filesystems"
+        dev(&dir.join("does-not-exist")),
+        None,
+        "an unresolvable path has no volume identity"
     );
 }

--- a/crates/engine/src/walk/walkdir_impl.rs
+++ b/crates/engine/src/walk/walkdir_impl.rs
@@ -65,7 +65,9 @@ pub struct WalkdirWalker {
     root: PathBuf,
     config: WalkConfig,
     inner: JwalkIterator,
-    #[cfg(unix)]
+    /// Volume identity of the walk root when `--one-file-system` is active;
+    /// `None` disables the boundary check. Unix uses the root's `st_dev`,
+    /// Windows the volume serial number (native Windows has no `st_dev`).
     root_dev: Option<u64>,
     /// Depth at which to skip subtree entries (entries with depth > this are skipped).
     skip_dir_depth: Option<usize>,
@@ -108,12 +110,12 @@ impl WalkdirWalker {
         if config.sort_entries {
             builder = builder.sort(true);
         }
-        #[cfg(unix)]
+        // upstream: flist.c records the root's device (`filesystem_dev`) so
+        // recursion can skip any directory on a different device. Native
+        // Windows has no `st_dev`, so the volume serial number stands in as the
+        // per-volume identity; both are resolved through `fast_io::same_fs`.
         let root_dev = if config.one_file_system {
-            fs::metadata(root).ok().map(|m| {
-                use std::os::unix::fs::MetadataExt;
-                m.dev()
-            })
+            fast_io::same_fs::volume_id(root)
         } else {
             None
         };
@@ -122,30 +124,49 @@ impl WalkdirWalker {
             root: root.to_path_buf(),
             config,
             inner: Box::new(builder.into_iter()),
-            #[cfg(unix)]
             root_dev,
             skip_dir_depth: None,
             last_depth: 0,
         }
     }
 
-    /// Checks if an entry should be skipped due to one_file_system constraint.
+    /// Checks if an entry should be skipped due to the one-file-system
+    /// constraint - i.e. it lives on a different volume than the walk root.
     #[cfg(unix)]
-    fn should_skip_for_filesystem(&self, metadata: &fs::Metadata) -> bool {
-        if let Some(root_dev) = self.root_dev {
-            use std::os::unix::fs::MetadataExt;
-            metadata.dev() != root_dev
-        } else {
-            false
-        }
+    fn should_skip_for_filesystem(&self, _path: &Path, metadata: &fs::Metadata) -> bool {
+        use std::os::unix::fs::MetadataExt;
+        crosses_filesystem_boundary(self.root_dev, Some(metadata.dev()))
     }
 
-    /// Non-Unix platforms lack POSIX device IDs, so the one-file-system
-    /// constraint is a no-op.
-    #[cfg(not(unix))]
-    fn should_skip_for_filesystem(&self, _metadata: &fs::Metadata) -> bool {
+    /// Windows analog: native Windows has no `st_dev`, so the per-directory
+    /// volume serial number stands in. upstream restricts `-x` to directories
+    /// (a plain file is never a mount point), so only directories pay the extra
+    /// per-entry volume probe.
+    #[cfg(windows)]
+    fn should_skip_for_filesystem(&self, path: &Path, metadata: &fs::Metadata) -> bool {
+        if self.root_dev.is_none() || !metadata.is_dir() {
+            return false;
+        }
+        crosses_filesystem_boundary(self.root_dev, fast_io::same_fs::volume_id(path))
+    }
+
+    /// Other platforms lack a stable per-volume identity, so the constraint is
+    /// a no-op.
+    #[cfg(not(any(unix, windows)))]
+    fn should_skip_for_filesystem(&self, _path: &Path, _metadata: &fs::Metadata) -> bool {
         false
     }
+}
+
+/// Returns `true` when `entry_dev` sits on a different volume than the walk
+/// root (`root_dev`) - the filesystem boundary `--one-file-system` (`-x`) must
+/// not cross. `None` on either side (volume identity unavailable) never prunes,
+/// mirroring upstream's reliance on a definitive `st_dev` comparison rather
+/// than guessing across an unknown boundary.
+///
+/// upstream: flist.c - `one_file_system && st.st_dev != filesystem_dev`.
+fn crosses_filesystem_boundary(root_dev: Option<u64>, entry_dev: Option<u64>) -> bool {
+    matches!((root_dev, entry_dev), (Some(root), Some(entry)) if root != entry)
 }
 
 impl Iterator for WalkdirWalker {
@@ -185,14 +206,14 @@ impl Iterator for WalkdirWalker {
                         }
                     };
 
-                    if self.should_skip_for_filesystem(&metadata) {
+                    let path = dir_entry.path();
+
+                    if self.should_skip_for_filesystem(&path, &metadata) {
                         if metadata.is_dir() {
                             self.skip_dir_depth = Some(depth);
                         }
                         continue;
                     }
-
-                    let path = dir_entry.path();
 
                     self.last_depth = depth;
 
@@ -343,6 +364,18 @@ mod tests {
         let results: Vec<_> = walker.collect();
         assert_eq!(results.len(), 1);
         assert!(results[0].is_err());
+    }
+
+    #[test]
+    fn boundary_decision_is_pure_and_platform_agnostic() {
+        // Same volume -> not a boundary.
+        assert!(!crosses_filesystem_boundary(Some(7), Some(7)));
+        // A volume-serial / st_dev mismatch is the -x skip trigger.
+        assert!(crosses_filesystem_boundary(Some(7), Some(9)));
+        // Unknown identity on either side must never prune the walk.
+        assert!(!crosses_filesystem_boundary(None, Some(9)));
+        assert!(!crosses_filesystem_boundary(Some(7), None));
+        assert!(!crosses_filesystem_boundary(None, None));
     }
 
     #[cfg(unix)]

--- a/crates/fast_io/src/same_fs.rs
+++ b/crates/fast_io/src/same_fs.rs
@@ -61,6 +61,84 @@ pub fn paths_same_device(_a: &Path, _b: &Path) -> Option<bool> {
     None
 }
 
+/// Returns a stable per-volume identity for the filesystem that contains
+/// `path`, or `None` when it cannot be determined.
+///
+/// This is the cross-platform analog of the POSIX `st_dev` that
+/// `--one-file-system` (`-x`) compares to detect a mount/volume boundary:
+///
+/// - **Unix**: the `st_dev` of `path` (following symlinks, like `stat(2)`), so
+///   a directory that is a mount point reports the mounted filesystem's device.
+/// - **Windows**: the volume serial number reported by
+///   `GetFileInformationByHandle`. Native Windows has no `st_dev`; the volume
+///   serial is a per-volume identity that differs across a junction or a volume
+///   mounted at a directory - a boundary a drive-letter path prefix cannot see.
+///   The handle is opened with `FILE_FLAG_BACKUP_SEMANTICS` (so a directory can
+///   be opened) and *without* `FILE_FLAG_OPEN_REPARSE_POINT` (so a junction
+///   resolves to its target volume, matching the Unix follow-symlink `stat`).
+/// - **Other platforms**: `None`.
+///
+/// upstream: flist.c uses `st.st_dev != filesystem_dev` to skip mount-point
+/// dirs. Native Windows lacks `st_dev`, so this mirrors the *semantic* (do not
+/// cross a filesystem/volume boundary) with the closest stable volume identity.
+#[must_use]
+pub fn volume_id(path: &Path) -> Option<u64> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        std::fs::metadata(path).ok().map(|m| m.dev())
+    }
+
+    #[cfg(windows)]
+    {
+        windows_volume_serial(path).ok()
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+/// Windows helper: opens `path` and returns its volume serial number.
+#[cfg(windows)]
+fn windows_volume_serial(path: &Path) -> std::io::Result<u64> {
+    use std::fs::OpenOptions;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, FILE_FLAG_BACKUP_SEMANTICS, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, GetFileInformationByHandle,
+    };
+
+    // Query-only access, shared for everything, with BACKUP_SEMANTICS so a
+    // directory handle can be opened. No OPEN_REPARSE_POINT: a junction is
+    // followed to its target so the reported volume is the one the directory's
+    // contents actually live on - the boundary `-x` must not cross.
+    let file = OpenOptions::new()
+        .access_mode(FILE_READ_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)?;
+
+    // SAFETY: `BY_HANDLE_FILE_INFORMATION` is plain-old-data with no invalid
+    // bit patterns, so a zeroed value is valid before the call fills it. `file`
+    // owns a valid open handle for the duration of the call, and
+    // `GetFileInformationByHandle` only writes into `info`, returning 0 on
+    // failure.
+    #[allow(unsafe_code)]
+    unsafe {
+        let mut info: BY_HANDLE_FILE_INFORMATION = std::mem::zeroed();
+        if GetFileInformationByHandle(file.as_raw_handle() as HANDLE, &mut info) == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(u64::from(info.dwVolumeSerialNumber))
+    }
+}
+
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
@@ -88,5 +166,30 @@ mod tests {
         std::fs::write(&present, b"x").expect("write");
         let missing = dir.path().join("missing");
         assert_eq!(paths_same_device(&present, &missing), None);
+    }
+}
+
+#[cfg(all(test, any(unix, windows)))]
+mod volume_tests {
+    use super::*;
+
+    #[test]
+    fn volume_id_agrees_for_a_file_and_its_parent() {
+        // A file and the directory that contains it always live on the same
+        // volume, so their identities must match on every platform that
+        // resolves one (all CI targets: Linux, macOS, Windows).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("probe");
+        std::fs::write(&file, b"x").expect("write probe");
+
+        let dir_id = volume_id(dir.path());
+        assert!(dir_id.is_some(), "temp dir must resolve a volume id here");
+        assert_eq!(dir_id, volume_id(&file));
+    }
+
+    #[test]
+    fn volume_id_missing_path_is_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(volume_id(&dir.path().join("does-not-exist")), None);
     }
 }


### PR DESCRIPTION
## Summary

`--one-file-system` (`-x`) must not recurse across a filesystem/volume
boundary. Upstream rsync compares `st.st_dev != filesystem_dev` (flist.c) to
detect a mount-point directory. Native Windows (this is not a Cygwin build)
has no POSIX `st_dev`, so the two `-x` code paths could not honour that
semantic:

- the local-copy recursion / delete mount-point check derived a device id
  from the **drive-letter path prefix**, so a volume mounted at `C:\mnt\vol`
  or a junction to another volume read the same `C:` and was never treated as
  a boundary;
- the parallel walker's boundary check was a **no-op** on non-Unix targets and
  silently recursed across a mounted volume.

Since the exact mechanism (`st_dev`) is unavailable on native Windows, this
mirrors the *semantic* using the volume serial number, which differs across a
junction or a volume mount and is the closest stable per-volume identity.

## Change

- New `fast_io::same_fs::volume_id(path) -> Option<u64>`: the cross-platform
  analog of `st_dev`. Unix returns the `st_dev`; Windows opens the path with
  `FILE_FLAG_BACKUP_SEMANTICS` (so a directory handle opens) and no
  `FILE_FLAG_OPEN_REPARSE_POINT` (so a junction resolves to its target volume,
  matching the Unix follow-symlink stat) and reads
  `BY_HANDLE_FILE_INFORMATION.dwVolumeSerialNumber` via
  `GetFileInformationByHandle`. The FFI lives behind a safe wrapper in
  `fast_io`, the crate permitted to hold platform `unsafe`.
- `engine` local-copy `device_identifier` Windows branch now calls
  `volume_id`, replacing the drive-letter heuristic. This fixes both the `-x`
  recursion boundary and the delete mount-point guard in one place.
- The parallel walker (`WalkdirWalker`) now resolves the root's volume via
  `volume_id` on every platform and compares each directory's volume on
  Windows (directories only, matching upstream's "-x only affects dirs"). The
  Unix path is unchanged and still reads the already-stat'd `st_dev` (no extra
  syscall). The boundary rule is factored into a pure, platform-agnostic
  `crosses_filesystem_boundary(root, entry)` helper.

An unavailable identity on either side never prunes, mirroring upstream's
reliance on a definitive comparison rather than guessing across an unknown
boundary.

## Tests

- `fast_io`: `volume_id` agrees for a file and its parent directory, and
  returns `None` for a missing path (runs on Unix and Windows).
- `engine`: `crosses_filesystem_boundary` unit test asserts a
  volume-serial / `st_dev` mismatch is treated as a boundary and that an
  unknown identity never prunes (platform-agnostic).
- Verified on Linux: `cargo fmt --all -- --check`,
  `cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings`,
  targeted `cargo nextest` for `fast_io` and `engine`, and
  `cargo check --target x86_64-pc-windows-gnu -p fast_io -p engine
  --all-features` (msvc target unavailable on the Linux host: its C
  build-script needs `lib.exe`).
