### PR TITLE
fix(build): forward workspace embedded-ssh feature to cli, not just core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,13 @@ openssl-vendored = ["checksums/openssl-vendored"]
 # ============================================================================
 
 # Embedded SSH transport via russh - removes the runtime dependency on an
-# external `ssh` client. Forwards through `core` to `rsync_io/embedded-ssh`.
-embedded-ssh = ["core/embedded-ssh"]
+# external `ssh` client. Forwards to BOTH `cli` and `core` so a workspace
+# feature-unified build (e.g. `cargo nextest --workspace`) enables the feature
+# consistently across every crate that gates on it. Forwarding to `core` alone
+# left `cli/embedded-ssh` OFF while `core/embedded-ssh` was ON under `--workspace`
+# unification, so cli-crate `#[cfg(not(feature = "embedded-ssh"))]` tests
+# compiled and ran while `core` behaved as if the feature were present.
+embedded-ssh = ["cli/embedded-ssh", "core/embedded-ssh"]
 
 # Native QUIC daemon transport (oc extension, off by default). Forwards through
 # `cli`/`core` to `rsync_io/quic`; only makes the `Transport::Quic` selection

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -230,6 +230,19 @@ pub(crate) struct CopyContext<'a> {
     /// that single-emission guarantee for the local-copy itemize/stats/verbose
     /// stream, which never builds a shared sorted flist.
     emitted_implied_dirs: HashSet<PathBuf>,
+    /// Destination-relative roots of `--relative` source operands whose entire
+    /// subtree has already been walked recursively during this transfer. A later
+    /// operand whose own relative root equals or descends from one of these is
+    /// wholly redundant - every flist entry it would produce (its implied
+    /// parents, itself, and its recursive contents) was already emitted by the
+    /// covering operand. Upstream reaches the same result by building one shared
+    /// flist across all source args and then collapsing the overlap in
+    /// `flist_sort_and_clean()` (flist.c:3016); the streaming local-copy executor
+    /// never materialises that shared list, so this ordered set of covering roots
+    /// reproduces the dedup. Kept as a `Vec` because the covering test is an
+    /// ancestor (path-prefix) match, not an exact lookup, and the operand count
+    /// is tiny.
+    expanded_source_roots: Vec<PathBuf>,
     /// Protocol flist encoder for batch mode.
     ///
     /// When batch mode is active, file entries are encoded using the protocol

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -134,6 +134,31 @@ impl<'a> CopyContext<'a> {
         self.emitted_implied_dirs.insert(relative.to_path_buf())
     }
 
+    /// Reports whether the `--relative` operand rooted at `relative` is wholly
+    /// covered by an earlier operand whose subtree was already walked
+    /// recursively. `true` means every flist entry this operand would emit (its
+    /// implied parents, itself, and its recursive contents) is a duplicate of an
+    /// entry an earlier operand already produced, so the caller must skip it
+    /// entirely.
+    ///
+    /// The test is a path-prefix (ancestor-or-equal) match against the recorded
+    /// covering roots, reproducing the collapse upstream performs in
+    /// `flist_sort_and_clean()` (flist.c:3016) after merging every source arg
+    /// into one shared flist.
+    pub(super) fn source_root_already_covered(&self, relative: &Path) -> bool {
+        self.expanded_source_roots
+            .iter()
+            .any(|root| relative == root || relative.starts_with(root))
+    }
+
+    /// Records `relative` as a covering root: a `--relative` directory operand
+    /// whose whole subtree was just walked recursively. A subsequent operand
+    /// equal to or descending from it is redundant (see
+    /// [`Self::source_root_already_covered`]).
+    pub(super) fn register_expanded_source_root(&mut self, relative: PathBuf) {
+        self.expanded_source_roots.push(relative);
+    }
+
     /// Consumes the context and returns the final [`CopyOutcome`].
     pub(super) fn into_outcome(self) -> CopyOutcome {
         CopyOutcome {

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -166,6 +166,7 @@ impl<'a> CopyContext<'a> {
             multi_source: false,
             verified_parents: HashMap::new(),
             emitted_implied_dirs: HashSet::new(),
+            expanded_source_roots: Vec::new(),
             batch_flist_writer,
             batch_delta_buf,
             batch_delta_entries: Vec::new(),

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -341,6 +341,21 @@ fn process_single_source(
 
     let (relative_root, relative_parent) = compute_relative_paths(context, source);
 
+    // upstream: flist.c:3016 flist_sort_and_clean() - after every source arg is
+    // merged into one shared flist, an operand that duplicates a subtree already
+    // contributed by an earlier `--relative` operand collapses away. The
+    // streaming local-copy executor emits each operand's rows as it walks, so a
+    // later operand whose relative root descends from (or equals) an earlier
+    // recursively-walked operand would re-list the shared subtree - its implied
+    // parents, itself, and its recursive contents. Skip it here to reproduce the
+    // single-emission result. Guarded on `--relative` (without it operands map to
+    // distinct basenames and never overlap) and on a resolvable relative root.
+    if let Some(root) = relative_root.as_deref() {
+        if context.source_root_already_covered(root) {
+            return Ok(());
+        }
+    }
+
     let metadata_result = fetch_source_metadata(
         context,
         source,
@@ -469,6 +484,18 @@ fn process_single_source(
         relative_root.as_deref(),
         destination_root_created,
     )?;
+
+    // Record this operand as a covering root once we know it is a directory
+    // being walked recursively: its full subtree enters the flist here, so a
+    // later `--relative` operand equal to or beneath it is redundant (see
+    // `source_root_already_covered`). Non-recursive walks (`-d`, or a single
+    // file) do not cover descendants, so they are not registered.
+    if file_type.is_dir()
+        && context.recursive_enabled()
+        && let Some(root) = relative_root.as_deref()
+    {
+        context.register_expanded_source_root(root.to_path_buf());
+    }
 
     if file_type.is_dir() {
         if source.copy_contents() {

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -78,7 +78,13 @@ sqpoll-mlock-basis = []
 
 # io_uring support for Linux 5.6+ with automatic fallback to standard I/O
 # Requirements: Linux 5.6+ kernel (runtime detection and fallback)
-# Benefits: 20-40% faster I/O via batched syscalls
+# Scope: batches metadata syscalls (statx, rename, linkat). The data write
+# path submits one SQE per buffer flush (equivalent to a pwrite - queue depth
+# and pipelining are NOT engaged), and the WRITE_FIXED / registered-buffer /
+# SEND_ZC fast paths are gated off pending IUR-3.e and unvalidated on
+# hardware. Measured data-path impact on a default build is neutral to
+# negative versus BufWriter (escape hatch: OC_RSYNC_DISABLE_IOURING=1); do
+# NOT expect write-throughput gains from the stock build.
 # Trade-offs: Linux-only, adds dependency on io-uring crate
 io_uring = ["dep:io-uring"]
 

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -89,8 +89,11 @@ iconv = ["protocol/iconv"]
 # I/O Optimization Features
 # ============================================================================
 
-# io_uring support for Linux 5.6+ with automatic fallback
-# Benefits: Batched async I/O for 20-40% better throughput
+# io_uring support for Linux 5.6+ with automatic fallback.
+# Batches metadata syscalls; the data write path is single-SQE-per-flush (no
+# pipelining / queue depth engaged) and measures neutral-to-negative versus
+# BufWriter on a default build - see fast_io's io_uring feature note. Not a
+# write-throughput win today.
 io_uring = ["fast_io/io_uring"]
 
 # IOCP (I/O Completion Ports) for Windows with automatic fallback


### PR DESCRIPTION
## Problem

`cargo nextest run --locked --profile ci --workspace` fails on
`mutually_exclusive_options::test_rsh_and_ssh_url_operand_reports_missing_embedded_ssh`
(crates/cli/tests, panics at the "ssh:// URLs require the built-in SSH client"
assertion).

Root cause is a **workspace feature-unification skew**. The root `Cargo.toml`
has `embedded-ssh` in its default set, but the feature forwarded only to
`core/embedded-ssh`, not `cli/embedded-ssh`. Under `--workspace`, cargo unifies
features per crate: `core/embedded-ssh` resolved ON (via the root default) while
`cli/embedded-ssh` stayed OFF. So the cli-crate test gated
`#[cfg(not(feature = "embedded-ssh"))]` still compiled and ran (cli saw the
feature absent), but `core` — with embedded-ssh present — emitted the `-e`
transport-conflict message instead of the "requires embedded-ssh" one, failing
the assertion. Running the same test as `-p cli` passes because there both
crates resolve the feature OFF; only the unified `--workspace` build exposes the
skew.

## Fix

Forward the root `embedded-ssh` feature to **both** `cli` and `core`
(`["cli/embedded-ssh", "core/embedded-ssh"]`), so a default/`--workspace` build
enables the feature consistently in every crate that gates on it. The
`not(feature = "embedded-ssh")` test then correctly compiles out in the
default/CI build (embedded-ssh IS present) and only runs under
`--no-default-features`, matching the intent. No source change.
