### PR TITLE
docs: fix broken rustdoc intra-doc links breaking the Pages build

### DIFF
--- a/crates/fast_io/src/ewma.rs
+++ b/crates/fast_io/src/ewma.rs
@@ -8,7 +8,8 @@
 //!
 //! # Smoothing rule
 //!
-//! Each [`Ewma::update`] blends the fresh `sample` with the running estimate:
+//! Each [`Ewma::update`](crate::ewma::Ewma::update) blends the fresh `sample`
+//! with the running estimate:
 //!
 //! ```text
 //! value = alpha * sample + (1 - alpha) * value

--- a/crates/rsync_io/src/quic/error.rs
+++ b/crates/rsync_io/src/quic/error.rs
@@ -70,7 +70,7 @@ impl TransportFault {
 
     /// Rebuilds the classified [`std::io::Error`] for the facade to return.
     ///
-    /// Protocol violations are emitted through [`protocol::protocol_violation`]
+    /// Protocol violations are emitted through [`protocol::protocol_violation()`]
     /// so they carry the [`protocol::ProtocolViolation`] tag (mapped to
     /// `RERR_PROTOCOL` = 2); every other fault carries its selected
     /// [`io::ErrorKind`] verbatim.


### PR DESCRIPTION
## Problem

The **Pages** workflow (`cargo doc --workspace --all-features --no-deps --locked`, with `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links`) was failing on master, so rustdoc/GitHub Pages never deployed.

Two broken intra-doc links, both only reachable under `--all-features`:

1. **`fast_io`** — `crates/fast_io/src/ewma.rs` `//!` links `` [`Ewma::update`] ``. Because `pub mod ewma;` in `lib.rs` also carries an outer `///` summary, rustdoc resolves the merged module docs at the **crate root**, where `Ewma` is not in scope. Fully-qualified to `crate::ewma::Ewma::update`.
2. **`rsync_io`** (quic feature) — `crates/rsync_io/src/quic/error.rs` links `` [`protocol::protocol_violation`] ``, which is **ambiguous** (`protocol_violation` is both a function and a module in `protocol`). It refers to the function, so disambiguated with parentheses.

## Verification

Full workspace all-features rustdoc build (the exact Pages command) is clean:

```
cargo doc --workspace --all-features --no-deps --locked   # Finished, exit 0
```

Doc-comment-only change; no code or behavior affected.
