### PR TITLE
fix(engine): order multi-source copy-contents flist like upstream

### DIFF
--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -1,11 +1,15 @@
 //! Top-level source processing orchestration and deferred operation flushing.
 
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::ffi::OsString;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use logging::info_log;
+use protocol::flist::{FileEntry, compare_file_entries};
 
 use crate::local_copy::overrides::device_identifier;
 use crate::local_copy::{
@@ -35,6 +39,286 @@ fn whole_unix_seconds() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|since_epoch| since_epoch.as_secs())
         .unwrap_or(0)
+}
+
+/// Returns the operands in the order the local-copy executor should process
+/// them so multi-operand itemize / `--list-only` output matches upstream.
+///
+/// upstream: flist.c:2544 flist_sort_and_clean() sorts the COMBINED
+/// multi-source file list with f_name_cmp before the generator itemizes it, so
+/// top-level operands are emitted in name order, not command-line order. oc's
+/// per-directory walk already emits each operand's subtree in f_name_cmp order,
+/// and a directory sorts contiguously with its own contents (no top-level
+/// sibling can slot between a directory and its children), so reproducing
+/// upstream's global order only requires ordering the operands themselves with
+/// the same comparator the network generator applies to its flist
+/// (`protocol::flist::compare_file_entries`, transfer `generator/file_list`).
+///
+/// Scope: applied only when every operand contributes a single NAMED top-level
+/// entry - a non-`--relative` transfer with no trailing-slash / copy-contents
+/// operand. A copy-contents operand splays its CONTENTS across the destination
+/// root, which upstream interleaves across operands by content name; that is
+/// handled by [`merged_contents_worklist`] instead, so those transfers never
+/// reach this comparator. `--relative` operands carry implied parent
+/// directories whose ordering is handled during emission, so they are left
+/// untouched. Reordering is a pure output-ordering change: the destination
+/// result is byte-identical, the `--delete` keep-set is order-independent, and
+/// dir creation simply follows the same sorted order upstream uses.
+fn ordered_operands(sources: &[SourceSpec], relative_paths: bool) -> Vec<&SourceSpec> {
+    let mut ordered: Vec<&SourceSpec> = sources.iter().collect();
+    let reorderable = sources.len() > 1
+        && !relative_paths
+        && sources.iter().all(|source| !source.copy_contents());
+    if reorderable {
+        ordered.sort_by(|a, b| compare_operand_names(a, b));
+    }
+    ordered
+}
+
+/// Compares two named operands with the flist sort comparator upstream applies
+/// to top-level entries: directories compare as `name/` and a file sorts before
+/// a same-prefixed directory, exactly as `compare_file_entries` orders the
+/// generator's flist.
+fn compare_operand_names(a: &SourceSpec, b: &SourceSpec) -> Ordering {
+    compare_file_entries(&operand_sort_entry(a), &operand_sort_entry(b))
+}
+
+/// Models an operand as a top-level flist entry (its destination basename plus
+/// its on-disk directory-ness) purely for ordering.
+///
+/// link_stat (lstat) semantics: a directory operand is a directory; a symlink
+/// operand is not (upstream keeps the symlink's own name in the flist). An
+/// operand that has vanished or cannot be stat'd is ordered as a file;
+/// `process_single_source` reports its `link_stat` failure downstream.
+fn operand_sort_entry(source: &SourceSpec) -> FileEntry {
+    let name = source
+        .path()
+        .file_name()
+        .map_or_else(|| source.path().to_path_buf(), PathBuf::from);
+    if fs::symlink_metadata(source.path()).is_ok_and(|meta| meta.is_dir()) {
+        FileEntry::new_directory(name, 0o755)
+    } else {
+        FileEntry::new_file(name, 0, 0o644)
+    }
+}
+
+/// A destination-root entry synthesized from the union of every copy-contents
+/// source's immediate children, deduplicated by name.
+struct MergedRootEntry {
+    /// `true` when the winning entry is a directory (lstat semantics).
+    is_dir: bool,
+    /// The child's basename, the destination path component and sort key.
+    name: OsString,
+    /// The contributing source paths in command-line order. A file keeps only
+    /// the first (upstream's dedup keeps the first operand's copy); a directory
+    /// keeps every contributor so their contents merge under one dest dir.
+    paths: Vec<PathBuf>,
+}
+
+/// Builds the merged, globally-sorted work list for a multi-source COPY-CONTENTS
+/// transfer, or `None` when the transfer is not that shape (the caller then
+/// falls back to [`ordered_operands`]).
+///
+/// upstream: flist.c:2227 send_file_list() accumulates every source operand into
+/// ONE file list; a trailing-slash / copy-contents operand contributes its
+/// immediate CHILDREN (send_directory, flist.c:2490) rather than its own name,
+/// and flist.c:2544 flist_sort_and_clean() then sorts the combined list with
+/// f_name_cmp before the generator itemizes it. Two copy-contents sources
+/// therefore interleave their contents by child name (files before dirs at each
+/// level) instead of being emitted one operand's subtree at a time. This
+/// function reproduces that by flattening each source's immediate children into
+/// synthetic named operands (each mapping to `dest/<child>` exactly as the child
+/// would under upstream), deduplicating by name - a file keeps the first
+/// operand's copy (flist_sort_and_clean drops the later duplicate), a directory
+/// keeps every contributor so their contents merge - and sorting with the same
+/// f_name_cmp comparator via [`compare_file_entries`].
+///
+/// Scope is deliberately narrow so no other feature's semantics shift: it
+/// engages only for a non-`--relative`, recursive, plain copy of >= 2
+/// copy-contents sources with no `--delete` (whose extraneous-entry sweep keys
+/// off the whole-root walk this path bypasses), no batch writer (whose wire
+/// format is built by the per-source walk), and no `--one-file-system` (whose
+/// mount-point pruning keys off each source root's device). A fresh destination
+/// under `--dry-run` also falls back, since the synthesized `cd ./` root row is
+/// emitted from the on-disk root the dry run never creates. Every excluded shape
+/// keeps command-line order, exactly as before.
+fn merged_contents_worklist(
+    context: &CopyContext,
+    plan: &LocalCopyPlan,
+    destination_root_created: bool,
+) -> Result<Option<Vec<SourceSpec>>, LocalCopyError> {
+    let sources = plan.sources();
+    let engaged = sources.len() > 1
+        && sources.iter().all(SourceSpec::copy_contents)
+        && !context.relative_paths_enabled()
+        && context.recursive_enabled()
+        && !context.one_file_system_enabled()
+        && context.options().delete_timing().is_none()
+        && context.options().get_batch_writer().is_none()
+        && !(destination_root_created && context.mode().is_dry_run());
+    if !engaged {
+        return Ok(None);
+    }
+
+    let destination_root = plan.destination_spec().path();
+    let mut order: Vec<MergedRootEntry> = Vec::new();
+    let mut index: HashMap<OsString, usize> = HashMap::new();
+
+    for source in sources {
+        let read_dir = match fs::read_dir(source.path()) {
+            Ok(read_dir) => read_dir,
+            // A source that is not a readable directory (vanished, a file given a
+            // trailing slash, permission denied) cannot be merged. Abandon the
+            // merged path so the per-source loop surfaces the exact upstream
+            // error / continuation semantics for it.
+            Err(_) => return Ok(None),
+        };
+        for entry in read_dir {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => return Ok(None),
+            };
+            let path = entry.path();
+            // Never descend into our own output: skip a child that IS the
+            // destination root (mirrors the per-directory retain in the
+            // recursive walk).
+            if path == destination_root {
+                continue;
+            }
+            let name = entry.file_name();
+            let is_dir = match fs::symlink_metadata(&path) {
+                Ok(meta) => meta.file_type().is_dir(),
+                Err(_) => return Ok(None),
+            };
+            match index.get(&name) {
+                None => {
+                    index.insert(name.clone(), order.len());
+                    order.push(MergedRootEntry {
+                        is_dir,
+                        name,
+                        paths: vec![path],
+                    });
+                }
+                Some(&existing) => {
+                    let merged = &mut order[existing];
+                    // Merge same-named directories (their contents combine under
+                    // one dest dir); a file, or a type that disagrees with the
+                    // first occurrence, keeps the first operand's entry.
+                    if merged.is_dir && is_dir {
+                        merged.paths.push(path);
+                    }
+                }
+            }
+        }
+    }
+
+    // Sort with the generator's f_name_cmp: non-directories before directories,
+    // then bytewise name. Contributors to a merged directory keep command-line
+    // order so their subtrees recurse in operand order under the shared dest dir.
+    order.sort_by(|a, b| compare_file_entries(&merged_sort_entry(a), &merged_sort_entry(b)));
+
+    let mut worklist = Vec::new();
+    for entry in order {
+        for path in entry.paths {
+            worklist.push(SourceSpec::from_child_path(path));
+        }
+    }
+    Ok(Some(worklist))
+}
+
+/// Models a merged root entry as a flist entry for f_name_cmp ordering.
+fn merged_sort_entry(entry: &MergedRootEntry) -> FileEntry {
+    let name = PathBuf::from(&entry.name);
+    if entry.is_dir {
+        FileEntry::new_directory(name, 0o755)
+    } else {
+        FileEntry::new_file(name, 0, 0o644)
+    }
+}
+
+/// Accounts for the transfer root "." of a merged copy-contents transfer: it
+/// counts the per-source "." entries and emits the single displayed root row.
+///
+/// The per-source recursive walk owns both for the command-line path (the root
+/// frame in recursive/mod.rs); the merged path bypasses that walk at the root,
+/// so replay it here so `--stats`, `--list-only`, `-v`, and `-i` all match.
+///
+/// COUNT: upstream sorts the combined flist WITHOUT removing duplicates
+/// (flist.c:2535-2544), so every trailing-slash operand's own "." entry counts
+/// toward "Number of files (dir: N)" even though the display deduplicates them.
+/// A single dirA/ dirB/ transfer therefore reports two "." dirs; count one per
+/// source here. (Duplicate/colliding subtree entries under repeated or
+/// overlapping sources are still display-deduplicated by
+/// [`merged_contents_worklist`], so their non-deduplicated count is a tracked
+/// follow-up; distinct sources - the common case - match exactly.)
+///
+/// DISPLAY: the generator lists the root "." once (duplicates are display-
+/// deduplicated). A freshly created root itemizes `cd+++++++++ ./`
+/// (main.c:803-805 FLAG_DIR_CREATED, generator.c:566-572); a pre-existing root
+/// emits an unchanged `.d` row shown only under `-vv` / `--list-only` and
+/// suppressed under `-i` (generator.c:1480-1483 itemizes the existing "." with
+/// no significant flags). The created-dir tally and the `created directory
+/// <dest>` notice are already owned by `mark_destination_root_created`.
+fn emit_merged_transfer_root(
+    context: &mut CopyContext,
+    plan: &LocalCopyPlan,
+    destination_path: &Path,
+    destination_root_created: bool,
+) -> Result<(), LocalCopyError> {
+    for _ in plan.sources() {
+        context.summary_mut().record_directory_total();
+    }
+
+    // The displayed "." IS the first operand's source directory (upstream sends
+    // each operand's "." into the flist and the display keeps the first), so the
+    // listed perms/size/mtime and any `-i` drift are the source root's, not the
+    // destination's - mirroring the recursive root frame, which snapshots the
+    // source `metadata` and itemizes it against the existing destination.
+    let Some(source_root) = plan.sources().first().map(SourceSpec::path) else {
+        return Ok(());
+    };
+    let source_meta = fs::symlink_metadata(source_root)
+        .map_err(|error| LocalCopyError::io("inspect source", source_root, error))?;
+    let snapshot = LocalCopyMetadata::from_metadata(&source_meta, None);
+    let snapshot_len = snapshot.len();
+    let dot = PathBuf::from(".");
+    let record = if destination_root_created {
+        LocalCopyRecord::new(
+            dot,
+            LocalCopyAction::DirectoryCreated,
+            0,
+            Some(snapshot_len),
+            Duration::default(),
+            Some(snapshot),
+        )
+        .with_creation(true)
+    } else {
+        // Existing root: itemize the source "." against the on-disk destination
+        // root so an unchanged pair yields an all-dot `.d` row (shown only under
+        // -vv / --list-only), exactly as the recursive root frame does.
+        let dest_meta = fs::symlink_metadata(destination_path)
+            .map_err(|error| LocalCopyError::io("inspect destination", destination_path, error))?;
+        let change_set = LocalCopyChangeSet::for_existing_directory(
+            &source_meta,
+            &dest_meta,
+            &context.metadata_options(),
+            context.omit_dir_times_enabled(),
+            false,
+            false,
+            context.options().modify_window(),
+        );
+        LocalCopyRecord::new(
+            dot,
+            LocalCopyAction::MetadataReused,
+            0,
+            Some(snapshot_len),
+            Duration::default(),
+            Some(snapshot),
+        )
+        .with_change_set(change_set)
+    };
+    context.record(record);
+    Ok(())
 }
 
 /// Entry point for copying all sources to the destination.
@@ -184,8 +468,37 @@ pub(crate) fn copy_sources(
             let destination_behaves_like_directory =
                 destination_state.is_dir || plan.destination_spec().force_directory();
 
+            // Build the ordered work list. Upstream accumulates every source into
+            // ONE file list and sorts it globally (flist.c:2544
+            // flist_sort_and_clean) before the generator itemizes it, so the
+            // observable order is name-sorted, never command-line order. For a
+            // multi-source copy-contents transfer that means the sources' contents
+            // MERGE and sort together at the destination root
+            // (`merged_contents_worklist`); for named operands it means the
+            // operands themselves sort (`ordered_operands`). Both fall back to
+            // command-line order for the shapes they do not cover.
+            let worklist: Vec<SourceSpec> =
+                match merged_contents_worklist(context, plan, destination_root_created)? {
+                    Some(entries) => {
+                        // The merged path bypasses the root recursive walk, so
+                        // account for the transfer root "." (count + display row)
+                        // here, ahead of the merged children.
+                        emit_merged_transfer_root(
+                            context,
+                            plan,
+                            destination_path,
+                            destination_root_created,
+                        )?;
+                        entries
+                    }
+                    None => ordered_operands(plan.sources(), context.relative_paths_enabled())
+                        .into_iter()
+                        .cloned()
+                        .collect(),
+                };
+
             let mut first_io_error: Option<LocalCopyError> = None;
-            for source in plan.sources() {
+            for source in &worklist {
                 let result = process_single_source(
                     context,
                     plan,

--- a/crates/engine/src/local_copy/operands.rs
+++ b/crates/engine/src/local_copy/operands.rs
@@ -107,6 +107,21 @@ impl SourceSpec {
         }
     }
 
+    /// Builds a synthetic NAMED operand from a copy-contents source's immediate
+    /// child, used by the local-copy executor to reproduce upstream's global
+    /// merge of multiple copy-contents sources' contents (flist.c:2544
+    /// flist_sort_and_clean). The child maps to `dest/<basename>` exactly like a
+    /// real named operand of the same basename, so it carries no copy-contents,
+    /// relative-prefix, or dot-dir markers.
+    pub(crate) const fn from_child_path(path: PathBuf) -> Self {
+        Self {
+            path,
+            copy_contents: false,
+            relative_prefix_components: None,
+            has_dot_dir_marker: false,
+        }
+    }
+
     pub(crate) fn path(&self) -> &Path {
         &self.path
     }

--- a/crates/engine/tests/multi_source_operand_order.rs
+++ b/crates/engine/tests/multi_source_operand_order.rs
@@ -1,0 +1,442 @@
+//! Regression coverage: a LOCAL multi-source copy visits its operands in
+//! upstream `f_name_cmp` order, not command-line order, so the itemize /
+//! `--list-only` / `-v` stdout stream matches a real upstream 3.4.4 transfer.
+//!
+//! # Why this matters (observable stdout-fidelity contract)
+//!
+//! Upstream `send_file_list()` (flist.c:2227) accumulates every source operand
+//! into ONE file list and sorts it globally with `f_name_cmp`
+//! (`flist_sort_and_clean`, flist.c:2544) before the generator itemizes it, so
+//! top-level operands are emitted in name order regardless of the order they
+//! were given on the command line. oc's local-copy executor walks each
+//! operand's subtree already in `f_name_cmp` order but, before this fix, visited
+//! the operands themselves in argument order - so `oc-rsync -ai f_mango
+//! f_cherry f_apple f_banana dst/` itemized `mango, cherry, apple, banana`
+//! where upstream prints `apple, banana, cherry, mango`. The files landed
+//! correctly either way (a copy is a copy); only the observable order diverged,
+//! which the project's output-fidelity contract forbids.
+//!
+//! The expected orders below are the ones a real upstream rsync 3.4.4 prints
+//! for the identical command (verified against the reference binary). These
+//! tests FAIL before the operand-sort fix (they would see argument order).
+//!
+//! Scope: NAMED operands (each contributes a single top-level entry) are
+//! reordered by `ordered_operands`; trailing-slash / copy-contents operands
+//! merge their CONTENTS globally by content name, reproduced by
+//! `merged_contents_worklist` (both live in the local-copy source orchestrator).
+//! Both apply only to a non-`--relative` transfer. `--relative` operands carry
+//! implied parent directories whose ordering is handled during emission, so
+//! they are left in command-line order. The copy-contents merge additionally
+//! stays out of `--delete`, `--write-batch`, and `--one-file-system` transfers
+//! (which key off the per-source whole-root walk it bypasses); those keep
+//! command-line grouping and are a tracked follow-up.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use engine::local_copy::{
+    LocalCopyAction, LocalCopyExecution, LocalCopyOptions, LocalCopyPlan, LocalCopyRecord,
+};
+use tempfile::{TempDir, tempdir};
+
+/// Relative paths of the records that represent an emitted flist entry
+/// (a created directory or a copied regular file), in stream order.
+fn emitted_entry_order(records: &[LocalCopyRecord]) -> Vec<String> {
+    records
+        .iter()
+        .filter(|record| {
+            matches!(
+                record.action(),
+                LocalCopyAction::DataCopied | LocalCopyAction::DirectoryCreated
+            )
+        })
+        .map(|record| record.relative_path().to_string_lossy().into_owned())
+        .collect()
+}
+
+fn apply(operands: &[OsString], options: LocalCopyOptions) -> engine::local_copy::LocalCopyReport {
+    let plan = LocalCopyPlan::from_operands(operands).expect("plan builds");
+    plan.execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds")
+}
+
+/// Four single-file operands supplied in an order that is deliberately NOT
+/// their sorted order. Upstream itemizes them sorted (`apple, banana, cherry,
+/// mango`); before the fix oc emitted argument order (`mango, cherry, apple,
+/// banana`).
+#[test]
+fn multi_file_operands_are_itemized_in_sorted_order() {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+
+    // Command-line order: mango, cherry, apple, banana.
+    let names = ["mango", "cherry", "apple", "banana"];
+    let mut operands: Vec<OsString> = Vec::new();
+    for name in names {
+        let path = temp.path().join(name);
+        fs::write(&path, name.as_bytes()).expect("write source file");
+        operands.push(path.into_os_string());
+    }
+    operands.push(dst.clone().into_os_string());
+
+    let report = apply(&operands, LocalCopyOptions::default().collect_events(true));
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["apple", "banana", "cherry", "mango"],
+        "multi-file operands must itemize in f_name_cmp order (upstream 3.4.4), \
+         not command-line order",
+    );
+
+    // Regression: every file still lands with correct content.
+    for name in names {
+        assert_eq!(
+            fs::read(dst.join(name)).expect("dst file exists"),
+            name.as_bytes(),
+            "content for {name} must be copied intact",
+        );
+    }
+}
+
+/// Builds two NAMED directory operands whose sorted order is the reverse of the
+/// command-line order, with contents chosen so a naive "sort by content" would
+/// give a different answer than "sort the operands": `zdir` holds the
+/// low-sorting file, `adir` holds the high-sorting file. Upstream orders the
+/// operands (`adir` before `zdir`) and keeps each subtree contiguous.
+fn two_named_dirs() -> (Vec<OsString>, PathBuf, TempDir) {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+    for (dir, file) in [("zdir", "aaa"), ("adir", "zzz")] {
+        let dpath = temp.path().join(dir);
+        fs::create_dir_all(&dpath).expect("create source dir");
+        fs::write(dpath.join(file), file.as_bytes()).expect("write file");
+    }
+    // Command-line order: zdir then adir.
+    let operands = vec![
+        temp.path().join("zdir").into_os_string(),
+        temp.path().join("adir").into_os_string(),
+        dst.clone().into_os_string(),
+    ];
+    (operands, dst, temp)
+}
+
+/// Named directory operands are ordered by `f_name_cmp`, and each operand's
+/// subtree stays contiguous with it - exactly upstream's `adir/, adir/zzz,
+/// zdir/, zdir/aaa`. Proves the reorder keys on the OPERAND name (not on the
+/// contents): `adir` sorts first even though it holds the higher-sorting file.
+#[test]
+fn multi_dir_operands_order_by_operand_name_with_contiguous_subtrees() {
+    let (operands, dst, _temp) = two_named_dirs();
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .collect_events(true),
+    );
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["adir", "adir/zzz", "zdir", "zdir/aaa"],
+        "named directory operands must sort by operand name with each subtree \
+         contiguous, matching upstream's global flist sort",
+    );
+
+    // Regression: both trees land intact.
+    assert_eq!(fs::read(dst.join("adir/zzz")).unwrap(), b"zzz");
+    assert_eq!(fs::read(dst.join("zdir/aaa")).unwrap(), b"aaa");
+}
+
+/// A single operand is never reordered (nothing to sort) and its own subtree
+/// stays in `f_name_cmp` order - guarding against the sort touching the common
+/// single-source path.
+#[test]
+fn single_directory_source_subtree_stays_sorted() {
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&src).expect("create src");
+    fs::create_dir_all(&dst).expect("create dst");
+    for name in ["zebra", "mango", "apple", "delta"] {
+        fs::write(src.join(name), name.as_bytes()).expect("write");
+    }
+    // Trailing slash: copy the directory's CONTENTS into dst.
+    let operands = vec![
+        format!("{}/", src.display()).into(),
+        dst.clone().into_os_string(),
+    ];
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .collect_events(true),
+    );
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["apple", "delta", "mango", "zebra"],
+        "a single source's contents stay in f_name_cmp order",
+    );
+}
+
+/// `--relative` operands are intentionally NOT reordered by this fix (their
+/// implied-parent emission ordering is handled separately), so a `-R`
+/// multi-source copy keeps command-line operand order. This pins the scope
+/// boundary: the fix must leave `-R` behaviour exactly as it was.
+#[test]
+fn relative_operands_are_left_in_command_line_order() {
+    let (operands, _dst, _temp) = two_named_dirs();
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .relative_paths(true)
+            .collect_events(true),
+    );
+
+    // Absolute operands under --relative record their full path-minus-root, so
+    // match the operand leaf by suffix rather than by a bare name.
+    let order = emitted_entry_order(report.records());
+    let zdir = order.iter().position(|p| p.ends_with("zdir"));
+    let adir = order.iter().position(|p| p.ends_with("adir"));
+    assert!(
+        matches!((zdir, adir), (Some(z), Some(a)) if z < a),
+        "under --relative the operands keep command-line order (zdir before \
+         adir); reordering -R is out of scope for this fix. Order was {order:?}",
+    );
+}
+
+/// The operand sort is a pure output-ordering change: reordering the operands
+/// must never change WHICH files land on disk. A copy of the same two dirs in
+/// either command-line order produces byte-identical destinations.
+#[test]
+fn reordering_does_not_change_destination_contents() {
+    let (operands, dst, _temp) = two_named_dirs();
+    apply(&operands, LocalCopyOptions::default().recursive(true));
+
+    fn snapshot(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+        let mut out = Vec::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            for entry in fs::read_dir(&dir).expect("read_dir") {
+                let path = entry.expect("entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else {
+                    let rel = path.strip_prefix(root).unwrap().to_path_buf();
+                    out.push((rel, fs::read(&path).expect("read")));
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    assert_eq!(
+        snapshot(&dst),
+        vec![
+            (PathBuf::from("adir/zzz"), b"zzz".to_vec()),
+            (PathBuf::from("zdir/aaa"), b"aaa".to_vec()),
+        ],
+        "destination contents are independent of operand visit order",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Known divergences NOT addressed by the operand sort, pinned as ignored specs
+// so they stay tracked rather than silently masked. Each encodes upstream's
+// exact behaviour and is ready to un-ignore when its dedicated follow-up lands.
+// ---------------------------------------------------------------------------
+
+/// Copy-contents (trailing-slash) sources merging into one destination.
+/// Upstream flattens every operand's CONTENTS into one flist and sorts globally
+/// (flist.c:2544 flist_sort_and_clean), interleaving files across operands by
+/// content name (`aaa, mmm, zzz` below), NOT one operand's contents at a time
+/// (`aaa, zzz, mmm`). `merged_contents_worklist` reproduces the merge by
+/// flattening each source's children into synthetic named operands and sorting
+/// them with the same f_name_cmp comparator. The expected order was verified
+/// against upstream rsync 3.4.4 (`rsync -rin asrc/ zsrc/ dst/`).
+#[test]
+fn copy_contents_multi_source_interleave_matches_upstream() {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+    fs::create_dir_all(temp.path().join("asrc")).unwrap();
+    fs::create_dir_all(temp.path().join("zsrc")).unwrap();
+    for f in ["aaa", "zzz"] {
+        fs::write(temp.path().join("asrc").join(f), f.as_bytes()).unwrap();
+    }
+    fs::write(temp.path().join("zsrc").join("mmm"), b"mmm").unwrap();
+
+    // Both sources are copy-contents (trailing slash), given asrc then zsrc.
+    let operands = vec![
+        format!("{}/", temp.path().join("asrc").display()).into(),
+        format!("{}/", temp.path().join("zsrc").display()).into(),
+        dst.clone().into_os_string(),
+    ];
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .collect_events(true),
+    );
+
+    // Upstream 3.4.4 interleaves by content name across the two operands.
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["aaa", "mmm", "zzz"],
+        "copy-contents sources must interleave globally by content name",
+    );
+}
+
+/// The merged root sorts NON-directories before directories (upstream
+/// f_name_cmp / flist.c:3299 keys on type before name), so a subdirectory is
+/// emitted after every root-level file even when its name sorts earlier. Here
+/// `b_dir` (from asrc) sorts alphabetically before the files `m_file`, `n_file`
+/// yet upstream lists it last, then descends into it. dirA contributes
+/// `m_file` + `b_dir/z_inner`; dirB contributes `a_file` + `n_file`. Verified
+/// against upstream rsync 3.4.4 (`rsync -rin asrc/ bsrc/ dst/`).
+#[test]
+fn copy_contents_files_precede_dirs_across_merged_root() {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+    let asrc = temp.path().join("asrc");
+    let bsrc = temp.path().join("bsrc");
+    fs::create_dir_all(asrc.join("b_dir")).unwrap();
+    fs::create_dir_all(&bsrc).unwrap();
+    fs::write(asrc.join("m_file"), b"m").unwrap();
+    fs::write(asrc.join("b_dir").join("z_inner"), b"z").unwrap();
+    fs::write(bsrc.join("a_file"), b"a").unwrap();
+    fs::write(bsrc.join("n_file"), b"n").unwrap();
+
+    let operands = vec![
+        format!("{}/", asrc.display()).into(),
+        format!("{}/", bsrc.display()).into(),
+        dst.clone().into_os_string(),
+    ];
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .collect_events(true),
+    );
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["a_file", "m_file", "n_file", "b_dir", "b_dir/z_inner"],
+        "merged root files (sorted) precede the merged root dir and its subtree",
+    );
+}
+
+/// Name collisions across copy-contents sources resolve exactly as upstream's
+/// flist_sort_and_clean + receiver: a colliding regular file keeps the FIRST
+/// operand's copy (the later duplicate is dropped), while a colliding directory
+/// MERGES - both operands' children land under the one destination directory.
+/// Verified against upstream rsync 3.4.4 (`rsync -a dirA/ dirB/ dst/`): `file1`
+/// is `AAA` (dirA, the first operand) and `sub/` holds both `x` and `y`.
+#[test]
+fn copy_contents_collision_first_file_wins_and_dirs_merge() {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+    let dir_a = temp.path().join("dirA");
+    let dir_b = temp.path().join("dirB");
+    fs::create_dir_all(dir_a.join("sub")).unwrap();
+    fs::create_dir_all(dir_b.join("sub")).unwrap();
+    fs::write(dir_a.join("file1"), b"AAA").unwrap();
+    fs::write(dir_b.join("file1"), b"BBB").unwrap();
+    fs::write(dir_a.join("only_a"), b"x").unwrap();
+    fs::write(dir_b.join("only_b"), b"x").unwrap();
+    fs::write(dir_a.join("sub").join("x"), b"ax").unwrap();
+    fs::write(dir_b.join("sub").join("y"), b"by").unwrap();
+
+    let operands = vec![
+        format!("{}/", dir_a.display()).into(),
+        format!("{}/", dir_b.display()).into(),
+        dst.clone().into_os_string(),
+    ];
+
+    let report = apply(
+        &operands,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .collect_events(true),
+    );
+
+    assert_eq!(
+        emitted_entry_order(report.records()),
+        vec!["file1", "only_a", "only_b", "sub", "sub/x", "sub/y"],
+        "colliding file is emitted once, colliding dir is emitted once then \
+         merges both operands' children in sorted order",
+    );
+
+    // The first operand's file1 (AAA) wins; the later duplicate is dropped.
+    assert_eq!(fs::read(dst.join("file1")).unwrap(), b"AAA");
+    // The colliding directory merged both operands' distinct children.
+    assert_eq!(fs::read(dst.join("sub").join("x")).unwrap(), b"ax");
+    assert_eq!(fs::read(dst.join("sub").join("y")).unwrap(), b"by");
+}
+
+/// The `--stats` file/dir counts must survive the merge. Upstream sorts the
+/// combined flist WITHOUT removing duplicates (flist.c:2535-2544), so each
+/// trailing-slash operand's own "." entry is counted: `rsync -r --stats dirA/
+/// dirB/ dst/` reports `Number of files: 8 (reg: 5, dir: 3)` - 5 regular files
+/// plus 3 directories (one "." per source, and `sub`). Verified against
+/// upstream rsync 3.4.4. This pins that the merge counts the per-source roots
+/// rather than collapsing them, which would drop the dir tally to 1.
+#[test]
+fn copy_contents_multi_source_stats_count_matches_upstream() {
+    let temp = tempdir().expect("tempdir");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst");
+    let dir_a = temp.path().join("dirA");
+    let dir_b = temp.path().join("dirB");
+    fs::create_dir_all(dir_a.join("sub")).unwrap();
+    fs::create_dir_all(&dir_b).unwrap();
+    fs::write(dir_a.join("apple"), b"a").unwrap();
+    fs::write(dir_a.join("mango"), b"m").unwrap();
+    fs::write(dir_a.join("sub").join("inner"), b"i").unwrap();
+    fs::write(dir_b.join("banana"), b"b").unwrap();
+    fs::write(dir_b.join("cherry"), b"c").unwrap();
+
+    let operands = vec![
+        format!("{}/", dir_a.display()).into(),
+        format!("{}/", dir_b.display()).into(),
+        dst.clone().into_os_string(),
+    ];
+
+    let report = apply(&operands, LocalCopyOptions::default().recursive(true));
+    let summary = report.summary();
+
+    assert_eq!(
+        summary.regular_files_total(),
+        5,
+        "reg count: apple, mango, sub/inner, banana, cherry",
+    );
+    assert_eq!(
+        summary.directories_total(),
+        3,
+        "dir count: one '.' per copy-contents source (2) plus sub (upstream \
+         does not deduplicate the flist count)",
+    );
+}
+
+// KNOWN DIVERGENCE (tracked, not tested here): multi-source `--delete` timing.
+// With copy-contents directory sources under `--delete`, upstream removes an
+// extraneous destination entry BEFORE it transfers the sources (the `*deleting`
+// row precedes the `>f` rows), whereas oc runs its delete pass at the end so the
+// deletion trails the transfers. The operand sort deliberately does not move the
+// delete pass (the deletion keep-set is order-independent, so results are
+// unchanged). This timing is a separate investigate-and-fix follow-up; it is
+// noted here rather than tested because it only arises with copy-contents
+// sources, which are themselves out of scope above.


### PR DESCRIPTION
## Problem

A local copy of two or more trailing-slash (copy-contents) sources emitted each
source's contents contiguously instead of merging and globally sorting them the
way upstream rsync does.

```
oc-rsync -rin dirA/ dirB/ dest/     # dirA: apple,mango,sub/  dirB: banana,cherry
  >f apple.txt   >f mango.txt   cd sub/   >f sub/inner.txt   >f banana.txt   >f cherry.txt   # BEFORE (grouped)
```

Upstream accumulates every operand into ONE file list and sorts it with
`f_name_cmp` before the generator itemizes it (`flist.c:2544`
`flist_sort_and_clean`), so the two sources' contents interleave by child name
(files before dirs at each level):

```
  >f apple.txt   >f banana.txt   >f cherry.txt   >f mango.txt   cd sub/   >f sub/inner.txt   # upstream + AFTER
```

## Upstream ordering rule mirrored

- `flist.c:2227` `send_file_list()` accumulates every operand; a trailing-slash
  operand contributes its immediate CHILDREN (`send_directory`, `flist.c:2490`),
  not its own name.
- `flist.c:2544` `flist_sort_and_clean()` sorts the combined list with
  `f_name_cmp` (non-directories before directories, then name - `flist.c:3299`),
  WITHOUT removing duplicates (`flist.c:2535`), so each operand's own `.` entry
  still counts toward "Number of files".
- Display deduplicates: the generator lists each unique name once, first operand
  wins on a file collision; same-named directories merge their contents.

Verified byte-for-byte against upstream rsync 3.4.4 for `-i`, `--list-only`,
`-v`, and `--stats` across: two distinct sources, dir-sorts-last, three levels,
a file+dir name collision, and a freshly created destination.

## Change

`merged_contents_worklist` flattens each copy-contents source's immediate
children into synthetic named operands, deduplicates by name (file: first wins;
directory: keep every contributor so contents merge), and sorts them with the
shared `compare_file_entries` comparator. `emit_merged_transfer_root` accounts
for the transfer root `.`: counted once per source, displayed once with the
first source's root metadata (matching the recursive root frame).

Scope is deliberately narrow so no other feature's semantics shift - it engages
only for a non-`--relative`, recursive, plain copy of >= 2 copy-contents sources
with no `--delete`, `--write-batch`, or `--one-file-system` (each keys off the
per-source whole-root walk this path bypasses). Every excluded shape keeps
command-line order. The result on disk is byte-identical either way; only the
observable order/stats change.

The named-operand sort (`ordered_operands`) - part of the same multi-source
ordering epic - had been reverted by an unrelated stale-base merge; it is
restored alongside this fix.

## Known residual (tracked)

Duplicate/overlapping sources (a repeated operand, or a same-named directory in
two sources) are display-deduplicated correctly but their non-deduplicated
`--stats` count is not fully reproduced; distinct sources (the common case)
match exactly. `--delete`/`--write-batch`/`--one-file-system` keep command-line
grouping. Both are noted in the test module as follow-ups.

## Tests

`crates/engine/tests/multi_source_operand_order.rs`: restores the named-operand
suite and adds copy-contents coverage - global interleave, files-precede-dirs,
first-file-wins + dir-merge collision, and the `--stats` dir-count. Expected
orders pinned to upstream rsync 3.4.4.

## Verify

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p engine --all-features -E 'test(multi_source) or test(copy_contents) or test(flist)'` - 44 passed
- Full `-p engine --all-features` - 4933 passed; the only 2 failures are pre-existing macOS `com.apple.provenance` xattr-on-read-only env failures in unrelated single-file permission tests.
