### PR TITLE
perf(transfer): drop the disk-commit thread's full-flist clone

### DIFF
--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -129,10 +129,6 @@ pub struct DiskCommitConfig {
     /// Temporary directory for staging received files before final placement.
     /// Shared across all files in a transfer session.
     pub temp_dir: Option<PathBuf>,
-    /// Shared file list for metadata application. The disk thread looks up
-    /// entries by `file_entry_index` instead of receiving cloned entries
-    /// per file, eliminating ~88-295 bytes of cloning per file.
-    pub file_list: Option<Arc<Vec<protocol::flist::FileEntry>>>,
     /// Metadata options for applying file attributes after commit.
     /// When `Some`, the disk thread applies metadata (mtime, perms, ownership)
     /// immediately after rename - mirroring upstream `finish_transfer()` ->
@@ -260,7 +256,6 @@ impl Default for DiskCommitConfig {
             #[cfg(unix)]
             sandbox: None,
             temp_dir: None,
-            file_list: None,
             metadata_opts: None,
             backup: None,
             acl_cache: None,

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -29,10 +29,10 @@ pub(super) fn apply_file_metadata(
     begin: &BeginMessage,
     config: &DiskCommitConfig,
 ) -> Option<(PathBuf, String)> {
-    let file_entry = config
-        .file_list
-        .as_ref()
-        .and_then(|fl| fl.get(begin.file_entry_index));
+    // The desired metadata rides on the begin message per-file (see
+    // `BeginMessage::file_entry`), so the disk thread no longer indexes a shared
+    // clone of the whole receiver flist.
+    let file_entry = begin.file_entry.as_ref();
 
     if begin.is_device_target {
         None
@@ -201,4 +201,141 @@ pub(super) fn finalize_checksum(verifier: Option<ChecksumVerifier>) -> Option<Co
         let len = v.finalize_into(&mut buf);
         ComputedChecksum { bytes: buf, len }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_file_metadata;
+    use crate::disk_commit::DiskCommitConfig;
+    use crate::pipeline::messages::BeginMessage;
+
+    fn begin_for(
+        path: &std::path::Path,
+        entry: Option<protocol::flist::FileEntry>,
+    ) -> BeginMessage {
+        BeginMessage {
+            file_path: path.to_path_buf(),
+            target_size: 0,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+            xattr_basis: None,
+            file_entry: entry,
+        }
+    }
+
+    /// The disk thread must source a file's metadata from the entry carried on
+    /// its begin message, not from a shared receiver flist (which this crate no
+    /// longer clones for the disk thread). Proven by handing `apply_file_metadata`
+    /// a config with an empty flist context and an entry only on the message:
+    /// the permission and mtime it applies must be the message entry's, which
+    /// only holds if the message channel is the source of truth.
+    #[cfg(unix)]
+    #[test]
+    fn metadata_is_sourced_from_begin_message_entry() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("from_message.dat");
+        std::fs::write(&path, b"payload").unwrap();
+        // Seed a mode that differs from the entry's so a pass-through (no apply)
+        // or a wrong source would be visible.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let mut entry = protocol::flist::FileEntry::new_file(
+            std::path::PathBuf::from("from_message.dat"),
+            7,
+            0o640,
+        );
+        entry.set_mtime(1_600_000_000, 0);
+
+        let config = DiskCommitConfig {
+            metadata_opts: Some(
+                metadata::MetadataOptions::new()
+                    .preserve_permissions(true)
+                    .preserve_times(true),
+            ),
+            ..DiskCommitConfig::default()
+        };
+
+        // target_path == file_path: the final-destination apply path.
+        let begin = begin_for(&path, Some(entry));
+        let err = apply_file_metadata(&path, &begin, &config);
+        assert!(err.is_none(), "metadata apply reported an error: {err:?}");
+
+        let meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(
+            meta.permissions().mode() & 0o777,
+            0o640,
+            "permissions must come from the begin-message entry"
+        );
+        let mtime = filetime::FileTime::from_last_modification_time(&meta).unix_seconds();
+        assert_eq!(
+            mtime, 1_600_000_000,
+            "mtime must come from the begin-message entry"
+        );
+    }
+
+    /// With no entry on the message (and no shared flist), the apply path is a
+    /// no-op rather than a panic or an index into a list that no longer exists.
+    /// This pins the `None` contract that replaced the old
+    /// `file_list.get(index)` miss.
+    #[test]
+    fn absent_entry_applies_no_metadata() {
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("no_entry.dat");
+        std::fs::write(&path, b"payload").unwrap();
+
+        let config = DiskCommitConfig {
+            metadata_opts: Some(metadata::MetadataOptions::new().preserve_permissions(true)),
+            ..DiskCommitConfig::default()
+        };
+        let begin = begin_for(&path, None);
+        assert!(apply_file_metadata(&path, &begin, &config).is_none());
+    }
+
+    /// ACL case: the access/default ACL indices live in the entry's `extras`
+    /// box, which the receiver's `reclaim_heap_data` zeroes when it frees a
+    /// completed flist segment. Carrying the entry on the begin message means
+    /// the disk thread reads those indices from its own per-file copy, immune to
+    /// that reclaim - so the ACL apply branch (`entry.acl_ndx()` /
+    /// `entry.def_acl_ndx()` in `apply_metadata_acls_and_xattrs`) sees the right
+    /// values. This pins the delivery of the ACL indices via the message; the OS
+    /// ACL application itself is covered by the daemon ACL integration tests.
+    #[test]
+    fn acl_indices_ride_on_the_begin_message_entry() {
+        let dir = test_support::create_tempdir();
+        let path = dir.path().join("acl.dat");
+        std::fs::write(&path, b"payload").unwrap();
+
+        let mut entry =
+            protocol::flist::FileEntry::new_file(std::path::PathBuf::from("acl.dat"), 7, 0o640);
+        entry.set_acl_ndx(3);
+        entry.set_def_acl_ndx(4);
+
+        let begin = begin_for(&path, Some(entry));
+        let carried = begin.file_entry.as_ref().expect("entry present on message");
+        assert_eq!(
+            carried.acl_ndx(),
+            Some(3),
+            "access ACL index must survive on the begin-message entry"
+        );
+        assert_eq!(
+            carried.def_acl_ndx(),
+            Some(4),
+            "default ACL index must survive on the begin-message entry"
+        );
+
+        // With no ACL cache configured the apply path skips ACLs cleanly (the
+        // `if let Some(cache)` guard), so carrying acl indices never regresses a
+        // plain metadata apply.
+        let config = DiskCommitConfig {
+            metadata_opts: Some(metadata::MetadataOptions::new().preserve_permissions(true)),
+            ..DiskCommitConfig::default()
+        };
+        assert!(apply_file_metadata(&path, &begin, &config).is_none());
+    }
 }

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -857,6 +857,7 @@ fn begin_with_append_offset(path: &Path, append_offset: u64) -> BeginMessage {
         append_offset,
         xattr_list: None,
         xattr_basis: None,
+        file_entry: None,
     }
 }
 

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -184,6 +184,7 @@ fn write_file_with_io_uring_auto_policy() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -229,6 +230,7 @@ fn device_target_inplace_commit_does_not_truncate() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
     h.file_tx
@@ -346,6 +348,7 @@ fn write_and_commit_file() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -406,6 +409,7 @@ fn inplace_skip_matched_seeks_without_rewriting() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -454,6 +458,7 @@ fn abort_cleans_up_temp_file() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -496,6 +501,7 @@ fn multiple_files_sequential() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             })))
             .unwrap();
 
@@ -550,6 +556,7 @@ fn multi_chunk_file() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -589,6 +596,7 @@ fn buffer_recycling() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -637,6 +645,7 @@ fn whole_file_coalesced() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"whole dat".to_vec(),
             expected_checksum: Default::default(),
@@ -684,6 +693,7 @@ fn commit_file_rename_via_io_uring_or_fallback() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -732,6 +742,7 @@ fn commit_file_rename_replaces_existing_via_io_uring_or_fallback() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -780,6 +791,7 @@ fn delay_updates_stages_to_partial_dir() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -850,6 +862,7 @@ fn delay_updates_whole_file_stages_to_partial_dir() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"whole delayed!".to_vec(),
             expected_checksum: Default::default(),
@@ -897,6 +910,7 @@ fn whole_file_commit_via_io_uring_or_fallback() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"whole iouring".to_vec(),
             expected_checksum: Default::default(),
@@ -940,6 +954,7 @@ fn partial_mode_partial_retains_file_on_shutdown() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -987,6 +1002,7 @@ fn partial_mode_none_deletes_file_on_shutdown() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1032,6 +1048,7 @@ fn partial_mode_partial_retains_file_on_abort() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1082,6 +1099,7 @@ fn partial_mode_partial_dir_retains_file_in_directory() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1135,6 +1153,7 @@ fn partial_mode_no_retention_without_data() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1177,6 +1196,7 @@ fn partial_mode_channel_disconnect_retains_file() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1223,6 +1243,7 @@ fn partial_mode_relative_partial_dir() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1276,6 +1297,7 @@ fn cleanup_manager_removes_orphaned_temp_files_on_simulated_signal() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1365,6 +1387,7 @@ fn cleanup_manager_unregisters_on_successful_commit() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1427,6 +1450,7 @@ fn cleanup_manager_mixed_committed_and_orphaned_files() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
     h.file_tx
@@ -1452,6 +1476,7 @@ fn cleanup_manager_mixed_committed_and_orphaned_files() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
     h.file_tx
@@ -1547,6 +1572,7 @@ fn cleanup_manager_whole_file_unregisters_on_commit() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"whole file".to_vec(),
             expected_checksum: Default::default(),
@@ -1598,6 +1624,7 @@ fn cleanup_manager_inplace_skips_registration() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
     h.file_tx
@@ -1659,6 +1686,7 @@ fn inplace_abort_does_not_delete_existing_destination() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1722,6 +1750,7 @@ fn non_inplace_abort_discards_temp_and_leaves_existing_dest() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1799,6 +1828,7 @@ fn partial_dir_abort_mid_stream_moves_to_partial_dir() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1870,6 +1900,7 @@ fn partial_dir_channel_disconnect_moves_to_partial_dir() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1923,6 +1954,7 @@ fn partial_dir_auto_created_on_interrupt() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -1986,6 +2018,7 @@ fn partial_dir_mid_stream_has_intermediate_size() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -2052,6 +2085,7 @@ fn partial_dir_whole_file_success_no_leftover_in_partial_dir() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"complete-dat".to_vec(),
             expected_checksum: Default::default(),
@@ -2108,6 +2142,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_shutdown() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -2160,6 +2195,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_abort() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -2215,6 +2251,7 @@ fn partial_mode_partial_dir_does_not_stamp_mtime_zero() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -2271,6 +2308,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -2334,6 +2372,7 @@ fn verify_failure_keeps_recent_mtime_on_plain_partial() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: data.to_vec(),
             // Sender's sum is for different bytes: forces a verify mismatch.
@@ -2405,6 +2444,7 @@ fn delay_updates_interrupt_leaves_committed_files_in_staging() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"file1 staged".to_vec(),
             expected_checksum: Default::default(),
@@ -2429,6 +2469,7 @@ fn delay_updates_interrupt_leaves_committed_files_in_staging() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"file2 staged".to_vec(),
             expected_checksum: Default::default(),
@@ -2501,6 +2542,7 @@ fn delay_updates_interrupt_mid_file_retains_prior_staged_files() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"committed".to_vec(),
             expected_checksum: Default::default(),
@@ -2523,6 +2565,7 @@ fn delay_updates_interrupt_mid_file_retains_prior_staged_files() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
 
@@ -2584,6 +2627,7 @@ fn delay_updates_manual_sweep_after_commit_moves_to_final() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"sweep1".to_vec(),
             expected_checksum: Default::default(),
@@ -2605,6 +2649,7 @@ fn delay_updates_manual_sweep_after_commit_moves_to_final() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"sweep2".to_vec(),
             expected_checksum: Default::default(),
@@ -2667,6 +2712,7 @@ fn delay_updates_channel_disconnect_preserves_staged_files() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: b"disconnect data".to_vec(),
             expected_checksum: Default::default(),
@@ -2738,6 +2784,7 @@ fn pipelined_backup_default_suffix_returns_destination_relative_notice() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
     h.file_tx
@@ -2809,6 +2856,7 @@ fn pipelined_backup_with_backup_dir_reports_destination_relative_paths() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
     h.file_tx
@@ -2885,6 +2933,7 @@ fn inplace_redo_pass_does_not_overwrite_phase1_backup() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
     h.file_tx
@@ -2958,6 +3007,7 @@ fn whole_file_checksum_mismatch_is_not_committed_to_dest() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: data.to_vec(),
             // Sender's sum for entirely different bytes: forces a mismatch.
@@ -3006,6 +3056,7 @@ fn whole_file_checksum_match_commits_to_dest() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: data.to_vec(),
             expected_checksum: expected_md5(data),
@@ -3045,6 +3096,7 @@ fn chunked_checksum_mismatch_is_not_committed_to_dest() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: None,
         })))
         .unwrap();
     h.file_tx.send(FileMessage::Chunk(b"aaa".to_vec())).unwrap();
@@ -3091,6 +3143,7 @@ fn checksum_mismatch_leaves_preexisting_dest_untouched() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             }),
             data: data.to_vec(),
             expected_checksum: expected_md5(b"a different payload"),
@@ -3116,16 +3169,19 @@ const SPARSE_MTIME_SECS: i64 = 1_614_830_767;
 /// entry stamped with [`SPARSE_MTIME_SECS`] and whose metadata options preserve
 /// times, so the disk thread applies that mtime via `apply_file_metadata`
 /// (upstream `set_file_attrs()` -> `set_modtime()`).
-fn sparse_mtime_config(sparse: bool, size: u64) -> DiskCommitConfig {
+fn sparse_mtime_entry(size: u64) -> protocol::flist::FileEntry {
     let mut entry = protocol::flist::FileEntry::new_file(
         std::path::PathBuf::from("sparse_mtime.dat"),
         size,
         0o644,
     );
     entry.set_mtime(SPARSE_MTIME_SECS, 0);
+    entry
+}
+
+fn sparse_mtime_config(sparse: bool, _size: u64) -> DiskCommitConfig {
     DiskCommitConfig {
         use_sparse: sparse,
-        file_list: Some(std::sync::Arc::new(vec![entry])),
         metadata_opts: Some(
             metadata::MetadataOptions::new()
                 .preserve_permissions(true)
@@ -3179,6 +3235,7 @@ fn sparse_streaming_commit_preserves_source_mtime() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: Some(sparse_mtime_entry(size)),
         })))
         .unwrap();
     h.file_tx.send(FileMessage::Chunk(payload)).unwrap();
@@ -3229,6 +3286,7 @@ fn sparse_whole_file_commit_preserves_source_mtime() {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: Some(sparse_mtime_entry(size)),
             }),
             data: payload,
             expected_checksum: Default::default(),
@@ -3276,6 +3334,7 @@ fn non_sparse_commit_preserves_source_mtime() {
             append_offset: 0,
             xattr_list: None,
             xattr_basis: None,
+            file_entry: Some(sparse_mtime_entry(size)),
         })))
         .unwrap();
     h.file_tx.send(FileMessage::Chunk(payload)).unwrap();

--- a/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
+++ b/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
@@ -39,6 +39,7 @@ fn begin_msg(file_path: std::path::PathBuf, target_size: u64) -> FileMessage {
         append_offset: 0,
         xattr_list: None,
         xattr_basis: None,
+        file_entry: None,
     }))
 }
 
@@ -54,6 +55,7 @@ fn begin_msg_inplace(file_path: std::path::PathBuf, target_size: u64) -> FileMes
         append_offset: 0,
         xattr_list: None,
         xattr_basis: None,
+        file_entry: None,
     }))
 }
 

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -141,6 +141,23 @@ pub struct BeginMessage {
     /// - `xattrs.c:944-1009` `rsync_xal_set(fname, ..., fnamecmp, ...)` - the
     ///   abbreviated resolution re-reads `fnamecmp`, the basis actually used.
     pub xattr_basis: Option<PathBuf>,
+    /// Flist entry whose metadata (permissions, ownership, timestamps, ACL
+    /// indices) the disk thread applies after committing this file.
+    ///
+    /// Carried per-file so the disk thread never has to index a shared copy of
+    /// the whole receiver file list. Previously the disk thread read
+    /// `DiskCommitConfig.file_list[file_entry_index]`, which forced the receiver
+    /// to hand it an `Arc<Vec<FileEntry>>` clone of the entire flist that stayed
+    /// resident for the whole transfer (a second full name-heap copy). A single
+    /// cloned entry per in-flight file is transient (dropped once the file
+    /// commits) and window-bounded, and it is immune to the receiver
+    /// progressively reclaiming its own flist segments (`reclaim_heap_data`
+    /// zeroes the very fields - mode/uid/gid/mtime and the `acl_ndx` in
+    /// `extras` - that this apply path reads).
+    ///
+    /// `None` means no metadata is applied (matches the former behavior when the
+    /// index did not resolve in the shared list).
+    pub file_entry: Option<protocol::flist::FileEntry>,
 }
 
 /// Sender's trailing whole-file checksum, carried to the disk thread for

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -622,6 +622,7 @@ mod tests {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             })))
             .unwrap();
 
@@ -968,6 +969,7 @@ mod tests {
                     append_offset: 0,
                     xattr_list: None,
                     xattr_basis: None,
+                    file_entry: None,
                 }),
                 data: b"test data".to_vec(),
                 expected_checksum: Default::default(),
@@ -1047,6 +1049,7 @@ mod tests {
                 append_offset: 0,
                 xattr_list: None,
                 xattr_basis: None,
+                file_entry: None,
             })))
             .unwrap();
         pr.file_sender()
@@ -1108,6 +1111,7 @@ mod tests {
                     append_offset: 0,
                     xattr_list: None,
                     xattr_basis: None,
+                    file_entry: None,
                 }),
                 data: b"next".to_vec(),
                 expected_checksum: Default::default(),
@@ -1172,6 +1176,7 @@ mod tests {
                     append_offset: 0,
                     xattr_list: None,
                     xattr_basis: None,
+                    file_entry: None,
                 }),
                 data: b"test data".to_vec(),
                 expected_checksum: Default::default(),
@@ -1249,6 +1254,7 @@ mod tests {
                     append_offset: 0,
                     xattr_list: None,
                     xattr_basis: None,
+                    file_entry: None,
                 }),
                 data: b"test data".to_vec(),
                 expected_checksum: Default::default(),
@@ -1456,6 +1462,7 @@ mod tests {
                     append_offset: 0,
                     xattr_list: None,
                     xattr_basis: None,
+                    file_entry: None,
                 }),
                 data: b"drop staged".to_vec(),
                 expected_checksum: Default::default(),
@@ -1521,6 +1528,7 @@ mod tests {
                     append_offset: 0,
                     xattr_list: None,
                     xattr_basis: None,
+                    file_entry: None,
                 }),
                 data: b"shutdown stage".to_vec(),
                 expected_checksum: Default::default(),
@@ -1576,6 +1584,7 @@ mod tests {
                     append_offset: 0,
                     xattr_list: None,
                     xattr_basis: None,
+                    file_entry: None,
                 }),
                 data: b"e2e staged".to_vec(),
                 expected_checksum: Default::default(),

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -14,7 +14,6 @@
 use std::collections::VecDeque;
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use logging::{debug_log, info_log};
 use protocol::codec::{MonotonicNdxWriter, NdxCodec, create_ndx_codec};
@@ -237,7 +236,6 @@ impl ReceiverContext {
         } else {
             None
         };
-        let file_list_arc = Arc::new(self.file_list.clone());
         // upstream: cleanup.c - compute partial mode from --partial / --partial-dir flags
         let partial_mode = if let Some(ref dir) = self.config.partial_dir {
             PartialMode::PartialDir(dir.clone())
@@ -256,7 +254,6 @@ impl ReceiverContext {
             #[cfg(unix)]
             sandbox: setup.sandbox.clone(),
             temp_dir: self.config.temp_dir.as_ref().map(PathBuf::from),
-            file_list: Some(file_list_arc),
             metadata_opts: Some(setup.metadata_opts.clone()),
             // upstream: generator.c:2187 `make_backups = -make_backups`
             // negates make_backups during the redo pass so the inplace
@@ -539,6 +536,7 @@ impl ReceiverContext {
                     pipelined_receiver.file_sender(),
                     pipelined_receiver.buf_return_rx(),
                     file_idx,
+                    file_entry,
                     is_device_target,
                     xattr_list,
                     &mut token_reader,

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -69,7 +69,10 @@ pub struct StreamingResult {
 /// * `checksum_verifier` - Reusable checksum verifier (reset per call)
 /// * `file_tx` - Channel sender to the disk commit thread
 /// * `buf_return_rx` - Return channel for recycled buffers from the disk thread
-/// * `file_entry_index` - Index into the file list for metadata application
+/// * `file_entry_index` - Index into the file list, correlated back on the
+///   returned [`crate::pipeline::messages::CommitResult`]
+/// * `file_entry` - This file's flist entry, cloned into the begin message so
+///   the disk thread applies its metadata without indexing a shared flist copy
 /// * `is_device_target` - Whether the target is a device file
 /// * `xattr_list` - Optional extended attribute list for metadata application
 /// * `token_reader` - Reusable token reader, shared across files in a session.
@@ -86,6 +89,7 @@ pub fn process_file_response_streaming<R: Read>(
     file_tx: &spsc::Sender<FileMessage>,
     buf_return_rx: &spsc::Receiver<Vec<u8>>,
     file_entry_index: usize,
+    file_entry: &protocol::flist::FileEntry,
     is_device_target: bool,
     xattr_list: Option<protocol::xattr::XattrList>,
     token_reader: &mut TokenReader,
@@ -139,6 +143,11 @@ pub fn process_file_response_streaming<R: Read>(
         // is not the primary destination. Carry that basis so an entry the
         // generator left abbreviated (it matched the basis) still resolves.
         xattr_basis: header.basis_path.clone(),
+        // Carry this file's metadata entry with the message instead of having
+        // the disk thread index a shared clone of the whole flist. Cloning one
+        // entry per in-flight file is transient (freed at commit) and immune to
+        // the receiver reclaiming its own flist segments mid-transfer.
+        file_entry: Some(file_entry.clone()),
     });
 
     let mut basis_map = if let Some(ref path) = header.basis_path {


### PR DESCRIPTION
## What

The pipelined receiver's disk-commit thread applied each file's metadata
(permissions, ownership, timestamps, ACL indices) by indexing a shared
`Arc<Vec<FileEntry>>` clone of the **entire** receiver file list, handed to it
via `DiskCommitConfig.file_list`. That clone (`Arc::new(self.file_list.clone())`,
built at the top of the transfer loop) is a full second copy of the flist and
stays resident for the whole transfer.

This change carries the file's own `FileEntry` on its `BeginMessage` instead.
Cloning one entry per in-flight file is transient (freed once the file commits)
and window-bounded, and it is immune to the receiver reclaiming its own flist
segments mid-transfer (`reclaim_heap_data` zeroes the mode/uid/gid/mtime scalars
and the `acl_ndx`/`def_acl_ndx` in `extras` that this apply path reads).

- Removes `DiskCommitConfig.file_list` and the whole-list clone.
- Adds `BeginMessage.file_entry`, threaded through
  `process_file_response_streaming`.
- `metadata.rs` reads the entry from the message rather than the shared list.

Metadata application is byte-identical: the disk thread sees the same
`FileEntry`, only via the message channel rather than a shared index. Wire
output, stats, and exit codes are unchanged (this touches memory ownership only).

## Correctness

- Unit tests that permissions + mtime and the ACL indices are sourced from the
  begin-message entry, plus a no-entry no-op case.
- The three sparse-mtime disk-commit integration tests now carry the entry on
  the message.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings`: clean.
- `cargo nextest run -p transfer --all-features`: 2673 passed, 3 skipped.

## Measured memory impact: PEAK receiver RSS is NEUTRAL

Measured on an 8-core x86_64 Linux host, oc<->oc daemon PULL of 200k small files,
client (receiver) peak RSS via `/usr/bin/time -v`, 3 runs each:

| build | run 1 | run 2 | run 3 |
|-------|-------|-------|-------|
| master (with clone) | 149.9 MB | 148.7 MB | 147.2 MB |
| this branch (no clone) | 145.7 MB | 146.6 MB | 148.1 MB |

The ranges overlap; there is **no meaningful peak-RSS reduction**. Root cause,
found while measuring:

1. The receiver eagerly materializes the **entire** INC_RECURSE flist up front
   via `ensure_all_segments_loaded` before the transfer loop runs. A list-only
   pull (flist reception, no transfer, no clone) already peaks at ~117 MB, i.e.
   ~79% of the ~148 MB full-transfer peak. The peak is set during reception,
   before the removed clone ever existed.
2. The binary uses jemalloc with page-return tuning; freeing the clone returns
   pages to the arena, not the OS, so removing an allocation that is freed
   anyway does not lower the high-water mark.

So the real receiver-RSS lever is the eager up-front segment load (upstream
scans lazily per segment via `recv_additional_file_list` and never holds the
whole flist), not this clone and not an end-of-transfer reclaim.

## Why keep it anyway

Even though it does not move peak RSS, this is a correctness-neutral decoupling
that (a) removes a redundant O(N) full-list copy from every pipelined transfer
(lower total allocation / steady-state memory), and (b) severs the disk thread's
dependency on `self.file_list`, which is a prerequisite for making the receiver
load and reclaim flist segments lazily without the disk thread reading zeroed
entries. It is safe to merge as a cleanup or to shelve pending that larger work.

Does not close any issue on its own.
