### PR TITLE
ci: run CI on Depot runners to relieve runner starvation

### DIFF
--- a/.github/workflows/_ci-skip-interop-macos.yml
+++ b/.github/workflows/_ci-skip-interop-macos.yml
@@ -9,6 +9,6 @@ permissions:
 jobs:
   interop-with-upstream-macos:
     name: interop with upstream rsync (macOS)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no code changes"

--- a/.github/workflows/_ci-skip-interop-windows.yml
+++ b/.github/workflows/_ci-skip-interop-windows.yml
@@ -9,6 +9,6 @@ permissions:
 jobs:
   interop-with-upstream-windows:
     name: interop with upstream rsync (Windows, best-effort)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no code changes"

--- a/.github/workflows/_ci-skip-interop.yml
+++ b/.github/workflows/_ci-skip-interop.yml
@@ -9,6 +9,6 @@ permissions:
 jobs:
   interop-with-upstream:
     name: interop with upstream rsync
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no code changes"

--- a/.github/workflows/_ci-skip-upstream-testsuite.yml
+++ b/.github/workflows/_ci-skip-upstream-testsuite.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   upstream-testsuite:
     name: upstream testsuite
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no relevant changes"
 
@@ -19,6 +19,6 @@ jobs:
   # context leaves a skipped pull request permanently unmergeable.
   upstream-testsuite-root:
     name: upstream testsuite (root)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no relevant changes"

--- a/.github/workflows/_interop-macos.yml
+++ b/.github/workflows/_interop-macos.yml
@@ -51,7 +51,7 @@ permissions:
 jobs:
   interop-macos:
     name: interop with upstream rsync (macOS)
-    runs-on: macos-latest
+    runs-on: depot-macos-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     env:

--- a/.github/workflows/_interop-windows.yml
+++ b/.github/workflows/_interop-windows.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   interop-windows:
     name: interop with upstream rsync (Windows, best-effort)
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
     # Best-effort: do not block merges on Windows interop quirks while
     # baseline parity is being established. Promote to required once

--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   interop:
     name: interop with upstream rsync
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     env:

--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -32,7 +32,7 @@ jobs:
   # ---------------------------------------------------------------------------
   feature-flags-cross-os:
     name: ${{ matrix.row.name }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: depot-${{ matrix.os }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     strategy:
@@ -149,7 +149,7 @@ jobs:
   # ---------------------------------------------------------------------------
   feature-flags-linux:
     name: ${{ matrix.name }} (linux)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     strategy:

--- a/.github/workflows/_upstream-testsuite.yml
+++ b/.github/workflows/_upstream-testsuite.yml
@@ -23,7 +23,7 @@ jobs:
   upstream-testsuite:
     name: upstream testsuite
     if: ${{ inputs.variant == 'all' || inputs.variant == 'nonroot' }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 45
 
     env:
@@ -176,7 +176,7 @@ jobs:
   upstream-testsuite-root:
     name: upstream testsuite (root)
     if: ${{ inputs.variant == 'all' || inputs.variant == 'root' }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 45
 
     env:

--- a/.github/workflows/bin-build-coverage.yml
+++ b/.github/workflows/bin-build-coverage.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   check:
     name: Test cells build oc-rsync
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/build-rsync-2-6-9.yml
+++ b/.github/workflows/build-rsync-2-6-9.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   build-rsync-2-6-9:
     name: Build rsync 2.6.9 from source
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/cargo-lockfile-sync.yml
+++ b/.github/workflows/cargo-lockfile-sync.yml
@@ -52,7 +52,7 @@ permissions:
 jobs:
   sync-lockfile:
     name: Sync Cargo.lock
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 15
     if: github.event.pull_request.user.login != 'github-actions[bot]'
 

--- a/.github/workflows/cargo-lockfile-weekly.yml
+++ b/.github/workflows/cargo-lockfile-weekly.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   update-lockfile:
     name: Refresh Cargo.lock
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/check-locked-flags.yml
+++ b/.github/workflows/check-locked-flags.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   check:
     name: Gate --locked on cargo invocations
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -46,31 +46,31 @@ permissions:
 jobs:
   lint:
     name: fmt + clippy
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no code changes"
 
   test:
     name: nextest (stable)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no code changes"
 
   windows-test:
     name: Windows (stable)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no code changes"
 
   macos-test:
     name: macOS (stable)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no code changes"
 
   musl-test:
     name: Linux musl (stable)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - run: echo "Skipped — no code changes"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
   # ===========================================================================
   lint:
     name: fmt + clippy
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -140,7 +140,7 @@ jobs:
   # ===========================================================================
   fuzz-workspace-check:
     name: fuzz workspaces check
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -177,7 +177,7 @@ jobs:
   # ===========================================================================
   unsafe-safety-comment-audit:
     name: unsafe-safety-comment-audit (informational)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     timeout-minutes: 5
     continue-on-error: true
@@ -194,7 +194,7 @@ jobs:
   # ===========================================================================
   test:
     name: nextest (${{ matrix.toolchain }})
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: lint
     timeout-minutes: 120
     # Stable gates merge; beta/nightly are informational so a churning
@@ -283,7 +283,7 @@ jobs:
   # ===========================================================================
   windows-test:
     name: Windows (${{ matrix.toolchain }})
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     needs: lint
     timeout-minutes: 45
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
@@ -373,7 +373,7 @@ jobs:
   # ===========================================================================
   windows-iocp:
     name: Windows IOCP (--features iocp)
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     needs: lint
     timeout-minutes: 30
 
@@ -449,7 +449,7 @@ jobs:
   # ===========================================================================
   windows-acl-xattr:
     name: Windows ACL/xattr
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     needs: lint
     timeout-minutes: 30
 
@@ -527,7 +527,7 @@ jobs:
   # ===========================================================================
   windows-daemon:
     name: Windows daemon
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     needs: lint
     timeout-minutes: 30
 
@@ -576,7 +576,7 @@ jobs:
   # ===========================================================================
   windows-gnu-cross-check:
     name: Windows GNU cross-check
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: lint
     timeout-minutes: 20
 
@@ -634,7 +634,7 @@ jobs:
   # ===========================================================================
   macos-test:
     name: macOS (${{ matrix.toolchain }})
-    runs-on: macos-latest
+    runs-on: depot-macos-latest
     needs: lint
     timeout-minutes: 30
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
@@ -699,7 +699,7 @@ jobs:
   # ===========================================================================
   linux-musl:
     name: Linux musl (${{ matrix.toolchain }})
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: lint
     timeout-minutes: 30
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
@@ -865,7 +865,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: depot-${{ matrix.os }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   dependency-review:
     name: Review
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/differential-fuzzer-overnight.yml
+++ b/.github/workflows/differential-fuzzer-overnight.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   fuzz:
     name: ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     # Per-target budget + 30 minutes for build/setup overhead.
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/filter-fuzzer-overnight.yml
+++ b/.github/workflows/filter-fuzzer-overnight.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   fuzz:
     name: ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     # Each target budget + 30 minutes for build/upstream/setup overhead.
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/fuzz-coverage-report.yml
+++ b/.github/workflows/fuzz-coverage-report.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   coverage:
     name: ${{ matrix.target }} (informational)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     # 5 min per target + 25 min for toolchain install, upstream build, and
     # cargo-fuzz coverage compilation overhead.
     timeout-minutes: 30

--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   smoke:
     name: fuzz coverage smoke
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/interop-validation.yml
+++ b/.github/workflows/interop-validation.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   build:
     name: Build oc-rsync and upstream rsync
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 45
 
     steps:
@@ -100,7 +100,7 @@ jobs:
   validate-exit-codes:
     name: Exit Code Validation
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -152,7 +152,7 @@ jobs:
   validate-messages:
     name: Message Format Validation
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -204,7 +204,7 @@ jobs:
   validate-behavior:
     name: Behavior Comparison
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 45
 
     steps:
@@ -258,7 +258,7 @@ jobs:
   validate-batch:
     name: Batch Mode Interop
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -296,7 +296,7 @@ jobs:
   validate-filters:
     name: Filter Rules Interop
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -336,7 +336,7 @@ jobs:
   validate-compress:
     name: Compression Codec Interop
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -376,7 +376,7 @@ jobs:
   validate-inc-recurse:
     name: INC_RECURSE Interop
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -419,7 +419,7 @@ jobs:
   regenerate-goldens:
     name: Regenerate Golden Files (Manual)
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     # Only run on workflow_dispatch
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/known-failures.yml
+++ b/.github/workflows/known-failures.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-known-failures:
     name: Track known failure status
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
 
     env:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/locked-gate.yml
+++ b/.github/workflows/locked-gate.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   gate:
     name: gate
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Checkout

--- a/.github/workflows/mdf-8-filter-diff.yml
+++ b/.github/workflows/mdf-8-filter-diff.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   diff:
     name: filter-diff
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     continue-on-error: true
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   build:
     name: Build rustdoc
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -74,7 +74,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release-cross.yml
+++ b/.github/workflows/release-cross.yml
@@ -48,7 +48,7 @@ jobs:
   # ===========================================================================
   validate-version:
     name: validate tag matches Cargo.toml
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 5
     outputs:
       version: ${{ steps.extract.outputs.version }}
@@ -94,7 +94,7 @@ jobs:
   # ===========================================================================
   linux-gnu:
     name: linux-gnu-${{ matrix.arch }}-${{ matrix.toolchain }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: validate-version
     timeout-minutes: 30
 
@@ -293,7 +293,7 @@ jobs:
   # ===========================================================================
   linux-musl:
     name: linux-musl-${{ matrix.arch }}-${{ matrix.toolchain }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: validate-version
     timeout-minutes: 45
 
@@ -416,7 +416,7 @@ jobs:
   # ===========================================================================
   linux-alpine:
     name: alpine-apk-${{ matrix.arch }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs:
       - validate-version
       - linux-musl
@@ -516,7 +516,7 @@ jobs:
   # ===========================================================================
   macos:
     name: macos-${{ matrix.arch }}-${{ matrix.toolchain }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: depot-${{ matrix.runner }}
     needs: validate-version
     timeout-minutes: 30
 
@@ -601,7 +601,7 @@ jobs:
   # ===========================================================================
   windows:
     name: windows-${{ matrix.toolchain }}
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     needs: validate-version
     timeout-minutes: 45
 
@@ -701,7 +701,7 @@ jobs:
   # ===========================================================================
   release-artifacts:
     name: create GitHub Release and upload assets
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 15
     needs:
       - validate-version
@@ -816,7 +816,7 @@ jobs:
   # ===========================================================================
   brew-formula:
     name: update Homebrew formula
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 10
     needs:
       - validate-version
@@ -1019,7 +1019,7 @@ jobs:
   # ===========================================================================
   docker:
     name: build and push Docker image
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 15
     needs:
       - validate-version

--- a/.github/workflows/reorder-spill-regression.yml
+++ b/.github/workflows/reorder-spill-regression.yml
@@ -50,7 +50,7 @@ env:
 jobs:
   reorder-spill-check:
     name: Reorder spill regression
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     # Non-required: ROB-13.b will promote this check after a bake-in
     # period on master. Do not add to branch protection here.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   audit:
     name: cargo-deny
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/track-3.5.0dev-testsuite.yml
+++ b/.github/workflows/track-3.5.0dev-testsuite.yml
@@ -78,7 +78,7 @@ jobs:
     # All four legs are surfaced independently so a divergence is attributable
     # to a specific (privilege, transport) cell.
     name: 3.5.0dev testsuite (${{ matrix.privilege }}/${{ matrix.transport }})
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 45
     # Best-effort tracker: never let a 3.5.0dev break look like a repo failure
     # that someone must firefight. The step summary + run status carry the

--- a/.github/workflows/upstream-release-watch.yml
+++ b/.github/workflows/upstream-release-watch.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   check:
     name: Check upstream rsync release
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-daemon-environmental.yml
+++ b/.github/workflows/validate-daemon-environmental.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   validate:
     name: validate environmental
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/windows-nightly-case-insensitive.yml
+++ b/.github/workflows/windows-nightly-case-insensitive.yml
@@ -61,7 +61,7 @@ env:
 jobs:
   windows-case-insensitive:
     name: Windows case-insensitive collision detection
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/windows-nightly-daemon.yml
+++ b/.github/workflows/windows-nightly-daemon.yml
@@ -52,7 +52,7 @@ env:
 jobs:
   windows-daemon:
     name: Windows daemon-crate tests
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/windows-nightly-iocp.yml
+++ b/.github/workflows/windows-nightly-iocp.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   windows-iocp-stress:
     name: Windows IOCP stress (high-IOPS)
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/windows-nightly-long-path.yml
+++ b/.github/workflows/windows-nightly-long-path.yml
@@ -56,7 +56,7 @@ env:
 jobs:
   windows-long-path:
     name: Windows long-path (\\?\) round-trip
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/windows-nightly-ntfs-acl.yml
+++ b/.github/workflows/windows-nightly-ntfs-acl.yml
@@ -82,7 +82,7 @@ env:
 jobs:
   windows-ntfs-acl:
     name: Windows NTFS ACL round-trip
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/windows-nightly-openssh.yml
+++ b/.github/workflows/windows-nightly-openssh.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   windows-openssh-push:
     name: Windows rsync_io / OpenSSH tests
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/windows-nightly-reparse-symlinks.yml
+++ b/.github/workflows/windows-nightly-reparse-symlinks.yml
@@ -82,7 +82,7 @@ env:
 jobs:
   windows-reparse-symlinks:
     name: Windows reparse-point + symlink round-trip
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/windows-nightly-xattr-ads.yml
+++ b/.github/workflows/windows-nightly-xattr-ads.yml
@@ -56,7 +56,7 @@ env:
 jobs:
   windows-xattr-ads:
     name: Windows xattr ADS round-trip
-    runs-on: windows-latest
+    runs-on: depot-windows-latest
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## What

Prefix `runs-on` labels with `depot-` so CI schedules on the Depot runner pool instead of the constrained GitHub-hosted pool.

## Why

Each PR fires a large job matrix (platform stable/beta/nightly, feature-flag combinations across three OSes, stress cells). On the GitHub-hosted pool this serializes and the required checks queue for a long time behind non-required jobs. Depot provides a larger/faster pool so the matrix runs concurrently and required checks clear quickly.

## Scope

- Standard runner literals prefixed: `ubuntu-latest`, `ubuntu-24.04`, `ubuntu-22.04`, `macos-latest`, `macos-15`, `windows-latest` → `depot-*`.
- Matrix-driven jobs prefixed at the `runs-on` line (`depot-${{ matrix.os }}`, `depot-${{ matrix.runner }}`) so the matrix values used in **job names and cache keys stay unchanged** (required-check names are preserved for branch protection).

## Left on GitHub-hosted runners (deliberate)

Hardware/kernel-sensitive workflows keep their results valid:

- `iouring-kernel-compat`, `send-zc-5-15-lts` — pin specific kernel versions; Depot images run their own kernels.
- `bench-*`, `benchmark*`, `_benchmark-*` — benchmarks need stable baseline hardware for comparable numbers.

## Verify before merge

Confirm the Depot organization has these runner labels provisioned; if a label is not available, adjust it (e.g. `depot-windows-latest` → `depot-windows-2022`, `depot-macos-15` → `depot-macos-14`):

- `depot-ubuntu-latest` / `depot-ubuntu-24.04` / `depot-ubuntu-22.04`
- `depot-macos-latest` / `depot-macos-15`
- `depot-windows-latest`

This PR's own CI runs from its head, so a green run here confirms the labels resolve on Depot.
