### PR TITLE
refactor(cli): unify duplicated atoi leading-integer env parsers

### DIFF
--- a/crates/cli/src/frontend/arguments/env.rs
+++ b/crates/cli/src/frontend/arguments/env.rs
@@ -23,9 +23,14 @@ pub(crate) fn env_protect_args_default() -> Option<bool> {
 /// Parses a leading base-10 integer like C's `atoi`, ignoring leading
 /// whitespace and any trailing non-digit suffix. Returns 0 when no digits lead.
 ///
-/// Kept consistent with the `RSYNC_OLD_ARGS` parser (`run.rs::atoi_leading`,
-/// upstream: options.c:1971 `old_style_args = atoi(arg)`).
-fn atoi_leading(s: &str) -> i32 {
+/// Shared leading-integer parser for the CLI's environment defaults:
+/// `RSYNC_PROTECT_ARGS` (options.c:1987 `protect_args = atoi(arg) ? 1 : 0`) and
+/// `RSYNC_OLD_ARGS` (options.c:1971 `old_style_args = atoi(arg)`, via
+/// `run.rs::resolve_old_args`).
+///
+/// upstream: options.c:1971 & 1987 call libc `atoi(3)` (stdlib.h); this mirrors
+/// its optional-sign, leading-decimal parse.
+pub(crate) fn atoi_leading(s: &str) -> i32 {
     let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() && bytes[i].is_ascii_whitespace() {
@@ -127,17 +132,26 @@ mod tests {
         }
     }
 
-    /// upstream: options.c:1988 - `atoi(arg) ? 1 : 0` uses C `atoi`, a leading
-    /// base-10 parse. This pins the exact mapping oc must reproduce.
+    /// upstream: options.c:1971 & 1987 call libc `atoi(3)` on the env value; it
+    /// reads an optional sign plus leading decimal digits and stops at the first
+    /// non-digit, so `12abc` -> 12 while `yes`/`true`/`abc`/`` -> 0. This pins
+    /// the exact mapping both `RSYNC_PROTECT_ARGS` and `RSYNC_OLD_ARGS` reuse.
     #[test]
     fn atoi_leading_matches_c_atoi() {
         assert_eq!(atoi_leading("1"), 1);
         assert_eq!(atoi_leading("2"), 2);
+        assert_eq!(atoi_leading("10"), 10);
+        assert_eq!(atoi_leading("12abc"), 12);
         assert_eq!(atoi_leading("  2"), 2);
         assert_eq!(atoi_leading("2 "), 2);
         assert_eq!(atoi_leading("3x"), 3);
+        assert_eq!(atoi_leading("-5"), -5);
+        assert_eq!(atoi_leading("0"), 0);
+        assert_eq!(atoi_leading("0x"), 0);
         assert_eq!(atoi_leading("0abc"), 0);
+        assert_eq!(atoi_leading("abc"), 0);
         assert_eq!(atoi_leading("yes"), 0);
+        assert_eq!(atoi_leading("true"), 0);
         assert_eq!(atoi_leading(""), 0);
     }
 

--- a/crates/cli/src/frontend/arguments/mod.rs
+++ b/crates/cli/src/frontend/arguments/mod.rs
@@ -17,7 +17,9 @@ mod stop;
 mod tests;
 
 pub(crate) use bandwidth::BandwidthArgument;
-pub(crate) use env::{env_iconv_default, env_max_alloc_default, env_protect_args_default};
+pub(crate) use env::{
+    atoi_leading, env_iconv_default, env_max_alloc_default, env_protect_args_default,
+};
 pub use parsed_args::ParsedArgs; // Changed to pub for test_utils
 pub(crate) use parser::ChecksumThreadsSetting;
 pub use parser::parse_args; // Changed to pub for test_utils

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -15,7 +15,7 @@ use crate::frontend::log_format_has;
 use crate::frontend::outbuf::parse_outbuf_mode;
 use crate::frontend::progress::{ProgressOutputConfig, StderrMode};
 use crate::frontend::{
-    arguments::{ChecksumThreadsSetting, ParsedArgs, StopRequest},
+    arguments::{ChecksumThreadsSetting, ParsedArgs, StopRequest, atoi_leading},
     execution::{
         chown::ParsedChown, extract_operands, load_file_list_operands, operand_is_remote,
         parse_chown_argument, resolve_file_list_entries, resolve_files_from_source,
@@ -1162,31 +1162,6 @@ fn resolve_old_args(explicit: Option<u8>, protect_args: Option<bool>) -> Option<
     }
 }
 
-/// Parses a leading base-10 integer like C's `atoi`, ignoring leading
-/// whitespace and any trailing non-digit suffix. Returns 0 when no digits lead.
-fn atoi_leading(s: &str) -> i32 {
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-        i += 1;
-    }
-    let mut sign = 1i32;
-    if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
-        if bytes[i] == b'-' {
-            sign = -1;
-        }
-        i += 1;
-    }
-    let mut value = 0i32;
-    while i < bytes.len() && bytes[i].is_ascii_digit() {
-        value = value
-            .saturating_mul(10)
-            .saturating_add((bytes[i] - b'0') as i32);
-        i += 1;
-    }
-    sign * value
-}
-
 /// Returns the explicit checksum seed to record in a batch header, or `None`
 /// when the seed must be derived from time/pid.
 ///
@@ -1230,7 +1205,7 @@ fn open_log_file(path: &PathBuf) -> io::Result<File> {
 
 #[cfg(test)]
 mod tests {
-    use super::{atoi_leading, derive_batch_seed, explicit_batch_seed, resolve_old_args};
+    use super::{derive_batch_seed, explicit_batch_seed, resolve_old_args};
     use platform::env::EnvGuard;
     use std::ffi::OsStr;
     use std::sync::Mutex;
@@ -1238,21 +1213,6 @@ mod tests {
     /// Serialises the `RSYNC_OLD_ARGS` env mutations so the resolver tests never
     /// race on the process environment even under a threaded test runner.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    /// `atoi_leading` mirrors C `atoi`: it reads a leading integer and ignores a
-    /// trailing non-digit suffix, which is exactly how upstream parses
-    /// `RSYNC_OLD_ARGS` (options.c:1971 `old_style_args = atoi(arg)`).
-    #[test]
-    fn atoi_leading_matches_c_atoi() {
-        assert_eq!(atoi_leading("2"), 2);
-        assert_eq!(atoi_leading("1"), 1);
-        assert_eq!(atoi_leading("  2"), 2);
-        assert_eq!(atoi_leading("2 "), 2);
-        assert_eq!(atoi_leading("2abc"), 2);
-        assert_eq!(atoi_leading("10"), 10);
-        assert_eq!(atoi_leading("yes"), 0);
-        assert_eq!(atoi_leading(""), 0);
-    }
 
     /// An explicit `--old-args` counter must flow through unchanged and suppress
     /// the env lookup, mirroring upstream skipping the `old_style_args < 0`


### PR DESCRIPTION
## Summary

Two byte-identical `atoi`-style leading-integer parsers lived in the `cli`
crate:

- `crates/cli/src/frontend/arguments/env.rs::atoi_leading` - parses
  `RSYNC_PROTECT_ARGS` (`options.c:1987` `protect_args = atoi(arg) ? 1 : 0`).
- `crates/cli/src/frontend/execution/drive/workflow/run.rs::atoi_leading` -
  parses `RSYNC_OLD_ARGS` (`options.c:1971` `old_style_args = atoi(arg)`).

Both functions were identical character-for-character (optional leading
whitespace, optional `+`/`-` sign, leading decimal digits, stop at the first
non-digit, saturating, return 0 when no digit leads). This unifies them into a
single shared helper and routes both call sites through it.

## Change

- `atoi_leading` in `env.rs` becomes `pub(crate)` and is re-exported from
  `arguments/mod.rs`. It is now the one canonical implementation.
- `run.rs` deletes its copy and imports the shared helper; `resolve_old_args`
  now calls the shared function. No logic change.
- The boundary-case unit test is consolidated in `env.rs` (co-located with the
  helper) and broadened to cover `12abc -> 12`, `0`/`0x`/`0abc`/`abc -> 0`,
  `-5 -> -5`, and `yes`/`true`/`` -> 0. The duplicate test in `run.rs` is
  removed.

## Behavior

No behavior change. The two implementations were already byte-identical, so
neither call site changes its observable output. `RSYNC_PROTECT_ARGS` and
`RSYNC_OLD_ARGS` parse exactly as before.

## Citation note

The task brief suggested a `// upstream: util.c atoi` citation, but `atoi` is
not defined in `util.c` - it is the C standard library function (`stdlib.h`).
The comments therefore cite the real upstream call sites that invoke libc
`atoi(3)`: `options.c:1971` (`RSYNC_OLD_ARGS`) and `options.c:1987`
(`RSYNC_PROTECT_ARGS`).

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run -p cli --all-features` - pass
