### PR TITLE
test(cli): guard the -vv local total: line against a duplicate emitter

### DIFF
--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -442,6 +442,15 @@ fn level_2_local_brackets_name_list_with_delta_and_total() {
         last_name < total && total < sent,
         "total: line must follow the name list and precede the summary trailer, got: {rendered:?}"
     );
+    // A single well-placed emitter: the match_report total: line must appear
+    // exactly once. Guards against a second emitter (e.g. an engine-side
+    // debug_log flushed dead-last) re-introducing a duplicate or mispositioned
+    // total: line. upstream: match.c:439 match_report() prints it once.
+    assert_eq!(
+        rendered.matches("total: matches=").count(),
+        1,
+        "the match_report total: line must be emitted exactly once, got: {rendered:?}"
+    );
 }
 
 /// Verifies that -vvv produces output that is at least as verbose as -vv.


### PR DESCRIPTION
## Summary

Hardens the local `-vv` `total:` match-report line test to assert the line is
emitted **exactly once**, guarding against a second emitter re-introducing a
duplicate or mispositioned line.

## Context: the duplicate this guards against is already gone

An earlier change (`921af6f4f`) added a second `total:` emitter in the
local-copy engine that accumulated real delta match counts and printed the line
via `debug_log!(Deltasum, 1, ...)` at end-of-run. Because local-copy
diagnostics flush after the summary trailer, that produced a **duplicate /
dead-last** `total:` line alongside the correctly-positioned one in
`cli/.../progress/render.rs`.

That engine emitter was subsequently removed in full by `ce9e8f6fe` (a
stale-base merge), so at `HEAD` there is exactly **one** emitter (the CLI one),
correctly positioned:

```
sending incremental file list
delta-transmission disabled for local transfer or --whole-file
<name list>
total: matches=0  hash_hits=0  false_alarms=0 data=<literal bytes>

sent ... received ... total size ...
```

This matches upstream rsync 3.4.4 byte-for-byte for the default (whole-file)
local `-vv` copy: upstream's forked sender prints `match_report()`
(`match.c:439-448`) once, after `send_files()` and before `output_summary()`.
Verified against `/usr/bin/rsync` 3.4.4 on both a fresh copy and an
up-to-date rerun.

The existing `level_2_local_brackets_name_list_with_delta_and_total` test pins
the content and position but uses `find()`, so it cannot catch a duplicate.
This adds a `matches("total: matches=").count() == 1` assertion so any future
regression that adds a second emission fails loudly.

## What this does not change

No production code. The single CLI emitter remains the sole source of the line.
