### PR TITLE
fix(flist): emit positional leading-./ transfer-root entry

### DIFF
--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -966,9 +966,15 @@ fn emit_relative_implied_parents(
         }
 
         let source_dir = source_root.join(&accumulated);
-        // Best-effort, matching send_implied_dirs()'s tolerance for an ancestor
-        // that vanished or is not a directory: skip it silently.
-        let source_meta = match fs::symlink_metadata(&source_dir) {
+        // upstream: flist.c:1985 - send_implied_dirs() sets `copy_links =
+        // xfer_dirs = 1` around the ancestor loop, so the implied-parent stat
+        // FOLLOWS symlinks: a symlinked ancestor is emitted as a real directory
+        // (its `-i` itemize row and `--stats` dir count), matching the two
+        // protocol paths (generator/file_list/mod.rs:326,491). symlink_metadata
+        // reports a symlinked ancestor as a non-directory and drops it, losing
+        // the itemize row and the dir count. Best-effort: an ancestor that
+        // vanished or is not a directory is skipped silently.
+        let source_meta = match fs::metadata(&source_dir) {
             Ok(meta) if meta.file_type().is_dir() => meta,
             _ => continue,
         };

--- a/crates/engine/tests/relative_implied_parent_records.rs
+++ b/crates/engine/tests/relative_implied_parent_records.rs
@@ -148,3 +148,58 @@ fn no_implied_dirs_suppresses_rows_but_still_counts_ancestors() {
         "ancestors still ship in the flist at protocol >= 30, so they count"
     );
 }
+
+/// A `-R` operand whose implied ancestor is a SYMLINK to a directory:
+/// `<from>/./link/c.txt` where `link -> real`. Upstream sets
+/// `copy_links = xfer_dirs = 1` around the implied-ancestor loop
+/// (`flist.c:1985`), so a symlinked ancestor is FOLLOWED and emitted as a real
+/// directory - it earns an itemize row and counts under `--stats`. The
+/// local-copy executor previously stat'd ancestors with `symlink_metadata`,
+/// which reports the symlink as a non-directory and dropped it, losing the row
+/// and the dir count while still materialising the directory on disk.
+#[test]
+fn symlinked_implied_ancestor_is_followed_itemized_and_counted() {
+    let temp = tempdir().expect("tempdir");
+    let from = temp.path().join("from");
+    let to = temp.path().join("to");
+    let real = from.join("real");
+    fs::create_dir_all(&real).expect("create real dir");
+    fs::create_dir_all(&to).expect("create dest root");
+    fs::write(real.join("c.txt"), b"payload").expect("write leaf file");
+    std::os::unix::fs::symlink("real", from.join("link")).expect("symlink ancestor");
+
+    let mut operand = from.clone();
+    operand.push(".");
+    operand.push("link");
+    operand.push("c.txt");
+    let operands = vec![operand.into_os_string(), to.clone().into_os_string()];
+
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .collect_events(true);
+
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("relative copy succeeds");
+
+    // Data is unaffected: the leaf still lands under the followed ancestor.
+    assert!(to.join("link").join("c.txt").is_file());
+
+    let records = report.records();
+    let dir_paths: Vec<PathBuf> = records
+        .iter()
+        .filter(|r| is_created_dir(r))
+        .map(|r| r.relative_path().to_path_buf())
+        .collect();
+    assert_eq!(
+        dir_paths,
+        vec![PathBuf::from("link")],
+        "the symlinked ancestor must be followed and itemized as a created dir"
+    );
+
+    let summary = report.summary();
+    assert_eq!(summary.directories_created(), 1, "created dirs: link");
+    assert_eq!(summary.directories_total(), 1, "total dirs: link");
+}

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -88,6 +88,10 @@ impl GeneratorContext {
         // can find it via flist_find_name() (generator.c:1313). We track
         // emitted ancestors across sources to avoid duplicate entries.
         let mut implied_ancestors: HashSet<PathBuf> = HashSet::new();
+        // upstream: flist.c:2368 - a positional operand whose transmitted name
+        // begins with a bare `./` sets `implied_dot_dir`, which fires the
+        // synthetic `.` transfer-root emission below (once per build).
+        let mut implied_dot_dir = false;
         for base_path in base_paths {
             // upstream: flist.c:2338-2349 - non-relative mode splits each
             // positional on the LAST `/`: `dir = strrchr(fbuf, '/')` becomes
@@ -111,6 +115,13 @@ impl GeneratorContext {
             if !self.try_walk_source_entry(&base, &path)? {
                 continue;
             }
+            // upstream: flist.c:2368-2369 - the first operand whose relative
+            // name begins with a bare `./` arms `implied_dot_dir` (set after
+            // the operand's containing dir is validated, mirrored here by the
+            // successful walk above).
+            if relative_paths && !implied_dot_dir && operand_sets_implied_dot(base_path) {
+                implied_dot_dir = true;
+            }
             // upstream: flist.c:2257-2258 - `if (relative_paths &&
             // protocol_version >= 30) implied_dirs = 1;` forces the sender to
             // emit flagged implied parent dirs at protocol >= 30 regardless of
@@ -123,6 +134,33 @@ impl GeneratorContext {
             if relative_paths && (!self.config.flags.no_implied_dirs || self.protocol.as_u8() >= 30)
             {
                 self.emit_implied_parents(&base, &path, &mut implied_ancestors)?;
+            }
+        }
+
+        // upstream: flist.c:2417-2419 - a positional operand beginning with a
+        // bare `./` (implied_dot_dir) makes send_file_list() emit a single
+        // synthetic `.` transfer-root entry via
+        // send_file_name(".", ..., (flags | FLAG_IMPLIED_DIR) & ~FLAG_CONTENT_DIR).
+        // Upstream routes that call through send_file1(), which drops a
+        // directory when xfer_dirs is off (flist.c:2451, printing "skipping
+        // directory ."), so the `.` rides the wire ONLY when directories are
+        // transferred (`-r` / `-d` / list-only; --files-from forces xfer_dirs on
+        // and takes the build_file_list_with_base path instead). Mirror both:
+        // emit exactly once, gated on the same xfer_dirs condition. The `.` maps
+        // to the sender's current directory (the transfer root); mark it
+        // FLAG_IMPLIED_DIR with FLAG_CONTENT_DIR cleared so a real receiver does
+        // not scope `--delete` over the destination root. The post-loop sort
+        // orders it ahead of every other entry (flist.c f_name_cmp).
+        let xfer_dirs =
+            self.config.flags.recursive || self.config.flags.dirs || self.config.flags.list_only;
+        if implied_dot_dir && xfer_dirs {
+            let dot_root = Path::new(".");
+            if let Ok(meta) = std::fs::symlink_metadata(dot_root) {
+                if meta.is_dir() {
+                    let mut dot_entry = self.create_entry(dot_root, PathBuf::from("."), &meta)?;
+                    mark_implied_dir(&mut dot_entry);
+                    self.push_file_item(dot_entry, dot_root.to_path_buf());
+                }
             }
         }
 
@@ -549,6 +587,29 @@ fn relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
     (base, path.to_path_buf())
 }
 
+/// Returns true when a positional operand carries a bare leading `./` anchor
+/// that upstream's `implied_dot_dir` trigger recognises.
+///
+/// Upstream computes the operand's transmitted name `fn` - everything after the
+/// first `/./` split, with any leading slashes skipped - and fires when
+/// `*fn == '.' && fn[1] == '/' && fn[2]` (`flist.c:2364-2369`). A bare `.` or
+/// `./` (no third byte) does not qualify, matching `has_leading_dot_anchor` on
+/// the `--files-from` path.
+fn operand_sets_implied_dot(path: &Path) -> bool {
+    let Some(s) = path.as_os_str().to_str() else {
+        return false;
+    };
+    // upstream: flist.c:2351 - split on the first `/./`; the transmitted name is
+    // everything after it (leading slashes skipped). Without a `/./` the whole
+    // operand is the name.
+    let fn_part = match s.find("/./") {
+        Some(idx) => s[idx + 3..].trim_start_matches('/'),
+        None => s,
+    };
+    let b = fn_part.as_bytes();
+    b.len() > 2 && b[0] == b'.' && b[1] == b'/'
+}
+
 /// Locates the byte offset of `/./` in a path, used as the `--relative`
 /// anchor separator.
 fn find_dot_dir_anchor(path: &Path) -> Option<usize> {
@@ -601,3 +662,29 @@ fn non_relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
 
 #[cfg(test)]
 pub(super) use protocol::flist::apply_permutation_in_place;
+
+#[cfg(test)]
+mod implied_dot_tests {
+    use super::operand_sets_implied_dot;
+    use std::path::Path;
+
+    /// upstream: flist.c:2368-2369 - `implied_dot_dir` fires for a bare leading
+    /// `./` with content after it, whether the operand is bare or the remainder
+    /// of a `/./` split; it never fires for `.`/`./`, a plain relative name, an
+    /// absolute path, or a `/./` anchor whose remainder is a plain name.
+    #[test]
+    fn detects_leading_dot_anchor_like_upstream() {
+        for yes in ["./a", "./a/b/file", "./x/", "/abs/././x"] {
+            assert!(
+                operand_sets_implied_dot(Path::new(yes)),
+                "expected {yes:?} to arm implied_dot_dir"
+            );
+        }
+        for no in [".", "./", "a/b/file", "/abs/a/b/file", "/abs/./a/b/file"] {
+            assert!(
+                !operand_sets_implied_dot(Path::new(no)),
+                "expected {no:?} to NOT arm implied_dot_dir"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two narrow upstream-fidelity fixes for `-R`/`--relative` implied parents,
found by an implied-parent audit against rsync 3.4.4 (protocol 32).

### 1. Positional leading-`./` transfer-root entry (wire, generator path)

A positional operand that begins with a bare `./` (e.g. `-R ./a/b/file`) sets
upstream's `implied_dot_dir` and emits a synthetic `.` transfer-root entry via
`send_file_name(".", ..., (flags | FLAG_IMPLIED_DIR) & ~FLAG_CONTENT_DIR)`
(`flist.c:2417-2419`). Upstream routes that call through `send_file1()`, which
drops a directory when `xfer_dirs` is off (`flist.c:2451`, printing
`skipping directory .`), so the `.` rides the wire only when directories are
transferred (`-r` / `-d`).

oc's positional generator path (`build_file_list`) handled only the embedded
`/./` anchor and never a whole-operand leading `./`, so it dropped the `.`
root that upstream sends. The two other relative paths already emit it
(`--files-from` via `build_file_list_with_base`, local-copy via
`dot_dir_anchor`). The fix detects the leading `./` (mirroring upstream's
post-`/./`-split `fn` check), emits the `.` once per build gated on the same
`xfer_dirs` condition, and marks it `FLAG_IMPLIED_DIR` with `FLAG_CONTENT_DIR`
cleared so a real receiver does not scope `--delete` over the destination root.

### 2. Symlinked implied parent skipped in local-copy itemize/stats

Upstream sets `copy_links = xfer_dirs = 1` around the implied-ancestor loop
(`flist.c:1985`), so a symlinked ancestor is followed and emitted as a real
directory. The local-copy executor stat'd ancestors with `symlink_metadata`,
which reports a symlinked ancestor as a non-directory and dropped it - no `-i`
itemize row and no `--stats` dir count (the directory was still created on
disk, so data was unaffected). It now follows the symlink with `fs::metadata`,
matching the two protocol paths.

## Verification

Oracle diffs against `/usr/bin/rsync` 3.4.4 on Linux x86_64:

- `-R -r ./a/b/file` (ssh push to an upstream receiver): oc now emits
  `cd+++++++++ ./`, byte-identical to upstream; `-d` and `--list-only`
  likewise. Plain `-R` (no `xfer_dirs`) sends no `.` in either, matching the
  wire. A `/./`-anchored operand (no leading `./`) still emits no `.` -
  no regression.
- Real `-R -r --delete` push: destination trees identical and a stale
  root-level file is preserved by both (the `.` root does not scope deletion).
- `-R -r` local copy through a symlinked ancestor: oc now emits `cd link/`
  and reports `dir: 2`, identical to upstream.

## Tests

- `symlinked_implied_ancestor_is_followed_itemized_and_counted`
  (`crates/engine/tests/relative_implied_parent_records.rs`).
- `detects_leading_dot_anchor_like_upstream`
  (`crates/transfer/src/generator/file_list/mod.rs`).

`cargo fmt --all --check`, CI-exact `clippy` (workspace, all-targets,
all-features, `-D warnings`), and targeted `nextest` on `transfer` + `engine`
all pass.
