### PR TITLE
feat(receiver): sanitize + re-filter INC_RECURSE sub-list entries

### DIFF
--- a/crates/transfer/src/receiver/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/file_list/filter_recheck.rs
@@ -27,6 +27,7 @@ use std::io;
 use std::path::Path;
 
 use filters::{FilterSet, ImpliedIncludeOptions, ImpliedIncludes};
+use protocol::flist::FileEntry;
 
 use super::super::ReceiverContext;
 use crate::receiver::transfer::parse_wire_filters_for_receiver;
@@ -56,6 +57,19 @@ impl ReceiverContext {
     ///
     /// - `flist.c:1049-1052` `recv_file_entry()`
     pub(in crate::receiver) fn recheck_received_filter(&self) -> io::Result<()> {
+        self.recheck_received_filter_entries(&self.file_list)
+    }
+
+    /// Range-scoped variant of
+    /// [`recheck_received_filter`](Self::recheck_received_filter) that re-checks
+    /// only `entries` (an INC_RECURSE sub-list at `self.file_list[flat_start..]`),
+    /// so sub-list entries received on a pull get the same defense-in-depth as
+    /// the level-1 list. upstream: flist.c:1022 `recv_file_entry()` runs the
+    /// server-filter check for every received entry, including sub-lists.
+    pub(in crate::receiver) fn recheck_received_filter_entries(
+        &self,
+        entries: &[FileEntry],
+    ) -> io::Result<()> {
         // upstream: flist.c:1021 - `!trust_sender_filter` guards the whole
         // re-check (options.c:2512/main.c:1496 set it for local/--trust-sender).
         if self.config.trust_sender {
@@ -88,7 +102,7 @@ impl ReceiverContext {
             return Ok(());
         };
 
-        for entry in &self.file_list {
+        for entry in entries {
             let path = entry.path().as_path();
             // upstream: flist.c:1019 - the transfer root (`.` / `/.`) is never
             // re-checked. Cleared entries (empty name, mode 0) are no-ops.
@@ -153,6 +167,20 @@ impl ReceiverContext {
     /// - `exclude.c:379` `add_implied_include()` - rule construction.
     /// - `options.c:2510-2513` - `trust_sender_args` disables the mechanism.
     pub(in crate::receiver) fn recheck_received_implied_includes(&self) -> io::Result<()> {
+        self.recheck_received_implied_includes_entries(&self.file_list)
+    }
+
+    /// Range-scoped variant of
+    /// [`recheck_received_implied_includes`](Self::recheck_received_implied_includes)
+    /// that validates only `entries` (an INC_RECURSE sub-list at
+    /// `self.file_list[flat_start..]`) so sub-list entries get the same
+    /// CVE-2022-29154 defense as the level-1 list. upstream: flist.c:1026
+    /// `recv_file_entry()` runs the implied-include check for every received
+    /// entry, including sub-lists.
+    pub(in crate::receiver) fn recheck_received_implied_includes_entries(
+        &self,
+        entries: &[FileEntry],
+    ) -> io::Result<()> {
         // upstream: options.c:2510 / exclude.c:385 - trust_sender_args makes
         // add_implied_include() a no-op, leaving implied_filter_list empty.
         if self.config.trust_sender {
@@ -184,7 +212,7 @@ impl ReceiverContext {
             return Ok(());
         }
 
-        for entry in &self.file_list {
+        for entry in entries {
             let path = entry.path().as_path();
             // upstream: flist.c:1019 - the transfer root (`.` / `/.`) is exempt.
             if path.as_os_str().is_empty() || path == Path::new(".") {

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -377,6 +377,19 @@ impl ReceiverContext {
             let (cleaned, _clean) = sort_and_clean_file_list(tail, true, false, false, true);
             self.file_list.extend(cleaned);
         }
+
+        // INC_RECURSE-on-pull security prerequisite: mirror upstream
+        // recv_file_entry()'s per-entry defenses (flist.c:769-771 clean_fname /
+        // absolute-path, 1022-1024 server-filter, 1026-1028 implied-include) for
+        // every sub-list entry, not just the level-1 list validated in
+        // build_pipeline_setup(). Upstream aborts with exit_cleanup(RERR_UNSUPPORTED)
+        // per offending entry; we abort too, so no Vec compaction runs on the
+        // multi-segment file_list (which would desync ndx_segments flat-starts).
+        // Runs after the per-segment sort/clean so the entries examined are final.
+        self.sanitize_segment_paths(flat_start)?;
+        self.recheck_received_filter_entries(&self.file_list[flat_start..])?;
+        self.recheck_received_implied_includes_entries(&self.file_list[flat_start..])?;
+
         match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);
 
         // Normalize pre-30 hardlinks in this segment.

--- a/crates/transfer/src/receiver/file_list/sanitize.rs
+++ b/crates/transfer/src/receiver/file_list/sanitize.rs
@@ -5,6 +5,8 @@
 //! components, and (on Windows) drive/UNC prefixes are stripped from the
 //! file list before any disk operation runs against them.
 
+use std::io;
+
 use logging::info_log;
 
 use super::super::ReceiverContext;
@@ -111,5 +113,87 @@ impl ReceiverContext {
         }
 
         removed
+    }
+
+    /// Segment-scoped, abort-based path-safety check for an INC_RECURSE sub-list
+    /// occupying `self.file_list[flat_start..]`.
+    ///
+    /// Unlike [`sanitize_file_list`](Self::sanitize_file_list) - which runs once
+    /// on the level-1 list and drops offending entries - sub-list entries mirror
+    /// upstream `recv_file_entry()` (flist.c:769-771), which calls
+    /// `exit_cleanup(RERR_UNSUPPORTED)` on the first entry carrying a `..`
+    /// component, an absolute path (without `--relative`), or (on Windows) a
+    /// drive/UNC prefix. Aborting rather than dropping is also required for
+    /// correctness on a multi-segment `file_list`: a `Vec::retain()` compaction
+    /// would shift every later segment's entries and desync the `ndx_segments`
+    /// flat-start bookkeeping. The `--relative` leading-slash strip is an
+    /// in-place mutation (no removal) and is always segment-safe.
+    ///
+    /// Returns [`io::ErrorKind::Unsupported`] so the error maps to
+    /// `RERR_UNSUPPORTED` (exit 4), matching upstream.
+    pub(in crate::receiver) fn sanitize_segment_paths(
+        &mut self,
+        flat_start: usize,
+    ) -> io::Result<()> {
+        let relative_paths = self.config.flags.relative;
+
+        if !self.config.trust_sender {
+            for entry in &self.file_list[flat_start..] {
+                let path = entry.path();
+
+                // upstream: flist.c:769 `!relative_paths && *thisname == '/'`
+                if !relative_paths && path.has_root() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "ABORTING due to unsafe pathname from sender: {}",
+                            path.display()
+                        ),
+                    ));
+                }
+
+                // Windows-only drive/UNC prefix - same rationale as
+                // sanitize_file_list; joining such a path onto dest_dir escapes
+                // the destination tree.
+                #[cfg(windows)]
+                if path
+                    .components()
+                    .next()
+                    .is_some_and(|c| matches!(c, std::path::Component::Prefix(_)))
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "ABORTING due to unsafe pathname from sender: {}",
+                            path.display()
+                        ),
+                    ));
+                }
+
+                // upstream: flist.c:769 clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS) < 0
+                if path_contains_dot_dot(path) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "ABORTING due to unsafe pathname from sender: {}",
+                            path.display()
+                        ),
+                    ));
+                }
+            }
+        }
+
+        // upstream: flist.c:3106-3119 strip_root in flist_sort_and_clean() -
+        // leading-slash stripping is a functional requirement for --relative,
+        // applied in place (no removal, segment-safe).
+        if relative_paths {
+            for entry in &mut self.file_list[flat_start..] {
+                if entry.path().has_root() {
+                    entry.strip_leading_slashes();
+                }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/sanitize_file_list.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/sanitize_file_list.rs
@@ -209,3 +209,89 @@ fn windows_drive_relative_path_allowed_when_trusted() {
     assert_eq!(removed, 0);
     assert_eq!(ctx.file_list.len(), 2);
 }
+
+// --- sanitize_segment_paths: per-INC_RECURSE-sub-list, abort-based variant. ---
+// Unlike sanitize_file_list (level-1, drop-and-continue), sub-list entries
+// mirror upstream recv_file_entry (flist.c:769-771): the first unsafe path
+// ABORTS with RERR_UNSUPPORTED so no Vec compaction runs on the multi-segment
+// file_list. These drive the check in isolation (no live peer needed).
+
+#[test]
+fn segment_absolute_path_aborts_when_untrusted() {
+    let entries = vec![
+        FileEntry::new_file("safe.txt".into(), 10, 0o644),
+        FileEntry::new_file("/etc/passwd".into(), 20, 0o644),
+    ];
+    let mut ctx = receiver_with_trust(entries, false);
+    let err = ctx.sanitize_segment_paths(0).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+    // Aborts, never drops: the segment stays intact for teardown.
+    assert_eq!(ctx.file_list.len(), 2);
+}
+
+#[test]
+fn segment_dot_dot_path_aborts_when_untrusted() {
+    let entries = vec![
+        FileEntry::new_file("ok.txt".into(), 10, 0o644),
+        FileEntry::new_file("sub/../../escape.txt".into(), 20, 0o644),
+    ];
+    let mut ctx = receiver_with_trust(entries, false);
+    let err = ctx.sanitize_segment_paths(0).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+    assert_eq!(ctx.file_list.len(), 2);
+}
+
+#[test]
+fn segment_safe_paths_ok_when_untrusted() {
+    let entries = vec![
+        FileEntry::new_file("dir/a.txt".into(), 10, 0o644),
+        FileEntry::new_file("dir/b.txt".into(), 20, 0o644),
+    ];
+    let mut ctx = receiver_with_trust(entries, false);
+    assert!(ctx.sanitize_segment_paths(0).is_ok());
+}
+
+#[test]
+fn segment_checks_skipped_when_trusted() {
+    let entries = vec![
+        FileEntry::new_file("/abs".into(), 10, 0o644),
+        FileEntry::new_file("../dotdot".into(), 20, 0o644),
+    ];
+    let mut ctx = receiver_with_trust(entries, true);
+    assert!(ctx.sanitize_segment_paths(0).is_ok());
+    assert_eq!(ctx.file_list.len(), 2);
+}
+
+#[test]
+fn segment_range_scoped_ignores_entries_before_flat_start() {
+    // A `..` entry BEFORE flat_start (an earlier, already-validated segment)
+    // must not be re-examined: only file_list[flat_start..] is checked.
+    let entries = vec![
+        FileEntry::new_file("../earlier_segment_entry".into(), 10, 0o644),
+        FileEntry::new_file("current/ok.txt".into(), 20, 0o644),
+    ];
+    let mut ctx = receiver_with_trust(entries, false);
+    assert!(ctx.sanitize_segment_paths(1).is_ok());
+}
+
+#[test]
+fn segment_relative_strips_leading_slash_in_range_only() {
+    let entries = vec![
+        FileEntry::new_file("/before.txt".into(), 10, 0o644),
+        FileEntry::new_file("/after.txt".into(), 20, 0o644),
+    ];
+    let mut ctx = receiver_with_trust_and_relative(entries, false);
+    assert!(ctx.sanitize_segment_paths(1).is_ok());
+    // Entry before flat_start is untouched; the in-range one is stripped.
+    assert!(ctx.file_list[0].path().has_root());
+    assert!(!ctx.file_list[1].path().has_root());
+}
+
+#[cfg(windows)]
+#[test]
+fn segment_windows_drive_prefix_aborts_when_untrusted() {
+    let entries = vec![FileEntry::new_file("C:foo".into(), 20, 0o644)];
+    let mut ctx = receiver_with_trust(entries, false);
+    let err = ctx.sanitize_segment_paths(0).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+}


### PR DESCRIPTION
## Summary

Extends the receiver's per-entry file-list defenses to every INC_RECURSE
sub-list, not just the level-1 list validated in `build_pipeline_setup()`.
This is the security prerequisite for enabling INC_RECURSE reception on a pull:
today the receiver never negotiates INC_RECURSE on the receive path, so it holds
the whole flist as one segment; a follow-up will enable per-segment reception,
at which point sub-list entries must get the same validation the level-1 list
already receives.

Upstream `recv_file_entry()` runs the absolute-path/`..`, server-filter, and
implied-include checks for **every** received entry — including sub-lists — and
aborts with `RERR_UNSUPPORTED` on a violation (`flist.c:769-771,1022-1028`).
`receive_one_extra_segment()` now mirrors that over each newly received segment:

- `sanitize_segment_paths()` — abort-based path safety (absolute, `..`, Windows
  drive/UNC prefix) plus the in-place `--relative` leading-slash strip. Aborting
  rather than dropping mirrors upstream **and** is required for correctness on a
  multi-segment list: a `Vec::retain()` compaction would shift later segments and
  desync the `ndx_segments` flat-start bookkeeping.
- `recheck_received_filter_entries()` / `recheck_received_implied_includes_entries()`
  — range-scoped variants of the existing whole-list re-checks (the no-arg
  versions now delegate to them over the full list, behaviour unchanged).

Wire-neutral while INC_RECURSE-on-pull stays disabled (the segment path is not
driven on a pull yet).

## Tests

Adds isolation tests that drive the segment checks directly (no live peer): a
`..` and an absolute path each abort with `Unsupported`, safe paths pass, the
checks are skipped when `trust_sender`, the check is range-scoped (entries before
`flat_start` are not re-examined), the `--relative` strip is range-scoped, and a
Windows drive-prefix aborts.

## Verification (x86_64 Linux, rustc 1.88.0)

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p transfer --all-targets --all-features --no-deps -- -D warnings`: clean
- `cargo nextest run -p transfer` (segment/sanitize/recheck/filter selector): 187 passed, 0 failed

Note: the real-daemon integration test `daemon_pull_forced_verification_failure_recovers_via_redo`
failed on the shared local host with an environmental truncated-frame error; it
is a daemon-pull test that executes none of this change's code (the segment path
is not reached on a pull) and passes in CI. Relying on CI's clean environment for
that cell.
