### PR TITLE
fix(flist): report "skipping directory ." for a dropped -R dot root

### DIFF
--- a/crates/cli/tests/relative_dot_root_skipped_directory.rs
+++ b/crates/cli/tests/relative_dot_root_skipped_directory.rs
@@ -1,0 +1,147 @@
+//! A positional leading-`./` `-R` operand reports `skipping directory .` when
+//! directories are not being transferred.
+//!
+//! Upstream arms `implied_dot_dir` for an operand whose transmitted name starts
+//! with a bare `./` and then injects a synthetic transfer-root entry with
+//! `send_file_name(f, flist, ".", NULL, (flags | FLAG_IMPLIED_DIR) &
+//! ~FLAG_CONTENT_DIR, ALL_FILTERS)` (`flist.c:2417-2419`). That call reaches
+//! `make_file()`, whose directory branch is
+//!
+//! ```c
+//! if (S_ISDIR(st.st_mode)) {
+//!         if (!xfer_dirs) {
+//!                 rprintf(FINFO, "skipping directory %s\n", thisname);
+//!                 return NULL;
+//!         }
+//! ```
+//!
+//! (`flist.c:1336-1340`). `thisname` is the cleaned name handed in, so the text
+//! is exactly `skipping directory .` - a bare `.`, unquoted, no trailing slash
+//! and no "(no recursion)" suffix. Returning NULL also keeps the `.` out of the
+//! file list entirely, so it must not be counted under `--stats`.
+//!
+//! `xfer_dirs` resolves to `recurse || -d`, falling back to `list_only` when
+//! neither was given (`options.c:2197-2203`); `--files-from` forces it on
+//! (`options.c:2190-2191`). The implied ancestors of the operand are emitted
+//! either way, because `send_implied_dirs()` sets `copy_links = xfer_dirs = 1`
+//! for the duration of its loop (`flist.c:1982-2012`).
+//!
+//! Expectations below were captured from rsync 3.4.4 (protocol 32) run in the
+//! same layout: `rsync -Rv ./sub/f.txt dst/` prints `skipping directory .`,
+//! `sub/`, `sub/f.txt`, and `rsync -R --stats ./sub/f.txt dst/` reports
+//! `Number of files: 2 (reg: 1, dir: 1)`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+use test_support::oc_rsync_bin;
+
+/// Creates `src/sub/f.txt` plus an empty `dst/` and returns the temp root.
+fn dot_root_tree() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join("src/sub")).expect("source tree");
+    fs::create_dir_all(tmp.path().join("dst")).expect("destination root");
+    fs::write(tmp.path().join("src/sub/f.txt"), b"hi\n").expect("leaf file");
+    tmp
+}
+
+/// Runs `oc-rsync` from inside `src/` (so the operand really is a relative
+/// `./...` path, the only form that arms upstream's `implied_dot_dir`) and
+/// returns its stdout.
+fn run_from_source(root: &Path, args: &[&str]) -> String {
+    let mut cmd = Command::new(oc_rsync_bin());
+    cmd.current_dir(root.join("src"));
+    cmd.args(args);
+    let mut destination = root.join("dst").into_os_string();
+    destination.push("/");
+    cmd.arg(destination);
+    let output = cmd.output().expect("spawn oc-rsync");
+    assert!(
+        output.status.success(),
+        "oc-rsync {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("stdout is utf-8")
+}
+
+/// The upstream text, verbatim. A drift in wording, quoting or the printed name
+/// breaks this and every downstream log scraper that greps for it.
+const SKIP_LINE: &str = "skipping directory .";
+
+/// Without `-r`/`-d` the synthetic `.` transfer root is dropped and announced,
+/// while the operand's implied ancestor still ships. The line must lead the
+/// listing: upstream prints it from `send_file_list()`, before any name row.
+#[test]
+fn leading_dot_operand_without_xfer_dirs_reports_skipping_directory_dot() {
+    let tmp = dot_root_tree();
+    let stdout = run_from_source(tmp.path(), &["-Rv", "./sub/f.txt"]);
+
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines.first().copied(),
+        Some(SKIP_LINE),
+        "rsync 3.4.4 leads with {SKIP_LINE:?} for `-Rv ./sub/f.txt`, got: {stdout}"
+    );
+    assert_eq!(
+        &lines[1..3],
+        ["sub/", "sub/f.txt"],
+        "the implied ancestor and the leaf must still be listed: {stdout}"
+    );
+
+    // The skip is announced, not enforced: the payload still lands.
+    assert_eq!(
+        fs::read(tmp.path().join("dst/sub/f.txt")).expect("leaf copied"),
+        b"hi\n"
+    );
+}
+
+/// `make_file()` returns NULL for the skipped `.`, so it never enters the file
+/// list and must not inflate the `--stats` directory tally. rsync 3.4.4 reports
+/// `dir: 1` here (the implied ancestor `sub` only).
+#[test]
+fn skipped_dot_root_is_not_counted_in_stats() {
+    let tmp = dot_root_tree();
+    let stdout = run_from_source(tmp.path(), &["-R", "--stats", "./sub/f.txt"]);
+
+    assert!(
+        stdout.contains("Number of files: 2 (reg: 1, dir: 1)"),
+        "the dropped `.` must not be counted; rsync 3.4.4 reports dir: 1: {stdout}"
+    );
+}
+
+/// `-r` and `-d` both turn `xfer_dirs` on, so the `.` rides the file list and
+/// nothing is skipped. Guards against emitting the notice unconditionally.
+#[test]
+fn xfer_dirs_suppresses_the_skip_notice() {
+    for flag in ["-r", "-d"] {
+        let tmp = dot_root_tree();
+        let stdout = run_from_source(tmp.path(), &["-Rv", flag, "./sub/f.txt"]);
+        assert!(
+            !stdout.contains("skipping directory"),
+            "{flag} enables xfer_dirs, so upstream skips nothing: {stdout}"
+        );
+    }
+}
+
+/// An operand without the bare leading `./` never arms `implied_dot_dir`, so
+/// there is no `.` entry to skip and no notice - even though `xfer_dirs` is
+/// still off. Guards against keying the notice on `!xfer_dirs` alone.
+#[test]
+fn operand_without_leading_dot_reports_nothing() {
+    let tmp = dot_root_tree();
+    let stdout = run_from_source(tmp.path(), &["-Rv", "sub/f.txt"]);
+
+    assert!(
+        !stdout.contains("skipping directory"),
+        "no leading `./` means no implied `.` root to skip: {stdout}"
+    );
+    assert_eq!(
+        stdout.lines().take(2).collect::<Vec<_>>(),
+        ["sub/", "sub/f.txt"],
+        "the ancestor and leaf listing is unchanged: {stdout}"
+    );
+}

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -890,7 +890,8 @@ fn emit_relative_implied_parents(
 
     // Dot-dir transfer root ".": upstream flist.c:2368+2417-2419 injects a
     // synthetic "." entry into the flist only for an operand that *begins* with
-    // `./` (`implied_dot_dir`), so it counts toward "Number of files". A dot in
+    // `./` (`implied_dot_dir`), so it counts toward "Number of files" whenever
+    // directories are being transferred (the `xfer_dirs` gate below). A dot in
     // the middle of the path (e.g. `src/./sub`) reroots the relative path but
     // adds no "." entry. `dot_dir_anchor()` returns "." exactly for the leading
     // form (its prefix-skip is zero). The receiver never itemizes the
@@ -901,39 +902,60 @@ fn emit_relative_implied_parents(
     if source.dot_dir_anchor().as_deref() == Some(Path::new(".")) {
         let dot = PathBuf::from(".");
         if context.mark_implied_dir_emitted(&dot) {
-            context.record_file_list_entry(non_empty_path(dot.as_path()));
-            context.summary_mut().record_directory_total();
+            // upstream: flist.c:2419 routes the synthetic "." through
+            // send_file_name() -> make_file(), whose `if (S_ISDIR(st.st_mode))
+            // { if (!xfer_dirs) { rprintf(FINFO, "skipping directory %s\n",
+            // thisname); return NULL; } }` (flist.c:1336-1340) drops it when
+            // directories are not being transferred. `thisname` is the
+            // cleaned name passed in, so the text is exactly
+            // `skipping directory .`. A NULL from make_file means no flist
+            // entry at all: the "." is neither sized into the flist nor
+            // counted under "Number of files (dir: N)".
+            //
+            // upstream: options.c:2197-2203 resolves `xfer_dirs` to
+            // `recurse || -d || (list_only when neither was given)`;
+            // options.c:2190-2191 forces it on for --files-from, which takes
+            // the operand's own path and never reaches this branch.
+            let xfer_dirs = context.recursive_enabled()
+                || context.dirs_enabled()
+                || context.list_only_enabled();
+            if xfer_dirs {
+                context.record_file_list_entry(non_empty_path(dot.as_path()));
+                context.summary_mut().record_directory_total();
 
-            // The leading-dot "." maps to the destination transfer root. When
-            // that root is freshly created this run, upstream itemizes it
-            // `cd+++++++++ ./` and counts it as a created dir (main.c:803-808);
-            // a pre-existing root stays count-only (unchanged, suppressed under
-            // -i). `--no-implied-dirs` (itemize == false) drops both. In dry-run
-            // the mkdir is elided, so "would create" is inferred from the root's
-            // absence on disk. The itemize row snapshots the source anchor dir,
-            // which exists in both modes (the destination may not yet).
-            let root_created = destination_root_created
-                || (context.mode().is_dry_run() && !destination_path.exists());
-            if root_created
-                && itemize
-                && let Some(anchor) = source.dot_dir_anchor()
-                && let Ok(meta) = fs::symlink_metadata(&anchor)
-                && meta.file_type().is_dir()
-            {
-                context.summary_mut().record_directory();
-                let snapshot = LocalCopyMetadata::from_metadata(&meta, None);
-                let snapshot_len = snapshot.len();
-                context.record(
-                    LocalCopyRecord::new(
-                        dot.clone(),
-                        LocalCopyAction::DirectoryCreated,
-                        0,
-                        Some(snapshot_len),
-                        Duration::default(),
-                        Some(snapshot),
-                    )
-                    .with_creation(true),
-                );
+                // The leading-dot "." maps to the destination transfer root. When
+                // that root is freshly created this run, upstream itemizes it
+                // `cd+++++++++ ./` and counts it as a created dir (main.c:803-808);
+                // a pre-existing root stays count-only (unchanged, suppressed under
+                // -i). `--no-implied-dirs` (itemize == false) drops both. In dry-run
+                // the mkdir is elided, so "would create" is inferred from the root's
+                // absence on disk. The itemize row snapshots the source anchor dir,
+                // which exists in both modes (the destination may not yet).
+                let root_created = destination_root_created
+                    || (context.mode().is_dry_run() && !destination_path.exists());
+                if root_created
+                    && itemize
+                    && let Some(anchor) = source.dot_dir_anchor()
+                    && let Ok(meta) = fs::symlink_metadata(&anchor)
+                    && meta.file_type().is_dir()
+                {
+                    context.summary_mut().record_directory();
+                    let snapshot = LocalCopyMetadata::from_metadata(&meta, None);
+                    let snapshot_len = snapshot.len();
+                    context.record(
+                        LocalCopyRecord::new(
+                            dot.clone(),
+                            LocalCopyAction::DirectoryCreated,
+                            0,
+                            Some(snapshot_len),
+                            Duration::default(),
+                            Some(snapshot),
+                        )
+                        .with_creation(true),
+                    );
+                }
+            } else {
+                context.record_skipped_directory(non_empty_path(dot.as_path()));
             }
         }
     }


### PR DESCRIPTION
## Problem

A positional `-R` operand whose transmitted name begins with a bare `./` arms upstream's `implied_dot_dir` and injects a synthetic transfer-root entry:

```c
if (implied_dot_dir < 0) {
        implied_dot_dir = 1;
        send_file_name(f, flist, ".", NULL, (flags | FLAG_IMPLIED_DIR) & ~FLAG_CONTENT_DIR, ALL_FILTERS);
}
```
(`flist.c:2417-2419`)

`send_file_name()` hands `"."` to `make_file()`, which drops any directory - and says so - when directories are not being transferred:

```c
if (S_ISDIR(st.st_mode)) {
        if (!xfer_dirs) {
                rprintf(FINFO, "skipping directory %s\n", thisname);
                return NULL;
        }
```
(`flist.c:1336-1340`)

`thisname` is the cleaned name handed in, so the text is exactly `skipping directory .` - a bare `.`, unquoted, no trailing slash, no `(no recursion)` suffix. The `NULL` return also keeps the entry out of the file list entirely, so it must not be counted.

`xfer_dirs` resolves to `recurse || -d`, falling back to `list_only` when neither was given (`options.c:2197-2203`); `--files-from` forces it on (`options.c:2190-2191`).

The local-copy executor recorded the `.` transfer root unconditionally. Two divergences followed for `-R ./sub/f.txt dst/` without `-r`/`-d`:

| | rsync 3.4.4 | oc-rsync (before) |
|---|---|---|
| `-Rv` first line | `skipping directory .` | *(absent)* |
| `-R --stats` | `Number of files: 2 (reg: 1, dir: 1)` | `Number of files: 3 (reg: 1, dir: 2)` |

## Fix

Gate the synthetic `.` entry on the same `xfer_dirs` condition and record a skipped-directory row otherwise. The row flows through the client's existing `skipping directory <name>` renderer - no second rendering path is added.

The operand's implied ancestors are untouched: `send_implied_dirs()` sets `copy_links = xfer_dirs = 1` for the duration of its loop (`flist.c:1982-2012`), so `sub/` ships either way.

## Verification against rsync 3.4.4

`rsync -Rv ./sub/f.txt dst/` and `oc-rsync -Rv ./sub/f.txt dst/` now agree line for line:

```
skipping directory .
sub/
sub/f.txt
```

`-R --stats` reports `Number of files: 2 (reg: 1, dir: 1)` on both. `-Rrv`, `-Rdv`, a mid-path `/./` anchor and an operand without the leading `./` are all unchanged.

## Tests

`crates/cli/tests/relative_dot_root_skipped_directory.rs` drives the real binary from inside the source directory (the only way to give it a genuinely relative `./` operand) and pins:

- the exact text and its leading position in the listing;
- that the dropped `.` is not counted under `--stats`;
- that `-r` and `-d` suppress the notice (guards against emitting it unconditionally);
- that an operand without the leading `./` reports nothing (guards against keying on `!xfer_dirs` alone).

Every expectation was captured from rsync 3.4.4 run in the same layout.

## Follow-ups found but not addressed here

- `skipping directory` is `FINFO` upstream (printed unless `--quiet`), but oc renders it only under `-v`. This affects the pre-existing directory-operand case identically and needs `quiet` plumbed into the renderer, so it is left for a separate change.
- The local-copy operand parser recognises the leading-`./` form only when the operand itself starts with `./`; upstream also arms `implied_dot_dir` for `<dir>/././a/b/c.txt` (the remainder after the first `/./` starts with `./`). The generator's `operand_sets_implied_dot` already handles that form, so the two paths disagree.
- `-R --list-only ./sub/f.txt` omits the `.` row that upstream lists.
