### PR TITLE
fix(cli): one match_report total: emitter with upstream gate + counters

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -159,9 +159,7 @@ where
     let is_local_transfer = !config.is_pull() && !is_sender;
     // upstream: main.c:650-653 forces whole_file=1 for a local transfer unless
     // the user passed --[no-]whole-file; the local-copy default is therefore
-    // whole-file. This decides the `delta-transmission` wording and gates the
-    // `total:` line (whose zero match counts are only provable in whole-file
-    // mode).
+    // whole-file. This decides the `delta-transmission` wording.
     let whole_file = config.whole_file();
     // upstream: generator.c:2291-2294 + match.c:439-446 - the delta-transmission
     // notice fires at DEBUG_GTE(FLIST, 1) and the match_report `total:` line at
@@ -175,7 +173,11 @@ where
     };
     let delta_notice = DeltaTransmissionSummary {
         notice: (is_local_transfer && debug_gte(DebugFlag::Flist, 1)).then_some(delta_state),
-        emit_total: is_local_transfer && whole_file && debug_gte(DebugFlag::Deltasum, 1),
+        // upstream: match_report() (match.c:440) is gated on DEBUG_GTE(DELTASUM, 1)
+        // alone - `--whole-file` does not suppress it, it just leaves the match
+        // counters at zero. MEASURED against rsync 3.4.4: both `-rvv` and
+        // `-rvv --no-whole-file` print the line.
+        emit_total: is_local_transfer && debug_gte(DebugFlag::Deltasum, 1),
     };
     // Capture the preserve-links state before `config` is consumed so the
     // `--list-only` renderer knows whether to append the ` -> <target>` arrow

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -91,9 +91,9 @@ pub(crate) struct DeltaTransmissionSummary {
     /// a local transfer. upstream: generator.c:2291-2294.
     pub notice: Option<DeltaTransmissionState>,
     /// Whether to print the `match_report()` `total:` line after the name list.
-    /// `true` only at `DEBUG_GTE(DELTASUM, 1)` on a whole-file local transfer,
-    /// where every match count is provably zero and `data` is the literal bytes
-    /// copied (read from the summary). upstream: match.c:439-446.
+    /// `true` at `DEBUG_GTE(DELTASUM, 1)` on a local transfer, whole-file or
+    /// not; the counters and `data` are read from the summary.
+    /// upstream: match.c:439-446.
     pub emit_total: bool,
 }
 
@@ -279,14 +279,25 @@ pub(crate) fn emit_transfer_summary(
 
     // upstream: match.c:439-446 match_report() - the sender prints the
     // cumulative match totals once at DEBUG_GTE(DELTASUM, 1) (first active at
-    // -vv) after send_files() finishes and before output_summary(). On a
-    // whole-file local transfer no block matching runs, so matches, hash_hits
-    // and false_alarms are all zero; `data` is the literal bytes copied, which
-    // upstream renders with big_num() (plain digits, no separator: inums.h:19).
+    // -vv) after send_files() finishes (sender.c:491) and before
+    // output_summary(). The gate is the debug level alone: a whole-file
+    // transfer still prints the line, with the match counters left at their
+    // zero initial values. `data` is the cumulative literal-byte count
+    // (`stats.literal_data`), which upstream renders with big_num() (plain
+    // digits, no separator: inums.h:19).
+    //
+    // This is the sole `total:` emitter. Upstream prints it from exactly one
+    // place; oc renders the local-copy name list post-hoc, so emitting it here
+    // is what puts it at upstream's position (after the name list, before the
+    // summary trailer) instead of dead-last through the deferred diagnostic
+    // flush.
     if delta_notice.emit_total {
         writeln!(
             writer,
-            "total: matches=0  hash_hits=0  false_alarms=0 data={}",
+            "total: matches={}  hash_hits={}  false_alarms={} data={}",
+            summary.delta_matches(),
+            summary.delta_hash_hits(),
+            summary.delta_false_alarms(),
             summary.bytes_copied()
         )?;
     }

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -453,6 +453,95 @@ fn level_2_local_brackets_name_list_with_delta_and_total() {
     );
 }
 
+/// A local `--no-whole-file` transfer must print the same single `total:` line,
+/// carrying the delta matcher's REAL counters rather than hardcoded zeros.
+///
+/// upstream: `match_report()` (match.c:439-448) is gated on
+/// `DEBUG_GTE(DELTASUM, 1)` alone - `--whole-file` does not suppress the line,
+/// it merely leaves the counters at zero. Two regressions this pins, both of
+/// which oc has actually shipped:
+///
+/// 1. Gating the emitter on whole-file mode, which dropped the line entirely
+///    from every `--no-whole-file` local transfer.
+/// 2. Hardcoding `matches=0  hash_hits=0  false_alarms=0`, which is only ever
+///    correct when no block matching ran.
+///
+/// MEASURED against upstream rsync 3.4.4 on this exact fixture (700 'A' + 700
+/// 'B' basis, 700 'A' + 700 'C' source):
+///
+/// ```text
+/// total: matches=1  hash_hits=1  false_alarms=0 data=700
+/// ```
+///
+/// The exactly-once assertion is the guard against a second emitter: upstream
+/// prints the line from one place (sender.c:491), so any additional oc-side
+/// emitter - for example an engine `debug_log!` flushed dead-last - must fail
+/// here rather than silently duplicate or displace the line.
+#[test]
+fn level_2_local_delta_total_reports_real_match_counters() {
+    use filetime::{FileTime, set_file_mtime};
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source = tmp.path().join("src");
+    let destination = tmp.path().join("dst");
+    std::fs::create_dir(&source).expect("mkdir src");
+    std::fs::create_dir(&destination).expect("mkdir dst");
+
+    // Basis = 700 'A' + 700 'B'; source = 700 'A' + 700 'C'. The leading block
+    // is reusable, so the matcher confirms exactly one match and sends the
+    // changed 700-byte suffix as literal data.
+    let mut basis = vec![b'A'; 700];
+    basis.extend(std::iter::repeat_n(b'B', 700));
+    let mut updated = vec![b'A'; 700];
+    updated.extend(std::iter::repeat_n(b'C', 700));
+    std::fs::write(destination.join("f.bin"), &basis).expect("write basis");
+    // Backdate the basis so the quick-check (same size + mtime) cannot skip it.
+    set_file_mtime(destination.join("f.bin"), FileTime::from_unix_time(1, 0))
+        .expect("backdate basis");
+    std::fs::write(source.join("f.bin"), &updated).expect("write source");
+
+    let mut src_arg = source.clone().into_os_string();
+    src_arg.push("/");
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-r"),
+        OsString::from("-vv"),
+        OsString::from("--no-whole-file"),
+        src_arg,
+        destination.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rendered = String::from_utf8(stdout).expect("utf8");
+
+    let total = rendered
+        .find("total: matches=1  hash_hits=1  false_alarms=0 data=700")
+        .unwrap_or_else(|| panic!("missing or malformed delta total: line, got: {rendered:?}"));
+    let name = rendered
+        .rfind("f.bin")
+        .unwrap_or_else(|| panic!("missing name list, got: {rendered:?}"));
+    let sent = rendered
+        .find("\nsent ")
+        .unwrap_or_else(|| panic!("missing summary trailer, got: {rendered:?}"));
+    assert!(
+        name < total && total < sent,
+        "total: line must follow the name list and precede the summary trailer, \
+         got: {rendered:?}"
+    );
+    assert_eq!(
+        rendered.matches("total: matches=").count(),
+        1,
+        "the match_report total: line must be emitted exactly once, got: {rendered:?}"
+    );
+
+    assert_eq!(
+        std::fs::read(destination.join("f.bin")).expect("read dest"),
+        updated,
+        "the delta must still reconstruct the file byte-exactly"
+    );
+}
+
 /// Verifies that -vvv produces output that is at least as verbose as -vv.
 /// It should still contain the descriptor prefix and totals.
 #[test]

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -317,6 +317,34 @@ impl ClientSummary {
         self.stats.matched_bytes()
     }
 
+    /// Returns the number of basis blocks the delta matcher reused, reported as
+    /// `matches=` on the `-vv` `total:` line.
+    ///
+    /// upstream: `match.c:435` `total_matches`, printed by `match_report()`
+    /// (`match.c:439`).
+    #[must_use]
+    pub const fn delta_matches(&self) -> u64 {
+        self.stats.delta_matches()
+    }
+
+    /// Returns the delta matcher's cumulative hash hits, reported as
+    /// `hash_hits=` on the `-vv` `total:` line.
+    ///
+    /// upstream: `match.c:433` `total_hash_hits`.
+    #[must_use]
+    pub const fn delta_hash_hits(&self) -> u64 {
+        self.stats.delta_hash_hits()
+    }
+
+    /// Returns the delta matcher's cumulative false alarms, reported as
+    /// `false_alarms=` on the `-vv` `total:` line.
+    ///
+    /// upstream: `match.c:434` `total_false_alarms`.
+    #[must_use]
+    pub const fn delta_false_alarms(&self) -> u64 {
+        self.stats.delta_false_alarms()
+    }
+
     /// Returns the aggregate number of bytes received during the transfer.
     #[must_use]
     pub const fn bytes_received(&self) -> u64 {

--- a/crates/engine/src/delta/mod.rs
+++ b/crates/engine/src/delta/mod.rs
@@ -22,7 +22,8 @@
 /// - [`generate_delta`] is the high-level convenience wrapper around
 ///   [`DeltaGenerator`].
 pub use matching::{
-    DeltaGenerator, DeltaScript, DeltaSignatureIndex, DeltaToken, apply_delta, generate_delta,
+    DeltaGenerator, DeltaScript, DeltaSignatureIndex, DeltaToken, ProbeCounters, apply_delta,
+    generate_delta,
 };
 
 /// Signature-layout primitives mirroring upstream `generator.c:sum_sizes_sqroot()`.

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -42,7 +42,7 @@ use super::{
     trace_make_backup_hlink, trace_make_backup_rename, trace_make_backup_symlink,
     write_sparse_chunk,
 };
-use crate::delta::DeltaSignatureIndex;
+use crate::delta::{DeltaSignatureIndex, ProbeCounters};
 use crate::signature::SignatureBlock;
 use ::metadata::{
     MetadataOptions, apply_file_metadata_with_options, apply_symlink_metadata_with_options,

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -112,6 +112,13 @@ impl<'a> CopyContext<'a> {
         let mut compressed_progress = 0u64;
         let mut total_bytes = 0u64;
         let mut literal_bytes = 0u64;
+        // upstream: match.c:363-366 match_sums() zeroes the per-file counters
+        // before scanning; the loop tallies confirmed matches inline and
+        // hash_hits/false_alarms through the counted probe, folded into the run
+        // totals at the end for the `-vv` `total:` line (match.c:439
+        // match_report()).
+        let mut probe = ProbeCounters::default();
+        let mut file_matches = 0u64;
         let mut sparse_state = SparseWriteState::default();
         sparse_state.set_preallocated_len(preallocated_len);
         let mut window: VecDeque<u8> = VecDeque::with_capacity(index.block_length());
@@ -168,7 +175,10 @@ impl<'a> CopyContext<'a> {
             }
 
             let digest = rolling.digest();
-            if let Some(block_index) = index.find_match_window(digest, &window, &mut scratch) {
+            if let Some(block_index) =
+                index.find_match_window_counted(digest, &window, &mut scratch, &mut probe)
+            {
+                file_matches = file_matches.saturating_add(1);
                 if !pending_literals.is_empty() {
                     let flushed_len = pending_literals.len();
                     if inplace_mode {
@@ -297,6 +307,11 @@ impl<'a> CopyContext<'a> {
             index.find_tail_match_window(digest, &window, &mut scratch)
         };
         if let Some(block_index) = tail_matched_block {
+            // A matched trailing partial block is one confirmed match, and its
+            // bucket lookup is one hash hit. upstream: match.c hash_search()
+            // counts the shrunk-window tail probe the same as any other.
+            file_matches = file_matches.saturating_add(1);
+            probe.hash_hits = probe.hash_hits.saturating_add(1);
             if !pending_literals.is_empty() {
                 let flushed_len = pending_literals.len();
                 if inplace_mode {
@@ -449,6 +464,11 @@ impl<'a> CopyContext<'a> {
                 )
             })?;
         }
+
+        // upstream: match.c:433-435 folds the per-file counters into the run
+        // totals after match_sums() returns; do the same so the end-of-run
+        // `-vv` `total:` line reports cumulative figures.
+        self.summary.record_delta_probe(file_matches, probe);
 
         let outcome = if let Some(encoder) = compressor {
             let compressed_total = encoder.finish().map_err(|error| {

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -145,6 +145,15 @@ pub struct LocalCopySummary {
     transferred_file_size: u64,
     bytes_copied: u64,
     matched_bytes: u64,
+    // Cumulative delta-matcher diagnostics for the `-vv` `total:` line.
+    // upstream: match.c:433-435 folds each file's per-file `matches`,
+    // `hash_hits`, and `false_alarms` into `total_*` after `match_sums()`
+    // returns, and `match_report()` (match.c:439) prints the totals once. The
+    // local-copy executor has no forked sender running `match_sums()`, so it
+    // accumulates the same running totals here.
+    delta_matches: u64,
+    delta_hash_hits: u64,
+    delta_false_alarms: u64,
     bytes_sent: u64,
     bytes_received: u64,
     compressed_bytes: u64,
@@ -355,6 +364,36 @@ impl LocalCopySummary {
     #[must_use]
     pub const fn matched_bytes(&self) -> u64 {
         self.matched_bytes
+    }
+
+    /// Returns the number of basis blocks the delta matcher reused across the
+    /// whole run - the `matches=` field of the `-vv` `total:` line.
+    ///
+    /// upstream: `match.c:435` `total_matches`.
+    #[must_use]
+    pub const fn delta_matches(&self) -> u64 {
+        self.delta_matches
+    }
+
+    /// Returns the run's cumulative delta-probe hash hits - the `hash_hits=`
+    /// field of the `-vv` `total:` line.
+    ///
+    /// upstream: `match.c:433` `total_hash_hits`. oc counts bithash-prefilter
+    /// positives rather than upstream's `SUM2HASH` bucket hits; see
+    /// [`crate::delta::ProbeCounters`] for why the two are not comparable.
+    #[must_use]
+    pub const fn delta_hash_hits(&self) -> u64 {
+        self.delta_hash_hits
+    }
+
+    /// Returns the run's cumulative delta-probe false alarms - the
+    /// `false_alarms=` field of the `-vv` `total:` line.
+    ///
+    /// upstream: `match.c:434` `total_false_alarms`. See
+    /// [`crate::delta::ProbeCounters`] for oc's counting semantics.
+    #[must_use]
+    pub const fn delta_false_alarms(&self) -> u64 {
+        self.delta_false_alarms
     }
 
     /// Returns the aggregate number of bytes that were sent to the peer.
@@ -727,6 +766,9 @@ impl LocalCopySummary {
             transferred_file_size: 0,
             bytes_copied: 0,
             matched_bytes: 0,
+            delta_matches: 0,
+            delta_hash_hits: 0,
+            delta_false_alarms: 0,
             compressed_bytes: 0,
             compression_used: false,
             total_source_bytes: 0,
@@ -764,6 +806,21 @@ impl LocalCopySummary {
             self.compression_used = true;
             self.compressed_bytes = self.compressed_bytes.saturating_add(compressed_bytes);
         }
+    }
+
+    /// Folds one delta-scanned file's match diagnostics into the run totals
+    /// rendered on the `-vv` `total:` line.
+    ///
+    /// upstream: `match.c:433-435` - `total_hash_hits += hash_hits` etc. once
+    /// per file, immediately after that file's `match_sums()` returns.
+    pub(in crate::local_copy) fn record_delta_probe(
+        &mut self,
+        matches: u64,
+        probe: crate::delta::ProbeCounters,
+    ) {
+        self.delta_matches = self.delta_matches.saturating_add(matches);
+        self.delta_hash_hits = self.delta_hash_hits.saturating_add(probe.hash_hits);
+        self.delta_false_alarms = self.delta_false_alarms.saturating_add(probe.false_alarms);
     }
 
     /// Records a would-be transfer for a `--dry-run`, mirroring upstream's
@@ -1257,6 +1314,35 @@ mod tests {
         // "Total transferred file size: 0").
         assert_eq!(summary.transferred_file_size(), 204_800);
         assert_eq!(summary.total_elapsed(), Duration::from_secs(3));
+    }
+
+    /// The `-vv` `total:` line reports RUN totals, not the last file's figures.
+    /// upstream: match.c:433-435 folds each file's counters into `total_*` and
+    /// match_report() prints the accumulation once, so a per-file overwrite
+    /// would under-report every multi-file transfer.
+    #[test]
+    fn record_delta_probe_accumulates_across_files() {
+        let mut summary = LocalCopySummary::default();
+        assert_eq!(summary.delta_matches(), 0);
+
+        summary.record_delta_probe(
+            3,
+            crate::delta::ProbeCounters {
+                hash_hits: 5,
+                false_alarms: 2,
+            },
+        );
+        summary.record_delta_probe(
+            1,
+            crate::delta::ProbeCounters {
+                hash_hits: 4,
+                false_alarms: 3,
+            },
+        );
+
+        assert_eq!(summary.delta_matches(), 4);
+        assert_eq!(summary.delta_hash_hits(), 9);
+        assert_eq!(summary.delta_false_alarms(), 5);
     }
 
     #[test]

--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -732,16 +732,13 @@ impl DeltaGenerator {
             matches
         );
 
-        // upstream: match.c match_report() equivalent.
-        debug_log!(
-            Deltasum,
-            1,
-            "delta: {} tokens, {} total, {} literal, {} matched",
-            tokens.len(),
-            total_bytes,
-            literal_bytes,
-            total_bytes.saturating_sub(literal_bytes)
-        );
+        // Nothing is printed at DELTASUM level 1 here. upstream's only level-1
+        // delta diagnostic is match_report()'s `total:` line (match.c:439-448),
+        // which the sender emits ONCE for the whole run - not once per file -
+        // from a single place (sender.c:491). oc renders that one line from the
+        // client summary; a per-file line here would both invent output
+        // upstream never prints and land dead-last through the deferred
+        // diagnostic flush.
 
         Ok(DeltaScript::new(tokens, total_bytes, literal_bytes))
     }

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -62,6 +62,31 @@ const TAG_TABLE_SIZE: usize = 1 << 16;
 /// itself a `u32` and one slot is consumed by the sentinel.
 const NEXT_MATCH_NONE: u32 = u32::MAX;
 
+/// Per-run tally of the delta matcher's probe diagnostics, mirroring the two
+/// counters upstream reports on the `-vv` `total:` line.
+///
+/// Semantics are oc-native. Upstream (`match.c:202`) increments `hash_hits`
+/// once per source offset whose `SUM2HASH` bucket is non-empty, and
+/// (`match.c:239`) `false_alarms` once per candidate whose weak sum matches but
+/// whose strong sum does not. oc has no such hashed-bucket table: instead
+/// `hash_hits` counts positives of the zsync bithash prefilter (the coarse gate
+/// analogous to a bucket hit) and `false_alarms` counts bithash positives that
+/// then fail the exact rolling-sum + strong-sum verify. Because upstream's
+/// counts are inflated by `SUM2HASH` collisions that oc's structure does not
+/// have, the two numbers are NOT expected to equal the upstream oracle; they
+/// carry genuine signal about oc's own bithash false-positive rate. The
+/// `matches` count and the `data` byte total on the same line DO match upstream
+/// exactly.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ProbeCounters {
+    /// Source offsets that passed the bithash prefilter (the coarse gate; some
+    /// will still fail the exact verify and count as false alarms).
+    pub hash_hits: u64,
+    /// Bithash positives that produced no confirmed match (exact rolling-sum or
+    /// strong-sum verify rejected them).
+    pub false_alarms: u64,
+}
+
 /// Index over a file signature that accelerates delta matching.
 ///
 /// Uses a chained bucket table (`CompactLookup`) addressed by the upper
@@ -559,6 +584,24 @@ impl DeltaSignatureIndex {
         window: &[u8],
         matched: Option<&MatchedBlocks>,
     ) -> Option<usize> {
+        self.probe_bytes(digest, window, matched, None)
+    }
+
+    /// Shared probe core behind [`Self::find_match_bytes_filtered`] and the
+    /// counted [`Self::find_match_window_counted`].
+    ///
+    /// When `counters` is `Some`, tallies upstream-style
+    /// `hash_hits`/`false_alarms` (see [`ProbeCounters`]) as a side effect; the
+    /// returned match index is identical either way, so the counted probe can
+    /// never change which bytes the matcher reuses.
+    #[inline]
+    fn probe_bytes(
+        &self,
+        digest: RollingDigest,
+        window: &[u8],
+        matched: Option<&MatchedBlocks>,
+        mut counters: Option<&mut ProbeCounters>,
+    ) -> Option<usize> {
         if window.len() != self.block_length {
             return None;
         }
@@ -569,11 +612,20 @@ impl DeltaSignatureIndex {
             return None;
         }
 
-        // zsync-style bithash prefilter: rejects ~7/8 of post-tag misses
-        // using both sum halves before the hash-table probe. One-sided, so
-        // never produces a false negative.
+        // zsync-style bithash prefilter: rejects ~7/8 of post-tag misses using
+        // both sum halves before the hash-table probe. One-sided (no false
+        // negatives) but it does admit false positives. A positive here is oc's
+        // analogue of upstream's coarse hash-bucket hit (match.c:202
+        // `hash_hits++`): it still has to pass the exact rolling-sum +
+        // strong-sum verify below, and a positive that fails that verify is a
+        // false alarm (match.c:239). oc counts bithash positives rather than
+        // upstream's SUM2HASH bucket hits, so these two diagnostics are
+        // oc-native - see [`ProbeCounters`].
         if !self.bithash.contains(digest.value()) {
             return None;
+        }
+        if let Some(counters) = counters.as_mut() {
+            counters.hash_hits = counters.hash_hits.saturating_add(1);
         }
 
         let strong = self.algorithm.compute_truncated(window, self.strong_length);
@@ -593,6 +645,12 @@ impl DeltaSignatureIndex {
             if strong.as_slice() == block.strong() {
                 return Some(index);
             }
+        }
+        // A bithash positive that produced no confirmed match: the exact
+        // rolling-sum / strong-sum verify rejected it. upstream: match.c:239
+        // `false_alarms++`.
+        if let Some(counters) = counters.as_mut() {
+            counters.false_alarms = counters.false_alarms.saturating_add(1);
         }
         None
     }
@@ -769,6 +827,30 @@ impl DeltaSignatureIndex {
         scratch.extend_from_slice(front);
         scratch.extend_from_slice(back);
         self.find_match_bytes(digest, scratch.as_slice())
+    }
+
+    /// [`Self::find_match_window`] that also tallies upstream-style
+    /// `hash_hits`/`false_alarms` into `counters` for the `-vv` `total:` line.
+    ///
+    /// upstream: `match.c:180-244 hash_search()` maintains the same two counters
+    /// while scanning a file; the local-copy delta loop calls this in place of
+    /// the uncounted probe so it can reproduce `match_report()` (`match.c:439`).
+    pub fn find_match_window_counted(
+        &self,
+        digest: RollingDigest,
+        window: &VecDeque<u8>,
+        scratch: &mut Vec<u8>,
+        counters: &mut ProbeCounters,
+    ) -> Option<usize> {
+        if window.len() != self.block_length {
+            return None;
+        }
+
+        scratch.clear();
+        let (front, back) = window.as_slices();
+        scratch.extend_from_slice(front);
+        scratch.extend_from_slice(back);
+        self.probe_bytes(digest, scratch.as_slice(), None, Some(counters))
     }
 
     /// Attempts to match a short trailing [`VecDeque`] window against a basis

--- a/crates/matching/src/index/tests.rs
+++ b/crates/matching/src/index/tests.rs
@@ -74,6 +74,90 @@ fn find_match_window_handles_split_buffers() {
     assert_eq!(found, 0);
 }
 
+/// The counted probe must tally `hash_hits`/`false_alarms` for the `-vv`
+/// `total:` line WITHOUT changing which block it matches: upstream's
+/// `hash_search()` (match.c:180-244) maintains the counters as a pure side
+/// effect of the same scan. A counted probe that returned a different index
+/// than the uncounted one would let a debug-only diagnostic alter the bytes the
+/// delta reuses, so this pins both the counts and the returned index.
+#[test]
+fn find_match_window_counted_tallies_probe_diagnostics() {
+    let data = vec![b'a'; 2048];
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature = generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4)
+        .expect("signature");
+    let index =
+        DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
+
+    let digest = index.block(0).rolling();
+    let mut window = VecDeque::with_capacity(index.block_length());
+    let mut scratch = Vec::with_capacity(index.block_length());
+    for &byte in &data[..index.block_length()] {
+        window.push_back(byte);
+    }
+
+    let uncounted = index
+        .find_match_window(digest, &window, &mut scratch)
+        .expect("uncounted match");
+    let mut counters = ProbeCounters::default();
+    assert_eq!(
+        index.find_match_window_counted(digest, &window, &mut scratch, &mut counters),
+        Some(uncounted),
+        "counting must not change the matched block"
+    );
+    assert_eq!(counters.hash_hits, 1, "one bithash-prefilter positive");
+    assert_eq!(counters.false_alarms, 0, "exact verify confirmed the match");
+
+    // Counters accumulate across probes: the probe does not consume the block.
+    index
+        .find_match_window_counted(digest, &window, &mut scratch, &mut counters)
+        .expect("second match");
+    assert_eq!(counters.hash_hits, 2, "counters accumulate across probes");
+    assert_eq!(counters.false_alarms, 0);
+}
+
+/// A window whose rolling sum belongs to no basis block must not be counted as
+/// a hash hit: upstream only bumps `hash_hits` once the coarse lookup admits a
+/// candidate (match.c:202), so an unrelated window is rejected before any
+/// counter moves.
+#[test]
+fn find_match_window_counted_leaves_counters_untouched_on_a_clean_miss() {
+    let data = vec![b'a'; 2048];
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature = generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4)
+        .expect("signature");
+    let index =
+        DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
+
+    let foreign = vec![b'z'; index.block_length()];
+    let mut rolling = checksums::RollingChecksum::new();
+    rolling.update(&foreign);
+    let mut window = VecDeque::with_capacity(index.block_length());
+    for &byte in &foreign {
+        window.push_back(byte);
+    }
+    let mut scratch = Vec::with_capacity(index.block_length());
+
+    let mut counters = ProbeCounters::default();
+    assert_eq!(
+        index.find_match_window_counted(rolling.digest(), &window, &mut scratch, &mut counters),
+        None
+    );
+    assert_eq!(counters, ProbeCounters::default());
+}
+
 #[test]
 fn delta_signature_index_block_length() {
     let data = vec![b'a'; 2048];

--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -36,7 +36,7 @@ pub use fuzzy::{
 };
 pub use generator::{DeltaGenerator, generate_delta};
 pub use index::{
-    DeltaSignatureIndex, HASH_KEY_BITS, HashtableRole, MatchedBlocks, trace_hashtable_created,
-    trace_hashtable_destroyed, trace_hashtable_growing,
+    DeltaSignatureIndex, HASH_KEY_BITS, HashtableRole, MatchedBlocks, ProbeCounters,
+    trace_hashtable_created, trace_hashtable_destroyed, trace_hashtable_growing,
 };
 pub use script::{DeltaScript, DeltaToken, apply_delta};

--- a/crates/matching/tests/deltasum_emissions.rs
+++ b/crates/matching/tests/deltasum_emissions.rs
@@ -1,0 +1,157 @@
+//! Guards the delta scanner's `--debug=DELTASUM` emissions against upstream
+//! rsync 3.4.4.
+//!
+//! Upstream's sender prints exactly two things while scanning, and they live at
+//! different debug levels:
+//!
+//! - `DELTASUM >= 2`, once per file, at the end of `match_sums()`:
+//!   `false_alarms=%d hash_hits=%d matches=%d` (match.c:428-431).
+//! - `DELTASUM >= 1`, once per RUN, from `match_report()` (match.c:439-448),
+//!   called from a single place - `sender.c:491`, after `send_files()` has
+//!   finished every file:
+//!   `total: matches=%d  hash_hits=%d  false_alarms=%d data=%s`.
+//!
+//! The scanner therefore emits NOTHING at DELTASUM level 1: the run-total line
+//! is not a per-file diagnostic and is not the scanner's to print. oc renders
+//! it once from the client summary (`cli::frontend::progress::render`), which is
+//! also what puts it at upstream's position - after the name list and before the
+//! `sent ... received ...` trailer - rather than dead-last through the deferred
+//! diagnostic flush.
+//!
+//! oc previously emitted a second, invented run-report from here:
+//!
+//! ```text
+//! delta: 2 tokens, 1400 total, 700 literal, 700 matched
+//! ```
+//!
+//! commented `// upstream: match.c match_report() equivalent`. MEASURED on a
+//! `-rvv --no-whole-file` daemon push, upstream printed
+//! `total: matches=1  hash_hits=1  false_alarms=0 data=700` between the name
+//! list and the trailer, while oc printed the `delta:` line after the trailer.
+//! Wrong text, wrong position, wrong cardinality (per file, not per run), and a
+//! second emitter competing with the renderer's.
+//!
+//! These tests pin both halves so neither can drift back: level 1 stays silent,
+//! and the level-2 per-file line keeps upstream's exact wording and field order.
+
+use std::num::NonZeroU8;
+
+use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+use matching::{DeltaGenerator, DeltaSignatureIndex};
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+/// Basis and source that produce one real block match plus one literal run, so
+/// the scan has non-zero counters to report if it were inclined to.
+const BLOCK: usize = 700;
+
+fn basis_bytes() -> Vec<u8> {
+    let mut data = vec![b'A'; BLOCK];
+    data.extend(std::iter::repeat_n(b'B', BLOCK));
+    data
+}
+
+fn source_bytes() -> Vec<u8> {
+    let mut data = vec![b'A'; BLOCK];
+    data.extend(std::iter::repeat_n(b'C', BLOCK));
+    data
+}
+
+fn build_index(basis: &[u8]) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        basis.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(basis, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+/// Initializes the given DELTASUM debug level and clears pending events so the
+/// assertions only see emissions from the scan itself.
+fn init_deltasum(level: u8) {
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.deltasum = level;
+    init(cfg);
+    let _ = drain_events();
+}
+
+fn deltasum_messages() -> Vec<String> {
+    drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Deltasum,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect()
+}
+
+fn scan() {
+    let basis = basis_bytes();
+    let index = build_index(&basis);
+    let source = source_bytes();
+    let script = DeltaGenerator::new()
+        .generate(std::io::Cursor::new(source.as_slice()), &index)
+        .expect("delta scan");
+    assert!(
+        script.literal_bytes() > 0 && script.total_bytes() > script.literal_bytes(),
+        "fixture must produce both a match and a literal run so the scan has \
+         something to report"
+    );
+}
+
+/// At `-vv` (DELTASUM level 1) the scanner must stay silent.
+///
+/// upstream: the only level-1 delta output is `match_report()`'s `total:` line,
+/// which is a once-per-run summary printed from `sender.c:491` - not from the
+/// per-file scan. A per-file emission here is both an invented line and a
+/// second `total:` emitter competing with the one in the client renderer.
+#[test]
+fn level_1_scan_emits_nothing() {
+    init_deltasum(1);
+    scan();
+
+    let msgs = deltasum_messages();
+    assert!(
+        msgs.is_empty(),
+        "the delta scan must emit no DELTASUM level-1 line; upstream prints only \
+         match_report()'s once-per-run `total:` line at this level, and oc \
+         renders that from the client summary. Got: {msgs:?}"
+    );
+}
+
+/// At `-vvv` (DELTASUM level 2) the per-file counter line must survive, with
+/// upstream's exact wording and field order.
+///
+/// upstream: match.c:428-431 - `false_alarms=%d hash_hits=%d matches=%d`, note
+/// the single spaces and the order, which is deliberately the REVERSE of the
+/// `total:` line's `matches / hash_hits / false_alarms`.
+#[test]
+fn level_2_scan_emits_upstream_per_file_counter_line() {
+    init_deltasum(2);
+    scan();
+
+    let msgs = deltasum_messages();
+    let counters = msgs
+        .iter()
+        .find(|m| m.starts_with("false_alarms="))
+        .unwrap_or_else(|| panic!("missing per-file counter line, got: {msgs:?}"));
+    let fields: Vec<&str> = counters.split(' ').collect();
+    assert_eq!(fields.len(), 3, "unexpected field count in {counters:?}");
+    assert!(fields[0].starts_with("false_alarms="), "{counters:?}");
+    assert!(fields[1].starts_with("hash_hits="), "{counters:?}");
+    assert!(fields[2].starts_with("matches="), "{counters:?}");
+    assert!(
+        !msgs.iter().any(|m| m.starts_with("total:")),
+        "the run-total line is never emitted per file, got: {msgs:?}"
+    );
+}


### PR DESCRIPTION
## Upstream ground truth

`match_report()` (`match.c:439-448`) is the *only* producer of the `total:` line, it is called from exactly one place - `sender.c:491`, after `send_files()` has finished every file - and it is gated on `DEBUG_GTE(DELTASUM, 1)` alone:

```c
void match_report(void)
{
	if (!DEBUG_GTE(DELTASUM, 1))
		return;

	rprintf(FINFO,
		"total: matches=%d  hash_hits=%d  false_alarms=%d data=%s\n",
		total_matches, total_hash_hits, total_false_alarms,
		big_num(stats.literal_data));
}
```

Note the double space after `matches=%d` and `hash_hits=%d`, the single space before `data=`, and that `--whole-file` does **not** suppress the line - it merely leaves the counters at their zero initial values. The per-file line at `match.c:428-431` is a different, `DELTASUM >= 2` diagnostic with the reversed field order `false_alarms / hash_hits / matches`.

MEASURED against rsync 3.4.4:

| invocation | client output |
|---|---|
| `rsync -rvv src/ dst/` (local, whole-file) | `total: matches=0  hash_hits=0  false_alarms=0 data=17` |
| `rsync -rvv --no-whole-file` (local, fresh dest) | `total: matches=0  hash_hits=0  false_alarms=0 data=17` |
| `rsync -rvv --no-whole-file` (local, real basis) | `total: matches=1  hash_hits=1  false_alarms=0 data=700` |
| `rsync -rvv --no-whole-file` (daemon **push**) | `total: matches=1  hash_hits=1  false_alarms=0 data=700` |
| `rsync -rvv --no-whole-file` (daemon **pull**) | *no line* - the sender is remote |

Position in every emitting case: after the per-file name list, before the blank line and the `sent ... received ...` trailer.

## What oc had

Two places claimed to implement `match_report()`, on disjoint paths, which is why a count-based guard never caught it:

1. **`crates/cli/src/frontend/progress/render.rs`** - local-copy path. Right text, right position, but it hardcoded `matches=0  hash_hits=0  false_alarms=0` and was additionally gated on whole-file mode, so a local `--no-whole-file` delta printed no line at all.
2. **`crates/matching/src/generator.rs`** - network sender path, commented `// upstream: match.c match_report() equivalent`, emitting once **per file** at `DELTASUM` level 1:

   ```
   delta: 2 tokens, 1400 total, 700 literal, 700 matched
   ```

   Wrong text, wrong cardinality, and wrong position: the scanner's `debug_log!` lands dead-last through the deferred diagnostic flush, *after* the summary trailer.

## What this PR does

**One emitter**, the renderer's - the only one that can place the line where upstream puts it.

- The local-copy delta loop now tallies real `matches` / `hash_hits` / `false_alarms` through a counted probe and folds them into run totals on `LocalCopySummary`, mirroring `match.c:433-435`. The renderer prints them.
- The gate loses its `whole_file` condition, matching `match.c:440`. A whole-file transfer still prints the line, with zeros.
- The invented per-file `delta: ...` line is deleted, leaving exactly one `total:` producer in the tree.

MEASURED after the change, byte-identical to upstream on all three local cases, including `total: matches=1  hash_hits=1  false_alarms=0 data=700`.

`matches` and `data` match upstream exactly. `hash_hits` / `false_alarms` are oc-native: oc has no `SUM2HASH` bucket table, so it counts zsync bithash-prefilter positives and the subset that fails the exact verify. Documented on `ProbeCounters`. This is a `-vv` debug diagnostic only - no wire, stats, or exit-code impact.

## Restoration note

The local counting machinery landed once before and was silently reverted by an unrelated stale-base merge that clobbered the same files; the multi-source flist ordering lost in that same revert was restored separately. It comes back here routed through the single renderer emitter rather than an engine-side `debug_log`, so there is still only one place that prints the line.

## Known remaining gap, stated plainly

A remote **push** now prints nothing at `DELTASUM` level 1, where upstream prints the `total:` line (on a push the client is the sender, so upstream's sender-side `match_report()` runs locally and reaches the terminal). A **pull** correctly prints nothing, MEASURED.

Closing the push gap needs the probe counters plumbed out of all three scan paths - the sequential scan, the consecutive-match gated scan, and the parallel chunked scan, whose overlapping stripes make a truthful `hash_hits` non-obvious. Shipping it now would mean a line that reads zero on two paths out of three, so it is deliberately left to its own change.

## Tests

- `level_2_local_delta_total_reports_real_match_counters` - a local `--no-whole-file` delta pins the exact MEASURED line, its position between the name list and the trailer, and that it is emitted exactly once. Fails both if a second emitter appears and if the counters regress to hardcoded zeros.
- `deltasum_emissions.rs` - pins `DELTASUM` level 1 to silence in the scanner (VERIFIED to fail when a level-1 emitter is reintroduced) and pins the level-2 per-file line to upstream's exact field order.
- `find_match_window_counted_*` - the counted probe must return the same block index as the uncounted one, so a debug diagnostic can never alter which bytes the delta reuses; and a clean miss must leave the counters untouched.
- `record_delta_probe_accumulates_across_files` - the totals sum across files rather than being overwritten per file, which is what `match.c:433-435` does.

The pre-existing `level_2_local_brackets_name_list_with_delta_and_total` guard was left unchanged: its assertions describe upstream's real whole-file output and still hold.
