### PR TITLE
refactor(transfer): one marker-aware NDX reader for every role

### DIFF
--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -14,7 +14,54 @@ use protocol::codec::{MonotonicNdxWriter, NDX_DEL_STATS, NDX_DONE, NdxCodec};
 use protocol::stats::DeleteStats;
 
 use super::super::{GeneratorContext, is_early_close_error};
+use crate::receiver::ndx_stream::{FlistMarkerSink, NdxFrame, StreamRole, read_marker_aware_ndx};
 use crate::role_trailer::error_location;
+
+/// The sender's view of the goodbye NDX stream.
+///
+/// Borrows the generator so `NDX_DEL_STATS` lands in its counters, and reports
+/// [`StreamRole::Sender`] so upstream's `am_sender` term (`rsync.c:343`) is what
+/// rejects any file-list marker. `inc_recurse` is reported truthfully rather
+/// than forced off, so the rejection is attributable to the role and not to a
+/// capability the transfer actually negotiated.
+///
+/// The primitive is defined under `receiver` because that is where the lazy
+/// file-list state it inverts lives; it holds no receiver-only types, and the
+/// generator already reaches across for shared wire types (see
+/// `generator/protocol_io.rs`'s use of `receiver::SumHead`).
+struct GoodbyeNdxSink<'a>(&'a mut GeneratorContext);
+
+impl FlistMarkerSink for GoodbyeNdxSink<'_> {
+    type FrameMark = ();
+
+    fn role(&self) -> StreamRole {
+        StreamRole::Sender
+    }
+
+    fn last_file_ndx(&self) -> i32 {
+        // upstream: rsync.c:345-348 - the last index of the newest flist, or -1
+        // when nothing has been sent.
+        self.0.file_list().len() as i32 - 1
+    }
+
+    fn begin_frame(&mut self) {}
+
+    fn on_del_stats(&mut self, stats: &DeleteStats) -> io::Result<()> {
+        // upstream: main.c:238-247 read_del_stats() adds to the global counters.
+        self.0.accumulate_delete_stats(stats);
+        debug_log!(
+            Flist,
+            2,
+            "consumed NDX_DEL_STATS during goodbye: {} deletions",
+            stats.total()
+        );
+        Ok(())
+    }
+
+    fn inc_recurse(&self) -> bool {
+        self.0.inc_recurse()
+    }
+}
 
 impl GeneratorContext {
     /// Handles the goodbye handshake at end of transfer.
@@ -221,32 +268,30 @@ impl GeneratorContext {
 
     /// Reads the next NDX value, consuming any NDX_DEL_STATS messages.
     ///
-    /// Upstream `read_ndx_and_attrs()` (rsync.c:337-342) loops over NDX_DEL_STATS,
-    /// calling `read_del_stats()` which reads 5 varints and accumulates counts.
+    /// Delegates to the shared marker-aware reader
+    /// ([`crate::receiver::ndx_stream::read_marker_aware_ndx`]) so the branch
+    /// order lives in one place. The asymmetry with the receiver is upstream's:
+    /// `rsync.c:343` rejects every negative NDX other than NDX_DONE and
+    /// NDX_DEL_STATS when `am_sender` is set, so a file-list marker arriving
+    /// here is a protocol violation rather than a segment to consume - hence
+    /// [`GoodbyeNdxSink`] declares [`StreamRole::Sender`] while still reporting
+    /// this transfer's real `inc_recurse`, leaving the `am_sender` term as the
+    /// thing that rejects.
     ///
     /// # Upstream Reference
     ///
-    /// - `rsync.c:337-342` - NDX_DEL_STATS loop in `read_ndx_and_attrs()`
+    /// - `rsync.c:336-342` - NDX_DEL_STATS drain in `read_ndx_and_attrs()`
+    /// - `rsync.c:343-352` - the `am_sender` rejection
     /// - `main.c:238-247` - `read_del_stats()` accumulates into global counters
     fn read_ndx_skipping_del_stats<R: Read>(
         &mut self,
         reader: &mut R,
         ndx_read_codec: &mut protocol::codec::NdxCodecEnum,
     ) -> io::Result<i32> {
-        loop {
-            let ndx = ndx_read_codec.read_ndx(reader)?;
-            if ndx == NDX_DEL_STATS {
-                let stats = DeleteStats::read_from(reader)?;
-                self.accumulate_delete_stats(&stats);
-                debug_log!(
-                    Flist,
-                    2,
-                    "consumed NDX_DEL_STATS during goodbye: {} deletions",
-                    stats.total()
-                );
-                continue;
-            }
-            return Ok(ndx);
+        let mut sink = GoodbyeNdxSink(self);
+        match read_marker_aware_ndx(reader, ndx_read_codec, &mut sink)? {
+            NdxFrame::Done => Ok(NDX_DONE),
+            NdxFrame::File(ndx) => Ok(ndx),
         }
     }
 

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -8,10 +8,11 @@
 //! cover. This module provides that primitive as methods on
 //! [`ReceiverContext`]:
 //!
-//! - [`ReceiverContext::read_next_frame`] classifies and dispatches one frame,
-//!   appending a segment via
-//!   [`receive_one_extra_segment`](ReceiverContext::receive_one_extra_segment)
-//!   and setting `flist_eof` at the terminator.
+//! - [`ReceiverContext::read_next_frame`] classifies and dispatches one frame
+//!   through the shared marker-aware reader
+//!   ([`crate::receiver::ndx_stream::read_ndx_step`]), which appends a segment
+//!   via [`receive_one_extra_segment`](ReceiverContext::receive_one_extra_segment)
+//!   and sets `flist_eof` at the terminator.
 //! - [`ReceiverContext::ensure_flat_idx`] pulls segments until a target flat
 //!   index is materialized (or the list ends), never indexing out of bounds.
 //! - [`ReceiverContext::ensure_all_segments_loaded`] drains every remaining
@@ -31,65 +32,29 @@
 
 use std::io::{self, Read};
 
-use protocol::codec::{NDX_DONE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum};
+use protocol::codec::NdxCodecEnum;
 
 use super::super::ReceiverContext;
-
-/// Classification of one frame read off the sender's flist/transfer stream.
-///
-/// Mirrors the four outcomes of upstream `read_ndx_and_attrs()`
-/// (`rsync.c:318-429`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::receiver) enum FrameKind {
-    /// An INC_RECURSE sub-list segment for the content-directory wire NDX was
-    /// consumed and appended to `file_list`.
-    Segment(i32),
-    /// `NDX_FLIST_EOF`: no more segments follow. `flist_eof` is now set.
-    FlistEof,
-    /// `NDX_DONE`: the sender signalled phase completion.
-    Done,
-    /// A non-negative NDX - a per-file reply/echo.
-    Reply(i32),
-}
+use super::super::ndx_stream::{NdxStep, read_ndx_step};
 
 impl ReceiverContext {
     /// Reads and dispatches one frame off the sender's stream.
     ///
-    /// A segment marker (`ndx <= NDX_FLIST_OFFSET`) is consumed in full via
+    /// A thin adapter over [`read_ndx_step`], the shared marker-aware reader:
+    /// the receiver *is* the lazy file-list sink, so a segment marker is
+    /// consumed in full via
     /// [`receive_one_extra_segment`](Self::receive_one_extra_segment) and
-    /// reported as [`FrameKind::Segment`]. `NDX_FLIST_EOF` sets `flist_eof` and
-    /// reports [`FrameKind::FlistEof`]; `NDX_DONE` reports [`FrameKind::Done`];
-    /// any non-negative value reports [`FrameKind::Reply`].
+    /// `NDX_FLIST_EOF` sets `flist_eof`, both as side effects of the step.
     ///
     /// # Upstream Reference
     ///
-    /// - `rsync.c:330-381` - segment marker vs NDX_DONE vs positive-ndx dispatch
+    /// - `rsync.c:329-381` - the `read_loop` this steps through
     pub(in crate::receiver) fn read_next_frame<R: Read + ?Sized>(
         &mut self,
         reader: &mut R,
         ndx_codec: &mut NdxCodecEnum,
-    ) -> io::Result<FrameKind> {
-        // Snapshot before the ndx read: upstream's raw counter ticks on arrival
-        // (io.c:820), so a segment header or the EOF marker is attributed to an
-        // adjacent recv_file_list span on any real link. The span is kept only
-        // when the frame turns out to be flist traffic; NDX_DONE and per-file
-        // replies are transfer-phase frames upstream never counts.
-        let span_start = self.flist_span_start();
-        let ndx = ndx_codec.read_ndx(reader)?;
-
-        if ndx == NDX_FLIST_EOF {
-            self.flist_eof = true;
-            self.flist_span_end(span_start);
-            return Ok(FrameKind::FlistEof);
-        }
-        if ndx == NDX_DONE {
-            return Ok(FrameKind::Done);
-        }
-        if ndx <= NDX_FLIST_OFFSET {
-            self.receive_one_extra_segment(reader, ndx, span_start)?;
-            return Ok(FrameKind::Segment(NDX_FLIST_OFFSET - ndx));
-        }
-        Ok(FrameKind::Reply(ndx))
+    ) -> io::Result<NdxStep> {
+        read_ndx_step(reader, ndx_codec, self)
     }
 
     /// Ensures `file_list[flat_idx]` is materialized, pulling INC_RECURSE
@@ -101,7 +66,7 @@ impl ReceiverContext {
     /// when `flist_eof` is already set - so on a non-INC_RECURSE transfer this
     /// simply reports `flat_idx < file_list.len()` without touching the reader.
     ///
-    /// Encountering a per-file [`FrameKind::Reply`] while fetching a segment is
+    /// Encountering a per-file [`NdxStep::File`] while fetching a segment is
     /// a protocol desync and surfaces as [`io::ErrorKind::InvalidData`].
     ///
     /// # Upstream Reference
@@ -122,14 +87,14 @@ impl ReceiverContext {
                 return Ok(false);
             }
             match self.read_next_frame(reader, ndx_codec)? {
-                FrameKind::Segment(_) | FrameKind::FlistEof => {}
-                FrameKind::Done => {
+                NdxStep::Segment(_) | NdxStep::FlistEof | NdxStep::DelStats => {}
+                NdxStep::Done => {
                     // The sender signalled completion before NDX_FLIST_EOF;
                     // treat it as the end of the list.
                     self.flist_eof = true;
                     return Ok(false);
                 }
-                FrameKind::Reply(ndx) => return Err(unexpected_reply(ndx)),
+                NdxStep::File(ndx) => return Err(unexpected_reply(ndx)),
             }
         }
     }
@@ -148,9 +113,9 @@ impl ReceiverContext {
     ) -> io::Result<()> {
         while !self.flist_eof {
             match self.read_next_frame(reader, ndx_codec)? {
-                FrameKind::Segment(_) | FrameKind::FlistEof => {}
-                FrameKind::Done => self.flist_eof = true,
-                FrameKind::Reply(ndx) => return Err(unexpected_reply(ndx)),
+                NdxStep::Segment(_) | NdxStep::FlistEof | NdxStep::DelStats => {}
+                NdxStep::Done => self.flist_eof = true,
+                NdxStep::File(ndx) => return Err(unexpected_reply(ndx)),
             }
         }
         Ok(())
@@ -173,11 +138,11 @@ impl ReceiverContext {
     ) -> io::Result<()> {
         while !self.flist_eof && self.file_list.len() < self.hardlink_lookahead_target {
             match self.read_next_frame(reader, ndx_codec)? {
-                FrameKind::Segment(_) | FrameKind::FlistEof => {}
-                FrameKind::Done => self.flist_eof = true,
+                NdxStep::Segment(_) | NdxStep::FlistEof | NdxStep::DelStats => {}
+                NdxStep::Done => self.flist_eof = true,
                 // A per-file reply here means the transfer phase has started;
                 // stop prefetching rather than treat it as a desync.
-                FrameKind::Reply(_) => break,
+                NdxStep::File(_) => break,
             }
         }
         Ok(())

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use logging::debug_log;
 use protocol::CompatibilityFlags;
-use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, create_ndx_codec};
+use protocol::codec::{NDX_FLIST_OFFSET, create_ndx_codec};
 use protocol::flist::{FileEntry, IncrementalFileListBuilder, sort_and_clean_file_list};
 
 use super::super::ReceiverContext;
@@ -238,25 +238,14 @@ impl ReceiverContext {
         }
 
         let mut ndx_codec = create_ndx_codec(self.protocol.as_u8());
-        let mut total_extra = 0;
+        let start_len = self.file_list.len();
 
-        loop {
-            // Snapshot before the header ndx: upstream's raw counter ticks on
-            // arrival (io.c:820), so the segment header and EOF marker bytes are
-            // attributed to an adjacent recv_file_list span on any real link;
-            // covering them here reproduces upstream's observable flist_size.
-            let span_start = self.flist_span_start();
-            let ndx = ndx_codec.read_ndx(reader)?;
-
-            if ndx == NDX_FLIST_EOF {
-                debug_log!(Flist, 2, "received NDX_FLIST_EOF, file list complete");
-                self.flist_eof = true;
-                self.flist_span_end(span_start);
-                break;
-            }
-
-            total_extra += self.receive_one_extra_segment(reader, ndx, span_start)?;
-        }
+        // The batched drain is the lazy fetch run to the terminator, so it goes
+        // through the same shared marker-aware reader rather than repeating the
+        // branch order. Sub-list slots are tombstoned, never compacted, so the
+        // length delta is the entry count the wire carried.
+        self.ensure_all_segments_loaded(reader, &mut ndx_codec)?;
+        let total_extra = self.file_list.len() - start_len;
 
         debug_log!(
             Flist,

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -35,6 +35,7 @@ mod dest_root;
 mod directory;
 mod file_list;
 mod itemize;
+pub(crate) mod ndx_stream;
 mod pipeline_setup;
 mod quick_check;
 mod stats;

--- a/crates/transfer/src/receiver/ndx_stream.rs
+++ b/crates/transfer/src/receiver/ndx_stream.rs
@@ -1,0 +1,471 @@
+//! One marker-aware NDX reader shared by every role, mirroring upstream
+//! `read_ndx_and_attrs()` (`rsync.c:322-431`).
+//!
+//! Upstream funnels every NDX read on a live transfer stream through a single
+//! function whose loop classifies the value before any attribute byte is
+//! touched. The branch order is load-bearing:
+//!
+//! 1. `ndx >= 0` - a real per-file index; leave the loop (`rsync.c:332-333`).
+//! 2. `NDX_DONE` - return immediately, reading **no** attributes
+//!    (`rsync.c:334-335`).
+//! 3. `NDX_DEL_STATS` - drain the five deletion varints and continue
+//!    (`rsync.c:336-342`). This sits *before* the `inc_recurse` gate, so a peer
+//!    that never negotiated INC_RECURSE still drains them.
+//! 4. `!inc_recurse || am_sender` - any other negative value is a protocol
+//!    violation (`rsync.c:343-352`).
+//! 5. `NDX_FLIST_EOF` - the sub-list stream ended; set `flist_eof` and continue
+//!    (`rsync.c:353-359`).
+//! 6. otherwise - `dir_ndx = NDX_FLIST_OFFSET - ndx`, receive that sub-list
+//!    segment and continue (`rsync.c:360-380`).
+//!
+//! After the loop the attribute tail is decoded: `iflags` via `read_shortint`
+//! for protocol >= 29 (`rsync.c:383-384`), the basis-type byte on
+//! `ITEM_BASIS_TYPE_FOLLOWS` (`rsync.c:403-405`) and the xname vstring on
+//! `ITEM_XNAME_FOLLOWS` (`rsync.c:407-417`). That tail lives in
+//! [`SenderAttrs::read_attrs_after_ndx`].
+//!
+//! # Why a sink trait
+//!
+//! Steps 3, 5 and 6 mutate state that belongs to the *caller's* role - the
+//! receiver's `file_list` / `ndx_segments` / `flist_eof`, or the generator's
+//! deletion counters - while the classifier itself owns nothing. Inverting the
+//! dependency ([`FlistMarkerSink`]) lets the free function keep the branch
+//! order in exactly one place while each role supplies its own effects.
+//!
+//! # Deliberate omissions
+//!
+//! - **Nothing is written on the `NDX_FLIST_EOF` branch.** Upstream's
+//!   `write_int(f_out, NDX_FLIST_EOF)` (`rsync.c:358`) never reaches a socket:
+//!   the sender is rejected by the `rsync.c:343` gate before it can get there,
+//!   and the receiver child runs with `sock_f_out = -1; f_out = error_pipe[1]`
+//!   (`main.c:1063-1067`), so the marker goes down the error pipe to its own
+//!   generator. oc runs the generator and the receiver in one process over one
+//!   `file_list`, so there is no peer to forward to.
+//! - **No `start_flist_forward()` / `stop_flist_forward()`** (`io.c:1483-1489`).
+//!   That teeing exists only because upstream's generator and receiver are
+//!   separate processes that each parse their own copy of the sub-list bytes.
+//! - **The `dir_ndx` range check** (`rsync.c:361-369`) is not duplicated here;
+//!   [`ReceiverContext::receive_one_extra_segment`] already performs it
+//!   (mirroring `flist.c:2622-2626`) before appending anything.
+//! - **The protocol-29 keep-alive re-entry** (`rsync.c:386-391`) is not
+//!   implemented. It is a known incompleteness, tracked separately. Note that
+//!   it is *not* dead code: rsync 3.0.9 emits the raw form at exactly protocol
+//!   29 (`io.c:953-968` - `write_int(sock_f_out, cur_flist->used)` followed by
+//!   `write_shortint(sock_f_out, ITEM_IS_NEW)`), and 3.4.4 replaced it with an
+//!   unconditional empty `MSG_DATA` (`io.c:1445-1453`), so the cutoff is rsync
+//!   3.1.0 and the reader branch exists solely for peers <= 3.0.x. oc
+//!   negotiates down to protocol 28, so the frame is reachable. Because the
+//!   branch re-enters the loop *after* `iflags` is decoded, [`read_ndx_and_attrs`]
+//!   keeps the attribute read inside its loop and marks the insertion point.
+//! - **The non-regular-file guard** (`rsync.c:420-428`) and the xname
+//!   `sanitize_path()` pass (`rsync.c:407-417`) stay with their current owners.
+
+use std::io::{self, Read};
+
+use protocol::codec::{NDX_DEL_STATS, NDX_DONE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec};
+use protocol::stats::DeleteStats;
+
+use super::ReceiverContext;
+use super::wire::SenderAttrs;
+
+/// Which side of the connection is reading, mirroring upstream's `am_sender`
+/// global and the `who_am_i()` tag in its diagnostics (`log.c:who_am_i()`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StreamRole {
+    /// Reading the receiver's replies (upstream `am_sender = 1`).
+    Sender,
+    /// Reading the sender's echoes (upstream `am_sender = 0`).
+    Receiver,
+}
+
+impl StreamRole {
+    /// Upstream's `am_sender` term in the `rsync.c:343` gate.
+    const fn am_sender(self) -> bool {
+        matches!(self, Self::Sender)
+    }
+
+    /// The `[role=VERSION]` trailer standing in for upstream's `who_am_i()`.
+    fn trailer(self) -> String {
+        match self {
+            Self::Sender => crate::role_trailer::sender(),
+            Self::Receiver => crate::role_trailer::receiver(),
+        }
+    }
+}
+
+/// The state a marker-aware NDX read mutates, inverted out of the classifier.
+///
+/// Implementors supply the role-specific effects of upstream's `read_loop`
+/// branches; [`read_ndx_step`] owns the order in which they are consulted.
+pub(crate) trait FlistMarkerSink {
+    /// Bookkeeping captured before the NDX read and handed back to the branch
+    /// that consumes flist bytes.
+    ///
+    /// The receiver uses it to snapshot the raw read counter so a sub-list
+    /// header or the EOF marker is billed to `flist_size`, exactly as upstream
+    /// brackets `recv_file_list()` with `stats.total_read` (`flist.c:2615`,
+    /// `flist.c:2789`).
+    type FrameMark: Copy;
+
+    /// Which side is reading (upstream `am_sender` / `who_am_i()`).
+    fn role(&self) -> StreamRole;
+
+    /// The highest valid file index, for the `(%d - %d)` span upstream prints
+    /// on rejection (`rsync.c:344-350`).
+    fn last_file_ndx(&self) -> i32;
+
+    /// Captures [`Self::FrameMark`] before the NDX is read.
+    fn begin_frame(&mut self) -> Self::FrameMark;
+
+    /// Consumes the deletion counters of an `NDX_DEL_STATS` frame.
+    ///
+    /// upstream: `rsync.c:338-341` - `read_del_stats(f_in)`, plus
+    /// `write_del_stats(f_out)` when `am_sender && am_server`. oc's server
+    /// sender emits its counters from its own goodbye sequence rather than from
+    /// inside this loop, so the echo is the implementor's business.
+    fn on_del_stats(&mut self, stats: &DeleteStats) -> io::Result<()>;
+
+    /// Upstream `inc_recurse`: whether this reader may grow its file list from
+    /// the stream at all (`rsync.c:343`).
+    ///
+    /// Defaults to `false`, which makes every sub-list marker a protocol
+    /// violation - the correct answer for a call site outside the lazy
+    /// file-list window.
+    fn inc_recurse(&self) -> bool {
+        false
+    }
+
+    /// Records that the sub-list stream has ended (`rsync.c:354`).
+    ///
+    /// Unreachable unless [`Self::inc_recurse`] is true and the role is the
+    /// receiver, because the `rsync.c:343` gate runs first; the default is the
+    /// no-lazy-file-list case, which tracks no such flag.
+    fn set_flist_eof(&mut self, _mark: Self::FrameMark) {}
+
+    /// Receives one INC_RECURSE sub-list segment framed by the raw marker
+    /// `raw_ndx` (`rsync.c:375` - `recv_file_list(f_in, ndx)`).
+    ///
+    /// Unreachable unless [`Self::inc_recurse`] is true and the role is the
+    /// receiver; the default restates the `rsync.c:343` rejection so no call
+    /// site can silently grow a list it does not own.
+    fn receive_segment<R: Read + ?Sized>(
+        &mut self,
+        _reader: &mut R,
+        raw_ndx: i32,
+        _mark: Self::FrameMark,
+    ) -> io::Result<()> {
+        Err(invalid_file_index(
+            raw_ndx,
+            self.last_file_ndx(),
+            self.role(),
+        ))
+    }
+}
+
+/// A sink for call sites that must never grow a file list.
+///
+/// Upstream reaches `read_ndx_and_attrs()` from places where `inc_recurse` is
+/// off or `am_sender` is set (`main.c:903` `read_final_goodbye()` on the sender
+/// being the clearest); there every marker trips the `rsync.c:343` gate. This
+/// is that peer expressed as a value.
+///
+/// Deletion counters are read off the wire (upstream drains them before the
+/// gate) and discarded: oc's receiver runs its delete pass inline and reports
+/// from `pending_del_stats`, so a peer-supplied echo carries no new information.
+pub(crate) struct NoLazyFlist {
+    role: StreamRole,
+    last_file_ndx: i32,
+}
+
+impl NoLazyFlist {
+    /// Builds the rejecting sink for `role`, whose highest valid file index is
+    /// `last_file_ndx`.
+    pub(crate) const fn new(role: StreamRole, last_file_ndx: i32) -> Self {
+        Self {
+            role,
+            last_file_ndx,
+        }
+    }
+}
+
+impl FlistMarkerSink for NoLazyFlist {
+    type FrameMark = ();
+
+    fn role(&self) -> StreamRole {
+        self.role
+    }
+
+    fn last_file_ndx(&self) -> i32 {
+        self.last_file_ndx
+    }
+
+    fn begin_frame(&mut self) {}
+
+    fn on_del_stats(&mut self, _stats: &DeleteStats) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// One iteration of upstream's `read_loop` (`rsync.c:329-381`).
+///
+/// Every variant names the branch that produced it so a reordering of
+/// [`read_ndx_step`] is observable in tests, not just a behaviour change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NdxStep {
+    /// `ndx >= 0`: a per-file index; the loop ends here (`rsync.c:332-333`).
+    File(i32),
+    /// `NDX_DONE`: phase complete, no attribute tail follows
+    /// (`rsync.c:334-335`).
+    Done,
+    /// `NDX_DEL_STATS`: five deletion varints were drained (`rsync.c:336-342`).
+    DelStats,
+    /// `NDX_FLIST_EOF`: the sub-list stream ended (`rsync.c:353-359`).
+    FlistEof,
+    /// A sub-list segment for `dir_ndx` was received (`rsync.c:360-380`).
+    Segment(i32),
+}
+
+/// Terminal outcome of upstream's `read_loop`: the only two ways out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NdxFrame {
+    /// A per-file index whose attribute tail is still on the wire.
+    File(i32),
+    /// `NDX_DONE`, which upstream returns before reading any attributes.
+    Done,
+}
+
+/// Builds upstream's `rsync.c:346-349` rejection.
+///
+/// Keeps upstream's wording - `Invalid file index: %d (%d - %d)` - and appends
+/// oc's source location plus the `[role=VERSION]` trailer that stands in for
+/// `who_am_i()`. Tagged as a protocol violation so the exit-code mapper yields
+/// `RERR_PROTOCOL` (2), matching `exit_cleanup(RERR_PROTOCOL)` at
+/// `rsync.c:351`.
+fn invalid_file_index(ndx: i32, last: i32, role: StreamRole) -> io::Error {
+    protocol::protocol_violation(format!(
+        "Invalid file index: {ndx} ({NDX_DONE} - {last}) {}{}",
+        crate::role_trailer::error_location!(),
+        role.trailer()
+    ))
+}
+
+/// Reads and classifies exactly one NDX frame, running the marker side effects
+/// through `sink`.
+///
+/// This is one iteration of upstream's `read_loop`; the branch order is the
+/// contract. Callers that want upstream's *whole* loop use
+/// [`read_marker_aware_ndx`]; callers that must react to each marker as it
+/// lands (the lazy sub-list fetch, which may not over-read past the segment it
+/// needed) drive this directly.
+///
+/// # Upstream Reference
+///
+/// - `rsync.c:329-381` - `read_loop`
+pub(crate) fn read_ndx_step<R, C, S>(
+    reader: &mut R,
+    ndx_codec: &mut C,
+    sink: &mut S,
+) -> io::Result<NdxStep>
+where
+    R: Read + ?Sized,
+    C: NdxCodec + ?Sized,
+    S: FlistMarkerSink + ?Sized,
+{
+    let mark = sink.begin_frame();
+    let ndx = ndx_codec.read_ndx(reader)?;
+
+    // upstream: rsync.c:332-333 - a real file index leaves the loop.
+    if ndx >= 0 {
+        return Ok(NdxStep::File(ndx));
+    }
+
+    // upstream: rsync.c:334-335 - NDX_DONE returns before any attribute byte.
+    if ndx == NDX_DONE {
+        return Ok(NdxStep::Done);
+    }
+
+    // upstream: rsync.c:336-342 - drained ahead of the inc_recurse gate below,
+    // so a peer without INC_RECURSE still consumes the counters instead of
+    // desyncing on them.
+    if ndx == NDX_DEL_STATS {
+        let stats = DeleteStats::read_from(reader)?;
+        sink.on_del_stats(&stats)?;
+        return Ok(NdxStep::DelStats);
+    }
+
+    // upstream: rsync.c:343-352 - every remaining negative value is a file-list
+    // marker, which only a receiver inside the INC_RECURSE window may consume.
+    if !sink.inc_recurse() || sink.role().am_sender() {
+        return Err(invalid_file_index(ndx, sink.last_file_ndx(), sink.role()));
+    }
+
+    // upstream: rsync.c:353-359 - flist_eof = 1. See the module docs for why
+    // nothing is written back here.
+    if ndx == NDX_FLIST_EOF {
+        sink.set_flist_eof(mark);
+        return Ok(NdxStep::FlistEof);
+    }
+
+    // upstream: rsync.c:360-380 - dir_ndx = NDX_FLIST_OFFSET - ndx, then
+    // recv_file_list(f_in, ndx). The range check against dir_flist->used
+    // (rsync.c:361-369) lives in the sink's segment receiver.
+    sink.receive_segment(reader, ndx, mark)?;
+    Ok(NdxStep::Segment(NDX_FLIST_OFFSET - ndx))
+}
+
+/// Runs upstream's `read_loop` for a call site that reads **no** attribute
+/// tail, consuming markers until a per-file index or `NDX_DONE` surfaces.
+///
+/// oc's phase-boundary and goodbye reads accept only `NDX_DONE`; a per-file
+/// index there is a protocol violation the caller reports without ever needing
+/// its attributes. Because no `iflags` is decoded, the protocol-29 keep-alive
+/// re-entry (`rsync.c:386-391`, predicated on `iflags == ITEM_IS_NEW`) cannot
+/// apply to this entry point - that seam belongs to [`read_ndx_and_attrs`].
+///
+/// # Upstream Reference
+///
+/// - `rsync.c:329-381` - `read_loop`
+pub(crate) fn read_marker_aware_ndx<R, C, S>(
+    reader: &mut R,
+    ndx_codec: &mut C,
+    sink: &mut S,
+) -> io::Result<NdxFrame>
+where
+    R: Read + ?Sized,
+    C: NdxCodec + ?Sized,
+    S: FlistMarkerSink + ?Sized,
+{
+    loop {
+        match read_ndx_step(reader, ndx_codec, sink)? {
+            NdxStep::File(ndx) => return Ok(NdxFrame::File(ndx)),
+            NdxStep::Done => return Ok(NdxFrame::Done),
+            NdxStep::DelStats | NdxStep::FlistEof | NdxStep::Segment(_) => {}
+        }
+    }
+}
+
+/// Upstream `read_ndx_and_attrs()` end to end: the marker loop plus the
+/// attribute tail, which `NDX_DONE` deliberately skips.
+///
+/// `None` is `NDX_DONE`. Returning the attributes only alongside a per-file
+/// index is what makes it impossible to consume the two phantom `iflags` bytes
+/// that upstream never sends after `NDX_DONE` (`rsync.c:334-335`).
+///
+/// The attribute read sits **inside** the loop on purpose. Upstream's
+/// `read_loop` has a second entry point *after* `iflags` is decoded: the
+/// protocol-29 keep-alive branch (`rsync.c:386-391`) `goto`s back into it. That
+/// branch is not implemented here (see the module docs); the `continue` seam it
+/// needs is marked below so adding it is an insertion, not a restructuring.
+///
+/// # Upstream Reference
+///
+/// - `rsync.c:322-431` - `read_ndx_and_attrs()`
+/// - `rsync.c:328` - the `read_loop:` label this `loop` stands for
+pub(crate) fn read_ndx_and_attrs<R, C, S>(
+    reader: &mut R,
+    ndx_codec: &mut C,
+    sink: &mut S,
+    preserve_xattrs: bool,
+    want_xattr_optim: bool,
+) -> io::Result<Option<(i32, SenderAttrs)>>
+where
+    R: Read + ?Sized,
+    C: NdxCodec + ?Sized,
+    S: FlistMarkerSink + ?Sized,
+{
+    let protocol_version = ndx_codec.protocol_version();
+
+    loop {
+        // upstream: rsync.c:329-381 - the marker loop.
+        let ndx = match read_ndx_step(reader, ndx_codec, sink)? {
+            NdxStep::File(ndx) => ndx,
+            NdxStep::Done => return Ok(None),
+            NdxStep::DelStats | NdxStep::FlistEof | NdxStep::Segment(_) => continue,
+        };
+
+        // upstream: rsync.c:383-417 - iflags, then the optional basis-type byte
+        // and xname vstring.
+        let attrs = SenderAttrs::read_attrs_after_ndx(
+            reader,
+            protocol_version,
+            preserve_xattrs,
+            want_xattr_optim,
+        )?;
+
+        // SEAM - upstream: rsync.c:386-391
+        //   if (protocol_version < 30 && ndx == cur_flist->used && iflags == ITEM_IS_NEW) {
+        //       if (am_sender) maybe_send_keepalive(time(NULL), MSK_ALLOW_FLUSH);
+        //       goto read_loop;
+        //   }
+        // A `continue` here re-enters the loop above. Deliberately absent; see
+        // the module docs for why it is tracked separately.
+
+        return Ok(Some((ndx, attrs)));
+    }
+}
+
+/// The receiver's own state is the lazy file-list sink: it owns `file_list`,
+/// `ndx_segments`, `flist_eof` and the sub-list decoder, so it delegates
+/// straight to [`ReceiverContext::receive_one_extra_segment`] rather than
+/// reimplementing segment reception.
+impl FlistMarkerSink for ReceiverContext {
+    /// The raw-read snapshot bracketing a flist span (`flist.c:2615`).
+    type FrameMark = u64;
+
+    fn role(&self) -> StreamRole {
+        StreamRole::Receiver
+    }
+
+    fn last_file_ndx(&self) -> i32 {
+        // upstream: rsync.c:345-348 - `first_flist->prev->ndx_start +
+        // first_flist->prev->used - 1`, i.e. the last index of the newest
+        // segment, or -1 when no list has been received yet.
+        let &(flat_start, ndx_start) = self
+            .ndx_segments
+            .last()
+            .expect("initial segment always exists");
+        let used = self.file_list.len().saturating_sub(flat_start) as i32;
+        ndx_start + used - 1
+    }
+
+    fn begin_frame(&mut self) -> u64 {
+        // Snapshot before the ndx read: upstream's raw counter ticks on arrival
+        // (io.c:820), so a segment header or the EOF marker is attributed to an
+        // adjacent recv_file_list span on any real link. The span is kept only
+        // when the frame turns out to be flist traffic; NDX_DONE and per-file
+        // replies are transfer-phase frames upstream never counts.
+        self.flist_span_start()
+    }
+
+    fn on_del_stats(&mut self, _stats: &DeleteStats) -> io::Result<()> {
+        // upstream: rsync.c:338 read_del_stats() folds the peer's counters into
+        // the global stats. oc's receiver performs its delete pass inline and
+        // reports from `pending_del_stats`, so the echoed copy is redundant; it
+        // is drained purely to keep the stream aligned.
+        Ok(())
+    }
+
+    fn inc_recurse(&self) -> bool {
+        self.compat_flags
+            .is_some_and(|f| f.contains(protocol::CompatibilityFlags::INC_RECURSE))
+    }
+
+    fn set_flist_eof(&mut self, mark: u64) {
+        logging::debug_log!(Flist, 2, "received NDX_FLIST_EOF, file list complete");
+        self.flist_eof = true;
+        self.flist_span_end(mark);
+    }
+
+    fn receive_segment<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        raw_ndx: i32,
+        mark: u64,
+    ) -> io::Result<()> {
+        self.receive_one_extra_segment(reader, raw_ndx, mark)
+            .map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/transfer/src/receiver/ndx_stream/tests.rs
+++ b/crates/transfer/src/receiver/ndx_stream/tests.rs
@@ -1,0 +1,466 @@
+//! Branch-order tests for the shared marker-aware NDX reader.
+//!
+//! Every case here pins a specific line of upstream's `read_loop`
+//! (`rsync.c:329-431`). They are written so that *reordering* the branches
+//! fails them, not merely changing what each branch does: the `NDX_DEL_STATS`
+//! cases run against a sink whose `inc_recurse` is off, which only passes while
+//! `rsync.c:336-342` is evaluated ahead of the `rsync.c:343` gate, and the
+//! `NDX_DONE` case asserts the reader position so a stray attribute read is
+//! visible.
+//!
+//! Wire bytes are built with the same encoders the receiver's other wire-parity
+//! tests use (`create_ndx_codec` for framing, `FileListWriter` for sub-list
+//! entries).
+
+use std::ffi::OsString;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use protocol::codec::{
+    NDX_DEL_STATS, NDX_DONE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum,
+    create_ndx_codec,
+};
+use protocol::flist::{FileEntry, FileListWriter};
+use protocol::stats::DeleteStats;
+use protocol::{CompatibilityFlags, ProtocolVersion};
+
+use super::*;
+use crate::config::ServerConfig;
+use crate::handshake::HandshakeResult;
+use crate::role::ServerRole;
+
+const PROTOCOL: u8 = 32;
+
+/// Protocol-32 receiver config with no flags set.
+fn test_config() -> ServerConfig {
+    ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(PROTOCOL).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        args: vec![OsString::from(".")],
+        ..Default::default()
+    }
+}
+
+/// Protocol-32 handshake carrying `flags`.
+fn test_handshake(flags: Option<CompatibilityFlags>) -> HandshakeResult {
+    HandshakeResult {
+        protocol: ProtocolVersion::try_from(PROTOCOL).unwrap(),
+        buffered: Vec::new(),
+        compat_exchanged: false,
+        client_args: None,
+        io_timeout: None,
+        negotiated_algorithms: None,
+        compat_flags: flags,
+        checksum_seed: 0,
+    }
+}
+
+/// An INC_RECURSE receiver that has already seen `dirs` level-1 directories,
+/// so their `dir_ndx` values pass the fail-closed range check.
+fn inc_recurse_receiver(dirs: &[&str]) -> ReceiverContext {
+    let mut ctx = ReceiverContext::new_for_test(
+        &test_handshake(Some(CompatibilityFlags::INC_RECURSE)),
+        test_config(),
+    );
+    ctx.dir_flist_used = dirs.len();
+    ctx.dir_flist_names = dirs.iter().map(PathBuf::from).collect();
+    ctx
+}
+
+/// Appends one sub-list segment for `dir_ndx` (header + entries + end marker).
+fn push_segment(wire: &mut Vec<u8>, codec: &mut NdxCodecEnum, dir_ndx: i32, entries: &[&str]) {
+    let protocol = ProtocolVersion::try_from(PROTOCOL).unwrap();
+    let mut writer = FileListWriter::new(protocol);
+    codec
+        .write_ndx(wire, NDX_FLIST_OFFSET - dir_ndx)
+        .expect("segment header encodes");
+    for name in entries {
+        let mut entry = FileEntry::new_file(PathBuf::from(*name), 8, 0o100644);
+        entry.set_mtime(1_700_000_000, 0);
+        writer.write_entry(wire, &entry).expect("entry encodes");
+    }
+    writer.write_end(wire, None).expect("end marker encodes");
+}
+
+/// Appends a per-file echo: NDX plus the two-byte protocol >= 29 `iflags` word.
+fn push_file_echo(wire: &mut Vec<u8>, codec: &mut NdxCodecEnum, ndx: i32, iflags: u16) {
+    codec.write_ndx(wire, ndx).expect("file ndx encodes");
+    wire.extend_from_slice(&iflags.to_le_bytes());
+}
+
+/// Appends an `NDX_DEL_STATS` frame carrying `stats`.
+fn push_del_stats(wire: &mut Vec<u8>, codec: &mut NdxCodecEnum, stats: &DeleteStats) {
+    codec
+        .write_ndx(wire, NDX_DEL_STATS)
+        .expect("del-stats marker encodes");
+    stats.write_to(wire).expect("del-stats varints encode");
+}
+
+/// A sub-list marker arriving BETWEEN two per-file echoes is consumed in full;
+/// only the file indices surface to the caller.
+///
+/// WHY: upstream `rsync.c:360-380` handles the marker inside `read_loop` and
+/// `continue`s, so the sender may interleave sub-list traffic with per-file
+/// echoes at any point. A reader that surfaced the marker (or that decoded its
+/// leading `0xFF` byte as an `iflags` word) would desync the transfer stream.
+#[test]
+fn segment_between_file_echoes_is_consumed_and_never_surfaces() {
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    push_file_echo(&mut wire, &mut codec, 3, 0);
+    push_segment(&mut wire, &mut codec, 0, &["d0/a.txt", "d0/b.txt"]);
+    push_file_echo(&mut wire, &mut codec, 4, 0);
+
+    let mut ctx = inc_recurse_receiver(&["d0"]);
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+
+    let (first, _) = read_ndx_and_attrs(&mut reader, &mut read_codec, &mut ctx, false, false)
+        .expect("first echo decodes")
+        .expect("a per-file index, not NDX_DONE");
+    assert_eq!(first, 3);
+    assert_eq!(ctx.file_list().len(), 0, "no segment consumed yet");
+
+    let (second, _) = read_ndx_and_attrs(&mut reader, &mut read_codec, &mut ctx, false, false)
+        .expect("the interleaved segment is consumed, then the next echo decodes")
+        .expect("a per-file index, not NDX_DONE");
+    assert_eq!(second, 4, "only file NDXs surface");
+    assert_eq!(
+        ctx.file_list().len(),
+        2,
+        "the interleaved sub-list was appended as a side effect"
+    );
+    assert!(!ctx.flist_eof);
+}
+
+/// `NDX_FLIST_EOF` mid-transfer sets `flist_eof` and does not surface.
+///
+/// WHY: upstream `rsync.c:353-359` sets the flag and `continue`s - it never
+/// leaves the loop - so the caller's next value must be the following frame.
+/// The receiver relies on this flag to stop pulling segments; surfacing the
+/// marker instead would strand the lazy fetch loop.
+#[test]
+fn flist_eof_sets_the_flag_and_continues() {
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    codec.write_ndx(&mut wire, NDX_FLIST_EOF).unwrap();
+    push_file_echo(&mut wire, &mut codec, 7, 0);
+
+    let mut ctx = inc_recurse_receiver(&["d0"]);
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+
+    let (ndx, _) = read_ndx_and_attrs(&mut reader, &mut read_codec, &mut ctx, false, false)
+        .expect("the terminator is consumed, then the echo decodes")
+        .expect("a per-file index, not NDX_DONE");
+    assert_eq!(ndx, 7);
+    assert!(ctx.flist_eof, "NDX_FLIST_EOF must set flist_eof");
+}
+
+/// Sub-list `dir_ndx` values are NOT monotonic and NOT contiguous.
+///
+/// WHY: upstream's sender walks its dir_flist while *appending* newly
+/// discovered subdirectories to it (`flist.c:2695-2704`), so an `-a` pull of a
+/// nested tree interleaves level-1 directories with their children. A measured
+/// upstream oracle produced the header sequence `1, 9, 2, 10, 3, 11`. The
+/// range check (`rsync.c:361-369` / `flist.c:2622-2626`) is the ONLY constraint:
+/// any validation that assumed ordering or contiguity would reject a legitimate
+/// upstream stream.
+#[test]
+fn non_monotonic_dir_ndx_sequence_is_accepted() {
+    const OBSERVED: [i32; 6] = [1, 9, 2, 10, 3, 11];
+
+    let dirs: Vec<String> = (0..12).map(|i| format!("d{i}")).collect();
+    let dir_refs: Vec<&str> = dirs.iter().map(String::as_str).collect();
+
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    for dir_ndx in OBSERVED {
+        let entry = format!("d{dir_ndx}/f.txt");
+        push_segment(&mut wire, &mut codec, dir_ndx, &[entry.as_str()]);
+    }
+    codec.write_ndx(&mut wire, NDX_FLIST_EOF).unwrap();
+
+    let mut ctx = inc_recurse_receiver(&dir_refs);
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+
+    let mut seen = Vec::new();
+    loop {
+        match read_ndx_step(&mut reader, &mut read_codec, &mut ctx).expect("segment decodes") {
+            NdxStep::Segment(dir_ndx) => seen.push(dir_ndx),
+            NdxStep::FlistEof => break,
+            other => panic!("unexpected frame {other:?}"),
+        }
+    }
+
+    assert_eq!(
+        seen,
+        OBSERVED.to_vec(),
+        "every out-of-order dir_ndx must be accepted in arrival order"
+    );
+    assert_eq!(ctx.file_list().len(), OBSERVED.len());
+}
+
+/// `NDX_DEL_STATS` is drained even by a reader whose `inc_recurse` is off.
+///
+/// WHY: upstream evaluates the `NDX_DEL_STATS` branch (`rsync.c:336-342`)
+/// BEFORE the `!inc_recurse || am_sender` gate (`rsync.c:343`). Moving the gate
+/// ahead of it would make a plain non-incremental peer abort on a frame it is
+/// required to consume, and would desync the five varints that follow.
+#[test]
+fn del_stats_is_drained_before_the_inc_recurse_gate() {
+    let stats = DeleteStats {
+        files: 4,
+        dirs: 3,
+        symlinks: 2,
+        devices: 1,
+        specials: 5,
+    };
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    push_del_stats(&mut wire, &mut codec, &stats);
+    codec.write_ndx(&mut wire, NDX_DONE).unwrap();
+
+    let mut sink = NoLazyFlist::new(StreamRole::Receiver, 5);
+    assert!(!sink.inc_recurse(), "the gate term under test is off");
+
+    let mut reader = Cursor::new(wire.clone());
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+    assert_eq!(
+        read_ndx_step(&mut reader, &mut read_codec, &mut sink).unwrap(),
+        NdxStep::DelStats
+    );
+    assert_eq!(
+        read_ndx_step(&mut reader, &mut read_codec, &mut sink).unwrap(),
+        NdxStep::Done
+    );
+    assert_eq!(
+        reader.position() as usize,
+        wire.len(),
+        "the five deletion varints must be fully consumed"
+    );
+}
+
+/// The sender drains `NDX_DEL_STATS` too, and hands the counters to its sink.
+///
+/// WHY: `rsync.c:336-342` runs before `rsync.c:343`, so `am_sender` does not
+/// exempt the sender from draining. This is what lets the generator accumulate
+/// the receiver's deletion counts during `read_final_goodbye()`
+/// (`main.c:904`).
+#[test]
+fn sender_drains_del_stats_and_receives_the_counters() {
+    /// Records every drained frame so the ordering claim is observable.
+    struct RecordingSink(Vec<DeleteStats>);
+
+    impl FlistMarkerSink for RecordingSink {
+        type FrameMark = ();
+
+        fn role(&self) -> StreamRole {
+            StreamRole::Sender
+        }
+
+        fn last_file_ndx(&self) -> i32 {
+            9
+        }
+
+        fn begin_frame(&mut self) {}
+
+        fn on_del_stats(&mut self, stats: &DeleteStats) -> io::Result<()> {
+            self.0.push(*stats);
+            Ok(())
+        }
+
+        // The sender reports INC_RECURSE truthfully; `am_sender` is what
+        // rejects markers (see `marker_rejected_by_sender_with_upstream_text`).
+        fn inc_recurse(&self) -> bool {
+            true
+        }
+    }
+
+    let stats = DeleteStats {
+        files: 7,
+        dirs: 1,
+        symlinks: 0,
+        devices: 0,
+        specials: 2,
+    };
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    push_del_stats(&mut wire, &mut codec, &stats);
+    codec.write_ndx(&mut wire, NDX_DONE).unwrap();
+
+    let mut sink = RecordingSink(Vec::new());
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+
+    assert_eq!(
+        read_marker_aware_ndx(&mut reader, &mut read_codec, &mut sink).unwrap(),
+        NdxFrame::Done
+    );
+    assert_eq!(sink.0, vec![stats], "the drained counters reach the sink");
+}
+
+/// `NDX_DONE` returns without consuming the attribute tail.
+///
+/// WHY: upstream `rsync.c:334-335` returns from inside the loop, *before* the
+/// `read_shortint()` at `rsync.c:383`. A combined read-ndx-and-iflags helper
+/// swallows two bytes the peer never sent, which shifts every subsequent frame.
+/// The reader position is asserted so the regression is caught even though the
+/// returned value would look correct.
+#[test]
+fn ndx_done_reads_no_attribute_tail() {
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    codec.write_ndx(&mut wire, NDX_DONE).unwrap();
+    let done_len = wire.len() as u64;
+    // Two bytes that a buggy reader would swallow as `iflags`.
+    wire.extend_from_slice(&[0xAB, 0xCD]);
+
+    let mut sink = NoLazyFlist::new(StreamRole::Receiver, 0);
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+
+    assert!(
+        read_ndx_and_attrs(&mut reader, &mut read_codec, &mut sink, false, false)
+            .unwrap()
+            .is_none(),
+        "NDX_DONE yields no attributes"
+    );
+    assert_eq!(
+        reader.position(),
+        done_len,
+        "NDX_DONE must not consume the two trailing iflags bytes"
+    );
+}
+
+/// A per-file index still reads its attribute tail.
+///
+/// WHY: guards the split in [`SenderAttrs::read_attrs_after_ndx`] against the
+/// opposite regression - skipping `rsync.c:383-417` for a real index would
+/// leave `iflags` on the wire.
+#[test]
+fn file_ndx_reads_its_attribute_tail() {
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    push_file_echo(&mut wire, &mut codec, 2, SenderAttrs::ITEM_TRANSFER);
+    let total = wire.len() as u64;
+
+    let mut sink = NoLazyFlist::new(StreamRole::Receiver, 9);
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+
+    let (ndx, attrs) = read_ndx_and_attrs(&mut reader, &mut read_codec, &mut sink, false, false)
+        .unwrap()
+        .expect("a per-file index");
+    assert_eq!(ndx, 2);
+    assert_eq!(attrs.iflags, SenderAttrs::ITEM_TRANSFER);
+    assert_eq!(reader.position(), total, "the iflags word must be consumed");
+}
+
+/// The sender rejects a file-list marker with upstream's wording.
+///
+/// WHY: `rsync.c:343-352` - `if (!inc_recurse || am_sender) ... "Invalid file
+/// index: %d (%d - %d) [%s]" ... exit_cleanup(RERR_PROTOCOL)`. The sender never
+/// consumes sub-list traffic; only the receiver inside the INC_RECURSE window
+/// may. The sink below reports `inc_recurse = true`, so a passing test proves
+/// the `am_sender` term is what rejects, not the capability term.
+#[test]
+fn marker_rejected_by_sender_with_upstream_text() {
+    /// A sender with INC_RECURSE genuinely negotiated.
+    struct IncRecurseSender;
+
+    impl FlistMarkerSink for IncRecurseSender {
+        type FrameMark = ();
+
+        fn role(&self) -> StreamRole {
+            StreamRole::Sender
+        }
+
+        fn last_file_ndx(&self) -> i32 {
+            5
+        }
+
+        fn begin_frame(&mut self) {}
+
+        fn on_del_stats(&mut self, _stats: &DeleteStats) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn inc_recurse(&self) -> bool {
+            true
+        }
+    }
+
+    for marker in [NDX_FLIST_EOF, NDX_FLIST_OFFSET] {
+        let mut wire = Vec::new();
+        let mut codec = create_ndx_codec(PROTOCOL);
+        codec.write_ndx(&mut wire, marker).unwrap();
+
+        let mut reader = Cursor::new(wire);
+        let mut read_codec = create_ndx_codec(PROTOCOL);
+        let err = read_ndx_step(&mut reader, &mut read_codec, &mut IncRecurseSender)
+            .expect_err("the sender must reject every file-list marker");
+
+        assert!(
+            err.to_string()
+                .starts_with(&format!("Invalid file index: {marker} (-1 - 5)")),
+            "unexpected message: {err}"
+        );
+        assert!(
+            err.to_string().contains("[sender="),
+            "the who_am_i() tag must name the sender: {err}"
+        );
+        assert!(
+            err.get_ref()
+                .and_then(|e| e.downcast_ref::<protocol::ProtocolViolation>())
+                .is_some(),
+            "rejection must map to RERR_PROTOCOL, got {err:?}"
+        );
+    }
+}
+
+/// A receiver outside the INC_RECURSE window rejects markers by the
+/// `!inc_recurse` term.
+///
+/// WHY: the same `rsync.c:343` gate has two terms. This pins the first one, so
+/// dropping it would let a phase-boundary or goodbye read silently grow a file
+/// list it does not own.
+#[test]
+fn marker_rejected_by_receiver_without_inc_recurse() {
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    codec.write_ndx(&mut wire, NDX_FLIST_OFFSET).unwrap();
+
+    let mut sink = NoLazyFlist::new(StreamRole::Receiver, 11);
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+    let err = read_ndx_step(&mut reader, &mut read_codec, &mut sink)
+        .expect_err("a no-lazy-flist sink must reject markers");
+
+    assert!(
+        err.to_string()
+            .starts_with(&format!("Invalid file index: {NDX_FLIST_OFFSET} (-1 - 11)")),
+        "unexpected message: {err}"
+    );
+    assert!(err.to_string().contains("[receiver="), "message: {err}");
+}
+
+/// The receiver's `last_file_ndx` tracks the newest segment, matching upstream's
+/// `first_flist->prev->ndx_start + first_flist->prev->used - 1`
+/// (`rsync.c:345-348`).
+#[test]
+fn receiver_last_file_ndx_matches_upstream_span() {
+    let ctx = inc_recurse_receiver(&["d0"]);
+    // INC_RECURSE starts numbering at 1 (flist.c:2958), so an empty list has no
+    // valid index and reports one below the first.
+    assert_eq!(FlistMarkerSink::last_file_ndx(&ctx), 0);
+
+    let mut ctx = inc_recurse_receiver(&["d0"]);
+    for i in 0..3 {
+        ctx.file_list
+            .push(FileEntry::new_file(format!("f{i}").into(), 1, 0o100644));
+    }
+    assert_eq!(FlistMarkerSink::last_file_ndx(&ctx), 3);
+}

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -15,11 +15,13 @@ use std::io::{self, Read, Write};
 use logging::debug_log;
 use protocol::CompatibilityFlags;
 use protocol::codec::{
-    NDX_DEL_STATS, NDX_DONE, NdxCodec, NdxCodecEnum, ProtocolCodec, create_ndx_codec,
-    create_protocol_codec,
+    NDX_DEL_STATS, NdxCodec, NdxCodecEnum, ProtocolCodec, create_ndx_codec, create_protocol_codec,
 };
 
 use crate::receiver::ReceiverContext;
+use crate::receiver::ndx_stream::{
+    FlistMarkerSink, NdxFrame, NoLazyFlist, StreamRole, read_marker_aware_ndx, read_ndx_and_attrs,
+};
 use crate::receiver::stats::SenderStats;
 use crate::transfer_state::TransferPhase;
 
@@ -123,38 +125,60 @@ impl ReceiverContext {
     /// framing is delta-state independent, so consuming with the fresh phase
     /// codec still advances by the exact wire bytes even though the discarded
     /// index values are not needed.
+    ///
+    /// Returns `true` once the sender's NDX_DONE has surfaced mid-drain: that
+    /// value reads no attribute tail (upstream `rsync.c:334-335`), so the phase
+    /// boundary is already satisfied and no further NDX may be consumed.
     fn drain_hardlink_follower_echoes<R: Read>(
         &self,
         ndx_read_codec: &mut NdxCodecEnum,
         reader: &mut R,
-    ) -> io::Result<()> {
+        sink: &mut NoLazyFlist,
+    ) -> io::Result<bool> {
         for _ in 0..self.hardlink_follower_echoes.take() {
-            crate::receiver::wire::SenderAttrs::read_with_codec(reader, ndx_read_codec)?;
+            if read_ndx_and_attrs(reader, ndx_read_codec, sink, false, false)?.is_none() {
+                return Ok(true);
+            }
         }
-        Ok(())
+        Ok(false)
     }
 
     /// Reads an NDX and validates it is NDX_DONE (-1).
+    ///
+    /// Routed through the shared marker-aware reader
+    /// ([`read_marker_aware_ndx`]), which drains an `NDX_DEL_STATS` frame ahead
+    /// of the check exactly as upstream does (`rsync.c:336-342`, evaluated
+    /// before the `rsync.c:343` gate). A phase boundary is outside the lazy
+    /// file-list window, so the sink refuses to grow the list.
     pub(in crate::receiver) fn read_expected_ndx_done<R: Read>(
         &self,
         ndx_read_codec: &mut NdxCodecEnum,
         reader: &mut R,
         context: &str,
     ) -> io::Result<()> {
-        self.drain_hardlink_follower_echoes(ndx_read_codec, reader)?;
-        let ndx = ndx_read_codec.read_ndx(reader)?;
-        if ndx != -1 {
+        let mut sink = self.no_lazy_flist_sink();
+        if self.drain_hardlink_follower_echoes(ndx_read_codec, reader, &mut sink)? {
+            return Ok(());
+        }
+        match read_marker_aware_ndx(reader, ndx_read_codec, &mut sink)? {
+            NdxFrame::Done => Ok(()),
             // upstream: io.c read_ndx / rsync.c:818 - a wire index that is not
             // the expected NDX_DONE (-1) is "File-list index N not in ..." and
             // aborts with exit_cleanup(RERR_PROTOCOL) (exit 2). Tag the error so
             // the core exit-code mapper yields RERR_PROTOCOL, not RERR_STREAMIO.
-            return Err(protocol::protocol_violation(format!(
+            NdxFrame::File(ndx) => Err(protocol::protocol_violation(format!(
                 "expected NDX_DONE (-1) from sender during {context}, got {ndx} {}{}",
                 crate::role_trailer::error_location!(),
                 crate::role_trailer::receiver()
-            )));
+            ))),
         }
-        Ok(())
+    }
+
+    /// Builds the marker-rejecting sink used by the phase-boundary and goodbye
+    /// reads, seeded with the highest valid file index so a rejection carries
+    /// upstream's `(%d - %d)` span (`rsync.c:344-350`).
+    fn no_lazy_flist_sink(&self) -> NoLazyFlist {
+        NoLazyFlist::new(StreamRole::Receiver, FlistMarkerSink::last_file_ndx(self))
     }
 
     /// Handles the goodbye handshake at end of transfer.
@@ -204,26 +228,21 @@ impl ReceiverContext {
         writer.flush()?;
 
         if self.protocol.supports_extended_goodbye() {
-            // upstream: main.c:893-924 read_final_goodbye() - the sender may
-            // send NDX_DEL_STATS before the NDX_DONE echo. Loop to skip it.
-            loop {
-                let ndx = ndx_read_codec.read_ndx(reader)?;
-                if ndx == NDX_DONE {
-                    break;
-                }
-                if ndx == NDX_DEL_STATS {
-                    // Consume the 5 varints of deletion statistics
-                    let _stats = protocol::stats::DeleteStats::read_from(reader)?;
-                    continue;
-                }
+            // upstream: main.c:904 read_final_goodbye() calls read_ndx_and_attrs(),
+            // which is where the sender's NDX_DEL_STATS frame gets drained
+            // (rsync.c:336-342) before NDX_DONE surfaces.
+            match read_marker_aware_ndx(reader, ndx_read_codec, &mut self.no_lazy_flist_sink())? {
+                NdxFrame::Done => {}
                 // upstream: main.c:922 exit_cleanup(RERR_PROTOCOL) (exit 2) - a
                 // non-NDX_DONE goodbye echo is a protocol violation, tagged so
                 // the core exit-code mapper yields 2 rather than RERR_STREAMIO(12).
-                return Err(protocol::protocol_violation(format!(
-                    "expected goodbye NDX_DONE echo (-1) from sender, got {ndx} {}{}",
-                    crate::role_trailer::error_location!(),
-                    crate::role_trailer::receiver()
-                )));
+                NdxFrame::File(ndx) => {
+                    return Err(protocol::protocol_violation(format!(
+                        "expected goodbye NDX_DONE echo (-1) from sender, got {ndx} {}{}",
+                        crate::role_trailer::error_location!(),
+                        crate::role_trailer::receiver()
+                    )));
+                }
             }
 
             ndx_write_codec.write_ndx_done(&mut *writer)?;

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -372,9 +372,37 @@ impl SenderAttrs {
     ) -> io::Result<(i32, Self)> {
         // Read NDX using protocol-aware codec (handles delta encoding for protocol 30+)
         let ndx = ndx_codec.read_ndx(reader)?;
-
         let protocol_version = ndx_codec.protocol_version();
+        let attrs = Self::read_attrs_after_ndx(
+            reader,
+            protocol_version,
+            preserve_xattrs,
+            want_xattr_optim,
+        )?;
+        Ok((ndx, attrs))
+    }
 
+    /// Reads the attribute tail that follows a per-file NDX.
+    ///
+    /// This is the second half of upstream `read_ndx_and_attrs()`: everything
+    /// from the `iflags` read onwards. Splitting it from the NDX read is what
+    /// lets [`crate::receiver::ndx_stream::read_ndx_and_attrs`] honour
+    /// `rsync.c:334-335`, where `NDX_DONE` returns *before* any attribute byte
+    /// is consumed - calling the combined helper there would swallow two
+    /// phantom `iflags` bytes that the peer never sent.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:383-384` - `iflags` via `read_shortint` for protocol >= 29
+    /// - `rsync.c:403-405` - basis-type byte on `ITEM_BASIS_TYPE_FOLLOWS`
+    /// - `rsync.c:407-417` - xname vstring on `ITEM_XNAME_FOLLOWS`
+    /// - `receiver.c:721-723` - xattr data on `ITEM_REPORT_XATTR`
+    pub fn read_attrs_after_ndx<R: Read + ?Sized>(
+        reader: &mut R,
+        protocol_version: u8,
+        preserve_xattrs: bool,
+        want_xattr_optim: bool,
+    ) -> io::Result<Self> {
         // For protocol >= 29, read iflags (shortint = 2 bytes LE)
         let iflags = if protocol_version >= 29 {
             let mut iflags_buf = [0u8; 2];
@@ -433,15 +461,12 @@ impl SenderAttrs {
             Vec::new()
         };
 
-        Ok((
-            ndx,
-            Self {
-                iflags,
-                fnamecmp_type,
-                xname,
-                xattr_values,
-            },
-        ))
+        Ok(Self {
+            iflags,
+            fnamecmp_type,
+            xname,
+            xattr_values,
+        })
     }
 
     /// Reads sender attributes from the wire (legacy method for tests).
@@ -582,7 +607,9 @@ pub fn write_signature_blocks<W: Write + ?Sized>(
 /// # Upstream Reference
 ///
 /// - `xattrs.c:681-757` - `recv_xattr_request()` called by receiver (!am_sender)
-fn read_xattr_abbreviation_data<R: Read>(reader: &mut R) -> io::Result<Vec<(i32, Vec<u8>)>> {
+fn read_xattr_abbreviation_data<R: Read + ?Sized>(
+    reader: &mut R,
+) -> io::Result<Vec<(i32, Vec<u8>)>> {
     let mut values = Vec::new();
     let mut prior_req = 0i32;
 


### PR DESCRIPTION
## Why

Upstream funnels every NDX read on a live transfer stream through one function,
`read_ndx_and_attrs()` (`rsync.c:322-431`). Its loop classifies the value before
any attribute byte is touched, and the branch order is load-bearing - most
notably `NDX_DEL_STATS` is drained *before* the `!inc_recurse || am_sender` gate,
so a peer that never negotiated INC_RECURSE still consumes the counters instead
of desyncing on them.

oc had four partial re-implementations of that rule, each missing a different
branch:

| Copy | Missing |
|------|---------|
| `receiver/file_list/on_demand.rs` `read_next_frame` | the `NDX_DEL_STATS` branch |
| `receiver/file_list/receive.rs` `receive_extra_file_lists` | `NDX_DONE` and `NDX_DEL_STATS` |
| `receiver/transfer/phases.rs` phase-boundary + goodbye reads | the sub-list branches; goodbye had its own del-stats loop |
| `generator/transfer/goodbye.rs` `read_ndx_skipping_del_stats` | the `rsync.c:343` rejection |

## What

`crates/transfer/src/receiver/ndx_stream.rs` holds the rule once:

- **`read_ndx_step()`** - one iteration of upstream's `read_loop`, in upstream's
  order: file index (`:332`), `NDX_DONE` (`:334`), `NDX_DEL_STATS` (`:336`), the
  `!inc_recurse || am_sender` gate (`:343`), `NDX_FLIST_EOF` (`:353`), sub-list
  segment (`:360`).
- **`read_marker_aware_ndx()`** - the whole loop, for call sites that read no
  attribute tail.
- **`read_ndx_and_attrs()`** - loop plus tail. The attribute read sits *inside*
  the loop because upstream's protocol-29 keep-alive branch (`rsync.c:386-391`)
  jumps back into `read_loop` after `iflags` is decoded; that branch stays
  unimplemented and is documented as a known incompleteness (it is reachable -
  rsync 3.0.9 emits the raw form at exactly protocol 29, `io.c:953-968`, and oc
  negotiates down to 28), with the `continue` seam marked so adding it is an
  insertion rather than a restructuring.

Those branches mutate state the classifier does not own - the receiver's
`file_list` / `ndx_segments` / `flist_eof`, or the generator's deletion counters.
A `FlistMarkerSink` trait inverts the dependency. `ReceiverContext` implements it
by delegating to the existing `receive_one_extra_segment` (segment reception is
reused, not reimplemented); a `NoLazyFlist` value stands in for the call sites
that must never grow a list, and the generator's goodbye borrows itself through
a small adapter that declares the sender role so upstream's `am_sender` term is
what rejects a marker.

`SenderAttrs::read_with_codec_xattr` is split into an NDX half and
`read_attrs_after_ndx()`. That split is what lets `NDX_DONE` stop consuming two
phantom `iflags` bytes the peer never sent (`rsync.c:334-335`).

## Scope

Deliberately **not** in this change: routing the pipelined per-file echo sites,
collapsing the two NDX codecs in the drivers, the protocol-29 keep-alive branch,
the non-regular-file guard (`rsync.c:420-428`), and the xname `sanitize_path()`
pass (`rsync.c:407-417`). The `dir_ndx` range check is not duplicated either -
`receive_one_extra_segment` already performs it (`flist.c:2622-2626`).

Nothing is written on the `NDX_FLIST_EOF` branch. Upstream's
`write_int(f_out, NDX_FLIST_EOF)` (`rsync.c:358`) never reaches a socket: the
sender is rejected by the `:343` gate first, and the receiver child runs with
`sock_f_out = -1; f_out = error_pipe[1]` (`main.c:1063-1067`). Upstream's
`start_flist_forward()` / `stop_flist_forward()` teeing (`io.c:1483-1489`) is
likewise not ported - it exists only because upstream's generator and receiver
are separate processes each parsing their own copy; oc runs both over one
`file_list`.

## Tests

New tests pin the branch *order*, not just behaviour:

- a sub-list marker interleaved between two per-file echoes is consumed and only
  file NDXs surface;
- `NDX_FLIST_EOF` mid-transfer sets `flist_eof` and does not surface;
- **sub-list `dir_ndx` values are non-monotonic and non-contiguous** - a measured
  upstream oracle produced `1, 9, 2, 10, 3, 11` (level-1 dirs interleaved with
  newly discovered subdirs appended to `dir_flist`), so no validation may assume
  ordering or contiguity;
- `NDX_DEL_STATS` is drained by a sink whose `inc_recurse` is off, which only
  passes while `rsync.c:336-342` precedes `rsync.c:343`; the sender drains it too
  and its counters reach the sink;
- `NDX_DONE` returns without consuming the attribute tail (asserted on the reader
  position, so the regression is visible even though the returned value looks
  correct);
- a sender whose `inc_recurse` is genuinely on still rejects every marker with
  upstream's wording, `Invalid file index: %d (%d - %d)`, tagged `RERR_PROTOCOL`.

The byte-for-byte upstream 3.4.4 daemon capture
(`real_upstream_multisegment_sublist_decodes_as_segments`) passes unchanged as
the no-regression gate on the classifier.
