### PR TITLE
perf(transfer): own the in-flight FileEntry window in the receiver pipeline

### DIFF
--- a/crates/transfer/src/receiver/tests/push_metadata_itemize.rs
+++ b/crates/transfer/src/receiver/tests/push_metadata_itemize.rs
@@ -103,7 +103,7 @@ fn server_push_pipeline_forwards_metadata_only_record_and_drains_echo() {
     let sent = SharedBuf::default();
     let mut writer = crate::writer::ServerWriter::new_plain(sent.clone());
     let mut metadata_errors = Vec::new();
-    let files: Vec<(usize, &FileEntry, PathBuf, u32)> = Vec::new();
+    let files: Vec<(usize, PathBuf, u32)> = Vec::new();
     let mut ndx_write_codec = protocol::codec::MonotonicNdxWriter::new(ctx.protocol.as_u8());
     let mut ndx_read_codec = protocol::codec::create_ndx_codec(ctx.protocol.as_u8());
     let result = ctx

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -97,16 +97,15 @@ impl ReceiverContext {
     /// `(files_transferred, bytes, literal, matched, redo_indices, delayed_updates)`.
     #[allow(clippy::too_many_arguments)]
     pub(in crate::receiver) fn run_pipeline_loop_decoupled<
-        'a,
         R: Read,
         W: Write + crate::writer::MsgInfoSender + ?Sized,
     >(
-        &'a self,
+        &mut self,
         reader: &mut crate::reader::ServerReader<R>,
         writer: &mut W,
         pipeline_config: PipelineConfig,
         setup: &PipelineSetup,
-        files_to_transfer: Vec<(usize, &'a FileEntry, PathBuf, u32)>,
+        files_to_transfer: Vec<(usize, PathBuf, u32)>,
         metadata_errors: &mut Vec<(PathBuf, String)>,
         is_redo_pass: bool,
         total_files: usize,
@@ -148,12 +147,12 @@ impl ReceiverContext {
             for item in files_to_transfer {
                 while let Some(&(idx, iflags)) = rows.peek().filter(|&&(idx, _)| idx < item.0) {
                     rows.next();
-                    merged.push((idx, &self.file_list[idx], PathBuf::new(), u32::from(iflags)));
+                    merged.push((idx, PathBuf::new(), u32::from(iflags)));
                 }
                 merged.push(item);
             }
             for (idx, iflags) in rows {
-                merged.push((idx, &self.file_list[idx], PathBuf::new(), u32::from(iflags)));
+                merged.push((idx, PathBuf::new(), u32::from(iflags)));
             }
             merged
         };
@@ -220,7 +219,10 @@ impl ReceiverContext {
 
         let mut pipeline = PipelineState::new(pipeline_config);
         let mut file_iter = files_to_transfer.into_iter();
-        let mut pending_files_info: VecDeque<(usize, PathBuf, &FileEntry, u32)> =
+        // Stage 0: the in-flight window OWNS its FileEntry (cloned at push,
+        // bounded to the pipeline window = O(window)), so the loop no longer
+        // holds a borrow into `self.file_list`.
+        let mut pending_files_info: VecDeque<(usize, PathBuf, FileEntry, u32)> =
             VecDeque::with_capacity(pipeline.window_size());
         let mut files_transferred = 0usize;
         // upstream: receiver.c:784 stats.total_transferred_size += F_LENGTH(file),
@@ -314,9 +316,14 @@ impl ReceiverContext {
                 {
                     use rayon::prelude::*;
 
-                    let batch: Vec<_> = file_iter
+                    // Stage 0: resolve each queued flist index to an owned
+                    // FileEntry clone as it enters the window (bounded by
+                    // available_slots <= window size), releasing the borrow on
+                    // `self.file_list` before the rest of the loop body.
+                    let batch: Vec<(usize, FileEntry, PathBuf, u32)> = file_iter
                         .by_ref()
                         .take(pipeline.available_slots())
+                        .map(|(idx, path, iflags)| (idx, self.file_list[idx].clone(), path, iflags))
                         .collect();
 
                     if !batch.is_empty() && !is_redo_pass {
@@ -419,7 +426,7 @@ impl ReceiverContext {
                             // --link-dest / --compare-dest / --partial-dir bases
                             // drive the resolution in upstream's priority order.
                             let xattr_request = self.build_xattr_request(
-                                file_entry,
+                                &file_entry,
                                 basis_result.basis_path.as_deref(),
                             );
                             let pending = send_file_request_xattr(
@@ -466,7 +473,7 @@ impl ReceiverContext {
                             // abbreviated value is requested. This keeps a large
                             // xattr on a new or redo'd file from being dropped
                             // for lack of a local copy to resolve it against.
-                            let xattr_request = self.build_xattr_request(file_entry, None);
+                            let xattr_request = self.build_xattr_request(&file_entry, None);
                             let pending = send_file_request_xattr(
                                 writer,
                                 &mut *ndx_write_codec,
@@ -534,7 +541,7 @@ impl ReceiverContext {
                     dest_dir: Some(setup.dest_dir.as_path()),
                 };
 
-                let xattr_list = self.resolve_xattr_list(file_entry);
+                let xattr_list = self.resolve_xattr_list(&file_entry);
                 let is_device_target = self.config.write.write_devices && file_entry.is_device();
                 let result = process_file_response_streaming(
                     reader,
@@ -545,7 +552,7 @@ impl ReceiverContext {
                     pipelined_receiver.file_sender(),
                     pipelined_receiver.buf_return_rx(),
                     file_idx,
-                    file_entry,
+                    &file_entry,
                     is_device_target,
                     xattr_list,
                     &mut token_reader,
@@ -634,7 +641,7 @@ impl ReceiverContext {
                         // produces a client-visible row (record_itemize gates on
                         // client_mode), so this stays the no-op it already was,
                         // whether or not deferral is active.
-                        let _ = self.emit_or_record_itemize(writer, file_idx, &iflags, file_entry);
+                        let _ = self.emit_or_record_itemize(writer, file_idx, &iflags, &file_entry);
                     }
                 }
 
@@ -730,14 +737,14 @@ impl ReceiverContext {
     /// - `generator.c:584-587` - `write_ndx()` + `write_shortint(iflags)`
     /// - `sender.c:292-294` - the sender logs the row, then echoes the attrs
     #[allow(clippy::too_many_arguments)]
-    fn send_no_transfer_itemize<'a, W: Write + ?Sized>(
+    fn send_no_transfer_itemize<W: Write + ?Sized>(
         &self,
         writer: &mut W,
         ndx_write_codec: &mut impl protocol::codec::NdxCodec,
         pipeline: &mut PipelineState,
-        pending_files_info: &mut VecDeque<(usize, PathBuf, &'a FileEntry, u32)>,
+        pending_files_info: &mut VecDeque<(usize, PathBuf, FileEntry, u32)>,
         file_idx: usize,
-        file_entry: &'a FileEntry,
+        file_entry: FileEntry,
         file_path: PathBuf,
         base_iflags: u32,
     ) -> io::Result<()> {

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -10,7 +10,6 @@ use std::path::PathBuf;
 
 use logging::{PhaseTimer, debug_log, info_log};
 use protocol::codec::{MonotonicNdxWriter, create_ndx_codec};
-use protocol::flist::FileEntry;
 
 use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
@@ -203,6 +202,13 @@ impl ReceiverContext {
             }
             ReceiverMode::Transfer => {
                 let total_files = files_to_transfer.len();
+                // Stage 0: hand the pipeline the transfer set by flist index;
+                // the in-flight window clones each FileEntry as it is pushed
+                // (O(window)), so the loop no longer borrows `self.file_list`.
+                let files_to_transfer: Vec<(usize, PathBuf, u32)> = files_to_transfer
+                    .into_iter()
+                    .map(|(idx, _entry, path, iflags)| (idx, path, iflags))
+                    .collect();
                 let redo_config = pipeline_config.clone();
                 let redo_indices;
                 let delayed;
@@ -244,7 +250,7 @@ impl ReceiverContext {
 
                     // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
                     // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
-                    let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
+                    let redo_files: Vec<(usize, PathBuf, u32)> = redo_indices
                         .iter()
                         .filter_map(|&idx| {
                             self.file_list.get(idx).map(|entry| {
@@ -254,12 +260,7 @@ impl ReceiverContext {
                                 } else {
                                     setup.dest_dir.join(p)
                                 };
-                                (
-                                    idx,
-                                    entry,
-                                    file_path,
-                                    crate::generator::ItemFlags::ITEM_TRANSFER,
-                                )
+                                (idx, file_path, crate::generator::ItemFlags::ITEM_TRANSFER)
                             })
                         })
                         .collect();

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -10,7 +10,6 @@ use std::path::PathBuf;
 
 use logging::{PhaseTimer, debug_log, info_log};
 use protocol::codec::{MonotonicNdxWriter, create_ndx_codec};
-use protocol::flist::FileEntry;
 
 use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
@@ -237,6 +236,13 @@ impl ReceiverContext {
             }
             ReceiverMode::Transfer => {
                 let total_files = files_to_transfer.len();
+                // Stage 0: hand the pipeline the transfer set by flist index;
+                // the in-flight window clones each FileEntry as it is pushed
+                // (O(window)), so the loop no longer borrows `self.file_list`.
+                let files_to_transfer: Vec<(usize, PathBuf, u32)> = files_to_transfer
+                    .into_iter()
+                    .map(|(idx, _entry, path, iflags)| (idx, path, iflags))
+                    .collect();
                 let redo_config = pipeline_config.clone();
                 let redo_indices;
                 let delayed;
@@ -278,7 +284,7 @@ impl ReceiverContext {
 
                     // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
                     // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
-                    let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
+                    let redo_files: Vec<(usize, PathBuf, u32)> = redo_indices
                         .iter()
                         .filter_map(|&idx| {
                             self.file_list.get(idx).map(|entry| {
@@ -288,12 +294,7 @@ impl ReceiverContext {
                                 } else {
                                     setup.dest_dir.join(p)
                                 };
-                                (
-                                    idx,
-                                    entry,
-                                    file_path,
-                                    crate::generator::ItemFlags::ITEM_TRANSFER,
-                                )
+                                (idx, file_path, crate::generator::ItemFlags::ITEM_TRANSFER)
                             })
                         })
                         .collect();


### PR DESCRIPTION
Pure borrow-model refactor of the receiver pipeline. No behaviour change, no wire change.

`run_pipeline_loop_decoupled` took `&'a self` and held `&'a FileEntry` borrows into
`self.file_list` for the whole loop - both the input `files_to_transfer` and the
in-flight `pending_files_info` window. While those borrows are live `self.file_list`
cannot grow, which blocks any future work that needs to append to it mid-loop.

This changes the signature to `&mut self`, drops the `&'a FileEntry` from the input
tuple (`Vec<(usize, PathBuf, u32)>`), and lets the in-flight window own its
`FileEntry` - cloned as it enters the window and bounded by `pipeline.available_slots()`,
so the clone count is O(window), not O(total).

What is deliberately unchanged: the `no_transfer_rows` merge order, the flush and
keepalive cadence, the NDX write order, and the phase-2 redo codec threading
(one `ndx_write_codec`/`ndx_read_codec` pair through both the phase-1 and redo
calls - upstream keeps a single connection-wide `prev_positive`/`prev_negative`,
`io.c:2245`, and the redo re-requests through that same state).

## Verification

`cargo fmt --all -- --check` and `cargo check --workspace --all-features` are clean on
x86_64 Linux, and `cargo nextest run --workspace --all-features` runs there against this
branch.

Byte-neutrality was re-checked against a release binary built from the merge base
(`8c68fdb46`) over six daemon-pull scenarios: fresh and delta-seeded pulls on protocol 32
and protocol 29, plus an `--append-verify --ignore-times` run on each protocol that forces
the phase-2 verification redo. Both sides of each transfer used the binary under test. For
every scenario the destination tree (per-file md5, type, mode, size, mtime, symlink target)
and the normalized client stdout - itemize rows plus the whole `--stats` block, including
`Total bytes sent` / `Total bytes received` - are identical. Only the `bytes/sec` figure is
normalized.

```
===== scenario p32  (args: ) =====                                   IDENTICAL
===== scenario p32d (args: ) =====                                   IDENTICAL
===== scenario p29  (--protocol=29) =====                            IDENTICAL
===== scenario p29d (--protocol=29) =====                            IDENTICAL
===== scenario redo32 (--append-verify --ignore-times) =====         IDENTICAL
===== scenario redo29 (--protocol=29 --append-verify --ignore-times) IDENTICAL
BYTE_NEUTRALITY_FAIL=0
```

`daemon_pull_forced_verification_failure_recovers_via_redo` - the regression guard for the
redo NDX codec threading - passes on this branch (1 passed).

Known follow-up, filed separately: `build_files_to_transfer` still yields the
4-tuple and the caller discards the entry. Changing the producer would have widened
this diff, which is gated on byte-neutrality, so the shim stays for now.

