### PR TITLE
fix(ci): plot peak RSS, not duration, in the benchmark memory row

### DIFF
--- a/.github/scripts/benchmark_chart.py
+++ b/.github/scripts/benchmark_chart.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 """Generate an SVG benchmark chart from benchmark_results.json.
 
-Pure Python -- no external dependencies.  Reads CI benchmark timing data
-and produces a grouped horizontal bar chart comparing oc-rsync against
-upstream rsync across all transfer modes.
+Pure Python -- no external dependencies.  Reads CI benchmark data and
+produces a grouped horizontal bar chart comparing oc-rsync against upstream
+rsync across all transfer modes.
+
+Not every mode measures the same thing.  Most compare elapsed time, but the
+`memory` mode compares peak resident set size, so each mode declares its
+metric unit (`MODE_UNITS`) and that unit selects both the value read out of
+the results JSON and the formatter used to label it.
 
 Design patterns:
   - Builder (ChartBuilder) for incremental SVG construction
   - Data classes for typed, immutable layout geometry
+  - Strategy for unit-driven value extraction, formatting and ratio wording
   - Strategy for adaptive text placement (inside vs outside bars)
   - Single Responsibility per function
 """
@@ -20,6 +26,7 @@ import math
 import os
 import sys
 from dataclasses import dataclass
+from enum import Enum
 from html import escape
 
 # ---------------------------------------------------------------------------
@@ -43,8 +50,9 @@ MODE_GAP = 16
 MIN_BAR_WIDTH = 2
 TEXT_INSIDE_THRESHOLD = 60
 
-# Speedup classification thresholds (oc_rsync / upstream timing ratio).
-# < FASTER: oc-rsync clearly faster.  <= SAME_UPPER: within noise.  > SAME_UPPER: slower.
+# Comparison thresholds on the oc_rsync / upstream ratio, in whichever unit
+# the mode measures.  < FASTER: oc-rsync clearly better.  <= SAME_UPPER:
+# within noise.  > SAME_UPPER: worse.
 RATIO_FASTER_BELOW = 0.95
 RATIO_SAME_UPPER = 1.05
 
@@ -119,6 +127,39 @@ MODE_CLI_HINTS = {
     ),
 }
 
+
+class MetricUnit(Enum):
+    """What a mode's bars measure.
+
+    Only the two units the benchmark actually produces exist here: elapsed
+    wall-clock time and peak resident set size.
+    """
+
+    DURATION = "duration"
+    BYTES = "bytes"
+
+
+# Every mode states its unit explicitly.  There is deliberately no default:
+# a new mode must declare what it measures, because a mode silently
+# inheriting "duration" is how peak RSS came to be plotted and labelled as
+# elapsed time.
+MODE_UNITS = {
+    "local": MetricUnit.DURATION,
+    "ssh_pull": MetricUnit.DURATION,
+    "ssh_push": MetricUnit.DURATION,
+    "daemon_pull": MetricUnit.DURATION,
+    "daemon_push": MetricUnit.DURATION,
+    "compression": MetricUnit.DURATION,
+    "delta": MetricUnit.DURATION,
+    "large_file": MetricUnit.DURATION,
+    "many_small": MetricUnit.DURATION,
+    "sparse": MetricUnit.DURATION,
+    "memory": MetricUnit.BYTES,
+    "checksum_openssl": MetricUnit.DURATION,
+    "io_uring": MetricUnit.DURATION,
+    "ssh_transport": MetricUnit.DURATION,
+}
+
 # Modes where bars represent alternative labels instead of upstream vs oc-rsync
 OPENSSL_MODES = {"checksum_openssl"}
 IO_URING_MODES = {"io_uring"}
@@ -133,11 +174,16 @@ CLI_HINT_HEIGHT = 16
 
 @dataclass(frozen=True)
 class BarSpec:
-    """One horizontal bar in the chart."""
+    """One horizontal bar in the chart.
+
+    `value` is the measured magnitude in the owning mode's unit -- seconds
+    for a duration mode, bytes for a byte mode.  The field is deliberately
+    unit-neutral; the unit lives on the enclosing `ModeGroup`.
+    """
 
     y: float
     width: float
-    timing: float
+    value: float
     color: str
     series_label: str
 
@@ -166,18 +212,28 @@ class TestPair:
 
 @dataclass(frozen=True)
 class ModeGroup:
-    """A group of test pairs under one transfer mode header."""
+    """A group of test pairs under one transfer mode header.
+
+    `unit` is the metric every bar and ratio in this group is expressed in;
+    it selects the label formatter and the ratio wording.
+    """
 
     label: str
     header_y: float
     cli_hint: str
     cli_hint_y: float
+    unit: MetricUnit
     tests: list[TestPair]
 
 
 @dataclass(frozen=True)
 class ChartLayout:
-    """Complete layout geometry for the chart."""
+    """Complete layout geometry for the chart.
+
+    `max_time` and `scale` describe a shared duration axis and are therefore
+    derived from duration modes only -- a single axis spanning seconds and
+    bytes would be meaningless.
+    """
 
     groups: list[ModeGroup]
     chart_height: float
@@ -196,20 +252,60 @@ def _is_three_way_ssh(mode: str, t: dict) -> bool:
     return mode in SSH_TRANSPORT_MODES and "upstream_ssh" in t
 
 
+def _series_keys(mode: str, t: dict) -> tuple[str, ...]:
+    """Result-JSON keys holding this row's series, left to right."""
+    if _is_three_way_ssh(mode, t):
+        return ("upstream_ssh", "oc_subprocess", "oc_russh")
+    return ("upstream", "oc_rsync")
+
+
+def metric_value(series: dict, unit: MetricUnit) -> float:
+    """Read one series' measured magnitude in `unit` from a results entry.
+
+    benchmark.py reports every series with the same timing keys (`mean`,
+    `min`, `max`) and attaches peak resident set size under a separate
+    `peak_rss_kb` key.  A byte-unit mode must therefore read `peak_rss_kb`:
+    its `mean` is the run's elapsed time, not its memory use.
+
+    `peak_rss_kb` is absent when /usr/bin/time could not be parsed; report
+    zero so the row renders as visibly empty rather than aborting the chart.
+    """
+    if unit is MetricUnit.BYTES:
+        return float(series.get("peak_rss_kb") or 0.0) * 1024.0
+    return float(series["mean"])
+
+
+def metric_values(mode: str, t: dict) -> list[float]:
+    """Measured magnitudes for every bar of one test row, in the mode's unit."""
+    unit = MODE_UNITS[mode]
+    return [metric_value(t[key], unit) for key in _series_keys(mode, t)]
+
+
+def pair_ratio(t: dict, unit: MetricUnit, up_v: float, oc_v: float) -> float:
+    """oc-rsync vs upstream ratio for one row, in the row's own unit.
+
+    The results JSON carries a single `ratio` field that benchmark.py always
+    derives from elapsed time -- benchmark_report.py renders it under a
+    column headed "Time Ratio" and prints peak RSS in separate columns.  A
+    byte-unit row must therefore derive its ratio from the magnitudes it
+    actually plots, otherwise the memory row is annotated with a speed-up
+    that says nothing about memory.
+    """
+    if unit is MetricUnit.BYTES:
+        return oc_v / up_v if up_v > 0 else 0.0
+    return t.get("ratio", 0.0)
+
+
 def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
     """Compute y-positions for every element and overall chart dimensions."""
     all_times = []
     for mode, mode_tests in tests_by_mode.items():
+        if MODE_UNITS.get(mode) is not MetricUnit.DURATION:
+            continue
         for t in mode_tests:
-            if _is_three_way_ssh(mode, t):
-                all_times.append(t["upstream_ssh"]["mean"])
-                all_times.append(t["oc_subprocess"]["mean"])
-                all_times.append(t["oc_russh"]["mean"])
-            else:
-                all_times.append(t["upstream"]["mean"])
-                all_times.append(t["oc_rsync"]["mean"])
+            all_times.extend(metric_values(mode, t))
 
-    max_time = max(all_times) if all_times else 1.0
+    max_time = max(all_times, default=0.0) or 1.0
     scale = BAR_AREA_WIDTH / (max_time * 1.1)
 
     y = TOP_MARGIN
@@ -220,25 +316,24 @@ def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
         if not mode_tests:
             continue
 
+        unit = MODE_UNITS[mode]
+
         if groups:
             y += MODE_GAP
 
         # Per-group horizontal scale. A single global scale (driven by the one
-        # slowest test across every mode) crushes the sub-second groups into
-        # unreadable stubs while a few multi-second cases stretch across, so
-        # each mode group is scaled to its own slowest bar instead. Absolute
-        # times stay legible via the per-bar ms labels; the ratio column
-        # carries the cross-group comparison.
-        group_times: list[float] = []
+        # largest test across every mode) crushes the small groups into
+        # unreadable stubs while a few outliers stretch across, so each mode
+        # group is scaled to its own largest bar instead. Absolute magnitudes
+        # stay legible via the per-bar labels; the ratio column carries the
+        # cross-group comparison. Per-group scaling is also what keeps modes
+        # in different units from sharing an axis.
+        group_values: list[float] = []
         for t in mode_tests:
-            if _is_three_way_ssh(mode, t):
-                group_times.append(t["upstream_ssh"]["mean"])
-                group_times.append(t["oc_subprocess"]["mean"])
-                group_times.append(t["oc_russh"]["mean"])
-            else:
-                group_times.append(t["upstream"]["mean"])
-                group_times.append(t["oc_rsync"]["mean"])
-        group_max = max(group_times) if group_times else 1.0
+            group_values.extend(metric_values(mode, t))
+        # `or 1.0` also covers an all-zero group (every measurement missing),
+        # which would otherwise divide by zero.
+        group_max = max(group_values, default=0.0) or 1.0
         group_scale = BAR_AREA_WIDTH / (group_max * 1.1)
 
         header_y = y + MODE_HEADER_HEIGHT * 0.7
@@ -266,20 +361,17 @@ def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
             else:
                 center_y = y + BAR_HEIGHT + BAR_GAP / 2
 
+            values = metric_values(mode, t)
             if three_way:
-                up_t = t["upstream_ssh"]["mean"]
-                oc_t = t["oc_subprocess"]["mean"]
-                third_t = t["oc_russh"]["mean"]
+                up_v, oc_v, third_v = values
             else:
-                up_t = t["upstream"]["mean"]
-                oc_t = t["oc_rsync"]["mean"]
-                third_t = None
+                (up_v, oc_v), third_v = values, None
 
-            up_w = max(up_t * group_scale, MIN_BAR_WIDTH)
-            oc_w = max(oc_t * group_scale, MIN_BAR_WIDTH)
+            up_w = max(up_v * group_scale, MIN_BAR_WIDTH)
+            oc_w = max(oc_v * group_scale, MIN_BAR_WIDTH)
             third_w = (
-                max(third_t * group_scale, MIN_BAR_WIDTH)
-                if third_t is not None
+                max(third_v * group_scale, MIN_BAR_WIDTH)
+                if third_v is not None
                 else None
             )
 
@@ -315,20 +407,20 @@ def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
             ratio_secondary = None
             if three_way and third_w is not None and bar3_color is not None:
                 third_bar = BarSpec(
-                    third_y, third_w, third_t, bar3_color, bar3_label
+                    third_y, third_w, third_v, bar3_color, bar3_label
                 )
                 # Primary ratio = russh / oc subprocess.
                 # Secondary ratio = oc subprocess / upstream.
                 ratio_primary = t.get("ratio_russh_vs_sub", t.get("ratio", 0.0))
                 ratio_secondary = t.get("ratio_sub_vs_upstream", 0.0)
             else:
-                ratio_primary = t.get("ratio", 0.0)
+                ratio_primary = pair_ratio(t, unit, up_v, oc_v)
 
             pairs.append(
                 TestPair(
                     name=t["name"],
-                    upstream=BarSpec(up_y, up_w, up_t, bar1_color, bar1_label),
-                    oc_rsync=BarSpec(oc_y, oc_w, oc_t, bar2_color, bar2_label),
+                    upstream=BarSpec(up_y, up_w, up_v, bar1_color, bar1_label),
+                    oc_rsync=BarSpec(oc_y, oc_w, oc_v, bar2_color, bar2_label),
                     ratio=ratio_primary,
                     center_y=center_y,
                     third=third_bar,
@@ -346,6 +438,7 @@ def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
             header_y=header_y,
             cli_hint=cli_hint,
             cli_hint_y=cli_hint_y,
+            unit=unit,
             tests=pairs,
         ))
 
@@ -373,22 +466,91 @@ def fmt_time(seconds: float) -> str:
     return f"{seconds:.2f}s"
 
 
-def ratio_text(ratio: float) -> tuple[str, str]:
-    """Return (display_text, color) for a speedup annotation.
+def fmt_bytes(num_bytes: float) -> str:
+    """Human-readable size: '512 KiB' for <1 MiB, '12.34 MiB', '1.21 GiB'.
 
-    A non-positive ratio means timing data was missing or rounded to zero
-    on at least one side of the comparison (benchmark.py rounds ratios to
-    two decimals, collapsing sub-millisecond ratios such as 250x faster
-    to 0.0); render a neutral marker rather than dividing by zero.
+    IEC binary prefixes, because the underlying measurement is /usr/bin/time's
+    peak resident set size, reported in 1024-byte kbytes; the digits therefore
+    match the memory table in benchmark_report.py, which divides by 1024 too.
+    Mirrors fmt_time's shape: whole units for the smallest step, two decimals
+    once the value crosses into a larger one.
     """
+    kib = num_bytes / 1024.0
+    if kib < 1024.0:
+        return f"{kib:.0f} KiB"
+    mib = kib / 1024.0
+    if mib < 1024.0:
+        return f"{mib:.2f} MiB"
+    return f"{mib / 1024.0:.2f} GiB"
+
+
+def fmt_time_exact(seconds: float) -> str:
+    """Unabbreviated timing for hover text: '2.986s'."""
+    return f"{seconds:.3f}s"
+
+
+def fmt_bytes_exact(num_bytes: float) -> str:
+    """Unabbreviated size for hover text, in the measured unit: '7924 KiB'.
+
+    /usr/bin/time reports peak RSS in whole kilobytes, so this is the raw
+    measurement with no rounding of its own.
+    """
+    return f"{num_bytes / 1024:.0f} KiB"
+
+
+# Strategy: the mode's unit selects the formatter.  One formatter for all
+# modes is what put a duration under the "Memory Usage" header.  Bar and
+# axis labels are abbreviated for width; hover text keeps full precision.
+UNIT_FORMATTERS = {
+    MetricUnit.DURATION: fmt_time,
+    MetricUnit.BYTES: fmt_bytes,
+}
+UNIT_EXACT_FORMATTERS = {
+    MetricUnit.DURATION: fmt_time_exact,
+    MetricUnit.BYTES: fmt_bytes_exact,
+}
+
+# (better, worse) wording for a ratio in each unit.  Spending more RSS is
+# not "slower", it is more memory.
+RATIO_WORDS = {
+    MetricUnit.DURATION: ("faster", "slower"),
+    MetricUnit.BYTES: ("less memory", "more memory"),
+}
+
+
+def fmt_value(value: float, unit: MetricUnit) -> str:
+    """Format a measured magnitude for a bar or axis label."""
+    return UNIT_FORMATTERS[unit](value)
+
+
+def fmt_value_exact(value: float, unit: MetricUnit) -> str:
+    """Format a measured magnitude for hover text, without abbreviating."""
+    return UNIT_EXACT_FORMATTERS[unit](value)
+
+
+def ratio_text(ratio: float, unit: MetricUnit) -> tuple[str, str]:
+    """Return (display_text, color) for an oc-rsync vs upstream annotation.
+
+    Wording follows the unit: a duration ratio reads faster/slower, a memory
+    ratio reads less/more memory.
+
+    A non-positive ratio is only meaningful for durations, where benchmark.py
+    rounds ratios to two decimals and so collapses a sub-millisecond ratio
+    such as 250x faster to 0.0.  Peak RSS has no comparable rounding floor --
+    it is measured in whole kilobytes -- so for a byte metric a non-positive
+    ratio can only mean the measurement is missing, and claiming a win there
+    would invent a result.
+    """
+    better, worse = RATIO_WORDS[unit]
     if ratio <= 0:
-        return (">100x faster", COLOR_FASTER)
+        if unit is MetricUnit.DURATION:
+            return (f">100x {better}", COLOR_FASTER)
+        return ("no data", COLOR_SAME)
     if ratio < RATIO_FASTER_BELOW:
-        speedup = 1.0 / ratio
-        return (f"{speedup:.1f}x faster", COLOR_FASTER)
+        return (f"{1.0 / ratio:.1f}x {better}", COLOR_FASTER)
     if ratio <= RATIO_SAME_UPPER:
         return ("~same", COLOR_SAME)
-    return (f"{ratio:.1f}x slower", COLOR_SLOWER)
+    return (f"{ratio:.1f}x {worse}", COLOR_SLOWER)
 
 
 def nice_grid_step(max_val: float, target_steps: int = 5) -> float:
@@ -448,7 +610,14 @@ class ChartBuilder:
         scale: float,
         y_top: float,
         y_bottom: float,
+        unit: MetricUnit = MetricUnit.DURATION,
     ) -> None:
+        """Draw an axis of dashed gridlines labelled in `unit`.
+
+        Axis labels are formatted at a different site from the bar labels, so
+        they take the same unit-driven formatter; a grid drawn over a byte
+        axis must not be labelled in milliseconds.
+        """
         step = nice_grid_step(max_time)
         self._parts.append("<g>")
         val = step
@@ -464,12 +633,12 @@ class ChartBuilder:
             self._parts.append(
                 f'<text x="{x:.1f}" y="{y_bottom + 14}" '
                 f'text-anchor="middle" font-size="10" fill="{COLOR_SUBTITLE}">'
-                f"{fmt_time(val)}</text>"
+                f"{fmt_value(val, unit)}</text>"
             )
             val += step
         self._parts.append("</g>")
 
-    def add_mode_group(self, group: ModeGroup, scale: float) -> None:
+    def add_mode_group(self, group: ModeGroup) -> None:
         self._parts.append(
             f'<text x="10" y="{group.header_y:.1f}" '
             f'font-size="13" font-weight="600" fill="{COLOR_MODE_HEADER}">'
@@ -489,11 +658,11 @@ class ChartBuilder:
                 f'text-anchor="end" font-size="11" fill="{COLOR_LABEL}">'
                 f"{escape(pair.name)}</text>"
             )
-            self._add_bar(pair.upstream, scale)
-            self._add_bar(pair.oc_rsync, scale)
+            self._add_bar(pair.upstream, group.unit)
+            self._add_bar(pair.oc_rsync, group.unit)
             if pair.third is not None:
-                self._add_bar(pair.third, scale)
-            self._add_speedup(pair)
+                self._add_bar(pair.third, group.unit)
+            self._add_speedup(pair, group.unit)
 
     def add_legend(
         self,
@@ -603,38 +772,39 @@ class ChartBuilder:
         self._parts.append("</svg>")
         return "\n".join(self._parts)
 
-    def _add_bar(self, bar: BarSpec, scale: float) -> None:
+    def _add_bar(self, bar: BarSpec, unit: MetricUnit) -> None:
+        value_str = fmt_value(bar.value, unit)
         self._parts.append(
             f'<rect x="{LEFT_MARGIN}" y="{bar.y:.1f}" '
             f'width="{bar.width:.1f}" height="{BAR_HEIGHT}" '
             f'rx="3" fill="{bar.color}">'
-            f"<title>{escape(bar.series_label)}: {bar.timing:.3f}s</title>"
+            f"<title>{escape(bar.series_label)}: "
+            f"{fmt_value_exact(bar.value, unit)}</title>"
             f"</rect>"
         )
-        time_str = fmt_time(bar.timing)
         text_y = bar.y + BAR_HEIGHT - 4
         if bar.width > TEXT_INSIDE_THRESHOLD:
             tx = LEFT_MARGIN + bar.width - 8
             self._parts.append(
                 f'<text x="{tx:.1f}" y="{text_y:.1f}" '
                 f'text-anchor="end" font-size="10" fill="{COLOR_TEXT_ON_BAR}">'
-                f"{time_str}</text>"
+                f"{value_str}</text>"
             )
         else:
             tx = LEFT_MARGIN + bar.width + 4
             self._parts.append(
                 f'<text x="{tx:.1f}" y="{text_y:.1f}" '
                 f'text-anchor="start" font-size="10" fill="{COLOR_TEXT_OFF_BAR}">'
-                f"{time_str}</text>"
+                f"{value_str}</text>"
             )
 
-    def _add_speedup(self, pair: TestPair) -> None:
-        text, color = ratio_text(pair.ratio)
+    def _add_speedup(self, pair: TestPair, unit: MetricUnit) -> None:
+        text, color = ratio_text(pair.ratio, unit)
         x = CHART_WIDTH - RIGHT_MARGIN + 10
         if pair.ratio_secondary is not None:
             # Stack two ratios for the 3-way comparison: oc-sub vs upstream
             # above, russh vs oc-sub below.
-            sec_text, sec_color = ratio_text(pair.ratio_secondary)
+            sec_text, sec_color = ratio_text(pair.ratio_secondary, unit)
             y_top = pair.center_y - 4
             y_bot = pair.center_y + 12
             self._parts.append(
@@ -694,10 +864,11 @@ def generate_chart(data: dict) -> str:
         f"{size_mb} MB, {files} files \u2014 Linux x86_64 CI",
     )
 
-    # No global x-axis grid: with per-group scaling a single shared axis would
-    # be misleading. Each bar carries its own ms label instead.
+    # No global x-axis grid: with per-group scaling -- and with modes that do
+    # not even share a unit -- a single shared axis would be misleading. Each
+    # bar carries its own label in its mode's unit instead.
     for group in layout.groups:
-        builder.add_mode_group(group, layout.scale)
+        builder.add_mode_group(group)
 
     builder.add_legend(
         chart_height - 30 - extra_legend,

--- a/.github/workflows/benchmark-tooling.yml
+++ b/.github/workflows/benchmark-tooling.yml
@@ -1,0 +1,51 @@
+# Regression guard for the release benchmark renderers.
+#
+# `benchmark.yml` runs only on tag pushes, so a defect in the chart or
+# report scripts is not discovered until it has already been published as a
+# release asset. That is exactly how the benchmark chart came to plot
+# wall-clock durations under its "Memory Usage" header: the mode's peak RSS
+# measurement lives under a separate `peak_rss_kb` key that the chart never
+# read, and nobody rendered the output between tags.
+#
+# This job renders both scripts against synthetic results on every pull
+# request that touches them, and asserts the memory mode plots RSS-derived
+# magnitudes in byte units while the timing modes stay in ms/s.
+
+name: Benchmark tooling
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/benchmark_chart.py'
+      - '.github/scripts/benchmark_report.py'
+      - 'tools/ci/tests/test_benchmark_chart.py'
+      - '.github/workflows/benchmark-tooling.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/scripts/benchmark_chart.py'
+      - '.github/scripts/benchmark_report.py'
+      - 'tools/ci/tests/test_benchmark_chart.py'
+      - '.github/workflows/benchmark-tooling.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark-tooling-${{ github.ref }}
+  # Superseded pull request pushes still cancel; pushes to master do not, so
+  # every merge commit keeps a completed run for bisection.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  renderers:
+    name: Benchmark renderer self-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Self-test benchmark_chart.py and benchmark_report.py
+        run: python3 tools/ci/tests/test_benchmark_chart.py

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -116,6 +116,13 @@ jobs:
           python3 .github/scripts/benchmark_report.py > benchmark_report.md
           cat benchmark_report.md
 
+      - name: Self-test benchmark renderers
+        # The chart and report are published as release assets, so the
+        # renderers are exercised against synthetic results before the real
+        # ones are drawn. A metric regression here fails the tag build
+        # instead of shipping a misleading chart to the release page.
+        run: python3 tools/ci/tests/test_benchmark_chart.py
+
       - name: Generate benchmark chart
         run: |
           pip install cairosvg

--- a/tools/ci/tests/test_benchmark_chart.py
+++ b/tools/ci/tests/test_benchmark_chart.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Regression tests for the release benchmark chart and report renderers.
+
+Why this exists: benchmark.py measures two different things.  Most modes
+measure elapsed time, but the `memory` mode measures peak resident set size
+and reports it under a separate `peak_rss_kb` key, leaving `mean` holding
+the run's duration.  The chart read `mean` for every mode, so the published
+"Memory Usage" row plotted durations, labelled them in milliseconds, and
+annotated them with a time ratio -- advertising a speed-up where oc-rsync
+was in fact using several times more memory than upstream.  Nothing caught
+it because nothing rendered the chart outside CI.
+
+These tests therefore assert on the rendered SVG text rather than on
+internal helpers, and they assert magnitudes derived from `peak_rss_kb`
+rather than merely the presence of a unit suffix: a chart that still read
+`mean` but formatted it as bytes would satisfy a suffix-only check while
+being just as wrong.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = REPO_ROOT / ".github" / "scripts"
+
+
+def load_script(name: str):
+    """Import one of the .github/scripts modules by path.
+
+    They are standalone CI scripts rather than an importable package, so
+    they are loaded explicitly instead of through sys.path.
+    """
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    # Registered before execution so the dataclasses in the module can
+    # resolve their own postponed annotations.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bc = load_script("benchmark_chart")
+
+# Synthetic results with hand-picked magnitudes that make a metric mix-up
+# unmistakable:
+#   - memory RSS is 8 MiB vs 64 MiB, an 8.0x regression;
+#   - memory `mean` says the opposite (oc-rsync twice as quick), and the
+#     JSON `ratio` (0.5) is that time ratio, exactly as benchmark.py emits;
+#   - the durations are chosen so that leaking them into the memory row
+#     would print recognisable strings ("500 ms", "250 ms").
+MEMORY_UPSTREAM_RSS_KB = 8192
+MEMORY_OC_RSS_KB = 65536
+SYNTHETIC = {
+    "upstream_version": "3.4.4",
+    "test_data": {"size_mb": 100, "files": 1000},
+    "summary": {"avg_ratio": 0.5, "best_ratio": 0.2, "worst_ratio": 1.0,
+                "by_mode": {}},
+    "tests": [
+        {
+            "id": "local_initial",
+            "name": "Initial sync",
+            "mode": "local",
+            "upstream": {"mean": 2.0, "min": 2.0, "max": 2.0},
+            "oc_rsync": {"mean": 0.4, "min": 0.4, "max": 0.4},
+            "ratio": 0.2,
+        },
+        {
+            "id": "memory_initial",
+            "name": "Initial sync",
+            "mode": "memory",
+            "upstream": {
+                "mean": 0.5, "min": 0.5, "max": 0.5,
+                "peak_rss_kb": MEMORY_UPSTREAM_RSS_KB,
+                "avg_rss_kb": MEMORY_UPSTREAM_RSS_KB,
+            },
+            "oc_rsync": {
+                "mean": 0.25, "min": 0.25, "max": 0.25,
+                "peak_rss_kb": MEMORY_OC_RSS_KB,
+                "avg_rss_kb": MEMORY_OC_RSS_KB,
+            },
+            "ratio": 0.5,
+        },
+    ],
+}
+
+# Any label the duration formatter would emit.
+DURATION_LABEL = re.compile(r"\d+\s*ms\b|\d+\.\d{2}s\b|\d+\.\d{3}s\b")
+# Any label the byte formatter would emit.
+BYTE_LABEL = re.compile(r"\d[\d.]*\s*(KiB|MiB|GiB)\b")
+
+
+def texts(svg: str) -> list[str]:
+    """Every rendered text run: bar labels, axis labels, hover titles."""
+    return [
+        (m.group(1) or m.group(2) or "").strip()
+        for m in re.finditer(r"<title>([^<]*)</title>|>([^<>]*)</text>", svg)
+    ]
+
+
+def mode_section(svg: str, header: str, next_header: str | None) -> str:
+    """The slice of the SVG between one mode header and the next."""
+    start = svg.index(">" + header + "<")
+    if next_header is None:
+        return svg[start:]
+    end = svg.find(">" + next_header + "<", start)
+    return svg[start:end if end > 0 else len(svg)]
+
+
+class ModeUnitDeclarations(unittest.TestCase):
+    """Every mode must state its unit, so none can silently inherit one."""
+
+    def test_every_ordered_mode_declares_a_unit(self):
+        missing = [m for m in bc.MODE_ORDER if m not in bc.MODE_UNITS]
+        self.assertEqual(
+            missing, [],
+            "a mode without a MODE_UNITS entry would fall back to whatever "
+            "the caller assumes, which is how peak RSS became milliseconds",
+        )
+
+    def test_memory_mode_is_a_byte_metric(self):
+        self.assertIs(bc.MODE_UNITS["memory"], bc.MetricUnit.BYTES)
+
+    def test_transfer_modes_are_duration_metrics(self):
+        for mode in ("local", "ssh_pull", "daemon_push", "sparse"):
+            self.assertIs(bc.MODE_UNITS[mode], bc.MetricUnit.DURATION, mode)
+
+
+class MetricExtraction(unittest.TestCase):
+    """A byte mode must read peak RSS, never the timing keys."""
+
+    def test_byte_unit_reads_peak_rss_not_mean(self):
+        series = {"mean": 0.5, "peak_rss_kb": 8192}
+        self.assertEqual(
+            bc.metric_value(series, bc.MetricUnit.BYTES), 8192 * 1024
+        )
+
+    def test_duration_unit_reads_mean(self):
+        series = {"mean": 0.5, "peak_rss_kb": 8192}
+        self.assertEqual(bc.metric_value(series, bc.MetricUnit.DURATION), 0.5)
+
+    def test_missing_rss_reports_zero_rather_than_aborting(self):
+        # /usr/bin/time output can fail to parse; the chart still has to
+        # render the other thirteen modes.
+        self.assertEqual(bc.metric_value({"mean": 0.5}, bc.MetricUnit.BYTES), 0.0)
+
+
+class Formatters(unittest.TestCase):
+    """The two units must not share a formatter."""
+
+    def test_time_formatting_is_unchanged(self):
+        self.assertEqual(bc.fmt_time(0.042), "42 ms")
+        self.assertEqual(bc.fmt_time(1.234), "1.23s")
+
+    def test_bytes_use_binary_prefixes(self):
+        self.assertEqual(bc.fmt_bytes(512 * 1024), "512 KiB")
+        self.assertEqual(bc.fmt_bytes(8192 * 1024), "8.00 MiB")
+        self.assertEqual(bc.fmt_bytes(1536 * 1024 * 1024), "1.50 GiB")
+
+    def test_units_dispatch_to_distinct_formatters(self):
+        value = 8192 * 1024
+        self.assertNotEqual(
+            bc.fmt_value(value, bc.MetricUnit.BYTES),
+            bc.fmt_value(value, bc.MetricUnit.DURATION),
+            "a single shared formatter is the defect under test",
+        )
+
+    def test_hover_text_keeps_the_measured_precision(self):
+        self.assertEqual(bc.fmt_value_exact(2.986, bc.MetricUnit.DURATION), "2.986s")
+        self.assertEqual(
+            bc.fmt_value_exact(7924 * 1024, bc.MetricUnit.BYTES), "7924 KiB"
+        )
+
+
+class RatioWording(unittest.TestCase):
+    """Spending more memory is not being slower."""
+
+    def test_duration_ratio_reads_as_speed(self):
+        self.assertEqual(
+            bc.ratio_text(0.5, bc.MetricUnit.DURATION)[0], "2.0x faster"
+        )
+        self.assertEqual(
+            bc.ratio_text(2.0, bc.MetricUnit.DURATION)[0], "2.0x slower"
+        )
+
+    def test_byte_ratio_reads_as_memory(self):
+        self.assertEqual(
+            bc.ratio_text(8.0, bc.MetricUnit.BYTES)[0], "8.0x more memory"
+        )
+        self.assertEqual(
+            bc.ratio_text(0.5, bc.MetricUnit.BYTES)[0], "2.0x less memory"
+        )
+
+    def test_within_noise_is_neutral_in_both_units(self):
+        for unit in (bc.MetricUnit.DURATION, bc.MetricUnit.BYTES):
+            self.assertEqual(bc.ratio_text(1.0, unit)[0], "~same", unit)
+
+    def test_missing_byte_ratio_does_not_claim_a_win(self):
+        # The ">100x faster" fallback exists because benchmark.py rounds a
+        # sub-millisecond time ratio to 0.00.  Peak RSS is measured in whole
+        # kilobytes and has no such rounding floor, so a non-positive byte
+        # ratio only ever means the measurement is missing.
+        self.assertEqual(bc.ratio_text(0.0, bc.MetricUnit.BYTES)[0], "no data")
+        self.assertEqual(
+            bc.ratio_text(0.0, bc.MetricUnit.DURATION)[0], ">100x faster"
+        )
+
+    def test_byte_row_ratio_is_derived_from_plotted_values(self):
+        # benchmark.py's `ratio` field is a time ratio for every mode --
+        # benchmark_report.py renders it under a "Time Ratio" heading -- so a
+        # byte row must compute its own.
+        row = SYNTHETIC["tests"][1]
+        self.assertEqual(
+            bc.pair_ratio(row, bc.MetricUnit.BYTES, 8.0, 64.0), 8.0
+        )
+        self.assertEqual(
+            bc.pair_ratio(row, bc.MetricUnit.DURATION, 8.0, 64.0), 0.5
+        )
+
+
+class AxisLabels(unittest.TestCase):
+    """Axis labels are formatted at a different call site from bar labels."""
+
+    def _grid_labels(self, unit, max_val):
+        builder = bc.ChartBuilder(bc.CHART_WIDTH, 200)
+        scale = bc.BAR_AREA_WIDTH / (max_val * 1.1)
+        builder.add_grid(max_val, scale, 10, 100, unit)
+        labels = texts(builder.render())
+        self.assertTrue(labels, "grid produced no labels to assert on")
+        return labels
+
+    def test_duration_axis_is_labelled_in_time(self):
+        labels = self._grid_labels(bc.MetricUnit.DURATION, 2.0)
+        self.assertTrue(all(DURATION_LABEL.search(t) for t in labels), labels)
+        self.assertFalse(any(BYTE_LABEL.search(t) for t in labels), labels)
+
+    def test_byte_axis_is_labelled_in_bytes(self):
+        labels = self._grid_labels(bc.MetricUnit.BYTES, 64.0 * 1024 * 1024)
+        self.assertTrue(all(BYTE_LABEL.search(t) for t in labels), labels)
+        self.assertFalse(
+            any(DURATION_LABEL.search(t) for t in labels),
+            f"axis reverted to the duration formatter: {labels}",
+        )
+
+
+class RenderedChart(unittest.TestCase):
+    """End-to-end assertions on the SVG the release actually publishes."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.svg = bc.generate_chart(SYNTHETIC)
+        cls.memory = mode_section(cls.svg, "Memory Usage", None)
+        cls.local = mode_section(cls.svg, "Local Copy", "Memory Usage")
+
+    def test_memory_row_plots_the_peak_rss_magnitudes(self):
+        # 8192 KiB and 65536 KiB, not the 0.5s / 0.25s durations beside them.
+        self.assertIn("8.00 MiB", self.memory)
+        self.assertIn("64.00 MiB", self.memory)
+
+    def test_memory_row_carries_no_duration_label(self):
+        offenders = [t for t in texts(self.memory) if DURATION_LABEL.search(t)]
+        self.assertEqual(
+            offenders, [],
+            "peak RSS rendered through the duration formatter",
+        )
+        for leaked in ("500 ms", "250 ms"):
+            self.assertNotIn(leaked, self.memory)
+
+    def test_memory_row_reports_the_regression_not_a_speedup(self):
+        self.assertIn("8.0x more memory", self.memory)
+        self.assertNotIn("faster", self.memory)
+        self.assertNotIn("slower", self.memory)
+
+    def test_memory_hover_text_shows_the_measured_kilobytes(self):
+        self.assertIn(f"{MEMORY_UPSTREAM_RSS_KB} KiB", self.memory)
+        self.assertIn(f"{MEMORY_OC_RSS_KB} KiB", self.memory)
+
+    def test_timing_row_is_still_rendered_as_time(self):
+        self.assertIn("2.00s", self.local)
+        self.assertIn("400 ms", self.local)
+        self.assertIn("5.0x faster", self.local)
+
+    def test_timing_row_carries_no_byte_label(self):
+        offenders = [t for t in texts(self.local) if BYTE_LABEL.search(t)]
+        self.assertEqual(offenders, [], "duration rendered through fmt_bytes")
+
+    def test_chart_survives_missing_rss_measurements(self):
+        data = json.loads(json.dumps(SYNTHETIC))
+        for side in ("upstream", "oc_rsync"):
+            data["tests"][1][side].pop("peak_rss_kb")
+        section = mode_section(bc.generate_chart(data), "Memory Usage", None)
+        self.assertIn("no data", section)
+
+
+class RenderedReport(unittest.TestCase):
+    """The markdown report already handled RSS correctly; pin that."""
+
+    @classmethod
+    def setUpClass(cls):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "benchmark_results.json").write_text(
+                json.dumps(SYNTHETIC)
+            )
+            cls.report = subprocess.run(
+                [sys.executable, str(SCRIPTS / "benchmark_report.py")],
+                cwd=tmp, capture_output=True, text=True, check=True,
+            ).stdout
+
+    def test_memory_table_reports_rss_columns(self):
+        self.assertIn("8.0MB", self.report)
+        self.assertIn("64.0MB", self.report)
+
+    def test_memory_table_names_its_ratio_column_as_time(self):
+        # The chart derives its own byte ratio precisely because this column
+        # is, and remains, a time ratio.
+        self.assertIn("Time Ratio", self.report)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect is worse than reported

This was filed as "the benchmark chart renders memory as milliseconds" - a
formatting typo. It is not a formatting bug. **The chart never read the memory
measurement at all.**

`benchmark.py` reports every series with the same timing keys (`mean`, `min`,
`max`) and attaches peak resident set size under a *separate* `peak_rss_kb`
key. `benchmark_chart.py` read `mean` for every mode, including `memory`. So
the bars under the "Memory Usage" header - with the CLI hint
`rsync -av (peak RSS measurement)` - were wall-clock durations, correctly
formatted in ms, sitting under a memory label. The RSS data was silently
dropped, and the "Nx faster" annotation beside it was the time ratio.

### What the published v0.6.4 release asset actually claims

Regenerated from the real `benchmark_results.json` attached to the v0.6.4
release:

| Test | chart said | plotted (`mean`) | actual peak RSS | true ratio |
|------|-----------|------------------|-----------------|-----------|
| Initial sync (10K files) | **1.2x faster** | 0.403s vs 0.343s | 7924 KB vs 46480 KB | **5.9x more memory** |
| 1GB file sync | **1.6x faster** | 0.508s vs 0.310s | 7044 KB vs 15388 KB | **2.2x more memory** |
| 100K files sync | **~same** | 2.986s vs 3.016s | 7800 KB vs 94708 KB | **12.1x more memory** |

The chart advertised a memory win on every row where oc-rsync in fact used
between 2x and 12x more RSS than upstream. A label-only fix would have
formatted those same durations as bytes and made things strictly worse.

### Not affected

- **`benchmark_report.py` is correct** and is untouched. It reads
  `peak_rss_kb` into dedicated RSS columns and explicitly heads its timing
  column "Time Ratio". The release-notes *text* has always been right; only
  the PNG was wrong.
- **No cross-platform unit skew.** `parse_peak_rss_kb` already normalises both
  the Linux `/usr/bin/time -v` kbytes form and the macOS `-l` bytes form
  (`// 1024`), so `_benchmark-macos.yml` is not off by 1024x. The values
  themselves are sound; only the consumer was wrong.

## The fix

The single formatter over fourteen modes was a symptom of a missing
abstraction: nothing in the model recorded what a mode measures. Each mode now
declares a metric unit, and that unit drives everything downstream.

- **`MODE_UNITS`** declares `Duration` or `Bytes` for every mode, alongside
  `MODE_LABELS` and `MODE_CLI_HINTS`. There is deliberately no default, so a
  new mode must state what it measures.
- **Extraction** (the actual fix): a byte-unit mode reads `peak_rss_kb`; a
  duration mode reads `mean`. A missing RSS measurement yields zero rather
  than aborting the whole chart.
- **`fmt_bytes`** mirrors `fmt_time`'s shape and uses IEC binary prefixes,
  because the source measurement is `/usr/bin/time`'s 1024-byte kbytes. The
  digits therefore agree with the report table, which divides by 1024 too.
- **Dispatch by unit** at the bar labels, the axis grid labels and the bar
  hover text - the last of which had its own hardcoded `s` suffix.
- **`BarSpec.timing` -> `BarSpec.value`.** The old name encoded the assumption
  that caused the bug.
- **`ratio_text` is unit-aware.** Burning more RSS is not "slower", it is
  "more memory". A byte row also derives its ratio from the magnitudes it
  plots, since the JSON `ratio` is a time ratio by contract. The
  `ratio <= 0` fallback justified itself with sub-millisecond rounding - a
  duration-specific rationale - so for bytes, which are measured in whole
  kilobytes and have no such rounding floor, it renders "no data" instead of
  claiming ">100x faster".

## Before / after

Rendered through the exact workflow commands against the real v0.6.4 results.

Before:

```
Memory Usage / rsync -av (peak RSS measurement)
  Initial sync (10K files)   403 ms  |  343 ms   1.2x faster
  1GB file sync              508 ms  |  310 ms   1.6x faster
  100K files sync            2.99s   |  3.02s    ~same
```

After:

```
Memory Usage / rsync -av (peak RSS measurement)
  Initial sync (10K files)   7.74 MiB |  45.39 MiB   5.9x more memory
  1GB file sync              6.88 MiB |  15.03 MiB   2.2x more memory
  100K files sync            7.62 MiB |  92.49 MiB  12.1x more memory
```

Upstream peak RSS lands at single-digit MiB, as expected for these trees, and
hover text carries the raw measurement (`7924 KiB`). The PNG was rasterised
via `cairosvg` and inspected, not just diffed.

**All thirteen duration modes render byte-identically before and after** -
verified by segmenting both SVGs per mode header and comparing; `Memory Usage`
is the only changed segment.

## Testing

There was no test on this script at all, which is why a duration formatter on
a memory metric reached a release asset unnoticed.
`tools/ci/tests/test_benchmark_chart.py` adds 26 tests that assert on the
emitted SVG text, not on internal helpers.

The synthetic fixture is built so a suffix-only check cannot pass: memory RSS
is 8 MiB vs 64 MiB (an 8.0x regression) while the same row's `mean` says the
opposite and its JSON `ratio` is that time ratio. A chart that still read
`mean` but formatted it as bytes would satisfy "the label says MiB" and still
fail here.

Coverage: the memory row plots RSS-derived magnitudes and carries no duration
label; timing rows keep ms/s and gain no byte label; the axis grid is asserted
separately because it formats at a different call site; ratio wording and the
non-positive fallback are checked per unit; and the report's existing RSS
handling is pinned so it cannot regress.

Confirmed the suite fails against the pre-fix script (5 failures, 16 errors),
so it genuinely reproduces the defect rather than describing the new code.

Wired to run on pull requests touching the renderers
(`benchmark-tooling.yml`, following the `tools/ci/tests/` precedent) and again
in `benchmark.yml` before the chart is drawn, so a regression fails the tag
build instead of shipping to the release page. `.github/scripts/**` changes
take the CI-skip path, so without the dedicated workflow the test would never
run on a PR.

## Note for the reviewer

`ChartBuilder.add_grid` has **no caller** - `generate_chart` deliberately omits
a global x-axis. It is fixed here for consistency and covered by tests, but the
axis half of the reported symptom is not currently visible in the published
chart. Worth deciding separately whether to keep or drop it.
