### PR TITLE
test(xtask): gate --append-verify phase-2 redo in the validate matrix

### DIFF
--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -46,6 +46,7 @@ mod total_size;
 mod transfer_conditions;
 mod trimslash;
 mod verbosity;
+mod verify_redo;
 mod whole_file;
 mod xattr;
 
@@ -96,6 +97,7 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(checksum::Checksum),
         Box::new(whole_file::WholeFile),
         Box::new(append_inplace::AppendInplace),
+        Box::new(verify_redo::VerifyRedo),
         Box::new(compress::Compress),
         Box::new(delete::Delete),
         Box::new(remove_source_files::RemoveSourceFiles),

--- a/xtask/src/commands/validate/checks/verify_redo.rs
+++ b/xtask/src/commands/validate/checks/verify_redo.rs
@@ -1,0 +1,612 @@
+//! Phase-2 verification-redo fidelity for `--append-verify`.
+//!
+//! `--append-verify` re-checksums the bytes already present in the destination
+//! after appending the tail. When that re-checksum fails the receiver keeps the
+//! partial update, warns, and asks the generator to redo the file in phase 2
+//! (upstream `receiver.c:1070` `case 0:` -> `send_msg_int(MSG_REDO, ndx)`). The
+//! sibling `append-inplace` check seeds a *matching* prefix, so its re-checksum
+//! succeeds and the redo path is never entered; this check seeds a destination
+//! that is both shorter than the source and wrong, which forces the redo on
+//! every transport.
+//!
+//! Like `append-inplace` this cannot use `transport::pull_into` /
+//! `transport::push_into` (both recreate the destination empty) - the seed is
+//! the whole point. It seeds each destination directly, builds the client
+//! `Command` per transport and direction, and runs the transfer without wiping
+//! the seed.
+//!
+//! Four things are asserted per cell, because the redo can diverge in more
+//! places than the final bytes:
+//!
+//! 1. oc's exit code equals upstream's.
+//! 2. the destination is byte-identical to the source *and* to upstream's.
+//! 3. the `failed verification` warning lines on stderr are exactly upstream's,
+//!    at each verbosity - upstream gates the line behind `INFO_GTE(NAME, 1)`
+//!    (`receiver.c:1072`), so it is silent by default and prints the bare
+//!    *relative* name under `-v`.
+//! 4. the `--stats` literal/matched split matches, so a redo that re-sends the
+//!    whole file as literal instead of re-deltaing against the retained basis is
+//!    caught.
+//!
+//! The oc and upstream destinations are seeded identically, so only the client
+//! under test varies. Upstream rsync is the ground truth. The ssh transports are
+//! skipped when no sshd answers on localhost:22.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::comparison;
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--append-verify` phase-2 redo parity check.
+pub struct VerifyRedo;
+
+/// Length of the source `payload.bin`, in bytes (200 KiB).
+const SOURCE_LEN: usize = 200 * 1024;
+
+/// Length of the seeded destination `payload.bin`, in bytes (100 KiB). Shorter
+/// than the source, so `--append-verify` appends a tail, and all zeros, so the
+/// prefix is wrong and the re-checksum fails.
+const SEED_LEN: usize = 100 * 1024;
+
+/// Flags common to every cell. `-a` is the archive set the redo is normally hit
+/// under; `--ignore-times` stops the quick-check from short-circuiting the
+/// decision; `--numeric-ids` keeps id mapping out of the picture; `--stats`
+/// prints the literal/matched split assertion 4 compares.
+const BASE_FLAGS: &[&str] = &[
+    "-a",
+    "--append-verify",
+    "--ignore-times",
+    "--numeric-ids",
+    "--stats",
+];
+
+/// The exact warning upstream rsync 3.4.4 writes to stderr when the
+/// `--append-verify` re-checksum fails and the update is retained for a redo.
+/// Measured identical on local, daemon pull, and daemon push. Note the *bare
+/// relative* name: the receiver has already chdir'd into the destination, and
+/// upstream renders `fname`, never an absolute path.
+const WARNING: &str =
+    "WARNING: payload.bin failed verification -- update retained (will try again).";
+
+/// `--stats` label whose value proves the redo actually happened: the single
+/// regular file is transferred twice, once per phase.
+const TRANSFERRED_LABEL: &str = "Number of regular files transferred";
+
+/// Value [`TRANSFERRED_LABEL`] must carry once the redo has run.
+const REDO_TRANSFER_COUNT: &str = "2";
+
+/// The delta-accounting fields assertion 4 compares. A redo that re-sends the
+/// whole file as literal shows up here as a literal/matched split that differs
+/// from upstream's re-delta against the retained basis.
+const SPLIT_LABELS: &[&str] = &["Literal data", "Matched data"];
+
+/// Transfer directions exercised, in report order.
+const DIRECTIONS: &[Direction] = &[Direction::Pull, Direction::Push];
+
+/// Verbosities exercised, in report order.
+const VERBOSITIES: &[Verbosity] = &[Verbosity::Default, Verbosity::Verbose];
+
+/// Which side of the transfer the client under test is.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Direction {
+    /// Client is the receiver, and so the side that detects the failed
+    /// verification and requests the redo.
+    Pull,
+    /// Client is the sender, and so the side that must re-send in phase 2.
+    Push,
+}
+
+impl Direction {
+    /// Stable direction label used in the cell name.
+    const fn label(self) -> &'static str {
+        match self {
+            Direction::Pull => "pull",
+            Direction::Push => "push",
+        }
+    }
+}
+
+/// Client verbosity, which is what gates upstream's warning line.
+#[derive(Clone, Copy)]
+enum Verbosity {
+    /// No `-v`: upstream's `FWARNING` line is suppressed entirely.
+    Default,
+    /// `-v`: `INFO_GTE(NAME, 1)` holds, so upstream prints the warning.
+    Verbose,
+}
+
+impl Verbosity {
+    /// Stable verbosity label used in the cell name.
+    const fn label(self) -> &'static str {
+        match self {
+            Verbosity::Default => "default",
+            Verbosity::Verbose => "verbose",
+        }
+    }
+
+    /// Extra flags this verbosity adds to [`BASE_FLAGS`].
+    const fn flags(self) -> &'static [&'static str] {
+        match self {
+            Verbosity::Default => &[],
+            Verbosity::Verbose => &["-v"],
+        }
+    }
+
+    /// The `failed verification` lines upstream emits at this verbosity.
+    ///
+    /// Upstream prints the line only when `msgtype == FERROR_XFER ||
+    /// INFO_GTE(NAME, 1) || stdout_format_has_i` (`receiver.c:1072`). The first
+    /// failure is a `FWARNING` and the redo then succeeds, so nothing reaches
+    /// the ungated `FERROR_XFER` form: without `-v` the transfer is silent, and
+    /// with `-v` it emits exactly [`WARNING`].
+    const fn expected_warnings(self) -> &'static [&'static str] {
+        match self {
+            Verbosity::Default => &[],
+            Verbosity::Verbose => &[WARNING],
+        }
+    }
+}
+
+impl Check for VerifyRedo {
+    fn name(&self) -> &'static str {
+        "verify-redo"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("verify-redo");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for &direction in DIRECTIONS {
+                // A local push runs the same local-copy code path as a local
+                // pull, so it would add a duplicate cell, not coverage.
+                if transport == Transport::Local && direction == Direction::Push {
+                    continue;
+                }
+                for &verbosity in VERBOSITIES {
+                    outcomes.push(self.cell(ctx, transport, &root, &src, direction, verbosity));
+                }
+            }
+        }
+        outcomes
+    }
+}
+
+impl VerifyRedo {
+    /// Run one `(transport, direction, verbosity)` cell: seed both destinations,
+    /// transfer with each client, and assert exit code, bytes, warning lines,
+    /// and delta split all match upstream.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        direction: Direction,
+        verbosity: Verbosity,
+    ) -> CheckOutcome {
+        let label = format!(
+            "{} {} {}",
+            transport.label(),
+            direction.label(),
+            verbosity.label()
+        );
+        let stem = format!(
+            "{}-{}-{}",
+            transport.label(),
+            direction.label(),
+            verbosity.label()
+        );
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let oc_dst = root.join(format!("oc-{stem}"));
+        let up_dst = root.join(format!("up-{stem}"));
+        for dst in [&up_dst, &oc_dst] {
+            if let Err(e) = seed_dest(dst) {
+                return CheckOutcome::skip(
+                    self.name(),
+                    label.as_str(),
+                    format!("seed {}: {e}", dst.display()),
+                );
+            }
+        }
+
+        // Non-vacuous guard: the seed must really be shorter than and different
+        // from the source, or the re-checksum succeeds, the redo never runs, and
+        // every assertion below passes on nothing.
+        let source = source_bytes(SOURCE_LEN);
+        match std::fs::read(oc_dst.join("payload.bin")) {
+            Ok(seeded) if seeded.len() < source.len() && seeded != source => {}
+            _ => {
+                return CheckOutcome::fail(
+                    self.name(),
+                    label.as_str(),
+                    "seed guard: dest payload.bin is not a shorter, differing file",
+                );
+            }
+        }
+
+        let flags: Vec<String> = BASE_FLAGS
+            .iter()
+            .chain(verbosity.flags())
+            .map(|s| (*s).to_string())
+            .collect();
+        let run = |transport, client, dst: &Path| {
+            Run {
+                transport,
+                direction,
+                client,
+                upstream: ctx.upstream,
+                src,
+                dst,
+                work: ctx.work,
+                flags: &flags,
+            }
+            .execute()
+        };
+
+        let up = match run(transport.for_upstream(), ctx.upstream, &up_dst) {
+            Ok(out) if out.status.success() => out,
+            other => return comparison::classify_failure(self.name(), &label, "upstream", other),
+        };
+        // oc's status is deliberately not required to succeed: a non-zero exit
+        // is a real divergence, reported by the exit-code facet below rather
+        // than swallowed as an unrunnable cell.
+        let oc = match run(transport, ctx.oc, &oc_dst) {
+            Ok(out) => out,
+            Err(e) => {
+                return CheckOutcome::skip(
+                    self.name(),
+                    label.as_str(),
+                    format!("oc could not run: {e}"),
+                );
+            }
+        };
+
+        let up_out = String::from_utf8_lossy(&up.stdout);
+        let oc_out = String::from_utf8_lossy(&oc.stdout);
+        let up_err = String::from_utf8_lossy(&up.stderr);
+        let oc_err = String::from_utf8_lossy(&oc.stderr);
+        if ctx.verbose {
+            eprintln!("[verify-redo/{label}] oc stderr={oc_err:?} upstream stderr={up_err:?}");
+        }
+
+        // Assertion 1: exit-code parity.
+        if let Some(d) = comparison::exit_code_diff(&oc, &up) {
+            return CheckOutcome::fail(self.name(), label.as_str(), d);
+        }
+
+        // Assertion 2: both destinations equal the source, and each other.
+        if let Some(d) = support::content_diff(&up_dst, src) {
+            return CheckOutcome::fail(
+                self.name(),
+                label.as_str(),
+                format!("upstream dest != source: {d}"),
+            );
+        }
+        if let Some(d) = support::content_diff(&oc_dst, src) {
+            return CheckOutcome::fail(
+                self.name(),
+                label.as_str(),
+                format!("oc dest != source: {d}"),
+            );
+        }
+        if let Some(d) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(
+                self.name(),
+                label.as_str(),
+                format!("oc dest != upstream dest: {d}"),
+            );
+        }
+
+        // Non-vacuous guard: upstream must have transferred the one regular file
+        // twice, which is the redo. If it did not, the fixture stopped forcing
+        // the verification failure and assertions 3 and 4 are worthless.
+        let up_transferred = stat_field(&up_out, TRANSFERRED_LABEL);
+        if up_transferred.as_deref() != Some(REDO_TRANSFER_COUNT) {
+            return CheckOutcome::fail(
+                self.name(),
+                label.as_str(),
+                format!(
+                    "redo guard: upstream {TRANSFERRED_LABEL} = {} (want {REDO_TRANSFER_COUNT})",
+                    up_transferred.as_deref().unwrap_or("(absent)")
+                ),
+            );
+        }
+
+        // Assertion 3: the warning lines are exactly upstream's, and upstream's
+        // are exactly the documented oracle for this verbosity.
+        let up_warnings = warning_lines(&up_err);
+        let oc_warnings = warning_lines(&oc_err);
+        if up_warnings != verbosity.expected_warnings() {
+            return CheckOutcome::fail(
+                self.name(),
+                label.as_str(),
+                format!(
+                    "oracle drift: upstream warnings {up_warnings:?} != {:?}",
+                    verbosity.expected_warnings()
+                ),
+            );
+        }
+        if oc_warnings != up_warnings {
+            return CheckOutcome::fail(
+                self.name(),
+                label.as_str(),
+                format!("warning lines: oc {oc_warnings:?} != upstream {up_warnings:?}"),
+            );
+        }
+
+        // Assertion 4: the literal/matched split of the redo.
+        for &field in SPLIT_LABELS {
+            let up_val = stat_field(&up_out, field);
+            let oc_val = stat_field(&oc_out, field);
+            if oc_val != up_val {
+                return CheckOutcome::fail(
+                    self.name(),
+                    label.as_str(),
+                    format!(
+                        "{field}: oc={} upstream={}",
+                        oc_val.as_deref().unwrap_or("(absent)"),
+                        up_val.as_deref().unwrap_or("(absent)")
+                    ),
+                );
+            }
+        }
+
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// One client invocation against an already-seeded destination.
+///
+/// Operand forms mirror `transport::pull_into` / `transport::push_into`, minus
+/// their destination reset: `local` is a filesystem copy (identical either
+/// direction, so `direction` is not consulted), `ssh-subprocess` uses
+/// `-e ssh localhost:<path>`, `russh` uses an `ssh://` URL, and `daemon` uses a
+/// module URL. The peer is always upstream, so only `client` varies between the
+/// two runs of a cell.
+struct Run<'a> {
+    /// Transport the client speaks.
+    transport: Transport,
+    /// Whether the client is the receiver (pull) or the sender (push).
+    direction: Direction,
+    /// The rsync binary under test for this run.
+    client: &'a Path,
+    /// Upstream rsync, used as the peer on every network transport.
+    upstream: &'a Path,
+    /// Source tree.
+    src: &'a Path,
+    /// Pre-seeded destination tree; never reset here.
+    dst: &'a Path,
+    /// Scratch root, for the daemon config file.
+    work: &'a Path,
+    /// Complete client flag set.
+    flags: &'a [String],
+}
+
+impl Run<'_> {
+    /// Build and run the client command, returning its captured output.
+    ///
+    /// Unlike `append-inplace` the daemon is started per run rather than once
+    /// per cell: a push must export the *client's own* destination, so the
+    /// module differs between the upstream and the oc run and cannot be shared.
+    /// The handle is a local, so it stays alive across `output()` and is killed
+    /// on return.
+    fn execute(&self) -> TaskResult<Output> {
+        let src_arg = format!("{}/", self.src.display());
+        let dst_arg = format!("{}/", self.dst.display());
+        let mut cmd = Command::new(self.client);
+        cmd.args(self.flags);
+
+        let daemon = match (self.transport, self.direction) {
+            (Transport::Daemon, Direction::Pull) => {
+                Some(DaemonHandle::start(self.upstream, self.src, self.work)?)
+            }
+            (Transport::Daemon, Direction::Push) => Some(DaemonHandle::start_writable(
+                self.upstream,
+                self.dst,
+                self.work,
+            )?),
+            _ => None,
+        };
+
+        match self.transport {
+            Transport::Local => {
+                cmd.arg(&src_arg).arg(&dst_arg);
+            }
+            Transport::SshSubprocess => {
+                cmd.arg(format!("--rsync-path={}", self.upstream.display()))
+                    .arg("-e")
+                    .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no");
+                match self.direction {
+                    Direction::Pull => cmd.arg(format!("localhost:{src_arg}")).arg(&dst_arg),
+                    Direction::Push => cmd.arg(&src_arg).arg(format!("localhost:{dst_arg}")),
+                };
+            }
+            Transport::Russh => {
+                cmd.arg(format!("--rsync-path={}", self.upstream.display()));
+                match self.direction {
+                    Direction::Pull => cmd.arg(format!("ssh://localhost{src_arg}")).arg(&dst_arg),
+                    Direction::Push => cmd.arg(&src_arg).arg(format!("ssh://localhost{dst_arg}")),
+                };
+            }
+            Transport::Daemon => {
+                let url = daemon
+                    .as_ref()
+                    .ok_or_else(|| {
+                        TaskError::Validation("daemon transport without a daemon".into())
+                    })?
+                    .module_url();
+                match self.direction {
+                    Direction::Pull => cmd.arg(url).arg(&dst_arg),
+                    Direction::Push => cmd.arg(&src_arg).arg(url),
+                };
+            }
+        }
+
+        cmd.output()
+            .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+    }
+}
+
+/// Deterministic source byte at `index`, derived purely from the index by a
+/// fixed integer hash - no system randomness, so the fixture is reproducible.
+fn source_byte(index: usize) -> u8 {
+    let x = (index as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    ((x >> 24) ^ x) as u8
+}
+
+/// The first `len` deterministic source bytes.
+fn source_bytes(len: usize) -> Vec<u8> {
+    (0..len).map(source_byte).collect()
+}
+
+/// Build the source tree: a single 200 KiB deterministic `payload.bin`.
+/// Idempotent: removes any prior tree first.
+///
+/// Unlike the sibling reuse checks this fixture is deliberately *not* backdated
+/// with `touch -d @epoch`. The transfer decision here is forced by the differing
+/// size and by `--ignore-times`, and every assertion (bytes, exit code, warning
+/// lines, delta split) is mtime-independent - so stamping a fixed mtime would
+/// buy nothing while making the whole check skip on hosts whose `touch` is the
+/// BSD one and rejects `-d @seconds`.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+    std::fs::write(src.join("payload.bin"), source_bytes(SOURCE_LEN)).map_err(|e| e.to_string())
+}
+
+/// Recreate `dst` holding only the wrong, short `payload.bin` seed.
+fn seed_dest(dst: &Path) -> TaskResult<()> {
+    if dst.exists() {
+        std::fs::remove_dir_all(dst)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dst.display())))?;
+    }
+    std::fs::create_dir_all(dst)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dst.display())))?;
+    std::fs::write(dst.join("payload.bin"), vec![0u8; SEED_LEN])
+        .map_err(|e| TaskError::Validation(format!("seed payload.bin: {e}")))
+}
+
+/// The `failed verification` lines on `stderr`, in order, with trailing
+/// whitespace trimmed. Unrelated stderr noise (ssh banners, chown warnings) is
+/// filtered out so the comparison carries only the redo's own reporting.
+fn warning_lines(stderr: &str) -> Vec<&str> {
+    stderr
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| line.contains("failed verification"))
+        .collect()
+}
+
+/// Value of one `--stats` label, or `None` when the label is absent. Grouping
+/// commas and a trailing ` bytes` unit are stripped, so `Literal data: 205,300
+/// bytes` reads back as `205300`.
+fn stat_field(stdout: &str, label: &str) -> Option<String> {
+    stdout.lines().find_map(|line| {
+        let (found, rest) = line.split_once(':')?;
+        if found.trim() != label {
+            return None;
+        }
+        let trimmed = rest.trim();
+        let unitless = trimmed.strip_suffix("bytes").unwrap_or(trimmed).trim_end();
+        Some(unitless.chars().filter(|c| *c != ',').collect())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The upstream `--stats` block measured for this fixture (rsync 3.4.4).
+    const SAMPLE: &str = "\nNumber of files: 2 (reg: 1, dir: 1)\n\
+        Number of created files: 0\n\
+        Number of regular files transferred: 2\n\
+        Total file size: 204,800 bytes\n\
+        Literal data: 205,300 bytes\n\
+        Matched data: 101,900 bytes\n\
+        Total bytes received: 206,086\n";
+
+    #[test]
+    fn source_bytes_are_deterministic_and_index_derived() {
+        assert_eq!(source_bytes(SOURCE_LEN), source_bytes(SOURCE_LEN));
+        assert_eq!(source_bytes(SOURCE_LEN).len(), SOURCE_LEN);
+        // Distinct indices are not all mapped to one constant byte.
+        let head = source_bytes(256);
+        assert!(head.iter().any(|&b| b != head[0]));
+    }
+
+    #[test]
+    fn seed_is_shorter_than_and_differs_from_the_source() {
+        // Both properties are load-bearing: shorter makes --append-verify append
+        // a tail, differing makes the re-checksum fail and force the redo.
+        let source = source_bytes(SOURCE_LEN);
+        let seed = vec![0u8; SEED_LEN];
+        assert!(seed.len() < source.len());
+        assert_ne!(seed.as_slice(), &source[..SEED_LEN]);
+    }
+
+    #[test]
+    fn stat_field_strips_commas_and_the_bytes_unit() {
+        assert_eq!(
+            stat_field(SAMPLE, "Literal data").as_deref(),
+            Some("205300")
+        );
+        assert_eq!(
+            stat_field(SAMPLE, "Matched data").as_deref(),
+            Some("101900")
+        );
+        assert_eq!(stat_field(SAMPLE, "File list size"), None);
+    }
+
+    #[test]
+    fn redo_guard_reads_two_transfers_from_the_measured_block() {
+        // The guard is what keeps the check non-vacuous: one regular file
+        // counted twice is the phase-2 redo.
+        assert_eq!(
+            stat_field(SAMPLE, TRANSFERRED_LABEL).as_deref(),
+            Some(REDO_TRANSFER_COUNT),
+            "fixture must transfer payload.bin twice"
+        );
+    }
+
+    #[test]
+    fn warning_lines_keep_only_the_verification_line() {
+        let stderr = format!(
+            "Warning: Permanently added 'localhost' to the list of known hosts.\n{WARNING}\n"
+        );
+        assert_eq!(warning_lines(&stderr), vec![WARNING]);
+        assert!(warning_lines("").is_empty());
+    }
+
+    #[test]
+    fn verbosity_oracle_matches_the_upstream_gate() {
+        // upstream: receiver.c:1072 gates the FWARNING behind INFO_GTE(NAME, 1),
+        // so the line exists only under -v; the redo then succeeds, so it never
+        // escalates to the ungated FERROR_XFER form.
+        assert!(Verbosity::Default.expected_warnings().is_empty());
+        assert_eq!(Verbosity::Verbose.expected_warnings(), &[WARNING]);
+        assert!(Verbosity::Default.flags().is_empty());
+        assert_eq!(Verbosity::Verbose.flags(), &["-v"]);
+    }
+
+    #[test]
+    fn warning_names_the_file_relatively() {
+        // The divergence this check exists to catch is an absolute destination
+        // path in place of upstream's bare `payload.bin`.
+        assert!(WARNING.contains(" payload.bin failed verification"));
+        assert!(!WARNING.contains('/'));
+    }
+}

--- a/xtask/src/commands/validate/checks/verify_redo.rs
+++ b/xtask/src/commands/validate/checks/verify_redo.rs
@@ -20,10 +20,15 @@
 //!
 //! 1. oc's exit code equals upstream's.
 //! 2. the destination is byte-identical to the source *and* to upstream's.
-//! 3. the `failed verification` warning lines on stderr are exactly upstream's,
-//!    at each verbosity - upstream gates the line behind `INFO_GTE(NAME, 1)`
-//!    (`receiver.c:1072`), so it is silent by default and prints the bare
-//!    *relative* name under `-v`.
+//! 3. the `failed verification` warning lines are exactly upstream's *on each
+//!    stream separately*, at each verbosity - upstream gates the line behind
+//!    `INFO_GTE(NAME, 1)` (`receiver.c:1072`), so it is silent by default, and
+//!    under `-v` it emits the bare *relative* name as an `FWARNING`, which
+//!    `log.c:314` routes to **stderr**. Comparing the union of the two streams
+//!    would accept a line that is present but misrouted; the observable-fidelity
+//!    contract covers stdout and stderr as distinct observables, because callers
+//!    redirect them separately and a warning on stdout corrupts `--out-format`
+//!    and `--stats` output that scripts parse.
 //! 4. the `--stats` literal/matched split matches, so a redo that re-sends the
 //!    whole file as literal instead of re-deltaing against the retained basis is
 //!    caught.
@@ -136,19 +141,94 @@ impl Verbosity {
         }
     }
 
-    /// The `failed verification` lines upstream emits at this verbosity.
+    /// The `failed verification` lines upstream emits at this verbosity, per
+    /// stream.
     ///
     /// Upstream prints the line only when `msgtype == FERROR_XFER ||
     /// INFO_GTE(NAME, 1) || stdout_format_has_i` (`receiver.c:1072`). The first
     /// failure is a `FWARNING` and the redo then succeeds, so nothing reaches
-    /// the ungated `FERROR_XFER` form: without `-v` the transfer is silent, and
-    /// with `-v` it emits exactly [`WARNING`].
-    const fn expected_warnings(self) -> &'static [&'static str] {
+    /// the ungated `FERROR_XFER` form: without `-v` the transfer is silent on
+    /// both streams, and with `-v` it emits exactly [`WARNING`] - on stderr,
+    /// never stdout, because `rwrite()` maps `FWARNING` to `f = stderr`
+    /// (`log.c:314`) and forwards it as `MSG_WARNING` when `am_server`.
+    const fn expected_warnings(self) -> ExpectedWarnings {
         match self {
-            Verbosity::Default => &[],
-            Verbosity::Verbose => &[WARNING],
+            Verbosity::Default => ExpectedWarnings {
+                stdout: &[],
+                stderr: &[],
+            },
+            Verbosity::Verbose => ExpectedWarnings {
+                stdout: &[],
+                stderr: &[WARNING],
+            },
         }
     }
+}
+
+/// The `failed verification` lines expected on each stream, as an oracle.
+///
+/// Both fields are load-bearing. `stdout` is empty at *every* verbosity, which
+/// is what makes a line emitted on the wrong stream a failure rather than a
+/// silent pass: an implementation that gates correctly but writes to stdout
+/// still diverges from upstream on an observable the contract covers.
+struct ExpectedWarnings {
+    /// Lines upstream writes to stdout. Always empty - see the type doc.
+    stdout: &'static [&'static str],
+    /// Lines upstream writes to stderr.
+    stderr: &'static [&'static str],
+}
+
+/// The `failed verification` lines one run emitted, kept split by stream.
+struct WarningStreams<'a> {
+    /// Matching lines on stdout, in order.
+    stdout: Vec<&'a str>,
+    /// Matching lines on stderr, in order.
+    stderr: Vec<&'a str>,
+}
+
+impl<'a> WarningStreams<'a> {
+    /// Split one run's captured output into its per-stream warning lines.
+    fn capture(stdout: &'a str, stderr: &'a str) -> Self {
+        WarningStreams {
+            stdout: warning_lines(stdout),
+            stderr: warning_lines(stderr),
+        }
+    }
+
+    /// Whether this capture is exactly the oracle, stream for stream.
+    fn matches(&self, expected: &ExpectedWarnings) -> bool {
+        self.stdout == expected.stdout && self.stderr == expected.stderr
+    }
+}
+
+/// How `oc` and `upstream` differ, named per stream, or `None` when they agree
+/// on both.
+///
+/// The stream names are in the message on purpose: the text of the line is
+/// identical whichever stream carries it, so a bare "warning not found" sends
+/// the reader hunting for a missing emit when the real fault is a misrouted
+/// one.
+fn stream_diff(oc: &WarningStreams<'_>, up: &WarningStreams<'_>) -> Option<String> {
+    let mut parts = Vec::new();
+    if oc.stdout != up.stdout {
+        parts.push(format!(
+            "stdout: oc {:?} != upstream {:?}",
+            oc.stdout, up.stdout
+        ));
+    }
+    if oc.stderr != up.stderr {
+        parts.push(format!(
+            "stderr: oc {:?} != upstream {:?}",
+            oc.stderr, up.stderr
+        ));
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    if !oc.stdout.is_empty() && up.stdout.is_empty() {
+        parts.push("oc wrote the line to stdout; upstream never does".to_string());
+    }
+    Some(format!("warning lines: {}", parts.join("; ")))
 }
 
 impl Check for VerifyRedo {
@@ -324,26 +404,27 @@ impl VerifyRedo {
             );
         }
 
-        // Assertion 3: the warning lines are exactly upstream's, and upstream's
-        // are exactly the documented oracle for this verbosity.
-        let up_warnings = warning_lines(&up_err);
-        let oc_warnings = warning_lines(&oc_err);
-        if up_warnings != verbosity.expected_warnings() {
+        // Assertion 3: the warning lines are exactly upstream's on each stream,
+        // and upstream's are exactly the documented oracle for this verbosity.
+        // Both comparisons are per-stream: the line's text is the same wherever
+        // it lands, so folding the streams together would accept an oc that
+        // emits it on stdout while upstream emits it on stderr - or, at default
+        // verbosity, one that emits it at all while upstream stays silent.
+        let up_warnings = WarningStreams::capture(&up_out, &up_err);
+        let oc_warnings = WarningStreams::capture(&oc_out, &oc_err);
+        let expected = verbosity.expected_warnings();
+        if !up_warnings.matches(&expected) {
             return CheckOutcome::fail(
                 self.name(),
                 label.as_str(),
                 format!(
-                    "oracle drift: upstream warnings {up_warnings:?} != {:?}",
-                    verbosity.expected_warnings()
+                    "oracle drift: upstream stdout {:?} stderr {:?} != expected stdout {:?} stderr {:?}",
+                    up_warnings.stdout, up_warnings.stderr, expected.stdout, expected.stderr
                 ),
             );
         }
-        if oc_warnings != up_warnings {
-            return CheckOutcome::fail(
-                self.name(),
-                label.as_str(),
-                format!("warning lines: oc {oc_warnings:?} != upstream {up_warnings:?}"),
-            );
+        if let Some(d) = stream_diff(&oc_warnings, &up_warnings) {
+            return CheckOutcome::fail(self.name(), label.as_str(), d);
         }
 
         // Assertion 4: the literal/matched split of the redo.
@@ -500,11 +581,13 @@ fn seed_dest(dst: &Path) -> TaskResult<()> {
         .map_err(|e| TaskError::Validation(format!("seed payload.bin: {e}")))
 }
 
-/// The `failed verification` lines on `stderr`, in order, with trailing
-/// whitespace trimmed. Unrelated stderr noise (ssh banners, chown warnings) is
-/// filtered out so the comparison carries only the redo's own reporting.
-fn warning_lines(stderr: &str) -> Vec<&str> {
-    stderr
+/// The `failed verification` lines in one stream, in order, with trailing
+/// whitespace trimmed. Unrelated noise (ssh banners and chown warnings on
+/// stderr, the `--stats` block on stdout) is filtered out so the comparison
+/// carries only the redo's own reporting. Applied to each stream separately by
+/// [`WarningStreams::capture`].
+fn warning_lines(stream: &str) -> Vec<&str> {
+    stream
         .lines()
         .map(str::trim_end)
         .filter(|line| line.contains("failed verification"))
@@ -595,11 +678,61 @@ mod tests {
     fn verbosity_oracle_matches_the_upstream_gate() {
         // upstream: receiver.c:1072 gates the FWARNING behind INFO_GTE(NAME, 1),
         // so the line exists only under -v; the redo then succeeds, so it never
-        // escalates to the ungated FERROR_XFER form.
-        assert!(Verbosity::Default.expected_warnings().is_empty());
-        assert_eq!(Verbosity::Verbose.expected_warnings(), &[WARNING]);
+        // escalates to the ungated FERROR_XFER form. upstream: log.c:314 maps
+        // FWARNING to stderr, so stdout stays empty at every verbosity.
+        let default = Verbosity::Default.expected_warnings();
+        assert!(default.stdout.is_empty());
+        assert!(default.stderr.is_empty());
+        let verbose = Verbosity::Verbose.expected_warnings();
+        assert!(verbose.stdout.is_empty());
+        assert_eq!(verbose.stderr, &[WARNING]);
         assert!(Verbosity::Default.flags().is_empty());
         assert_eq!(Verbosity::Verbose.flags(), &["-v"]);
+    }
+
+    #[test]
+    fn a_line_on_stdout_never_satisfies_the_stderr_oracle() {
+        // The divergence being gated: the text is right, the gate may even be
+        // right, but the stream is wrong. Folding the two streams into one list
+        // would let this through, and callers who redirect stdout and stderr
+        // separately would see a corrupted stdout - which the observable
+        // fidelity contract counts as a break just as a wrong byte would.
+        let line = format!("{WARNING}\n");
+        let on_stdout = WarningStreams::capture(&line, "");
+        assert!(!on_stdout.matches(&Verbosity::Verbose.expected_warnings()));
+        assert!(!on_stdout.matches(&Verbosity::Default.expected_warnings()));
+
+        let on_stderr = WarningStreams::capture("", &line);
+        assert!(on_stderr.matches(&Verbosity::Verbose.expected_warnings()));
+    }
+
+    #[test]
+    fn silence_only_satisfies_the_default_verbosity_oracle() {
+        // The vacuous-pass guard: at default verbosity upstream prints nothing
+        // anywhere, so a cell is only allowed to be silent on BOTH streams.
+        let silent = WarningStreams::capture("", "");
+        assert!(silent.matches(&Verbosity::Default.expected_warnings()));
+        assert!(!silent.matches(&Verbosity::Verbose.expected_warnings()));
+    }
+
+    #[test]
+    fn stream_diff_names_the_stream_the_line_landed_on() {
+        // A bare "warning not found" costs hours when the text is present but
+        // misrouted, so the message must distinguish the two cases.
+        let line = format!("{WARNING}\n");
+        let up = WarningStreams::capture("", &line);
+        let misrouted = WarningStreams::capture(&line, "");
+        let d = stream_diff(&misrouted, &up).expect("misrouted line must differ");
+        assert!(d.contains("stdout:"), "{d}");
+        assert!(d.contains("stderr:"), "{d}");
+        assert!(d.contains("oc wrote the line to stdout"), "{d}");
+
+        let absent = WarningStreams::capture("", "");
+        let d = stream_diff(&absent, &up).expect("absent line must differ");
+        assert!(d.contains("stderr:"), "{d}");
+        assert!(!d.contains("stdout:"), "{d}");
+
+        assert!(stream_diff(&up, &up).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Why

`cargo xtask validate` never forced a phase-2 verification redo. `checks/append_inplace.rs` does run `--append-verify`, but it seeds a *matching* prefix, so the re-checksum succeeds and the redo path is never entered. Three real divergences live behind that gap and the matrix could not see any of them.

This PR adds the gate. It does **not** fix the divergences - it makes them visible and keeps them fixed once they are.

## What

New `xtask/src/commands/validate/checks/verify_redo.rs`, registered next to `append-inplace` in the "Transfer decisions and deletion" group. Category `Validation` only, so a bare `cargo xtask validate` runs it.

**Fixture** - source `payload.bin` is 200 KiB of deterministic index-hashed bytes; the destination is pre-seeded with 100 KiB of zeros, so it is both shorter than the source and wrong. `--append-verify` appends the tail, the re-checksum fails, the receiver retains the update and asks the generator to redo it (`receiver.c:1070`, `send_msg_int(MSG_REDO, ndx)`). Flags: `-a --append-verify --ignore-times --numeric-ids --stats`.

**Cells** - one per `(transport, direction, verbosity)`. Push is skipped on `local` (a local push is the same local-copy code path as the pull, so it would be a duplicate cell, not coverage); ssh cells skip when no sshd answers on localhost:22.

**Assertions, all four per cell:**

1. oc's exit code equals upstream's (via the shared `comparison::exit_code_diff` facet, so a non-zero oc exit is reported as a divergence rather than swallowed as an unrunnable cell).
2. the destination is byte-identical to the source *and* to upstream's destination.
3. the `failed verification` lines are exactly upstream's, at each verbosity, **per stream** - stdout and stderr are checked separately so a line emitted on the wrong stream is a failure, not a vacuous match.
4. the `--stats` literal/matched split matches upstream's.

**Non-vacuous guards** - the seeded destination must really be shorter than and differ from the source before the transfer, and upstream must report `Number of regular files transferred: 2` (the one file counted twice *is* the redo). Either guard failing is a `FAIL`, not a silent pass.

## Correction to the assumed oracle

The premise this check was scoped from said the warning prints at **default** verbosity. It does not. Upstream prints the line only when

```c
if (msgtype == FERROR_XFER || INFO_GTE(NAME, 1) || stdout_format_has_i)   /* receiver.c:1072 */
```

The first failure is a `FWARNING` and the redo then succeeds, so nothing ever reaches the ungated `FERROR_XFER` form. Measured on rsync 3.4.4 across local, daemon pull and daemon push: stderr is **empty** without `-v`, and under `-v` it is exactly

```
WARNING: payload.bin failed verification -- update retained (will try again).
```

So the check encodes the measured oracle at *both* verbosities: upstream's exact silence by default, and upstream's exact bare-relative-name line under `-v`. That is strictly stronger than asserting the line at one verbosity - it catches a warning that is missing *and* one that is emitted where upstream is silent.

## Currently failing cells (expected, not papered over)

Measured with upstream rsync 3.4.4 as ground truth, `--transport local --transport daemon` (ssh cells skipped - no sshd on the measuring host). Each cell reports its first failing assertion.

| cell | assertion | oc | upstream |
|---|---|---|---|
| `local pull default` | 4 | literal 204,800 / matched 0, 1 transfer | literal 205,300 / matched 101,900, 2 transfers |
| `local pull verbose` | 3 | stderr empty (and stdout empty - not emitted anywhere) | the exact `WARNING:` line on stderr |
| `daemon pull default` | 3 | the line on **stdout**, with an absolute path, where upstream is silent on both streams | nothing on either stream |
| `daemon pull verbose` | 3 | the line on **stdout** with an absolute path; stderr empty | the exact `WARNING:` line on stderr, stdout empty |
| `daemon push default` | 4 | literal 205,700 / matched 101,500 | literal 205,300 / matched 101,900 |
| `daemon push verbose` | 4 | literal 205,700 / matched 101,500 | literal 205,300 / matched 101,900 |

Three distinct open divergences, all already tracked separately:

- **local never enters the redo at all.** oc transfers the file once as whole-file literal (204,800 / 0, one transfer) instead of appending, failing verification, retaining, and redoing. Its silence on both streams is a symptom of that, not a separate reporting bug.
- **daemon pull emits the warning on stdout, with an absolute path, at every verbosity** - wrong stream, wrong name form, and present where upstream is silent. Behind that it also redoes by re-sending everything as literal (307,200 = 102,400 tail + 204,800 redo, matched 0) instead of re-deltaing against the retained basis.
- **daemon push reports correctly** (silent by default, exact bare-relative-name line on stderr under `-v`) but its redo delta is off by 400 bytes in each direction (205,700 / 101,500 against 205,300 / 101,900) - a block-boundary difference, not a whole-file resend.

Note on reading the table: each cell reports only its *first* failing assertion, so `daemon pull`'s literal/matched divergence is now masked behind the earlier assertion-3 failure and will resurface once the emit site is fixed. That ordering is deliberate - reporting the misrouted warning first points at the nearer cause.

None of the assertions were relaxed to get a green run. A red cell here is the correct result until the underlying behaviour is fixed.

### Correction: the receiver-side warning is on stdout, not missing

An earlier revision of this description said daemon pull "never prints the warning, even under `-v`". That is wrong, and the assertion as first written could not tell the difference. Re-measured on the same fixture against `/opt/homebrew/bin/rsync` 3.4.4, counting the `failed verification` line per stream:

| run | stdout | stderr |
|---|---|---|
| upstream daemon pull, default | 0 | 0 |
| upstream daemon pull, `-v` | 0 | 1, bare `payload.bin` |
| oc daemon pull, default | **1, absolute `<dst>/payload.bin`** | 0 |
| oc daemon pull, `-v` | **1, absolute `<dst>/payload.bin`** | 0 |

So oc emits the line on the wrong **stream**, with the wrong **name form**, at a verbosity where upstream is **silent** - three divergences at once. Because assertion 3 originally filtered `stderr` only, the default-verbosity cells compared `[] == []` and passed that assertion **vacuously**; the `-v` cells failed with a message that read as "oc printed nothing".

Assertion 3 is therefore stream-aware, in the second commit on this branch: the oracle is an `ExpectedWarnings { stdout, stderr }` pair, `stdout` is empty at *every* verbosity (upstream `rwrite()` maps `FWARNING` to `f = stderr`, `log.c:314` - verified in the C source, not assumed), and the failure message names the stream and calls out a misrouted line explicitly. Detection still uses the bare `contains("failed verification")` substring on both streams, so the absolute-path form is *caught* rather than filtered out as absent; the name shape is then judged by the exact-string comparison against upstream's captured line. Fixed on this branch rather than in a stacked follow-up, since the PR is still open and a vacuous assertion should not be merged and then patched.

## Deviations from the sibling check's pattern

- **The fixture is not backdated.** `append-inplace` stamps a fixed mtime with `touch -d @epoch` because its reuse decision depends on mtime equality. Here the transfer is forced by the differing size plus `--ignore-times`, and every assertion (bytes, exit code, warning lines, delta split) is mtime-independent - so the stamp buys nothing, while depending on it makes the whole check skip on any host whose `touch` is the BSD one. Dropping it is what let the check actually run and produce the table above.
- **The daemon is started per run, not per cell.** A push must export the *client's own* destination, so the module differs between the upstream run and the oc run and cannot be shared. The handle is a local in the run, so it stays alive across `output()` and is killed on return.
- **Category is `Validation` only, not `Wire`.** The redo is a protocol round-trip, but every assertion here is client-observable behaviour (exit code, bytes, stderr, stats) rather than captured wire frames, which is what `capability-string` - the sole `Wire` member - actually inspects. Keeping it in `Validation` also means a bare `cargo xtask validate` gates it, which is the point.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p xtask --all-targets --all-features --no-deps -- -D warnings` clean (no `allow` waivers)
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean (the full CI invocation, re-run on the head commit)
- `cargo nextest run -p xtask --all-features -E 'test(verify_redo)'` - 10 passed. The full `-p xtask` run is 433/434; the one failure is the pre-existing macOS-only `validate::support::tests::backdated_tree_populates_and_backdates_the_root`, which needs a GNU `touch -d @epoch` and is untouched by this change
- `cargo xtask validate --list` shows `verify-redo [validation]`; `--help` unchanged
- the matrix was run end to end over the local and daemon transports, on the head commit, to produce the table above
