### PR TITLE
fix(transfer): re-delta the phase-2 redo against the retained basis

### DIFF
--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -374,7 +374,16 @@ impl ReceiverContext {
                         .map(|(idx, path, iflags)| (idx, self.file_list[idx].clone(), path, iflags))
                         .collect();
 
-                    if !batch.is_empty() && !is_redo_pass {
+                    // The phase-2 redo takes this same path: upstream re-enters
+                    // the ordinary `recv_generator()` for a redo index
+                    // (generator.c:2200), so the redo re-stats the destination,
+                    // re-runs the basis selection, and re-sends a block
+                    // signature via `generate_and_send_sums()` (generator.c:1967)
+                    // - only with `csum_length = SUM_LENGTH` and `append_mode`
+                    // negated (generator.c:2178,2186), both already applied by
+                    // the caller and by `request_config` above. The retained
+                    // in-place partial IS the redo's basis.
+                    if !batch.is_empty() {
                         // Extract basis config fields for the closure to avoid
                         // capturing &self across rayon worker boundaries.
                         let fuzzy_level = self.config.flags.fuzzy_level;
@@ -486,51 +495,6 @@ impl ReceiverContext {
                                 basis_result.basis_path,
                                 basis_result.fnamecmp_type,
                                 basis_result.xname.as_deref(),
-                                file_entry.size(),
-                                base_iflags,
-                                &request_config,
-                                xattr_request.as_ref(),
-                            )?;
-
-                            pipeline.push(pending);
-                            pending_files_info.push_back((
-                                file_idx,
-                                file_path,
-                                file_entry,
-                                base_iflags,
-                            ));
-                        }
-                    } else {
-                        // Redo pass or empty batch: no basis files, skip signatures.
-                        for (file_idx, file_entry, file_path, base_iflags) in batch {
-                            if base_iflags & crate::generator::ItemFlags::ITEM_TRANSFER == 0 {
-                                self.send_no_transfer_itemize(
-                                    writer,
-                                    &mut *ndx_write_codec,
-                                    &mut pipeline,
-                                    &mut pending_files_info,
-                                    file_idx,
-                                    file_entry,
-                                    file_path,
-                                    base_iflags,
-                                )?;
-                                continue;
-                            }
-                            // upstream: generator.c:575,598 - with no basis the
-                            // xattr diff runs against an empty list, so every
-                            // abbreviated value is requested. This keeps a large
-                            // xattr on a new or redo'd file from being dropped
-                            // for lack of a local copy to resolve it against.
-                            let xattr_request = self.build_xattr_request(&file_entry, None);
-                            let pending = send_file_request_xattr(
-                                writer,
-                                &mut *ndx_write_codec,
-                                self.flat_to_wire_ndx(file_idx),
-                                file_path.clone(),
-                                None,
-                                None,
-                                protocol::FnameCmpType::Fname,
-                                None,
                                 file_entry.size(),
                                 base_iflags,
                                 &request_config,

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -248,8 +248,11 @@ impl ReceiverContext {
                 if !redo_indices.is_empty() {
                     setup.checksum_length = REDO_CHECKSUM_LENGTH;
 
-                    // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
-                    // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
+                    // upstream: generator.c:2200 - the phase-2 redo re-enters the
+                    // ordinary recv_generator() for the redo index, so the retry
+                    // is a full re-request: ITEM_TRANSFER (generator.c:1940), a
+                    // re-stat of the destination, and a fresh block signature
+                    // built from it (generator.c:1967).
                     let redo_files: Vec<(usize, PathBuf, u32)> = redo_indices
                         .iter()
                         .filter_map(|&idx| {

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -282,8 +282,11 @@ impl ReceiverContext {
                 if !redo_indices.is_empty() {
                     setup.checksum_length = REDO_CHECKSUM_LENGTH;
 
-                    // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
-                    // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
+                    // upstream: generator.c:2200 - the phase-2 redo re-enters the
+                    // ordinary recv_generator() for the redo index, so the retry
+                    // is a full re-request: ITEM_TRANSFER (generator.c:1940), a
+                    // re-stat of the destination, and a fresh block signature
+                    // built from it (generator.c:1967).
                     let redo_files: Vec<(usize, PathBuf, u32)> = redo_indices
                         .iter()
                         .filter_map(|&idx| {

--- a/crates/transfer/tests/verify_redo_recovers_network_paths.rs
+++ b/crates/transfer/tests/verify_redo_recovers_network_paths.rs
@@ -149,6 +149,44 @@ fn authoritative_payload() -> Vec<u8> {
     (0..SOURCE_LEN).map(|i| (i % 251) as u8).collect()
 }
 
+/// Deterministic payload with no two equal signature blocks.
+///
+/// [`authoritative_payload`] repeats with period 251, so a block at source
+/// offset X is byte-identical to a basis block at offset Y whenever
+/// `X == Y (mod 251)`. That is harmless when only the reconstructed bytes are
+/// asserted, but it lets a delta match blocks the retained tail never covered -
+/// measured at 204,400 matched bytes on a first run - which destroys any bound
+/// on *which* bytes the redo matched. [`daemon_pull_redo_redeltas_against_the_retained_basis`]
+/// needs distinct blocks; derived purely from the index by a fixed integer hash,
+/// so the fixture stays reproducible.
+fn distinct_block_payload() -> Vec<u8> {
+    (0..SOURCE_LEN)
+        .map(|i| {
+            let x = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+            ((x >> 24) ^ x) as u8
+        })
+        .collect()
+}
+
+/// Value of one `--stats` label, with grouping commas and the trailing ` bytes`
+/// unit stripped, so `Literal data: 205,300 bytes` reads back as `205300`.
+fn stat_field(stdout: &str, label: &str) -> Option<u64> {
+    stdout.lines().find_map(|line| {
+        let (found, rest) = line.split_once(':')?;
+        if found.trim() != label {
+            return None;
+        }
+        let trimmed = rest.trim();
+        let unitless = trimmed.strip_suffix("bytes").unwrap_or(trimmed).trim_end();
+        unitless
+            .chars()
+            .filter(|c| *c != ',')
+            .collect::<String>()
+            .parse()
+            .ok()
+    })
+}
+
 /// Write an `rsyncd.conf` exposing one module rooted at `module_root`.
 ///
 /// `read_only` distinguishes the pull cell (client reads the module) from the
@@ -584,3 +622,155 @@ fn rsh_pull_forced_verification_failure_recovers_via_redo() {
 // mode, so this fixture produces one clean whole-file transfer and no
 // verification failure to recover from. A test here could only assert an
 // outcome the redo never produced.
+
+/// The phase-2 redo must re-delta against the RETAINED partial, not re-send the
+/// whole file as literal data.
+///
+/// Upstream re-enters the ordinary `recv_generator()` for a redo index
+/// (`generator.c:2200`). That re-stats the destination - which still holds the
+/// phase-1 update, because `--append` implies `--inplace` (`options.c:2411`) and
+/// `receiver.c:1029` finishes the transfer in place even when `recv_ok == 0` -
+/// and re-sends a block signature built from it (`generator.c:1967`). Only
+/// `csum_length` (`:2178`) and the sign of `append_mode` (`:2186`) differ from
+/// phase 1; the latter is what stops the redo tripping the append short-circuit
+/// at `generator.c:1842`, where the destination now equals `F_LENGTH`.
+///
+/// Before the fix the receiver requested every redo index with a null sum head,
+/// so the sender fell into `match.c:403-409`'s literal branch and re-sent all
+/// 204,800 bytes: literal 307,200 / matched 0. The bytes still landed correctly,
+/// which is why every other cell in this file passes either way - the cost is
+/// invisible unless the delta split is asserted.
+#[test]
+fn daemon_pull_redo_redeltas_against_the_retained_basis() {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(scratch) = DaemonScratch::new() else {
+        eprintln!("skipping: tempdir allocation failed");
+        return;
+    };
+
+    let module_root = scratch.root.join("source");
+    let dest_dir = scratch.root.join("dest");
+    fs::create_dir_all(&module_root).expect("create module root");
+    fs::create_dir_all(&dest_dir).expect("create dest dir");
+
+    // Not `seed_fixture`: this cell bounds *which* bytes were matched, so it
+    // needs the distinct-block payload (see `distinct_block_payload`).
+    let payload = distinct_block_payload();
+    fs::write(module_root.join("payload.bin"), &payload).expect("seed authoritative source");
+    fs::write(dest_dir.join("payload.bin"), vec![0u8; BAD_PREFIX_LEN])
+        .expect("seed wrong-prefix basis");
+
+    write_daemon_config(
+        &scratch.config,
+        &scratch.pid,
+        &scratch.log,
+        "data",
+        &module_root,
+        true,
+    )
+    .expect("write daemon config");
+
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return;
+        }
+    };
+
+    let src_url = OsString::from(format!("rsync://127.0.0.1:{port}/data/payload.bin"));
+    let dest_arg = dest_dir.join("payload.bin").into_os_string();
+    let args: &[&OsStr] = &[
+        OsStr::new("--append-verify"),
+        OsStr::new("--ignore-times"),
+        OsStr::new("--stats"),
+        OsStr::new(VERBOSE),
+        &src_url,
+        &dest_arg,
+    ];
+
+    let outcome = run_oc_rsync_deadlined(&oc_bin, args).expect("run daemon-pull redo client");
+    // The shared oracle first: exit 0, byte-correct destination, upstream's
+    // verbatim warning on stderr and nowhere else, and the two transfers that
+    // prove the redo ran at all.
+    assert_recovered(
+        "daemon pull delta split",
+        &outcome,
+        &dest_dir.join("payload.bin"),
+        &payload,
+    );
+
+    let literal = stat_field(&outcome.stdout, "Literal data").expect("--stats prints Literal data");
+    let matched = stat_field(&outcome.stdout, "Matched data").expect("--stats prints Matched data");
+
+    // Frame: phase 1 appends the tail as literal, phase 2 re-transfers the whole
+    // file as some literal/matched split, so the two phases together always
+    // account for exactly this many bytes however the redo is delta'd. Pinning
+    // the sum keeps the bounds below honest - a redo that silently skipped bytes
+    // would satisfy a lone lower bound on `matched`.
+    let appended_tail = (SOURCE_LEN - BAD_PREFIX_LEN) as u64;
+    assert_eq!(
+        literal + matched,
+        appended_tail + SOURCE_LEN as u64,
+        "phase-1 append plus phase-2 resend must account for every byte \
+         (literal {literal}, matched {matched})\nstdout:\n{}",
+        outcome.stdout,
+    );
+
+    // The redo's basis is the destination as phase 1 left it: BAD_PREFIX_LEN
+    // zeros followed by the correctly appended tail, SOURCE_LEN bytes in all.
+    // Derive its block geometry the way the receiver does rather than hardcoding
+    // it (upstream: generator.c:sum_sizes_sqroot()).
+    let layout = signature::calculate_signature_layout(signature::SignatureLayoutParams::new(
+        SOURCE_LEN as u64,
+        None,
+        protocol::ProtocolVersion::NEWEST,
+        std::num::NonZeroU8::new(16).expect("redo strong-sum length"),
+    ))
+    .expect("basis layout");
+    let block_len = u64::from(layout.block_length().get());
+
+    // Non-vacuous guard for the ceiling below: with duplicate basis blocks a
+    // source block outside the retained tail could legitimately match one inside
+    // it, and no upper bound on `matched` would hold.
+    let mut seen_blocks = std::collections::HashSet::new();
+    for block in payload.chunks(block_len as usize) {
+        assert!(
+            seen_blocks.insert(block),
+            "fixture payload has duplicate {block_len}-byte blocks, so the \
+             matched-data ceiling would assert nothing",
+        );
+    }
+
+    // Every FULL basis block lying entirely inside the correctly-appended region
+    // is byte-identical to the source at the same offset, so the redo must match
+    // all of them. The first starts at the first block boundary at or after
+    // BAD_PREFIX_LEN; the last ends at the last boundary at or before SOURCE_LEN.
+    let first_full = (BAD_PREFIX_LEN as u64).div_ceil(block_len);
+    let full_blocks = SOURCE_LEN as u64 / block_len - first_full;
+    let full_block_bytes = full_blocks * block_len;
+    assert!(
+        full_blocks > 0,
+        "fixture geometry no longer yields whole matchable blocks",
+    );
+
+    assert!(
+        matched >= full_block_bytes,
+        "the phase-2 redo did not re-delta against the retained basis: matched \
+         {matched} < {full_block_bytes} (the {full_blocks} whole basis blocks \
+         inside the retained tail). A null sum head on the redo request reports \
+         matched 0.\nstdout:\n{}",
+        outcome.stdout,
+    );
+
+    // Upper bound: the zero prefix must NOT be counted as matched (upstream's
+    // append pass never calls matched() for the retained prefix - match.c:389-390
+    // sets `last_match = s->flength` and zeroes `s->count`). The only byte range
+    // matchable beyond the whole blocks is the basis's trailing short block.
+    assert!(
+        matched <= full_block_bytes + u64::from(layout.remainder()),
+        "matched {matched} exceeds the retained tail plus its short trailing \
+         block - the redo counted unmatchable bytes\nstdout:\n{}",
+        outcome.stdout,
+    );
+}


### PR DESCRIPTION
## Stacked on #7229

**Base is `perf/receiver-owned-inflight-window` (#7229), not `master`.** That PR
converts `run_pipeline_loop_decoupled` from `&'a self` to `&mut self` with an
owned in-flight window and rewrites the same batch loop this change edits, in all
three files touched here. Rebasing that borrow-model change underneath this edit
later would be far more disruptive than stacking now. Merge #7229 first; this PR
retargets to `master` cleanly afterwards.

## The bug

The receiver requested every phase-2 redo index with a **null sum head**, so the
sender fell into `match.c:403-409`'s literal branch and re-sent the whole file.
The bytes still landed correctly, which is why the existing redo-recovery test
passed throughout - the cost is invisible unless the delta split is asserted.

Measured on a forced `--append-verify` redo (200 KiB source, 100 KiB wrong-prefix
destination), oc as the pulling client against an upstream 3.4.4 daemon:

| | transfers | Literal | Matched |
|---|---|---|---|
| oc before | 2 | 307,200 | 0 |
| oc after | 2 | **205,300** | **101,900** |
| upstream 3.4.4 | 2 | 205,300 | 101,900 |

307,200 is exactly 102,400 (phase-1 append) + 204,800 (the whole file again).

## Why upstream re-deltas

The redo re-enters the **ordinary** `recv_generator()` for the redo index
(`generator.c:2200`) - not a reduced retry path. That re-stats the destination and
re-sends a block signature built from it (`generator.c:1967`). The destination
still holds the phase-1 update: `--append` implies `--inplace`
(`options.c:2411`), and `receiver.c:1029` (`(recv_ok && ...) || inplace`) finishes
the transfer in place even when `recv_ok == 0` - which is also why the warning
reads `retained` (`receiver.c:1074-1079`). So **the retained partial is the
redo's basis**.

Only two things differ from phase 1, and both were already applied on this side:
`csum_length = SUM_LENGTH` (`generator.c:2178`) and a negated `append_mode`
(`:2186`). The latter is load-bearing beyond the signature: without it the redo
would trip the append short-circuit at `generator.c:1842`
(`append_mode > 0 && sx.st.st_size >= F_LENGTH(file)`), where the destination now
equals `F_LENGTH` exactly.

## The change

Route the redo batch through the same basis lookup as phase 1. The former
no-basis arm is then unreachable - its only other selector was the empty batch,
whose loop body never ran - so it is deleted rather than left as dead code.

The comment that licensed this bug claimed *"the basis comparison is not re-run
for the retry"* and cited `generator.c:1939`, which is refuted by `:2200` and
`:1967` inside the very function it points at. It is replaced with a citation
that actually holds. A wrong upstream citation is worse than none.

## Testing

`crates/transfer/src/receiver/basis.rs` already asserted *"phase-2 redo must send
a checksum-based delta, not a whole-file literal transfer"* - but it called
`find_basis_file_with_config` directly, and the production redo path never called
that function, so it passed for the whole life of the bug. The new test drives a
real daemon pull end to end and asserts the split:

- the redo must match **every whole basis block inside the retained tail**
  (derived from `signature::calculate_signature_layout`, not hardcoded);
- it must **not** count the wrong prefix as matched (upstream's append pass never
  calls `matched()` for the retained prefix - `match.c:389-390`);
- `literal + matched` must account for exactly the phase-1 tail plus the phase-2
  resend, so a redo that skipped bytes cannot satisfy the lower bound alone;
- the file must be transferred twice, or there was no redo to measure.

Verified red before / green after by restoring `pipeline.rs` to its base revision:
fails with `matched 0 < 101500`, passes after.

The test payload is index-hashed rather than reusing the sibling's `i % 251`.
That sequence repeats with period 251, so a source block matches a basis block
whenever the offsets are congruent mod 251 - the first run of this test reported
`matched 204,400`, matching blocks the retained tail never covered. A guard now
asserts no two basis blocks are equal, so the ceiling cannot go vacuous.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run --workspace --all-features -E 'package(transfer) or package(engine)'`:
  7627/7629 passed. The 2 failures are `engine local_copy::tests::{execute_preserves_read_only_permissions,
  archive_preserves_mixed_permissions_across_files}`, both failing with
  `remove extended attribute ... Permission denied` on a local macOS temp dir.
  **Reproduced identically on the untouched base commit f01596f7b**, and this
  change touches only `crates/transfer`, so they are pre-existing and
  environment-specific.

## Scope

This fixes the receiver's redo request only. Two neighbouring divergences the same
fixture exposes are deliberately **not** in this PR, because each reproduces
independently of the redo:

- The daemon **push** cell still reports 205,700 / 101,500 - 400 bytes out. That
  is oc's sender never matching the basis's trailing short block, and it
  reproduces with no `--append`, no `--append-verify` and no phase 2 at all
  (plain `--no-whole-file` push against the same basis: 103,300 / 101,500 vs
  upstream's 102,900 / 101,900). Separate PR against `crates/matching`.
- The **local** cell still reports 1 transfer / 204,800 / 0, because the local-copy
  executor has no phase-2 model at all and implements `--append-verify` as an
  a-priori prefix comparison. Separate work in `crates/engine`.
