### PR TITLE
fix(matching): match the basis short final block on the sender

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -741,6 +741,12 @@ impl DeltaGenerator {
         // position - the source's trailing `tail_len` bytes - and let everything
         // ahead of it drain as literals, which is what upstream's scan does over
         // those offsets anyway.
+        //
+        // That derivation is also what keeps the cost honest. `find_tail_match`
+        // is O(block_count): a short block cannot live in the BitHash or the
+        // compact lookup, which are keyed on full-block rolling sums, so it has
+        // to be found by scan. This block sits OUTSIDE the scan loop and so runs
+        // at most once per call; probing per window would be quadratic.
         if tail_match {
             if let Some(tail_len) = short_final_block_len(index, block_len) {
                 if window.len() >= tail_len {

--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -11,7 +11,7 @@
 
 use std::io::{self, Cursor, Read};
 
-use checksums::RollingChecksum;
+use checksums::{RollingChecksum, RollingDigest};
 use logging::debug_log;
 use rayon::prelude::*;
 
@@ -66,6 +66,22 @@ fn flush_seq_match_run(
         }
     }
     *run_len = 0;
+}
+
+/// Length of the basis's final block when it is shorter than a full block.
+///
+/// The signature layout only ever leaves the *last* block short (every earlier
+/// block spans a full `block_len`), which is why upstream derives its scan
+/// bound from that one block: `end = len + 1 - s->sums[s->count-1].len`
+/// (`match.c:174`). Returns `None` when the basis divides evenly into full
+/// blocks, in which case there is no short tail to match.
+fn short_final_block_len(index: &DeltaSignatureIndex, block_len: usize) -> Option<usize> {
+    let count = index.block_count();
+    if count == 0 {
+        return None;
+    }
+    let len = index.block(count - 1).len();
+    (len > 0 && len < block_len).then_some(len)
 }
 
 /// The single source of truth for the literal-flush cadence.
@@ -372,7 +388,9 @@ impl DeltaGenerator {
         let prune_matched = self.prune_matched;
         #[cfg(not(any(test, feature = "bench-internal")))]
         let prune_matched = true;
-        self.generate_with_prune(reader, index, prune_matched)
+        // `reader` is the whole source, so its EOF is the file's EOF and the
+        // short-final-block probe is in scope.
+        self.generate_with_prune(reader, index, prune_matched, true)
     }
 
     /// Reports whether emitting a `Copy` for basis block `idx` is safe at the
@@ -407,11 +425,17 @@ impl DeltaGenerator {
     /// only read-only lookups on `index` (no [`DeltaSignatureIndex::mark_consumed`]
     /// or [`DeltaSignatureIndex::reset_consumed`]), so a shared `&index` is safe
     /// to scan from multiple rayon workers concurrently.
+    ///
+    /// `tail_match` states whether `reader`'s EOF is the source file's EOF. Only
+    /// then may the short-final-block probe run: upstream reaches that block
+    /// solely at offset `len - s->sums[s->count-1].len` (`match.c:174`), so a
+    /// stripe that merely stops early must not claim it mid-file.
     fn generate_with_prune<R: Read>(
         &self,
         mut reader: R,
         index: &DeltaSignatureIndex,
         prune_matched: bool,
+        tail_match: bool,
     ) -> io::Result<DeltaScript> {
         let block_len = index.block_length();
         let mut window = RingBuffer::with_capacity(block_len);
@@ -700,18 +724,88 @@ impl DeltaGenerator {
             }
         }
 
-        // Drain any bytes still in the window as literals (window held fewer
-        // than block_len bytes at EOF, so no further match is possible).
+        // EOF tail match, mirroring the three cooperating pieces of upstream's
+        // `hash_search()`:
         //
-        // Upstream rsync matches the basis's short final block here via
-        // `l = MIN(blength, len-offset)` (`match.c:222-224`), but on the wire
-        // sender path that would (a) fail signature-index construction for
-        // small single-partial-block files and (b) produce a token stream the
-        // upstream compressed-delta receiver rejects (`token.c:665`). The
-        // "trailing partial block emitted as literal" is a pre-existing wire
-        // efficiency gap, not a correctness issue - reconstruction is
-        // byte-exact either way - so the tail match stays confined to the
-        // local-copy delta path (`engine::local_copy`).
+        // - `end = len + 1 - s->sums[s->count-1].len` (`match.c:174`) derives the
+        //   scan bound from the LAST block's length, not from `blength`, so the
+        //   scan keeps going past `len - blength`.
+        // - the rolling window shrinks byte by byte once there is nothing left to
+        //   feed it (`--k` when `!more`, `match.c:321-331`).
+        // - a candidate is accepted only when `l = MIN(blength, len-offset)`
+        //   equals `s->sums[i].len` (`match.c:222-224`).
+        //
+        // Together those admit exactly one short match, at offset
+        // `len - tail_len` with a `tail_len`-byte window: every other shrunk
+        // window has a length no basis block carries. So probe just that one
+        // position - the source's trailing `tail_len` bytes - and let everything
+        // ahead of it drain as literals, which is what upstream's scan does over
+        // those offsets anyway.
+        if tail_match {
+            if let Some(tail_len) = short_final_block_len(index, block_len) {
+                if window.len() >= tail_len {
+                    while window.len() > tail_len {
+                        if let Some(byte) = window.pop_front() {
+                            pending_literals.push(byte);
+                            offset += 1;
+                        }
+                    }
+                    let tail_hit = {
+                        let tail = window.as_slice();
+                        let digest = RollingDigest::from_bytes(tail);
+                        index
+                            .find_tail_match(
+                                digest,
+                                tail,
+                                &[],
+                                prune_matched.then_some(&matched_blocks),
+                            )
+                            // upstream: match.c:211 - the in-place guard applies
+                            // to the tail candidate like any other.
+                            .filter(|&idx| self.basis_offset_ok(index, block_len, idx, offset))
+                    };
+                    if let Some(tail_idx) = tail_hit {
+                        matches += 1;
+                        debug_log!(
+                            Deltasum,
+                            3,
+                            "potential match at {} i={} len={}",
+                            offset,
+                            tail_idx,
+                            tail_len
+                        );
+                        if !pending_literals.is_empty() {
+                            literal_bytes += pending_literals.len() as u64;
+                            total_bytes += pending_literals.len() as u64;
+                            let filled = std::mem::replace(
+                                &mut pending_literals,
+                                Vec::with_capacity(block_len),
+                            );
+                            tokens.push(DeltaToken::Literal(filled));
+                        }
+                        let block = index.block(tail_idx);
+                        // The short block is emitted as its OWN Copy carrying its
+                        // TRUE length, never folded into a seq-match run:
+                        // `flush_seq_match_run` models a run as
+                        // `run_len * block_len`, so absorbing a shorter block
+                        // would over-state the run and desync the receiver's
+                        // compressed-token dictionary (`token.c:see_deflate_token`).
+                        tokens.push(DeltaToken::Copy {
+                            index: block.index(),
+                            len: block.len(),
+                        });
+                        total_bytes += block.len() as u64;
+                        matched_blocks.mark_matched(tail_idx);
+                        if prune_matched {
+                            index.mark_consumed(tail_idx as u32);
+                        }
+                        window.clear();
+                    }
+                }
+            }
+        }
+
+        // Drain whatever the tail probe left behind as literals.
         while let Some(byte) = window.pop_front() {
             pending_literals.push(byte);
         }
@@ -932,6 +1026,16 @@ impl DeltaGenerator {
         }
 
         // Drain any residual window bytes as literals.
+        //
+        // The ungated scan probes the basis's short final block here
+        // (`match.c:222-224`); this path deliberately does not. Its whole premise
+        // is that a halved strong sum is only trustworthy when a neighbouring
+        // block corroborates the match, and the final short block has no
+        // successor to corroborate it. Admitting it would mean a second, weaker
+        // acceptance rule on the one path whose checksums are half-length.
+        // Sending the tail as a literal stays byte-exact, only larger, and this
+        // path is opt-in on both peers (`OC_CONSECUTIVE_MATCH`) so the default
+        // wire is unaffected.
         while let Some(byte) = window.pop_front() {
             pending_literals.push(byte);
         }
@@ -1062,9 +1166,15 @@ impl DeltaGenerator {
             .collect();
 
         // Scan every stripe concurrently against the shared read-only index.
+        // Only a stripe that runs to `n` sees the file's real EOF, so only it may
+        // claim the basis's short final block; a stripe that stops at a boundary
+        // would otherwise place that block mid-file, where upstream's
+        // `l = MIN(blength, len-offset)` test (`match.c:222-224`) never admits it.
         let scripts: Vec<io::Result<DeltaScript>> = ranges
             .par_iter()
-            .map(|&(s, e)| self.generate_with_prune(Cursor::new(&source[s..e]), index, false))
+            .map(|&(s, e)| {
+                self.generate_with_prune(Cursor::new(&source[s..e]), index, false, e == n)
+            })
             .collect();
 
         // Lift every worker `Copy` to an absolute source offset. Literals are
@@ -1581,8 +1691,12 @@ mod tests {
                 _ => None,
             })
             .sum();
+        // The fallback is the ungated scan, which also takes the short final
+        // block through its EOF tail probe (`match.c:222-224`), so the whole
+        // basis is Copied: the full block plus the 200-byte tail.
         assert_eq!(
-            copied, BLOCK_LEN as usize,
+            copied,
+            basis.len(),
             "the full block must be Copied, not demoted to a literal"
         );
         assert_eq!(reconstruct(&basis, &index, &script), basis);

--- a/crates/matching/src/index/builder.rs
+++ b/crates/matching/src/index/builder.rs
@@ -83,10 +83,16 @@ fn detect_duplicate_blocks(blocks: &[SignatureBlock], block_length: usize) -> bo
 impl DeltaSignatureIndex {
     /// Builds a signature index from the provided [`FileSignature`].
     ///
-    /// The helper only indexes blocks that match the canonical block length
-    /// reported by the layout. Files that produce fewer than one full block
-    /// therefore return `None`, mirroring upstream rsync's behaviour of
-    /// disabling the rolling checksum pipeline for very small payloads.
+    /// Only full-length blocks go into the tag/bithash/lookup tables, because
+    /// only those can be found by the sliding-window fast path. A basis whose
+    /// single block is short still yields an index: upstream runs
+    /// `build_hash_table()` + `hash_search()` for any `s->count > 0`
+    /// (`match.c:match_sums()`), and its short-block rule
+    /// (`l = MIN(blength, len-offset) == s->sums[i].len`, `match.c:222-224`)
+    /// then matches that lone block through the EOF tail probe. Returning
+    /// `None` here would send such a file entirely as literal data. Only a
+    /// signature with no blocks at all - an empty basis, which upstream also
+    /// skips - returns `None`.
     ///
     /// The returned index emits its `--debug=HASH` create line with the
     /// default `HashtableRole::Sender` prefix - upstream's `who_am_i()`
@@ -124,16 +130,17 @@ impl DeltaSignatureIndex {
         // so `next_match[K]` is addressable for every K the lookup can yield.
         let mut next_match = vec![NEXT_MATCH_NONE; requested];
 
-        if !populate_index(
+        if blocks.is_empty() {
+            return None;
+        }
+        populate_index(
             &blocks,
             block_length,
             &mut tag_table,
             &mut bithash,
             &mut lookup,
             &mut next_match,
-        ) {
-            return None;
-        }
+        );
 
         let size = lookup.capacity();
         let consumed = build_consumed_words(blocks.len());

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -680,6 +680,36 @@ impl DeltaSignatureIndex {
     /// strong checksums match, returning its index. Partial blocks only ever
     /// occur as the final block, so this scan touches at most one candidate in
     /// practice.
+    ///
+    /// # Why this bypasses the BitHash, tag table and compact lookup
+    ///
+    /// Do not "optimize" this onto the prefilter path - it would silently stop
+    /// matching short blocks. All three structures are keyed on rolling sums
+    /// computed over `block_length` bytes, while a short final block's rolling
+    /// sum spans only `tail_len` bytes, so probing them with it is a category
+    /// error rather than a slower path. `populate_index` deliberately never
+    /// inserts a partial block, so the lookup cannot return one and the BitHash
+    /// would reject it as a negative. The linear scan is the only way in.
+    ///
+    /// The prunes that turn on block *identity* rather than rolling-sum
+    /// geometry do still apply, and are honoured below: the per-session
+    /// [`MatchedBlocks`] filter and the shared `consumed` bitset.
+    ///
+    /// # Cost
+    ///
+    /// O(`block_count`), with a single length comparison for every block that
+    /// is not the short one. Callers must invoke this **at most once per
+    /// file**: the sender's EOF drain probes exactly one source offset
+    /// (`len - tail_len`), because upstream's shrinking window admits no other
+    /// position where a short block can match. Calling it per window would be
+    /// quadratic.
+    ///
+    /// The scan is not narrowed to the last block even though the wire and
+    /// local signature builders both put the only short block there. This is a
+    /// public API over a [`FileSignature`], and `SignatureBlock::from_raw_parts`
+    /// lets a caller hand over blocks of any length in any order, so a
+    /// last-block-only check would be an unsound assumption rather than an
+    /// optimization.
     #[inline]
     pub fn find_tail_match(
         &self,

--- a/crates/matching/src/index/tests.rs
+++ b/crates/matching/src/index/tests.rs
@@ -4,8 +4,14 @@ use signature::{SignatureLayoutParams, calculate_signature_layout, generate_file
 use std::collections::VecDeque;
 use std::num::NonZeroU8;
 
+/// A basis smaller than one block still yields a usable index.
+///
+/// Upstream runs `build_hash_table()` + `hash_search()` for any `s->count > 0`
+/// (`match.c:match_sums()`), and the short-block rule at `match.c:222-224`
+/// matches that lone block. Refusing to build the index here made the sender
+/// re-send every sub-block-size file entirely as literal data.
 #[test]
-fn from_signature_returns_none_without_full_blocks() {
+fn from_signature_indexes_a_lone_partial_block() {
     let params = SignatureLayoutParams::new(
         64,
         None,
@@ -17,7 +23,17 @@ fn from_signature_returns_none_without_full_blocks() {
     let signature = generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4)
         .expect("signature");
 
-    assert!(DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).is_none());
+    let index =
+        DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
+    assert_eq!(index.block_count(), 1);
+    assert_eq!(index.block(0).len(), 64);
+    // The lone short block stays out of the fast-path tables; only the EOF
+    // tail probe can reach it.
+    assert!(
+        index
+            .find_match_bytes(index.block(0).rolling(), data.as_slice())
+            .is_none()
+    );
 }
 
 #[test]

--- a/crates/matching/tests/integration_tests.rs
+++ b/crates/matching/tests/integration_tests.rs
@@ -810,18 +810,22 @@ fn index_strong_length_accessor() {
     );
 }
 
-/// Verifies that index returns None for data without full blocks.
+/// A basis too small for even one full block still builds a usable index.
+///
+/// Upstream builds its hash table and searches for any `s->count > 0`
+/// (`match.c:match_sums()`), and reaches the lone short block through the
+/// short-block rule at `match.c:222-224`. Refusing the index here made the
+/// sender re-send every sub-block-size file entirely as literal data.
 #[test]
-fn index_returns_none_for_small_data() {
-    // Very small data that won't produce full blocks
+fn index_builds_for_a_lone_partial_block() {
     let basis = vec![0u8; 64];
-    let result = build_index(&basis);
+    let index = build_index(&basis).expect("a lone partial block is still indexable");
 
-    // The index should return None because there are no full blocks
-    assert!(
-        result.is_none(),
-        "small data should not produce index with full blocks"
-    );
+    assert_eq!(index.block_count(), 1);
+    assert_eq!(index.block(0).len(), 64);
+
+    let script = generate_delta(&basis[..], &index).expect("delta");
+    assert_eq!(script.literal_bytes(), 0, "the lone block must be matched");
 }
 
 /// Verifies DeltaScript byte accounting is accurate.
@@ -1531,7 +1535,10 @@ mod algorithm_correctness {
         let basis: Vec<u8> = (0..16384).map(|i| (i % 251) as u8).collect();
         let index = build_index(&basis).expect("index");
         let block_len = index.block_length();
-        let num_blocks = basis.len() / block_len;
+        // Count every signature block, including the short final one. A
+        // `basis.len() / block_len` count would omit it, and the scan does
+        // match it (`match.c:222-224`).
+        let num_blocks = index.block_count();
 
         let input = basis.clone();
         let script = generate_delta(&input[..], &index).expect("delta");
@@ -1546,16 +1553,26 @@ mod algorithm_correctness {
                     (*block_idx as usize) < num_blocks,
                     "copy token should reference valid block index: {block_idx} >= {num_blocks}"
                 );
-                // Seq-match coalesces consecutive matched basis blocks into
-                // a single fat Copy. The token length is therefore an
-                // integer multiple of the canonical block length, and the
-                // run must fit inside the indexed block range.
-                assert_eq!(
-                    *len % block_len,
-                    0,
-                    "copy length should be a multiple of block length"
-                );
-                let run = *len / block_len;
+                // Seq-match coalesces consecutive matched basis blocks into a
+                // single fat Copy, so a Copy is either a whole number of full
+                // blocks or the short final block standing alone. The tail is
+                // never folded into a run: a run's length is derived as
+                // `run * block_len`, which would misstate a shorter block.
+                let run = if *len % block_len == 0 {
+                    *len / block_len
+                } else {
+                    assert_eq!(
+                        *block_idx as usize,
+                        num_blocks - 1,
+                        "only the final basis block may carry a short Copy"
+                    );
+                    assert_eq!(
+                        *len,
+                        index.block(*block_idx as usize).len(),
+                        "a short Copy must carry its block's true length"
+                    );
+                    1
+                };
                 assert!(
                     (*block_idx as usize) + run <= num_blocks,
                     "copy run extends past last indexed block: index={block_idx} run={run} num_blocks={num_blocks}"

--- a/crates/matching/tests/short_final_block_match.rs
+++ b/crates/matching/tests/short_final_block_match.rs
@@ -1,0 +1,290 @@
+//! The sender scan must match the basis's short final block.
+//!
+//! Upstream reaches that block through three cooperating pieces of
+//! `hash_search()`: the scan bound comes from the LAST block's length
+//! (`end = len + 1 - s->sums[s->count-1].len`, `match.c:174`), the rolling
+//! window shrinks once there is nothing left to feed it (`--k` when `!more`,
+//! `match.c:321-331`), and a candidate is accepted only when
+//! `l = MIN(blength, len-offset)` equals `s->sums[i].len`
+//! (`match.c:222-224`). Together those admit exactly one short match, at
+//! offset `len - tail_len`.
+//!
+//! Why this matters beyond byte counts: the short block must be emitted as its
+//! OWN `Copy` carrying its TRUE length. The seq-match coalescer models a run as
+//! `run_len * block_len` (`generator.rs::flush_seq_match_run`), so a run that
+//! absorbed a 400-byte block would claim 700 bytes for it, over-run the source
+//! cursor the wire layer uses to feed `see_deflate_token`, and desync the
+//! receiver's compressed-token dictionary. A test that only checks totals would
+//! pass through that bug, so the assertions below pin token identity, not sums.
+
+use matching::{DeltaGenerator, DeltaScript, DeltaSignatureIndex, DeltaToken, apply_delta};
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+use std::io::Cursor;
+use std::num::NonZeroU8;
+
+/// Full basis block length that `calculate_block_length` picks for the sizes
+/// used here.
+const BLOCK_LEN: usize = 700;
+/// Length of the deliberately short final block.
+const TAIL_LEN: usize = 400;
+/// 292 full blocks plus a 400-byte tail: the layout that first exposed the gap.
+const FULL_BLOCKS: usize = 292;
+const BASIS_LEN: usize = FULL_BLOCKS * BLOCK_LEN + TAIL_LEN;
+
+/// Deterministic, non-repeating filler.
+///
+/// A short-cycle pattern would be actively misleading here: with a period that
+/// divides evenly into the scan, an unaligned window near EOF can match some
+/// earlier full block by content and swallow the trailing bytes, so the tail
+/// probe never sees them. This 64-bit LCG has a period far beyond any fixture
+/// size, which keeps "the tail was not matched" a statement about the matcher
+/// rather than about the data.
+fn pattern(len: usize) -> Vec<u8> {
+    let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+    (0..len)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (state >> 33) as u8
+        })
+        .collect()
+}
+
+fn build_index(data: &[u8]) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(data, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+fn scan(source: &[u8], index: &DeltaSignatureIndex) -> DeltaScript {
+    DeltaGenerator::new()
+        .generate(Cursor::new(source.to_vec()), index)
+        .expect("scan")
+}
+
+fn matched_bytes(script: &DeltaScript) -> u64 {
+    script
+        .tokens()
+        .iter()
+        .filter(|t| !t.is_literal())
+        .map(|t| t.byte_len() as u64)
+        .sum()
+}
+
+/// Walks the token stream and returns `(source_offset, basis_index, len)` for
+/// every `Copy` whose length is shorter than a full block.
+fn short_copies(script: &DeltaScript, block_len: usize) -> Vec<(u64, u64, usize)> {
+    let mut out = Vec::new();
+    let mut offset = 0u64;
+    for token in script.tokens() {
+        if let DeltaToken::Copy { index, len } = token {
+            if *len < block_len {
+                out.push((offset, *index, *len));
+            }
+        }
+        offset += token.byte_len() as u64;
+    }
+    out
+}
+
+fn reconstruct(script: &DeltaScript, basis: &[u8], index: &DeltaSignatureIndex) -> Vec<u8> {
+    let mut out = Vec::new();
+    apply_delta(&mut Cursor::new(basis.to_vec()), &mut out, index, script).expect("apply");
+    out
+}
+
+/// The layout premise every other test here rests on: the signature really does
+/// end in a 400-byte block, so a mismatch would otherwise silently make the
+/// tail assertions vacuous.
+#[test]
+fn basis_signature_ends_in_a_short_block() {
+    let index = build_index(&pattern(BASIS_LEN));
+    assert_eq!(index.block_length(), BLOCK_LEN);
+    assert_eq!(index.block_count(), FULL_BLOCKS + 1);
+    assert_eq!(index.block(FULL_BLOCKS).len(), TAIL_LEN);
+    assert_eq!(index.block(FULL_BLOCKS - 1).len(), BLOCK_LEN);
+}
+
+/// The regression itself: a source that differs in the interior but keeps the
+/// trailing 400 bytes must reuse the basis's final short block rather than
+/// re-sending it as literal data.
+#[test]
+fn short_final_block_is_matched_not_resent_as_literal() {
+    let basis = pattern(BASIS_LEN);
+    let index = build_index(&basis);
+
+    // Flip one byte in every odd full block; leave the 400-byte tail intact.
+    let mut source = basis.clone();
+    for block in (1..FULL_BLOCKS).step_by(2) {
+        source[block * BLOCK_LEN] ^= 0xFF;
+    }
+
+    let script = scan(&source, &index);
+    let tail = short_copies(&script, BLOCK_LEN);
+    assert_eq!(
+        tail,
+        vec![((BASIS_LEN - TAIL_LEN) as u64, FULL_BLOCKS as u64, TAIL_LEN)],
+        "expected exactly one short Copy: the final basis block, at the file's tail"
+    );
+
+    // The 400 tail bytes moved from the literal side of the ledger to the
+    // matched side - the measured symptom against upstream rsync 3.4.4.
+    let full_matches = matched_bytes(&script) - TAIL_LEN as u64;
+    assert_eq!(full_matches % BLOCK_LEN as u64, 0);
+    assert_eq!(
+        script.literal_bytes(),
+        BASIS_LEN as u64 - matched_bytes(&script)
+    );
+    assert_eq!(reconstruct(&script, &basis, &index), source);
+}
+
+/// The coalescing hazard, pinned directly.
+///
+/// With the source identical to the basis, every full block matches in one
+/// unbroken run, so the seq-match coalescer produces a single fat Copy. The
+/// short final block must stay OUTSIDE that run and carry `TAIL_LEN`, not
+/// `BLOCK_LEN`. Checking only `matched_bytes` would not catch a coalesced tail,
+/// because a fat Copy of 293 blocks reports the same total as 292 blocks plus a
+/// 700-byte tail - and both are wrong by the same 300 bytes on the wire.
+#[test]
+fn short_final_block_copy_is_standalone_and_carries_its_true_length() {
+    let basis = pattern(BASIS_LEN);
+    let index = build_index(&basis);
+
+    let script = scan(&basis, &index);
+    assert_eq!(
+        script.tokens(),
+        &[
+            DeltaToken::Copy {
+                index: 0,
+                len: FULL_BLOCKS * BLOCK_LEN,
+            },
+            DeltaToken::Copy {
+                index: FULL_BLOCKS as u64,
+                len: TAIL_LEN,
+            },
+        ],
+        "the short final block must be its own Copy, never folded into the run"
+    );
+    assert_eq!(script.literal_bytes(), 0);
+    assert_eq!(script.total_bytes(), BASIS_LEN as u64);
+    assert_eq!(reconstruct(&script, &basis, &index), basis);
+}
+
+/// A file smaller than one block is a single short block, and it must match.
+///
+/// This also settles a claim the removed in-code justification made: index
+/// construction does not fail for a single-partial-block basis.
+#[test]
+fn whole_file_shorter_than_one_block_matches_as_a_single_copy() {
+    let basis = pattern(TAIL_LEN);
+    let index = build_index(&basis);
+    assert_eq!(index.block_count(), 1);
+    assert_eq!(index.block(0).len(), TAIL_LEN);
+
+    let script = scan(&basis, &index);
+    assert_eq!(
+        script.tokens(),
+        &[DeltaToken::Copy {
+            index: 0,
+            len: TAIL_LEN,
+        }]
+    );
+    assert_eq!(script.literal_bytes(), 0);
+    assert_eq!(reconstruct(&script, &basis, &index), basis);
+}
+
+/// Upstream's window can only shrink to `tail_len` while it still has that many
+/// bytes left, so a source that ends fewer than `tail_len` bytes past its last
+/// match has no reachable tail position. Truncating the source mid-tail must
+/// therefore leave those bytes literal, not match a shorter prefix of the final
+/// block.
+#[test]
+fn a_tail_shorter_than_the_final_block_stays_literal() {
+    let basis = pattern(BASIS_LEN);
+    let index = build_index(&basis);
+
+    let source = &basis[..BASIS_LEN - 100];
+    let script = scan(source, &index);
+    assert!(
+        short_copies(&script, BLOCK_LEN).is_empty(),
+        "a 300-byte residue must not match the 400-byte final block"
+    );
+    assert_eq!(reconstruct(&script, &basis, &index), source);
+}
+
+/// The parallel striped scan must not place the short final block mid-file.
+///
+/// A stripe's EOF is not the file's EOF, and upstream's `l = MIN(blength,
+/// len-offset)` test never admits a short block anywhere but the true tail. The
+/// content of the final block is planted at a stripe-interior offset here, so an
+/// unguarded per-stripe probe would match it in the wrong place.
+#[test]
+fn striped_scan_places_the_short_block_only_at_the_true_tail() {
+    let basis = pattern(BASIS_LEN);
+    let index = build_index(&basis);
+
+    // 6 MiB of source: comfortably above the 1 MiB-per-stripe floor, so
+    // `generate_chunked` really splits.
+    let source_len = 6 * 1024 * 1024;
+    let mut source: Vec<u8> = (0..source_len)
+        .map(|i| ((i * 31 + 7) % 253) as u8)
+        .collect();
+    let tail_block = &basis[BASIS_LEN - TAIL_LEN..];
+    // Plant the final block's bytes deep inside the source, and again at the end.
+    let planted = 2 * 1024 * 1024;
+    source[planted..planted + TAIL_LEN].copy_from_slice(tail_block);
+    source[source_len - TAIL_LEN..].copy_from_slice(tail_block);
+
+    let script = DeltaGenerator::new()
+        .generate_chunked(&source, &index, 8)
+        .expect("chunked scan");
+
+    let shorts = short_copies(&script, BLOCK_LEN);
+    for &(offset, _, _) in &shorts {
+        assert_eq!(
+            offset,
+            (source_len - TAIL_LEN) as u64,
+            "a short Copy may only appear at the source's tail, never at a stripe boundary"
+        );
+    }
+    assert_eq!(reconstruct(&script, &basis, &index), source);
+}
+
+/// The consecutive-match extension deliberately does NOT take the tail.
+///
+/// That path halves the per-block strong sum and only trusts a match a
+/// neighbouring block corroborates; the final short block has no successor to
+/// corroborate it, so admitting it would mean a second, weaker acceptance rule
+/// on the one path whose checksums are half-length. The tail stays literal
+/// there - byte-exact, only larger - and this pins that choice so it cannot be
+/// changed silently. The path is opt-in on both peers
+/// (`OC_CONSECUTIVE_MATCH`), so the default wire is unaffected.
+#[test]
+fn consecutive_match_gate_leaves_the_short_final_block_literal() {
+    let basis = pattern(BASIS_LEN);
+    let index = build_index(&basis);
+
+    let script = DeltaGenerator::new()
+        .with_consecutive_match_needed(2)
+        .generate(Cursor::new(basis.clone()), &index)
+        .expect("gated scan");
+
+    assert!(
+        short_copies(&script, BLOCK_LEN).is_empty(),
+        "the gated path must not emit a short Copy"
+    );
+    assert_eq!(script.literal_bytes(), TAIL_LEN as u64);
+    assert_eq!(reconstruct(&script, &basis, &index), basis);
+}

--- a/crates/transfer/src/delta_config.rs
+++ b/crates/transfer/src/delta_config.rs
@@ -74,6 +74,27 @@ pub struct DeltaGeneratorConfig<'a> {
     /// upstream: match.c:211 (`updating_basis_file && s->sums[i].offset <
     /// offset`), sender.c:337 (the per-file assignment).
     pub updating_basis_file: bool,
+
+    /// Length of the basis's final block when it is short, or `0` when the
+    /// basis divides evenly into `block_length`-sized blocks.
+    ///
+    /// Carried straight off the wire: the receiver puts it in the `sum_head`
+    /// (`io.c:2061` `sum->remainder = read_int(f);`, range-checked at
+    /// `io.c:2062-2064`, which rejects `< 0` or `> blength` with "Invalid
+    /// remainder length"). It is the only thing that distinguishes the last
+    /// block's true length from `blength`, and upstream's sender applies it in
+    /// `receive_sums()`:
+    ///
+    /// ```text
+    /// sender.c:109-110
+    ///     if (i == s->count-1 && s->remainder != 0) s->sums[i].len = s->remainder;
+    ///     else                                      s->sums[i].len = s->blength;
+    /// ```
+    ///
+    /// Note the `&& s->remainder != 0` guard: a basis whose length is an exact
+    /// multiple of `blength` keeps `blength` for every block, including the
+    /// last. Defaults to `0`, which reproduces exactly that case.
+    pub remainder: u32,
 }
 
 impl<'a> DeltaGeneratorConfig<'a> {
@@ -95,7 +116,18 @@ impl<'a> DeltaGeneratorConfig<'a> {
             compat_flags: None,
             checksum_seed: 0,
             updating_basis_file: false,
+            remainder: 0,
         }
+    }
+
+    /// Sets the basis's short-final-block length from the wire `sum_head`.
+    ///
+    /// upstream: `sender.c:109-110` (`receive_sums()` applies it to the last
+    /// block only, and only when non-zero).
+    #[must_use]
+    pub fn with_remainder(mut self, remainder: u32) -> Self {
+        self.remainder = remainder;
+        self
     }
 
     /// Attaches negotiated algorithms from protocol >= 30 capability exchange.

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -464,29 +464,60 @@ fn build_signature_index(config: DeltaGeneratorConfig<'_>) -> io::Result<DeltaSi
 
     let block_count = config.sig_blocks.len() as u64;
 
-    // Reconstruct signature layout (remainder unknown, set to 0)
+    // The remainder is NOT unknown from the wire format. The receiver sends it
+    // in the sum_head - `io.c:2061` `sum->remainder = read_int(f);` - and
+    // `io.c:2062-2064` range-checks it, rejecting `< 0` or `> blength` with
+    // "Invalid remainder length". It is the only field that distinguishes the
+    // last block's true length from `blength`, and upstream's sender applies it
+    // to exactly one block, and only when non-zero:
+    //
+    //   sender.c:109-110 (receive_sums)
+    //     if (i == s->count-1 && s->remainder != 0) s->sums[i].len = s->remainder;
+    //     else                                      s->sums[i].len = s->blength;
+    //
+    // Dropping it left every reconstructed block claiming `blength`, so the
+    // basis's short final block could never match and was re-sent as literal
+    // data on every transfer.
+    let remainder = config.remainder;
     let layout = SignatureLayout::from_raw_parts(
         block_length_nz,
-        0, // remainder unknown from wire format
+        remainder,
         block_count,
         strong_sum_length_nz,
     );
 
-    // Convert wire blocks to engine signature blocks (consumes sig_blocks)
+    // Convert wire blocks to engine signature blocks (consumes sig_blocks). A
+    // block's length rides on its rolling digest, so this is where upstream's
+    // split above is reproduced: the last block takes the remainder, every
+    // other block takes `blength`. With `remainder == 0` - a basis that divides
+    // evenly - every block keeps `blength`, including the last.
+    let last_position = block_count.saturating_sub(1);
     let engine_blocks: Vec<SignatureBlock> = config
         .sig_blocks
         .into_iter()
-        .map(|wire_block| {
+        .enumerate()
+        .map(|(position, wire_block)| {
+            let len = if remainder != 0 && position as u64 == last_position {
+                remainder as usize
+            } else {
+                config.block_length as usize
+            };
             SignatureBlock::from_raw_parts(
                 wire_block.index as u64,
-                RollingDigest::from_value(wire_block.rolling_sum, config.block_length as usize),
+                RollingDigest::from_value(wire_block.rolling_sum, len),
                 &wire_block.strong_sum,
             )
         })
         .collect();
 
-    // Calculate total bytes (approximation since we don't know exact remainder)
-    let total_bytes = (block_count.saturating_sub(1)) * u64::from(config.block_length);
+    // upstream: generator.c:755-756 - `remainder = len % blength` and
+    // `count = len/blength + (remainder != 0)`, inverted here to recover the
+    // basis length the sum_head describes.
+    let total_bytes = if remainder == 0 {
+        block_count * u64::from(config.block_length)
+    } else {
+        last_position * u64::from(config.block_length) + u64::from(remainder)
+    };
     let signature = FileSignature::from_raw_parts(layout, engine_blocks, total_bytes);
 
     // Select checksum algorithm using ChecksumFactory (handles negotiated vs default)
@@ -1657,7 +1688,121 @@ mod tests {
             compat_flags: None,
             checksum_seed: 0,
             updating_basis_file: guard,
+            remainder: 0,
         }
+    }
+
+    /// The wire `remainder` must land on the LAST reconstructed block, and only
+    /// there.
+    ///
+    /// upstream: `sender.c:109-110` (receive_sums)
+    ///   `if (i == s->count-1 && s->remainder != 0) s->sums[i].len = s->remainder;`
+    ///   `else                                      s->sums[i].len = s->blength;`
+    ///
+    /// The field is on the wire (`io.c:2061`) and range-checked
+    /// (`io.c:2062-2064`); dropping it made every block claim `blength`, which
+    /// is what left the basis's short final block unmatchable.
+    #[test]
+    fn wire_remainder_shortens_only_the_final_reconstructed_block() {
+        const BLOCK_LEN: u32 = 700;
+        const REMAINDER: u32 = 400;
+        const FULL_BLOCKS: usize = 4;
+        let basis = vec![7u8; FULL_BLOCKS * BLOCK_LEN as usize + REMAINDER as usize];
+
+        let sig_blocks = wire_signature(&basis, BLOCK_LEN, 16);
+        assert_eq!(sig_blocks.len(), FULL_BLOCKS + 1);
+
+        let mut config = delta_config(sig_blocks, BLOCK_LEN, 16, false);
+        config.remainder = REMAINDER;
+        let index = build_signature_index(config).expect("index");
+
+        assert_eq!(index.block_count(), FULL_BLOCKS + 1);
+        for position in 0..FULL_BLOCKS {
+            assert_eq!(
+                index.block(position).len(),
+                BLOCK_LEN as usize,
+                "block {position} must keep blength"
+            );
+        }
+        assert_eq!(
+            index.block(FULL_BLOCKS).len(),
+            REMAINDER as usize,
+            "only the final block takes the remainder"
+        );
+    }
+
+    /// A basis whose length is an exact multiple of `blength` sends
+    /// `remainder == 0`, and upstream's `&& s->remainder != 0` guard then keeps
+    /// `blength` for EVERY block including the last. Getting this wrong would
+    /// zero-length the final block of the common, evenly-divided case.
+    #[test]
+    fn zero_remainder_keeps_blength_on_every_block() {
+        const BLOCK_LEN: u32 = 700;
+        const FULL_BLOCKS: usize = 4;
+        let basis = vec![9u8; FULL_BLOCKS * BLOCK_LEN as usize];
+
+        let sig_blocks = wire_signature(&basis, BLOCK_LEN, 16);
+        assert_eq!(sig_blocks.len(), FULL_BLOCKS);
+
+        // delta_config defaults remainder to 0, which is exactly the wire value
+        // an evenly-divided basis produces.
+        let config = delta_config(sig_blocks, BLOCK_LEN, 16, false);
+        assert_eq!(config.remainder, 0);
+        let index = build_signature_index(config).expect("index");
+
+        assert_eq!(index.block_count(), FULL_BLOCKS);
+        for position in 0..FULL_BLOCKS {
+            assert_eq!(
+                index.block(position).len(),
+                BLOCK_LEN as usize,
+                "block {position} must keep blength when remainder is 0"
+            );
+        }
+    }
+
+    /// End-to-end through the sender's delta scan: with the remainder carried,
+    /// the trailing short block is Copied instead of re-sent as literal data.
+    /// This is the pairing that makes either half verifiable - the matching-side
+    /// tail probe cannot fire while the index claims every block is `blength`.
+    #[test]
+    fn carried_remainder_lets_the_sender_copy_the_short_final_block() {
+        const BLOCK_LEN: u32 = 700;
+        const REMAINDER: u32 = 400;
+        const FULL_BLOCKS: usize = 4;
+        let mut basis = Vec::new();
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        for _ in 0..(FULL_BLOCKS * BLOCK_LEN as usize + REMAINDER as usize) {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            basis.push((state >> 33) as u8);
+        }
+
+        let sig_blocks = wire_signature(&basis, BLOCK_LEN, 16);
+        let mut config = delta_config(sig_blocks, BLOCK_LEN, 16, false);
+        config.remainder = REMAINDER;
+
+        let script =
+            generate_delta_from_signature(io::Cursor::new(basis.clone()), config).expect("delta");
+
+        let short_copies: Vec<usize> = script
+            .tokens()
+            .iter()
+            .filter_map(|token| match token {
+                DeltaToken::Copy { len, .. } if *len < BLOCK_LEN as usize => Some(*len),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            short_copies,
+            vec![REMAINDER as usize],
+            "the short final block must be Copied with its true length"
+        );
+        assert_eq!(
+            script.literal_bytes(),
+            0,
+            "an identical source matches whole"
+        );
     }
 
     // WHY: this pins the activation end-to-end - the config field must reach the

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -943,6 +943,11 @@ impl GeneratorContext {
                     compat_flags: self.compat_flags.as_ref(),
                     checksum_seed: self.checksum_seed,
                     updating_basis_file,
+                    // upstream: sender.c:109-110 - receive_sums() gives the
+                    // LAST basis block this length instead of blength, and only
+                    // when it is non-zero. The field is read and range-checked
+                    // at io.c:2061-2064, so it is always available here.
+                    remainder: sum_head.remainder,
                 };
                 // Upstream scans and emits tokens over the same map_ptr()
                 // window, so a read error is absorbed by the scan too. oc scans


### PR DESCRIPTION
## What

oc's sender never matched the basis's short final block, so that block was re-sent as literal data on every transfer. Measured against upstream rsync 3.4.4 over a daemon push (`--no-whole-file --block-size=700`), 204800-byte basis = 292 x 700 + 400, same upstream daemon as receiver in both runs so the sender is the only variable:

| sender | Literal | Matched |
|---|---|---|
| rsync 3.4.4 | 102,200 | 102,600 |
| oc-rsync (before) | 102,600 | 102,200 |

The 400-byte gap is exactly the short final block. This is not a redo defect: it reproduces with `--append`, `--append-verify`, phase 2 and MSG_REDO all absent, and identically with `--inplace`.

## Upstream rule

`hash_search()` reaches the short block through three cooperating pieces:

- `match.c:174` - `end = len + 1 - s->sums[s->count-1].len;` the scan bound comes from the LAST block's length, not from `blength`, so the scan continues past `len - blength`.
- `match.c:321-331` - `more = offset + k < len;` ... `else --k;` the rolling window shrinks once there is nothing left to feed it.
- `match.c:222-224` - `l = (int32)MIN((OFF_T)s->blength, len-offset); if (l != s->sums[i].len) continue;` a candidate is accepted only at a matching length.

Together those admit exactly **one** short match, at offset `len - tail_len`: every other shrunk window has a length no basis block carries. The EOF drain now probes that single position via the existing `find_tail_match()` primitive - the same one the local-copy path already used - so the rule has one implementation, not two.

## The coalescing hazard

The short block is emitted as its **own** `Copy` carrying its **true** length, never folded into a seq-match run. `flush_seq_match_run` derives a run as `run_len * block_len`; absorbing a shorter block would overstate the run, over-run the source cursor the wire layer feeds to `see_deflate_token`, and desync the receiver's compressed-token dictionary. `short_final_block_copy_is_standalone_and_carries_its_true_length` pins the exact token stream, because a test on byte totals alone would pass with a coalesced tail.

## Two adjacent corrections

**A false citation.** The in-code justification for declining the tail cited `token.c:665` as the upstream receiver rejecting short-block tokens. That line is `rprintf(FERROR, "inflate returned %d (%d bytes)\n", r, n);` - a generic inflate failure. Upstream sends such tokens routinely. Replaced with the three citations above.

**A basis smaller than one block.** `from_signature()` refused to build an index when no block was full-length, so such a file was sent entirely as literal. Upstream runs `build_hash_table()` + `hash_search()` for any `s->count > 0` (`match.c:match_sums()`) and matches the lone block. Measured with a 400-byte basis, `-I --block-size=700`: upstream Matched 400 / Literal 0, oc Matched 0 / Literal 400. Only an empty signature now returns `None`.

This one is also a **prerequisite**, not just an improvement: once the sender honours the wire remainder, a single-short-block basis has zero full blocks, and the old `None` would turn `build_signature_index()` into a hard error. It must land with or before that change.

## Scope guards

- **Striped scan.** A stripe's EOF is not the file's EOF. Unguarded, a non-final stripe would place the short final block mid-file, which upstream's length test never permits. A `tail_match` parameter restricts the probe to a stripe that runs to the source end.
- **Consecutive-match extension** (`OC_CONSECUTIVE_MATCH`, opt-in on both peers) keeps sending the tail as a literal. That path halves the strong sum and only trusts a match a neighbouring block corroborates; the final block has no successor to corroborate it, so admitting it would mean a second, weaker acceptance rule on the one path with half-length checksums. `consecutive_match_gate_leaves_the_short_final_block_literal` pins that choice.

## Known limitation - this is DRAFT for this reason

The fix is correct but **not yet observable on the wire**, because a second, independent root cause sits in `crates/transfer`, which is fenced to another task:

```
crates/transfer/src/generator/delta.rs:467-470   build_signature_index()
    SignatureLayout::from_raw_parts(block_length_nz, 0 /* remainder unknown from wire format */, ...)
```

The remainder is **not** unknown - it is on the wire (`io.c:2061` `sum->remainder = read_int(f)`), oc's `SumHead` parses it, and upstream applies it on the sender in `receive_sums()`:

```c
sender.c:109-110   if (i == s->count-1 && s->remainder != 0) s->sums[i].len = s->remainder;
```

oc drops it, so every reconstructed block claims `block_length` and the probe never fires. The local-copy path is unaffected because it builds its index from a real `FileSignature` carrying the true length - which is precisely why the tail matched locally and not on the wire. Tracked separately; the numbers above will not move until it lands.

## Tests

New `crates/matching/tests/short_final_block_match.rs`:

- `basis_signature_ends_in_a_short_block` - pins the fixture premise, so the other assertions cannot go vacuous
- `short_final_block_is_matched_not_resent_as_literal` - the regression
- `short_final_block_copy_is_standalone_and_carries_its_true_length` - the coalescing hazard, on token identity
- `whole_file_shorter_than_one_block_matches_as_a_single_copy`
- `a_tail_shorter_than_the_final_block_stays_literal` - the tail position must be reachable
- `striped_scan_places_the_short_block_only_at_the_true_tail` - plants the tail block's content mid-source
- `consecutive_match_gate_leaves_the_short_final_block_literal`

The fixture uses a 64-bit LCG rather than a short-cycle pattern: with a repeating period, an unaligned window near EOF matches an earlier full block by content and swallows the trailing bytes, so "the tail was not matched" would be a statement about the data instead of the matcher. That is how the first draft of these tests failed.

Three existing tests encoded the pre-fix behaviour and were corrected, not deleted - their intent is preserved and now expressed against the block count the signature actually carries.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean, no waivers
- `cargo nextest run -p matching -p signature -p engine --all-features --no-fail-fast` - 5632 passed
- `cargo nextest run -p protocol -p transfer --all-features --no-fail-fast` - 8713 passed
- No golden wire byte changed. Note honestly *why*: the wire-reconstructed index cannot yet carry a short final block, so the goldens are currently insensitive to this path. They must be re-run and reasoned about when the remainder fix lands.
- Interop against real upstream rsync 3.4.4 is the measurement table above; the full harness run is still outstanding.
