### PR TITLE
fix(matching): match the basis's trailing short block on the wire sender

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -372,7 +372,7 @@ impl DeltaGenerator {
         let prune_matched = self.prune_matched;
         #[cfg(not(any(test, feature = "bench-internal")))]
         let prune_matched = true;
-        self.generate_with_prune(reader, index, prune_matched)
+        self.generate_with_prune(reader, index, prune_matched, true)
     }
 
     /// Reports whether emitting a `Copy` for basis block `idx` is safe at the
@@ -407,11 +407,19 @@ impl DeltaGenerator {
     /// only read-only lookups on `index` (no [`DeltaSignatureIndex::mark_consumed`]
     /// or [`DeltaSignatureIndex::reset_consumed`]), so a shared `&index` is safe
     /// to scan from multiple rayon workers concurrently.
+    ///
+    /// `tail_probe` says whether this scan reaches the true end of the source.
+    /// Upstream's scan runs to `end = len + 1 - s->sums[s->count-1].len`
+    /// (`match.c:174`), so the basis's short trailing block is reachable only at
+    /// the file's own end; a stripe of [`Self::generate_chunked`] that stops
+    /// mid-file must not probe it, or a short block would match bytes upstream
+    /// never offers it.
     fn generate_with_prune<R: Read>(
         &self,
         mut reader: R,
         index: &DeltaSignatureIndex,
         prune_matched: bool,
+        tail_probe: bool,
     ) -> io::Result<DeltaScript> {
         let block_len = index.block_length();
         let mut window = RingBuffer::with_capacity(block_len);
@@ -700,18 +708,87 @@ impl DeltaGenerator {
             }
         }
 
-        // Drain any bytes still in the window as literals (window held fewer
-        // than block_len bytes at EOF, so no further match is possible).
+        // EOF tail match: when the basis ends with a short block, upstream can
+        // still match it. Its scan runs to `end = len + 1 -
+        // s->sums[s->count-1].len` (`match.c:174`) and shrinks the rolling
+        // window at EOF (`match.c:321-331`: `more` is false, so `--k`), while
+        // every candidate must satisfy `l = MIN(blength, len-offset) ==
+        // s->sums[i].len` (`match.c:222-224`). Only the trailing short block has
+        // a length below `blength`, so exactly one window can match it: the
+        // file's final `short_len` bytes. Drain down to that length and probe
+        // once, rather than re-probing at every shrink step.
         //
-        // Upstream rsync matches the basis's short final block here via
-        // `l = MIN(blength, len-offset)` (`match.c:222-224`), but on the wire
-        // sender path that would (a) fail signature-index construction for
-        // small single-partial-block files and (b) produce a token stream the
-        // upstream compressed-delta receiver rejects (`token.c:665`). The
-        // "trailing partial block emitted as literal" is a pre-existing wire
-        // efficiency gap, not a correctness issue - reconstruction is
-        // byte-exact either way - so the tail match stays confined to the
-        // local-copy delta path (`engine::local_copy`).
+        // The token MUST be emitted standalone, never folded into a seq-match
+        // run: a run is carried as `len = run_len * block_len`, and the wire
+        // layer expands any `Copy` whose `len` is a whole multiple of the block
+        // length into that many full-length ops. A short block inside a run
+        // would therefore go out claiming `block_len` bytes, over-reading the
+        // basis and desyncing the compressed-token dictionary both peers feed
+        // from the matched length (`token.c:685 see_deflate_token()`). Emitting
+        // it here, after the match loop has flushed its run, makes that
+        // structural: no run is open at this point.
+        let short_tail_len = index
+            .block_count()
+            .checked_sub(1)
+            .map(|last| index.block(last).len())
+            .filter(|&len| len > 0 && len < block_len);
+        if tail_probe && let Some(tail_len) = short_tail_len {
+            while window.len() > tail_len {
+                if let Some(byte) = window.pop_front() {
+                    pending_literals.push(byte);
+                    offset += 1;
+                }
+            }
+            if window.len() == tail_len {
+                let (first, second) = window.as_slices();
+                rolling.reset();
+                rolling.update(first);
+                if !second.is_empty() {
+                    rolling.update(second);
+                }
+                let tail_match = index
+                    .find_tail_match(
+                        rolling.digest(),
+                        first,
+                        second,
+                        prune_matched.then_some(&matched_blocks),
+                    )
+                    .filter(|&idx| self.basis_offset_ok(index, block_len, idx, offset));
+                if let Some(match_idx) = tail_match {
+                    matches += 1;
+                    debug_log!(
+                        Deltasum,
+                        3,
+                        "potential tail match at {} i={} len={}",
+                        offset,
+                        match_idx,
+                        tail_len
+                    );
+                    if !pending_literals.is_empty() {
+                        literal_bytes += pending_literals.len() as u64;
+                        total_bytes += pending_literals.len() as u64;
+                        let filled =
+                            std::mem::replace(&mut pending_literals, Vec::with_capacity(block_len));
+                        tokens.push(DeltaToken::Literal(filled));
+                    }
+                    let block = index.block(match_idx);
+                    tokens.push(DeltaToken::Copy {
+                        index: block.index(),
+                        len: block.len(),
+                    });
+                    total_bytes += block.len() as u64;
+                    matched_blocks.mark_matched(match_idx);
+                    if prune_matched {
+                        index.mark_consumed(match_idx as u32);
+                    }
+                    window.clear();
+                }
+            }
+        }
+
+        // Drain any bytes still in the window as literals (the window holds
+        // fewer than block_len bytes at EOF, so no full-block match is possible,
+        // and the short-block probe above has already run).
         while let Some(byte) = window.pop_front() {
             pending_literals.push(byte);
         }
@@ -1062,9 +1139,13 @@ impl DeltaGenerator {
             .collect();
 
         // Scan every stripe concurrently against the shared read-only index.
+        // Only the stripe that ends at the source's own end may probe the
+        // basis's short trailing block; see `generate_with_prune`'s `tail_probe`.
         let scripts: Vec<io::Result<DeltaScript>> = ranges
             .par_iter()
-            .map(|&(s, e)| self.generate_with_prune(Cursor::new(&source[s..e]), index, false))
+            .map(|&(s, e)| {
+                self.generate_with_prune(Cursor::new(&source[s..e]), index, false, e == n)
+            })
             .collect();
 
         // Lift every worker `Copy` to an absolute source offset. Literals are
@@ -1172,6 +1253,121 @@ mod tests {
         let signature =
             generate_file_signature(data, layout, SignatureAlgorithm::Md4).expect("signature");
         DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+    }
+
+    /// Every `Copy` token's `len`, in emission order.
+    fn copy_lens(script: &DeltaScript) -> Vec<usize> {
+        script
+            .tokens()
+            .iter()
+            .filter_map(|token| match token {
+                DeltaToken::Copy { len, .. } => Some(*len),
+                DeltaToken::Literal(_) => None,
+            })
+            .collect()
+    }
+
+    /// The basis's trailing short block is matched, and is emitted as its own
+    /// `Copy` carrying its real length.
+    ///
+    /// upstream: `match.c:174` ends the scan at `len + 1 -
+    /// s->sums[s->count-1].len`, and `match.c:222-224` accepts a candidate only
+    /// when `MIN(blength, len-offset)` equals the block's own length, so the
+    /// final short block is matchable at exactly one offset.
+    #[test]
+    fn tail_short_block_is_matched_as_a_standalone_copy() {
+        const BLOCK_LEN: u32 = 16;
+        const TAIL: usize = 7;
+        // 4 full blocks plus a 7-byte tail.
+        let basis = pseudo_random(BLOCK_LEN as usize * 4 + TAIL, 0x51D5);
+        let index = build_index_fixed(&basis, BLOCK_LEN);
+        assert_eq!(index.block_count(), 5, "4 full blocks plus a short tail");
+        assert_eq!(index.block(4).len(), TAIL, "trailing block is short");
+
+        let script = DeltaGenerator::new()
+            .generate(basis.as_slice(), &index)
+            .expect("generate");
+
+        assert_eq!(
+            copy_lens(&script).last().copied(),
+            Some(TAIL),
+            "the trailing short block must be copied, not sent as literal: {:?}",
+            script.tokens(),
+        );
+        assert_eq!(reconstruct(&basis, &index, &script), basis);
+    }
+
+    /// The tail `Copy` is never folded into a seq-match run.
+    ///
+    /// A run is carried as `len = run_len * block_len`, and the wire layer
+    /// expands any `Copy` whose `len` is a whole multiple of the block length
+    /// into that many FULL-length ops. A short block swept into a run would go
+    /// out claiming `block_len` bytes, over-reading the basis and desyncing the
+    /// compressed-token dictionary both peers feed from the matched length
+    /// (`token.c:685 see_deflate_token()`). The source here matches the basis
+    /// end to end, so the scan builds the longest possible run right up to the
+    /// tail - the case where coalescing would be most tempting.
+    #[test]
+    fn tail_copy_is_never_coalesced_into_a_seq_match_run() {
+        const BLOCK_LEN: u32 = 16;
+        const TAIL: usize = 5;
+        let basis = pseudo_random(BLOCK_LEN as usize * 6 + TAIL, 0x7A11);
+        let index = build_index_fixed(&basis, BLOCK_LEN);
+
+        let script = DeltaGenerator::new()
+            .generate(basis.as_slice(), &index)
+            .expect("generate");
+
+        let lens = copy_lens(&script);
+        assert_eq!(
+            lens.last().copied(),
+            Some(TAIL),
+            "tail copy must carry the short block's own length: {lens:?}",
+        );
+        for len in &lens[..lens.len() - 1] {
+            assert_eq!(
+                len % BLOCK_LEN as usize,
+                0,
+                "a non-tail copy must cover whole blocks: {lens:?}",
+            );
+        }
+        assert_eq!(
+            lens.iter().sum::<usize>(),
+            basis.len(),
+            "every basis byte must be copied exactly once: {lens:?}",
+        );
+        assert_eq!(reconstruct(&basis, &index, &script), basis);
+    }
+
+    /// A scan that stops mid-file must not probe the short trailing block.
+    ///
+    /// `generate_chunked` splits the source into stripes; only the stripe that
+    /// ends at the source's own end reaches upstream's `end = len + 1 -
+    /// s->sums[s->count-1].len` boundary (`match.c:174`). Probing at a stripe
+    /// seam would match the short block against mid-file bytes upstream never
+    /// offers it, so the parallel and sequential scans would frame differently.
+    #[test]
+    fn a_mid_file_stripe_does_not_probe_the_short_tail_block() {
+        const BLOCK_LEN: u32 = 16;
+        const TAIL: usize = 7;
+        let basis = pseudo_random(BLOCK_LEN as usize * 4 + TAIL, 0x51D5);
+        let index = build_index_fixed(&basis, BLOCK_LEN);
+
+        let generator = DeltaGenerator::new();
+        let stripe = generator
+            .generate_with_prune(Cursor::new(basis.as_slice()), &index, false, false)
+            .expect("stripe scan");
+        assert!(
+            !copy_lens(&stripe).contains(&TAIL),
+            "a stripe that does not reach EOF must leave the short block alone",
+        );
+
+        // The same bytes scanned as a whole file do match it, so the guard is
+        // about the scan's extent, not about this fixture being unmatchable.
+        let whole = generator
+            .generate_with_prune(Cursor::new(basis.as_slice()), &index, false, true)
+            .expect("whole-file scan");
+        assert!(copy_lens(&whole).contains(&TAIL));
     }
 
     /// Builds an index with a caller-chosen fixed block length so a
@@ -1573,17 +1769,18 @@ mod tests {
             .generate(&basis[..], &index)
             .expect("script");
 
-        let copied: usize = script
-            .tokens()
-            .iter()
-            .filter_map(|t| match t {
-                DeltaToken::Copy { len, .. } => Some(*len),
-                _ => None,
-            })
-            .sum();
+        let lens = copy_lens(&script);
+        assert!(
+            lens.contains(&(BLOCK_LEN as usize)),
+            "the full block must be Copied, not demoted to a literal: {lens:?}",
+        );
+        // The ungated fallback is upstream's own scan, so it also matches the
+        // basis's trailing short block at the file's end (match.c:174,222-224):
+        // source and basis are identical here, so nothing is left literal.
         assert_eq!(
-            copied, BLOCK_LEN as usize,
-            "the full block must be Copied, not demoted to a literal"
+            lens.iter().sum::<usize>(),
+            basis.len(),
+            "the fallback scan copies the full block and the short tail: {lens:?}",
         );
         assert_eq!(reconstruct(&basis, &index, &script), basis);
     }

--- a/crates/matching/src/index/builder.rs
+++ b/crates/matching/src/index/builder.rs
@@ -22,7 +22,13 @@ use super::{
 /// break the chain (they are not indexed and never become successors), which
 /// preserves wire compatibility under trailing-partial-block layouts.
 ///
-/// Returns `true` if at least one full-length block was indexed.
+/// Upstream's `build_hash_table()` (`match.c:75-87`) inserts every block,
+/// including the trailing short one, and relies on the length check at
+/// `match.c:222-224` to reject it at all but the one offset where the remaining
+/// byte count equals its length. Indexing only full-length blocks here is the
+/// same rule expressed in the data structure: the trailing short block is found
+/// by [`DeltaSignatureIndex::find_tail_match`]'s direct scan instead, at exactly
+/// that one offset.
 fn populate_index(
     blocks: &[SignatureBlock],
     block_length: usize,
@@ -30,14 +36,12 @@ fn populate_index(
     bithash: &mut BitHash,
     lookup: &mut CompactLookup,
     next_match: &mut [u32],
-) -> bool {
-    let mut has_full_blocks = false;
+) {
     let mut prev_full: Option<usize> = None;
     for (index, block) in blocks.iter().enumerate() {
         if block.len() != block_length {
             continue;
         }
-        has_full_blocks = true;
         let digest = block.rolling();
         tag_table[digest.sum1() as usize] = true;
         bithash.insert(digest.value());
@@ -49,7 +53,6 @@ fn populate_index(
         }
         prev_full = Some(index);
     }
-    has_full_blocks
 }
 
 /// Detects whether two or more full-length blocks carry identical content.
@@ -124,16 +127,24 @@ impl DeltaSignatureIndex {
         // so `next_match[K]` is addressable for every K the lookup can yield.
         let mut next_match = vec![NEXT_MATCH_NONE; requested];
 
-        if !populate_index(
+        // A basis smaller than one block indexes no full-length block, but it is
+        // still a usable signature: upstream builds a hash table from a
+        // one-short-block sum_struct like any other (match.c:75-87) and matches
+        // it at the file's end. Rejecting it here made the sender fail with
+        // "failed to create signature index" for any basis under one block.
+        // Only a signature with no blocks at all is unusable, and upstream never
+        // reaches match_sums()'s hash path for one either (match.c:393).
+        if blocks.is_empty() {
+            return None;
+        }
+        populate_index(
             &blocks,
             block_length,
             &mut tag_table,
             &mut bithash,
             &mut lookup,
             &mut next_match,
-        ) {
-            return None;
-        }
+        );
 
         let size = lookup.capacity();
         let consumed = build_consumed_words(blocks.len());
@@ -168,8 +179,10 @@ impl DeltaSignatureIndex {
     /// the table is cleared and repopulated rather than freed and
     /// re-allocated, avoiding per-file malloc/free overhead.
     ///
-    /// Returns `false` if the signature has no full blocks (caller
-    /// should discard the index).
+    /// Returns `false` only when the signature carries no blocks at all (the
+    /// caller should discard the index). A signature whose single block is
+    /// shorter than the block length is usable: it matches at the file's end
+    /// exactly as upstream's does (match.c:75-87,222-224).
     pub fn rebuild(&mut self, signature: &FileSignature, algorithm: SignatureAlgorithm) -> bool {
         let block_length = signature.layout().block_length().get() as usize;
         let strong_length = usize::from(signature.layout().strong_sum_length().get());
@@ -199,7 +212,7 @@ impl DeltaSignatureIndex {
         #[cfg(any(test, feature = "bench-internal"))]
         self.seq_match_counters.reset();
 
-        let ok = populate_index(
+        populate_index(
             &self.blocks,
             block_length,
             &mut self.tag_table,
@@ -207,6 +220,7 @@ impl DeltaSignatureIndex {
             &mut self.lookup,
             &mut self.next_match,
         );
+        let ok = !self.blocks.is_empty();
 
         self.has_duplicate_blocks = detect_duplicate_blocks(&self.blocks, block_length);
 

--- a/crates/matching/src/index/tests.rs
+++ b/crates/matching/src/index/tests.rs
@@ -4,8 +4,15 @@ use signature::{SignatureLayoutParams, calculate_signature_layout, generate_file
 use std::collections::VecDeque;
 use std::num::NonZeroU8;
 
+/// A signature whose only block is shorter than the block length is usable, and
+/// that short block is matchable through the tail probe.
+///
+/// upstream: `match.c:75-87` inserts every block into the hash table, including
+/// a lone short one, and `match.c:222-224` lets it match at the single offset
+/// where the remaining byte count equals its length. Only a signature with no
+/// blocks at all is unusable.
 #[test]
-fn from_signature_returns_none_without_full_blocks() {
+fn from_signature_accepts_a_basis_smaller_than_one_block() {
     let params = SignatureLayoutParams::new(
         64,
         None,
@@ -16,6 +23,35 @@ fn from_signature_returns_none_without_full_blocks() {
     let data = vec![0u8; 64];
     let signature = generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4)
         .expect("signature");
+
+    let index = DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4)
+        .expect("a sub-block basis is a usable signature");
+    assert_eq!(index.block_count(), 1);
+    assert!(index.block(0).len() < index.block_length());
+
+    let digest = checksums::RollingDigest::from_bytes(&data);
+    assert_eq!(
+        index.find_tail_match(digest, &data, &[], None),
+        Some(0),
+        "the lone short block must be findable at the file's end",
+    );
+}
+
+/// An empty signature carries no block to match, so it yields no index.
+///
+/// upstream: `match.c:393` skips the hash path entirely when `s->count == 0`.
+#[test]
+fn from_signature_returns_none_for_an_empty_signature() {
+    let params = SignatureLayoutParams::new(
+        0,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(&[][..], layout, SignatureAlgorithm::Md4).expect("signature");
+    assert_eq!(signature.blocks().len(), 0, "no blocks for an empty basis");
 
     assert!(DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).is_none());
 }

--- a/crates/matching/tests/integration_tests.rs
+++ b/crates/matching/tests/integration_tests.rs
@@ -810,17 +810,28 @@ fn index_strong_length_accessor() {
     );
 }
 
-/// Verifies that index returns None for data without full blocks.
+/// A basis smaller than one block still yields a usable index.
+///
+/// This asserted `is_none()` while the sender forced every wire block to the
+/// full block length, which made a sub-block basis look like a block-length
+/// block with the wrong checksum. Upstream builds a hash table from such a
+/// signature like any other (`match.c:75-87`) and matches its single short
+/// block at the file's end (`match.c:222-224`), so refusing to build the index
+/// made the sender fail outright on any basis under one block.
 #[test]
-fn index_returns_none_for_small_data() {
-    // Very small data that won't produce full blocks
+fn index_is_built_for_a_basis_smaller_than_one_block() {
     let basis = vec![0u8; 64];
-    let result = build_index(&basis);
+    let index = build_index(&basis).expect("a sub-block basis is a usable signature");
 
-    // The index should return None because there are no full blocks
+    assert_eq!(index.block_count(), 1, "one short block");
+    assert_eq!(
+        index.block(0).len(),
+        basis.len(),
+        "the block carries its real length, not the block length"
+    );
     assert!(
-        result.is_none(),
-        "small data should not produce index with full blocks"
+        index.block(0).len() < index.block_length(),
+        "the fixture must be shorter than one block"
     );
 }
 
@@ -1531,7 +1542,17 @@ mod algorithm_correctness {
         let basis: Vec<u8> = (0..16384).map(|i| (i % 251) as u8).collect();
         let index = build_index(&basis).expect("index");
         let block_len = index.block_length();
-        let num_blocks = basis.len() / block_len;
+        // Every indexed block, including the trailing short one. This was
+        // `basis.len() / block_len`, which floors away that last block: the
+        // basis does not divide evenly, and the scan can match its short tail
+        // (upstream: match.c:174,222-224), so the floor under-counted the
+        // legal index range by one.
+        let num_blocks = index.block_count();
+        let tail_len = index.block(num_blocks - 1).len();
+        assert!(
+            tail_len < block_len,
+            "fixture must end with a short block for the tail cases below",
+        );
 
         let input = basis.clone();
         let script = generate_delta(&input[..], &index).expect("delta");
@@ -1546,16 +1567,28 @@ mod algorithm_correctness {
                     (*block_idx as usize) < num_blocks,
                     "copy token should reference valid block index: {block_idx} >= {num_blocks}"
                 );
-                // Seq-match coalesces consecutive matched basis blocks into
-                // a single fat Copy. The token length is therefore an
-                // integer multiple of the canonical block length, and the
-                // run must fit inside the indexed block range.
-                assert_eq!(
-                    *len % block_len,
-                    0,
-                    "copy length should be a multiple of block length"
-                );
-                let run = *len / block_len;
+                // Seq-match coalesces consecutive matched basis blocks into a
+                // single fat Copy, so a run's length is an integer multiple of
+                // the canonical block length. The one exception is the basis's
+                // trailing short block, which is matched at the file's own end
+                // and emitted standalone with its real length - never folded
+                // into a run, because the wire layer expands a whole-multiple
+                // length into that many FULL-length ops.
+                let run = if *len % block_len == 0 {
+                    *len / block_len
+                } else {
+                    assert_eq!(
+                        *len, tail_len,
+                        "a copy length that is not a whole number of blocks may \
+                         only be the trailing short block"
+                    );
+                    assert_eq!(
+                        *block_idx as usize,
+                        num_blocks - 1,
+                        "only the last indexed block is short"
+                    );
+                    1
+                };
                 assert!(
                     (*block_idx as usize) + run <= num_blocks,
                     "copy run extends past last indexed block: index={block_idx} run={run} num_blocks={num_blocks}"

--- a/crates/transfer/src/delta_config.rs
+++ b/crates/transfer/src/delta_config.rs
@@ -41,6 +41,19 @@ pub struct DeltaGeneratorConfig<'a> {
     /// of the negotiated checksum algorithm.
     pub strong_sum_length: u8,
 
+    /// Length of the basis's trailing block when it is shorter than
+    /// [`Self::block_length`], or `0` when the basis divides evenly.
+    ///
+    /// This is the fourth field of the sum head the receiver's generator wrote
+    /// (`io.c:write_sum_head()`), so it is known from the wire, not inferred:
+    /// upstream's sender assigns `s->sums[i].len = s->remainder` for the last
+    /// block and `s->blength` for every other (`sender.c:109-112`). Without it
+    /// every block would claim a full `block_length`, and the basis's short
+    /// trailing block could never be matched - its rolling checksum covers
+    /// `remainder` bytes, and a candidate is accepted only when the lengths
+    /// agree (`match.c:222-224`).
+    pub remainder: u32,
+
     /// Protocol version used to pick the strong-checksum algorithm when no
     /// explicit negotiation result is present: protocol < 30 falls back to
     /// MD4/MD5, protocol >= 30 expects [`Self::negotiated_algorithms`].
@@ -91,11 +104,22 @@ impl<'a> DeltaGeneratorConfig<'a> {
             sig_blocks,
             strong_sum_length,
             protocol,
+            remainder: 0,
             negotiated_algorithms: None,
             compat_flags: None,
             checksum_seed: 0,
             updating_basis_file: false,
         }
+    }
+
+    /// Sets the trailing short block's length, as carried by the sum head.
+    ///
+    /// upstream: `sender.c:109-112` reads it from `read_sum_head()` and applies
+    /// it to the last block only.
+    #[must_use]
+    pub const fn with_remainder(mut self, remainder: u32) -> Self {
+        self.remainder = remainder;
+        self
     }
 
     /// Attaches negotiated algorithms from protocol >= 30 capability exchange.

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -464,29 +464,55 @@ fn build_signature_index(config: DeltaGeneratorConfig<'_>) -> io::Result<DeltaSi
 
     let block_count = config.sig_blocks.len() as u64;
 
-    // Reconstruct signature layout (remainder unknown, set to 0)
+    // The trailing block's length is the sum head's fourth field, written by the
+    // receiver's generator (io.c:write_sum_head()) - it is carried on the wire,
+    // not inferred. Ignoring it left every block claiming a full block_length,
+    // so the basis's short trailing block could never match: its rolling
+    // checksum covers `remainder` bytes and match.c:222-224 accepts a candidate
+    // only when the lengths agree.
+    // upstream: sender.c:109-112 - `if (i == s->count-1 && s->remainder != 0)
+    // s->sums[i].len = s->remainder; else s->sums[i].len = s->blength;`
+    let remainder = config.remainder;
+    let last_block_len = if remainder == 0 {
+        config.block_length
+    } else {
+        remainder
+    };
     let layout = SignatureLayout::from_raw_parts(
         block_length_nz,
-        0, // remainder unknown from wire format
+        remainder,
         block_count,
         strong_sum_length_nz,
     );
 
     // Convert wire blocks to engine signature blocks (consumes sig_blocks)
+    let last_index = block_count.saturating_sub(1);
     let engine_blocks: Vec<SignatureBlock> = config
         .sig_blocks
         .into_iter()
-        .map(|wire_block| {
+        .enumerate()
+        .map(|(position, wire_block)| {
+            let block_len = if position as u64 == last_index {
+                last_block_len
+            } else {
+                config.block_length
+            };
             SignatureBlock::from_raw_parts(
                 wire_block.index as u64,
-                RollingDigest::from_value(wire_block.rolling_sum, config.block_length as usize),
+                RollingDigest::from_value(wire_block.rolling_sum, block_len as usize),
                 &wire_block.strong_sum,
             )
         })
         .collect();
 
-    // Calculate total bytes (approximation since we don't know exact remainder)
-    let total_bytes = (block_count.saturating_sub(1)) * u64::from(config.block_length);
+    // upstream: sender.c:126 `s->flength = offset` - the basis length is the sum
+    // of every block's own length, so the trailing short block counts as
+    // `remainder`, not as a whole block.
+    let total_bytes = if block_count == 0 {
+        0
+    } else {
+        (block_count - 1) * u64::from(config.block_length) + u64::from(last_block_len)
+    };
     let signature = FileSignature::from_raw_parts(layout, engine_blocks, total_bytes);
 
     // Select checksum algorithm using ChecksumFactory (handles negotiated vs default)
@@ -1652,6 +1678,10 @@ mod tests {
             block_length: block_len,
             sig_blocks,
             strong_sum_length: strong_len,
+            // Every basis built for these cases is a whole number of blocks, so
+            // the sum head upstream would write carries remainder 0
+            // (generator.c:sum_sizes_sqroot()).
+            remainder: 0,
             protocol: ProtocolVersion::NEWEST,
             negotiated_algorithms: None,
             compat_flags: None,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -938,6 +938,9 @@ impl GeneratorContext {
                     block_length,
                     sig_blocks,
                     strong_sum_length,
+                    // upstream: sender.c:109-112 - the sum head's remainder is
+                    // the trailing block's real length.
+                    remainder: sum_head.remainder,
                     protocol: self.protocol,
                     negotiated_algorithms: self.negotiated_algorithms.as_ref(),
                     compat_flags: self.compat_flags.as_ref(),


### PR DESCRIPTION
## Overlaps #7238 - please pick one

#7238 targets the same defect and reaches the same design in `crates/matching`
(EOF tail probe, stripe-seam gating, index constructor accepting a sub-block
basis), independently. It is missing the half that lives in `crates/transfer`,
and **without that half the change does not move a single wire byte.**

Measured, both binaries built from their own heads, oc as sender against an
upstream 3.4.4 daemon receiver, same fixture:

| | Literal | Matched |
|---|---|---|
| master (39fe17d6c) | 103,300 | 101,500 |
| **#7238 (f979ec9fb)** | **103,300** | **101,500** |
| this branch | **102,900** | **101,900** |
| upstream 3.4.4 | 102,900 | 101,900 |

#7238's unit tests pass because they build the index from a real
`FileSignature`, which carries true per-block lengths. The wire path never does:
`build_signature_index` gives every block `block_length`, so `find_tail_match` -
which requires `block.len() == tail_len` - can never fire on a real transfer. I
hit exactly this trap first: my matching-only build measured no change at all.

Happy either way - land this one, or move the `crates/transfer` half into #7238
and close this. What must not ship is the matching-only version, which reads as
a fix and measures as a no-op.

## The defect

oc's sender never matched the basis's trailing short block, so every delta paid
for it as literal. This is **not** a redo defect - it reproduces with no
`--append`, no `--append-verify` and no phase 2 anywhere.

## Two halves

**Data model (`crates/transfer`).** `build_signature_index` set the layout
remainder to 0, commented *"remainder unknown from wire format"*. It is not
unknown: it is the fourth field of the sum head the receiver's generator wrote
(`io.c:write_sum_head()`), and upstream's sender applies it to the last block -
`if (i == s->count-1 && s->remainder != 0) s->sums[i].len = s->remainder;`
(`sender.c:109-112`). Every block claimed a full `block_length`, and a short
block matches only when the lengths agree (`match.c:222-224`). The remainder is
now carried on `DeltaGeneratorConfig` and applied to the trailing block; the
basis length is summed from real block lengths (`sender.c:126`).

**Scan (`crates/matching`).** The EOF drain flushed the trailing window as
literals. Upstream runs its scan to `end = len + 1 - s->sums[s->count-1].len`
(`match.c:174`) and shrinks the rolling window at EOF (`match.c:321-331`), so
exactly one window - the file's final `remainder` bytes - can match. The drain
now stops at that length and probes once.

## The coalescing hazard

The tail token is emitted standalone and never folded into a seq-match run. A
run is carried as `len = run_len * block_len`, and `script_to_wire_delta` expands
any `Copy` whose `len` is a whole multiple of the block length into that many
FULL-length ops - so a short block swept into a run would go out claiming
`block_len` bytes, over-reading the basis and desyncing the compressed-token
dictionary both peers feed from the matched length
(`token.c:685 see_deflate_token()`). Emitting it after the match loop has
flushed its run makes that structural, and
`tail_copy_is_never_coalesced_into_a_seq_match_run` pins it against the
longest-possible run.

Only a scan reaching the true end of the source may probe: `generate_chunked`
splits into stripes, and a stripe seam is not upstream's `end` boundary, so
`tail_probe` is set for the final stripe alone, with a test that a mid-file
stripe leaves the short block alone.

## The regression the test suite caught

Applying real block lengths made `daemon_pull_delay_updates_stages_through_tmp_dir`
fail with `failed to create signature index`: its destination basis is 5 bytes,
so the only block is short, and the index constructor rejected any signature
without a full-length block. That limitation was invisible while every wire block
was forced to `block_length`. Upstream builds a hash table from such a signature
like any other (`match.c:75-87`); only an empty one is unusable (`match.c:393`).
Indexing only full blocks in the tables is kept - it is upstream's length check
expressed in the data structure, with the short block found by
`find_tail_match`'s direct scan.

## The stale justification

The comment declining the tail match cited `token.c:665` as proof that the
upstream compressed-delta receiver rejects such a token stream. That line is a
generic `inflate returned %d` failure, unrelated - upstream sends short-block
tokens routinely. Its other claim, that the index constructor would fail for a
single-partial-block basis, was true, and is fixed here rather than worked
around.

## Tests that changed because they encoded the gap

- two asserted the index constructor returns `None` for a sub-block basis;
- one floored the legal block index at `len / block_len`, silently assuming the
  trailing block is never referenced, and required every copy length to be a
  whole multiple of the block length;
- the gated-fallback test now sees the tail copied too, which is what upstream's
  ungated scan does. Its stated intent (the lone full block must not be demoted
  to a literal) is asserted directly instead of via a total.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run --workspace --all-features -E 'package(transfer) or package(engine) or package(protocol) or package(matching)'`:
  14,008/14,010 passed. **Golden byte tests (package(protocol)) all pass** - this
  touches the wire, so that was the gate. The 2 failures are
  `engine local_copy::tests::{execute_preserves_read_only_permissions,
  archive_preserves_mixed_permissions_across_files}`, both
  `remove extended attribute ... Permission denied` on a local macOS temp dir,
  reproduced on an untouched base commit and unrelated to this change.
- Cross-implementation, against the real upstream 3.4.4 binary: oc sender ->
  upstream daemon receiver is now byte-exact on the delta split (above), and oc
  receiver <- upstream daemon sender still reconstructs identical bytes. The
  `--append-verify` phase-2 redo push cell (upstream receiving) reports 2
  transfers, literal 205,300 / matched 101,900 - byte-identical to upstream.
- `tools/ci/run_interop.sh` was **not** run locally: the harness is
  Ubuntu/Debian-oriented (fetches `.deb`s) and does not run on this macOS host.
  CI's required interop job is the gate for it.

There is a residual 20-byte difference in `Total bytes sent` (103,650 vs
upstream's 103,628) in that probe. It is unrelated protocol overhead, present
identically before this change (104,048 vs 103,628 = the 400 literal bytes plus
the same 20), and is not touched here.
