### PR TITLE
test(xtask): resolve cross-compiler against an injected host arch

### DIFF
--- a/xtask/src/commands/package/build.rs
+++ b/xtask/src/commands/package/build.rs
@@ -102,7 +102,7 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
 
     if options.build_tarball {
         let specs = tarball::tarball_specs(&branding, options.tarball_target.as_deref())?;
-        let resolved = resolve_tarball_builds(workspace, specs)?;
+        let resolved = resolve_tarball_builds(workspace, specs, env::consts::ARCH)?;
 
         if resolved.builds.is_empty() {
             if let Some(skipped) = resolved.skipped.first() {
@@ -141,12 +141,13 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
 fn resolve_tarball_builds(
     workspace: &Path,
     specs: Vec<tarball::TarballSpec>,
+    host_arch: &str,
 ) -> TaskResult<ResolvedTarballSpecs> {
     let mut builds = Vec::with_capacity(specs.len());
     let mut skipped = Vec::new();
 
     for spec in specs {
-        match resolve_cross_compiler(workspace, &spec) {
+        match resolve_cross_compiler(workspace, &spec, host_arch) {
             Ok(linker) => builds.push(TarballBuild { spec, linker }),
             Err(TaskError::ToolMissing(message)) => {
                 skipped.push(SkippedTarballSpec { spec, message })
@@ -162,8 +163,9 @@ fn resolve_tarball_builds(
 pub(super) fn resolve_tarball_cross_compilers_for_tests(
     workspace: &Path,
     specs: Vec<tarball::TarballSpec>,
+    host_arch: &str,
 ) -> TaskResult<ResolvedTarballSpecs> {
-    resolve_tarball_builds(workspace, specs)
+    resolve_tarball_builds(workspace, specs, host_arch)
 }
 
 pub(super) fn build_workspace_binaries(
@@ -244,8 +246,9 @@ pub(super) struct SkippedTarballSpec {
 fn resolve_cross_compiler(
     workspace: &Path,
     spec: &tarball::TarballSpec,
+    host_arch: &str,
 ) -> TaskResult<Option<LinkerOverride>> {
-    if !spec.requires_cross_compiler() {
+    if !spec.requires_cross_compiler(host_arch) {
         return Ok(None);
     }
 
@@ -632,6 +635,7 @@ fn rename_deb_with_variant_suffix(
 pub(super) fn resolve_cross_compiler_for_tests(
     workspace: &Path,
     target: &str,
+    host_arch: &str,
 ) -> TaskResult<Option<(OsString, OsString)>> {
     let spec = match target {
         "x86_64-unknown-linux-gnu" => tarball::TarballSpec {
@@ -653,7 +657,7 @@ pub(super) fn resolve_cross_compiler_for_tests(
         }
     };
 
-    resolve_cross_compiler(workspace, &spec).map(|override_opt| {
+    resolve_cross_compiler(workspace, &spec, host_arch).map(|override_opt| {
         override_opt.map(|override_value| (override_value.env_var, override_value.value))
     })
 }

--- a/xtask/src/commands/package/tarball.rs
+++ b/xtask/src/commands/package/tarball.rs
@@ -133,12 +133,15 @@ impl TarballSpec {
         self.platform.includes_daemon()
     }
 
-    pub fn requires_cross_compiler(&self) -> bool {
+    /// Reports whether building this spec on `host_arch` needs a cross-compiler.
+    ///
+    /// The host architecture is supplied by the caller rather than read from
+    /// `env::consts::ARCH` so that resolution is a pure function of its inputs.
+    pub fn requires_cross_compiler(&self, host_arch: &str) -> bool {
         if !matches!(self.platform, TarballPlatform::Linux) {
             return false;
         }
 
-        let host_arch = env::consts::ARCH;
         self.metadata_arch != host_arch
     }
 }

--- a/xtask/src/commands/package/tests.rs
+++ b/xtask/src/commands/package/tests.rs
@@ -21,6 +21,14 @@ fn workspace_root() -> &'static Path {
     })
 }
 
+/// Host architecture the cross-compiler fixtures resolve against.
+///
+/// Pinned so the expectations hold on every build host; resolving against the
+/// real host would make `aarch64-unknown-linux-gnu` a native target on an
+/// aarch64 machine and no cross-compiler would be looked for at all.
+#[cfg(all(test, target_os = "linux"))]
+const FIXTURE_HOST_ARCH: &str = "x86_64";
+
 type ScopedEnv = EnvGuard;
 
 fn scoped_env(keys: &[&'static str]) -> ScopedEnv {
@@ -155,8 +163,12 @@ fn execute_reports_missing_cross_compiler() {
         "aarch64-linux-gnu-gcc,zig",
     );
 
-    let error = resolve_cross_compiler_for_tests(workspace_root(), "aarch64-unknown-linux-gnu")
-        .unwrap_err();
+    let error = resolve_cross_compiler_for_tests(
+        workspace_root(),
+        "aarch64-unknown-linux-gnu",
+        FIXTURE_HOST_ARCH,
+    )
+    .unwrap_err();
 
     assert!(matches!(
         error,
@@ -174,10 +186,13 @@ fn cross_compiler_resolution_prefers_cross_gcc() {
     prepend_path(&mut env, dir.path());
     set_str(&mut env, "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "zig");
 
-    let override_value =
-        resolve_cross_compiler_for_tests(workspace_root(), "aarch64-unknown-linux-gnu")
-            .expect("resolution succeeds")
-            .expect("cross compiler override present");
+    let override_value = resolve_cross_compiler_for_tests(
+        workspace_root(),
+        "aarch64-unknown-linux-gnu",
+        FIXTURE_HOST_ARCH,
+    )
+    .expect("resolution succeeds")
+    .expect("cross compiler override present");
 
     assert_eq!(
         override_value.0,
@@ -198,10 +213,13 @@ fn cross_compiler_resolution_falls_back_to_zig() {
         "aarch64-linux-gnu-gcc",
     );
 
-    let override_value =
-        resolve_cross_compiler_for_tests(workspace_root(), "aarch64-unknown-linux-gnu")
-            .expect("resolution succeeds")
-            .expect("cross compiler override present");
+    let override_value = resolve_cross_compiler_for_tests(
+        workspace_root(),
+        "aarch64-unknown-linux-gnu",
+        FIXTURE_HOST_ARCH,
+    )
+    .expect("resolution succeeds")
+    .expect("cross compiler override present");
 
     assert_eq!(
         override_value.0,
@@ -238,8 +256,9 @@ fn tarball_resolution_skips_targets_without_cross_tooling() {
         },
     ];
 
-    let resolved = resolve_tarball_cross_compilers_for_tests(workspace_root(), specs)
-        .expect("resolution succeeds");
+    let resolved =
+        resolve_tarball_cross_compilers_for_tests(workspace_root(), specs, FIXTURE_HOST_ARCH)
+            .expect("resolution succeeds");
 
     assert_eq!(resolved.builds.len(), 1);
     assert_eq!(


### PR DESCRIPTION
## Problem

Four xtask packaging tests fail on any Linux host whose architecture is not
`x86_64`:

```
xtask::commands::package::tests::cross_compiler_resolution_prefers_cross_gcc
xtask::commands::package::tests::cross_compiler_resolution_falls_back_to_zig
xtask::commands::package::tests::execute_reports_missing_cross_compiler
xtask::commands::package::tests::tarball_resolution_skips_targets_without_cross_tooling
```

They pass on the x86_64 CI runner, so the required `nextest (stable)` cell is
green, but every aarch64 Linux checkout sees four red tests. The tests are
`#[cfg(all(test, target_os = "linux"))]`, so macOS and Windows never compile
them and the failure is invisible there.

## Cause

`TarballSpec::requires_cross_compiler()` decided "is this a cross build?" by
reading `env::consts::ARCH` directly:

```rust
let host_arch = env::consts::ARCH;
self.metadata_arch != host_arch
```

The fixtures target `aarch64-unknown-linux-gnu`. On an aarch64 host that is the
*native* target, so `requires_cross_compiler()` returns false, the resolver
short-circuits to `Ok(None)`, and no cross-compiler is looked for at all. The
tests then fail on their very first expectation - measured on an aarch64 Linux
checkout of master:

```
execute_reports_missing_cross_compiler
  called `Result::unwrap_err()` on an `Ok` value: None
cross_compiler_resolution_prefers_cross_gcc
  panicked at tests.rs:180: cross compiler override present
cross_compiler_resolution_falls_back_to_zig
  panicked at tests.rs:204: cross compiler override present
tarball_resolution_skips_targets_without_cross_tooling
  assertion `left == right` failed: left: 2, right: 1
```

The tests already control the other ambient input they depend on (`PATH`, plus
`OC_RSYNC_FORCE_MISSING_CARGO_TOOLS`) through `EnvGuard`. The host architecture
was the one input they could not control, because it was read from a global
several call frames below the function under test.

## Fix

Invert the dependency: the host architecture becomes an explicit parameter
threaded through `resolve_tarball_builds` -> `resolve_cross_compiler` ->
`requires_cross_compiler`. Production passes `env::consts::ARCH` at the single
call site in `package::execute`; the fixtures pass a pinned `x86_64`, which is
what their expectations were always written against.

A plain parameter is used rather than a trait or a source object - there is one
production value and one fixture value, so an abstraction would be dead weight.
Resolution order, the candidate list, and every assertion are unchanged; the
behaviour of `cargo xtask package` is identical.

This is oc-specific build tooling. Upstream rsync uses autotools and has no
equivalent, so there is no upstream behaviour to mirror here and no upstream
citation is claimed for this change; the governing standards are SOLID and the
repo's clean-code rules.

## Verification

Run on an aarch64 Linux host, where all four previously failed:

```
cargo fmt --all -- --check                                        clean
cargo clippy --locked -p xtask --all-targets --all-features
  --no-deps -- -D warnings                                        clean
cargo nextest run -p xtask --all-features
  -E 'test(cross_compiler) or test(tarball_resolution)'
    4 tests run: 4 passed
```

Both directions were checked. Reverting only the production side (making
`requires_cross_compiler` ignore its parameter and read `env::consts::ARCH`
again) while keeping the test side turns all four red:

```
4 tests run: 0 passed, 4 failed
```

so the tests do still exercise the resolver rather than passing vacuously.

## Follow-up, not changed here

The `#[cfg(all(test, target_os = "linux"))]` gate on these four tests is a
separate, smaller coverage hole: macOS and Windows never build them. Relaxing
it to `cfg(unix)` looks viable for macOS but not for Windows, where
`fake_tool()` writes a `.cmd` shim while `ensure_command_available` only
appends `EXE_SUFFIX`. Left alone deliberately.
