### PR TITLE
fix(daemon): stop counting the -e capability 'v' as a client -v

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -1,5 +1,5 @@
 // Construction of the `ServerConfig` from the parsed client arguments: server
-// role detection, compact-flag verbosity clamping, and the main
+// role detection, per-module output-verbosity limiting, and the main
 // `build_server_config` assembly that wires module directives into the config.
 /// Determines the server role based on client arguments.
 ///
@@ -13,45 +13,57 @@ fn determine_server_role(client_args: &[String]) -> ServerRole {
     }
 }
 
-/// Clamps `v` (verbose) characters in a compact flag string to respect `max_verbosity`.
+/// Largest verbosity level the `info_verbosity[]` / `debug_verbosity[]` tables
+/// describe. upstream: options.c:247 `#define MAX_VERBOSITY ((int)(sizeof
+/// debug_verbosity / sizeof debug_verbosity[0]) - 1)`, whose table
+/// (options.c:238-245) runs 0..=5.
+const MAX_VERBOSITY: u8 = 5;
+
+/// Caps the client's requested verbosity at the module's `max verbosity`,
+/// yielding the effective per-connection output level.
 ///
-/// When `max_verbosity` is 0 or negative, all `v` characters are removed.
-/// When positive, at most `max_verbosity` occurrences of `v` are retained.
+/// This limits the LEVEL only: the client's option string is never rewritten,
+/// so the `-e.<caps>` capability payload it carries reaches the capability
+/// decoder byte-for-byte.
 ///
-/// upstream: clientserver.c - the daemon clamps `verbose` to `lp_max_verbosity(i)`
-/// after parsing client args.
-fn clamp_verbose_flags(flag_string: &str, max_verbosity: i32) -> String {
-    if max_verbosity < 0 {
-        return flag_string.replace('v', "");
+/// upstream: clientserver.c:1141 `limit_output_verbosity(lp_max_verbosity(i))`
+/// runs after `parse_arguments()` and only lowers the entries of the
+/// `info_levels[]` / `debug_levels[]` output arrays (options.c:537-560); it
+/// leaves `verbose` and the parsed argv untouched. A `level` above
+/// `MAX_VERBOSITY` returns early (options.c:542-543), applying no limit at all.
+fn limit_output_verbosity(requested: u8, max_verbosity: i32) -> u8 {
+    if max_verbosity > i32::from(MAX_VERBOSITY) {
+        return requested;
     }
-
-    let max = max_verbosity as usize;
-    let mut count = 0usize;
-    flag_string
-        .chars()
-        .filter(|&ch| {
-            if ch == 'v' {
-                count += 1;
-                count <= max
-            } else {
-                true
-            }
-        })
-        .collect()
+    let max = u8::try_from(max_verbosity).unwrap_or(0);
+    requested.min(max)
 }
 
-/// Counts the `v` (verbose) characters in an already-clamped flag string,
-/// yielding the effective per-connection verbosity level.
+/// Applies the module's `max verbosity` to a freshly parsed [`ServerConfig`]
+/// and returns the effective output level.
 ///
-/// The input is expected to be the output of [`clamp_verbose_flags`], so the
-/// count already respects the module's `max verbosity`. The result seeds the
-/// worker thread's [`logging::VerbosityConfig`] via `apply_verbosity`,
-/// matching upstream's `limit_output_verbosity(lp_max_verbosity(i))`
-/// (clientserver.c:1127). Saturates at [`u8::MAX`].
-fn clamped_verbose_level(flag_string: &str) -> u8 {
-    let count = flag_string.chars().filter(|&ch| ch == 'v').count();
-    u8::try_from(count).unwrap_or(u8::MAX)
+/// The requested level is whatever `ParsedServerFlags` counted, and that scan
+/// stops at the `-e` capability separator, so the `v` that
+/// `maybe_add_e_option` (options.c:3040) always appends inside `-e.<caps>` is
+/// never mistaken for a `-v`. That letter is the client's
+/// `CF_VARINT_FLIST_FLAGS` / negotiated-strings advertisement
+/// (compat.c:730-733); upstream's popt hands everything after `-e` to
+/// `shell_cmd` (options.c:823 `{"rsh", 'e', POPT_ARG_STRING, &shell_cmd, ...}`)
+/// and only ever `strchr`es it, so nothing here may read it as option letters
+/// and nothing may rewrite it - `cfg.flag_string` stays byte-identical to what
+/// the client sent.
+///
+/// `cfg.flags` is capped alongside the returned level because oc gates some
+/// server-side output on the flags rather than on the thread-local
+/// `logging::VerbosityConfig`, while upstream's single capped `info_levels[]`
+/// array governs every output decision.
+fn apply_output_verbosity_limit(cfg: &mut ServerConfig, max_verbosity: i32) -> u8 {
+    let level = limit_output_verbosity(cfg.flags.verbose_level, max_verbosity);
+    cfg.flags.verbose_level = level;
+    cfg.flags.verbose = level > 0;
+    level
 }
+
 /// Applies module directives that force transfer-time behavior onto the
 /// per-session [`ServerConfig`], mirroring the daemon-only overrides upstream
 /// applies in `rsync_module()` after the client argv is parsed.
@@ -141,19 +153,6 @@ fn build_server_config(
         .cloned()
         .unwrap_or_default();
 
-    // upstream: clientserver.c - clamp verbose to lp_max_verbosity(i)
-    let flag_string = clamp_verbose_flags(&flag_string, module.max_verbosity);
-
-    // upstream: clientserver.c:1141 `limit_output_verbosity(lp_max_verbosity(i))`
-    // caps the per-connection log verbosity once the module is selected. Each
-    // oc-rsync connection runs on its own worker thread whose thread-local
-    // `logging::VerbosityConfig` starts at level 0, so seed it from the clamped
-    // client request here. Without this, daemon-side `info_log!`/`debug_log!`
-    // emissions during the transfer stay silent regardless of the client's
-    // `-v`/`-vv` and the module's `max verbosity`, since the daemon's own
-    // startup `apply_verbosity` only seeded the main accept-loop thread.
-    crate::daemon::apply_verbosity(clamped_verbose_level(&flag_string));
-
     // upstream: main.c:1203-1204 + util1.c:804 (glob_expand_module) - receivers
     // resolve their destination by joining the module path with the client's
     // module-relative tail (e.g. `upload/realdir/` -> module + `realdir/`).
@@ -191,6 +190,18 @@ fn build_server_config(
         positional_args,
     ) {
         Ok(mut cfg) => {
+            // upstream: clientserver.c:1141 `limit_output_verbosity(lp_max_verbosity(i))`
+            // caps the per-connection log verbosity once the module is selected.
+            // Each oc-rsync connection runs on its own worker thread whose
+            // thread-local `logging::VerbosityConfig` starts at level 0, so seed
+            // it here; without that, daemon-side `info_log!`/`debug_log!`
+            // emissions stay silent regardless of the client's `-v`, since the
+            // daemon's startup `apply_verbosity` only seeded the accept loop.
+            crate::daemon::apply_verbosity(apply_output_verbosity_limit(
+                &mut cfg,
+                module.max_verbosity,
+            ));
+
             // Parse long-form arguments that upstream rsync sends via server_options()
             // (options.c:2737-2980). The compact flag string only covers single-char
             // flags; these long-form options must be parsed separately.

--- a/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
@@ -175,12 +175,38 @@ mod output_verbosity_limit_tests {
         // must still leave the `-e` payload byte-identical, because that payload
         // is what the capability decoder turns into the compat flags written on
         // the wire (compat.c:712-738).
-        let mut cfg = parse(DEFAULT_CLIENT_BUNDLE);
-        apply_output_verbosity_limit(&mut cfg, 0);
-        assert_eq!(
-            cfg.flag_string, DEFAULT_CLIENT_BUNDLE,
-            "capping verbosity must cap the level, not edit the client's option string",
-        );
+        // `1` is the shipped default (upstream daemon-parm.txt:49), `0` the
+        // strongest limit an operator can set, `-1` the below-zero arm.
+        for max_verbosity in [-1, 0, 1, 2, 5, 9] {
+            for bundle in [
+                DEFAULT_CLIENT_BUNDLE,
+                "-vlogDtpre.iLsfxCIvu",
+                "-vvvlogDtpre.iLsfxCIvu",
+            ] {
+                let mut cfg = parse(bundle);
+                apply_output_verbosity_limit(&mut cfg, max_verbosity);
+                assert_eq!(
+                    cfg.flag_string, bundle,
+                    "max verbosity {max_verbosity} must cap the level, not edit the \
+                     client's option string",
+                );
+                // Spelled out rather than left implicit in the equality above:
+                // every capability letter the peer advertised has to survive,
+                // because each one is a compat-flag bit (compat.c:720-733).
+                let payload = cfg
+                    .flag_string
+                    .split_once('e')
+                    .expect("bundle carries an -e argument")
+                    .1;
+                for letter in ['i', 'L', 's', 'f', 'x', 'C', 'I', 'v', 'u'] {
+                    assert!(
+                        payload.contains(letter),
+                        "capability letter `{letter}` was stripped at \
+                         max verbosity {max_verbosity}",
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
@@ -119,74 +119,130 @@ mod iconv_charset_converter_tests {
 }
 
 #[cfg(test)]
-mod clamped_verbosity_tests {
-    use super::{clamp_verbose_flags, clamped_verbose_level};
+mod output_verbosity_limit_tests {
+    use super::{ServerConfig, ServerRole, apply_output_verbosity_limit};
     use crate::daemon::apply_verbosity;
     use logging::{InfoFlag, info_gte};
+    use std::ffi::OsString;
 
     // WHY: upstream gates per-connection log floods with
-    // `limit_output_verbosity(lp_max_verbosity(i))` (clientserver.c:1127). Each
-    // oc-rsync connection runs on its own worker thread, so the clamped client
-    // request must seed that thread's `logging::VerbosityConfig` or every
-    // `info_log!`/`debug_log!` emission stays silent. These tests pin the
-    // observable gate (`info_gte`) rather than the intermediate count so they
-    // fail if the clamp-then-seed chain ever stops controlling log output.
+    // `limit_output_verbosity(lp_max_verbosity(i))` (clientserver.c:1141), which
+    // lowers the `info_levels[]`/`debug_levels[]` OUTPUT arrays
+    // (options.c:537-560) and leaves the client's option string untouched. Two
+    // separate invariants ride on that shape and both are pinned here:
     //
-    // Each subtest spawns a fresh thread because `apply_verbosity` writes
-    // thread-local state; sharing the harness thread would leak the level into
+    //   1. The `v` inside the `-e.<caps>` payload is NOT a `-v`. It is the
+    //      client's `CF_VARINT_FLIST_FLAGS` / negotiated-strings advertisement
+    //      (compat.c:730-733), and upstream's popt gives everything after `-e`
+    //      to `shell_cmd` (options.c:823) rather than treating it as option
+    //      letters. Counting it inflates every connection's verbosity by one.
+    //   2. Limiting must not rewrite the option string. A rewrite that dropped
+    //      that `v` would silently strip the peer's capability advertisement -
+    //      a wire divergence, not a logging one.
+    //
+    // Each subtest that seeds the thread-local `logging::VerbosityConfig` spawns
+    // a fresh thread; sharing the harness thread would leak the level into
     // sibling tests.
 
-    fn seed_from_client(flag_string: &str, max_verbosity: i32) {
-        let clamped = clamp_verbose_flags(flag_string, max_verbosity);
-        apply_verbosity(clamped_verbose_level(&clamped));
+    // The exact compact bundle an oc/upstream client sends at DEFAULT verbosity
+    // for `-a` over a daemon transport, capability suffix included.
+    const DEFAULT_CLIENT_BUNDLE: &str = "-logDtpre.iLsfxCIvu";
+
+    fn parse(flag_string: &str) -> ServerConfig {
+        ServerConfig::from_flag_string_and_args(
+            ServerRole::Generator,
+            flag_string.to_owned(),
+            vec![OsString::from(".")],
+        )
+        .expect("server flag string parses")
     }
 
     #[test]
-    fn level0_request_suppresses_level1_message() {
-        // Client asked for no `-v`; a level-1 INFO (e.g. NAME) must not fire.
-        std::thread::spawn(|| {
-            seed_from_client("-logDtpr", 1);
-            assert!(
-                !info_gte(InfoFlag::Name, 1),
-                "verbosity 0 must suppress the level-1 NAME info message",
-            );
-        })
-        .join()
-        .expect("level0 thread");
+    fn capability_suffix_v_is_not_a_verbose_request() {
+        let mut cfg = parse(DEFAULT_CLIENT_BUNDLE);
+        let level = apply_output_verbosity_limit(&mut cfg, 1);
+        assert_eq!(
+            level, 0,
+            "the `v` in the -e.<caps> payload is the client's CF_VARINT_FLIST_FLAGS \
+             advertisement, not a -v: a default-verbosity connection must run at level 0",
+        );
+        assert!(!cfg.flags.verbose);
     }
 
     #[test]
-    fn level1_request_emits_level1_message() {
-        // Client asked for `-v` and the module permits it; level-1 INFO fires.
-        std::thread::spawn(|| {
-            seed_from_client("-logDtprv", 1);
+    fn limiting_never_rewrites_the_capability_suffix() {
+        // `max verbosity = 0` is the strongest limit an operator can set; it
+        // must still leave the `-e` payload byte-identical, because that payload
+        // is what the capability decoder turns into the compat flags written on
+        // the wire (compat.c:712-738).
+        let mut cfg = parse(DEFAULT_CLIENT_BUNDLE);
+        apply_output_verbosity_limit(&mut cfg, 0);
+        assert_eq!(
+            cfg.flag_string, DEFAULT_CLIENT_BUNDLE,
+            "capping verbosity must cap the level, not edit the client's option string",
+        );
+    }
+
+    #[test]
+    fn max_verbosity_caps_a_higher_client_request() {
+        // Client stacked `-vvv` but the module caps `max verbosity` at 1.
+        let mut cfg = parse("-vvvlogDtpre.iLsfxCIvu");
+        assert_eq!(cfg.flags.verbose_level, 3, "client asked for -vvv");
+        let level = apply_output_verbosity_limit(&mut cfg, 1);
+        assert_eq!(level, 1, "max verbosity 1 caps the client's -vvv");
+        assert_eq!(cfg.flag_string, "-vvvlogDtpre.iLsfxCIvu");
+
+        std::thread::spawn(move || {
+            apply_verbosity(level);
             assert!(
                 info_gte(InfoFlag::Name, 1),
-                "verbosity 1 must emit the level-1 NAME info message",
-            );
-        })
-        .join()
-        .expect("level1 thread");
-    }
-
-    #[test]
-    fn max_verbosity_clamps_higher_client_request() {
-        // Client stacked `-vvv` but the module caps `max verbosity` at 1: the
-        // effective level is 1, so a level-2 message stays suppressed even
-        // though the client requested far more.
-        std::thread::spawn(|| {
-            seed_from_client("-logDtprvvv", 1);
-            assert!(
-                info_gte(InfoFlag::Name, 1),
-                "clamped verbosity 1 must still emit the level-1 message",
+                "capped verbosity 1 must still emit the level-1 NAME message",
             );
             assert!(
                 !info_gte(InfoFlag::Name, 2),
-                "max verbosity 1 must clamp the client's -vvv down to level 1",
+                "max verbosity 1 must suppress the level-2 NAME message",
             );
         })
         .join()
-        .expect("clamp thread");
+        .expect("cap thread");
+    }
+
+    #[test]
+    fn zero_max_verbosity_silences_a_verbose_client() {
+        let mut cfg = parse("-vlogDtpre.iLsfxCIvu");
+        let level = apply_output_verbosity_limit(&mut cfg, 0);
+        assert_eq!(level, 0);
+        assert!(!cfg.flags.verbose);
+
+        std::thread::spawn(move || {
+            apply_verbosity(level);
+            assert!(
+                !info_gte(InfoFlag::Name, 1),
+                "max verbosity 0 must suppress the level-1 NAME info message",
+            );
+        })
+        .join()
+        .expect("zero thread");
+    }
+
+    #[test]
+    fn permissive_max_verbosity_passes_the_request_through() {
+        // upstream: options.c:542-543 - `limit_output_verbosity` returns without
+        // applying any limit once the module's cap exceeds MAX_VERBOSITY, so the
+        // client's own level survives intact.
+        let mut cfg = parse("-vlogDtpre.iLsfxCIvu");
+        assert_eq!(apply_output_verbosity_limit(&mut cfg, 9), 1);
+
+        let mut cfg = parse("-vvlogDtpre.iLsfxCIvu");
+        assert_eq!(apply_output_verbosity_limit(&mut cfg, 5), 2);
+    }
+
+    #[test]
+    fn negative_max_verbosity_silences_the_connection() {
+        // A negative `max verbosity` makes upstream's `for (j = 0; j <= level;)`
+        // loop body never run (options.c:548), leaving every limit at zero.
+        let mut cfg = parse("-vvlogDtpre.iLsfxCIvu");
+        assert_eq!(apply_output_verbosity_limit(&mut cfg, -1), 0);
     }
 }
 

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -97,7 +97,9 @@ pub struct ParsedServerFlags {
     pub perms: bool,
     /// Recursive transfer (`r` flag, `--recursive`).
     pub recursive: bool,
-    /// Remote shell specified (`e` flag, `--rsh`).
+    /// Remote shell specified (`-e`, `--rsh`). Set when the compact bundle
+    /// carries an `-e` capability argument; the argument itself is opaque
+    /// payload decoded by `setup::capability`, never option letters.
     pub rsh: bool,
     /// Archive mode shorthand (`a` flag, `--archive`).
     pub archive: bool,
@@ -524,23 +526,44 @@ impl ParsedServerFlags {
 
         let mut flags = ParsedServerFlags::default();
 
-        for &byte in &bytes[1..] {
-            // The only `.` in a compact server flag string is the `-e`
-            // capability separator emitted by upstream `maybe_add_e_option`
-            // (options.c:3021), which appends `e.<caps>` after the transfer
-            // letters, e.g. `-logDtpre.iLsfxCIvu`. Everything from the `.`
-            // onward is the `-e` argument - upstream's `client_info`
-            // (compat.c:165-169, which `strdup`s the payload after the `e`) - a
-            // capability string that upstream only `strchr`s for its OWN known
-            // letters (compat.c:712-732) and never interprets as `--info`
-            // output flags. Genuine `--info`/itemize output rides separate
-            // long-form args (`--log-format=%i`, options.c:2770-2775), never as
-            // compact letters. The capability payload is decoded independently
-            // by the `setup::capability` module, so transfer-flag decoding
-            // stops at the separator; the letters after it are not info flags.
-            if byte == b'.' {
-                break;
+        // Split the bundle into the two namespaces upstream's popt keeps apart,
+        // rather than scanning one flat string.
+        //
+        // upstream: options.c:823 `{"rsh", 'e', POPT_ARG_STRING, &shell_cmd, 0,
+        // 0, 0}` - `-e` TAKES AN ARGUMENT, so popt binds everything after it as
+        // a VALUE and it never re-enters option scanning. `-v` by contrast is
+        // `POPT_ARG_NONE` and is counted. The two namespaces happen to share the
+        // letter `v`: as an option it increments `verbose`; inside the `-e`
+        // argument it is `strchr(client_info, 'v')` -> `do_negotiated_strings`
+        // + `CF_VARINT_FLIST_FLAGS` (compat.c:730-733). Collapsing them is what
+        // lets a filter over the flat string mistake one for the other.
+        //
+        // The split point is the first `e`: `maybe_add_e_option`
+        // (options.c:3021) is the only writer of an `e` into `argstr`, and it
+        // appends last (options.c:2727) after every transfer letter, so the
+        // first `e` is always the capability introducer. The payload after it is
+        // upstream's `client_info` (compat.c:165-169) - opaque bytes that only
+        // `setup::capability` decodes, never option letters. Splitting at `e`
+        // rather than at the `.` also keeps a pre-release peer's `-e32.1iLsfx...`
+        // version prefix (options.c:3036) out of the transfer-letter scan.
+        let letters = match bytes[1..].iter().position(|&byte| byte == b'e') {
+            Some(pos) => {
+                // upstream: popt sets `shell_cmd` when `-e` carries an argument.
+                flags.rsh = true;
+                &bytes[1..1 + pos]
             }
+            // No `-e` at all: either a protocol 28/29 peer, for which
+            // `maybe_add_e_option` emits nothing (options.c:3025-3028), or a
+            // malformed bundle. A bare `.` with no preceding `e` is the second
+            // case - popt would reject `.` as an unknown option and abort, so
+            // stop there rather than feed a payload to the letter scan.
+            None => match bytes[1..].iter().position(|&byte| byte == b'.') {
+                Some(dot) => &bytes[1..1 + dot],
+                None => &bytes[1..],
+            },
+        };
+
+        for &byte in letters {
             flags.parse_transfer_flag(byte);
         }
 
@@ -571,7 +594,6 @@ impl ParsedServerFlags {
             b'U' => self.atimes = true,
             b'p' => self.perms = true,
             b'r' => self.recursive = true,
-            b'e' => self.rsh = true,
             b'a' => self.archive = true,
             b'v' => {
                 self.verbose = true;
@@ -737,6 +759,34 @@ mod tests {
                 "`e` still sets rsh before the capability payload"
             );
         }
+    }
+
+    /// The `-e` argument boundary is the `e`, not the `.`.
+    ///
+    /// upstream: options.c:823 `{"rsh", 'e', POPT_ARG_STRING, &shell_cmd, ...}` -
+    /// popt binds EVERYTHING after `-e` as the option's argument. A pre-release
+    /// peer emits its `VER.SUB` in front of the capability letters
+    /// (`maybe_add_e_option`, options.c:3036: `snprintf(buf + x, ..., "%d.%d",
+    /// PROTOCOL_VERSION, SUBPROTOCOL_VERSION)`), so the payload can begin with
+    /// digits and the `.` is no longer the first byte after the `e`. Stopping the
+    /// transfer-letter scan at the `.` instead would feed those digits to
+    /// `parse_transfer_flag`; stopping at the `e` is what upstream does.
+    #[test]
+    fn pre_release_version_prefix_is_part_of_the_e_argument() {
+        // `-e32.1<caps>` - a 3.5.0dev-style peer advertising protocol 32 sub 1.
+        let flags = ParsedServerFlags::parse("-logDtpre32.1iLsfxCIvu").unwrap();
+
+        assert!(flags.rsh, "the `-e` argument is present");
+        assert!(flags.links && flags.owner && flags.group && flags.recursive);
+        assert_eq!(
+            flags.verbose_level, 0,
+            "no `-v` was requested: the `v` lives inside the -e argument",
+        );
+        assert_eq!(
+            flags.info_flags,
+            InfoFlags::default(),
+            "nothing after the `e` may reach the option-letter scan",
+        );
     }
 
     /// Sanity floor for the guard above: a genuine itemize request, modeled the

--- a/crates/transfer/tests/acl_negotiation_missing_remote.rs
+++ b/crates/transfer/tests/acl_negotiation_missing_remote.rs
@@ -43,7 +43,13 @@ use transfer::setup::{ProtocolRestrictionFlags, apply_protocol_restrictions};
 const SERVER_FLAGS_NO_ACL_NO_XATTR: &str = "-logDtpre.iLsfxC";
 
 /// Compact flag string from a modern peer that DOES support ACLs and xattrs.
-const SERVER_FLAGS_WITH_ACL_AND_XATTR: &str = "-logDtpreAX.iLsfxC";
+///
+/// `A` and `X` sit BEFORE the `e`: upstream emits them at options.c:2695-2703,
+/// well ahead of `maybe_add_e_option`, which appends the `e.<caps>` suffix last
+/// (options.c:2727). The `-e` argument is the tail of the bundle by
+/// construction, so no peer - upstream or oc - ever places a transfer letter
+/// after it. `crates/core/.../flags.rs` emits the same order.
+const SERVER_FLAGS_WITH_ACL_AND_XATTR: &str = "-logDtpAXre.iLsfxC";
 
 /// When the remote peer's server flag string lacks `A`, parsing must report
 /// `acls = false` regardless of what the local side requested. This is the


### PR DESCRIPTION
## Problem

`build_server_config` picked the client's compact bundle out of the post-`OK` argv and scanned the **whole** string for `v` characters:

```rust
let flag_string = client_args.iter()
    .find(|arg| arg.starts_with('-') && !arg.starts_with("--"))
    .cloned().unwrap_or_default();
let flag_string = clamp_verbose_flags(&flag_string, module.max_verbosity);
crate::daemon::apply_verbosity(clamped_verbose_level(&flag_string));
```

That string ends with the `-e.<caps>` capability payload, and `maybe_add_e_option` (options.c:3040) always terminates it with `...Ivu`. Two defects follow.

**1. Off-by-one verbosity, reachable at stock defaults.** The `v` inside the capability payload was counted as a `-v`, so every connection ran one level above what the client asked for. `max verbosity` defaults to `1` (daemon-parm.txt:49; `finish.rs:183` `unwrap_or(1)`), so no operator configuration is needed.

**2. The count also rewrote the string it counted.** `clamp_verbose_flags` dropped `v` characters past the cap, mutating the peer's `CF_VARINT_FLIST_FLAGS` / negotiated-strings advertisement (compat.c:730-733) inside the retained `ServerConfig.flag_string`.

Measured on a loopback daemon at protocol 32 (instrumented build, real oc client):

| module `max verbosity` | client sent | flag string the server retained | seeded level |
|---|---|---|---|
| 1 (default) | *(nothing)* | `-logDtpre.LsfxCIvu` | **1** (should be 0) |
| 9 | `-v` | `-vlogDtpre.LsfxCIvu` | **2** (should be 1) |
| 0 | *(nothing)* | **`-logDtpre.LsfxCIu`** - `v` stripped | 0 |
| 0 | `-vv` | **`-logDtpre.LsfxCIu`** - `v` stripped | 0 |

## Blast radius of the string mutation

Measured, not inferred: the daemon derives `client_info` from the raw `client_args`, never from `flag_string`. An instrumented build printing what `build_compat_flags_from_client_info` actually receives shows `client_info="LsfxCIvu"` - `v` intact - in every row above, including the `max verbosity = 0` rows where the retained string had lost it. `setup::build_our_flags` takes the `config.client_args` branch whenever the daemon supplies it, and the daemon always does (`streams.rs` `client_args: Some(...)`).

So the mutation did not reach the wire. It was still a live landmine: `flag_string` is exactly the `client_info` fallback for the SSH server path (`setup/mod.rs:271`, `resolve_server_client_info`) and is what `perform_server_handshake` parses for the peer subprotocol.

## Fix

Mirror upstream's separation. `limit_output_verbosity` (clientserver.c:1141, options.c:537-560) lowers only the `info_levels[]` / `debug_levels[]` output arrays; it never touches `verbose`, never edits the parsed argv, and applies no limit at all once the cap exceeds `MAX_VERBOSITY` (options.c:542-543). The `-e` argument is opaque payload - upstream's popt hands everything after `-e` to `shell_cmd` (options.c:823 `{"rsh", 'e', POPT_ARG_STRING, &shell_cmd, ...}`) and only ever `strchr`es it.

- The requested level now comes from `ParsedServerFlags`, whose scan already stops at the `-e` separator.
- Capping writes back a **level**; the option string is passed through byte-identical.
- `cfg.flags.verbose{,_level}` is capped alongside the thread-local seed, because oc gates some server-side output on the flags while upstream's single capped `info_levels[]` array governs every output decision.

## Verification

- `cargo fmt --all -- --check` - clean.
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean.
- `cargo nextest run --workspace --all-features -E 'package(daemon) or (package(protocol) and test(golden)) or (package(transfer) and test(capability)) or (package(transfer) and test(setup))'` - 2309 passed.
- `cargo nextest run --workspace --all-features -E 'test(daemon) or test(verbos) or test(module)'` - 2712 passed.
- 4 of the 6 new tests fail when the pre-fix semantics are restored in place.

**Interop against rsync 3.4.4, both directions.** Loopback daemon, `-a --stats`, pinned source mtimes (unpinned trees make the delta-encoded mtimes drift the byte count a few bytes per run and swamp the signal):

| cell | `max verbosity` 0 / 1 / 5, bytes received |
|---|---|
| upstream daemon <- upstream client | 227 / 227 / 227 |
| oc daemon (before) <- upstream client | 241 / 241 / 241 |
| oc daemon (after) <- upstream client | 241 / 241 / 241 |
| upstream daemon <- oc client (after) | 214 / 214 / 214 |
| oc daemon (before) <- oc client (before) | 220 / 220 / 220 |
| oc daemon (after) <- oc client (after) | 220 / 220 / 220 |

Byte counts are unchanged before/after in every cell, and `max verbosity` does not move them - which is the invariant the fix protects.

## Other sites that scan a compact flag string

Audited every one; the `-e` argument is correctly excluded where it must be:

| site | behaviour |
|---|---|
| `ParsedServerFlags::parse` (transfer/src/flags.rs:519) | breaks at the `.` separator - correct |
| `refused_client_arg` (daemon refuse_options.rs) | `rest.split('.').next()` - correct |
| `parse_client_info` (transfer/src/setup/capability.rs:238) | reads the payload deliberately - correct |
| `parse_client_capability_info` (daemon request.rs:367) | reads the payload deliberately - correct |
| `parse_peer_subprotocol` / `e_capability_payload` (capability.rs:281,309) | reads the payload deliberately - correct |
| `clamp_verbose_flags` + `clamped_verbose_level` | **the defect** - fixed here |

Two follow-ups worth filing separately, both out of scope here:

1. `parse_client_capability_info` (daemon) and `parse_client_info` (transfer) are two independent implementations of the same upstream rule and they disagree for a pre-release peer. Against `-e32.1iLsfxCIvu` the daemon copy returns `1iLsfxCIvu` while the transfer copy returns `32.1iLsfxCIvu`; upstream's `client_info` is the latter (compat.c:139-148 parses the version prefix out of it).
2. Everything that splits at the first `.` rather than at the `e` diverges for that same pre-release form - a `3` and a `2` reach `parse_transfer_flag` before the `.` arrives. They are unmatched letters today, so it is inert, but it is the same class of conflation.

---

## Update: root-cause fix on top (commit 2)

The verbosity miscount above was a symptom. The root cause is that oc collapses two namespaces upstream keeps apart, and the second commit fixes that.

Upstream's popt table declares them separately:

```c
{"rsh",     'e', POPT_ARG_STRING, &shell_cmd, 0, 0, 0 },   /* options.c:823  - TAKES AN ARGUMENT */
{"verbose", 'v', POPT_ARG_NONE,   0, 'v', 0, 0 },          /* options.c:2620 - counted flag     */
```

Because `-e` takes an argument, popt binds everything after it as a VALUE that never re-enters option scanning. The two namespaces happen to share the letter `v`: as an option it increments `verbose`; inside the `-e` argument it is `strchr(client_info, 'v')` -> `do_negotiated_strings` + `CF_VARINT_FLIST_FLAGS` (compat.c:730-733).

`ParsedServerFlags::parse` scanned one flat string and stopped at the `.`, which is not popt's boundary. That is correct for a release peer only because its payload happens to begin with `.`. A pre-release peer emits its version first (`maybe_add_e_option`, options.c:3036 writes `"%d.%d"`), so `-e32.1iLsfxCIvu` fed `3` and `2` to the transfer-letter scan. Both are unmatched letters today, so it was inert - but it is the same conflation, one input away from mattering.

Now the split point is the first `e`. `maybe_add_e_option` is the only writer of an `e` into `argstr` and appends last (options.c:2727), after every transfer letter; `crates/core/.../flags.rs` builds the string in the same order. A bundle with no `e` still stops at a `.`, because that shape is malformed - popt would reject `.` as an unknown option and abort - so the letters after it are not options either.

### Two fixtures modelled unproducible bundles

Corrected rather than accommodated:

- `acl_negotiation_missing_remote.rs` used `-logDtpreAX.iLsfxC`, placing `A`/`X` after the `e`. Upstream emits them at options.c:2695-2703, ahead of the suffix. Now `-logDtpAXre.iLsfxC`.
- `copy_dirlinks_flist.rs` and `nxt_7_sender_flist_symlink_leak.rs` use a `.` payload with no `e` at all; the no-`e` dot stop keeps them working.

### Wire capture: `max verbosity` sweep against rsync 3.4.4

Both directions through a tee'd loopback socket, pinned source mtimes, `max verbosity` unset/0/1/2. The compat-flags varint the daemon writes:

| daemon | client | unset | 0 | 1 | 2 | CF_VARINT_FLIST_FLAGS |
|---|---|---|---|---|---|---|
| upstream 3.4.4 | upstream 3.4.4 | `81fb` | `81fb` | `81fb` | `81fb` | set |
| oc (before) | upstream 3.4.4 | `81ff` | `81ff` | `81ff` | `81ff` | set |
| oc (after) | upstream 3.4.4 | `81ff` | `81ff` | `81ff` | `81ff` | set |

The `-e` argument the client sent arrives unmodified in every cell (`-logDtpre.iLfxCIvu` from upstream, `-logDtpre.LsfxCIvu` from oc against an upstream daemon).

**The 4-bit delta (0x1FF vs 0x1FB) is CF_SYMLINK_ICONV, and it is a build-configuration difference, not a divergence.** The local upstream 3.4.4 reports `no iconv` in `--version`; oc reports `iconv`. Upstream sets that bit unconditionally under `#ifdef ICONV_OPTION` (compat.c:716-718) rather than gating it on the client, which is exactly what oc does. It is identical before and after this change, and an oc built without the `iconv` feature emits `81fb`.

### Design choice: (b) minimal namespace split, not (a) clap reuse

Recommending (b), which is what shipped.

- **(a) reuse the client clap `Command`** is task #138 and is a multi-PR structural change, not a bug fix. The server argv is a different grammar (compact bundle + long-form + a bare `.` positional), so it needs `allow_hyphen_values` and custom handling throughout; it changes what the server *accepts*, which is security-relevant (`refuse options`, daemon-mode unknown-option rejection at options.c:1460-1465); and it would move error text and exit codes on malformed argv. Landing it inside a verbosity fix would make the blast radius unreviewable.
- **(b) split once at the `-e` boundary and treat the remainder as opaque** is the actual invariant popt provides, and it is now enforced structurally: the payload is sliced off before the letter loop ever runs, so no filter can reach it. This is not a smarter regex over the same conflated string - the flat scan is gone.

(a) remains worth doing as #138; this change makes it strictly easier by pinning the boundary semantics with tests first.

### Invariants now tested

- the `-e` argument is never scanned for option letters (`pre_release_version_prefix_is_part_of_the_e_argument`, `capability_suffix_letters_are_not_info_flags`)
- the `-e` argument is never rewritten - every letter of `iLsfxCIvu` survives across `max verbosity` -1/0/1/2/5/9 and three client `-v` levels (`limiting_never_rewrites_the_capability_suffix`)
- `max verbosity` caps the LEVEL and still genuinely suppresses output (`max_verbosity_caps_a_higher_client_request`, `zero_max_verbosity_silences_a_verbose_client`)
