### PR TITLE
fix(cli): route diagnostic events by log code, not to stdout always

### DIFF
--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -34,21 +34,77 @@ pub fn msgs_to_stderr() -> bool {
     MSGS_TO_STDERR.with(|cell| cell.get())
 }
 
-/// Render diagnostic events to the appropriate output stream.
+/// The client-side destination `rwrite()` picks for a given log code.
 ///
-/// When `msgs2stderr` is true, all diagnostic output goes to stderr.
-/// Otherwise, info messages go to stdout and debug messages go to stderr.
+/// upstream: log.c:251-328 `rwrite()`. The four outcomes are the stdout
+/// default (`FILE *f = ... : stdout`, log.c:254), the stderr override for the
+/// error and warning codes (log.c:309-316), the silent return taken by an
+/// FLOG message with no log destination (log.c:306-307), and the fatal
+/// "Bad logcode" default arm (log.c:325-327).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ClientStream {
+    /// The client's stdout, unless `--msgs-to-stderr` moves it (log.c:254).
+    Stdout,
+    /// The client's stderr, whatever `--msgs-to-stderr` says (log.c:315).
+    Stderr,
+    /// Never reaches the client at all (log.c:306-307).
+    Dropped,
+    /// Not a code `rwrite()` accepts; upstream reports it and exits
+    /// `RERR_MESSAGEIO` (log.c:325-327).
+    Invalid,
+}
+
+/// Classify a [`logging::LogCode`] the way upstream's `rwrite()` does.
+///
+/// The match is exhaustive on purpose: a log code added to the vocabulary
+/// later must be classified here rather than inheriting stdout by default.
+// upstream: log.c:281-328 rwrite()
+const fn client_stream(code: logging::LogCode) -> ClientStream {
+    use logging::LogCode;
+
+    match code {
+        // FERROR_SOCKET is simplified to FERROR and FERROR_UTF8 becomes
+        // FERROR before the switch (log.c:281-286), so all five error and
+        // warning codes reach `f = stderr` (log.c:310-316).
+        LogCode::ErrorXfer
+        | LogCode::Error
+        | LogCode::Warning
+        | LogCode::ErrorSocket
+        | LogCode::ErrorUtf8 => ClientStream::Stderr,
+        // FCLIENT is rewritten to FINFO (log.c:288-289) and FINFO keeps the
+        // stdout default (log.c:317-320).
+        LogCode::Info | LogCode::Client => ClientStream::Stdout,
+        // An FLOG message goes to the log file when one is active and is
+        // otherwise discarded; it never reaches the client's stdout/stderr
+        // (log.c:290-307). The log-file sink consumes FLOG events via
+        // `logging::drain_events_coded` before this renderer runs, so any
+        // FLOG event still queued here has no log destination.
+        LogCode::Log => ClientStream::Dropped,
+        // FNONE is "never sent" (rsync.h:276) and falls into rwrite()'s
+        // default arm (log.c:325-327).
+        LogCode::None => ClientStream::Invalid,
+    }
+}
+
+/// Render diagnostic events to the stream their log code selects.
+///
+/// Error and warning codes go to stderr, info codes to stdout, and FLOG
+/// events are dropped, mirroring `rwrite()`. When `msgs2stderr` is true the
+/// stdout default becomes stderr, which upstream does by initialising `f` to
+/// stderr before the code switch (upstream: log.c:254).
 ///
 /// # Arguments
 ///
 /// * `events` - The diagnostic events to render.
-/// * `out` - The stdout writer (used for info messages when `msgs2stderr` is false).
-/// * `err` - The stderr writer (used for debug messages and all messages when `msgs2stderr` is true).
-/// * `msgs2stderr` - Whether to route all messages to stderr.
+/// * `out` - The stdout writer (used for info codes when `msgs2stderr` is false).
+/// * `err` - The stderr writer.
+/// * `msgs2stderr` - Whether to route the stdout-bound messages to stderr too.
 ///
 /// # Errors
 ///
-/// Returns an I/O error if writing to either stream fails.
+/// Returns an I/O error if writing to either stream fails, or if an event
+/// carries a code `rwrite()` rejects (upstream: log.c:325-327 exits
+/// `RERR_MESSAGEIO`).
 pub fn render_diagnostic_events<O: Write, E: Write>(
     events: &[DiagnosticEvent],
     out: &mut O,
@@ -56,45 +112,26 @@ pub fn render_diagnostic_events<O: Write, E: Write>(
     msgs2stderr: bool,
 ) -> io::Result<()> {
     for event in events {
-        // upstream: log.c:304-307 - an FLOG message goes to the log file when
-        // one is active and is otherwise discarded; it never reaches the
-        // client's stdout/stderr. The log-file sink consumes FLOG events via
-        // `logging::drain_events_coded` before this renderer runs, so any
-        // FLOG event still queued here has no log destination and is dropped.
-        if event.code() == logging::LogCode::Log {
-            continue;
-        }
-        match event {
-            DiagnosticEvent::Info {
-                flag: _,
-                level: _,
-                message,
-                ..
-            } => {
-                if msgs2stderr {
-                    writeln!(err, "{message}")?;
-                } else {
-                    writeln!(out, "{message}")?;
-                }
-            }
-            DiagnosticEvent::Debug {
-                flag: _,
-                level: _,
-                message,
-                ..
-            } => {
-                // upstream: log.c:rwrite() prints debug messages verbatim via
-                // rprintf(FINFO, ...) with no flag-category bracket. FINFO
-                // routes to the client's stdout (the same stream as info
-                // events) unless msgs-to-stderr is in effect, so debug lines
-                // like "fuzzy basis selected ..." land on stdout where the
-                // fuzzy testsuite greps them. The message already carries any
-                // role prefix (e.g. "[sender]") where upstream emits one.
-                if msgs2stderr {
-                    writeln!(err, "{message}")?;
-                } else {
-                    writeln!(out, "{message}")?;
-                }
+        let code = event.code();
+        let (DiagnosticEvent::Info { message, .. } | DiagnosticEvent::Debug { message, .. }) =
+            event;
+        // upstream: rwrite() prints debug traces through rprintf(FINFO, ...)
+        // with no flag-category bracket, so info and debug events differ only
+        // in the code they carry, never in their rendering.
+        match client_stream(code) {
+            ClientStream::Stderr => writeln!(err, "{message}")?,
+            ClientStream::Stdout if msgs2stderr => writeln!(err, "{message}")?,
+            ClientStream::Stdout => writeln!(out, "{message}")?,
+            ClientStream::Dropped => {}
+            ClientStream::Invalid => {
+                // upstream: log.c:325-327 reports the bad code on stderr and
+                // exits RERR_MESSAGEIO. A renderer cannot exit, so it reports
+                // and hands the failure back to its caller.
+                writeln!(err, "Bad logcode in rwrite(): {}", code.as_u8())?;
+                return Err(io::Error::other(format!(
+                    "Bad logcode in rwrite(): {}",
+                    code.as_u8()
+                )));
             }
         }
     }
@@ -175,6 +212,179 @@ mod tests {
             "excluding file foo.txt\n"
         );
         assert!(stderr.is_empty());
+    }
+
+    /// upstream: log.c:309-316 - FWARNING (and every error code) overrides the
+    /// stdout default with `f = stderr`. stdout and stderr are distinct
+    /// observables: a warning on stdout corrupts `--out-format` output for a
+    /// caller that redirects the two streams separately.
+    #[test]
+    fn test_warning_coded_event_renders_to_stderr_not_stdout() {
+        let events = vec![DiagnosticEvent::Info {
+            flag: InfoFlag::Misc,
+            level: 1,
+            code: LogCode::Warning,
+            message: "WARNING: foo.txt failed verification".to_owned(),
+        }];
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        render_diagnostic_events(&events, &mut stdout, &mut stderr, false).unwrap();
+
+        assert_eq!(
+            String::from_utf8(stderr).unwrap(),
+            "WARNING: foo.txt failed verification\n"
+        );
+        assert!(stdout.is_empty(), "a warning must never reach stdout");
+    }
+
+    /// Both directions in one render call: the info-coded line must land on
+    /// stdout and *only* stdout, the warning-coded line on stderr and *only*
+    /// stderr. Dispatching both by a single hardcoded stream fails this test
+    /// whichever stream is hardcoded.
+    #[test]
+    fn test_info_and_warning_split_across_streams() {
+        let events = vec![
+            DiagnosticEvent::Info {
+                flag: InfoFlag::Name,
+                level: 1,
+                code: LogCode::Info,
+                message: "foo.txt".to_owned(),
+            },
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Recv,
+                level: 1,
+                code: LogCode::Warning,
+                message: "WARNING: foo.txt failed verification".to_owned(),
+            },
+        ];
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        render_diagnostic_events(&events, &mut stdout, &mut stderr, false).unwrap();
+
+        assert_eq!(String::from_utf8(stdout).unwrap(), "foo.txt\n");
+        assert_eq!(
+            String::from_utf8(stderr).unwrap(),
+            "WARNING: foo.txt failed verification\n"
+        );
+    }
+
+    /// upstream: log.c:281-286 simplify FERROR_SOCKET and FERROR_UTF8 to
+    /// FERROR before the switch, and log.c:310-313 routes FERROR_XFER and
+    /// FERROR alongside FWARNING to stderr.
+    #[test]
+    fn test_every_error_code_renders_to_stderr() {
+        for code in [
+            LogCode::ErrorXfer,
+            LogCode::Error,
+            LogCode::Warning,
+            LogCode::ErrorSocket,
+            LogCode::ErrorUtf8,
+        ] {
+            let events = vec![DiagnosticEvent::Info {
+                flag: InfoFlag::Misc,
+                level: 1,
+                code,
+                message: format!("{code} message"),
+            }];
+
+            let mut stdout = Vec::new();
+            let mut stderr = Vec::new();
+
+            render_diagnostic_events(&events, &mut stdout, &mut stderr, false).unwrap();
+
+            assert_eq!(
+                String::from_utf8(stderr).unwrap(),
+                format!("{code} message\n")
+            );
+            assert!(stdout.is_empty(), "{code} must not reach stdout");
+        }
+    }
+
+    /// upstream: log.c:288-289 rewrites FCLIENT to FINFO, so it keeps the
+    /// stdout default rather than falling into the "Bad logcode" arm.
+    #[test]
+    fn test_client_coded_event_renders_to_stdout() {
+        let events = vec![DiagnosticEvent::Info {
+            flag: InfoFlag::Misc,
+            level: 1,
+            code: LogCode::Client,
+            message: "client note".to_owned(),
+        }];
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        render_diagnostic_events(&events, &mut stdout, &mut stderr, false).unwrap();
+
+        assert_eq!(String::from_utf8(stdout).unwrap(), "client note\n");
+        assert!(stderr.is_empty());
+    }
+
+    /// upstream: log.c:325-327 reports an unaccepted code on stderr and exits
+    /// RERR_MESSAGEIO. The renderer reports and fails instead of quietly
+    /// printing the message to stdout.
+    #[test]
+    fn test_none_coded_event_is_rejected_loudly() {
+        let events = vec![DiagnosticEvent::Info {
+            flag: InfoFlag::Misc,
+            level: 1,
+            code: LogCode::None,
+            message: "unclassified".to_owned(),
+        }];
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let error = render_diagnostic_events(&events, &mut stdout, &mut stderr, false)
+            .expect_err("FNONE must not be rendered");
+
+        assert!(error.to_string().contains("Bad logcode in rwrite()"));
+        assert!(String::from_utf8(stderr).unwrap().contains("Bad logcode"));
+        assert!(stdout.is_empty());
+    }
+
+    /// Pins the classification of every code in the vocabulary, so adding a
+    /// variant forces a deliberate choice here as well as in the match.
+    #[test]
+    fn test_client_stream_classification_is_total() {
+        for code in LogCode::ALL {
+            let expected = match code {
+                LogCode::ErrorXfer
+                | LogCode::Error
+                | LogCode::Warning
+                | LogCode::ErrorSocket
+                | LogCode::ErrorUtf8 => ClientStream::Stderr,
+                LogCode::Info | LogCode::Client => ClientStream::Stdout,
+                LogCode::Log => ClientStream::Dropped,
+                LogCode::None => ClientStream::Invalid,
+            };
+            assert_eq!(client_stream(code), expected, "{code}");
+        }
+    }
+
+    /// `--msgs-to-stderr` moves the stdout-bound codes only; a warning was
+    /// already on stderr and stays there (upstream: log.c:254 initialises `f`
+    /// to stderr, and the switch's `f = stderr` is then a no-op).
+    #[test]
+    fn test_msgs2stderr_does_not_move_warnings_to_stdout() {
+        let events = vec![DiagnosticEvent::Info {
+            flag: InfoFlag::Misc,
+            level: 1,
+            code: LogCode::Warning,
+            message: "warned".to_owned(),
+        }];
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        render_diagnostic_events(&events, &mut stdout, &mut stderr, true).unwrap();
+
+        assert_eq!(String::from_utf8(stderr).unwrap(), "warned\n");
+        assert!(stdout.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`render_diagnostic_events()` in `crates/cli/src/frontend/progress/diagnostic.rs` skipped `FLOG` events and then wrote **every** remaining event to stdout, ignoring the `LogCode` the event carries. A `LogCode::Warning` or `LogCode::Error` routed through the thread-local diagnostic queue would land on stdout.

This is currently inert - the only production `emit_info_coded()` caller (`crates/core/src/client/run/mod.rs:221`) passes `LogCode::Log`, and `emit_info()` / `emit_debug()` both default to `LogCode::Info` - so it is a latent trap rather than a live regression. It is a second, independent path to the same class of defect that the verification-warning work was about: stdout and stderr are distinct observables, and a warning on stdout corrupts `--out-format` output for a caller that redirects the two streams separately.

## Upstream rule

`rwrite()` (`log.c:251-328`) picks the client stream from the log code:

- `log.c:254` - `FILE *f = msgs2stderr == 1 ? stderr : stdout;` is the default.
- `log.c:281-286` - `FERROR_SOCKET` is simplified to `FERROR`; `FERROR_UTF8` sets `is_utf8` and becomes `FERROR`.
- `log.c:288-289` - `FCLIENT` becomes `FINFO`.
- `log.c:290-307` - the daemon/log-file branch; `FLOG` returns without ever reaching the client.
- `log.c:309-316` - `FERROR_XFER` (also setting `got_xfer_error`), `FERROR` and `FWARNING` all override with `f = stderr`.
- `log.c:317-320` - `FINFO` keeps the stdout default (returning early under `--quiet`).
- `log.c:325-327` - any other code prints `Bad logcode in rwrite(): %d [%s]` on stderr and calls `exit_cleanup(RERR_MESSAGEIO)`.

## Fix

Classify the event's `LogCode` with an exhaustive `match` into the four outcomes `rwrite()` has - stdout, stderr, dropped, and rejected - and dispatch on that. The match is exhaustive on purpose: `LogCode` is not `#[non_exhaustive]`, so a variant added later fails to compile until it is classified here rather than silently inheriting stdout. `FNONE` maps to the rejected arm: the renderer reports `Bad logcode in rwrite()` on stderr and returns an error instead of quietly printing the message to stdout.

`--msgs-to-stderr` keeps its existing meaning - it moves the stdout-bound codes only, which is what upstream does by initialising `f` to stderr before the switch, leaving the `f = stderr` override a no-op for warnings and errors.

Info and debug events now share one rendering path; they only ever differed in the code they carry, never in how they print (upstream emits debug traces through `rprintf(FINFO, ...)`).

## Tests

Seven new unit tests in the same module, all capturing stdout and stderr as separate buffers (never merged):

- `test_warning_coded_event_renders_to_stderr_not_stdout` - warning on stderr, stdout asserted empty.
- `test_info_and_warning_split_across_streams` - both directions in one render call: the info line on stdout and only stdout, the warning line on stderr and only stderr. Hardcoding either stream fails this test.
- `test_every_error_code_renders_to_stderr` - `FERROR_XFER`, `FERROR`, `FWARNING`, `FERROR_SOCKET`, `FERROR_UTF8`.
- `test_client_coded_event_renders_to_stdout` - `FCLIENT` follows `FINFO`.
- `test_none_coded_event_is_rejected_loudly` - `FNONE` returns an error and reports on stderr; stdout stays empty.
- `test_client_stream_classification_is_total` - pins the classification of every code in `LogCode::ALL`.
- `test_msgs2stderr_does_not_move_warnings_to_stdout`.

## Scope

`crates/cli/src/frontend/progress/diagnostic.rs` only. The transfer-side verification-warning emitter routes to stderr without going through this queue; that routing is unchanged.
