### PR TITLE
fix(options): --append must imply --inplace

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -1066,7 +1066,7 @@ where
         from0,
     };
 
-    let builder = match filters::apply_filters(builder, filter_inputs, stderr) {
+    let mut builder = match filters::apply_filters(builder, filter_inputs, stderr) {
         Ok(builder) => builder,
         Err(code) => return code,
     };

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -200,11 +200,12 @@ where
     config.file_selection.files_from_path = long_flags.files_from;
     config.file_selection.from0 = long_flags.from0;
     config.write.inplace = long_flags.inplace;
-    // upstream: options.c:2400-2412 - append mode implies inplace; the transfer
-    // layer derives that internally (transfer_ops.rs `use_inplace = inplace ||
-    // append`), so only the append flags need forwarding. append_verify
-    // (append_mode == 2) folds the on-disk prefix into the whole-file checksum
-    // (receiver.c:357, match.c:373). Mirrors the daemon long-form parser.
+    // upstream: options.c:2400-2411 - append mode implies inplace. The promotion
+    // is applied once for every role by `ServerConfig::apply_append_implies_inplace`
+    // on entry to the server body, so only the append flags need forwarding here.
+    // append_verify (append_mode == 2) folds the on-disk prefix into the
+    // whole-file checksum (receiver.c:357, match.c:373). Mirrors the daemon
+    // long-form parser.
     config.flags.append = long_flags.append;
     config.flags.append_verify = long_flags.append_verify;
     // upstream: receiver.c:320 - a server receiver that was passed --preallocate

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -319,17 +319,39 @@ pub struct ClientConfigBuilder {
 }
 
 impl ClientConfigBuilder {
-    /// Checks for mutually exclusive option combinations.
+    /// Applies the option implications upstream resolves after argument
+    /// parsing, before its conflict table runs.
     ///
-    /// Mirrors upstream rsync `options.c` validation:
-    /// - `--inplace` conflicts with `--partial-dir` and `--delay-updates`
-    /// - `--append` conflicts with `--partial-dir` and `--delay-updates`
-    ///   (upstream: `--append` sets `inplace = 1`, then the `inplace && partial_dir` check fires)
+    /// upstream: options.c:2410 - `if (append_mode) { ...; inplace = 1; }`.
+    /// From here on `inplace` is the only flag any consumer reads: the
+    /// receiver's write target (`receiver.c:968`), its closing truncate
+    /// (`receiver.c:496`), the pre-write backup copy (`generator.c:1862,1898`),
+    /// the basis switch to that backup (`receiver.c:872`), the
+    /// retained-vs-discarded branch (`receiver.c:1029`), the `keptstr` wording
+    /// (`receiver.c:1074`), the sender's `updating_basis_file`
+    /// (`sender.c:337`) and the protocol < 29 basis-dir refusal
+    /// (`compat.c:688`). Idempotent, so `validate` and `build` may both call it.
+    fn apply_implied_options(&mut self) {
+        if self.append {
+            self.inplace = true;
+        }
+    }
+
+    /// Resolves implied options, then checks for mutually exclusive
+    /// combinations.
+    ///
+    /// Mirrors upstream `options.c` in both content and order: the `--append`
+    /// implication lands first (`options.c:2410`), so the `inplace` conflict
+    /// table below fires for `--append` without naming the flag twice.
+    ///
     /// - `--append` conflicts with `--whole-file`
-    ///   (upstream: options.c:2400 `if (append_mode) { if (whole_file > 0) ... }`)
+    ///   (upstream: options.c:2401 `if (append_mode) { if (whole_file > 0) ... }`)
+    /// - `--inplace` conflicts with `--partial-dir` and `--delay-updates`
+    ///   (upstream: options.c:2424-2432), reported against the option the user
+    ///   typed - upstream's `append_mode ? "append" : "inplace"` ternary
     /// - `--rsh`/`-e` conflicts with an `ssh://` URL operand (oc-specific: the
     ///   URL scheme selects the built-in SSH client, which ignores `--rsh`)
-    pub fn validate(&self) -> Result<(), ConfigConflict> {
+    pub fn validate(&mut self) -> Result<(), ConfigConflict> {
         // oc-specific: an explicit --rsh/-e (or RSYNC_RSH) selects the external
         // system ssh binary, which is consulted only for `host:path` operands.
         // An `ssh://` URL operand instead dispatches to the built-in SSH
@@ -362,6 +384,8 @@ impl ClientConfigBuilder {
         // upstream: options.c:1974-1977 - --old-args conflicts with --protect-args.
         // Any active level (>= 1) triggers the conflict, matching upstream's
         // `else if (old_style_args)` truthiness test.
+        self.apply_implied_options();
+
         if self.old_args.unwrap_or(0) >= 1 && self.protect_args == Some(true) {
             return Err(ConfigConflict {
                 option1: "old-args",
@@ -379,8 +403,7 @@ impl ClientConfigBuilder {
             });
         }
 
-        let is_inplace = self.inplace || self.append;
-        if is_inplace {
+        if self.inplace {
             let mode = if self.append { "append" } else { "inplace" };
 
             if self.delay_updates {
@@ -417,6 +440,8 @@ impl ClientConfigBuilder {
     ///   `whole_file = 1` whenever the negotiated transfer checksum is
     ///   `CSUM_NONE`. The delta pipeline cannot run without a transfer
     ///   checksum, so whole-file transfer is the only valid mode.
+    /// - `--append` promotes `inplace` to `true`. Mirrors upstream
+    ///   `options.c:2410`, which sets `inplace = 1` for any `append_mode`.
     #[must_use]
     pub fn build(mut self) -> ClientConfig {
         // upstream: checksum.c:197-198 parse_checksum_choice() forces
@@ -424,6 +449,7 @@ impl ClientConfigBuilder {
         if self.checksum_choice.transfer_is_none() {
             self.whole_file = Some(true);
         }
+        self.apply_implied_options();
         // upstream: options.c:2336-2339 - inject `P *<suffix>` so files saved
         // as backups beside the destination are protected from the delete pass.
         self.push_backup_protect_filter();

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1154,6 +1154,38 @@ fn append_sets_flag() {
     assert!(config.append());
 }
 
+// upstream: options.c:2410 - `if (append_mode) { ...; inplace = 1; }`. Nothing
+// downstream reads `append_mode` to decide where the receiver writes: the write
+// target (receiver.c:968), the retained-vs-discarded branch for a failed
+// verification (receiver.c:1029), the keptstr wording (receiver.c:1074) and the
+// sender's updating_basis_file (sender.c:337) all read `inplace`. Materialising
+// the flag here is what lets those sites stay single-implementation.
+#[test]
+fn append_implies_inplace() {
+    let config = builder().append(true).build();
+    assert!(
+        config.inplace(),
+        "--append must promote inplace so the receiver rewrites the live \
+         destination and a failed update is retained, not discarded"
+    );
+}
+
+// `--append-verify` is append_mode == 2 upstream (options.c:719), the same
+// `if (append_mode)` truth test, so it promotes identically.
+#[test]
+fn append_verify_implies_inplace() {
+    let config = builder().append(true).append_verify(true).build();
+    assert!(config.inplace());
+}
+
+// The promotion is one-directional: it must not manufacture `inplace` for a
+// transfer that never asked for append semantics.
+#[test]
+fn without_append_inplace_is_untouched() {
+    assert!(!builder().build().inplace());
+    assert!(builder().inplace(true).build().inplace());
+}
+
 #[test]
 fn append_false_clears_flag_and_verify() {
     let config = builder().append_verify(true).append(false).build();
@@ -1263,7 +1295,7 @@ fn validate_inplace_with_partial_dir_conflicts() {
     // receiver's internal one_inplace optimization for a basis file in the
     // partial directory; it never relaxes this user-facing option conflict, so
     // validation must reject the pair regardless of negotiated capabilities.
-    let b = builder()
+    let mut b = builder()
         .inplace(true)
         .partial_directory(Some("/tmp/partial"));
     let err = b.validate().unwrap_err();
@@ -1273,7 +1305,7 @@ fn validate_inplace_with_partial_dir_conflicts() {
 
 #[test]
 fn validate_inplace_with_delay_updates_conflicts() {
-    let b = builder().inplace(true).delay_updates(true);
+    let mut b = builder().inplace(true).delay_updates(true);
     let err = b.validate().unwrap_err();
     assert_eq!(err.option1, "inplace");
     assert_eq!(err.option2, "delay-updates");
@@ -1281,7 +1313,7 @@ fn validate_inplace_with_delay_updates_conflicts() {
 
 #[test]
 fn validate_append_with_partial_dir_conflicts() {
-    let b = builder()
+    let mut b = builder()
         .append(true)
         .partial_directory(Some("/tmp/partial"));
     let err = b.validate().unwrap_err();
@@ -1291,7 +1323,7 @@ fn validate_append_with_partial_dir_conflicts() {
 
 #[test]
 fn validate_append_with_delay_updates_conflicts() {
-    let b = builder().append(true).delay_updates(true);
+    let mut b = builder().append(true).delay_updates(true);
     let err = b.validate().unwrap_err();
     assert_eq!(err.option1, "append");
     assert_eq!(err.option2, "delay-updates");
@@ -1300,7 +1332,7 @@ fn validate_append_with_delay_updates_conflicts() {
 #[test]
 fn validate_append_with_whole_file_conflicts() {
     // upstream: options.c:2400 - --append cannot be used with --whole-file.
-    let b = builder().append(true).whole_file(true);
+    let mut b = builder().append(true).whole_file(true);
     let err = b.validate().unwrap_err();
     assert_eq!(err.option1, "append");
     assert_eq!(err.option2, "whole-file");
@@ -1313,7 +1345,7 @@ fn validate_old_args_with_secluded_args_conflicts() {
     // (`--protect-args`) are mutually exclusive and abort with this exact
     // wording, which differs from the generic "cannot be used with" template:
     // the message names --secluded-args first and ends with a period.
-    let b = builder().old_args(Some(1)).protect_args(Some(true));
+    let mut b = builder().old_args(Some(1)).protect_args(Some(true));
     let err = b.validate().unwrap_err();
     assert_eq!(err.option1, "old-args");
     assert_eq!(err.option2, "secluded-args");
@@ -1326,38 +1358,38 @@ fn validate_old_args_with_secluded_args_conflicts() {
 #[test]
 fn validate_append_with_no_whole_file_ok() {
     // Explicit `--no-whole-file` is the upstream-compatible companion to --append.
-    let b = builder().append(true).whole_file(false);
+    let mut b = builder().append(true).whole_file(false);
     assert!(b.validate().is_ok());
 }
 
 #[test]
 fn validate_append_without_explicit_whole_file_ok() {
     // Default (None) leaves auto-detection in place and does not conflict.
-    let b = builder().append(true);
+    let mut b = builder().append(true);
     assert!(b.validate().is_ok());
 }
 
 #[test]
 fn validate_inplace_without_conflicts_ok() {
-    let b = builder().inplace(true);
+    let mut b = builder().inplace(true);
     assert!(b.validate().is_ok());
 }
 
 #[test]
 fn validate_delay_updates_without_inplace_ok() {
-    let b = builder().delay_updates(true);
+    let mut b = builder().delay_updates(true);
     assert!(b.validate().is_ok());
 }
 
 #[test]
 fn validate_partial_dir_without_inplace_ok() {
-    let b = builder().partial_directory(Some("/tmp/partial"));
+    let mut b = builder().partial_directory(Some("/tmp/partial"));
     assert!(b.validate().is_ok());
 }
 
 #[test]
 fn validate_default_builder_ok() {
-    let b = builder();
+    let mut b = builder();
     assert!(b.validate().is_ok());
 }
 
@@ -1370,7 +1402,7 @@ fn validate_rsh_with_ssh_url_operand_conflicts() {
     // than the user asked for, so the pair must be rejected as RERR_SYNTAX.
     // Only under `embedded-ssh`: without it, ssh:// has no transport at all and
     // the clearer "requires the embedded-ssh feature" diagnostic wins instead.
-    let b = builder()
+    let mut b = builder()
         .set_remote_shell(["ssh"])
         .transfer_args(["ssh://host/path", "dest"]);
     let err = b.validate().unwrap_err();
@@ -1385,7 +1417,7 @@ fn validate_rsh_with_ssh_url_operand_no_conflict_without_embedded_ssh() {
     // transport regardless of --rsh (or an implicit shell from RSYNC_RSH). The
     // -e conflict must NOT pre-empt run_client's clearer "ssh:// requires the
     // embedded-ssh feature" error, so validate() stays Ok here and defers.
-    let b = builder()
+    let mut b = builder()
         .set_remote_shell(["ssh"])
         .transfer_args(["ssh://host/path", "dest"]);
     assert!(b.validate().is_ok());
@@ -1395,7 +1427,7 @@ fn validate_rsh_with_ssh_url_operand_no_conflict_without_embedded_ssh() {
 fn validate_rsh_with_host_path_operand_ok() {
     // A `host:path` operand is exactly the case where --rsh is honoured (it
     // spawns the external ssh), so it must not trip the ssh:// conflict.
-    let b = builder()
+    let mut b = builder()
         .set_remote_shell(["ssh"])
         .transfer_args(["host:path", "dest"]);
     assert!(b.validate().is_ok());
@@ -1406,7 +1438,7 @@ fn validate_ssh_url_without_rsh_ok() {
     // An `ssh://` operand on its own is the normal built-in-SSH path. With no
     // explicit --rsh (remote_shell = None) there is nothing to conflict with,
     // so the default/unset shell must not trip the check.
-    let b = builder().transfer_args(["ssh://host/path", "dest"]);
+    let mut b = builder().transfer_args(["ssh://host/path", "dest"]);
     assert!(b.validate().is_ok());
 }
 
@@ -1417,7 +1449,7 @@ fn validate_rsh_ssh_url_conflict_message() {
     // the RSYNC_RSH environment variable) because the shell is often implicit,
     // and points the user at every way to resolve it (unset RSYNC_RSH, drop
     // --rsh, or use host:path for the external ssh).
-    let b = builder()
+    let mut b = builder()
         .set_remote_shell(["ssh"])
         .transfer_args(["ssh://host/path", "dest"]);
     let err = b.validate().unwrap_err();

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -727,6 +727,32 @@ impl ServerConfig {
         }
     }
 
+    /// Applies upstream's `--append` implies `--inplace` promotion.
+    ///
+    /// Upstream runs one `parse_arguments()` in every peer, so the flag is
+    /// already set by the time any consumer looks at it. oc parses the client
+    /// CLI, the `--server` argv and the daemon's client args in three separate
+    /// places, so the server-side halves pick the implication up here - the one
+    /// path every role's config reaches before the transfer starts.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2400-2411` - `if (append_mode) { ...; inplace = 1; }`.
+    /// - `receiver.c:968` - `if (inplace || one_inplace)` selects the live
+    ///   destination as the write target instead of a temp file.
+    /// - `receiver.c:496` - `inplace_sizing` truncates the destination to the
+    ///   received length.
+    /// - `receiver.c:1029` - `|| inplace` retains a failed-verification partial
+    ///   instead of discarding it.
+    /// - `receiver.c:1074` - `keptstr` reads "retained" off the same flag.
+    /// - `sender.c:337` - `updating_basis_file` gates `match.c:211`.
+    /// - `compat.c:688` - protocol < 29 refuses a basis dir with `inplace`.
+    pub(crate) fn apply_append_implies_inplace(&mut self) {
+        if self.flags.append {
+            self.write.inplace = true;
+        }
+    }
+
     /// Promotes plain `--append` to `--append-verify` semantics for legacy
     /// (protocol < 30) peers.
     ///
@@ -1045,6 +1071,35 @@ mod tests {
         config.flags.append = append;
         config.flags.append_verify = append_verify;
         config
+    }
+
+    // upstream: options.c:2410 - every peer's parse_arguments() sets `inplace`
+    // for any append_mode. The server-side halves (the `--server` argv parser
+    // and the daemon's client_args parser) build this config themselves, so the
+    // promotion has to land here or their sender would compute
+    // `updating_basis_file` (sender.c:337) off a false `inplace` and their
+    // receiver would skip the closing ftruncate (receiver.c:496).
+    #[test]
+    fn append_implies_inplace() {
+        let mut config = append_config(true, false);
+        assert!(!config.write.inplace, "precondition: parsed as append only");
+        config.apply_append_implies_inplace();
+        assert!(config.write.inplace);
+    }
+
+    #[test]
+    fn append_implies_inplace_is_one_directional() {
+        let mut config = append_config(false, false);
+        config.apply_append_implies_inplace();
+        assert!(
+            !config.write.inplace,
+            "a transfer that never asked for append must not gain inplace"
+        );
+
+        let mut explicit = append_config(false, false);
+        explicit.write.inplace = true;
+        explicit.apply_append_implies_inplace();
+        assert!(explicit.write.inplace, "an explicit --inplace must survive");
     }
 
     #[test]

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -608,6 +608,11 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         itemize,
         io_timeout_reapply,
     } = hooks;
+    // upstream: options.c:2410 - `--append` implies `--inplace`, applied by the
+    // same parse_arguments() every peer runs. This is the one path shared by
+    // the client's in-process half, the `--server` process and the daemon, so
+    // the implication lands before setup_protocol()'s protocol < 29 checks.
+    config.apply_append_implies_inplace();
     // FSM: begin at Handshake (version exchange is already complete when this
     // function is called - either via run_server_stdio or daemon greeting).
     let mut pipeline = TransferPipeline::new(config.role);

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -243,20 +243,24 @@ pub struct ResponseContext<'a> {
 ///
 /// # Upstream Reference
 ///
-/// - `receiver.c:968` - append mode implies inplace.
+/// `inplace` already carries `--append`: `ServerConfig::apply_append_implies_inplace`
+/// materialises upstream's `options.c:2410` promotion before the transfer starts,
+/// so this reads the single flag exactly as `receiver.c:968` does.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:968` - `if (inplace || one_inplace)`.
 /// - `receiver.c:910` - `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR`.
 /// - `receiver.c:969` - `fnametmp = one_inplace ? partialptr : fname`.
 /// - `cleanup.c:105-115` - `handle_partial_dir()` moves the temp into the partial dir.
 fn resolve_use_inplace(
     inplace: bool,
-    append: bool,
     inplace_partial: bool,
     fnamecmp_type: Option<protocol::FnameCmpType>,
 ) -> bool {
-    let write_to_destination = inplace || append;
     let one_inplace_partial_dir =
         inplace_partial && fnamecmp_type == Some(protocol::FnameCmpType::PartialDir);
-    write_to_destination && !one_inplace_partial_dir
+    inplace && !one_inplace_partial_dir
 }
 
 /// Reads and validates the echoed NDX and sum_head from the sender response.
@@ -299,7 +303,6 @@ fn read_response_header<R: Read>(
 
     let use_inplace = resolve_use_inplace(
         ctx.config.inplace,
-        ctx.config.append,
         ctx.config.inplace_partial,
         sender_attrs.fnamecmp_type,
     );
@@ -355,18 +358,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_use_inplace_writes_to_destination_for_inplace_and_append() {
-        // upstream: receiver.c:968 - append implies inplace; both write to the
-        // destination directly.
-        assert!(resolve_use_inplace(true, false, false, None));
-        assert!(resolve_use_inplace(false, true, false, None));
+    fn resolve_use_inplace_writes_to_destination_for_inplace() {
+        // upstream: receiver.c:968 - `inplace` selects the live destination as
+        // the write target. `--append` reaches this through the same flag,
+        // promoted by apply_append_implies_inplace (options.c:2410).
+        assert!(resolve_use_inplace(true, false, None));
     }
 
     #[test]
     fn resolve_use_inplace_temp_rename_without_inplace_flags() {
-        assert!(!resolve_use_inplace(false, false, false, None));
+        assert!(!resolve_use_inplace(false, false, None));
         assert!(!resolve_use_inplace(
-            false,
             false,
             false,
             Some(protocol::FnameCmpType::Fname)
@@ -383,7 +385,6 @@ mod tests {
         // upstream: receiver.c:910,969 write one_inplace to partialptr, never fname.
         assert!(!resolve_use_inplace(
             false,
-            false,
             true,
             Some(protocol::FnameCmpType::PartialDir)
         ));
@@ -391,11 +392,10 @@ mod tests {
         // or exact-name transfer) is likewise temp+rename.
         assert!(!resolve_use_inplace(
             false,
-            false,
             true,
             Some(protocol::FnameCmpType::Fname)
         ));
-        assert!(!resolve_use_inplace(false, false, true, None));
+        assert!(!resolve_use_inplace(false, true, None));
     }
 
     #[test]

--- a/tests/append_implies_inplace.rs
+++ b/tests/append_implies_inplace.rs
@@ -1,0 +1,274 @@
+//! `--append` must imply `--inplace` (upstream `options.c:2400-2411`).
+//!
+//! The promotion is not cosmetic. Upstream never branches on `append_mode`
+//! after option parsing; it branches on the implied `inplace` flag, and the
+//! two most consequential branches are about what happens to the DESTINATION:
+//!
+//! - `generator.c:1862,1898` - under `inplace`, `--backup` COPIES the pre-image
+//!   aside and leaves the destination inode alone, because that inode is the
+//!   basis the append is about to extend. Without the flag the generator takes
+//!   the non-inplace path and moves the destination away (upstream `rsync.c:740`
+//!   hard-links it into the backup area first), which both destroys the basis
+//!   and leaves the "backup" aliasing the file that is still being written.
+//! - `receiver.c:1029,1074` - `|| inplace` is what RETAINS a file whose
+//!   verification failed instead of discarding it, and what makes the warning
+//!   say "retained" rather than "discarded".
+//!
+//! These tests pin the observable end of that rule so a later change cannot
+//! silently drop the promotion and reach the old behaviour again.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    if built.is_file() {
+        return built;
+    }
+    PathBuf::from("oc-rsync")
+}
+
+/// Writes a 16-byte source and an 8-byte destination sharing the same prefix,
+/// so `--append` has a real prefix to keep and a real tail to send.
+fn seed(root: &Path) -> (PathBuf, PathBuf) {
+    let src = root.join("src");
+    let dest = root.join("dest");
+    fs::create_dir_all(&src).expect("create src");
+    fs::create_dir_all(&dest).expect("create dest");
+    fs::write(src.join("f.txt"), b"AAAABBBBCCCCDDDD").expect("write source");
+    fs::write(dest.join("f.txt"), b"AAAABBBB").expect("write destination");
+    (src, dest)
+}
+
+#[cfg(unix)]
+fn inode(path: &Path) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    fs::metadata(path).expect("stat").ino()
+}
+
+fn run(binary: &Path, args: &[&std::ffi::OsStr]) -> std::process::Output {
+    Command::new(binary)
+        .args(args)
+        .output()
+        .expect("run oc-rsync")
+}
+
+/// `--append --backup` must keep the pre-image in the backup file.
+///
+/// This is the case that separates "append happens to write in place" from
+/// "append IS inplace". Both paths append to the same inode, so the file
+/// content alone cannot tell them apart - only the backup does. Upstream
+/// (`generator.c:1862,1898`) copies the pre-image aside under `inplace`; the
+/// non-inplace path hard-links the destination into the backup area first
+/// (`rsync.c:740`), so the "backup" grows along with the file being appended
+/// to and preserves nothing.
+#[test]
+fn append_backup_preserves_the_pre_image() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (src, dest) = seed(temp.path());
+
+    let output = run(
+        &binary,
+        &[
+            "--append".as_ref(),
+            "--backup".as_ref(),
+            src.join("f.txt").as_os_str(),
+            dest.as_os_str(),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "--append --backup must exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(
+        fs::read(dest.join("f.txt")).expect("read destination"),
+        b"AAAABBBBCCCCDDDD",
+        "the appended destination must hold the full source content"
+    );
+    assert_eq!(
+        fs::read(dest.join("f.txt~")).expect("read backup"),
+        b"AAAABBBB",
+        "the backup must hold the PRE-image; holding the post-image means the \
+         backup was hard-linked to the destination before the append, which is \
+         the non-inplace path (--append did not imply --inplace)"
+    );
+    #[cfg(unix)]
+    assert_ne!(
+        inode(&dest.join("f.txt~")),
+        inode(&dest.join("f.txt")),
+        "the backup must be an independent copy (generator.c:1898 copy_file); \
+         a shared inode is the rsync.c:740 hard-link path, under which the \
+         append grows the backup along with the destination"
+    );
+}
+
+/// The same rule with `--backup-dir`: `get_backup_name()` honours it, so the
+/// pre-image copy must land there instead of beside the destination.
+#[test]
+fn append_backup_dir_preserves_the_pre_image() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (src, dest) = seed(temp.path());
+    let backup_dir = temp.path().join("bd");
+    fs::create_dir_all(&backup_dir).expect("create backup dir");
+
+    let backup_arg = {
+        let mut arg = std::ffi::OsString::from("--backup-dir=");
+        arg.push(&backup_dir);
+        arg
+    };
+    let output = run(
+        &binary,
+        &[
+            "--append".as_ref(),
+            "--backup".as_ref(),
+            backup_arg.as_os_str(),
+            src.join("f.txt").as_os_str(),
+            dest.as_os_str(),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "--append --backup --backup-dir must exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(
+        fs::read(dest.join("f.txt")).expect("read destination"),
+        b"AAAABBBBCCCCDDDD"
+    );
+    assert_eq!(
+        fs::read(backup_dir.join("f.txt")).expect("read backup-dir copy"),
+        b"AAAABBBB",
+        "the backup-dir copy must hold the PRE-image"
+    );
+}
+
+/// Control: an explicit `--inplace --backup` was always correct. Pinning it
+/// beside the `--append` case keeps the two honest - if this one ever breaks,
+/// the defect is in the backup path itself rather than in the implication.
+#[test]
+fn explicit_inplace_backup_preserves_the_pre_image() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (src, dest) = seed(temp.path());
+
+    let output = run(
+        &binary,
+        &[
+            "--inplace".as_ref(),
+            "--backup".as_ref(),
+            src.join("f.txt").as_os_str(),
+            dest.as_os_str(),
+        ],
+    );
+    assert!(output.status.success(), "--inplace --backup must exit 0");
+    assert_eq!(
+        fs::read(dest.join("f.txt~")).expect("read backup"),
+        b"AAAABBBB"
+    );
+}
+
+/// `--append` rewrites the live destination, never a temp file that is renamed
+/// over it. Upstream selects the write target with `if (inplace || one_inplace)`
+/// (`receiver.c:968`) and only then can `receiver.c:1029` retain a failed
+/// update: there is nothing to discard because the bytes already landed on the
+/// destination inode.
+#[cfg(unix)]
+#[test]
+fn append_writes_through_the_destination_inode() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (src, dest) = seed(temp.path());
+    let before = inode(&dest.join("f.txt"));
+
+    let output = run(
+        &binary,
+        &[
+            "--append".as_ref(),
+            src.join("f.txt").as_os_str(),
+            dest.as_os_str(),
+        ],
+    );
+    assert!(output.status.success(), "--append must exit 0");
+
+    assert_eq!(
+        inode(&dest.join("f.txt")),
+        before,
+        "an inplace write keeps the destination inode; a new inode means the \
+         update went through a temp file and was renamed over the destination"
+    );
+    assert_eq!(
+        fs::read(dest.join("f.txt")).expect("read destination"),
+        b"AAAABBBBCCCCDDDD"
+    );
+}
+
+/// The implication must not weaken the conflicts upstream derives FROM it.
+/// `options.c:2424-2432` rejects `inplace` with `--partial-dir`/`--delay-updates`
+/// and names the option the user actually typed (`append_mode ? "append" :
+/// "inplace"`), and `options.c:2401` rejects an explicit `--whole-file`.
+#[test]
+fn append_keeps_the_upstream_conflict_diagnostics() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (src, dest) = seed(temp.path());
+
+    for (extra, expected) in [
+        (
+            "--partial-dir=pd",
+            "--append cannot be used with --partial-dir",
+        ),
+        (
+            "--delay-updates",
+            "--append cannot be used with --delay-updates",
+        ),
+        ("--whole-file", "--append cannot be used with --whole-file"),
+    ] {
+        let output = run(
+            &binary,
+            &[
+                "--append".as_ref(),
+                extra.as_ref(),
+                src.join("f.txt").as_os_str(),
+                dest.as_os_str(),
+            ],
+        );
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{extra} must be a usage error (RERR_SYNTAX)"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(expected),
+            "expected {expected:?} in stderr, got:\n{stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Upstream rule

`options.c:2400-2411`:

```c
	if (append_mode) {
		if (whole_file > 0) {
			snprintf(err_buf, sizeof err_buf,
				 "--append cannot be used with --whole-file\n");
			goto cleanup;
		}
		if (refused_inplace) {
			create_refuse_error(refused_inplace);
			goto cleanup;
		}
		inplace = 1;
	}
```

After that assignment upstream never consults `append_mode` again to decide
where the receiver writes or what survives a failure. Every consumer reads the
implied flag:

| upstream site | what it decides |
|---|---|
| `receiver.c:968` `if (inplace \|\| one_inplace)` | write target is the live destination, not a temp file |
| `receiver.c:327,496` `inplace_sizing` | `preallocated_len = size_r`, and the closing `ftruncate(fd, offset)` |
| `generator.c:1862,1898` `if (inplace && make_backups > 0 && fnamecmp_type == FNAMECMP_FNAME)` | COPIES the pre-image aside before the in-place write destroys it |
| `receiver.c:872` `if (inplace && make_backups > 0)` | the delta basis switches to that backup, `fnamecmp_type = FNAMECMP_BACKUP` |
| `receiver.c:1029` `(recv_ok && ...) \|\| inplace` | RETAINS a failed-verification update instead of discarding it |
| `receiver.c:1074` `!(keep_partial && partialptr) && !inplace` | `keptstr` says "retained" rather than "discarded" |
| `sender.c:337` `updating_basis_file` | gates `match.c:211`'s backward-Copy suppression |
| `compat.c:688` `basis_dir_cnt && inplace` | protocol < 29 refuses a basis dir |
| `options.c:2424-2432` | rejects `--partial-dir` / `--delay-updates`, naming `append_mode ? "append" : "inplace"` |
| `batch.c:72` `flag_ptr[12] = &inplace` | the batch stream-flags bit carries the implied value |

## What oc did

`inplace` was never set. `ClientConfigBuilder::validate` reconstructed the rule
locally (`let is_inplace = self.inplace || self.append`), so the conflict table
fired correctly while `inplace` itself stayed false for every other consumer.
A second reconstruction sat in `transfer_ops::resolve_use_inplace`
(`inplace || append`), which is why the network receiver's write target was
right by accident.

## Observable consequence (measured, rsync 3.4.4 vs oc, aarch64 Linux)

Destination `AAAABBBB` (8 bytes), source `AAAABBBBCCCCDDDD` (16 bytes).

| cell | upstream 3.4.4 | oc before | oc after |
|---|---|---|---|
| `--append --backup`, backup content | `AAAABBBB` | `AAAABBBBCCCCDDDD` | `AAAABBBB` |
| `--append --backup`, backup shares dest inode | no | **YES** | no |
| `--append --backup --backup-dir`, copy content | `AAAABBBB` | `AAAABBBBCCCCDDDD` | `AAAABBBB` |
| `--append --backup` run twice, backup content | `AAAABBBB` | `AAAABBBBCCCCDDDD` | `AAAABBBB` |
| `--inplace --backup` (control), backup content | `AAAABBBB` | `AAAABBBB` | `AAAABBBB` |
| `--append`, destination content | `AAAABBBBCCCCDDDD` | same | same |
| `--append` onto a fresh destination | `AAAABBBBCCCCDDDD`, no temp left | same | same |
| `--append --partial-dir` / `--delay-updates` / `--whole-file` | exit 1, `--append cannot be used with --X` | same | same |

Without the flag the generator takes the non-inplace backup path, which
hard-links the destination into the backup area before the transfer
(`rsync.c:740`). The append then grows that shared inode, so the "backup" is
byte-identical to the new file and the pre-image is gone. The explicit
`--inplace --backup` control was always correct, which isolates the defect to
the missing implication rather than to the backup code.

Scope of that defect: the **local-copy** path only. On the network path
`resolve_use_inplace` already ORed `append`, so `disk_commit`'s
`make_inplace_backup` fired and the remote `--append --backup` cell measured
correct both before and after.

## Server argv - unchanged, and matching upstream

`options.c:2951-2956` sends `--append` (twice for `--append-verify`) and never
`--inplace` beside it. Measured through an `-e` shim that logs the server argv:

| invocation | `--inplace` in argv | `--append` count | `--append-verify` in argv |
|---|---|---|---|
| `--append` (upstream / oc before / oc after) | 0 / 0 / 0 | 1 / 1 / 1 | 0 / 0 / 0 |
| `--append-verify` (upstream / oc before / oc after) | 0 / 0 / 0 | 2 / 2 / 2 | 0 / 0 / 0 |
| `--inplace` (upstream / oc before / oc after) | 1 / 1 / 1 | 0 / 0 / 0 | - |

Both emitters (`invocation/builder.rs`, `daemon_transfer/.../arguments.rs`)
already used upstream's `if append { ... } else if inplace { ... }` shape, so
setting the flag does not add `--inplace` to any peer argv.

## Change

Set the flag; delete the reconstruction.

- `ClientConfigBuilder::apply_implied_options()` runs at the head of both
  `validate` and `build`, mirroring upstream's parse-then-check ordering, so
  the conflict table can test `self.inplace` directly. The `is_inplace`
  disjunction is gone; `self.inplace` is the single source of truth. The
  message still reads `if self.append { "append" } else { "inplace" }` -
  upstream's own naming ternary, not a second copy of the flag.
- `ServerConfig::apply_append_implies_inplace()` on entry to
  `run_server_with_handshake_adopting` - the one path the `--server` argv
  parser, the daemon's `client_args` parser and the client's in-process half
  all reach, and it runs before `setup_protocol()`'s protocol < 29 checks.
- `transfer_ops::resolve_use_inplace` drops its `append` parameter and reads
  `inplace` exactly as `receiver.c:968` does.

`--backup` is not in upstream's conflict table, and no rejection is added.

## Consumer audit

Every oc site that branches on `inplace`, and what it now does under `--append`:

- `transfer_ops::resolve_use_inplace` - unchanged result; now single-sourced.
- `pipeline/receiver.rs::verification_kept_str` - unchanged result; it reads
  the per-file `use_inplace`, which already carried append.
- `disk_commit::make_inplace_backup` - unchanged result, same reason. This is
  oc's `generator.c:1898` analogue and it is reached BY the flag.
- `transfer_ops/response.rs:402` - **newly reached.** The destination is
  truncated to the received length, matching `receiver.c:496`. Previously
  neither branch ran under `--append`.
- `generator/transfer/transfer_loop.rs:929 updating_basis_file` - **newly
  true**, matching `sender.c:337`. This is the server-side sender on a pull,
  the site neither local reconstruction could reach.
- `setup/restrictions.rs:132` - `--append` with a basis dir at protocol < 29 is
  now refused, matching `compat.c:688`.
- `config/builder.rs:564,583` - transfer-layer `--inplace` conflict checks. Not
  user-reachable; the client rejects the same pairs first with upstream's
  wording.
- `run/batch.rs:115` - the batch stream-flags `inplace` bit now carries the
  implied value, matching `batch.c:72` (`flag_ptr[12] = &inplace`).
- engine local copy: `select_write_strategy` picks `Inplace` for a fresh
  destination instead of a temp file (`receiver.c:968`); `execute/mod.rs:188`
  takes the copy-aside backup path (`generator.c:1862,1898`) - this is the
  fix above; `execute/mod.rs:517` sets `preallocated_len = size_r`
  (`receiver.c:334`). The FICLONE / clonefile / `CopyFileEx` fast paths now
  decline `--append`; they have no upstream analogue and the result is
  byte-identical either way.

## Tests

- `tests/append_implies_inplace.rs` - `--append --backup` must keep the
  pre-image AND must not share the destination inode (the two together are
  what separate "append happens to write in place" from "append IS inplace");
  the same for `--backup-dir`; an explicit `--inplace --backup` control;
  `--append` writes through the destination inode; the three upstream conflict
  diagnostics keep their exact wording and exit code.
- `crates/core/.../builder/tests.rs` - the promotion fires for `--append` and
  `--append-verify`, and is one-directional.
- `crates/transfer/src/config/mod.rs` - same for the server-side entry.

## Verification

Run on the aarch64 Linux host, since GitHub Actions is not scheduling:

- `cargo fmt --all -- --check` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run --workspace --all-features --no-fail-fast` - 32283 tests,
  32277 passed, 6 failed, all 6 reproduced on unpatched `origin/master`:
  4 `xtask::commands::package::tests::cross_compiler_*` and 2
  `transfer::uts_chmod_option` cases.
- Every cell in the tables above measured against a real `rsync 3.4.4` binary,
  and against an unpatched `origin/master` build of oc for the before column.

## Out of scope, found while auditing

`receiver.c:872` has no oc analogue: `FnameCmpType::Backup` exists in
`crates/protocol` but is never produced, so under `--inplace --backup` oc's
delta basis stays the destination rather than switching to the backup copy.
Independent of this PR (it reproduces with an explicit `--inplace`), and it
lives in the fenced receiver/generator crates.

`receiver.c:759,769` (`make_backups = -make_backups` on redo) is unreachable
under `--inplace`/`--append` in upstream itself: it is gated on `keep_partial`,
which `options.c:2439` clears inside the same `if (inplace)` block. Nothing to
mirror.

A local copy never runs `setup::restrictions`, so `--protocol=28 --inplace
--link-dest=...` exits 0 where rsync 3.4.4 exits 13. Not append-specific and
unchanged by this PR.

`--write-devices` has the same missing implication (`options.c:2413-2419` also
sets `inplace = 1`); left alone.
