### PR TITLE
ci: build legacy upstream rsync oracles on modern toolchains

### DIFF
--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -314,6 +314,17 @@ fetch_upstream_tarball() {
   return 1
 }
 
+# Configure + make the source tree in the current directory with one candidate
+# C dialect. Returns non-zero instead of exiting so the caller can try another
+# dialect; the caller reports the failure once every candidate is exhausted.
+try_upstream_build() {
+  local build_log=$1 attempt_cflags=$2
+  shift 2
+  make distclean >/dev/null 2>&1 || true
+  CFLAGS="${CFLAGS:-} ${attempt_cflags}" ./configure "$@" >"${build_log}" 2>&1 \
+    && make -j"$(build_jobs)" >>"${build_log}" 2>&1
+}
+
 build_upstream_from_source() {
   local version=$1
   local src_dir="${upstream_src_root}/rsync-${version}"
@@ -391,13 +402,30 @@ build_upstream_from_source() {
   # wrong arity etc.). Restoring the historical "warn, don't error" defaults
   # keeps the conftest results accurate without touching newer rsync builds.
   local extra_cflags="-O2 -Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion"
-  if ! CFLAGS="${CFLAGS:-} ${extra_cflags}" ./configure "${configure_args[@]}" >"${build_log}" 2>&1; then
-    echo "Upstream rsync ${version} configure failed; see ${build_log}" >&2
-    tail -n 50 "${build_log}" >&2 || true
-    exit 1
-  fi
 
-  if ! make -j"$(build_jobs)" >>"${build_log}" 2>&1; then
+  # gcc >= 14 also applies the C23 rule that an empty parameter list declares a
+  # function taking NO arguments. Releases through 3.1.3 declare helpers
+  # K&R-style - syscall.c's "off64_t lseek64();" and lib/pool_alloc.c's
+  # "void (*bomb)();" - so that rule turns them into hard "conflicting types"
+  # and "too many arguments" errors that no -Wno- flag suppresses. Compiling
+  # those releases in the dialect they were written for clears the whole class
+  # at once. Modern releases need the opposite: 3.4.4 uses C99 for-loop
+  # declarations that gnu89 rejects. The two dialects are mutually exclusive
+  # across the supported range, so probe rather than keep a version table -
+  # try the compiler default first and fall back to gnu89 only if it fails.
+  #
+  # The fallback also turns _FORTIFY_SOURCE off, which those releases need for
+  # a separate reason. Their bundled popt carves one malloc into the argv array
+  # plus its string storage (popt/poptparse.c poptDupArgv), so
+  # __builtin_object_size under-reports the destination. glibc 2.38 made
+  # strlcpy fortifiable, and the resulting mis-sized __strlcpy_chk aborts
+  # rsync 3.1.3 with "buffer overflow detected" as soon as it parses --daemon.
+  # That binary still compiles and prints its version, so without this the
+  # harness gets a silently broken oracle. This suppresses a false positive
+  # against a 2013 allocation idiom, not a defect in rsync's transfer logic.
+  local legacy_cflags="$extra_cflags -std=gnu89 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"
+  if ! try_upstream_build "$build_log" "$extra_cflags" "${configure_args[@]}" \
+    && ! try_upstream_build "$build_log" "$legacy_cflags" "${configure_args[@]}"; then
     echo "Upstream rsync ${version} build failed; see ${build_log}" >&2
     tail -n 50 "${build_log}" >&2 || true
     exit 1
@@ -406,6 +434,18 @@ build_upstream_from_source() {
   if ! make install >>"${build_log}" 2>&1; then
     echo "Upstream rsync ${version} install failed; see ${build_log}" >&2
     tail -n 50 "${build_log}" >&2 || true
+    exit 1
+  fi
+
+  # A binary that compiles and prints its version can still be unusable. The
+  # fortified-strlcpy abort described above fires inside popt's option parsing,
+  # so it only appears once --daemon is on the command line: a plain transfer
+  # exits 0 while every daemon scenario dies with "connection refused". Parsing
+  # the daemon options here turns that into one clear failure at build time
+  # instead of dozens of misleading scenario failures later.
+  if ! "${install_dir}/bin/rsync" --daemon --help >>"${build_log}" 2>&1; then
+    echo "Upstream rsync ${version} built but cannot parse --daemon options; see ${build_log}" >&2
+    tail -n 20 "${build_log}" >&2 || true
     exit 1
   fi
 
@@ -11754,8 +11794,13 @@ run_comprehensive_interop_case() {
   # compat.c:655-668), so the legs below only apply at proto 30+.
   local eff_proto="$fp"
   if [[ -z "$eff_proto" ]]; then
+    # Native PROTOCOL_VERSION per release (rsync.h). 3.0.x is 30, NOT 28 - the
+    # earlier value here silently failed the "proto >= 30" gate below, so the
+    # 3.0.9 ACL leg was skipped under a message blaming the host instead of
+    # running. 2.6.9 is 29 and previously fell through to the 32 default.
     case "$version" in
-      3.0.*) eff_proto=28 ;;
+      2.6.*) eff_proto=29 ;;
+      3.0.*) eff_proto=30 ;;
       3.1.*) eff_proto=31 ;;
       *) eff_proto=32 ;;
     esac
@@ -11883,8 +11928,18 @@ done
 # follow-up tasks (extra_build_versions) so the binary is on disk and on PATH
 # even when no scenarios reference it yet.
 mkdir -p "$upstream_src_root" "$upstream_install_root"
-for version in "${versions[@]}" "${extra_build_versions[@]}"; do
+for version in "${versions[@]}"; do
   ensure_upstream_build "$version"
+done
+# Cache-warming versions have no scenarios wired, so a build failure costs
+# coverage nothing and must not abort the versions that do. Run each in a
+# subshell: ensure_upstream_build exits on failure, and without the subshell
+# that exit would take the whole harness down. Failures for the versions above
+# stay fatal.
+for version in "${extra_build_versions[@]}"; do
+  if ! (ensure_upstream_build "$version"); then
+    echo "warning: upstream rsync ${version} failed to build; it has no scenarios wired, continuing" >&2
+  fi
 done
 
 # If build-only mode, exit after building upstream binaries


### PR DESCRIPTION
## Problem

`tools/ci/run_interop.sh` aborted before running a single scenario, so the interop harness could not run locally at all.

The abort was **not** on `2.6.9`. The build loop is `for version in "${versions[@]}" "${extra_build_versions[@]}"`, so it reaches `3.0.9` - the first version with scenarios wired - long before the cache-warming entry. Measured per-version, each built in isolation on aarch64:

| version | before | root cause |
|---|---|---|
| 2.6.9 | FAIL | `syscall.c:255: conflicting types for 'lseek64'` |
| 3.0.9 | FAIL | `syscall.c:296` same |
| 3.1.3 | FAIL | `syscall.c:355` same |
| 3.4.4 | OK | protocol 32 |

Local interop coverage was therefore protocol 32 only; the protocol 30 and 31 anchors were unavailable.

## Root cause

gcc >= 14 applies the C23 rule that an empty parameter list declares a function taking **no** arguments. Releases through 3.1.3 declare helpers K&R-style - `off64_t lseek64();` in `syscall.c`, `void (*bomb)();` in `lib/pool_alloc.c` - so that rule turns them into hard `conflicting types` / `too many arguments` errors. No `-Wno-` flag suppresses them; each suppression only exposes the next error of the same family (lseek64 -> qsort -> pool->bomb). Setting `ac_cv_func_lseek64=no` correctly undefines `HAVE_LSEEK64` and still does not build.

## Fix

Compile the legacy releases in the dialect they were written for. `-std=gnu89` alone builds all three.

This is a **probe, not a version table**: `-std=gnu89` *breaks* 3.4.4 (`syscall.c:1927: 'for' loop initial declarations are only allowed in C99 or C11 mode`), and `-std=gnu11` breaks the legacy autoconf probes (`lib/compat.c: too few arguments to function 'gettimeofday'`). The two dialects are mutually exclusive across the supported range, so the harness tries the compiler default first and falls back only when that fails. Nothing to keep in sync as versions change.

### The second defect, found by running it

With gnu89 the whole ladder built, but 3.1.3 then failed **all 17** of its `oc -> upstream` scenarios with `Connection refused`. That was not 17 protocol bugs - the upstream daemon never started:

```
*** buffer overflow detected ***: terminated
#8  __strlcpy_chk (s1=0xaaaaaab47730 "C/LC_CTYPE", n=25)
#10 poptDupArgv (argc=1, ...) at popt/poptparse.c:41
#11 handleAlias (con=..., longName=0xffffffffc732 "daemon", ...)
```

rsync's bundled popt carves a single `malloc` into the argv array plus its string storage, so `__builtin_object_size` under-reports the destination. glibc 2.38 made `strlcpy` fortifiable, and the mis-sized `__strlcpy_chk` aborts as soon as `--daemon` is parsed. It is a false positive against a 2013 allocation idiom, not a defect in rsync's transfer logic, so the legacy fallback also sets `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0`.

The binary still compiled and printed its version, i.e. it was a **silently broken oracle**. A plain transfer exits 0 with it; only `--daemon` in argv triggers the abort. The harness now parses the daemon options after install, so that class fails once, clearly, at build time:

```
BROKEN  local transfer exit=0   --daemon --help exit=134
GOOD    local transfer exit=0   --daemon --help exit=0
```

### Also

- Failures for versions with no scenarios wired warn and continue; versions that carry scenarios stay fatal. `set -e` is untouched and no errors are swallowed - the extras loop runs `ensure_upstream_build` in a subshell so its `exit` cannot take the harness down.
- Folds in the `eff_proto` table fix. `3.0.*` was mapped to 28, so it failed the `proto >= 30` gate and its ACL leg was skipped under a message blaming the host filesystem rather than the table. It was invisible until now only because 3.0.9 never built. `2.6.*` had no arm and fell through to the 32 default. Corrected to 2.6.*=29, 3.0.*=30, 3.1.*=31, else 32, verified against `PROTOCOL_VERSION` in each pinned `rsync.h` **and** against each built binary.

## Verification

Full ladder restored, built from scratch through the harness:

```
2.6.9   protocol 29      3.0.9   protocol 30
3.1.3   protocol 31      3.4.4   protocol 32
```

Fail-loud and fail-soft, both halves shown:

```
CASE A  wired 3.0.9 cannot build
        EXIT=1, "Upstream rsync 3.0.9 build failed", aborted before completion banner
CASE B  cache-warming 2.6.9 cannot build
        EXIT=0, warning printed, all three wired versions installed, 2.6.9 absent
```

The first attempt at these two cases was **vacuous** - corrupting the source tree does not work, because the harness re-fetches and re-extracts the tarball and restores the file. Both cases "passed" with EXIT=0 and no failure line. Redone with a cc shim that fails only while building the named version; the results above are from that run.

The harness now runs to completion. 3.1.3 went from 16/33 to 32/33.

## Pre-existing failures this exposes - not introduced here

Running to completion surfaces cells that have never executed on this host. Both are unrelated to this change and are filed separately:

- **1 per version**: `lsh: unable to connect to host lh` - the SSH shim cannot reach its test host. Environmental, identical across every version.
- **`--protocol=28`: 54 unexpected.** Genuine oc-to-upstream divergences at protocol 28: `filter rules are too modern for remote rsync.`, `inflate returned -3 (0 bytes)`, `received request to transfer non-regular file: 0 [sender]`.

## Scope

One file, +63/-8. `bash -n` and `shellcheck -S error` clean. No upstream citation is manufactured for the harness itself - this is oc tooling with no upstream equivalent; the only upstream references are to the C constructs that fail and to `rsync.h`.
