### PR TITLE
docs(transfer): replace the false "oc never chroots" invariant

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -633,15 +633,34 @@ impl GeneratorContext {
     /// every source file.
     ///
     /// Mirrors the branch upstream `sender.c` takes before reading a file:
-    /// a non-chroot daemon (`use_secure_symlinks = am_daemon && !am_chrooted`;
-    /// oc never chroots, so it is simply `is_daemon_connection`) confines the
-    /// open beneath the module root; otherwise `do_open_checklinks` opens with
-    /// `O_NOFOLLOW` unless `--copy-links` / `--copy-unsafe-links` follows the
-    /// symlink.
+    /// when `use_secure_symlinks` holds, confine the open beneath the module
+    /// root; otherwise `do_open_checklinks` opens with `O_NOFOLLOW` unless
+    /// `--copy-links` / `--copy-unsafe-links` follows the symlink.
+    ///
+    /// # Why the gate is `is_daemon_connection` alone
+    ///
+    /// Upstream's condition is `am_daemon && !am_chrooted`, and `am_chrooted`
+    /// is assigned in exactly ONE place: `clientserver.c:988`, inside
+    /// `rsync_module()`'s PER-MODULE `use chroot` handling. The daemon-level
+    /// `daemon chroot` deliberately leaves it 0 - `clientserver.c:1345-1357`
+    /// spells out why, since that chroot confines resolution to the daemon
+    /// root, not to a module boundary, so modules sharing it stay
+    /// distinguishable subtrees and the per-module defenses must keep firing.
+    ///
+    /// So for a daemon-chrooted oc (`accept_loop.rs` applies the global
+    /// `daemon chroot`) this gate is exactly right: upstream is also still
+    /// gated on. It diverges only when a per-module `use chroot` succeeds
+    /// (`privilege.rs` `chroot_or_fallback`, reachable on the sync daemon
+    /// path), where upstream sets `am_chrooted = 1` and stops confining while
+    /// oc keeps confining. That is fail-safe - strictly more confinement,
+    /// never less - and is tracked rather than silently relied on. Do NOT
+    /// restate this as "oc never chroots": oc does chroot, by both routes.
     ///
     /// # Upstream Reference
     ///
     /// - `clientserver.c:1018` - `use_secure_symlinks = am_daemon && !am_chrooted`
+    /// - `clientserver.c:988` - the only assignment of `am_chrooted`
+    /// - `clientserver.c:1345-1357` - why the daemon chroot does not set it
     /// - `sender.c:359-383` - `secure_relative_open` vs `do_open_checklinks`
     pub(crate) fn source_open(&self) -> open_source::SourceOpen {
         let confine_root = if self.config.connection.is_daemon_connection {


### PR DESCRIPTION
## What

Replaces a false invariant in the sender's source-open policy. Comment only; no behaviour change.

`crates/transfer/src/generator/context.rs` justified its gate with:

> `use_secure_symlinks = am_daemon && !am_chrooted`; oc never chroots, so it is simply `is_daemon_connection`

oc chroots by **two** routes, both production:

- global `daemon chroot` — `daemon/sections/server_runtime/accept_loop.rs`, applied before the accept loop services any client
- per-module `use chroot` — `daemon/sections/privilege.rs` `chroot_or_fallback`, reachable on the sync daemon path (rejected only on the async path)

Both reach the real `chroot(2)` wrapper in `crates/platform/src/privilege.rs`.

## The rule that actually holds

Upstream assigns `am_chrooted` in **exactly one place**: `clientserver.c:988`, inside `rsync_module()`'s **per-module** `use chroot`. The daemon-level chroot at `clientserver.c:1341` deliberately leaves it 0, and `clientserver.c:1345-1357` says why at length — that chroot confines resolution to the daemon root rather than to a module boundary, so modules sharing it stay distinguishable subtrees and a symlink in module A could still redirect into module B without the per-module defenses.

Consequences, which are narrower than "oc can chroot" suggests:

| case | upstream `use_secure_symlinks` | oc `is_daemon_connection` | verdict |
|---|---|---|---|
| daemon chroot | **true** (`am_chrooted` stays 0) | true | **correct, no divergence** |
| per-module `use chroot` | false (`am_chrooted = 1`) | true | oc over-confines |

So the evidence that motivated the task — the accept-loop chroot — is precisely the case where oc is already right. The divergence is only the per-module path.

## Severity

Fail-safe: strictly more confinement, never less. Not a vulnerability. The re-anchoring concern does not bite here either — `chroot_or_fallback` returns the post-chroot inner path from `split_chroot_path`, so oc re-anchors rather than retaining a stale pre-chroot root.

## Not done here

oc already computes the `am_chrooted` equivalent — `chroot_applied` in `daemon/sections/module_access/transfer/sandbox.rs` — and simply never threads it to the four transfer-layer gates. Making those gates two-part would *reduce* confinement to match upstream, which is a behaviour change to security gates and is left as a decision rather than made in a comment fix.

## Verification

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` — exit 0, zero warnings
- Tree grepped for the same false claim elsewhere; the only other hit is a test comment about *non-root* callers being unable to chroot, which is true and unrelated.
