### PR TITLE
fix(transfer): preserve an existing destination's mode on inplace writes

### DIFF
--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -227,6 +227,12 @@ pub(in crate::disk_commit) fn process_file(
     // temp+rename path instead backs up at commit time (see commit_file).
     let inplace_backup_notice = make_inplace_backup(&begin, config)?;
 
+    // upstream: rsync.c:449-472 dest_mode() reads the PRE-transfer destination
+    // stat. An inplace open writes through the destination itself, so capture
+    // that stat now - once the open below runs, the prior mode is gone and the
+    // metadata apply would fall back to the brand-new-file formula.
+    let inplace_pre_transfer = inplace_pre_transfer_stat(&begin);
+
     let (file, mut cleanup_guard, needs_rename) = match open_output_file(&begin, config) {
         Ok(triple) => triple,
         Err(open_err) => {
@@ -411,7 +417,12 @@ pub(in crate::disk_commit) fn process_file(
                 // file is already correct when it appears at the final
                 // path. For inplace/device, metadata is applied after.
                 let pre_meta_error = if needs_rename {
-                    apply_file_metadata(cleanup_guard.path(), &begin, config)
+                    apply_file_metadata(
+                        cleanup_guard.path(),
+                        &begin,
+                        config,
+                        inplace_pre_transfer.as_ref(),
+                    )
                 } else {
                     None
                 };
@@ -445,11 +456,16 @@ pub(in crate::disk_commit) fn process_file(
                         .delayed_path
                         .as_ref()
                         .expect("delayed_path is Some on the staged-partial path");
-                    apply_file_metadata(staged, &begin, config)
+                    apply_file_metadata(staged, &begin, config, inplace_pre_transfer.as_ref())
                 } else if needs_rename && !outcome.was_copy {
                     pre_meta_error
                 } else {
-                    apply_file_metadata(&begin.file_path, &begin, config)
+                    apply_file_metadata(
+                        &begin.file_path,
+                        &begin,
+                        config,
+                        inplace_pre_transfer.as_ref(),
+                    )
                 };
 
                 return Ok(CommitResult {
@@ -549,6 +565,9 @@ pub(in crate::disk_commit) fn process_whole_file(
     // before rewriting the destination in place (see process_file).
     let inplace_backup_notice = make_inplace_backup(&begin, config)?;
 
+    // See `inplace_pre_transfer_stat`: capture before the open destroys it.
+    let inplace_pre_transfer = inplace_pre_transfer_stat(&begin);
+
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
     if needs_rename {
         // The coalesced path carries its whole payload inline, so the
@@ -642,7 +661,12 @@ pub(in crate::disk_commit) fn process_whole_file(
     // upstream: rsync.c:748 finish_transfer() - apply metadata to the
     // temp file before rename (see process_file for full rationale).
     let pre_meta_error = if needs_rename {
-        apply_file_metadata(cleanup_guard.path(), &begin, config)
+        apply_file_metadata(
+            cleanup_guard.path(),
+            &begin,
+            config,
+            inplace_pre_transfer.as_ref(),
+        )
     } else {
         None
     };
@@ -665,11 +689,16 @@ pub(in crate::disk_commit) fn process_whole_file(
             .delayed_path
             .as_ref()
             .expect("delayed_path checked is_some above");
-        apply_file_metadata(staged, &begin, config)
+        apply_file_metadata(staged, &begin, config, inplace_pre_transfer.as_ref())
     } else if needs_rename && !outcome.was_copy {
         pre_meta_error
     } else {
-        apply_file_metadata(&begin.file_path, &begin, config)
+        apply_file_metadata(
+            &begin.file_path,
+            &begin,
+            config,
+            inplace_pre_transfer.as_ref(),
+        )
     };
 
     Ok(CommitResult {
@@ -767,6 +796,41 @@ fn make_inplace_backup(
         return Ok(None);
     };
     make_backup_copy(&begin.file_path, backup_config, config)
+}
+
+/// Stats the destination before an inplace write so `dest_mode()` keeps its
+/// permission bits.
+///
+/// Upstream computes the destination mode BEFORE opening the output file:
+///
+/// ```text
+/// int exists = fd1 != -1;                                     // receiver.c:955
+/// file->mode = dest_mode(file->mode, st.st_mode, dflt_perms, exists);
+/// if (inplace || one_inplace) { ... }                         // receiver.c:967
+/// ```
+///
+/// and for an existing destination `dest_mode()` returns
+/// `(flist_mode & ~CHMOD_BITS) | (stat_mode & CHMOD_BITS)` - the destination's
+/// own permission bits (rsync.c:449-472).
+///
+/// oc instead applies metadata at commit time. For the temp+rename path that is
+/// still equivalent, because the final path is untouched until the rename. An
+/// inplace write has no such luxury: it writes through the destination, so by
+/// commit time the pre-transfer stat is unrecoverable. Capture it here and hand
+/// it to [`super::metadata::apply_file_metadata`].
+///
+/// Returns `None` when the destination does not exist, which is upstream's
+/// `exists == 0` and selects `flist_mode & (~CHMOD_BITS | dflt_perms)`.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:955-965` - `dest_mode()` invocation before the output open
+/// - `rsync.c:449-472` - `dest_mode()` body
+fn inplace_pre_transfer_stat(begin: &BeginMessage) -> Option<fs::Metadata> {
+    if !begin.is_inplace || begin.is_device_target {
+        return None;
+    }
+    fs::symlink_metadata(&begin.file_path).ok()
 }
 
 /// Opens the output file using device write, inplace, or temp+rename strategy.

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -28,6 +28,7 @@ pub(super) fn apply_file_metadata(
     target_path: &Path,
     begin: &BeginMessage,
     config: &DiskCommitConfig,
+    inplace_pre_transfer: Option<&std::fs::Metadata>,
 ) -> Option<(PathBuf, String)> {
     // The desired metadata rides on the begin message per-file (see
     // `BeginMessage::file_entry`), so the disk thread no longer indexes a shared
@@ -43,13 +44,22 @@ pub(super) fn apply_file_metadata(
         // file it had before this transfer, so stat it to reproduce
         // dest_mode()'s `stat_mode`/`exists` inputs: `Some(meta)` -> keep the
         // prior perm bits; a missing final path (`None`) -> brand-new file,
-        // apply the umask-masked source mode. When metadata is applied
-        // directly to the final path (inplace/device/cross-device), the
-        // pre-transfer state is already gone, so pass `None`.
+        // apply the umask-masked source mode.
+        //
+        // Writing directly to the final path (inplace) destroys the
+        // pre-transfer state by the time we get here, so the caller stats the
+        // destination BEFORE `open_output_file` and hands it in. Passing `None`
+        // here instead would take the brand-new-file branch and chmod an
+        // existing destination to `source_mode & (~CHMOD_BITS | dflt_perms)` -
+        // mode 000 whenever the entry carries no perm bits - where upstream
+        // preserves the destination's own bits.
+        //
+        // upstream: rsync.c:449-472 dest_mode() is called (receiver.c:964) with
+        // `statret == 0` for an inplace write, because the destination exists.
         let pre_transfer_meta = if target_path != begin.file_path {
             std::fs::symlink_metadata(&begin.file_path).ok()
         } else {
-            None
+            inplace_pre_transfer.cloned()
         };
         apply_metadata_acls_and_xattrs(
             target_path,
@@ -263,7 +273,7 @@ mod tests {
 
         // target_path == file_path: the final-destination apply path.
         let begin = begin_for(&path, Some(entry));
-        let err = apply_file_metadata(&path, &begin, &config);
+        let err = apply_file_metadata(&path, &begin, &config, None);
         assert!(err.is_none(), "metadata apply reported an error: {err:?}");
 
         let meta = std::fs::metadata(&path).unwrap();
@@ -294,7 +304,7 @@ mod tests {
             ..DiskCommitConfig::default()
         };
         let begin = begin_for(&path, None);
-        assert!(apply_file_metadata(&path, &begin, &config).is_none());
+        assert!(apply_file_metadata(&path, &begin, &config, None).is_none());
     }
 
     /// ACL case: the access/default ACL indices live in the entry's `extras`
@@ -336,6 +346,6 @@ mod tests {
             metadata_opts: Some(metadata::MetadataOptions::new().preserve_permissions(true)),
             ..DiskCommitConfig::default()
         };
-        assert!(apply_file_metadata(&path, &begin, &config).is_none());
+        assert!(apply_file_metadata(&path, &begin, &config, None).is_none());
     }
 }

--- a/crates/transfer/tests/daemon_dest_mode_parity.rs
+++ b/crates/transfer/tests/daemon_dest_mode_parity.rs
@@ -1,0 +1,247 @@
+//! Pins upstream's `dest_mode()` permission rule on the daemon receiver.
+//!
+//! Upstream decides the destination's mode BEFORE it opens the output file, and
+//! the decision turns on whether the destination already existed:
+//!
+//! ```text
+//! int exists = fd1 != -1;                                      // receiver.c:955
+//! file->mode = dest_mode(file->mode, st.st_mode, dflt_perms, exists);
+//! if (inplace || one_inplace) { ... }                          // receiver.c:967
+//! ```
+//!
+//! and `dest_mode()` itself (rsync.c:449-472):
+//!
+//! ```text
+//! if (exists)  new_mode = (flist_mode & ~CHMOD_BITS) | (stat_mode & CHMOD_BITS);
+//! else         new_mode = flist_mode & (~CHMOD_BITS | dflt_perms);
+//! ```
+//!
+//! So without `-p`: an EXISTING destination keeps its own permission bits, and a
+//! NEW destination gets the source mode masked by the receiver's default perms.
+//! That holds for every write path - upstream picks the mode before it chooses
+//! between temp+rename and inplace.
+//!
+//! oc applies metadata at commit time instead. For temp+rename that is
+//! equivalent, because the final path is untouched until the rename. An inplace
+//! write is not: it writes through the destination, so the pre-transfer stat has
+//! to be captured before the open (see
+//! `disk_commit::process::file_ops::inplace_pre_transfer_stat`). Without that
+//! capture the commit took the brand-new-file branch and chmod'd an existing
+//! destination to `flist_mode & (~CHMOD_BITS | dflt_perms)` - mode 000 whenever
+//! the entry carried no permission bits, leaving the transferred file
+//! unreadable.
+//!
+//! These cells therefore cover the write paths as a SET. A regression that
+//! reintroduces the defect on any one of them fails here even if the others
+//! still behave, which is the point: the rule is one rule, and every path that
+//! commits a file has to land on it.
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+/// Source mode deliberately differs from the destination mode so the two
+/// `dest_mode()` branches produce DIFFERENT answers. With both at 0o644 the
+/// test would pass under either branch and prove nothing.
+const SOURCE_MODE: u32 = 0o600;
+/// Pre-existing destination mode: distinct from `SOURCE_MODE`, and not a mode
+/// the new-file formula could produce from it.
+const DEST_MODE: u32 = 0o644;
+
+struct DaemonGuard(Child);
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn write_config(config: &Path, root: &Path, module: &str) -> io::Result<()> {
+    fs::write(
+        config,
+        format!(
+            "pid file = {pid}\n\
+             log file = {log}\n\
+             use chroot = false\n\
+             \n\
+             [{module}]\n\
+             path = {root}\n\
+             read only = false\n",
+            pid = root.join("rsyncd.pid").display(),
+            log = root.join("rsyncd.log").display(),
+            module = module,
+            root = root.display(),
+        ),
+    )
+}
+
+fn spawn_daemon(oc_bin: &Path, config: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard(child), port))
+}
+
+/// Pushes one file to a daemon module and returns the destination's mode bits.
+///
+/// `pre_existing` seeds the destination at [`DEST_MODE`] when set, exercising
+/// upstream's `exists != 0` branch; otherwise the destination is absent and the
+/// `exists == 0` branch applies.
+fn dest_mode_after_push(extra_args: &[&str], pre_existing: bool) -> Option<u32> {
+    let oc_bin = test_support::oc_rsync_bin();
+    let tmp = test_support::create_tempdir();
+    let root = tmp.path();
+    let (source_dir, module_root) = (root.join("src"), root.join("dest"));
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::create_dir_all(&module_root).expect("create module root");
+
+    let payload: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+    let source = source_dir.join("payload.bin");
+    fs::write(&source, &payload).expect("seed source");
+    fs::set_permissions(&source, fs::Permissions::from_mode(SOURCE_MODE)).expect("chmod source");
+
+    let dest = module_root.join("payload.bin");
+    if pre_existing {
+        // A true prefix, so `--append-verify` appends rather than restarting.
+        fs::write(&dest, &payload[..1024]).expect("seed destination");
+        fs::set_permissions(&dest, fs::Permissions::from_mode(DEST_MODE)).expect("chmod dest");
+    }
+
+    let config = root.join("rsyncd.conf");
+    write_config(&config, &module_root, "data").expect("write daemon config");
+
+    let Ok((_daemon, port)) = spawn_daemon(&oc_bin, &config) else {
+        // The harness could not start a daemon; report it rather than passing
+        // vacuously. Callers treat `None` as "did not measure".
+        return None;
+    };
+
+    let mut args: Vec<OsString> = extra_args.iter().map(OsString::from).collect();
+    args.push(OsString::from("--ignore-times"));
+    args.push(source.clone().into_os_string());
+    args.push(OsString::from(format!(
+        "rsync://127.0.0.1:{port}/data/payload.bin"
+    )));
+
+    let status = Command::new(&oc_bin)
+        .args(args.iter().map(OsStr::new))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run oc-rsync client");
+    assert!(
+        status.status.success(),
+        "push {extra_args:?} (pre_existing={pre_existing}) exited {:?}\nstderr:\n{}",
+        status.status,
+        String::from_utf8_lossy(&status.stderr),
+    );
+
+    Some(
+        fs::metadata(&dest)
+            .expect("destination exists after push")
+            .permissions()
+            .mode()
+            & 0o7777,
+    )
+}
+
+/// Upstream's `exists != 0` branch: the destination keeps its OWN permission
+/// bits, whichever write path committed the file.
+///
+/// This is the cell the mode-000 defect failed: the inplace paths chmod'd the
+/// destination to the new-file formula's result instead of preserving 0o644.
+#[test]
+fn existing_destination_keeps_its_mode_on_every_write_path() {
+    for extra in [
+        &[][..],                  // temp + rename
+        &["--inplace"][..],       // writes through the destination
+        &["--append-verify"][..], // implies --inplace (options.c:2400-2411)
+    ] {
+        let Some(mode) = dest_mode_after_push(extra, true) else {
+            panic!("{extra:?}: could not start the daemon, so nothing was measured");
+        };
+        assert_eq!(
+            mode, DEST_MODE,
+            "{extra:?}: upstream dest_mode() keeps an existing destination's \
+             permission bits (rsync.c:449-472, exists != 0); got {mode:04o}, \
+             want {DEST_MODE:04o}",
+        );
+    }
+}
+
+/// Upstream's `exists == 0` branch: a brand-new destination takes the source
+/// mode masked by the receiver's default permissions, on every write path.
+///
+/// Pinned alongside the existing-destination cell so a fix for one branch
+/// cannot silently regress the other - the two share a single code path and a
+/// single upstream rule.
+///
+/// IGNORED - this cell currently FAILS, and the failure is real. It is a
+/// SEPARATE defect from the one this PR fixes, so it is registered here rather
+/// than deleted: the assertion is correct and upstream-derived, and un-ignoring
+/// it is the acceptance gate for that fix.
+///
+/// Measured: built `--all-features` across the WORKSPACE (what CI does), a new
+/// destination lands mode 000 on every write path, because `entry.permissions()`
+/// reaches the commit as 0 - a source chmod'd 0777 still lands 000, so the
+/// formula is fine and the entry mode is not. A default-feature build of the
+/// same source gives the correct 0600, and upstream 3.4.4 gives 0600 in both.
+/// Ruled out: incremental-flist (`--no-inc-recursive` still yields 000),
+/// `default_perms_for_dir` (faithful to acls.c:1084-1139), and `cached_umask`.
+/// The remaining work is to find which workspace feature drops the mode from the
+/// receiver's flist entry.
+#[test]
+#[ignore = "separate unfixed defect: entry.permissions() is 0 under a workspace --all-features build; see the doc comment"]
+fn new_destination_takes_the_masked_source_mode_on_every_write_path() {
+    let expected = masked_source_mode();
+    for extra in [&[][..], &["--inplace"][..], &["--append-verify"][..]] {
+        let Some(mode) = dest_mode_after_push(extra, false) else {
+            panic!("{extra:?}: could not start the daemon, so nothing was measured");
+        };
+        assert_eq!(
+            mode, expected,
+            "{extra:?}: upstream dest_mode() applies `flist_mode & (~CHMOD_BITS \
+             | dflt_perms)` to a new destination (rsync.c:449-472, exists == 0); \
+             got {mode:04o}, want {expected:04o}",
+        );
+    }
+}
+
+/// Returns `SOURCE_MODE` as the filesystem would create it, i.e. masked by the
+/// process umask.
+///
+/// Observed rather than computed: creating a file with `SOURCE_MODE` applies the
+/// umask exactly as the receiver's own `O_CREAT` does, which keeps this test
+/// free of `unsafe` (`crates/transfer` denies it) and of a `libc` dependency.
+fn masked_source_mode() -> u32 {
+    let probe_dir = test_support::create_tempdir();
+    let probe = probe_dir.path().join("umask-probe");
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(SOURCE_MODE)
+        .open(&probe)
+        .expect("create umask probe");
+    fs::metadata(&probe)
+        .expect("stat umask probe")
+        .permissions()
+        .mode()
+        & 0o7777
+}


### PR DESCRIPTION
## What upstream does

Upstream decides the destination's mode **before** it opens the output file, and the decision turns on whether the destination already existed:

```c
int exists = fd1 != -1;                                     /* receiver.c:955 */
file->mode = dest_mode(file->mode, st.st_mode, dflt_perms, exists);
}
/* We now check to see if we are writing the file "inplace" */
if (inplace || one_inplace)  {                              /* receiver.c:967 */
```

and `dest_mode()` itself (`rsync.c:449-472`):

```c
if (exists)  new_mode = (flist_mode & ~CHMOD_BITS) | (stat_mode & CHMOD_BITS);
else         new_mode = flist_mode & (~CHMOD_BITS | dflt_perms);
```

So without `-p`: an **existing** destination keeps its own permission bits, and a **new** destination gets the source mode masked by the receiver's default perms. The choice is made once, above the `inplace` branch, so it holds for every write path.

## The defect

oc applies metadata at commit time instead. For temp+rename that is equivalent, because the final path is untouched until the rename. An inplace write is not - it writes *through* the destination, so by commit time the pre-transfer state is already gone. `apply_file_metadata()` passed `None` for it:

```rust
let pre_transfer_meta = if target_path != begin.file_path {
    std::fs::symlink_metadata(&begin.file_path).ok()
} else {
    None            // forces the brand-new-file branch
};
```

which forced the `exists == 0` branch and chmod'd an **existing** destination to `flist_mode & (~CHMOD_BITS | dflt_perms)`. Without `-p` the entry carries no permission bits, so that product is `0` - the destination landed **mode 000** and the transferred file was unreadable. Observed as `fchmodat(12, "f.bin", 000) = 0` under strace.

## The fix

Mirror upstream: capture the stat **before** the inplace open and feed it to the same decision, so both write paths reach one rule rather than two.

- `file_ops.rs` - new `inplace_pre_transfer_stat()`, called before both `open_output_file` sites.
- `metadata.rs` - `apply_file_metadata()` takes the captured stat and uses it in place of the hardcoded `None`.

`--append` / `--append-verify` inherit the fix for free, because append implies inplace (`options.c:2400-2411`).

## Verification

Differential against upstream rsync 3.4.4, daemon push, 16 oracle cells (existing/new destination x plain / `--inplace` / `--append-verify` / `-p`): **16/16 identical** after the fix. Existing dest `0644` stays `0644`; new dest `0600` stays `0600`.

Red-check: reverting only the captured stat back to `None` turns the new test red with

```
["--inplace"]: upstream dest_mode() keeps an existing destination's permission bits
(rsync.c:449-472, exists != 0); got 0600, want 0644
```

Gates, all on the Linux host:

- `cargo fmt --all -- --check` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run --workspace --all-features` - **32366 passed, 0 failed**

This also clears a pre-existing red on master: `daemon_push_forced_verification_failure_recovers_via_redo` was failing under full-workspace parallelism for the same root cause, and passes now.

## The test pins the rule, not the instance

`crates/transfer/tests/daemon_dest_mode_parity.rs` covers the write paths as a **set** - plain, `--inplace`, `--append-verify` - for both `dest_mode()` branches. `SOURCE_MODE` (0600) and `DEST_MODE` (0644) are deliberately different, so a cell that took the wrong branch produces a different answer instead of passing vacuously. A daemon that fails to start panics rather than passing with nothing measured.

## ⚠ Loudly flagged: a SEPARATE defect, unfixed

`new_destination_takes_the_masked_source_mode_on_every_write_path` is committed **`#[ignore]`d**, and the ignore is not a waiver - the assertion is upstream-derived and correct, and un-ignoring it is the acceptance gate for the follow-up fix.

**Measured:** built `--all-features` across the **workspace** (what CI does), a brand-new destination lands **mode 000 on every write path, including plain temp+rename**, because `entry.permissions()` reaches the commit as `0`. A source chmod'd `0777` still lands `000`, so the formula is faithful and the entry mode is not. A default-feature build of the same source gives the correct `0600`, and upstream 3.4.4 gives `0600` under both.

**Ruled out:** incremental-flist (`--no-inc-recursive` still yields 000), `default_perms_for_dir` (faithful to `acls.c:1084-1139`), and `cached_umask`.

**Remaining work:** find which workspace-wide feature drops the mode from the receiver's flist entry - instrument `entry.permissions()` at the apply site under both feature sets and walk back to the flist decode.

Two smaller findings surfaced on the way, not fixed here:

- `pipeline/receiver.rs:336` reports a non-mkstemp `EACCES` as `mkstemp "payload.bin" ... Permission denied`, because it falls back to the destination name when `attempted_temp_path(error)` returns `None`. That mislabelling sent two investigations down a temp-file path that was never involved.
- `workspace_bin` does not check binary freshness, and `cargo build --bin` and `cargo nextest --all-features` write *different* binaries to the same `target/debug/oc-rsync` path (link count 2, cargo swaps the hardlink). Measurements flip between runs depending on which built last.
