### PR TITLE
fix(metadata): capture orig_umask before the daemon sandbox is installed

### DIFF
--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -258,6 +258,16 @@ where
     Out: Write,
     Err: Write,
 {
+    // Resolve the process umask before any mode dispatch. The daemon installs a
+    // seccomp filter whose worker allowlist has no `umask(2)`, and a
+    // non-allowlisted syscall is answered with EPERM, so a first read taken
+    // later - inside a sandboxed worker - would cache -1 and collapse
+    // `dest_mode()`'s new-file result to mode 000.
+    // upstream: main.c:1797 `umask(orig_umask = umask(0));` runs in main()
+    // before any privilege drop or sandbox setup.
+    #[cfg(unix)]
+    metadata::init_orig_umask();
+
     let mut args: Vec<OsString> = arguments.into_iter().map(Into::into).collect();
     if args.is_empty() {
         args.push(OsString::from(ProgramName::OcRsync.as_str()));

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -11,6 +11,8 @@ mod platform_warn;
 mod timestamps;
 
 pub use ownership::group_is_settable;
+#[cfg(unix)]
+pub use permissions::init_orig_umask;
 
 #[cfg(test)]
 mod tests;

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -56,18 +56,35 @@ fn fchmod_libc(
     .map_err(|errno| MetadataError::new(action, destination, io::Error::from(errno)))
 }
 
-/// Returns the process umask, cached for thread safety.
+/// Process-wide `orig_umask`, captured once. See [`init_orig_umask`].
+#[cfg(unix)]
+static ORIG_UMASK: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+
+/// Captures the process umask into the process-wide cache.
 ///
-/// upstream: `main.c` stores `orig_umask` once at startup. We query it
-/// the first time a permission application needs the umask and cache the
-/// result so the double set-and-restore syscall happens at most once per
-/// process.
+/// Must be called from the program entry point, BEFORE the daemon installs its
+/// seccomp filter. `umask(2)` is not on the worker allowlist
+/// (`daemon::seccomp::worker_seccomp_allowlist`), and a non-allowlisted syscall
+/// is failed with `EPERM` rather than killing the process, so a *lazy* first
+/// read inside a sandboxed worker gets `-1` back. Caching that sentinel makes
+/// `dflt_perms` (`ACCESSPERMS & ~orig_umask`) zero, which collapses
+/// `dest_mode()`'s new-file result to mode `000` on every write path.
+///
+/// Capturing eagerly at startup - the same place and for the same reason as
+/// upstream - keeps the sandbox allowlist minimal and removes the ordering
+/// hazard entirely: by the time any filter is installed the value is already
+/// resolved.
+///
+/// Idempotent: the first call wins, later calls are no-ops.
+///
+/// # Upstream Reference
+///
+/// - `main.c:1797` - `umask(orig_umask = umask(0));` runs in `main()` before
+///   any privilege drop or sandbox setup.
 #[cfg(unix)]
 #[allow(unsafe_code)]
-fn cached_umask() -> u32 {
-    use std::sync::OnceLock;
-    static UMASK: OnceLock<u32> = OnceLock::new();
-    *UMASK.get_or_init(|| {
+pub fn init_orig_umask() {
+    ORIG_UMASK.get_or_init(|| {
         // SAFETY: umask is a standard POSIX call. We set it to 0 to read
         // the current value, then immediately restore it. This is a
         // well-known pattern (used by upstream rsync main.c, GNU coreutils,
@@ -76,8 +93,46 @@ fn cached_umask() -> u32 {
         // modifications.
         let old = unsafe { libc::umask(0) };
         unsafe { libc::umask(old) };
-        old as u32
-    })
+        sanitize_umask(old as u32)
+    });
+}
+
+/// Default umask assumed when the `umask(2)` query itself failed.
+#[cfg(unix)]
+const FALLBACK_UMASK: u32 = 0o022;
+
+/// Rejects a `umask(2)` return value that cannot be a umask.
+///
+/// A umask is 9 significant bits, so anything outside `0o777` means the query
+/// failed rather than answered - a seccomp filter that fails a non-allowlisted
+/// syscall with `EPERM` hands back `-1`, which as a `u32` is `u32::MAX`. Caching
+/// that would make `dflt_perms` (`ACCESSPERMS & ~orig_umask`) zero and chmod
+/// every newly created destination to mode `000`, so fall back to the POSIX
+/// default instead of propagating a sentinel into `dest_mode()`.
+///
+/// Defence in depth only: [`init_orig_umask`] runs before any sandbox is
+/// installed, so a correctly wired binary never reaches the fallback.
+#[cfg(unix)]
+const fn sanitize_umask(raw: u32) -> u32 {
+    if raw & !0o777 == 0 {
+        raw
+    } else {
+        FALLBACK_UMASK
+    }
+}
+
+/// Returns the process umask captured by [`init_orig_umask`].
+///
+/// Falls back to capturing on first use for callers that never ran the entry
+/// point (unit tests, library embedders). Production binaries prime this from
+/// `main` so the value is resolved before any sandbox is installed.
+#[cfg(unix)]
+fn cached_umask() -> u32 {
+    if let Some(umask) = ORIG_UMASK.get() {
+        return *umask;
+    }
+    init_orig_umask();
+    *ORIG_UMASK.get().unwrap_or(&0o022)
 }
 
 /// Returns the default permission seed for a child created under `parent`.
@@ -1282,5 +1337,37 @@ mod tests {
 
         let result = apply_permissions_with_chmod(&dest, &source_meta, &options, None);
         assert!(result.is_err(), "expected Err with -p active, got Ok");
+    }
+
+    /// A real umask must survive verbatim: the sanitiser exists to reject a
+    /// failed query, not to second-guess the process's actual mask.
+    #[cfg(unix)]
+    #[test]
+    fn sanitize_umask_passes_every_real_umask_through() {
+        for raw in 0..=0o777u32 {
+            assert_eq!(
+                super::sanitize_umask(raw),
+                raw,
+                "{raw:o} is a valid 9-bit umask and must not be rewritten",
+            );
+        }
+    }
+
+    /// `umask(2)` failing returns `-1`, which as a `u32` is `u32::MAX`. Caching
+    /// it would make `dflt_perms` = `0o777 & !u32::MAX` = 0 and chmod every new
+    /// destination to mode 000, so it must be rejected. This is the value a
+    /// seccomp filter answering `EPERM` actually produced on the daemon
+    /// receiver.
+    #[cfg(unix)]
+    #[test]
+    fn sanitize_umask_rejects_a_failed_query() {
+        assert_eq!(super::sanitize_umask(u32::MAX), super::FALLBACK_UMASK);
+        assert_ne!(
+            0o777 & !super::sanitize_umask(u32::MAX),
+            0,
+            "a rejected sentinel must not yield dflt_perms == 0",
+        );
+        // Any value with bits above the 9 umask bits is equally impossible.
+        assert_eq!(super::sanitize_umask(0o1000), super::FALLBACK_UMASK);
     }
 }

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -283,7 +283,7 @@ pub use apply::group_is_settable;
 #[cfg(unix)]
 pub use apply::{
     apply_dest_mode_pre_transfer, apply_file_metadata_with_fd,
-    apply_file_metadata_with_fd_if_changed, transfer_root_chmod_self_lock,
+    apply_file_metadata_with_fd_if_changed, init_orig_umask, transfer_root_chmod_self_lock,
 };
 pub use apply::{
     apply_directory_metadata, apply_directory_metadata_with_options, apply_file_metadata,

--- a/crates/transfer/tests/daemon_dest_mode_parity.rs
+++ b/crates/transfer/tests/daemon_dest_mode_parity.rs
@@ -193,22 +193,16 @@ fn existing_destination_keeps_its_mode_on_every_write_path() {
 /// cannot silently regress the other - the two share a single code path and a
 /// single upstream rule.
 ///
-/// IGNORED - this cell currently FAILS, and the failure is real. It is a
-/// SEPARATE defect from the one this PR fixes, so it is registered here rather
-/// than deleted: the assertion is correct and upstream-derived, and un-ignoring
-/// it is the acceptance gate for that fix.
-///
-/// Measured: built `--all-features` across the WORKSPACE (what CI does), a new
-/// destination lands mode 000 on every write path, because `entry.permissions()`
-/// reaches the commit as 0 - a source chmod'd 0777 still lands 000, so the
-/// formula is fine and the entry mode is not. A default-feature build of the
-/// same source gives the correct 0600, and upstream 3.4.4 gives 0600 in both.
-/// Ruled out: incremental-flist (`--no-inc-recursive` still yields 000),
-/// `default_perms_for_dir` (faithful to acls.c:1084-1139), and `cached_umask`.
-/// The remaining work is to find which workspace feature drops the mode from the
-/// receiver's flist entry.
+/// This cell regressed under a workspace `--all-features` build, which is the
+/// only configuration that enables `daemon-seccomp`. `umask(2)` is absent from
+/// the worker allowlist, and a non-allowlisted syscall is answered with EPERM,
+/// so the receiver's first (lazy) umask read returned -1. Cached as `u32::MAX`,
+/// that made `dflt_perms` = `0o777 & !u32::MAX` = 0, collapsing this branch's
+/// `flist_mode & (~CHMOD_BITS | dflt_perms)` to mode 000 on every write path.
+/// The existing-destination cell was unaffected because its branch never reads
+/// `dflt_perms`. Fixed by capturing the umask at startup as upstream does
+/// (`main.c:1797`), before any sandbox is installed.
 #[test]
-#[ignore = "separate unfixed defect: entry.permissions() is 0 under a workspace --all-features build; see the doc comment"]
 fn new_destination_takes_the_masked_source_mode_on_every_write_path() {
     let expected = masked_source_mode();
     for extra in [&[][..], &["--inplace"][..], &["--append-verify"][..]] {


### PR DESCRIPTION
## Symptom

A brand-new destination landed **mode 000** on every write path (plain temp+rename included) when a daemon received it — but only in a build with `daemon-seccomp` enabled. An existing destination was unaffected.

## Root cause

Every link measured on Linux:

| # | Link | Evidence |
|---|------|----------|
| 1 | `daemon-seccomp` is **not** a default feature (`crates/daemon/Cargo.toml`, `default = []`) | only `--all-features` enables it — why this reproduced under the workspace test build and never under `cargo build --bin` |
| 2 | `worker_seccomp_allowlist()` has **no `SYS_umask`** | `grep -c SYS_umask` = 0 |
| 3 | Non-allowlisted syscalls are failed, not fatal: `SeccompAction::Errno(libc::EPERM)` | so `libc::umask(0)` returns `-1` |
| 4 | `cached_umask()` read lazily *inside* the sandboxed worker and cached `-1 as u32` | observed `cached_umask=37777777777` = `u32::MAX` |
| 5 | `dflt_perms = 0o777 & !u32::MAX` | **0** |
| 6 | `dest_mode()` new-file branch `flist_mode & (~CHMOD_BITS \| dflt_perms)` | `0o600 & (!0o7777 \| 0)` = **0** → chmod 000 |

The existing-destination branch is `(flist_mode & ~CHMOD_BITS) | (stat_mode & CHMOD_BITS)` and never reads `dflt_perms`, which is exactly why only new files broke.

## The divergence is *when* the umask is read

Both of oc's `dest_mode()` formulas were already faithful — only the input was poisoned. Upstream resolves the umask once in `main()`:

```c
umask(orig_umask = umask(0));      /* main.c:1797 */
```

before any privilege drop or sandbox setup. oc resolved it on first use, which in the daemon is *after* the seccomp filter is installed.

## Fix

Mirror upstream: prime the value at CLI entry, before any mode dispatch, so the sandbox can never observe an unresolved cache. This keeps the seccomp allowlist minimal instead of widening it, and removes the ordering hazard that a future sandbox tightening would otherwise re-trigger.

`sanitize_umask()` additionally rejects a value that cannot be a umask (more than 9 significant bits), so a failed query can never again be cached as a sentinel that silently zeroes `dflt_perms`. **That is defence in depth only** — see the load-bearing check below.

## Verification

- **Red check** — reverting only the production change reproduces `left: 0, right: 384`.
- **Load-bearing check** — the two mechanisms are indistinguishable under umask 022, so they were separated: with **`umask 077` and an 0644 source the destination lands 0600**, i.e. the *real* umask is honoured. The sanitiser's `0o022` fallback would have produced 0644. So the eager capture, not the fallback, is what fixes the daemon.
- `cargo nextest run --workspace --all-features` — **32385 passed, 0 failed**.
- `cargo fmt --all -- --check` clean; `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- `sanitize_umask` gets its own deterministic unit tests: every one of the 512 real umasks passes through unchanged, and `u32::MAX` is rejected with an explicit assertion that the result cannot yield `dflt_perms == 0`.

Un-ignores `new_destination_takes_the_masked_source_mode_on_every_write_path`, which #7258 landed `#[ignore]`d as the acceptance gate for precisely this fix.

## Class

A lazily-initialised process global whose initialising syscall a sandbox can silently fail, with the failure sentinel then cached forever. Other `OnceLock` + syscall pairs are worth an audit for the same shape — noted for follow-up, not swept here.

## Side finding — RETRACTED

An earlier draft of this body claimed `--debug=all` emits nothing for the permission path and called it a coverage gap. **That was wrong.** Upstream emits no debug line for the chmod/`dest_mode` decision either — its only relevant emits are `rsync.c:537-545` (`set uid of` / `set gid of`, `DEBUG_GTE(OWN,1)`) and `acls.c:1133` (`DEBUG_GTE(ACL,1)`), and oc already mirrors both (`crates/protocol/src/idlist/trace.rs:114,124` and `trace_default_perms_for_dir`). The zero output in my repro was correct behaviour: no ownership change and no default ACL, so neither emit fires. No gap, nothing to close.
