### PR TITLE
fix(engine): make --write-devices imply --inplace on every path

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -858,11 +858,16 @@ where
 
     let prune_empty_dirs_flag = prune_empty_dirs.unwrap_or(false);
     let fsync_flag = fsync_option.unwrap_or(false);
-    // upstream: options.c:2413-2419 - `--write-devices` forces the global
-    // inplace flag on, so device targets are written in place rather than via a
-    // temp file.
-    let inplace_enabled = inplace.unwrap_or(false) || write_devices.unwrap_or(false);
     let append_enabled = append.unwrap_or(false);
+    // upstream: options.c:2400-2419 - `--append` and `--write-devices` each
+    // force the global inplace flag on. Both live in
+    // `engine::write_strategy::implies_inplace`, the single owner of the rule,
+    // so this front end and the `ServerConfig` promotion cannot drift apart.
+    let inplace_enabled = engine::write_strategy::implies_inplace(
+        inplace.unwrap_or(false),
+        append_enabled,
+        write_devices.unwrap_or(false),
+    );
     let whole_file_enabled = whole_file_option;
 
     let checksum_for_config = checksum.unwrap_or(false);

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -137,6 +137,7 @@ pub mod operand;
 pub mod throughput;
 pub mod util;
 pub mod walk;
+pub mod write_strategy;
 
 #[doc(hidden)]
 pub mod batch {

--- a/crates/engine/src/write_strategy.rs
+++ b/crates/engine/src/write_strategy.rs
@@ -1,0 +1,79 @@
+//! Which resolved options force the inplace write strategy.
+//!
+//! This crate owns the temp-file-write-plus-atomic-rename strategy that
+//! `--inplace` bypasses, so the rule deciding when that bypass is mandatory
+//! lives here rather than being re-derived by each front end.
+//!
+//! Upstream resolves it once in `parse_arguments()` and every peer runs that
+//! same function, so client and server always agree. oc reaches the strategy
+//! from two independent places - the local-copy/client config built in `cli`
+//! and the `ServerConfig` built in `transfer` - which is how `--write-devices`
+//! came to be honoured on one and not the other. Both now call
+//! [`implies_inplace`], so a future option cannot be added to one and forgotten
+//! in the other.
+
+/// Whether the resolved options force `inplace` on.
+///
+/// Upstream evaluates two adjacent blocks, each setting the same global; this
+/// is that pair as a single expression.
+///
+/// # Upstream Reference
+///
+/// - `options.c:2400-2411` - `if (append_mode) { ...; inplace = 1; }`.
+/// - `options.c:2413-2419` - `if (write_devices) { ...; inplace = 1; }`.
+#[must_use]
+pub const fn implies_inplace(inplace: bool, append: bool, write_devices: bool) -> bool {
+    inplace || append || write_devices
+}
+
+#[cfg(test)]
+mod tests {
+    use super::implies_inplace;
+
+    /// The full truth table, so the rule is pinned rather than inferred from
+    /// whichever call site a reader happens to open first.
+    #[test]
+    fn every_input_combination_matches_upstream() {
+        for (inplace, append, write_devices, expected) in [
+            (false, false, false, false),
+            (false, false, true, true),
+            (false, true, false, true),
+            (false, true, true, true),
+            (true, false, false, true),
+            (true, false, true, true),
+            (true, true, false, true),
+            (true, true, true, true),
+        ] {
+            assert_eq!(
+                implies_inplace(inplace, append, write_devices),
+                expected,
+                "inplace={inplace} append={append} write_devices={write_devices}",
+            );
+        }
+    }
+
+    /// `--write-devices` alone must promote. This is the case that regressed:
+    /// the server-side promotion covered only `--append`, so a server given
+    /// `--write-devices` kept temp+rename where upstream writes in place.
+    ///
+    /// upstream: `options.c:2413-2419`.
+    #[test]
+    fn write_devices_alone_promotes() {
+        assert!(implies_inplace(false, false, true));
+    }
+
+    /// `--append` alone must promote, the sibling rule that was already
+    /// handled - pinned here so collapsing the two did not drop it.
+    ///
+    /// upstream: `options.c:2400-2411`.
+    #[test]
+    fn append_alone_promotes() {
+        assert!(implies_inplace(false, true, false));
+    }
+
+    /// No option set means no promotion: the default stays temp+rename.
+    #[test]
+    fn nothing_set_leaves_temp_plus_rename() {
+        assert!(!implies_inplace(false, false, false));
+    }
+}

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -738,6 +738,10 @@ impl ServerConfig {
     /// # Upstream Reference
     ///
     /// - `options.c:2400-2411` - `if (append_mode) { ...; inplace = 1; }`.
+    /// - `options.c:2413-2419` - `if (write_devices) { ...; inplace = 1; }`, the
+    ///   adjacent block carrying the same implication for `--write-devices`.
+    ///   Both are evaluated here through [`implies_inplace`] so the two options
+    ///   cannot drift apart the way they did when only `--append` was handled.
     /// - `receiver.c:968` - `if (inplace || one_inplace)` selects the live
     ///   destination as the write target instead of a temp file.
     /// - `receiver.c:496` - `inplace_sizing` truncates the destination to the
@@ -748,11 +752,15 @@ impl ServerConfig {
     /// - `sender.c:337` - `updating_basis_file` gates `match.c:211`.
     /// - `compat.c:688` - protocol < 29 refuses a basis dir with `inplace`.
     pub(crate) fn apply_append_implies_inplace(&mut self) {
-        if self.flags.append {
-            self.write.inplace = true;
-        }
+        self.write.inplace = engine::write_strategy::implies_inplace(
+            self.write.inplace,
+            self.flags.append,
+            self.write.write_devices,
+        );
     }
+}
 
+impl ServerConfig {
     /// Promotes plain `--append` to `--append-verify` semantics for legacy
     /// (protocol < 30) peers.
     ///


### PR DESCRIPTION
## Upstream

`parse_arguments()` resolves the inplace write strategy in two adjacent blocks:

```c
if (append_mode)   { if (refused_inplace) {...} inplace = 1; }   /* options.c:2400-2411 */
if (write_devices) { if (refused_inplace) {...} inplace = 1; }   /* options.c:2413-2419 */
```

Every peer runs that same function, so client and server always agree on the result.

## The defect

oc reaches the strategy from two independent places, and each learned only half the rule:

| Path | `--append` | `--write-devices` |
|------|-----------|-------------------|
| client config (`cli/.../workflow/run.rs`) | via `ServerConfig` | **applied inline** |
| `ServerConfig::apply_append_implies_inplace` (`transfer`) | **applied** | **missing** |

So a server invoked with `--write-devices` kept `inplace = false` and wrote regular files through temp+rename, where upstream writes in place. Confirmed by grep: nothing in `transfer` or `core` promotes `inplace` from `write_devices` — the only other references are doc comments and the separate `write_devices && IS_DEVICE(st.st_mode)` device-target branch, which is a *different* upstream rule (`receiver.c`).

This is the recurrence class, not a one-off: the `--append` half was fixed previously, and the sibling option was left behind precisely because the rule had two homes.

## Fix

Give the rule one owner. `engine` already documents itself as owning the strategy the rule selects — *"Temp-file write + atomic rename (`--inplace` bypasses the rename)"* (`engine/src/lib.rs:33`) — so `engine::write_strategy::implies_inplace(inplace, append, write_devices)` holds it and both front ends call it. `cli` and `transfer` already depend on `engine`, so **no new dependency edge** is introduced.

The client expression is *routed through* the shared rule rather than deleted. That distinction matters: a purely local copy never reaches `run_server_with_handshake_adopting`, so deleting the client site would have silently dropped the promotion for local `--write-devices`. Verified before changing it.

## Verification

- **Red check** — dropping `write_devices` from the rule fails exactly the two tests that pin it: `every_input_combination_matches_upstream` and `write_devices_alone_promotes`. Restored and re-run green.
- The new module carries the **full 8-row truth table** plus named cases for each option alone and for neither, so the rule is pinned rather than inferred from whichever call site a reader opens first.
- `cargo nextest run --workspace --all-features` — **32389 passed, 0 failed**.
- `cargo fmt --all -- --check` clean; `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean.

## ⚠ Out of scope, flagged not absorbed

Upstream's blocks also raise `create_refuse_error(refused_inplace)` when a daemon refuses `--inplace`. **oc models no `refused_inplace` state at all** — the daemon `refuse options` directive is unimplemented. That is materially larger than this fix and belongs in its own change; it is not silently folded in here.

## Note on the originating task

The task that prompted this recorded `--write-devices` as missing the implication outright. That premise was **half wrong** — the client already had it. Measuring first is what located the real defect (server-side only) and the real cause (one rule, two homes).
