### PR TITLE
fix(receiver): keep --partial from committing a matched-only temp

### DIFF
--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -293,6 +293,16 @@ pub(in crate::disk_commit) fn process_file(
     sum_append_prefix(config, &begin, &mut checksum_verifier)?;
 
     let mut bytes_written: u64 = 0;
+    // Literal bytes only - matched basis copies are excluded. This is upstream's
+    // `cleanup_got_literal`, which decides whether an interrupted temp is worth
+    // keeping. `bytes_written` cannot serve: it also counts basis copies, so a
+    // delta transfer with zero literal data would look like progress and get
+    // renamed over a complete destination.
+    //
+    // upstream: `receiver.c:392-403` sets the latch only in the literal branch;
+    // `cleanup.c:159` gates retention on it and `cleanup.c:199-200` unlinks the
+    // temp otherwise.
+    let mut literal_bytes: u64 = 0;
     // Tracks whether the temp's cleanup entry has been upgraded to name a
     // partial destination (see the `cleanup_got_literal` gate at the loop tail).
     let mut partial_registered = false;
@@ -310,7 +320,7 @@ pub(in crate::disk_commit) fn process_file(
                 // rename+mtime stamp (Windows resets mtime on handle close).
                 let _ = output.finish(false, &begin.file_path);
                 // upstream: cleanup.c - retain partial on unexpected disconnect
-                if bytes_written > 0 && needs_rename {
+                if literal_bytes > 0 && needs_rename {
                     // Interrupt path (cleanup.c:174-180): zero the mtime so an
                     // aborted partial stands out and --update will not skip it.
                     retain_partial_file(config, &mut cleanup_guard, &begin.file_path, true);
@@ -323,8 +333,16 @@ pub(in crate::disk_commit) fn process_file(
             }
         };
 
+        // Read the literal length before the match moves the payload. Matched
+        // basis copies contribute 0, which is what keeps them out of the
+        // retention gate below.
+        let literal_len = match &msg {
+            FileMessage::Chunk(data) => data.len() as u64,
+            _ => 0,
+        };
+
         match msg {
-            FileMessage::Chunk(data) => {
+            FileMessage::Chunk(data) | FileMessage::MatchedChunk(data) => {
                 // Update per-file checksum before writing (mirrors upstream
                 // receiver.c:315 which hashes each token before writing).
                 if let Some(ref mut verifier) = checksum_verifier {
@@ -337,6 +355,7 @@ pub(in crate::disk_commit) fn process_file(
                     output.write_chunk(&data)?;
                 }
                 bytes_written += data.len() as u64;
+                literal_bytes += literal_len;
                 // Return the buffer for reuse. Ignore errors - the network
                 // thread may have moved on (e.g. after an error).
                 let _ = buf_return_tx.try_send(data);
@@ -486,12 +505,13 @@ pub(in crate::disk_commit) fn process_file(
                 // finish() takes `self`, closing the file handle before
                 // rename+mtime stamp (Windows resets mtime on handle close).
                 let _ = output.finish(false, &begin.file_path);
-                // upstream: cleanup.c:105-115 - on abort, retain temp file
-                // if partial mode is enabled and literal data was received.
-                // bytes_written > 0 is a proxy for upstream's got_literal:
-                // if any data was written, the transfer made progress worth
-                // retaining for later resume.
-                if bytes_written > 0 && needs_rename {
+                // upstream: cleanup.c:159 - on abort, retain the temp only if
+                // LITERAL data was received. Matched basis copies do not count:
+                // upstream sets `cleanup_got_literal` solely in the literal
+                // branch (receiver.c:392-403), so a temp built entirely from
+                // basis blocks is unlinked (cleanup.c:199-200) rather than
+                // renamed over an intact destination.
+                if literal_bytes > 0 && needs_rename {
                     // Interrupt path (cleanup.c:174-180): zero the mtime so an
                     // aborted partial stands out and --update will not skip it.
                     retain_partial_file(config, &mut cleanup_guard, &begin.file_path, true);
@@ -507,7 +527,7 @@ pub(in crate::disk_commit) fn process_file(
                 // rename+mtime stamp (Windows resets mtime on handle close).
                 let _ = output.finish(false, &begin.file_path);
                 // upstream: cleanup.c - same partial retention on shutdown
-                if bytes_written > 0 && needs_rename {
+                if literal_bytes > 0 && needs_rename {
                     // Interrupt path (cleanup.c:174-180): zero the mtime so an
                     // aborted partial stands out and --update will not skip it.
                     retain_partial_file(config, &mut cleanup_guard, &begin.file_path, true);
@@ -533,7 +553,7 @@ pub(in crate::disk_commit) fn process_file(
         // gate the Abort/Shutdown/disconnect branches above apply; recorded in
         // the registry here so the process-wide abort path reaches the same
         // decision without the disk thread unwinding.
-        if needs_rename && !partial_registered && bytes_written > 0 {
+        if needs_rename && !partial_registered && literal_bytes > 0 {
             register_temp_with_cleanup(config, &mut cleanup_guard, &begin.file_path, true);
             partial_registered = true;
         }
@@ -739,7 +759,11 @@ fn discard_file_on_open_failure(
 ) -> io::Result<CommitResult> {
     loop {
         match file_rx.recv() {
-            Ok(FileMessage::Chunk(data) | FileMessage::SkipMatched(data)) => {
+            Ok(
+                FileMessage::Chunk(data)
+                | FileMessage::MatchedChunk(data)
+                | FileMessage::SkipMatched(data),
+            ) => {
                 // Recycle the buffer for the network thread; drop the bytes.
                 let _ = buf_return_tx.try_send(data);
             }

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -372,6 +372,159 @@ fn write_and_commit_file() {
     h.join_handle.join().unwrap();
 }
 
+/// Sends matched basis blocks only, then aborts via `abort`, and asserts the
+/// pre-existing destination survives untouched.
+///
+/// Shared by the abort paths because they all consult the same retention gate:
+/// fixing one and leaving the siblings is exactly how this class of bug
+/// survives a single-path regression test.
+fn matched_only_abort_must_not_clobber_dest(
+    name: &str,
+    abort: impl FnOnce(&crate::disk_commit::DiskThreadHandle),
+) {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join(name);
+
+    // A complete, correct destination. The transfer below is a delta whose
+    // tokens are ALL basis matches - no literal data is received.
+    const ORIGINAL: &[u8] = b"COMPLETE-AND-CORRECT-DESTINATION";
+    fs::write(&file_path, ORIGINAL).unwrap();
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: ORIGINAL.len() as u64,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            // temp+rename, NOT in-place: the path where matched blocks are
+            // still written, and the one that renames over the destination.
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+            xattr_basis: None,
+            file_entry: None,
+        })))
+        .unwrap();
+
+    // Basis copies only. Enough bytes that any byte-count-based gate would fire.
+    h.file_tx
+        .send(FileMessage::MatchedChunk(b"COMPLETE-AND-".to_vec()))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::MatchedChunk(b"CORRECT-".to_vec()))
+        .unwrap();
+
+    abort(&h);
+
+    assert_eq!(
+        fs::read(&file_path).unwrap(),
+        ORIGINAL,
+        "a matched-block-only transfer received NO literal data, so upstream \
+         unlinks the temp (cleanup.c:159, :199-200) and leaves the destination \
+         intact; renaming a truncated basis copy over it destroys a good file",
+    );
+}
+
+/// Interrupting a `--partial` delta transfer whose tokens are all basis matches
+/// must leave the destination untouched.
+///
+/// WHY: upstream arms partial retention from `cleanup_got_literal`, set ONLY in
+/// the literal branch (`receiver.c:392-403`); the matched branch at
+/// `receiver.c:413+` deliberately never sets it. `cleanup.c:159` keeps the temp
+/// only when that latch is set and `cleanup.c:199-200` unlinks it otherwise, so
+/// "no literal data received" means the destination is never disturbed.
+///
+/// oc stood that latch in with a plain written-byte counter. Because a
+/// temp+rename delta writes matched basis blocks through the same channel as
+/// literal data, the counter went non-zero with zero literal bytes, and an
+/// interrupted transfer renamed a partial basis copy over a complete file - a
+/// silent data-loss bug on the most common delta shape there is (a large,
+/// mostly-unchanged file).
+#[test]
+fn partial_matched_only_abort_preserves_destination() {
+    matched_only_abort_must_not_clobber_dest("matched_abort.dat", |h| {
+        h.file_tx
+            .send(FileMessage::Abort {
+                reason: "interrupted".into(),
+            })
+            .unwrap();
+        assert!(h.result_rx.recv().unwrap().is_err());
+    });
+}
+
+/// Shutdown-path sibling of [`partial_matched_only_abort_preserves_destination`].
+#[test]
+fn partial_matched_only_shutdown_preserves_destination() {
+    matched_only_abort_must_not_clobber_dest("matched_shutdown.dat", |h| {
+        h.file_tx.send(FileMessage::Shutdown).unwrap();
+        // The disk thread finalises the in-flight file before exiting.
+        let _ = h.result_rx.recv();
+    });
+}
+
+/// Literal data MUST still be retained. The fix narrows the retention gate;
+/// this pins that it was not narrowed to nothing - deleting the retention logic
+/// outright would otherwise pass both tests above.
+#[test]
+fn partial_literal_data_is_still_retained_on_abort() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("literal_retained.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 64,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+            xattr_basis: None,
+            file_entry: None,
+        })))
+        .unwrap();
+
+    // A matched block FOLLOWED by literal data: the literal bytes arm the gate
+    // even though the matched block alone must not.
+    h.file_tx
+        .send(FileMessage::MatchedChunk(b"basis-".to_vec()))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Chunk(b"literal".to_vec()))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Abort {
+            reason: "interrupted".into(),
+        })
+        .unwrap();
+    assert!(h.result_rx.recv().unwrap().is_err());
+
+    assert!(
+        file_path.exists(),
+        "literal data was received, so upstream keeps the partial (cleanup.c:159)",
+    );
+    assert_eq!(fs::read(&file_path).unwrap(), b"basis-literal");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
 /// A `SkipMatched` message in an in-place update must SEEK past the matched
 /// bytes, not rewrite them. This is upstream's `skip_matched()` optimization
 /// (receiver.c:468-474 -> fileio.c:202-209): a block that already sits at its

--- a/crates/transfer/src/disk_commit/thread.rs
+++ b/crates/transfer/src/disk_commit/thread.rs
@@ -262,6 +262,7 @@ fn disk_thread_main(
                 }
             }
             FileMessage::Chunk(_)
+            | FileMessage::MatchedChunk(_)
             | FileMessage::SkipMatched(_)
             | FileMessage::Commit { .. }
             | FileMessage::Abort { .. } => {

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -42,6 +42,24 @@ pub enum FileMessage {
     /// - `fileio.c:192-211` - `skip_matched()` flushes then `lseek`s past the
     ///   in-place bytes (or feeds the sparse processor with the seek flag).
     SkipMatched(Vec<u8>),
+    /// Matched basis bytes that must be written, but that are not literal data
+    /// received from the sender.
+    ///
+    /// Written exactly like [`FileMessage::Chunk`]; the variants differ only in
+    /// what they mean for `--partial` retention. Upstream sets the
+    /// `cleanup_got_literal` latch only in the literal branch, so a temp file
+    /// containing nothing but basis copies is unlinked on abort rather than
+    /// renamed over a complete destination. Routing matched blocks through
+    /// `Chunk` made a byte counter that was standing in for that latch non-zero
+    /// with zero literal data received.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:392-403` - `if (i > 0) { ...; cleanup_got_literal = 1; }`;
+    ///   the matched branch at `receiver.c:413+` deliberately does not.
+    /// - `cleanup.c:159` - retention is gated on `cleanup_got_literal`;
+    ///   `cleanup.c:199-200` unlinks the temp otherwise.
+    MatchedChunk(Vec<u8>),
     /// Finalize the current file: compute the whole-file checksum, verify it
     /// against the sender's trailing sum, and only then flush, fsync, and
     /// rename into place.

--- a/crates/transfer/src/transfer_ops/token_loop.rs
+++ b/crates/transfer/src/transfer_ops/token_loop.rs
@@ -203,10 +203,17 @@ pub(super) fn process_remaining_tokens<R: Read>(
                     // bytes are still hashed on the disk thread (upstream's
                     // sum_update runs regardless), so the file checksum and
                     // final size stay byte-identical to a full rewrite.
+                    // Matched bytes are never `Chunk`: `Chunk` means literal
+                    // data received from the sender, and the disk thread arms
+                    // `--partial` retention off that. upstream sets
+                    // `cleanup_got_literal` only in the literal branch
+                    // (receiver.c:392-403), so a temp holding nothing but basis
+                    // copies is unlinked on abort (cleanup.c:159, :199-200)
+                    // rather than renamed over a complete destination.
                     let msg = if updating_basis && offset == total_bytes {
                         FileMessage::SkipMatched(buf)
                     } else {
-                        FileMessage::Chunk(buf)
+                        FileMessage::MatchedChunk(buf)
                     };
                     file_tx.send(msg).map_err(|_| {
                         io::Error::new(


### PR DESCRIPTION
## The defect

An interrupted `--partial` delta could rename a truncated temp file over a
complete destination, destroying data that was already correct on disk.

## Upstream rule

Upstream sets `cleanup_got_literal` only in the literal branch of `recv_files`
(`receiver.c:392-403`); the matched branch deliberately does not. Retention is
then gated on that latch (`cleanup.c:159`), and the temp is unlinked when it is
unset (`cleanup.c:199-200`). Upstream keeps a partial file only when genuine
literal data arrived from the sender.

## What oc did

oc stood that latch in with `bytes_written`, which also counts blocks copied
from the local basis. A transfer that matched some blocks and received no
literal data therefore looked retainable, and the temp - holding only a prefix
of the basis - replaced the intact destination.

## The change

Split the copy path so the two kinds of bytes are distinguishable:

- matched basis copies travel as `FileMessage::MatchedChunk`
- literal payload stays `FileMessage::Chunk`
- all four retention gates key on a `literal_bytes` counter

Behaviour is unchanged whenever any literal data arrived, so this only affects
the matched-only case that upstream already declines to retain.

## Tests

Three cases in `disk_commit/tests.rs`, sharing one helper:

- `partial_matched_only_abort_preserves_destination`
- `partial_matched_only_shutdown_preserves_destination`
- `partial_literal_data_is_still_retained_on_abort` - the counterweight, so the
  fix cannot silently become "never retain anything"

## Verification

Rebased onto `0ed2894a` and verified there, not on the branch point:

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` | pass |
| `cargo nextest run --workspace --all-features` | 32388 run / 32388 passed / 152 skipped |

Note for reviewers: `-p transfer --all-features` reports an unrelated failure in
`daemon_dest_mode_parity` that also reproduces on unmodified master. Feature
unification differs between `-p <crate>` and the workspace build; the workspace
invocation above is the one CI runs.
