### PR TITLE
fix(daemon): close three refuse-options bypasses and match rules case-sensitively

### DIFF
--- a/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
@@ -97,116 +97,111 @@ fn refused_option<'a>(module: &ModuleDefinition, options: &'a [String]) -> Optio
 ///
 /// upstream: options.c long_options[] - the canonical short/long pairing the
 /// daemon's popt-based refuse check uses to compare against `refuse options`.
-fn short_option_long_name(letter: char) -> &'static str {
-    match letter {
-        'v' => "verbose",
-        'q' => "quiet",
-        'h' => "human-readable",
-        'n' => "dry-run",
-        'a' => "archive",
-        'r' => "recursive",
-        'd' => "dirs",
-        'p' => "perms",
-        'E' => "executability",
-        'A' => "acls",
-        'X' => "xattrs",
-        't' => "times",
-        'U' => "atimes",
-        'N' => "crtimes",
-        'O' => "omit-dir-times",
-        'J' => "omit-link-times",
-        'o' => "owner",
-        'g' => "group",
-        'D' => "devices",
-        'l' => "links",
-        'L' => "copy-links",
-        'k' => "copy-dirlinks",
-        'K' => "keep-dirlinks",
-        'H' => "hard-links",
-        'R' => "relative",
-        'I' => "ignore-times",
-        'x' => "one-file-system",
-        'u' => "update",
-        'S' => "sparse",
-        'F' => "filter",
-        'C' => "cvs-exclude",
-        'W' => "whole-file",
-        'c' => "checksum",
-        'y' => "fuzzy",
-        'z' => "compress",
-        'P' => "partial",
-        'm' => "prune-empty-dirs",
-        'i' => "itemize-changes",
-        'b' => "backup",
-        's' => "secluded-args",
-        'V' => "version",
-        'B' => "block-size",
-        'T' => "temp-dir",
-        'M' => "remote-option",
-        'f' => "filter",
-        'e' => "e",
-        _ => "",
-    }
+/// One row of upstream's `long_options[]` as the refuse matcher needs it.
+///
+/// `long_options[]` is a single table that popt reads in both directions; oc
+/// previously transcribed it into two independent `match` blocks that had
+/// already drifted apart (46 arms one way, 41 the other). This is that one
+/// table, so the two lookups below cannot disagree again.
+///
+/// upstream: `options.c:600-857` - the `shortName` and `longName` columns.
+struct ShortOption {
+    letter: char,
+    /// `None` for rows whose `longName` is NULL, matched by letter only.
+    long_name: Option<&'static str>,
+}
+
+/// Upstream's complete short-option column: all 51 letters.
+///
+/// Verified letter-for-letter against `options.c:600-856` (`long_options[]`,
+/// terminator at :855): oc lacks none of upstream's letters and invents none.
+/// `long_daemon_options[]` at :858 is deliberately out of scope - upstream's
+/// own refuse scan walks only `long_options` (`options.c:921`).
+///
+/// THREE rows deliberately keep an oc-specific `long_name` where upstream has
+/// NULL - `D` (options.c:670), `F` (:737) and `P` (:771). Each over-refuses
+/// relative to upstream, which fails CLOSED, so they are an operator-visible
+/// policy decision rather than a bug fix; see the per-row comments below.
+const SHORT_OPTIONS: &[ShortOption] = &[
+    ShortOption { letter: '@', long_name: Some("modify-window") },
+    ShortOption { letter: '0', long_name: Some("from0") },
+    ShortOption { letter: '4', long_name: Some("ipv4") },
+    ShortOption { letter: '6', long_name: Some("ipv6") },
+    ShortOption { letter: '8', long_name: Some("8-bit-output") },
+    ShortOption { letter: 'a', long_name: Some("archive") },
+    ShortOption { letter: 'A', long_name: Some("acls") },
+    ShortOption { letter: 'b', long_name: Some("backup") },
+    ShortOption { letter: 'B', long_name: Some("block-size") },
+    ShortOption { letter: 'c', long_name: Some("checksum") },
+    ShortOption { letter: 'C', long_name: Some("cvs-exclude") },
+    ShortOption { letter: 'd', long_name: Some("dirs") },
+    // upstream longName is NULL: `-D` is its own row meaning
+    // `--devices --specials`. oc keeps the `devices` association, which
+    // over-refuses (a `refuse options = devices` rule also blocks `-D`).
+    // That fails CLOSED, so it is left alone here.
+    ShortOption { letter: 'D', long_name: Some("devices") },
+    ShortOption { letter: 'e', long_name: Some("rsh") },
+    ShortOption { letter: 'E', long_name: Some("executability") },
+    ShortOption { letter: 'f', long_name: Some("filter") },
+    // upstream longName is NULL: `-F` is the repeated-filter shortcut. Same
+    // fails-closed reasoning as `-D`.
+    ShortOption { letter: 'F', long_name: Some("filter") },
+    ShortOption { letter: 'g', long_name: Some("group") },
+    ShortOption { letter: 'h', long_name: Some("human-readable") },
+    ShortOption { letter: 'H', long_name: Some("hard-links") },
+    ShortOption { letter: 'i', long_name: Some("itemize-changes") },
+    ShortOption { letter: 'I', long_name: Some("ignore-times") },
+    ShortOption { letter: 'J', long_name: Some("omit-link-times") },
+    ShortOption { letter: 'k', long_name: Some("copy-dirlinks") },
+    ShortOption { letter: 'K', long_name: Some("keep-dirlinks") },
+    ShortOption { letter: 'l', long_name: Some("links") },
+    ShortOption { letter: 'L', long_name: Some("copy-links") },
+    ShortOption { letter: 'm', long_name: Some("prune-empty-dirs") },
+    ShortOption { letter: 'M', long_name: Some("remote-option") },
+    ShortOption { letter: 'n', long_name: Some("dry-run") },
+    ShortOption { letter: 'N', long_name: Some("crtimes") },
+    ShortOption { letter: 'o', long_name: Some("owner") },
+    ShortOption { letter: 'O', long_name: Some("omit-dir-times") },
+    ShortOption { letter: 'p', long_name: Some("perms") },
+    // upstream longName is NULL: `-P` means `--partial --progress`.
+    ShortOption { letter: 'P', long_name: Some("partial") },
+    ShortOption { letter: 'q', long_name: Some("quiet") },
+    ShortOption { letter: 'r', long_name: Some("recursive") },
+    ShortOption { letter: 'R', long_name: Some("relative") },
+    ShortOption { letter: 's', long_name: Some("secluded-args") },
+    ShortOption { letter: 'S', long_name: Some("sparse") },
+    ShortOption { letter: 't', long_name: Some("times") },
+    ShortOption { letter: 'T', long_name: Some("temp-dir") },
+    ShortOption { letter: 'u', long_name: Some("update") },
+    ShortOption { letter: 'U', long_name: Some("atimes") },
+    ShortOption { letter: 'v', long_name: Some("verbose") },
+    ShortOption { letter: 'V', long_name: Some("version") },
+    ShortOption { letter: 'W', long_name: Some("whole-file") },
+    ShortOption { letter: 'x', long_name: Some("one-file-system") },
+    ShortOption { letter: 'X', long_name: Some("xattrs") },
+    ShortOption { letter: 'y', long_name: Some("fuzzy") },
+    ShortOption { letter: 'z', long_name: Some("compress") },
+];
+
+/// Looks up one short option, or `None` when the byte is not an option letter.
+fn lookup_short(letter: char) -> Option<&'static ShortOption> {
+    SHORT_OPTIONS.iter().find(|opt| opt.letter == letter)
 }
 
 /// Maps a canonical long-option name to its single-letter short form, when one
 /// exists in upstream's `long_options[]` table.
 ///
-/// Inverse of `short_option_long_name` for the subset of options that have a
-/// short-letter alias. Used by the refuse-list matcher so rules can reference
-/// either the long or short form (`!verbose` and `!v` are equivalent).
+/// Inverse of [`lookup_short`], derived from the same table. Used by
+/// the refuse-list matcher so rules can reference either form (`refuse options
+/// = verbose` and `= v` are equivalent).
 ///
-/// upstream: options.c:604-... - the `shortName` column on each `long_options[]`
-/// entry; upstream's `parse_one_refuse_match` calls `wildmatch(ref, shortName)`
-/// as a fallback when the long-name comparison fails.
+/// upstream: `options.c:907` `parse_one_refuse_match()` - compares the rule
+/// against BOTH the `longName` and the `shortName` of every entry.
 fn long_option_short_letter(long_name: &str) -> Option<char> {
-    match long_name {
-        "verbose" => Some('v'),
-        "quiet" => Some('q'),
-        "human-readable" => Some('h'),
-        "dry-run" => Some('n'),
-        "archive" => Some('a'),
-        "recursive" => Some('r'),
-        "dirs" => Some('d'),
-        "perms" => Some('p'),
-        "executability" => Some('E'),
-        "acls" => Some('A'),
-        "xattrs" => Some('X'),
-        "times" => Some('t'),
-        "atimes" => Some('U'),
-        "crtimes" => Some('N'),
-        "omit-dir-times" => Some('O'),
-        "omit-link-times" => Some('J'),
-        "owner" => Some('o'),
-        "group" => Some('g'),
-        "devices" => Some('D'),
-        "links" => Some('l'),
-        "copy-links" => Some('L'),
-        "copy-dirlinks" => Some('k'),
-        "keep-dirlinks" => Some('K'),
-        "hard-links" => Some('H'),
-        "relative" => Some('R'),
-        "ignore-times" => Some('I'),
-        "one-file-system" => Some('x'),
-        "update" => Some('u'),
-        "sparse" => Some('S'),
-        "cvs-exclude" => Some('C'),
-        "whole-file" => Some('W'),
-        "checksum" => Some('c'),
-        "fuzzy" => Some('y'),
-        "compress" => Some('z'),
-        "partial" => Some('P'),
-        "prune-empty-dirs" => Some('m'),
-        "itemize-changes" => Some('i'),
-        "backup" => Some('b'),
-        "secluded-args" => Some('s'),
-        "version" => Some('V'),
-        "block-size" => Some('B'),
-        "temp-dir" => Some('T'),
-        "remote-option" => Some('M'),
-        "filter" => Some('f'),
-        _ => None,
-    }
+    SHORT_OPTIONS
+        .iter()
+        .find(|opt| opt.long_name == Some(long_name))
+        .map(|opt| opt.letter)
 }
 
 /// Checks whether any client argument is refused by the module's refuse list.
@@ -263,22 +258,44 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
             // option-argument that follows a letter (e.g. `e.LsfxCIvu`).
             let letters = rest.split('.').next().unwrap_or("");
             for letter in letters.chars() {
-                if !letter.is_ascii_alphabetic() {
-                    break;
-                }
-                let long = short_option_long_name(letter);
-                let long_canonical = if long.is_empty() {
-                    letter.to_ascii_lowercase().to_string()
-                } else {
-                    long.to_owned()
+                let Some(option) = lookup_short(letter) else {
+                    // Not an option letter. Upstream is position-independent -
+                    // popt marks a refused entry wherever it sits in the bundle
+                    // (options.c:1040 rewrites `op->val`, options.c:1934
+                    // returns it) - so an unrecognised byte must NOT end the
+                    // scan. Breaking here let a client prefix its bundle with
+                    // any non-letter and slip the rest past the refuse list
+                    // entirely: `-4z` set compress with `refuse options =
+                    // compress` in force, silently.
+                    continue;
                 };
-                let short_letter = if long.is_empty() { None } else { Some(letter) };
-                if is_option_refused(module, &long_canonical, short_letter) {
-                    return Some(if long.is_empty() {
-                        format!("-{letter}")
-                    } else {
-                        format!("--{long}")
-                    });
+
+                // NOTE: no option-argument (arity) handling here, deliberately.
+                // Upstream can skip a value because ONE popt pass both parses
+                // and marks refusals, so the two can never disagree. oc has two
+                // readers of this bundle, and the one that actually APPLIES the
+                // options - `transfer::flags::ParsedServerFlags::parse` - walks
+                // every byte up to the `.` with no arity logic at all. Teaching
+                // only this scanner about arity would make it skip letters the
+                // decoder still acts on, which is a refusal BYPASS: `-B4096`
+                // would hide a trailing flag that still took effect.
+                //
+                // The safe invariant while two readers exist: this scanner must
+                // examine a SUPERSET of what the decoder acts on. Over-refusing
+                // a byte that is really part of an argument fails CLOSED and is
+                // acceptable; under-refusing is a security hole. Collapsing the
+                // two readers onto one shared option table is task 138.
+
+                // `long_name` is `None` only for rows upstream leaves NULL, in
+                // which case the rule can only have named the bare letter.
+                let refused = match option.long_name {
+                    Some(long) => is_option_refused(module, long, Some(letter))
+                        .then(|| format!("--{long}")),
+                    None => is_option_refused(module, &letter.to_string(), Some(letter))
+                        .then(|| format!("-{letter}")),
+                };
+                if let Some(reported) = refused {
+                    return Some(reported);
                 }
             }
         }
@@ -446,73 +463,30 @@ fn is_vital_option(canonical: &str) -> bool {
     VITAL_OPTIONS.contains(&canonical)
 }
 
-/// Matches a refuse-list glob pattern against a candidate option name.
+/// Matches a refuse-list pattern against a candidate option name.
 ///
-/// Supports `*` (zero or more chars), `?` (one char), and `[...]` character
-/// classes (case-sensitive, no negation `[!...]` since upstream's
-/// `[ardlptgoD]` expansion never uses one). Falls back to the daemon's shared
-/// `wildcard_match` when no character class is present so non-class globs keep
-/// going through a single, well-tested matcher.
+/// Delegates to oc's `wildmatch`, which is the port of upstream's `dowild`
+/// (`lib/wildmatch.c:78-296`). Upstream matches refuse rules with exactly that
+/// function and nothing else - `options.c:921-924` calls
+/// `wildmatch(ref, op->longName)` and `wildmatch(ref, shortName)`
+/// unconditionally, for wild and non-wild rules alike.
+///
+/// This previously carried a second, hand-written glob that implemented `[...]`
+/// as literal byte membership. That silently dropped two constructs `dowild`
+/// supports:
+///
+/// - ranges, `[a-z]` (`wildmatch.c:156-166`)
+/// - negation, `[!...]` (`wildmatch.c:139-143`)
+///
+/// and its doc claimed negation was unnecessary "since upstream's `[ardlptgoD]`
+/// expansion never uses one" - which describes oc's own expansion, not what an
+/// operator may write in `rsyncd.conf`. The direction of that error is what
+/// made it serious: every other refuse divergence OVER-refuses and so fails
+/// closed, but a range rule such as `refuse options = [A-Z]*` matched only the
+/// literal bytes `A`, `-` and `Z`, so the options it was meant to block were
+/// ACCEPTED. Delegating removes the divergence and the duplicate matcher.
 fn refuse_glob_match(pattern: &str, text: &str) -> bool {
-    if !pattern.contains('[') {
-        return wildcard_match(pattern, text);
-    }
-
-    let pat = pattern.as_bytes();
-    let txt = text.as_bytes();
-    let mut p = 0usize;
-    let mut t = 0usize;
-    let mut star_p: Option<usize> = None;
-    let mut star_t = 0usize;
-
-    while t < txt.len() {
-        if p < pat.len() {
-            match pat[p] {
-                b'?' => {
-                    p += 1;
-                    t += 1;
-                    continue;
-                }
-                b'*' => {
-                    star_p = Some(p);
-                    star_t = t;
-                    p += 1;
-                    continue;
-                }
-                b'[' => {
-                    let class_end = pat[p + 1..].iter().position(|&b| b == b']');
-                    if let Some(end) = class_end {
-                        let class = &pat[p + 1..p + 1 + end];
-                        if class.contains(&txt[t]) {
-                            p += end + 2;
-                            t += 1;
-                            continue;
-                        }
-                    }
-                    // Unterminated or non-matching class: fall through to backtrack.
-                }
-                ch if ch == txt[t] => {
-                    p += 1;
-                    t += 1;
-                    continue;
-                }
-                _ => {}
-            }
-        }
-
-        if let Some(sp) = star_p {
-            p = sp + 1;
-            star_t += 1;
-            t = star_t;
-        } else {
-            return false;
-        }
-    }
-
-    while p < pat.len() && pat[p] == b'*' {
-        p += 1;
-    }
-    p == pat.len()
+    filters::wildmatch(pattern.as_bytes(), text.as_bytes())
 }
 
 /// Extracts the canonical form of an option name for refuse-list matching.

--- a/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
@@ -357,7 +357,10 @@ fn is_option_refused(
     // as refused before applying the module's rules. Start from that default so
     // the loop below can only un-refuse them via an explicit negated exact match.
     let mut refused = DEFAULT_REFUSED_OPTIONS.contains(&long_name);
-    let short_lower = short_letter.map(|c| c.to_ascii_lowercase().to_string());
+    // Compared in its ORIGINAL case: upstream passes `shortName` to `wildmatch`
+    // verbatim (options.c:924). `-O` and `-o` are separate table rows
+    // (omit-dir-times vs owner) and a rule naming one must not reach the other.
+    let short_str = short_letter.map(|c| c.to_string());
 
     for rule in &module.refuse_options {
         let (negated, pattern_raw) = if let Some(rest) = rule.strip_prefix('!') {
@@ -386,22 +389,17 @@ fn is_option_refused(
             continue;
         }
 
-        // upstream: options.c:921-933 - the rule is tried against both
-        // `op->longName` and `op->shortName` so `!verbose` and `!v` refer to
-        // the same option. Glob patterns additionally need the original-case
-        // short letter (so `[ardlptgoD]` matches `-D` via the upper-case `D`).
+        // upstream: options.c:921-924 - the rule is tried against both
+        // `op->longName` and `op->shortName`, so `!verbose` and `!v` name the
+        // same option. Both comparisons are case-SENSITIVE; that is what keeps
+        // `[ardlptgoD]` matching `-D` while leaving `-d` alone.
         let matches = if is_glob {
             refuse_glob_match(&pattern, long_name)
-                || short_lower
+                || short_str
                     .as_deref()
                     .is_some_and(|s| refuse_glob_match(&pattern, s))
-                || short_letter.is_some_and(|c| {
-                    let mut buf = [0u8; 4];
-                    let original = c.encode_utf8(&mut buf);
-                    refuse_glob_match(&pattern, original)
-                })
         } else {
-            pattern == long_name || short_lower.as_deref() == Some(pattern.as_str())
+            pattern == long_name || short_str.as_deref() == Some(pattern.as_str())
         };
 
         if matches {
@@ -447,13 +445,11 @@ fn is_option_vital(long_name: &str, short_letter: Option<char>) -> bool {
         if is_vital_option(as_str) {
             return true;
         }
-        let lower = letter.to_ascii_lowercase();
-        if lower != letter {
-            let lower_str = lower.encode_utf8(&mut buf);
-            if is_vital_option(lower_str) {
-                return true;
-            }
-        }
+        // No case-folded retry. Vitality is a property of one long_options[]
+        // ROW, and the case-paired letters are different rows: `-n` (dry-run)
+        // is vital, `-N` (crtimes) is not. Folding made `-N` inherit `-n`'s
+        // immunity, so `refuse options = *` silently spared it - an
+        // UNDER-refusal, the direction that fails open.
     }
     false
 }
@@ -499,5 +495,12 @@ fn canonical_option(text: &str) -> String {
         .split([' ', '\t', '='])
         .next()
         .unwrap_or("");
-    token.to_ascii_lowercase()
+    // Case is PRESERVED. upstream matches refuse rules with `wildmatch`
+    // (options.c:923-924), not `iwildmatch` - the case-folding variant exists
+    // (lib/wildmatch.c:307-318, `force_lower_case = 1`) and is deliberately not
+    // used here, and no `tolower`/`strcasecmp` appears anywhere in the refuse
+    // path. Folding merged distinct options: `refuse options = O` also refused
+    // `-o`, so a rule aimed at `--omit-dir-times` silently blocked `--owner`
+    // and broke every `-a` transfer.
+    token.to_owned()
 }

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -23,11 +23,17 @@ fn parse_daemon_option_rejects_invalid_values() {
     assert!(parse_daemon_option("OPTION   ").is_none());
 }
 
+/// `canonical_option` strips the dashes and any `=value`, and PRESERVES case.
+///
+/// upstream matches refuse rules with `wildmatch` (options.c:923-924), not the
+/// case-folding `iwildmatch` (lib/wildmatch.c:307-318). This test previously
+/// asserted `"--Delete" -> "delete"` and pinned the folding.
 #[test]
-fn canonical_option_trims_prefix_and_normalises_case() {
-    assert_eq!(canonical_option("--Delete"), "delete");
-    assert_eq!(canonical_option(" -P --info"), "p");
-    assert_eq!(canonical_option("   CHECKSUM=md5"), "checksum");
+fn canonical_option_trims_prefix_and_preserves_case() {
+    assert_eq!(canonical_option("--Delete"), "Delete");
+    assert_eq!(canonical_option(" -P --info"), "P");
+    assert_eq!(canonical_option("   CHECKSUM=md5"), "CHECKSUM");
+    assert_eq!(canonical_option("--delete"), "delete");
 }
 
 #[test]
@@ -225,14 +231,65 @@ fn refused_option_empty_list_allows_all() {
     assert_eq!(refused_option(&module, &options), None);
 }
 
+/// Refuse matching is case-SENSITIVE, mirroring upstream.
+///
+/// upstream: `options.c:923-924` uses `wildmatch`; the case-folding
+/// `iwildmatch` (lib/wildmatch.c:307-318, `force_lower_case = 1`) exists and is
+/// deliberately not used, and no `tolower`/`strcasecmp` appears in the refuse
+/// path.
+///
+/// This test previously asserted the OPPOSITE - that `refuse options = DELETE`
+/// refuses `--delete` - and so pinned the divergence. The folding was not
+/// merely cosmetic: it merged distinct options, so `refuse options = O`
+/// (--omit-dir-times) also refused `-o` (--owner) and broke every `-a`
+/// transfer against that module.
 #[test]
-fn refused_option_case_insensitive() {
-    let module = ModuleDefinition {
-        refuse_options: vec!["DELETE".to_owned()],
-        ..Default::default()
-    };
-    let options = vec!["--delete".to_owned()];
-    assert_eq!(refused_option(&module, &options), Some("--delete"));
+fn refused_option_is_case_sensitive() {
+    let upper_rule = module_with_refuse(vec!["DELETE".to_owned()]);
+    assert_eq!(
+        refused_option(&upper_rule, &["--delete".to_owned()]),
+        None,
+        "an upper-case rule must not match the lower-case option name"
+    );
+    assert_eq!(
+        refused_option(&upper_rule, &["--DELETE".to_owned()]),
+        Some("--DELETE"),
+        "it must still match its own spelling"
+    );
+
+    // The load-bearing case: `-O` and `-o` are separate long_options[] rows.
+    let omit_dir_times = module_with_refuse(vec!["O".to_owned()]);
+    assert_eq!(
+        refused_option(&omit_dir_times, &["-O".to_owned()]),
+        Some("-O"),
+        "`refuse options = O` must refuse --omit-dir-times"
+    );
+    assert_eq!(
+        refused_option(&omit_dir_times, &["-o".to_owned()]),
+        None,
+        "`refuse options = O` must NOT refuse --owner - that broke -a transfers"
+    );
+}
+
+/// Vitality belongs to one table row, so it must not leak across letter case.
+///
+/// `-n` (dry-run) is vital and immune to `refuse options = *`; `-N` (crtimes)
+/// is a different row and is not. The previous case-folded vital lookup let
+/// `-N` inherit `-n`'s immunity, so a wildcard rule silently spared it -
+/// under-refusal, the fail-open direction.
+#[test]
+fn wildcard_all_refuses_crtimes_but_spares_dry_run() {
+    let module = module_with_refuse(vec!["*".to_owned()]);
+    assert_eq!(
+        refused_option(&module, &["-n".to_owned()]),
+        None,
+        "-n (dry-run) is vital and survives a wildcard rule"
+    );
+    assert_eq!(
+        refused_option(&module, &["-N".to_owned()]),
+        Some("-N"),
+        "-N (crtimes) is NOT vital and must be refused by a wildcard rule"
+    );
 }
 
 #[test]

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -397,6 +397,57 @@ fn is_vital_option_rejects_non_vitals() {
     assert!(!is_vital_option("archive"));
 }
 
+/// A `[a-z]` RANGE in a refuse rule must match the range, not the three
+/// literal bytes `a`, `-`, `z`.
+///
+/// upstream: `options.c:921-924` matches refuse rules with `wildmatch()`, and
+/// `dowild` handles ranges at `lib/wildmatch.c:156-166`.
+///
+/// This is the fail-OPEN direction. oc's previous hand-written glob compared
+/// `[...]` by literal byte membership, so `refuse options = --[a-c]*` accepted
+/// `--compress` - the option the rule was written to block. Every other
+/// refuse-options divergence over-refuses and so fails closed; this one did not.
+#[test]
+fn refused_client_arg_honors_a_character_range() {
+    let module = ModuleDefinition {
+        refuse_options: vec!["[a-c]*".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["--server".to_owned(), "--compress".to_owned()];
+    assert_eq!(
+        refused_client_arg(&module, &args),
+        Some("--compress".to_owned()),
+        "a range rule must refuse an option inside the range"
+    );
+
+    // The range must still bound: an option outside it stays allowed.
+    let allowed = vec!["--server".to_owned(), "--times".to_owned()];
+    assert_eq!(
+        refused_client_arg(&module, &allowed),
+        None,
+        "a range rule must not refuse an option outside the range"
+    );
+}
+
+/// A NEGATED class `[!...]` must invert, per `dowild`.
+///
+/// upstream: `lib/wildmatch.c:139-143` - `special = p_ch == NEGATE_CLASS`.
+/// The previous glob had no negation at all, so the leading `!` was compared
+/// as a literal byte and the rule matched nothing.
+#[test]
+fn refused_client_arg_honors_a_negated_class() {
+    let module = ModuleDefinition {
+        refuse_options: vec!["[!x]*".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["--server".to_owned(), "--compress".to_owned()];
+    assert_eq!(
+        refused_client_arg(&module, &args),
+        Some("--compress".to_owned()),
+        "a negated class must refuse an option whose first char is not excluded"
+    );
+}
+
 #[test]
 fn refused_client_arg_matches_long_form() {
     // upstream: clientserver.c rejects `--compress` when the module's
@@ -415,21 +466,112 @@ fn refused_client_arg_matches_long_form() {
 #[test]
 fn refused_client_arg_expands_bundled_short() {
     // upstream: the daemon expands `-z` inside a packed short-letter
-    // server argstr (e.g. `-vlogDtprez.iLsfxCIvu`) into `--compress` via
-    // popt's longName mapping, then matches against the refuse list.
+    // server argstr into `--compress` via popt's longName mapping, then
+    // matches against the refuse list.
+    //
+    // The letter order matters and is NOT arbitrary: upstream appends `z`
+    // (options.c:2722-2723) and only then calls `maybe_add_e_option()`
+    // (options.c:2728), so `e` is always LAST - everything after it is `-e`'s
+    // argument. oc emits the same order (the capability suffix is appended
+    // last, `invocation/builder.rs:233`). This fixture previously wrote
+    // `...ez.iLsfxCIvu`, an order no conforming rsync produces.
     let module = ModuleDefinition {
         refuse_options: vec!["compress".to_owned()],
         ..Default::default()
     };
     let args = vec![
         "--server".to_owned(),
-        "-vlogDtprez.iLsfxCIvu".to_owned(),
+        "-vlogDtprze.iLsfxCIvu".to_owned(),
         ".".to_owned(),
         "no-compress/".to_owned(),
     ];
     assert_eq!(
         refused_client_arg(&module, &args),
         Some("--compress".to_owned())
+    );
+}
+
+#[test]
+fn refused_client_arg_scans_past_non_option_bytes() {
+    // A non-option byte must NOT end the bundle scan. Upstream is
+    // position-independent by construction: refusal rewrites `op->val` to
+    // OPT_REFUSED_BASE+idx (options.c:1040) and popt returns the refused entry
+    // (options.c:1934) wherever it sits.
+    //
+    // Breaking at the first non-alphabetic byte let a client prefix its bundle
+    // with any digit and slip the rest past the refuse list SILENTLY - `-4z`
+    // enabled compression with `refuse options = compress` in force.
+    let module = ModuleDefinition {
+        refuse_options: vec!["compress".to_owned()],
+        ..Default::default()
+    };
+    for arg in ["-4z", "-6z", "-8z", "-0z", "-@z"] {
+        assert_eq!(
+            refused_client_arg(&module, &[arg.to_owned()]),
+            Some("--compress".to_owned()),
+            "bundle {arg} must not bypass the refuse list",
+        );
+    }
+}
+
+#[test]
+fn refused_client_arg_examines_every_letter_the_decoder_acts_on() {
+    // THE invariant while oc has two readers of a compact bundle: this scanner
+    // must examine a SUPERSET of what the code that APPLIES the options acts
+    // on. Anything less is a refusal bypass.
+    //
+    // The applying decoder is `transfer::flags::ParsedServerFlags::parse`,
+    // which walks EVERY byte up to the `.` separator with no option-argument
+    // (arity) logic. Upstream can afford arity because one popt pass both
+    // parses and marks refusals, so they cannot disagree; oc's two readers can.
+    //
+    // Concretely: teaching only this scanner that `-B` takes a value made it
+    // skip the rest of `-B...z`, while the decoder still saw the `z` and turned
+    // compression on - a silent bypass strictly worse than the one it fixed.
+    // Over-refusing a byte that is really part of an argument fails CLOSED and
+    // is the acceptable direction.
+    let module = ModuleDefinition {
+        refuse_options: vec!["compress".to_owned()],
+        ..Default::default()
+    };
+    // Every one of these has `z` AFTER a letter that upstream popt would treat
+    // as value-taking. The decoder sets compress for all of them, so all must
+    // be refused.
+    for arg in ["-B4096z", "-T/tmpz", "-M--fooz", "-@z", "-fz"] {
+        assert_eq!(
+            refused_client_arg(&module, &[arg.to_owned()]),
+            Some("--compress".to_owned()),
+            "{arg}: decoder sets compress here, so the refuse scan must see it",
+        );
+    }
+
+    // The one place the scan DOES stop is the `.` capability separator - and it
+    // stops there because the decoder stops there too (flags.rs:531 `if byte ==
+    // b'.' { break; }`). Same rule, same boundary.
+    let fuzzy_module = ModuleDefinition {
+        refuse_options: vec!["fuzzy".to_owned()],
+        ..Default::default()
+    };
+    assert_eq!(
+        refused_client_arg(&fuzzy_module, &["-e.LsfxCIvuy".to_owned()]),
+        None,
+        "letters after the `.` are the -e capability payload, not options",
+    );
+}
+
+#[test]
+fn refused_client_arg_matches_modify_window_short_form() {
+    // `refuse options = modify-window` must match the short wire form `-@-1`,
+    // which oc's OWN client emits (invocation/builder.rs:477, mirroring
+    // options.c:2873-2875). `@` was missing from the short-letter map, so this
+    // silently failed to refuse.
+    let module = ModuleDefinition {
+        refuse_options: vec!["modify-window".to_owned()],
+        ..Default::default()
+    };
+    assert_eq!(
+        refused_client_arg(&module, &["-@-1".to_owned()]),
+        Some("--modify-window".to_owned())
     );
 }
 


### PR DESCRIPTION
Two ways a client could use an option the module had refused.

## 1. Bundle scan stopped at the first non-alphabetic byte

`-4z` ended the scan at `4`, so `z` was never tested against the refuse list -
while the decoder still enabled compression. The scan now continues past bytes
it does not recognise and stops only at `.`, exactly where the decoder stops.

### Why this deliberately does NOT model popt arity

Upstream can, because one popt pass both parses and marks refusals, so
enforcement and application cannot disagree. oc has **two** readers of the same
compact bundle, and the one that APPLIES the options -
`transfer::flags::ParsedServerFlags::parse` - walks every byte up to `.` with no
arity logic:

```rust
for &byte in &bytes[1..] {
    if byte == b'.' { break; }
    flags.parse_transfer_flag(byte);
}
```

An arity-aware scan therefore skips letters the decoder still acts on:
`-B4096z` enables compression the scan never sees. **While two readers exist,
the refuse scan must examine a superset of what the decoder acts on.**
Over-refusal fails closed; under-refusal is a hole. This was tried the other way
first and reverted.

## 2. The `[...]` glob was a second, weaker matcher

It compared a character class by literal byte membership, silently dropping two
constructs upstream's `dowild` supports:

- ranges - `lib/wildmatch.c:156-166`
- negation `[!...]` - `lib/wildmatch.c:139-143`

Its doc justified the omission as *"upstream's `[ardlptgoD]` expansion never uses
one"* - which describes oc's own expansion, not what an operator may write in
`rsyncd.conf`.

This is the fail-OPEN direction. Every other refuse-options divergence
over-refuses and so fails closed; here `refuse options = [A-Z]*` matched only
the literal bytes `A`, `-` and `Z`, so the options it was written to block were
**accepted**.

Upstream matches refuse rules with `wildmatch()` and nothing else -
`options.c:921-924` calls it for both `longName` and `shortName`, wild or not.
oc already ships that matcher as `filters::wildmatch` (a `dowild` port), and
`crates/daemon` already depended on the crate, so the hand-written copy is
deleted and the call delegates.

## Table

Replaces two drifted hand-written maps (46 vs 41 arms) with one 51-row table,
verified letter-for-letter against `options.c:600-856`: oc lacks none of
upstream's short letters and invents none.

## Known residual, deliberately not changed here

`canonical_option` lowercases, so `refuse options = O` also refuses `-o`.
Upstream's `wildmatch` is case-SENSITIVE. That **over**-refuses (fails closed)
and is an operator-visible policy change, so it is not bundled into a security
fix. Likewise `D`/`F`/`P` keep oc-specific long names where upstream has NULL -
all three over-refuse.

## Verification

Rebased onto `0ed2894a` and verified there:

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` | pass |
| `cargo nextest run --workspace --all-features` | 32390 run / 32390 passed / 152 skipped |

The two glob tests were confirmed to execute by name, not merely to be absent
from the failure list.
