### PR TITLE
fix(fast_io): assert io_uring progress on the reap, not the submit

### DIFF
--- a/crates/fast_io/src/io_uring/shared_ring.rs
+++ b/crates/fast_io/src/io_uring/shared_ring.rs
@@ -305,6 +305,13 @@ impl SharedRing {
     ///
     /// Wraps [`io_uring::IoUring::submit_and_wait`] so the caller does not
     /// have to import the underlying type.
+    ///
+    /// The returned count is the number of SQEs consumed from the submission
+    /// queue, *not* the number of completions. Once an earlier call has
+    /// drained the queue, a later call legitimately returns `Ok(0)` after
+    /// blocking for `wait_for` CQEs. Callers must therefore measure progress
+    /// by draining [`reap`](Self::reap) and must never treat this value as a
+    /// completion count.
     pub fn submit_and_wait(&mut self, wait_for: usize) -> io::Result<usize> {
         self.ring.submit_and_wait(wait_for)
     }

--- a/crates/fast_io/tests/io_uring_mmap_pressure.rs
+++ b/crates/fast_io/tests/io_uring_mmap_pressure.rs
@@ -182,14 +182,20 @@ fn submit_and_verify_reads(
     let mut received = 0usize;
     let mut seen = vec![false; target];
     while received < target {
-        let n = ring
-            .submit_and_wait(1)
+        // The return value counts SQEs consumed from the submission queue,
+        // not completions: after the first iteration the queue is empty and
+        // this legitimately returns 0 while still blocking for a CQE. Progress
+        // is asserted on the reap, which is what actually advances the loop.
+        ring.submit_and_wait(1)
             .unwrap_or_else(|e| panic!("{label}: submit_and_wait failed: {e}"));
-        assert!(n > 0, "{label}: submit_and_wait returned 0");
 
         let completions = ring
             .reap()
             .unwrap_or_else(|e| panic!("{label}: reap failed: {e}"));
+        assert!(
+            !completions.is_empty(),
+            "{label}: submit_and_wait(1) returned with nothing to reap"
+        );
         for c in completions {
             match c {
                 SharedCompletion::Read { op_id, result } => {

--- a/crates/fast_io/tests/io_uring_shared_ring.rs
+++ b/crates/fast_io/tests/io_uring_shared_ring.rs
@@ -289,6 +289,58 @@ mod linux_only {
         }
     }
 
+    /// `submit_and_wait` returns the number of SQEs consumed from the
+    /// submission queue, never a completion count. A caller that conflates
+    /// the two breaks as soon as the kernel delivers CQEs piecemeal: the
+    /// follow-up call finds the queue already drained and returns 0 while
+    /// completions are still waiting to be reaped. That is a load-dependent
+    /// failure in the wild, so it is pinned here deterministically - the two
+    /// reads are awaited but deliberately not reaped, which makes the
+    /// submission queue provably empty while the completion queue provably
+    /// holds entries.
+    #[test]
+    fn submit_and_wait_returns_zero_once_the_submission_queue_is_drained() {
+        if !is_io_uring_available() {
+            eprintln!("skipping drained-queue test: io_uring unavailable");
+            return;
+        }
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("drained_queue.bin");
+        std::fs::write(&path, vec![0x5au8; 512]).expect("write payload");
+        let file = std::fs::File::open(&path).expect("open payload");
+        let (sock, _peer) = UnixStream::pair().expect("socketpair");
+
+        let cfg = SharedRingConfig::default();
+        let mut ring = match SharedRing::try_new(file.as_raw_fd(), sock.as_raw_fd(), &cfg) {
+            Some(r) => r,
+            None => {
+                eprintln!("skipping drained-queue test: SharedRing::try_new returned None");
+                return;
+            }
+        };
+
+        let mut first = vec![0u8; 256];
+        let mut second = vec![0u8; 256];
+        ring.submit_read(1, 0, &mut first).expect("submit read 1");
+        ring.submit_read(2, 256, &mut second)
+            .expect("submit read 2");
+        ring.submit_and_wait(2).expect("first submit_and_wait");
+
+        // Both CQEs are now available and the submission queue is empty, so
+        // this call submits nothing and returns immediately.
+        assert_eq!(
+            ring.submit_and_wait(1).expect("second submit_and_wait"),
+            0,
+            "a drained submission queue must report zero SQEs submitted"
+        );
+        assert_eq!(
+            ring.reap().expect("reap").len(),
+            2,
+            "both completions must survive the zero-submit call"
+        );
+    }
+
     /// `OpTag::encode` followed by `OpTag::decode` must be lossless for the
     /// full 56-bit op_id range. This is a stronger version of the unit test
     /// in the live module - it picks a few values across the boundary so


### PR DESCRIPTION
## Problem

`io_uring_reads_tolerate_mmap_madv_dontneed` fails intermittently under a
full-workspace `nextest` run and passes in isolation, including at `-j 32`.
The failure is pre-existing on master and is not caused by any recent change.

## Root cause

The completion loop asserted on the wrong value:

```rust
let n = ring.submit_and_wait(1)?;
assert!(n > 0, "submit_and_wait returned 0");
```

`SharedRing::submit_and_wait` delegates to `io_uring`'s submitter, whose
return value is **the number of SQEs consumed from the submission queue**,
not the number of completions. It is `io_uring_enter(to_submit, min_complete,
GETEVENTS)`: with an already-drained submission queue it still blocks for
`min_complete` CQEs and then correctly reports `Ok(0)`.

The loop re-enters after every `reap()`. If the first reap drains all four
CQEs the loop exits and the assertion never sees a second call - which is
what happens on an idle machine. Under full-workspace load the reads are
punted to io-wq workers and complete piecemeal, so the first reap returns a
subset, the loop iterates, and the second `submit_and_wait` finds nothing
left to submit and returns 0. The assertion then fires on a perfectly
healthy ring. That is precisely the observed load dependence.

No production code makes this assumption: every caller in `crates/fast_io`
discards the count and measures progress by draining CQEs.

## Fix

Assert on the value that actually advances the loop. `submit_and_wait(1)`
returns only once at least one CQE is available (an interrupted wait
surfaces as `Err`), so a non-empty reap is a true invariant where a
non-zero submit count is not.

The contract that permitted the confusion is corrected at its source:
`SharedRing::submit_and_wait`'s rustdoc documented what the call *waits*
for but never what the returned number *is*. It now states that the count
is SQEs consumed, that `Ok(0)` is legitimate once the queue is drained, and
that callers must measure progress via `reap`.

## Recurrence guard

The original failure is timing-dependent, but the contract is not. A new
test pins it deterministically: two reads are submitted and awaited but
deliberately **not** reaped, making the submission queue provably empty
while the completion queue provably holds entries. The follow-up
`submit_and_wait(1)` must report `0` submitted, and both completions must
survive it. This fails against the old understanding without depending on
scheduler timing.

## Notes

No production behaviour changes; the only non-test edit is a rustdoc
correction on a public method. io_uring has no upstream rsync counterpart,
so the oracle here is the `io_uring_enter(2)` contract rather than the
C source.

## Verification

Linux x86_64, on `origin/master`:

- `cargo fmt --all -- --check` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run --workspace --all-features` - 32386 passed, 0 failed, 152 skipped
