### PR TITLE
docs: repair two broken rustdoc links failing the Pages build

### DIFF
--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -764,7 +764,7 @@ impl DeltaSignatureIndex {
     ///
     /// The scan is not narrowed to the last block even though the wire and
     /// local signature builders both put the only short block there. This is a
-    /// public API over a [`FileSignature`], and `SignatureBlock::from_raw_parts`
+    /// public API over a [`signature::FileSignature`], and `SignatureBlock::from_raw_parts`
     /// lets a caller hand over blocks of any length in any order, so a
     /// last-block-only check would be an unsound assumption rather than an
     /// optimization.

--- a/xtask/src/commands/citations.rs
+++ b/xtask/src/commands/citations.rs
@@ -27,7 +27,7 @@
 //! skips in the one place it must run is not a gate. `tools/ci/
 //! upstream-3.4.4-lines.tsv` carries one line count per upstream file. rsync
 //! 3.4.4 is a released tarball and is immutable, so the manifest cannot drift
-//! from it; [`tests::manifest_matches_the_pinned_source`] re-derives it wherever
+//! from it; `tests::manifest_matches_the_pinned_source` re-derives it wherever
 //! the source is present.
 
 use crate::error::TaskResult;


### PR DESCRIPTION
## Problem

The `Pages` workflow has failed on **every** master commit going back to at
least 2026-08-06. It is not a required check, so it went unnoticed, but it
means the published rustdoc has not been rebuilt in that window.

`.github/workflows/pages.yml` builds docs with
`RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links"`, and two crates also
carry `#![deny(rustdoc::broken_intra_doc_links)]`. Two links do not resolve,
so the build exits 101.

## Root cause

**1. `xtask/src/commands/citations.rs:30`** linked to
`` [`tests::manifest_matches_the_pinned_source`] ``. That item lives in a
`#[cfg(test)] mod tests` (line 332). rustdoc builds without `cfg(test)`, so
the item does not exist in the documented crate and the link can never
resolve - it is not a stale path, it is unresolvable by construction.
Downgraded to plain backticks, matching how the same sentence already refers
to `SignatureBlock::from_raw_parts`.

**2. `crates/matching/src/index/mod.rs:767`** linked to `` [`FileSignature`] ``,
which is not in scope there. Unlike the first, this target is genuinely
reachable: it is `signature::FileSignature`, and `matching` already depends on
the `signature` crate. The path is corrected so the link keeps working as a
link rather than being downgraded.

Only the first failure was ever visible in CI, because the build aborted on
it. The second surfaced only after the first was fixed - which is why this was
verified by reproducing the gate locally rather than pushing a one-line fix
and waiting.

## Verification

Reproduced the exact workflow command on Linux, before and after:

```
RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" \
  cargo doc --workspace --all-features --no-deps --locked
```

- before: `error: unresolved link to 'tests::manifest_matches_the_pinned_source'` -> exit 101
- after fix 1: `error: unresolved link to 'FileSignature'` -> exit 101
- after both: **exit 0**

Documentation comments only; no code paths change.
