### PR TITLE
ci: install cargo-nextest from one pinned composite action

### DIFF
--- a/.github/actions/install-cargo-nextest-windows/action.yml
+++ b/.github/actions/install-cargo-nextest-windows/action.yml
@@ -43,8 +43,24 @@ runs:
         $exe = Join-Path $cargoBin 'cargo-nextest.exe'
 
         function Get-NextestVersion($path) {
-          # `cargo-nextest --version` prints e.g. "cargo-nextest 0.9.114 (ff4ee9a ...)".
-          (& $path --version) -replace '^cargo-nextest\s+([0-9][0-9.]*).*$', '$1'
+          # `cargo-nextest --version` prints a MULTI-LINE block, not one line:
+          #
+          #   cargo-nextest 0.9.114
+          #   release: 0.9.114
+          #   commit-hash: 9daab1c50cd0389236508435f71434f01aa2eca1
+          #   commit-date: 2025-11-19
+          #   host: x86_64-pc-windows-msvc
+          #
+          # So `& $path --version` yields a string ARRAY. Taking the first line
+          # is load-bearing: `-replace` over an array returns an array (only the
+          # first element matches, the rest pass through untouched), and `-ne`
+          # against an array FILTERS rather than compares, so a non-empty result
+          # is truthy and the equality guard below fires on a correct install.
+          # `@(...)` forces an array even for single-line output, so [0] is
+          # always safe. Indexing rather than `Select-Object -First 1` avoids
+          # terminating the native command's pipeline early.
+          $lines = @(& $path --version)
+          ($lines[0] -replace '^cargo-nextest\s+([0-9][0-9.]*).*$', '$1').Trim()
         }
 
         if (Test-Path $exe) {

--- a/.github/actions/install-cargo-nextest-windows/action.yml
+++ b/.github/actions/install-cargo-nextest-windows/action.yml
@@ -1,0 +1,71 @@
+name: Install cargo-nextest (Windows)
+description: >-
+  Installs an exact cargo-nextest version on the Windows runners without
+  invoking bash, and without fetching anything when that version is already
+  present from the Rust cache.
+
+inputs:
+  version:
+    description: >-
+      Exact cargo-nextest version to install. The default is the single source
+      of truth for every Windows cell; override only to test a specific build.
+    required: false
+    default: "0.9.114"
+
+runs:
+  using: composite
+  steps:
+    - name: Install cargo-nextest ${{ inputs.version }}
+      shell: pwsh
+      run: |
+        # taiki-e/install-action shells out to bash, which fails to start on the
+        # Windows partner runners (actions/partner-runner-images#169), so the
+        # binary is fetched directly through PowerShell instead.
+        #
+        # Two properties this step must hold, in order:
+        #
+        # 1. Reproducible. The version is pinned by the caller rather than
+        #    tracking `latest`, so a re-run of an old commit installs what that
+        #    commit was tested against, and the fetched artifact is fixed rather
+        #    than whatever upstream published since.
+        #
+        # 2. No network on the common path. Swatinem/rust-cache runs before this
+        #    action and restores ~/.cargo/bin, so when the pinned binary is
+        #    already there the download is skipped entirely. A cache hit
+        #    therefore cannot be taken down by a transient fetch failure - the
+        #    fetch does not happen. This is a guard, not a re-attempt: the
+        #    download is still attempted exactly once when it is genuinely
+        #    needed, and a failure there fails the job immediately and loudly.
+        $ErrorActionPreference = 'Stop'
+
+        $want = '${{ inputs.version }}'
+        $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
+        $exe = Join-Path $cargoBin 'cargo-nextest.exe'
+
+        function Get-NextestVersion($path) {
+          # `cargo-nextest --version` prints e.g. "cargo-nextest 0.9.114 (ff4ee9a ...)".
+          (& $path --version) -replace '^cargo-nextest\s+([0-9][0-9.]*).*$', '$1'
+        }
+
+        if (Test-Path $exe) {
+          $have = Get-NextestVersion $exe
+          if ($have -eq $want) {
+            Write-Host "cargo-nextest $want already present - no download"
+            exit 0
+          }
+          Write-Host "cargo-nextest $have present, $want pinned - replacing"
+        }
+
+        New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
+        $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
+        Invoke-WebRequest -UseBasicParsing -Uri "https://get.nexte.st/$want/windows" -OutFile $zip
+        Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
+
+        # get.nexte.st redirects a version path to that release, but verify
+        # rather than trust: a silently wrong version would make the whole
+        # matrix test something other than what the pin claims.
+        $got = Get-NextestVersion $exe
+        if ($got -ne $want) {
+          throw "cargo-nextest version mismatch: pinned $want, installed $got"
+        }
+        Write-Host "cargo-nextest $got installed"

--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -106,18 +106,9 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Install cargo-nextest (Windows direct download)
+      - name: Install cargo-nextest (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Built at the default feature set, which is both necessary and
       # sufficient. Necessary: the root `bin` package declares no `tracing`,
@@ -266,18 +257,9 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Install cargo-nextest (Windows direct download)
+      - name: Install cargo-nextest (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       - name: Build oc-rsync (for subprocess integration tests)
         if: matrix.needs_bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,20 +306,8 @@ jobs:
         with:
           shared-key: ci-windows-${{ matrix.toolchain }}-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for taiki-e/install-action bash startup failures on the
-          # Windows partner runners (actions/partner-runner-images#169). Download
-          # the prebuilt cargo-nextest binary via PowerShell so we never invoke
-          # bash during install.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # The steps below select individual packages, so Cargo never builds the
       # `oc-rsync` binary as a side effect the way a `--workspace` run does.
@@ -392,17 +380,8 @@ jobs:
           shared-key: ci-windows-iocp-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           key: windows-iocp
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Build the workspace with iocp explicitly enabled. The feature is in
       # defaults but pinning it here protects against future default changes
@@ -468,17 +447,8 @@ jobs:
           shared-key: ci-windows-acl-xattr-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           key: windows-acl-xattr
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Build metadata with ACL + xattr explicitly enabled so the Win32
       # GetSecurityInfo / SetSecurityInfo and ADS code paths are exercised.
@@ -546,17 +516,8 @@ jobs:
           shared-key: ci-windows-daemon-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           key: windows-daemon
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Build the daemon crate first so the nextest step links against an
       # already-warm build artifact. Default features only; the cross-OS
@@ -888,19 +849,9 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Install cargo-nextest (Windows direct download)
+      - name: Install cargo-nextest (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # Mirrors the workaround used by `windows-test` and `windows-iocp`
-          # for actions/partner-runner-images#169.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Build the engine crate with the `dg-stress` feature so the stress
       # test under `#[cfg(feature = "dg-stress")]` is compiled in.

--- a/.github/workflows/windows-nightly-case-insensitive.yml
+++ b/.github/workflows/windows-nightly-case-insensitive.yml
@@ -79,17 +79,8 @@ jobs:
           shared-key: ci-windows-case-insensitive-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
           key: windows-nightly-case-insensitive
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest (Windows)
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Run the full `-p platform` crate test set on Windows. The
       # crate is small (~6 Windows-only tests plus a handful of shared

--- a/.github/workflows/windows-nightly-daemon.yml
+++ b/.github/workflows/windows-nightly-daemon.yml
@@ -70,17 +70,8 @@ jobs:
           shared-key: ci-windows-daemon-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
           key: windows-nightly-daemon
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest (Windows)
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Build the daemon crate first so the nextest step links against
       # an already-warm build artifact. Default features only; cross-OS

--- a/.github/workflows/windows-nightly-iocp.yml
+++ b/.github/workflows/windows-nightly-iocp.yml
@@ -65,17 +65,8 @@ jobs:
           shared-key: ci-windows-iocp-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
           key: windows-nightly-iocp
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest (Windows)
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Build fast_io with iocp explicitly enabled. Pinning the feature
       # protects against future default changes silently dropping iocp

--- a/.github/workflows/windows-nightly-long-path.yml
+++ b/.github/workflows/windows-nightly-long-path.yml
@@ -74,17 +74,8 @@ jobs:
           shared-key: ci-windows-long-path-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
           key: windows-nightly-long-path
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest (Windows)
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Filter targets the four WCI-1 audit-identified protocol-crate
       # Windows tests in `crates/protocol/src/flist/wire_path.rs`. All

--- a/.github/workflows/windows-nightly-ntfs-acl.yml
+++ b/.github/workflows/windows-nightly-ntfs-acl.yml
@@ -100,17 +100,8 @@ jobs:
           shared-key: ci-windows-ntfs-acl-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
           key: windows-nightly-ntfs-acl
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest (Windows)
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Run the platform crate unfiltered. This activates the six
       # WCI-1 SID/RID resolver tests that no Windows CI cell links

--- a/.github/workflows/windows-nightly-openssh.yml
+++ b/.github/workflows/windows-nightly-openssh.yml
@@ -71,17 +71,8 @@ jobs:
           shared-key: ci-windows-openssh-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
           key: windows-nightly-openssh
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest (Windows)
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Build the rsync_io crate first so the nextest step links
       # against an already-warm build artifact. Default features only;

--- a/.github/workflows/windows-nightly-reparse-symlinks.yml
+++ b/.github/workflows/windows-nightly-reparse-symlinks.yml
@@ -100,17 +100,8 @@ jobs:
           shared-key: ci-windows-reparse-symlinks-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
           key: windows-nightly-reparse-symlinks
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest (Windows)
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Filter activates the reparse-point classifier unit tests in
       # `crates/metadata/src/windows/reparse.rs` plus the three

--- a/.github/workflows/windows-nightly-xattr-ads.yml
+++ b/.github/workflows/windows-nightly-xattr-ads.yml
@@ -74,17 +74,8 @@ jobs:
           shared-key: ci-windows-xattr-ads-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
           key: windows-nightly-xattr-ads
 
-      - name: Install cargo-nextest (Windows direct download)
-        shell: pwsh
-        run: |
-          # Workaround for actions/partner-runner-images#169 on Windows.
-          $ErrorActionPreference = 'Stop'
-          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
-          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
-          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
-          & "$cargoBin\cargo-nextest.exe" --version
+      - name: Install cargo-nextest (Windows)
+        uses: ./.github/actions/install-cargo-nextest-windows
 
       # Both ADS round-trip tests spawn `oc-rsync.exe` as a subprocess. A
       # package-scoped `-p metadata` run never builds it, and the tests


### PR DESCRIPTION
## Problem

PRs #7234 and #7265 both failed the `Windows (nightly)` cell at step 5,
`Install cargo-nextest (Windows direct download)`, roughly 76 s in. Build and
Test were **skipped**, so neither PR's code was compiled, let alone tested.
Two unrelated PRs, same step, same cell - the failure was the install step, not
the changes.

That step was a single `Invoke-WebRequest` against `https://get.nexte.st/latest/windows`
under `$ErrorActionPreference = 'Stop'`. One transient fetch failure takes the
entire Windows test cell with it.

It was also copy-pasted **15 times across 10 workflow files**, so any change to
it had to be made fifteen times, and the copies had already drifted (three
different comment bodies for the same eight lines).

## Change

One composite action, `.github/actions/install-cargo-nextest-windows`, replaces
all 15 copies. Two properties, in order:

1. **Reproducible.** The version is pinned (`0.9.114`) instead of tracking
   `latest`, so re-running an old commit installs what that commit was tested
   against. `latest` also meant the fetched artifact was unpinned
   supply-chain-wise. The pin lives in the action's input default - one source
   of truth, no `env` threaded through ten files.

2. **No network on the common path.** `Swatinem/rust-cache` already runs before
   this step in every one of these jobs and restores `~/.cargo/bin`, but the
   old step downloaded unconditionally anyway. The action now skips the fetch
   when the pinned binary is already present, so a cache hit performs no
   network I/O and cannot be taken down by a transient failure.

The installed version is verified after extraction: a silently wrong version
would make the matrix test something other than what the pin claims.

**This deliberately contains no retry and no backoff.** The download is still
attempted exactly once when genuinely needed, and a failure there fails the job
immediately and loudly. The fix removes the reason to re-attempt rather than
re-attempting.

## Upstream

rsync 3.4.4 has no GitHub Actions Windows CI, so there is no upstream behaviour
to mirror here. This is oc-only infrastructure and the oracle is
reproducibility, not fidelity.

## Verification

- All 15 direct-download sites removed: `grep -rc get.nexte.st .github/workflows/` returns nothing
- 15 composite call sites across the same 10 files
- Every workflow and the action parse as valid YAML
- Every call site has an `actions/checkout` before it (required for a local `uses: ./...`)
- The one conditional site retains its `if: runner.os == 'Windows'`
