### PR TITLE
test(cli): un-ignore exclude leg 3, which no longer fails

### DIFF
--- a/crates/cli/src/frontend/tests/exclude_lsh_matrix.rs
+++ b/crates/cli/src/frontend/tests/exclude_lsh_matrix.rs
@@ -221,7 +221,6 @@ fn exclude_lsh_leg_2_exclude_from_delete_during() {
 }
 
 #[test]
-#[ignore = "UTS-V3.B.F.14 pending"]
 fn exclude_lsh_leg_3_merge_with_cvs_modifier_delete_excluded() {
     // upstream: exclude.test:173-174
     let (tmp, fromdir) = setup_fixture();
@@ -252,10 +251,7 @@ fn exclude_lsh_leg_3_merge_with_cvs_modifier_delete_excluded() {
         dest.clone().into_os_string(),
     ]);
 
-    // Leg 3 currently fails because the per-directory `:C` modifier
-    // interaction with `--delete-excluded` is still being landed
-    // (see UTS-V3.B.F.14). Surface the exit code as the test diagnostic.
-    assert_eq!(code, 0, "leg 3 exited non-zero (pending UTS-V3.B.F.14)");
+    assert_eq!(code, 0, "leg 3 exited non-zero");
     assert_dest_has(&dest, "bar/down/to/foo/file4.junk");
     assert_dest_missing(&dest, "bar/down/to/foo/file1.bak");
 }


### PR DESCRIPTION
## What

`exclude_lsh_leg_3_merge_with_cvs_modifier_delete_excluded` was `#[ignore]`d as `"UTS-V3.B.F.14 pending"`, with an inline comment asserting the per-directory `:C` modifier interaction with `--delete-excluded` was "still being landed". It has landed - **the test passes**.

## How this was found

By auditing every `#[ignore]` in the tree and *running* them rather than trusting the reason strings. That discipline came out of #7269, where a marker claiming `--delay-updates` + `--delete` was broken had outlived its bug by months.

Of the 10 known-broken markers measured this way, **9 still fail exactly as their reason claims** and stay put:

| test | verdict |
|---|---|
| `exclude_lsh_leg_3_merge_with_cvs_modifier_delete_excluded` | **passes - stale, removed here** |
| `exclude_lsh_leg_6_dir_merge_excl_restricted` | still fails |
| `walk_detects_direct_symlink_loop` | still fails |
| `error_recovery_symlink_loop` | still fails |
| `min_size_does_not_affect_symlinks` | still fails |
| `no_implied_dirs_does_not_create_intermediate_directories` | still fails |
| `copy_unsafe_links_emits_info_symsafe_notice` | still fails |
| `list_only_without_recursive_shows_only_top_level` | still fails |
| `spill_env_e2e_engages_spill_layer` | still fails |
| `verbose_1_no_debug_unlike_level_2` | still fails |

So this PR removes exactly one marker. Leg 6 keeps its `#[ignore]` and its reason.

## Also

Drops the stale inline comment and the `"(pending UTS-V3.B.F.14)"` suffix from the exit-code assertion message - left in place it would misattribute any *future* failure to a gap that is closed.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run --workspace --all-features -E 'test(exclude_lsh_leg)'` - 5 run, 5 passed (leg 6 correctly still ignored)

Note: the per-crate form (`cargo nextest run -p <crate>`) resolves a different feature set than `--workspace` and compiles a different test set, so it does **not** substitute for the workspace command when checking whether a test runs at all. All measurements above use `--workspace`.
