### PR TITLE
fix(engine): --delay-updates must not reschedule the delete pass

### DIFF
--- a/crates/engine/src/local_copy/options/deletion.rs
+++ b/crates/engine/src/local_copy/options/deletion.rs
@@ -100,22 +100,27 @@ impl LocalCopyOptions {
 
     /// Returns the effective deletion timing when deletion sweeps are enabled.
     ///
-    /// When `--delay-updates` is active, files are staged in `.~tmp~`
-    /// subdirectories during the transfer phase and renamed into place only
-    /// after all transfers complete.  Deleting with `During` timing would
-    /// treat those staging directories as extraneous and remove them before
-    /// the rename sweep runs, corrupting the transfer.  We therefore promote
-    /// `During` to `After` whenever `delay_updates` is set.
+    /// `--delay-updates` does not change *when* deletions happen. Upstream
+    /// resolves a bare `--delete` to delete-during without consulting
+    /// `delay_updates`, so `--delete --delay-updates` sweeps on the same
+    /// schedule as `--delete` alone; only an explicit `--delete-after`
+    /// defers it.
     ///
-    /// upstream: generator.c - delete_in_dir() is only invoked after the
-    /// receiver rename sweep completes when delay_updates is active.
+    /// The staging directories are safe without a timing change: the sweep of
+    /// a directory runs before any file in it has been staged into its
+    /// `.~tmp~`, so no staging directory exists yet to look extraneous.
+    /// Upstream relies on that same ordering, and guards its *late* passes
+    /// with a barrier rather than a mode change - the generator parks on the
+    /// receiver's phase-2 `MSG_DONE`, by which point `handle_delayed_updates()`
+    /// has renamed everything and dropped each staging directory.
+    ///
+    /// upstream: compat.c:672-677 - `delete_mode` with no `--delete-WHEN`
+    /// resolves to `delete_during = 1` at protocol >= 30, and `delay_updates`
+    /// is not consulted; generator.c:2409-2419 is the barrier and 2425-2428
+    /// the late passes it guards; generator.c:1532-1535 is the during sweep.
     pub const fn delete_timing(&self) -> Option<DeleteTiming> {
         if self.delete {
-            if self.delay_updates && matches!(self.delete_timing, DeleteTiming::During) {
-                Some(DeleteTiming::After)
-            } else {
-                Some(self.delete_timing)
-            }
+            Some(self.delete_timing)
         } else {
             None
         }
@@ -130,9 +135,7 @@ impl LocalCopyOptions {
     /// Reports whether deletions should occur after transfers instead of immediately.
     #[must_use]
     pub const fn delete_after_enabled(&self) -> bool {
-        self.delete
-            && (matches!(self.delete_timing, DeleteTiming::After)
-                || (self.delay_updates && matches!(self.delete_timing, DeleteTiming::During)))
+        self.delete && matches!(self.delete_timing, DeleteTiming::After)
     }
 
     /// Reports whether deletions are deferred until after transfers but determined during the walk.
@@ -144,7 +147,7 @@ impl LocalCopyOptions {
     /// Reports whether deletions should occur while processing directory entries.
     #[must_use]
     pub const fn delete_during_enabled(&self) -> bool {
-        matches!(self.delete_timing, DeleteTiming::During) && self.delete && !self.delay_updates
+        matches!(self.delete_timing, DeleteTiming::During) && self.delete
     }
 
     /// Reports whether excluded paths should also be removed during deletion sweeps.
@@ -317,12 +320,39 @@ mod tests {
         assert_eq!(DeleteTiming::default(), DeleteTiming::During);
     }
 
+    /// `--delay-updates` must not change the delete schedule.
+    ///
+    /// Upstream resolves a bare `--delete` to delete-during without consulting
+    /// `delay_updates` (compat.c:672-677), so `--delete --delay-updates` sweeps
+    /// exactly like `--delete`. Promoting it to `After` here would silently
+    /// give the user `--delete-after` semantics they did not ask for, which is
+    /// observable: the `deleting` lines move to the end of the output.
     #[test]
-    fn delay_updates_promotes_during_to_after() {
+    fn delay_updates_leaves_during_timing_alone() {
         let opts = LocalCopyOptions::new().delete(true).delay_updates(true);
-        assert_eq!(opts.delete_timing(), Some(DeleteTiming::After));
-        assert!(opts.delete_after_enabled());
-        assert!(!opts.delete_during_enabled());
+        assert_eq!(opts.delete_timing(), Some(DeleteTiming::During));
+        assert!(opts.delete_during_enabled());
+        assert!(!opts.delete_after_enabled());
+    }
+
+    /// The whole point of the rule above: `--delete --delay-updates` and
+    /// `--delete` must be indistinguishable in delete scheduling, so a change
+    /// to one that forgets the other fails here.
+    #[test]
+    fn delay_updates_delete_schedule_matches_plain_delete() {
+        let plain = LocalCopyOptions::new().delete(true);
+        let delayed = LocalCopyOptions::new().delete(true).delay_updates(true);
+        assert_eq!(plain.delete_timing(), delayed.delete_timing());
+        assert_eq!(
+            plain.delete_during_enabled(),
+            delayed.delete_during_enabled()
+        );
+        assert_eq!(plain.delete_after_enabled(), delayed.delete_after_enabled());
+        assert_eq!(
+            plain.delete_before_enabled(),
+            delayed.delete_before_enabled()
+        );
+        assert_eq!(plain.delete_delay_enabled(), delayed.delete_delay_enabled());
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`crates/engine/src/local_copy/options/deletion.rs` promoted `DeleteTiming::During` to `After` whenever `--delay-updates` was set, at three sites (`delete_timing`, `delete_after_enabled`, `delete_during_enabled`). The effect: **`--delete --delay-updates` silently behaved like `--delete-after`**, which the user did not ask for.

## Upstream

Upstream never reschedules the delete pass for `--delay-updates`:

- `options.c:2210-2228` — a bare `--delete` leaves before/during/after all `0`, setting only `delete_mode`.
- `compat.c:672-677` — `delete_mode` with no `--delete-WHEN` resolves to `delete_during = 1` at protocol ≥ 30. `delay_updates` is not consulted.
- `compat.c:172-177` — `delay_updates` affects only `allow_inc_recurse`.

The staging directories are protected by **ordering and a barrier**, not a mode change:

- `generator.c:1532-1535` — the delete-during sweep reaches a directory before any file in it has been received, so `.~tmp~` does not exist yet.
- `generator.c:2409-2419` → `2425-2428` — the generator parks on the receiver's phase-2 `MSG_DONE` (`handle_delayed_updates()` has renamed everything and dropped each staging dir) *before* running the delayed/after passes.

Nothing in `exclude.c` or `options.c` filters `.~tmp~` out of the sweep.

## Measured

Oracle: `target/interop/upstream-src/rsync-3.4.4/rsync` (banner `rsync version 3.4.4 protocol version 32`). Nested tree, extraneous entries at both levels, `-av`:

| command | output order |
|---|---|
| upstream `--delete` | `deleting`, `deleting`, transfers |
| upstream `--delete --delay-updates` | **identical to plain `--delete`** |
| upstream `--delete-after --delay-updates` | transfers, `deleting`, `deleting` |
| **oc before** | transfers, `deleting`, `deleting` ← the `--delete-after` shape |
| **oc after** | same as its own `--delete` ✔ |

After the change: destination content correct, **zero staging directories survive**, and `--delete-after --delay-updates` still defers.

## Not fixed here (separate, pre-existing)

oc's local copy interleaves `deleting` with transfer lines (`deleting a`, `a`, `deleting b`, `b`) where upstream emits both deletes first. That is an artifact of upstream's generator/receiver process pipeline versus oc's synchronous local copy — unrelated to this promotion, and untouched. Related: tasks for `deletion.rs` itemize framing.

## Tests

The old unit test asserted only that the promotion existed, so it could not survive the fix. Replaced with:

- `delay_updates_leaves_during_timing_alone` — the upstream rule, with the reason in the doc comment.
- `delay_updates_delete_schedule_matches_plain_delete` — `--delete` and `--delete --delay-updates` must agree on *every* delete-schedule accessor, so a future change that updates one path and forgets the other fails here.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run --workspace --all-features -E 'package(engine) or test(delete_timing) or test(delay_updates)'` — 2507 passed, 1 failed
- The single failure is `archive_preserves_mixed_permissions_across_files`, which **fails identically on clean `origin/master`** on this macOS host and is unrelated (tracked separately).
