### PR TITLE
ci: keep master CI runs by making the exemption structural

### DIFF
--- a/.github/workflows/bin-build-coverage.yml
+++ b/.github/workflows/bin-build-coverage.yml
@@ -28,10 +28,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: bin-build-coverage-${{ github.ref }}
+  group: bin-build-coverage-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
   # Superseded pull request pushes still cancel; pushes to master do not, so
-  # every merge commit keeps a completed run for bisection.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  # every merge commit keeps a completed run for bisection. The master
+  # exemption lives in the GROUP KEY, not in cancel-in-progress: giving each
+  # master commit its own group means there is never an older run in the group
+  # to evict, which holds regardless of how the flag is evaluated.
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/.github/workflows/check-locked-flags.yml
+++ b/.github/workflows/check-locked-flags.yml
@@ -26,10 +26,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: check-locked-flags-${{ github.ref }}
+  group: check-locked-flags-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
   # Superseded pull request pushes still cancel; pushes to master do not, so
-  # every merge commit keeps a completed run for bisection.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  # every merge commit keeps a completed run for bisection. The master
+  # exemption lives in the GROUP KEY, not in cancel-in-progress: giving each
+  # master commit its own group means there is never an older run in the group
+  # to evict, which holds regardless of how the flag is evaluated.
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,13 @@ on:
     - cron: '30 3 * * *'
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
   # Superseded pull request pushes still cancel; pushes to master do not, so
-  # every merge commit keeps a completed run for bisection.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  # every merge commit keeps a completed run for bisection. The master
+  # exemption lives in the GROUP KEY, not in cancel-in-progress: giving each
+  # master commit its own group means there is never an older run in the group
+  # to evict, which holds regardless of how the flag is evaluated.
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/interop-validation.yml
+++ b/.github/workflows/interop-validation.yml
@@ -26,10 +26,13 @@ on:
     - cron: '0 2 * * *'
 
 concurrency:
-  group: interop-validation-${{ github.ref }}
+  group: interop-validation-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
   # Superseded pull request pushes still cancel; pushes to master do not, so
-  # every merge commit keeps a completed run for bisection.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  # every merge commit keeps a completed run for bisection. The master
+  # exemption lives in the GROUP KEY, not in cancel-in-progress: giving each
+  # master commit its own group means there is never an older run in the group
+  # to evict, which holds regardless of how the flag is evaluated.
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/iouring-kernel-compat.yml
+++ b/.github/workflows/iouring-kernel-compat.yml
@@ -37,10 +37,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: iouring-kernel-compat-${{ github.ref }}
+  group: iouring-kernel-compat-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
   # Superseded pull request pushes still cancel; pushes to master do not, so
-  # every merge commit keeps a completed run for bisection.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  # every merge commit keeps a completed run for bisection. The master
+  # exemption lives in the GROUP KEY, not in cancel-in-progress: giving each
+  # master commit its own group means there is never an older run in the group
+  # to evict, which holds regardless of how the flag is evaluated.
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,10 +20,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: security-${{ github.ref }}
+  group: security-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
   # Superseded pull request pushes still cancel; pushes to master do not, so
-  # every merge commit keeps a completed run for bisection.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  # every merge commit keeps a completed run for bisection. The master
+  # exemption lives in the GROUP KEY, not in cancel-in-progress: giving each
+  # master commit its own group means there is never an older run in the group
+  # to evict, which holds regardless of how the flag is evaluated.
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/send-zc-5-15-lts.yml
+++ b/.github/workflows/send-zc-5-15-lts.yml
@@ -42,10 +42,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: send-zc-5-15-lts-${{ github.ref }}
+  group: send-zc-5-15-lts-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
   # Superseded pull request pushes still cancel; pushes to master do not, so
-  # every merge commit keeps a completed run for bisection.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  # every merge commit keeps a completed run for bisection. The master
+  # exemption lives in the GROUP KEY, not in cancel-in-progress: giving each
+  # master commit its own group means there is never an older run in the group
+  # to evict, which holds regardless of how the flag is evaluated.
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## The defect

**Every master CI run is being cancelled.** No merge commit has a completed run, so master carries no verified-green state and the bisection guarantee `ci.yml` describes is not delivered.

Over the last 60 runs: **4 cancelled, 1 pending, 0 successful.**

## Evidence

Each run's `ended` lands within 1–2 seconds of the **next** run's `created` — that is the concurrency mechanism evicting it, not a timeout or a manual cancel:

| commit | ended | evicted by |
|---|---|---|
| `0a674e256` | 04:02:02 | `8b4e56715` created 04:02:01 |
| `8b4e56715` | 04:27:30 | `6b20f260c` created 04:27:29 |
| `6b20f260c` | 05:10:28 | `851f26c4c` created 05:10:26 |
| `851f26c4c` | 05:39:44 | `ba45575c3` created 05:39:42 |

The cancelled runs carry **no jobs at all** and sit ~25 minutes between `created` and `ended` — evicted while still queued, before any job materialised.

## Why the existing config doesn't achieve its stated intent

```yaml
group: ci-${{ github.ref }}
# Superseded pull request pushes still cancel; pushes to master do not, so
# every merge commit keeps a completed run for bisection.
cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
```

For a push to master, `github.ref` **is** `refs/heads/master`, so the expression is `false` and the run should survive. Empirically it does not.

## The fix

Move the exemption into the **group key**, where it is a property of identity rather than of expression evaluation:

```yaml
group: ci-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
cancel-in-progress: true
```

On master each commit gets its own group, so **there is never an older run in the group to evict** — that holds regardless of how the flag is evaluated. PR branches keep a per-ref group and keep cancelling superseded pushes, unchanged.

I chose this over debugging the expression because the group-identity form is correct by construction; the flag form depends on a runtime evaluation that is demonstrably not producing the documented behaviour.

**This does not loosen cancellation anywhere.** PR-branch behaviour is byte-identical. Only master stops evicting its own history.

## Scope

Applied to **all seven** workflows carrying the identical exemption, so the class is fixed rather than one instance: `bin-build-coverage`, `check-locked-flags`, `ci`, `iouring-kernel-compat`, `security`, `send-zc-5-15-lts`, `interop-validation`.

## Verification

- All seven files parse as valid YAML; each `concurrency` block re-read after patching and confirmed to have the widened group and `cancel-in-progress: true`.
- The real test is observational and lands with this PR: after merge, the next two master commits should each retain a **completed** CI run instead of cancelling the previous one. If they still cancel, the cause is not concurrency and this PR should be reverted rather than built on.
