### PR TITLE
fix(cli): --quiet must suppress info output regardless of -v

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/output.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/output.rs
@@ -13,8 +13,7 @@ pub(super) fn add_output_args(command: ClapCommand) -> ClapCommand {
                 .short('v')
                 .help("Increase verbosity; may be supplied multiple times.")
                 .action(ArgAction::Count)
-                .overrides_with("no-verbose")
-                .overrides_with("quiet"),
+                .overrides_with("no-verbose"),
         )
         .arg(
             Arg::new("no-verbose")
@@ -29,8 +28,7 @@ pub(super) fn add_output_args(command: ClapCommand) -> ClapCommand {
                 .long("quiet")
                 .short('q')
                 .help("Suppress non-error messages.")
-                .action(ArgAction::SetTrue)
-                .overrides_with("verbose"),
+                .action(ArgAction::SetTrue),
         )
         .arg(
             // upstream: options.c:616 `{"human-readable", 'h', POPT_ARG_NONE, ...}`

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -1785,3 +1785,61 @@ fn verbose_delete_renders_deleting_before_summary_no_bare_leak() {
         "staledir should have been deleted"
     );
 }
+
+/// `--quiet` suppresses info output no matter where `-v` sits on the command
+/// line, and `-v` alone still produces output.
+///
+/// upstream: `-q` and `-v` are independent - `options.c:1598` just does
+/// `quiet++`, and the suppression happens once at the output funnel
+/// (`log.c:317-319` `case FINFO: if (quiet) return;`). Neither flag overrides
+/// the other during parsing, so the result does not depend on their order.
+///
+/// oc previously declared the two clap args as mutually `overrides_with` each
+/// other, which made them exclusive and last-one-wins: `-qv` cleared quiet and
+/// printed the whole listing plus the summary, while `-vq` printed nothing.
+///
+/// The `-v` leg is a positive control and is load-bearing: without it this test
+/// would still pass if verbosity were broken outright and every invocation went
+/// silent.
+#[test]
+fn quiet_suppresses_info_regardless_of_verbose_order() {
+    use tempfile::tempdir;
+
+    let run = |flags: &[&str]| {
+        let tmp = tempdir().expect("tempdir");
+        let source = tmp.path().join("q.txt");
+        let destination = tmp.path().join("q.out");
+        std::fs::write(&source, b"payload").expect("write source");
+
+        let mut args = vec![OsString::from(RSYNC)];
+        args.extend(flags.iter().map(OsString::from));
+        args.push(source.into_os_string());
+        args.push(destination.clone().into_os_string());
+
+        let (code, stdout, stderr) = run_with_args(args);
+        assert_eq!(code, 0, "{flags:?} must succeed");
+        assert!(stderr.is_empty(), "{flags:?} must not warn");
+        assert_eq!(
+            std::fs::read(destination).expect("read destination"),
+            b"payload",
+            "{flags:?} must still transfer the file"
+        );
+        stdout
+    };
+
+    for flags in [&["-q", "-v"][..], &["-v", "-q"][..], &["-q"][..]] {
+        let stdout = run(flags);
+        assert!(
+            stdout.is_empty(),
+            "{flags:?} must print nothing, got: {:?}",
+            String::from_utf8_lossy(&stdout)
+        );
+    }
+
+    let verbose_only = run(&["-v"]);
+    assert!(
+        !verbose_only.is_empty(),
+        "-v alone must still print; an always-silent build would make the \
+         quiet assertions above vacuous"
+    );
+}


### PR DESCRIPTION
## Problem

`-qv` printed the entire file listing and the summary. Upstream prints nothing. Measured against rsync 3.4.4:

```
$ rsync -qv -r src/ dst/
upstream 3.4.4 : (no output)
oc             : sending incremental file list
                 top.txt
                 sub/
                 sub/f.txt
                 sent 4 bytes  received 0 bytes  8.00 bytes/sec
                 total size is 4  speedup is 1.00
```

## Upstream's model

`-q` and `-v` are **independent**. `-q` is just a counter (`options.c:1598` → `quiet++`), and the suppression happens once, at the output funnel:

```c
case FINFO:
    if (quiet)
        return;          /* log.c:317-319, rwrite() */
```

Neither flag overrides the other during parsing, so the result is **order-independent**. Verified on the oracle:

| flags | upstream | oc before | oc after |
|---|---|---|---|
| `-qv` | 0 lines | **5 lines** | 0 lines |
| `-vq` | 0 lines | 0 lines | 0 lines |
| `-q`  | 0 lines | 0 lines | 0 lines |
| `-v`  | 5 lines | 5 lines | 5 lines |

## Root cause

oc declared the two clap args as mutually `overrides_with` each other:

```rust
Arg::new("verbose") ... .overrides_with("quiet"),
Arg::new("quiet")   ... .overrides_with("verbose"),
```

That makes them exclusive and last-one-wins, so `-qv` **cleared quiet entirely** — no downstream check could fire — while `-vq` happened to work.

## Fix

Drop the two override declarations. That is the whole change.

Notably **no new suppression logic was needed**: `logging::message_stream` already implements upstream's rule and already has a `quiet_suppresses_info_and_nothing_else` unit test. The flag simply wasn't surviving argument parsing to reach it.

`--no-verbose` keeps its override against `--verbose` — that pair is a genuine last-one-wins toggle and is unrelated.

## Test

`quiet_suppresses_info_regardless_of_verbose_order` asserts the **class**, not the one broken ordering: both orders, `-q` alone, and `-v` alone.

The `-v` leg is a positive control and is load-bearing — without it the test would still pass if verbosity were broken outright and every invocation went silent.

Confirmed to be a real oracle: with the overrides restored it fails with
`["-q", "-v"] must print nothing, got: "q.txt\n\nsent 7 bytes ..."`, and passes with the fix.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` exit 0
- `cargo test -p cli --lib verbose_tests::` — 43 passed, 0 failed
- Behaviour re-measured against the 3.4.4 oracle after the change (table above)

Found while measuring three output-fidelity divergences against upstream; the other two (`-dv` missing `building file list ... done`, and `-R --list-only` omitting the `.` row) are recorded separately and are **not** in this PR.
