### PR TITLE
docs: align the upstream reference to rsync 3.5.0 and report peak RSS

### DIFF
--- a/.github/scripts/benchmark_report.py
+++ b/.github/scripts/benchmark_report.py
@@ -8,6 +8,12 @@ a markdown table grouped by transfer mode to stdout.
 import json
 import sys
 
+# Both scripts live in .github/scripts and are invoked as
+# `python3 .github/scripts/<name>.py`, which puts that directory on sys.path[0].
+# benchmark_chart is pure stdlib, so importing its size formatter here keeps one
+# definition of the IEC convention rather than a second copy that can drift.
+from benchmark_chart import fmt_bytes
+
 MODE_LABELS = {
     "local": "Local Copy",
     "ssh_pull": "SSH Pull",
@@ -111,11 +117,49 @@ def highlight_lines(summary):
     return lines
 
 
+def memory_indicator(ratio):
+    """Ratio wording for a BYTES metric.
+
+    ratio_indicator() says "faster"/"slower", which is meaningless for peak
+    RSS -- memory is not fast. Using it here would repeat the unit conflation
+    benchmark_chart.py already had to fix, where a bytes metric was described
+    in duration language. Same 5% noise band as the timing indicator so the
+    two columns agree on what counts as a real difference.
+    """
+    if ratio < 0.95:
+        return "lower"
+    if ratio <= 1.05:
+        return "~same"
+    return "higher"
+
+
+def rss_cells(t):
+    """Return the three peak-RSS cells for a comparison row.
+
+    benchmark_rss() records `peak_rss_kb` for every mode, not just the memory
+    mode, so a throughput comparison can show what the speed cost in memory
+    without a second benchmark run. The measurement can still be absent -- a
+    run that timed out, or a platform whose /usr/bin/time output this parser
+    does not recognise -- so a missing value degrades to a dash rather than
+    inventing a number or dropping the row.
+    """
+    up_kb = t["upstream"].get("peak_rss_kb")
+    oc_kb = t["oc_rsync"].get("peak_rss_kb")
+    if not up_kb or not oc_kb:
+        return "-", "-", "-"
+    ratio = oc_kb / up_kb
+    return (
+        fmt_bytes(up_kb * 1024),
+        fmt_bytes(oc_kb * 1024),
+        f"{memory_indicator(ratio)} {ratio:.2f}x",
+    )
+
+
 def main():
     with open("benchmark_results.json") as f:
         data = json.load(f)
 
-    upstream_version = data.get("upstream_version") or "3.4.4"
+    upstream_version = data.get("upstream_version") or "3.5.0"
 
     print("## Benchmark Results\n")
     print(
@@ -138,15 +182,22 @@ def main():
             continue
 
         print(f"### {label}\n")
-        print(f"| Test | rsync {upstream_version} | oc-rsync | Ratio |")
-        print("|------|----------|----------|-------|")
+        print(
+            f"| Test | rsync {upstream_version} | oc-rsync | Time | "
+            f"rsync {upstream_version} RSS | oc-rsync RSS | Peak RSS |"
+        )
+        print("|------|----------|----------|------|----------|----------|----------|")
 
         for t in tests:
             up = t["upstream"]["mean"]
             oc = t["oc_rsync"]["mean"]
             ratio = t["ratio"]
             ind = ratio_indicator(ratio)
-            print(f"| {t['name']} | {up:.3f}s | {oc:.3f}s | {ind} {ratio:.2f}x |")
+            up_rss, oc_rss, rss_ratio = rss_cells(t)
+            print(
+                f"| {t['name']} | {up:.3f}s | {oc:.3f}s | {ind} {ratio:.2f}x "
+                f"| {up_rss} | {oc_rss} | {rss_ratio} |"
+            )
 
         print()
 

--- a/.github/workflows/_benchmark-macos.yml
+++ b/.github/workflows/_benchmark-macos.yml
@@ -1,7 +1,7 @@
 name: Benchmark (macOS throughput)
 
 # Reusable workflow: macOS throughput comparison between oc-rsync and
-# upstream rsync 3.4.4 built from source.
+# upstream rsync 3.5.0 built from source.
 #
 # Best-effort: macOS runners have more wall-clock variance than
 # bare-metal Linux. Numbers are a regression sniff, not a merge gate.
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   benchmark-macos:
-    name: throughput vs upstream rsync 3.4.4 (macOS, best-effort)
+    name: throughput vs upstream rsync 3.5.0 (macOS, best-effort)
     runs-on: macos-15
     timeout-minutes: ${{ inputs.timeout_minutes || 90 }}
     continue-on-error: true
@@ -62,21 +62,21 @@ jobs:
         id: cache-rsync
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: target/interop/upstream-src/rsync-3.4.4
-          key: upstream-rsync-3.4.4-${{ runner.os }}-full
+          path: target/interop/upstream-src/rsync-3.5.0
+          key: upstream-rsync-3.5.0-${{ runner.os }}-full
 
-      - name: Build upstream rsync 3.4.4
+      - name: Build upstream rsync 3.5.0
         if: steps.cache-rsync.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p target/interop/upstream-src
           cd target/interop/upstream-src
 
-          if [ ! -d rsync-3.4.4 ]; then
-            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz | tar xz
+          if [ ! -d rsync-3.5.0 ]; then
+            curl -L https://download.samba.org/pub/rsync/src/rsync-3.5.0.tar.gz | tar xz
           fi
 
-          cd rsync-3.4.4
+          cd rsync-3.5.0
           if [ ! -f rsync ]; then
             BREW_PREFIX="$(brew --prefix)"
             PKG_CONFIG_PATH="${BREW_PREFIX}/opt/openssl@3/lib/pkgconfig:${BREW_PREFIX}/opt/xxhash/lib/pkgconfig:${BREW_PREFIX}/opt/zstd/lib/pkgconfig:${BREW_PREFIX}/opt/lz4/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
@@ -89,7 +89,7 @@ jobs:
           fi
 
       - name: Verify upstream rsync binary
-        run: target/interop/upstream-src/rsync-3.4.4/rsync --version | head -3
+        run: target/interop/upstream-src/rsync-3.5.0/rsync --version | head -3
 
       - name: Set up SSH loopback
         run: |

--- a/.github/workflows/benchmark-tooling.yml
+++ b/.github/workflows/benchmark-tooling.yml
@@ -19,6 +19,7 @@ on:
       - '.github/scripts/benchmark_chart.py'
       - '.github/scripts/benchmark_report.py'
       - 'tools/ci/tests/test_benchmark_chart.py'
+      - 'tools/ci/tests/test_benchmark_report.py'
       - '.github/workflows/benchmark-tooling.yml'
   push:
     branches:
@@ -27,6 +28,7 @@ on:
       - '.github/scripts/benchmark_chart.py'
       - '.github/scripts/benchmark_report.py'
       - 'tools/ci/tests/test_benchmark_chart.py'
+      - 'tools/ci/tests/test_benchmark_report.py'
       - '.github/workflows/benchmark-tooling.yml'
 
 permissions:
@@ -48,4 +50,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Self-test benchmark_chart.py and benchmark_report.py
-        run: python3 tools/ci/tests/test_benchmark_chart.py
+        run: |
+          python3 tools/ci/tests/test_benchmark_chart.py
+          python3 tools/ci/tests/test_benchmark_report.py

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,21 +73,21 @@ jobs:
         id: cache-rsync
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: target/interop/upstream-src/rsync-3.4.4
-          key: upstream-rsync-3.4.4-${{ runner.os }}-full
+          path: target/interop/upstream-src/rsync-3.5.0
+          key: upstream-rsync-3.5.0-${{ runner.os }}-full
 
-      - name: Build upstream rsync 3.4.4
+      - name: Build upstream rsync 3.5.0
         if: steps.cache-rsync.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p target/interop/upstream-src
           cd target/interop/upstream-src
 
-          if [ ! -d rsync-3.4.4 ]; then
-            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz | tar xz
+          if [ ! -d rsync-3.5.0 ]; then
+            curl -L https://download.samba.org/pub/rsync/src/rsync-3.5.0.tar.gz | tar xz
           fi
 
-          cd rsync-3.4.4
+          cd rsync-3.5.0
           if [ ! -f rsync ]; then
             ./configure
             make -j$(nproc)
@@ -103,7 +103,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no localhost true
 
       - name: Install upstream rsync to PATH
-        run: sudo cp target/interop/upstream-src/rsync-3.4.4/rsync /usr/local/bin/rsync
+        run: sudo cp target/interop/upstream-src/rsync-3.5.0/rsync /usr/local/bin/rsync
 
       - name: Run benchmark
         id: benchmark
@@ -121,7 +121,9 @@ jobs:
         # renderers are exercised against synthetic results before the real
         # ones are drawn. A metric regression here fails the tag build
         # instead of shipping a misleading chart to the release page.
-        run: python3 tools/ci/tests/test_benchmark_chart.py
+        run: |
+          python3 tools/ci/tests/test_benchmark_chart.py
+          python3 tools/ci/tests/test_benchmark_report.py
 
       - name: Generate benchmark chart
         run: |
@@ -231,8 +233,8 @@ jobs:
 
   # macOS throughput sniff: runs on tag, weekly schedule, and manual
   # dispatch. Best-effort (continue-on-error in the reusable workflow);
-  # not wired into branch protection. Builds upstream rsync 3.4.4 from
+  # not wired into branch protection. Builds upstream rsync 3.5.0 from
   # source and compares against oc-rsync release build.
   macos-throughput:
-    name: macOS throughput (vs upstream rsync 3.4.4)
+    name: macOS throughput (vs upstream rsync 3.5.0)
     uses: ./.github/workflows/_benchmark-macos.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,32 @@ All notable changes to oc-rsync are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-oc-rsync is wire-compatible with upstream rsync 3.4.4 (protocol 32). Release
-tags are mirrored on GitHub at <https://github.com/oferchen/rsync/releases>.
+oc-rsync is wire-compatible with upstream rsync 3.5.0 and the 3.4.x series
+(protocol 32). Release tags are mirrored on GitHub at
+<https://github.com/oferchen/rsync/releases>.
+
+## [Unreleased]
+
+### Changed
+
+- Tracked upstream reference moved to rsync 3.5.0 (released 13 Aug 2026) in
+  prose, comparison docs and the release benchmark. 3.5.0 carries the same wire
+  protocol as 3.4.4 (`PROTOCOL_VERSION` 32, `SUBPROTOCOL_VERSION` 0, unchanged
+  `errcode.h`), so wire compatibility is unaffected; the release is behavioural,
+  covering 33 CVEs in path handling and the daemon.
+- Release benchmarks now compare against upstream rsync 3.5.0 and report **peak
+  RSS alongside elapsed time for every mode**. The measurement was already being
+  collected for each run and discarded for all but the memory mode, so a speed
+  win paid for in memory was invisible in the published numbers.
+- Added rsync 3.5.0 to the interop harness as a built-and-cached oracle binary.
+  The "this release has no distro package, build from source" fact is now stated
+  once in a shared list instead of being duplicated across two dispatch tables.
+
+### Added
+
+- Regression tests for the benchmark report renderer, covering the peak-RSS
+  columns, the missing-measurement fallback, and the requirement that a bytes
+  metric is not described in duration language ("higher", not "slower").
 
 ## [0.6.4] - 2026-07-18
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 [![Interop Validation](https://github.com/oferchen/rsync/actions/workflows/interop-validation.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/interop-validation.yml)
 [![Upstream Testsuite (rsync 3.4.4)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite.yml)
 [![Upstream Testsuite root (rsync 3.4.4)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite-root.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite-root.yml)
-[![Track 3.5.0dev Testsuite (RsyncProject master)](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml)
+[![Testsuite (rsync 3.5.0, tracking)](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml)
 [![Release](https://img.shields.io/github/v/release/oferchen/rsync?include_prereleases)](https://github.com/oferchen/rsync/releases)
 
 # oc-rsync
 
-`rsync` re-implemented in Rust. Wire-compatible with upstream rsync 3.4.4 (and back-compat with 3.4.3 / 3.4.2 / 3.4.1, protocol 32), works as a drop-in replacement.
+`rsync` re-implemented in Rust. Wire-compatible with upstream rsync 3.5.0 (and with the whole 3.4.x series, protocol 32), works as a drop-in replacement.
 
 Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict.
 
@@ -15,9 +15,11 @@ Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict
 
 ## Status
 
-**Release:** 0.6.4 - Wire-compatible drop-in replacement for rsync 3.4.4 (and 3.4.3 / 3.4.2 / 3.4.1, protocols 28-32).
+**Release:** 0.6.4 - Wire-compatible drop-in replacement for rsync 3.5.0 and the 3.4.x series (protocols 28-32).
 
-All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop scenarios run in CI against upstream rsync 3.0.9, 3.1.3, and 3.4.4, with 2.6.9 built and cached for wire-byte regression coverage; 3.4.4 represents the whole 3.4.x series (3.4.1/3.4.2/3.4.3 share protocol 32 and are superseded by it). Upstream rsync's own `testsuite/*.test` corpus runs in CI against `oc-rsync` as `$RSYNC` - all tests now pass (known-failures roster is empty).
+All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop scenarios run in CI against upstream rsync 3.0.9, 3.1.3, and 3.4.4, with 2.6.9 and 3.5.0 built and cached; 3.4.4 represents the whole 3.4.x series (3.4.1/3.4.2/3.4.3 share protocol 32 and are superseded by it). Upstream rsync's own testsuite runs in CI against `oc-rsync` as `$RSYNC`; against the 3.4.4 corpus all tests pass and the known-failures roster is empty.
+
+**Tracking rsync 3.5.0.** Upstream released 3.5.0 on 13 Aug 2026. It is wire-identical to 3.4.4 - `PROTOCOL_VERSION` 32, `SUBPROTOCOL_VERSION` 0, unchanged `errcode.h` - so protocol compatibility carries over unchanged and is what the "wire-compatible" claim above rests on. What 3.5.0 changes is *behaviour*: 33 CVEs concentrated in path handling and the daemon, a rewritten path resolver, three new options (`--confine-root`, `--insecure-links`, `--no-insecure-links`), three new daemon directives (`proxy protocol hosts`, `auth digest`, `insecure links`), and a test suite rebuilt from shell scripts into Python. Aligning oc-rsync to those behaviours is in progress and tracked openly: the 3.5.0 suite currently reports 133 divergences, measured nightly by the [3.5.0 testsuite tracker](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml). The gating upstream-testsuite check remains pinned to 3.4.4 until that set is closed or registered.
 
 | Component | Status |
 |-----------|--------|
@@ -73,7 +75,7 @@ See the [CHANGELOG](./CHANGELOG.md) for the full, per-release change history.
 
 ### Interop Testing
 
-Tested against upstream rsync **2.6.9**, **3.0.9**, **3.1.3**, and **3.4.4** in CI across protocols 28-32. The 3.4.x series shares protocol 32 and is represented in the matrix by 3.4.4, the latest conservative regression-fix release; 3.4.1/3.4.2/3.4.3 cells are subsumed because they run identical wire scenarios. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth. Wire differential fuzzing against upstream rsync validates protocol-level byte equivalence. See the [full interop compatibility matrix](./docs/user/interop-compatibility-matrix.md) for per-version, per-feature, and per-platform detail.
+Tested against upstream rsync **2.6.9**, **3.0.9**, **3.1.3**, and **3.4.4** in CI across protocols 28-32, with **3.5.0** built and cached as an oracle binary ahead of joining the gating matrix. The 3.4.x series shares protocol 32 and is represented in the matrix by 3.4.4; 3.4.1/3.4.2/3.4.3 cells are subsumed because they run identical wire scenarios. 3.5.0 shares that same protocol 32 wire format, so it adds behavioural coverage rather than new protocol coverage. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth. Wire differential fuzzing against upstream rsync validates protocol-level byte equivalence. See the [full interop compatibility matrix](./docs/user/interop-compatibility-matrix.md) for per-version, per-feature, and per-platform detail.
 
 ### Supported rsync protocol versions
 
@@ -81,7 +83,7 @@ oc-rsync negotiates `protocol_version` per upstream, defaults to 32, and support
 
 | Protocol | Upstream rsync version | Status in oc-rsync | Notes |
 |----------|------------------------|--------------------|-------|
-| 32       | 3.4.x (current)        | Full support        | Primary target; all features negotiated. Protocol 32 was introduced in rsync 3.4.0 |
+| 32       | 3.4.x, 3.5.0 (current) | Full support        | Primary target; all features negotiated. Protocol 32 was introduced in rsync 3.4.0 and is unchanged in 3.5.0 |
 | 31       | 3.1.x - 3.3.x          | Full support        | Verified via interop matrix (3.1.3); introduced in rsync 3.1.0 and used through the 3.2.x/3.3.x series |
 | 30       | 3.0.x                  | Full support        | Verified via interop matrix (3.0.9) |
 | 29       | 2.6.9                  | Full support        | Non-blocking interop against upstream 2.6.9 (RP28.c/RP28.d); sort.rs t_PATH/t_ITEM gate (RP28.h) |
@@ -99,6 +101,7 @@ Per-version dispatch is implemented as `protocol_version` gates in the wire code
 | 3.0.9                  | 30       | push, pull, daemon       | gating |
 | 3.1.3                  | 31       | push, pull, daemon       | gating |
 | 3.4.4                  | 32       | push, pull, daemon, SSH  | gating |
+| 3.5.0                  | 32       | push, pull, daemon, SSH  | built + cached (not yet gating) |
 
 Wire format is verified byte-identical to upstream rsync via CI golden-byte tests for the listed versions. Wire differential fuzzing validates protocol-level byte equivalence against upstream. Other versions may work but are not regression-tested.
 
@@ -137,9 +140,9 @@ See also the `SSH TRANSPORT` section of `oc-rsync(1)` for the man-page summary.
 
 ### Performance
 
-![Benchmark: oc-rsync vs upstream rsync 3.4.4](https://github.com/oferchen/rsync/releases/latest/download/benchmark.png)
+![Benchmark: oc-rsync vs upstream rsync 3.5.0](https://github.com/oferchen/rsync/releases/latest/download/benchmark.png)
 
-Benchmarked against upstream rsync 3.4.4 on each tagged release across local, SSH, and daemon transfer modes; the chart and a per-mode breakdown are attached to every [GitHub release](https://github.com/oferchen/rsync/releases/latest).
+Benchmarked against upstream rsync 3.5.0 on each tagged release across local, SSH, and daemon transfer modes. Every mode reports both **elapsed time** and **peak RSS**, so a throughput win bought with memory is visible rather than hidden; the chart, a per-mode breakdown and the exact upstream build string are attached to every [GitHub release](https://github.com/oferchen/rsync/releases/latest).
 
 Threaded architecture replaces upstream's fork-based pipeline while keeping full protocol compatibility, reducing syscall overhead and context switches. Adaptive I/O buffers scale from 8KB to 1MB based on file size. Optional io_uring on Linux 5.6+ with three policies: *auto* (default; probe kernel and fall back to standard I/O), `--io-uring` (require io_uring; error if unavailable), `--no-io-uring` (always use standard buffered I/O). The active backend is reported in `--version` output. See `oc-rsync(1)` for details.
 
@@ -189,7 +192,7 @@ Three one-shot warnings may appear on stderr (sync path) or via `tracing` target
 
 ### Known Limitations / Architectural Trade-offs
 
-oc-rsync is wire-compatible with upstream rsync 3.4.4, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:
+oc-rsync is wire-compatible with upstream rsync 3.5.0, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:
 
 - **io_uring kernel requirement.** Provided buffer rings (PBUF_RING) require Linux **5.19+**; older 5.6-5.18 kernels fall back to standard buffered I/O via runtime probing.
 - **io_uring buffer pool.** The registered buffer pool defaults to 1024 × 4 KiB = 4 MiB and does not auto-adapt under sustained I/O pressure, though its slot count, memory cap, and block size are tunable at runtime via the `OC_RSYNC_BUFFER_POOL_SIZE`, `OC_RSYNC_BUFFER_POOL_MEMORY_CAP`, and `OC_BUFFER_POOL_BLOCK_SIZE` environment variables. Workloads with very high concurrent file fan-out may still see throughput plateau before saturating the device.
@@ -199,7 +202,7 @@ oc-rsync is wire-compatible with upstream rsync 3.4.4, but a few architectural c
 - **Daemon encryption.** The daemon protocol is plaintext, matching upstream rsync (authentication only, no encryption). oc-rsync has no built-in TLS client - the former `--ssl` / `client-tls` path was removed to match upstream. Encrypt with the SSH transport, or place the daemon behind a TLS-terminating proxy (`stunnel`, HAProxy, nginx) and reach it through an external wrapper such as `rsync-ssl` or `stunnel`, the same model as upstream.
 - **Windows IOCP scope.** IOCP is wired for socket I/O (daemon and SSH transports) and for the receive-side disk-write pipeline (`transfer::disk_commit` dispatches `Writer::Iocp` when the IOCP backend is selected on Windows). An IOCP file *reader* also exists, but the per-file dispatch that would select it is behind the experimental, non-default `adaptive-basis-dispatch` feature, so default builds still read files via standard buffered I/O.
 - **`.rsync-filter` per-directory inheritance.** Per-directory merge inheritance passes upstream's `testsuite/*.test` filter corpus (the known-failures roster is empty), including nested merges and `!`-clear semantics; the deepest anchored-vs-unanchored corner cases remain an area of ongoing hardening.
-- **`--checksum-seed` / `--fuzzy`.** Both are implemented and honoured on the common path (`--fuzzy` ports upstream's `fuzzy_distance` basis selection); deeper corner-case conformance audits against upstream rsync 3.4.4 are tracked separately.
+- **`--checksum-seed` / `--fuzzy`.** Both are implemented and honoured on the common path (`--fuzzy` ports upstream's `fuzzy_distance` basis selection); deeper corner-case conformance audits against upstream rsync 3.5.0 are tracked separately.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,6 +75,32 @@ oc-rsync monitors upstream rsync CVEs to verify continued non-applicability. Rec
 | CVE-2026-43620 | OOB read in `recv_files` via negative `parent_ndx` → client SIGSEGV | Not vulnerable | oc-rsync consumes the parent reference as `Option<usize>` and indexes into a bounds-checked `Vec` (`crates/protocol/src/flist/dir_tree.rs`). The validating entry point `DirectoryTree::try_add_directory` returns `DirTreeError::OutOfBoundsParent` on a malformed wire index; the unchecked `add_directory` aborts via Rust's bounds-check panic. Regression coverage: `try_add_directory_rejects_out_of_range_parent_idx`, `try_add_directory_rejects_boundary_off_by_one`, `add_directory_panics_safely_on_oob_parent_idx` in `crates/protocol/src/flist/dir_tree.rs`. SEC-4 closed. |
 | CVE-2026-45232 | Off-by-one stack write in HTTP CONNECT proxy response handler | **Fixed** | `read_proxy_line()` in `crates/core/src/client/module_list/connect/proxy.rs` reads byte-by-byte into a heap `Vec<u8>` and explicitly caps the response line at `MAX_PROXY_LINE_BYTES = 1023` bytes, matching upstream's 1024-byte `establish_proxy_connection()` stack buffer (socket.c:86). The C off-by-one stack-write is structurally impossible (bounds-checked `Vec::push`), and indefinite buffering is bounded by the explicit cap. Audit: SEC-2.a (PR #4609); upstream-parity alignment SEC-2.b (PR #4812). |
 
+### Upstream rsync 3.5.0 (13 Aug 2026) - triage in progress
+
+rsync 3.5.0 is a major security release closing **33 CVEs**, concentrated in path handling and the daemon. Unlike the 3.4.2/3.4.3 batches below, this set is **not yet fully audited against oc-rsync**, and this section states that plainly rather than implying coverage that does not exist.
+
+**What is established.** 3.5.0 is wire-identical to 3.4.4 (`PROTOCOL_VERSION` 32, `SUBPROTOCOL_VERSION` 0, unchanged `errcode.h`), so none of these CVEs stem from a protocol change and none require a wire-format response. They are implementation vulnerabilities in areas oc-rsync reimplements independently, which means neither "inherited" nor "not applicable" can be assumed for any of them - each needs its own evidence.
+
+**What is measured.** Running upstream's 3.5.0 test suite against oc-rsync reports 133 divergent tests. That set is the triage input, not a vulnerability count: it mixes real behavioural gaps, harness differences, and probes for C-level memory errors that have no Rust analogue. Classification requires per-test evidence.
+
+**Highest-severity items and their oc-rsync bearing:**
+
+| CVE | Severity | Upstream issue | oc-rsync bearing |
+|-----|----------|----------------|------------------|
+| CVE-2026-53791 | CRITICAL | `proxy protocol = true` let a directly-connecting client forge a PROXY header and spoof its source address, defeating `hosts allow`/`hosts deny`. Fixed by a new `proxy protocol hosts` allow-list that fails **closed** when unset. | Related and independently tracked: oc-rsync's daemon currently derives a placeholder peer address on its stdio paths, which weakens `hosts allow`/`hosts deny` in the same direction. Being fixed as a prerequisite. |
+| CVE-2026-70452 | HIGH | `hosts deny` failed **open** when a configured hostname would not resolve. | Under audit. Same fail-open class as the above. |
+| CVE-2026-70464 | HIGH | An unauthenticated peer could complete the `@RSYNCD` handshake. | Under audit; 3.5.0 also adds an `auth digest` floor directive. |
+| CVE-2026-53784 / 53793 | HIGH | Daemon module-root chdir escape under `use chroot`, and a `/./` inner-module escape via a symlinked path. | Under audit. |
+| CVE-2026-53795 | HIGH | An absolute `--temp-dir` or `--link-dest` **disabled path confinement entirely**. | Directly applicable: oc-rsync's confinement is narrower than 3.5.0's and is being widened to the new model. |
+| CVE-2026-53783 | HIGH | `rrsync` restricted-directory escape - each path was validated, but the validation could be walked out of. | oc-rsync ships no restricted-shell wrapper today; one is being added, enforcing through the same path resolver rather than a separate validator. |
+| CVE-2026-53790 | HIGH | Command / argument injection via unquoted peer- or config-supplied values. | Under audit. |
+| CVE-2026-70453 | HIGH | Quadratic CPU exhaustion in `hash_search()` from a long equal-weak-checksum chain. | Under audit; oc-rsync's block matcher differs from upstream's, so the bound must be reasoned about independently. |
+| CVE-2026-70455 / 70463 / 70461 / 70458 / 70456 | HIGH | Peer-controlled Zstandard thread count; `auth users` separator handling; three out-of-bounds heap writes. | The memory-safety trio has no direct Rust analogue, but each also has an observable half - whether malformed input is **rejected** rather than accepted with wrong state - which is being checked rather than assumed. |
+
+**New defensive surfaces in 3.5.0** that oc-rsync is adopting: `--confine-root=DIR`, `--insecure-links` / `--no-insecure-links`, and the `insecure links`, `proxy protocol hosts` and `auth digest` daemon directives.
+
+A Rust reimplementation is immune to the *memory-corruption* half of several of these by construction. It is **not** immune to the logic half - a fail-open access check, an unconfined path, or an unbounded peer-supplied count is equally reachable in safe Rust. This section will be updated per-CVE as each is closed or evidenced as non-applicable.
+
 ### Upstream rsync 3.4.3 audits (2026-05-20)
 
 rsync 3.4.3 (released 2026-05-20) is a major security release closing six CVEs and a defense-in-depth batch. Per-CVE applicability is captured in the table above (CVE-2026-29518 / 43617 / 43618 / 43619 / 43620 / 45232). The defense-in-depth items were audited as follows:
@@ -118,7 +144,7 @@ Additionally shipped since the last update:
 
 **Status: Fixed.** All receiver call sites are wired through `DirSandbox`, and the SEC-1.m / SEC-1.n regression suites pass against the fully-wired pipeline. The SEC-1.p Landlock layer provides defense-in-depth.
 
-CI integration: as of 2026-05-21 the interop job (`.github/workflows/_interop.yml`) runs upstream rsync's own `testsuite/*.test` corpus against oc-rsync as `$RSYNC`, pinned to upstream 3.4.4 by default. The known-failures roster lives at `tools/ci/upstream_testsuite_known_failures.conf`.
+CI integration: as of 2026-05-21 the interop job (`.github/workflows/_interop.yml`) runs upstream rsync's own testsuite corpus against oc-rsync as `$RSYNC`, pinned to upstream 3.4.4 by default. A separate nightly job runs the rewritten 3.5.0 Python suite so the divergence set above stays measured rather than estimated. The known-failures roster lives at `tools/ci/upstream_testsuite_known_failures.conf`.
 
 ### Upstream rsync 3.4.2 audits
 

--- a/docs/UPSTREAM_COMPARISON.md
+++ b/docs/UPSTREAM_COMPARISON.md
@@ -1,8 +1,12 @@
-# Rust rsync vs Upstream rsync 3.4.4 Comparison
+# Rust rsync vs Upstream rsync 3.5.0 Comparison
 
-This document provides a systematic comparison between the Rust rsync implementation and upstream rsync 3.4.4 (protocol 32), treating the upstream C source at `target/interop/upstream-src/rsync-3.4.4/` as the source of truth.
+This document provides a systematic comparison between the Rust rsync implementation and upstream rsync 3.5.0 (protocol 32), treating the upstream C source at `target/interop/upstream-src/rsync-3.5.0/` as the source of truth.
 
-**Last verified:** 2026-07-22
+> **Retarget note (2026-08-13).** The comparisons below were verified line-by-line against rsync 3.4.4 and have been repointed at 3.5.0. That repoint is sound for everything protocol-level: 3.5.0 declares the same `PROTOCOL_VERSION` 32 and `SUBPROTOCOL_VERSION` 0, ships a byte-identical `errcode.h`, and adds no `MSG_*`, `XMIT_*` or compat-flag constants, so every wire constant and algorithm claim here carries over unchanged.
+>
+> It is **not** a re-verification of the behavioural sections. 3.5.0 rewrote the path resolver and hardened the daemon across 33 CVEs, growing `syscall.c` by 85% and `generator.c`, `acls.c`, `sender.c`, `flist.c`, `exclude.c` and `receiver.c` substantially. Sections touching path resolution, symlink handling, chroot or daemon access control describe 3.4.4 behaviour until individually re-checked, and line-number citations point at 3.4.4 offsets.
+
+**Last verified:** 2026-07-22 (against 3.4.4; see retarget note above)
 **Validation commands:**
 ```sh
 cargo fmt --all -- --check \
@@ -541,7 +545,7 @@ pipeline: rayon workers compute per-directory delete plans in parallel
 (`compute_extras`), and a single emitter thread walks directories in
 upstream depth-first order to perform every `unlink`, emit every
 `*deleting` itemize line, and update every counter. The emitter
-preserves upstream rsync 3.4.4's wall-clock event sequence
+preserves upstream rsync 3.5.0's wall-clock event sequence
 byte-for-byte while keeping candidate computation parallel. See
 [`docs/architecture/delete-during.md`](architecture/delete-during.md)
 and the full specification in
@@ -874,7 +878,7 @@ delete pass, matching `delete.c:165-174`. The `make_backups && (backup_dir ||
 
 ## Summary
 
-The Rust rsync implementation achieves **full wire protocol compatibility** with upstream rsync 3.4.4:
+The Rust rsync implementation achieves **full wire protocol compatibility** with upstream rsync 3.5.0:
 
 1. **Protocol versions 28-32** fully supported with version-specific feature gates
 2. **All compatibility flags** match upstream bit positions
@@ -906,7 +910,7 @@ The Rust rsync implementation achieves **full wire protocol compatibility** with
 4. **ACL handling:** rsync-specific synchronization semantics
 5. **Filter rules:** rsync syntax differs from gitignore
 
-These custom implementations are necessary for byte-level wire protocol compatibility with upstream rsync 3.4.4.
+These custom implementations are necessary for byte-level wire protocol compatibility with upstream rsync 3.5.0.
 
 ---
 
@@ -944,4 +948,4 @@ These custom implementations are necessary for byte-level wire protocol compatib
 
 ---
 
-**Verification methodology:** Each constant and algorithm was verified by reading upstream rsync 3.4.4 source code and comparing against the corresponding Rust implementation.
+**Verification methodology:** Each constant and algorithm was verified by reading upstream rsync 3.5.0 source code and comparing against the corresponding Rust implementation.

--- a/tools/ci/tests/test_benchmark_report.py
+++ b/tools/ci/tests/test_benchmark_report.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Regression tests for the release benchmark report's peak-RSS columns.
+
+Why this exists: benchmark_rss() records `peak_rss_kb` for every mode, not
+just the `memory` mode, but the report published only elapsed time. A mode
+could therefore get 3x faster while using 3x the memory and the release
+notes would show only the win. The report now prints both.
+
+The trap being guarded is the one benchmark_chart.py already had to fix
+once: describing a BYTES metric in DURATION language. A peak-RSS ratio
+rendered as "slower 3.11x" is meaningless -- memory is not fast -- so these
+tests assert the wording, not just the presence of a number. They also
+assert the magnitude is derived from `peak_rss_kb` and not from `mean`,
+because a report that still read `mean` but formatted it as bytes would
+satisfy a suffix-only check while being exactly as wrong as before.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REPORT = REPO_ROOT / ".github" / "scripts" / "benchmark_report.py"
+
+
+def render(results: dict) -> str:
+    """Run benchmark_report.py against `results` and return its markdown."""
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "benchmark_results.json").write_text(json.dumps(results))
+        proc = subprocess.run(
+            [sys.executable, str(REPORT)],
+            cwd=tmp,
+            capture_output=True,
+            text=True,
+        )
+    if proc.returncode != 0:
+        raise AssertionError(f"report failed ({proc.returncode}):\n{proc.stderr}")
+    return proc.stdout
+
+
+def results_with(upstream: dict, oc_rsync: dict, ratio: float = 0.5) -> dict:
+    """A minimal single-mode result set, so each test states only what it varies."""
+    return {
+        "upstream_version": "3.5.0",
+        "test_data": {"size_mb": 512, "files": 2000},
+        "summary": {
+            "by_mode": {"local": ratio},
+            "avg_ratio": ratio,
+            "best_ratio": ratio,
+            "worst_ratio": ratio,
+        },
+        "tests": [
+            {
+                "mode": "local",
+                "name": "512MB local",
+                "ratio": ratio,
+                "upstream": upstream,
+                "oc_rsync": oc_rsync,
+            }
+        ],
+    }
+
+
+class PeakRssColumns(unittest.TestCase):
+    def test_rss_is_reported_for_a_timing_mode(self):
+        """A duration mode must still publish the peak RSS it already measured."""
+        out = render(
+            results_with(
+                {"mean": 2.986, "peak_rss_kb": 7924},
+                {"mean": 0.925, "peak_rss_kb": 24680},
+            )
+        )
+        self.assertIn("7.74 MiB", out)
+        self.assertIn("24.10 MiB", out)
+
+    def test_rss_magnitude_comes_from_peak_rss_kb_not_mean(self):
+        """Guard the chart's original bug: reading `mean` and calling it bytes.
+
+        `mean` here is 2.986/0.925; if either were formatted as a size the
+        output would be a sub-KiB value, never the MiB figures above.
+        """
+        out = render(
+            results_with(
+                {"mean": 2.986, "peak_rss_kb": 7924},
+                {"mean": 0.925, "peak_rss_kb": 24680},
+            )
+        )
+        self.assertNotIn("0 KiB", out)
+        self.assertIn("7.74 MiB", out)
+
+    def test_higher_memory_is_not_described_as_slower(self):
+        """A BYTES ratio must not borrow DURATION wording."""
+        out = render(
+            results_with(
+                {"mean": 2.986, "peak_rss_kb": 7924},
+                {"mean": 0.925, "peak_rss_kb": 24680},
+            )
+        )
+        self.assertIn("higher 3.11x", out)
+        self.assertNotIn("slower 3.11x", out)
+
+    def test_lower_memory_reads_as_lower(self):
+        out = render(
+            results_with(
+                {"mean": 1.0, "peak_rss_kb": 20000},
+                {"mean": 1.0, "peak_rss_kb": 10000},
+                ratio=1.0,
+            )
+        )
+        self.assertIn("lower 0.50x", out)
+
+    def test_memory_within_noise_reads_as_same(self):
+        out = render(
+            results_with(
+                {"mean": 1.0, "peak_rss_kb": 10000},
+                {"mean": 1.0, "peak_rss_kb": 10100},
+                ratio=1.0,
+            )
+        )
+        self.assertIn("~same 1.01x", out)
+
+    def test_missing_rss_degrades_to_a_dash_and_keeps_the_row(self):
+        """A run whose RSS could not be parsed must not invent a number.
+
+        It must also not drop the row: the timing comparison is still valid
+        and silently omitting it would understate the mode count.
+        """
+        out = render(results_with({"mean": 1.0}, {"mean": 0.9}, ratio=0.9))
+        self.assertIn("512MB local", out)
+        self.assertIn("| - | - | - |", out)
+
+
+class UpstreamVersionLabel(unittest.TestCase):
+    def test_version_label_comes_from_the_measured_binary(self):
+        """The column header must name the build actually benchmarked.
+
+        benchmark.py probes `<binary> --version`, so a hardcoded header would
+        silently mislabel the comparison whenever the pinned oracle moves.
+        """
+        results = results_with(
+            {"mean": 1.0, "peak_rss_kb": 1000},
+            {"mean": 1.0, "peak_rss_kb": 1000},
+            ratio=1.0,
+        )
+        results["upstream_version"] = "9.9.9"
+        out = render(results)
+        self.assertIn("rsync 9.9.9", out)
+        self.assertNotIn("rsync 3.5.0", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Moves the tracked upstream reference from rsync 3.4.4 to **3.5.0** (released 13 Aug 2026) across README, SECURITY, CHANGELOG and the upstream comparison, and reworks the release benchmark to compare against 3.5.0 while publishing **peak RSS alongside elapsed time for every mode**.

## Why the version move is safe, and what it does not claim

3.5.0 declares the same `PROTOCOL_VERSION` 32 and `SUBPROTOCOL_VERSION` 0 as 3.4.4 and ships a byte-identical `errcode.h`, with no new `MSG_*`, `XMIT_*` or compat-flag constants. Wire compatibility therefore carries over unchanged, which is what the "wire-compatible with 3.5.0" claim rests on.

Everything else in 3.5.0 is behavioural — 33 CVEs in path handling and the daemon, a rewritten path resolver, three new options, three new daemon directives — and oc-rsync is **not** aligned to that yet. Rather than let a version bump imply parity, the docs state the gap:

- README reports the measured **133 divergences** against the 3.5.0 suite and links the nightly tracker.
- The two upstream-testsuite badges stay on 3.4.4, because that is the version the gating workflow actually runs.
- SECURITY.md's new 3.5.0 section marks the cohort **triage in progress** and lists the high-severity CVEs with oc-rsync's actual bearing on each. It deliberately does not assert per-CVE non-applicability that has not been established, and it notes that Rust removes the memory-corruption half of several of these but not the logic half — a fail-open access check or an unconfined path is equally reachable in safe Rust.
- UPSTREAM_COMPARISON.md carries a retarget note separating what the repoint covers (all protocol-level claims, constants unchanged) from what it does not (behavioural sections still describe 3.4.4; line citations still point at 3.4.4 offsets).

## Benchmark: the metric that was already being measured

`benchmark_rss()` records `peak_rss_kb` on every run, but `MODE_UNITS` surfaced bytes for the `memory` mode alone — so thirteen modes measured memory and threw it away. A mode could get 3x faster on 3x the memory and the release notes would show only the win. This surfaces the existing measurement; no new benchmark run is added.

Two things fell out of doing it properly:

- **Unit wording.** `ratio_indicator()` says faster/slower, which is meaningless for bytes. Reusing it would have reintroduced in the report the exact conflation `benchmark_chart.py` already had to fix. Memory now reads lower/~same/higher against the same 5% noise band.
- **Missing data.** A timed-out run, or a platform whose `/usr/bin/time` output the parser does not recognise, renders as a dash and keeps its row — it must not invent a number, and must not silently drop a valid timing row.

The report reuses the chart's byte formatter rather than growing a second copy; both scripts are pure stdlib and share a directory.

## Tests

Adds `tools/ci/tests/test_benchmark_report.py` — the first tests for the report renderer — wired into `benchmark.yml` and `benchmark-tooling.yml` next to the existing chart tests.

They pin the byte wording, the missing-measurement fallback, the version label coming from the measured binary rather than a constant, and that RSS magnitudes derive from `peak_rss_kb` rather than `mean`. That last one matters: a report that still read `mean` but formatted it as bytes would satisfy a suffix-only check while being exactly as wrong as the bug the chart tests were written for.

## Verification

- `test_benchmark_report.py` 7/7 pass; existing `test_benchmark_chart.py` 26/26 still pass.
- All three benchmark workflows parse as valid YAML.
- Report rendered end-to-end against synthetic results, including the missing-RSS path, exiting 0.
- Remaining `3.4.4` references audited individually — all deliberate: the two badges for the still-3.4.4 gate, the factual protocol comparison, the interop matrix, and historical CHANGELOG entries. `docs/audits/` is untouched, since those record what was measured against 3.4.4 at a point in time.
