### PR TITLE
chore(ci): add a mechanical sweep of path-mutating call sites

### DIFF
--- a/tools/ci/path_site_sweep.py
+++ b/tools/ci/path_site_sweep.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Enumerate every path-mutating / path-opening call site in crates/.
+
+Why this exists: upstream rsync 3.5.0 routes every such operation through a
+confinement resolver (see docs/design/upstream-3.5.0-path-confinement-model.md).
+To mirror that, oc-rsync first needs to know the complete set of sites. A list
+maintained by hand is a list that rots, so this derives it mechanically and can
+be re-run to prove no site was missed after the resolver is wired in.
+
+`#[cfg(test)]` blocks are excluded: test code creates and removes files
+constantly and is not an attack surface, so counting it buries the real
+sites. Integration tests under crates/*/tests/ are skipped for the same
+reason. The exclusion is brace-depth tracked rather than line-matched, so a
+multi-line test module is dropped whole.
+
+Exit status is always 0; this reports, it does not gate. Task 607 turns the
+comparison into a ratchet once every site is classified.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import os
+import re
+import sys
+
+# One pattern per operation class. The class matters because the confinement
+# obligation differs: a create/rename/link/unlink mutates the filesystem, an
+# open exposes content, and a stat only resolves a path (still TOCTOU-relevant,
+# but a different fix).
+OPERATION_PATTERNS = [
+    ("MUTATE_CREATE", r"\bFile::create\b"),
+    ("MUTATE_RENAME", r"\bfs::rename\b"),
+    ("MUTATE_LINK", r"\bfs::hard_link\b|\bsymlink(?:_file|_dir)?\("),
+    ("MUTATE_UNLINK", r"\bfs::remove_(?:file|dir|dir_all)\b"),
+    ("MUTATE_MKDIR", r"\bfs::create_dir(?:_all)?\b"),
+    ("MUTATE_PERM", r"\bfs::set_permissions\b"),
+    ("OPEN_READ", r"\bFile::open\b"),
+]
+
+_MATCHER = re.compile(
+    "|".join(f"(?P<{name}>{pattern})" for name, pattern in OPERATION_PATTERNS)
+)
+_CFG_TEST = re.compile(r"#\[cfg\(test\)\]")
+
+
+def production_lines(path: str):
+    """Yield (lineno, text) for lines outside any #[cfg(test)] block.
+
+    Brace depth is tracked from the attribute onward so an entire test module
+    is skipped, not just the attribute line.
+    """
+    in_test = False
+    depth = 0
+    with open(path, errors="replace") as handle:
+        for lineno, line in enumerate(handle, 1):
+            if _CFG_TEST.search(line):
+                in_test = True
+                depth = 0
+                continue
+            if in_test:
+                depth += line.count("{") - line.count("}")
+                if depth <= 0 and "}" in line:
+                    in_test = False
+                continue
+            yield lineno, line
+
+
+def sweep(root: str):
+    """Return a list of (operation, crate, path, lineno, text) for every site."""
+    sites = []
+    for dirpath, _, filenames in os.walk(root):
+        # crates/<name>/tests/ is integration-test scaffolding, not a surface.
+        if f"{os.sep}tests" in dirpath:
+            continue
+        for filename in filenames:
+            if not filename.endswith(".rs") or filename == "tests.rs":
+                continue
+            path = os.path.join(dirpath, filename)
+            parts = path.split(os.sep)
+            crate = parts[1] if len(parts) > 1 else "?"
+            for lineno, line in production_lines(path):
+                match = _MATCHER.search(line)
+                if match:
+                    sites.append(
+                        (match.lastgroup, crate, path, lineno, line.strip())
+                    )
+    return sites
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default="crates")
+    parser.add_argument(
+        "--list", action="store_true", help="print one line per site, not a summary"
+    )
+    args = parser.parse_args()
+
+    sites = sweep(args.root)
+    if args.list:
+        for operation, crate, path, lineno, text in sorted(sites):
+            print(f"{operation}\t{crate}\t{path}:{lineno}\t{text}")
+        return 0
+
+    by_operation = collections.Counter(site[0] for site in sites)
+    by_crate = collections.Counter(site[1] for site in sites)
+
+    print("path-mutating / path-opening sites in production code")
+    print(f"(root={args.root}, #[cfg(test)] blocks and */tests/ excluded)\n")
+    print("by operation:")
+    for operation in sorted(by_operation):
+        print(f"  {operation:16} {by_operation[operation]:5}")
+    print("\nby crate:")
+    for crate, count in by_crate.most_common():
+        print(f"  {crate:16} {count:5}")
+    print(f"\nTOTAL {len(sites)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

A committed, re-runnable enumeration of every path-mutating and path-opening call site in `crates/`. Reports only — exit status is always 0, and it is not wired into CI.

## Why

Upstream rsync 3.5.0 routes every such operation through a confinement resolver (see `docs/design/upstream-3.5.0-path-confinement-model.md`, merged in #7280). Mirroring that needs the complete set of oc-rsync sites first — and a hand-maintained list of 529 entries would be stale within a week. Deriving it mechanically also means it can be **re-run after the resolver is wired in, to prove no site was missed**.

## The measurement that shaped it

A naive grep returns **2035** hits, which buries the real surface:

| filter | sites |
|---|---:|
| naive grep | 2035 |
| excluding `crates/*/tests/` | 1804 |
| also excluding `#[cfg(test)]` blocks in `src/` | **529** |

Test code creates and removes files constantly and is not an attack surface. The exclusion tracks **brace depth from the attribute onward** rather than matching a line, so a multi-line test module is dropped whole rather than leaving its body counted.

## Current distribution

```
MUTATE_UNLINK  125     fast_io   162      (platform FFI layer -
MUTATE_MKDIR   118     transfer  136       expected to lead; it would
OPEN_READ       94     engine    121       HOST the resolver, not
MUTATE_CREATE   75     metadata   25       consume it)
MUTATE_RENAME   40     core       24
MUTATE_PERM     40     batch      21
MUTATE_LINK     37     + long tail
```

Sites are classified **by operation** because the confinement obligation differs: create/rename/link/unlink/mkdir/chmod mutate the filesystem, `File::open` exposes content, and a stat only resolves a path — still TOCTOU-relevant, but a different fix.

Each site records its crate, so the resolver's API can respect the unsafe-code boundary: `daemon`, `cli`, `core` and `transfer` must never contain unsafe, which constrains where raw `*at` calls may live.

## What this is not

- **Not a gate.** Turning the comparison into a ratchet — so a *new* unconfined path call fails the build — is a follow-up, once every site has been classified as confined / deliberately-excluded / dead.
- **Not a classification.** 529 sites does not mean 529 gaps. Upstream deliberately excludes the sender from confinement, so a sender-side site left unconfined may be correct.

## Verification

`python3 tools/ci/path_site_sweep.py` (summary) and `--list` (one line per site) both run clean; `--list` emits exactly 529 rows, matching the summary total.
