### PR TITLE
ci: gate upstream citations on the cited file existing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,16 @@ upstream rsync C source, e.g. `// upstream: sender.c:477 - "sender finished"`.
   Re-anchor each flagged citation individually against the new source. Never
   bulk-shift line numbers by a fixed offset: already-correct citations drift by
   different amounts (or not at all), so a blind shift corrupts them.
+- **The hard gate.** `cargo xtask citations` asserts that every citation in the
+  repository - not only under `crates/` - names a `.c`, `.h`, `.py` or `.sh`
+  file the pinned release actually has, at a line that file actually has. It
+  reads `tools/ci/upstream-3.4.4-lines.tsv` rather than the source tree, so it
+  runs everywhere, including under `nextest`. Regenerate that manifest with
+  `cargo xtask citations --write-manifest` when the pin moves. Citations
+  qualified by a directory the rsync tarball does not ship - zsync's
+  `librcksum/`, an explicitly-versioned `rsync-3.4.1/` path - name a different
+  upstream and are out of scope; write a bare name only when you mean a file of
+  the pinned release.
 
 ---
 

--- a/crates/matching/tests/sparse_match_fixture.rs
+++ b/crates/matching/tests/sparse_match_fixture.rs
@@ -17,7 +17,7 @@
 //! `match.c`'s `tag_table[s1]`). With ~60k indexed blocks the table
 //! saturates and almost every rolling-checksum probe survives the gate,
 //! which means the full hash-table lookup runs at every offset. A
-//! bithash-style probabilistic prefilter (upstream `rsum.c:362-366`)
+//! bithash-style probabilistic prefilter (zsync `librcksum/rsum.c:362-366`)
 //! reduces the survival rate. The assertion below pins the *correctness*
 //! invariant - matched bytes equal exactly `K * block_size` - so the
 //! prefilter work can be benchmarked against this fixture without the
@@ -198,7 +198,7 @@ fn xxh3_algo() -> SignatureAlgorithm {
 /// Centralised so every scale + algorithm combination exercises the
 /// same checks.
 ///
-/// upstream: rsum.c:362-366 - bithash will reduce probes; today's
+/// upstream: zsync librcksum/rsum.c:362-366 - bithash will reduce probes; today's
 /// pre-bithash baseline assertion is that matched_bytes equals exactly
 /// `K * block_size` and literal_bytes equals `source.len() - K *
 /// block_size`. The number of strong-checksum verify calls is not

--- a/docs/audits/interop-known-failures-inventory.md
+++ b/docs/audits/interop-known-failures-inventory.md
@@ -49,7 +49,8 @@ forced protocol):
 
 All entries are basenames under
 `target/interop/upstream-src/rsync-3.4.1/testsuite/*.test`, surfaced through
-`run_upstream_testsuite.sh:42-46`.
+`tools/ci/run_upstream_testsuite.sh:63-76` (`known_failures_conf`, sourced when
+the file is present).
 
 | # | Test script | File:Line | Category |
 |---|---|---|---|

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # run_upstream_testsuite.sh - run upstream rsync's testsuite/ against oc-rsync.
 #
-# Mirrors the contract of upstream's runtests.sh:
+# Mirrors the contract of upstream's runtests.py:
 #   - exports $RSYNC, $TOOLDIR, $srcdir, $suitedir, $scratchdir per test
 #   - sources rsync.fns indirectly (each *.test sources it itself)
 #   - exit codes from a test: 0=pass, 77=skip, 78=xfail, anything else=fail
 #
-# Differences vs upstream runtests.sh:
+# Differences vs upstream runtests.py:
 #   - $RSYNC is oc-rsync, not the upstream rsync binary
 #   - we still need upstream's helper tools (tls, getgroups, lsh.sh) and
 #     config.h/shconfig artifacts; those come from a one-time `./configure`
@@ -181,9 +181,11 @@ build_upstream_helpers() {
 }
 
 find_setfacl_nodef() {
-    # upstream: runtests.sh:205-215 - detect the platform's command for
-    # removing default ACLs from a directory.  The ACL tests rely on this
-    # variable being exported into their environment.
+    # upstream: runtests.py find_setfacl_nodef() (3.5.0 runtests.py:146-161,
+    # 3.4.4 runtests.py:67-82) - detect the platform's command for removing
+    # default ACLs from a directory.  The ACL tests rely on this variable being
+    # exported into their environment.  Anchored on the function name because
+    # the line offsets move between releases.
     local probe_dir=$1
     if setacl -k u::7,g::5,o:5 "$probe_dir" 2>/dev/null; then
         echo 'setacl -k'
@@ -249,8 +251,9 @@ prep_scratch() {
     local sd=$1
     [[ -d "$sd" ]] && chmod -R u+rwX "$sd" 2>/dev/null && rm -rf "$sd"
     mkdir -p "$sd"
-    # upstream: runtests.sh:254 - clear default ACLs and setgid to avoid
-    # confusing tests that depend on inheritable permission state.
+    # upstream: runtests.py prep_scratch() (3.5.0 runtests.py:230-241) - clear
+    # default ACLs and setgid to avoid confusing tests that depend on
+    # inheritable permission state.
     $setfacl_nodef "$sd" 2>/dev/null || true
     chmod g-s "$sd" 2>/dev/null || true
     ln -sfn "$srcdir" "$sd/src"
@@ -778,8 +781,8 @@ main() {
     # when a loop mount is unavailable.
     setup_scratch_fs "${log_root}/scratch"
 
-    # upstream: runtests.sh:205-217 - detect and export setfacl_nodef so
-    # ACL tests can clear default ACLs from directories.
+    # upstream: runtests.py find_setfacl_nodef() - detect and export
+    # setfacl_nodef so ACL tests can clear default ACLs from directories.
     setfacl_nodef=$(find_setfacl_nodef "$scratchbase")
     export setfacl_nodef
 

--- a/tools/ci/upstream-3.4.4-lines.tsv
+++ b/tools/ci/upstream-3.4.4-lines.tsv
@@ -1,7 +1,9 @@
-# Line counts for every .c/.h in rsync 3.4.4, the pinned upstream source.
+# Line counts for every .c/.h/.py/.sh in rsync 3.4.4, the pinned upstream source.
 # Lets the citation gate run where the source tree is absent (the required
 # nextest cell does not fetch it). rsync 3.4.4 is a released tarball and is
 # immutable, so this cannot drift; it is regenerated only when the pin moves.
+# The key set is also the gate's answer to "does this upstream file exist", so
+# a name missing here is a citation defect, not a manifest gap.
 # Regenerate: cargo xtask citations --write-manifest  (needs the source present)
 access.c	292
 acls.c	1141
@@ -18,6 +20,7 @@ clientname.c	538
 clientserver.c	1588
 compat.c	892
 config.h	870
+configure.sh	14048
 connection.c	47
 daemon-parm.h	381
 default-cvsignore.h	3
@@ -67,6 +70,9 @@ log.c	916
 main.c	1879
 match.c	448
 options.c	3156
+packaging/pkglib.py	255
+packaging/release.py	703
+packaging/solaris/build_pkg.sh	94
 params.c	645
 pipe.c	178
 popt/lookup3.c	959
@@ -85,14 +91,18 @@ rounding.c	38
 rounding.h	1
 rsync.c	831
 rsync.h	1512
+runtests.py	485
 sender.c	494
 socket.c	845
+support/install_deps_ubuntu.sh	11
+support/lsh.sh	37
 support/savetransfer.c	175
 syscall.c	2149
 t_chmod_secure.c	117
 t_secure_relpath.c	151
 t_stub.c	120
 t_unsafe.c	47
+testhelp/maketree.py	133
 testrun.c	61
 tls.c	299
 token.c	1143

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -58,7 +58,7 @@ pub enum Command {
     /// Generate man page from markdown source using pandoc.
     ManPage,
 
-    /// Verify upstream C citations name lines the cited files have.
+    /// Verify upstream citations name a pinned file, at a line it has.
     Citations(CitationsArgs),
 
     /// Assert the git index contains no binary artifacts.

--- a/xtask/src/commands/citations.rs
+++ b/xtask/src/commands/citations.rs
@@ -1,24 +1,39 @@
-//! Verifies that `upstream: <file>:<line>` citations point inside the pinned
-//! upstream rsync source.
+//! Verifies that `upstream: <file>:<line>` citations name a file the pinned
+//! upstream rsync source has, at a line that file has.
 //!
-//! A citation naming a line past the end of the file it names cannot be
-//! checked by a reader and cannot be right. `crates/metadata/src/apply/
-//! permissions.rs` cited `rsync.c:954-965` for a `dest_mode()` call site; rsync
-//! 3.4.4's `rsync.c` is 831 lines. The claim looked specific enough that seven
-//! call sites copied it.
+//! Two rules, both mechanical, both with no false-positive tension:
 //!
-//! # Why only the line-range check
+//! 1. **The cited file must exist.** `tools/ci/run_upstream_testsuite.sh` cited
+//!    `runtests.sh:205-215` and `runtests.sh:254`. Neither rsync 3.4.4 nor
+//!    3.5.0 ships a `runtests.sh`; both ship `runtests.py`. The citation named
+//!    a file that has never existed, and nothing noticed for as long as it took
+//!    someone to read the script, because every citation checker in the tree
+//!    only ever opened `crates/**/*.rs`.
+//! 2. **The cited line must be inside the file.** `crates/metadata/src/apply/
+//!    permissions.rs` cited `rsync.c:954-965` for a `dest_mode()` call site;
+//!    rsync 3.4.4's `rsync.c` is 831 lines. The claim looked specific enough
+//!    that seven call sites copied it.
 //!
-//! Checking that a comment's quoted text appears in the cited file was measured
-//! and rejected: 27-52% of citations fail it depending on the matcher, and the
-//! failures are dominated by correct documentation idioms - `foo()` names a
-//! function and never appears verbatim in C, a comment routinely cites a call
-//! site while naming the callee, and quoted spans are deliberately elided with
-//! `...` or paraphrased. Gating on that would mean annotating hundreds of
-//! correct comments, and an exemption that common stops being read.
+//! # What is deliberately NOT checked, and must not be "finished"
 //!
-//! This check has no such tension, so it carries no exemption mechanism: every
-//! violation is a defect, and the only way to silence one is to fix it.
+//! Neither rule says anything about whether the cited line means what the
+//! comment claims. That is the open question, not an oversight:
+//!
+//! - Checking that a comment's quoted text appears in the cited file was
+//!   measured and rejected: 27-52% of citations fail it depending on the
+//!   matcher, and the failures are dominated by correct documentation idioms -
+//!   `foo()` names a function and never appears verbatim in C, a comment
+//!   routinely cites a call site while naming the callee, and quoted spans are
+//!   deliberately elided with `...` or paraphrased. Gating on that would mean
+//!   annotating hundreds of correct comments, and an exemption that common
+//!   stops being read.
+//! - Line-number *accuracy* is worse than unsettled, it is version-bound. The
+//!   same citation set audits at 11% suspected drift against 3.4.4 and 93%
+//!   against 3.5.0. Whether these citations should carry line numbers at all,
+//!   or name a function and let the reader grep, is an open decision that has
+//!   to be made before the pin moves - not something to be pre-empted by a
+//!   gate. `tools/ci/citation_drift_audit.py` reports on that question as a
+//!   ratchet; it is not, and must not become, a hard gate.
 //!
 //! # Why a manifest instead of the source tree
 //!
@@ -31,48 +46,87 @@
 //! the source is present.
 
 use crate::error::TaskResult;
-use crate::util::{list_rust_sources_via_git, validation_error};
+use crate::util::{list_sources_via_git_unfiltered, validation_error};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-/// Committed line counts for every `.c`/`.h` in the pinned upstream release.
+/// Committed line counts for every citable source file in the pinned upstream
+/// release: `.c`, `.h`, `.py` and `.sh`.
 pub const MANIFEST_PATH: &str = "tools/ci/upstream-3.4.4-lines.tsv";
 
 /// The pinned upstream source, present only where the interop tarball was fetched.
 pub const PINNED_SOURCE_DIR: &str = "target/interop/upstream-src/rsync-3.4.4";
 
+/// Extensions a citation may name. Upstream carries protocol logic in C and its
+/// test and release harness in Python and shell, and citations reach all four -
+/// `runtests.py`, `support/lsh.sh` and `packaging/release.py` are cited by the
+/// CI tooling exactly as `flist.c` is cited by the crates.
+const CITED_EXTENSIONS: [&str; 4] = ["c", "h", "py", "sh"];
+
 /// Header written above the generated counts, explaining why the file exists.
 const MANIFEST_HEADER: &str = "\
-# Line counts for every .c/.h in rsync 3.4.4, the pinned upstream source.
+# Line counts for every .c/.h/.py/.sh in rsync 3.4.4, the pinned upstream source.
 # Lets the citation gate run where the source tree is absent (the required
 # nextest cell does not fetch it). rsync 3.4.4 is a released tarball and is
 # immutable, so this cannot drift; it is regenerated only when the pin moves.
+# The key set is also the gate's answer to \"does this upstream file exist\", so
+# a name missing here is a citation defect, not a manifest gap.
 # Regenerate: cargo xtask citations --write-manifest  (needs the source present)
 ";
 
-/// One citation that names a line the cited file does not have.
+/// One citation that cannot be followed to the pinned upstream source.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Violation {
-    /// Workspace-relative Rust file carrying the citation.
-    pub source: String,
-    /// Line in the Rust file.
-    pub line: usize,
-    /// Upstream file as resolved against the manifest.
-    pub upstream: String,
-    /// The out-of-range line number that was cited.
-    pub cited: usize,
-    /// Number of lines the upstream file actually has.
-    pub actual: usize,
+pub enum Violation {
+    /// The cited file exists but does not have the cited line.
+    OutOfRange {
+        /// Workspace-relative file carrying the citation.
+        source: String,
+        /// Line in the citing file.
+        line: usize,
+        /// Upstream file as resolved against the manifest.
+        upstream: String,
+        /// The out-of-range line number that was cited.
+        cited: usize,
+        /// Number of lines the upstream file actually has.
+        actual: usize,
+    },
+    /// The pinned upstream release has no file of that name at all.
+    MissingFile {
+        /// Workspace-relative file carrying the citation.
+        source: String,
+        /// Line in the citing file.
+        line: usize,
+        /// The upstream file name as written in the comment.
+        upstream: String,
+        /// The line number that was cited, echoed so the site is greppable.
+        cited: usize,
+    },
 }
 
 impl std::fmt::Display for Violation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}:{}: cites {}:{} but {} has {} lines",
-            self.source, self.line, self.upstream, self.cited, self.upstream, self.actual
-        )
+        match self {
+            Self::OutOfRange {
+                source,
+                line,
+                upstream,
+                cited,
+                actual,
+            } => write!(
+                f,
+                "{source}:{line}: cites {upstream}:{cited} but {upstream} has {actual} lines"
+            ),
+            Self::MissingFile {
+                source,
+                line,
+                upstream,
+                cited,
+            } => write!(
+                f,
+                "{source}:{line}: cites {upstream}:{cited} but rsync 3.4.4 has no {upstream}"
+            ),
+        }
     }
 }
 
@@ -92,32 +146,68 @@ fn parse_manifest(raw: &str) -> BTreeMap<String, usize> {
         .collect()
 }
 
+/// What a cited path turned out to be.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Resolution {
+    /// A file of the pinned rsync release, at this manifest path.
+    Pinned(String),
+    /// A bare name several manifest paths share, so the file exists but there
+    /// is no single one to range-check. rsync ships both `compat.c` and
+    /// `lib/compat.c`; a comment writing the bare form has named a real file
+    /// and is not a defect, it is merely unresolvable.
+    Ambiguous,
+    /// A bare name the pinned release does not have. This is the `runtests.sh`
+    /// case: no directory component, so it cannot be a reference to some other
+    /// project, and no such upstream file exists.
+    Missing,
+    /// Carries a directory component the pinned tarball does not have.
+    ///
+    /// RULE, not an allow-list: a path qualified by a directory rsync does not
+    /// ship is a citation to a *different* upstream and is out of scope for a
+    /// gate that only knows rsync. The zsync references in `crates/matching`
+    /// are written `librcksum/rsum.c:262`; the historical audit notes cite
+    /// `target/interop/upstream-src/rsync-3.4.1/flist.c:713`, a release this
+    /// gate does not pin. Both are excluded by the same sentence, and neither
+    /// is named anywhere in this file.
+    ForeignUpstream,
+}
+
 /// Resolves a cited path against the manifest.
 ///
-/// Returns `None` for anything that is not a file of the pinned rsync release,
-/// which is how citations to a *different* upstream stay out of scope: the
-/// zsync references in `crates/matching` are written `librcksum/rsum.c:262`,
-/// and `librcksum/` is not a directory of the rsync tarball. Resolution is by
-/// exact path first so `lib/wildmatch.c` beats a bare-name guess, then by
-/// unique basename so the common `flist.c:2477` form keeps working.
-pub fn resolve_upstream_path(cited: &str, manifest: &BTreeMap<String, usize>) -> Option<String> {
+/// Resolution is by exact path first so `lib/wildmatch.c` beats a bare-name
+/// guess, then by unique basename so the common `flist.c:2477` form keeps
+/// working.
+pub fn resolve_upstream_path(cited: &str, manifest: &BTreeMap<String, usize>) -> Resolution {
     if manifest.contains_key(cited) {
-        return Some(cited.to_owned());
+        return Resolution::Pinned(cited.to_owned());
     }
     if cited.contains('/') {
-        // A directory that the tarball does not have means a different upstream.
-        return None;
+        return Resolution::ForeignUpstream;
     }
     let mut hits = manifest.keys().filter(|k| {
         Path::new(k)
             .file_name()
             .is_some_and(|n| n == std::ffi::OsStr::new(cited))
     });
-    let first = hits.next()?;
+    let Some(first) = hits.next() else {
+        return Resolution::Missing;
+    };
     if hits.next().is_some() {
+        return Resolution::Ambiguous;
+    }
+    Resolution::Pinned(first.clone())
+}
+
+/// Byte index of the `:` ending a `.<ext>:` at `dot`, for any cited extension.
+fn extension_end(bytes: &[u8], dot: usize) -> Option<usize> {
+    if bytes[dot] != b'.' {
         return None;
     }
-    Some(first.clone())
+    CITED_EXTENSIONS.iter().find_map(|ext| {
+        let colon = dot + 1 + ext.len();
+        (bytes.get(dot + 1..colon) == Some(ext.as_bytes()) && bytes.get(colon) == Some(&b':'))
+            .then_some(colon)
+    })
 }
 
 /// Extracts `(cited path, line numbers)` from one comment line.
@@ -130,14 +220,11 @@ pub fn citations_in_line(line: &str) -> Vec<(String, Vec<usize>)> {
     let bytes = line.as_bytes();
     let mut out = Vec::new();
     let mut i = 0;
-    while i + 2 < bytes.len() {
-        let is_ext = (bytes[i] == b'.')
-            && (bytes[i + 1] == b'c' || bytes[i + 1] == b'h')
-            && bytes[i + 2] == b':';
-        if !is_ext {
+    while i < bytes.len() {
+        let Some(colon) = extension_end(bytes, i) else {
             i += 1;
             continue;
-        }
+        };
         let mut start = i;
         while start > 0 {
             let c = bytes[start - 1];
@@ -147,8 +234,8 @@ pub fn citations_in_line(line: &str) -> Vec<(String, Vec<usize>)> {
                 break;
             }
         }
-        let path = &line[start..i + 2];
-        let mut j = i + 3;
+        let path = &line[start..colon];
+        let mut j = colon + 1;
         let mut nums = Vec::new();
         let mut cur = String::new();
         while j < bytes.len() {
@@ -175,19 +262,19 @@ pub fn citations_in_line(line: &str) -> Vec<(String, Vec<usize>)> {
         if !path.is_empty() && !nums.is_empty() {
             out.push((path.to_owned(), nums));
         }
-        i = j.max(i + 3);
+        i = j.max(colon + 1);
     }
     out
 }
 
-/// Collects every out-of-range citation in `contents`, and counts how many
-/// citations were actually resolved and checked. The count is what lets callers
-/// tell "clean" apart from "examined nothing".
+/// Collects every unfollowable citation in `contents` and tallies what was
+/// examined. The tallies are what let callers tell "clean" apart from
+/// "examined nothing".
 pub fn scan_contents(
     source: &str,
     contents: &str,
     manifest: &BTreeMap<String, usize>,
-    checked: &mut usize,
+    tally: &mut ScanTally,
 ) -> Vec<Violation> {
     let mut out = Vec::new();
     for (lineno, line) in contents.lines().enumerate() {
@@ -195,14 +282,31 @@ pub fn scan_contents(
             continue;
         }
         for (cited_path, nums) in citations_in_line(line) {
-            let Some(resolved) = resolve_upstream_path(&cited_path, manifest) else {
+            let resolution = resolve_upstream_path(&cited_path, manifest);
+            if matches!(resolution, Resolution::ForeignUpstream) {
                 continue;
+            }
+            tally.names_checked += 1;
+            let resolved = match resolution {
+                Resolution::Pinned(path) => path,
+                // The file exists under several paths; nothing to range-check.
+                Resolution::Ambiguous => continue,
+                Resolution::Missing => {
+                    out.push(Violation::MissingFile {
+                        source: source.to_owned(),
+                        line: lineno + 1,
+                        upstream: cited_path,
+                        cited: nums[0],
+                    });
+                    continue;
+                }
+                Resolution::ForeignUpstream => unreachable!("filtered above"),
             };
-            *checked += 1;
+            tally.ranges_checked += 1;
             let actual = manifest[&resolved];
             for n in nums {
                 if n > actual {
-                    out.push(Violation {
+                    out.push(Violation::OutOfRange {
                         source: source.to_owned(),
                         line: lineno + 1,
                         upstream: resolved.clone(),
@@ -217,18 +321,33 @@ pub fn scan_contents(
     out
 }
 
+/// How much each rule actually examined during a scan.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ScanTally {
+    /// Citations whose file name was tested against the pinned release.
+    pub names_checked: usize,
+    /// Citations that resolved to one pinned file and were range-checked.
+    pub ranges_checked: usize,
+}
+
 /// What one full scan of the workspace saw.
 #[derive(Debug, Default)]
 pub struct ScanReport {
-    /// Citations naming a line the cited file does not have.
+    /// Citations that cannot be followed to the pinned upstream source.
     pub violations: Vec<Violation>,
-    /// Rust sources opened.
+    /// Sources opened.
     pub files_read: usize,
-    /// Citations that resolved to a pinned upstream file and were range-checked.
-    pub citations_checked: usize,
+    /// What each rule examined.
+    pub tally: ScanTally,
 }
 
-/// Scans every tracked Rust source for out-of-range upstream citations.
+/// Scans every file in the repository for unfollowable upstream citations.
+///
+/// Every file, not a curated extension list: the phantom `runtests.sh`
+/// citations sat in a shell script for as long as they did because the only
+/// checker in the tree globbed `crates/**/*.rs`. Whatever cannot be decoded as
+/// UTF-8 is skipped, which is how binary goldens stay out of the way without
+/// anyone having to name them.
 ///
 /// Refuses to return a clean report it did not earn. An empty manifest, a
 /// source list that resolves to nothing, or a citation extractor that stopped
@@ -244,7 +363,7 @@ pub fn collect_violations(workspace: &Path) -> TaskResult<ScanReport> {
         )));
     }
     let mut report = ScanReport::default();
-    for relative in list_rust_sources_via_git(workspace)? {
+    for relative in list_sources_via_git_unfiltered(workspace)? {
         let contents = match fs::read_to_string(workspace.join(&relative)) {
             Ok(c) => c,
             Err(_) => continue,
@@ -254,23 +373,50 @@ pub fn collect_violations(workspace: &Path) -> TaskResult<ScanReport> {
             &relative.display().to_string(),
             &contents,
             &manifest,
-            &mut report.citations_checked,
+            &mut report.tally,
         ));
     }
     if report.files_read == 0 {
         return Err(validation_error(
-            "read zero Rust sources; `git ls-files` returned nothing, so a clean \
+            "read zero sources; `git ls-files` returned nothing, so a clean \
              result would mean nothing",
         ));
     }
-    if report.citations_checked == 0 {
+    if report.tally.names_checked == 0 {
         return Err(validation_error(format!(
-            "read {} Rust source(s) but resolved ZERO upstream citations; the \
+            "read {} source(s) but resolved ZERO upstream citations; the \
              citation extractor or {MANIFEST_PATH} is broken",
             report.files_read
         )));
     }
     Ok(report)
+}
+
+/// Re-derives the manifest by walking the pinned source tree.
+///
+/// Shared by `write_manifest` and the cross-check test so the two cannot drift
+/// into disagreeing about which files belong in the manifest.
+pub fn derive_manifest(root: &Path) -> TaskResult<BTreeMap<String, usize>> {
+    let mut rows = BTreeMap::new();
+    for entry in walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        let p = entry.path();
+        let citable = p
+            .extension()
+            .is_some_and(|e| CITED_EXTENSIONS.iter().any(|ext| e == *ext));
+        if !citable || !p.is_file() {
+            continue;
+        }
+        let rel = p
+            .strip_prefix(root)
+            .map_err(|e| validation_error(e.to_string()))?
+            .to_string_lossy()
+            .replace('\\', "/");
+        rows.insert(rel, fs::read_to_string(p)?.lines().count());
+    }
+    Ok(rows)
 }
 
 /// Rewrites the manifest from the pinned source. Needed only when the upstream
@@ -282,23 +428,7 @@ pub fn write_manifest(workspace: &Path) -> TaskResult<()> {
             "pinned source missing at {PINNED_SOURCE_DIR}; run tools/ci/run_interop.sh to fetch it"
         )));
     }
-    let mut rows: Vec<(String, usize)> = Vec::new();
-    for entry in walkdir::WalkDir::new(&root)
-        .into_iter()
-        .filter_map(Result::ok)
-    {
-        let p = entry.path();
-        if !p.is_file() || !p.extension().is_some_and(|e| e == "c" || e == "h") {
-            continue;
-        }
-        let rel = p
-            .strip_prefix(&root)
-            .map_err(|e| validation_error(e.to_string()))?
-            .to_string_lossy()
-            .replace('\\', "/");
-        rows.push((rel, fs::read_to_string(p)?.lines().count()));
-    }
-    rows.sort();
+    let rows = derive_manifest(&root)?;
     let mut out = String::from(MANIFEST_HEADER);
     for (rel, n) in &rows {
         out.push_str(&format!("{rel}\t{n}\n"));
@@ -313,10 +443,11 @@ pub fn execute(workspace: &Path) -> TaskResult<()> {
     let report = collect_violations(workspace)?;
     if report.violations.is_empty() {
         eprintln!(
-            "citations: {} checked across {} file(s) - all name a line that \
-             exists. This does NOT mean the cited line says what the comment \
-             claims; nothing here checks that.",
-            report.citations_checked, report.files_read
+            "citations: {} name(s) and {} line range(s) checked across {} \
+             file(s) - every citation names a file rsync 3.4.4 has, at a line \
+             that file has. This does NOT mean the cited line says what the \
+             comment claims; nothing here checks that.",
+            report.tally.names_checked, report.tally.ranges_checked, report.files_read
         );
         return Ok(());
     }
@@ -324,8 +455,10 @@ pub fn execute(workspace: &Path) -> TaskResult<()> {
         eprintln!("{v}");
     }
     Err(validation_error(format!(
-        "{} upstream citation(s) name a line the cited file does not have; \
-         re-locate the construct in {PINNED_SOURCE_DIR} and correct the number",
+        "{} upstream citation(s) cannot be followed to {PINNED_SOURCE_DIR}; \
+         re-locate the construct there and correct the file name or the line \
+         number, or - if the behaviour has no upstream analogue any more - \
+         drop the citation",
         report.violations.len()
     )))
 }
@@ -334,15 +467,26 @@ pub fn execute(workspace: &Path) -> TaskResult<()> {
 mod tests {
     use super::*;
 
-    /// `scan_contents` with the check-counter discarded, for tests that only
-    /// care about the violations.
+    /// `scan_contents` with the tally discarded, for tests that only care about
+    /// the violations.
     fn scan(source: &str, contents: &str, m: &BTreeMap<String, usize>) -> Vec<Violation> {
-        let mut checked = 0;
-        scan_contents(source, contents, m, &mut checked)
+        let mut tally = ScanTally::default();
+        scan_contents(source, contents, m, &mut tally)
     }
 
     fn manifest() -> BTreeMap<String, usize> {
-        parse_manifest("# c\nrsync.c\t831\nflist.c\t3500\nlib/wildmatch.c\t100\n")
+        parse_manifest(
+            "# c\nrsync.c\t831\nflist.c\t3500\nlib/wildmatch.c\t100\n\
+             runtests.py\t400\nsupport/lsh.sh\t60\ncompat.c\t700\nlib/compat.c\t272\n\
+             popt/dup.h\t20\nzlib/dup.h\t30\n",
+        )
+    }
+
+    /// The cited line number of a violation, whichever kind it is.
+    fn cited_line(v: &Violation) -> usize {
+        match v {
+            Violation::OutOfRange { cited, .. } | Violation::MissingFile { cited, .. } => *cited,
+        }
     }
 
     /// Builds a citation at run time so this file's own fixtures are not
@@ -368,37 +512,111 @@ mod tests {
     }
 
     #[test]
+    fn parses_a_python_and_a_shell_path() {
+        // The defect that motivated the file-existence rule was a `.sh`
+        // citation, so the extractor has to see past `.c`/`.h`.
+        assert_eq!(
+            citations_in_line(&cite("runtests.py", "205-215")),
+            vec![("runtests.py".to_owned(), vec![205, 215])]
+        );
+        assert_eq!(
+            citations_in_line(&cite("support/lsh.sh", "42")),
+            vec![("support/lsh.sh".to_owned(), vec![42])]
+        );
+    }
+
+    #[test]
     fn resolves_bare_name_and_exact_path() {
         let m = manifest();
         assert_eq!(
-            resolve_upstream_path("rsync.c", &m).as_deref(),
-            Some("rsync.c")
+            resolve_upstream_path("rsync.c", &m),
+            Resolution::Pinned("rsync.c".to_owned())
         );
         assert_eq!(
-            resolve_upstream_path("wildmatch.c", &m).as_deref(),
-            Some("lib/wildmatch.c")
+            resolve_upstream_path("wildmatch.c", &m),
+            Resolution::Pinned("lib/wildmatch.c".to_owned())
         );
         assert_eq!(
-            resolve_upstream_path("lib/wildmatch.c", &m).as_deref(),
-            Some("lib/wildmatch.c")
+            resolve_upstream_path("lib/wildmatch.c", &m),
+            Resolution::Pinned("lib/wildmatch.c".to_owned())
         );
     }
 
     #[test]
     fn a_foreign_upstream_is_out_of_scope() {
-        // zsync citations carry a `librcksum/` prefix the rsync tarball lacks.
-        // They must not be gated against rsync's line counts.
+        // RULE: a directory the rsync tarball does not ship means the citation
+        // is to some other project. zsync's `librcksum/` and the audit notes'
+        // explicitly-versioned `rsync-3.4.1/` paths are both excluded by it,
+        // and neither is named in the gate.
         let m = manifest();
-        assert_eq!(resolve_upstream_path("librcksum/rsum.c", &m), None);
-        assert_eq!(resolve_upstream_path("rsum.c", &m), None);
+        assert_eq!(
+            resolve_upstream_path("librcksum/rsum.c", &m),
+            Resolution::ForeignUpstream
+        );
+        assert_eq!(
+            resolve_upstream_path("target/interop/upstream-src/rsync-3.4.1/flist.c", &m),
+            Resolution::ForeignUpstream
+        );
+    }
+
+    #[test]
+    fn a_bare_name_the_release_lacks_is_missing_not_foreign() {
+        // Without a directory component there is nothing to say the citation
+        // means a different project, so `rsum.c` is a defect while
+        // `librcksum/rsum.c` is out of scope. This asymmetry is the whole
+        // reason the existence rule has no false positives.
+        assert_eq!(
+            resolve_upstream_path("rsum.c", &manifest()),
+            Resolution::Missing
+        );
+    }
+
+    #[test]
+    fn an_ambiguous_bare_name_exists_and_is_not_a_violation() {
+        // A bare name several manifest paths share, none of them top-level. The
+        // file exists, so this is not a missing-file defect; it just cannot be
+        // range-checked. Note the near miss: rsync ships both `compat.c` and
+        // `lib/compat.c`, but the exact-path branch resolves the bare form to
+        // the top-level file, so the common case is checked, not skipped.
+        let m = manifest();
+        assert_eq!(resolve_upstream_path("dup.h", &m), Resolution::Ambiguous);
+        assert_eq!(
+            resolve_upstream_path("compat.c", &m),
+            Resolution::Pinned("compat.c".to_owned())
+        );
+        assert!(scan("a.rs", &cite("dup.h", "999999"), &m).is_empty());
+    }
+
+    #[test]
+    fn flags_a_file_the_pinned_release_does_not_have() {
+        // THE DEFECT THIS RULE EXISTS FOR. `tools/ci/run_upstream_testsuite.sh`
+        // cited `runtests.sh:205-215`; rsync ships `runtests.py` and has never
+        // shipped a `runtests.sh`.
+        let v = scan(
+            "tools/ci/x.sh",
+            &cite("runtests.sh", "205-215"),
+            &manifest(),
+        );
+        assert_eq!(v.len(), 1);
+        assert!(matches!(v[0], Violation::MissingFile { .. }), "{:?}", v[0]);
+        assert_eq!(cited_line(&v[0]), 205);
+        assert!(
+            v[0].to_string().contains("runtests.sh"),
+            "the message must name the missing target: {}",
+            v[0]
+        );
     }
 
     #[test]
     fn flags_a_line_past_the_end_of_the_file() {
         let v = scan("a.rs", &cite("rsync.c", "954-965"), &manifest());
         assert_eq!(v.len(), 1);
-        assert_eq!(v[0].cited, 954);
-        assert_eq!(v[0].actual, 831);
+        assert!(
+            matches!(v[0], Violation::OutOfRange { actual: 831, .. }),
+            "{:?}",
+            v[0]
+        );
+        assert_eq!(cited_line(&v[0]), 954);
     }
 
     #[test]
@@ -407,7 +625,7 @@ mod tests {
         // would miss this.
         let v = scan("a.rs", &cite("rsync.c", "820-900"), &manifest());
         assert_eq!(v.len(), 1);
-        assert_eq!(v[0].cited, 900);
+        assert_eq!(cited_line(&v[0]), 900);
     }
 
     #[test]
@@ -421,9 +639,24 @@ mod tests {
         assert!(scan("a.rs", &not_a_citation, &manifest()).is_empty());
     }
 
-    /// THE GATE. Every upstream citation in the workspace must name a line the
-    /// cited file actually has. Runs from the committed manifest, so it is not
-    /// silently skipped in the cell that lacks the upstream tarball.
+    /// THE GATE. Every upstream citation in the repository must name a file the
+    /// pinned release has, at a line that file has. Runs from the committed
+    /// manifest, so it is not silently skipped in the cell that lacks the
+    /// upstream tarball, and over every file git knows about, so it is not
+    /// silently skipped in whichever directory the next defect lands in.
+    ///
+    /// WHY EVERY FILE. The file-existence rule was added because
+    /// `tools/ci/run_upstream_testsuite.sh` cited a `runtests.sh` that has never
+    /// existed in any rsync release. It survived because the only citation
+    /// checkers in the tree globbed `crates/**/*.rs`, so every citation under
+    /// `tools/`, `.github/` and `xtask/` was unexamined. A gate scoped to where
+    /// the last defect was found does not cover where the next one lands.
+    ///
+    /// RESIDUAL, stated rather than hidden: the scan reaches `docs/`, but
+    /// `.github/workflows/ci.yml` does not list `docs/**` among the paths that
+    /// start the nextest cell, so a documentation-only pull request introducing
+    /// a phantom citation is caught at the next change that does touch code or
+    /// tooling, not at the pull request that added it.
     ///
     /// WHAT GREEN HERE DOES NOT MEAN. This proves only that the coordinates are
     /// reachable. It does not check that the cited line says what the comment
@@ -466,12 +699,12 @@ mod tests {
     /// comment does. Each design would need 130-250 in-source exemptions, and
     /// an exemption written that often stops being read.
     #[test]
-    fn every_upstream_citation_names_a_line_that_exists() {
+    fn every_upstream_citation_names_a_file_and_line_that_exist() {
         let workspace = crate::workspace::workspace_root().expect("workspace root");
         let report = collect_violations(&workspace).expect("scan succeeds");
         assert!(
             report.violations.is_empty(),
-            "upstream citations name lines their files do not have:\n{}",
+            "upstream citations that cannot be followed to rsync 3.4.4:\n{}",
             report
                 .violations
                 .iter()
@@ -480,14 +713,42 @@ mod tests {
                 .join("\n")
         );
         // A green run must have been earned. `collect_violations` already
-        // refuses to return an unearned clean report; this pins the floor so a
-        // future change that quietly narrows the scan cannot pass as success.
+        // refuses to return an unearned clean report; these pin the floor so a
+        // future change that quietly narrows either rule's reach cannot pass as
+        // success. Both are asserted: a scan that resolved names but stopped
+        // range-checking would still look clean under one alone.
         assert!(
-            report.citations_checked > 100,
-            "only {} citations checked across {} file(s) - the scan collapsed, \
-             and an empty violation list here would mean nothing",
-            report.citations_checked,
+            report.tally.names_checked > 100 && report.tally.ranges_checked > 100,
+            "only {} name(s) and {} range(s) checked across {} file(s) - the \
+             scan collapsed, and an empty violation list here would mean nothing",
+            report.tally.names_checked,
+            report.tally.ranges_checked,
             report.files_read
+        );
+    }
+
+    /// The gate must see past `crates/`. A floor on the count of non-Rust files
+    /// read is what keeps that true: `collect_violations` could be narrowed back
+    /// to a Rust glob and every other assertion here would still pass.
+    #[test]
+    fn the_scan_reaches_beyond_rust_sources() {
+        let workspace = crate::workspace::workspace_root().expect("workspace root");
+        let files = list_sources_via_git_unfiltered(&workspace).expect("git ls-files");
+        let non_rust = files
+            .iter()
+            .filter(|p| p.extension().is_some_and(|e| e != "rs"))
+            .count();
+        assert!(
+            non_rust > 500,
+            "only {non_rust} non-Rust file(s) enumerated; the scan has been \
+             narrowed back to a Rust glob, which is the hole this gate closed"
+        );
+        assert!(
+            files
+                .iter()
+                .any(|p| p.ends_with("run_upstream_testsuite.sh")),
+            "the shell script that carried the phantom citations is not in the \
+             scan set"
         );
     }
 
@@ -498,22 +759,38 @@ mod tests {
         // mode this whole check exists to make impossible.
         let m: BTreeMap<String, usize> = parse_manifest("# only comments\n");
         assert!(m.is_empty());
-        let mut checked = 0;
-        let v = scan_contents("a.rs", &cite("rsync.c", "954-965"), &m, &mut checked);
-        assert!(v.is_empty(), "no manifest means nothing resolves");
-        assert_eq!(checked, 0, "and nothing was checked - the tell");
+        let mut tally = ScanTally::default();
+        let v = scan_contents("a.rs", &cite("rsync.c", "954-965"), &m, &mut tally);
+        // With no manifest the bare name looks missing rather than resolvable,
+        // so the violation is real but meaningless. `collect_violations`
+        // rejects an empty manifest outright for exactly that reason.
+        assert_eq!(v.len(), 1);
+        assert_eq!(
+            tally.ranges_checked, 0,
+            "nothing was range-checked - the tell"
+        );
     }
 
     #[test]
-    fn a_resolved_citation_is_counted_as_checked() {
-        let mut checked = 0;
-        scan_contents(
+    fn a_resolved_citation_is_counted_under_both_rules() {
+        let mut tally = ScanTally::default();
+        scan_contents("a.rs", &cite("rsync.c", "457-465"), &manifest(), &mut tally);
+        assert_eq!(tally.names_checked, 1);
+        assert_eq!(tally.ranges_checked, 1);
+    }
+
+    #[test]
+    fn a_foreign_citation_is_counted_under_neither_rule() {
+        let mut tally = ScanTally::default();
+        let v = scan_contents(
             "a.rs",
-            &cite("rsync.c", "457-465"),
+            &cite("librcksum/rsum.c", "262"),
             &manifest(),
-            &mut checked,
+            &mut tally,
         );
-        assert_eq!(checked, 1);
+        assert!(v.is_empty());
+        assert_eq!(tally.names_checked, 0);
+        assert_eq!(tally.ranges_checked, 0);
     }
 
     /// Proves the committed manifest still describes the real pinned source.
@@ -529,26 +806,7 @@ mod tests {
             return;
         }
         let manifest = load_manifest(&workspace).expect("manifest loads");
-        let mut derived = BTreeMap::new();
-        for entry in walkdir::WalkDir::new(&root)
-            .into_iter()
-            .filter_map(Result::ok)
-        {
-            let p = entry.path();
-            let is_source = p.extension().is_some_and(|e| e == "c" || e == "h");
-            if !is_source || !p.is_file() {
-                continue;
-            }
-            let rel = p
-                .strip_prefix(&root)
-                .expect("under root")
-                .to_string_lossy()
-                .replace('\\', "/");
-            let n = fs::read_to_string(p)
-                .map(|s| s.lines().count())
-                .unwrap_or_default();
-            derived.insert(rel, n);
-        }
+        let derived = derive_manifest(&root).expect("pinned source walks");
         assert_eq!(
             manifest, derived,
             "{MANIFEST_PATH} is stale or hand-edited; regenerate it from {PINNED_SOURCE_DIR}"

--- a/xtask/src/task/tasks/release.rs
+++ b/xtask/src/task/tasks/release.rs
@@ -67,7 +67,7 @@ impl Task for ReleaseTask {
     }
 }
 
-/// Verifies upstream C citations against the pinned source line counts.
+/// Verifies upstream citations against the pinned source manifest.
 pub struct CitationsTask;
 
 impl Task for CitationsTask {
@@ -76,7 +76,7 @@ impl Task for CitationsTask {
     }
 
     fn description(&self) -> &'static str {
-        "Verify upstream citations name lines that exist"
+        "Verify upstream citations name files and lines that exist"
     }
 
     fn explicit_duration(&self) -> Option<Duration> {

--- a/xtask/src/util/git.rs
+++ b/xtask/src/util/git.rs
@@ -31,17 +31,34 @@ pub fn list_tracked_files(workspace: &Path) -> TaskResult<Vec<PathBuf>> {
 
 /// Returns all Rust sources tracked or untracked within the repository via git.
 pub fn list_rust_sources_via_git(workspace: &Path) -> TaskResult<Vec<PathBuf>> {
+    list_sources_via_git(workspace, Some("*.rs"))
+}
+
+/// Returns every file in the repository, tracked or untracked-but-not-ignored.
+///
+/// Callers that scan for text patterns want this rather than a per-extension
+/// pathspec: an extension list is a guess about where the pattern may appear,
+/// and the citation gate exists because a defect hid in the one directory an
+/// earlier glob did not cover.
+pub fn list_sources_via_git_unfiltered(workspace: &Path) -> TaskResult<Vec<PathBuf>> {
+    list_sources_via_git(workspace, None)
+}
+
+fn list_sources_via_git(workspace: &Path, pathspec: Option<&str>) -> TaskResult<Vec<PathBuf>> {
+    let mut args = vec![
+        "ls-files",
+        "-z",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+    ];
+    if let Some(spec) = pathspec {
+        args.push("--");
+        args.push(spec);
+    }
     let output = Command::new("git")
         .current_dir(workspace)
-        .args([
-            "ls-files",
-            "-z",
-            "--cached",
-            "--others",
-            "--exclude-standard",
-            "--",
-            "*.rs",
-        ])
+        .args(&args)
         .output()
         .map_err(|error| {
             map_command_error(

--- a/xtask/src/util/mod.rs
+++ b/xtask/src/util/mod.rs
@@ -14,7 +14,7 @@ pub use commands::{
     run_cargo_tool_with_env,
 };
 pub use filesystem::{is_probably_binary, read_file_with_context, resolve_workspace_path};
-pub use git::{list_rust_sources_via_git, list_tracked_files};
+pub use git::{list_rust_sources_via_git, list_sources_via_git_unfiltered, list_tracked_files};
 
 use crate::error::{TaskError, TaskResult};
 


### PR DESCRIPTION
## The defect

`tools/ci/run_upstream_testsuite.sh` cited `runtests.sh:205-215` and
`runtests.sh:254`. Neither rsync 3.4.4 nor 3.5.0 ships a `runtests.sh`; both ship
`runtests.py`. The citation named a file that has never existed in any release,
and nothing noticed, because every citation checker in the tree only ever opened
`crates/**/*.rs` - so every upstream citation under `tools/`, `.github/` and
`xtask/` was unexamined.

## Why this extends `cargo xtask citations` instead of adding a script

It is the same question that gate already asks - can a reader follow this
citation to the pinned source - read from the same manifest, reported through the
same command, and enforced by the same nextest test. A parallel checker would
have meant a second scanner, a second citation extractor, and a second place to
keep the version pin in step, which is precisely how the tree ended up with a
Rust-only glob that nobody widened.

## What changed

1. **Scan every file git knows about**, not `*.rs`. Whatever does not decode as
   UTF-8 is skipped, so binary goldens stay out without anyone naming them.
2. **Recognise `.py` and `.sh` citations** alongside `.c`/`.h`, and **fail when a
   citation's bare file name is not a file of the pinned release**, printing the
   citing `file:line` and the missing target.
3. The manifest gains the eight `.py`/`.sh` files of the pinned tarball, so its
   key set is the gate's answer to "does this upstream file exist". Still derived
   mechanically; `derive_manifest` is now shared with the cross-check test rather
   than duplicated there.

**Scope rule, not an allow-list.** A citation qualified by a directory the rsync
tarball does not ship - zsync's `librcksum/`, an explicitly-versioned
`rsync-3.4.1/` path - names a *different* upstream and is out of scope. That rule
already existed; it is now stated and tested. Nothing is exempted by name, and
there is no waiver mechanism.

## Proof it catches the motivating defect

Reverting the script to its pre-fix state:

```
tools/ci/run_upstream_testsuite.sh:184: cites runtests.sh:205 but rsync 3.4.4 has no runtests.sh
tools/ci/run_upstream_testsuite.sh:252: cites runtests.sh:254 but rsync 3.4.4 has no runtests.sh
tools/ci/run_upstream_testsuite.sh:781: cites runtests.sh:205 but rsync 3.4.4 has no runtests.sh
3 upstream citation(s) cannot be followed to target/interop/upstream-src/rsync-3.4.4
EXIT=1
```

## Violations found and fixed

Scanned 7746 citations across 4909 files. **Three violations**, all repointed:

| Site | Was | Now |
|---|---|---|
| `crates/matching/tests/sparse_match_fixture.rs:20` | `rsum.c:362-366` | `librcksum/rsum.c:362-366` (zsync) |
| `crates/matching/tests/sparse_match_fixture.rs:201` | `rsum.c:362-366` | `librcksum/rsum.c:362-366` (zsync) |
| `docs/audits/interop-known-failures-inventory.md:52` | `run_upstream_testsuite.sh:42-46` | `tools/ci/run_upstream_testsuite.sh:63-76` |

The zsync sites are bare names for a file rsync does not ship; the qualified form
is what their siblings in `crates/matching` already use. The docs site cited a
repo-local script by bare name, and its line range was stale on top of that -
42-46 is now the git-ref-mode block, while `known_failures_conf` is read at
63-76.

## What is deliberately NOT built

Line-number **accuracy** for these files. The same citation set audits at 11%
suspected drift against 3.4.4 and 93% against 3.5.0, and whether these citations
should carry line numbers at all is an open decision that has to be settled
before the pin moves. The module doc says this explicitly so the next reader does
not "finish" it wrongly. This gate asserts only that the coordinates are
reachable.

## Residual, stated rather than hidden

`ci.yml` does not list `docs/**` among the paths that start the nextest cell, so
a documentation-only pull request introducing a phantom citation is caught at the
next change that does touch code or tooling. Recorded in the gate test's doc
comment.

## Verification

- `cargo xtask citations`: 7746 names and 7746 line ranges checked across 4909
  files, clean.
- `cargo test -p xtask --bin xtask`: 470 passed. The one failure,
  `validate::support::backdated_tree_populates_and_backdates_the_root`, is the
  known macOS BSD-`touch` issue in a file this branch does not touch.
- `cargo fmt --all -- --check` clean; `cargo clippy --locked -p xtask
  --all-targets --all-features --no-deps -- -D warnings` clean.
- No shell, Python or workflow files were modified by this branch.

## Sequencing

Stacked on #7281, which repoints the `runtests.sh` citations. The gate is red on
`master` until that merges - which is the point. Merge #7281 first.
