### PR TITLE
fix(filters): collapse a merge-file name's '..' before opening it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "seccompiler",
  "socket2",
  "tempfile",
+ "test-support",
  "tokio",
  "tracing",
  "windows",

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -30,11 +30,18 @@ pub(crate) fn apply_merge_directive(
         (PathBuf::from("-"), String::from("-"), None)
     } else {
         let raw_path = PathBuf::from(directive.source());
-        let resolved = if raw_path.is_absolute() {
+        let joined = if raw_path.is_absolute() {
             raw_path
         } else {
             base_dir.join(raw_path)
         };
+        // upstream: exclude.c parse_merge_name() runs the merge-file name
+        // through `clean_fname(fn, CFN_COLLAPSE_DOT_DOT_DIRS)`, and again after
+        // joining it onto the filter dir, so `merge a/b/../test` opens
+        // `a/test`. The collapse is lexical and happens before the open, which
+        // is why it succeeds when `a/b` does not exist - handing the raw name
+        // to the OS instead fails with ENOENT.
+        let resolved = filters::collapse_dot_dot_dirs(&joined);
         let display = resolved.display().to_string();
         let canonical = std::fs::canonicalize(&resolved).ok();
         (resolved, display, canonical)

--- a/crates/cli/src/frontend/tests/merge.rs
+++ b/crates/cli/src/frontend/tests/merge.rs
@@ -98,3 +98,55 @@ fn merge_directive_options_respect_child_overrides() {
     assert_eq!(merged.sender_side_override(), Some(false));
     assert_eq!(merged.receiver_side_override(), Some(true));
 }
+
+/// A merge-file name with a `..` in it is collapsed lexically before the file
+/// is opened, so `a/b/../rules.txt` reads `a/rules.txt` even though `a/b` does
+/// not exist.
+///
+/// This is upstream's rule, not a convenience: `parse_merge_name` cleans the
+/// name with `clean_fname(fn, CFN_COLLAPSE_DOT_DOT_DIRS)` *before* the open, so
+/// the `..` never reaches the kernel and the intermediate directory need not
+/// exist. Handing the raw name to the OS instead fails with ENOENT and the
+/// whole run aborts, which is what rsync did until 3.5.0 fixed the off-by-one
+/// that left this collapse dead for multi-component paths. Measured against a
+/// real rsync 3.5.0 build: it loads the rules and exits 0.
+// upstream: exclude.c parse_merge_name(); util1.c clean_fname()
+#[test]
+fn apply_merge_directive_collapses_dot_dot_before_opening_the_file() {
+    use std::collections::HashSet;
+    use tempfile::tempdir;
+
+    let temp = tempdir().expect("tempdir");
+    std::fs::create_dir(temp.path().join("a")).expect("mkdir a");
+    std::fs::write(temp.path().join("a/rules.txt"), "- *.log\n").expect("write merge rules");
+    // `a/b` deliberately does not exist: only the lexical collapse can find the
+    // file, so this fails if the raw name is passed through to open().
+
+    let directive = MergeDirective::new(OsString::from("a/b/../rules.txt"), None);
+    let mut rules = Vec::new();
+    let mut visited = HashSet::new();
+    apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).expect("apply merge");
+
+    assert!(
+        rules
+            .iter()
+            .any(|rule| { rule.kind() == FilterRuleKind::Exclude && rule.pattern() == "*.log" })
+    );
+}
+
+/// The collapse must not invent a file: a `..` name whose collapsed form does
+/// not exist still fails, so the rewrite cannot mask a genuinely bad rule.
+// upstream: exclude.c parse_merge_name(); util1.c clean_fname()
+#[test]
+fn apply_merge_directive_still_fails_when_the_collapsed_name_is_absent() {
+    use std::collections::HashSet;
+    use tempfile::tempdir;
+
+    let temp = tempdir().expect("tempdir");
+    std::fs::create_dir(temp.path().join("a")).expect("mkdir a");
+
+    let directive = MergeDirective::new(OsString::from("a/b/../missing.txt"), None);
+    let mut rules = Vec::new();
+    let mut visited = HashSet::new();
+    assert!(apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).is_err());
+}

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -132,6 +132,7 @@ windows = { workspace = true, features = [
 bandwidth = { path = "../bandwidth", features = ["test-support"] }
 criterion = { workspace = true }
 filetime = { workspace = true }
+test-support = { path = "../test-support" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
@@ -306,3 +306,53 @@ mod daemon_module_suffix_tests {
         assert_eq!(ServerConfig::default().connection.daemon_module, None);
     }
 }
+
+#[cfg(test)]
+mod daemon_clean_fname_collapse_tests {
+    use super::lexically_normalize;
+    use std::path::{Path, PathBuf};
+    use test_support::COLLAPSE_CASES;
+
+    /// Every upstream `clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS)` case must
+    /// collapse identically here.
+    ///
+    /// `lexically_normalize` folds a client-supplied `--link-dest` /
+    /// `--copy-dest` / `--compare-dest` basis before
+    /// `confine_basis_under_module` tests it against the module root. The
+    /// containment check is a `starts_with` on the folded path, so a `..` that
+    /// fails to consume the component before it leaves a path that still
+    /// *looks* like it sits under the module while resolving elsewhere. That is
+    /// exactly the shape of upstream's off-by-one, which left the collapse dead
+    /// for every multi-component and absolute path.
+    ///
+    /// The table is shared (`test_support::COLLAPSE_CASES`) so a new edge case
+    /// is one row and reaches every oc-rsync copy of this rule at once.
+    // upstream: util1.c clean_fname() CFN_COLLAPSE_DOT_DOT_DIRS; t_clean_fname.c
+    #[test]
+    fn upstream_collapse_cases_consume_the_preceding_component() {
+        for (input, expected) in COLLAPSE_CASES {
+            assert_eq!(
+                lexically_normalize(Path::new(input)),
+                PathBuf::from(expected),
+                "clean_fname collapse case {input:?}"
+            );
+        }
+    }
+
+    /// A `..` with nothing left to pop survives into the result so the
+    /// caller's `starts_with(module_root)` check sees the escape and rejects
+    /// the basis. Silently swallowing it would hand the caller a path that
+    /// passes containment while naming a directory outside the module.
+    // upstream: util1.c clean_fname() - "collapse '..' elements (except at the start)"
+    #[test]
+    fn unpoppable_leading_dot_dot_is_preserved_for_the_containment_check() {
+        assert_eq!(
+            lexically_normalize(Path::new("../outside")),
+            PathBuf::from("../outside")
+        );
+        assert_eq!(
+            lexically_normalize(Path::new("mod/../../outside")),
+            PathBuf::from("../outside")
+        );
+    }
+}

--- a/crates/engine/src/local_copy/clean_fname_collapse_tests.rs
+++ b/crates/engine/src/local_copy/clean_fname_collapse_tests.rs
@@ -1,0 +1,51 @@
+use super::lexically_normalize;
+use std::path::{Path, PathBuf};
+use test_support::COLLAPSE_CASES;
+
+/// Every upstream `clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS)` case must
+/// collapse identically here.
+///
+/// `lexically_normalize` is the alt-basis resolver for `--link-dest`,
+/// `--copy-dest` and `--compare-dest`: it decides which directory a basis file
+/// is read from, and its result is what any containment check downstream sees.
+/// A `..` that fails to consume the component before it therefore does not
+/// merely produce an ugly path - it resolves the basis somewhere other than
+/// where the collapsed name points, which is the traversal shape upstream's
+/// off-by-one had. Pinning the upstream table here keeps that rule honest.
+///
+/// The table is shared (`test_support::COLLAPSE_CASES`) so a new edge case is
+/// one row and is checked against every oc-rsync copy of this rule at once.
+// upstream: util1.c clean_fname() CFN_COLLAPSE_DOT_DOT_DIRS; t_clean_fname.c
+#[test]
+fn upstream_collapse_cases_consume_the_preceding_component() {
+    for (input, expected) in COLLAPSE_CASES {
+        assert_eq!(
+            lexically_normalize(Path::new(input)),
+            PathBuf::from(expected),
+            "clean_fname collapse case {input:?}"
+        );
+    }
+}
+
+/// A `..` with nothing before it is kept verbatim, and `/..` stays at the root.
+///
+/// Upstream's `clean_fname` documents the collapse as applying "except at the
+/// start", and its `s == name && anchored` guard drops a root-relative `..`
+/// rather than climbing above `/`. Both arms matter here: keeping the leading
+/// `..` is what lets the caller's containment check see the escape and reject
+/// it, and refusing to climb past the root is what stops an absolute basis from
+/// walking out of the filesystem root.
+// upstream: util1.c clean_fname() - "collapse '..' elements (except at the start)"
+#[test]
+fn leading_dot_dot_is_preserved_and_root_dot_dot_stays_at_root() {
+    assert_eq!(
+        lexically_normalize(Path::new("../a")),
+        PathBuf::from("../a")
+    );
+    assert_eq!(
+        lexically_normalize(Path::new("../../a")),
+        PathBuf::from("../../a")
+    );
+    assert_eq!(lexically_normalize(Path::new("/..")), PathBuf::from("/"));
+    assert_eq!(lexically_normalize(Path::new("/../a")), PathBuf::from("/a"));
+}

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -230,27 +230,12 @@ const CROSS_DEVICE_ERROR_CODE: i32 = 18;
 /// Used when resolving relative `--link-dest` / `--copy-dest` / `--compare-dest`
 /// candidates so they resolve even when an intermediate directory (e.g. a
 /// not-yet-created dry-run destination) is absent from disk.
+///
+/// Delegates to `filters::collapse_dot_dot_dirs`, the single implementation of
+/// upstream's `clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS)` rule.
+// upstream: util1.c clean_fname() CFN_COLLAPSE_DOT_DOT_DIRS
 pub(crate) fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf {
-    use std::path::{Component, PathBuf};
-
-    let mut normalized: Vec<Component<'_>> = Vec::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => match normalized.last() {
-                Some(Component::Normal(_)) => {
-                    normalized.pop();
-                }
-                Some(Component::RootDir) => {}
-                _ => normalized.push(component),
-            },
-            other => normalized.push(other),
-        }
-    }
-    if normalized.is_empty() {
-        return PathBuf::from(".");
-    }
-    normalized.iter().collect()
+    filters::collapse_dot_dot_dirs(path)
 }
 
 #[cfg(test)]

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -286,6 +286,10 @@ mod tests;
 mod filter_program_internal_tests;
 
 #[cfg(test)]
+#[path = "clean_fname_collapse_tests.rs"]
+mod clean_fname_collapse_tests;
+
+#[cfg(test)]
 pub(crate) mod test_support {
     #[allow(unused_imports)]
     pub(crate) use super::executor::take_fsync_call_count;

--- a/crates/filters/src/clean_fname.rs
+++ b/crates/filters/src/clean_fname.rs
@@ -1,0 +1,115 @@
+//! Lexical `..` collapse, mirroring upstream `clean_fname()` with
+//! `CFN_COLLAPSE_DOT_DOT_DIRS`.
+//!
+//! Upstream cleans a merge-file name before opening it, so `merge a/b/../test`
+//! reads `a/test` even when `a/b` does not exist. That is a lexical rewrite,
+//! not a filesystem resolution: it never touches the disk and never follows a
+//! symlink, which is what makes it well defined for a path whose intermediate
+//! directories are absent.
+//!
+//! rsync 3.5.0 fixed an off-by-one that left this collapse dead for every
+//! multi-component and absolute path, so pre-3.5.0 releases open the uncleaned
+//! name instead.
+//!
+//! # Upstream References
+//!
+//! - `util1.c` - `clean_fname()`, the `CFN_COLLAPSE_DOT_DOT_DIRS` branch.
+//! - `exclude.c` - `parse_merge_name()` cleans the merge-file name (and again
+//!   after joining it onto the filter dir) before the file is read.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Collapses `.` and `..` components in `path` purely lexically.
+///
+/// Mirrors upstream `clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS)`:
+///
+/// - a `..` consumes the component before it;
+/// - a `..` with nothing left to consume is kept, so a relative path that
+///   climbs above its anchor still says so;
+/// - a `..` directly under the root stays at the root, matching upstream's
+///   `s == name && anchored` guard;
+/// - `.` components and duplicate separators are dropped;
+/// - an empty result becomes `"."`.
+///
+/// The rewrite is lexical, so it is defined for paths whose intermediate
+/// directories do not exist - and, like upstream, it does not agree with the
+/// kernel when a consumed component is a symlink.
+///
+/// # Upstream Reference
+///
+/// - `util1.c` - `clean_fname()` with `CFN_COLLAPSE_DOT_DOT_DIRS`.
+#[must_use]
+pub fn collapse_dot_dot_dirs(path: &Path) -> PathBuf {
+    let mut out: Vec<Component<'_>> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => match out.last() {
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                }
+                // upstream: util1.c clean_fname() - `s == name && anchored`
+                // drops a root-relative `..` instead of climbing past `/`.
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => out.push(component),
+            },
+            other => out.push(other),
+        }
+    }
+    if out.is_empty() {
+        return PathBuf::from(".");
+    }
+    out.iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collapse_dot_dot_dirs;
+    use std::path::{Path, PathBuf};
+
+    /// Every upstream `clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS)` case must
+    /// collapse identically here.
+    ///
+    /// This helper decides which file a `merge`/`dir-merge` rule opens, so a
+    /// `..` that fails to consume the component before it does not just render
+    /// oddly - it reads a different file, or none. The table is upstream's own
+    /// `t_clean_fname.c` `cases[]`, shared via `test_support` so a new edge case
+    /// is one row and reaches every oc-rsync copy of this rule at once.
+    // upstream: util1.c clean_fname() CFN_COLLAPSE_DOT_DOT_DIRS; t_clean_fname.c
+    #[test]
+    fn upstream_collapse_cases_consume_the_preceding_component() {
+        for (input, expected) in test_support::COLLAPSE_CASES {
+            assert_eq!(
+                collapse_dot_dot_dirs(Path::new(input)),
+                PathBuf::from(expected),
+                "clean_fname collapse case {input:?}"
+            );
+        }
+    }
+
+    /// The boundary arms `clean_fname` documents, measured against a real
+    /// rsync 3.5.0 build rather than derived from reading: a leading `..` with
+    /// nothing to consume survives, `/..` stays at the root, and a path that
+    /// cancels out becomes `"."`.
+    // upstream: util1.c clean_fname() - "collapse '..' elements (except at the start)"
+    #[test]
+    fn boundary_arms_match_upstream() {
+        for (input, expected) in [
+            ("../a", "../a"),
+            ("../../a", "../../a"),
+            ("/..", "/"),
+            ("/../a", "/a"),
+            ("..", ".."),
+            ("a/..", "."),
+            ("mod/../../outside", "../outside"),
+            ("a/b/../../c", "c"),
+            ("./a/../b", "b"),
+        ] {
+            assert_eq!(
+                collapse_dot_dot_dirs(Path::new(input)),
+                PathBuf::from(expected),
+                "clean_fname boundary case {input:?}"
+            );
+        }
+    }
+}

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -104,6 +104,8 @@ mod action;
 pub mod apple_double;
 /// Per-directory scoped filter chain with push/pop semantics.
 pub mod chain;
+/// Lexical `..` collapse for filter paths, mirroring `clean_fname()`.
+pub mod clean_fname;
 mod compiled;
 /// CVS exclusion patterns for rsync's `--cvs-exclude` (`-C`) option.
 pub mod cvs;
@@ -124,6 +126,7 @@ pub use apple_double::{
     DEFAULT_APPLE_DOUBLE_PATTERN, default_patterns as apple_double_default_patterns,
 };
 pub use chain::{DirFilterGuard, DirMergeConfig, FilterChain, FilterChainError};
+pub use clean_fname::collapse_dot_dot_dirs;
 pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};

--- a/crates/test-support/src/clean_fname.rs
+++ b/crates/test-support/src/clean_fname.rs
@@ -1,0 +1,46 @@
+//! Upstream `clean_fname()` `..`-collapse cases, shared by every oc-rsync
+//! module that implements the same rule.
+//!
+//! rsync 3.5.0 fixed an off-by-one in `clean_fname()`'s `..`-collapse: after
+//! walking the write pointer back over the previous component, the boundary
+//! test read `*s` instead of `s[-1]` and the truncation point was `s + 1`
+//! instead of `s`. The effect was that the collapse silently did nothing for
+//! every multi-component and absolute path - `a/b/../c` stayed `a/b/../c`.
+//! Upstream shipped `t_clean_fname.c` as the unit harness that pins the fix.
+//!
+//! oc-rsync has no single `clean_fname`; the same rule is implemented
+//! independently in several places (alt-basis resolution in `engine`, daemon
+//! basis confinement, `sanitize_path` in `transfer`). Keeping the case table
+//! here means a new edge case is one row and is checked against every
+//! implementation at once, rather than fixed in whichever copy happened to be
+//! reported.
+//!
+//! # Upstream References
+//!
+//! - `util1.c` - `clean_fname()`, the `CFN_COLLAPSE_DOT_DOT_DIRS` branch.
+//! - `t_clean_fname.c` - upstream's unit harness; this table is its `cases[]`.
+//! - `testsuite/clean-fname-collapse_test.py` - the testsuite entry that runs it.
+
+/// Input / expected-output pairs for upstream
+/// `clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS)`.
+///
+/// Transcribed verbatim from the `cases[]` array in upstream's own
+/// `t_clean_fname.c` (rsync 3.5.0), so the expectations are upstream's, not a
+/// re-derivation. Every entry exercises a `..` that must consume the component
+/// before it: interior (`a/b/../c`), absolute (`/x/y/../z`), single-component
+/// (`a/../b`), consecutive (`p/q/r/../../s`), and trailing (`d/e/..`).
+///
+/// Only `a/../b` collapsed correctly before the 3.5.0 fix - its backward walk
+/// stops at the buffer start, which took the one branch arm the off-by-one did
+/// not corrupt. The other four are the regression cases.
+///
+/// # Upstream Reference
+///
+/// - `t_clean_fname.c` - `cases[]`.
+pub const COLLAPSE_CASES: &[(&str, &str)] = &[
+    ("a/b/../c", "a/c"),
+    ("/x/y/../z", "/x/z"),
+    ("a/../b", "b"),
+    ("p/q/r/../../s", "p/s"),
+    ("d/e/..", "d"),
+];

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -6,6 +6,7 @@
 //! duplicated retry logic and setup boilerplate across crates.
 
 pub mod bin_path;
+pub mod clean_fname;
 pub mod cli;
 pub mod daemon_port;
 pub mod dir_diff;
@@ -14,6 +15,7 @@ pub mod skip;
 pub mod upstream_compat;
 
 pub use bin_path::{oc_rsync_bin, target_profile_dir, workspace_bin, workspace_bin_path};
+pub use clean_fname::COLLAPSE_CASES;
 pub use cli::{CliOutput, OcRsyncCliRunner, RunnerError};
 pub use daemon_port::{daemon_listen_port, spawn_daemon_on_free_port};
 pub use dir_diff::{DirDiff, DirDiffEntry, DirDiffError, DirDiffMismatch, DirDiffOptions};

--- a/crates/transfer/src/sanitize_path.rs
+++ b/crates/transfer/src/sanitize_path.rs
@@ -237,6 +237,34 @@ mod tests {
         assert_eq!(sanitize_path("a/b/../c"), "a/c");
     }
 
+    /// Every upstream `clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS)` case must
+    /// collapse identically through `sanitize_path`.
+    ///
+    /// `sanitize_path` is the daemon-side traversal guard: it is what turns a
+    /// peer-supplied name into the path actually opened under the module root.
+    /// It shares its `..`-collapse rule with upstream's `clean_fname`, and
+    /// upstream shipped an off-by-one there that left the collapse dead for
+    /// every multi-component and absolute path. A collapse that silently does
+    /// nothing means the retained name still carries `..` segments into the
+    /// open, so this is a confinement invariant, not formatting.
+    ///
+    /// `sanitize_path` additionally strips the leading `/` (that is the
+    /// `sanitize_path`-vs-`clean_fname` difference, not a collapse difference),
+    /// so the absolute row's expectation is de-anchored before comparison.
+    /// The table is shared (`test_support::COLLAPSE_CASES`) so a new edge case
+    /// is one row and reaches every oc-rsync copy of this rule at once.
+    // upstream: util1.c clean_fname() CFN_COLLAPSE_DOT_DOT_DIRS; t_clean_fname.c
+    #[test]
+    fn upstream_collapse_cases_consume_the_preceding_component() {
+        for (input, expected) in test_support::COLLAPSE_CASES {
+            assert_eq!(
+                sanitize_path(input),
+                expected.trim_start_matches('/'),
+                "clean_fname collapse case {input:?}"
+            );
+        }
+    }
+
     #[test]
     fn dotdot_at_end_collapses() {
         assert_eq!(sanitize_path("a/b/.."), "a");


### PR DESCRIPTION
Mirrors rsync 3.5.0's fix for the off-by-one in `clean_fname()`'s `..`-collapse
path normalization, and pins the rule across every oc-rsync copy of it.

## What upstream changed

`util1.c` `clean_fname()`, `CFN_COLLAPSE_DOT_DOT_DIRS` branch. After walking the
write pointer back over the previous component, `s` points at that component's
first character and `s[-1]` is its leading `/`. The old code tested `*s` and
truncated to `s + 1`:

```c
-if (s != t - 1 && (s <= name || *s == '/')) {
-        t = (s == name) ? name : s + 1;
+if (s != t - 1 && (s <= name || s[-1] == '/')) {
+        t = (s == name) ? name : s;
```

Only the single-component shape (`a/../b`) collapsed before the fix, because its
backward walk stops at the buffer start and takes the one branch arm the
off-by-one did not corrupt. Everything else was left uncollapsed.

Measured on Linux/aarch64 against a real rsync 3.5.0 build, and against the same
build with only those two lines reverted:

| input | 3.5.0 | off-by-one reverted |
|---|---|---|
| `a/b/../c` | `a/c` | `a/b/../c` |
| `/x/y/../z` | `/x/z` | `/x/y/../z` |
| `d/e/..` | `d` | `d/e/..` |
| `a/b/../../c` | `c` | `a/b/../../c` |
| `a/../b` | `b` | `b` |

## Did oc have it?

**Two answers, both measured.**

**The off-by-one itself: no.** oc-rsync has no single `clean_fname`; the rule is
implemented independently in three places - the engine alt-basis resolver
(`--link-dest`/`--copy-dest`/`--compare-dest`), the daemon basis-confinement
resolver, and `sanitize_path` in `transfer`. All three collapse by popping whole
components rather than by pointer arithmetic, so the off-by-one has no analogue.
All five of upstream's own `t_clean_fname.c` cases pass against each of them.

**The behaviour the fix restores: yes, on the merge-filter path.** `exclude.c`
`parse_merge_name()` cleans a merge-file name *before* opening it, so the `..`
never reaches the kernel and the intermediate directory need not exist. oc had no
collapse there at all - it handed the raw name to `open()` - so its observable
behaviour matched pre-3.5.0 rsync. Measured, `a/test` present and `a/b` absent:

```
rsync-3.5.0 [merge a/b/../test] exit=0  rules applied
oc-rsync    [merge a/b/../test] exit=1  ENOENT on 'a/b/../test'   <- before
oc-rsync    [merge a/b/../test] exit=0  rules applied             <- after
```

## The change

- New `filters::collapse_dot_dot_dirs` - one implementation of the rule, in the
  crate that owns `exclude.c` semantics.
- The merge-file name is collapsed before the open, mirroring `parse_merge_name`.
- The engine alt-basis resolver delegates to the shared helper instead of
  carrying its own byte-identical copy.
- The daemon and `sanitize_path` copies are left alone (see below) and are
  covered by the shared test table.

## Tests

`test_support::COLLAPSE_CASES` carries upstream's own `t_clean_fname.c`
`cases[]`, so a new edge case is one row and is checked against every copy of the
rule at once - `filters`, `engine`, `daemon`, and `transfer::sanitize_path`
(which additionally strips the leading `/`, its own documented difference from
`clean_fname`). Each site also pins the two boundary arms `clean_fname`
documents - a leading `..` that cannot be collapsed survives, `/..` stays at the
root - taken from a probe of the real 3.5.0 `clean_fname`, not from reading it.

Behavioural tests cover both directions of the merge fix: the collapsed name is
found when the intermediate directory is absent, and a collapsed name that does
not exist still fails, so the rewrite cannot mask a bad rule.

## Verification

Run on Linux/aarch64 against the branch head.

```
cargo fmt --all -- --check                                       exit 0
cargo clippy --locked --workspace --all-targets --all-features
    --no-deps -- -D warnings                                     exit 0

cargo nextest run -p filters --all-features
    1431 tests run: 1431 passed, 0 skipped
cargo nextest run -p cli --all-features
    3796 tests run: 3796 passed, 3 skipped
cargo nextest run -p engine -p daemon -p transfer --all-features \
    -E 'test(/upstream_collapse_cases|leading_dot_dot_is_preserved|
             unpoppable_leading_dot_dot|link_dest|copy_dest|compare_dest/)'
    120 tests run: 120 passed, 9461 skipped
```

The alt-dest cells are included because the engine resolver now delegates.

## Out of scope, reported not fixed

- On the *failure* path the two implementations still differ: rsync 3.5.0 exits
  11 with `failed to open exclude file a/missing`, oc exits 1 with its own
  wording. Pre-existing, unrelated to the collapse.
- The daemon's copy of the rule pops the root component, so it renders `/..` as
  `.` where `clean_fname` gives `/`. Its one caller fails closed on that input,
  so there is no reachable defect, but the two copies disagree. Folding the
  daemon and `sanitize_path` copies onto the shared helper is a separate change.
