### PR TITLE
ci(interop): run the full scenario matrix against upstream 3.5.0

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -20,11 +20,17 @@
 KNOWN_FAILURES=()
 
 # Newest upstream release still carrying the compressed-batch self-roundtrip
-# bug. Verified failing on 3.4.4 (the newest release) on both Linux/x86_64 and
-# macOS/arm64, so the defect is version-scoped, not platform-scoped. Bump this
-# only after re-verifying against the newer release; leaving it behind makes
-# the standalone test report UNEXPECTED FAIL once a fixed upstream enters the
-# matrix, which is the point.
+# bug. Verified failing on 3.4.4 (the newest release when that was measured) on
+# both Linux/x86_64 and macOS/arm64, so the defect is version-scoped, not
+# platform-scoped. Bump this only after re-verifying against the newer release;
+# leaving it behind makes the standalone test report UNEXPECTED FAIL once a
+# fixed upstream enters the matrix, which is the point.
+#
+# 3.5.0 has now entered the matrix and this value is deliberately UNCHANGED:
+# whether 3.5.0 still carries the bug is unverified, and asserting it here
+# would be a guess. The ledger is designed to answer that empirically - if
+# 3.5.0 fixed it the cell reports UNEXPECTED FAIL and this bumps to "3.5.0"
+# with evidence; if it still fails, the entry was already correct.
 UPSTREAM_BATCH_SELF_ROUNDTRIP_FIXED_AFTER="3.4.4"
 
 # Newest upstream release that refuses a protocol-32 batch header outright.

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -57,18 +57,25 @@ interop_log_dir="${workspace_root}/target/interop/logs"
 # the same wire protocol (proto 32). Testing the intermediate 3.4.x point
 # releases is redundant once 3.4.4 is green. 3.0.9 (proto 30) and 3.1.3
 # (proto 31, xattrs/ACL wire baseline) remain as protocol-level anchors.
-versions=(3.0.9 3.1.3 3.4.4)
+#
+# 3.5.0 is the current upstream release and runs the full scenario matrix. It
+# does NOT replace 3.4.4: this list is a set of peers we must interoperate
+# with, not a single "supported version", so an operator still running 3.4.4
+# stays covered. The 3.4.x collapse above was sound because those releases
+# share a wire protocol AND a behaviour baseline; 3.5.0 shares the protocol
+# (rsync.h: PROTOCOL_VERSION 32, SUBPROTOCOL_VERSION 0, unchanged) but rewrites
+# the path resolver and hardens the daemon, so it earns its own cells.
+#
+# Scope note: these cells exercise WIRE interoperability. 3.5.0's behavioural
+# divergences are a separate axis measured by the upstream testsuite, and are
+# deliberately not gated here - a wire-compatible peer with different local
+# path-resolution rules should pass interop and fail testsuite cells, and
+# conflating the two would hide which one broke.
+versions=(3.0.9 3.1.3 3.4.4 3.5.0)
 # Versions we only build and cache (no scenarios wired up yet). 2.6.9 is the
 # protocol-28 cutoff peer (advertises protocol 29, accepts down to 28); the
 # binary is needed so follow-up tasks can wire push/pull cells against it.
-#
-# 3.5.0 is the current upstream release. It carries the same wire protocol as
-# 3.4.4 (rsync.h: PROTOCOL_VERSION 32, SUBPROTOCOL_VERSION 0) but rewrites the
-# path resolver and hardens the daemon, so it is built and cached here first to
-# validate the fetch/configure/build path and give the follow-up triage a real
-# 3.5.0 oracle binary. Promoting it into `versions` (running the full scenario
-# matrix against it) is deliberately a separate step.
-extra_build_versions=(2.6.9 3.5.0)
+extra_build_versions=(2.6.9)
 
 # Versions with no usable per-arch .deb in any pool we track, so the harness
 # builds them from the release tarball instead. 2.6.9 predates the per-arch


### PR DESCRIPTION
Closes the build-only gap from #7278: 3.5.0 was fetched, built and cached, but ran **no scenarios**. This puts it in `versions`, which is what makes it a *tested peer* rather than a binary we merely compile.

## 3.5.0 does not replace 3.4.4

`versions` is the set of peers oc must interoperate with, not a single "supported version" - an operator still running 3.4.4 stays covered.

Collapsing 3.4.1/3.4.2/3.4.3 into 3.4.4 was sound because those share a wire protocol **and** a behaviour baseline. 3.5.0 shares the protocol (`rsync.h`: `PROTOCOL_VERSION 32`, `SUBPROTOCOL_VERSION 0`, both unchanged) but **rewrites the path resolver and hardens the daemon**, so it earns its own cells rather than inheriting 3.4.4's.

## Why this is low-risk

Interop cells test **wire** interoperability, and 3.5.0 is wire-identical to 3.4.4. The 133 known behavioural divergences live on a **different axis** - the upstream testsuite - which this PR does not touch.

That separation is deliberate and worth keeping: a wire-compatible peer with different local path-resolution rules *should* pass interop and fail testsuite cells. Conflating the two would hide which one actually broke.

## The known-failures interaction, handled honestly

`known_failures.conf` carries `UPSTREAM_BATCH_SELF_ROUNDTRIP_FIXED_AFTER="3.4.4"`, meaning releases newer than 3.4.4 are expected to have the compressed-batch self-roundtrip bug fixed. Adding 3.5.0 activates that expectation.

**The value is deliberately left unchanged.** Whether 3.5.0 still carries the bug is unverified, and asserting either way here would be a guess. The ledger is built to answer this empirically - its own comment says leaving the value behind is precisely what makes a fixed upstream report `UNEXPECTED FAIL`. So:

- if 3.5.0 fixed it → the cell reports `UNEXPECTED FAIL`, and the entry bumps to `"3.5.0"` **with evidence**
- if 3.5.0 still fails → the entry was already correct, nothing to do

Either outcome is information. The stale `(the newest release)` aside is corrected, since 3.5.0 now holds that title.

## Sequencing

This is the **oracle-first** step of a staged alignment. It does **not** flip `Cargo.toml upstream_version`, the required `upstream-testsuite` gate, or `citation_drift_audit.py VER` - those come last, after the 133 divergences are classified into a ledger (tasks 531-542) and the ~4,900 line-number citations are settled (task 530). Master stays green throughout.

`bash -n` clean on both files; `shellcheck -S error` clean on `run_interop.sh`.