### PR TITLE
fix(protocol): mask peer-supplied io_error to the defined IOERR_* bits

### DIFF
--- a/crates/protocol/src/flist/read/mod.rs
+++ b/crates/protocol/src/flist/read/mod.rs
@@ -549,9 +549,11 @@ impl FileListReader {
         let flags = match self.read_flags(reader)? {
             FlagsResult::EndOfList => return Ok(None),
             FlagsResult::IoError(code) => {
-                // upstream: flist.c:recv_file_list() does `io_error |= err`
-                // and breaks the loop - it does NOT abort the transfer.
-                self.io_error |= code;
+                // upstream: flist.c:2950,2968 recv_file_list() does
+                // `io_error |= err & IOERR_VALID_MASK` and breaks the loop - it
+                // does NOT abort the transfer. The mask keeps a hostile peer
+                // from planting undefined bits in the local io_error.
+                self.io_error |= crate::io_error::sanitize_peer_io_error(code);
                 return Ok(None);
             }
             FlagsResult::Flags(f) => f,

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -89,10 +89,43 @@ fn read_entry_detects_error_marker_with_safe_file_list() {
     let mut cursor = Cursor::new(&data[..]);
     let result = reader.read_entry(&mut cursor);
 
-    // io_error markers are now accumulated (upstream: flist.c io_error |= err)
-    // rather than returned as hard errors.
+    // io_error markers are accumulated (upstream: flist.c:2968
+    // `io_error |= err & IOERR_VALID_MASK`) rather than returned as hard errors.
+    // 42 = 0b101010 carries two undefined bits; only IOERR_VANISHED survives.
     assert!(result.unwrap().is_none());
-    assert_eq!(reader.io_error(), 42);
+    assert_eq!(reader.io_error(), 42 & crate::IOERR_VALID_MASK);
+    assert_eq!(reader.io_error(), crate::IOERR_VANISHED);
+}
+
+/// The varint end-of-list form (`write_varint(0); write_varint(io_error)`) is a
+/// second, independent way for a peer to deliver an `io_error`. It must mask
+/// too - upstream applies the mask on both flist branches, and covering only
+/// one of them leaves the hole open.
+///
+/// upstream: flist.c:2946-2952 - `if ((flags = read_varint(f)) == 0) { int err
+/// = read_varint(f); io_error |= err & IOERR_VALID_MASK; break; }`
+#[test]
+fn varint_end_of_list_masks_undefined_bits_from_a_hostile_peer() {
+    use crate::varint::encode_varint_to_vec;
+
+    let protocol = test_protocol();
+    let flags = CompatibilityFlags::SAFE_FILE_LIST | CompatibilityFlags::VARINT_FLIST_FLAGS;
+
+    for wire_value in [0x7fff_fff8, 0x0100_0000 | crate::IOERR_GENERAL, 0x2a] {
+        let mut reader = FileListReader::with_compat_flags(protocol, flags);
+
+        let mut data = Vec::new();
+        encode_varint_to_vec(0, &mut data);
+        encode_varint_to_vec(wire_value, &mut data);
+
+        let mut cursor = Cursor::new(&data[..]);
+        assert!(reader.read_entry(&mut cursor).unwrap().is_none());
+        assert_eq!(
+            reader.io_error(),
+            wire_value & crate::IOERR_VALID_MASK,
+            "wire value {wire_value:#x} must be masked before it is accumulated"
+        );
+    }
 }
 
 #[test]
@@ -135,8 +168,10 @@ fn read_entry_with_protocol_31_accepts_error_marker() {
     let mut cursor = Cursor::new(&data[..]);
     let result = reader.read_entry(&mut cursor);
 
+    // 99 = 0b1100011: the two high bits are undefined and must not survive.
+    // upstream: flist.c:2968 - `io_error |= err & IOERR_VALID_MASK`.
     assert!(result.unwrap().is_none());
-    assert_eq!(reader.io_error(), 99);
+    assert_eq!(reader.io_error(), 99 & crate::IOERR_VALID_MASK);
 }
 
 #[test]
@@ -146,16 +181,20 @@ fn read_write_round_trip_with_safe_file_list_error_nonvarint() {
     let protocol = ProtocolVersion::try_from(30u8).unwrap();
     let flags = CompatibilityFlags::SAFE_FILE_LIST;
 
+    // A real sender's io_error only ever holds defined IOERR_* bits, so the
+    // round trip is exact. Undefined bits are covered by the masking tests.
+    let sent = crate::IOERR_VALID_MASK;
+
     let writer = FileListWriter::with_compat_flags(protocol, flags);
     let mut data = Vec::new();
-    writer.write_end(&mut data, Some(123)).unwrap();
+    writer.write_end(&mut data, Some(sent)).unwrap();
 
     let mut reader = FileListReader::with_compat_flags(protocol, flags);
     let mut cursor = Cursor::new(&data[..]);
     let result = reader.read_entry(&mut cursor);
 
     assert!(result.unwrap().is_none());
-    assert_eq!(reader.io_error(), 123);
+    assert_eq!(reader.io_error(), sent);
 }
 
 #[test]
@@ -177,15 +216,17 @@ fn read_write_round_trip_with_varint_end_marker() {
     assert!(result.unwrap().is_none());
     assert_eq!(cursor.position() as usize, data.len());
 
-    // Test end marker with non-zero error accumulates io_error
+    // Test end marker with non-zero error accumulates io_error. A real sender
+    // only ever emits defined IOERR_* bits, so the round trip is exact.
+    let sent = crate::IOERR_VALID_MASK;
     let mut data2 = Vec::new();
-    writer.write_end(&mut data2, Some(123)).unwrap();
+    writer.write_end(&mut data2, Some(sent)).unwrap();
 
     let mut reader2 = FileListReader::with_compat_flags(protocol, flags);
     let mut cursor2 = Cursor::new(&data2[..]);
     let result2 = reader2.read_entry(&mut cursor2);
     assert!(result2.unwrap().is_none());
-    assert_eq!(reader2.io_error(), 123);
+    assert_eq!(reader2.io_error(), sent);
 }
 
 #[test]

--- a/crates/protocol/src/io_error.rs
+++ b/crates/protocol/src/io_error.rs
@@ -1,0 +1,86 @@
+//! `io_error` bit definitions and the peer-value sanitising mask.
+//!
+//! These are wire values: a peer reports its accumulated `io_error` in the file
+//! list trailer and in `MSG_IO_ERROR`, and the local side ORs the received value
+//! into its own `io_error`. The bits then steer local behaviour (deletion is
+//! suppressed while `IOERR_GENERAL` is set) and the final exit code.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync.h:191-200` - `IOERR_GENERAL`, `IOERR_VANISHED`, `IOERR_DEL_LIMIT`,
+//!   `IOERR_VALID_MASK`.
+
+/// General I/O error occurred during file operations.
+/// Must be 1 for backward compatibility with upstream rsync.
+///
+/// upstream: `rsync.h:191`
+pub const IOERR_GENERAL: i32 = 1 << 0;
+/// A file or directory vanished (was deleted) during the transfer.
+///
+/// upstream: `rsync.h:192`
+pub const IOERR_VANISHED: i32 = 1 << 1;
+/// Delete limit was exceeded during --delete operations.
+///
+/// upstream: `rsync.h:193`
+pub const IOERR_DEL_LIMIT: i32 = 1 << 2;
+
+/// Mask of every defined `IOERR_*` bit.
+///
+/// Every `io_error` value read from a peer must be reduced through this mask
+/// before it is OR'd into the local `io_error`, so a hostile peer cannot plant
+/// undefined bits that are then stored, re-forwarded to the next hop, and used
+/// to steer local decisions. Apply it at each point the value is read off the
+/// wire, not at the consumers.
+///
+/// upstream: `rsync.h:200` - `IOERR_VALID_MASK`, applied at `io.c:1706`
+/// (`MSG_IO_ERROR`) and `flist.c:2950`, `flist.c:2968`, `flist.c:3071`
+/// (`recv_file_list()`).
+pub const IOERR_VALID_MASK: i32 = IOERR_GENERAL | IOERR_VANISHED | IOERR_DEL_LIMIT;
+
+/// Reduces a peer-supplied `io_error` value to the defined `IOERR_*` bits.
+///
+/// upstream: `flist.c:2950` - `io_error |= err & IOERR_VALID_MASK;`
+#[must_use]
+pub const fn sanitize_peer_io_error(value: i32) -> i32 {
+    value & IOERR_VALID_MASK
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        IOERR_DEL_LIMIT, IOERR_GENERAL, IOERR_VALID_MASK, IOERR_VANISHED, sanitize_peer_io_error,
+    };
+
+    /// The mask is derived from the bit set, so adding an `IOERR_*` bit without
+    /// widening the mask cannot silently make that bit unreachable.
+    ///
+    /// upstream: `rsync.h:200`
+    #[test]
+    fn mask_covers_exactly_the_defined_bits() {
+        assert_eq!(IOERR_VALID_MASK, 0b111);
+        for bit in [IOERR_GENERAL, IOERR_VANISHED, IOERR_DEL_LIMIT] {
+            assert_eq!(sanitize_peer_io_error(bit), bit);
+        }
+    }
+
+    /// A hostile peer can put any 32-bit value on the wire. None of the
+    /// undefined bits may survive into the local `io_error`.
+    #[test]
+    fn undefined_bits_never_survive() {
+        for value in [-1, i32::MIN, i32::MAX, 0x7fff_fff8, 42, 0x0100_0000] {
+            let masked = sanitize_peer_io_error(value);
+            assert_eq!(masked & !IOERR_VALID_MASK, 0, "value {value:#x}");
+            assert_eq!(masked, value & IOERR_VALID_MASK, "value {value:#x}");
+        }
+    }
+
+    /// Masking must not disturb a well-behaved peer's value: every combination
+    /// of defined bits round-trips unchanged, so the fix is inert on the
+    /// honest path.
+    #[test]
+    fn defined_combinations_round_trip_unchanged() {
+        for bits in 0..=IOERR_VALID_MASK {
+            assert_eq!(sanitize_peer_io_error(bits), bits);
+        }
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -132,6 +132,8 @@ pub mod fnamecmp;
 pub mod iconv;
 /// UID/GID mapping lists for name-based ownership transfer.
 pub mod idlist;
+/// `io_error` bit definitions and the peer-value sanitising mask.
+pub mod io_error;
 pub mod iobuf;
 mod legacy;
 /// Process-global `--max-alloc` allocation ceiling shared by wire decoders.
@@ -176,6 +178,9 @@ pub use fnamecmp::{FnameCmpType, InvalidFnameCmpType};
 pub use iconv::{
     ConversionError, EncodingConverter, EncodingError, EncodingPair, FilenameConverter,
     converter_from_locale,
+};
+pub use io_error::{
+    IOERR_DEL_LIMIT, IOERR_GENERAL, IOERR_VALID_MASK, IOERR_VANISHED, sanitize_peer_io_error,
 };
 pub use legacy::{
     AdvertisedDigests, DAEMON_AUTH_DIGEST_NAMES, DigestListTokens, EARLY_INPUT_CMD,

--- a/crates/transfer/src/generator/io_error_flags.rs
+++ b/crates/transfer/src/generator/io_error_flags.rs
@@ -7,13 +7,10 @@
 //!
 //! - `rsync.h:168-170` - `IOERR_GENERAL`, `IOERR_VANISHED`, `IOERR_DEL_LIMIT`
 
-/// General I/O error occurred during file operations.
-/// Must be 1 for backward compatibility with upstream rsync.
-pub const IOERR_GENERAL: i32 = 1 << 0;
-/// A file or directory vanished (was deleted) during the transfer.
-pub const IOERR_VANISHED: i32 = 1 << 1;
-/// Delete limit was exceeded during --delete operations.
-pub const IOERR_DEL_LIMIT: i32 = 1 << 2;
+// The bit definitions and the peer-value mask live in `protocol` because they
+// are wire values shared with the file-list and multiplex decoders; re-exported
+// here so this module stays the generator's single view of `io_error`.
+pub use protocol::{IOERR_DEL_LIMIT, IOERR_GENERAL, IOERR_VALID_MASK, IOERR_VANISHED};
 
 /// Converts an accumulated `io_error` bitfield into the corresponding rsync
 /// exit code.

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -448,8 +448,11 @@ impl<R> MultiplexReader<R> {
     /// Handles a `MSG_IO_ERROR` payload by accumulating the error flags.
     ///
     /// The payload must be exactly 4 bytes (little-endian `i32`); any other size
-    /// is a fatal invalid message.
-    /// upstream: io.c:1542-1547 (`if (msg_bytes != 4) goto invalid_msg;`)
+    /// is a fatal invalid message. The value is reduced to `IOERR_VALID_MASK`
+    /// before it is accumulated, so a hostile peer cannot plant undefined bits
+    /// that would then be stored and re-forwarded to the next hop.
+    /// upstream: io.c:1703-1710 (`if (msg_bytes != 4) goto invalid_msg;` then
+    /// `val &= IOERR_VALID_MASK; io_error |= val;`)
     fn handle_io_error_msg(&mut self) {
         if !self.require_payload_len(&[4]) {
             return;
@@ -460,7 +463,7 @@ impl<R> MultiplexReader<R> {
             self.buffer[2],
             self.buffer[3],
         ]);
-        self.io_error |= val;
+        self.io_error |= protocol::sanitize_peer_io_error(val);
     }
 
     /// Handles a `MSG_REDO` payload by recording the file index.

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -286,6 +286,86 @@ fn multiplex_reader_io_error_wrong_payload_length_aborts() {
     );
 }
 
+/// Feeds one `MSG_IO_ERROR` frame and returns what the reader accumulated.
+fn accumulate_one_msg_io_error(value: i32) -> i32 {
+    let mut stream = Vec::new();
+    protocol::send_msg(
+        &mut stream,
+        protocol::MessageCode::IoError,
+        &value.to_le_bytes(),
+    )
+    .unwrap();
+    protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"x").unwrap();
+
+    let mut mux = MultiplexReader::new(Cursor::new(stream));
+    let mut buf = [0u8; 1];
+    assert_eq!(mux.read(&mut buf).unwrap(), 1);
+    mux.take_io_error()
+}
+
+/// A peer controls all 32 bits of the `MSG_IO_ERROR` payload. Upstream reduces
+/// the value to the defined bits at the read site, so undefined bits are never
+/// stored locally and never re-forwarded to the next hop.
+///
+/// upstream: io.c:1703-1710 - `val &= IOERR_VALID_MASK; io_error |= val;`
+#[test]
+fn msg_io_error_masks_undefined_bits_from_a_hostile_peer() {
+    use protocol::{IOERR_GENERAL, IOERR_VALID_MASK, IOERR_VANISHED};
+
+    // A value made entirely of undefined bits must accumulate to nothing.
+    assert_eq!(accumulate_one_msg_io_error(0x7fff_fff8), 0);
+    // Defined bits survive, undefined ones alongside them do not.
+    assert_eq!(accumulate_one_msg_io_error(-1), IOERR_VALID_MASK);
+    assert_eq!(
+        accumulate_one_msg_io_error(IOERR_VANISHED | 0x0100_0000),
+        IOERR_VANISHED
+    );
+    // The honest path is untouched.
+    assert_eq!(accumulate_one_msg_io_error(IOERR_GENERAL), IOERR_GENERAL);
+}
+
+/// CLASS-level guard: whatever 32-bit value a peer puts on the wire, the two
+/// consumers that the value steers - the delete-pass suppression guard
+/// (`io_error & IOERR_GENERAL`) and the exit-code mapping - must only ever see
+/// defined bits. Masking at one entry point but not the other is exactly the
+/// defect upstream fixed, so this asserts the property, not one call site.
+///
+/// upstream: rsync.h:195-200 (the mask's rationale), generator.c:304 (the
+/// delete guard), cleanup.c:213-218 (the exit-code mapping).
+#[test]
+fn no_peer_value_can_steer_the_delete_guard_or_exit_code_off_the_defined_bits() {
+    use crate::generator::io_error_flags::to_exit_code;
+    use protocol::IOERR_VALID_MASK;
+
+    const DOCUMENTED_EXIT_CODES: [i32; 4] = [0, 23, 24, 25];
+
+    for value in [
+        -1,
+        i32::MIN,
+        i32::MAX,
+        0x7fff_fff8,
+        42,
+        0x0100_0000,
+        0x0000_0008,
+    ] {
+        let accumulated = accumulate_one_msg_io_error(value);
+        assert_eq!(
+            accumulated & !IOERR_VALID_MASK,
+            0,
+            "undefined bits reached local io_error from wire value {value:#x}"
+        );
+        assert!(
+            DOCUMENTED_EXIT_CODES.contains(&to_exit_code(accumulated)),
+            "wire value {value:#x} produced an undocumented exit code"
+        );
+        assert_eq!(
+            accumulated,
+            value & IOERR_VALID_MASK,
+            "the surviving bits must be exactly the masked wire value"
+        );
+    }
+}
+
 #[test]
 fn server_reader_take_io_error_plain_returns_zero() {
     let mut reader = ServerReader::new_plain(Cursor::new(vec![]));

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -93,13 +93,15 @@ impl ReceiverContext {
             self.remap_flist_ownership_from_id_lists();
         }
 
-        // upstream: flist.c:2773-2777 - read io_error flag for protocol < 30.
+        // upstream: flist.c:3068-3072 - read io_error flag for protocol < 30.
         // The sender writes write_int(f, io_error) as a 4-byte LE integer after
         // the id lists. Protocol >= 30 uses MSG_IO_ERROR or SAFE_FILE_LIST instead.
+        // `io_error |= err & IOERR_VALID_MASK` - a hostile peer must not be able
+        // to plant undefined bits in the local io_error.
         if self.protocol.uses_fixed_encoding() {
             let mut buf = [0u8; 4];
             reader.read_exact(&mut buf)?;
-            let err = i32::from_le_bytes(buf);
+            let err = protocol::sanitize_peer_io_error(i32::from_le_bytes(buf));
             if err != 0 && !self.config.deletion.ignore_errors {
                 self.flist_io_error |= err;
             }

--- a/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
+++ b/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
@@ -101,6 +101,45 @@ fn receive_file_list_skips_io_error_for_proto30() {
     assert_eq!(ctx.flist_io_error, 0);
 }
 
+/// The pre-30 trailer is the third place a peer hands us an `io_error`, and it
+/// is decoded outside the file-list reader - so it needs its own mask. A value
+/// of purely undefined bits must accumulate to nothing, and defined bits must
+/// still survive.
+///
+/// upstream: flist.c:3068-3072 - `io_error |= err & IOERR_VALID_MASK`.
+#[test]
+fn receive_file_list_masks_hostile_io_error_for_proto28() {
+    for (wire_value, expected) in [
+        (0x7fff_fff8, 0),
+        (0x0100_0002, protocol::IOERR_VANISHED),
+        (-1, protocol::IOERR_VALID_MASK),
+    ] {
+        let handshake = test_handshake_with_protocol(28);
+        let config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(28u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            flags: ParsedServerFlags {
+                numeric_ids: NumericIds::Explicit,
+                ..Default::default()
+            },
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+        let mut wire = vec![0x00u8];
+        wire.extend_from_slice(&i32::to_le_bytes(wire_value));
+
+        let mut cursor = Cursor::new(wire);
+        assert_eq!(ctx.receive_file_list(&mut cursor).unwrap(), 0);
+        assert_eq!(
+            ctx.flist_io_error, expected,
+            "wire value {wire_value:#x} must be masked to the defined IOERR_* bits"
+        );
+    }
+}
+
 /// Verifies that `ignore_errors` prevents accumulating the io_error flag.
 #[test]
 fn receive_file_list_ignore_errors_suppresses_io_error() {


### PR DESCRIPTION
## Problem

Upstream rsync 3.5.0 added `IOERR_VALID_MASK` and applies it to every `io_error`
value read from a peer, so a hostile peer cannot set arbitrary undefined bits
that are then stored locally, re-forwarded to the next hop, and used to steer
local behaviour.

```c
/* rsync.h:200 */
#define IOERR_VALID_MASK (IOERR_GENERAL | IOERR_VANISHED | IOERR_DEL_LIMIT)
```

Applied at:

| upstream site | what it decodes |
|---|---|
| `io.c:1706` (`read_a_msg`) | `MSG_IO_ERROR` frame: `val &= IOERR_VALID_MASK; io_error \|= val;` |
| `flist.c:2950`, `flist.c:2968` (`recv_file_list`) | flist end-of-list marker, varint and `XMIT_IO_ERROR_ENDLIST` forms |
| `flist.c:3071` (`recv_file_list`) | protocol < 30 4-byte trailer |

3.4.4 has none of these masks (`diff -u rsync-3.4.4 rsync-3.5.0` shows the four
added `& IOERR_VALID_MASK` sites and the new `rsync.h` constant).

## oc had the defect at every one of those sites

All three ingress points OR'd the raw wire value straight into the local
`io_error`:

- `crates/transfer/src/reader/multiplex.rs` - `self.io_error |= val;`
- `crates/protocol/src/flist/read/mod.rs` - `self.io_error |= code;`
- `crates/transfer/src/receiver/file_list/receive.rs` - `self.flist_io_error |= err;`

The pre-existing test `read_entry_detects_error_marker_with_safe_file_list`
asserted `reader.io_error() == 42` (`0b101010`, two undefined bits) - it
encoded the unmasked behaviour.

The value reaches the delete-pass suppression guard
(`io_error & IOERR_GENERAL`, upstream `generator.c:304`) and the
`io_error -> RERR_*` mapping (upstream `cleanup.c:213-218`), so undefined bits
could plausibly reach both.

## Change

Mirrors upstream's placement exactly - the mask is applied where the value is
read, not at the consumers.

- New `crates/protocol/src/io_error.rs` holds `IOERR_GENERAL`,
  `IOERR_VANISHED`, `IOERR_DEL_LIMIT`, the derived `IOERR_VALID_MASK`, and
  `sanitize_peer_io_error()`. `rsync.h` is the constants' upstream home, and
  both crates decode the wire value, so the lower crate owns them.
- `crates/transfer/src/generator/io_error_flags.rs` re-exports them; every
  existing consumer is unchanged and `to_exit_code` stays where it is.
- Each of the three read sites now masks.

No new `unsafe`; both crates keep `#![deny(unsafe_code)]`.

## Wire neutrality

Only the interpretation of a received value changes. A well-behaved peer's
`io_error` holds nothing but defined bits, so the masked value is identical and
the emitted bytes are unchanged. The golden byte tests in
`crates/protocol/tests/` are untouched and pass.

Two round-trip tests emitted `123` (undefined bits a real sender never
produces) and asserted it came back verbatim; they now emit
`IOERR_VALID_MASK`, which keeps the round trip exact. Masking is covered by
the dedicated tests below rather than by conflating it with a round trip.

## Tests

**There is no upstream oracle to diff against here.** Upstream added the mask but
did not test it, and says so itself in `testsuite/ki62-io-error-mask_test.py`:

> This is only an interrupted-transfer exit-code smoke test ... It does NOT craft
> a hostile MSG_IO_ERROR frame, so it does not exercise the mask itself (no test
> does yet) -- it just guards the normal-peer exit path.

So the tests below are the first coverage this rule has in either implementation.
They are not redundant with anything upstream ships, and a reader looking for an
upstream test to diff against will not find one.

Per entry point:

- `msg_io_error_masks_undefined_bits_from_a_hostile_peer` (`MSG_IO_ERROR`)
- `varint_end_of_list_masks_undefined_bits_from_a_hostile_peer` (flist varint
  end marker), plus the two existing marker tests now assert the masked value
- `receive_file_list_masks_hostile_io_error_for_proto28` (pre-30 trailer)

Class-level:

- `no_peer_value_can_steer_the_delete_guard_or_exit_code_off_the_defined_bits` -
  for a spread of hostile 32-bit values, asserts the accumulated value has no
  bit outside the mask, equals `value & IOERR_VALID_MASK`, and maps to a
  documented `RERR_*` exit code. Masking one entry point but not the other is
  exactly the defect upstream fixed, so this asserts the property rather than a
  single call site.
- `protocol::io_error::tests` - the mask is derived from the bit set (adding an
  `IOERR_*` bit without widening the mask cannot make it silently unreachable),
  undefined bits never survive, and every defined combination round-trips
  unchanged (the fix is inert on the honest path).

## Verification

```
cargo fmt --all -- --check                                              # clean
cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings
                                                                        # clean
cargo nextest run -p protocol -p transfer --all-features
  Summary [80.787s] 8743 tests run: 8743 passed, 5 skipped
```

## Related, not included

Three adjacent findings surfaced while measuring and are filed separately
rather than folded in:

- the receiver never re-forwards `MSG_IO_ERROR` to the generator
  (upstream `io.c:1548`), though doc comments say it does;
- `--ignore-errors` is applied inconsistently across the `io_error` sites;
- the flist trailer is decoded in two places whose behaviour differed (this PR
  makes both mask, but the duplication remains).

There is an unmerged branch touching `io_error` -> `RERR_*` *precedence*
(`to_exit_code`). That is a different concern and is not touched here; the only
overlap is the file `io_error_flags.rs`, where this PR replaces the constant
definitions with a re-export and that branch rewrites `to_exit_code` - disjoint
line ranges.

