### PR TITLE
fix(matching): bound the equal-weak-checksum chain in the delta matcher

### DIFF
--- a/crates/matching/src/index/chain_bound_tests.rs
+++ b/crates/matching/src/index/chain_bound_tests.rs
@@ -1,0 +1,281 @@
+//! Class-level tests for the equal-weak-checksum chain bound
+//! ([`MAX_CHAIN_LEN`], upstream `match.c`, CVE-2026-70453).
+//!
+//! The signature that populates a chain is peer-supplied, so a hostile peer
+//! can hand the sender thousands of basis blocks sharing one weak checksum.
+//! Without a bound, every source offset walks the whole chain and the scan
+//! degrades to `O(source_len * chain_len)`.
+//!
+//! These tests are written over the whole class - chain length and the
+//! candidate's position within the chain, swept across the boundary - rather
+//! than over one hand-picked case, so a regression cannot slip through by
+//! moving the cap or the counter.
+
+use super::*;
+use crate::{DeltaGenerator, DeltaToken, apply_delta};
+use checksums::RollingDigest;
+use protocol::ProtocolVersion;
+use signature::{SignatureLayoutParams, calculate_signature_layout, generate_file_signature};
+use std::num::{NonZeroU8, NonZeroU32};
+
+/// Block length of the crafted basis. Must exceed [`SITE_STRIDE`] so both
+/// halves of a site pair land inside the same block.
+const BLOCK_LEN: usize = 2048;
+
+/// Distance between the two bytes of a site pair.
+///
+/// The rolling sum weights byte `k` by `BLOCK_LEN - k`, so a `+d` at `i` and a
+/// `-d` at `i + stride` shifts `s2` by `d * stride`. Choosing `d = 64` and
+/// `stride = 1024` gives `65536`, which is zero modulo the 16-bit `s2`.
+const SITE_STRIDE: usize = 1024;
+
+/// Builds a `BLOCK_LEN`-byte block whose rolling checksum is exactly `(0, 0)`
+/// - identical to an all-zero window - but whose content is not all-zero.
+///
+/// Each set bit of `variant` toggles one site pair: byte `site` becomes `+64`
+/// and byte `site + SITE_STRIDE` becomes `-64` under the signed-byte
+/// interpretation upstream uses (`checksum.c`, `schar *buf`). `s1` is
+/// unchanged (`+64 - 64`) and `s2` shifts by a multiple of `2^16`, so every
+/// variant collides on the weak checksum while differing in content, and
+/// therefore in its strong checksum.
+fn crafted_block(variant: u32) -> Vec<u8> {
+    let mut block = vec![0u8; BLOCK_LEN];
+    for bit in 0..12 {
+        if variant & (1 << bit) != 0 {
+            let site = bit * 64;
+            block[site] = 0x40;
+            block[site + SITE_STRIDE] = 0xC0;
+        }
+    }
+    block
+}
+
+/// Concatenates `n_blocks` distinct crafted blocks into a hostile basis.
+///
+/// Variant 0 is skipped because it is the all-zero block, which would match an
+/// all-zero probe window and mask the chain walk under test.
+fn hostile_basis(n_blocks: u32) -> Vec<u8> {
+    let mut basis = Vec::with_capacity(n_blocks as usize * BLOCK_LEN);
+    for variant in 1..=n_blocks {
+        basis.extend_from_slice(&crafted_block(variant));
+    }
+    basis
+}
+
+fn index_over(basis: &[u8], block_len: u32) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        basis.len() as u64,
+        Some(NonZeroU32::new(block_len).expect("non-zero block length")),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).expect("non-zero checksum length"),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(basis, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+fn block_bytes(basis: &[u8], position: usize) -> &[u8] {
+    &basis[position * BLOCK_LEN..(position + 1) * BLOCK_LEN]
+}
+
+/// Probes the index with the exact content of basis block `position`.
+fn probe(index: &DeltaSignatureIndex, basis: &[u8], position: usize) -> Option<usize> {
+    let window = block_bytes(basis, position);
+    index.find_match_bytes(RollingDigest::from_bytes(window), window)
+}
+
+/// The construction the rest of this module rests on: every crafted block
+/// shares the all-zero window's rolling checksum, so they all land in one
+/// chain, yet no two share a strong checksum.
+#[test]
+fn crafted_blocks_collide_on_the_weak_checksum_only() {
+    let basis = hostile_basis(64);
+    let index = index_over(&basis, BLOCK_LEN as u32);
+
+    let zero_window = vec![0u8; BLOCK_LEN];
+    let zero_digest = RollingDigest::from_bytes(&zero_window);
+
+    for position in 0..64 {
+        let block = index.block(position);
+        assert_eq!(
+            block.rolling(),
+            zero_digest,
+            "block {position} must collide with the all-zero window",
+        );
+    }
+    for position in 1..64 {
+        assert_ne!(
+            index.block(0).strong(),
+            index.block(position).strong(),
+            "blocks 0 and {position} must differ on the strong checksum",
+        );
+    }
+    // The whole chain really is one chain: every crafted block is reachable
+    // from the same lookup key.
+    assert_eq!(
+        index.lookup_probe(zero_digest.sum1(), zero_digest.sum2()),
+        64,
+        "all crafted blocks must share one lookup chain",
+    );
+}
+
+/// CLASS TEST over the candidate's position in the chain.
+///
+/// upstream `match.c` counts candidates that reach the strong-checksum compare
+/// and abandons the offset once the count would exceed `MAX_CHAIN_LEN`. With
+/// candidates walked in insertion order, basis block `p` is the `p + 1`-th
+/// candidate, so it is reachable exactly while `p < MAX_CHAIN_LEN`.
+#[test]
+fn candidate_is_reachable_exactly_below_the_bound() {
+    let n_blocks = MAX_CHAIN_LEN + 200;
+    let basis = hostile_basis(n_blocks);
+    let index = index_over(&basis, BLOCK_LEN as u32);
+
+    let positions = [
+        0,
+        1,
+        2,
+        (MAX_CHAIN_LEN / 2) as usize,
+        (MAX_CHAIN_LEN - 2) as usize,
+        (MAX_CHAIN_LEN - 1) as usize,
+        MAX_CHAIN_LEN as usize,
+        (MAX_CHAIN_LEN + 1) as usize,
+        (n_blocks - 1) as usize,
+    ];
+
+    for position in positions {
+        let found = probe(&index, &basis, position);
+        if (position as u32) < MAX_CHAIN_LEN {
+            assert_eq!(
+                found,
+                Some(position),
+                "candidate at chain position {position} is within the bound \
+                 and must still match",
+            );
+        } else {
+            assert_eq!(
+                found, None,
+                "candidate at chain position {position} is past the bound, so \
+                 the walk must have stopped and reported a non-match",
+            );
+        }
+    }
+}
+
+/// CLASS TEST over chain length. However long the chain grows, the walk stops
+/// at the bound: the first candidate always matches and the last matches only
+/// while the chain is short enough to reach it.
+#[test]
+fn bound_holds_across_chain_lengths() {
+    for n_blocks in [
+        1u32,
+        2,
+        16,
+        MAX_CHAIN_LEN - 1,
+        MAX_CHAIN_LEN,
+        MAX_CHAIN_LEN + 1,
+    ] {
+        let basis = hostile_basis(n_blocks);
+        let index = index_over(&basis, BLOCK_LEN as u32);
+
+        assert_eq!(
+            probe(&index, &basis, 0),
+            Some(0),
+            "the first candidate must match at chain length {n_blocks}",
+        );
+
+        let last = (n_blocks - 1) as usize;
+        let expected = ((last as u32) < MAX_CHAIN_LEN).then_some(last);
+        assert_eq!(
+            probe(&index, &basis, last),
+            expected,
+            "last candidate at chain length {n_blocks}",
+        );
+    }
+}
+
+/// Reaching the bound must never corrupt a transfer. An all-zero source over
+/// the hostile basis matches nothing, so the delta is pure literal data - and
+/// applying it must still reproduce the source byte for byte.
+#[test]
+fn skipped_data_is_sent_literally_not_corrupted() {
+    let n_blocks = MAX_CHAIN_LEN + 200;
+    let basis = hostile_basis(n_blocks);
+    let index = index_over(&basis, BLOCK_LEN as u32);
+
+    let source = vec![0u8; 8 * BLOCK_LEN];
+    let script = DeltaGenerator::new()
+        .generate(std::io::Cursor::new(source.clone()), &index)
+        .expect("generate");
+
+    assert!(
+        script
+            .tokens()
+            .iter()
+            .all(|token| matches!(token, DeltaToken::Literal(_))),
+        "no crafted block matches an all-zero window, so the delta is literal",
+    );
+
+    let mut rebuilt = Vec::new();
+    apply_delta(std::io::Cursor::new(&basis), &mut rebuilt, &index, &script).expect("apply");
+    assert_eq!(
+        rebuilt, source,
+        "the delta must reproduce the source exactly"
+    );
+}
+
+/// NEUTRALITY. On an honest basis the bound is inert: no chain comes close to
+/// it, so the bound cannot change which blocks the matcher finds and cannot
+/// perturb the emitted delta.
+#[test]
+fn bound_is_inert_on_a_realistic_basis() {
+    const HONEST_BLOCK_LEN: u32 = 512;
+    const HONEST_BLOCKS: usize = 10_000;
+
+    let mut basis = vec![0u8; HONEST_BLOCKS * HONEST_BLOCK_LEN as usize];
+    let mut state: u32 = 0x1234_5678;
+    for byte in basis.iter_mut() {
+        state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        *byte = (state >> 24) as u8;
+    }
+    let index = index_over(&basis, HONEST_BLOCK_LEN);
+
+    let longest = (0..index.block_count())
+        .map(|position| {
+            let rolling = index.block(position).rolling();
+            index.lookup_probe(rolling.sum1(), rolling.sum2())
+        })
+        .max()
+        .expect("at least one block");
+
+    assert!(
+        (longest as u32) < MAX_CHAIN_LEN,
+        "longest honest chain was {longest}, which reaches the bound of \
+         {MAX_CHAIN_LEN}; the bound would stop being observably neutral",
+    );
+
+    // End to end: an unmodified source over an honest basis must still resolve
+    // to pure Copy tokens.
+    let script = DeltaGenerator::new()
+        .generate(std::io::Cursor::new(basis.clone()), &index)
+        .expect("generate");
+    assert!(
+        script
+            .tokens()
+            .iter()
+            .all(|token| matches!(token, DeltaToken::Copy { .. })),
+        "an identical source must match every block",
+    );
+}
+
+/// Pins the cap to upstream's literal value. oc must not invent a different
+/// limit: a smaller one starts sending literals where upstream sends a Copy,
+/// a larger one leaves the DoS window open.
+#[test]
+fn bound_matches_upstream_max_chain_len() {
+    assert_eq!(
+        MAX_CHAIN_LEN, 1024,
+        "upstream match.c defines MAX_CHAIN_LEN as 1024",
+    );
+}

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -20,6 +20,8 @@ mod trace;
 #[cfg(test)]
 mod bithash_tests;
 #[cfg(test)]
+mod chain_bound_tests;
+#[cfg(test)]
 mod compact_key_tests;
 #[cfg(test)]
 mod matched_blocks_tests;
@@ -53,6 +55,22 @@ pub use trace::{
 /// rolling checksum to reject non-matching positions before probing the hash
 /// table. This constant matches upstream's `TABLESIZE` in `match.c`.
 const TAG_TABLE_SIZE: usize = 1 << 16;
+
+/// Maximum number of equal-weak-checksum candidates verified at a single
+/// source offset before the matcher gives up and rolls forward a byte.
+///
+/// upstream: `match.c` `MAX_CHAIN_LEN` (rsync 3.5.0), added for
+/// CVE-2026-70453. A weak checksum that collides thousands of times turns the
+/// per-offset chain walk into an `O(source_len * chain_len)` scan, and the
+/// signature that populates the chain is peer-supplied, so a hostile peer can
+/// pin a CPU for hours with a crafted basis. Bounding the per-offset work
+/// caps that at `O(source_len * MAX_CHAIN_LEN)`.
+///
+/// Reaching the bound is a non-match, never an error: the skipped bytes are
+/// sent as literal data, so the transfer stays correct and only its size can
+/// change. Honest bases never approach the bound - see the
+/// `bound_is_inert_on_a_realistic_basis` test.
+const MAX_CHAIN_LEN: u32 = 1024;
 
 /// Sentinel marking the absence of a stored successor in [`DeltaSignatureIndex::next_match`].
 ///
@@ -629,22 +647,8 @@ impl DeltaSignatureIndex {
         }
 
         let strong = self.algorithm.compute_truncated(window, self.strong_length);
-        for index in self.lookup.find_all(digest.sum1(), digest.sum2()) {
-            if matches!(matched, Some(m) if m.is_matched(index)) {
-                continue;
-            }
-            // ZSO-3 hash-chain prune: skip basis blocks the matcher has
-            // already emitted as `Copy` tokens. Atomic load keeps the
-            // probe `&self`-compatible so the index can be shared
-            // read-only across concurrent generators.
-            if self.is_consumed(index as u32) {
-                continue;
-            }
-            let block = &self.blocks[index];
-            debug_assert_eq!(block.len(), self.block_length);
-            if strong.as_slice() == block.strong() {
-                return Some(index);
-            }
+        if let Some(index) = self.walk_chain(digest, matched, strong.as_slice()) {
+            return Some(index);
         }
         // A bithash positive that produced no confirmed match: the exact
         // rolling-sum / strong-sum verify rejected it. upstream: match.c:239
@@ -700,19 +704,53 @@ impl DeltaSignatureIndex {
         let strong = self
             .algorithm
             .compute_truncated_slices(first, second, self.strong_length);
+        self.walk_chain(digest, matched, strong.as_slice())
+    }
+
+    /// Walks the equal-weak-checksum chain for `digest` and returns the first
+    /// candidate whose strong checksum equals `strong`.
+    ///
+    /// Shared by the contiguous and two-slice probes so the chain-walk rule -
+    /// the prune skips and the [`MAX_CHAIN_LEN`] bound - lives in one place.
+    ///
+    /// upstream: `match.c` `hash_search()` inner chain loop. Candidates dropped
+    /// by the prune bitsets are the analogue of upstream's bypassed in-place
+    /// entries, which upstream unlinks from the chain before its counter runs;
+    /// like upstream's, they do not spend the budget, so the bound covers
+    /// exactly the candidates that reach the strong-checksum compare. That
+    /// placement is what keeps the bound inert on honest bases: a duplicate
+    /// basis block is matched by the first live candidate, never by walking
+    /// past a thousand dead ones.
+    #[inline]
+    fn walk_chain(
+        &self,
+        digest: RollingDigest,
+        matched: Option<&MatchedBlocks>,
+        strong: &[u8],
+    ) -> Option<usize> {
+        let mut chain_len = 0u32;
         for index in self.lookup.find_all(digest.sum1(), digest.sum2()) {
             if matches!(matched, Some(m) if m.is_matched(index)) {
                 continue;
             }
-            // ZSO-3 hash-chain prune: see [`Self::find_match_bytes_filtered`]
-            // for the duplicate-block correctness contract; the slice
-            // variant follows the same protocol.
+            // ZSO-3 hash-chain prune: skip basis blocks the matcher has
+            // already emitted as `Copy` tokens. Atomic load keeps the probe
+            // `&self`-compatible so the index can be shared read-only across
+            // concurrent generators. See [`MatchedBlocks`] for the
+            // duplicate-block correctness contract.
             if self.is_consumed(index as u32) {
                 continue;
             }
+            // upstream: `match.c` - bound the work spent on one pathological
+            // bucket. Past the cap the offset is a non-match and the caller
+            // rolls forward a byte, so the skipped data goes out as literals.
+            chain_len += 1;
+            if chain_len > MAX_CHAIN_LEN {
+                return None;
+            }
             let block = &self.blocks[index];
             debug_assert_eq!(block.len(), self.block_length);
-            if strong.as_slice() == block.strong() {
+            if strong == block.strong() {
                 return Some(index);
             }
         }


### PR DESCRIPTION
## Problem

The delta matcher's hash chain is populated from the **peer-supplied** signature. A crafted basis whose blocks all share one weak (rolling) checksum makes every source offset walk the entire chain, turning the scan into `O(source_len * chain_len)` — the quadratic-CPU DoS fixed upstream in rsync 3.5.0 as CVE-2026-70453.

oc has the defect. The two probe paths in `crates/matching/src/index/mod.rs` walked `CompactLookup::find_all` to exhaustion with no bound, and neither zsync-inspired structure helps here:

- the **BitHash** prefilter admits, because the probed rolling sum is genuinely present in the basis;
- the **compact key** (`sum1` discriminator + `sum2` bucket) does not discriminate, because every candidate carries exactly the probed sum.

### Measured

Fixture: a basis of blocks crafted to share the all-zero window's rolling sum `(0, 0)` while differing in content, probed with an all-zero source so every offset hits the chain and never matches. Release build, 64 KiB source, aarch64:

| basis blocks | elapsed |
|---|---|
| control (4000 blocks, distinct rolling sums) | 138 ms |
| 500 colliding | 373 ms |
| 1000 colliding | 474 ms |
| 2000 colliding | 684 ms |
| 4000 colliding | 1077 ms |

Linear in chain length at fixed source size (~0.20 ms per 1000 blocks), i.e. `O(source_len * chain_len)`. Extrapolating the measured ~3.15 ns per candidate step, a 1 GiB source against a 40000-block chain is on the order of tens of hours of pure CPU — matching the multi-hour hangs upstream reports.

## Fix

Mirror upstream's rule from `match.c` exactly:

- cap the candidates verified at a single source offset at `MAX_CHAIN_LEN = 1024`;
- past the cap, report a **non-match** — the caller rolls the window forward a byte and the skipped data goes out as literal bytes. Never an error, never corruption.

The counter is placed **after** the prune skips, mirroring upstream's placement after its own chain unlink. That is what keeps the bound observably neutral: a duplicate basis block is still matched by the first live candidate rather than by walking past a thousand dead ones.

The two probe paths that each carried their own copy of the chain walk are collapsed onto a single `walk_chain` helper, so the rule (prune skips + bound + strong compare) has one home.

## Neutrality

Delta output is unchanged for non-malicious input:

- `bound_is_inert_on_a_realistic_basis` asserts that in a 10000-block pseudo-random basis the longest chain is far below the cap, and that an identical source still resolves to pure `Copy` tokens;
- the crate's existing wire-parity and golden corpora (`zsync_wire_parity`, `parallel_delta_wire_parity`, `seq_match_golden`, `block_matching_accuracy`) are green;
- `crates/protocol` is *upstream* of `crates/matching` in the dependency graph, so the protocol golden-byte tests cannot be affected by this change; `engine` and `transfer`, which do consume the matcher, are green.

## Tests

New `crates/matching/src/index/chain_bound_tests.rs`, written over the class rather than one hand-picked case:

- `candidate_is_reachable_exactly_below_the_bound` — sweeps the candidate's position across the boundary (0, 1, 2, 512, 1022, 1023, **1024**, 1025, 1199); reachable exactly while `position < MAX_CHAIN_LEN`.
- `bound_holds_across_chain_lengths` — sweeps chain length (1, 2, 16, 1023, 1024, 1025).
- `skipped_data_is_sent_literally_not_corrupted` — the delta over a hostile basis is pure literal and `apply_delta` reproduces the source byte for byte.
- `bound_is_inert_on_a_realistic_basis` — the neutrality check above.
- `crafted_blocks_collide_on_the_weak_checksum_only` — validates the fixture construction itself (all blocks share the rolling sum, none share a strong sum, all land in one chain).
- `bound_matches_upstream_max_chain_len` — pins the constant to upstream's literal 1024, so oc cannot drift to a limit upstream does not have.

Non-vacuity confirmed: with the bound removed, `candidate_is_reachable_exactly_below_the_bound` fails at position 1024 with `Some(1024)` instead of `None`.

## Verification

```
cargo fmt --all -- --check                                                    clean
cargo clippy --locked --workspace --all-targets --all-features --no-deps
    -- -D warnings                                                            clean
cargo nextest run -p matching  --all-features    379 passed, 3 skipped
cargo nextest run -p engine    --all-features   4969 passed, 24 skipped
cargo nextest run -p transfer  --all-features   2715 passed, 3 skipped
```

## Follow-up noted, deliberately not in scope

oc's consumed-block prune (ZSO-3) skips chain entries rather than unlinking them the way upstream unlinks its bypassed in-place entries. Those skipped entries stay on the chain and are re-walked on every later probe, so a basis with a very large run of *genuinely duplicate* blocks retains an unbounded walk over dead entries. That is an oc-only characteristic, distinct from CVE-2026-70453, and bounding it by counting skipped candidates would break output neutrality against upstream. The correct fix is to unlink consumed entries, which touches the `&self`-shared lookup structure — a separate change.
