### PR TITLE
test(checksums): guard-page over-read harness for the SIMD rolling checksum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
  "criterion",
  "digest 0.10.7",
  "fast_io",
+ "libc",
  "logging",
  "md-5",
  "md4",

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -70,6 +70,7 @@ sha1 = { version = "0.10", default-features = false, features = ["std"] }
 sha2 = { version = "0.10", default-features = false, features = ["std"] }
 
 [dev-dependencies]
+libc = { workspace = true }
 proptest = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/crates/checksums/tests/simd_audit_guard_page.rs
+++ b/crates/checksums/tests/simd_audit_guard_page.rs
@@ -1,0 +1,94 @@
+//! Guard-page over-read harness for the SIMD rolling checksum.
+//!
+//! Places the input buffer flush against an unreadable page so any load past
+//! `buf + len` faults here. Mirrors upstream 3.5.0's `test_no_overread()` in
+//! `simd-checksum-x86_64.cpp`.
+
+#![cfg(unix)]
+
+use checksums::RollingChecksum;
+use checksums::cpu_features::{SimdLevel, reset_simd_override_for_tests};
+
+fn checksum_at(level: SimdLevel, data: &[u8]) -> u32 {
+    reset_simd_override_for_tests(level);
+    let mut c = RollingChecksum::new();
+    c.update(data);
+    c.value()
+}
+
+/// Reports which backends this host can actually exercise. A pass on a host
+/// without the vector unit proves nothing about that unit, and must not read
+/// as coverage.
+fn report_coverage() {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    println!(
+        "guard-page: avx2={} sse2={}",
+        std::arch::is_x86_feature_detected!("avx2"),
+        std::arch::is_x86_feature_detected!("sse2")
+    );
+    #[cfg(target_arch = "aarch64")]
+    println!(
+        "guard-page: neon={}",
+        std::arch::is_aarch64_feature_detected!("neon")
+    );
+    println!(
+        "guard-page: simd_acceleration_available={}",
+        checksums::simd_acceleration_available()
+    );
+}
+
+#[test]
+fn simd_rolling_checksum_never_reads_past_the_slice_end() {
+    report_coverage();
+    let pagesz = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    assert!(pagesz > 0, "sysconf(_SC_PAGESIZE) gave {pagesz}");
+    let pagesz = pagesz as usize;
+    let region = pagesz * 4;
+
+    let base = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            region,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANON,
+            -1,
+            0,
+        )
+    };
+    assert_ne!(base, libc::MAP_FAILED, "mmap failed");
+    let base = base as *mut u8;
+
+    let rc =
+        unsafe { libc::mprotect(base.add(region - pagesz) as *mut _, pagesz, libc::PROT_NONE) };
+    assert_eq!(rc, 0, "mprotect failed");
+
+    let levels: &[SimdLevel] = &[
+        SimdLevel::Auto,
+        SimdLevel::Avx2,
+        SimdLevel::Sse4,
+        SimdLevel::Neon,
+        SimdLevel::None,
+    ];
+
+    // Every length up to 3 pages, so every remainder mod 16/32/64 and both
+    // alignments are covered with the last byte abutting the guard page.
+    for len in 1..=4096usize {
+        let buf = unsafe { base.add(region - pagesz - len) };
+        for i in 0..len {
+            unsafe { buf.add(i).write(((i + (i % 3) + (i % 11)) % 256) as u8) };
+        }
+        let data = unsafe { std::slice::from_raw_parts(buf, len) };
+
+        let reference = checksum_at(SimdLevel::None, data);
+        for &level in levels {
+            assert_eq!(
+                checksum_at(level, data),
+                reference,
+                "len={len} level={}",
+                level.as_cli_str()
+            );
+        }
+    }
+
+    unsafe { libc::munmap(base as *mut _, region) };
+}


### PR DESCRIPTION
Adds a guard-page over-read harness for the SIMD rolling checksum, mirroring the `test_no_overread()` that rsync 3.5.0 shipped alongside its AVX2 fix.

This PR contains **no production change**. It is a test only, and it fixes nothing — hence the `test(...)` prefix.

## The defect class this detects

rsync 3.5.0 fixed a buffer over-read in `simd-checksum-avx2.S : get_checksum1_avx2_asm`. The main `.loop` is software-pipelined: each iteration folds the 64 bytes already held in `ymm2`/`ymm3` while preloading the **next** 64 into `ymm8`/`ymm9`.

```asm
vmovdqu ymm8,  [rdi]      # preload the next
vmovdqu ymm9,  [rdi+32]   # 64 bytes.
add     rdi, 64
...
sub     esi, 1
jnz     .loop
```

Entry computes `and esi, ~63` then `shr rsi, 6`, so the loop runs `N = (len & ~63)/64` times. On the final iteration it preloads block `N`, at `buf + (len & ~63)`, reading 64 bytes from a remainder region holding only `len & 63` bytes (0-63). It therefore reads up to 64 bytes past `buf+len` on every call, and faults only when the allocation happens to end flush against a page boundary. Upstream's fix runs the loop one block short and finishes the last block in a new `.last` label carrying no preload.

## Why a parity test cannot catch this, and why this test is needed

The over-read bytes are discarded, so the checksum stays correct. Upstream's own SIMD-vs-scalar tests passed for years while the bug was live. Our existing parity corpus in `crates/checksums` is blind in exactly the same way: no amount of value comparison can observe a load that lands outside the buffer.

A guard page can. This harness runs every backend over buffers whose last byte abuts a `PROT_NONE` page, for every length `1..=4096`, so any load past the slice end faults in CI instead of in a user's transfer.

## This test can fail — demonstrated, not asserted

A test that passes and looks incapable of failing reads as decoration and gets deleted in the next cleanup. So the harness was validated against a deliberately broken build: upstream's exact defect was injected into the NEON loop,

```rust
let _preload = vld1q_u8(chunk.as_ptr().add(BLOCK_LEN));
```

and the result was:

```
running 1 test

(test aborted with signal 10)

Summary [0.013s] 1 test run: 0 passed, 1 failed, 1157 skipped
ABORT SIG 10 [0.010s] checksums::simd_audit_guard_page simd_rolling_checksum_never_reads_past_the_slice_end
error: test run failed
```

That control proves two things: the harness detects this class, and the SIMD loop is genuinely reached rather than being skipped by a fallback. The control was then reverted; it is not part of this branch.

**The test reproduces nothing today. It passes because there is nothing to reproduce** — the current implementation has no such over-read. Its value rests on the control above, not on the green run.

## Why the current implementation is clean

Each of the three loops loads exactly the block it consumes, with no lookahead:

- `crates/checksums/src/rolling/checksum/x86.rs:277` — `_mm256_loadu_si256(chunk.as_ptr())` under `while chunk.len() >= AVX2_BLOCK_LEN`, then `chunk = &chunk[32..]`
- `crates/checksums/src/rolling/checksum/x86.rs:205` — the same shape over 16 bytes
- `crates/checksums/src/rolling/checksum/neon.rs:134` — the same shape over 16 bytes

There is no offset arithmetic and no preload in any of them. The only pointer expression is `chunk.as_ptr()`, and `chunk` is a reslice whose length the loop condition re-checks each iteration, so the load range is within the slice by construction.

## What was exercised, versus argued from source

| Backend | Status |
|---|---|
| NEON | **Exercised** — native aarch64, PASS |
| SSE2 | **Exercised** — `x86_64-apple-darwin` under Rosetta, real compiled SSE2 intrinsics, PASS |
| AVX2 | **Argued from source only** — not executed anywhere reachable |

The x86_64 test host was down during this work (`connect: Operation timed out`), and Rosetta reports `avx2=false sse2=true`, so no reachable machine could run the AVX2 path. **Executing the AVX2 arm is precisely what CI adds here** — its x86_64 runners are the only place that code will actually run, which converts the source-level AVX2 argument into a measured one.

To keep that distinction honest, the harness prints the units it actually ran:

```
guard-page: avx2=false sse2=true
guard-page: simd_acceleration_available=true
```

A pass on a host lacking a vector unit therefore cannot be mistaken for coverage of that unit, and the test cannot silently degrade into a vacuous gate on a machine without the SIMD hardware.

## Scope

No production file is touched, so the rolling checksum's output is unchanged for all valid inputs and the existing parity and golden corpora are untouched by construction. The diff is the new test plus `libc` as a `checksums` dev-dependency.

## Verification

```
cargo fmt --all -- --check
  clean

cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings
  clean - Finished `dev` profile in 2m 11s, zero warnings

cargo nextest run -p checksums --all-features
  Summary [30.316s] 1158 tests run: 1158 passed, 0 skipped
```

## Related

The same whole-file diff surfaced two further 3.5.0 changes outside this scope, both filed separately: a runtime AVX2 gate added to `get_checksum1_avx2_asm`'s caller (`roll_asm_have_avx2()`, guarding against SIGILL on non-AVX2 CPUs — already handled here by the cached `is_x86_feature_detected!` dispatch), and a new `auth_digest_rank()` in `checksum.c` belonging to the daemon `auth digest` work.
