### PR TITLE
feat(chmod): support chmod(1)-style --chmod permission copies

### DIFF
--- a/crates/cli/src/frontend/tests/run.rs
+++ b/crates/cli/src/frontend/tests/run.rs
@@ -13,10 +13,12 @@ fn run_reports_invalid_chmod_specification() {
     let destination = tmp.path().join("dest.txt");
     std::fs::write(&source, b"data").expect("write source");
 
-    // A category letter (u/g/o) in the permission half is rejected exactly as
-    // upstream chmod.c STATE_2ND_HALF does; rsync has no chmod(1)-style copy
-    // form. Also exercise a plainly bogus letter.
-    for spec in ["a+q", "g=u", "o=g", "u+g"] {
+    // A lone category letter (u/g/o) in the permission half is a valid
+    // permission COPY since rsync 3.5.0, but mixing it with literal bits, with
+    // `s`/`t`, or with a second copy letter still hits chmod.c STATE_2ND_HALF's
+    // error transitions - as does `a`, which is never a copy source. Also
+    // exercise a plainly bogus letter.
+    for spec in ["a+q", "g=ur", "o=gs", "u+gg", "g=a"] {
         let (code, stdout, stderr) = run_with_args([
             OsString::from(RSYNC),
             OsString::from(format!("--chmod={spec}")),

--- a/crates/metadata/src/chmod/apply.rs
+++ b/crates/metadata/src/chmod/apply.rs
@@ -1,11 +1,14 @@
 //! Evaluator that applies parsed [`Clause`] modifiers to a mode value.
 //!
 //! Faithful port of upstream rsync's `chmod.c:tweak_mode()`: each clause is a
-//! `mode = (mode & ModeAND) | ModeOR` transform, gated by the `D`/`F` selector
-//! and the `X` conditional-execute flag. Non-permission bits (the file-type
-//! bits above `CHMOD_BITS`) are preserved unchanged.
+//! `mode = (mode & ModeAND) | ModeOR` transform followed by the permission-copy
+//! fold, gated by the `D`/`F` selector and the `X` conditional-execute flag.
+//! Non-permission bits (the file-type bits above `CHMOD_BITS`) are preserved
+//! unchanged.
 
 use super::spec::Clause;
+#[cfg(unix)]
+use super::spec::Op;
 // CHMOD_BITS is only referenced by the unix-only mode-tweaking path; importing
 // it unconditionally is an unused import on Windows.
 #[cfg(unix)]
@@ -23,11 +26,32 @@ pub(crate) fn apply_clauses(_clauses: &[Clause], mode: u32, _file_type: std::fs:
     mode
 }
 
+/// Permission bits a copy clause contributes, read from `mode` as it stands
+/// *before* the clause's own AND/OR is applied.
+///
+/// The source triad is taken from the mode accumulated by the preceding
+/// clauses, which is what makes a comma-separated copy list order-dependent
+/// (`u=g,g=o` and `g=o,u=g` differ). upstream: chmod.c `mode_copy_bits()`.
+#[cfg(unix)]
+const fn copy_bits(mode: u32, clause: &Clause) -> u32 {
+    let mut bits = 0;
+    if clause.copy_src & 0o100 != 0 {
+        bits |= (mode >> 6) & 7;
+    }
+    if clause.copy_src & 0o010 != 0 {
+        bits |= (mode >> 3) & 7;
+    }
+    if clause.copy_src & 0o001 != 0 {
+        bits |= mode & 7;
+    }
+    (clause.copy_dst * bits) & clause.copy_and
+}
+
 /// Core of `chmod.c:tweak_mode()`.
 ///
 /// `is_x` is sampled once from the original executable bits and `non_perm`
 /// holds the file-type bits, both restored per upstream. upstream:
-/// chmod.c:218-236.
+/// chmod.c `tweak_mode()`.
 #[cfg(unix)]
 fn tweak_mode(clauses: &[Clause], orig: u32, is_dir: bool) -> u32 {
     let is_x = orig & 0o111;
@@ -35,7 +59,7 @@ fn tweak_mode(clauses: &[Clause], orig: u32, is_dir: bool) -> u32 {
     let mut mode = orig & CHMOD_BITS;
 
     for clause in clauses {
-        // upstream: chmod.c:224-227 - honour the D/F selector.
+        // upstream: chmod.c tweak_mode() - honour the D/F selector.
         if clause.dirs_only && !is_dir {
             continue;
         }
@@ -43,14 +67,25 @@ fn tweak_mode(clauses: &[Clause], orig: u32, is_dir: bool) -> u32 {
             continue;
         }
 
+        // Sampled before the AND/OR, exactly where upstream calls it.
+        let copied = copy_bits(mode, clause);
+
         mode &= clause.mode_and;
 
-        // upstream: chmod.c:229-232 - a conditional `X` only sets the execute
-        // bits when the file was already executable or is a directory.
+        // upstream: chmod.c tweak_mode() - a conditional `X` only sets the
+        // execute bits when the file was already executable or is a directory.
         if clause.x_keep && is_x == 0 && !is_dir {
             mode |= clause.mode_or & !0o111;
         } else {
             mode |= clause.mode_or;
+        }
+
+        // upstream: chmod.c tweak_mode() - `-` removes the copied bits, every
+        // other operator adds them.
+        if clause.op == Op::Sub {
+            mode &= CHMOD_BITS - copied;
+        } else {
+            mode |= copied;
         }
     }
 

--- a/crates/metadata/src/chmod/matrix_tests.rs
+++ b/crates/metadata/src/chmod/matrix_tests.rs
@@ -1,16 +1,25 @@
 //! Table-driven `--chmod` conformance matrix pinned to upstream rsync.
 //!
-//! The defect class this guards is "a who-letter does not expand to every bit
-//! it covers": `--chmod=a+s` set setuid only, because the `a` clause left the
-//! set-id top bits unset and the `s` clause fell through to its no-who default.
-//! A single `a+s` assertion would not catch the siblings of that bug (`a-s`,
-//! `a=s`, `a+st`, `a=t`, ...), so the whole `{who} x {op} x {perm}` grid is
-//! evaluated here.
+//! Two grids are evaluated here, because `--chmod` has two defect classes worth
+//! guarding as classes rather than as single cases:
 //!
-//! upstream: chmod.c `parse_chmod()` + `tweak_mode()`. Every expected value in
-//! [`MATRIX`] was produced by compiling rsync 3.5.0's `chmod.c` verbatim
-//! against a stubbed `rsync.h` and printing `tweak_mode()` for each spec and
-//! probe, so the table is upstream's own output rather than a hand-derivation.
+//! * [`MATRIX`] - "a who-letter does not expand to every bit it covers":
+//!   `--chmod=a+s` set setuid only, because the `a` clause left the set-id top
+//!   bits unset and the `s` clause fell through to its no-who default. A single
+//!   `a+s` assertion would not catch the siblings of that bug (`a-s`, `a=s`,
+//!   `a+st`, `a=t`, ...), so the whole `{who} x {op} x {perm}` grid runs.
+//! * [`COPY_MATRIX`] / [`COPY_SEQUENCE_MATRIX`] / [`REJECTED_RHS`] - the
+//!   chmod(1)-style permission copies (`u=g`, `g+u`, `o=u`) rsync 3.5.0 added.
+//!   Their whole substance is *which* class is read, *which* classes are
+//!   written, and *when* the source is sampled, so the grid spans
+//!   `{who} x {op} x {source class} x {starting mode}`, plus multi-clause rows
+//!   that pin the order dependence and an exhaustive accept/reject sweep that
+//!   pins the grammar against widening.
+//!
+//! upstream: chmod.c `parse_chmod()` + `tweak_mode()`. Every expected value
+//! below was produced by compiling rsync 3.5.0's `chmod.c` verbatim against a
+//! stubbed `rsync.h` and printing `tweak_mode()` for each spec and probe, so the
+//! tables are upstream's own output rather than a hand-derivation.
 
 use super::apply::apply_clauses;
 use super::parse::parse_with_umask;
@@ -28,6 +37,23 @@ const PROBES: [(u32, bool); 4] = [
     (0o7777, false),
     (0o750, true),
 ];
+
+/// Who-classes every grid is swept over. upstream: chmod.c parse_chmod()
+/// STATE_1ST_HALF accepts `u`, `g`, `o`, `a` in any combination, or none.
+const WHO: [&str; 8] = ["", "u", "g", "o", "a", "ug", "go", "ugo"];
+
+/// Operators every grid is swept over. upstream: `CHMOD_ADD`, `CHMOD_SUB`,
+/// `CHMOD_EQ`.
+const OP: [&str; 3] = ["+", "-", "="];
+
+/// Literal permission halves [`MATRIX`] is swept over.
+const WHAT: [&str; 12] = [
+    "r", "w", "x", "X", "s", "t", "rw", "rwx", "rwxXst", "st", "sX", "ts",
+];
+
+/// Permission *classes* a copy may read from. upstream: chmod.c parse_chmod()
+/// STATE_2ND_HALF `case 'u'/'g'/'o'` - `a` is deliberately absent.
+const COPY_SOURCES: [&str; 3] = ["u", "g", "o"];
 
 /// `(spec, [result per PROBES entry])` as produced by upstream rsync 3.5.0.
 const MATRIX: &[(&str, [u32; 4])] = &[
@@ -321,24 +347,152 @@ const MATRIX: &[(&str, [u32; 4])] = &[
     ("ugo=ts", [0o7000, 0o7000, 0o7000, 0o7000]),
 ];
 
-/// Every matrix cell must reproduce upstream's `tweak_mode()` output.
-#[test]
-fn chmod_matrix_matches_upstream() {
+/// Starting modes the permission-copy tables are evaluated against, in
+/// [`COPY_MATRIX`] column order. Every probe carries three *distinct* owner /
+/// group / other triads so a copy that lands in the wrong class is visible, and
+/// `07124` additionally has all three special bits set to exercise the
+/// destination-class clearing a `=` copy performs. The last probe is a
+/// directory.
+const COPY_PROBES: [(u32, bool); 4] = [
+    (0o0761, false),
+    (0o7124, false),
+    (0o0405, false),
+    (0o0752, true),
+];
+
+/// `(spec, [result per COPY_PROBES entry])` for the permission-copy grid, as
+/// produced by upstream rsync 3.5.0.
+const COPY_MATRIX: &[(&str, [u32; 4])] = &[
+    ("+u", [0o0775, 0o7135, 0o0445, 0o0757]),
+    ("+g", [0o0765, 0o7324, 0o0405, 0o0757]),
+    ("+o", [0o0771, 0o7564, 0o0555, 0o0752]),
+    ("-u", [0o0020, 0o7024, 0o0001, 0o0002]),
+    ("-g", [0o0121, 0o7124, 0o0405, 0o0202]),
+    ("-o", [0o0660, 0o7120, 0o0000, 0o0552]),
+    ("=u", [0o0755, 0o0111, 0o0444, 0o0755]),
+    ("=g", [0o0644, 0o0200, 0o0000, 0o0555]),
+    ("=o", [0o0111, 0o0444, 0o0555, 0o0200]),
+    ("u+u", [0o0761, 0o7124, 0o0405, 0o0752]),
+    ("u+g", [0o0761, 0o7324, 0o0405, 0o0752]),
+    ("u+o", [0o0761, 0o7524, 0o0505, 0o0752]),
+    ("u-u", [0o0061, 0o7024, 0o0005, 0o0052]),
+    ("u-g", [0o0161, 0o7124, 0o0405, 0o0252]),
+    ("u-o", [0o0661, 0o7124, 0o0005, 0o0552]),
+    ("u=u", [0o0761, 0o3124, 0o0405, 0o0752]),
+    ("u=g", [0o0661, 0o3224, 0o0005, 0o0552]),
+    ("u=o", [0o0161, 0o3424, 0o0505, 0o0252]),
+    ("g+u", [0o0771, 0o7134, 0o0445, 0o0772]),
+    ("g+g", [0o0761, 0o7124, 0o0405, 0o0752]),
+    ("g+o", [0o0771, 0o7164, 0o0455, 0o0772]),
+    ("g-u", [0o0701, 0o7124, 0o0405, 0o0702]),
+    ("g-g", [0o0701, 0o7104, 0o0405, 0o0702]),
+    ("g-o", [0o0761, 0o7124, 0o0405, 0o0752]),
+    ("g=u", [0o0771, 0o5114, 0o0445, 0o0772]),
+    ("g=g", [0o0761, 0o5124, 0o0405, 0o0752]),
+    ("g=o", [0o0711, 0o5144, 0o0455, 0o0722]),
+    ("o+u", [0o0767, 0o7125, 0o0405, 0o0757]),
+    ("o+g", [0o0767, 0o7126, 0o0405, 0o0757]),
+    ("o+o", [0o0761, 0o7124, 0o0405, 0o0752]),
+    ("o-u", [0o0760, 0o7124, 0o0401, 0o0750]),
+    ("o-g", [0o0761, 0o7124, 0o0405, 0o0752]),
+    ("o-o", [0o0760, 0o7120, 0o0400, 0o0750]),
+    ("o=u", [0o0767, 0o6121, 0o0404, 0o0757]),
+    ("o=g", [0o0766, 0o6122, 0o0400, 0o0755]),
+    ("o=o", [0o0761, 0o6124, 0o0405, 0o0752]),
+    ("a+u", [0o0777, 0o7135, 0o0445, 0o0777]),
+    ("a+g", [0o0767, 0o7326, 0o0405, 0o0757]),
+    ("a+o", [0o0771, 0o7564, 0o0555, 0o0772]),
+    ("a-u", [0o0000, 0o7024, 0o0001, 0o0000]),
+    ("a-g", [0o0101, 0o7104, 0o0405, 0o0202]),
+    ("a-o", [0o0660, 0o7120, 0o0000, 0o0550]),
+    ("a=u", [0o0777, 0o0111, 0o0444, 0o0777]),
+    ("a=g", [0o0666, 0o0222, 0o0000, 0o0555]),
+    ("a=o", [0o0111, 0o0444, 0o0555, 0o0222]),
+    ("ug+u", [0o0771, 0o7134, 0o0445, 0o0772]),
+    ("ug+g", [0o0761, 0o7324, 0o0405, 0o0752]),
+    ("ug+o", [0o0771, 0o7564, 0o0555, 0o0772]),
+    ("ug-u", [0o0001, 0o7024, 0o0005, 0o0002]),
+    ("ug-g", [0o0101, 0o7104, 0o0405, 0o0202]),
+    ("ug-o", [0o0661, 0o7124, 0o0005, 0o0552]),
+    ("ug=u", [0o0771, 0o1114, 0o0445, 0o0772]),
+    ("ug=g", [0o0661, 0o1224, 0o0005, 0o0552]),
+    ("ug=o", [0o0111, 0o1444, 0o0555, 0o0222]),
+    ("go+u", [0o0777, 0o7135, 0o0445, 0o0777]),
+    ("go+g", [0o0767, 0o7126, 0o0405, 0o0757]),
+    ("go+o", [0o0771, 0o7164, 0o0455, 0o0772]),
+    ("go-u", [0o0700, 0o7124, 0o0401, 0o0700]),
+    ("go-g", [0o0701, 0o7104, 0o0405, 0o0702]),
+    ("go-o", [0o0760, 0o7120, 0o0400, 0o0750]),
+    ("go=u", [0o0777, 0o4111, 0o0444, 0o0777]),
+    ("go=g", [0o0766, 0o4122, 0o0400, 0o0755]),
+    ("go=o", [0o0711, 0o4144, 0o0455, 0o0722]),
+    ("ugo+u", [0o0777, 0o7135, 0o0445, 0o0777]),
+    ("ugo+g", [0o0767, 0o7326, 0o0405, 0o0757]),
+    ("ugo+o", [0o0771, 0o7564, 0o0555, 0o0772]),
+    ("ugo-u", [0o0000, 0o7024, 0o0001, 0o0000]),
+    ("ugo-g", [0o0101, 0o7104, 0o0405, 0o0202]),
+    ("ugo-o", [0o0660, 0o7120, 0o0000, 0o0550]),
+    ("ugo=u", [0o0777, 0o0111, 0o0444, 0o0777]),
+    ("ugo=g", [0o0666, 0o0222, 0o0000, 0o0555]),
+    ("ugo=o", [0o0111, 0o0444, 0o0555, 0o0222]),
+];
+
+/// Multi-clause specs, as produced by upstream rsync 3.5.0. These pin the
+/// resolution ORDER: a copy reads the mode left by the clauses before it, so
+/// `u=g,g=o` and `g=o,u=g` must differ, and a copy composes with octal and
+/// literal clauses and with the `D`/`F` selectors.
+const COPY_SEQUENCE_MATRIX: &[(&str, [u32; 4])] = &[
+    ("u=g,g=o", [0o0611, 0o1244, 0o0055, 0o0522]),
+    ("g=o,u=g", [0o0111, 0o1444, 0o0555, 0o0222]),
+    ("g=u,u=g", [0o0771, 0o1114, 0o0445, 0o0772]),
+    ("u+g,g+o", [0o0771, 0o7364, 0o0455, 0o0772]),
+    ("g-u,u-g", [0o0701, 0o7124, 0o0405, 0o0702]),
+    ("700,u=g", [0o0000, 0o0000, 0o0000, 0o0000]),
+    ("u=g,700", [0o0700, 0o0700, 0o0700, 0o0700]),
+    ("u=g,u=o", [0o0161, 0o3424, 0o0505, 0o0252]),
+    ("a=u,g-o", [0o0707, 0o0101, 0o0404, 0o0707]),
+    ("Du=g,F=o", [0o0111, 0o0444, 0o0555, 0o0552]),
+    ("u=g,g+x", [0o0671, 0o3234, 0o0015, 0o0552]),
+    ("g+x,u=g", [0o0771, 0o3334, 0o0115, 0o0552]),
+    ("o=u,u=o", [0o0767, 0o2121, 0o0404, 0o0757]),
+];
+
+/// Permission halves upstream rsync 3.5.0 REJECTS, out of every one- and
+/// two-letter string over `rwxXstugoa`. The verdict is independent of the
+/// who-class and the operator, so this set is keyed on the half alone.
+const REJECTED_RHS: &[&str] = &[
+    "Xa", "Xg", "Xo", "Xu", "a", "aX", "aa", "ag", "ao", "ar", "as", "at", "au", "aw", "ax", "gX",
+    "ga", "gg", "go", "gr", "gs", "gt", "gu", "gw", "gx", "oX", "oa", "og", "oo", "or", "os", "ot",
+    "ou", "ow", "ox", "ra", "rg", "ro", "ru", "sa", "sg", "so", "su", "ta", "tg", "to", "tu", "uX",
+    "ua", "ug", "uo", "ur", "us", "ut", "uu", "uw", "ux", "wa", "wg", "wo", "wu", "xa", "xg", "xo",
+    "xu",
+];
+/// Real `FileType` values for the file and directory probes; `tweak_mode()`
+/// branches on `S_ISDIR` for both the `D`/`F` selector and the conditional `X`.
+fn probe_file_types() -> (std::fs::FileType, std::fs::FileType) {
     let temp = tempfile::tempdir().expect("tempdir");
     let file_path = temp.path().join("f");
     let dir_path = temp.path().join("d");
     std::fs::write(&file_path, b"payload").expect("write file");
     std::fs::create_dir(&dir_path).expect("create dir");
-    let file_type = std::fs::metadata(&file_path)
-        .expect("file metadata")
-        .file_type();
-    let dir_type = std::fs::metadata(&dir_path)
-        .expect("dir metadata")
-        .file_type();
+    (
+        std::fs::metadata(&file_path)
+            .expect("file metadata")
+            .file_type(),
+        std::fs::metadata(&dir_path)
+            .expect("dir metadata")
+            .file_type(),
+    )
+}
 
-    for (spec, expected) in MATRIX {
+/// Evaluates every `(spec, probe)` cell of `matrix` and asserts it reproduces
+/// upstream's value.
+fn assert_matrix(matrix: &[(&str, [u32; 4])], probes: &[(u32, bool); 4]) {
+    let (file_type, dir_type) = probe_file_types();
+
+    for (spec, expected) in matrix {
         let clauses = parse_with_umask(spec, UMASK).unwrap_or_else(|e| panic!("`{spec}`: {e}"));
-        for (probe, want) in PROBES.iter().zip(expected) {
+        for (probe, want) in probes.iter().zip(expected) {
             let (mode, is_dir) = *probe;
             let file_type = if is_dir { dir_type } else { file_type };
             let got = apply_clauses(&clauses, mode, file_type) & 0o7777;
@@ -352,16 +506,25 @@ fn chmod_matrix_matches_upstream() {
     }
 }
 
+/// Expected row for `spec`, which must be present in `matrix`.
+fn lookup(matrix: &[(&str, [u32; 4])], spec: &str) -> [u32; 4] {
+    matrix
+        .iter()
+        .find(|(s, _)| *s == spec)
+        .unwrap_or_else(|| panic!("matrix is missing `{spec}`"))
+        .1
+}
+
+/// Every matrix cell must reproduce upstream's `tweak_mode()` output.
+#[test]
+fn chmod_matrix_matches_upstream() {
+    assert_matrix(MATRIX, &PROBES);
+}
+
 /// The matrix must cover every `{who} x {op} x {perm}` combination it claims to,
 /// so a row silently dropped from the table cannot shrink the guard.
 #[test]
 fn chmod_matrix_covers_the_full_grid() {
-    const WHO: [&str; 8] = ["", "u", "g", "o", "a", "ug", "go", "ugo"];
-    const OP: [&str; 3] = ["+", "-", "="];
-    const WHAT: [&str; 12] = [
-        "r", "w", "x", "X", "s", "t", "rw", "rwx", "rwxXst", "st", "sX", "ts",
-    ];
-
     for who in WHO {
         for op in OP {
             for what in WHAT {
@@ -398,4 +561,97 @@ fn a_plus_s_sets_both_setid_bits() {
     assert_eq!(apply("a+s"), 0o6644);
     assert_eq!(apply("u+s"), 0o4644);
     assert_eq!(apply("g+s"), 0o2644);
+}
+
+/// Every permission-copy cell must reproduce upstream's `tweak_mode()` output.
+///
+/// upstream: rsync 3.5.0 chmod.c `mode_copy_bits()` - `u=g` and friends read
+/// the source class out of the mode and spread it across the destination
+/// classes. rsync 3.4.4 rejected the whole form, so this is the grid that a
+/// regression would silently take back to a parse error.
+#[test]
+fn chmod_copy_matrix_matches_upstream() {
+    assert_matrix(COPY_MATRIX, &COPY_PROBES);
+}
+
+/// The copy matrix must cover every `{who} x {op} x {source-class}` triple it
+/// claims to, so a row silently dropped from the table cannot shrink the guard.
+#[test]
+fn chmod_copy_matrix_covers_the_full_grid() {
+    for who in WHO {
+        for op in OP {
+            for src in COPY_SOURCES {
+                let spec = format!("{who}{op}{src}");
+                assert!(
+                    COPY_MATRIX.iter().any(|(s, _)| *s == spec),
+                    "copy matrix is missing `{spec}`"
+                );
+            }
+        }
+    }
+    assert_eq!(COPY_MATRIX.len(), WHO.len() * OP.len() * COPY_SOURCES.len());
+}
+
+/// A copy reads the mode as the *preceding* clauses left it, not the mode the
+/// file started with, so a comma-separated list is order-dependent.
+///
+/// upstream: chmod.c `tweak_mode()` calls `mode_copy_bits(mode, ...)` inside the
+/// clause loop, before that clause's own AND/OR is applied.
+#[test]
+fn chmod_copy_sequences_match_upstream() {
+    assert_matrix(COPY_SEQUENCE_MATRIX, &COPY_PROBES);
+}
+
+/// Reordering two copy clauses must change the result - the pin that would fail
+/// if the source were ever read from the original mode instead of the running
+/// one.
+#[test]
+fn chmod_copy_is_order_dependent() {
+    let forward = lookup(COPY_SEQUENCE_MATRIX, "u=g,g=o");
+    let reverse = lookup(COPY_SEQUENCE_MATRIX, "g=o,u=g");
+    assert_ne!(forward, reverse);
+}
+
+/// The grammar must not widen: for every `{who} x {op} x {one- or two-letter
+/// permission half}` spec, oc's accept/reject decision must equal upstream
+/// 3.5.0's.
+///
+/// upstream: chmod.c parse_chmod() STATE_2ND_HALF - a copy letter may not be
+/// combined with literal bits, with `s`/`t`, or with a second copy letter, in
+/// either order, and `a` is never a copy source. The verdict depends only on
+/// the permission half, which is why [`REJECTED_RHS`] is keyed on it.
+#[test]
+fn chmod_permission_half_verdicts_match_upstream() {
+    const LETTERS: [char; 10] = ['r', 'w', 'x', 'X', 's', 't', 'u', 'g', 'o', 'a'];
+
+    let mut halves = Vec::with_capacity(LETTERS.len() * (LETTERS.len() + 1));
+    for a in LETTERS {
+        halves.push(a.to_string());
+        for b in LETTERS {
+            halves.push(format!("{a}{b}"));
+        }
+    }
+    assert_eq!(
+        REJECTED_RHS.len(),
+        halves
+            .iter()
+            .filter(|h| REJECTED_RHS.contains(&h.as_str()))
+            .count(),
+        "REJECTED_RHS holds an entry outside the enumerated universe"
+    );
+
+    for who in WHO {
+        for op in OP {
+            for half in &halves {
+                let spec = format!("{who}{op}{half}");
+                let rejected = parse_with_umask(&spec, UMASK).is_err();
+                assert_eq!(
+                    rejected,
+                    REJECTED_RHS.contains(&half.as_str()),
+                    "`{spec}`: oc {} it, upstream 3.5.0 does not",
+                    if rejected { "rejects" } else { "accepts" }
+                );
+            }
+        }
+    }
 }

--- a/crates/metadata/src/chmod/mod.rs
+++ b/crates/metadata/src/chmod/mod.rs
@@ -5,13 +5,14 @@
 //! The upstream rsync CLI allows multiple `--chmod=SPEC` occurrences where each
 //! specification may contain comma-separated numeric or symbolic clauses. This
 //! module mirrors upstream rsync's `chmod.c:parse_chmod()` grammar exactly,
-//! reducing every clause to an AND/OR mask pair (`ModeAND`/`ModeOR`) plus the
-//! `D`/`F` selectors, then applying them through `chmod.c:tweak_mode()` order:
-//! conditional execute bits (`X`), the set-id/sticky bits driven by the who
-//! letters, and the umask masking applied to an implied who-class. A category
-//! letter (`u`/`g`/`o`) in the permission half is rejected exactly as upstream
-//! does - rsync has no chmod(1)-style copy-from-category form. The
-//! [`ChmodModifiers`] type wraps the parsed clauses and exposes
+//! reducing every clause to an AND/OR mask pair (`ModeAND`/`ModeOR`) plus a
+//! permission-copy triple and the `D`/`F` selectors, then applying them through
+//! `chmod.c:tweak_mode()` order: conditional execute bits (`X`), the
+//! set-id/sticky bits driven by the who letters, the umask masking applied to
+//! an implied who-class, and finally the chmod(1)-style permission copies
+//! (`u=g`, `g+u`, `o=u`) whose source class is read from the mode as the
+//! preceding clauses left it. The [`ChmodModifiers`] type wraps the parsed
+//! clauses and exposes
 //! [`ChmodModifiers::apply`] so higher layers can evaluate modifiers after the
 //! standard metadata preservation step.
 

--- a/crates/metadata/src/chmod/parse.rs
+++ b/crates/metadata/src/chmod/parse.rs
@@ -2,23 +2,31 @@
 //!
 //! Faithful port of upstream rsync's `chmod.c:parse_chmod()` state machine. The
 //! whole modestring is scanned in a single pass so that comma handling, the
-//! `D`/`F` selectors, octal modes, and the symbolic `[ugoa][-+=][rwxXst]` forms
-//! match upstream byte for byte, including the error transitions. A category
-//! letter (`u`/`g`/`o`) in the second half is rejected exactly as upstream does
-//! (chmod.c STATE_2ND_HALF `default:` -> STATE_ERROR): rsync's `--chmod` grammar
-//! has no chmod(1)-style copy-from-category form. Each clause is reduced to an
-//! AND/OR pair consumed by the evaluator in `apply.rs`.
+//! `D`/`F` selectors, octal modes, the symbolic `[ugoa][-+=][rwxXst]` forms and
+//! the chmod(1)-style permission copies `[ugoa][-+=][ugo]` match upstream byte
+//! for byte, including the error transitions. Each clause is reduced to an
+//! AND/OR pair plus a permission-copy triple, consumed by the evaluator in
+//! `apply.rs`.
 
-use super::{ChmodError, spec::CHMOD_BITS, spec::Clause};
+use super::{ChmodError, spec::CHMOD_BITS, spec::Clause, spec::Op};
 
-// upstream: chmod.c CHMOD_ADD / CHMOD_SUB / CHMOD_EQ / CHMOD_SET.
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum Op {
-    None,
-    Add,
-    Sub,
-    Eq,
-    Set,
+/// Set-id/sticky bits owned by the who-classes in `where_`.
+///
+/// upstream: chmod.c `mode_dest_special_bits()` - a `=` clause that copies
+/// permissions also clears the special bit each destination class owns, so
+/// `u=g` drops setuid, `g=o` drops setgid and `o=u` drops the sticky bit.
+const fn dest_special_bits(where_: u32) -> u32 {
+    let mut bits = 0;
+    if where_ & 0o100 != 0 {
+        bits |= 0o4000;
+    }
+    if where_ & 0o010 != 0 {
+        bits |= 0o2000;
+    }
+    if where_ & 0o001 != 0 {
+        bits |= 0o1000;
+    }
+    bits
 }
 
 // upstream: chmod.c STATE_1ST_HALF / STATE_2ND_HALF / STATE_OCTAL_NUM.
@@ -71,9 +79,10 @@ pub(crate) fn parse_with_umask(modestr: &str, umask: u32) -> Result<Vec<Clause>,
     let mut state = State::FirstHalf;
     let mut where_: u32 = 0;
     let mut what: u32 = 0;
-    let mut op = Op::None;
+    let mut op: Option<Op> = None;
     let mut topbits: u32 = 0;
     let mut topoct: u32 = 0;
+    let mut copybits: u32 = 0;
     let mut x_keep = false;
     let mut dirs_only = false;
     let mut files_only = false;
@@ -85,35 +94,59 @@ pub(crate) fn parse_with_umask(modestr: &str, umask: u32) -> Result<Vec<Clause>,
 
         // upstream: chmod.c:58 - at end-of-string or a comma, close the clause.
         if ch.is_none() || ch == Some(b',') {
-            if op == Op::None {
+            let Some(clause_op) = op else {
                 return Err(ChmodError::new(
                     "invalid --chmod specification: empty clause",
                 ));
-            }
+            };
 
-            // upstream: chmod.c:73-78.
-            let bits = if where_ != 0 {
+            // upstream: chmod.c parse_chmod() - an omitted who-class becomes
+            // `a` and folds `~orig_umask` into both the literal and the copied
+            // bits (`ModeCOPY_AND`).
+            let where_specified = where_ != 0;
+            let bits = if where_specified {
                 where_ * what
             } else {
                 where_ = 0o111;
                 (where_ * what) & !umask
             };
+            let mode_copy_and = if where_specified { CHMOD_BITS } else { !umask };
 
-            // upstream: chmod.c:80-97.
-            let (mode_and, mode_or) = match op {
+            // upstream: chmod.c parse_chmod() `switch (op)`.
+            let (mode_and, mode_or) = match clause_op {
                 Op::Add => (CHMOD_BITS, bits + topoct),
                 Op::Sub => (CHMOD_BITS - bits - topoct, 0),
                 Op::Eq => {
                     let special = if topoct != 0 { topbits } else { 0 };
-                    (CHMOD_BITS - (where_ * 7) - special, bits + topoct)
+                    // A copy also clears the special bit each destination class
+                    // owns, so `u=g` drops setuid. upstream:
+                    // chmod.c `mode_dest_special_bits()`.
+                    let copy_special = if copybits != 0 {
+                        dest_special_bits(where_)
+                    } else {
+                        0
+                    };
+                    (
+                        CHMOD_BITS - (where_ * 7) - special - copy_special,
+                        bits + topoct,
+                    )
                 }
                 Op::Set => (0, bits),
-                Op::None => unreachable!(),
+            };
+            // A numeric mode never copies. upstream: the CHMOD_SET arm zeroes
+            // the copy triple and pins ModeCOPY_AND to CHMOD_BITS.
+            let (copy_src, copy_dst, copy_and) = match clause_op {
+                Op::Set => (0, 0, CHMOD_BITS),
+                Op::Add | Op::Sub | Op::Eq => (copybits, where_, mode_copy_and),
             };
 
             clauses.push(Clause {
                 mode_and,
                 mode_or,
+                copy_src,
+                copy_dst,
+                copy_and,
+                op: clause_op,
                 x_keep,
                 dirs_only,
                 files_only,
@@ -129,9 +162,10 @@ pub(crate) fn parse_with_umask(modestr: &str, umask: u32) -> Result<Vec<Clause>,
             state = State::FirstHalf;
             where_ = 0;
             what = 0;
-            op = Op::None;
+            op = None;
             topbits = 0;
             topoct = 0;
+            copybits = 0;
             x_keep = false;
             dirs_only = false;
             files_only = false;
@@ -175,22 +209,22 @@ pub(crate) fn parse_with_umask(modestr: &str, umask: u32) -> Result<Vec<Clause>,
                     topbits |= 0o6000;
                 }
                 b'+' => {
-                    op = Op::Add;
+                    op = Some(Op::Add);
                     state = State::SecondHalf;
                 }
                 b'-' => {
-                    op = Op::Sub;
+                    op = Some(Op::Sub);
                     state = State::SecondHalf;
                 }
                 b'=' => {
-                    op = Op::Eq;
+                    op = Some(Op::Eq);
                     state = State::SecondHalf;
                 }
                 _ => {
                     // upstream: chmod.c:148-156 - an octal digit (< 8) starts a
                     // numeric mode only when no who-class has been seen.
                     if byte.is_ascii_digit() && byte < b'8' && where_ == 0 {
-                        op = Op::Set;
+                        op = Some(Op::Set);
                         state = State::OctalNum;
                         where_ = 1;
                         what = u32::from(byte - b'0');
@@ -199,11 +233,13 @@ pub(crate) fn parse_with_umask(modestr: &str, umask: u32) -> Result<Vec<Clause>,
                     }
                 }
             },
-            // upstream: chmod.c:159-185 STATE_2ND_HALF. Only `rwxXst` are valid;
-            // anything else (including a `u`/`g`/`o` category letter - rsync has
-            // no chmod(1)-style copy-from-category form) hits `default:` and
-            // routes to STATE_ERROR.
+            // upstream: chmod.c parse_chmod() STATE_2ND_HALF. `rwxXst` name
+            // literal bits; a lone `u`/`g`/`o` names a permission CLASS to copy
+            // from. The two are mutually exclusive and at most one copy letter
+            // is allowed, so every guard below routes to STATE_ERROR. `a` is
+            // not a copy source and falls to `default:`.
             State::SecondHalf => match byte {
+                b'r' | b'w' | b'x' | b'X' if copybits != 0 => return Err(err(c)),
                 b'r' => what |= 4,
                 b'w' => what |= 2,
                 b'X' => {
@@ -211,6 +247,7 @@ pub(crate) fn parse_with_umask(modestr: &str, umask: u32) -> Result<Vec<Clause>,
                     what |= 1;
                 }
                 b'x' => what |= 1,
+                b's' | b't' if copybits != 0 => return Err(err(c)),
                 b's' => {
                     if topbits != 0 {
                         topoct |= topbits;
@@ -219,6 +256,12 @@ pub(crate) fn parse_with_umask(modestr: &str, umask: u32) -> Result<Vec<Clause>,
                     }
                 }
                 b't' => topoct |= 0o1000,
+                b'u' | b'g' | b'o' if what != 0 || topoct != 0 || copybits != 0 => {
+                    return Err(err(c));
+                }
+                b'u' => copybits = 0o100,
+                b'g' => copybits = 0o010,
+                b'o' => copybits = 0o001,
                 _ => return Err(err(c)),
             },
             // upstream: chmod.c:187-194.
@@ -365,13 +408,41 @@ mod tests {
     }
 
     #[test]
-    fn copy_from_category_forms_rejected() {
-        // upstream: chmod.c:159-185 STATE_2ND_HALF has no `u`/`g`/`o` case, so a
-        // category letter in the permission half falls to `default:` ->
-        // STATE_ERROR and parse_chmod returns NULL. rsync's `--chmod` grammar
-        // does not implement chmod(1)'s copy-from-category form; the caller emits
-        // `Invalid argument passed to --chmod (<spec>)` and exits RERR_SYNTAX.
-        for spec in ["g=u", "o=g", "u+g", "a=u", "g-o", "o=u", "g=ur", "g=us"] {
+    fn permission_copy_records_the_source_class() {
+        // upstream: chmod.c parse_chmod() STATE_2ND_HALF `case 'u'/'g'/'o'` -
+        // a lone category letter sets ModeCOPY_SRC and leaves the literal bits
+        // empty; ModeCOPY_DST is the who-class the clause writes to.
+        let c = one("u=g");
+        assert_eq!((c.copy_src, c.copy_dst), (0o010, 0o100));
+        assert_eq!(c.mode_or, 0);
+        // `=` also clears the destination class's own special bit (setuid here).
+        assert_eq!(c.mode_and, CHMOD_BITS - 0o700 - 0o4000);
+
+        let c = one("go+u");
+        assert_eq!((c.copy_src, c.copy_dst), (0o100, 0o011));
+        assert_eq!(c.mode_and, CHMOD_BITS);
+        // An explicit who-class leaves the copied bits unmasked.
+        assert_eq!(c.copy_and, CHMOD_BITS);
+    }
+
+    #[test]
+    fn implied_who_masks_the_copied_bits_by_umask() {
+        // upstream: chmod.c parse_chmod() - ModeCOPY_AND is `~orig_umask` when
+        // the who-class was implied, mirroring the literal-bit path.
+        assert_eq!(one("+u").copy_and, !UMASK);
+        assert_eq!(one("a+u").copy_and, CHMOD_BITS);
+    }
+
+    #[test]
+    fn copy_source_is_exclusive_within_its_clause() {
+        // upstream: chmod.c parse_chmod() STATE_2ND_HALF guards every branch on
+        // `copybits`, and the copy branches on `what || topoct || copybits`, so a
+        // copy letter may not be mixed with literal bits, set-id/sticky letters,
+        // or a second copy letter - in either order. `a` is never a copy source.
+        for spec in [
+            "u=gr", "u=rg", "u=gs", "u=sg", "u=gt", "u=tg", "u=gX", "u=Xg", "u=ug", "u=gg", "u+a",
+            "u=a", "a=a", "+a",
+        ] {
             assert!(parse(spec).is_err(), "`{spec}` must be rejected");
         }
     }

--- a/crates/metadata/src/chmod/spec.rs
+++ b/crates/metadata/src/chmod/spec.rs
@@ -1,25 +1,55 @@
 //! Crate-internal representation of parsed `--chmod` clauses.
 //!
 //! Mirrors upstream rsync's `chmod.c:struct chmod_mode_struct`: each clause is
-//! reduced to an AND mask and an OR mask plus the three behavioural flags
-//! (`FLAG_X_KEEP`, `FLAG_DIRS_ONLY`, `FLAG_FILES_ONLY`). The evaluator applies
-//! `mode = (mode & ModeAND) | ModeOR` clause by clause, exactly as
-//! `chmod.c:tweak_mode()` does. None of these types are exposed publicly.
+//! reduced to an AND mask and an OR mask, a permission-copy triple, the
+//! originating operator, and the three behavioural flags (`FLAG_X_KEEP`,
+//! `FLAG_DIRS_ONLY`, `FLAG_FILES_ONLY`). The evaluator applies
+//! `mode = (mode & ModeAND) | ModeOR` and then folds in the copied bits clause
+//! by clause, exactly as `chmod.c:tweak_mode()` does. None of these types are
+//! exposed publicly.
 
 /// Permission bits touched by a chmod clause. upstream: `rsync.h` `CHMOD_BITS`
 /// (setuid, setgid, sticky, plus the nine rwx bits).
 pub(crate) const CHMOD_BITS: u32 = 0o7777;
 
+/// Operator a clause was built from. upstream: chmod.c `CHMOD_ADD`,
+/// `CHMOD_SUB`, `CHMOD_EQ`, `CHMOD_SET` stored as `ModeOP`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Op {
+    /// `+`
+    Add,
+    /// `-`
+    Sub,
+    /// `=`
+    Eq,
+    /// A bare octal mode.
+    Set,
+}
+
 /// One parsed `--chmod` clause reduced to an AND/OR transform.
 ///
 /// upstream: chmod.c `struct chmod_mode_struct` fields `ModeAND`, `ModeOR`,
-/// `flags`.
+/// `ModeCOPY_SRC`, `ModeCOPY_DST`, `ModeCOPY_AND`, `ModeOP`, `flags`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct Clause {
     /// Bits retained from the existing mode. upstream: `ModeAND`.
     pub(crate) mode_and: u32,
     /// Bits unconditionally set after masking. upstream: `ModeOR`.
     pub(crate) mode_or: u32,
+    /// Who-class the copied permissions are read *from*, as a `0o100`/`0o010`/
+    /// `0o001` selector; zero when the clause copies nothing. upstream:
+    /// `ModeCOPY_SRC`.
+    pub(crate) copy_src: u32,
+    /// Who-classes the copied permissions are written *to*, as the same
+    /// selector the clause's `bits` were multiplied by. upstream:
+    /// `ModeCOPY_DST`.
+    pub(crate) copy_dst: u32,
+    /// Mask applied to the spread copied bits: `CHMOD_BITS` when the who-class
+    /// was written out, `!umask` when it was implied. upstream: `ModeCOPY_AND`.
+    pub(crate) copy_and: u32,
+    /// Operator this clause came from; only `Op::Sub` inverts the copy fold.
+    /// upstream: `ModeOP`.
+    pub(crate) op: Op,
     /// `X` conditional-execute flag. upstream: `FLAG_X_KEEP`.
     pub(crate) x_keep: bool,
     /// `D` selector: apply to directories only. upstream: `FLAG_DIRS_ONLY`.

--- a/crates/metadata/src/chmod/tests.rs
+++ b/crates/metadata/src/chmod/tests.rs
@@ -110,22 +110,23 @@ fn conditional_execute_bit_behaviour_matches_rsync() {
     assert_eq!(dir_mode & 0o777, 0o711);
 }
 
-/// upstream: chmod.c:159-185 STATE_2ND_HALF has no `u`/`g`/`o` case, so a
-/// category letter in the permission half falls to `default:` -> STATE_ERROR
-/// and parse_chmod returns NULL. rsync's `--chmod` grammar has no chmod(1)-style
-/// copy-from-category form; upstream 3.4.4 prints
-/// `Invalid argument passed to --chmod (g=u)` and exits RERR_SYNTAX. An empty
-/// permission half (e.g. `o=`) is a distinct, legitimate clause and still
-/// parses (the operator was seen, so it is not an empty clause).
+/// upstream: chmod.c parse_chmod() STATE_2ND_HALF `case 'u'/'g'/'o'` - a lone
+/// category letter in the permission half names a class to COPY permissions
+/// from, the chmod(1)-style form rsync 3.5.0 added. Mixing it with literal bits
+/// still falls to STATE_ERROR, and the caller prints
+/// `Invalid argument passed to --chmod (g=ur)` and exits RERR_SYNTAX. An empty
+/// permission half (e.g. `o=`) is a distinct, legitimate clause and parses too
+/// (the operator was seen, so it is not an empty clause).
 #[test]
-fn who_letter_copy_forms_are_rejected() {
-    assert!(ChmodModifiers::parse("g=u").is_err());
-    assert!(ChmodModifiers::parse("o=g").is_err());
-    assert!(ChmodModifiers::parse("u+g").is_err());
-    assert!(ChmodModifiers::parse("g-o").is_err());
+fn who_letter_copy_forms_are_accepted() {
+    assert!(ChmodModifiers::parse("g=u").is_ok());
+    assert!(ChmodModifiers::parse("o=g").is_ok());
+    assert!(ChmodModifiers::parse("u+g").is_ok());
+    assert!(ChmodModifiers::parse("g-o").is_ok());
+    assert!(ChmodModifiers::parse("g=o,o=").is_ok());
+    // A copy letter mixed with literal bits is still an error.
     assert!(ChmodModifiers::parse("g=ur").is_err());
     // An empty permission half clears the class and remains valid.
-    assert!(ChmodModifiers::parse("g=o,o=").is_err());
     assert!(ChmodModifiers::parse("o=").is_ok());
     assert!(ChmodModifiers::parse("Dg=").is_ok());
 }


### PR DESCRIPTION
## What

rsync 3.5.0 lets the permission half of a `--chmod` clause name a permission **class** instead of literal `rwx` bits - `u=g`, `go+u`, `o-u`. rsync 3.4.4 and oc-rsync both rejected every such spec with `Invalid argument passed to --chmod`, exit 1.

This adds no option and no daemon directive: it is a new grammar inside an existing option's argument, which is why an option-table diff cannot see it.

## Grammar

`chmod.c` `parse_chmod()` STATE_2ND_HALF gains `case 'u'/'g'/'o'`, each setting `copybits` to `0100`/`0010`/`0001`. Every branch is mutually exclusive:

- the literal branches (`r`, `w`, `x`, `X`, `s`, `t`) error when `copybits` is already set;
- the copy branches error when `what`, `topoct` or `copybits` is already set.

So a copy letter must be the whole permission half - `u=gr`, `u=rg`, `u=gs`, `u=ug` are all errors - and `a` is never a copy source (it falls to `default:`). The verdict depends only on the permission half, not on the who-class or the operator.

## Resolution semantics

`chmod.c` `mode_copy_bits(mode, ModeCOPY_SRC, ModeCOPY_DST, ModeCOPY_AND)` extracts the source class's three bits from `mode`, spreads them over the destination classes (`ModeCOPY_DST * bits`) and masks with `ModeCOPY_AND`. `tweak_mode()` calls it **inside the clause loop, before that clause's own `mode &= ModeAND`**, so:

- the source is the mode as the **preceding clauses left it**, not the mode the file started with - a comma-separated list is order-dependent, and `u=g,g=o` differs from `g=o,u=g`;
- `ModeCOPY_DST` is the who-class after the implied-`a` substitution, so `+u` copies to all three classes;
- `ModeCOPY_AND` is `CHMOD_BITS` when the who-class was written out and `~orig_umask` when it was implied, mirroring the literal-bit path;
- `CHMOD_SUB` removes the copied bits (`mode &= CHMOD_BITS - copy_bits`); every other operator adds them;
- `CHMOD_EQ` additionally subtracts `mode_dest_special_bits(where)` from `ModeAND`, so `u=g` clears setuid, `g=o` setgid, `o=u` sticky;
- `CHMOD_SET` (a numeric mode) zeroes the copy triple - a numeric clause never copies.

Multiple copies compose because each is just another clause in the list.

## Scope proof

Upstream's `chmod.c` was compiled verbatim - once from 3.4.4, once from 3.5.0 - against a stubbed `rsync.h`, printing `tweak_mode()` for each spec against four probe modes. Over a 360-spec universe (`{8 who} x {3 op} x {12 literal halves + 3 copy classes}`), with umask 022:

| | count |
|---|---|
| identical between 3.4.4 and 3.5.0 | 272 |
| newly **accepted** by 3.5.0 | **72** (this feature: `{who} x {op} x {u,g,o}`) |
| value changed | 16 (all `a` + `s`/`t`; the separate fix already on master) |
| newly rejected | 0 |

So the change is confined to the 72 copy rows, and no previously valid spec changes meaning or becomes invalid.

## Before

```
$ oc-rsync --chmod=u=g src/f dst/
oc-rsync error: Invalid argument passed to --chmod (u=g) (code 1) ...
$ echo $?
1
```

## After (mode 0761 source, `-p`)

| spec | oc-rsync | upstream 3.5.0 oracle |
|---|---|---|
| `u=g` | 0661 | 0661 |
| `go+u` | 0777 | 0777 |
| `u=g,g=o` | 0611 | 0611 |
| `g=o,u=g` | 0111 | 0111 |

The last two rows are the order dependence.

## Tests

Expected values are upstream's own `tweak_mode()` output, not hand-derived. Added to `crates/metadata/src/chmod/matrix_tests.rs`:

- `chmod_copy_matrix_matches_upstream` - the `{8 who} x {3 op} x {3 source class}` grid against four starting modes chosen so all three permission triads differ (one with every special bit set, one a directory): 288 assertions.
- `chmod_copy_matrix_covers_the_full_grid` - completeness, so a row dropped from the table cannot silently shrink the guard.
- `chmod_copy_sequences_match_upstream` + `chmod_copy_is_order_dependent` - multi-clause rows, including composition with octal, literal and `D`/`F` clauses, pinning the resolution order.
- `chmod_permission_half_verdicts_match_upstream` - every one- and two-letter permission half over `rwxXstugoa`, across who-classes and operators (1320 specs): oc's accept/reject decision must equal 3.5.0's. This is the guard against widening the grammar.

All four fail against the pre-change implementation (verified by restoring `parse.rs`/`apply.rs`/`spec.rs` from `master` and re-running: `` `u=g,g=o`: invalid --chmod specification: 'g' `` and `` `+u`: oc rejects it, upstream 3.5.0 does not ``).

## Verification

```
cargo fmt --all -- --check                                                      clean
cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings   clean
cargo nextest run -p metadata -p cli --all-features    4404 passed, 3 skipped
python3 tools/ci/citation_drift_audit.py --ratchet     ratchet OK
```

No new unsafe code; `crates/metadata`'s existing FFI sites are untouched.
