### PR TITLE
fix(logging): escape control characters in log-file output

### DIFF
--- a/crates/cli/src/frontend/escape.rs
+++ b/crates/cli/src/frontend/escape.rs
@@ -1,13 +1,70 @@
 //! Filename octal escaping matching upstream rsync's `filtered_fwrite`
-//! in `log.c:225-246`.
+//! in `log.c:242-263`.
 //!
 //! Upstream rsync escapes non-printable bytes in filenames as `\#ooo`
-//! (backslash, hash, three octal digits). The `--8-bit-output` / `-8`
-//! flag disables escaping for high-bit characters (0x80-0xFF), leaving
-//! only control characters below 0x20 (except tab) escaped.
+//! (backslash, hash, three octal digits). Which bytes qualify depends on the
+//! destination, so `filtered_fwrite` takes two independent switches - see
+//! [`EscapeStyle`].
 
 use std::io::Write;
 use std::path::Path;
+
+/// The two `filtered_fwrite` escape switches, resolved per destination.
+///
+/// upstream: log.c:242 `filtered_fwrite(FILE *f, const char *in_buf, int
+/// in_len, int use_isprint, int escape_c1, char end_char)`. Upstream passes a
+/// different pair for each sink, so oc-rsync carries the pair rather than the
+/// `--8-bit-output` flag alone:
+///   - the terminal sink gets `use_isprint = !allow_8bit_chars, escape_c1 = 0`
+///     (log.c:425);
+///   - the log-file sink gets `use_isprint = 0, escape_c1 = 1` (log.c:132),
+///     which is deliberately *not* gated on `--8-bit-output`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EscapeStyle {
+    /// Escape every byte libc `isprint()` rejects (upstream `use_isprint`).
+    use_isprint: bool,
+    /// Escape the C1 control range 0x80-0x9F (upstream `escape_c1`).
+    escape_c1: bool,
+}
+
+impl Default for EscapeStyle {
+    /// The terminal style without `-8` - oc-rsync's default output sink.
+    fn default() -> Self {
+        Self::terminal(false)
+    }
+}
+
+impl EscapeStyle {
+    /// Escaping for stdout/stderr, honouring `--8-bit-output` / `-8`.
+    ///
+    /// upstream: log.c:425 `filtered_fwrite(f, buf, len, !allow_8bit_chars, 0,
+    /// trailing_CR_or_NL)`. Without `-8` every non-`isprint` byte is escaped,
+    /// which covers DEL (0x7F) and the whole high range 0x80-0xFF; with `-8`
+    /// only the sub-0x20 controls (tab excepted) are.
+    #[must_use]
+    pub(crate) const fn terminal(allow_8bit: bool) -> Self {
+        Self {
+            use_isprint: !allow_8bit,
+            escape_c1: false,
+        }
+    }
+
+    /// Escaping for the log file (CWE-117 log injection defence).
+    ///
+    /// upstream: log.c:132 `filtered_fwrite(logfile_fp, buf, len, 0, 1,
+    /// trailing)`. The `isprint()` filter is off, so DEL and 0xA0-0xFF reach
+    /// the log verbatim and a non-UTF-8 name stays readable; in exchange the
+    /// C1 range is escaped unconditionally, so neither a 7-bit `ESC` nor an
+    /// 8-bit `CSI` can forge a log line or drive the operator's terminal. The
+    /// pair does not depend on `--8-bit-output`.
+    #[must_use]
+    pub(crate) const fn log_file() -> Self {
+        Self {
+            use_isprint: false,
+            escape_c1: true,
+        }
+    }
+}
 
 /// Returns `true` when a byte is printable in the C locale.
 ///
@@ -20,29 +77,22 @@ fn is_c_print(byte: u8) -> bool {
 
 /// Decides whether a single byte must be octal-escaped as `\#ooo`.
 ///
-/// upstream: log.c:237 `filtered_fwrite` escape condition:
-///   `*in_buf != '\t' && ((use_isprint && !isPrint(in_buf)) || *(uchar*)in_buf < ' ')`
-/// where `use_isprint = !allow_8bit_chars` (log.c:398). Strategy on the
-/// `--8-bit-output` flag:
-///   - default (`eight_bit` false): escape tab-excluded non-printable bytes,
-///     which includes DEL (0x7F) and the high range 0x80-0xFF.
-///   - `-8` (`eight_bit` true): escape only control bytes below 0x20 (except
-///     tab); DEL and high bytes pass through raw for terminal rendering.
+/// upstream: log.c:253-255 `filtered_fwrite` escape condition:
+///   `*in_buf != '\t' && ((use_isprint && !isPrint(in_buf)) || *(uchar*)in_buf < ' '
+///     || (escape_c1 && *(uchar*)in_buf >= 0x80 && *(uchar*)in_buf <= 0x9f))`
 #[inline]
-fn should_escape_byte(byte: u8, eight_bit: bool) -> bool {
-    byte != b'\t' && ((!eight_bit && !is_c_print(byte)) || byte < b' ')
+fn should_escape_byte(byte: u8, style: EscapeStyle) -> bool {
+    byte != b'\t'
+        && ((style.use_isprint && !is_c_print(byte))
+            || byte < b' '
+            || (style.escape_c1 && (0x80..=0x9F).contains(&byte)))
 }
 
 /// Escapes non-printable bytes for display output, matching upstream
-/// rsync's `filtered_fwrite` in `log.c:225-246`.
+/// rsync's `filtered_fwrite` in `log.c:242-263`.
 ///
-/// When `allow_8bit` is false (the default), bytes outside ASCII
-/// printable range (0x20-0x7E) are escaped as `\#ooo` (backslash, hash,
-/// three octal digits). Tab (0x09) is passed through unescaped.
-///
-/// When `allow_8bit` is true (`--8-bit-output`), only control characters
-/// below 0x20 (except tab) are escaped. High-bit bytes (0x80-0xFF) and
-/// DEL (0x7F) pass through for terminal rendering.
+/// Which bytes qualify is decided by `style` - see [`EscapeStyle`]. Tab
+/// (0x09) is always passed through unescaped.
 ///
 /// Literal `\#ddd` sequences (where each `d` is an ASCII digit) in the
 /// input are also escaped to prevent ambiguity with the escape notation.
@@ -53,21 +103,19 @@ fn should_escape_byte(byte: u8, eight_bit: bool) -> bool {
 /// must survive verbatim. A `String` cannot hold arbitrary invalid UTF-8, so
 /// returning `Vec<u8>` and writing it directly to a byte sink is the only way
 /// to reach byte-for-byte parity with upstream on that edge case.
-pub(crate) fn escape_for_output(input: &[u8], allow_8bit: bool) -> Vec<u8> {
+pub(crate) fn escape_for_output(input: &[u8], style: EscapeStyle) -> Vec<u8> {
     // Fast path: all bytes ASCII-printable or tab (0x09, 0x20-0x7E) -> no byte
-    // needs escaping in either mode and there is no literal `\#ddd` to guard,
+    // needs escaping under any style and there is no literal `\#ddd` to guard,
     // so return the bytes verbatim.
     //
     // DEL (0x7F) and high bytes (0x80-0xFF) are deliberately excluded here so
-    // they always take the slow path, which applies the correct per-mode
-    // handling: escape as \#ooo when !allow_8bit, or pass through raw when
-    // allow_8bit.
+    // they always take the slow path, which applies the style's own rule.
     let all_safe = input.iter().all(|&b| is_c_print(b) || b == b'\t');
     if all_safe && !has_literal_escape_sequence(input) {
         return input.to_vec();
     }
 
-    escape_bytes_slow(input, allow_8bit)
+    escape_bytes_slow(input, style)
 }
 
 /// Returns `true` when the input contains a literal `\#ddd` sequence.
@@ -92,12 +140,13 @@ fn has_literal_escape_sequence(input: &[u8]) -> bool {
 /// Slow path: escapes bytes one at a time into a raw byte buffer.
 ///
 /// Non-escaped bytes are emitted raw (upstream `filtered_fwrite` copies the
-/// input byte verbatim). This matters under `-8`: a multi-byte UTF-8 filename
+/// input byte verbatim). This matters whenever a style lets high bytes through
+/// (`-8` on the terminal, or any log-file line): a multi-byte UTF-8 filename
 /// such as `café` (bytes `63 61 66 c3 a9`) passes through as the original bytes
 /// `c3 a9`, and a lone invalid byte such as `0x80` passes through as the single
 /// byte `80` - neither is re-encoded nor replaced with U+FFFD. Escaped bytes
 /// are written as their ASCII `\#ooo` form.
-fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> Vec<u8> {
+fn escape_bytes_slow(input: &[u8], style: EscapeStyle) -> Vec<u8> {
     let mut output: Vec<u8> = Vec::with_capacity(input.len() + input.len() / 4);
     let len = input.len();
     let mut i = 0;
@@ -105,7 +154,7 @@ fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> Vec<u8> {
     while i < len {
         let byte = input[i];
 
-        // upstream: log.c:235-236 - escape literal \#ddd sequences to prevent
+        // upstream: log.c:252-254 - escape literal \#ddd sequences to prevent
         // ambiguity with the escape notation. If the input contains \#001
         // literally, escape the backslash so the output reads \#134#001.
         if i + 4 < len
@@ -120,7 +169,7 @@ fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> Vec<u8> {
             continue;
         }
 
-        if should_escape_byte(byte, allow_8bit) {
+        if should_escape_byte(byte, style) {
             let _ = write!(output, "\\#{byte:03o}");
         } else {
             output.push(byte);
@@ -135,7 +184,7 @@ fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> Vec<u8> {
 ///
 /// On Unix, operates on the raw bytes of the path to faithfully represent
 /// non-UTF-8 filenames: a lone invalid byte such as `0x80` reaches the escape
-/// layer verbatim, matching upstream `filtered_fwrite` (log.c:224-245), which
+/// layer verbatim, matching upstream `filtered_fwrite` (log.c:242-263), which
 /// copies filename bytes to the output fd unmodified.
 ///
 /// On non-Unix hosts (chiefly Windows) a path is an `OsStr` whose internal
@@ -148,17 +197,17 @@ fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> Vec<u8> {
 /// transcode of otherwise-representable filenames: stable std offers no API to
 /// recover the raw WTF-8 bytes, so full byte-fidelity for lone surrogates is
 /// unreachable on Windows today.
-pub(crate) fn escape_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
+pub(crate) fn escape_path(path: &Path, style: EscapeStyle) -> Vec<u8> {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;
-        escape_for_output(path.as_os_str().as_bytes(), allow_8bit)
+        escape_for_output(path.as_os_str().as_bytes(), style)
     }
     #[cfg(not(unix))]
     {
         match path.as_os_str().to_str() {
-            Some(valid) => escape_for_output(valid.as_bytes(), allow_8bit),
-            None => escape_for_output(path.to_string_lossy().as_bytes(), allow_8bit),
+            Some(valid) => escape_for_output(valid.as_bytes(), style),
+            None => escape_for_output(path.to_string_lossy().as_bytes(), style),
         }
     }
 }
@@ -169,65 +218,81 @@ pub(crate) fn escape_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
 /// `to_string_lossy()`). Escapes non-printable bytes in the UTF-8
 /// representation.
 #[cfg(test)]
-fn escape_str(s: &str, allow_8bit: bool) -> Vec<u8> {
-    escape_for_output(s.as_bytes(), allow_8bit)
+fn escape_str(s: &str, style: EscapeStyle) -> Vec<u8> {
+    escape_for_output(s.as_bytes(), style)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // -- escape_for_output: default mode (allow_8bit = false) --
+    /// stdout/stderr without `-8` (upstream log.c:425 `!allow_8bit_chars`).
+    const TERMINAL: EscapeStyle = EscapeStyle::terminal(false);
+    /// stdout/stderr with `-8` (upstream log.c:425 `allow_8bit_chars`).
+    const TERMINAL_8BIT: EscapeStyle = EscapeStyle::terminal(true);
+    /// The log-file sink (upstream log.c:132 `logit`).
+    const LOGFILE: EscapeStyle = EscapeStyle::log_file();
+
+    // -- escape_for_output: terminal style, no -8 (use_isprint=1, escape_c1=0) --
 
     #[test]
     fn ascii_printable_passes_through() {
         let input = b"hello_world.txt";
-        assert_eq!(escape_for_output(input, false), b"hello_world.txt".to_vec());
+        assert_eq!(
+            escape_for_output(input, TERMINAL),
+            b"hello_world.txt".to_vec()
+        );
     }
 
     #[test]
     fn space_passes_through() {
         let input = b"hello world.txt";
-        assert_eq!(escape_for_output(input, false), b"hello world.txt".to_vec());
+        assert_eq!(
+            escape_for_output(input, TERMINAL),
+            b"hello world.txt".to_vec()
+        );
     }
 
     #[test]
     fn tab_passes_through() {
         let input = b"before\tafter";
-        assert_eq!(escape_for_output(input, false), b"before\tafter".to_vec());
+        assert_eq!(
+            escape_for_output(input, TERMINAL),
+            b"before\tafter".to_vec()
+        );
     }
 
     #[test]
     fn control_char_0x01_escaped() {
-        assert_eq!(escape_for_output(&[0x01], false), b"\\#001".to_vec());
+        assert_eq!(escape_for_output(&[0x01], TERMINAL), b"\\#001".to_vec());
     }
 
     #[test]
     fn del_0x7f_escaped() {
-        assert_eq!(escape_for_output(&[0x7F], false), b"\\#177".to_vec());
+        assert_eq!(escape_for_output(&[0x7F], TERMINAL), b"\\#177".to_vec());
     }
 
     #[test]
     fn high_bit_0x80_escaped_in_default_mode() {
         // upstream: default mode (use_isprint=1) octal-escapes a lone high byte.
-        assert_eq!(escape_for_output(&[0x80], false), b"\\#200".to_vec());
+        assert_eq!(escape_for_output(&[0x80], TERMINAL), b"\\#200".to_vec());
     }
 
     #[test]
     fn high_bit_0xff_escaped_in_default_mode() {
-        assert_eq!(escape_for_output(&[0xFF], false), b"\\#377".to_vec());
+        assert_eq!(escape_for_output(&[0xFF], TERMINAL), b"\\#377".to_vec());
     }
 
     #[test]
     fn null_byte_escaped() {
-        assert_eq!(escape_for_output(&[0x00], false), b"\\#000".to_vec());
+        assert_eq!(escape_for_output(&[0x00], TERMINAL), b"\\#000".to_vec());
     }
 
     #[test]
     fn mixed_printable_and_control() {
         let input = b"file\x01name\x7f.txt";
         assert_eq!(
-            escape_for_output(input, false),
+            escape_for_output(input, TERMINAL),
             b"file\\#001name\\#177.txt".to_vec()
         );
     }
@@ -235,48 +300,51 @@ mod tests {
     #[test]
     fn all_specified_bytes_escaped_correctly() {
         // Verify the exact values from the task description.
-        assert_eq!(escape_for_output(&[0x01], false), b"\\#001".to_vec());
-        assert_eq!(escape_for_output(&[0x7F], false), b"\\#177".to_vec());
-        assert_eq!(escape_for_output(&[0x80], false), b"\\#200".to_vec());
-        assert_eq!(escape_for_output(&[0xFF], false), b"\\#377".to_vec());
+        assert_eq!(escape_for_output(&[0x01], TERMINAL), b"\\#001".to_vec());
+        assert_eq!(escape_for_output(&[0x7F], TERMINAL), b"\\#177".to_vec());
+        assert_eq!(escape_for_output(&[0x80], TERMINAL), b"\\#200".to_vec());
+        assert_eq!(escape_for_output(&[0xFF], TERMINAL), b"\\#377".to_vec());
     }
 
-    // -- escape_for_output: 8-bit mode (allow_8bit = true) --
+    // -- escape_for_output: terminal style under -8 (use_isprint=0, escape_c1=0) --
 
     #[test]
     fn control_char_escaped_in_8bit_mode() {
-        assert_eq!(escape_for_output(&[0x01], true), b"\\#001".to_vec());
+        assert_eq!(
+            escape_for_output(&[0x01], TERMINAL_8BIT),
+            b"\\#001".to_vec()
+        );
     }
 
     #[test]
     fn del_0x7f_passes_through_in_8bit_mode() {
         // upstream: with use_isprint=0 (allow_8bit=1), the condition is
         // byte != '\t' && byte < ' ', which excludes 0x7F.
-        assert_eq!(escape_for_output(&[0x7F], true), vec![0x7F]);
+        assert_eq!(escape_for_output(&[0x7F], TERMINAL_8BIT), vec![0x7F]);
     }
 
     #[test]
     fn lone_high_byte_0x80_is_raw_in_8bit_mode() {
         // upstream: `filtered_fwrite` writes the raw byte to the output fd when
-        // allow_8bit_chars is set (log.c:225-246). A lone 0x80 is invalid UTF-8
+        // allow_8bit_chars is set (log.c:242-263). A lone 0x80 is invalid UTF-8
         // and cannot live in a Rust String, so the escape layer returns raw
         // bytes and the writer emits exactly one byte, matching `rsync -8`
         // byte-for-byte. Previously the `from_utf8_lossy` return type yielded
         // U+FFFD here.
-        assert_eq!(escape_for_output(&[0x80], true), vec![0x80]);
+        assert_eq!(escape_for_output(&[0x80], TERMINAL_8BIT), vec![0x80]);
         // Exactly one byte reaches the sink - no U+FFFD (ef bf bd) expansion.
-        assert_eq!(escape_for_output(&[0x80], true).len(), 1);
+        assert_eq!(escape_for_output(&[0x80], TERMINAL_8BIT).len(), 1);
     }
 
     #[test]
     fn lone_high_byte_0xff_is_raw_in_8bit_mode() {
-        assert_eq!(escape_for_output(&[0xFF], true), vec![0xFF]);
-        assert_eq!(escape_for_output(&[0xFF], true).len(), 1);
+        assert_eq!(escape_for_output(&[0xFF], TERMINAL_8BIT), vec![0xFF]);
+        assert_eq!(escape_for_output(&[0xFF], TERMINAL_8BIT).len(), 1);
     }
 
     #[test]
     fn tab_passes_through_in_8bit_mode() {
-        assert_eq!(escape_for_output(b"\t", true), b"\t".to_vec());
+        assert_eq!(escape_for_output(b"\t", TERMINAL_8BIT), b"\t".to_vec());
     }
 
     #[test]
@@ -286,7 +354,7 @@ mod tests {
         // c3 a9, matching `rsync -v -8` byte-for-byte. A byte-to-code-point cast
         // would re-encode to c3 83 c2 a9 (mojibake `Ã©`).
         let input = b"caf\xc3\xa9";
-        let out = escape_for_output(input, true);
+        let out = escape_for_output(input, TERMINAL_8BIT);
         assert_eq!(out, b"caf\xc3\xa9".to_vec());
     }
 
@@ -295,14 +363,20 @@ mod tests {
         // WHY: default mode (use_isprint=1) escapes every non-printable byte,
         // so each UTF-8 continuation byte of `café` becomes its own \#ooo.
         let input = b"caf\xc3\xa9";
-        assert_eq!(escape_for_output(input, false), b"caf\\#303\\#251".to_vec());
+        assert_eq!(
+            escape_for_output(input, TERMINAL),
+            b"caf\\#303\\#251".to_vec()
+        );
     }
 
     #[test]
     fn only_control_chars_escaped_in_8bit_mode() {
         // 0x01 and 0x7F: only 0x01 is escaped (< 0x20)
         let input = &[0x01, 0x7F];
-        assert_eq!(escape_for_output(input, true), b"\\#001\x7F".to_vec());
+        assert_eq!(
+            escape_for_output(input, TERMINAL_8BIT),
+            b"\\#001\x7F".to_vec()
+        );
     }
 
     // -- Literal \#ddd sequence escaping --
@@ -312,7 +386,7 @@ mod tests {
         // A filename containing literal \#001 should escape the backslash.
         let input = b"file\\#001.txt";
         assert_eq!(
-            escape_for_output(input, false),
+            escape_for_output(input, TERMINAL),
             b"file\\#134#001.txt".to_vec()
         );
     }
@@ -321,7 +395,7 @@ mod tests {
     fn literal_escape_sequence_escaped_in_8bit_mode() {
         let input = b"file\\#999.txt";
         assert_eq!(
-            escape_for_output(input, true),
+            escape_for_output(input, TERMINAL_8BIT),
             b"file\\#134#999.txt".to_vec()
         );
     }
@@ -330,14 +404,17 @@ mod tests {
     fn non_digit_after_hash_not_escaped() {
         // \#abc is not a valid escape sequence - leave it alone.
         let input = b"file\\#abc.txt";
-        assert_eq!(escape_for_output(input, false), b"file\\#abc.txt".to_vec());
+        assert_eq!(
+            escape_for_output(input, TERMINAL),
+            b"file\\#abc.txt".to_vec()
+        );
     }
 
     #[test]
     fn partial_escape_sequence_at_end_not_escaped() {
         // \#12 at end (only 2 digits) - not an escape sequence.
         let input = b"file\\#12";
-        assert_eq!(escape_for_output(input, false), b"file\\#12".to_vec());
+        assert_eq!(escape_for_output(input, TERMINAL), b"file\\#12".to_vec());
     }
 
     // -- escape_path --
@@ -345,13 +422,13 @@ mod tests {
     #[test]
     fn escape_path_ascii() {
         let path = Path::new("src/main.rs");
-        assert_eq!(escape_path(path, false), b"src/main.rs".to_vec());
+        assert_eq!(escape_path(path, TERMINAL), b"src/main.rs".to_vec());
     }
 
     #[test]
     fn escape_path_with_directory_separator() {
         let path = Path::new("foo/bar/baz.txt");
-        assert_eq!(escape_path(path, false), b"foo/bar/baz.txt".to_vec());
+        assert_eq!(escape_path(path, TERMINAL), b"foo/bar/baz.txt".to_vec());
     }
 
     #[cfg(unix)]
@@ -361,12 +438,12 @@ mod tests {
         // path through a `String` (which would replace it with U+FFFD): under
         // `-8` the raw byte passes verbatim to the byte sink, matching upstream
         // `filtered_fwrite`, which copies filename bytes unmodified
-        // (log.c:224-245). This is the round-trip that `--8-bit-output` parity
+        // (log.c:242-263). This is the round-trip that `--8-bit-output` parity
         // depends on.
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
         let path = Path::new(OsStr::from_bytes(b"a\x80b"));
-        let out = escape_path(path, true);
+        let out = escape_path(path, TERMINAL_8BIT);
         assert_eq!(out, b"a\x80b".to_vec());
         // Exactly three bytes reach the sink - no U+FFFD (ef bf bd) expansion.
         assert_eq!(out.len(), 3);
@@ -380,7 +457,7 @@ mod tests {
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
         let path = Path::new(OsStr::from_bytes(b"a\x80b"));
-        assert_eq!(escape_path(path, false), b"a\\#200b".to_vec());
+        assert_eq!(escape_path(path, TERMINAL), b"a\\#200b".to_vec());
     }
 
     #[cfg(not(unix))]
@@ -390,8 +467,8 @@ mod tests {
         // keeps the original bytes (no U+FFFD), matching upstream
         // `filtered_fwrite` byte-for-byte. `café` is bytes 63 61 66 c3 a9.
         let path = Path::new("caf\u{e9}");
-        assert_eq!(escape_path(path, true), b"caf\xc3\xa9".to_vec());
-        assert_eq!(escape_path(path, false), b"caf\\#303\\#251".to_vec());
+        assert_eq!(escape_path(path, TERMINAL_8BIT), b"caf\xc3\xa9".to_vec());
+        assert_eq!(escape_path(path, TERMINAL), b"caf\\#303\\#251".to_vec());
     }
 
     #[cfg(windows)]
@@ -410,19 +487,19 @@ mod tests {
         let os = OsString::from_wide(&[0x0061, 0xD800, 0x0062]);
         let path = Path::new(&os);
         // Under -8 the U+FFFD bytes (all high) pass through raw.
-        assert_eq!(escape_path(path, true), b"a\xef\xbf\xbdb".to_vec());
+        assert_eq!(escape_path(path, TERMINAL_8BIT), b"a\xef\xbf\xbdb".to_vec());
     }
 
     // -- escape_str --
 
     #[test]
     fn escape_str_passes_printable() {
-        assert_eq!(escape_str("hello.txt", false), b"hello.txt".to_vec());
+        assert_eq!(escape_str("hello.txt", TERMINAL), b"hello.txt".to_vec());
     }
 
     #[test]
     fn escape_str_escapes_control() {
-        assert_eq!(escape_str("a\x01b", false), b"a\\#001b".to_vec());
+        assert_eq!(escape_str("a\x01b", TERMINAL), b"a\\#001b".to_vec());
     }
 
     // -- Fast path coverage --
@@ -431,14 +508,99 @@ mod tests {
     fn fast_path_all_printable() {
         let input = b"abcdefghijklmnopqrstuvwxyz/0123456789";
         assert_eq!(
-            escape_for_output(input, false),
+            escape_for_output(input, TERMINAL),
             b"abcdefghijklmnopqrstuvwxyz/0123456789".to_vec()
         );
     }
 
     #[test]
     fn empty_input() {
-        assert_eq!(escape_for_output(b"", false), Vec::<u8>::new());
-        assert_eq!(escape_for_output(b"", true), Vec::<u8>::new());
+        assert_eq!(escape_for_output(b"", TERMINAL), Vec::<u8>::new());
+        assert_eq!(escape_for_output(b"", TERMINAL_8BIT), Vec::<u8>::new());
+    }
+
+    // -- log-file style (upstream log.c:132: use_isprint=0, escape_c1=1) --
+
+    /// WHY: a filename carrying `\n` or `ESC` must not be able to forge a log
+    /// line or drive the operator's terminal when they later `cat` the log
+    /// (CWE-117). upstream: log.c:126-131 escapes the message before it is
+    /// written to `logfile_fp`.
+    #[test]
+    fn log_file_escapes_sub_0x20_controls() {
+        assert_eq!(escape_for_output(b"a\nb", LOGFILE), b"a\\#012b".to_vec());
+        assert_eq!(escape_for_output(b"a\x1bb", LOGFILE), b"a\\#033b".to_vec());
+        assert_eq!(escape_for_output(b"a\rb", LOGFILE), b"a\\#015b".to_vec());
+        assert_eq!(escape_for_output(&[0x00], LOGFILE), b"\\#000".to_vec());
+    }
+
+    /// WHY: 0x9B is the 8-bit CSI - on a terminal that decodes C1 it starts a
+    /// control sequence exactly as `ESC [` does, so the log sink escapes the
+    /// whole C1 range whether or not `--8-bit-output` is in play.
+    /// upstream: log.c:255 `escape_c1 && *(uchar*)in_buf >= 0x80 && <= 0x9f`.
+    #[test]
+    fn log_file_escapes_the_c1_range() {
+        assert_eq!(escape_for_output(&[0x80], LOGFILE), b"\\#200".to_vec());
+        assert_eq!(escape_for_output(&[0x9B], LOGFILE), b"\\#233".to_vec());
+        assert_eq!(escape_for_output(&[0x9F], LOGFILE), b"\\#237".to_vec());
+    }
+
+    /// WHY: the log sink runs with `use_isprint = 0`, so DEL and everything
+    /// above the C1 range reaches the log verbatim - a non-UTF-8 filename stays
+    /// readable there. Escaping them would be as much a divergence as failing
+    /// to escape a control byte. MEASURED against rsync 3.5.0 with
+    /// `--log-file`: `\x7f` and `\xff` appear raw in the log while `\x1b`,
+    /// `\n` and `\x9b` appear as `\#033`, `\#012` and `\#233`.
+    #[test]
+    fn log_file_passes_del_and_high_bytes_raw() {
+        assert_eq!(escape_for_output(&[0x7F], LOGFILE), vec![0x7F]);
+        assert_eq!(escape_for_output(&[0xA0], LOGFILE), vec![0xA0]);
+        assert_eq!(escape_for_output(&[0xFF], LOGFILE), vec![0xFF]);
+        assert_eq!(
+            escape_for_output(b"caf\xc3\xa9", LOGFILE),
+            b"caf\xc3\xa9".to_vec()
+        );
+    }
+
+    /// upstream: log.c:253-254 - tab survives in every style.
+    #[test]
+    fn log_file_passes_tab_raw() {
+        assert_eq!(escape_for_output(b"a\tb", LOGFILE), b"a\tb".to_vec());
+    }
+
+    /// upstream: log.c:252-254 - a literal `\#ddd` in a name is disambiguated
+    /// from a real escape in every style, including the log sink.
+    #[test]
+    fn log_file_disambiguates_literal_escape_sequence() {
+        assert_eq!(
+            escape_for_output(b"file\\#001.txt", LOGFILE),
+            b"file\\#134#001.txt".to_vec()
+        );
+    }
+
+    /// CLASS GUARD: for every byte value, the log style must escape exactly the
+    /// set upstream's `filtered_fwrite(.., use_isprint=0, escape_c1=1, ..)`
+    /// escapes - no more, no less - and must never be gated on `-8`.
+    #[test]
+    fn log_file_style_matches_upstream_predicate_for_every_byte() {
+        for byte in 0u8..=255 {
+            let expected_escape = byte != b'\t' && (byte < 0x20 || (0x80..=0x9F).contains(&byte));
+            let out = escape_for_output(&[byte], LOGFILE);
+            let escaped = out != vec![byte];
+            assert_eq!(
+                escaped, expected_escape,
+                "byte {byte:#04x} escaped={escaped} expected={expected_escape}"
+            );
+            if expected_escape {
+                assert_eq!(out, format!("\\#{byte:03o}").into_bytes());
+            }
+        }
+    }
+
+    /// The log style is a fixed pair, so it cannot be reached from the `-8`
+    /// flag: constructing it twice must yield the same rule either way.
+    #[test]
+    fn log_file_style_is_independent_of_eight_bit_output() {
+        assert_ne!(EscapeStyle::log_file(), EscapeStyle::terminal(false));
+        assert_ne!(EscapeStyle::log_file(), EscapeStyle::terminal(true));
     }
 }

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -13,6 +13,8 @@ use core::{
 use logging::{DebugFlag, InfoFlag, LogCode, debug_gte, info_gte};
 use logging_sink::{MessageSink, logfile::LogFileWriter};
 
+use crate::frontend::escape::EscapeStyle;
+
 use crate::frontend::{
     out_format::{OutFormat, OutFormatContext},
     progress::{
@@ -225,7 +227,7 @@ where
                 .with_id_preservation(preserve_owner, preserve_group)
                 .with_emit_unchanged(emit_unchanged)
                 .with_itemize_repeated(itemize_repeated)
-                .with_eight_bit_output(eight_bit_output)
+                .with_escape_style(EscapeStyle::terminal(eight_bit_output))
                 .with_preserve_links(preserve_links)
                 .with_full_checksum(full_checksum_algorithm, always_checksum);
             if let Err(error) = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
@@ -249,7 +251,7 @@ where
                     show_copy_method,
                     show_atimes,
                     show_crtimes,
-                    eight_bit_output,
+                    EscapeStyle::terminal(eight_bit_output),
                     writer,
                 )
             }) {
@@ -279,7 +281,6 @@ where
                     itemize_repeated,
                     show_atimes,
                     show_crtimes,
-                    eight_bit_output,
                     preserve_links,
                     full_checksum_algorithm,
                     always_checksum,
@@ -345,9 +346,6 @@ struct EmitLogOutputParams<'a> {
     show_atimes: bool,
     /// `--crtimes`: render the CRTIME column in `--list-only` log output.
     show_crtimes: bool,
-    /// `--8-bit-output` / `-8`: pass high-bit characters through without
-    /// octal escaping in log-file output.
-    eight_bit_output: bool,
     /// `--links` / `-l`: whether symlink rows in `--list-only` log output get
     /// the ` -> <target>` arrow (upstream: generator.c:1183).
     preserve_links: bool,
@@ -377,7 +375,6 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         itemize_repeated,
         show_atimes,
         show_crtimes,
-        eight_bit_output,
         preserve_links,
         full_checksum_algorithm,
         always_checksum,
@@ -392,7 +389,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         .with_id_preservation(preserve_owner, preserve_group)
         .with_emit_unchanged(emit_unchanged)
         .with_itemize_repeated(itemize_repeated)
-        .with_eight_bit_output(eight_bit_output)
+        .with_escape_style(EscapeStyle::log_file())
         .with_preserve_links(preserve_links)
         .with_full_checksum(full_checksum_algorithm, always_checksum);
     // upstream: log.c:290-305 - FLOG messages are written to the log file
@@ -432,7 +429,12 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         false,
         show_atimes,
         show_crtimes,
-        eight_bit_output,
+        // upstream: log.c:132 `logit()` writes the log line through
+        // `filtered_fwrite(.., use_isprint=0, escape_c1=1, ..)` - a fixed pair
+        // that `--8-bit-output` does not reach, so a name carrying `ESC`, a
+        // newline or an 8-bit CSI cannot forge a log line (CWE-117) while DEL
+        // and 0xA0-0xFF stay verbatim.
+        EscapeStyle::log_file(),
         &mut log.file,
     )?;
     // upstream: cleanup.c:222-226 gates log_exit() on

--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -168,10 +168,7 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
         // of `-i`/`-ii`.
         if matches!(event.kind(), ClientEventKind::SkippedNewerDestination) {
             if info_gte(InfoFlag::Skip, 1) {
-                writer.write_all(&escape_path(
-                    event.relative_path(),
-                    context.eight_bit_output,
-                ))?;
+                writer.write_all(&escape_path(event.relative_path(), context.escape))?;
                 writer.write_all(b" is newer\n")?;
             }
             continue;
@@ -186,10 +183,7 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
             _ => None,
         } {
             if info_gte(InfoFlag::Skip, 1) {
-                writer.write_all(&escape_path(
-                    event.relative_path(),
-                    context.eight_bit_output,
-                ))?;
+                writer.write_all(&escape_path(event.relative_path(), context.escape))?;
                 writer.write_all(suffix)?;
             }
             continue;

--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 use std::time::SystemTime;
 
-use crate::frontend::escape::escape_path;
+use crate::frontend::escape::{EscapeStyle, escape_path};
 use crate::{LIST_TIMESTAMP_FORMAT, format_list_permissions};
 use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
 
@@ -49,10 +49,10 @@ pub(super) fn render_placeholder_value(
     context: &OutFormatContext,
     spec: &PlaceholderToken,
 ) -> Option<Vec<u8>> {
-    let allow_8bit = context.eight_bit_output;
+    let escape = context.escape;
     match spec.kind {
-        OutFormatPlaceholder::FileName => Some(render_name(event, allow_8bit)),
-        OutFormatPlaceholder::FullPath => Some(render_full_path(event, allow_8bit)),
+        OutFormatPlaceholder::FileName => Some(render_name(event, escape)),
+        OutFormatPlaceholder::FullPath => Some(render_full_path(event, escape)),
         OutFormatPlaceholder::ItemizedChanges => Some(match event.itemize_override() {
             // A remote transfer supplies the sender's already-correct 11-char
             // itemize string; a local event derives it from its change set.
@@ -97,7 +97,7 @@ pub(super) fn render_placeholder_value(
             // `symlink_target_connector` in the else-branch).
             if let Some(leader) = event.hardlink_leader() {
                 let mut rendered = b" => ".to_vec();
-                rendered.extend_from_slice(&escape_path(leader, allow_8bit));
+                rendered.extend_from_slice(&escape_path(leader, escape));
                 Some(rendered)
             } else {
                 match event
@@ -106,7 +106,7 @@ pub(super) fn render_placeholder_value(
                 {
                     Some(target) => {
                         let mut rendered = symlink_target_connector(event).as_bytes().to_vec();
-                        rendered.extend_from_slice(&escape_path(target, allow_8bit));
+                        rendered.extend_from_slice(&escape_path(target, escape));
                         Some(rendered)
                     }
                     // upstream: log.c:650-654 - the `case 'L'` else-branch sets n
@@ -265,8 +265,8 @@ fn normalize_render_separators(escaped: &[u8]) -> Vec<u8> {
 /// upstream: flist.c / log.c - itemize and out-format paths use POSIX
 /// forward-slash separators regardless of host OS. Storage retains the
 /// platform-native form; this normalizes only at the rendering boundary.
-fn escape_render_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
-    let rendered = escape_path(path, allow_8bit);
+fn escape_render_path(path: &Path, escape: EscapeStyle) -> Vec<u8> {
+    let rendered = escape_path(path, escape);
     #[cfg(windows)]
     {
         normalize_render_separators(&rendered)
@@ -279,8 +279,8 @@ fn escape_render_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
 
 /// Renders `%n`: the transfer-relative name, with a trailing slash for a
 /// directory (upstream `log.c:639-640`).
-fn render_name(event: &ClientEvent, allow_8bit: bool) -> Vec<u8> {
-    let mut rendered = escape_render_path(event.relative_path(), allow_8bit);
+fn render_name(event: &ClientEvent, escape: EscapeStyle) -> Vec<u8> {
+    let mut rendered = escape_render_path(event.relative_path(), escape);
     if rendered.last() != Some(&b'/')
         && event.metadata().map(ClientEntryMetadata::kind).map_or_else(
             // `EntryDeleted` rows carry no metadata snapshot, so fall back to the
@@ -299,12 +299,12 @@ fn render_name(event: &ClientEvent, allow_8bit: bool) -> Vec<u8> {
 /// (upstream `pathjoin(F_PATHNAME(file), f_name(file))` with a single leading
 /// `/` stripped, `log.c`), otherwise the transfer-relative name. Unlike `%n`, no
 /// trailing slash is appended for directories.
-fn render_full_path(event: &ClientEvent, allow_8bit: bool) -> Vec<u8> {
+fn render_full_path(event: &ClientEvent, escape: EscapeStyle) -> Vec<u8> {
     let path = match event.source_prefix() {
         Some(prefix) => prefix,
         None => event.relative_path(),
     };
-    let mut rendered = escape_render_path(path, allow_8bit);
+    let mut rendered = escape_render_path(path, escape);
     // upstream: log.c `%f` strips a single leading '/' from the joined path.
     if rendered.first() == Some(&b'/') {
         rendered.remove(0);

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use core::client::{ClientEntryKind, ClientEvent, ClientEventKind, RemoteItemizeFields};
 use engine::local_copy::{LocalCopyChangeSet, TimeChange};
 
+use crate::frontend::escape::EscapeStyle;
 use crate::frontend::out_format::parser::parse_out_format;
 use crate::frontend::out_format::tokens::{
     HumanizeMode, OutFormatContext, PlaceholderAlignment, PlaceholderFormat,
@@ -1857,7 +1858,7 @@ fn render_remote_host_with_context_populated() {
         preserve_group: false,
         emit_unchanged: false,
         itemize_repeated: false,
-        eight_bit_output: false,
+        escape: EscapeStyle::default(),
         preserve_links: false,
         full_checksum_algorithm: None,
         always_checksum: false,
@@ -1887,7 +1888,7 @@ fn render_remote_address_with_context_populated() {
         preserve_group: false,
         emit_unchanged: false,
         itemize_repeated: false,
-        eight_bit_output: false,
+        escape: EscapeStyle::default(),
         preserve_links: false,
         full_checksum_algorithm: None,
         always_checksum: false,
@@ -1917,7 +1918,7 @@ fn render_module_name_with_context_populated() {
         preserve_group: false,
         emit_unchanged: false,
         itemize_repeated: false,
-        eight_bit_output: false,
+        escape: EscapeStyle::default(),
         preserve_links: false,
         full_checksum_algorithm: None,
         always_checksum: false,
@@ -1944,7 +1945,7 @@ fn render_module_path_with_context_populated() {
         preserve_group: false,
         emit_unchanged: false,
         itemize_repeated: false,
-        eight_bit_output: false,
+        escape: EscapeStyle::default(),
         preserve_links: false,
         full_checksum_algorithm: None,
         always_checksum: false,
@@ -1974,7 +1975,7 @@ fn render_all_remote_placeholders_with_full_context() {
         preserve_group: false,
         emit_unchanged: false,
         itemize_repeated: false,
-        eight_bit_output: false,
+        escape: EscapeStyle::default(),
         preserve_links: false,
         full_checksum_algorithm: None,
         always_checksum: false,

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -4,6 +4,8 @@
 
 use core::client::StrongChecksumAlgorithm;
 
+use crate::frontend::escape::EscapeStyle;
+
 /// Maximum width accepted for placeholder formatting.
 pub(super) const MAX_PLACEHOLDER_WIDTH: usize = 4096;
 
@@ -189,10 +191,10 @@ pub(crate) struct OutFormatContext {
     /// all-dot rows even without `-vv`. The render path uses this to bypass
     /// the empty-change-set suppression independently of `emit_unchanged`.
     pub(super) itemize_repeated: bool,
-    /// `--8-bit-output` / `-8`: when true, high-bit characters pass through
-    /// without octal escaping. Only control characters below 0x20 (except
-    /// tab) are escaped. Matches upstream `allow_8bit_chars`.
-    pub(super) eight_bit_output: bool,
+    /// Which `filtered_fwrite` escape rule this render pass writes under -
+    /// the terminal pair (honouring `--8-bit-output`) or the log-file pair.
+    /// See `crate::frontend::escape::EscapeStyle`.
+    pub(super) escape: EscapeStyle,
     /// `--links` / `-l` (also set by `-a`): whether symbolic links are
     /// preserved.
     ///
@@ -288,11 +290,11 @@ impl OutFormatContext {
         self.itemize_repeated
     }
 
-    /// Sets the `--8-bit-output` flag for filename escaping in the
-    /// out-format renderer.
+    /// Sets the sink's `filtered_fwrite` escape rule for the out-format
+    /// renderer (upstream: log.c:132 for the log file, log.c:425 for stdout).
     #[must_use]
-    pub(crate) fn with_eight_bit_output(mut self, eight_bit_output: bool) -> Self {
-        self.eight_bit_output = eight_bit_output;
+    pub(crate) fn with_escape_style(mut self, escape: EscapeStyle) -> Self {
+        self.escape = escape;
         self
     }
 
@@ -486,7 +488,7 @@ mod tests {
             preserve_group: false,
             emit_unchanged: false,
             itemize_repeated: false,
-            eight_bit_output: false,
+            escape: EscapeStyle::default(),
             preserve_links: false,
             full_checksum_algorithm: None,
             always_checksum: false,

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -7,7 +7,7 @@ use core::client::{
     HumanReadableMode,
 };
 
-use crate::frontend::escape::escape_path;
+use crate::frontend::escape::{EscapeStyle, escape_path};
 
 /// Writes `<prefix><escaped path><suffix>\n` to a byte sink.
 ///
@@ -19,11 +19,11 @@ fn writeln_wrapped<W: Write + ?Sized>(
     stdout: &mut W,
     prefix: &str,
     path: &Path,
-    allow_8bit: bool,
+    escape: EscapeStyle,
     suffix: &str,
 ) -> io::Result<()> {
     stdout.write_all(prefix.as_bytes())?;
-    stdout.write_all(&escape_path(path, allow_8bit))?;
+    stdout.write_all(&escape_path(path, escape))?;
     stdout.write_all(suffix.as_bytes())?;
     stdout.write_all(b"\n")
 }
@@ -31,8 +31,8 @@ fn writeln_wrapped<W: Write + ?Sized>(
 /// Renders a path with any trailing platform path separators trimmed as raw
 /// bytes, mirroring upstream rsync's `*cp = '\0'` slash-lopping in `main.c:789`
 /// before the `created directory %s\n` print.
-fn display_without_trailing_separators(path: &Path, allow_8bit: bool) -> Vec<u8> {
-    let mut rendered = escape_path(path, allow_8bit);
+fn display_without_trailing_separators(path: &Path, escape: EscapeStyle) -> Vec<u8> {
+    let mut rendered = escape_path(path, escape);
     while rendered.len() > 1
         && rendered
             .last()
@@ -120,7 +120,7 @@ pub(crate) fn emit_transfer_summary(
     show_copy_method: bool,
     show_atimes: bool,
     show_crtimes: bool,
-    eight_bit_output: bool,
+    escape: EscapeStyle,
     writer: &mut dyn Write,
 ) -> io::Result<()> {
     let events = summary.events();
@@ -135,7 +135,7 @@ pub(crate) fn emit_transfer_summary(
                 human_readable_mode,
                 show_atimes,
                 show_crtimes,
-                eight_bit_output,
+                escape,
                 out_format_context.preserve_links(),
             )?;
             wrote_listing = true;
@@ -199,10 +199,7 @@ pub(crate) fn emit_transfer_summary(
         && let Some(dest_root) = events.iter().map(ClientEvent::destination_root).next()
     {
         writer.write_all(b"created directory ")?;
-        writer.write_all(&display_without_trailing_separators(
-            dest_root,
-            eight_bit_output,
-        ))?;
+        writer.write_all(&display_without_trailing_separators(dest_root, escape))?;
         writer.write_all(b"\n")?;
     }
 
@@ -230,7 +227,7 @@ pub(crate) fn emit_transfer_summary(
     let progress_rendered = if progress_already_rendered {
         true
     } else if matches!(progress_mode, Some(ProgressMode::PerFile)) && !events.is_empty() {
-        emit_progress(events, writer, human_readable_mode, eight_bit_output)?
+        emit_progress(events, writer, human_readable_mode, escape)?
     } else {
         false
     };
@@ -272,7 +269,7 @@ pub(crate) fn emit_transfer_summary(
             name_level,
             name_overridden,
             human_readable_mode,
-            eight_bit_output,
+            escape,
             writer,
         )?;
     }
@@ -376,7 +373,7 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
     human_readable: HumanReadableMode,
     show_atimes: bool,
     show_crtimes: bool,
-    eight_bit_output: bool,
+    escape: EscapeStyle,
     preserve_links: bool,
 ) -> io::Result<()> {
     for event in events {
@@ -401,7 +398,7 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
             } else {
                 String::new()
             };
-            let mut rendered = escape_path(event.relative_path(), eight_bit_output);
+            let mut rendered = escape_path(event.relative_path(), escape);
             // upstream: generator.c:1183 list_file_entry() - the ` -> <target>`
             // arrow is emitted only when `preserve_links && S_ISLNK(f->mode)`.
             // Without `--links`/`-l` the symlink is still listed (with its
@@ -411,7 +408,7 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
                 && let Some(target) = metadata.symlink_target()
             {
                 rendered.extend_from_slice(b" -> ");
-                rendered.extend_from_slice(&escape_path(target, eight_bit_output));
+                rendered.extend_from_slice(&escape_path(target, escape));
             }
 
             // The columns are ASCII; the filename bytes follow raw so an invalid
@@ -423,7 +420,7 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
             stdout.write_all(&rendered)?;
             stdout.write_all(b"\n")?;
         } else {
-            let rendered = escape_path(event.relative_path(), eight_bit_output);
+            let rendered = escape_path(event.relative_path(), escape);
             write!(
                 stdout,
                 "?????????? {:>width$} {} ",
@@ -466,7 +463,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
     events: &[ClientEvent],
     stdout: &mut W,
     human_readable: HumanReadableMode,
-    eight_bit_output: bool,
+    escape: EscapeStyle,
 ) -> io::Result<bool> {
     // upstream: progress.c counts every checked file-list entry toward
     // `to-chk=<remaining>/<total>`, but prints a per-file block and advances
@@ -503,8 +500,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
         xfr_index += 1;
         let remaining = total.saturating_sub(checked);
 
-        let name =
-            normalize_progress_separators(escape_path(event.relative_path(), eight_bit_output));
+        let name = normalize_progress_separators(escape_path(event.relative_path(), escape));
         stdout.write_all(&name)?;
         stdout.write_all(b"\n")?;
 
@@ -901,7 +897,7 @@ fn is_deferred_hardlink_event(event: &ClientEvent) -> bool {
 ///
 /// upstream: log.c:639-640 - the `%n` token strlcat()s a `/` for S_ISDIR
 /// entries; the transfer root is listed as `./`.
-fn verbose_listing_name(event: &ClientEvent, eight_bit_output: bool) -> Vec<u8> {
+fn verbose_listing_name(event: &ClientEvent, escape: EscapeStyle) -> Vec<u8> {
     let path = event.relative_path();
     let is_dir = matches!(
         event.metadata().map(ClientEntryMetadata::kind),
@@ -910,7 +906,7 @@ fn verbose_listing_name(event: &ClientEvent, eight_bit_output: bool) -> Vec<u8> 
     if is_dir && path.as_os_str() == "." {
         return b"./".to_vec();
     }
-    let mut rendered = escape_path(path, eight_bit_output);
+    let mut rendered = escape_path(path, escape);
     // upstream: flist.c f_name() emits POSIX forward-slash separators
     // regardless of host OS. Normalize Windows native backslashes at the
     // rendering boundary; storage retains the platform-native form.
@@ -933,7 +929,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
     name_level: NameOutputLevel,
     name_overridden: bool,
     _human_readable: HumanReadableMode,
-    eight_bit_output: bool,
+    escape: EscapeStyle,
     stdout: &mut W,
 ) -> io::Result<()> {
     // upstream: log.c:870 log_delete() prints "deleting %n" whenever
@@ -987,7 +983,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
         // engine cleanup pass.
         if matches!(kind, ClientEventKind::EntryDeleted) {
             if info_gte(InfoFlag::Del, 1) {
-                let mut name = escape_path(event.relative_path(), eight_bit_output);
+                let mut name = escape_path(event.relative_path(), escape);
                 // upstream: flist.c f_name() emits POSIX forward-slash
                 // separators regardless of host OS. The stored relative path
                 // keeps the platform-native separator, so normalize Windows
@@ -1034,23 +1030,17 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 {
                     continue;
                 }
-                writeln_wrapped(
-                    stdout,
-                    "",
-                    event.relative_path(),
-                    eight_bit_output,
-                    " is uptodate",
-                )?;
+                writeln_wrapped(stdout, "", event.relative_path(), escape, " is uptodate")?;
                 continue;
             }
 
-            let mut rendered = verbose_listing_name(event, eight_bit_output);
+            let mut rendered = verbose_listing_name(event, escape);
             if matches!(kind, ClientEventKind::SymlinkCopied)
                 && let Some(metadata) = event.metadata()
                 && let Some(target) = metadata.symlink_target()
             {
                 rendered.extend_from_slice(b" -> ");
-                rendered.extend_from_slice(&escape_path(target, eight_bit_output));
+                rendered.extend_from_slice(&escape_path(target, escape));
             }
             stdout.write_all(&rendered)?;
             stdout.write_all(b"\n")?;
@@ -1069,13 +1059,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // INFO_GTE(SKIP, 1), which the info verbosity table raises only
                 // at -vv (options.c:252).
                 if info_gte(InfoFlag::Skip, 1) {
-                    writeln_wrapped(
-                        stdout,
-                        "",
-                        event.relative_path(),
-                        eight_bit_output,
-                        " exists",
-                    )?;
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, " exists")?;
                 }
                 continue;
             }
@@ -1089,7 +1073,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                         stdout,
                         "not creating new file \"",
                         event.relative_path(),
-                        eight_bit_output,
+                        escape,
                         "\"",
                     )?;
                 }
@@ -1100,13 +1084,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // newer\n", fname)` for an --update skip: the bare relative name
                 // followed by " is newer", gated on INFO_GTE(SKIP, 1).
                 if info_gte(InfoFlag::Skip, 1) {
-                    writeln_wrapped(
-                        stdout,
-                        "",
-                        event.relative_path(),
-                        eight_bit_output,
-                        " is newer",
-                    )?;
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, " is newer")?;
                 }
                 continue;
             }
@@ -1120,7 +1098,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                         stdout,
                         "",
                         event.relative_path(),
-                        eight_bit_output,
+                        escape,
                         " is over max-size",
                     )?;
                 }
@@ -1136,7 +1114,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                         stdout,
                         "",
                         event.relative_path(),
-                        eight_bit_output,
+                        escape,
                         " is under min-size",
                     )?;
                 }
@@ -1147,7 +1125,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                     stdout,
                     "skipping non-regular file \"",
                     event.relative_path(),
-                    eight_bit_output,
+                    escape,
                     "\"",
                 )?;
                 continue;
@@ -1161,20 +1139,20 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                     stdout,
                     "skipping directory ",
                     event.relative_path(),
-                    eight_bit_output,
+                    escape,
                     "",
                 )?;
                 continue;
             }
             ClientEventKind::SkippedUnsafeSymlink => {
                 let mut rendered = b"ignoring unsafe symlink \"".to_vec();
-                rendered.extend_from_slice(&escape_path(event.relative_path(), eight_bit_output));
+                rendered.extend_from_slice(&escape_path(event.relative_path(), escape));
                 rendered.push(b'"');
                 if let Some(metadata) = event.metadata()
                     && let Some(target) = metadata.symlink_target()
                 {
                     rendered.extend_from_slice(b" -> ");
-                    rendered.extend_from_slice(&escape_path(target, eight_bit_output));
+                    rendered.extend_from_slice(&escape_path(target, escape));
                 }
                 stdout.write_all(&rendered)?;
                 stdout.write_all(b"\n")?;
@@ -1185,7 +1163,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                     stdout,
                     "skipping mount point \"",
                     event.relative_path(),
-                    eight_bit_output,
+                    escape,
                     "\"",
                 )?;
                 continue;
@@ -1216,13 +1194,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                     continue;
                 }
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln_wrapped(
-                        stdout,
-                        "",
-                        event.relative_path(),
-                        eight_bit_output,
-                        " is uptodate",
-                    )?;
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, " is uptodate")?;
                 }
                 continue;
             }
@@ -1233,13 +1205,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // the bare path. Mirror the same gate so `-vv` without `-i`
                 // matches the upstream `testsuite/itemize.test` golden.
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln_wrapped(
-                        stdout,
-                        "",
-                        event.relative_path(),
-                        eight_bit_output,
-                        " is uptodate",
-                    )?;
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, " is uptodate")?;
                 }
                 continue;
             }
@@ -1254,13 +1220,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // `was_created`, so they fall through to the bare-path emission.
             ClientEventKind::ReferenceCopied => {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln_wrapped(
-                        stdout,
-                        "",
-                        event.relative_path(),
-                        eight_bit_output,
-                        " is uptodate",
-                    )?;
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, " is uptodate")?;
                 }
                 continue;
             }
@@ -1268,13 +1228,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // hard-linked from the basis prints `"%s is uptodate"` at NAME>=2.
             ClientEventKind::HardLink if is_hardlinked_symlink_event(event) => {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln_wrapped(
-                        stdout,
-                        "",
-                        event.relative_path(),
-                        eight_bit_output,
-                        " is uptodate",
-                    )?;
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, " is uptodate")?;
                 }
                 continue;
             }
@@ -1282,13 +1236,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 if !event.was_created() && !event.change_set().has_any_change() =>
             {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln_wrapped(
-                        stdout,
-                        "",
-                        event.relative_path(),
-                        eight_bit_output,
-                        "/ is uptodate",
-                    )?;
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, "/ is uptodate")?;
                 }
                 continue;
             }
@@ -1296,26 +1244,20 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 if !event.was_created() && !event.change_set().has_any_change() =>
             {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln_wrapped(
-                        stdout,
-                        "",
-                        event.relative_path(),
-                        eight_bit_output,
-                        " is uptodate",
-                    )?;
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, " is uptodate")?;
                 }
                 continue;
             }
             _ => {}
         }
 
-        let mut rendered = verbose_listing_name(event, eight_bit_output);
+        let mut rendered = verbose_listing_name(event, escape);
         if matches!(kind, ClientEventKind::SymlinkCopied)
             && let Some(metadata) = event.metadata()
             && let Some(target) = metadata.symlink_target()
         {
             rendered.extend_from_slice(b" -> ");
-            rendered.extend_from_slice(&escape_path(target, eight_bit_output));
+            rendered.extend_from_slice(&escape_path(target, escape));
         } else if matches!(kind, ClientEventKind::HardLink)
             && let Some(metadata) = event.metadata()
             && let Some(leader) = metadata.symlink_target()
@@ -1323,7 +1265,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // upstream: hlink.c:236 - a freshly-linked alias prints
             // `"%s => %s"` with the group leader's relative path.
             rendered.extend_from_slice(b" => ");
-            rendered.extend_from_slice(&escape_path(leader, eight_bit_output));
+            rendered.extend_from_slice(&escape_path(leader, escape));
         }
 
         // upstream: log.c:log_formatted() emits the default `%n%L` per-file
@@ -1351,7 +1293,7 @@ mod tests {
             NameOutputLevel::UpdatedAndUnchanged,
             false,
             HumanReadableMode::Grouped,
-            false,
+            EscapeStyle::terminal(false),
             &mut out,
         )
         .expect("emit_verbose writes to an in-memory buffer");
@@ -1370,7 +1312,7 @@ mod tests {
             NameOutputLevel::UpdatedAndUnchanged,
             false,
             HumanReadableMode::Grouped,
-            false,
+            EscapeStyle::terminal(false),
             &mut out,
         )
         .expect("emit_verbose writes to an in-memory buffer");
@@ -1557,7 +1499,7 @@ mod tests {
             false,                               // show_copy_method
             false,                               // show_atimes
             false,                               // show_crtimes
-            false,                               // eight_bit_output
+            EscapeStyle::terminal(false),        // escape style
             &mut out,
         )
         .expect("emit_transfer_summary writes to an in-memory buffer");

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -1,5 +1,6 @@
 use super::common::*;
 use super::*;
+use crate::frontend::escape::EscapeStyle;
 
 #[test]
 fn list_only_lists_entries_without_copying() {
@@ -1476,7 +1477,7 @@ fn list_only_renders_specials_and_symlink_arrow_gate() {
             HumanReadableMode::Grouped,
             false,
             false,
-            false,
+            EscapeStyle::terminal(false),
             preserve_links,
         )
         .expect("render");
@@ -1561,7 +1562,7 @@ fn list_only_renders_atime_and_crtime_columns() {
         HumanReadableMode::Grouped,
         true,
         true,
-        false,
+        EscapeStyle::terminal(false),
         true,
     )
     .expect("render");

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -11,6 +11,7 @@
 //! - Multiple events rendered in order
 
 use super::*;
+use crate::frontend::escape::EscapeStyle;
 use core::client::run_client;
 
 #[test]
@@ -245,7 +246,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,                               // show_copy_method
         false,                               // show_atimes
         false,                               // show_crtimes
-        false,                               // eight_bit_output
+        EscapeStyle::terminal(false),        // escape style
         &mut with_out_format,
     )
     .expect("render with out-format");
@@ -271,7 +272,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,                               // show_copy_method
         false,                               // show_atimes
         false,                               // show_crtimes
-        false,                               // eight_bit_output
+        EscapeStyle::terminal(false),        // escape style
         &mut without_out_format,
     )
     .expect("render without out-format");

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -9,6 +9,7 @@ use super::*;
 use super::{
     NameOutputLevel, OutFormatContext, ProgressSetting, emit_transfer_summary, parse_out_format,
 };
+use crate::frontend::escape::EscapeStyle;
 use core::client::{
     ClientConfig, ClientEntryKind, ClientEvent, ClientEventKind, ClientSummary, HumanReadableMode,
     run_client,
@@ -76,7 +77,7 @@ fn render_stats_at_level(
         false,                               // show_copy_method
         false,                               // show_atimes
         false,                               // show_crtimes
-        false,                               // eight_bit_output
+        EscapeStyle::terminal(false),        // escape style
         &mut rendered,
     )
     .expect("render stats");
@@ -105,7 +106,7 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         false,                               // show_copy_method
         false,                               // show_atimes
         false,                               // show_crtimes
-        false,                               // eight_bit_output
+        EscapeStyle::terminal(false),        // escape style
         &mut rendered,
     )
     .expect("render verbose");
@@ -150,7 +151,7 @@ fn info_name_only_suppresses_stats_footer() {
         false,                               // show_copy_method
         false,                               // show_atimes
         false,                               // show_crtimes
-        false,                               // eight_bit_output
+        EscapeStyle::terminal(false),        // escape style
         &mut rendered,
     )
     .expect("render");
@@ -548,7 +549,7 @@ fn parity_totals_only_without_stats_flag() {
         false,                               // show_copy_method
         false,                               // show_atimes
         false,                               // show_crtimes
-        false,                               // eight_bit_output
+        EscapeStyle::terminal(false),        // escape style
         &mut rendered,
     )
     .expect("render");
@@ -820,7 +821,7 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         false,                               // show_copy_method
         false,                               // show_atimes
         false,                               // show_crtimes
-        false,                               // eight_bit_output
+        EscapeStyle::terminal(false),        // escape style
         &mut rendered,
     )
     .expect("render");

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -2,6 +2,7 @@ use super::*;
 use super::{
     NameOutputLevel, OutFormatContext, ProgressSetting, emit_transfer_summary, parse_out_format,
 };
+use crate::frontend::escape::EscapeStyle;
 use core::client::{ClientConfig, ClientSummary, HumanReadableMode, run_client};
 use tempfile::TempDir;
 
@@ -60,7 +61,7 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         false,                               // show_copy_method
         false,                               // show_atimes
         false,                               // show_crtimes
-        false,                               // eight_bit_output
+        EscapeStyle::terminal(false),        // escape style
         &mut rendered,
     )
     .expect("render summary");
@@ -97,7 +98,7 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         false,                               // show_copy_method
         false,                               // show_atimes
         false,                               // show_crtimes
-        false,                               // eight_bit_output
+        EscapeStyle::terminal(false),        // escape style
         &mut rendered,
     )
     .expect("render summary");
@@ -142,7 +143,7 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
-        false, // eight_bit_output
+        EscapeStyle::terminal(false), // escape style
         &mut rendered,
     )
     .expect("render summary");

--- a/crates/cli/tests/log_file_control_char_escape.rs
+++ b/crates/cli/tests/log_file_control_char_escape.rs
@@ -23,6 +23,10 @@
 //!
 //! Expectations below were captured byte-for-byte from rsync 3.5.0 running the
 //! same layout with `--log-file` at both default verbosity and under `-8`.
+//!
+//! The fixtures are split by what the host filesystem can name. Every Unix
+//! runs [`PORTABLE_NAME`]; only Linux runs [`NON_UTF8_NAME`] - see the
+//! `non_utf8_names` module for why.
 
 #![cfg(unix)]
 
@@ -35,17 +39,20 @@ use std::process::Command;
 use tempfile::TempDir;
 use test_support::oc_rsync_bin;
 
-/// Source filename carrying one byte from each interesting class:
-/// `ESC` (0x1B), `LF` (0x0A), `CSI` (0x9B), `DEL` (0x7F), a high byte (0xFF)
-/// that is not valid UTF-8, and a tab.
-const EVIL_NAME: &[u8] = b"A\x1bB\nC\x9bD\x7fE\xffF\tG";
+/// Source filename carrying the interesting bytes that every Unix filesystem
+/// can name: `ESC` (0x1B) and `LF` (0x0A), which must be escaped, plus `DEL`
+/// (0x7F) and a tab, which must survive verbatim.
+const PORTABLE_NAME: &[u8] = b"A\x1bB\nC\x7fD\tE";
 
-/// Builds `src/<EVIL_NAME>` and returns the temp root.
-fn evil_named_tree() -> TempDir {
+/// [`PORTABLE_NAME`] as the log file must render it.
+const PORTABLE_RENDERING: &[u8] = b"A\\#033B\\#012C\x7fD\tE";
+
+/// Builds `src/<name>` and returns the temp root.
+fn named_tree(name: &[u8]) -> TempDir {
     let tmp = TempDir::new().expect("tempdir");
     let src = tmp.path().join("src");
     fs::create_dir_all(&src).expect("create src");
-    fs::write(src.join(OsStr::from_bytes(EVIL_NAME)), b"payload\n").expect("write source");
+    fs::write(src.join(OsStr::from_bytes(name)), b"payload\n").expect("write source");
     tmp
 }
 
@@ -65,8 +72,8 @@ fn log_bytes(root: &Path, dest: &str, extra: &[&str]) -> Vec<u8> {
     fs::read(&log).expect("read log file")
 }
 
-/// The escaped leader of [`EVIL_NAME`]; identifies the entry's log record
-/// without depending on which itemize letters precede it.
+/// The escaped leader shared by both fixtures; identifies the entry's log
+/// record without depending on which itemize letters precede it.
 const ESCAPED_LEADER: &[u8] = b"A\\#033B";
 
 /// Returns every log line that carries the transferred filename.
@@ -93,27 +100,20 @@ fn name_line(log: &[u8]) -> Vec<u8> {
     lines.remove(0)
 }
 
-/// upstream: log.c:126-131 - `LF`, `ESC` and the 8-bit `CSI` are escaped as
-/// `\#ooo`, so a filename cannot forge a log line or drive the terminal of an
-/// operator who later `cat`s the log; `DEL`, 0xFF and tab survive verbatim
-/// because the log sink runs with `use_isprint = 0`.
-#[test]
-fn log_file_escapes_controls_and_c1_but_keeps_high_bytes() {
-    let tmp = evil_named_tree();
+/// Asserts the log renders `name` exactly as rsync 3.5.0 does.
+fn assert_rendering(name: &[u8], expected: &[u8]) {
+    let tmp = named_tree(name);
     let line = name_line(&log_bytes(tmp.path(), "dst", &[]));
     assert!(
-        line.ends_with(b"A\\#033B\\#012C\\#233D\x7fE\xffF\tG"),
+        line.ends_with(expected),
         "log line {:?} does not match the rsync 3.5.0 rendering",
         String::from_utf8_lossy(&line)
     );
 }
 
-/// upstream: log.c:131 passes a fixed `use_isprint = 0, escape_c1 = 1` pair, so
-/// the log-file rendering is identical with and without `--8-bit-output`. A
-/// name-supplied control byte must not become raw just because `-8` was given.
-#[test]
-fn log_file_escaping_is_not_weakened_by_eight_bit_output() {
-    let tmp = evil_named_tree();
+/// Asserts `-8` leaves the log-file rendering of `name` untouched.
+fn assert_eight_bit_does_not_weaken(name: &[u8]) {
+    let tmp = named_tree(name);
     let plain = name_line(&log_bytes(tmp.path(), "dst", &[]));
     let eight_bit = name_line(&log_bytes(tmp.path(), "dst8", &["-8"]));
     let strip_prefix = |line: Vec<u8>| {
@@ -126,12 +126,9 @@ fn log_file_escaping_is_not_weakened_by_eight_bit_output() {
     assert_eq!(strip_prefix(plain), strip_prefix(eight_bit));
 }
 
-/// No raw `ESC` or C1 byte may reach the log file anywhere - not just on the
-/// itemize line - or an attacker-chosen name could rewrite what the operator
-/// sees for surrounding entries.
-#[test]
-fn log_file_contains_no_raw_escape_or_c1_bytes() {
-    let tmp = evil_named_tree();
+/// Asserts no raw `ESC` or C1 byte reaches any part of the log for `name`.
+fn assert_no_raw_escape_or_c1(name: &[u8]) {
+    let tmp = named_tree(name);
     for extra in [&[][..], &["-8"][..]] {
         let dest = if extra.is_empty() { "dst" } else { "dst8" };
         let log = log_bytes(tmp.path(), dest, extra);
@@ -148,5 +145,72 @@ fn log_file_contains_no_raw_escape_or_c1_bytes() {
             1,
             "the embedded newline split the log record"
         );
+    }
+}
+
+/// upstream: log.c:126-131 - `LF` and `ESC` are escaped as `\#ooo`, so a
+/// filename cannot forge a log line or drive the terminal of an operator who
+/// later `cat`s the log; `DEL` and tab survive verbatim because the log sink
+/// runs with `use_isprint = 0`.
+#[test]
+fn log_file_escapes_controls_but_keeps_del() {
+    assert_rendering(PORTABLE_NAME, PORTABLE_RENDERING);
+}
+
+/// upstream: log.c:131 passes a fixed `use_isprint = 0, escape_c1 = 1` pair, so
+/// the log-file rendering is identical with and without `--8-bit-output`. A
+/// name-supplied control byte must not become raw just because `-8` was given.
+#[test]
+fn log_file_escaping_is_not_weakened_by_eight_bit_output() {
+    assert_eight_bit_does_not_weaken(PORTABLE_NAME);
+}
+
+/// No raw `ESC` byte may reach the log file anywhere - not just on the itemize
+/// line - or an attacker-chosen name could rewrite what the operator sees for
+/// surrounding entries.
+#[test]
+fn log_file_contains_no_raw_escape_bytes() {
+    assert_no_raw_escape_or_c1(PORTABLE_NAME);
+}
+
+/// The same contract exercised with a filename that is not valid UTF-8.
+///
+/// This is Linux-only because macOS/APFS rejects a filename containing a byte
+/// sequence that is not valid UTF-8, failing `write(2)` with `EILSEQ`
+/// ("Illegal byte sequence") - so [`NON_UTF8_NAME`] cannot be created there at
+/// all. That is a platform limit on constructing the *fixture*, not a relaxed
+/// expectation: the escaping contract is identical on both platforms, and the
+/// bytes macOS *can* name are covered by the tests above, which run everywhere.
+/// Nothing here is weakened or skipped for convenience.
+#[cfg(target_os = "linux")]
+mod non_utf8_names {
+    use super::{assert_eight_bit_does_not_weaken, assert_no_raw_escape_or_c1, assert_rendering};
+
+    /// Adds the two bytes macOS cannot name: the 8-bit `CSI` (0x9B), which must
+    /// be escaped because it is in the C1 range, and 0xFF, which must survive
+    /// verbatim because it is above it.
+    const NON_UTF8_NAME: &[u8] = b"A\x1bB\nC\x9bD\x7fE\xffF\tG";
+
+    /// [`NON_UTF8_NAME`] as the log file must render it.
+    const NON_UTF8_RENDERING: &[u8] = b"A\\#033B\\#012C\\#233D\x7fE\xffF\tG";
+
+    /// upstream: log.c:126-131 - the 8-bit `CSI` is escaped as `\#233` because
+    /// `escape_c1 = 1`, while 0xFF survives verbatim because `use_isprint = 0`,
+    /// keeping a non-UTF-8 name readable in the log.
+    #[test]
+    fn log_file_escapes_c1_but_keeps_high_bytes() {
+        assert_rendering(NON_UTF8_NAME, NON_UTF8_RENDERING);
+    }
+
+    /// `-8` must not turn the C1 byte raw.
+    #[test]
+    fn log_file_c1_escaping_is_not_weakened_by_eight_bit_output() {
+        assert_eight_bit_does_not_weaken(NON_UTF8_NAME);
+    }
+
+    /// No raw C1 byte may reach the log file anywhere.
+    #[test]
+    fn log_file_contains_no_raw_c1_bytes() {
+        assert_no_raw_escape_or_c1(NON_UTF8_NAME);
     }
 }

--- a/crates/cli/tests/log_file_control_char_escape.rs
+++ b/crates/cli/tests/log_file_control_char_escape.rs
@@ -25,8 +25,10 @@
 //! same layout with `--log-file` at both default verbosity and under `-8`.
 //!
 //! The fixtures are split by what the host filesystem can name. Every Unix
-//! runs [`PORTABLE_NAME`]; only Linux runs [`NON_UTF8_NAME`] - see the
-//! `non_utf8_names` module for why.
+//! runs [`PORTABLE_NAME`], which spells the C1 and high bytes as valid UTF-8 so
+//! the full escaping contract is exercised on every platform. Only Linux runs
+//! [`NON_UTF8_NAME`], whose *lone* invalid bytes no UTF-8-enforcing filesystem
+//! can hold - see the `non_utf8_names` module for why.
 
 #![cfg(unix)]
 
@@ -39,13 +41,20 @@ use std::process::Command;
 use tempfile::TempDir;
 use test_support::oc_rsync_bin;
 
-/// Source filename carrying the interesting bytes that every Unix filesystem
-/// can name: `ESC` (0x1B) and `LF` (0x0A), which must be escaped, plus `DEL`
-/// (0x7F) and a tab, which must survive verbatim.
-const PORTABLE_NAME: &[u8] = b"A\x1bB\nC\x7fD\tE";
+/// Source filename carrying one byte from every interesting class, spelled so
+/// that every Unix filesystem can name it.
+///
+/// `ESC` (0x1B) and `LF` (0x0A) must be escaped; `DEL` (0x7F) and a tab must
+/// survive verbatim. The C1 `CSI` is written as the UTF-8 encoding of U+009B
+/// (`c2 9b`) rather than the bare byte: the raw 0x9B is still physically in the
+/// name, so `escape_c1` is genuinely exercised, but the name stays valid UTF-8
+/// and so remains creatable on macOS. U+00FF (`c3 bf`) supplies the
+/// above-the-C1-range high bytes that must survive verbatim - `c2`, `c3` and
+/// `bf` are all above 0x9F.
+const PORTABLE_NAME: &[u8] = b"A\x1bB\nC\xc2\x9bD\x7fE\xc3\xbfF\tG";
 
-/// [`PORTABLE_NAME`] as the log file must render it.
-const PORTABLE_RENDERING: &[u8] = b"A\\#033B\\#012C\x7fD\tE";
+/// [`PORTABLE_NAME`] as the log file must render it. 0x9B is octal 233.
+const PORTABLE_RENDERING: &[u8] = b"A\\#033B\\#012C\xc2\\#233D\x7fE\xc3\xbfF\tG";
 
 /// Builds `src/<name>` and returns the temp root.
 fn named_tree(name: &[u8]) -> TempDir {
@@ -148,12 +157,12 @@ fn assert_no_raw_escape_or_c1(name: &[u8]) {
     }
 }
 
-/// upstream: log.c:126-131 - `LF` and `ESC` are escaped as `\#ooo`, so a
-/// filename cannot forge a log line or drive the terminal of an operator who
-/// later `cat`s the log; `DEL` and tab survive verbatim because the log sink
-/// runs with `use_isprint = 0`.
+/// upstream: log.c:126-131 - `LF`, `ESC` and the 8-bit `CSI` are escaped as
+/// `\#ooo`, so a filename cannot forge a log line or drive the terminal of an
+/// operator who later `cat`s the log; `DEL`, the high bytes above the C1 range
+/// and tab survive verbatim because the log sink runs with `use_isprint = 0`.
 #[test]
-fn log_file_escapes_controls_but_keeps_del() {
+fn log_file_escapes_controls_and_c1_but_keeps_high_bytes() {
     assert_rendering(PORTABLE_NAME, PORTABLE_RENDERING);
 }
 
@@ -165,30 +174,35 @@ fn log_file_escaping_is_not_weakened_by_eight_bit_output() {
     assert_eight_bit_does_not_weaken(PORTABLE_NAME);
 }
 
-/// No raw `ESC` byte may reach the log file anywhere - not just on the itemize
-/// line - or an attacker-chosen name could rewrite what the operator sees for
-/// surrounding entries.
+/// No raw `ESC` or C1 byte may reach the log file anywhere - not just on the
+/// itemize line - or an attacker-chosen name could rewrite what the operator
+/// sees for surrounding entries.
 #[test]
-fn log_file_contains_no_raw_escape_bytes() {
+fn log_file_contains_no_raw_escape_or_c1_bytes() {
     assert_no_raw_escape_or_c1(PORTABLE_NAME);
 }
 
-/// The same contract exercised with a filename that is not valid UTF-8.
+/// The same contract exercised with *lone* invalid bytes rather than their
+/// UTF-8 encodings.
 ///
 /// This is Linux-only because macOS/APFS rejects a filename containing a byte
 /// sequence that is not valid UTF-8, failing `write(2)` with `EILSEQ`
 /// ("Illegal byte sequence") - so [`NON_UTF8_NAME`] cannot be created there at
 /// all. That is a platform limit on constructing the *fixture*, not a relaxed
 /// expectation: the escaping contract is identical on both platforms, and the
-/// bytes macOS *can* name are covered by the tests above, which run everywhere.
-/// Nothing here is weakened or skipped for convenience.
+/// escaping rules themselves - including C1 and the high bytes - are already
+/// covered everywhere by the tests above, which spell the same bytes as valid
+/// UTF-8. What is exclusive to this module is the claim in the file header that
+/// "a non-UTF-8 name stays readable in the log": that needs a name no
+/// UTF-8-enforcing filesystem can hold. Nothing is weakened or skipped for
+/// convenience.
 #[cfg(target_os = "linux")]
 mod non_utf8_names {
     use super::{assert_eight_bit_does_not_weaken, assert_no_raw_escape_or_c1, assert_rendering};
 
-    /// Adds the two bytes macOS cannot name: the 8-bit `CSI` (0x9B), which must
-    /// be escaped because it is in the C1 range, and 0xFF, which must survive
-    /// verbatim because it is above it.
+    /// The bare bytes macOS cannot name: a lone 0x9B, which must be escaped
+    /// because it is in the C1 range, and a lone 0xFF, which must survive
+    /// verbatim because it is above it. Neither is valid UTF-8 on its own.
     const NON_UTF8_NAME: &[u8] = b"A\x1bB\nC\x9bD\x7fE\xffF\tG";
 
     /// [`NON_UTF8_NAME`] as the log file must render it.

--- a/crates/cli/tests/log_file_control_char_escape.rs
+++ b/crates/cli/tests/log_file_control_char_escape.rs
@@ -1,0 +1,152 @@
+//! `--log-file` escapes control characters in filenames (CWE-117).
+//!
+//! Upstream writes every log-file line through `logit()`, which since rsync
+//! 3.5.0 filters the message before it reaches `logfile_fp`:
+//!
+//! ```c
+//! int len = strlen(buf);
+//! char trailing = len && (buf[len-1] == '\n' || buf[len-1] == '\r') ? buf[--len] : '\0';
+//! fprintf(logfile_fp, "%s [%d] ", timestring(time(NULL)), (int)getpid());
+//! filtered_fwrite(logfile_fp, buf, len, 0, 1, trailing);
+//! ```
+//!
+//! (`log.c:126-131`). The `0, 1` pair is `use_isprint = 0, escape_c1 = 1`, so
+//! `filtered_fwrite` (`log.c:242-263`) escapes, as `\#ooo`:
+//!
+//! - every byte below 0x20 except tab, which covers `LF` and `ESC`; and
+//! - the C1 range 0x80-0x9F, which covers the 8-bit `CSI` (0x9B).
+//!
+//! and leaves everything else - notably `DEL` (0x7F) and 0xA0-0xFF - verbatim,
+//! so a non-UTF-8 name stays readable in the log. The pair is fixed: unlike the
+//! terminal sink (`log.c:425`, `!allow_8bit_chars`), it is not reachable from
+//! `--8-bit-output`, so `-8` must not weaken the log file.
+//!
+//! Expectations below were captured byte-for-byte from rsync 3.5.0 running the
+//! same layout with `--log-file` at both default verbosity and under `-8`.
+
+#![cfg(unix)]
+
+use std::ffi::OsStr;
+use std::fs;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+use test_support::oc_rsync_bin;
+
+/// Source filename carrying one byte from each interesting class:
+/// `ESC` (0x1B), `LF` (0x0A), `CSI` (0x9B), `DEL` (0x7F), a high byte (0xFF)
+/// that is not valid UTF-8, and a tab.
+const EVIL_NAME: &[u8] = b"A\x1bB\nC\x9bD\x7fE\xffF\tG";
+
+/// Builds `src/<EVIL_NAME>` and returns the temp root.
+fn evil_named_tree() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(src.join(OsStr::from_bytes(EVIL_NAME)), b"payload\n").expect("write source");
+    tmp
+}
+
+/// Runs a transfer that logs the transferred name and returns the log bytes.
+fn log_bytes(root: &Path, dest: &str, extra: &[&str]) -> Vec<u8> {
+    let log = root.join(format!("{dest}.log"));
+    let mut command = Command::new(oc_rsync_bin());
+    command
+        .arg("-a")
+        .args(extra)
+        .arg(format!("--log-file={}", log.display()))
+        .arg("--log-file-format=%i %n")
+        .arg(format!("{}/", root.join("src").display()))
+        .arg(format!("{}/", root.join(dest).display()));
+    let status = command.status().expect("run oc-rsync");
+    assert!(status.success(), "transfer failed: {status:?}");
+    fs::read(&log).expect("read log file")
+}
+
+/// The escaped leader of [`EVIL_NAME`]; identifies the entry's log record
+/// without depending on which itemize letters precede it.
+const ESCAPED_LEADER: &[u8] = b"A\\#033B";
+
+/// Returns every log line that carries the transferred filename.
+fn name_lines(log: &[u8]) -> Vec<Vec<u8>> {
+    log.split(|&byte| byte == b'\n')
+        .filter(|line| {
+            line.windows(ESCAPED_LEADER.len())
+                .any(|window| window == ESCAPED_LEADER)
+        })
+        .map(<[u8]>::to_vec)
+        .collect()
+}
+
+/// Returns the single log line that carries the transferred filename.
+fn name_line(log: &[u8]) -> Vec<u8> {
+    let mut lines = name_lines(log);
+    assert_eq!(
+        lines.len(),
+        1,
+        "expected exactly one record for the entry, got {}: {}",
+        lines.len(),
+        String::from_utf8_lossy(log)
+    );
+    lines.remove(0)
+}
+
+/// upstream: log.c:126-131 - `LF`, `ESC` and the 8-bit `CSI` are escaped as
+/// `\#ooo`, so a filename cannot forge a log line or drive the terminal of an
+/// operator who later `cat`s the log; `DEL`, 0xFF and tab survive verbatim
+/// because the log sink runs with `use_isprint = 0`.
+#[test]
+fn log_file_escapes_controls_and_c1_but_keeps_high_bytes() {
+    let tmp = evil_named_tree();
+    let line = name_line(&log_bytes(tmp.path(), "dst", &[]));
+    assert!(
+        line.ends_with(b"A\\#033B\\#012C\\#233D\x7fE\xffF\tG"),
+        "log line {:?} does not match the rsync 3.5.0 rendering",
+        String::from_utf8_lossy(&line)
+    );
+}
+
+/// upstream: log.c:131 passes a fixed `use_isprint = 0, escape_c1 = 1` pair, so
+/// the log-file rendering is identical with and without `--8-bit-output`. A
+/// name-supplied control byte must not become raw just because `-8` was given.
+#[test]
+fn log_file_escaping_is_not_weakened_by_eight_bit_output() {
+    let tmp = evil_named_tree();
+    let plain = name_line(&log_bytes(tmp.path(), "dst", &[]));
+    let eight_bit = name_line(&log_bytes(tmp.path(), "dst8", &["-8"]));
+    let strip_prefix = |line: Vec<u8>| {
+        let start = line
+            .windows(ESCAPED_LEADER.len())
+            .position(|window| window == ESCAPED_LEADER)
+            .expect("escaped name leader");
+        line[start..].to_vec()
+    };
+    assert_eq!(strip_prefix(plain), strip_prefix(eight_bit));
+}
+
+/// No raw `ESC` or C1 byte may reach the log file anywhere - not just on the
+/// itemize line - or an attacker-chosen name could rewrite what the operator
+/// sees for surrounding entries.
+#[test]
+fn log_file_contains_no_raw_escape_or_c1_bytes() {
+    let tmp = evil_named_tree();
+    for extra in [&[][..], &["-8"][..]] {
+        let dest = if extra.is_empty() { "dst" } else { "dst8" };
+        let log = log_bytes(tmp.path(), dest, extra);
+        assert!(
+            !log.iter()
+                .any(|&byte| byte == 0x1B || (0x80..=0x9F).contains(&byte)),
+            "raw ESC or C1 byte reached the log: {:?}",
+            String::from_utf8_lossy(&log)
+        );
+        // Exactly one line for the entry: an embedded LF must have been escaped
+        // rather than splitting the record in two.
+        assert_eq!(
+            name_lines(&log).len(),
+            1,
+            "the embedded newline split the log record"
+        );
+    }
+}


### PR DESCRIPTION
## Upstream rule

rsync 3.5.0 filters every log-file line in `logit()` before it reaches `logfile_fp`:

```c
int len = strlen(buf);
char trailing = len && (buf[len-1] == '\n' || buf[len-1] == '\r') ? buf[--len] : '\0';
fprintf(logfile_fp, "%s [%d] ", timestring(time(NULL)), (int)getpid());
filtered_fwrite(logfile_fp, buf, len, 0, 1, trailing);
```

(`log.c:126-131`; 3.4.4 wrote the message raw with a single `fprintf`.) The `0, 1` pair
is `use_isprint = 0, escape_c1 = 1`, so `filtered_fwrite` (`log.c:242-263`) escapes as
`\#ooo`:

* every byte below `0x20` except tab - covering `LF` and `ESC`;
* the C1 range `0x80-0x9F` - covering the 8-bit `CSI` (`0x9B`);
* a literal backslash that begins a `\#DDD` sequence, to keep the escape unambiguous.

Everything else is copied verbatim, notably `DEL` (`0x7F`) and `0xA0-0xFF`, so a
non-UTF-8 filename stays readable in the log. The line's own trailing newline is
written raw via `end_char`. The pair is fixed - unlike the terminal sink
(`log.c:425`, `filtered_fwrite(f, buf, len, !allow_8bit_chars, 0, ...)`), it is not
reachable from `--8-bit-output`. The syslog branch of `logit()` is unaffected.

## Measured behaviour before this change

Filename `A<ESC>B<LF>C<0x9B>D<DEL>E<0xFF>F<TAB>G`, transferred with
`--log-file --log-file-format='%i %n'` against `rsync 3.5.0` and `oc-rsync`:

| byte | 3.5.0 log (default and `-8`) | oc log, default | oc log, `-8` |
|------|------------------------------|-----------------|--------------|
| `ESC` 0x1B | `\#033` | `\#033` | `\#033` |
| `LF` 0x0A | `\#012` | `\#012` | `\#012` |
| `CSI` 0x9B | `\#233` | `\#233` | **raw** |
| `DEL` 0x7F | raw | **`\#177`** | raw |
| 0xFF | raw | **`\#377`** | raw |
| `TAB` | raw | raw | raw |

oc-rsync escapes filenames at the format layer and hands the same bytes to stdout and
to the log file, so the log file inherited the terminal rule. Two divergences follow:
the default log over-escapes `DEL` and `0xA0-0xFF`, and under `-8` the C1 range reaches
the log raw - a filename carrying the 8-bit CSI can drive the terminal of an operator
who later `cat`s the log (CWE-117). Sub-`0x20` controls were already escaped in both
modes, so raw `LF`/`ESC` log injection was already closed.

## Change

Carry the two `filtered_fwrite` switches as an `EscapeStyle` rather than the
`--8-bit-output` flag alone, and resolve the pair per sink:

* stdout/stderr: `EscapeStyle::terminal(allow_8bit)` - unchanged rendering;
* the log file: `EscapeStyle::log_file()` - the fixed `use_isprint = 0, escape_c1 = 1`
  pair, which the `-8` flag no longer reaches.

`--log-file` output is now byte-identical to rsync 3.5.0 in both modes (re-measured
after the change). stdout output is untouched.

## Tests

* `crates/cli/src/frontend/escape.rs` - a class-level guard walking all 256 byte values
  against the upstream predicate, plus per-class cases for the controls, C1, DEL, high
  bytes, tab, and the `\#DDD` disambiguation.
* `crates/cli/tests/log_file_control_char_escape.rs` - end-to-end through the binary:
  the log rendering matches the 3.5.0 bytes, is identical with and without `-8`, and no
  raw `ESC` or C1 byte reaches the log.

Negative control: with only the new test file applied to the current `master`, all three
end-to-end tests fail, reporting exactly the two divergences above. No existing test
pinned the old rendering - nothing went red.

## Verification

Run on Linux (aarch64):

```
cargo fmt --all -- --check                                                    clean
cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings   clean
cargo nextest run -p logging -p logging-sink -p cli --all-features            4311 passed, 4 skipped
```

## Platform split of the end-to-end fixture

macOS/APFS rejects a filename holding a byte sequence that is not valid UTF-8, failing
`write(2)` with `EILSEQ`. The fixture is therefore split by what the host filesystem can
name, with no assertion weakened on either side:

* Every Unix runs `PORTABLE_NAME`, which spells the C1 `CSI` as the UTF-8 encoding of
  U+009B (`c2 9b`) and the high byte as U+00FF (`c3 bf`). The raw `0x9B` is still
  physically in the filename, so `escape_c1` is genuinely exercised everywhere, while
  `c2`, `c3` and `bf` all sit above `0x9F` and so keep the "no byte in `0x80-0x9F`
  reaches the log" assertion non-vacuous.
* Linux additionally runs `NON_UTF8_NAME`, whose *lone* invalid bytes no
  UTF-8-enforcing filesystem can hold. That module covers the one claim the portable
  fixture cannot make: that a non-UTF-8 name stays readable in the log.

Non-vacuity of the portable half was measured, not assumed, by restoring the pre-fix
terminal rule at both log-file call sites and rebuilding:

| pre-fix rule | log rendering of the fixture | portable tests failing |
| --- | --- | --- |
| `terminal(true)` (under `-8`) | `A\#033B\#012C` + raw `0x9B` + `D` + raw `0x7F` + `E...` | rendering, no-raw-C1 |
| `terminal(false)` (default) | `A\#033B\#012C\#302\#233D\#177E\#303\#277F\tG` | rendering |

A raw `0x9B` reaching the log file is the CWE-117 leak this change closes, so that
assertion reproduces the defect itself rather than a proxy for it.

One limit stated explicitly: the `-8`-invariance test cannot be failed by a static
probe, since both of its legs use whichever single style is pinned. Its non-vacuity
follows from the two probes rendering the same name differently while the pre-fix code
chose between them on exactly `-8`; it was not reproduced directly, because doing so
would mean re-adding the `eight_bit_output` field this change removes from
`EmitLogOutputParams`.

## Out of scope (separate findings, not addressed here)

* The daemon `log file` sink writes module names, usernames and other peer-supplied
  strings without going through this escape layer; the client `--log-file` path is what
  this change covers.
* On stdout at default verbosity oc escapes `DEL` as `\#177` where the reference binary
  leaves it raw. That comes from upstream's iconv branch of `rwrite()`
  (`log.c:396-421`), which oc has no counterpart for; it is pre-existing and unchanged
  by this PR.

