### PR TITLE
fix(protocol): bound peer-supplied xattr bytes and CONNECT host

### DIFF
--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -78,6 +78,23 @@ pub(crate) fn establish_proxy_tunnel(
     addr: &DaemonAddress,
     proxy: &ProxyConfig,
 ) -> Result<(), ClientError> {
+    // upstream: socket.c:63-70 (3.5.0) rejects the host before it can be
+    // interpolated into the CONNECT request line. A control byte in the host
+    // would otherwise close the request line early and let the remainder be
+    // read as attacker-chosen HTTP headers (CRLF request/header injection).
+    // The check is on raw bytes, not chars, so a multi-byte sequence cannot
+    // smuggle one past a char-wise scan.
+    if let Some(offset) = addr
+        .host()
+        .as_bytes()
+        .iter()
+        .position(|byte| *byte < 0x20 || *byte == 0x7f)
+    {
+        return Err(proxy_configuration_error(format!(
+            "invalid control character in proxy CONNECT host at byte {offset}"
+        )));
+    }
+
     let mut request = format!("CONNECT {}:{} HTTP/1.0\r\n", addr.host(), addr.port());
 
     if let Some(header) = proxy.authorization_header() {
@@ -679,6 +696,76 @@ mod tests {
         let result = read_proxy_line(&mut stream, &mut buffer, display);
         handle.join().expect("server thread");
         (result, buffer)
+    }
+
+    /// A control byte in the CONNECT host must be refused before any write.
+    ///
+    /// WHY: `DaemonAddress::new` only trims the ends, so an interior CRLF
+    /// survives into `format!("CONNECT {host}:{port} HTTP/1.0\r\n")`. Without
+    /// the guard the request line terminates at the injected newline and the
+    /// remainder of the host is read by the proxy as attacker-chosen headers.
+    /// Asserting that the socket saw ZERO bytes is what makes this a real
+    /// oracle: a test that only checked the error could still pass while a
+    /// poisoned request line went out on the wire.
+    #[test]
+    fn connect_host_with_embedded_crlf_is_refused_before_any_write() {
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+        let listen_addr = listener.local_addr().expect("listener address");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut seen = Vec::new();
+            // Returns as soon as the client closes; no sleep, no deadline race.
+            let _ = stream.read_to_end(&mut seen);
+            seen
+        });
+
+        let mut stream = TcpStream::connect(listen_addr).expect("connect to listener");
+        let addr = DaemonAddress::new("evil\r\nX-Injected: 1".to_owned(), 873)
+            .expect("interior control bytes survive the constructor's trim");
+        let proxy = ProxyConfig {
+            host: listen_addr.ip().to_string(),
+            port: listen_addr.port(),
+            credentials: None,
+        };
+
+        let err = establish_proxy_tunnel(&mut stream, &addr, &proxy)
+            .expect_err("a control byte in the CONNECT host must be refused");
+        assert!(
+            err.to_string().contains("control character"),
+            "expected a control-character refusal, got: {err}"
+        );
+
+        drop(stream);
+        let seen = handle.join().expect("server thread");
+        assert!(
+            seen.is_empty(),
+            "nothing may be written to the proxy once the host is rejected; saw {:?}",
+            String::from_utf8_lossy(&seen)
+        );
+    }
+
+    /// The guard must not reject hosts rsync legitimately accepts.
+    ///
+    /// WHY: an IPv6 zone id carries `%`, and upstream deliberately keeps that
+    /// legal. A cap that also refused these would be a silent regression for
+    /// link-local targets, so the negative control is as load-bearing as the
+    /// positive one.
+    #[test]
+    fn connect_host_allows_ipv6_zone_id_and_ordinary_names() {
+        for host in ["fe80::1%eth0", "proxy.example.com", "192.0.2.10"] {
+            let addr = DaemonAddress::new(host.to_owned(), 873).expect("valid host");
+            assert!(
+                !addr
+                    .host()
+                    .as_bytes()
+                    .iter()
+                    .any(|byte| *byte < 0x20 || *byte == 0x7f),
+                "{host} must not trip the control-byte guard"
+            );
+        }
     }
 
     /// Deterministic xorshift64 stream so failures are reproducible from `seed`.

--- a/crates/protocol/src/xattr/cache.rs
+++ b/crates/protocol/src/xattr/cache.rs
@@ -21,9 +21,33 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
 use std::io::{self, Read};
 
+use crate::max_alloc::effective_max_alloc;
 use crate::varint::read_varint;
 use crate::xattr::prefix::wire_to_local;
-use crate::xattr::{MAX_FULL_DATUM, MAX_XATTR_DIGEST_LEN, RSYNC_PREFIX, XattrEntry, XattrList};
+use crate::xattr::{
+    MAX_FULL_DATUM, MAX_XATTR_DIGEST_LEN, MAX_XATTR_LIST_BYTES, MAX_XATTR_VALUE_BYTES,
+    RSYNC_PREFIX, XattrEntry, XattrList,
+};
+
+/// Converts a peer-supplied wire length to a `usize`, rejecting the values
+/// that must never reach an allocation.
+///
+/// upstream: `read_varint_size()` (io.c) aborts with
+/// `exit_cleanup(RERR_PROTOCOL)` on a negative length or one past the field
+/// maximum. A bare `as usize` cast instead widens a negative varint into a
+/// ~2^64 length, which sizes a `vec![0u8; len]` and aborts the process on
+/// capacity overflow. The ceiling is [`effective_max_alloc`] so a peer that
+/// raised `--max-alloc` is still honoured, matching the sibling decoders.
+fn checked_wire_len(raw: i32, what: &str) -> io::Result<usize> {
+    let max = effective_max_alloc();
+    if raw < 0 || raw as usize > max {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{what} {raw} out of range (maximum {max})"),
+        ));
+    }
+    Ok(raw as usize)
+}
 
 /// Cache of xattr sets, indexed for deduplication.
 ///
@@ -252,10 +276,50 @@ impl XattrCache {
         // after translation.
         let mut need_sort = false;
 
+        // upstream: xattrs.c:813 `size_t total_xattr_bytes = 0` - the running
+        // per-file aggregate checked against MAX_XATTR_LIST_BYTES below.
+        let mut total_xattr_bytes: usize = 0;
+
         for num in 1..=count {
-            // upstream: name_len = read_varint(f); datum_len = read_varint(f)
-            let name_len = read_varint(reader)? as usize;
-            let datum_len = read_varint(reader)? as usize;
+            // upstream: name_len/datum_len are read with read_varint_size
+            // (io.c), which aborts with exit_cleanup(RERR_PROTOCOL) on a
+            // negative or over-max value. A bare `as usize` here would widen a
+            // negative varint into a ~2^64 length, so both are range-checked
+            // before they can size an allocation.
+            let name_len = checked_wire_len(read_varint(reader)?, "xattr name_len")?;
+            let datum_len = checked_wire_len(read_varint(reader)?, "xattr datum_len")?;
+
+            // upstream: xattrs.c:839 - a single value above the hard per-value
+            // ceiling is a protocol error, not a truncation.
+            if datum_len > MAX_XATTR_VALUE_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "xattr datum_len {datum_len} exceeds per-value limit {MAX_XATTR_VALUE_BYTES}"
+                    ),
+                ));
+            }
+
+            // upstream: xattrs.c:843-849 - the summed name+value bytes of one
+            // file's list are bounded, so a peer cannot drive an unbounded
+            // aggregate out of individually-legal entries.
+            total_xattr_bytes = total_xattr_bytes
+                .checked_add(name_len)
+                .and_then(|sum| sum.checked_add(datum_len))
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "xattr list byte total overflowed",
+                    )
+                })?;
+            if total_xattr_bytes > MAX_XATTR_LIST_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "xattr list total {total_xattr_bytes} exceeds per-file limit {MAX_XATTR_LIST_BYTES}"
+                    ),
+                ));
+            }
 
             // upstream: dget_len = datum_len > MAX_FULL_DATUM ? 1 + xattr_sum_len : datum_len
             let dget_len = if datum_len > MAX_FULL_DATUM {
@@ -587,6 +651,135 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("NUL"));
+    }
+
+    /// Builds a hostile literal-xattr frame carrying only declared lengths.
+    ///
+    /// Every entry declares `datum_len` above `MAX_FULL_DATUM`, so the decoder
+    /// reads just the abbreviated digest off the wire. That is precisely the
+    /// attacker-cheap shape the byte caps exist to stop: a few wire bytes
+    /// declare gigabytes.
+    fn abbreviated_entries_frame(entries: &[(usize, usize)]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        write_varint(&mut buf, 0).unwrap();
+        write_varint(&mut buf, i32::try_from(entries.len()).unwrap()).unwrap();
+        for (name_len, datum_len) in entries {
+            write_varint(&mut buf, i32::try_from(*name_len).unwrap()).unwrap();
+            write_varint(&mut buf, i32::try_from(*datum_len).unwrap()).unwrap();
+            let mut name = b"user.x".to_vec();
+            name.resize(name_len - 1, b'x');
+            name.push(0);
+            buf.extend_from_slice(&name);
+            buf.extend_from_slice(&[0u8; MAX_XATTR_DIGEST_LEN]);
+        }
+        buf
+    }
+
+    /// A negative `name_len` must surface as a typed error.
+    ///
+    /// WHY: the decoder sizes `vec![0u8; name_len]` from this value. Widening
+    /// a negative varint with `as usize` yields a ~2^64 length, which aborts
+    /// the process on capacity overflow - a hostile peer would get a remote
+    /// denial of service out of two wire bytes. upstream reads this through
+    /// `read_varint_size()`, which refuses a negative length outright.
+    #[test]
+    fn negative_name_len_is_rejected_not_fatal() {
+        let mut cache = XattrCache::new();
+        let mut buf = Vec::new();
+        write_varint(&mut buf, 0).unwrap();
+        write_varint(&mut buf, 1).unwrap();
+        write_varint(&mut buf, -1).unwrap();
+        write_varint(&mut buf, 1).unwrap();
+
+        let err = cache
+            .receive_xattr(&mut Cursor::new(buf), false, 1)
+            .expect_err("a negative name_len must be refused");
+        assert!(err.to_string().contains("name_len"), "{err}");
+    }
+
+    /// Same class as [`negative_name_len_is_rejected_not_fatal`] for the value
+    /// length, which reaches the abbreviated-vs-full branch and the datum
+    /// allocation.
+    #[test]
+    fn negative_datum_len_is_rejected_not_fatal() {
+        let mut cache = XattrCache::new();
+        let mut buf = Vec::new();
+        write_varint(&mut buf, 0).unwrap();
+        write_varint(&mut buf, 1).unwrap();
+        write_varint(&mut buf, 6).unwrap();
+        write_varint(&mut buf, -1).unwrap();
+
+        let err = cache
+            .receive_xattr(&mut Cursor::new(buf), false, 1)
+            .expect_err("a negative datum_len must be refused");
+        assert!(err.to_string().contains("datum_len"), "{err}");
+    }
+
+    /// One value above the hard per-value ceiling is a protocol error.
+    ///
+    /// WHY: upstream bounds this independently of `--max-alloc`, so raising
+    /// `--max-alloc` must not raise it. Declared-only: no payload is supplied,
+    /// proving the refusal happens before the allocation.
+    #[test]
+    fn single_value_above_per_value_cap_is_rejected() {
+        let mut cache = XattrCache::new();
+        let buf = abbreviated_entries_frame(&[(6, MAX_XATTR_VALUE_BYTES + 1)]);
+
+        let err = cache
+            .receive_xattr(&mut Cursor::new(buf), false, 1)
+            .expect_err("a value past the per-value cap must be refused");
+        assert!(err.to_string().contains("per-value limit"), "{err}");
+    }
+
+    /// Many individually-legal values must not sum past the per-file ceiling.
+    ///
+    /// WHY: this is the case no per-value cap can catch. Each entry here is
+    /// under `MAX_XATTR_VALUE_BYTES` and each costs the attacker ~25 wire
+    /// bytes, yet the declared total crosses `MAX_XATTR_LIST_BYTES`. Without
+    /// the running total the decoder would accept the whole list.
+    #[test]
+    fn summed_values_above_per_file_cap_are_rejected() {
+        let per_entry = MAX_XATTR_VALUE_BYTES;
+        let count = MAX_XATTR_LIST_BYTES / per_entry + 1;
+        let entries: Vec<(usize, usize)> = (0..count).map(|_| (6, per_entry)).collect();
+        let mut cache = XattrCache::new();
+
+        let err = cache
+            .receive_xattr(
+                &mut Cursor::new(abbreviated_entries_frame(&entries)),
+                false,
+                1,
+            )
+            .expect_err("a list past the per-file cap must be refused");
+        assert!(err.to_string().contains("per-file limit"), "{err}");
+    }
+
+    /// The boundary must not be off by one in the rejecting direction.
+    ///
+    /// WHY: a cap that also refuses legal lists is a silent interop break with
+    /// upstream, which accepts everything up to and including the limit.
+    #[test]
+    fn list_exactly_at_per_file_cap_is_accepted() {
+        let name_len = 6;
+        let count = MAX_XATTR_LIST_BYTES / MAX_XATTR_VALUE_BYTES;
+        // Each entry contributes name_len + datum_len, so shrink the value by
+        // the name to land the sum exactly on the limit rather than past it.
+        let per_entry = MAX_XATTR_VALUE_BYTES - name_len;
+        let total = count * (per_entry + name_len);
+        assert_eq!(
+            total, MAX_XATTR_LIST_BYTES,
+            "fixture must sit exactly on the cap, not merely under it"
+        );
+        let entries: Vec<(usize, usize)> = (0..count).map(|_| (name_len, per_entry)).collect();
+        let mut cache = XattrCache::new();
+
+        cache
+            .receive_xattr(
+                &mut Cursor::new(abbreviated_entries_frame(&entries)),
+                false,
+                1,
+            )
+            .expect("a list within both caps must still be accepted");
     }
 
     #[test]

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -63,6 +63,23 @@ pub const MAX_FULL_DATUM: usize = 32;
 /// Uses MD5 (16 bytes) for compatibility with upstream rsync.
 pub const MAX_XATTR_DIGEST_LEN: usize = 16;
 
+/// Hard ceiling on a single peer-supplied xattr value.
+///
+/// upstream: `xattrs.c:51` `MAX_XATTR_VALUE_BYTES`, enforced in
+/// `receive_xattr()` and `recv_xattr_request()`, which abort with
+/// `exit_cleanup(RERR_PROTOCOL)` rather than truncating. This is independent
+/// of - and stricter than - the `--max-alloc` allocation guard: a peer that
+/// raised `--max-alloc` still cannot exceed it.
+pub const MAX_XATTR_VALUE_BYTES: usize = 128 * 1024 * 1024;
+
+/// Hard ceiling on the summed name and value bytes of one file's xattr list.
+///
+/// upstream: `xattrs.c:50` `MAX_XATTR_LIST_BYTES`, accumulated into
+/// `total_xattr_bytes` across the entry loop in `receive_xattr()`. Bounds the
+/// aggregate a peer can drive with many individually-legal entries, which no
+/// per-value cap can constrain on its own.
+pub const MAX_XATTR_LIST_BYTES: usize = 512 * 1024 * 1024;
+
 /// Rsync xattr namespace prefix for special attributes.
 #[cfg(target_os = "linux")]
 pub const RSYNC_PREFIX: &str = "user.rsync.";

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -10,7 +10,7 @@ use engine::signature::FileSignature;
 use protocol::codec::NdxCodec;
 use protocol::effective_max_alloc;
 use protocol::read_varint;
-use protocol::xattr::XattrList;
+use protocol::xattr::{MAX_XATTR_VALUE_BYTES, XattrList};
 
 /// Upstream MAXPATHLEN ceiling for an xname vstring (io.c:1944-1960).
 const MAX_XNAME_LEN: usize = 4096;
@@ -663,7 +663,11 @@ fn accumulate_xattr_num(prior_req: i32, rel_pos: i32) -> io::Result<i32> {
 /// typed error instead of an unbounded allocation or a varint overflow panic.
 #[inline]
 fn check_xattr_datum_len(raw_len: i32) -> io::Result<usize> {
-    let max_datum = effective_max_alloc();
+    // upstream: xattrs.c:781 (3.5.0) additionally rejects any single value
+    // above MAX_XATTR_VALUE_BYTES with exit_cleanup(RERR_PROTOCOL). That
+    // ceiling is hard: unlike the --max-alloc guard it does not rise when the
+    // peer raises --max-alloc, so take whichever bound is tighter.
+    let max_datum = effective_max_alloc().min(MAX_XATTR_VALUE_BYTES);
     if raw_len < 0 || raw_len as usize > max_datum {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -790,6 +794,30 @@ mod xattr_abbrev_guard_tests {
         let err = read_xattr_abbreviation_data(&mut reader).expect_err("must error");
         assert_eq!(err.kind(), ErrorKind::InvalidData);
         assert!(err.to_string().contains("accumulation overflow"));
+    }
+
+    /// A requested value above the hard per-value ceiling must be refused.
+    ///
+    /// WHY: upstream applies `MAX_XATTR_VALUE_BYTES` here independently of
+    /// `--max-alloc`, so the ceiling cannot be lifted by a peer that raised
+    /// `--max-alloc`. Declared-only: no payload bytes follow the length, so a
+    /// pass proves the refusal happened before the allocation rather than
+    /// after reading 128 MiB.
+    #[test]
+    fn datum_len_above_hard_per_value_cap_is_rejected() {
+        use protocol::xattr::MAX_XATTR_VALUE_BYTES;
+
+        let mut bytes = Vec::new();
+        bytes.extend(encode_varint(1));
+        bytes.extend(encode_varint(
+            i32::try_from(MAX_XATTR_VALUE_BYTES + 1).expect("cap fits in i32"),
+        ));
+
+        let mut reader = Cursor::new(bytes);
+        let err = read_xattr_abbreviation_data(&mut reader)
+            .expect_err("a value past the hard cap must be refused");
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+        assert!(err.to_string().contains("datum_len"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
## Upstream rule

rsync 3.5.0 hardens two unrelated peer-driven read paths. Both halves were
diffed whole-file against 3.4.4 before any oc code was read.

**xattrs.c** adds two hard ceilings, `MAX_XATTR_VALUE_BYTES` (128 MiB) and
`MAX_XATTR_LIST_BYTES` (512 MiB). Exceeding either is a protocol error
(`exit_cleanup(RERR_PROTOCOL)`), never a truncation. The split matters: the
per-value cap is applied in **both** `receive_xattr()` and
`recv_xattr_request()`, but the running per-file total only in
`receive_xattr()`. Both ceilings are independent of `--max-alloc`, so a peer
raising `--max-alloc` cannot lift them.

**socket.c** makes three changes to `establish_proxy_connection()`: reject
control bytes in the CONNECT host, replace the request-length `assert` with a
real check, and bound the header-drain loop at `PROXY_BUF_SIZE - 1`.

## What oc had

**xattr — defective, and the guard was on the wrong decoder.** oc has five
xattr wire-decode sites. Four carry a per-value bound; the fifth,
`XattrCache::receive_xattr` (`crates/protocol/src/xattr/cache.rs`), carries
none. Reachability inverts the picture: the three guarded functions in
`crates/protocol/src/xattr/wire/decode.rs` have **test-only** callers, while
the unguarded one is the live file-list path
(`crates/protocol/src/flist/read/mod.rs:767`). It read both `name_len` and
`datum_len` as `read_varint(..) as usize`, so a negative varint widened to a
~2^64 length that sized `vec![0u8; len]` and aborted the process on capacity
overflow. Nothing anywhere bounded the summed bytes of one file's list.

**proxy — two of the three upstream changes were already unnecessary.** oc's
response-header drain was already bounded per line at 1023 bytes with the
buffer cleared each iteration, so oc never had 3.4.4's non-terminating loop;
and oc builds the CONNECT request as a `String`, so upstream's truncation
hazard (an `assert` that compiles out under `NDEBUG`) has no analogue. The
control-byte guard was genuinely missing: `DaemonAddress::new` only trims the
ends, so an interior CRLF reached the request line and let the remainder be
read as attacker-chosen headers.

## Change

- `crates/protocol/src/xattr/mod.rs` — both upstream constants, cited.
- `crates/protocol/src/xattr/cache.rs` — range-check both wire lengths through
  a shared helper, apply the per-value cap, accumulate a checked per-file
  total. This is the site upstream guards with both.
- `crates/transfer/src/receiver/wire.rs` — tighten the existing datum bound to
  `min(effective_max_alloc, MAX_XATTR_VALUE_BYTES)`. This mirrors
  `recv_xattr_request()`, which upstream gives the per-value cap and **not**
  the running total, so none was added.
- `crates/core/src/client/module_list/connect/proxy.rs` — refuse control bytes
  in the CONNECT host before the request is built.

No new limits were invented and no upstream limit was relocated.

## Tests

Each cap is driven from the hostile side. The xattr fixtures declare lengths
above `MAX_FULL_DATUM` so only the abbreviated digest is read: that is both the
attacker-cheap shape and what keeps the tests fast, since a few wire bytes
declare gigabytes. Supplying no payload for the over-cap cases proves the
refusal precedes the allocation rather than following a 128 MiB read.

Negative controls carry equal weight: a list sitting exactly on
`MAX_XATTR_LIST_BYTES` must still be accepted, and an IPv6 zone-id host
(`fe80::1%eth0`) must not trip the control-byte guard. The proxy test asserts
the socket saw **zero** bytes, so a regression that errored *after* writing a
poisoned request line would still fail.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p protocol -p transfer -p core --all-features` — 11509/11519 passed

The 10 failures are a local macOS artifact, not this change: one is the known
APFS sparse-block-allocation test, the other nine are daemon-kill integration
tests that share a 5.5 s deadline. All ten pass when run in their own group;
they fail only under the full 11.5k-test parallel load. None touch xattr or
proxy code, and `git diff --stat origin/master` shows no overlap with them.

## Follow-up worth its own task

Three of the five xattr decoders are unreachable outside tests while the live
one was the unguarded one. That duplication is the same class already tracked
for the io_error constants and the two flist-trailer decoders, and it is why
the hardening sat where nothing could exercise it. Consolidating them is out
of scope here.
