### PR TITLE
fix(filters): mirror upstream's clear-list token boundary exactly

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/entry.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/entry.rs
@@ -9,6 +9,7 @@ use std::ffi::OsStr;
 use core::client::{FilterRuleKind, FilterRuleSpec};
 use core::message::{Message, Role};
 use core::rsync_error;
+use filters::{ClearToken, classify_clear_token};
 
 use super::super::directive::FilterDirective;
 use super::directives::{parse_dir_merge_alias, parse_long_merge_directive};
@@ -68,11 +69,14 @@ pub(crate) fn parse_old_prefix_rule(
     }
 
     let bytes = line.as_bytes();
-    // upstream: `*s == '!'` triggers FILTRULE_CLEAR_LIST tentatively. Any
-    // trailing non-whitespace then turns the rule back into a pattern, so
-    // we honor `!` (optionally followed by whitespace) as a clear and let
-    // `!pattern` fall through to the default rule kind.
-    if bytes[0] == b'!' && (line.len() == 1 || line[1..].trim().is_empty()) {
+    // upstream: exclude.c parse_rule_tok() XFLG_OLD_PREFIXES branch - `*s ==
+    // '!'` sets FILTRULE_CLEAR_LIST tentatively WITHOUT advancing `s`, so the
+    // later `if (len > 1) rule->rflags &= ~FILTRULE_CLEAR_LIST` measures the
+    // whole line. Only a line that is exactly `!` stays a clear; anything
+    // longer - including `! ` - is demoted back to a literal pattern. The
+    // trailing-characters error cannot fire here, because its guard excludes
+    // XFLG_OLD_PREFIXES.
+    if line == "!" {
         return Ok(FilterDirective::Clear);
     }
 
@@ -119,23 +123,20 @@ pub(super) fn parse_rule_directive(text: &str) -> Result<FilterDirective, Messag
         return Ok(FilterDirective::Noop);
     }
 
-    if let Some(remainder) = trimmed.strip_prefix('!') {
-        if remainder.trim().is_empty() {
-            return Ok(FilterDirective::Clear);
+    // upstream: exclude.c parse_rule_tok() - both the bare `!` and the `clear`
+    // long name set FILTRULE_CLEAR_LIST, and both leave exactly one character
+    // for the shared `if (*s) s++` to step over, so a lone trailing space is
+    // already "trailing characters". `RULE_STRCMP` is a case-sensitive strncmp
+    // reached only via `case 'c'`, so `CLEAR`/`Clear` are not the directive and
+    // fall through to "Unknown filter rule".
+    match classify_clear_token(trimmed.as_bytes()) {
+        ClearToken::Clear => return Ok(FilterDirective::Clear),
+        ClearToken::TrailingCharacters => {
+            let message = rsync_error!(1, "'!' rule has trailing characters: {}", trimmed)
+                .with_role(Role::Client);
+            return Err(message);
         }
-
-        let message = rsync_error!(1, "'!' rule has trailing characters: {}", trimmed)
-            .with_role(Role::Client);
-        return Err(message);
-    }
-
-    // upstream: exclude.c:1139 RULE_STRCMP(s, "clear") is a case-sensitive
-    // strncmp reached only via `case 'c'`, so `CLEAR`/`Clear` are not the clear
-    // directive - they fall through to the inner switch default and raise
-    // "Unknown filter rule". Match the exact lowercase keyword, matching the
-    // merge-file path (merge/parse.rs parse_rule_line).
-    if trimmed == "clear" {
-        return Ok(FilterDirective::Clear);
+        ClearToken::NotClearToken => {}
     }
 
     if is_cvs_convenience_rule(trimmed) {

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -662,23 +662,33 @@ fn old_prefix_plus_space_flips_to_include() {
     }
 }
 
+/// Only a line that is exactly `!` clears under the old-prefix options.
+///
+/// upstream: exclude.c parse_rule_tok() XFLG_OLD_PREFIXES branch - `*s == '!'`
+/// sets FILTRULE_CLEAR_LIST but does NOT advance `s`, so the later
+/// `if (len > 1) rule->rflags &= ~FILTRULE_CLEAR_LIST` measures the whole line
+/// and demotes anything longer back to a literal pattern. `! ` is a pattern
+/// spelled "! ", not a clear; rsync 3.5.0 keeps a `keep2.txt` exclude standing
+/// across `--exclude='! '` for exactly this reason.
 #[test]
-fn old_prefix_bang_emits_clear() {
+fn old_prefix_clear_requires_an_exact_bang() {
     assert!(matches!(
         parse_old_prefix_rule("!", FilterRuleKind::Exclude).unwrap(),
         FilterDirective::Clear
     ));
-    assert!(matches!(
-        parse_old_prefix_rule("!   ", FilterRuleKind::Exclude).unwrap(),
-        FilterDirective::Clear
-    ));
+    for line in ["! ", "!  ", "!\t", "!   "] {
+        match parse_old_prefix_rule(line, FilterRuleKind::Exclude).unwrap() {
+            FilterDirective::Rule(spec) => assert_eq!(spec.pattern(), line),
+            other => panic!("`{line}` must be a literal pattern, got {other:?}"),
+        }
+    }
 }
 
 #[test]
 fn old_prefix_bang_with_pattern_is_raw_pattern() {
-    // upstream: `!pattern` (no space) is NOT a clear - it's the raw
-    // pattern because XFLG_OLD_PREFIXES only recognizes `!` as clear
-    // when followed by whitespace or end-of-line.
+    // upstream: `!pattern` is NOT a clear - `len > 1` demotes the tentative
+    // FILTRULE_CLEAR_LIST back to a literal pattern. Whitespace does not
+    // rescue it either; see old_prefix_clear_requires_an_exact_bang.
     let result = parse_old_prefix_rule("!keepme", FilterRuleKind::Exclude).unwrap();
     match result {
         FilterDirective::Rule(spec) => {
@@ -868,4 +878,129 @@ fn lowercase_modifiers_and_uppercase_prefixes_still_parse() {
         FilterDirective::Rule(spec) => assert_eq!(spec.kind(), FilterRuleKind::Protect),
         other => panic!("expected protect Rule, got {other:?}"),
     }
+}
+
+/// Every spelling the clear-list token can take, and what upstream rsync 3.5.0
+/// does with it in the two parser contexts this module owns.
+///
+/// The grid is the guard: the token has two spellings (`!` and `clear`), two
+/// separators (whitespace and `_`) that do NOT rescue it, one (`,`) that does,
+/// and two contexts whose rules genuinely differ - so a handful of cases would
+/// not pin it. Expectations were measured against a locally built rsync 3.5.0.
+///
+/// upstream: exclude.c parse_rule_tok() - the full-syntax branch runs
+/// `if (*s) s++` and then errors on any remaining `len`, while the
+/// XFLG_OLD_PREFIXES branch never errors and instead demotes on `len > 1`.
+const CLEAR_TOKEN_GRID: &[(&str, FullSyntax, OldPrefix)] = &[
+    ("!", FullSyntax::Clear, OldPrefix::Clear),
+    ("!,", FullSyntax::Clear, OldPrefix::Pattern),
+    ("! ", FullSyntax::TrailingCharacters, OldPrefix::Pattern),
+    ("!  ", FullSyntax::TrailingCharacters, OldPrefix::Pattern),
+    ("!_", FullSyntax::TrailingCharacters, OldPrefix::Pattern),
+    ("!x", FullSyntax::TrailingCharacters, OldPrefix::Pattern),
+    ("!,x", FullSyntax::TrailingCharacters, OldPrefix::Pattern),
+    ("!clear", FullSyntax::TrailingCharacters, OldPrefix::Pattern),
+    ("clear", FullSyntax::Clear, OldPrefix::Pattern),
+    ("clear ", FullSyntax::TrailingCharacters, OldPrefix::Pattern),
+    (
+        "clear  ",
+        FullSyntax::TrailingCharacters,
+        OldPrefix::Pattern,
+    ),
+    ("clear_", FullSyntax::TrailingCharacters, OldPrefix::Pattern),
+    ("clear,", FullSyntax::Clear, OldPrefix::Pattern),
+    (
+        "clear,x",
+        FullSyntax::TrailingCharacters,
+        OldPrefix::Pattern,
+    ),
+    ("clearx", FullSyntax::Rejected, OldPrefix::Pattern),
+    ("Clear", FullSyntax::Rejected, OldPrefix::Pattern),
+];
+
+/// Outcome of a spelling in full `--filter` syntax.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FullSyntax {
+    /// Clears the list in scope.
+    Clear,
+    /// `'!' rule has trailing characters`, RERR_SYNTAX.
+    TrailingCharacters,
+    /// Not the clear token at all; rejected as an unrecognised rule.
+    Rejected,
+}
+
+/// Outcome of a spelling under `--exclude`/`--include` old-prefix parsing,
+/// where the trailing-characters error cannot fire.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OldPrefix {
+    /// Clears the list in scope.
+    Clear,
+    /// Demoted to a literal pattern equal to the whole line.
+    Pattern,
+}
+
+#[test]
+fn clear_token_grid_matches_upstream_in_full_filter_syntax() {
+    for (spelling, expected, _) in CLEAR_TOKEN_GRID {
+        let result = parse_filter_directive(OsStr::new(spelling));
+        match (expected, result) {
+            (FullSyntax::Clear, Ok(FilterDirective::Clear)) => {}
+            (FullSyntax::TrailingCharacters, Err(message)) => {
+                let rendered = message.to_string();
+                assert!(
+                    rendered.contains(&format!("'!' rule has trailing characters: {spelling}")),
+                    "`--filter={spelling}` must report trailing characters, got: {rendered}"
+                );
+            }
+            (FullSyntax::Rejected, Err(message)) => {
+                let rendered = message.to_string();
+                assert!(
+                    !rendered.contains("trailing characters"),
+                    "`--filter={spelling}` is not the clear token, so it must not \
+                     report trailing characters, got: {rendered}"
+                );
+            }
+            (expected, actual) => {
+                panic!("`--filter={spelling}`: expected {expected:?}, got {actual:?}")
+            }
+        }
+    }
+}
+
+#[test]
+fn clear_token_grid_matches_upstream_in_old_prefix_syntax() {
+    for (spelling, _, expected) in CLEAR_TOKEN_GRID {
+        let result = parse_old_prefix_rule(spelling, FilterRuleKind::Exclude)
+            .unwrap_or_else(|e| panic!("`--exclude={spelling}` must parse: {e}"));
+        match (expected, result) {
+            (OldPrefix::Clear, FilterDirective::Clear) => {}
+            (OldPrefix::Pattern, FilterDirective::Rule(spec)) => {
+                assert_eq!(
+                    spec.pattern(),
+                    *spelling,
+                    "`--exclude={spelling}` must keep the whole line as the pattern"
+                );
+            }
+            (expected, actual) => {
+                panic!("`--exclude={spelling}`: expected {expected:?}, got {actual:?}")
+            }
+        }
+    }
+}
+
+/// The grid must cover both spellings crossed with every separator class, so a
+/// row dropped from the table cannot silently shrink the guard.
+#[test]
+fn clear_token_grid_covers_both_spellings_and_every_separator() {
+    for token in ["!", "clear"] {
+        for suffix in ["", " ", "_", ",", "x"] {
+            let spelling = format!("{token}{suffix}");
+            assert!(
+                CLEAR_TOKEN_GRID.iter().any(|(s, _, _)| *s == spelling),
+                "clear-token grid is missing `{spelling}`"
+            );
+        }
+    }
+    // Both contexts must be exercised for every row.
+    assert!(CLEAR_TOKEN_GRID.len() >= 2 * 5);
 }

--- a/crates/filters/src/clear_token.rs
+++ b/crates/filters/src/clear_token.rs
@@ -1,0 +1,175 @@
+//! Recognition of the `!` clear-list token in full filter-rule syntax.
+//!
+//! Upstream accepts the clear-list token in two spellings - the bare `!`
+//! character and the `clear` long name - and is exact about what may follow
+//! each. Anything left over once the token has been consumed is a "trailing
+//! characters" syntax error, and that includes a single trailing space. The one
+//! exception is a comma, which introduces the (here always empty) modifier
+//! list, so both `!,` and `clear,` are valid clears.
+//!
+//! The same rule governs a `--filter` argument and a line inside a merge file,
+//! so it lives here rather than being restated at each call site.
+//!
+//! upstream: exclude.c `parse_rule_tok()`. The single-character spelling lands
+//! in the prefix switch's `default:` arm - `ch = *s; if (s[1] == ',') s++;` -
+//! and the long name goes through `RULE_STRCMP(s, "clear")`, whose comma arm
+//! returns `str + rule_len`. Either way `s` ends on the last consumed character
+//! and the shared `if (*s) s++` steps onto the remainder, whose length is the
+//! `len` that `"'!' rule has trailing characters"` tests. That is why the comma
+//! is tolerated identically by both spellings.
+
+/// The `clear` long name. upstream: exclude.c `RULE_STRCMP(s, "clear")`.
+const CLEAR_KEYWORD: &[u8] = b"clear";
+
+/// How a rule's text relates to the clear-list token.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ClearToken {
+    /// The text is exactly the clear-list token: clear the list in scope.
+    Clear,
+    /// The text names the clear-list token but has characters left over.
+    /// upstream reports `'!' rule has trailing characters` and exits
+    /// `RERR_SYNTAX`.
+    TrailingCharacters,
+    /// The text does not name the clear-list token; keep dispatching.
+    NotClearToken,
+}
+
+/// Whether `byte` separates a long rule name from what follows it.
+///
+/// upstream: exclude.c `rule_strcmp()` accepts `isspace()`, `_` or the end of
+/// the string after a keyword. `isspace()` in the C locale also covers the
+/// vertical tab, which Rust's `is_ascii_whitespace` omits, so the set is
+/// written out rather than borrowed.
+const fn is_name_separator(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t' | b'\n' | 0x0B | 0x0C | b'\r' | b'_')
+}
+
+/// Classifies `rule` against upstream's clear-list token.
+///
+/// `rule` is the raw rule text with no prefix stripped, as bytes - filter rules
+/// are byte strings, not required to be UTF-8.
+///
+/// upstream: exclude.c `parse_rule_tok()`. Both spellings leave `s` on the
+/// token's final character and then run `if (*s) s++`, so the remainder that
+/// decides the trailing-characters error is everything past the token - a lone
+/// separator included. `rule_strcmp()` returns `str + rule_len` (rather than
+/// `- 1`) for a comma, which makes the comma itself the character `s++` steps
+/// over, so `clear,` clears while `clear,x` does not.
+#[must_use]
+pub fn classify_clear_token(rule: &[u8]) -> ClearToken {
+    let remainder = match rule.first() {
+        // The bare `!` spelling consumes one character, plus a comma
+        // immediately after it. upstream: the prefix switch's `default:` arm
+        // does `ch = *s; if (s[1] == ',') s++;`.
+        Some(b'!') => {
+            let after_token = &rule[1..];
+            match after_token.first() {
+                Some(b',') => &after_token[1..],
+                _ => after_token,
+            }
+        }
+        _ => {
+            let Some(after_keyword) = rule.strip_prefix(CLEAR_KEYWORD) else {
+                return ClearToken::NotClearToken;
+            };
+            match after_keyword.first() {
+                None => after_keyword,
+                Some(b',') => &after_keyword[1..],
+                Some(&byte) if is_name_separator(byte) => after_keyword,
+                // Any other character means this is a different word that
+                // merely starts with "clear"; upstream falls through to
+                // "Unknown filter rule".
+                Some(_) => return ClearToken::NotClearToken,
+            }
+        }
+    };
+
+    if remainder.is_empty() {
+        ClearToken::Clear
+    } else {
+        ClearToken::TrailingCharacters
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClearToken, classify_clear_token};
+
+    fn classify(rule: &str) -> ClearToken {
+        classify_clear_token(rule.as_bytes())
+    }
+
+    #[test]
+    fn bare_token_clears_bare_or_with_a_lone_comma() {
+        assert_eq!(classify("!"), ClearToken::Clear);
+        // upstream: `if (s[1] == ',') s++` swallows one comma, exactly as the
+        // `clear` spelling does.
+        assert_eq!(classify("!,"), ClearToken::Clear);
+        // Anything else is left over - even a lone trailing space.
+        assert_eq!(classify("! "), ClearToken::TrailingCharacters);
+        assert_eq!(classify("!x"), ClearToken::TrailingCharacters);
+        assert_eq!(classify("!_"), ClearToken::TrailingCharacters);
+        assert_eq!(classify("!,x"), ClearToken::TrailingCharacters);
+        assert_eq!(classify("!,,"), ClearToken::TrailingCharacters);
+    }
+
+    /// Once a spelling IS recognised, both share the same `if (*s) s++` and the
+    /// same one-comma tolerance, so every separator suffix must classify alike.
+    #[test]
+    fn both_spellings_agree_on_every_separator() {
+        for suffix in ["", ",", " ", "_", ",x", ",,"] {
+            assert_eq!(
+                classify(&format!("!{suffix}")),
+                classify(&format!("clear{suffix}")),
+                "`!{suffix}` and `clear{suffix}` must classify alike"
+            );
+        }
+    }
+
+    /// The one place the spellings legitimately differ: a non-separator suffix.
+    ///
+    /// `!` is a single-character prefix, so it is always consumed and whatever
+    /// follows is trailing. `clear` is a keyword that upstream's `rule_strcmp()`
+    /// only accepts when a separator follows, so `clearx` is a different word
+    /// entirely and never reaches the clear-list branch.
+    #[test]
+    fn a_non_separator_suffix_separates_the_two_spellings() {
+        assert_eq!(classify("!x"), ClearToken::TrailingCharacters);
+        assert_eq!(classify("clearx"), ClearToken::NotClearToken);
+    }
+
+    #[test]
+    fn keyword_clears_bare_or_with_a_lone_comma() {
+        assert_eq!(classify("clear"), ClearToken::Clear);
+        // upstream: rule_strcmp() returns past the comma, so `s++` steps over
+        // it and nothing remains.
+        assert_eq!(classify("clear,"), ClearToken::Clear);
+        assert_eq!(classify("clear "), ClearToken::TrailingCharacters);
+        assert_eq!(classify("clear_"), ClearToken::TrailingCharacters);
+        assert_eq!(classify("clear,x"), ClearToken::TrailingCharacters);
+    }
+
+    #[test]
+    fn a_longer_word_is_not_the_keyword() {
+        // upstream: rule_strcmp() requires a separator, so these reach the
+        // prefix switch and become "Unknown filter rule".
+        assert_eq!(classify("clearx"), ClearToken::NotClearToken);
+        assert_eq!(classify("cle"), ClearToken::NotClearToken);
+        assert_eq!(classify(""), ClearToken::NotClearToken);
+        assert_eq!(classify("- x"), ClearToken::NotClearToken);
+    }
+
+    #[test]
+    fn classification_is_byte_oriented() {
+        // A non-UTF-8 rule must classify without going through a lossy
+        // conversion. upstream compares bytes.
+        assert_eq!(
+            classify_clear_token(&[b'!', 0xFF]),
+            ClearToken::TrailingCharacters
+        );
+        assert_eq!(
+            classify_clear_token(b"clear\xFF"),
+            ClearToken::NotClearToken
+        );
+    }
+}

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -106,6 +106,7 @@ pub mod apple_double;
 pub mod chain;
 /// Lexical `..` collapse for filter paths, mirroring `clean_fname()`.
 pub mod clean_fname;
+pub mod clear_token;
 mod compiled;
 /// CVS exclusion patterns for rsync's `--cvs-exclude` (`-C`) option.
 pub mod cvs;
@@ -127,6 +128,7 @@ pub use apple_double::{
 };
 pub use chain::{DirFilterGuard, DirMergeConfig, FilterChain, FilterChainError};
 pub use clean_fname::collapse_dot_dot_dirs;
+pub use clear_token::{ClearToken, classify_clear_token};
 pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -7,6 +7,7 @@
 use std::path::Path;
 
 use crate::FilterRule;
+use crate::clear_token::{ClearToken, classify_clear_token};
 
 use super::error::MergeFileError;
 
@@ -571,10 +572,21 @@ fn parse_rule_line(
     source_path: &Path,
     line_num: usize,
 ) -> Result<FilterRule, MergeFileError> {
-    // upstream: exclude.c:1139 RULE_STRCMP(s, "clear") is a case-sensitive
-    // strncmp, so `CLEAR`/`Clear` are not the clear directive.
-    if line == "!" || line == "clear" {
-        return Ok(FilterRule::clear());
+    // upstream: exclude.c parse_rule_tok() - the bare `!` and the `clear` long
+    // name are the two spellings of FILTRULE_CLEAR_LIST, and each leaves one
+    // character for `if (*s) s++`, so anything left over (a lone trailing space
+    // included) is a trailing-characters error. `RULE_STRCMP` is a
+    // case-sensitive strncmp, so `CLEAR`/`Clear` are not the directive.
+    match classify_clear_token(line.as_bytes()) {
+        ClearToken::Clear => return Ok(FilterRule::clear()),
+        ClearToken::TrailingCharacters => {
+            return Err(MergeFileError::parse_error(
+                source_path,
+                line_num,
+                format!("'!' rule has trailing characters: {line}"),
+            ));
+        }
+        ClearToken::NotClearToken => {}
     }
 
     if let Some(rule) = try_parse_short_form(line, source_path, line_num)? {

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -1159,3 +1159,108 @@ fn short_form_comma_not_after_prefix_is_invalid() {
 fn long_form_keyword_without_separator_is_unknown() {
     assert!(parse_rules("excludes foo", Path::new("test")).is_err());
 }
+
+/// Every clear-list spelling a merge-file line can take, and what upstream
+/// rsync 3.5.0 does with it.
+///
+/// A merge file runs the full rule syntax, so both the `!` and `clear`
+/// spellings are live and the trailing-characters error can fire - unlike the
+/// no-prefixes (`.cvsignore`) path, where `!` is a whitespace-delimited token
+/// and a longer one is simply a pattern. Expectations were measured against a
+/// locally built rsync 3.5.0.
+///
+/// upstream: exclude.c parse_rule_tok() - both spellings leave one character
+/// for `if (*s) s++`, so a lone trailing space is already trailing characters;
+/// `rule_strcmp()` steps past a comma instead, which is why `clear,` clears.
+const MERGE_CLEAR_TOKEN_GRID: &[(&str, bool)] = &[
+    ("!", true),
+    ("clear", true),
+    ("clear,", true),
+    ("!,", true),
+    ("! ", false),
+    ("!  ", false),
+    ("!_", false),
+    ("!x", false),
+    ("clear ", false),
+    ("clear  ", false),
+    ("clear_", false),
+    ("clear,x", false),
+    ("!,x", false),
+];
+
+#[test]
+fn merge_clear_token_grid_matches_upstream() {
+    for (line, clears) in MERGE_CLEAR_TOKEN_GRID {
+        let result = parse_rules(line, Path::new("test"));
+        if *clears {
+            let rules =
+                result.unwrap_or_else(|e| panic!("merge line `{line}` must parse as a clear: {e}"));
+            assert_eq!(rules.len(), 1, "merge line `{line}` must yield one rule");
+            assert_eq!(
+                rules[0].action(),
+                FilterAction::Clear,
+                "merge line `{line}` must clear the list"
+            );
+        } else {
+            let error = result
+                .err()
+                .unwrap_or_else(|| panic!("merge line `{line}` must be rejected"));
+            assert!(
+                error.to_string().contains("trailing characters"),
+                "merge line `{line}` must report trailing characters, got: {error}"
+            );
+        }
+    }
+}
+
+/// The grid must cross both spellings with every separator class, so a dropped
+/// row cannot silently shrink the guard.
+#[test]
+fn merge_clear_token_grid_covers_both_spellings_and_every_separator() {
+    for token in ["!", "clear"] {
+        for suffix in ["", " ", "_", ","] {
+            let line = format!("{token}{suffix}");
+            assert!(
+                MERGE_CLEAR_TOKEN_GRID.iter().any(|(l, _)| *l == line),
+                "merge clear-token grid is missing `{line}`"
+            );
+        }
+    }
+}
+
+/// A no-prefixes merge file (`.cvsignore` under `-C`, or a `:-` dir-merge) has
+/// no trailing-characters error at all: `!` is a plain token there and anything
+/// longer is a literal pattern.
+///
+/// upstream: exclude.c parse_rule_tok() - the FILTRULE_NO_PREFIXES branch is
+/// what rsync 3.5.0 fixed the guard to consult (`template->rflags`, not
+/// `rule->rflags`), which is precisely what suppresses the error on this path.
+#[test]
+fn no_prefixes_clear_token_never_reports_trailing_characters() {
+    let rules = parse_rules_no_prefixes("!\n", Path::new("test"), false, true, true);
+    assert_eq!(rules.len(), 1);
+    assert_eq!(
+        rules[0].action(),
+        FilterAction::Clear,
+        "a bare `!` token clears under -C"
+    );
+
+    // `!foo` is longer than the token, so upstream demotes it to a pattern
+    // rather than erroring.
+    let rules = parse_rules_no_prefixes("!foo\n", Path::new("test"), false, true, true);
+    assert_eq!(rules.len(), 1);
+    assert_ne!(
+        rules[0].action(),
+        FilterAction::Clear,
+        "`!foo` is a literal pattern, not a clear"
+    );
+
+    // Without CVS_IGNORE the `!` is not special at all.
+    let rules = parse_rules_no_prefixes("!\n", Path::new("test"), false, false, false);
+    assert_eq!(rules.len(), 1);
+    assert_ne!(
+        rules[0].action(),
+        FilterAction::Clear,
+        "`!` is literal without the C modifier"
+    );
+}


### PR DESCRIPTION
## A file the operator excluded gets shipped

```
--exclude=keep2.txt --exclude='! '

  rsync 3.5.0 :  keep2.txt stays EXCLUDED
  oc-rsync    :  keep2.txt is TRANSFERRED
```

That is the headline. This PR is filed under "filter parser", and three of its four fixes are exit codes and message text — but **this one changes which bytes leave the machine**. Upstream demotes `! ` to a literal pattern (`len > 1` un-does the tentative clear); oc trimmed the whitespace, treated it as a clear-list token, dropped the `keep2.txt` exclusion, and sent the file.

Its sibling is nearly as bad and equally silent:

```
--filter='! '   (and the identical line inside a merge file)

  rsync 3.5.0 :  exit 1, "'!' rule has trailing characters"
  oc-rsync    :  exit 0 — and the ENTIRE filter list is wiped, no diagnostic
```

A whole exclusion set can evaporate with nothing on stderr and a success exit code.

## The brief said oc was too strict. It is too permissive.

The task was "the `!` clear-list token in .cvsignore / -C must not abort with `'!' rule has trailing characters`" — i.e. go fix oc for aborting the way rsync 3.4.4 does.

**oc never had that bug, and this area is not fine.** Those two statements are both true and it is worth being explicit about it, because "oc already matches 3.5.0 on all 20 cvsignore cells" is exactly the sentence a future reader will misread as "nothing to see here". oc matches 3.5.0 on the path the brief named, and diverges — in the opposite direction, toward accepting what upstream rejects — on three paths it did not.

### Root cause, both halves at once

Upstream's bug was `rule->rflags` vs `template->rflags` at exclude.c:1468 (the same line in 3.4.4). `FILTRULE_NO_PREFIXES` is deliberately excluded from `FILTRULES_FROM_CONTAINER`, so it is never inherited into an individual rule and the guard was always false — which is why 3.4.4 aborted on a `.cvsignore` containing only `!`. **oc never had that inherited-flag structure, so it never had the bug — and that same structural difference is why oc's own boundary drifted the other way.** There was no shared `template`-vs-`rule` distinction to get wrong, and equally no single place where the token's exact extent was decided, so each of oc's three parsers grew its own approximation of it.

Upstream ships `testsuite/ki73-cvs-clear-list_test.py` documenting their half.

## The four divergences

| | rsync 3.5.0 | oc before |
|---|---|---|
| `--exclude=keep2.txt --exclude='! '` | keep2.txt stays **excluded** | keep2.txt **transferred** |
| `--filter='! '` (and merge-file line) | exit 1, trailing characters | exit 0, filter list silently wiped |
| `--filter='clear '` / `clear_` / `clear,x` | `'!' rule has trailing characters: ...` | generic `unsupported filter rule ...` |
| `--filter='clear,'`, `--filter='!,'` | **accepted**, clears the list | exit 1, rejected |

## Upstream rule

`exclude.c parse_rule_tok()`. The single-character spelling lands in the prefix switch's `default:` arm:

```c
default:
        ch = *s;
        if (s[1] == ',')
                s++;
        break;
```

and the long name goes through `RULE_STRCMP(s, "clear")` -> `rule_strcmp()` (exclude.c:1218-1227), whose comma arm returns `str + rule_len` rather than `- 1`. Either way `s` finishes on the last consumed character, and the shared `if (*s) s++` steps onto the remainder — whose length is the `len` the trailing-characters check tests. Hence a lone trailing space already errors, and exactly one comma does not, symmetrically for both spellings.

`rule_strcmp()`'s separator set is mirrored rather than approximated — `isspace()` (including the vertical tab, which `is_ascii_whitespace` omits), `_`, end-of-string, and the distinct `,` arm. **`clear,` is not special-cased as "tolerate a trailing comma".** The probe that shows the difference: `clear;` and `clear-` are *not* separators, so upstream treats them as a different word entirely and they must keep falling through to the unrecognised-rule path — which they do.

The `XFLG_OLD_PREFIXES` branch never advances `s` and its trailing-characters guard is disabled by construction; it demotes on `if (len > 1)` instead. So under `--exclude`/`--include`/`--exclude-from`, only a line that is exactly `!` clears.

## Change

The rule now lives once, in `filters::classify_clear_token`, byte-oriented because filter patterns are byte strings, not UTF-8. Its three call sites — the `--filter` parser, the merge-file line parser, and the old-prefix parser — stop restating it.

**The generic catch-all's coverage is not narrowed.** It loses exactly the cases that *are* the clear token and now get upstream's specific message. Measured before/after across `clearx`, `cle`, `Clear`, `CLEAR`, `bogus`, `zzz pat`, `clea`, `clearing`, `c`, `clear;`, `clear-`, `@ x`, `X pat`: **13/13 identical**, zero changed.

## Deliberately out of scope

`clearx` / `cle` / `Clear` get oc's generic unrecognised-rule message where upstream says `Unknown filter rule`, and `--filter='-!'` reports a different message for an empty pattern after a prefix. Both exit-code-identical, both the generic unknown-keyword family rather than the clear token; fixing them touches every keyword. Filed separately.

## A defect I caught in my own patch before shipping

My first classifier rejected `!,`. The C looked like it should. The 3.5.0 binary said otherwise — `!,` clears. That sent me back to the source and turned up the `if (s[1] == ',') s++;` line above, which is what makes the two spellings symmetric. Reasoning from the C alone would have shipped a false-reject.

## Tests

Grids, not cases — `{!, clear}` x `{end, comma, space, _, non-separator}` across all three contexts:

- `clear_token.rs` — the classifier's boundary table, a both-spellings-agree test over the separator suffixes, and a test for the one place they legitimately differ (`!x` is trailing because `!` is a one-char prefix always consumed; `clearx` is not the keyword at all).
- `crates/cli/.../parsing/tests.rs` — a 16-row grid crossed with full-filter and old-prefix outcomes, plus a completeness assertion.
- `crates/filters/src/merge/tests.rs` — the merge-file grid with its own completeness assertion, **plus a guard** that the no-prefixes (`.cvsignore`) path still never reports trailing characters, so this fix cannot drift onto the path that was already correct.

Four of the new tests fail against the pre-change parsers (verified by restoring `entry.rs` and `merge/parse.rs` from master and re-running):

```
merge line `clear,` must parse as a clear: Unknown filter rule: `clear,'
`! ` must be a literal pattern, got Clear
clear_token_grid_matches_upstream_in_full_filter_syntax  FAILED
clear_token_grid_matches_upstream_in_old_prefix_syntax   FAILED
```

### A test that encoded the defect

`old_prefix_bang_emits_clear` asserted that `!   ` parses as a clear — the behaviour upstream does not have. A neighbouring comment also stated the wrong rule ("`!` is a clear when followed by whitespace or end-of-line"), which is how the too-permissive trim got justified. Both corrected with the upstream reason, not merely re-pointed.

## Verification

```
cargo fmt --all -- --check                                                             clean
cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings   clean
cargo nextest run -p filters -p cli --all-features         5246 passed, 3 skipped
```

Expectations come from a locally built rsync 3.5.0 (`./configure --disable-openssl`), run as a three-way differential against 3.4.4 and oc.

**The fix does not disturb what already agreed.** All 20 cvsignore/`-C` cells — per-directory `.cvsignore`, `$HOME/.cvsignore`, `$CVSIGNORE`, word-split, subdirectory inheritance, CRLF, `!foo` demotion, `!!`, `:C` dir-merge, `-C` plus `:C` — matched 3.5.0 before this change and **still match after** (20/20, re-measured post-fix). rsync 3.4.4 aborts in 15 of them. Overall: **41/41 boundary cells and 39/40 transfer cells** now match 3.5.0, the one remainder being the out-of-scope `--filter='-!'` message.

Scope of what `!` clears, also measured and unchanged: a per-directory `.cvsignore` clears only that dir-merge's own list, while `$HOME/.cvsignore` and `$CVSIGNORE` clear the shared CVS list and so discard the built-in defaults.

No unsafe code; `crates/filters` remains unsafe-free.
