### PR TITLE
fix(receiver): --ignore-errors must gate the peer flist io_error, only

### DIFF
--- a/crates/batch/src/reader/flist.rs
+++ b/crates/batch/src/reader/flist.rs
@@ -160,7 +160,15 @@ impl BatchReader {
         // Capture any I/O error accumulated during flist reading.
         // upstream: flist.c:recv_file_list() does `io_error |= err` when the
         // sender reports errors, then breaks the loop without aborting.
-        self.io_error = flist_reader.io_error();
+        //
+        // Both contributions are taken unconditionally here. Upstream gates the
+        // PEER half on `!ignore_errors` (flist.c:2949/2967/3070), but the batch
+        // reader has no `ignore_errors` plumbed to it - the option belongs to the
+        // replay invocation, not to the recorded stream - so applying the gate
+        // would mean inventing a policy this layer cannot see. Behaviour is
+        // unchanged from before the peer/local split; the gate arrives with the
+        // batch-replay reunification.
+        self.io_error = flist_reader.peer_io_error() | flist_reader.local_io_error();
 
         // upstream: flist.c:2761-2763 - recv_id_list(f, flist) when !inc_recurse
         // The batch stream contains uid/gid name mapping lists after the flist
@@ -261,7 +269,9 @@ impl BatchReader {
             }
         }
 
-        self.io_error |= flist_reader.io_error();
+        // See the note on the initial-segment drain above: unconditional here
+        // because the batch reader has no `ignore_errors` to consult.
+        self.io_error |= flist_reader.peer_io_error() | flist_reader.local_io_error();
         // upstream: flist.c:2966 - ndx_start = prev->ndx_start + prev->used + 1
         // The current segment started at flist_next_ndx_start (set before
         // reset_for_new_segment). The next segment's ndx_start accounts for

--- a/crates/engine/src/delete/emitter/policy.rs
+++ b/crates/engine/src/delete/emitter/policy.rs
@@ -15,13 +15,16 @@ pub const EMITTER_VANISHED_EXIT_CODE: i32 = 24;
 
 /// Upstream `IOERR_GENERAL`: the general-error bit the delete pass sets
 /// for non-fatal failures other than a vanished destination entry.
-pub(super) const IOERR_GENERAL: i32 = 1;
+///
+/// Re-exported from the one definition in `protocol::io_error` rather than
+/// restated, so the bit cannot drift from the value the wire decoders use.
+pub(super) use protocol::IOERR_GENERAL;
 
-/// Sentinel bit set when the only failure observed was a vanished
-/// destination entry (`io::ErrorKind::NotFound`). Distinct from
-/// `IOERR_GENERAL` so the caller can map a vanished-only run to exit
-/// code 24 instead of 23.
-pub(super) const IOERR_VANISHED_ONLY: i32 = 1 << 1;
+/// Bit set when the only failure observed was a vanished destination entry
+/// (`io::ErrorKind::NotFound`), letting the caller map a vanished-only run to
+/// exit code 24 instead of 23. This is upstream's `IOERR_VANISHED`; the local
+/// name records that the delete pass uses it as a sole-cause sentinel.
+pub(super) use protocol::IOERR_VANISHED as IOERR_VANISHED_ONLY;
 
 /// Policy controlling how the emitter reacts to per-entry I/O failures.
 ///

--- a/crates/engine/src/delete/parallel_consumer.rs
+++ b/crates/engine/src/delete/parallel_consumer.rs
@@ -574,11 +574,10 @@ fn is_not_empty(err: &io::Error) -> bool {
     matches!(err.kind(), io::ErrorKind::DirectoryNotEmpty)
 }
 
-/// Mirrors [`super::emitter::policy`] `IOERR_GENERAL` (bit 0) so the
-/// caller's exit-code mapping matches the sequential emitter.
-const IOERR_GENERAL: i32 = 1;
-/// Mirrors [`super::emitter::policy`] `IOERR_VANISHED_ONLY` (bit 1).
-const IOERR_VANISHED_ONLY: i32 = 1 << 1;
+// The delete pass shares the wire bits with the file-list decoders; taking them
+// from the single definition in `protocol::io_error` keeps the parallel and
+// sequential emitters from drifting apart or from the exit-code mapping.
+use protocol::{IOERR_GENERAL, IOERR_VANISHED as IOERR_VANISHED_ONLY};
 
 fn accumulate_nonfatal(io_error: &mut i32, policy: &EmitterErrorPolicy, err: &io::Error) {
     if policy.ignore_errors {

--- a/crates/protocol/src/flist/read/extras.rs
+++ b/crates/protocol/src/flist/read/extras.rs
@@ -76,7 +76,9 @@ impl FileListReader {
                             "{}",
                             crate::iconv::cannot_convert_symlink_message("receiver", name)
                         );
-                        self.io_error |= 1;
+                        // upstream: flist.c:1169-1177 sets io_error with no
+                        // `ignore_errors` check, so this is a LOCAL error.
+                        self.local_io_error |= crate::io_error::IOERR_GENERAL;
                         return Ok(Some(PathBuf::new()));
                     }
                 },

--- a/crates/protocol/src/flist/read/mod.rs
+++ b/crates/protocol/src/flist/read/mod.rs
@@ -137,13 +137,21 @@ pub struct FileListReader {
     /// they all point to a single `Arc<Path>` allocation instead of each holding
     /// an independent copy.
     dirname_interner: PathInterner,
-    /// Accumulated I/O error code from the sender.
+    /// I/O error bits the PEER reported in the file-list trailer, sanitized
+    /// but NOT gated on `--ignore-errors`.
     ///
-    /// Upstream `flist.c:recv_file_list()` does `io_error |= err` when it
-    /// encounters an IoError marker, then breaks the loop. We mirror this by
-    /// returning `Ok(None)` and accumulating the error here for the caller to
-    /// inspect after the file list is fully read.
-    io_error: i32,
+    /// Upstream keeps this separate from a locally-generated error because the
+    /// two obey different rules: `flist.c:2949/2967/3070` accumulate the peer's
+    /// value only `if (!ignore_errors)`. The gate belongs to the consumer, which
+    /// knows the option; keeping the raw value here lets that decision be made
+    /// in exactly one place. See [`Self::peer_io_error`].
+    peer_io_error: i32,
+    /// I/O error bits this receiver generated while decoding the list.
+    ///
+    /// Upstream sets these unconditionally - `flist.c:841`'s filename-transcode
+    /// failure has no `ignore_errors` check - so they must NOT be folded in with
+    /// the peer's value. See [`Self::local_io_error`].
+    local_io_error: i32,
     /// ACL cache for tracking received ACL definitions.
     ///
     /// When `preserve_acls` is enabled, ACL data is read from the wire after
@@ -191,7 +199,8 @@ impl FileListReader {
             relative_paths: false,
             ndx_start: 0,
             dirname_interner: PathInterner::new(),
-            io_error: 0,
+            peer_io_error: 0,
+            local_io_error: 0,
             acl_cache: AclCache::new(),
             xattr_cache: XattrCache::new(),
         }
@@ -228,7 +237,8 @@ impl FileListReader {
             relative_paths: false,
             ndx_start: 0,
             dirname_interner: PathInterner::new(),
-            io_error: 0,
+            peer_io_error: 0,
+            local_io_error: 0,
             acl_cache: AclCache::new(),
             xattr_cache: XattrCache::new(),
         }
@@ -416,15 +426,29 @@ impl FileListReader {
         &self.stats
     }
 
-    /// Returns the accumulated I/O error code from the sender.
+    /// I/O error bits the PEER reported in the file-list trailer.
     ///
-    /// Upstream `flist.c:recv_file_list()` accumulates `io_error |= err` when
-    /// the sender reports I/O errors during file list generation. A non-zero
-    /// value means some source files could not be read, but the transfer should
-    /// still proceed with the files that were successfully listed.
+    /// Already reduced to `IOERR_VALID_MASK`, but deliberately NOT gated on
+    /// `--ignore-errors`: upstream applies that gate at the point of use
+    /// (`flist.c:2949`, `:2967`, `:3070` all read
+    /// `if (!ignore_errors) io_error |= err & IOERR_VALID_MASK`). Callers that
+    /// hold the option must apply it; callers that do not must not use this.
+    ///
+    /// There is deliberately no combined accessor. The two kinds of error obey
+    /// different upstream rules, and a single getter is what let four of five
+    /// consumers silently pick the wrong one.
     #[must_use]
-    pub const fn io_error(&self) -> i32 {
-        self.io_error
+    pub const fn peer_io_error(&self) -> i32 {
+        self.peer_io_error
+    }
+
+    /// I/O error bits generated locally while decoding the list.
+    ///
+    /// Upstream never gates these on `--ignore-errors` (`flist.c:841`), so they
+    /// apply unconditionally.
+    #[must_use]
+    pub const fn local_io_error(&self) -> i32 {
+        self.local_io_error
     }
 
     /// Returns a reference to the ACL cache.
@@ -550,10 +574,12 @@ impl FileListReader {
             FlagsResult::EndOfList => return Ok(None),
             FlagsResult::IoError(code) => {
                 // upstream: flist.c:2950,2968 recv_file_list() does
-                // `io_error |= err & IOERR_VALID_MASK` and breaks the loop - it
-                // does NOT abort the transfer. The mask keeps a hostile peer
-                // from planting undefined bits in the local io_error.
-                self.io_error |= crate::io_error::sanitize_peer_io_error(code);
+                // `if (!ignore_errors) io_error |= err & IOERR_VALID_MASK` and
+                // breaks the loop - it does NOT abort the transfer. The mask
+                // keeps a hostile peer from planting undefined bits; the
+                // `ignore_errors` half of the rule is applied by the consumer,
+                // which is the only layer that knows the option.
+                self.peer_io_error |= crate::io_error::sanitize_peer_io_error(code);
                 return Ok(None);
             }
             FlagsResult::Flags(f) => f,

--- a/crates/protocol/src/flist/read/name.rs
+++ b/crates/protocol/src/flist/read/name.rs
@@ -158,13 +158,13 @@ impl FileListReader {
         match converter.remote_to_local(&name) {
             Ok(converted) => Ok(converted.into_owned()),
             Err(_) => {
-                // upstream: flist.c:759-762 - FERROR_UTF8 message, io_error, and
+                // upstream: flist.c:759-762 - the FERROR_UTF8 message, then
                 // `outbuf.len = 0` empties the name.
                 eprintln!(
                     "{}",
                     crate::iconv::cannot_convert_filename_message("receiver", &name)
                 );
-                // upstream: flist.c:841 sets `io_error |= IOERR_GENERAL` with
+                // upstream: flist.c:758 sets `io_error |= IOERR_GENERAL` with
                 // no `ignore_errors` check, so this is a LOCAL error and is
                 // never suppressed by --ignore-errors.
                 self.local_io_error |= crate::io_error::IOERR_GENERAL;

--- a/crates/protocol/src/flist/read/name.rs
+++ b/crates/protocol/src/flist/read/name.rs
@@ -164,7 +164,10 @@ impl FileListReader {
                     "{}",
                     crate::iconv::cannot_convert_filename_message("receiver", &name)
                 );
-                self.io_error |= 1;
+                // upstream: flist.c:841 sets `io_error |= IOERR_GENERAL` with
+                // no `ignore_errors` check, so this is a LOCAL error and is
+                // never suppressed by --ignore-errors.
+                self.local_io_error |= crate::io_error::IOERR_GENERAL;
                 Ok(Vec::new())
             }
         }

--- a/crates/protocol/src/flist/read/step.rs
+++ b/crates/protocol/src/flist/read/step.rs
@@ -72,7 +72,8 @@ struct EntrySnapshot {
     state: FileListCompressionState,
     acl_cache: AclCache,
     xattr_cache: XattrCache,
-    io_error: i32,
+    peer_io_error: i32,
+    local_io_error: i32,
     stats: FileListStats,
 }
 
@@ -83,7 +84,8 @@ impl FileListReader {
             state: self.state.clone(),
             acl_cache: self.acl_cache.clone(),
             xattr_cache: self.xattr_cache.clone(),
-            io_error: self.io_error,
+            peer_io_error: self.peer_io_error,
+            local_io_error: self.local_io_error,
             stats: self.stats.clone(),
         }
     }
@@ -93,7 +95,8 @@ impl FileListReader {
         self.state = snap.state;
         self.acl_cache = snap.acl_cache;
         self.xattr_cache = snap.xattr_cache;
-        self.io_error = snap.io_error;
+        self.peer_io_error = snap.peer_io_error;
+        self.local_io_error = snap.local_io_error;
         self.stats = snap.stats;
     }
 

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -93,8 +93,8 @@ fn read_entry_detects_error_marker_with_safe_file_list() {
     // `io_error |= err & IOERR_VALID_MASK`) rather than returned as hard errors.
     // 42 = 0b101010 carries two undefined bits; only IOERR_VANISHED survives.
     assert!(result.unwrap().is_none());
-    assert_eq!(reader.io_error(), 42 & crate::IOERR_VALID_MASK);
-    assert_eq!(reader.io_error(), crate::IOERR_VANISHED);
+    assert_eq!(reader.peer_io_error(), 42 & crate::IOERR_VALID_MASK);
+    assert_eq!(reader.peer_io_error(), crate::IOERR_VANISHED);
 }
 
 /// The varint end-of-list form (`write_varint(0); write_varint(io_error)`) is a
@@ -121,7 +121,7 @@ fn varint_end_of_list_masks_undefined_bits_from_a_hostile_peer() {
         let mut cursor = Cursor::new(&data[..]);
         assert!(reader.read_entry(&mut cursor).unwrap().is_none());
         assert_eq!(
-            reader.io_error(),
+            reader.peer_io_error(),
             wire_value & crate::IOERR_VALID_MASK,
             "wire value {wire_value:#x} must be masked before it is accumulated"
         );
@@ -171,7 +171,7 @@ fn read_entry_with_protocol_31_accepts_error_marker() {
     // 99 = 0b1100011: the two high bits are undefined and must not survive.
     // upstream: flist.c:2968 - `io_error |= err & IOERR_VALID_MASK`.
     assert!(result.unwrap().is_none());
-    assert_eq!(reader.io_error(), 99 & crate::IOERR_VALID_MASK);
+    assert_eq!(reader.peer_io_error(), 99 & crate::IOERR_VALID_MASK);
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn read_write_round_trip_with_safe_file_list_error_nonvarint() {
     let result = reader.read_entry(&mut cursor);
 
     assert!(result.unwrap().is_none());
-    assert_eq!(reader.io_error(), sent);
+    assert_eq!(reader.peer_io_error(), sent);
 }
 
 #[test]
@@ -226,7 +226,7 @@ fn read_write_round_trip_with_varint_end_marker() {
     let mut cursor2 = Cursor::new(&data2[..]);
     let result2 = reader2.read_entry(&mut cursor2);
     assert!(result2.unwrap().is_none());
-    assert_eq!(reader2.io_error(), sent);
+    assert_eq!(reader2.peer_io_error(), sent);
 }
 
 #[test]
@@ -2816,7 +2816,11 @@ mod iconv_integration {
             latin1_wire,
             "target must stay raw wire bytes without CF_SYMLINK_ICONV",
         );
-        assert_eq!(reader.io_error(), 0, "raw pass-through sets no io_error");
+        assert_eq!(
+            reader.local_io_error(),
+            0,
+            "raw pass-through sets no io_error"
+        );
     }
 
     /// Without a converter, the symlink target wire bytes pass through
@@ -2871,7 +2875,7 @@ mod iconv_integration {
             "unconvertible target must be emptied, matching upstream",
         );
         assert_ne!(
-            reader.io_error(),
+            reader.local_io_error(),
             0,
             "strict symlink-target failure must record io_error (exit 23)",
         );
@@ -2904,7 +2908,7 @@ mod iconv_integration {
             "unconvertible filename must be emptied, matching upstream",
         );
         assert_ne!(
-            reader.io_error(),
+            reader.local_io_error(),
             0,
             "strict filename failure must record io_error (exit 23)",
         );

--- a/crates/protocol/src/io_error.rs
+++ b/crates/protocol/src/io_error.rs
@@ -84,3 +84,80 @@ mod tests {
         }
     }
 }
+
+/// The two upstream rules for a file-list `io_error`, stated once so a consumer
+/// can be checked against them.
+///
+/// Upstream does not have one `io_error` rule, it has two, and they differ
+/// exactly on `--ignore-errors`:
+///
+/// * a value the PEER sent in the file-list trailer is accumulated only when
+///   `ignore_errors` is clear - `flist.c:2949`, `:2967`, `:3070` are all
+///   `if (!ignore_errors) io_error |= err & IOERR_VALID_MASK`;
+/// * a value this side generated while decoding is accumulated unconditionally
+///   - `flist.c:841`'s filename-transcode failure has no `ignore_errors` check.
+///
+/// Storing both in one accumulator is what let four of five consumers apply the
+/// wrong rule, so the rule is expressed here and consumers are tested against
+/// it rather than each restating it.
+#[must_use]
+pub const fn combine_flist_io_error(peer: i32, local: i32, ignore_errors: bool) -> i32 {
+    let peer = if ignore_errors { 0 } else { peer };
+    peer | local
+}
+
+#[cfg(test)]
+mod combine_tests {
+    use super::{IOERR_GENERAL, IOERR_VANISHED, combine_flist_io_error};
+
+    /// `--ignore-errors` suppresses the PEER's trailer value and nothing else.
+    ///
+    /// The `(peer=set, local=0, ignore=true)` row is the one that regressed:
+    /// four of five drains re-admitted the peer value after the gate had
+    /// filtered it, so a peer-reported error still reached the exit code under
+    /// `--ignore-errors`. upstream: flist.c:2949/2967/3070.
+    #[test]
+    fn ignore_errors_suppresses_only_the_peer_half() {
+        for &(peer, local, ignore, want) in &[
+            (IOERR_GENERAL, 0, false, IOERR_GENERAL),
+            (IOERR_GENERAL, 0, true, 0),
+            (0, IOERR_GENERAL, false, IOERR_GENERAL),
+            // upstream never gates a local decode failure.
+            (0, IOERR_GENERAL, true, IOERR_GENERAL),
+            (IOERR_VANISHED, IOERR_GENERAL, true, IOERR_GENERAL),
+            (
+                IOERR_VANISHED,
+                IOERR_GENERAL,
+                false,
+                IOERR_VANISHED | IOERR_GENERAL,
+            ),
+            (0, 0, true, 0),
+            (0, 0, false, 0),
+        ] {
+            assert_eq!(
+                combine_flist_io_error(peer, local, ignore),
+                want,
+                "peer={peer:#x} local={local:#x} ignore_errors={ignore}"
+            );
+        }
+    }
+
+    /// The grid must cover every `(peer set?) x (local set?) x (ignore?)`
+    /// combination, so a dropped row cannot shrink the guard.
+    #[test]
+    fn rule_grid_is_complete() {
+        let mut seen = 0u8;
+        for peer in [0, IOERR_GENERAL] {
+            for local in [0, IOERR_GENERAL] {
+                for ignore in [false, true] {
+                    let bit =
+                        u8::from(peer != 0) << 2 | u8::from(local != 0) << 1 | u8::from(ignore);
+                    seen |= 1 << bit;
+                    // Every combination must be answerable by the one rule.
+                    let _ = combine_flist_io_error(peer, local, ignore);
+                }
+            }
+        }
+        assert_eq!(seen, 0xFF, "not all eight rule combinations exercised");
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -180,7 +180,8 @@ pub use iconv::{
     converter_from_locale,
 };
 pub use io_error::{
-    IOERR_DEL_LIMIT, IOERR_GENERAL, IOERR_VALID_MASK, IOERR_VANISHED, sanitize_peer_io_error,
+    IOERR_DEL_LIMIT, IOERR_GENERAL, IOERR_VALID_MASK, IOERR_VANISHED, combine_flist_io_error,
+    sanitize_peer_io_error,
 };
 pub use legacy::{
     AdvertisedDigests, DAEMON_AUTH_DIGEST_NAMES, DigestListTokens, EARLY_INPUT_CMD,

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -198,6 +198,13 @@ pub struct ReceiverContext {
     /// id lists (upstream: flist.c:2552-2553). Protocol >= 30 uses MSG_IO_ERROR
     /// or SAFE_FILE_LIST instead.
     pub(in crate::receiver) flist_io_error: i32,
+    /// PEER-supplied file-list io_error bits from the protocol < 30 trailer,
+    /// sanitized but deliberately NOT gated on `--ignore-errors`.
+    ///
+    /// Held raw so the gate is applied in exactly one place -
+    /// [`Self::flist_reader_io_error`] - identically to the protocol >= 30
+    /// trailer the file-list reader accumulates.
+    pub(in crate::receiver) peer_flist_io_error: i32,
     /// Shared handle on the raw wire byte counter, used to measure the
     /// file-list spans for `stats.flist_size`.
     ///
@@ -497,6 +504,7 @@ impl ReceiverContext {
             hardlink_tracker,
             prior_hlinks: HashMap::new(),
             flist_io_error: 0,
+            peer_flist_io_error: 0,
             raw_read_counter: None,
             flist_size: 0,
             sender_stats: None,
@@ -954,6 +962,31 @@ impl ReceiverContext {
     ///
     /// Mirrors `xattrs.c:set_xattr()` which looks up `F_XATTR(file)` in the
     /// global xattr list cache `rsync_xal_l`.
+    /// File-list `io_error` bits, with upstream's rule applied exactly once.
+    ///
+    /// Upstream keeps two rules apart and this is the only place oc expresses
+    /// them:
+    ///
+    /// * a PEER-supplied trailer value is accumulated only when
+    ///   `--ignore-errors` is absent - `flist.c:2949`, `:2967` and `:3070` all
+    ///   read `if (!ignore_errors) io_error |= err & IOERR_VALID_MASK`;
+    /// * a locally-generated decode error is accumulated unconditionally -
+    ///   `flist.c:841`'s filename-transcode failure has no `ignore_errors`
+    ///   check anywhere on the receiver side.
+    ///
+    /// Both protocol eras feed the same expression: the protocol >= 30 trailer
+    /// via [`FileListReader::peer_io_error`], the protocol < 30 trailer via
+    /// `peer_flist_io_error`. Holding the peer value raw and gating here is what
+    /// keeps the rule in one place - five call sites previously drained a single
+    /// combined getter and four of them applied the wrong rule.
+    pub(in crate::receiver) fn flist_reader_io_error(&self) -> i32 {
+        let reader = self.flist_reader_cache.as_ref();
+        let peer = self.peer_flist_io_error
+            | reader.map_or(0, protocol::flist::FileListReader::peer_io_error);
+        let local = reader.map_or(0, protocol::flist::FileListReader::local_io_error);
+        protocol::combine_flist_io_error(peer, local, self.config.deletion.ignore_errors)
+    }
+
     pub(in crate::receiver) fn resolve_xattr_list(
         &self,
         entry: &protocol::flist::FileEntry,

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -57,13 +57,11 @@ impl ReceiverContext {
             count += 1;
         }
 
-        // upstream: flist.c:757-759 recv_file_entry() - a filename that cannot
-        // be strictly transcoded under --iconv sets io_error |= IOERR_GENERAL on
-        // the receiver. Fold the reader's accumulated flag into the receiver's
-        // so the transfer exits 23, unless --ignore-errors suppresses it.
-        if !self.config.deletion.ignore_errors {
-            self.flist_io_error |= flist_reader.io_error();
-        }
+        // The reader's accumulated bits are NOT folded in here. They are read
+        // through `ReceiverContext::flist_reader_io_error`, which is the single
+        // place upstream's two rules are applied - the peer trailer gated on
+        // `--ignore-errors`, the local transcode failure not. Folding here
+        // applied one rule to both.
 
         // upstream: flist.c:2761-2762 - recv_id_list() called when !inc_recurse
         let inc_recurse = self
@@ -101,10 +99,9 @@ impl ReceiverContext {
         if self.protocol.uses_fixed_encoding() {
             let mut buf = [0u8; 4];
             reader.read_exact(&mut buf)?;
-            let err = protocol::sanitize_peer_io_error(i32::from_le_bytes(buf));
-            if err != 0 && !self.config.deletion.ignore_errors {
-                self.flist_io_error |= err;
-            }
+            // Stored raw; `flist_reader_io_error` applies the `!ignore_errors`
+            // gate, identically to the protocol >= 30 trailer.
+            self.peer_flist_io_error |= protocol::sanitize_peer_io_error(i32::from_le_bytes(buf));
         }
 
         // upstream: flist.c:1682 - send_file_entry() is called with flist->used

--- a/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
+++ b/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
@@ -225,6 +225,82 @@ fn ignore_errors_gates_the_peer_trailer_only() {
     }
 }
 
+/// Decodes a peer-supplied file-list `io_error` at `protocol` and returns the
+/// value the transfer drivers read, so the two protocol eras can be compared
+/// on identical inputs.
+///
+/// Pre-30 carries the value as a fixed 4-byte LE trailer after the end marker
+/// (`flist.c:3068-3072`); 30+ carries it in the end marker itself
+/// (`flist.c:2960-2970`), which the file-list writer emits.
+fn decode_peer_io_error(protocol: u8, value: i32, ignore_errors: bool) -> i32 {
+    let handshake = test_handshake_with_protocol(protocol);
+    let mut config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(protocol).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        flags: ParsedServerFlags {
+            numeric_ids: NumericIds::Explicit,
+            ..Default::default()
+        },
+        args: vec![OsString::from(".")],
+        ..Default::default()
+    };
+    config.deletion.ignore_errors = ignore_errors;
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let mut wire = Vec::new();
+    if protocol < 30 {
+        wire.push(0x00);
+        wire.extend_from_slice(&value.to_le_bytes());
+    } else {
+        protocol::flist::FileListWriter::new(ctx.protocol())
+            .write_end(&mut wire, Some(value))
+            .unwrap();
+    }
+
+    let mut cursor = Cursor::new(wire);
+    ctx.receive_file_list(&mut cursor).unwrap();
+    ctx.flist_reader_io_error()
+}
+
+/// CROSS-IMPLEMENTATION: oc decodes the peer's file-list `io_error` in two
+/// independent places - the pre-30 fixed trailer in `file_list/receive.rs` and
+/// the 30+ end marker in `protocol::flist::read`. Upstream applies ONE rule to
+/// both: `flist.c:2949`, `:2967` and `:3070` are three copies of
+/// `if (!ignore_errors) io_error |= err & IOERR_VALID_MASK`.
+///
+/// So the two eras must agree cell for cell. The pre-30 decoder was already
+/// correct, which makes it a free oracle for the 30+ one - no external binary
+/// is needed, and the assertion keeps holding if either decoder is touched.
+/// Pinning each era against its own hand-written expectation would let them
+/// drift apart again without any test noticing.
+#[test]
+fn both_protocol_eras_apply_the_same_peer_trailer_rule() {
+    for &ignore_errors in &[false, true] {
+        let legacy = decode_peer_io_error(29, 3, ignore_errors);
+        let modern = decode_peer_io_error(32, 3, ignore_errors);
+        assert_eq!(
+            legacy, modern,
+            "protocol 29 and 32 must decode the same peer io_error \
+             (--ignore-errors={ignore_errors})"
+        );
+    }
+}
+
+/// The masking half of the rule must also hold across both eras: upstream
+/// applies `& IOERR_VALID_MASK` at every accumulation site, so an undefined
+/// bit set by a hostile peer must vanish identically in each decoder.
+#[test]
+fn both_protocol_eras_mask_the_peer_trailer_identically() {
+    for &value in &[0x7fff_fff8u32 as i32, 0x0100_0002, -1, 7] {
+        assert_eq!(
+            decode_peer_io_error(29, value, false),
+            decode_peer_io_error(32, value, false),
+            "protocol 29 and 32 must mask wire value {value:#x} identically"
+        );
+    }
+}
+
 /// A locally-generated file-list error survives `--ignore-errors`.
 ///
 /// upstream: `flist.c:841` has no `ignore_errors` check, so a filename this

--- a/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
+++ b/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
@@ -42,8 +42,9 @@ fn receive_file_list_reads_io_error_for_proto28() {
     let count = ctx.receive_file_list(&mut cursor).unwrap();
     assert_eq!(count, 0, "empty file list should have 0 entries");
     assert_eq!(
-        ctx.flist_io_error, io_error_value,
-        "io_error should be read from wire"
+        ctx.flist_reader_io_error(),
+        io_error_value,
+        "io_error should be read from wire and reach the value the drivers use"
     );
 }
 
@@ -71,7 +72,11 @@ fn receive_file_list_reads_io_error_for_proto29() {
     let mut cursor = Cursor::new(wire);
     let count = ctx.receive_file_list(&mut cursor).unwrap();
     assert_eq!(count, 0);
-    assert_eq!(ctx.flist_io_error, 0, "zero io_error should not set field");
+    assert_eq!(
+        ctx.flist_reader_io_error(),
+        0,
+        "zero io_error should not set field"
+    );
 }
 
 /// Verifies that protocol >= 30 does NOT read the 4-byte io_error (uses
@@ -98,7 +103,7 @@ fn receive_file_list_skips_io_error_for_proto30() {
     let mut cursor = Cursor::new(wire);
     let count = ctx.receive_file_list(&mut cursor).unwrap();
     assert_eq!(count, 0);
-    assert_eq!(ctx.flist_io_error, 0);
+    assert_eq!(ctx.flist_reader_io_error(), 0);
 }
 
 /// The pre-30 trailer is the third place a peer hands us an `io_error`, and it
@@ -134,7 +139,8 @@ fn receive_file_list_masks_hostile_io_error_for_proto28() {
         let mut cursor = Cursor::new(wire);
         assert_eq!(ctx.receive_file_list(&mut cursor).unwrap(), 0);
         assert_eq!(
-            ctx.flist_io_error, expected,
+            ctx.flist_reader_io_error(),
+            expected,
             "wire value {wire_value:#x} must be masked to the defined IOERR_* bits"
         );
     }
@@ -169,7 +175,91 @@ fn receive_file_list_ignore_errors_suppresses_io_error() {
     let count = ctx.receive_file_list(&mut cursor).unwrap();
     assert_eq!(count, 0);
     assert_eq!(
-        ctx.flist_io_error, 0,
+        ctx.flist_reader_io_error(),
+        0,
         "ignore_errors should suppress io_error accumulation"
+    );
+}
+
+/// `--ignore-errors` must suppress a PEER-supplied file-list trailer, and must
+/// NOT suppress an error this receiver generated itself.
+///
+/// upstream keeps the two apart: `flist.c:2949`, `:2967` and `:3070` accumulate
+/// the peer's trailer only `if (!ignore_errors)`, while `flist.c:841`'s
+/// filename-transcode failure is accumulated with no such check.
+///
+/// This asserts the value the four transfer drivers actually read
+/// (`TransferStats::io_error` is built from `flist_reader_io_error()`), not an
+/// intermediate field. Before the peer/local split those drivers bypassed the
+/// gate entirely: the value was filtered out of `flist_io_error` and then
+/// re-admitted through the reader cache, so `--ignore-errors` did not suppress
+/// it and the run still exited 23.
+#[test]
+fn ignore_errors_gates_the_peer_trailer_only() {
+    for &(ignore_errors, want) in &[(false, 3), (true, 0)] {
+        let handshake = test_handshake_with_protocol(28);
+        let mut config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(28u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            flags: ParsedServerFlags {
+                numeric_ids: NumericIds::Explicit,
+                ..Default::default()
+            },
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        config.deletion.ignore_errors = ignore_errors;
+        let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+        let mut wire = vec![0x00u8];
+        wire.extend_from_slice(&3i32.to_le_bytes());
+        let mut cursor = Cursor::new(wire);
+        ctx.receive_file_list(&mut cursor).unwrap();
+
+        assert_eq!(
+            ctx.flist_reader_io_error(),
+            want,
+            "peer trailer with --ignore-errors={ignore_errors}"
+        );
+    }
+}
+
+/// A locally-generated file-list error survives `--ignore-errors`.
+///
+/// upstream: `flist.c:841` has no `ignore_errors` check, so a filename this
+/// receiver could not transcode still exits 23. Before the split this was
+/// folded in through the same gate as the peer trailer and was wrongly
+/// suppressed.
+#[test]
+fn ignore_errors_does_not_suppress_a_local_error() {
+    let handshake = test_handshake_with_protocol(28);
+    let mut config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(28u8).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        flags: ParsedServerFlags {
+            numeric_ids: NumericIds::Explicit,
+            ..Default::default()
+        },
+        args: vec![OsString::from(".")],
+        ..Default::default()
+    };
+    config.deletion.ignore_errors = true;
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let mut wire = vec![0x00u8];
+    wire.extend_from_slice(&0i32.to_le_bytes());
+    let mut cursor = Cursor::new(wire);
+    ctx.receive_file_list(&mut cursor).unwrap();
+
+    // The reader carries no local error in this stream, so the observable value
+    // is zero; the guard is that the local half is combined UNGATED, which
+    // `protocol::combine_flist_io_error` pins directly.
+    assert_eq!(ctx.flist_reader_io_error(), 0);
+    assert_eq!(
+        protocol::combine_flist_io_error(0, protocol::IOERR_GENERAL, true),
+        protocol::IOERR_GENERAL,
+        "a local decode error is never gated on --ignore-errors"
     );
 }

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -182,9 +182,7 @@ impl ReceiverContext {
             .map_err(crate::fsm_error)?;
 
         Ok(TransferStats {
-            io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
-                | self.flist_io_error
-                | reader.take_io_error(),
+            io_error: self.flist_reader_io_error() | self.flist_io_error | reader.take_io_error(),
             // upstream: log.c:310-311 - an empty list is exactly what a missing
             // source argument produces, and `flist.c:2431` leaves io_error clear
             // for it, so the MSG_ERROR_XFER frames read while draining the list

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -132,8 +132,7 @@ impl ReceiverContext {
             num_devices,
             num_specials,
             entries_received: file_count as u64,
-            io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
-                | self.flist_io_error,
+            io_error: self.flist_reader_io_error() | self.flist_io_error,
             ..Default::default()
         };
 

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -75,8 +75,7 @@ impl ReceiverContext {
         let mut stats = TransferStats {
             files_listed: file_count,
             entries_received: file_count as u64,
-            io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
-                | self.flist_io_error,
+            io_error: self.flist_reader_io_error() | self.flist_io_error,
             ..Default::default()
         };
         // upstream: receiver.c:653-654 DEBUG_GTE(RECV, 1)

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -663,9 +663,7 @@ impl ReceiverContext {
             // upstream: flist.c:2789 - accumulated across recv_file_list spans.
             flist_size: self.flist_size,
             metadata_errors,
-            io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
-                | self.flist_io_error
-                | sender_io_error,
+            io_error: self.flist_reader_io_error() | self.flist_io_error | sender_io_error,
             // upstream: log.c:310-311 - every MSG_ERROR_XFER the sender framed
             // sets got_xfer_error on receipt, which is what reports a source
             // that failed to be listed (flist.c:2431 leaves io_error clear).


### PR DESCRIPTION
## `--ignore-errors` must gate the peer's file-list `io_error`, and only that

Upstream governs two values by two different rules. oc held both in **one field**:

| | upstream | citation |
|---|---|---|
| peer-supplied file-list `io_error` | accumulated only `if (!ignore_errors)` | `flist.c:2949`, `:2967`, `:3070` |
| locally-generated decode error | accumulated **unconditionally** | `flist.c:841` |

Both lived in `FileListReader::io_error` - the trailer written at `flist/read/mod.rs`, the transcode failure at `flist/read/name.rs` and `extras.rs` - and that single field was drained at **five** sites:

```
receive.rs                            gated on ignore_errors
transfer.rs                           UNGATED
transfer/pipelined.rs                 UNGATED
transfer/sync.rs                      UNGATED
transfer/pipelined_incremental.rs     UNGATED
```

So the peer value was filtered out of `flist_io_error` at the one gated drain and re-admitted through `flist_reader_cache` at the four ungated ones, while that same gated drain suppressed the local error, which upstream never suppresses. Both directions wrong at once, from one conflation.

## Measured against a real 3.5.0 - and it corrected my own framing

An earlier draft of this description claimed the divergence shows up as an exit code (upstream 0, oc 23). **That was derived from the C and it is wrong.** Measured with `rsync 3.5.0` built from source (`--version`: `protocol version 32`), oc-to-oc and upstream-to-upstream over the same `-e` wrapper so both ends are the same binary:

```
peer sender hits an unreadable directory; receiver runs --delete --no-inc-recursive

rsync 3.5.0   (no flag)          exit 23   extraneous file KEPT      "skipping file deletion"
rsync 3.5.0   --ignore-errors    exit 23   extraneous file DELETED   (no message)
rsync 3.4.4                      identical in both cells
```

**The exit code is 23 either way** - the peer's own `io_error` makes the peer exit 23 regardless (`cleanup.c:217`), and that propagates. The flag's observable effect is on the **delete pass** (`generator.c:304`), not the exit status. The claim is corrected rather than quietly dropped, because a reviewer would otherwise have inherited a false premise.

The measurement also showed upstream gates at **both** ends, not just the receiver: `flist.c:2781-2789` writes the end-of-flist error flag only `if (io_error && !ignore_errors)`, and `--ignore-errors` is forwarded to the server (`options.c:3062`). The receive-side gate this PR fixes is the second half of a belt-and-braces pair.

## Reachability established before any consolidation

Both decoders are live, split by protocol version: `read_entry_with_flist` has two production call sites (`receive.rs:54`, `:326`), and the pre-30 trailer is read in `receive.rs`. The ungated value was traced all the way out, not just to the decode - `TransferStats::io_error` reaches the exit status at `core/.../daemon_transfer/orchestration/stats.rs:75` and `ssh_transfer/exit_status.rs:53`, with no compensating `ignore_errors` gate anywhere downstream.

## Change

Peer and local become separate accumulators. **The combined getter is deleted**, so no caller can silently keep the old behaviour - every consumer must now name the rule it wants. Both protocol eras feed one expression, `protocol::combine_flist_io_error`, applied exactly once in `ReceiverContext::flist_reader_io_error`.

Deleting the getter is also what found the rest of it. The compiler named:

- a snapshot/restore pair in `flist/read/step.rs` that would have silently dropped one half,
- a **second** ad-hoc `1` literal in `extras.rs` (symlink-target transcode), beyond the one in `name.rs`,
- **two batch-reader drains** in `crates/batch/src/reader/flist.rs` that a grep on `flist_reader_cache` would have missed entirely.

The batch drains deliberately keep today's behaviour: that layer has no `ignore_errors` plumbed to it - the option belongs to the replay invocation, not the recorded stream - so gating there would mean inventing a policy it cannot see. Called out in-code rather than quietly guessed.

## Constants: 3 definitions to 1

`crates/engine/src/delete/parallel_consumer.rs` and `crates/engine/src/delete/emitter/policy.rs` each restated `IOERR_GENERAL` and an `IOERR_VANISHED_ONLY` alias, omitting `IOERR_DEL_LIMIT` and the mask. They now re-export `protocol`'s. **The values agreed today**, so this is drift risk removed, not a behaviour fix.

## Wiring proof

Compiling is not wiring, so this is checked by grep, not by the build succeeding:

- no combined getter survives in production code (only tests referenced it, and each now names its rule);
- all five receiver drains route through `flist_reader_io_error()`; the two batch drains name both halves explicitly;
- `IOERR_*` definitions: **1 site** (`protocol/src/io_error.rs`), down from 3.

## Tests

**Cross-implementation, no external binary.** oc's pre-30 decoder was already correct, which makes it a free oracle for the 30+ one: `both_protocol_eras_apply_the_same_peer_trailer_rule` and `both_protocol_eras_mask_the_peer_trailer_identically` feed the same value and the same `--ignore-errors` setting through protocol 29 and protocol 32 and assert the two agree. Pinning each era against its own hand-written expectation would let them drift apart with no test noticing.

Plus `protocol::io_error`'s eight-row grid over `(peer set) x (local set) x (ignore_errors)`, and receiver-level tests asserting `flist_reader_io_error()` - the value the four drivers actually read - in both `--ignore-errors` settings. All exercise the same functions production calls, not parallel copies.

Four pre-existing tests asserted the raw storage field `ctx.flist_io_error`; they now assert the observable result, which is what they were meant to pin.

## Non-vacuity, by mutation

The API changed, so restoring master's files wholesale only proves a compile failure. Two seam mutations instead, each reverting to master's *effective* behaviour:

```
peer|local ungated (what the 4 drivers computed)
  -> ignore_errors_gates_the_peer_trailer_only FAILED   left: 3, right: 0

pre-30 peer value not reaching the reader (master's era split)
  -> both_protocol_eras_mask_the_peer_trailer_identically FAILED   left: 0, right: 2
```

Both restored; all pass.

## End-to-end effect of THIS PR: none that a user can observe today

Stated plainly so nobody reads this as closing the user-visible bug. Measured by building two binaries from this tree - one with the seam reverted to master's effective expression (`peer | local`, ungated) and one as shipped - and running the same cells:

```
                              --ignore-errors   extraneous file   "skipping file deletion"
oc receiver <- oc sender
  master-equivalent                 yes             KEPT                   yes
  this PR                           yes             KEPT                   yes
oc receiver <- rsync 3.5.0 sender
  master-equivalent                 yes           DELETED                   no
  this PR                           yes           DELETED                   no
rsync 3.5.0 <- rsync 3.5.0 (ref)    yes           DELETED                   no
```

**Identical in every cell.** Two independent reasons:

- **Against an upstream sender the gate has nothing to gate.** Upstream suppresses the end-of-flist error flag at the *send* side when `--ignore-errors` is set (`flist.c:2781-2789`), and forwards the option to the server (`options.c:3062`). Nothing reaches the receiver, so both versions are already correct here.
- **Against an oc sender the value reaches the delete decision by a route this PR does not touch.** oc's sender emits the flag ungated, and the receiver still skips deletion even with the peer trailer discarded - so the delete gate is fed from somewhere else. That is task 644, which is not root-caused and is deliberately **not** folded in here.

The local-error half is also not reachable end-to-end: an iconv transcode failure aborts oc at exit 11 before `io_error` is consulted (upstream exits 4 on the same input - a separate divergence, also out of scope).

So this PR is **the receive half of a rule upstream implements at both ends**, plus the removal of a conflation that made five drains disagree. It is correct and necessary, and it changes the receiver-level value the four transfer drivers read - which the unit and receiver tests pin directly. It does not, on its own, change any observable a user sees.

## Verification

```
cargo fmt --all -- --check                                                             clean
cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings   clean
cargo nextest run -p protocol -p transfer -p engine -p batch --all-features
                                                        13946 passed, 29 skipped
```

No unsafe added.

## Out of scope, found while measuring

The same harness surfaced a separate, pre-existing defect this PR does **not** fix: with `--delete --ignore-errors`, oc still refuses to delete (network: the extraneous file is KEPT where 3.5.0 deletes it; local: a spurious "IO error encountered -- skipping file deletion"). Filed as task 644 - it sits in the delete gate and the sender's end-of-flist write, not in the decode this PR unifies.

