### PR TITLE
fix(receiver): honour -B / --block-size on every wire transport

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -672,6 +672,22 @@ fn apply_value_flags<Err: Write>(
         }
     }
 
+    // upstream: options.c:2953-2954 - the client re-emits `-B%u` to the server,
+    // and options.c:1795-1805 parses it back into the same `block_size` global
+    // the client used. Without this the server receiver's generator silently
+    // fell back to the square-root heuristic, so every `--block-size` transfer
+    // over the wire produced a different block signature and a different
+    // matched/literal split than upstream.
+    if let Some(size_str) = &long_flags.block_size {
+        match core::server::config::parse_block_size_arg(size_str, config.protocol) {
+            Ok(size) => config.block_size = size,
+            Err(msg) => {
+                write_server_error(stderr, brand, msg);
+                return Err(1);
+            }
+        }
+    }
+
     if let Some(size_str) = &long_flags.min_size {
         match parse_server_size_limit(size_str, "--min-size") {
             Ok(size) => config.file_selection.min_file_size = Some(size),

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -408,12 +408,14 @@ pub(super) fn build_full_daemon_args(
         ));
     }
 
-    // upstream: options.c:2953-2957 - `-B%u` (block_size). oc mirrors the SSH
-    // builder's `--block-size=` spelling; both are accepted by the daemon's
-    // option parser and carry the identical value, so the remote receiver's
-    // generator sizes delta blocks exactly like the client requested.
+    // upstream: options.c:2953-2957 - `asprintf(&arg, "-B%u", (int)block_size)`
+    // inside `if (block_size) {`. The SHORT spelling is what upstream puts on
+    // the wire, so the daemon arg vector must carry it too: a `--block-size=`
+    // token is an oc-only spelling that no upstream daemon parses, and it left
+    // the remote generator sizing blocks by the square-root heuristic instead
+    // of the requested size.
     if let Some(bs) = config.block_size_override() {
-        args.push(format!("--block-size={}", bs.get()));
+        args.push(format!("-B{}", bs.get()));
     }
 
     // upstream: options.c:2793-2797 - --timeout=N so both peers enforce the
@@ -1485,27 +1487,34 @@ mod server_option_fidelity_tests {
         assert!(flag.contains('p'), "perms on must pack 'p': {flag}");
     }
 
-    // upstream: options.c:2953-2957 - -B/block_size must reach the remote so its
-    // generator sizes delta blocks identically. Role-agnostic (both directions).
+    // upstream: options.c:2953-2957 - `asprintf(&arg, "-B%u", (int)block_size)`.
+    // The remote generator sizes delta blocks from this token, so both the value
+    // and the SPELLING matter: this assertion previously pinned
+    // `--block-size=4096`, an oc-only long form that no upstream daemon parses,
+    // and that is exactly why an operator's `-B` was silently ignored on every
+    // rsync:// transfer. Role-agnostic (both directions).
     #[test]
-    fn block_size_forwarded_both_directions() {
+    fn block_size_forwarded_both_directions_in_the_upstream_short_spelling() {
         let size = std::num::NonZeroU32::new(4096).unwrap();
         let config = ClientConfig::builder()
             .block_size_override(Some(size))
             .build();
         for is_sender in [true, false] {
+            let built = args(&config, is_sender);
             assert!(
-                args(&config, is_sender)
-                    .iter()
-                    .any(|a| a == "--block-size=4096"),
-                "block-size must forward (is_sender={is_sender})"
+                built.iter().any(|a| a == "-B4096"),
+                "block-size must forward as upstream `-B4096` (is_sender={is_sender}): {built:?}"
+            );
+            assert!(
+                !built.iter().any(|a| a.starts_with("--block-size")),
+                "the non-upstream long spelling must be gone (is_sender={is_sender}): {built:?}"
             );
         }
         let off = ClientConfig::builder().build();
         assert!(
             !args(&off, false)
                 .iter()
-                .any(|a| a.starts_with("--block-size")),
+                .any(|a| a.starts_with("-B") || a.starts_with("--block-size")),
             "no block-size when unset"
         );
     }

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -472,6 +472,11 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
         .unwrap_or(protocol::ProtocolVersion::NEWEST);
     server_config.trust_sender = config.trust_sender();
     server_config.qsort = config.qsort();
+    // upstream: generator.c:720-721 - `-B` is honoured by whichever side runs
+    // the generator, so the client half needs it for a pull exactly as the
+    // server half needs the forwarded `-B%u` for a push. Both roles share this
+    // function, so one assignment covers SSH, daemon and embedded-SSH.
+    server_config.block_size = config.block_size_override();
     // upstream: options.c:2190-2203 - `xfer_dirs` is resolved locally by each
     // side (`--files-from`, recursion and `--list-only` all imply level 1), and
     // the compact `d` letter is packed only for an EXPLICIT `-d`

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -49,7 +49,7 @@ use core::{
     rsync_error, rsync_info, rsync_warning,
     server::{
         HandshakeResult, ReferenceDirectory, ReferenceDirectoryKind, ServerConfig, ServerResult,
-        ServerRole, ServerStats, run_server_with_handshake,
+        ServerRole, ServerStats, config::parse_block_size_arg, run_server_with_handshake,
     },
 };
 use logging_sink::MessageSink;

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -269,6 +269,19 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     if let Ok(n) = val.trim_start_matches('+').parse::<i64>() {
                         config.file_selection.modify_window = ::metadata::ModifyWindow::from_secs(n);
                     }
+                // upstream: options.c:2953-2954 - the client forwards the block
+                // size as a standalone `-B%u` token, and options.c:1795-1805
+                // parses it back into the same `block_size` global. The daemon
+                // decodes the client argv here rather than through the
+                // `--server` argv parser, so it needs its own arm; both call the
+                // one shared bound check.
+                } else if let Some(val) = arg
+                    .strip_prefix("-B")
+                    .or_else(|| arg.strip_prefix("--block-size="))
+                {
+                    if let Ok(size) = parse_block_size_arg(val, config.protocol) {
+                        config.block_size = size;
+                    }
                 // upstream: options.c:2874 - a negative modify_window is
                 // forwarded via the short `-@%d` spelling (e.g. `-@-1`) for
                 // nanosecond-exact comparison (util1.c:1482).

--- a/crates/engine/src/delta/mod.rs
+++ b/crates/engine/src/delta/mod.rs
@@ -32,6 +32,7 @@ pub use matching::{
 /// from the file size using the upstream square-root heuristic.
 /// [`SignatureLayoutParams`] captures the inputs; [`SignatureLayout`] carries
 /// the resolved layout; [`SignatureLayoutError`] reports invalid inputs.
+pub use signature::block_size::{MAX_BLOCK_SIZE_OLD, MAX_BLOCK_SIZE_V30};
 pub use signature::{
     SignatureLayout, SignatureLayoutError, SignatureLayoutParams, calculate_signature_layout,
 };

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -18,6 +18,7 @@
 //! ```
 
 use std::ffi::OsString;
+use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -73,6 +74,7 @@ pub struct ServerConfigBuilder {
     write: WriteConfig,
     checksum_seed: Option<u32>,
     checksum_choice: Option<protocol::ChecksumAlgorithm>,
+    block_size: Option<NonZeroU32>,
     trust_sender: bool,
     stop_at: Option<SystemTime>,
     qsort: bool,
@@ -115,6 +117,7 @@ impl ServerConfigBuilder {
             write: WriteConfig::default(),
             checksum_seed: None,
             checksum_choice: None,
+            block_size: None,
             trust_sender: false,
             stop_at: None,
             qsort: false,
@@ -355,6 +358,15 @@ impl ServerConfigBuilder {
     /// Sets an optional checksum algorithm override.
     pub fn checksum_choice(&mut self, choice: Option<protocol::ChecksumAlgorithm>) -> &mut Self {
         self.checksum_choice = choice;
+        self
+    }
+
+    /// Sets the fixed delta block length from `-B` / `--block-size`.
+    ///
+    /// Only the receiving side acts on it, at the one point that sizes the
+    /// blocks it checksums. upstream: generator.c:720-721.
+    pub fn block_size(&mut self, size: Option<NonZeroU32>) -> &mut Self {
+        self.block_size = size;
         self
     }
 
@@ -633,6 +645,7 @@ impl ServerConfigBuilder {
             write: self.write.clone(),
             checksum_seed: self.checksum_seed,
             checksum_choice: self.checksum_choice,
+            block_size: self.block_size,
             trust_sender: self.trust_sender,
             stop_at: self.stop_at,
             qsort: self.qsort,

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -7,6 +7,7 @@ pub use builder::ServerConfigBuilder;
 pub use error::BuilderError;
 
 use std::ffi::OsString;
+use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -409,6 +410,23 @@ pub struct ServerConfig {
     /// protocol instead of using automatic negotiation. Propagated from
     /// the client configuration to ensure both sides agree on the algorithm.
     pub checksum_choice: Option<protocol::ChecksumAlgorithm>,
+    /// Fixed delta block length from `-B` / `--block-size`, when the operator
+    /// set one.
+    ///
+    /// The receiving side owns this value: it is the generator that sizes the
+    /// blocks it checksums, so the sender never consults it. `None` selects the
+    /// square-root heuristic.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:1804` - `OPT_BLOCK_SIZE` stores the parsed size in the
+    ///   `block_size` global.
+    /// - `options.c:2953-2954` - the client re-emits it to the server as a
+    ///   standalone `-B%u` token, so a server receiver parses it back into the
+    ///   same global.
+    /// - `generator.c:720-721` - `if (block_size) blength = block_size;` is the
+    ///   single point where it displaces the heuristic.
+    pub block_size: Option<NonZeroU32>,
     /// Disables sender path safety checks when true (`--trust-sender`).
     ///
     /// When false (default), the receiver validates file list entries from the
@@ -648,6 +666,45 @@ pub struct ServerConfig {
     pub munge_symlinks: bool,
 }
 
+/// Parses a forwarded `-B<digits>` / `--block-size=NUM` value into the
+/// [`ServerConfig::block_size`] field.
+///
+/// Shared by every side that decodes a peer's argument vector - the `--server`
+/// argv parser and the daemon's long-form parser - so the bound check exists
+/// once rather than once per decoder.
+///
+/// upstream: options.c:1795-1805 `OPT_BLOCK_SIZE` runs the same check on the
+/// server as on the client: `parse_size_arg(arg, 'b', "block-size", 0,
+/// max_blength, False)` with `max_blength = protocol_version < 30 ?
+/// OLD_MAX_BLOCK_SIZE : MAX_BLOCK_SIZE`. A `0` means "unset" and falls back to
+/// the square-root heuristic (`generator.c:720` tests `if (block_size)`), so it
+/// maps to `None` rather than to an error.
+///
+/// # Errors
+///
+/// Returns a human-readable message when the value is not a plain integer or
+/// exceeds the protocol's maximum block length.
+pub fn parse_block_size_arg(
+    value: &str,
+    protocol: ProtocolVersion,
+) -> Result<Option<NonZeroU32>, String> {
+    let max_blength = if protocol < ProtocolVersion::V30 {
+        engine::delta::MAX_BLOCK_SIZE_OLD
+    } else {
+        engine::delta::MAX_BLOCK_SIZE_V30
+    };
+    let parsed: u32 = value
+        .trim()
+        .parse()
+        .map_err(|_| format!("invalid -B value '{value}': must be 0..{max_blength}"))?;
+    if parsed > max_blength {
+        return Err(format!(
+            "invalid -B value '{value}': must be 0..{max_blength}"
+        ));
+    }
+    Ok(NonZeroU32::new(parsed))
+}
+
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
@@ -662,6 +719,7 @@ impl Default for ServerConfig {
             write: WriteConfig::default(),
             checksum_seed: None,
             checksum_choice: None,
+            block_size: None,
             trust_sender: false,
             stop_at: None,
             qsort: false,
@@ -1157,5 +1215,47 @@ mod tests {
         let mut config = append_config(true, true);
         config.promote_append_mode_for_protocol(ProtocolVersion::V29);
         assert!(config.flags.append_verify);
+    }
+
+    /// upstream: options.c:1795-1805 - `max_blength = protocol_version < 30 ?
+    /// OLD_MAX_BLOCK_SIZE : MAX_BLOCK_SIZE`, so the ceiling is protocol-dependent
+    /// and a value legal at protocol 29 is rejected at 30+.
+    #[test]
+    fn block_size_ceiling_is_protocol_dependent() {
+        let at_29 = parse_block_size_arg("200000", ProtocolVersion::V29);
+        assert_eq!(
+            at_29
+                .expect("legal below OLD_MAX_BLOCK_SIZE")
+                .map(NonZeroU32::get),
+            Some(200_000),
+        );
+        assert!(
+            parse_block_size_arg("200000", ProtocolVersion::V32).is_err(),
+            "200000 exceeds MAX_BLOCK_SIZE (1 << 17) at protocol >= 30",
+        );
+    }
+
+    /// upstream: generator.c:720 tests `if (block_size)`, so a forwarded `0` is
+    /// "unset" and must select the square-root heuristic rather than error.
+    #[test]
+    fn block_size_zero_means_heuristic_not_error() {
+        assert_eq!(
+            parse_block_size_arg("0", ProtocolVersion::V32).expect("0 is legal"),
+            None,
+        );
+    }
+
+    #[test]
+    fn block_size_rejects_a_non_integer() {
+        assert!(parse_block_size_arg("1K", ProtocolVersion::V32).is_err());
+        assert!(parse_block_size_arg("", ProtocolVersion::V32).is_err());
+        assert!(parse_block_size_arg("-1", ProtocolVersion::V32).is_err());
+    }
+
+    /// The field must default to `None` so a peer that never sends `-B` keeps
+    /// the heuristic, byte-identical to upstream.
+    #[test]
+    fn block_size_defaults_to_none() {
+        assert_eq!(ServerConfig::default().block_size, None);
     }
 }

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -5,7 +5,7 @@
 //! the file signature used by the sender to compute deltas.
 
 use std::fs;
-use std::num::NonZeroU8;
+use std::num::{NonZeroU8, NonZeroU32};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -114,6 +114,14 @@ pub struct BasisFileConfig<'a> {
     /// [`protocol::effective_s2length`]). `None` (local copy / no negotiation)
     /// leaves the strong sum at full length, byte-identical to upstream.
     pub compat_flags: Option<protocol::CompatibilityFlags>,
+    /// Fixed delta block length from `-B` / `--block-size`, when the operator
+    /// set one. `None` selects the square-root heuristic.
+    ///
+    /// upstream: generator.c:720-721 - `if (block_size) blength = block_size;`
+    /// inside `sum_sizes_sqroot()`, the one point where the option displaces
+    /// the heuristic. The receiving side owns it: the generator sizes the
+    /// blocks it checksums, so the sender never consults the value.
+    pub block_size: Option<NonZeroU32>,
 }
 
 /// Configuration for generating a signature from a basis file.
@@ -131,6 +139,8 @@ struct SignatureGenerationConfig {
     checksum_algorithm: engine::signature::SignatureAlgorithm,
     /// Mutually negotiated compatibility flags (see [`BasisFileConfig::compat_flags`]).
     compat_flags: Option<protocol::CompatibilityFlags>,
+    /// Fixed delta block length (see [`BasisFileConfig::block_size`]).
+    block_size: Option<NonZeroU32>,
 }
 
 impl SignatureGenerationConfig {
@@ -141,6 +151,7 @@ impl SignatureGenerationConfig {
             checksum_length: config.checksum_length,
             checksum_algorithm: config.checksum_algorithm,
             compat_flags: config.compat_flags,
+            block_size: config.block_size,
         }
     }
 }
@@ -396,9 +407,13 @@ fn generate_basis_signature(
     let digest_len =
         NonZeroU8::new(config.checksum_algorithm.digest_len().min(u8::MAX as usize) as u8)
             .expect("negotiated digest length is at least one byte");
-    let params =
-        SignatureLayoutParams::new(basis_size, None, config.protocol, config.checksum_length)
-            .with_transfer_digest_length(digest_len);
+    let params = SignatureLayoutParams::new(
+        basis_size,
+        config.block_size,
+        config.protocol,
+        config.checksum_length,
+    )
+    .with_transfer_digest_length(digest_len);
 
     let layout = match calculate_signature_layout(params) {
         Ok(layout) => layout,
@@ -952,6 +967,7 @@ mod tests {
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
             compat_flags: None,
+            block_size: None,
         };
 
         // Production path (windowed BufReader over the basis file).
@@ -1020,6 +1036,7 @@ mod tests {
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
             compat_flags: None,
+            block_size: None,
         };
 
         // Open the basis exactly as the live path does, then let "another
@@ -1087,6 +1104,7 @@ mod tests {
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
             compat_flags: None,
+            block_size: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1140,6 +1158,7 @@ mod tests {
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
             compat_flags: None,
+            block_size: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1182,6 +1201,7 @@ mod tests {
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
             compat_flags: None,
+            block_size: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1258,6 +1278,7 @@ mod tests {
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
             compat_flags: None,
+            block_size: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1329,6 +1350,7 @@ mod tests {
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
             compat_flags: None,
+            block_size: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1389,6 +1411,7 @@ mod tests {
             checksum_algorithm: SignatureAlgorithm::Md4,
             whole_file: false,
             compat_flags: None,
+            block_size: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1449,6 +1472,7 @@ mod tests {
             // Not --whole-file: the redo path must still search for a basis.
             whole_file: false,
             compat_flags: None,
+            block_size: None,
         };
 
         let strong_len = |result: &BasisFileResult| -> u8 {
@@ -1524,6 +1548,7 @@ mod tests {
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
             compat_flags: None,
+            block_size: None,
         };
 
         // No flags -> full length (byte-identical to upstream).
@@ -1537,6 +1562,7 @@ mod tests {
         assert_eq!(
             strong_len(SignatureGenerationConfig {
                 compat_flags: Some(no_cap),
+                block_size: None,
                 ..base
             }),
             16
@@ -1549,6 +1575,7 @@ mod tests {
         assert_eq!(
             strong_len(SignatureGenerationConfig {
                 compat_flags: Some(with_cap),
+                block_size: None,
                 ..base
             }),
             8,
@@ -1587,6 +1614,7 @@ mod tests {
                 checksum_length: NonZeroU8::new(phase_len).unwrap(),
                 checksum_algorithm: algo,
                 compat_flags: None,
+                block_size: None,
             };
             let params = SignatureLayoutParams::new(
                 file_size,
@@ -1666,5 +1694,59 @@ mod tests {
                 sig(size, block, 16, xxh3_64);
             }
         }
+    }
+
+    /// upstream: generator.c:720-721 - `if (block_size) blength = block_size;`.
+    /// The generator is the side that sizes the blocks it checksums, so the
+    /// value has to reach `generate_basis_signature`, not merely be parsed.
+    /// Without a fixture that CHANGES the block length this assertion would be
+    /// vacuous, so it pins both halves: the requested length is used, and a
+    /// `None` request still selects the square-root heuristic (700 here).
+    #[test]
+    fn block_size_reaches_the_generated_signature() {
+        const SIZE: usize = 4096;
+        let data: Vec<u8> = (0..SIZE).map(|i| ((i * 31 + 7) % 256) as u8).collect();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("basis.bin");
+        fs::write(&path, &data).expect("write basis");
+
+        let sign = |block_size: Option<NonZeroU32>| {
+            let cfg = SignatureGenerationConfig {
+                protocol: ProtocolVersion::NEWEST,
+                checksum_length: NonZeroU8::new(16).unwrap(),
+                checksum_algorithm: SignatureAlgorithm::Md4,
+                compat_flags: None,
+                block_size,
+            };
+            generate_basis_signature(
+                fast_io::open_basis_nofollow(&path).expect("open basis"),
+                SIZE as u64,
+                path.clone(),
+                protocol::FnameCmpType::Fname,
+                None,
+                cfg,
+            )
+            .signature
+            .expect("signature")
+        };
+
+        let heuristic = sign(None);
+        assert_eq!(
+            heuristic.layout().block_length().get(),
+            700,
+            "no -B must keep upstream's BLOCK_SIZE default (rsync.h:25)",
+        );
+
+        let requested = sign(NonZeroU32::new(2048));
+        assert_eq!(
+            requested.layout().block_length().get(),
+            2048,
+            "-B 2048 must displace the heuristic",
+        );
+        assert_eq!(
+            requested.blocks().len(),
+            2,
+            "4096 bytes at 2048 is exactly two blocks",
+        );
     }
 }

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -830,6 +830,7 @@ impl ReceiverContext {
             checksum_algorithm,
             whole_file: self.config.flags.whole_file,
             compat_flags: self.compat_flags,
+            block_size: self.config.block_size,
         }
     }
 

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -392,6 +392,7 @@ impl ReceiverContext {
                         let protocol = self.protocol;
                         let compat_flags = self.compat_flags;
                         let whole_file = self.config.flags.whole_file;
+                        let block_size = self.config.block_size;
                         let dest_dir = &setup.dest_dir;
                         let checksum_length = setup.checksum_length;
                         let checksum_algorithm = setup.checksum_algorithm;
@@ -426,6 +427,7 @@ impl ReceiverContext {
                                         checksum_algorithm,
                                         whole_file,
                                         compat_flags,
+                                        block_size,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })
@@ -452,6 +454,7 @@ impl ReceiverContext {
                                         checksum_algorithm,
                                         whole_file,
                                         compat_flags,
+                                        block_size,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })
@@ -990,6 +993,7 @@ impl ReceiverContext {
                 checksum_algorithm: setup.checksum_algorithm,
                 whole_file: self.config.flags.whole_file,
                 compat_flags: self.compat_flags,
+                block_size: self.config.block_size,
             };
             let basis = find_basis_file_with_config(&basis_config);
 

--- a/crates/transfer/tests/fuzzy_level2_basis_search.rs
+++ b/crates/transfer/tests/fuzzy_level2_basis_search.rs
@@ -76,6 +76,7 @@ fn fuzzy_level2_finds_basis_in_reference_directory() {
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
         compat_flags: None,
+        block_size: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -136,6 +137,7 @@ fn fuzzy_level1_does_not_search_reference_directories() {
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
         compat_flags: None,
+        block_size: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -199,6 +201,7 @@ fn fuzzy_level2_selects_best_match_across_reference_dirs() {
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
         compat_flags: None,
+        block_size: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -255,6 +258,7 @@ fn fuzzy_level2_generates_valid_signature_from_basis() {
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
         compat_flags: None,
+        block_size: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -314,6 +318,7 @@ fn fuzzy_level0_skips_search() {
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
         compat_flags: None,
+        block_size: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -363,6 +368,7 @@ fn whole_file_bypasses_fuzzy_search() {
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: true,
         compat_flags: None,
+        block_size: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -414,6 +420,7 @@ fn fuzzy_basis_selection_emits_debug_fuzzy_line() {
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
         compat_flags: None,
+        block_size: None,
     };
 
     let result = find_basis_file_with_config(&config);

--- a/tests/block_size_wire.rs
+++ b/tests/block_size_wire.rs
@@ -1,0 +1,276 @@
+//! `-B` / `--block-size` must reach the generator on EVERY transport.
+//!
+//! The generator - the receiving side - is what sizes the blocks it checksums:
+//!
+//! ```c
+//! /* generator.c:720-721, inside sum_sizes_sqroot() */
+//! if (block_size)
+//!     blength = block_size;
+//! else if (len <= BLOCK_SIZE * BLOCK_SIZE)
+//!     blength = BLOCK_SIZE;            /* rsync.h:25 - 700 */
+//! ```
+//!
+//! and the client re-emits the option to the server so the remote generator
+//! reaches the same `blength`:
+//!
+//! ```c
+//! /* options.c:2953-2954 */
+//! if (block_size) {
+//!     if (asprintf(&arg, "-B%u", (int)block_size) < 0)
+//! ```
+//!
+//! WHY this is a class test rather than one regression case: oc has THREE
+//! places that decide the receiving side's block length - the local-copy
+//! executor, the `--server` argv parser, and the daemon's own client-args
+//! parser - and until this test existed only the local one honoured `-B`. A
+//! per-path test would have passed on whichever path its author happened to
+//! pick. Asserting the same option across every transport in one loop is what
+//! makes a newly added or newly forgotten path fail.
+//!
+//! The assertions are not free-floating expectations; both are arithmetic
+//! consequences of the block length, and they were confirmed against rsync
+//! 3.5.0 (protocol 32) on this exact fixture:
+//!
+//! ```text
+//! $ rsync -I --no-whole-file --stats -B 2048 src/f.bin host:dest/f.bin
+//! Literal data: 2,048 bytes    Matched data: 2,048 bytes
+//! $ rsync -I --no-whole-file --stats     src/f.bin host:dest/f.bin
+//! Literal data: 700 bytes      Matched data: 3,396 bytes
+//! ```
+//!
+//! - 4096 bytes at `-B 2048` is two blocks; only the first differs, so
+//!   literal == matched == 2048.
+//! - 4096 bytes at the 700-byte default is five full blocks plus a 596-byte
+//!   remainder; only the first differs, so literal == 700 and the rest
+//!   (3396 bytes, INCLUDING the short final block) matches.
+//!
+//! The default case therefore does double duty: it is the non-vacuity control
+//! (a run that ignored `-B` would print these numbers for BOTH cases, which the
+//! `assert_ne!` below rejects) and it pins the short-final-block match.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the remote-shell shim uses `/bin/sh`).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// 4096 = 2 x 2048 = 5 x 700 + 596, so the fixture exercises both an exact
+/// division and a short final block without changing size between cases.
+const FILE_LEN: usize = 4096;
+
+/// Bytes 0..DIFF_LEN are rewritten in the source; everything after is shared
+/// with the basis, so exactly one block of any tested size is dirty.
+const DIFF_LEN: usize = 50;
+
+/// Deterministic, NON-PERIODIC filler.
+///
+/// An arithmetic sequence (`i * k + c`) repeats with a short period, which
+/// creates duplicate blocks; with duplicates present the rolling-hash probe
+/// order decides which basis block a window resolves to, and nothing in the
+/// protocol makes that choice canonical. A comparison built on such data can
+/// diverge between two correct runs. A seeded xorshift keeps the fixture
+/// reproducible without that hazard.
+fn filler(seed: u64, len: usize) -> Vec<u8> {
+    let mut state = seed | 1;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 24) as u8
+        })
+        .collect()
+}
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// A remote-shell stand-in: drops the leading options and the host token, then
+/// execs the server command, so the "remote" is this same binary running for
+/// real as `--server`.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Transport {
+    Local,
+    Push,
+    Pull,
+}
+
+impl Transport {
+    const ALL: [Self; 3] = [Self::Local, Self::Push, Self::Pull];
+}
+
+/// The `--stats` literal/matched split for one transfer.
+#[derive(Debug, PartialEq, Eq)]
+struct Split {
+    literal: u64,
+    matched: u64,
+}
+
+fn parse_split(output: &str) -> Split {
+    let field = |label: &str| -> u64 {
+        output
+            .lines()
+            .find_map(|line| line.strip_prefix(label))
+            .and_then(|rest| rest.split_whitespace().next())
+            .map(|n| n.replace(',', ""))
+            .and_then(|n| n.parse().ok())
+            .unwrap_or_else(|| panic!("no `{label}` line in --stats output:\n{output}"))
+    };
+    Split {
+        literal: field("Literal data: "),
+        matched: field("Matched data: "),
+    }
+}
+
+/// Runs one delta transfer and returns its literal/matched split.
+///
+/// `-I` defeats the quick-check (source and basis share a size, and without it
+/// a same-second mtime would skip the transfer outright and report 0/0);
+/// `--no-whole-file` forces the delta algorithm on the local path, which
+/// otherwise copies whole files.
+fn run(transport: Transport, block_size: Option<u32>) -> Split {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let shim = write_rsh_shim(tmp.path());
+    let binary = oc_binary();
+
+    let src_dir = tmp.path().join("src");
+    let dst_dir = tmp.path().join("dst");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    fs::create_dir_all(&dst_dir).expect("mkdir dst");
+
+    let basis = filler(0x5eed_1234, FILE_LEN);
+    let mut source = basis.clone();
+    source[..DIFF_LEN].copy_from_slice(&filler(0xd1ff_9876, DIFF_LEN));
+
+    let src = src_dir.join("f.bin");
+    let dst = dst_dir.join("f.bin");
+    fs::write(&src, &source).expect("write source");
+    fs::write(&dst, &basis).expect("write basis");
+
+    let mut cmd = Command::new(&binary);
+    cmd.arg("-I").arg("--no-whole-file").arg("--stats");
+    if let Some(size) = block_size {
+        cmd.arg("-B").arg(size.to_string());
+    }
+    match transport {
+        Transport::Local => {
+            cmd.arg(&src).arg(&dst);
+        }
+        Transport::Push => {
+            cmd.arg("--rsh")
+                .arg(&shim)
+                .arg("--rsync-path")
+                .arg(&binary)
+                .arg(&src)
+                .arg(format!("bshost:{}", dst.display()));
+        }
+        Transport::Pull => {
+            cmd.arg("--rsh")
+                .arg(&shim)
+                .arg("--rsync-path")
+                .arg(&binary)
+                .arg(format!("bshost:{}", src.display()))
+                .arg(&dst);
+        }
+    }
+
+    let out = cmd.output().expect("run oc-rsync");
+    assert!(
+        out.status.success(),
+        "{transport:?} with -B {block_size:?} failed: {}\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert_eq!(
+        fs::read(&dst).expect("read dest"),
+        source,
+        "{transport:?} must still reconstruct the file byte-for-byte",
+    );
+
+    let split = parse_split(&String::from_utf8_lossy(&out.stdout));
+    assert_eq!(
+        split.literal + split.matched,
+        FILE_LEN as u64,
+        "{transport:?}: literal + matched must account for the whole file",
+    );
+    split
+}
+
+/// upstream: generator.c:720-721 - `-B` displaces the square-root heuristic on
+/// whichever side runs the generator, so every transport must land on the same
+/// block length. Before this test, the wire paths silently used the 700-byte
+/// default and produced the `no -B` numbers even when `-B 2048` was given.
+#[test]
+fn block_size_is_honoured_on_every_transport() {
+    let with_b: Vec<_> = Transport::ALL.map(|t| (t, run(t, Some(2048)))).into();
+    for (transport, split) in &with_b {
+        assert_eq!(
+            (split.literal, split.matched),
+            (2048, 2048),
+            "{transport:?}: 4096 bytes at -B 2048 is two blocks, one of them dirty",
+        );
+    }
+}
+
+/// The non-vacuity control for [`block_size_is_honoured_on_every_transport`]:
+/// with no `-B` the heuristic picks upstream's 700-byte `BLOCK_SIZE`
+/// (rsync.h:25), which yields a DIFFERENT split. A path that ignores `-B`
+/// prints these numbers in both tests, so the `assert_ne!` is what turns the
+/// pair into a discriminating oracle.
+#[test]
+fn default_block_size_differs_and_matches_the_short_final_block() {
+    for transport in Transport::ALL {
+        let split = run(transport, None);
+        assert_eq!(
+            (split.literal, split.matched),
+            (700, 3396),
+            "{transport:?}: 5 x 700 + a 596-byte tail, first block dirty, tail matched",
+        );
+        assert_ne!(
+            (split.literal, split.matched),
+            (2048, 2048),
+            "{transport:?}: the default must not coincide with -B 2048",
+        );
+    }
+}
+
+/// A block size larger than the file is one block, and that block is dirty, so
+/// the delta degenerates to a whole-file send. This pins the upper edge of the
+/// range: a path that clamped or ignored a large `-B` would still find matches.
+#[test]
+fn block_size_at_least_the_file_length_matches_nothing() {
+    for transport in Transport::ALL {
+        let split = run(transport, Some(FILE_LEN as u32));
+        assert_eq!(
+            (split.literal, split.matched),
+            (FILE_LEN as u64, 0),
+            "{transport:?}: one whole-file block, and it differs",
+        );
+    }
+}

--- a/tests/block_size_wire.rs
+++ b/tests/block_size_wire.rs
@@ -44,9 +44,15 @@
 //!   remainder; only the first differs, so literal == 700 and the rest
 //!   (3396 bytes, INCLUDING the short final block) matches.
 //!
-//! The default case therefore does double duty: it is the non-vacuity control
-//! (a run that ignored `-B` would print these numbers for BOTH cases, which the
-//! `assert_ne!` below rejects) and it pins the short-final-block match.
+//! The default case is the non-vacuity control: a run that ignored `-B` would
+//! print those numbers for BOTH cases, which the `assert_ne!` below rejects.
+//!
+//! It is deliberately NOT a short-final-block pin, though it looks like one.
+//! The basis differs only in bytes 0..49, so the 596-byte tail is preceded by a
+//! four-block match run and is reachable by adjacency continuation alone. A
+//! build that could only reach a short final block by adjacency would pass this
+//! identically. Pinning standalone-tail reachability needs a fixture that shares
+//! ONLY the tail; that belongs with the tail-block work, not here.
 //!
 //! Skip conditions (test passes with a printed reason):
 //! - Not Unix (the remote-shell shim uses `/bin/sh`).
@@ -243,14 +249,17 @@ fn block_size_is_honoured_on_every_transport() {
 /// (rsync.h:25), which yields a DIFFERENT split. A path that ignores `-B`
 /// prints these numbers in both tests, so the `assert_ne!` is what turns the
 /// pair into a discriminating oracle.
+///
+/// The 3396 matched bytes include the 596-byte tail, but that does NOT pin
+/// standalone short-block reachability - see the module docs for why.
 #[test]
-fn default_block_size_differs_and_matches_the_short_final_block() {
+fn default_block_size_differs_from_an_explicit_one() {
     for transport in Transport::ALL {
         let split = run(transport, None);
         assert_eq!(
             (split.literal, split.matched),
             (700, 3396),
-            "{transport:?}: 5 x 700 + a 596-byte tail, first block dirty, tail matched",
+            "{transport:?}: 5 x 700 + a 596-byte tail, first block dirty",
         );
         assert_ne!(
             (split.literal, split.matched),


### PR DESCRIPTION
## What

`-B` / `--block-size` was honoured only on the local-copy path. Every network transfer silently fell back to the 700-byte `BLOCK_SIZE` default (rsync.h:25), so an operator-tuned block size produced a different block signature, a different delta token stream and a different matched/literal split than upstream — in both directions, on both transports.

## Measured

Against rsync 3.5.0 (protocol 32). 4096-byte file, basis differing only in bytes 0..49:

| | | `-B 2048` | no `-B` (control) |
|---|---|---|---|
| upstream 3.5.0 | local / ssh / daemon | 2048 / 2048 | 700 / 3396 |
| oc-rsync | local | 2048 / 2048 | 700 / 3396 |
| oc-rsync | ssh push, ssh pull | **700 / 3396** | 700 / 3396 |
| oc-rsync | daemon push | **700 / 3396** | 700 / 3396 |

oc's wire output *with* `-B 2048` was byte-for-byte its own *no*-`-B` output. The control column is what makes that unambiguous: identical numbers with and without the option mean the option was never applied, not that it happened to agree.

After the fix every cell matches upstream, including oc-client-to-upstream-daemon and upstream-client-to-oc-daemon.

## Why it happened: three decoders, three drops

The generator is the side that sizes the blocks it checksums (`generator.c:720-721`, `if (block_size) blength = block_size;`), so `-B` is only ever acted on by the receiving side. oc has three places that decode a peer's options into a receiving-side config, and the value was lost in all three:

1. **`crates/cli/src/frontend/server/run.rs`** — the `--server` argv parser captured `-B<digits>` into `ServerLongFlags::block_size` (so it would not leak into the positional path list) and then never read the field.
2. **`crates/core/src/client/remote/flags.rs`** — `block_size_override` never crossed from `ClientConfig` into the in-process `ServerConfig`, so a PULL (client is the receiver) had no value to apply either.
3. **`crates/daemon/.../client_args/long_form_args.rs`** — the daemon decodes the client argv through its own parser, which had no `-B` arm at all.

Plus one emission divergence found alongside them: the daemon arg vector emitted `--block-size=N`, an oc-only long spelling. Upstream emits the short `-B%u` (`options.c:2953-2954`), which the SSH builder already did. No upstream daemon parses the long form, so even a correct decoder would not have seen it.

## What the fix does *not* do

It does not add a second block-length rule. There is exactly one heuristic — `signature::block_size::calculate_block_length`, which already accepts the override — and the receiving side was reaching it through `SignatureLayoutParams::new(basis_size, None, ..)`. Carrying `block_size` on `ServerConfig` and threading it through `BasisFileConfig` replaces that hardcoded `None`. The bound check mirroring upstream's `parse_size_arg(.., 0, max_blength, False)` lives once, in `transfer::config::parse_block_size_arg`, and is called by both the `--server` parser and the daemon parser.

Adding the field to `BasisFileConfig` also made the compiler enumerate every construction site (four in `crates/transfer`, seven more in its integration tests) rather than leaving it to grep.

## A test pinned the defect

`block_size_forwarded_both_directions` asserted the daemon vector contained `--block-size=4096`. That assertion was the bug's monument: it locked in the spelling no peer parses. It now asserts `-B4096` **and** that the long form is absent, and is renamed accordingly.

## Tests

- `tests/block_size_wire.rs` runs the same option across local, SSH push and SSH pull **in one loop**. A per-path test would have passed on whichever path its author happened to pick — that is precisely how this survived. Reverting either wiring site independently turns it red (verified both ways).
- The no-`-B` case is the non-vacuity control (`assert_ne!` against the `-B 2048` numbers): 5 x 700 plus a 596-byte tail.
  It is **not** a short-final-block pin, though it looks like one — an earlier revision of this body claimed it was. The basis differs only in bytes 0..49, so the tail is preceded by a four-block match run and is reachable by adjacency continuation alone; a build that could only reach a short final block by adjacency would pass it identically. Pinning standalone-tail reachability needs a fixture sharing *only* the tail, which belongs with the tail-block work.
- A third case pins the upper edge: `-B` at or above the file length is one dirty block, so the delta degenerates to a whole-file send.
- Unit tests for the shared parser (protocol-dependent ceiling, `0` means heuristic, junk rejected) and for the generator actually *using* the value rather than merely storing it.
- Fixture bytes come from a seeded xorshift, not an arithmetic sequence: a short-period filler creates duplicate blocks, and with duplicates present the probe order decides which basis block a window resolves to, so two correct runs can legitimately disagree.

## Verification

```
cargo fmt --all -- --check                                                        clean
cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings   clean
cargo nextest run --all-features -p transfer -p core -p cli -E '...'              243 passed
```

Plus the manual oracle matrix above against a real rsync 3.5.0 binary, on local, SSH (push and pull) and rsync:// daemon, at `-B` 512 / 700 / 2048 / 4096 and with no `-B`.

## Not covered here

The daemon end-to-end cell is verified by hand (script in the reproducer) but not yet in nextest — the suite has no reusable daemon harness for a delta-stats assertion. Follow-up task filed.

