### PR TITLE
fix(delete): carry --ignore-errors onto the local receiver and local copy

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -538,7 +538,7 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // config (the wire-side sender conversion in build_wire_format_rules only
     // affects what the remote sender hides, not local delete protection).
     server_config.deletion.delete_excluded = config.delete_excluded();
-    // upstream: generator.c:304 delete_in_dir() - `io_error & IOERR_GENERAL &&
+    // upstream: generator.c:298 delete_in_dir() - `io_error & IOERR_GENERAL &&
     // !ignore_errors` skips the whole delete pass, so `--ignore-errors` is what
     // lets deletions proceed after a source-scan error. Like `--preallocate` and
     // `--remove-source-files` above, it is long-form-only with no compact letter,
@@ -909,7 +909,7 @@ mod tests {
     }
 
     /// `--ignore-errors` governs the receiver's delete pass
-    /// (upstream: generator.c:304 `io_error & IOERR_GENERAL && !ignore_errors`).
+    /// (upstream: generator.c:298 `io_error & IOERR_GENERAL && !ignore_errors`).
     /// On a pull the LOCAL client is the receiver, and the flag is long-form-only
     /// so it never rides the compact flag string this config is parsed from -
     /// exactly like `--preallocate` and `--remove-source-files`. Without this the

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -538,6 +538,16 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // config (the wire-side sender conversion in build_wire_format_rules only
     // affects what the remote sender hides, not local delete protection).
     server_config.deletion.delete_excluded = config.delete_excluded();
+    // upstream: generator.c:304 delete_in_dir() - `io_error & IOERR_GENERAL &&
+    // !ignore_errors` skips the whole delete pass, so `--ignore-errors` is what
+    // lets deletions proceed after a source-scan error. Like `--preallocate` and
+    // `--remove-source-files` above, it is long-form-only with no compact letter,
+    // so build_server_flag_string never packs it and the local ServerConfig
+    // parsed from that string never sees it. On a pull the LOCAL client is the
+    // receiver and owns the delete pass, so the flag has to be carried here; on
+    // a push the remote receiver picks it up from the forwarded `--ignore-errors`
+    // arg (options.c:3062), which is why only the pull direction was affected.
+    server_config.deletion.ignore_errors = config.ignore_errors();
     // upstream: delete.c:156 - `--max-delete` is enforced by the generator,
     // which for a remote-shell pull runs on the local client (the receiver).
     // The `--max-delete=NUM` server arg is forwarded to the remote sender too,
@@ -896,6 +906,42 @@ mod tests {
         let mut server_config = ServerConfig::default();
         apply_common_server_flags(&config, &mut server_config);
         assert!(!server_config.flags.info_flags.itemize);
+    }
+
+    /// `--ignore-errors` governs the receiver's delete pass
+    /// (upstream: generator.c:304 `io_error & IOERR_GENERAL && !ignore_errors`).
+    /// On a pull the LOCAL client is the receiver, and the flag is long-form-only
+    /// so it never rides the compact flag string this config is parsed from -
+    /// exactly like `--preallocate` and `--remove-source-files`. Without this the
+    /// receiver keeps a destination file the operator asked to have deleted.
+    #[test]
+    fn apply_common_server_flags_propagates_ignore_errors() {
+        let config = ClientConfig::builder().ignore_errors(true).build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(
+            server_config.deletion.ignore_errors,
+            "--ignore-errors must reach the local receiver on a pull"
+        );
+    }
+
+    /// CLASS GUARD: every deletion option the client can set must survive the
+    /// bridge. `ignore_errors` was the third long-form-only flag to be dropped
+    /// here, so this asserts the whole group at once rather than one field -
+    /// a newly added `DeletionConfig` field that nobody carries fails here.
+    #[test]
+    fn apply_common_server_flags_carries_every_deletion_option() {
+        let config = ClientConfig::builder()
+            .delete_excluded(true)
+            .ignore_errors(true)
+            .max_delete(Some(7))
+            .build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+
+        assert!(server_config.deletion.delete_excluded, "delete_excluded");
+        assert!(server_config.deletion.ignore_errors, "ignore_errors");
+        assert_eq!(server_config.deletion.max_delete, Some(7), "max_delete");
     }
 
     #[test]

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -925,13 +925,22 @@ mod tests {
         );
     }
 
-    /// CLASS GUARD: every deletion option the client can set must survive the
-    /// bridge. `ignore_errors` was the third long-form-only flag to be dropped
-    /// here, so this asserts the whole group at once rather than one field -
-    /// a newly added `DeletionConfig` field that nobody carries fails here.
+    /// CLASS GUARD: every deletion option must survive the bridge.
+    ///
+    /// `ignore_errors` was the THIRD long-form-only flag dropped by this
+    /// function - `--preallocate` and `--remove-source-files` came before it,
+    /// and their fix comments sit a few lines above the fix for this one. A
+    /// per-flag test would have caught none of the three, so this asserts the
+    /// group rather than a field.
+    ///
+    /// The completeness half is enforced by the COMPILER, not by a hand-kept
+    /// list: the exhaustive destructure below stops building the moment a field
+    /// is added to `DeletionConfig`, forcing whoever adds it to decide how it
+    /// crosses the bridge instead of silently inheriting `Default`.
     #[test]
     fn apply_common_server_flags_carries_every_deletion_option() {
         let config = ClientConfig::builder()
+            .delete_after(true)
             .delete_excluded(true)
             .ignore_errors(true)
             .max_delete(Some(7))
@@ -939,9 +948,19 @@ mod tests {
         let mut server_config = ServerConfig::default();
         apply_common_server_flags(&config, &mut server_config);
 
-        assert!(server_config.deletion.delete_excluded, "delete_excluded");
-        assert!(server_config.deletion.ignore_errors, "ignore_errors");
-        assert_eq!(server_config.deletion.max_delete, Some(7), "max_delete");
+        let ::transfer::config::DeletionConfig {
+            max_delete,
+            ignore_errors,
+            late_delete,
+            delete_after,
+            delete_excluded,
+        } = server_config.deletion;
+
+        assert_eq!(max_delete, Some(7), "max_delete");
+        assert!(ignore_errors, "ignore_errors");
+        assert!(late_delete, "late_delete");
+        assert!(delete_after, "delete_after");
+        assert!(delete_excluded, "delete_excluded");
     }
 
     #[test]

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -925,20 +925,24 @@ mod tests {
         );
     }
 
-    /// CLASS GUARD: every deletion option must survive the bridge.
+    /// GROUP guard: every `DeletionConfig` field must survive the bridge.
     ///
-    /// `ignore_errors` was the THIRD long-form-only flag dropped by this
-    /// function - `--preallocate` and `--remove-source-files` came before it,
-    /// and their fix comments sit a few lines above the fix for this one. A
-    /// per-flag test would have caught none of the three, so this asserts the
-    /// group rather than a field.
+    /// ⚠ This is NOT a guard for the defect class. The class is "long-form-only
+    /// flag with no compact letter, so it never rides the flag string this
+    /// config is parsed from and MUST be bridged explicitly". `ignore_errors`
+    /// is its third member; the first two, `--preallocate` and
+    /// `--remove-source-files`, land in `ServerConfig.flags`, NOT in
+    /// `DeletionConfig` - so this guard would have caught one of the three.
+    /// It stops the next missing DELETION field and nothing wider. Closing the
+    /// class needs the long-form-only set enumerated, which is not derivable
+    /// from `build_server_flag_string` by inspection; that is tracked separately.
     ///
-    /// The completeness half is enforced by the COMPILER, not by a hand-kept
-    /// list: the exhaustive destructure below stops building the moment a field
-    /// is added to `DeletionConfig`, forcing whoever adds it to decide how it
-    /// crosses the bridge instead of silently inheriting `Default`.
+    /// Within its group the completeness half is enforced by the COMPILER, not
+    /// by a hand-kept list: the exhaustive destructure below stops building the
+    /// moment a field is added to `DeletionConfig`, forcing whoever adds it to
+    /// decide how it crosses the bridge instead of silently inheriting `Default`.
     #[test]
-    fn apply_common_server_flags_carries_every_deletion_option() {
+    fn apply_common_server_flags_carries_every_deletion_config_field() {
         let config = ClientConfig::builder()
             .delete_after(true)
             .delete_excluded(true)

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -775,8 +775,14 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             DeleteMode::During | DeleteMode::DuringDefault | DeleteMode::Disabled => options,
         };
 
+        // upstream: generator.c:304 delete_in_dir() - `--ignore-errors` lets the
+        // delete pass run after a source-scan I/O error instead of skipping it
+        // with a notice. The local-copy engine reads the flag from its own
+        // options, so it has to be carried across this bridge exactly as the
+        // remote path carries it onto ServerConfig.
         options
             .delete_excluded(config.delete_excluded())
+            .ignore_errors(config.ignore_errors())
             .max_deletions(config.max_delete())
     }
 
@@ -1696,6 +1702,50 @@ mod local_copy_option_wiring_tests {
                 .temp_directory_path()
                 .is_none()
         );
+    }
+
+    /// `--ignore-errors` lets the delete pass run despite a general I/O error
+    /// (upstream: generator.c:304). The local-copy engine reads it from
+    /// `LocalCopyOptions`, so it has to be carried across this bridge - without
+    /// it the engine sees the default `false` and prints the upstream skip
+    /// notice on a run where upstream stays silent and deletes.
+    ///
+    /// The engine-side setter has an extensive test file of its own, every case
+    /// of which passed while nothing in production ever called it. This asserts
+    /// the WIRING, which is the part that was missing.
+    #[test]
+    fn local_copy_options_carry_ignore_errors() {
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("src"), OsString::from("dst")])
+            .delete(true)
+            .ignore_errors(true)
+            .build();
+
+        assert!(config.ignore_errors(), "client config must hold the flag");
+        assert!(
+            build_local_copy_options(&config, None).ignore_errors_enabled(),
+            "--ignore-errors must reach the local-copy engine"
+        );
+    }
+
+    /// CLASS GUARD: the deletion group must survive this bridge as a whole.
+    /// `ignore_errors` was carried by neither of oc's two config bridges, so
+    /// this asserts every deletion option together rather than one field.
+    #[test]
+    fn local_copy_options_carry_every_deletion_option() {
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("src"), OsString::from("dst")])
+            .delete(true)
+            .delete_excluded(true)
+            .ignore_errors(true)
+            .max_delete(Some(7))
+            .build();
+
+        let options = build_local_copy_options(&config, None);
+        assert!(options.delete_extraneous(), "delete");
+        assert!(options.delete_excluded_enabled(), "delete_excluded");
+        assert!(options.ignore_errors_enabled(), "ignore_errors");
+        assert_eq!(options.max_deletion_limit(), Some(7), "max_deletions");
     }
 
     #[test]

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -775,7 +775,7 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             DeleteMode::During | DeleteMode::DuringDefault | DeleteMode::Disabled => options,
         };
 
-        // upstream: generator.c:304 delete_in_dir() - `--ignore-errors` lets the
+        // upstream: generator.c:298 delete_in_dir() - `--ignore-errors` lets the
         // delete pass run after a source-scan I/O error instead of skipping it
         // with a notice. The local-copy engine reads the flag from its own
         // options, so it has to be carried across this bridge exactly as the
@@ -1705,7 +1705,7 @@ mod local_copy_option_wiring_tests {
     }
 
     /// `--ignore-errors` lets the delete pass run despite a general I/O error
-    /// (upstream: generator.c:304). The local-copy engine reads it from
+    /// (upstream: generator.c:298). The local-copy engine reads it from
     /// `LocalCopyOptions`, so it has to be carried across this bridge - without
     /// it the engine sees the default `false` and prints the upstream skip
     /// notice on a run where upstream stays silent and deletes.

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -1728,6 +1728,12 @@ mod local_copy_option_wiring_tests {
         );
     }
 
+    /// ⚠ Weaker than its sibling in `remote::flags`, which destructures
+    /// `DeletionConfig` exhaustively so the compiler rejects a newly added field
+    /// until someone decides how it crosses the bridge. `LocalCopyOptions` keeps
+    /// its fields private to `engine`, so this side can only assert an explicit
+    /// list - a new option added there will not fail here on its own.
+    ///
     /// CLASS GUARD: the deletion group must survive this bridge as a whole.
     /// `ignore_errors` was carried by neither of oc's two config bridges, so
     /// this asserts every deletion option together rather than one field.

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -1228,3 +1228,110 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod delivery_classification {
+    use super::*;
+
+    /// CLASS GUARD for the "long-form-only flag was never bridged" defect.
+    ///
+    /// `ParsedServerFlags` exists to be *parsed from the compact flag string*.
+    /// That is what made the defect invisible three times: everything around a
+    /// given field arrives for free, so a field the string CANNOT carry looks
+    /// no different from one it can. `--preallocate`, `--remove-source-files`
+    /// and (in `DeletionConfig`) `--ignore-errors` were each dropped this way.
+    ///
+    /// The exhaustive destructure below is the guard. Adding a field to
+    /// `ParsedServerFlags` stops the build with `error[E0027]` until the author
+    /// puts it in one of the three groups, which forces the question "how does
+    /// this reach the peer, and the LOCAL receiver on a pull?" to be answered
+    /// once, here, instead of being discovered by an operator.
+    ///
+    /// The classification was MEASURED, not inspected: each option was set on a
+    /// `ClientConfig`, round-tripped through `build_server_flag_string` ->
+    /// `from_flag_string_and_args`, then through `apply_common_server_flags`.
+    /// An automated text-analysis pass over `parse()` was tried first and
+    /// returned 44 of 56 fields as "never assigned", including `compress`,
+    /// `delete` and `dry_run` - obviously wrong. That is why these are hand
+    /// classifications: the automation gives a confidently incorrect answer.
+    #[test]
+    fn every_parsed_server_flags_field_is_classified() {
+        #[allow(unused_variables)]
+        let ParsedServerFlags {
+            // -- DECODED FROM THE FLAG STRING (parse_transfer_flag assigns it,
+            //    and build_server_flag_string emits the letter). ------------
+            links,
+            owner,
+            group,
+            devices,
+            specials,
+            times,
+            atimes,
+            perms,
+            recursive,
+            rsh,
+            archive,
+            verbose,
+            verbose_level,
+            compress,
+            checksum,
+            hard_links,
+            acls,
+            xattrs,
+            xattrs_level,
+            dry_run,
+            dirs,
+            whole_file,
+            sparse,
+            one_file_system,
+            relative,
+            update,
+            crtimes,
+            ignore_times,
+            backup,
+            cvs_exclude,
+
+            // -- CARRIED BY apply_common_server_flags (no compact letter, so
+            //    the string cannot deliver it and a bridge is mandatory). ---
+            preallocate,
+            remove_source_files,
+            no_implied_dirs,
+            copy_unsafe_links,
+            safe_links,
+            append,
+            append_verify,
+            copy_devices,
+            info_flags,
+
+            // -- ⚠ DECODER-CAPABLE BUT NEVER EMITTED. `parse_transfer_flag`
+            //    handles the letter, but build_server_flag_string never writes
+            //    it and no long arg is forwarded, so the peer is never told.
+            //    Upstream DOES pack all of these (options.c server_options:
+            //    K k L E y O J m). Tracked as task 650 - do not "fix" by
+            //    moving them to the bridge; the letter is the upstream rule.
+            keep_dirlinks,
+            copy_dirlinks,
+            copy_links,
+            preserve_executability,
+            fuzzy_level,
+            omit_dir_times,
+            omit_link_times,
+            prune_empty_dirs,
+
+            // -- ⚠ NEITHER MECHANISM. No compact letter, no bridge. Each needs
+            //    a decision; tracked as task 647. `partial` is forwarded as a
+            //    long arg so it is delivered, just not through these two.
+            //    `parallel_delta_scan` is an oc extension with no upstream
+            //    letter, so a bridge is its only possible route.
+            partial,
+            parallel_delta_scan,
+            mkpath,
+            incremental_recursion,
+            msgs_to_stderr,
+            numeric_ids,
+            delete,
+            list_only,
+            only_write_batch,
+        } = ParsedServerFlags::default();
+    }
+}

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -1243,7 +1243,7 @@ mod delivery_classification {
     ///
     /// The exhaustive destructure below is the guard. Adding a field to
     /// `ParsedServerFlags` stops the build with `error[E0027]` until the author
-    /// puts it in one of the three groups, which forces the question "how does
+    /// puts it in one of the four groups, which forces the question "how does
     /// this reach the peer, and the LOCAL receiver on a pull?" to be answered
     /// once, here, instead of being discovered by an operator.
     ///
@@ -1254,6 +1254,12 @@ mod delivery_classification {
     /// returned 44 of 56 fields as "never assigned", including `compress`,
     /// `delete` and `dry_run` - obviously wrong. That is why these are hand
     /// classifications: the automation gives a confidently incorrect answer.
+    ///
+    /// ⚠ `build_server_flag_string` alone is NOT the wire. It is role-agnostic
+    /// on purpose, so measuring only through it makes the role-gated letters
+    /// look absent when they are emitted one layer up. Group 3 below is exactly
+    /// that set; check the role-aware emitters before concluding anything is
+    /// missing from the wire.
     #[test]
     fn every_parsed_server_flags_field_is_classified() {
         #[allow(unused_variables)]
@@ -1303,12 +1309,20 @@ mod delivery_classification {
             copy_devices,
             info_flags,
 
-            // -- ⚠ DECODER-CAPABLE BUT NEVER EMITTED. `parse_transfer_flag`
-            //    handles the letter, but build_server_flag_string never writes
-            //    it and no long arg is forwarded, so the peer is never told.
-            //    Upstream DOES pack all of these (options.c server_options:
-            //    K k L E y O J m). Tracked as task 650 - do not "fix" by
-            //    moving them to the bridge; the letter is the upstream rule.
+            // -- EMITTED ONLY BY THE ROLE-AWARE EMITTERS. Upstream packs these
+            //    inside the direction branches of server_options()
+            //    (options.c:2641-2660 `if (am_sender) { K m O J y } else { L k
+            //    }`, plus :2690-2693 `else if (preserve_executability &&
+            //    am_sender) 'E'`), so the letter's presence depends on which
+            //    side we are. `build_server_flag_string` is deliberately
+            //    role-agnostic and therefore cannot pack them; the two emitters
+            //    that know the role do:
+            //    `core::client::remote::invocation::builder` (SSH argv) and
+            //    `daemon_transfer::orchestration::arguments` (daemon argv,
+            //    where upstream's `am_sender` is oc's `!is_sender`).
+            //    A new field belonging here must be added to BOTH of those with
+            //    upstream's own condition - not to build_server_flag_string, and
+            //    not to the bridge, which would drop the role gate.
             keep_dirlinks,
             copy_dirlinks,
             copy_links,

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -330,7 +330,7 @@ fn msg_io_error_masks_undefined_bits_from_a_hostile_peer() {
 /// defined bits. Masking at one entry point but not the other is exactly the
 /// defect upstream fixed, so this asserts the property, not one call site.
 ///
-/// upstream: rsync.h:195-200 (the mask's rationale), generator.c:304 (the
+/// upstream: rsync.h:195-200 (the mask's rationale), generator.c:298 (the
 /// delete guard), cleanup.c:213-218 (the exit-code mapping).
 #[test]
 fn no_peer_value_can_steer_the_delete_guard_or_exit_code_off_the_defined_bits() {


### PR DESCRIPTION
## ⚠ A 770-line green test file was sitting on a setter nothing called

`crates/engine/src/local_copy/tests/execute_ignore_errors.rs` exercises `--ignore-errors` across **28 call sites** on the local-copy path. **The setter it drives had zero production callers.** Every case passed, on every CI run, while the flag could never reach the engine in a real transfer.

The file is not worthless and was never vacuous about what it asserts - it drives the real engine through `execute_with_options`, so the delete-pass semantics it pins are genuine. It is **mis-scoped**: it enters *below* the bridge, constructing `LocalCopyOptions` by hand. That is unchanged by this PR. What it never covered - and still would not - is whether the option ever gets set from the CLI.

The volume of green is the hazard. 28 passing cases read as "this flag is well covered".

So the new tests assert the **wiring**, not the behaviour behind it; routing through the setter again would have reproduced the blind spot exactly.

## `--ignore-errors` did not enable deletion on a pull, or locally

```
-a --no-inc-recursive --delete --ignore-errors, source scan hits an unreadable directory

                                extraneous file    "skipping file deletion"
  rsync 3.5.0                      DELETED                 no
  oc-rsync, pull (before)          KEPT                    yes     <- operator-requested delete refused
  oc-rsync, local copy (before)    DELETED                 yes     <- spurious notice
  oc-rsync, both (after)           matches 3.5.0           matches 3.5.0
```

Upstream skips the entire delete pass unless the flag is set - `generator.c:304`, `io_error & IOERR_GENERAL && !ignore_errors`. A destination file the operator explicitly asked to have deleted survived instead.

## Root cause: the flag reaches `ClientConfig` and then stops

Not an `io_error` bug. The value is decoded, stored and forwarded correctly; it is simply never handed to the two components that own the delete pass.

```
CLI --ignore-errors
  -> ParsedArgs.ignore_errors                       parser/entry.rs           OK
  -> ClientConfig.ignore_errors                     drive/config.rs           OK
       +-> forwarded argv, ssh and daemon           invocation/builder.rs     OK   <- push worked
       +-> ServerConfig.deletion.ignore_errors      ** MISSING **                  pull
       +-> LocalCopyOptions.ignore_errors           ** MISSING **                  local copy
```

`apply_common_server_flags` carried `late_delete`, `delete_after`, `delete_excluded` and `max_delete` but not this one; `apply_recursion_and_delete` carried `delete`, the three timings, `delete_excluded` and `max_deletions` but not this one. Two sites, one flag, both defaults `false`.

**The defect class is already documented three lines above the first fix.** `--ignore-errors` is long-form-only with no compact letter, so `build_server_flag_string` never packs it and the local config parsed back out of that string cannot see it. `--preallocate` and `--remove-source-files` hit exactly this and their fix comments sit in the same function. It was recognised twice and missed the third time.

## How the sites were isolated

A **push** is correct and a **pull** is not, which is the whole diagnosis in one comparison: on a push the remote receiver parses the forwarded `--ignore-errors` argument (`options.c:3062` -> oc's server arg parser), so the argv path was never in doubt; only the in-process config bridge was.

This also explains an earlier dead end. PR #7300's receive-side gate reads `config.deletion.ignore_errors`, which this bug pinned to `false` on every pull - so that gate was correct and being fed a false flag. An A/B of two binaries built from that branch showed no behavioural difference, which is what pointed here rather than at the `io_error` plumbing.

## Two independent sites, one root cause - proven by reverting each alone

The lead asked whether the network symptom and the local symptom shared a cause or whether one fix happened to cover both. Measured by reverting each wiring line separately:

```
                                  network extraneous    local "skipping file deletion"
  D1 reverted (network bridge)          KEPT                      absent
  D2 reverted (local bridge)            DELETED                   PRESENT
  both present (as shipped)             DELETED                   absent
```

Each revert breaks exactly one cell. **Same root cause and same defect class, but two independent sites - neither fix covers the other's symptom.**

## Tests: wiring, and a compiler-enforced class guard

Per-flag tests would have caught none of the three instances, so each bridge gets a group guard. On the `ServerConfig` side the completeness half is enforced by the **compiler**, not a hand-kept list - the guard destructures `DeletionConfig` exhaustively:

```
error[E0027]: pattern does not mention field `probe_new_field`
```

That is the measured result of adding a field, so a future `DeletionConfig` member cannot silently inherit `Default`. The local-copy sibling is **weaker and says so in-code**: `LocalCopyOptions` keeps its fields private to `engine`, so that side can only assert an explicit list.

Audit run alongside: all five `DeletionConfig` fields now have a production assignment, so there is **no fourth instance inside the guarded group**. A full triage of the ~170-getter `ClientConfig` surface is audit-sized and deliberately not attempted here - a naive diff yields ~100 candidates that are overwhelmingly delivered as forwarded long args, which is the false-positive shape this repo has been bitten by before.

## Scope

**Not fixed here, deliberately:** oc's sender emits the end-of-flist `io_error` flag ungated, where upstream suppresses it at the send side when `--ignore-errors` is set (`flist.c:2781-2789`). With this change every measured cell already matches upstream, because both an upstream receiver and oc's own receiver gate the value on receipt - so the send-side gate is belt-and-braces and a wire-content difference, not an observable one. Filed separately rather than bundled.

The notice also renders after the summary where upstream prints it during the delete pass; that ordering belongs with the output-funnel work, not here.

## Verification

Measured with `rsync 3.5.0` built from source, both ends of the `-e` wrapper pinned to the same binary (an unpinned wrapper execs `rsync` from `PATH` and silently measures a mixed pair). `--no-inc-recursive` is required or the root delete pass runs before the sender reaches the failing directory and the cell proves nothing.

```
cargo fmt --all -- --check                                                             clean
cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings   clean
cargo nextest run -p core -p engine -p transfer --all-features
                                                        10459 passed, 94 skipped
```

