### PR TITLE
fix(daemon): resolve the real peer address on both stdio paths

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -72,6 +72,7 @@ use crate::{
 
 mod at_error;
 mod help;
+pub(crate) mod peer_address;
 pub(crate) mod tracing_stream;
 
 pub(crate) use self::at_error::AtError;
@@ -432,10 +433,34 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
     let pair = crate::daemon_stream::StdioPair::new(Box::new(stdin), Box::new(stdout));
     let stream = DaemonStream::stdio(pair);
 
-    // upstream: start_daemon() with stdin/stdout fds uses 127.0.0.1:0 as the
-    // synthetic peer address. In remote-shell daemon mode the real peer address
-    // is not available since there is no TCP socket to query.
-    let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+    // upstream: clientname.c:63-78 - a daemon behind a remote shell
+    // (`am_daemon < 0`) has no socket to interrogate, so the peer address comes
+    // from the environment, seeded with `0.0.0.0`.
+    //
+    // The seed is the security-relevant part. This site previously fabricated
+    // `127.0.0.1` and cited upstream for it; upstream does no such thing, and
+    // the synthetic loopback matched `hosts allow = 127.0.0.1` - the canonical
+    // "local only" rule - admitting every client. `0.0.0.0` matches no
+    // realistic allow token, so an unconfigured remote-shell daemon denies.
+    let peer_addr = match peer_address::remote_shell_peer_addr() {
+        peer_address::RemoteShellPeer::Addr(ip) => SocketAddr::new(ip, 0),
+        // upstream: clientname.c:76-81 - a set-but-unparsable variable falls
+        // through to `client_sockaddr()`, which on a remote shell's pipe fails
+        // `getpeername` and exits `RERR_SOCKETIO`. Refuse rather than silently
+        // fall back to a default the operator did not configure.
+        peer_address::RemoteShellPeer::Unusable => {
+            let code = ExitCode::SocketIo;
+            return Err(DaemonError::with_code(
+                code,
+                rsync_error!(
+                    code.as_i32(),
+                    "unable to determine the peer address: a peer-address environment \
+                     variable is set but holds no usable IP address"
+                )
+                .with_role(Role::Daemon),
+            ));
+        }
+    };
 
     // Resolve hostname for the synthetic peer (will resolve localhost).
     // upstream: clientname.c `client_name` forward-confirms unconditionally;

--- a/crates/daemon/src/daemon/peer_address.rs
+++ b/crates/daemon/src/daemon/peer_address.rs
@@ -121,6 +121,13 @@ pub(in crate::daemon) fn remote_shell_peer_addr() -> RemoteShellPeer {
 ///
 /// upstream: clientname.c:47-74 - `client_sockaddr()` rewrites a V4MAPPED
 /// `sockaddr_in6` into a `sockaddr_in` before any lookup or comparison.
+///
+/// Gated to Unix because its only caller is [`inherited_socket_peer_addr`],
+/// which is itself Unix-only: a V4MAPPED peer can only arrive through the
+/// inetd stdin socket this module reads. Without the gate the function is dead
+/// on Windows, and `-D warnings` (set in `_interop-windows.yml` and
+/// `_test-features.yml`) turns that into a build failure.
+#[cfg(unix)]
 fn normalize_v4_mapped(addr: IpAddr) -> IpAddr {
     match addr {
         IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(addr, IpAddr::V4),
@@ -225,6 +232,8 @@ mod tests {
     /// upstream: clientname.c:47-74 - a V4MAPPED peer is rewritten to IPv4
     /// before any ACL comparison, so `hosts allow = 192.0.2.0/24` matches an
     /// IPv4 client arriving on a dual-stack listener.
+    /// Unix-only for the same reason the function is: it has no Windows caller.
+    #[cfg(unix)]
     #[test]
     fn v4_mapped_ipv6_normalises_to_ipv4() {
         let mapped: IpAddr = "::ffff:192.0.2.128".parse().unwrap();
@@ -234,6 +243,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn genuine_ipv6_is_left_alone() {
         let v6: IpAddr = "2001:db8::1".parse().unwrap();

--- a/crates/daemon/src/daemon/peer_address.rs
+++ b/crates/daemon/src/daemon/peer_address.rs
@@ -1,0 +1,254 @@
+// Resolution of the connecting peer's address for the two stdio daemon entry
+// points, mirroring upstream's `client_addr()`.
+//
+// upstream: clientname.c:55-84 - `client_addr(int fd)` has two arms, chosen by
+// the sign of `am_daemon`:
+//
+// ```c
+// if (am_daemon < 0) {              /* daemon over --rsh mode */
+//     strlcpy(ipaddr_buf, "0.0.0.0", sizeof ipaddr_buf);
+//     if ((env_str = getenv("REMOTE_HOST"))    != NULL
+//      || (env_str = getenv("SSH_CONNECTION")) != NULL
+//      || (env_str = getenv("SSH_CLIENT"))     != NULL
+//      || (env_str = getenv("SSH2_CLIENT"))    != NULL) {
+//         strlcpy(ipaddr_buf, env_str, sizeof ipaddr_buf);
+//         if ((p = strchr(ipaddr_buf, ' ')) != NULL) *p = '\0';
+//     }
+//     if (valid_ipaddr(ipaddr_buf, True)) return ipaddr_buf;
+// }
+// client_sockaddr(fd, &ss, &length);
+// getnameinfo(..., NI_NUMERICHOST);
+// ```
+//
+// and `client_sockaddr()` (clientname.c:37-45) does NOT invent a fallback when
+// the socket cannot name its peer - it aborts the connection:
+//
+// ```c
+// if (getpeername(fd, (struct sockaddr *) ss, ss_len)) {
+//     rsyserr(FLOG, errno, "getpeername on fd%d failed", fd);
+//     exit_cleanup(RERR_SOCKETIO);
+// }
+// ```
+//
+// The two entry points are therefore NOT the same case, which is what made the
+// previous code look defensible: under inetd, fd 0 *is* the connected socket
+// and `getpeername` succeeds, so there is a real address to be had; under a
+// remote shell, fd 0 is a pipe and the address can only come from the
+// environment. Fabricating `127.0.0.1` for both made every `hosts allow` /
+// `hosts deny` rule evaluate against a synthetic localhost - admitting every
+// client under the canonical `hosts allow = 127.0.0.1`, and rejecting every
+// legitimate client under an allow-list naming real subnets.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+/// Peer-address environment variables consulted on the remote-shell path, in
+/// upstream's order. The first one that is set wins, even if a later one would
+/// parse and it does not.
+///
+/// upstream: clientname.c:66-69 - the `||` chain assigns `env_str` from the
+/// first non-NULL `getenv`, so ordering is significant.
+const REMOTE_SHELL_PEER_ENV: [&str; 4] =
+    ["REMOTE_HOST", "SSH_CONNECTION", "SSH_CLIENT", "SSH2_CLIENT"];
+
+/// The address upstream seeds before consulting the environment, and the one it
+/// keeps when no variable is set.
+///
+/// This value is load-bearing for access control rather than cosmetic: it
+/// matches no realistic `hosts allow` token, so a remote-shell daemon with no
+/// peer information in its environment fails CLOSED. `127.0.0.1` failed open
+/// against exactly the rule an operator writes to mean "local only".
+///
+/// upstream: clientname.c:65 - `strlcpy(ipaddr_buf, "0.0.0.0", ...)`.
+pub(in crate::daemon) const REMOTE_SHELL_DEFAULT_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+
+/// Parses one environment value the way upstream does: truncate at the first
+/// space, then validate.
+///
+/// `SSH_CONNECTION` is `"<client-ip> <client-port> <server-ip> <server-port>"`
+/// and `SSH_CLIENT` is `"<client-ip> <client-port> <server-port>"`, so the
+/// leading field is the peer address in both.
+///
+/// A scope suffix (`fe80::1%eth0`) is accepted because upstream passes
+/// `allow_scope = True`; `IpAddr`'s parser rejects it, so the scope is stripped
+/// before parsing. The scope itself names a *local* interface and has no
+/// bearing on which peer this is, so dropping it loses nothing an ACL can use.
+///
+/// upstream: clientname.c:70-77 plus `valid_ipaddr(buf, True)`.
+fn parse_peer_env_value(value: &str) -> Option<IpAddr> {
+    let field = value.split(' ').next().unwrap_or(value);
+    if let Ok(addr) = field.parse::<IpAddr>() {
+        return Some(addr);
+    }
+    let (bare, _scope) = field.split_once('%')?;
+    bare.parse::<IpAddr>().ok()
+}
+
+/// Outcome of resolving a remote-shell peer address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::daemon) enum RemoteShellPeer {
+    /// An address to use: either one parsed from the environment, or the
+    /// `0.0.0.0` default when the environment said nothing.
+    Addr(IpAddr),
+    /// An environment variable was set but did not hold a usable address.
+    ///
+    /// Upstream falls through to `client_sockaddr()` here, which on a remote
+    /// shell's pipe fails `getpeername` and aborts the connection. Reporting it
+    /// separately lets the caller mirror that abort instead of quietly
+    /// substituting a default the operator did not configure.
+    Unusable,
+}
+
+/// Resolves the peer address for a daemon started behind a remote shell.
+///
+/// upstream: clientname.c:63-78 (`am_daemon < 0`).
+pub(in crate::daemon) fn remote_shell_peer_addr() -> RemoteShellPeer {
+    let Some(raw) = REMOTE_SHELL_PEER_ENV
+        .iter()
+        .find_map(|name| std::env::var(name).ok())
+    else {
+        return RemoteShellPeer::Addr(REMOTE_SHELL_DEFAULT_ADDR);
+    };
+
+    parse_peer_env_value(&raw).map_or(RemoteShellPeer::Unusable, RemoteShellPeer::Addr)
+}
+
+/// Normalises an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) to plain IPv4.
+///
+/// Without this a dual-stack listener reports `::ffff:192.0.2.1` for an IPv4
+/// client, which matches neither an IPv4 `hosts allow` pattern nor a reverse
+/// lookup, so the normalisation is part of the ACL contract rather than
+/// cosmetic.
+///
+/// upstream: clientname.c:47-74 - `client_sockaddr()` rewrites a V4MAPPED
+/// `sockaddr_in6` into a `sockaddr_in` before any lookup or comparison.
+fn normalize_v4_mapped(addr: IpAddr) -> IpAddr {
+    match addr {
+        IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(addr, IpAddr::V4),
+        IpAddr::V4(_) => addr,
+    }
+}
+
+/// Reads the real peer address from the socket inherited on stdin.
+///
+/// Used by the inetd / socket-activation / `RSYNC_CONNECT_PROG` entry point,
+/// where fd 0 is the connected socket and the address is genuinely available.
+///
+/// `socket2::SockRef::from(&io::Stdin)` borrows the descriptor through `AsFd`
+/// without taking ownership, so nothing closes stdin and no `unsafe` is needed
+/// - the same construction `is_stdin_socket()` already uses to classify fd 0.
+///
+/// A peer that HAS an address but not an IP one - an `AF_UNIX` socketpair, as
+/// used by systemd socket activation with `Accept=yes` and by
+/// `RSYNC_CONNECT_PROG` - degrades to [`REMOTE_SHELL_DEFAULT_ADDR`] rather than
+/// failing. Upstream serves such a connection: `getpeername` succeeds, and the
+/// `getnameinfo` that follows fails but its return value is never checked
+/// (clientname.c:81), so `ipaddr_buf` is simply left empty. Both "" and
+/// `0.0.0.0` match no realistic `hosts allow` token, so the ACL outcome is the
+/// same; using the sentinel keeps oc from inventing an address it does not have
+/// while still serving a configuration upstream supports.
+///
+/// # Errors
+///
+/// Returns the `getpeername` error unchanged when the call itself fails. The
+/// caller must abort the session rather than substitute a placeholder; upstream
+/// treats that as `RERR_SOCKETIO` (clientname.c:41-45).
+#[cfg(unix)]
+pub(in crate::daemon) fn inherited_socket_peer_addr() -> std::io::Result<SocketAddr> {
+    let stdin = std::io::stdin();
+    let sock = socket2::SockRef::from(&stdin);
+    let peer = sock.peer_addr()?;
+    Ok(peer.as_socket().map_or_else(
+        || SocketAddr::new(REMOTE_SHELL_DEFAULT_ADDR, 0),
+        |addr| SocketAddr::new(normalize_v4_mapped(addr.ip()), addr.port()),
+    ))
+}
+
+/// Non-Unix stub: the inetd entry point is Unix-only (`is_stdin_socket()`
+/// returns `false` on other platforms), so this is unreachable in practice and
+/// exists to keep the module compiling everywhere.
+#[cfg(not(unix))]
+pub(in crate::daemon) fn inherited_socket_peer_addr() -> std::io::Result<SocketAddr> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "inetd-style stdin sockets are not supported on this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    /// upstream: clientname.c:73-74 - `SSH_CONNECTION` carries four
+    /// space-separated fields and only the first is the peer.
+    #[test]
+    fn env_value_truncates_at_the_first_space() {
+        assert_eq!(
+            parse_peer_env_value("192.0.2.7 54321 198.51.100.1 22"),
+            Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)))
+        );
+    }
+
+    #[test]
+    fn env_value_accepts_a_bare_address() {
+        assert_eq!(
+            parse_peer_env_value("198.51.100.9"),
+            Some(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)))
+        );
+    }
+
+    /// upstream passes `allow_scope = True` to `valid_ipaddr`, so a link-local
+    /// address carrying an interface scope is usable.
+    #[test]
+    fn env_value_accepts_a_scoped_ipv6_address() {
+        assert_eq!(
+            parse_peer_env_value("fe80::1%eth0 22 fe80::2 22"),
+            Some(IpAddr::V6("fe80::1".parse::<Ipv6Addr>().unwrap()))
+        );
+    }
+
+    #[test]
+    fn env_value_rejects_a_non_address() {
+        assert_eq!(parse_peer_env_value("not-an-address 22"), None);
+        assert_eq!(parse_peer_env_value(""), None);
+    }
+
+    /// The security-relevant default. `0.0.0.0` matches no realistic
+    /// `hosts allow` token, so an unconfigured remote-shell daemon denies
+    /// rather than admits.
+    #[test]
+    fn default_remote_shell_address_is_unspecified_not_loopback() {
+        assert_eq!(REMOTE_SHELL_DEFAULT_ADDR, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        assert_ne!(REMOTE_SHELL_DEFAULT_ADDR, IpAddr::V4(Ipv4Addr::LOCALHOST));
+    }
+
+    /// upstream: clientname.c:47-74 - a V4MAPPED peer is rewritten to IPv4
+    /// before any ACL comparison, so `hosts allow = 192.0.2.0/24` matches an
+    /// IPv4 client arriving on a dual-stack listener.
+    #[test]
+    fn v4_mapped_ipv6_normalises_to_ipv4() {
+        let mapped: IpAddr = "::ffff:192.0.2.128".parse().unwrap();
+        assert_eq!(
+            normalize_v4_mapped(mapped),
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 128))
+        );
+    }
+
+    #[test]
+    fn genuine_ipv6_is_left_alone() {
+        let v6: IpAddr = "2001:db8::1".parse().unwrap();
+        assert_eq!(normalize_v4_mapped(v6), v6);
+    }
+
+    /// An `AF_UNIX` peer has no IP address. Upstream serves such a connection
+    /// (its `getnameinfo` failure is unchecked, leaving the address empty), so
+    /// refusing it would break systemd socket activation with `Accept=yes` and
+    /// `RSYNC_CONNECT_PROG`. The sentinel matches no realistic allow token, so
+    /// the ACL still fails closed.
+    #[test]
+    fn a_non_ip_peer_degrades_to_the_unknown_sentinel_not_loopback() {
+        let sentinel = SocketAddr::new(REMOTE_SHELL_DEFAULT_ADDR, 0);
+        assert_eq!(sentinel.ip(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        assert_ne!(sentinel.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+    }
+}

--- a/crates/daemon/src/daemon/sections/inetd.rs
+++ b/crates/daemon/src/daemon/sections/inetd.rs
@@ -102,10 +102,33 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
     let pair = crate::daemon_stream::StdioPair::new(Box::new(stdin), Box::new(stdout));
     let stream = DaemonStream::stdio(pair);
 
-    // upstream: start_daemon() with inherited fds uses 127.0.0.1:0 as the
-    // synthetic peer address since there is no TCP socket to query for a real
-    // peer address.
-    let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+    // upstream: clientserver.c:1559 - `start_daemon(STDIN_FILENO, STDIN_FILENO)`.
+    // Under inetd, fd 0 IS the connected socket, so `client_addr()` skips the
+    // environment arm entirely and `client_sockaddr()` reads the real peer via
+    // `getpeername` (clientname.c:37-45).
+    //
+    // This site previously fabricated `127.0.0.1` on the stated premise that
+    // "there is no TCP socket to query" - which is simply untrue here, and is
+    // why the hole survived review. Every `hosts allow` / `hosts deny` rule was
+    // evaluated against a synthetic localhost instead of the real client.
+    let peer_addr = match crate::daemon::peer_address::inherited_socket_peer_addr() {
+        Ok(addr) => addr,
+        // upstream: clientname.c:41-45 - `getpeername` failure is fatal
+        // (`exit_cleanup(RERR_SOCKETIO)`), never a fallback address. Serving a
+        // session whose peer cannot be named would evaluate the ACL against
+        // nothing.
+        Err(err) => {
+            let code = ExitCode::SocketIo;
+            return Err(DaemonError::with_code(
+                code,
+                rsync_error!(
+                    code.as_i32(),
+                    format!("getpeername on the inherited stdin socket failed: {err}")
+                )
+                .with_role(Role::Daemon),
+            ));
+        }
+    };
 
     // upstream: clientname.c `client_name` forward-confirms the reverse-DNS
     // name unconditionally, so this pre-module log/registry name is confirmed

--- a/tests/daemon_inetd_peer_address_acl.rs
+++ b/tests/daemon_inetd_peer_address_acl.rs
@@ -1,0 +1,190 @@
+//! On the inetd path the daemon must read its peer from the inherited socket.
+//!
+//! Under inetd / socket activation, fd 0 IS the connected socket, so the real
+//! client address is available and upstream simply asks for it:
+//!
+//! ```c
+//! /* clientserver.c:1559 */
+//! start_daemon(STDIN_FILENO, STDIN_FILENO);
+//! /* clientname.c:80-83 - am_daemon > 0 skips the env arm entirely */
+//! client_sockaddr(fd, &ss, &length);
+//! getnameinfo(..., NI_NUMERICHOST);
+//! /* clientname.c:41-45 */
+//! if (getpeername(fd, (struct sockaddr *) ss, ss_len)) {
+//!     rsyserr(FLOG, errno, "getpeername on fd%d failed", fd);
+//!     exit_cleanup(RERR_SOCKETIO);
+//! }
+//! ```
+//!
+//! oc previously hardcoded `127.0.0.1:0` here too, on the stated premise that
+//! "there is no TCP socket to query" - which is false on this path. Every
+//! `hosts allow` / `hosts deny` rule was therefore evaluated against a
+//! synthetic localhost.
+//!
+//! HOW this discriminates: an IPv4-loopback test would be useless, because the
+//! fabricated value and the true value would coincide. The daemon's socket is
+//! therefore peered over IPv6 loopback, so its true peer is `::1` while the
+//! fabricated value was `127.0.0.1`. A build that fabricates fails
+//! `hosts allow = ::1` and passes `hosts allow = 127.0.0.1`; a build that reads
+//! the socket does the opposite. Both directions are asserted, so neither can
+//! pass vacuously - and an earlier revision of this file used `127.0.0.2`,
+//! which silently SKIPPED on macOS (only `127.0.0.1` is configured there) and
+//! therefore proved nothing on half the CI matrix.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the daemon inherits a socket on fd 0).
+//! - IPv6 loopback (`::1`) is unavailable.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::io::OwnedFd;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+/// A local address distinct from `127.0.0.1`, so the fabricated value and the
+/// true value cannot coincide. IPv6 loopback is configured by default on both
+/// Linux and macOS, unlike `127.0.0.2`.
+const PEER_IP: &str = "::1";
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Binds a listener on [`PEER_IP`], or returns `None` when IPv6 loopback is
+/// unavailable.
+fn bind_peer_listener() -> Option<TcpListener> {
+    TcpListener::bind((PEER_IP, 0)).ok()
+}
+
+fn write_config(root: &Path, allow: &str) -> PathBuf {
+    let module = root.join("mod");
+    fs::create_dir_all(&module).expect("mkdir module");
+    fs::write(module.join("payload.txt"), b"payload\n").expect("write payload");
+    let conf = root.join("rsyncd.conf");
+    fs::write(
+        &conf,
+        format!(
+            "use chroot = false\n\
+             [m]\n\
+             \x20   path = {}\n\
+             \x20   read only = true\n\
+             \x20   hosts allow = {allow}\n",
+            module.display()
+        ),
+    )
+    .expect("write rsyncd.conf");
+    conf
+}
+
+/// Spawns the daemon with `stdin` bound to a socket whose peer is [`PEER_IP`],
+/// which is what inetd/socket activation hands a server process.
+fn spawn_inetd_daemon(conf: &Path, socket: TcpStream) -> Child {
+    // `TcpStream` -> `OwnedFd` -> `Stdio`: the child inherits the socket on
+    // fd 0 and fd 1 exactly as inetd would hand it over.
+    let stdin = Stdio::from(OwnedFd::from(
+        socket.try_clone().expect("clone socket for stdin"),
+    ));
+    let stdout = Stdio::from(OwnedFd::from(socket));
+    Command::new(oc_binary())
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdin(stdin)
+        .stdout(stdout)
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn inetd daemon")
+}
+
+/// Speaks the opening `@RSYNCD:` exchange and asks for module `m`, returning
+/// the daemon's reply to the module request.
+fn request_module(peer: TcpStream) -> String {
+    peer.set_read_timeout(Some(Duration::from_secs(10)))
+        .expect("set read timeout");
+    let mut writer = peer.try_clone().expect("clone for write");
+    let mut reader = BufReader::new(peer);
+
+    let mut greeting = String::new();
+    if reader.read_line(&mut greeting).is_err() || greeting.is_empty() {
+        return String::new();
+    }
+    // Echo a compatible version line INCLUDING the digest name list (protocol
+    // 32 rejects a bare version), then name the module.
+    let _ = writer.write_all(b"@RSYNCD: 32.0 md5 md4\n");
+    let _ = writer.write_all(b"m\n");
+    let _ = writer.flush();
+
+    let mut reply = String::new();
+    let mut line = String::new();
+    while reader.read_line(&mut line).map(|n| n > 0).unwrap_or(false) {
+        reply.push_str(&line);
+        if line.starts_with("@ERROR") || line.starts_with("@RSYNCD: OK") || line == "\n" {
+            break;
+        }
+        line.clear();
+    }
+    reply
+}
+
+/// Runs one inetd session against a module whose `hosts allow` names `allow`,
+/// returning the daemon's reply. `None` means IPv6 loopback is unavailable.
+fn run_session(allow: &str) -> Option<String> {
+    let listener = bind_peer_listener()?;
+    let addr = listener.local_addr().expect("local addr");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let conf = write_config(tmp.path(), allow);
+
+    // The daemon holds the CONNECTING end, so its peer is the listener's
+    // address - `127.0.0.2` - and the test drives the client side.
+    let daemon_side = TcpStream::connect(addr).expect("connect daemon side");
+    let accepted = thread::spawn(move || listener.accept().map(|(stream, _)| stream));
+
+    let mut child = spawn_inetd_daemon(&conf, daemon_side);
+    let client_side = accepted
+        .join()
+        .expect("accept thread")
+        .expect("accept client side");
+
+    let reply = request_module(client_side);
+
+    let _ = child.kill();
+    let _ = child.wait();
+    drop(tmp);
+    Some(reply)
+}
+
+/// THE headline case: a rule naming the REAL peer must admit it. A build that
+/// fabricates `127.0.0.1` denies here, because the true peer never matched.
+#[test]
+fn allow_rule_naming_the_real_peer_admits_it() {
+    let Some(reply) = run_session(PEER_IP) else {
+        println!("skipped: IPv6 loopback ({PEER_IP}) is unavailable on this host");
+        return;
+    };
+    assert!(
+        !reply.contains("access denied"),
+        "`hosts allow = {PEER_IP}` must admit a client whose real peer is \
+         {PEER_IP}; daemon replied: {reply:?}"
+    );
+}
+
+/// The control: a rule naming loopback must NOT admit a peer that is not
+/// loopback. A build that fabricates `127.0.0.1` admits here - that is the
+/// fail-open the fix closes.
+#[test]
+fn loopback_allow_does_not_admit_a_non_loopback_peer() {
+    let Some(reply) = run_session("127.0.0.1") else {
+        println!("skipped: IPv6 loopback ({PEER_IP}) is unavailable on this host");
+        return;
+    };
+    assert!(
+        reply.contains("access denied"),
+        "`hosts allow = 127.0.0.1` must NOT admit a client whose real peer is \
+         {PEER_IP}; daemon replied: {reply:?}"
+    );
+}

--- a/tests/daemon_stdio_peer_address_acl.rs
+++ b/tests/daemon_stdio_peer_address_acl.rs
@@ -1,0 +1,213 @@
+//! `hosts allow` / `hosts deny` must be evaluated against the REAL peer on the
+//! remote-shell daemon path, not a fabricated localhost.
+//!
+//! A daemon started behind a remote shell (`--server --daemon`, upstream's
+//! `am_daemon < 0`) has no socket to interrogate, so upstream takes the peer
+//! address from the environment and seeds it with `0.0.0.0`:
+//!
+//! ```c
+//! /* clientname.c:63-78 */
+//! if (am_daemon < 0) {              /* daemon over --rsh mode */
+//!     strlcpy(ipaddr_buf, "0.0.0.0", sizeof ipaddr_buf);
+//!     if ((env_str = getenv("REMOTE_HOST"))    != NULL
+//!      || (env_str = getenv("SSH_CONNECTION")) != NULL
+//!      || (env_str = getenv("SSH_CLIENT"))     != NULL
+//!      || (env_str = getenv("SSH2_CLIENT"))    != NULL) {
+//!         strlcpy(ipaddr_buf, env_str, sizeof ipaddr_buf);
+//!         if ((p = strchr(ipaddr_buf, ' ')) != NULL) *p = '\0';
+//!     }
+//!     if (valid_ipaddr(ipaddr_buf, True)) return ipaddr_buf;
+//! }
+//! ```
+//!
+//! oc previously hardcoded `127.0.0.1:0` here, which made
+//! `hosts allow = 127.0.0.1` - the canonical "local only" rule - admit every
+//! client on earth, and made an allow-list naming real subnets reject every
+//! legitimate one. The `0.0.0.0` seed is what closes it: that address matches
+//! no realistic allow token, so an unconfigured remote-shell daemon denies.
+//!
+//! WHY these three cases and not one: a single denial case would also pass on a
+//! daemon that denied everything, and a single admit case would pass on the old
+//! fabricating build. The pair that discriminates is
+//! [`loopback_allow_does_not_admit_a_remote_shell_client`] (must DENY - it
+//! ADMITTED before this fix) together with
+//! [`remote_host_env_admits_the_matching_allow_rule`] (must ADMIT - it would
+//! have been DENIED before, since the fabricated peer was never `192.0.2.7`).
+//! Each is the other's control, so neither can pass vacuously.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the remote-shell shim uses `/bin/sh`).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// An address that is neither loopback nor anything the harness runs on, so a
+/// rule naming it can only match when the environment is genuinely consulted.
+const PEER_IP: &str = "192.0.2.7";
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Writes a remote-shell shim that changes into the module directory (so the
+/// daemon finds `rsyncd.conf` in its CWD, upstream `RSYNCD_USERCONF`) and execs
+/// the server command it was handed.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("rsh.sh");
+    let body = format!(
+        "#!/bin/sh\n\
+         cd {} || exit 1\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+        dir.display()
+    );
+    fs::write(&script, body).expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+/// Lays out a daemon module whose `hosts allow` names exactly `allow`.
+fn setup(allow: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let module = root.join("mod");
+    fs::create_dir_all(&module).expect("mkdir module");
+    fs::write(module.join("payload.txt"), b"payload\n").expect("write payload");
+    fs::write(
+        root.join("rsyncd.conf"),
+        format!(
+            "use chroot = false\n\
+             [m]\n\
+             \x20   path = {}\n\
+             \x20   read only = true\n\
+             \x20   hosts allow = {allow}\n",
+            module.display()
+        ),
+    )
+    .expect("write rsyncd.conf");
+    (tmp, root)
+}
+
+/// Pulls from the module over a remote-shell daemon, optionally advertising a
+/// peer address the way `sshd` would.
+fn pull(root: &Path, peer_env: Option<(&str, &str)>) -> Output {
+    let shim = write_rsh_shim(root);
+    let dest = root.join("dest");
+    fs::create_dir_all(&dest).expect("mkdir dest");
+
+    let mut cmd = Command::new(oc_binary());
+    cmd.current_dir(root)
+        .arg("-e")
+        .arg(&shim)
+        .arg("--rsync-path")
+        .arg(oc_binary())
+        .arg("fakehost::m/")
+        .arg(&dest);
+
+    // A remote shell that has no peer information in its environment must not
+    // inherit one from the test runner.
+    for name in ["REMOTE_HOST", "SSH_CONNECTION", "SSH_CLIENT", "SSH2_CLIENT"] {
+        cmd.env_remove(name);
+    }
+    if let Some((name, value)) = peer_env {
+        cmd.env(name, value);
+    }
+
+    cmd.output().expect("run oc-rsync")
+}
+
+fn transferred(output: &Output, dest: &Path) -> bool {
+    output.status.success() && dest.join("payload.txt").is_file()
+}
+
+/// THE headline case. Before this fix the daemon fabricated `127.0.0.1`, so the
+/// canonical "local only" rule matched a client that is not local at all.
+///
+/// upstream: clientname.c:65 seeds `0.0.0.0`, which matches no loopback token.
+#[test]
+fn loopback_allow_does_not_admit_a_remote_shell_client() {
+    let (tmp, root) = setup("127.0.0.1");
+    let out = pull(&root, None);
+    assert!(
+        !transferred(&out, &root.join("dest")),
+        "`hosts allow = 127.0.0.1` must NOT admit a remote-shell client whose \
+         peer address is unknown; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    drop(tmp);
+}
+
+/// The control for the case above: with a real peer advertised the way sshd
+/// does it, the matching allow rule admits. Without this, the denial above
+/// would also pass on a daemon that denied everything unconditionally.
+///
+/// upstream: clientname.c:66 - `REMOTE_HOST` is the first variable consulted.
+#[test]
+fn remote_host_env_admits_the_matching_allow_rule() {
+    let (tmp, root) = setup(PEER_IP);
+    let out = pull(&root, Some(("REMOTE_HOST", PEER_IP)));
+    assert!(
+        transferred(&out, &root.join("dest")),
+        "REMOTE_HOST={PEER_IP} must satisfy `hosts allow = {PEER_IP}`; \
+         stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    drop(tmp);
+}
+
+/// `SSH_CONNECTION` carries four space-separated fields; only the first is the
+/// peer. A build that used the whole value would fail to parse it and deny.
+///
+/// upstream: clientname.c:70-74 - truncate at the first space.
+#[test]
+fn ssh_connection_env_is_truncated_to_the_peer_address() {
+    let (tmp, root) = setup(PEER_IP);
+    let out = pull(
+        &root,
+        Some((
+            "SSH_CONNECTION",
+            &format!("{PEER_IP} 54321 198.51.100.1 22"),
+        )),
+    );
+    assert!(
+        transferred(&out, &root.join("dest")),
+        "SSH_CONNECTION's first field must be used as the peer; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    drop(tmp);
+}
+
+/// An allow-list naming a real subnet must still deny an unknown peer rather
+/// than admitting it - the same defect in its other direction.
+///
+/// ⚠ This case does NOT discriminate on its own: `127.0.0.1` fails a
+/// `198.51.100.0/24` rule too, so it passed on the fabricating build as well.
+/// It is kept because it pins the second operator-visible symptom (an allow-list
+/// of real subnets), not because it would have caught the defect.
+#[test]
+fn subnet_allow_does_not_admit_an_unknown_peer() {
+    let (tmp, root) = setup("198.51.100.0/24");
+    let out = pull(&root, None);
+    assert!(
+        !transferred(&out, &root.join("dest")),
+        "an unknown peer must not satisfy a subnet allow rule; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    drop(tmp);
+}


### PR DESCRIPTION
## What

`hosts allow` / `hosts deny` were evaluated against a synthetic `127.0.0.1:0` on **both** stdio daemon entry points. The canonical "local only" rule admitted every client; an allow-list naming real subnets rejected every legitimate one. Broken in both directions depending on the config, and `%a` / `%h` misattributed every audit line.

## The two paths are not the same case

That is what made the old code look defensible, and it is why the fix has two halves:

| | upstream | oc before |
|---|---|---|
| **inetd / socket activation** (`am_daemon > 0`) | fd 0 **is** the connected socket; `client_addr()` skips the env arm and `client_sockaddr()` reads the peer via `getpeername` (clientname.c:80-83, :37-45) | fabricated `127.0.0.1`, with a comment claiming *"there is no TCP socket to query"* |
| **daemon behind a remote shell** (`am_daemon < 0`) | fd 0 is a pipe; seed `"0.0.0.0"`, then the first of `REMOTE_HOST` / `SSH_CONNECTION` / `SSH_CLIENT` / `SSH2_CLIENT`, truncated at the first space, kept only if it parses (clientname.c:63-78) | fabricated `127.0.0.1`; none of those four variables appeared anywhere in the tree |

**Both sites carried an `upstream:` comment asserting that upstream uses `127.0.0.1:0`.** It does not, on either path, and on the inetd path the stated premise is simply false. Those comments are why the hole survived review; they are deleted and replaced with real citations.

The `0.0.0.0` seed is the security-relevant half: it matches no realistic allow token, so a remote-shell daemon with no peer information in its environment fails **closed**, where `127.0.0.1` failed **open** against exactly the rule operators write to mean "local only".

## Also mirrored

- **`getpeername` failure aborts** with `RERR_SOCKETIO` rather than substituting a placeholder (clientname.c:41-45). Serving a session whose peer cannot be named would evaluate the ACL against nothing.
- **IPv4-mapped IPv6 normalisation** (`::ffff:a.b.c.d` → IPv4) before any lookup or comparison (clientname.c:47-74). This changes what an IPv4 `hosts allow` matches on a dual-stack listener, so it is part of the ACL contract, not cosmetics.

## One deliberate, documented narrowing

A peer that has an address but **not an IP one** — an `AF_UNIX` socketpair, as used by systemd socket activation with `Accept=yes` and by `RSYNC_CONNECT_PROG` — degrades to the same `0.0.0.0` sentinel instead of aborting. Upstream serves that configuration: `getpeername` succeeds, and the `getnameinfo` that follows fails but **its return value is never checked** (clientname.c:81), so the address is simply left empty. Both `""` and `0.0.0.0` match no realistic allow token, so the ACL outcome is identical; the sentinel just stops oc inventing an address it does not have.

I found this the honest way: the first revision aborted, and it broke the existing `daemon_empty_digest_list_refused` tests, which hand the daemon a `UnixStream::pair()`. I verified those three pass on clean `origin/master` before concluding it was my regression rather than a pre-existing failure.

## No new unsafe, no new dependency

`socket2` is already a direct dependency of `crates/daemon` (Cargo.toml:87, v0.6.5). `SockRef::from(&io::Stdin)` borrows fd 0 through `AsFd` — the same construction `is_stdin_socket()` already uses to classify that descriptor. The task anticipated relocating unsafe into `fast_io`; there is none to relocate.

## Tests — one per entry point

A per-path test would have passed on whichever path its author happened to pick, which is how this survived.

- **`tests/daemon_stdio_peer_address_acl.rs`** (remote shell): the loopback rule must **DENY** (it ADMITTED before) and `REMOTE_HOST` must **ADMIT** (it would have been DENIED before, since the fabricated peer was never `192.0.2.7`). Each is the other's control. Plus `SSH_CONNECTION` first-field truncation.
- **`tests/daemon_inetd_peer_address_acl.rs`** (inetd): the daemon's socket is peered over **IPv6 loopback**, so the fabricated `127.0.0.1` and the true `::1` cannot coincide, and both directions are asserted.

⚠ An earlier revision of the inetd file used `127.0.0.2`, which **silently skipped on macOS** (only `127.0.0.1` is configured there). It reported "2 passed" in 0.00s and proved nothing on half the CI matrix. Caught by checking `--nocapture` for the skip reason rather than trusting the green.

One case (`subnet_allow_does_not_admit_an_unknown_peer`) is explicitly annotated as **not** discriminating — `127.0.0.1` fails a `198.51.100.0/24` rule too, so it passed pre-fix. It is kept for the second operator-visible symptom, and says so.

## Non-vacuity

Restoring the fabricated address at each site independently:

- remote shell: **3 of 4** cases turn red (the 4th is the annotated non-discriminating one);
- inetd: **both** cases turn red.

## Verification

```
cargo fmt --all -- --check                                                       clean
cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings  clean
cargo nextest run -p daemon -E 'test(peer)+test(host)+test(inetd)+test(access)+test(module)'   652 passed
cargo nextest run -E 'binary(/daemon/)'                                          67 passed
cargo nextest run -E 'binary(/peer_address_acl/)'                                6 passed
```

## Scope

Task 401, covering 412 / 413 / 414. Deliberately **not** included: 416 (`%a` / `%h`) is gated on this landing — rendering those from a fabricated address is the same defect in a costume — and 417, which on reading upstream turns out to be **client-side** (`start_inband_exchange`, clientserver.c:263), not daemon, and is unrelated to the peer address.
