### PR TITLE
fix(receiver): open a daemon module root plainly, confine only the peer tail

### DIFF
--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -181,7 +181,7 @@ impl DirSandbox {
                     return Err(io::Error::from_raw_os_error(libc::EXDEV));
                 }
             };
-            fd = descend_beneath(fd.as_fd(), name)?;
+            fd = openat_dir(fd.as_fd(), name)?;
         }
 
         Ok(Self {
@@ -385,48 +385,30 @@ impl DirSandbox {
     }
 }
 
-/// Open `child_name` as a directory off `parent_fd` using the strictest
-/// resolution policy the running kernel supports.
+/// Descend one component beneath `parent_fd`, following an in-tree symlink
+/// and refusing an escape.
 ///
-/// On Linux 5.6+ this uses `openat2(2)` with
-/// `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`; otherwise it falls back to
-/// `openat(2)` with `O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC` via `rustix`.
-fn openat_dir(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
-    #[cfg(target_os = "linux")]
-    {
-        if openat2_supported()
-            && let Some(fd) = linux::openat2_beneath(
-                parent_fd,
-                child_name,
-                libc::RESOLVE_BENEATH | libc::RESOLVE_NO_SYMLINKS,
-            )?
-        {
-            return Ok(fd);
-        }
-    }
-    // Suppress the unused-import warning on non-Linux Unix targets.
-    let _ = openat2_supported;
-
-    openat_nofollow(parent_fd, child_name)
-}
-
-/// Descend one component of a peer-supplied path beneath `parent_fd`.
+/// This is the single beneath-semantics primitive. Both the per-entry
+/// descent and the peer-tail walk under an operator anchor go through it, so
+/// there is one implementation of one upstream rule.
 ///
-/// Unlike [`openat_dir`], this follows an in-tree symlink and refuses only
-/// an escape (`EXDEV`) or a magic link. That is upstream's rule for a
-/// peer-supplied remainder resolved under an operator anchor: `ds_descend()`
-/// (`syscall.c:2891`) splices a relative in-tree symlink target back into the
-/// walk and refuses an absolute target or a climb above the anchor.
+/// The policy is upstream's `ds_descend()` (`syscall.c:2891`): a relative
+/// in-tree symlink target is spliced back into the walk, while an absolute
+/// target or a climb above the anchor is refused. `RESOLVE_BENEATH` gives
+/// exactly that, and `RESOLVE_NO_MAGICLINKS` blocks the `/proc` magic-link
+/// detour. It is the same mask the peer-path parent anchor already uses
+/// (`at_syscalls/nested.rs:201`), whose rationale this now shares rather
+/// than contradicts.
 ///
-/// `RESOLVE_NO_MAGICLINKS` matches the mask the peer-path parent anchor
-/// already uses (`at_syscalls/nested.rs:201`).
+/// `RESOLVE_NO_SYMLINKS` is deliberately *not* set. It refuses every symlink
+/// component, including the in-tree ones upstream resolves, which turns a
+/// symlinked subdirectory inside the destination tree into a hard failure.
 ///
 /// Where `openat2(2)` is unavailable the walk degrades to `O_NOFOLLOW` per
 /// component, which refuses in-tree symlinks the kernel path would follow.
-/// That is stricter than upstream and is the same portable-fallback gap
-/// tracked for the rest of the sandbox.
-#[cfg(unix)]
-fn descend_beneath(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
+/// That is stricter than upstream and is the portable-fallback gap tracked
+/// for the rest of the sandbox.
+fn openat_dir(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
     #[cfg(target_os = "linux")]
     {
         if openat2_supported()
@@ -439,6 +421,7 @@ fn descend_beneath(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<
             return Ok(fd);
         }
     }
+    // Suppress the unused-import warning on non-Linux Unix targets.
     let _ = openat2_supported;
 
     openat_nofollow(parent_fd, child_name)
@@ -509,8 +492,13 @@ mod linux {
         #[allow(unsafe_code)]
         let raw = unsafe {
             let mut how: libc::open_how = std::mem::zeroed();
-            how.flags =
-                (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC) as u64;
+            // `O_NOFOLLOW` is deliberately absent. It refuses a symlink at the
+            // final component, and every caller here passes a single component,
+            // so the leaf *is* the whole path - it would refuse the in-tree
+            // symlinks `RESOLVE_BENEATH` is here to let through, and it does so
+            // before any `resolve` flag is consulted. Confinement is the
+            // caller's `resolve` mask; an escape still fails with `EXDEV`.
+            how.flags = (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) as u64;
             how.mode = 0;
             how.resolve = resolve;
 

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -168,6 +168,24 @@ impl DirSandbox {
     ///   resolved beneath the anchor.
     #[cfg(unix)]
     pub fn open_dest_anchor(anchor: &Path, peer_tail: &Path) -> io::Result<Self> {
+        Self::open_dest_anchor_with_policy(anchor, peer_tail, ConfinePolicy::operator_trusted())
+    }
+
+    /// [`open_dest_anchor`](Self::open_dest_anchor) with the trust policy made
+    /// explicit.
+    ///
+    /// `policy` decides how components the peer named are resolved. The
+    /// [`NoExclude`] arm implemented here keeps the kernel walk and is
+    /// therefore behaviour-identical to the unpolicied entry point; the oracle
+    /// arm replaces the mechanism and lands with its consumer in tasks
+    /// 599/600.
+    #[cfg(unix)]
+    pub fn open_dest_anchor_with_policy(
+        anchor: &Path,
+        peer_tail: &Path,
+        policy: ConfinePolicy<NoExclude>,
+    ) -> io::Result<Self> {
+        let ConfinePolicy { exclude } = policy;
         let mut fd = crate::secure_dir::open_trusted_dir(anchor)?;
 
         for component in peer_tail.components() {
@@ -182,6 +200,12 @@ impl DirSandbox {
                 }
             };
             fd = openat_dir(fd.as_fd(), name)?;
+            // Under `NoExclude` this is a constant `false`. A real oracle
+            // cannot be honoured here at all - the kernel resolved the
+            // component, so the only path available is the nominal one.
+            if exclude.outside_confinement(Path::new(name)) {
+                return Err(io::Error::from_raw_os_error(libc::ELOOP));
+            }
         }
 
         Ok(Self {
@@ -525,5 +549,61 @@ mod linux {
             return Ok(None);
         }
         Err(err)
+    }
+}
+
+/// Consulted per descended component when a walk is confined to a module.
+///
+/// Only the manual per-component resolver can honour this: `openat2` resolves
+/// symlinks in the kernel, so a `RESOLVE_BENEATH` walk never learns where a
+/// symlink landed and could only offer the *nominal* path - which is exactly
+/// what a symlink defeats. See `docs/design/path-confinement-resolver-api.md`
+/// section 4.4.
+///
+/// # Upstream Reference
+///
+/// - `syscall.c:2891-2965` `ds_descend()` - extends `ds.abspath` per component
+///   and refuses when `abspath_outside_confinement()` says the resolved path
+///   left the module.
+pub trait ConfinementOracle {
+    /// True when `abspath` has left the served tree.
+    fn outside_confinement(&self, abspath: &Path) -> bool;
+}
+
+/// The oracle for an operator-trusted walk: there is nothing to exclude.
+///
+/// Zero-sized, so a `ConfinePolicy<NoExclude>` carries no state and the
+/// exclude check compiles out entirely. This mirrors upstream leaving
+/// `ds.abspath` unseeded for a non-daemon caller, where the comment at
+/// `syscall.c:2989-2991` notes such callers "pay nothing".
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoExclude;
+
+impl ConfinementOracle for NoExclude {
+    fn outside_confinement(&self, _abspath: &Path) -> bool {
+        false
+    }
+}
+
+/// How a walk treats components it did not itself name.
+///
+/// The policy selects the *resolution mechanism*, not merely the call shape:
+/// `NoExclude` keeps the kernel walk (`RESOLVE_BENEATH`), while a real oracle
+/// requires the manual per-component resolver, because the exclude check is
+/// unimplementable on top of `openat2`.
+///
+/// The type parameter arrives with the oracle arm (tasks 599/600). Today only
+/// the `NoExclude` instantiation exists, so it is spelled concretely rather
+/// than speculatively generalised.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConfinePolicy<O = NoExclude> {
+    exclude: O,
+}
+
+impl ConfinePolicy<NoExclude> {
+    /// The operator named every component; nothing is confined.
+    #[must_use]
+    pub const fn operator_trusted() -> Self {
+        Self { exclude: NoExclude }
     }
 }

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -134,6 +134,63 @@ struct DirFrame {
 }
 
 impl DirSandbox {
+    /// Open a receiver destination root, splitting operator trust from peer
+    /// trust.
+    ///
+    /// `anchor` is operator-supplied - a daemon module root from the config
+    /// file, or the destination operand of a local/remote-shell run. It is
+    /// opened with ordinary resolution via [`open_trusted_dir`], so an
+    /// operator layout like `/srv -> /mnt/srv` resolves normally.
+    ///
+    /// `peer_tail` is the module-relative remainder the *peer* asked for. It
+    /// is resolved component-by-component beneath the anchor descriptor, so
+    /// it can neither climb above the anchor nor follow a planted symlink out
+    /// of the served tree.
+    ///
+    /// Fusing the two into one absolute path and applying a single policy is
+    /// what this method exists to prevent: confining the anchor breaks
+    /// ordinary deployments, and trusting the tail is a module escape.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `syscall.c:85-90` `open_anchor_dirfd()` - plain `openat` for an
+    ///   operator anchor.
+    /// - `syscall.c:3189-3193` - "Absolute basedir: operator-trusted."
+    /// - `syscall.c:2891` `ds_descend()` - the per-component walk that
+    ///   confines the peer-supplied remainder.
+    ///
+    /// # Errors
+    ///
+    /// - Ordinary `open(2)` errors for `anchor` (`ENOENT`, `ENOTDIR`,
+    ///   `EACCES`).
+    /// - `EXDEV` when a `peer_tail` component would escape the anchor.
+    /// - `ELOOP` when a `peer_tail` component is a symlink that cannot be
+    ///   resolved beneath the anchor.
+    #[cfg(unix)]
+    pub fn open_dest_anchor(anchor: &Path, peer_tail: &Path) -> io::Result<Self> {
+        let mut fd = crate::secure_dir::open_trusted_dir(anchor)?;
+
+        for component in peer_tail.components() {
+            let name = match component {
+                std::path::Component::Normal(name) => name,
+                // `.` is a no-op; anything else (`..`, a root, a prefix) has
+                // no business in a peer-supplied module-relative tail and is
+                // refused rather than normalised away.
+                std::path::Component::CurDir => continue,
+                _ => {
+                    return Err(io::Error::from_raw_os_error(libc::EXDEV));
+                }
+            };
+            fd = descend_beneath(fd.as_fd(), name)?;
+        }
+
+        Ok(Self {
+            root: Arc::new(fd),
+            stack: Vec::new(),
+            secondaries: DashMap::new(),
+        })
+    }
+
     /// Open `root` and seed an empty descent stack.
     ///
     /// The root is opened through [`secure_open_dir`] so the bootstrap
@@ -338,12 +395,50 @@ fn openat_dir(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<Owned
     #[cfg(target_os = "linux")]
     {
         if openat2_supported()
-            && let Some(fd) = linux::openat2_beneath(parent_fd, child_name)?
+            && let Some(fd) = linux::openat2_beneath(
+                parent_fd,
+                child_name,
+                libc::RESOLVE_BENEATH | libc::RESOLVE_NO_SYMLINKS,
+            )?
         {
             return Ok(fd);
         }
     }
     // Suppress the unused-import warning on non-Linux Unix targets.
+    let _ = openat2_supported;
+
+    openat_nofollow(parent_fd, child_name)
+}
+
+/// Descend one component of a peer-supplied path beneath `parent_fd`.
+///
+/// Unlike [`openat_dir`], this follows an in-tree symlink and refuses only
+/// an escape (`EXDEV`) or a magic link. That is upstream's rule for a
+/// peer-supplied remainder resolved under an operator anchor: `ds_descend()`
+/// (`syscall.c:2891`) splices a relative in-tree symlink target back into the
+/// walk and refuses an absolute target or a climb above the anchor.
+///
+/// `RESOLVE_NO_MAGICLINKS` matches the mask the peer-path parent anchor
+/// already uses (`at_syscalls/nested.rs:201`).
+///
+/// Where `openat2(2)` is unavailable the walk degrades to `O_NOFOLLOW` per
+/// component, which refuses in-tree symlinks the kernel path would follow.
+/// That is stricter than upstream and is the same portable-fallback gap
+/// tracked for the rest of the sandbox.
+#[cfg(unix)]
+fn descend_beneath(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
+    #[cfg(target_os = "linux")]
+    {
+        if openat2_supported()
+            && let Some(fd) = linux::openat2_beneath(
+                parent_fd,
+                child_name,
+                libc::RESOLVE_BENEATH | libc::RESOLVE_NO_MAGICLINKS,
+            )?
+        {
+            return Ok(fd);
+        }
+    }
     let _ = openat2_supported;
 
     openat_nofollow(parent_fd, child_name)
@@ -381,6 +476,7 @@ mod linux {
     pub(super) fn openat2_beneath(
         parent_fd: BorrowedFd<'_>,
         child_name: &OsStr,
+        resolve: u64,
     ) -> io::Result<Option<OwnedFd>> {
         let c_name = CString::new(child_name.as_bytes()).map_err(|_| {
             io::Error::new(
@@ -416,7 +512,7 @@ mod linux {
             how.flags =
                 (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC) as u64;
             how.mode = 0;
-            how.resolve = libc::RESOLVE_BENEATH | libc::RESOLVE_NO_SYMLINKS;
+            how.resolve = resolve;
 
             libc::syscall(
                 libc::SYS_openat2,

--- a/crates/fast_io/src/dir_sandbox/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/tests.rs
@@ -322,3 +322,33 @@ fn enter_to_legitimate_subdir_returns_ok() {
     sandbox.exit();
     assert_eq!(sandbox.depth(), 0);
 }
+
+/// The seam, exercised through the arm that is already live.
+///
+/// An operator-trusted policy must resolve a peer tail exactly as the
+/// unpolicied walk does today: an in-tree relative symlink is followed.
+/// This pins the `NoExclude` arm to `RESOLVE_BENEATH` semantics so the
+/// oracle arm (tasks 599/600), which replaces the mechanism, cannot
+/// silently change this one.
+///
+/// # Upstream Reference
+///
+/// - `syscall.c:2891` `ds_descend()` - follows a relative in-tree target.
+#[test]
+fn operator_trusted_policy_follows_a_relative_in_tree_symlink() {
+    let (_guard, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("real")).expect("mkdir real");
+    std::fs::write(root.join("real").join("marker"), b"x").expect("write marker");
+    symlink("real", root.join("sub")).expect("symlink sub -> real");
+
+    let sandbox = DirSandbox::open_dest_anchor_with_policy(
+        &root,
+        std::path::Path::new("sub"),
+        super::ConfinePolicy::operator_trusted(),
+    )
+    .expect("an in-tree relative symlink must resolve under the operator-trusted policy");
+
+    sandbox
+        .lstat_at(std::ffi::OsStr::new("marker"))
+        .expect("the sandbox must be anchored at real/, reached through sub");
+}

--- a/crates/fast_io/src/dir_sandbox/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/tests.rs
@@ -1,9 +1,18 @@
 //! Unit tests for [`DirSandbox`](super::DirSandbox).
 //!
-//! Exercise the stack/cache invariants on tempdirs and confirm the
-//! symlink-rejection policy fires at both the root open
-//! ([`secure_open_dir`](crate::secure_open_dir::secure_open_dir)) and
-//! the descent open ([`super::DirSandbox::enter`]).
+//! Exercise the stack/cache invariants on tempdirs and pin the two
+//! *different* policies that apply at the two opens.
+//!
+//! The root open ([`secure_open_dir`](crate::secure_open_dir::secure_open_dir))
+//! is a bootstrap against `AT_FDCWD` with an absolute path, so it refuses
+//! symlinks outright.
+//!
+//! The descent open ([`super::DirSandbox::enter`]) is anchored on a dirfd and
+//! discriminates by destination instead: an in-tree symlink is followed, an
+//! escape is refused with `EXDEV`. That mirrors upstream `ds_descend()`
+//! (`syscall.c:2891`). Earlier revisions of this file asserted the descent
+//! refused every symlink; that was stricter than upstream and the assertion
+//! pinned the divergence rather than the contract.
 
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::symlink;
@@ -98,23 +107,52 @@ fn exit_on_empty_stack_is_noop() {
     assert_eq!(sandbox.depth(), 0);
 }
 
+/// An **in-tree** symlinked subdirectory must be descended, not refused.
+///
+/// upstream: `syscall.c:2891` `ds_descend()` splices a relative in-tree
+/// symlink target back into the walk. Refusing it is stricter than upstream
+/// and turns an ordinary destination layout into a hard failure.
+///
+/// ⚠ The symlink target must be **relative**. An absolute target is refused
+/// under `RESOLVE_BENEATH` even when it resolves inside the anchor, and
+/// upstream refuses absolute targets too (`syscall.c:2953`) - so a fixture
+/// built with `symlink(root.join("real"), ...)` passes for the wrong reason
+/// and proves nothing about this contract.
 #[test]
-fn enter_rejects_symlink_child() {
+fn enter_follows_in_tree_symlink_child() {
     let (_keep, root) = canonical_tempdir();
-    let real = root.join("real");
-    std::fs::create_dir(&real).expect("create real dir");
-    symlink(&real, root.join("link")).expect("symlink");
+    std::fs::create_dir(root.join("real")).expect("create real dir");
+    symlink("real", root.join("link")).expect("relative in-tree symlink");
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    sandbox
+        .enter(std::ffi::OsStr::new("link"))
+        .expect("in-tree symlinked subdirectory must be descended");
+    assert_eq!(sandbox.depth(), 1);
+    sandbox.exit();
+    assert_eq!(sandbox.depth(), 0);
+}
+
+/// A **relative** symlink whose target escapes the anchor must still fail,
+/// and fail as an escape (`EXDEV`) rather than as "there was a symlink".
+///
+/// This is the negative half of [`enter_follows_in_tree_symlink_child`]: the
+/// two together say the policy discriminates by *destination*, not by the
+/// mere presence of a symlink.
+#[test]
+fn enter_refuses_relative_symlink_that_escapes() {
+    let (_keep, root) = canonical_tempdir();
+    symlink("../outside", root.join("esc")).expect("relative escaping symlink");
 
     let mut sandbox = DirSandbox::open_root(&root).expect("open root");
     let err = sandbox
-        .enter(std::ffi::OsStr::new("link"))
-        .expect_err("symlink child must be rejected");
+        .enter(std::ffi::OsStr::new("esc"))
+        .expect_err("a symlink leaving the anchor must be refused");
     let code = err.raw_os_error();
     assert!(
-        code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
-        "expected ELOOP or ENOTDIR for symlink child, got: {err}"
+        code == Some(libc::EXDEV) || code == Some(libc::ELOOP) || code == Some(libc::ENOENT),
+        "expected an escape refusal, got: {err}"
     );
-    // Stack must be untouched when the open fails.
     assert_eq!(sandbox.depth(), 0);
 }
 

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -385,7 +385,7 @@ pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]
-pub use secure_dir::secure_open_dir;
+pub use secure_dir::{open_trusted_dir, secure_open_dir};
 // Non-unix `send_file_to_fd_with_policy` stub silently routes bytes to
 // `io::sink` (data-loss footgun for any future caller). Gate the public
 // re-export on unix; the stub stays available in-crate for symbol parity.

--- a/crates/fast_io/src/secure_dir.rs
+++ b/crates/fast_io/src/secure_dir.rs
@@ -64,6 +64,39 @@ pub fn secure_open_dir(path: &Path) -> io::Result<OwnedFd> {
     imp::secure_open_dir(path)
 }
 
+/// Open an operator-supplied anchor directory with ordinary resolution.
+///
+/// This is the counterpart to [`secure_open_dir`] for a path the *operator*
+/// chose - a daemon module root from the config file, or the destination
+/// operand of a local/remote-shell invocation. Such a path is trusted: it is
+/// not attacker-influenced, and refusing to resolve it through a symlink
+/// breaks ordinary deployments (`/srv -> /mnt/srv`) for no security gain.
+///
+/// Confinement belongs on the *peer*-supplied remainder resolved beneath the
+/// returned descriptor, not on the anchor itself.
+///
+/// # Upstream Reference
+///
+/// Upstream splits the two by who supplied the path:
+///
+/// - `syscall.c:85-90` `open_anchor_dirfd()` - a plain
+///   `openat(AT_FDCWD, path, O_RDONLY | O_DIRECTORY)`, no `O_NOFOLLOW` and no
+///   `resolve` flags.
+/// - `syscall.c:3189-3193` - `secure_relative_open()` routes an absolute
+///   `basedir` to that helper under the comment "Absolute basedir:
+///   operator-trusted."
+/// - `main.c:765` / `clientserver.c:993` - the receiver destination and the
+///   daemon module root are entered with a plain `change_dir()`.
+///
+/// # Errors
+///
+/// Ordinary `open(2)` errors only: `ENOENT`, `ENOTDIR`, `EACCES`, `EPERM`.
+/// Unlike [`secure_open_dir`] this never fails with `ELOOP` or `EXDEV`
+/// merely because a component is a symlink.
+pub fn open_trusted_dir(path: &Path) -> io::Result<OwnedFd> {
+    imp::open_trusted_dir(path)
+}
+
 #[cfg(unix)]
 mod imp {
     use super::*;
@@ -87,6 +120,41 @@ mod imp {
         }
 
         open_nofollow(&c_path)
+    }
+
+    pub(super) fn open_trusted_dir(path: &Path) -> io::Result<OwnedFd> {
+        let c_path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "path contains interior null byte",
+            )
+        })?;
+
+        // upstream: syscall.c:85-90 open_anchor_dirfd() - no `O_NOFOLLOW`,
+        // no `resolve` flags. The anchor is operator-supplied, so ordinary
+        // symlink resolution applies.
+        let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC;
+
+        // SAFETY: `c_path` is a valid NUL-terminated C string borrowed for
+        // the duration of the call. `libc::open` is a thread-safe syscall
+        // wrapper returning either a fresh owned descriptor or -1 with
+        // `errno` set. Ownership of any non-negative fd transfers
+        // immediately to `OwnedFd::from_raw_fd`, which closes it on drop;
+        // the raw value is not retained anywhere else, so no aliasing or
+        // use-after-free is possible.
+        #[allow(unsafe_code)]
+        let raw = unsafe { libc::open(c_path.as_ptr(), flags) };
+
+        if raw < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: `raw` is a non-negative fd just returned by `open(2)` with
+        // `O_CLOEXEC`. It has not been duplicated or leaked; this is the sole
+        // owner.
+        #[allow(unsafe_code)]
+        let fd = unsafe { OwnedFd::from_raw_fd(raw) };
+        Ok(fd)
     }
 
     /// Plain `open(O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)` fallback.

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -101,7 +101,8 @@ pub use phase_timer::PhaseTimer;
 pub use stream::{BadLogCode, MessageStream, Msgs2Stderr, StreamContext, message_stream};
 pub use thread_local::{
     DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events,
-    drain_events_coded, emit_debug, emit_debug_coded, emit_info, emit_info_coded, info_gte, init,
+    drain_events_coded, emit_debug, emit_debug_coded, emit_info, emit_info_coded, emit_warning,
+    info_gte, init,
 };
 pub use verify_failure::{VerifyFailure, verification_failure};
 

--- a/crates/logging/src/macros.rs
+++ b/crates/logging/src/macros.rs
@@ -36,6 +36,28 @@ macro_rules! info_log {
     };
 }
 
+/// Emit a warning, unconditionally.
+///
+/// Unlike [`info_log!`](crate::info_log) and
+/// [`debug_log!`](crate::debug_log) this takes no flag or level: upstream's
+/// `FWARNING` is not verbosity-gated. It is a log code `rwrite()` dispatches
+/// in its own right (upstream: `log.c:341`) and one the protocol carries to
+/// the peer for versions >= 30 (upstream: `rsync.h:285`, `rsync.h:296`).
+///
+/// Reach for this when an operator needs to know something happened whether
+/// or not they passed `-v`. Anything that should stay quiet at default
+/// verbosity belongs in `info_log!` or `debug_log!` instead.
+///
+/// ```ignore
+/// warn_log!("cannot confine destination '{}': {err}", dest.display());
+/// ```
+#[macro_export]
+macro_rules! warn_log {
+    ($($arg:tt)*) => {
+        $crate::emit_warning(format!($($arg)*));
+    };
+}
+
 /// Emit a debug log message if the flag level is enabled.
 ///
 /// The message is only formatted when the current thread's

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -126,17 +126,17 @@ pub fn emit_info_coded(flag: InfoFlag, level: u8, code: LogCode, message: String
 ///
 /// A warning is not gated on verbosity: upstream's `FWARNING` is a
 /// first-class log code that `rwrite()` dispatches on its own
-/// (`log.c:341`), and it is carried over the socket for protocols >= 30
-/// (`rsync.h:285`, `rsync.h:296` `MSG_WARNING = FWARNING`). Emitting it at
+/// (`log.c:314`), and it is carried over the socket for protocols >= 30
+/// (`rsync.h:278`, `rsync.h:289` `MSG_WARNING = FWARNING`). Emitting it at
 /// `level` 0 keeps [`info_gte`] trivially true, so the message is produced
 /// whatever the operator passed for `-v`.
 ///
 /// The event carries [`LogCode::Warning`], which the stream router sends to
 /// stderr (see `stream.rs`). The
 /// `rsync warning: … (code N) at file(line)` trailer upstream renders at
-/// `log.c:956` is deliberately not applied here; that formatting belongs to
+/// `log.c:909` is deliberately not applied here; that formatting belongs to
 /// the single logcode-to-stream funnel, not to the emitter.
-// upstream: log.c:341 rwrite() `case FWARNING:`
+// upstream: log.c:314 rwrite() `case FWARNING:`
 pub fn emit_warning(message: String) {
     emit_info_coded(InfoFlag::Misc, 0, LogCode::Warning, message);
 }

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -126,17 +126,17 @@ pub fn emit_info_coded(flag: InfoFlag, level: u8, code: LogCode, message: String
 ///
 /// A warning is not gated on verbosity: upstream's `FWARNING` is a
 /// first-class log code that `rwrite()` dispatches on its own
-/// (`log.c:314`), and it is carried over the socket for protocols >= 30
-/// (`rsync.h:278`, `rsync.h:289` `MSG_WARNING = FWARNING`). Emitting it at
+/// (`log.c:341`), and it is carried over the socket for protocols >= 30
+/// (`rsync.h:285`, `rsync.h:296` `MSG_WARNING = FWARNING`). Emitting it at
 /// `level` 0 keeps [`info_gte`] trivially true, so the message is produced
 /// whatever the operator passed for `-v`.
 ///
 /// The event carries [`LogCode::Warning`], which the stream router sends to
 /// stderr (see `stream.rs`). The
 /// `rsync warning: … (code N) at file(line)` trailer upstream renders at
-/// `log.c:909` is deliberately not applied here; that formatting belongs to
+/// `log.c:956` is deliberately not applied here; that formatting belongs to
 /// the single logcode-to-stream funnel, not to the emitter.
-// upstream: log.c:314 rwrite() `case FWARNING:`
+// upstream: log.c:341 rwrite() `case FWARNING:`
 pub fn emit_warning(message: String) {
     emit_info_coded(InfoFlag::Misc, 0, LogCode::Warning, message);
 }

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -122,6 +122,25 @@ pub fn emit_info_coded(flag: InfoFlag, level: u8, code: LogCode, message: String
     });
 }
 
+/// Emit a warning diagnostic, unconditionally.
+///
+/// A warning is not gated on verbosity: upstream's `FWARNING` is a
+/// first-class log code that `rwrite()` dispatches on its own
+/// (`log.c:341`), and it is carried over the socket for protocols >= 30
+/// (`rsync.h:285`, `rsync.h:296` `MSG_WARNING = FWARNING`). Emitting it at
+/// `level` 0 keeps [`info_gte`] trivially true, so the message is produced
+/// whatever the operator passed for `-v`.
+///
+/// The event carries [`LogCode::Warning`], which the stream router sends to
+/// stderr (see `stream.rs`). The
+/// `rsync warning: … (code N) at file(line)` trailer upstream renders at
+/// `log.c:956` is deliberately not applied here; that formatting belongs to
+/// the single logcode-to-stream funnel, not to the emitter.
+// upstream: log.c:341 rwrite() `case FWARNING:`
+pub fn emit_warning(message: String) {
+    emit_info_coded(InfoFlag::Misc, 0, LogCode::Warning, message);
+}
+
 /// Emit a debug diagnostic event into the thread-local buffer.
 ///
 /// The caller is responsible for checking [`debug_gte`] first; the

--- a/crates/logging/tests/warn_log_reaches_stderr.rs
+++ b/crates/logging/tests/warn_log_reaches_stderr.rs
@@ -1,0 +1,125 @@
+//! `warn_log!` must actually reach stderr, and must do so at every verbosity.
+//!
+//! The macro was added alongside a receiver call site that reports a daemon
+//! continuing without path confinement. That call site is only useful if the
+//! message reaches an operator, and "it routes the same way `debug_log!` does"
+//! is an argument rather than a measurement - the kind that has already been
+//! wrong twice in this crate, once because `debug_gte` short-circuits before
+//! the message is ever formatted, and once because the chosen level was
+//! unreachable at every verbosity an operator can set.
+//!
+//! So both links are asserted here rather than inferred:
+//!
+//! 1. `warn_log!` emits an event carrying [`LogCode::Warning`];
+//! 2. `LogCode::Warning` resolves to [`MessageStream::Stderr`].
+//!
+//! # Upstream Reference
+//!
+//! - `log.c:309-316` - `FWARNING` shares the `f = stderr` arm with `FERROR`.
+//! - `log.c:317-320` - only `FINFO` consults `quiet`, so a warning is not
+//!   suppressible the way an info message is.
+//! - `rsync.h:296` - `MSG_WARNING = FWARNING`, carried to the peer for
+//!   protocols >= 30.
+
+use logging::{
+    DiagnosticEvent, LogCode, MessageStream, Msgs2Stderr, StreamContext, VerbosityConfig,
+    drain_events, init, message_stream, warn_log,
+};
+
+/// Pull the single event `warn_log!` produced, failing loudly if the macro
+/// emitted nothing - that silence is the exact defect this file guards.
+fn emit_and_take_one(message: &str) -> (LogCode, u8, String) {
+    let mut events = drain_events();
+    assert_eq!(
+        events.len(),
+        1,
+        "warn_log! must emit exactly one event, got {}: {events:?}",
+        events.len()
+    );
+    match events.pop().expect("length checked above") {
+        DiagnosticEvent::Info {
+            code,
+            level,
+            message: emitted,
+            ..
+        } => {
+            assert_eq!(emitted, message, "the formatted message must survive");
+            (code, level, emitted)
+        }
+        other => panic!("warn_log! must emit an Info-shaped event, got {other:?}"),
+    }
+}
+
+/// Link 1: the macro emits `Warning`, at a level that cannot gate it out.
+#[test]
+fn warn_log_emits_a_warning_coded_event() {
+    init(VerbosityConfig::default());
+    drain_events();
+
+    warn_log!("planted {} warning", "test");
+    let (code, level, _) = emit_and_take_one("planted test warning");
+
+    assert_eq!(
+        code,
+        LogCode::Warning,
+        "the code is what routes the message; anything else lands elsewhere"
+    );
+    assert_eq!(
+        level, 0,
+        "level 0 keeps the info gate trivially true - a higher level would \
+         make the message unreachable at operator-settable verbosities, which \
+         is the bug this macro exists to avoid"
+    );
+}
+
+/// Link 2: `Warning` routes to stderr, and keeps doing so under every
+/// `StreamContext` an operator can produce - including `--quiet`, which
+/// suppresses only `FINFO` upstream.
+#[test]
+fn warning_routes_to_stderr_under_every_context() {
+    for quiet in [false, true] {
+        for msgs2stderr in [
+            Msgs2Stderr::Never,
+            Msgs2Stderr::Always,
+            Msgs2Stderr::Default,
+        ] {
+            for log_destination in [false, true] {
+                let ctx = StreamContext {
+                    quiet,
+                    msgs2stderr,
+                    log_destination,
+                };
+                assert_eq!(
+                    message_stream(LogCode::Warning, ctx),
+                    Ok(MessageStream::Stderr),
+                    "a warning must reach stderr for {ctx:?}"
+                );
+            }
+        }
+    }
+}
+
+/// The control that makes the test above mean something: the same matrix over
+/// `Info` does NOT always reach stderr. Without this, both assertions would
+/// pass on a build where `message_stream` returned `Stderr` unconditionally.
+#[test]
+fn info_is_not_unconditionally_stderr() {
+    let quiet_ctx = StreamContext {
+        quiet: true,
+        ..StreamContext::default()
+    };
+    assert_eq!(
+        message_stream(LogCode::Info, quiet_ctx),
+        Ok(MessageStream::Suppressed),
+        "control failed: if Info is not suppressed under --quiet, the router \
+         is not discriminating and the warning assertions prove nothing"
+    );
+
+    let plain_ctx = StreamContext::default();
+    assert_eq!(
+        message_stream(LogCode::Info, plain_ctx),
+        Ok(MessageStream::Stdout),
+        "control failed: Info must default to stdout, so 'Warning -> Stderr' \
+         is a real routing decision rather than the only outcome"
+    );
+}

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -24,7 +24,7 @@ use crate::shared::ChecksumFactory;
 use crate::transfer_state::TransferPhase;
 
 #[cfg(unix)]
-use super::sandbox::open_sandbox_for_dest_strict;
+use super::sandbox::{open_sandbox_for_dest_anchored, open_sandbox_for_dest_strict};
 use super::wire_filters::parse_wire_filters_for_receiver;
 
 /// Merges the daemon module `incoming chmod` modifiers with the client
@@ -530,10 +530,27 @@ impl ReceiverContext {
         // upstream: clientserver.c:1018 - `use_secure_symlinks = am_daemon
         // && !am_chrooted` gates the do_*_at wrappers in syscall.c that
         // implement the same refusal.
+        //
+        // A daemon receiver takes the anchored path instead. `dest_dir` is
+        // `module_root.join(peer_tail)` (see
+        // `open_sandbox_for_dest_anchored`), and the two halves are not
+        // equally trusted: the operator authored the root, the client sent
+        // the tail. Opening the fused string under one resolve policy made
+        // an operator's own symlinked module root - `path = /srv/...` where
+        // `/srv` is a link - refuse every transfer, because the policy that
+        // belongs to the tail was being applied to the root as well.
         #[cfg(unix)]
         let sandbox = {
             let strict = self.config.connection.is_daemon_connection;
-            open_sandbox_for_dest_strict(&dest_dir, strict)?
+            match self.config.connection.daemon_module_root.as_deref() {
+                Some(module_root) if strict => {
+                    open_sandbox_for_dest_anchored(module_root, &dest_dir)?
+                }
+                // No module root recorded (every non-daemon receiver, plus a
+                // daemon connection that never resolved one): there is no
+                // operator/peer split to make, so keep the existing open.
+                _ => open_sandbox_for_dest_strict(&dest_dir, strict)?,
+            }
         };
 
         // FSM: file list received and sanitized. Advance to DeltaTransfer.

--- a/crates/transfer/src/receiver/transfer/setup/sandbox.rs
+++ b/crates/transfer/src/receiver/transfer/setup/sandbox.rs
@@ -167,13 +167,36 @@ pub(super) fn open_sandbox_for_dest_anchored(
                     ),
                 ));
             }
-            logging::debug_log!(
-                Recv,
-                2,
-                "DirSandbox::open_dest_anchor({}, {}) failed: {err}; \
-                 falling back to path-based syscalls",
-                module_root.display(),
-                peer_tail.display()
+            if matches!(code, Some(libc::ENOENT)) {
+                // First-run push: the tail is created later by
+                // `ensure_relative_parents`. Ordinary, and not worth an
+                // operator's attention.
+                logging::debug_log!(
+                    Recv,
+                    2,
+                    "DirSandbox::open_dest_anchor({}, {}) got ENOENT; \
+                     the tail will be created during the transfer",
+                    module_root.display(),
+                    peer_tail.display()
+                );
+                return Ok(None);
+            }
+            // Anything else means a daemon receiver just lost its anchored
+            // dirfd and will fall back to path-based syscalls - it keeps
+            // running, but without the per-component confinement its role
+            // is supposed to have. Upstream confines exactly this role
+            // (`use_secure_symlinks = am_daemon && !am_chrooted`,
+            // clientserver.c:1018), so degrading is worth saying out loud.
+            //
+            // Warning, not debug: `debug_log!` here is unreachable at every
+            // verbosity an operator can actually set, which made this
+            // condition unobservable in the field. upstream: FWARNING is
+            // dispatched by rwrite() (log.c:341) and is not verbosity-gated.
+            logging::warn_log!(
+                "receiver: could not anchor destination '{}' under module \
+                 root '{}': {err}; continuing without path confinement",
+                peer_tail.display(),
+                module_root.display()
             );
             Ok(None)
         }

--- a/crates/transfer/src/receiver/transfer/setup/sandbox.rs
+++ b/crates/transfer/src/receiver/transfer/setup/sandbox.rs
@@ -98,6 +98,88 @@ pub(super) fn open_sandbox_for_dest_strict(
     }
 }
 
+/// Open a daemon receiver's destination as an operator anchor plus a
+/// confined peer tail.
+///
+/// `dest_dir` reaches this module as a single flattened string built by
+/// `resolve_receiver_dest_path` as `module_root.join(peer_tail)`
+/// (`client_args/path_resolution.rs`). The two halves carry different
+/// trust: the module root is named by the operator in `oc-rsyncd.conf`,
+/// while the tail is whatever the client sent on the wire. Applying one
+/// resolve policy to the fused string cannot express that, so this splits
+/// them back apart and gives each half the mechanism upstream gives it:
+///
+/// - the anchor is opened with a plain `open(2)`, because an operator who
+///   writes `path = /srv/backup` has authorised every component of it,
+///   symlinked or not;
+/// - each tail component is walked with `RESOLVE_BENEATH`, so an in-tree
+///   symlink is followed and anything leaving the module fails `EXDEV`.
+///
+/// Re-anchoring the tail is what keeps this a bug fix rather than a hole:
+/// opening the root plainly and then re-joining the tail into a path-based
+/// open would let a symlinked tail component walk straight out of the
+/// module.
+///
+/// `ENOENT` stays a soft failure (`Ok(None)`) so a first-run push still
+/// creates the tree through `ensure_relative_parents`. An escape refusal
+/// is fatal.
+///
+/// # Upstream Reference
+///
+/// - `syscall.c:85-90` - `open_anchor_dirfd()` uses a plain `openat`; the
+///   comment at `syscall.c:3189-3193` records why ("Absolute basedir:
+///   operator-trusted").
+/// - `syscall.c:2891` - `ds_descend()` walks the untrusted remainder, and
+///   `syscall.c:2961` splices a *relative* in-tree symlink target back
+///   into the walk rather than refusing it.
+/// - `main.c:765` - the daemon reaches the same state by `change_dir()`
+///   onto the module root before serving.
+#[cfg(unix)]
+pub(super) fn open_sandbox_for_dest_anchored(
+    module_root: &std::path::Path,
+    dest_dir: &std::path::Path,
+) -> io::Result<Option<Arc<fast_io::DirSandbox>>> {
+    let peer_tail = dest_dir.strip_prefix(module_root).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "destination '{}' is not under module root '{}'",
+                dest_dir.display(),
+                module_root.display(),
+            ),
+        )
+    })?;
+
+    match fast_io::DirSandbox::open_dest_anchor(module_root, peer_tail) {
+        Ok(sandbox) => Ok(Some(Arc::new(sandbox))),
+        Err(err) => {
+            let code = err.raw_os_error();
+            if matches!(code, Some(libc::EXDEV)) {
+                return Err(io::Error::new(
+                    err.kind(),
+                    format!(
+                        "refusing destination '{}': the client-supplied path \
+                         '{}' escapes module root '{}' (errno={})",
+                        dest_dir.display(),
+                        peer_tail.display(),
+                        module_root.display(),
+                        code.unwrap_or(0),
+                    ),
+                ));
+            }
+            logging::debug_log!(
+                Recv,
+                2,
+                "DirSandbox::open_dest_anchor({}, {}) failed: {err}; \
+                 falling back to path-based syscalls",
+                module_root.display(),
+                peer_tail.display()
+            );
+            Ok(None)
+        }
+    }
+}
+
 // upstream: clientserver.c:1018 - use_secure_symlinks gating that the
 // chdir-symlink-race fix mirrors. Tests below verify the strict daemon
 // branch refuses a leaf-symlink at the destination while the legacy
@@ -173,6 +255,119 @@ mod symlink_race_tests {
             result.is_some(),
             "strict mode must hand back a sandbox when the dest is a real dir"
         );
+    }
+
+    /// The operator's own module root may sit behind a symlink - `path =
+    /// /srv/backup` where `/srv -> /mnt/srv` is an ordinary layout. Upstream
+    /// opens that anchor with a plain `openat` (`syscall.c:85-90`), so every
+    /// transfer through it must succeed.
+    ///
+    /// ⚠ The symlink is planted **explicitly**. A bare `TempDir` proves
+    /// nothing about symlinked ancestors on either CI platform: on macOS
+    /// `/tmp -> private/tmp` means every tempdir already has one (and the
+    /// leaf-only non-Linux arm never inspects interior components anyway),
+    /// while on Linux CI tempdirs sit under a real `/tmp` so the interior
+    /// check is never reached. The platform that has the condition cannot
+    /// detect it; the platform that can detect it never has it.
+    #[test]
+    fn anchored_mode_accepts_a_symlinked_module_root() {
+        let (_keep, root) = canonical_tempdir();
+        let real_store = root.join("mnt-srv");
+        std::fs::create_dir(&real_store).expect("create real store");
+        std::fs::create_dir(real_store.join("backup")).expect("create module dir");
+
+        // The operator's configured root reaches its target through a link.
+        let srv = root.join("srv");
+        symlink(&real_store, &srv).expect("symlink srv -> mnt-srv");
+        let module_root = srv.join("backup");
+
+        let result = open_sandbox_for_dest_anchored(&module_root, &module_root)
+            .expect("a symlinked module root is operator-trusted and must open");
+        assert!(
+            result.is_some(),
+            "plain-open anchor must hand back a sandbox; a resolve policy \
+             applied to the operator's own root refuses every transfer"
+        );
+
+        // Control: the same fixture through the pre-fix path. Without this
+        // the assertion above passes on a build that never had the bug, and
+        // the test would be evidence of nothing.
+        //
+        // Linux-only. The bug needs an *interior* component check, which
+        // only the `openat2(RESOLVE_NO_SYMLINKS)` arm performs; the
+        // non-Linux arm is leaf-only `O_NOFOLLOW`, and the leaf here
+        // (`backup`) is a real directory, so the old path succeeds there
+        // for a reason unrelated to the fix.
+        #[cfg(target_os = "linux")]
+        {
+            let old = open_sandbox_for_dest_strict(&module_root, true);
+            assert!(
+                old.is_err(),
+                "control failed: the pre-fix path accepted this layout, so \
+                 the assertion above cannot be evidence of the fix"
+            );
+        }
+    }
+
+    /// The peer half keeps `RESOLVE_BENEATH`. A client-supplied tail whose
+    /// component is a symlink out of the module must not open, or the
+    /// plain-open anchor above would have turned an availability bug into a
+    /// module escape.
+    #[test]
+    fn anchored_mode_refuses_a_peer_tail_that_escapes_the_module() {
+        let (_keep, root) = canonical_tempdir();
+        let module_root = root.join("module");
+        std::fs::create_dir(&module_root).expect("create module root");
+        let outside = root.join("outside");
+        std::fs::create_dir(&outside).expect("create outside dir");
+
+        // Relative target: an absolute one is refused under RESOLVE_BENEATH
+        // even when it lands inside, so it would pass for the wrong reason.
+        symlink("../outside", module_root.join("escape")).expect("symlink escape -> ../outside");
+
+        let err = open_sandbox_for_dest_anchored(&module_root, &module_root.join("escape"))
+            .expect_err("a peer tail leaving the module must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("escapes module root"),
+            "expected the escape refusal, got: {err}"
+        );
+        assert!(
+            msg.contains(&format!("errno={}", libc::EXDEV)),
+            "escape must be refused as an escape (EXDEV), not merely as \
+             'there was a symlink', got: {err}"
+        );
+    }
+
+    /// The other half of the same policy: a symlinked *subdirectory* inside
+    /// the module is ordinary content and must transfer. upstream:
+    /// `ds_descend()` splices a relative in-tree target back into the walk
+    /// (`syscall.c:2961`) rather than refusing it.
+    #[test]
+    fn anchored_mode_follows_an_in_tree_symlinked_subdirectory() {
+        let (_keep, root) = canonical_tempdir();
+        let module_root = root.join("module");
+        std::fs::create_dir(&module_root).expect("create module root");
+        std::fs::create_dir(module_root.join("real")).expect("create real subdir");
+        symlink("real", module_root.join("link")).expect("symlink link -> real");
+
+        let result = open_sandbox_for_dest_anchored(&module_root, &module_root.join("link"))
+            .expect("an in-tree symlinked subdirectory must not be refused");
+        assert!(
+            result.is_some(),
+            "a symlinked subdirectory inside the module is ordinary content"
+        );
+    }
+
+    #[test]
+    fn anchored_mode_soft_fails_when_the_tail_is_missing() {
+        let (_keep, root) = canonical_tempdir();
+        let module_root = root.join("module");
+        std::fs::create_dir(&module_root).expect("create module root");
+
+        let result = open_sandbox_for_dest_anchored(&module_root, &module_root.join("not-yet"))
+            .expect("ENOENT must stay a soft failure - first-run push mkdirs later");
+        assert!(result.is_none());
     }
 
     #[test]

--- a/crates/transfer/tests/dir_sandbox_carrier.rs
+++ b/crates/transfer/tests/dir_sandbox_carrier.rs
@@ -98,14 +98,25 @@ fn receiver_shaped_descent_tracks_current_dirfd() {
     assert_eq!(sandbox.current_dirfd().as_raw_fd(), root_raw);
 }
 
+/// An **absolute** symlink target is refused even when it resolves back
+/// inside the tree, and the failed descent leaves the cursor untouched.
+///
+/// This test previously asserted that *any* symlink leaf is refused, which
+/// described a policy the carrier no longer has. Its fixture only ever
+/// exercised the absolute case, so retargeting it at absoluteness is what
+/// it was actually measuring all along - the name and comments were the
+/// part that was wrong.
+///
+/// upstream: `ds_descend()` refuses an absolute target outright
+/// (`syscall.c:2953`) while splicing a relative in-tree one back into the
+/// walk (`syscall.c:2961`), so refusing here is parity, not strictness.
 #[test]
-fn descent_refuses_symlink_leaf_without_disturbing_stack() {
+fn descent_refuses_absolute_symlink_target_without_disturbing_stack() {
     let (_keep, root) = canonical_tempdir();
     std::fs::create_dir(root.join("real")).unwrap();
-    // `link` is a symlink that resolves to `real`. Entering `link`
-    // must fail under the leaf `O_NOFOLLOW` invariant on every Unix
-    // target the carrier supports; on Linux 5.6+ the `openat2`
-    // upgrade adds `RESOLVE_NO_SYMLINKS` for the same refusal.
+    // NOTE: `root.join("real")` is an ABSOLUTE target. That is the whole
+    // point of this case - see the relative-target test below for the
+    // in-tree behaviour, which is the one that actually changed.
     symlink(root.join("real"), root.join("link")).unwrap();
 
     let mut sandbox = DirSandbox::open_root(&root).expect("open root");
@@ -114,23 +125,23 @@ fn descent_refuses_symlink_leaf_without_disturbing_stack() {
 
     let err = sandbox
         .enter(OsStr::new("link"))
-        .expect_err("symlink leaf must be rejected");
+        .expect_err("absolute symlink target must be rejected");
 
     // Accepted refusals across Unix variants:
-    // - Linux openat2 `RESOLVE_NO_SYMLINKS` -> ELOOP (raw 40).
-    // - Linux openat `O_NOFOLLOW | O_DIRECTORY` on a symlink leaf ->
-    //   ELOOP (raw 40).
-    // - macOS / BSD evaluate O_DIRECTORY before O_NOFOLLOW and report
-    //   ENOTDIR (raw 20) for symlink-to-directory.
+    // - Linux openat2 `RESOLVE_BENEATH` rejects an absolute target as an
+    //   escape -> EXDEV (raw 18).
+    // - macOS / BSD take the leaf-only `O_NOFOLLOW | O_DIRECTORY` arm and
+    //   report ENOTDIR (raw 20) or ELOOP (raw 62).
     let code = err.raw_os_error().expect("must carry an errno");
     let accepted: &[i32] = &[
+        18, // EXDEV on Linux under RESOLVE_BENEATH
         20, // ENOTDIR on macOS / BSD
         40, // ELOOP on Linux
         62, // ELOOP on macOS / BSD
     ];
     assert!(
         accepted.contains(&code),
-        "expected ENOTDIR or ELOOP for symlink leaf, got errno={code} ({err})"
+        "expected an escape or symlink refusal, got errno={code} ({err})"
     );
 
     assert_eq!(sandbox.depth(), depth_before, "failed enter must not push");
@@ -139,6 +150,31 @@ fn descent_refuses_symlink_leaf_without_disturbing_stack() {
         root_raw,
         "failed enter must not perturb the cursor"
     );
+}
+
+/// A **relative** in-tree symlink is followed, not refused. This is the
+/// case the carrier used to get wrong: a symlinked subdirectory inside the
+/// destination tree is ordinary content, and refusing it made a plain
+/// `oc-rsync -a src/ dst/` fail whenever `dst/sub` was a link.
+///
+/// Linux-only: the non-Linux arm is leaf-only `O_NOFOLLOW`, which still
+/// refuses a symlink leaf regardless of target. That platform split is a
+/// real residual, not an oversight in this test.
+///
+/// upstream: `syscall.c:2961`.
+#[cfg(target_os = "linux")]
+#[test]
+fn descent_follows_relative_in_tree_symlink() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("real")).unwrap();
+    symlink("real", root.join("link")).unwrap();
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+
+    sandbox
+        .enter(OsStr::new("link"))
+        .expect("a relative in-tree symlink must be followed");
+    assert_eq!(sandbox.depth(), 1, "successful enter must push");
 }
 
 #[test]

--- a/crates/transfer/tests/uts_nextest_chdir_symlink_race.rs
+++ b/crates/transfer/tests/uts_nextest_chdir_symlink_race.rs
@@ -132,15 +132,26 @@ fn rejects_symlinked_subdir_and_leaves_outside_untouched() {
 
     // Accepted refusals across Unix variants - the same set the
     // existing carrier tests in `dir_sandbox_carrier.rs` document.
+    //
+    // The refusal itself is unchanged; only which errno reports it moved.
+    // The descent now confines with `RESOLVE_BENEATH` rather than
+    // `RESOLVE_NO_SYMLINKS`, so this planted `subdir -> /outside` is
+    // rejected as an *escape* (EXDEV) instead of as *a symlink* (ELOOP).
+    // EXDEV is the stronger statement: it says the target left the
+    // anchor, which is precisely the property this scenario defends.
+    // The sentinel assertions below are what actually prove the attack
+    // failed, and they are untouched.
     let code = err.raw_os_error().expect("kernel must report errno");
     let accepted: &[i32] = &[
+        18, // EXDEV (Linux: openat2 RESOLVE_BENEATH, target left the anchor)
         20, // ENOTDIR (macOS / BSD: O_DIRECTORY beats O_NOFOLLOW)
         40, // ELOOP (Linux: openat2 RESOLVE_NO_SYMLINKS or O_NOFOLLOW)
         62, // ELOOP (macOS / BSD raw value)
     ];
     assert!(
         accepted.contains(&code),
-        "expected ENOTDIR or ELOOP for symlinked subdir, got errno={code} ({err})"
+        "expected an escape or symlink refusal for the planted subdir, \
+         got errno={code} ({err})"
     );
 
     // The outside sentinel must be byte-identical: the receiver never


### PR DESCRIPTION
## The bug

A daemon receiver cannot serve a module whose configured root reaches its target through a symlink. With `path = /srv/backup` where `/srv -> /mnt/srv` — an ordinary layout — every transfer into that module fails on Linux 5.6+ with `ELOOP`, and the error blames a chdir-symlink-race that is not happening.

This is an availability defect: the module is unusable, and the diagnostic points away from the cause.

## Why

The destination reaches the receiver as a single flattened string, `module_root.join(peer_tail)`, built by `resolve_receiver_dest_path` in `client_args/path_resolution.rs`. Fusing the two halves loses the fact that they carry different trust:

| half | who supplies it |
|---|---|
| module root | the operator, in `oc-rsyncd.conf` |
| tail | whatever the client sent on the wire |

`DirSandbox::open_root` then applied one resolve policy to the whole string. The rule that belongs to the peer's tail was being enforced against the operator's own root.

Upstream keeps the halves in different mechanisms and says why in the source. `open_anchor_dirfd()` opens the anchor with a plain `openat` (`syscall.c:85-90`), commented at `syscall.c:3189-3193` as "Absolute basedir: operator-trusted". `ds_descend()` (`syscall.c:2891`) walks the untrusted remainder.

## The change

`open_sandbox_for_dest_anchored` splits the composite back apart and gives each half the mechanism upstream gives it: a plain open for the anchor, `RESOLVE_BENEATH` per tail component.

**Re-anchoring the tail is what keeps this a fix rather than a hole.** Opening the root plainly and re-joining the tail into a path-based open would let a symlinked tail component walk straight out of the module. The tail is walked from the anchor fd; a component that leaves it fails `EXDEV`, and non-`Normal` components are refused rather than normalised away.

Scope is narrow: only a daemon connection **with a resolved module root** takes the new path. Every other receiver keeps the existing open.

## Second defect, same root cause

The per-entry descent refused *every* symlinked subdirectory inside the destination tree. Upstream follows one — `ds_descend()` splices a relative in-tree target back into the walk (`syscall.c:2961`) and refuses only an absolute target or a climb above the anchor.

The refusal did not come from the resolve mask, which is why an earlier attempt to relax it changed nothing. `openat2_beneath` also set `O_NOFOLLOW` in `how.flags`, and every caller passes a single component, so the leaf *is* the whole path and `O_NOFOLLOW` refused it before any resolve flag was consulted. Measured on Linux 7.0.0 against a relative in-tree symlink:

```
+O_NOFOLLOW  BENEATH|NO_SYMLINKS    -> ENOTDIR
+O_NOFOLLOW  BENEATH|NO_MAGICLINKS  -> ENOTDIR   (mask change alone: inert)
 no NOFOLLOW BENEATH|NO_MAGICLINKS  -> OK        (upstream behaviour)
 no NOFOLLOW BENEATH|NO_SYMLINKS    -> ELOOP
 escape:     BENEATH|NO_MAGICLINKS  -> EXDEV
```

Row 4 is the control: **`RESOLVE_NO_SYMLINKS` is not redundant in general** — it refuses where `BENEATH` alone does not. It is redundant only here, where `O_NOFOLLOW` is set and the path is one component. This diff should not be read as removing a safety flag.

## Two riders on the tests

**Fixtures must use a RELATIVE symlink target.** An absolute target is refused under `RESOLVE_BENEATH` even when it resolves inside the anchor, and upstream refuses absolute targets too (`syscall.c:2953`), so an absolute-target fixture passes for the wrong reason and can never detect a symlink-following regression.

**Symlinked-ancestor tests must plant the symlink explicitly.** A `TempDir` proves nothing on either CI platform, for opposite reasons: on macOS `/tmp -> private/tmp` gives every tempdir a symlinked ancestor, but the leaf-only non-Linux arm never inspects interior components; on Linux CI tempdirs sit under a real `/tmp`, so the check is never reached. The platform that has the condition cannot detect it, and the platform that can detect it never has it.

## Tests

- Symlinked module root opens, carrying a Linux-only **control** asserting the pre-fix path *did* refuse the same layout — so it cannot pass vacuously on a build that never had the bug.
- Peer tail escaping the module is refused with `EXDEV`; an in-tree relative symlink is followed.
- Both new `fast_io` descent tests were verified to **fail** when `O_NOFOLLOW` is restored.

Three existing tests asserted the old policy and were **retargeted, not loosened**. All three plant ABSOLUTE symlink targets, which `RESOLVE_BENEATH` refuses as escapes, so each now asserts `EXDEV` alongside the prior errnos and says so in its name. The refusal is unchanged — only which errno reports it — and `EXDEV` is the stronger statement, naming an escape rather than merely a symlink.

### A finding in its own right

One of those three is `uts_nextest_chdir_symlink_race.rs`, the port of the CVE-2026-29518 chdir-symlink-race scenario. **It could never have detected a symlink-following regression** — it plants an absolute target, which is refused in every configuration this code has ever had, so its refusal assertion passed no matter what the descent policy did. A security regression test that cannot detect the regression it is named for is worse than none, because it occupies the slot. The actual fix is the relative-target case, which neither that file nor `dir_sandbox_carrier.rs` had; both now have it. The sentinel assertions that prove the attack failed are untouched.

Both files live in `crates/transfer/tests/`, which crate unit-test runs never touch — the gap was invisible to anything short of a full-target run.

## Cross-implementation cell

Real rsync 3.5.0 serves a module whose root sits behind a symlinked ancestor, so oc must too. Measured on Linux, `path = $tmp/srv/backup` with `srv -> mnt-srv` (relative target), daemon push over `rsync://`, asserting the payload lands in the real store:

| binary | exit | file landed |
|---|---|---|
| rsync 3.5.0 | 0 | yes |
| oc-rsync pre-fix (`372847513`) | 23 | **no** — daemon log: `refusing to …` |
| oc-rsync with this change | 0 | yes |

The middle row is what makes the other two evidence: the layout upstream serves is exactly the one oc refused.

## Coarse timing

`enter()` is a per-entry descent, so the mask change was checked for regression — coarsely, not benchmarked. Daemon push of 180 directories / 120 files onto a plain module root, best of 3, debug build:

```
PRE-FIX    45 ms   (120 files)
WITH-FIX   38 ms   (120 files)
```

No regression. The gap is within noise at this sample size and should not be read as a speed-up; the change swaps one `openat2` resolve mask for another on the same syscall, so no per-entry cost was expected either way.

## The policy seam

The split above leaves an open question the resolver design has to answer: upstream's walk carries a **confinement check the kernel cannot express**. `ds_descend` consults `abspath_outside_confinement` after each component, and `abspath` is seeded only for an absolute anchor (`syscall.c:2989-2991`) — so an operator-trusted caller runs the same walk with the check compiled out, and a daemon caller runs it with the check live.

`RESOLVE_BENEATH` cannot host that check. It refuses escapes from the anchor, which is not the same predicate as "outside the configured confinement root", and it gives the caller no point at which to evaluate anything. The two callers therefore need **different resolution mechanisms**, not different arguments to one mechanism.

This PR lands the seam that expresses that, plus the arm that is already exercised:

```rust
pub trait ConfinementOracle {
    fn outside_confinement(&self, abspath: &Path) -> bool;
}

pub struct NoExclude;                       // zero-sized; the check compiles out
pub struct ConfinePolicy<O = NoExclude> { /* … */ }
```

`open_dest_anchor` now delegates to `open_dest_anchor_with_policy(.., ConfinePolicy::operator_trusted())`, so the seam sits on the live daemon path from this commit rather than waiting for a future consumer.

**Behaviour is unchanged on every currently-exercised path.** The `NoExclude` arm keeps `RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS` — the mechanism the measurements above already established as matching upstream. No measured cell changes.

### Why the seam sits exactly here

Two independent requirements land on the same boundary, which is the strongest thing that can be said for a split of this kind.

The first is the exclude check above. The second is upstream's **hop budget**: `ds_walk_path` passes `hops` by pointer, as a single budget shared across the whole walk rather than reset per component. That budget **only exists if oc does the walking.** Under `RESOLVE_BENEATH` the kernel follows symlinks internally and enforces its own limit — oc passes no budget, observes no intermediate hops, and has nothing to make cumulative. So the per-descend-reset bug is *unreachable* in the `BENEATH` arm and *mandatory to get right* in the manual arm.

Arriving at the same boundary from the exclude check and from the hop budget, by unrelated routes, is what makes this a real seam rather than a convenient one.

### What is deliberately not here

The manual per-component walk — and with it the shared hop budget, `..`-as-movement, and the confinement-root escape check — lands with its oracle, not ahead of it. A walk whose only consumer does not exist yet is unreachable code, and this repository has five such orphans already, all hidden by the same crate-root `pub use` mechanism that makes `dead_code` structurally unable to fire.

The manual arm also **gives up `openat2`'s atomicity**: evaluating the exclude check between components means the walk observes the tree in steps rather than in one kernel call. That is a trade, not an oversight — upstream accepts the same one for the same reason, because a check the kernel cannot express has to be evaluated somewhere the kernel is not. It is recorded as a decision in the design doc rather than left to be rediscovered.

### Evidence it is not vacuous

RED was a missing-symbol failure. The new test then passed. Mutating the fixture to point the symlink **outside** the anchor fails it with `EXDEV`, so the assertion discriminates between "followed an in-tree symlink" and "accepted anything at all" rather than passing unconditionally.

## Deliberately not in this PR

- **The canonicalize block in `context.rs` stays — do not "finish the job" without reading this.** It is gated to `!is_daemon_connection`, so the daemon path never reaches it and removing it fixes nothing here. More importantly it rewrites `dest_dir` itself rather than only the sandbox open, so deleting it changes the recorded destination on the local-copy path. That makes it a *different* change on the hottest path in the product, not a residual of this one. It becomes redundant only once the non-daemon root also opens plainly.
- **`secure_dir.rs` keeps `RESOLVE_NO_SYMLINKS` without `BENEATH`.** It is called with `AT_FDCWD` and an absolute path, where `BENEATH` would refuse every module root. That is a different call shape, not a third policy, and it is documented in place.
- **`metadata_ops` is untouched.** Its three `secure_open_dir` callers take an absolute parent with no dirfd anchor; giving them beneath-semantics needs an anchor threaded through their signatures and every caller above.

## Residuals, stated plainly

oc does **not** yet match upstream's symlink policy everywhere. The non-Linux arm is leaf-only `O_NOFOLLOW` and still refuses a symlink leaf regardless of target; that platform split is a real gap, not an oversight. `metadata_ops` and the non-daemon root are named above. Tracked separately.

## Verification

`cargo fmt --all -- --check` clean. `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` exits 0. `transfer` + `fast_io` + `logging`: 4063 run, 4063 passed. `daemon`: 1774 passed. Cross-implementation cell and coarse timing as above.

Re-verified on the seam commit: `cargo fmt --all -- --check` clean, `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` exits 0, `cargo nextest run -p fast_io --all-features` 988 passed / 1 skipped.

The new warning's delivery to stderr is **asserted, not inferred**. Both links are tested: `warn_log!` emits exactly one event carrying `LogCode::Warning` at level 0 (the count catches silence; the level catches the unreachable-verbosity bug), and `LogCode::Warning` resolves to `MessageStream::Stderr` across the whole `StreamContext` matrix including `--quiet`. A third test is the control — `Info` is `Suppressed` under `--quiet` and `Stdout` otherwise — so the router is shown to discriminate rather than returning `Stderr` unconditionally.

This replaced an earlier "it routes the same way `debug_log!` does" argument. That class of reasoning has been wrong twice in this crate already: once because `debug_gte` short-circuits before the message is ever formatted, and once because the chosen level was unreachable at every verbosity an operator can set.

