### PR TITLE
fix(tools): correct path-site sweep filters and add the missing classes

### DIFF
--- a/tools/ci/path_site_sweep.py
+++ b/tools/ci/path_site_sweep.py
@@ -7,14 +7,21 @@ To mirror that, oc-rsync first needs to know the complete set of sites. A list
 maintained by hand is a list that rots, so this derives it mechanically and can
 be re-run to prove no site was missed after the resolver is wired in.
 
-`#[cfg(test)]` blocks are excluded: test code creates and removes files
-constantly and is not an attack surface, so counting it buries the real
-sites. Integration tests under crates/*/tests/ are skipped for the same
-reason. The exclusion is brace-depth tracked rather than line-matched, so a
-multi-line test module is dropped whole.
+What is excluded, and why: test code creates and removes files constantly and
+is not an attack surface, so counting it buries the real sites. That means
+`#[cfg(test)]` *and* its `#[cfg(all(test, ...))]` spellings, `crates/*/tests/`,
+`benches/`, `examples/`, and `build.rs`. Comments are excluded too - a doc
+comment naming `File::open` is documentation, not a call site.
 
-Exit status is always 0; this reports, it does not gate. Task 607 turns the
-comparison into a ratchet once every site is classified.
+What is deliberately NOT counted, so the number is not read as more than it is:
+bare `.metadata()`, because it is `File::metadata` (fd-based, already anchored)
+as often as `Path::metadata` (path-resolving), and the two are not
+distinguishable by regex. The `fs::` and `symlink_metadata` spellings that are
+unambiguously path-resolving are counted.
+
+Exit status is 0 unless `--check-patterns` is passed and some pattern matched
+nothing: a pattern that matches nothing is the same defect as a filter that
+matches too much, and it fails silently, so it is checkable on demand.
 """
 
 from __future__ import annotations
@@ -37,16 +44,69 @@ OPERATION_PATTERNS = [
     ("MUTATE_MKDIR", r"\bfs::create_dir(?:_all)?\b"),
     ("MUTATE_PERM", r"\bfs::set_permissions\b"),
     ("OPEN_READ", r"\bFile::open\b"),
+    # How the receiver actually opens destination files. Absent from the
+    # original pattern set, which is why 61 of the most security-relevant
+    # sites in the tree were invisible to it.
+    ("OPEN_OPTS", r"\bOpenOptions::new\b"),
+    # The docstring always named stat as a class; the patterns never had it.
+    # Only the unambiguously path-resolving spellings - see the module docstring
+    # on why bare `.metadata()` is left out.
+    (
+        "STAT",
+        r"\bfs::(?:metadata|symlink_metadata|read_link|canonicalize)\b"
+        r"|\.symlink_metadata\(",
+    ),
 ]
 
 _MATCHER = re.compile(
     "|".join(f"(?P<{name}>{pattern})" for name, pattern in OPERATION_PATTERNS)
 )
-_CFG_TEST = re.compile(r"#\[cfg\(test\)\]")
+
+# `#[cfg(test)]` is only the simplest spelling. `#[cfg(all(test, unix))]` and
+# `#[cfg(all(unix, test))]` are equally common and the literal pattern missed
+# every one of them. Match any `cfg` attribute carrying a bare `test` token,
+# after quoted strings are removed so `feature = "test-utils"` does not count.
+_CFG_ATTR = re.compile(r"#\[cfg(?:_attr)?\((?P<pred>.*)\)\]")
+_QUOTED = re.compile(r'"[^"]*"')
+_BARE_TEST = re.compile(r"\btest\b")
+
+SKIP_DIRS = frozenset({"tests", "benches", "examples"})
+SKIP_FILES = frozenset({"tests.rs", "build.rs"})
+
+
+def is_test_cfg(line: str) -> bool:
+    """True when `line` carries a cfg attribute gated on `test`."""
+    match = _CFG_ATTR.search(line)
+    if not match:
+        return False
+    return bool(_BARE_TEST.search(_QUOTED.sub("", match.group("pred"))))
+
+
+def code_before_comment(line: str) -> str:
+    """Return the part of `line` outside a `//` comment.
+
+    A doc comment naming an API is not a call site. Quote-parity is tracked so
+    a `//` inside a string literal - a path like `"rsync://host/mod"` - is not
+    mistaken for a comment. Block comments are not handled; they are rare in
+    this tree and would need multi-line state.
+    """
+    quoted = False
+    index = 0
+    while index < len(line) - 1:
+        char = line[index]
+        if char == "\\":
+            index += 2
+            continue
+        if char == '"':
+            quoted = not quoted
+        elif char == "/" and line[index + 1] == "/" and not quoted:
+            return line[:index]
+        index += 1
+    return line
 
 
 def production_lines(path: str):
-    """Yield (lineno, text) for lines outside any #[cfg(test)] block.
+    """Yield (lineno, code) for code outside any test-gated block or comment.
 
     Brace depth is tracked from the attribute onward so an entire test module
     is skipped, not just the attribute line.
@@ -55,7 +115,7 @@ def production_lines(path: str):
     depth = 0
     with open(path, errors="replace") as handle:
         for lineno, line in enumerate(handle, 1):
-            if _CFG_TEST.search(line):
+            if is_test_cfg(line):
                 in_test = True
                 depth = 0
                 continue
@@ -64,28 +124,31 @@ def production_lines(path: str):
                 if depth <= 0 and "}" in line:
                     in_test = False
                 continue
-            yield lineno, line
+            code = code_before_comment(line)
+            if code.strip():
+                yield lineno, code
 
 
 def sweep(root: str):
     """Return a list of (operation, crate, path, lineno, text) for every site."""
     sites = []
-    for dirpath, _, filenames in os.walk(root):
-        # crates/<name>/tests/ is integration-test scaffolding, not a surface.
-        if f"{os.sep}tests" in dirpath:
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune in place so os.walk does not descend at all. The original
+        # substring check on dirpath only caught "tests", so benches/ and
+        # examples/ were swept as if they were production.
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        if any(part in SKIP_DIRS for part in dirpath.split(os.sep)):
             continue
         for filename in filenames:
-            if not filename.endswith(".rs") or filename == "tests.rs":
+            if not filename.endswith(".rs") or filename in SKIP_FILES:
                 continue
             path = os.path.join(dirpath, filename)
             parts = path.split(os.sep)
             crate = parts[1] if len(parts) > 1 else "?"
-            for lineno, line in production_lines(path):
-                match = _MATCHER.search(line)
+            for lineno, code in production_lines(path):
+                match = _MATCHER.search(code)
                 if match:
-                    sites.append(
-                        (match.lastgroup, crate, path, lineno, line.strip())
-                    )
+                    sites.append((match.lastgroup, crate, path, lineno, code.strip()))
     return sites
 
 
@@ -94,6 +157,12 @@ def main() -> int:
     parser.add_argument("--root", default="crates")
     parser.add_argument(
         "--list", action="store_true", help="print one line per site, not a summary"
+    )
+    parser.add_argument(
+        "--check-patterns",
+        action="store_true",
+        help="exit 1 if any declared pattern matched nothing (a dead pattern "
+        "is a silent hole, not a passing check)",
     )
     args = parser.parse_args()
 
@@ -107,14 +176,27 @@ def main() -> int:
     by_crate = collections.Counter(site[1] for site in sites)
 
     print("path-mutating / path-opening sites in production code")
-    print(f"(root={args.root}, #[cfg(test)] blocks and */tests/ excluded)\n")
+    print(
+        f"(root={args.root}; test-gated cfg blocks, {'/, '.join(sorted(SKIP_DIRS))}/, "
+        f"{', '.join(sorted(SKIP_FILES))} and comments excluded)\n"
+    )
     print("by operation:")
-    for operation in sorted(by_operation):
+    for operation, _ in OPERATION_PATTERNS:
         print(f"  {operation:16} {by_operation[operation]:5}")
+
     print("\nby crate:")
     for crate, count in by_crate.most_common():
         print(f"  {crate:16} {count:5}")
+
     print(f"\nTOTAL {len(sites)}")
+
+    dead = [name for name, _ in OPERATION_PATTERNS if not by_operation[name]]
+    if dead:
+        print(f"\nWARNING: patterns matching nothing: {', '.join(dead)}")
+        print("A pattern that matches nothing hides sites exactly as a")
+        print("too-broad filter invents them. Fix the pattern or drop it.")
+        if args.check_patterns:
+            return 1
     return 0
 
 


### PR DESCRIPTION
## The defect

The sweep over-counted and under-counted at the same time, and the two errors partly cancelled — so the total looked plausible while roughly half the entries were not call sites and one of the most security-relevant classes in the tree was invisible.

Measured on `origin/master`, same tree before and after:

| | sites |
|---|---|
| before | 530 |
| original 7 classes, **corrected filters** | 255 &nbsp;&nbsp;(−275; **51% were non-sites**) |
| **+ OpenOptions + stat classes** | 564 &nbsp;&nbsp;(+309 real sites) |

Reporting only "530 → 564" would hide both halves.

## Over-counting — three causes

- The directory skip was a **substring test** for `"tests"`, so `benches/` and `examples/` were swept as production. Now pruned in `os.walk`, along with `build.rs`.
- The test-cfg exclusion was the **literal** `#[cfg(test)]`, so every `#[cfg(all(test, unix))]` module was counted whole. Now any `cfg` attribute carrying a bare `test` token, with quoted strings stripped first so `feature = "test-utils"` does not match.
- **Comments were not filtered**, so a doc comment naming `File::open` counted as a call site. Now stripped, with quote-parity tracking so a `//` inside a string literal — an `rsync://` URL — is not read as a comment.

## Under-counting — two classes the patterns never had

- **`OpenOptions::new`, 46 production sites.** This is how the receiver opens destination files, so the most security-relevant opens in the tree were invisible to a tool whose entire purpose is finding them.
- **stat, 263 sites.** The module docstring always named stat as an operation class; the pattern list never contained it.

## Reconciling the OpenOptions number

46 is lower than the 61 that has been quoted, so here is the full chain rather than an assertion:

```
102  raw `OpenOptions::new` matches in crates/
-21  in crates/*/tests/
 -2  in tests.rs
 -7  in benches/ or examples/
----
 72  in files the sweep visits
-26  inside test-gated cfg blocks or comments
----
 46  production
```

The 61 was a raw-grep figure at different scoping. 46 is the production count.

## Deliberately not counted

Bare `.metadata()` — it is `File::metadata` (fd-based, already anchored) as often as `Path::metadata` (path-resolving), and the two are not distinguishable by regex. Counting it would inflate the total with sites that carry no confinement obligation. The unambiguous `fs::` and `symlink_metadata` spellings **are** counted. This is recorded in the module docstring so the number is not later read as more than it is.

## Non-vacuity

A pattern that matches nothing is the same defect as a filter that matches too much, and it fails silently. `--check-patterns` exits 1 if any declared pattern matched nothing. All nine match; the check exits 0 today, and the per-class counts are in the table above.

## Why this blocks the ratchet

Task 546 would otherwise build its ratchet on the 530 baseline. That baseline fires on test edits — adding a `#[cfg(all(test, unix))]` module moves the number — and stays silent when a real `OpenOptions::new` destination open is added, because it was never counted. A ratchet with those two properties is worse than none.

Demonstrated accidentally on a sibling branch: the old tool scored that branch 10 higher than master purely because a new `#[cfg(all(test, unix))]` test module was counted as production.
