### PR TITLE
docs(fast_io): stop claiming RESOLVE_BENEATH where the code omits it

### DIFF
--- a/crates/fast_io/src/secure_dir.rs
+++ b/crates/fast_io/src/secure_dir.rs
@@ -3,10 +3,16 @@
 //! [`secure_open_dir`] returns a directory file descriptor that callers can
 //! anchor subsequent `*at` syscalls against. The resolution policy refuses to
 //! follow symlinks at the leaf on every Unix target, and on Linux 5.6+ kernels
-//! it upgrades to `openat2(2)` with
-//! `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` so that **any** symlink anywhere in
-//! the path - not just at the leaf - and any `..` traversal outside the open
-//! point are rejected with `EXDEV` / `ELOOP`.
+//! it upgrades to `openat2(2)` with `RESOLVE_NO_SYMLINKS`, so that **any**
+//! symlink anywhere in the path - not just at the leaf - is rejected with
+//! `ELOOP`.
+//!
+//! `RESOLVE_BENEATH` is deliberately NOT set; the reasoning is on `how.resolve`
+//! in the `linux` submodule below. This helper *produces* an anchor, and
+//! `AT_FDCWD` plus an absolute path would make `RESOLVE_BENEATH` refuse every
+//! path outside the process cwd. Confining a path beneath an anchor belongs to
+//! the `*at` walk that uses the fd this returns. A `..` component is therefore
+//! **not** rejected here, and this function never returns `EXDEV`.
 //!
 //! This module is Unix-only. Windows callers use NTFS handle-based APIs
 //! (see the SEC-1.l audit), which sidestep path TOCTOU naturally; they
@@ -19,9 +25,9 @@
 //! [`openat2_supported`](crate::linux_capabilities::openat2_supported) probe
 //! caches that result and we use plain
 //! `open(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)` thereafter. The plain `open`
-//! path still rejects a symlink at the leaf - it just cannot reject `..`
-//! traversal mid-path, which is the marginal extra confinement
-//! `RESOLVE_BENEATH` gives us.
+//! path still rejects a symlink at the leaf - it just cannot reject symlinks
+//! in interior components, which is the extra confinement
+//! `RESOLVE_NO_SYMLINKS` gives us.
 //!
 //! # Single unsafe block
 //!
@@ -35,19 +41,17 @@ use std::path::Path;
 /// Open `path` as a directory file descriptor with strict resolution
 /// semantics.
 ///
-/// On Linux 5.6+ this uses `openat2` with
-/// `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` for full path-component
-/// confinement. On older Linux, macOS, and other Unix targets, this falls
-/// back to `open(O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`, which
-/// only rejects a symlink at the leaf.
+/// On Linux 5.6+ this uses `openat2` with `RESOLVE_NO_SYMLINKS`, which
+/// refuses a symlink in any path component. On older Linux, macOS, and other
+/// Unix targets, this falls back to
+/// `open(O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`, which only rejects
+/// a symlink at the leaf.
 ///
 /// # Errors
 ///
 /// - `ELOOP` when the leaf is a symlink (plain `open` path) or any path
 ///   component is a symlink (`openat2` path with `RESOLVE_NO_SYMLINKS`).
 /// - `ENOTDIR` when the path resolves to a non-directory.
-/// - `EXDEV` (Linux only) when `openat2` rejects a `..` component that would
-///   escape the open point under `RESOLVE_BENEATH`.
 /// - `ENOENT` when the path does not exist.
 /// - `EACCES` / `EPERM` per the usual `open(2)` semantics.
 pub fn secure_open_dir(path: &Path) -> io::Result<OwnedFd> {

--- a/crates/fast_io/src/secure_dir.rs
+++ b/crates/fast_io/src/secure_dir.rs
@@ -47,6 +47,12 @@ use std::path::Path;
 /// `open(O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`, which only rejects
 /// a symlink at the leaf.
 ///
+/// `RESOLVE_BENEATH` is **not** set, so a `..` component is not rejected and
+/// this never returns `EXDEV`. That is deliberate: this call produces the
+/// anchor, and `AT_FDCWD` with an absolute path would make `RESOLVE_BENEATH`
+/// refuse every path outside the process cwd. Confinement beneath an anchor
+/// belongs to the `*at` walk that uses the returned fd.
+///
 /// # Errors
 ///
 /// - `ELOOP` when the leaf is a symlink (plain `open` path) or any path

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -31,8 +31,8 @@ use std::os::unix::fs::MetadataExt;
 ///
 /// When `--keep-dirlinks` is inactive, dispatches to
 /// [`fast_io::secure_chown_at`], which walks the parent through
-/// `secure_open_dir` (`openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` on
-/// Linux 5.6+, `open(O_NOFOLLOW | O_DIRECTORY)` elsewhere) and anchors
+/// `secure_open_dir` (`openat2(RESOLVE_NO_SYMLINKS)` on Linux 5.6+,
+/// `open(O_NOFOLLOW | O_DIRECTORY)` elsewhere) and anchors
 /// `fchownat` on that dirfd. `AT_SYMLINK_NOFOLLOW` alone only guards the leaf;
 /// a symlink swapped into a receiver-created ancestor directory would
 /// otherwise be followed, redirecting the chown outside the module. Mirrors

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -684,7 +684,7 @@ pub(super) fn apply_permissions_with_chmod_fd(
 ///
 /// Both branches remain visible to `fakeroot`: `secure_chmod_at` performs the
 /// mode change with the libc `fchmodat(2)` symbol (only the parent-directory
-/// walk uses `openat2`/`RESOLVE_BENEATH`, which fakeroot ignores because it
+/// walk uses `openat2`/`RESOLVE_NO_SYMLINKS`, which fakeroot ignores because it
 /// tracks modes per inode on the chmod call, not on directory opens), and
 /// `std::fs::set_permissions` uses the libc `chmod(2)` symbol. Both are
 /// interposed by fakeroot's LD_PRELOAD wrapper, so no raw-syscall path bypasses
@@ -1139,7 +1139,7 @@ pub(super) fn apply_permissions_from_entry(
 
             if needs_chmod {
                 // upstream: syscall.c:do_chmod_at() - chmod the leaf through a
-                // dirfd opened with RESOLVE_BENEATH/RESOLVE_NO_SYMLINKS so a
+                // dirfd opened with RESOLVE_NO_SYMLINKS so a
                 // symlink swapped into any parent component cannot redirect
                 // the chmod outside the receiver's confinement (testsuite
                 // chdir-symlink-race). Under `--keep-dirlinks` the helper


### PR DESCRIPTION
## The claim and the code

`secure_open_dir`'s docs said the `openat2` path uses `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`, rejects `..` traversal outside the open point, and can return `EXDEV`.

`crates/fast_io/src/secure_dir.rs:150` sets:

```rust
how.resolve = libc::RESOLVE_NO_SYMLINKS;
```

No `BENEATH`. `..` is not rejected. This function cannot return `EXDEV`.

## The code was never wrong, and never unexplained

**Two separate in-code comments already say BENEATH is deliberately absent and why** — `secure_dir.rs:148-152` and again at `:244-247`. The reason is sound: this helper *produces* the anchor, and pairing `AT_FDCWD` with an absolute path makes the kernel refuse every path outside the process cwd, which is almost never where a daemon module root or a CI tempdir lives. Confining beneath an anchor belongs to the `*at` walk that consumes the returned fd.

The module docstring contradicted both of those comments from thirteen lines above the first one.

## What changed

Four claims in `secure_dir.rs` — module docstring (twice), the fn doc, and the `EXDEV` error bullet, which documented an error this function cannot produce — plus the three in `crates/metadata` that name oc's `secure_open_dir` or its dirfd:

| file | claim |
|---|---|
| `apply/ownership.rs` | `openat2(RESOLVE_BENEATH \| RESOLVE_NO_SYMLINKS)` |
| `apply/permissions.rs` | "the parent-directory walk uses `openat2`/`RESOLVE_BENEATH`" |
| `apply/permissions.rs` | "a dirfd opened with RESOLVE_BENEATH/RESOLVE_NO_SYMLINKS" |

## Two mentions deliberately left alone

`apply/tests.rs:2226` describes **upstream's** `do_chmod_at`, which does confine per-component through `ds_descend`. `:2350` states a general property of `openat2`. Both are accurate. I initially counted six sites and re-checked each before editing; correcting these two would have replaced a true statement with a false one.

## Why this is not tidying

The false claim made a follow-up task look like small signature-threading work — on the reading that beneath-semantics were already in place and merely needed an anchor passed down to three callers. They are not in place. And upstream does not thread an anchor either: `do_chmod_at`, `do_lchown_at` and the utimes site all call `secure_relative_open(NULL, dirpath, ...)`, and the resolver substitutes `module_dir` itself (`syscall.c:3126`, `:3145`, *"absolute, operator-trusted anchor"*).

A doc asserting a confinement property the code does not have is what the next person designs against.

## Verification

Docs-only; no behaviour change. `cargo fmt --all -- --check` clean, `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` exit 0, `cargo doc -p fast_io -p metadata` no warnings. Every surviving `RESOLVE_BENEATH` mention in the touched files now either explains that it is *not* set, or describes upstream.

## What a green CI run on this PR does NOT check

⚠ `ci.yml` does not run the nextest cell on docs-only changes (task 619), so **the citation-drift gate will not see this PR**. That gate is the one mechanism that would otherwise check the upstream references in the text I touched.

Harmless here — no citation line numbers changed, and the two `syscall.c` references added to the commit message are not in a gated file — but a clean run on this PR means "nothing else broke", not "the new wording was validated". Stating it so nobody reads the green as more than it is.

## Where the reasoning now lives

Not just the deletion of the false claim. The explanation for why `RESOLVE_BENEATH` is absent now appears in **three** places a reader can land:

- the module docstring's second paragraph, immediately after the resolution policy;
- the `secure_open_dir` fn doc, which is what shows on hover and docs.rs;
- the two pre-existing in-code comments at `:148-152` and `:244-247`.

Deleting a false statement does not stop it returning. The claim was re-asserted in four places over time precisely because the reason it was wrong sat 140 lines below the docstring that contradicted it.
