### PR TITLE
ci: run the citation gate on docs-only changes

### DIFF
--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -30,6 +30,20 @@
 # This deliberately overlaps the copy that runs under nextest. The duplication is
 # cheap and the two have different trigger sets; the standalone job is the one
 # that covers docs-only changes.
+#
+# ADVISORY, NOT REQUIRED - a deliberate choice, not an oversight.
+#
+# `Upstream citations resolve` is not in the master ruleset's required-status-check
+# list and is not being added to it. Master enforces strict up-to-date merges, so
+# every additional required context lengthens the serial merge queue; a docs-typo
+# pull request should not have to round-trip that queue behind a comment checker.
+# The failure being closed here is *invisibility* - a wrong citation currently
+# reaches master with nothing anywhere reporting on it - and an advisory red is
+# visible on the pull request, which is exactly what was missing.
+#
+# The identical assertion still runs REQUIRED inside `nextest (stable)` for any
+# change that touches code, so no code path loses enforcement. Promote this to
+# required only together with a decision about that merge-queue cost.
 name: Citations
 
 on:

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -1,0 +1,73 @@
+# Gate: every `upstream: <file>:<line>` citation must name a file the pinned
+# upstream rsync release has, at a line that file has.
+#
+# WHY THIS IS ITS OWN WORKFLOW, AND WHY IT HAS NO `paths:` FILTER.
+#
+# The check itself lives in `xtask/src/commands/citations.rs` and also runs as a
+# unit test, so it rides the `nextest` cell in ci.yml. But ci.yml is path-filtered
+# to code (`crates/**`, `xtask/**`, `tools/**`, ...) and lists no documentation
+# path, so a docs-only pull request triggers ci.yml not at all - and with it, the
+# citation gate.
+#
+# That is exactly backwards. `cargo xtask citations` scans every git-tracked file,
+# markdown included; documentation is where citations are least likely to be
+# checked by a compiler and most likely to be wrong. A docs-only PR is precisely
+# the change this gate exists to validate, and it was the one change that skipped
+# it. A green run on such a PR meant "nothing else broke", not "the new wording
+# was checked".
+#
+# Adding doc globs to ci.yml's filter would work until someone adds a doc
+# directory the list does not enumerate - a filter that must track every
+# documentation location is a filter that drifts back into this hole. Running
+# unfiltered removes the failure mode instead of re-describing it.
+#
+# The cost of running this on every pull request is small and was measured, not
+# assumed: `cargo xtask citations` builds 68 packages, where the workspace
+# nextest cell builds 490. It needs no upstream tarball either - the gate reads
+# the committed `tools/ci/upstream-3.4.4-lines.tsv` manifest, which is why the
+# manifest exists.
+#
+# This deliberately overlaps the copy that runs under nextest. The duplication is
+# cheap and the two have different trigger sets; the standalone job is the one
+# that covers docs-only changes.
+name: Citations
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: citations-${{ github.ref }}
+  # Superseded pull request pushes cancel; pushes to master do not, so every
+  # merge commit keeps a completed run for bisection.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
+
+jobs:
+  citations:
+    name: Upstream citations resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          shared-key: citations-${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check every citation resolves in the pinned upstream release
+        run: cargo xtask citations


### PR DESCRIPTION
## Why

`cargo xtask citations` asserts that every `upstream: <file>:<line>` comment names a
file the pinned rsync release has, at a line that file has. It scans **every
git-tracked file, markdown included** - 7754 citations across 4920 files.

It ran only as a unit test inside the workspace `nextest` cell, and ci.yml is
path-filtered to code:

```
crates/** src/** tests/** tools/** xtask/** fuzz/** Cargo.toml Cargo.lock
.github/workflows/ci.yml .github/actions/** .github/workflows/_*.yml
docker/** Cross.toml
```

No documentation path appears there. None appears in `citation-drift.yml`'s filter
either (`crates/**/*.rs` + the tool + its baseline + itself). **A docs-only pull
request triggered neither citation gate.**

That is inverted. Documentation is where a citation has no compiler to check it and
is likeliest to be wrong; a docs-only change is precisely what the gate exists to
validate, and was the one change it skipped. A green run on such a PR meant
"nothing else broke", not "the new wording was checked".

Found on #7307 - a documentation change whose entire purpose was correcting false
claims about upstream `RESOLVE_BENEATH` behaviour. The gate that checks
documentation claims against upstream is the one that skipped.

## Shape: a separate unfiltered workflow, not doc globs added to ci.yml

Adding `docs/**` and `*.md` to ci.yml's filter works until someone adds a
documentation location the list does not enumerate. A filter that must track every
doc directory drifts back into this hole; unfiltered has no such failure mode.

**This shape is already the repo's precedent, not a new pattern.** Two existing gate
workflows use a bare unfiltered `pull_request:` for exactly this reason:

| workflow | gate it runs |
| --- | --- |
| `.github/workflows/check-locked-flags.yml` | `check_locked_flags.sh`, `check_cargo_lockfile_sync.sh` |
| `.github/workflows/bin-build-coverage.yml` | `check_bin_build_coverage.py` |

`citations.yml` is a third instance of a shape already in use, so there is no new
convention to review.

**The cost was measured, not assumed** - this was the deciding fact, since a split
would not be worth it if the gate needed a full workspace build:

| what | packages built |
| --- | --- |
| workspace `nextest` cell (where the gate rode) | **490** |
| `cargo xtask citations` alone | **68** |

It also needs no upstream tarball: it reads the committed
`tools/ci/upstream-3.4.4-lines.tsv` line-count manifest, which is exactly why that
manifest exists.

The check still runs under `nextest` too. The duplication is cheap and the two have
different trigger sets; this job is the one that covers docs.

## Demonstration - the hole, then the hole closed

Both halves are shown on **the same changeset**, which is stronger than two
branches: this PR's diff touches only `docs/ARCHITECTURE.md` and
`.github/workflows/citations.yml`, and **neither matches any ci.yml path glob**
(ci.yml lists `ci.yml`, `.github/actions/**` and specific `_*.yml` reusables - not
`citations.yml`).

The first pushed commit deliberately plants a wrong citation in a docs file:

```
docs/ARCHITECTURE.md:  See upstream: io.c:99999 for the lull computation.
```

`io.c` is 2536 lines in rsync 3.4.4, so that line does not exist.

* **Before** - observable in this same run: ci.yml does not trigger, and neither does
  citation-drift.yml. But the board is **not** merely empty - `.github/workflows/
  ci-skip.yml` fires instead and publishes **SUCCESS for every required context**,
  including `nextest (stable)`, from jobs whose entire body is
  `echo "Skipped — no code changes"`.

  That shim is correct and necessary: without it a docs-only PR matches neither
  workflow, no required check reports, and the PR can never merge. Its own comment
  says so. **But the citation hard gate lives inside `nextest (stable)`** - so on a
  docs-only PR that context goes green having measured nothing. The hole did not look
  like a gap; it looked like a passing test cell. That is why it survived.
* **After** - the new `Upstream citations resolve` job runs and goes **red** on the
  planted citation. Being unfiltered, it runs on both sides of the ci.yml/ci-skip.yml
  split, so it is the only real citation signal a docs-only PR gets.

### Measured, not predicted

Both states were observed. On the planted commit the job failed with exactly one
violation - the planted one - and the message names the mechanism, not just a status:

```
Running `target/debug/xtask citations`
docs/ARCHITECTURE.md:114: cites io.c:99999 but io.c has 2536 lines
1 upstream citation(s) cannot be followed to target/interop/upstream-src/rsync-3.4.4;
  re-locate the construct there and correct the file name or the line number, or -
  if the behaviour has no upstream analogue any more - drop the citation
##[error]Process completed with exit code 1.
```

**On that same run**, the skip shim reported SUCCESS for `fmt + clippy`,
`nextest (stable)`, `Windows (stable)`, `macOS (stable)`, `Linux musl (stable)`,
`interop`, `interop (macOS)`, `interop (Windows, best-effort)` and both
`upstream-testsuite` contexts - all from `echo` jobs. One changeset, one run, both
states side by side; no two-branch comparison and no appeal to a previous PR.

**This is the first docs-only change in this cycle to produce a red at all.** Every
prior docs-only PR showed a fully green board sourced from those same `echo` jobs.
That contrast is the argument for the job existing.

The temp commit was then removed; the job is expected green on the final head. See the
check runs on this PR for both states.

## Scope of the guarantee - read this before relying on it

This job closes the **trigger** hole: a docs-only PR now gets a real citation check
where it previously got an `echo`. It does **not** make every citation in every doc
checked, and the difference matters.

`cargo xtask citations` inspects only lines containing the word `upstream`
(`xtask/src/commands/citations.rs:281`, `if !line.to_ascii_lowercase().contains("upstream")
{ continue; }`). A bare `` `socket.c:736-846` `` in prose is invisible to it.

That limit is **not hypothetical**. A whole-corpus bounds check - cited line number vs
`wc -l` of the pinned file, which needs no anchor string - finds four out-of-bounds
citations in committed docs, and **the gate cannot see any of them**:

| site | citation | 3.4.4 length |
| --- | --- | --- |
| `docs/audits/ssh-socketpair-claim-verification.md:179` | `socket.c:736-846` | 845 |
| `docs/audits/ssh-socketpair-vs-pipes.md:185` | `socket.c:805-846` | 845 |
| `docs/audits/ssh-socketpair-vs-pipes.md:218` | `socket.c:740-802` … `-846` | 845 |
| `docs/audits/ssh-socketpair-vs-pipes.md:762` | `socket.c:736-846` | 845 |

None of those four lines contains the word `upstream`. The planted demonstration
citation was caught because it was written as `See upstream: io.c:99999 …` - had it
been written as bare prose, this PR's demonstration would have produced a **green**.
Worth stating plainly: the demonstration proves the trigger fix, not full coverage.

Widening the line filter, and adding the bounds check as a second, anchor-free
mechanism, are follow-ups (tasks 672 and 652 class (c)) and deliberately not bundled
here - this PR changes **when** the gate runs, not **what** it inspects.

## Not done here

* `citation_drift_audit.py`'s filter is **left alone and is correct**: it scans only
  `crates/*/src/**/*.rs`, so a docs-only change genuinely cannot alter its result.
  There is no hole on that side. Extending its *scope* to docs is task VAL-2.


