### PR TITLE
fix(sender): honour --ignore-errors in the end-of-flist io_error marker

### DIFF
--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -762,8 +762,17 @@ impl GeneratorContext {
             self.flist_send_stats.record(entry);
         }
 
-        // upstream: flist.c:2553 - write io_error with end marker (SAFE_FILE_LIST)
-        let io_error_for_end = if self.io_error != 0 {
+        // upstream: flist.c:2781-2788 - `if (io_error == 0 || ignore_errors)
+        // write_end_of_flist(f, 0); else if (use_safe_inc_flist)
+        // write_end_of_flist(f, 1); ...`. --ignore-errors suppresses the value
+        // exactly as it does on the pre-30 path (send_io_error_flag above,
+        // flist.c:2825 `write_int(f, ignore_errors ? 0 : io_error)`): the
+        // operator asked for scan errors not to steer the peer's delete pass,
+        // and that request applies to both eras of the wire encoding. The
+        // `use_safe_inc_flist` half of upstream's rule lives inside
+        // `FileListWriter::write_end`, which emits the marker only when the
+        // peer negotiated a safe file list.
+        let io_error_for_end = if self.io_error != 0 && !self.config.deletion.ignore_errors {
             Some(self.io_error)
         } else {
             None

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -1994,6 +1994,70 @@ fn send_io_error_flag_ignore_errors_suppresses_value() {
     assert_eq!(output, &[0, 0, 0, 0]);
 }
 
+/// Captures the sender's ENTIRE io_error surface for `protocol` with an empty
+/// file list.
+///
+/// The two wire eras carry io_error on different channels, so a test that looks
+/// at only one of them measures nothing on the other: pre-30 uses the standalone
+/// 4-byte field (`flist.c:2825`) and leaves the end-of-list marker a bare zero
+/// byte, while 30+ folds the value into the marker itself (`flist.c:2384-2394`).
+/// Concatenating both channels lets one assertion state the single upstream
+/// rule that governs them.
+fn sender_io_error_bytes(protocol: u8, io_error: i32, ignore_errors: bool) -> Vec<u8> {
+    let handshake = test_handshake_with_protocol(protocol);
+    let mut config = test_config();
+    config.deletion.ignore_errors = ignore_errors;
+
+    let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+    if io_error != 0 {
+        ctx.add_io_error(io_error);
+    }
+
+    let mut output = Vec::new();
+    ctx.send_file_list(&mut output).unwrap();
+    ctx.send_io_error_flag(&mut output).unwrap();
+    output
+}
+
+/// CLASS GUARD: `--ignore-errors` suppresses the sender's io_error in BOTH wire
+/// eras, not just the legacy one.
+///
+/// Upstream states one rule twice - `flist.c:2781-2788` selects
+/// `write_end_of_flist(f, 0)` when `io_error == 0 || ignore_errors`, and
+/// `flist.c:2825` writes `ignore_errors ? 0 : io_error` on the pre-30 path.
+/// oc implemented only the second, and the gap was invisible from behaviour:
+/// the peer receives `--ignore-errors` too (options.c:3062) and gates its own
+/// decode on `!ignore_errors`, so a real 3.5.0 receiver masks the extra value.
+/// Assert the BYTES, and assert both eras in one test, or a future encoding era
+/// repeats this.
+#[test]
+fn ignore_errors_suppresses_the_sender_io_error_in_both_wire_eras() {
+    for &protocol in &[29u8, 32u8] {
+        let clean = sender_io_error_bytes(protocol, 0, false);
+        let reported = sender_io_error_bytes(protocol, io_error_flags::IOERR_GENERAL, false);
+        let suppressed = sender_io_error_bytes(protocol, io_error_flags::IOERR_GENERAL, true);
+
+        // Non-vacuity: this protocol must be able to put the value on the wire
+        // at all, otherwise `suppressed == clean` would also hold for a sender
+        // that never encodes io_error and the assertion below would prove
+        // nothing. This control has already earned its place - written against
+        // the end-of-list marker alone it failed at protocol 29, because that
+        // era carries io_error on the other channel entirely.
+        assert_ne!(
+            reported, clean,
+            "protocol {protocol}: the sender does not encode io_error on any \
+             channel, so this test cannot detect a missing ignore_errors gate"
+        );
+
+        assert_eq!(
+            suppressed, clean,
+            "protocol {protocol}: --ignore-errors must leave the sender's \
+             io_error surface byte-identical to the no-error case \
+             (flist.c:2781-2788 for 30+, flist.c:2825 for pre-30)"
+        );
+    }
+}
+
 #[test]
 fn apply_permutation_in_place_identity() {
     let mut a = vec![1, 2, 3, 4];


### PR DESCRIPTION
## What

`--ignore-errors` did not suppress the sender's io_error in the protocol 30+ end-of-flist marker. Upstream states one rule and oc implemented half of it:

| upstream | oc before | oc after |
|---|---|---|
| `flist.c:2825` pre-30 - `write_int(f, ignore_errors ? 0 : io_error)` | correct (`send_io_error_flag`) | unchanged |
| `flist.c:2781-2788` 30+ - `write_end_of_flist(f, 0)` when `io_error == 0 \|\| ignore_errors` | **ungated** | gated |

The generator module referenced `ignore_errors` exactly once, on the legacy path. Protocol 32 is the default, so the ungated branch is the one every modern transfer takes.

## Why it was invisible

The receiving half of the rule was already right. `--ignore-errors` is forwarded to the peer unconditionally (`options.c:3062`, outside any `am_sender` block), and the peer gates its own decode on `!ignore_errors`. A real 3.5.0 receiver therefore discards the value oc should not have sent.

Measured against a built `rsync 3.5.0`, both ends pinned through the `-e` wrapper (push; sender under test, receiver always 3.5.0; source contains a mode-000 subdirectory so the sender's scan sets `IOERR_GENERAL`; destination holds an extraneous file so `--delete` has work):

| sender | flag | exit | extraneous deleted | "IO error encountered -- skipping file deletion" |
|---|---|---|---|---|
| 3.5.0 | none (control) | 23 | yes | yes |
| 3.5.0 | `--ignore-errors` | 23 | yes | no |
| oc | none (control) | 23 | no | yes |
| oc | `--ignore-errors` | 23 | yes | no |

The two `--ignore-errors` rows agree exactly, so **this change has no behavioural symptom against a peer that shares the flag**, and no configuration was found that unmasks it. It is a wire-fidelity correction, stated plainly rather than dressed up.

The control rows are the reason the harness was run: they disagree, and that divergence is **not** this bug (upstream deletes in the already-processed directory before the io_error reaches it, oc knows earlier). That is delete-pass timing, reported separately and deliberately not folded in.

## Test

One case covering both wire eras, asserting bytes rather than behaviour, since behaviour cannot see this.

Its non-vacuity control earned its place immediately: written against the end-of-list marker alone it **failed at protocol 29**, which carries io_error on the standalone 4-byte field and leaves the marker a bare zero. The helper now captures the sender's whole io_error surface, so one assertion can state the single rule that governs both channels.

Mutation check: reverting the production gate fails the test at protocol 32 and leaves 29 passing - exactly the asymmetry being closed.

## Verification

- `cargo fmt --all -- --check` - exit 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - exit 0
- `cargo nextest run -p transfer --all-features` - 2719 passed, 3 skipped

## Not included

Three findings surfaced alongside this and are filed rather than folded in:

1. The delete-pass timing divergence in the control rows above.
2. `send_extra_file_list` (`flist.c:2446-2453`) sends a per-segment io_error when a **new** error occurs during that segment; oc's segment sender always passes `None`, so it under-reports in the opposite direction.
3. oc has no analogue of `fatal_unsafe_io_error()` (`flist.c:2384`), upstream's abort when `delete_during && inc_recurse` without a safe file list.

## Site audit: the rule is missing at ONE site, not all of them

The usual pattern here is that a rule found missing at one site is missing at every site. **It is not, and that is load-bearing** - a blanket "gate every io_error emit" fix would have introduced a new divergence while closing this one.

| upstream | rule | oc | verdict |
|---|---|---|---|
| `flist.c:2781-2788` | initial-list end marker, gated on `ignore_errors` | ungated | **fixed here** |
| `flist.c:2825` | initial-list pre-30 field, gated | gated (`send_io_error_flag`) | already correct |
| `sender.c:809-810` | post-transfer `MSG_IO_ERROR`, `protocol_version >= 30`, **no `ignore_errors` term** | ungated (`transfer_loop.rs:1245`) | **already correct - must NOT be gated** |
| `flist.c:2446-2453` | sub-list end marker, gated, keyed on `save_io_error` | always `None` | separate: under-reports |
| `flist.c:2495` | sub-list `MSG_IO_ERROR`, `protocol_version == 30` exactly | no analogue | separate: proto-30 only |
| `flist.c:2826` | initial-list `MSG_IO_ERROR`, `!use_safe_inc_flist` | no analogue | separate: proto-30 only |

`grep -n ignore_errors sender.c` returns **nothing** - upstream deliberately does not gate the post-transfer emit, and oc matches it. The last three rows are proto-30-only or sub-list-only and are filed, not folded in.

## Composition with the receive-side gate

Measured with the fixed binary on both ends, same fixture:

| cells | flag | exit | delete ran | "skipping file deletion" |
|---|---|---|---|---|
| 3.5.0 -> 3.5.0 | `--ignore-errors` | 23 | yes | no |
| oc(fixed) -> oc(fixed) | `--ignore-errors` | 23 | yes | no |
| oc(fixed) -> 3.5.0 | `--ignore-errors` | 23 | yes | no |

The sender fix composes with the existing receive-side gate and matches upstream end-to-end in both the symmetric and cross-implementation cells.
