### PR TITLE
fix(cli): --iconv with an unopenable charset must exit 4, not transfer

### DIFF
--- a/crates/cli/src/frontend/execution/options/iconv.rs
+++ b/crates/cli/src/frontend/execution/options/iconv.rs
@@ -56,10 +56,24 @@ pub(crate) fn resolve_iconv_setting(
     }
 }
 
-/// Accepts a parsed setting when the `iconv` feature is enabled.
+/// Accepts a parsed setting when the `iconv` feature is enabled, after
+/// checking that every charset it names can actually be opened.
+///
+/// Upstream refuses to start when `iconv_open` fails, exiting
+/// `RERR_UNSUPPORTED` (4) from `setup_iconv()` (`rsync.c:130-140`). oc used
+/// to accept the option, resolve the converter to `None`, and then complete
+/// the transfer with filenames untranscoded and nothing on stderr - the same
+/// silent passthrough this function's `#[cfg(not(feature = "iconv"))]` twin
+/// below already refuses for a build-time-disabled iconv. The two have
+/// identical consequences for the operator, so they are treated alike; only
+/// the exit code differs, each matching its own upstream site.
 #[cfg(feature = "iconv")]
 fn accept_parsed_setting(setting: IconvSetting) -> Result<IconvSetting, Message> {
-    Ok(setting)
+    match setting.validate_charsets() {
+        Ok(()) => Ok(setting),
+        // upstream: rsync.c:134 - `exit_cleanup(RERR_UNSUPPORTED)`.
+        Err(detail) => Err(rsync_error!(4, detail).with_role(Role::Client)),
+    }
 }
 
 /// Rejects an explicit iconv setting with a hard error when the `iconv`
@@ -86,6 +100,66 @@ mod tests {
     fn resolve_iconv_setting_none_not_disabled() {
         let result = resolve_iconv_setting(None, false).unwrap();
         assert_eq!(result, IconvSetting::Unspecified);
+    }
+
+    /// An unopenable charset must ABORT with upstream's exit code and text,
+    /// never resolve to "no conversion".
+    ///
+    /// Upstream `setup_iconv()` calls `exit_cleanup(RERR_UNSUPPORTED)` when
+    /// `iconv_open` fails (`rsync.c:130-140`) and prints
+    /// `iconv_open("UTF-8", "<charset>") failed`. Measured against a built
+    /// rsync 3.5.0: `--iconv=NOSUCHCHARSET` gives exit 4 and transfers
+    /// nothing, where oc used to give exit 0 having copied every file with
+    /// the conversion silently dropped.
+    ///
+    /// Asserts the exit code AND the message, because on a path whose whole
+    /// purpose is telling the operator what went wrong, exit-4-with-other-
+    /// wording is a half-fix.
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn unopenable_charset_exits_4_with_upstream_text() {
+        let error = resolve_iconv_setting(Some(&os("NOSUCHCHARSET")), false)
+            .expect_err("an unopenable charset must not resolve to a setting");
+
+        assert_eq!(
+            error.code(),
+            Some(4),
+            "upstream: rsync.c:134 RERR_UNSUPPORTED"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains(r#"iconv_open("UTF-8", "NOSUCHCHARSET") failed"#),
+            "message must match upstream rsync.c:131-132, got: {error}"
+        );
+    }
+
+    /// The post-comma half names the peer's charset and is validated too:
+    /// upstream reaches the same `exit_cleanup` in the peer process, and a
+    /// local copy runs both halves here.
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn unopenable_remote_charset_is_rejected_too() {
+        let error = resolve_iconv_setting(Some(&os("UTF-8,NOSUCHCHARSET")), false)
+            .expect_err("an unopenable remote charset must not resolve to a setting");
+
+        assert_eq!(error.code(), Some(4));
+        assert!(
+            error
+                .to_string()
+                .contains(r#"iconv_open("UTF-8", "NOSUCHCHARSET") failed"#),
+            "the failing charset must be named, got: {error}"
+        );
+    }
+
+    /// Non-vacuity: a charset that CAN be opened still resolves, so the two
+    /// assertions above are detecting the rejection rather than a parser
+    /// that rejects every explicit spec.
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn openable_charset_still_resolves() {
+        resolve_iconv_setting(Some(&os("UTF-8,ISO-8859-1")), false)
+            .expect("a charset pair that opens must be accepted");
     }
 
     #[test]

--- a/crates/cli/src/frontend/execution/options/iconv.rs
+++ b/crates/cli/src/frontend/execution/options/iconv.rs
@@ -155,10 +155,19 @@ mod tests {
     /// Non-vacuity: a charset that CAN be opened still resolves, so the two
     /// assertions above are detecting the rejection rather than a parser
     /// that rejects every explicit spec.
+    ///
+    /// Deliberately `UTF-8,UTF-8` rather than a legacy name. The charset
+    /// NAMESPACE is under review: oc resolves WHATWG labels via
+    /// `encoding_rs::Encoding::for_label`, upstream uses POSIX iconv, and
+    /// names like `ISO-8859-1` or `ascii` are precisely the ones that work
+    /// may change - WHATWG currently folds both onto windows-1252. Pinning
+    /// this control to a name under review would make it fail on a CORRECT
+    /// namespace fix and read as a regression. UTF-8 resolves identically
+    /// in both systems and under every candidate outcome.
     #[cfg(feature = "iconv")]
     #[test]
     fn openable_charset_still_resolves() {
-        resolve_iconv_setting(Some(&os("UTF-8,ISO-8859-1")), false)
+        resolve_iconv_setting(Some(&os("UTF-8,UTF-8")), false)
             .expect("a charset pair that opens must be accepted");
     }
 

--- a/crates/core/src/client/config/iconv.rs
+++ b/crates/core/src/client/config/iconv.rs
@@ -120,14 +120,70 @@ impl IconvSetting {
     ///   each peer's local charset); the post-comma half of
     ///   `--iconv=LOCAL,REMOTE` describes the *peer's* local charset and
     ///   is forwarded to the remote CLI by the invocation builder, not
-    ///   used for transcoding on this side. When the local charset is not
-    ///   recognised by `encoding_rs`, this returns `None` and emits a
-    ///   `tracing::warn!` (gated on the `tracing` feature) so the
-    ///   transfer falls back to verbatim bytes rather than aborting in
-    ///   the middle of a file list. The CLI parser already validates
-    ///   that the spec is non-empty, so reaching this fallback
-    ///   indicates an unsupported encoding label.
+    ///   used for transcoding on this side. An unrecognised charset is
+    ///   rejected earlier by [`IconvSetting::validate_charsets`], which the
+    ///   CLI runs at option-resolution time and which exits 4 exactly as
+    ///   upstream's `setup_iconv()` does; the `None` arm below is therefore
+    ///   defence in depth, not the operator-visible path. It must NOT be
+    ///   relaxed back into a silent fallback: returning `None` here reads to
+    ///   every caller as "no conversion requested", which is why an
+    ///   unsupported charset used to produce a full transfer with
+    ///   untranscoded filenames and no diagnostic.
     ///
+    /// Validates that every charset named by `--iconv` can actually be
+    /// opened, returning upstream's `iconv_open(...) failed` text when one
+    /// cannot.
+    ///
+    /// Upstream performs this check once at startup: `setup_iconv()` opens
+    /// both directions and calls `exit_cleanup(RERR_UNSUPPORTED)` if either
+    /// `iconv_open` fails (`rsync.c:130-140`), so an unusable charset stops
+    /// the run before a single file is examined. oc previously had no
+    /// equivalent - `resolve_converter` and `resolve_local_copy_converter`
+    /// each turned the failure into `None`, which every caller reads as "no
+    /// conversion requested", so the operator got a full transfer with the
+    /// filenames untranscoded and nothing on stderr.
+    ///
+    /// Validating here rather than at the point of use is what makes that
+    /// safe: the concern recorded on those two call sites - not wanting to
+    /// abort midway through a file list - is real, and upstream answers it
+    /// by refusing at startup. Once this gate runs there is no unknown
+    /// charset left to discover mid-transfer.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:130-140` - `iconv_open` failure is fatal with
+    ///   `RERR_UNSUPPORTED`, message `iconv_open("%s", "%s") failed`.
+    pub fn validate_charsets(&self) -> Result<(), String> {
+        let Self::Explicit { local, remote } = self else {
+            return Ok(());
+        };
+
+        // upstream: rsync.c:130 - `ic_send = iconv_open(UTF8_CHARSET,
+        // charset)` is attempted first, so its message is the one an
+        // operator sees for a charset that cannot be opened at all.
+        Self::check_charset(local)?;
+
+        // The post-comma half names the PEER's charset. Upstream validates
+        // it in the peer process, which reaches the same `exit_cleanup`
+        // (clientserver.c:168/762, main.c:651-666 all call setup_iconv);
+        // a local copy runs both halves here, so check it here too.
+        if let Some(remote) = remote {
+            Self::check_charset(remote)?;
+        }
+        Ok(())
+    }
+
+    /// Returns upstream's failure text when `charset` cannot be opened
+    /// against the UTF-8 wire charset.
+    fn check_charset(charset: &str) -> Result<(), String> {
+        if FilenameConverter::new(charset, "UTF-8").is_err() {
+            // upstream: rsync.c:131-132 - `iconv_open("%s", "%s") failed`
+            // with UTF8_CHARSET as the destination.
+            return Err(format!(r#"iconv_open("UTF-8", "{charset}") failed"#));
+        }
+        Ok(())
+    }
+
     /// # Upstream Reference
     ///
     /// - `rsync.c:87-140` `setup_iconv()` - wire is always UTF-8.


### PR DESCRIPTION
## What

`--iconv` with a charset that cannot be opened was accepted, and the transfer ran to completion with the requested conversion silently discarded.

Measured against a built `rsync 3.5.0`, local copy, `--iconv=NOSUCHCHARSET`:

| | exit | files transferred | output |
|---|---|---|---|
| 3.5.0 | **4** | **0** | `iconv_open("UTF-8", "NOSUCHCHARSET") failed` |
| oc before | **0** | 1 | *(nothing)* |
| oc after | **4** | **0** | `iconv_open("UTF-8", "NOSUCHCHARSET") failed` |

Upstream: `setup_iconv()` calls `exit_cleanup(RERR_UNSUPPORTED)` when either `iconv_open` fails (`rsync.c:130-140`).

## Mechanism

A `.ok()`. The strict constructor is correctly wired and **does** return an error; the chain converted it to `None`, which every caller reads as "no conversion requested". The only diagnostic was a `tracing::warn!` behind `#[cfg(feature = "tracing")]` - a diagnostic a normal build cannot emit - and an in-code comment presented the fallback as intentional.

That comment's stated reason (not wanting to abort midway through a file list) is a real concern, and it is exactly why the check belongs where upstream puts it. `setup_iconv()` runs once at startup, before any file list exists, so refusing there cannot strand a partial transfer. Both resolve sites keep their `None` arms as defence in depth, now with a note that they must not be relaxed back into a silent fallback.

## Why this shape

It extends a guard that already exists two functions away. The `#[cfg(not(feature = "iconv"))]` twin already refuses an explicit `--iconv` when the feature was compiled out, and its doc comment describes this precise failure mode:

> Without this guard, the parsed setting would flow through `resolve_converter` and produce `None`, causing filenames containing non-ASCII bytes to be passed through verbatim despite the user's explicit conversion request.

The build-time-disabled case and the unopenable-charset case have identical consequences for the operator, so they now get identical treatment. Only the exit code differs, each matching its own upstream site (1 for the oc-specific build condition, 4 for upstream's `RERR_UNSUPPORTED`).

## Scope

Deliberately the **setup-failure path only**, as agreed.

The transcode-failure path is a *different upstream rule* - `flist.c:843`/`:1796` set `io_error`, print `cannot convert filename`, and **continue** - and is filed separately (task 646 residual, task 665). Applying "exit 4" there would make oc abort where upstream deliberately keeps going, which is the over-application pattern that PR #7309's site audit just refuted.

Also filed, not folded in: oc resolves charset labels through `encoding_rs` (WHATWG), where `"ascii"` aliases windows-1252 rather than 7-bit ASCII. That namespace difference is a separate divergence from this one and needs its own measurement.

## Tests

Three cases, asserting the exit code **and** the message text - on a path whose entire purpose is telling the operator what went wrong, exit-4-with-different-wording would be a half-fix:

- unopenable local charset rejected with upstream's text
- unopenable **remote** charset (post-comma half) rejected too - upstream validates it in the peer process, and a local copy runs both halves here
- **non-vacuity control**: a charset pair that *can* be opened still resolves, so the two assertions above detect the rejection rather than a parser that rejects every explicit spec

## Verification

- `cargo fmt --all -- --check` - exit 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - exit 0
- `cargo nextest run -p cli --all-features -E 'test(iconv)'` - 27 passed
- End-to-end against the built 3.5.0 oracle, with a valid-charset control that still transfers

⚠ `cargo nextest run -p cli -p core` also surfaced `run_client_sparse_copy_creates_holes`. That is the pre-existing APFS flake already recorded (task 653: fails only under a full parallel `-p core` run, passes in isolation, verified failing on the untouched base). Confirmed here two ways: it **passes in isolation** on this branch, and the diff contains **zero** sparse-related references - it touches two iconv files only.

---

## ⚠ Scope of this change: 697 charset names, not just nonsense input

The description above says "an unopenable charset", which reads as invalid input. **It is not.** Measured after the fact by enumerating all **871** unique names from `iconv -l` — the namespace upstream links against — against a built `rsync 3.5.0` and oc, with an **ASCII-only fixture** so the exit code reflects charset *resolution* alone:

| upstream / oc | count | |
|---|---|---|
| resolves / **refuses (exit 4)** | **697 (80%)** | oc cannot resolve most of the namespace |
| resolves / resolves | 156 | the mainstream set: `ASCII`, `BIG5`, `BIG5-HKSCS`, `CP1250`-`CP1253`, `ANSI_X3.4-1968`, `ASMO-708`, `EUC-*`, `KOI8-*` |
| refuses / refuses | 6 | genuine agreement: `FI`, `SE`, `ISO646-FI`, `ISO646-SE`, `ISO-IR-10`, `SEN_850200_B` |

The 697 are dominated by libiconv's numeric CCSID aliases (`037`, `1026`, `1046`, `1124`, `10000`, …) and the EBCDIC family. oc resolves charset labels through `encoding_rs::Encoding::for_label()` — the WHATWG label set, which is deliberately small and fixed — while upstream uses POSIX iconv, which supports far more.

**Before this PR, oc accepted all 697 silently and performed no conversion**, measured against a pre-PR binary:

```
--iconv=037        before: exit 0, file transferred (untranscoded)
--iconv=EBCDIC-US  before: exit 0, file transferred (untranscoded)
```

So this PR does not break a working case — it reveals a broken one. An operator asking for EBCDIC previously believed the conversion happened when it had not. A loud refusal is a strict improvement over silent infidelity, which is the defect class this project treats as most serious. But the change is visible to anyone using one of those 697 names, and a reviewer should see that here rather than discover it.

### What an operator should do

- **If the charset is in the 156**, nothing changes.
- **If it is one of the 697**, oc cannot perform that conversion today; there is no oc-side workaround. Options: transcode filenames out of band, or use upstream `rsync` for that transfer. Broadening the set requires a libiconv-compatible conversion path — `encoding_rs` does not *contain* the EBCDIC/CCSID encodings, so this is not a label-mapping fix. Tracked as task 665.

### ⚠ One genuine regression, narrow but real

An **identity pair** needs no conversion, so the previous no-op happened to produce the correct result. Measured:

| `--iconv=037,037` | exit | files |
|---|---|---|
| rsync 3.5.0 | 0 | 2 |
| oc before | 0 | 2 |
| oc after | **4** | **0** |

For that shape only, this PR turns a working transfer into a refusal. It is accepted deliberately: distinguishing "identity pair, safe to no-op" from "real conversion requested, cannot honour it" requires knowing which names oc resolves — which is task 665's table. `--iconv=UTF-8,UTF-8` is unaffected (both sides resolve it).

### ⚠ Known message imprecision, deliberately not fixed here

`iconv_open("UTF-8", "EBCDIC-US") failed` mirrors upstream's text, which is right for the **6** names upstream also refuses and misleading for the **697**, where the charset exists and *this build* cannot do it. Making the message honest requires distinguishing the two sets — task 665's table again. Recorded there rather than guessed at here.
