### PR TITLE
ci: trigger CI on merge_group so a merge queue can validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,18 +40,32 @@ on:
       - '.github/workflows/_upstream-testsuite.yml'
       - 'docker/**'
       - 'Cross.toml'
+  # Merge-queue validation. This is the workflow that publishes every required
+  # context, so without this trigger a merge group would never receive them and
+  # would sit unmergeable forever. `merge_group` accepts no `paths` filter, so
+  # the full matrix runs for every batch regardless of what it touches - which
+  # is the intent: the merge group is the last gate before master, and the
+  # docs-only stand-in contexts published by ci-skip.yml are deliberately not
+  # wired here (ci-skip.yml stays `pull_request`-only; giving it this trigger
+  # would publish a second check run per required context and race this one).
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
   schedule:
     # Run nightly to exercise beta/nightly toolchains (not run on PRs)
     - cron: '30 3 * * *'
 
 concurrency:
-  group: ci-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
+  group: ci-${{ github.ref }}${{ (github.ref == 'refs/heads/master' || github.event_name == 'merge_group') && format('-{0}', github.sha) || '' }}
   # Superseded pull request pushes still cancel; pushes to master do not, so
   # every merge commit keeps a completed run for bisection. The master
   # exemption lives in the GROUP KEY, not in cancel-in-progress: giving each
   # master commit its own group means there is never an older run in the group
   # to evict, which holds regardless of how the flag is evaluated.
+  #
+  # Merge groups take the same exemption for a sharper reason: a cancelled
+  # merge-group run reports as a FAILED required context, which evicts the whole
+  # batch from the queue. Batches must never cancel one another.
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Enabling a GitHub merge queue on `master` requires this first, or it deadlocks the whole board.

## The precondition

All eight required status contexts are published by jobs in `ci.yml`:

| context | job |
|---|---|
| `fmt + clippy` | `lint` |
| `nextest (stable)` | `test` |
| `Windows (stable)` | `windows-test` |
| `macOS (stable)` | `macos-test` |
| `Linux musl (stable)` | `linux-musl` |
| `interop / interop with upstream rsync` | `interop-upstream` |
| `upstream-testsuite / upstream testsuite` | `upstream-testsuite` |
| `upstream-testsuite / upstream testsuite (root)` | `upstream-testsuite` |

`ci.yml` triggers only on `push` and `pull_request`. A merge group would therefore receive **none** of the eight, and every pull request entering the queue would sit unmergeable forever. Measured: `grep -l merge_group .github/workflows/*.yml` returns zero files.

## What this changes

`merge_group: types: [checks_requested]` on `ci.yml` only.

`ci-skip.yml` deliberately keeps its `pull_request`-only triggers. `merge_group` accepts no `paths` filter, so both workflows would fire for every batch and publish **two check runs per required context**, racing each other. Running the real matrix for every merge group is the intent: the merge group is the last gate before master, and the docs-only stand-in contexts have no place there.

Merge groups also take the unique-concurrency-key exemption master already has. A cancelled run reports as a *failed* required context, which evicts the whole batch from the queue - batches must never cancel one another.

## Verification

Every job publishing a required context is unconditional, so none skip on `merge_group`:

```
lint                     name='fmt + clippy'                if=-
test                     name='nextest (${{ matrix.toolchain }})'  if=-
windows-test             name='Windows (${{ matrix.toolchain }})'  if=-
macos-test               name='macOS (${{ matrix.toolchain }})'    if=-
linux-musl               name='Linux musl (${{ matrix.toolchain }})' if=-
interop-upstream         name='interop'                     if=-
upstream-testsuite       name='upstream-testsuite'          if=-
```

The only `event_name`-gated job is `unsafe-safety-comment-audit`, which is informational and not required.

No job or job ID is renamed, so the frozen context surface is untouched.

## Why now

One merge (#7297) put all sixteen open pull requests `BEHIND` in a single step. Under `strict_required_status_checks_policy` the drain is strictly serial: each merge invalidates every other branch, so sixteen pull requests cost sixteen full CI cycles. The queue is already 47 runs deep against 2 executing runners.

This pull request is only the precondition. The queue itself is enabled separately, after this is on master.
