### PR TITLE
fix(cli): four upstream parity fixes in option and filter handling

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -302,19 +302,14 @@ where
 
     let min_size = matches.remove_one::<OsString>("min-size");
     let max_size = matches.remove_one::<OsString>("max-size");
-    let block_size = match matches.remove_one::<OsString>("block-size") {
-        Some(value) => {
-            let s = value.to_string_lossy();
-            if s.parse::<u64>().is_err() {
-                return Err(clap::Error::raw(
-                    clap::error::ErrorKind::ValueValidation,
-                    format!("invalid --block-size value '{s}': must be a positive integer\n"),
-                ));
-            }
-            Some(value)
-        }
-        None => None,
-    };
+    // `--block-size` is validated where `--min-size` / `--max-size` are, by the
+    // shared suffix-aware parser (`parse_block_size_argument`). A bare-integer
+    // gate here would pre-empt it and make upstream's whole size grammar
+    // unreachable for this one option.
+    //
+    // upstream: options.c:1802 `parse_size_arg(arg, 'b', "block-size", 0,
+    // max_blength, False)` - the same parser the three siblings use.
+    let block_size = matches.remove_one::<OsString>("block-size");
 
     let rayon_threads = parse_thread_count(&mut matches, "rayon-threads")?;
     let tokio_threads = parse_thread_count(&mut matches, "tokio-threads")?;

--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -188,6 +188,10 @@ fn render_compress_choice_error(err: CompressionAlgorithmParseError, trimmed: &s
 /// and too-large values are rejected with a `--bwlimit` error.
 // upstream: options.c:1714 parse_size_arg(bwlimit_arg, 'K', "bwlimit", 512, -1, True)
 pub(crate) fn parse_bandwidth_limit(argument: &OsStr) -> Result<Option<BandwidthLimit>, Message> {
+    // upstream: an empty value resolves to 0, and `unlimited_0` makes 0 mean
+    // "no limit" for this option (options.c:1821). Measured: `--bwlimit=`
+    // behaves exactly like `--bwlimit=0` on rsync 3.5.0.
+    let argument = super::empty_size_means_zero(argument);
     let text = argument.to_string_lossy();
     match BandwidthLimit::parse(&text) {
         Ok(Some(limit)) => Ok(Some(limit)),

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -13,9 +13,10 @@ use core::client::{
 use logging_sink::MessageSink;
 
 use super::super::{
-    parse_bandwidth_limit, parse_block_size_argument, parse_compress_choice, parse_compress_level,
-    parse_compress_threads, parse_debug_flags, parse_info_flags, parse_max_alloc_argument,
-    parse_max_delete_argument, parse_modify_window_argument, parse_size_limit_argument,
+    empty_size_means_zero, parse_bandwidth_limit, parse_block_size_argument, parse_compress_choice,
+    parse_compress_level, parse_compress_threads, parse_debug_flags, parse_info_flags,
+    parse_max_alloc_argument, parse_max_delete_argument, parse_modify_window_argument,
+    parse_size_limit_argument,
 };
 use super::messages::fail_with_message;
 use crate::frontend::{
@@ -320,18 +321,24 @@ where
     };
 
     let min_size_limit = match inputs.min_size.as_ref() {
-        Some(value) => match parse_size_limit_argument(value.as_os_str(), "--min-size") {
-            Ok(limit) => Some(limit),
-            Err(message) => return Err(fail_with_message(message, stderr)),
-        },
+        Some(value) => {
+            match parse_size_limit_argument(empty_size_means_zero(value.as_os_str()), "--min-size")
+            {
+                Ok(limit) => Some(limit),
+                Err(message) => return Err(fail_with_message(message, stderr)),
+            }
+        }
         None => None,
     };
 
     let max_size_limit = match inputs.max_size.as_ref() {
-        Some(value) => match parse_size_limit_argument(value.as_os_str(), "--max-size") {
-            Ok(limit) => Some(limit),
-            Err(message) => return Err(fail_with_message(message, stderr)),
-        },
+        Some(value) => {
+            match parse_size_limit_argument(empty_size_means_zero(value.as_os_str()), "--max-size")
+            {
+                Ok(limit) => Some(limit),
+                Err(message) => return Err(fail_with_message(message, stderr)),
+            }
+        }
         None => None,
     };
 

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -31,10 +31,10 @@ pub(crate) use flags::{
 pub(crate) use module_list::render_module_list;
 pub(crate) use operands::{extract_operands, parse_bind_address_argument};
 pub(crate) use options::{
-    ProtocolArg, legacy_remote_rejection, parse_block_size_argument, parse_checksum_seed_argument,
-    parse_max_alloc_argument, parse_max_delete_argument, parse_modify_window_argument,
-    parse_protocol_version_arg, parse_size_limit_argument, parse_timeout_argument,
-    resolve_iconv_setting,
+    ProtocolArg, empty_size_means_zero, legacy_remote_rejection, parse_block_size_argument,
+    parse_checksum_seed_argument, parse_max_alloc_argument, parse_max_delete_argument,
+    parse_modify_window_argument, parse_protocol_version_arg, parse_size_limit_argument,
+    parse_timeout_argument, resolve_iconv_setting,
 };
 pub(crate) use stop::{parse_stop_after_argument, parse_stop_at_argument};
 

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -23,7 +23,8 @@ pub(crate) use numeric::{
 };
 pub(crate) use protocol::{ProtocolArg, legacy_remote_rejection, parse_protocol_version_arg};
 pub(crate) use size::{
-    parse_block_size_argument, parse_max_alloc_argument, parse_size_limit_argument,
+    empty_size_means_zero, parse_block_size_argument, parse_max_alloc_argument,
+    parse_size_limit_argument,
 };
 
 #[cfg(test)]

--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -39,6 +39,35 @@ impl From<SizeArgError> for SizeParseError {
 /// Parses a size argument with an optional unit suffix (K/M/G/T/P/E).
 ///
 /// The `flag` parameter is used in error messages (e.g. `"--max-size"`).
+/// Maps an empty value to `0`, mirroring what upstream's `parse_size_arg` does
+/// with an empty string.
+///
+/// upstream: options.c:1172-1175 - the digit scan leaves `arg` on the string
+/// terminator, so the suffix switch takes `def_suf` and `strtod("")` yields 0.
+///
+/// Applied PER OPTION rather than inside the shared string parser, because
+/// whether the resulting 0 is legal is decided by that option's own
+/// `min_value`: legal for `--block-size`, `--min-size` and `--max-size`
+/// (min 0 - options.c:1802, :1809, :1815) and for `--bwlimit` (`unlimited_0`,
+/// :1821); NOT legal for `--max-alloc` (min 1 MiB, :2067), which upstream and
+/// oc both reject. Folding the rule into `parse_size_spec` would silently
+/// start accepting `--max-alloc=`.
+///
+/// Measured against rsync 3.5.0: an empty value behaves exactly like `=0` on
+/// each option - and for `--max-size` that EXCLUDES every non-empty file
+/// rather than meaning "no limit", so this is not a "fall back to the
+/// default" rule.
+pub(crate) fn empty_size_means_zero(value: &OsStr) -> &OsStr {
+    if value
+        .to_string_lossy()
+        .trim_matches(|ch: char| ch.is_ascii_whitespace())
+        .is_empty()
+    {
+        return OsStr::new("0");
+    }
+    value
+}
+
 pub(crate) fn parse_size_limit_argument(value: &OsStr, flag: &str) -> Result<u64, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
@@ -181,7 +210,7 @@ pub(crate) fn parse_block_size_argument(value: &OsStr) -> Result<Option<NonZeroU
         trimmed
     };
 
-    let limit = parse_size_limit_argument(value, "--block-size")?;
+    let limit = parse_size_limit_argument(empty_size_means_zero(value), "--block-size")?;
 
     // upstream: options.c:1692-1695 - min_value 0 accepts `--block-size=0`,
     // which stores block_size = 0 and later falls back to the default.
@@ -645,9 +674,22 @@ mod tests {
         );
     }
 
+    /// An empty value resolves to 0, which for `--block-size` means "no
+    /// override, use the default" - the same `Ok(None)` that `=0` yields.
+    ///
+    /// This previously asserted a rejection, pinning oc's divergence: upstream
+    /// accepts the empty spelling (options.c:1172-1175 + :1802, min 0).
     #[test]
-    fn parse_block_size_argument_empty() {
-        assert!(parse_block_size_argument(&os("")).is_err());
+    fn parse_block_size_argument_empty_resolves_like_zero() {
+        assert_eq!(
+            parse_block_size_argument(&os("")).expect("empty is accepted"),
+            parse_block_size_argument(&os("0")).expect("zero is accepted"),
+        );
+        assert!(
+            parse_block_size_argument(&os(""))
+                .expect("empty is accepted")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -81,7 +81,13 @@ pub(crate) fn apply_merge_directive(
         let contents = if is_stdin {
             read_merge_from_standard_input()?
         } else {
-            read_merge_file(&resolved_path)?
+            // upstream: exclude.c:1715 - the include/exclude wording of a
+            // failed open follows FILTRULE_INCLUDE, which a `+` modifier on the
+            // merge rule (`.+ FILE`, `merge,+ FILE`) sets.
+            read_merge_file(
+                &resolved_path,
+                options.enforced_kind() == Some(DirMergeEnforcedKind::Include),
+            )?
         };
 
         parse_merge_contents(

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -1,11 +1,12 @@
 use std::ffi::OsString;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read};
 use std::path::Path;
 
-use core::client::{FilterRuleKind, FilterRuleSpec};
+use core::client::{FILE_IO_EXIT_CODE, FilterRuleKind, FilterRuleSpec};
 use core::message::{Message, Role};
 use core::rsync_error;
+use engine::local_copy::upstream_io_error;
 
 use super::directive::FilterDirective;
 use super::parsing::parse_old_prefix_rule;
@@ -42,7 +43,11 @@ pub(crate) fn append_filter_rules_from_files(
     // file's rules locally so a `!` inside the file clears only that scope
     // and parent CLI rules survive.
     for path in files {
-        let patterns = load_filter_file_patterns(Path::new(path.as_os_str()), eol_nulls)?;
+        let patterns = load_filter_file_patterns(
+            Path::new(path.as_os_str()),
+            eol_nulls,
+            matches!(kind, FilterRuleKind::Include),
+        )?;
         let mut local: Vec<FilterRuleSpec> = Vec::new();
         for pattern in patterns {
             if honor_old_prefixes {
@@ -74,36 +79,65 @@ pub(crate) fn append_filter_rules_from_files(
     Ok(())
 }
 
+/// Reports a filter file that could not be opened the way upstream's
+/// `parse_filter_file` does, under upstream's exit code.
+///
+/// upstream: exclude.c:1712-1719 - `rsyserr(FERROR, errno, "failed to open
+/// %sclude file %s", ...)` then `exit_cleanup(RERR_FILEIO)`. The include/exclude
+/// wording follows `template->rflags & FILTRULE_INCLUDE`, so a merge rule
+/// carrying a `+` modifier (`.+ FILE`, `merge,+ FILE`) says "include file".
+///
+/// This rule is deliberately NOT shared with `--files-from`, whose own open
+/// failure upstream reports from a different site and exits 1, not 11
+/// (main.c:1886) - measured on 3.5.0.
+fn filter_file_open_error(path: &Path, include: bool, error: &io::Error) -> Message {
+    let text = format!(
+        "failed to open {}clude file {}: {}",
+        if include { "in" } else { "ex" },
+        path.display(),
+        upstream_io_error(error)
+    );
+    rsync_error!(FILE_IO_EXIT_CODE, text).with_role(Role::Client)
+}
+
 /// Reads the raw pattern lines from a filter file, or from standard input when
 /// `path` is `-`. `eol_nulls` selects NUL-delimited records (`--from0`).
+/// `include` selects upstream's include/exclude wording if the open fails.
 pub(crate) fn load_filter_file_patterns(
     path: &Path,
     eol_nulls: bool,
+    include: bool,
 ) -> Result<Vec<String>, Message> {
     if path == Path::new("-") {
         return read_filter_patterns_from_standard_input(eol_nulls);
     }
 
-    let path_display = path.display().to_string();
-    let file = File::open(path).map_err(|error| {
-        let text = format!("failed to read filter file '{path_display}': {error}");
-        rsync_error!(1, text).with_role(Role::Client)
-    })?;
+    let file = File::open(path).map_err(|error| filter_file_open_error(path, include, &error))?;
 
     let mut reader = BufReader::new(file);
     read_filter_patterns(&mut reader, eol_nulls).map_err(|error| {
-        let text = format!("failed to read filter file '{path_display}': {error}");
+        // Upstream has no analogue: its getc loop cannot distinguish a read
+        // error from EOF, so a post-open failure silently ends the file. Keep
+        // oc's louder report rather than inventing an upstream citation for it.
+        let text = format!("failed to read filter file '{}': {error}", path.display());
         rsync_error!(1, text).with_role(Role::Client)
     })
 }
 
-/// Reads a merge file's entire contents as a string.
-pub(super) fn read_merge_file(path: &Path) -> Result<String, Message> {
-    let display = path.display();
-    fs::read_to_string(path).map_err(|error| {
-        let text = format!("failed to read filter file '{display}': {error}");
+/// Reads a merge file's entire contents as a string. `include` selects
+/// upstream's include/exclude wording if the open fails.
+pub(super) fn read_merge_file(path: &Path, include: bool) -> Result<String, Message> {
+    // Opened separately from the read so that only a genuine open failure takes
+    // upstream's wording and exit code; a mid-file read error (or non-UTF-8
+    // contents) is a different condition and keeps its own report.
+    let mut file =
+        File::open(path).map_err(|error| filter_file_open_error(path, include, &error))?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).map_err(|error| {
+        let text = format!("failed to read filter file '{}': {error}", path.display());
         rsync_error!(1, text).with_role(Role::Client)
-    })
+    })?;
+    Ok(contents)
 }
 
 /// Reads an entire merge file from standard input.
@@ -297,16 +331,32 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("filter.txt");
         std::fs::write(&path, "pattern1\npattern2\n").expect("write");
-        let result = load_filter_file_patterns(&path, false).expect("load");
+        let result = load_filter_file_patterns(&path, false, false).expect("load");
         assert_eq!(result, vec!["pattern1", "pattern2"]);
     }
 
+    /// upstream: exclude.c:1712-1719 - a missing --exclude-from/--include-from
+    /// file is fatal with RERR_FILEIO (11) and upstream's own wording, not the
+    /// generic exit 1 this previously accepted.
     #[test]
-    fn load_filter_file_patterns_fails_for_missing_file() {
+    fn load_filter_file_patterns_reports_a_missing_file_like_upstream() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("nonexistent.txt");
-        let result = load_filter_file_patterns(&path, false);
-        assert!(result.is_err());
+
+        let excluded = load_filter_file_patterns(&path, false, false).expect_err("must fail");
+        assert_eq!(excluded.code(), Some(11));
+        assert!(
+            excluded.text().starts_with("failed to open exclude file "),
+            "unexpected text: {}",
+            excluded.text()
+        );
+
+        let included = load_filter_file_patterns(&path, false, true).expect_err("must fail");
+        assert!(
+            included.text().starts_with("failed to open include file "),
+            "unexpected text: {}",
+            included.text()
+        );
     }
 
     #[test]
@@ -314,16 +364,23 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("merge.txt");
         std::fs::write(&path, "content here").expect("write");
-        let result = read_merge_file(&path).expect("read");
+        let result = read_merge_file(&path, false).expect("read");
         assert_eq!(result, "content here");
     }
 
+    /// A merge rule naming a missing file is fatal under the same rule
+    /// (upstream: exclude.c:1587 passes XFLG_FATAL_ERRORS for `merge`/`.`).
     #[test]
-    fn read_merge_file_fails_for_missing_file() {
+    fn read_merge_file_reports_a_missing_file_like_upstream() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("nonexistent.txt");
-        let result = read_merge_file(&path);
-        assert!(result.is_err());
+        let error = read_merge_file(&path, false).expect_err("must fail");
+        assert_eq!(error.code(), Some(11));
+        assert!(
+            error.text().starts_with("failed to open exclude file "),
+            "unexpected text: {}",
+            error.text()
+        );
     }
 
     #[test]
@@ -343,7 +400,7 @@ mod tests {
     #[test]
     fn load_filter_file_patterns_handles_dash_path() {
         set_filter_stdin_input(b"stdin_pattern\n".to_vec());
-        let result = load_filter_file_patterns(Path::new("-"), false).expect("load");
+        let result = load_filter_file_patterns(Path::new("-"), false, false).expect("load");
         assert_eq!(result, vec!["stdin_pattern"]);
     }
 

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -161,7 +161,7 @@ pub(crate) use std::num::NonZeroU64;
 
 #[cfg(test)]
 pub(crate) fn load_filter_file_patterns(path: &Path) -> Result<Vec<String>, Message> {
-    filter_rules::load_filter_file_patterns(path, false)
+    filter_rules::load_filter_file_patterns(path, false, false)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/frontend/tests/parse_args_recognises_block_size.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_block_size.rs
@@ -13,40 +13,66 @@ fn parse_args_recognises_block_size_argument() {
     assert_eq!(parsed.block_size, Some(OsString::from("16384")));
 }
 
+/// The argv layer carries the value through verbatim; it is not the validator.
+///
+/// upstream: options.c:1802 hands the raw string to `parse_size_arg`, which
+/// owns the whole grammar - `1K`, `1KB`, `1KiB`, `1.5K`, `1K+1`. A bare-integer
+/// check here would reject all of those before the real parser ran, which is
+/// exactly the defect this replaces: `--min-size` and `--max-size`, parsed by
+/// the same helper one layer down, accepted them while `--block-size` did not.
 #[test]
-fn parse_args_rejects_non_numeric_block_size() {
-    let error = match parse_args([
-        OsString::from(RSYNC),
+fn parse_args_carries_suffixed_block_size_through_to_the_size_parser() {
+    for value in ["1K", "1KiB", "1.5K", "1K+1", "128K"] {
+        let parsed = parse_args([
+            OsString::from(RSYNC),
+            OsString::from(format!("--block-size={value}")),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .unwrap_or_else(|error| panic!("--block-size={value} must reach the size parser: {error}"));
+        assert_eq!(parsed.block_size, Some(OsString::from(value)));
+    }
+}
+
+/// Rejection still happens - one layer down, and with upstream's wording.
+///
+/// These two cases previously asserted a clap `ValueValidation` error, which
+/// pinned the LAYER rather than the behaviour. The layer moved; the outcome
+/// must not, so they now assert the outcome: a syntax-error exit with the
+/// offending value named.
+///
+/// upstream: options.c:1253-1264 - `--block-size=abc is invalid`, exit 1.
+#[test]
+fn non_numeric_block_size_is_rejected_with_the_value_named() {
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(OC_RSYNC),
         OsString::from("--block-size=abc"),
-        OsString::from("source"),
-        OsString::from("dest"),
-    ]) {
-        Ok(_) => panic!("parse should fail"),
-        Err(error) => error,
-    };
-    assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        OsString::from("src"),
+        OsString::from("dst"),
+    ]);
+    let stderr = String::from_utf8_lossy(&stderr);
+
+    assert_eq!(code, 1, "stderr: {stderr}");
     assert!(
-        error
-            .to_string()
-            .contains("invalid --block-size value 'abc'")
+        stderr.contains("--block-size") && stderr.contains("abc"),
+        "the diagnostic must name the option and the value: {stderr}"
     );
 }
 
+/// upstream: options.c:1216-1221 - a negative size fails the `dsize < 0` check.
 #[test]
-fn parse_args_rejects_negative_block_size() {
-    let error = match parse_args([
-        OsString::from(RSYNC),
+fn negative_block_size_is_rejected_with_the_value_named() {
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(OC_RSYNC),
         OsString::from("--block-size=-1"),
-        OsString::from("source"),
-        OsString::from("dest"),
-    ]) {
-        Ok(_) => panic!("parse should fail"),
-        Err(error) => error,
-    };
-    assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        OsString::from("src"),
+        OsString::from("dst"),
+    ]);
+    let stderr = String::from_utf8_lossy(&stderr);
+
+    assert_eq!(code, 1, "stderr: {stderr}");
     assert!(
-        error
-            .to_string()
-            .contains("invalid --block-size value '-1'")
+        stderr.contains("--block-size") && stderr.contains("-1"),
+        "the diagnostic must name the option and the value: {stderr}"
     );
 }

--- a/crates/cli/src/frontend/tests/run.rs
+++ b/crates/cli/src/frontend/tests/run.rs
@@ -79,15 +79,21 @@ fn run_rejects_excess_alt_dest_dirs() {
 
 #[test]
 fn clap_value_error_does_not_double_error_prefix() {
-    // A clap value-validation failure (here `--block-size`) surfaces through
+    // A clap value-validation failure (here `--io-uring-depth`) surfaces through
     // `clap::Error::to_string()`, which prepends a stock `error: ` header. oc
     // wraps the detail with the canonical `syntax or usage error: ` category
     // (upstream `rerr_names`), so an unstripped clap header would render the
     // wording twice as `syntax or usage error: error: ...`. Upstream rsync
     // prints the category exactly once; this guards that parity.
+    //
+    // The vehicle used to be `--block-size=abc`, but that option no longer
+    // fails at the clap layer: its validation moved to the shared size parser
+    // so the upstream suffix grammar (`1K`, `1KiB`, `1.5K`) could reach it.
+    // Any option that still raises a clap `ValueValidation` serves equally -
+    // the guard is about the prefix, not about which option produced it.
     let (code, _stdout, stderr) = run_with_args([
         OsString::from(OC_RSYNC),
-        OsString::from("--block-size=abc"),
+        OsString::from("--io-uring-depth=abc"),
         OsString::from("src"),
         OsString::from("dst"),
     ]);
@@ -101,7 +107,7 @@ fn clap_value_error_does_not_double_error_prefix() {
         "diagnostic should keep the canonical rerr_names category"
     );
     assert!(
-        rendered.contains("invalid --block-size value 'abc'"),
+        rendered.contains("invalid --io-uring-depth value 'abc'"),
         "diagnostic should include the clap-provided detail"
     );
     assert!(

--- a/crates/cli/src/frontend/tests/transfer_request_reports.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_reports.rs
@@ -26,9 +26,14 @@ fn transfer_request_reports_filter_file_errors() {
         OsString::from("dst"),
     ]);
 
-    assert_eq!(code, 1);
+    // upstream: exclude.c:1712-1719 - RERR_FILEIO (11), not the generic 1 this
+    // asserted before, and upstream's own wording.
+    assert_eq!(code, 11);
     assert!(stdout.is_empty());
     let rendered = String::from_utf8(stderr).expect("diagnostic utf8");
-    assert!(rendered.contains("failed to read filter file 'missing.txt'"));
+    assert!(
+        rendered.contains("failed to open exclude file missing.txt"),
+        "unexpected diagnostic: {rendered}"
+    );
     assert_contains_client_trailer(&rendered);
 }

--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -172,6 +172,59 @@ fn parse_protocol_from_greeting(greeting: &str) -> Result<ProtocolVersion, Clien
     })
 }
 
+/// Resolves the username the client sends in its `@RSYNCD` auth response.
+///
+/// Two upstream stages, in order:
+///
+/// ```c
+/// /* clientserver.c:289-292, start_inband_exchange() */
+/// if (!user)
+///     user = getenv("USER");
+/// if (!user)
+///     user = getenv("LOGNAME");
+/// /* authenticate.c:451-452, auth_client() */
+/// if (!user || !*user)
+///     user = "nobody";
+/// ```
+///
+/// Three details are load-bearing and were each wrong before:
+///
+/// * the second variable is `LOGNAME`, not `USERNAME` - `USERNAME` is a Windows
+///   convention upstream never consults, so a peer that sets only `USERNAME`
+///   must still authenticate as `nobody`;
+/// * the final fallback is `nobody`, not `rsync`;
+/// * the env chain stops at the first variable that is **set**, even when its
+///   value is empty. `USER=""` with `LOGNAME=bob` therefore yields `nobody`,
+///   not `bob` - `getenv` returns a non-NULL empty string, so `if (!user)`
+///   is false and only `auth_client`'s `!*user` catches it. `env::var` mirrors
+///   this exactly: `Ok("")` when set-empty, `Err` only when absent.
+///
+/// An explicitly requested username (`rsync://user@host/mod`) skips the
+/// environment entirely, and an explicitly empty one still degrades to
+/// `nobody`, because upstream applies the emptiness check inside `auth_client`
+/// regardless of where the name came from.
+fn daemon_auth_username(requested: Option<&str>) -> String {
+    resolve_auth_username(
+        requested,
+        std::env::var("USER").ok().as_deref(),
+        std::env::var("LOGNAME").ok().as_deref(),
+    )
+}
+
+/// The decision half of [`daemon_auth_username`], with the environment passed
+/// in so it is testable without mutating process-global state.
+pub(crate) fn resolve_auth_username(
+    requested: Option<&str>,
+    user_env: Option<&str>,
+    logname_env: Option<&str>,
+) -> String {
+    let resolved = requested.or(user_env).or(logname_env);
+    match resolved {
+        Some(name) if !name.is_empty() => name.to_owned(),
+        _ => "nobody".to_owned(),
+    }
+}
+
 /// Echoes a daemon `@ERROR` line to stderr and constructs the matching
 /// client error.
 ///
@@ -356,11 +409,7 @@ pub(crate) fn perform_daemon_handshake<R: std::io::Read, W: Write>(
                     )
                 })?;
 
-            let username = request.username.clone().unwrap_or_else(|| {
-                std::env::var("USER")
-                    .or_else(|_| std::env::var("USERNAME"))
-                    .unwrap_or_else(|_| "rsync".to_owned())
-            });
+            let username = daemon_auth_username(request.username.as_deref());
 
             // upstream: authenticate.c:242 `auth_client()` negotiates only
             // after the daemon asked for credentials. An absent list falls back

--- a/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
@@ -710,3 +710,70 @@ mod quic_url_tests {
         assert_eq!(request.address.port(), 873);
     }
 }
+
+/// The username sent in the `@RSYNCD` auth response, one case per row of the
+/// table measured against the real rsync 3.5.0 client.
+///
+/// upstream: clientserver.c:289-292 (`USER` then `LOGNAME`) composed with
+/// authenticate.c:451-452 (`if (!user || !*user) user = "nobody";`).
+mod daemon_auth_username_tests {
+    use super::super::resolve_auth_username;
+
+    /// `USER` wins when set, and is the only variable consulted.
+    #[test]
+    fn user_env_is_preferred() {
+        assert_eq!(resolve_auth_username(None, Some("alice"), None), "alice");
+        assert_eq!(
+            resolve_auth_username(None, Some("alice"), Some("bob")),
+            "alice"
+        );
+    }
+
+    /// `LOGNAME` is the second variable - NOT `USERNAME`, which upstream never
+    /// reads. oc previously consulted `USERNAME` and so authenticated as
+    /// `rsync` on any host that sets only `LOGNAME`.
+    #[test]
+    fn logname_is_the_second_variable() {
+        assert_eq!(resolve_auth_username(None, None, Some("bob")), "bob");
+    }
+
+    /// An unset environment authenticates as `nobody`, not `rsync`.
+    ///
+    /// upstream: authenticate.c:452.
+    #[test]
+    fn absent_environment_falls_back_to_nobody() {
+        assert_eq!(resolve_auth_username(None, None, None), "nobody");
+    }
+
+    /// A SET-but-empty `USER` stops the chain: upstream's `getenv` returns a
+    /// non-NULL empty string, so `if (!user)` is false and `LOGNAME` is never
+    /// consulted; only `auth_client`'s `!*user` rescues it, as `nobody`.
+    ///
+    /// This is the row most likely to be got wrong by a naive
+    /// "first non-empty wins" reading, and the real 3.5.0 client was measured
+    /// producing `nobody` here.
+    #[test]
+    fn empty_user_env_does_not_fall_through_to_logname() {
+        assert_eq!(resolve_auth_username(None, Some(""), Some("bob")), "nobody");
+    }
+
+    /// An explicit `rsync://user@host/` name skips the environment entirely.
+    #[test]
+    fn an_explicit_username_skips_the_environment() {
+        assert_eq!(
+            resolve_auth_username(Some("carol"), Some("alice"), Some("bob")),
+            "carol"
+        );
+    }
+
+    /// ...and an explicitly empty one still degrades to `nobody`, because
+    /// upstream applies the emptiness check inside `auth_client` regardless of
+    /// where the name came from.
+    #[test]
+    fn an_explicit_empty_username_degrades_to_nobody() {
+        assert_eq!(
+            resolve_auth_username(Some(""), Some("alice"), None),
+            "nobody"
+        );
+    }
+}

--- a/docs/user/windows-support-matrix.md
+++ b/docs/user/windows-support-matrix.md
@@ -126,6 +126,14 @@ are in `docs/design/windows-device-file-strategy.md`.
 - NFSv4-to-DACL conversion audit: tracked under XAP series.
 - ARM64 Windows build and test: not in CI matrix.
 - Windows Event Log integration: not wired; daemon logs to STDERR.
+- Daemon auth username: set `USER` explicitly. Upstream resolves the username
+  it sends in the `@RSYNCD` auth response from `USER`, then `LOGNAME`, falling
+  back to `nobody` (`clientserver.c:289-292`, `authenticate.c:451-452`); it
+  never consults `USERNAME`. A native Windows shell typically sets only
+  `USERNAME`, so a client that does not set `USER` authenticates as `nobody`
+  and an `auth users` rule naming the login account rejects it. oc mirrors
+  upstream here deliberately: the username is a wire byte, and sending a
+  different one would be a silent, non-negotiated divergence.
 
 ## 6. Build and packaging requirements
 

--- a/tests/block_size_suffix_grammar.rs
+++ b/tests/block_size_suffix_grammar.rs
@@ -1,0 +1,198 @@
+//! `--block-size` must accept upstream's whole size grammar, not bare integers.
+//!
+//! Upstream parses it with the same helper as `--min-size`, `--max-size` and
+//! `--bwlimit`:
+//!
+//! ```c
+//! /* options.c:1802 */
+//! if ((size = parse_size_arg(arg, 'b', "block-size", 0, max_blength, False)) < 0)
+//! ```
+//!
+//! and `parse_size_arg` (options.c:1163-1265) accepts a decimal number with an
+//! optional fraction, an optional `b/k/m/g/t/p` scale, an optional `B` (x1000)
+//! or `iB` (x1024) qualifier, and a trailing `+1` / `-1` adjustment.
+//!
+//! oc reached that parser for the three siblings but not for `--block-size`: a
+//! bare-`u64` gate in the argv layer rejected every suffixed spelling before
+//! the shared parser ran, so `size.rs`'s tested suffix support was unreachable
+//! in production for this one option.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - The cross-implementation cell needs a built upstream 3.5.0 binary; without
+//!   it, it reports why it did not run.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn upstream_binary() -> Option<PathBuf> {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("target/interop/upstream-src/rsync-3.5.0/rsync");
+    path.is_file().then_some(path)
+}
+
+/// Every spelling measured against the real 3.5.0 binary, with whether it is
+/// accepted. `1M` and above exceed `MAX_BLOCK_SIZE` (131072) at protocol >= 30,
+/// so they are rejected for a reason unrelated to the grammar - which is what
+/// makes them useful: a parser that ignored the scale entirely would accept
+/// them.
+const GRAMMAR: &[(&str, bool)] = &[
+    ("700", true),
+    ("1K", true),
+    ("1k", true),
+    ("1KB", true),
+    ("1kb", true),
+    ("1KiB", true),
+    ("1kib", true),
+    ("128K", true),
+    ("1.5K", true),
+    ("0", true),
+    ("1K+1", true),
+    ("1K-1", true),
+    ("1B", true),
+    ("8b", true),
+    ("131072", true),
+    ("1M", false),
+    ("1G", false),
+    ("1T", false),
+    ("1P", false),
+    ("131073", false),
+    ("1Z", false),
+    ("1KX", false),
+];
+
+struct Fixture {
+    root: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = tempfile::tempdir().expect("temp dir");
+        fs::create_dir_all(root.path().join("src")).expect("src dir");
+        fs::write(root.path().join("src/f"), b"hello\n").expect("src file");
+        Self { root }
+    }
+
+    /// Runs a dry-run copy with the given `--block-size` and reports acceptance.
+    fn accepts(&self, binary: &Path, value: &str) -> bool {
+        Command::new(binary)
+            .arg("-n")
+            .arg(format!("--block-size={value}"))
+            .arg(self.root.path().join("src/").display().to_string())
+            .arg(self.root.path().join("dst/").display().to_string())
+            .output()
+            .expect("run binary")
+            .status
+            .success()
+    }
+}
+
+/// oc must accept and reject exactly what the grammar table says.
+#[test]
+fn block_size_accepts_the_upstream_size_grammar() {
+    let fixture = Fixture::new();
+    let oc = oc_binary();
+    for (value, expected) in GRAMMAR {
+        assert_eq!(
+            fixture.accepts(&oc, value),
+            *expected,
+            "--block-size={value} acceptance"
+        );
+    }
+}
+
+/// CROSS-IMPLEMENTATION: the table above is the oracle's, so assert it against
+/// the oracle directly rather than trusting a transcribed constant.
+#[test]
+fn the_grammar_table_matches_the_real_upstream_binary() {
+    let Some(upstream) = upstream_binary() else {
+        println!(
+            "SKIP: upstream 3.5.0 oracle not built \
+             (target/interop/upstream-src/rsync-3.5.0/rsync)"
+        );
+        return;
+    };
+    let fixture = Fixture::new();
+    for (value, expected) in GRAMMAR {
+        assert_eq!(
+            fixture.accepts(&upstream, value),
+            *expected,
+            "upstream 3.5.0 --block-size={value} acceptance"
+        );
+    }
+}
+
+/// Acceptance alone would pass on a parser that ignored the scale, so pin the
+/// VALUES: `K` is 1024 and `KB` is 1000 (options.c:1197-1202).
+///
+/// The observable is the delta itemization: a basis differing from the source
+/// only in its opening bytes yields a different matched/literal split at 1024
+/// than at 1000, so `1K` must behave as `1024` and differ from `1000`.
+#[test]
+fn the_k_suffix_is_1024_and_kb_is_1000() {
+    let fixture = Fixture::new();
+    let oc = oc_binary();
+    let root = fixture.root.path();
+
+    // Non-periodic filler: a repeating pattern would match at any offset and
+    // make every block size look identical.
+    let mut data = Vec::with_capacity(8192);
+    let mut state: u32 = 0x1234_5678;
+    for _ in 0..8192 {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        data.push((state & 0xff) as u8);
+    }
+    fs::write(root.join("src/big"), &data).expect("source");
+
+    let stats_for = |block_size: &str| -> String {
+        let dest = root.join(format!("dst-{block_size}"));
+        fs::create_dir_all(&dest).expect("dest dir");
+        let mut basis = data.clone();
+        basis[0..40].fill(0);
+        fs::write(dest.join("big"), &basis).expect("basis");
+
+        let output = Command::new(&oc)
+            // `--ignore-times` defeats the quick-check: the basis has the same
+            // size and a fresh mtime, so without it rsync skips the file and
+            // every block size reports 0 matched / 0 literal - which the
+            // control assertion below caught when this fixture omitted it.
+            .args(["--no-whole-file", "--ignore-times", "--stats", "-v"])
+            .arg(format!("--block-size={block_size}"))
+            .arg(root.join("src/big").display().to_string())
+            .arg(dest.join("big").display().to_string())
+            .output()
+            .expect("run oc-rsync");
+        assert!(
+            output.status.success(),
+            "--block-size={block_size} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let text = String::from_utf8_lossy(&output.stdout);
+        text.lines()
+            .filter(|line| line.contains("Matched data") || line.contains("Literal data"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let k = stats_for("1K");
+    let plain_1024 = stats_for("1024");
+    let kb = stats_for("1KB");
+    let plain_1000 = stats_for("1000");
+
+    assert!(!k.is_empty(), "expected Matched/Literal lines in --stats");
+    assert_eq!(k, plain_1024, "`1K` must resolve to 1024");
+    assert_eq!(kb, plain_1000, "`1KB` must resolve to 1000");
+    // The discriminator: without it, a parser that mapped every suffix to the
+    // same number would satisfy both equalities above.
+    assert_ne!(
+        plain_1024, plain_1000,
+        "fixture does not distinguish 1024 from 1000, so the two \
+         assertions above prove nothing"
+    );
+}

--- a/tests/daemon_auth_username_wire.rs
+++ b/tests/daemon_auth_username_wire.rs
@@ -1,0 +1,154 @@
+//! The username a client puts on the wire in its `@RSYNCD` auth response.
+//!
+//! Upstream resolves it in two stages, and the daemon matches the result
+//! against `auth users`, so every stage is observable and wire-affecting:
+//!
+//! ```c
+//! /* clientserver.c:289-292, start_inband_exchange() */
+//! if (!user)
+//!     user = getenv("USER");
+//! if (!user)
+//!     user = getenv("LOGNAME");
+//! /* authenticate.c:451-452 + :473, auth_client() */
+//! if (!user || !*user)
+//!     user = "nobody";
+//! io_printf(fd, "%s %s\n", user, pass2);
+//! ```
+//!
+//! oc consulted `USERNAME` (a Windows convention upstream never reads) instead
+//! of `LOGNAME`, and fell back to `rsync` instead of `nobody`. On a host that
+//! sets only `LOGNAME` - a plain `su`, cron, or a login shell that does not
+//! export `USER` - `auth users = alice` therefore rejected a correctly
+//! configured client.
+//!
+//! The daemon side here is a stub: it speaks just enough of the greeting to
+//! reach `AUTHREQD` and then captures the response line, so the assertion is on
+//! the actual bytes rather than on a success/failure proxy. The environment is
+//! set on the CHILD only - never on the test process - so these cases stay
+//! correct under parallel nextest.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Loopback TCP is unavailable.
+//! - The cross-implementation cell additionally needs a built upstream 3.5.0
+//!   binary; without it that cell reports why it did not run.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Locates the built upstream 3.5.0 oracle, or `None` when the interop tree has
+/// not been fetched and built.
+fn upstream_binary() -> Option<PathBuf> {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("target/interop/upstream-src/rsync-3.5.0/rsync");
+    path.is_file().then_some(path)
+}
+
+/// Serves one stub daemon session and returns the username field of the auth
+/// response the client sent.
+fn capture_auth_username(client: &Path, env: &[(&str, &str)]) -> Option<String> {
+    let listener = TcpListener::bind("127.0.0.1:0").ok()?;
+    let port = listener.local_addr().ok()?.port();
+
+    let server = thread::spawn(move || -> Option<String> {
+        let (stream, _) = listener.accept().ok()?;
+        let mut writer = stream.try_clone().ok()?;
+        let mut reader = BufReader::new(stream);
+        writer.write_all(b"@RSYNCD: 32.0 md5 md4\n").ok()?;
+        writer.flush().ok()?;
+
+        let mut line = String::new();
+        reader.read_line(&mut line).ok()?; // client greeting
+        line.clear();
+        reader.read_line(&mut line).ok()?; // module request
+
+        writer
+            .write_all(b"@RSYNCD: AUTHREQD 0123456789abcdef\n")
+            .ok()?;
+        writer.flush().ok()?;
+
+        line.clear();
+        reader.read_line(&mut line).ok()?; // "<user> <hash>"
+        let _ = writer.write_all(b"@ERROR: probe complete\n");
+
+        line.split_whitespace().next().map(str::to_owned)
+    });
+
+    let mut command = Command::new(client);
+    command
+        .args(["-q", &format!("rsync://127.0.0.1:{port}/m/f"), "/dev/null"])
+        .env_remove("USER")
+        .env_remove("LOGNAME")
+        .env_remove("USERNAME")
+        // A password source keeps the client from blocking on a prompt; the
+        // stub never checks it.
+        .env("RSYNC_PASSWORD", "probe")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let _ = command.status();
+
+    server.join().ok().flatten()
+}
+
+/// Runs the six-row table against `client`.
+///
+/// An empty auth line would mean the client never authenticated, so every row
+/// asserts a concrete username rather than merely "not the old value".
+fn assert_table(client: &Path, label: &str) {
+    let rows: [(&[(&str, &str)], &str); 6] = [
+        (&[("USER", "alice")], "alice"),
+        (&[("LOGNAME", "bob")], "bob"),
+        (&[("USER", "alice"), ("LOGNAME", "bob")], "alice"),
+        (&[("USER", ""), ("LOGNAME", "bob")], "nobody"),
+        (&[], "nobody"),
+        (&[("USERNAME", "win")], "nobody"),
+    ];
+
+    for (env, expected) in rows {
+        let Some(sent) = capture_auth_username(client, env) else {
+            println!("SKIP: loopback TCP unavailable");
+            return;
+        };
+        assert_eq!(
+            sent, expected,
+            "{label}: env {env:?} must authenticate as {expected:?}"
+        );
+    }
+}
+
+/// The headline case and its five siblings, measured on oc.
+///
+/// `LOGNAME`-only and the two unset rows are the ones that were wrong; the
+/// `USER` rows are the over-correction guard - they passed before the fix and
+/// must keep passing, so a change that simply always sent `nobody` fails here.
+#[test]
+fn oc_sends_the_upstream_username_for_every_environment() {
+    assert_table(&oc_binary(), "oc");
+}
+
+/// CROSS-IMPLEMENTATION: the real 3.5.0 client is the source of the expected
+/// column, so the same table is asserted against it directly. If upstream ever
+/// changed this resolution, this cell would fail rather than oc silently
+/// encoding a stale rule.
+#[test]
+fn upstream_sends_the_same_username_for_every_environment() {
+    let Some(upstream) = upstream_binary() else {
+        println!(
+            "SKIP: upstream 3.5.0 oracle not built \
+             (target/interop/upstream-src/rsync-3.5.0/rsync)"
+        );
+        return;
+    };
+    assert_table(&upstream, "upstream 3.5.0");
+}

--- a/tests/empty_size_value_parity.rs
+++ b/tests/empty_size_value_parity.rs
@@ -1,0 +1,197 @@
+//! An empty size value means `0`, per option, exactly as upstream resolves it.
+//!
+//! ```c
+//! /* options.c:1172-1175 - the digit scan stops on the terminator, so the
+//!    suffix switch takes def_suf and strtod("") gives 0. */
+//! for (arg = size_arg; isDigit(arg); arg++) {}
+//! ...
+//! dsize = strtod(size_arg, NULL);
+//! ```
+//!
+//! **This is not a "fall back to the default" rule**, which is how the defect
+//! was first written up. Whether the resulting 0 is legal, and what it means,
+//! is decided by each option's own `min_value` / `unlimited_0`:
+//!
+//! | option | upstream call | empty resolves to |
+//! |---|---|---|
+//! | `--block-size` | min 0 (options.c:1802) | 0 -> default block size |
+//! | `--min-size` | min 0 (:1809) | 0 -> no lower bound |
+//! | `--max-size` | min 0 (:1815) | 0 -> **excludes every non-empty file** |
+//! | `--bwlimit` | min 512, `unlimited_0` (:1821) | 0 -> unlimited |
+//! | `--max-alloc` | min 1 MiB (:2067) | **rejected** |
+//!
+//! `--max-size=` excluding everything is why a success-only assertion would be
+//! the wrong oracle here, and why the rule cannot live in the shared string
+//! parser: folding it in would silently start accepting `--max-alloc=`, undoing
+//! the guard that landed for the zero case.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - The cross-implementation cell needs a built upstream 3.5.0 binary.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn upstream_binary() -> Option<PathBuf> {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("target/interop/upstream-src/rsync-3.5.0/rsync");
+    path.is_file().then_some(path)
+}
+
+/// The observable outcome of one run: did it succeed, and did the file arrive.
+#[derive(Debug, PartialEq, Eq)]
+struct Outcome {
+    success: bool,
+    transferred: bool,
+}
+
+struct Fixture {
+    root: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = tempfile::tempdir().expect("temp dir");
+        fs::create_dir_all(root.path().join("src")).expect("src dir");
+        // Six bytes: non-empty, so a `--max-size=0` bound excludes it.
+        fs::write(root.path().join("src/f"), b"hello\n").expect("src file");
+        Self { root }
+    }
+
+    /// Runs one copy with the given option spelling and reports what happened.
+    fn run(&self, binary: &Path, arg: Option<&str>) -> Outcome {
+        let dest = self.root.path().join("dst");
+        let _ = fs::remove_dir_all(&dest);
+        fs::create_dir_all(&dest).expect("dest dir");
+
+        let mut command = Command::new(binary);
+        command.arg("-r");
+        if let Some(arg) = arg {
+            command.arg(arg);
+        }
+        let status = command
+            .arg(format!("{}/", self.root.path().join("src").display()))
+            .arg(format!("{}/", dest.display()))
+            .status()
+            .expect("run binary");
+
+        Outcome {
+            success: status.success(),
+            transferred: dest.join("f").is_file(),
+        }
+    }
+}
+
+/// Every option whose empty value upstream accepts, and the one it does not.
+const OPTIONS: &[&str] = &["--block-size", "--min-size", "--max-size", "--bwlimit"];
+
+/// The whole rule in one assertion: for each option, an empty value must be
+/// indistinguishable from `=0`.
+///
+/// This pins the RESOLVED VALUE rather than mere acceptance - for `--max-size`
+/// the two agree by both *excluding* the file, which a success-only check would
+/// have missed and an "it falls back to the default" check would have got
+/// backwards.
+fn assert_empty_matches_zero(binary: &Path, label: &str) {
+    let fixture = Fixture::new();
+    for option in OPTIONS {
+        let empty = fixture.run(binary, Some(&format!("{option}=")));
+        let zero = fixture.run(binary, Some(&format!("{option}=0")));
+        assert_eq!(
+            empty, zero,
+            "{label}: `{option}=` must resolve exactly like `{option}=0`"
+        );
+        assert!(
+            empty.success,
+            "{label}: `{option}=` must be accepted, got {empty:?}"
+        );
+    }
+}
+
+#[test]
+fn oc_resolves_an_empty_size_value_to_zero() {
+    assert_empty_matches_zero(&oc_binary(), "oc");
+}
+
+/// CROSS-IMPLEMENTATION: the expected column is the oracle's behaviour, so
+/// assert it against the oracle rather than trusting the transcription.
+#[test]
+fn upstream_resolves_an_empty_size_value_to_zero() {
+    let Some(upstream) = upstream_binary() else {
+        println!(
+            "SKIP: upstream 3.5.0 oracle not built \
+             (target/interop/upstream-src/rsync-3.5.0/rsync)"
+        );
+        return;
+    };
+    assert_empty_matches_zero(&upstream, "upstream 3.5.0");
+}
+
+/// THE DISCRIMINATOR. `--max-size=` is not "no limit" and not "the default":
+/// it is a real bound of 0 that excludes every non-empty file. Without this
+/// case, a build that accepted the empty string and then ignored it would
+/// satisfy every assertion above.
+#[test]
+fn an_empty_max_size_excludes_the_file_rather_than_defaulting() {
+    let fixture = Fixture::new();
+    let oc = oc_binary();
+
+    let unset = fixture.run(&oc, None);
+    let empty = fixture.run(&oc, Some("--max-size="));
+
+    assert!(unset.transferred, "control: an unset --max-size transfers");
+    assert!(
+        empty.success && !empty.transferred,
+        "an empty --max-size must be accepted AND bound the size to 0, got {empty:?}"
+    );
+}
+
+/// CONTROL: the fix must not accept everything - a real value still parses and
+/// still applies.
+#[test]
+fn a_non_empty_size_value_still_parses_and_applies() {
+    let fixture = Fixture::new();
+    let oc = oc_binary();
+
+    assert!(
+        fixture.run(&oc, Some("--max-size=1K")).transferred,
+        "a 6-byte file is under a 1K cap and must transfer"
+    );
+    assert!(
+        !fixture.run(&oc, Some("--max-size=3")).transferred,
+        "a 6-byte file is over a 3-byte cap and must be excluded"
+    );
+    assert!(
+        !fixture.run(&oc, Some("--max-size=nonsense")).success,
+        "an unparseable size must still be rejected"
+    );
+}
+
+/// GUARD: `--max-alloc` has a 1 MiB minimum upstream, so 0 - and therefore an
+/// empty value - is rejected by both implementations. The empty-to-zero rule is
+/// applied per option precisely so this stays rejected; putting it in the
+/// shared string parser would have quietly re-opened it.
+///
+/// upstream: options.c:2067 `parse_size_arg(..., "max-alloc", 1024*1024, ...)`.
+#[test]
+fn an_empty_max_alloc_is_still_rejected() {
+    let fixture = Fixture::new();
+    let oc = oc_binary();
+
+    assert!(
+        !fixture.run(&oc, Some("--max-alloc=")).success,
+        "--max-alloc= must stay rejected"
+    );
+    assert!(
+        !fixture.run(&oc, Some("--max-alloc=0")).success,
+        "--max-alloc=0 must stay rejected"
+    );
+    assert!(
+        fixture.run(&oc, Some("--max-alloc=1048576")).success,
+        "control: a legal --max-alloc must still be accepted"
+    );
+}

--- a/tests/filter_file_open_failure_parity.rs
+++ b/tests/filter_file_open_failure_parity.rs
@@ -1,0 +1,265 @@
+//! A filter file that cannot be opened is fatal with `RERR_FILEIO` (11).
+//!
+//! ```c
+//! /* exclude.c:1712-1719 - parse_filter_file(), the single site upstream
+//!    reports every failed filter-file open from. */
+//! if (!fp) {
+//!     if (xflags & XFLG_FATAL_ERRORS) {
+//!         ...
+//!         rsyserr(FERROR, errno, "failed to open %sclude file %s",
+//!                 template->rflags & FILTRULE_INCLUDE ? "in" : "ex", fname);
+//!         exit_cleanup(RERR_FILEIO);
+//!     }
+//!     merge_depth--;
+//!     return;
+//! }
+//! ```
+//!
+//! CLASS, not one option: `XFLG_FATAL_ERRORS` is passed by every operator-named
+//! filter file - `--exclude-from` and `--include-from` (options.c:1648) and the
+//! non-per-directory merge rules `merge FILE` / `. FILE` (exclude.c:1587). All
+//! of them therefore share one rule, and the table below drives them together.
+//!
+//! Two things the table deliberately pins as NOT fatal, because getting either
+//! wrong would be a worse bug than the one being fixed:
+//!
+//! - `dir-merge` (`:` / `-F`) passes no fatal flag (exclude.c:912), so a missing
+//!   per-directory filter file is normal and must stay silent. A fix that keyed
+//!   off "filter file missing" rather than off the call site would break every
+//!   `-F` transfer.
+//! - `--files-from` is a different site with a different code: upstream exits 1
+//!   there (main.c:1886), measured. Folding both onto one helper because the
+//!   messages look alike would change an exit code nobody asked to change.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - The cross-implementation cell needs a built upstream 3.5.0 binary.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn upstream_binary() -> Option<PathBuf> {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("target/interop/upstream-src/rsync-3.5.0/rsync");
+    path.is_file().then_some(path)
+}
+
+/// One option spelling, and what upstream does when its file is missing.
+struct Case {
+    /// Formatted with the missing path.
+    argument: &'static str,
+    /// `None` when the missing file is not an error at all.
+    expected: Option<Expected>,
+}
+
+struct Expected {
+    code: i32,
+    /// Substring both implementations must render, minus the path.
+    wording: &'static str,
+}
+
+const FATAL_EXCLUDE: Option<Expected> = Some(Expected {
+    code: 11,
+    wording: "failed to open exclude file ",
+});
+const FATAL_INCLUDE: Option<Expected> = Some(Expected {
+    code: 11,
+    wording: "failed to open include file ",
+});
+
+/// Every operator-named filter file, plus the two that must NOT be fatal.
+const CASES: &[Case] = &[
+    Case {
+        argument: "--exclude-from={path}",
+        expected: FATAL_EXCLUDE,
+    },
+    Case {
+        argument: "--include-from={path}",
+        expected: FATAL_INCLUDE,
+    },
+    Case {
+        argument: "--filter=merge {path}",
+        expected: FATAL_EXCLUDE,
+    },
+    Case {
+        argument: "--filter=. {path}",
+        expected: FATAL_EXCLUDE,
+    },
+    // The `+` modifier flips the wording, which is the only evidence that the
+    // include/exclude word is derived rather than hardcoded per option.
+    Case {
+        argument: "--filter=.+ {path}",
+        expected: FATAL_INCLUDE,
+    },
+    Case {
+        argument: "--filter=merge,+ {path}",
+        expected: FATAL_INCLUDE,
+    },
+    // Per-directory merges carry no fatal flag: a missing .rsync-filter is the
+    // normal case for -F and must not fail the transfer.
+    Case {
+        argument: "--filter=dir-merge {path}",
+        expected: None,
+    },
+    Case {
+        argument: "-F",
+        expected: None,
+    },
+];
+
+struct Outcome {
+    code: i32,
+    stderr: String,
+    transferred: bool,
+}
+
+struct Fixture {
+    root: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = tempfile::tempdir().expect("temp dir");
+        fs::create_dir_all(root.path().join("src")).expect("src dir");
+        fs::write(root.path().join("src/f"), b"hello\n").expect("src file");
+        Self { root }
+    }
+
+    /// The path that does not exist. Kept free of shell metacharacters and
+    /// spaces so the `--filter=merge {path}` spelling stays unambiguous.
+    fn missing(&self) -> PathBuf {
+        self.root.path().join("absent-filter-file")
+    }
+
+    fn run(&self, binary: &Path, argument: &str) -> Outcome {
+        let dest = self.root.path().join("dst");
+        let _ = fs::remove_dir_all(&dest);
+        fs::create_dir_all(&dest).expect("dest dir");
+
+        let argument = argument.replace("{path}", &self.missing().display().to_string());
+        let output = Command::new(binary)
+            .arg("-r")
+            .arg(argument)
+            .arg(format!("{}/", self.root.path().join("src").display()))
+            .arg(format!("{}/", dest.display()))
+            .output()
+            .expect("run binary");
+
+        Outcome {
+            code: output.status.code().expect("exited normally"),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            transferred: dest.join("f").is_file(),
+        }
+    }
+}
+
+/// The whole table against one binary. Asserts the exit CODE and the WORDING,
+/// not merely that something failed: a build that exited 11 with an unrelated
+/// message, or produced upstream's text under exit 1, would be a different bug
+/// and must not pass here.
+fn assert_table(binary: &Path, label: &str) {
+    let fixture = Fixture::new();
+    let missing = fixture.missing().display().to_string();
+
+    for case in CASES {
+        let outcome = fixture.run(binary, case.argument);
+        match &case.expected {
+            Some(expected) => {
+                assert_eq!(
+                    outcome.code, expected.code,
+                    "{label}: `{}` must exit {}, got {} - {}",
+                    case.argument, expected.code, outcome.code, outcome.stderr
+                );
+                assert!(
+                    outcome.stderr.contains(expected.wording),
+                    "{label}: `{}` must report `{}`, got: {}",
+                    case.argument,
+                    expected.wording,
+                    outcome.stderr
+                );
+                assert!(
+                    outcome.stderr.contains(&missing),
+                    "{label}: `{}` must name the file it could not open, got: {}",
+                    case.argument,
+                    outcome.stderr
+                );
+                assert!(
+                    !outcome.transferred,
+                    "{label}: `{}` aborts before transferring",
+                    case.argument
+                );
+            }
+            None => {
+                assert_eq!(
+                    outcome.code, 0,
+                    "{label}: `{}` must succeed - a missing per-directory filter \
+                     file is the normal case, got: {}",
+                    case.argument, outcome.stderr
+                );
+                assert!(
+                    outcome.transferred,
+                    "{label}: `{}` must still transfer the file",
+                    case.argument
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn oc_reports_an_unopenable_filter_file_like_upstream() {
+    assert_table(&oc_binary(), "oc");
+}
+
+/// CROSS-IMPLEMENTATION: the expected column is upstream's behaviour, so assert
+/// it against upstream rather than trusting the transcription.
+#[test]
+fn upstream_reports_an_unopenable_filter_file_as_expected() {
+    let Some(upstream) = upstream_binary() else {
+        println!(
+            "SKIP: upstream 3.5.0 oracle not built \
+             (target/interop/upstream-src/rsync-3.5.0/rsync)"
+        );
+        return;
+    };
+    assert_table(&upstream, "upstream 3.5.0");
+}
+
+/// CONTROL: a filter file that DOES open must still work, so the fix cannot be
+/// satisfied by failing on every filter file.
+#[test]
+fn a_readable_filter_file_still_applies() {
+    let fixture = Fixture::new();
+    let rules = fixture.root.path().join("rules");
+    fs::write(&rules, b"f\n").expect("write rules");
+
+    let outcome = fixture.run(
+        &oc_binary(),
+        &format!("--exclude-from={}", rules.display()).replace("{path}", ""),
+    );
+
+    assert_eq!(outcome.code, 0, "a readable filter file must not fail");
+    assert!(
+        !outcome.transferred,
+        "the rule inside the file must still be applied"
+    );
+}
+
+/// GUARD: `--files-from` shares the "operator names a file that is missing"
+/// shape but NOT the exit code - upstream reports it from main.c and exits 1.
+/// Pinned here so a later tidy-up that unifies the two messages has to notice.
+#[test]
+fn a_missing_files_from_stays_exit_1() {
+    let fixture = Fixture::new();
+    let outcome = fixture.run(&oc_binary(), "--files-from={path}");
+
+    assert_eq!(
+        outcome.code, 1,
+        "--files-from is a different upstream site and keeps exit 1: {}",
+        outcome.stderr
+    );
+}


### PR DESCRIPTION
Four independent CLI-layer parity fixes, split out of a larger daemon branch because none of them touch daemon code. Each commit carries its own upstream citation, measurement table and non-vacuity note; this body is the index.

## 1. `fix(client): send upstream's daemon-auth username, not rsync/USERNAME`

Upstream's client picks the daemon-auth user as `USER` -> `LOGNAME` -> `"nobody"`. oc used `USER` -> `USERNAME` -> `"rsync"`, so a login where only `LOGNAME` is set authenticated under the wrong name, and the fallback name differed from upstream's on every platform.

## 2. `fix(cli): let --block-size reach the shared size parser`

`--block-size` was gated to bare integers at the argv layer, so `--block-size=1K` was rejected before the shared suffix parser it is supposed to use ever ran. Upstream accepts the full size grammar here. The gate was the only thing making the shared parser unreachable from this option.

## 3. `fix(cli): resolve an empty size value to 0, per option`

An empty size value (`--max-size=`) is exactly `=0` on upstream, not "fall back to the default" - measured on 3.5.0, `--max-size=` excludes every non-empty file on both implementations. Applied per option at the four sites that share upstream's semantics, and deliberately **not** in the shared `parse_size_spec`: `--max-alloc` has a 1 MiB minimum and rejects 0, so folding the rule into the shared parser would have re-opened the guard added in #7285.

## 4. `fix(cli): a filter file that will not open is fatal with RERR_FILEIO`

Upstream reports every failed filter-file open from one site with one message and one exit code (`exclude.c:1712-1719`), exiting 11. oc exited 1 with its own wording. Two look-alikes are deliberately excluded and pinned as such:

- per-directory merges (`dir-merge`, `-F`) pass no `XFLG_FATAL_ERRORS` (`exclude.c:912`) and must stay a silent success - scoping the fix by the condition rather than the call site would have broken every `-F` transfer;
- `--files-from` is reported from `main.c:1886` and exits 1 on both binaries.

## Verification

Measured on this branch rebased onto `origin/master` (`e997c2c66`):

- `cargo fmt --all -- --check` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - no issues
- `cargo nextest run -p cli --all-features` - 3801 passed, 3 skipped (pristine `origin/master` control: 3800 passed, same 3 skipped)
- the four new integration binaries (`block_size_suffix_grammar`, `empty_size_value_parity`, `filter_file_open_failure_parity`, `daemon_auth_username_wire`) - 14 passed

Every new test table asserts against oc **and** against the real upstream 3.5.0 binary in the same cell, so a shared misunderstanding of upstream cannot pass. Non-vacuity was measured per fix by reverting the production change and confirming the new rows redden.
