### PR TITLE
fix(daemon): match upstream's peer-host naming and ACL evaluation

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -247,7 +247,7 @@ use self::module_state::TEST_CONFIG_CANDIDATES;
 use self::module_state::build_module_runtimes;
 pub(crate) use self::module_state::{
     AuthUser, ConnectionLimiter, GidSetting, MaxConnections, ModuleConnectionError,
-    ModuleDefinition, ModuleRuntime, UserAccessLevel, module_peer_hostname,
+    ModuleDefinition, ModuleRuntime, PeerHost, UserAccessLevel, module_peer_hostname,
 };
 #[cfg(test)]
 pub(crate) use self::module_state::{

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -245,7 +245,6 @@ mod module_state;
 #[cfg(test)]
 use self::module_state::TEST_CONFIG_CANDIDATES;
 use self::module_state::build_module_runtimes;
-use self::module_state::resolve_peer_hostname;
 pub(crate) use self::module_state::{
     AuthUser, ConnectionLimiter, GidSetting, MaxConnections, ModuleConnectionError,
     ModuleDefinition, ModuleRuntime, UserAccessLevel, module_peer_hostname,
@@ -256,6 +255,7 @@ pub(crate) use self::module_state::{
     clear_test_hostname_overrides, set_test_forward_override, set_test_hostname_override,
     set_test_netgroup_members,
 };
+use self::module_state::{peer_host_display, resolve_peer_hostname};
 
 // upstream: log.c:122-132 logit() - every daemon log-file line is stamped
 // with `%Y/%m/%d %H:%M:%S [pid] `, provided by the LogFileWriter wrapper.
@@ -472,7 +472,11 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
     };
 
     if let Some(log) = log_sink.as_ref() {
-        log_connection(log, peer_host.as_deref(), peer_addr);
+        log_connection(
+            log,
+            peer_host_display(peer_host.as_deref(), reverse_lookup),
+            peer_addr,
+        );
     }
 
     let outcome = handle_legacy_session(

--- a/crates/daemon/src/daemon/module_state/definition.rs
+++ b/crates/daemon/src/daemon/module_state/definition.rs
@@ -239,7 +239,7 @@ impl ModuleDefinition {
     /// upstream: clientserver.c (3.4.3 commit c38f20c5) - reverse DNS
     /// before chroot ensures `client_name()` returns a real hostname when
     /// ACLs are evaluated.
-    pub(crate) fn permits(&self, addr: std::net::IpAddr, hostname: Option<&str>) -> bool {
+    pub(crate) fn permits(&self, addr: std::net::IpAddr, host: super::PeerHost<'_>) -> bool {
         // upstream: access.c:277-283 - allow-list short-circuit. A peer
         // matching any allow pattern is admitted before the deny list is
         // consulted; a peer matching nothing in a non-empty allow list is
@@ -248,7 +248,7 @@ impl ModuleDefinition {
             if self
                 .hosts_allow
                 .iter()
-                .any(|pattern| self.host_matches(pattern, addr, hostname))
+                .any(|pattern| self.host_matches(pattern, addr, host))
             {
                 return true;
             }
@@ -257,14 +257,19 @@ impl ModuleDefinition {
             }
         }
 
-        // GHSA-rjfm-3w2m-jf4f: fail closed when hostname resolution failed
-        // and any deny rule is hostname-based. Without this guard, a peer
-        // whose reverse DNS returns no name (e.g., because the daemon's
+        // GHSA-rjfm-3w2m-jf4f: fail closed when hostname resolution produced
+        // no name and any deny rule is hostname-based. Without this guard, a
+        // peer whose reverse DNS returns no name (e.g., because the daemon's
         // chroot lacks `/etc/resolv.conf` and the NSS shared objects)
         // silently bypasses hostname-pattern deny rules. This guard only
         // fires on the deny path - the allow short-circuit above lets a
-        // matched peer through without depending on hostname state.
-        if hostname.is_none()
+        // matched peer through without depending on hostname state, which is
+        // what keeps `hosts allow = UNKNOWN` usable.
+        //
+        // Keyed on the SENTINEL, not on the string being absent: the host is
+        // now always a matchable name, so `is_resolved()` is the only thing
+        // that still distinguishes "DNS gave us this" from "nobody could".
+        if !host.is_resolved()
             && self
                 .hosts_deny
                 .iter()
@@ -276,7 +281,7 @@ impl ModuleDefinition {
         if self
             .hosts_deny
             .iter()
-            .any(|pattern| self.host_matches(pattern, addr, hostname))
+            .any(|pattern| self.host_matches(pattern, addr, host))
         {
             return false;
         }
@@ -297,9 +302,9 @@ impl ModuleDefinition {
         &self,
         pattern: &HostPattern,
         addr: std::net::IpAddr,
-        hostname: Option<&str>,
+        host: super::PeerHost<'_>,
     ) -> bool {
-        pattern.matches(addr, hostname)
+        pattern.matches(addr, host.as_str())
             || pattern.forward_resolve_matches(addr, self.forward_lookup)
     }
 

--- a/crates/daemon/src/daemon/module_state/definition.rs
+++ b/crates/daemon/src/daemon/module_state/definition.rs
@@ -267,9 +267,22 @@ impl ModuleDefinition {
         // what keeps `hosts allow = UNKNOWN` usable.
         //
         // Keyed on the SENTINEL, not on the string being absent: the host is
-        // now always a matchable name, so `is_resolved()` is the only thing
-        // that still distinguishes "DNS gave us this" from "nobody could".
-        if !host.is_resolved()
+        // now always a matchable name, so the variant is the only thing that
+        // still distinguishes "DNS gave us this" from "nobody could".
+        //
+        // Matched EXHAUSTIVELY rather than through a boolean helper. "sentinel
+        // iff no name was resolved" is a biconditional over today's two
+        // variants and would silently become false if a third were added - a
+        // resolved-but-empty name, say - defaulting the new state into
+        // "allowed". With the match, adding a variant is a compile error here,
+        // so the decision has to be made rather than inherited. This is the one
+        // line in the module where being wrong is a security regression rather
+        // than a parity one.
+        let name_was_resolved = match host {
+            super::PeerHost::Resolved(_) => true,
+            super::PeerHost::Sentinel(_) => false,
+        };
+        if !name_was_resolved
             && self
                 .hosts_deny
                 .iter()

--- a/crates/daemon/src/daemon/module_state/definition.rs
+++ b/crates/daemon/src/daemon/module_state/definition.rs
@@ -248,7 +248,7 @@ impl ModuleDefinition {
             if self
                 .hosts_allow
                 .iter()
-                .any(|pattern| self.host_matches(pattern, addr, host))
+                .any(|pattern| self.host_matches(pattern, addr, host, false))
             {
                 return true;
             }
@@ -294,7 +294,7 @@ impl ModuleDefinition {
         if self
             .hosts_deny
             .iter()
-            .any(|pattern| self.host_matches(pattern, addr, host))
+            .any(|pattern| self.host_matches(pattern, addr, host, true))
         {
             return false;
         }
@@ -306,19 +306,27 @@ impl ModuleDefinition {
     /// reverse-DNS name-pattern match with forward-DNS resolution of the
     /// rule's hostname token.
     ///
-    /// upstream: access.c:254 `match_hostname(host_ptr, addr, tok) ||
+    /// upstream: access.c:260 `match_hostname(host_ptr, addr, tok, deny) ||
     /// match_address(addr, tok)` - a peer matches a `hosts allow`/`hosts deny`
     /// token when its reverse-DNS name matches the token pattern OR the token
     /// forward-resolves to the peer's address. Forward resolution is gated on
     /// the module's `forward lookup` parameter (access.c:49 `allow_forward_dns`).
+    ///
+    /// `deny` names which list is being scanned. Upstream threads it as a
+    /// per-call flag through `access_match` - 0 for the allow list
+    /// (access.c:284), 1 for the deny list (access.c:293) - and the ONE place
+    /// it is read is the unresolvable-token branch (access.c:57-63). It is a
+    /// parameter rather than module state for the same reason it is upstream:
+    /// one rule, read differently per call.
     fn host_matches(
         &self,
         pattern: &HostPattern,
         addr: std::net::IpAddr,
         host: super::PeerHost<'_>,
+        deny: bool,
     ) -> bool {
         pattern.matches(addr, host.as_str())
-            || pattern.forward_resolve_matches(addr, self.forward_lookup)
+            || pattern.forward_resolve_matches(addr, self.forward_lookup, deny)
     }
 
     /// Returns whether any host pattern requires DNS hostname resolution.

--- a/crates/daemon/src/daemon/module_state/hostname.rs
+++ b/crates/daemon/src/daemon/module_state/hostname.rs
@@ -11,6 +11,49 @@ use std::cell::RefCell;
 #[cfg(test)]
 use std::collections::HashMap;
 
+/// Host string reported when reverse lookup is switched off, so no name was
+/// ever sought.
+///
+/// upstream: clientserver.c:126 `const char undetermined_hostname[] =
+/// "UNDETERMINED";`, selected at clientserver.c:1525 when
+/// `lp_reverse_lookup(-1)` is false.
+pub(in crate::daemon) const UNDETERMINED_HOSTNAME: &str = "UNDETERMINED";
+
+/// Host string reported when a lookup WAS attempted and produced no usable
+/// name - the address is the `0.0.0.0` sentinel, the reverse lookup failed, or
+/// forward confirmation rejected the result.
+///
+/// upstream: clientname.c:34 `static const char default_name[] = "UNKNOWN";`,
+/// returned by `client_name()` on the `0.0.0.0` short-circuit (clientname.c:114)
+/// and on every lookup failure (clientname.c:127, :150).
+pub(in crate::daemon) const UNKNOWN_HOSTNAME: &str = "UNKNOWN";
+
+/// Renders the peer host the way every upstream daemon log escape and
+/// environment variable renders it.
+///
+/// The two sentinels are NOT interchangeable and the distinction is the whole
+/// point: `UNDETERMINED` means nobody asked, `UNKNOWN` means we asked and the
+/// answer was unusable. Collapsing them - as a bare `Option<&str>` does - loses
+/// the reason, which is why oc previously printed one lowercase `unknown` for
+/// both, the bare IP in one log line, and an empty string in
+/// `RSYNC_HOST_NAME`.
+///
+/// This is the display/logging rule only. Access control keeps consuming the
+/// `Option<&str>`: upstream does pass these sentinels to `allow_access()`
+/// (access.c:37-38, and clientname.c:93-95 documents `UNKNOWN` as usable in a
+/// `hosts allow` line), but adopting that would widen oc's ACL matching and is
+/// tracked separately.
+///
+/// upstream: clientserver.c:1525 `host = lp_reverse_lookup(-1) ?
+/// client_name(addr) : undetermined_hostname;`
+pub(in crate::daemon) fn peer_host_display(resolved: Option<&str>, reverse_lookup: bool) -> &str {
+    match resolved {
+        Some(name) => name,
+        None if reverse_lookup => UNKNOWN_HOSTNAME,
+        None => UNDETERMINED_HOSTNAME,
+    }
+}
+
 /// Resolves the peer's hostname for a module that requires hostname-based access control.
 ///
 /// Returns `None` when hostname lookup is disabled, the module has no hostname-based

--- a/crates/daemon/src/daemon/module_state/hostname.rs
+++ b/crates/daemon/src/daemon/module_state/hostname.rs
@@ -175,9 +175,7 @@ fn reverse_lookup_name(peer_ip: IpAddr) -> Option<String> {
 /// matching upstream `check_name`'s fail-closed behaviour on `getaddrinfo`
 /// error (clientname.c:437-441).
 fn forward_confirms(name: &str, peer_ip: IpAddr) -> bool {
-    forward_resolve(name)
-        .into_iter()
-        .any(|addr| addr == peer_ip)
+    forward_resolve(name).is_some_and(|addrs| addrs.into_iter().any(|addr| addr == peer_ip))
 }
 
 /// Forward-resolves `name` to its A/AAAA records.
@@ -188,34 +186,36 @@ fn forward_confirms(name: &str, peer_ip: IpAddr) -> bool {
 /// (`HostPattern::forward_resolve_matches`). The lookup key is normalized so
 /// both callers agree on casing and trailing dots.
 ///
-/// A name that does not resolve yields an empty vector, so callers fail
-/// closed - mirroring upstream `access.c:57-58`, where a NULL `gethostbyname`
-/// result produces no match.
+/// `None` means the LOOKUP FAILED; `Some(addrs)` means it succeeded, possibly
+/// with an empty or non-matching set. Upstream draws exactly this line and the
+/// two sides differ: a NULL `gethostbyname` returns the caller's `deny` flag
+/// (access.c:57-63), while a successful lookup whose records do not include the
+/// peer falls out of the loop and returns 0 (access.c:66-73). Collapsing both
+/// into "no records" - as an empty `Vec` did - makes an unresolvable `hosts
+/// deny` token fail OPEN.
 ///
-/// Tests inject deterministic results via `TEST_FORWARD_OVERRIDES`, keeping
-/// the daemon's access-control logic hermetic and free of real DNS traffic.
-pub(in crate::daemon) fn forward_resolve(name: &str) -> Vec<IpAddr> {
+/// Tests inject deterministic results via `TEST_FORWARD_OVERRIDES`: a name with
+/// an entry resolved successfully to those addresses (an empty slice models a
+/// successful lookup with no records); a name with no entry models a failed
+/// lookup.
+pub(in crate::daemon) fn forward_resolve(name: &str) -> Option<Vec<IpAddr>> {
     let key = normalize_hostname_owned(name.to_owned());
     resolve_forward_key(&key)
 }
 
 /// Test-build forward resolver: consults the injected override table and
-/// returns an empty set for unknown names, keeping access-control tests
+/// reports a FAILED lookup for unknown names, keeping access-control tests
 /// hermetic and free of real DNS traffic.
 #[cfg(test)]
-fn resolve_forward_key(key: &str) -> Vec<IpAddr> {
-    TEST_FORWARD_OVERRIDES
-        .with(|map| map.borrow().get(key).cloned())
-        .unwrap_or_default()
+fn resolve_forward_key(key: &str) -> Option<Vec<IpAddr>> {
+    TEST_FORWARD_OVERRIDES.with(|map| map.borrow().get(key).cloned())
 }
 
-/// Production forward resolver: queries the system resolver, returning an
-/// empty set on error so callers fail closed.
+/// Production forward resolver: queries the system resolver, reporting `None`
+/// when the lookup itself fails so callers can apply upstream's per-list rule.
 #[cfg(not(test))]
-fn resolve_forward_key(key: &str) -> Vec<IpAddr> {
-    lookup_host(key)
-        .map(|addrs| addrs.collect())
-        .unwrap_or_default()
+fn resolve_forward_key(key: &str) -> Option<Vec<IpAddr>> {
+    lookup_host(key).map(|addrs| addrs.collect()).ok()
 }
 
 /// Tests whether the connecting client `host` belongs to the named `netgroup`.

--- a/crates/daemon/src/daemon/module_state/hostname.rs
+++ b/crates/daemon/src/daemon/module_state/hostname.rs
@@ -67,7 +67,9 @@ pub(in crate::daemon) fn peer_host_display(resolved: Option<&str>, reverse_looku
 /// so the result is cached); oc resolves per connection after a process-wide
 /// chroot, where a chroot without NSS configuration silently yields no name.
 /// Keying that guard on the sentinel rather than on `Option::is_none` is what
-/// lets the allow-side sentinels match without disarming it.
+/// lets the allow-side sentinels match without disarming it. The guard matches
+/// this enum EXHAUSTIVELY rather than calling a helper, so a third variant is a
+/// compile error there instead of silently defaulting to "allowed".
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum PeerHost<'a> {
     /// A name that reverse DNS produced (and forward-confirmed, when the
@@ -94,11 +96,6 @@ impl<'a> PeerHost<'a> {
         match self {
             Self::Resolved(name) | Self::Sentinel(name) => name,
         }
-    }
-
-    /// Whether the name came from DNS. Only the fail-closed deny guard may ask.
-    pub(crate) const fn is_resolved(&self) -> bool {
-        matches!(self, Self::Resolved(_))
     }
 }
 

--- a/crates/daemon/src/daemon/module_state/hostname.rs
+++ b/crates/daemon/src/daemon/module_state/hostname.rs
@@ -38,11 +38,8 @@ pub(in crate::daemon) const UNKNOWN_HOSTNAME: &str = "UNKNOWN";
 /// both, the bare IP in one log line, and an empty string in
 /// `RSYNC_HOST_NAME`.
 ///
-/// This is the display/logging rule only. Access control keeps consuming the
-/// `Option<&str>`: upstream does pass these sentinels to `allow_access()`
-/// (access.c:37-38, and clientname.c:93-95 documents `UNKNOWN` as usable in a
-/// `hosts allow` line), but adopting that would widen oc's ACL matching and is
-/// tracked separately.
+/// Access control consumes the same string through [`PeerHost`], which keeps
+/// the resolved/sentinel distinction the ACL rules need.
 ///
 /// upstream: clientserver.c:1525 `host = lp_reverse_lookup(-1) ?
 /// client_name(addr) : undetermined_hostname;`
@@ -51,6 +48,57 @@ pub(in crate::daemon) fn peer_host_display(resolved: Option<&str>, reverse_looku
         Some(name) => name,
         None if reverse_lookup => UNKNOWN_HOSTNAME,
         None => UNDETERMINED_HOSTNAME,
+    }
+}
+
+/// The peer host as access control sees it: always a name to match against,
+/// plus whether that name came from DNS or is one of upstream's two sentinels.
+///
+/// Upstream passes a never-empty string into `allow_access()`, so a sentinel is
+/// matched like any other name - `match_hostname` bails only on `!host ||
+/// !*host` (access.c:37-38), and clientname.c:93-95 documents `UNKNOWN` as
+/// deliberately usable in a `hosts allow` line. Modelling the host as a bare
+/// `Option<&str>` made both sentinels unmatchable, so `hosts allow =
+/// UNDETERMINED` refused every peer.
+///
+/// The variant is still needed because oc keeps one rule upstream does not: a
+/// hostname-based DENY rule fails closed when no name was resolved. Upstream
+/// can rely on reverse DNS being available (it resolves before `daemon chroot`,
+/// so the result is cached); oc resolves per connection after a process-wide
+/// chroot, where a chroot without NSS configuration silently yields no name.
+/// Keying that guard on the sentinel rather than on `Option::is_none` is what
+/// lets the allow-side sentinels match without disarming it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PeerHost<'a> {
+    /// A name that reverse DNS produced (and forward-confirmed, when the
+    /// module's `forward lookup` is on).
+    Resolved(&'a str),
+    /// `UNDETERMINED` (no lookup was attempted) or `UNKNOWN` (one was, and
+    /// produced nothing usable).
+    Sentinel(&'a str),
+}
+
+impl<'a> PeerHost<'a> {
+    /// Builds the host exactly as the display path builds it, so the string an
+    /// ACL matches is the string the log line prints.
+    pub(crate) fn new(resolved: Option<&'a str>, reverse_lookup: bool) -> Self {
+        match resolved {
+            Some(name) => Self::Resolved(name),
+            None => Self::Sentinel(peer_host_display(None, reverse_lookup)),
+        }
+    }
+
+    /// The name to match patterns against - never empty, mirroring upstream's
+    /// `host` argument to `allow_access()`.
+    pub(crate) const fn as_str(&self) -> &'a str {
+        match self {
+            Self::Resolved(name) | Self::Sentinel(name) => name,
+        }
+    }
+
+    /// Whether the name came from DNS. Only the fail-closed deny guard may ask.
+    pub(crate) const fn is_resolved(&self) -> bool {
+        matches!(self, Self::Resolved(_))
     }
 }
 

--- a/crates/daemon/src/daemon/module_state/mod.rs
+++ b/crates/daemon/src/daemon/module_state/mod.rs
@@ -28,11 +28,15 @@ pub(crate) use auth::{
 pub(crate) use connection_limiter::{ConnectionLimiter, ConnectionLockGuard};
 pub(crate) use definition::{GidSetting, ModuleDefinition};
 pub(crate) use hostname::module_peer_hostname;
-pub(in crate::daemon) use hostname::{forward_resolve, netgroup_contains, resolve_peer_hostname};
+pub(in crate::daemon) use hostname::{
+    forward_resolve, netgroup_contains, peer_host_display, resolve_peer_hostname,
+};
 pub(crate) use max_connections::MaxConnections;
 pub(in crate::daemon) use runtime::build_module_runtimes;
 pub(crate) use runtime::{ModuleConnectionError, ModuleRuntime};
 
+#[cfg(test)]
+pub(in crate::daemon) use hostname::UNKNOWN_HOSTNAME;
 #[cfg(test)]
 pub(crate) use hostname::{
     clear_test_hostname_overrides, set_test_forward_override, set_test_hostname_override,

--- a/crates/daemon/src/daemon/module_state/mod.rs
+++ b/crates/daemon/src/daemon/module_state/mod.rs
@@ -27,6 +27,7 @@ pub(crate) use auth::{
 };
 pub(crate) use connection_limiter::{ConnectionLimiter, ConnectionLockGuard};
 pub(crate) use definition::{GidSetting, ModuleDefinition};
+pub(crate) use hostname::PeerHost;
 pub(crate) use hostname::module_peer_hostname;
 pub(in crate::daemon) use hostname::{
     forward_resolve, netgroup_contains, peer_host_display, resolve_peer_hostname,

--- a/crates/daemon/src/daemon/module_state/tests.rs
+++ b/crates/daemon/src/daemon/module_state/tests.rs
@@ -30,8 +30,8 @@ fn module_definition_default() {
 fn module_definition_permits_all_when_no_rules() {
     let def = ModuleDefinition::default();
     let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
-    assert!(def.permits(addr, None));
-    assert!(def.permits(addr, Some("example.com")));
+    assert!(def.permits(addr, PeerHost::new(None, true)));
+    assert!(def.permits(addr, PeerHost::new(Some("example.com"), true)));
 }
 
 #[test]
@@ -45,8 +45,8 @@ fn module_definition_permits_respects_hosts_allow() {
     };
     let allowed = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
     let denied = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-    assert!(def.permits(allowed, None));
-    assert!(!def.permits(denied, None));
+    assert!(def.permits(allowed, PeerHost::new(None, true)));
+    assert!(!def.permits(denied, PeerHost::new(None, true)));
 }
 
 #[test]
@@ -60,8 +60,8 @@ fn module_definition_permits_respects_hosts_deny() {
     };
     let allowed = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
     let denied = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-    assert!(def.permits(allowed, None));
-    assert!(!def.permits(denied, None));
+    assert!(def.permits(allowed, PeerHost::new(None, true)));
+    assert!(!def.permits(denied, PeerHost::new(None, true)));
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn module_definition_allow_match_short_circuits_deny() {
         ..Default::default()
     };
     let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-    assert!(def.permits(peer, None));
+    assert!(def.permits(peer, PeerHost::new(None, true)));
 }
 
 #[test]
@@ -100,14 +100,14 @@ fn module_definition_deny_applies_when_allow_does_not_match() {
         ..Default::default()
     };
     let denied = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-    assert!(!def.permits(denied, None));
+    assert!(!def.permits(denied, PeerHost::new(None, true)));
 
     // Peer outside both allow and deny: admitted because access.c:287
     // returns 0 only on a deny-list match; otherwise access.c:291 allows.
     // The allow-list non-match short-circuits to refuse only when the
     // deny list is empty (access.c:281-282).
     let outside_both = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
-    assert!(def.permits(outside_both, None));
+    assert!(def.permits(outside_both, PeerHost::new(None, true)));
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn module_definition_allow_short_circuit_skips_dns_fail_closed_guard() {
         ..Default::default()
     };
     let allowed = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50));
-    assert!(def.permits(allowed, None));
+    assert!(def.permits(allowed, PeerHost::new(None, true)));
 }
 
 #[test]
@@ -167,7 +167,7 @@ fn module_definition_matches_upstream_rsync_fns_allow_list() {
         Ipv4Addr::new(10, 255, 255, 254),
     ] {
         assert!(
-            def.permits(IpAddr::V4(ip), None),
+            def.permits(IpAddr::V4(ip), PeerHost::new(None, true)),
             "{ip} must be permitted by testsuite allow list",
         );
     }
@@ -178,7 +178,7 @@ fn module_definition_matches_upstream_rsync_fns_allow_list() {
         Ipv4Addr::new(203, 0, 113, 5),
     ] {
         assert!(
-            !def.permits(IpAddr::V4(ip), None),
+            !def.permits(IpAddr::V4(ip), PeerHost::new(None, true)),
             "{ip} must be refused by testsuite allow list",
         );
     }

--- a/crates/daemon/src/daemon/sections/auth_helpers.rs
+++ b/crates/daemon/src/daemon/sections/auth_helpers.rs
@@ -1,30 +1,27 @@
-fn log_connection(log: &SharedLogSink, host: Option<&str>, peer_addr: SocketAddr) {
-    let display = format_host(host, peer_addr.ip());
+fn log_connection(log: &SharedLogSink, host: &str, peer_addr: SocketAddr) {
     let ip = peer_addr.ip();
-    let text = format!("connect from {display} ({ip})");
+    let text = format!("connect from {host} ({ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
-pub(crate) fn log_list_request(log: &SharedLogSink, host: Option<&str>, peer_addr: SocketAddr) {
-    let display = format_host(host, peer_addr.ip());
+pub(crate) fn log_list_request(log: &SharedLogSink, host: &str, peer_addr: SocketAddr) {
     let ip = peer_addr.ip();
     // upstream: clientserver.c:1555 - `module-list request from %s (%s)`
-    let text = format!("module-list request from {display} ({ip})");
+    let text = format!("module-list request from {host} ({ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
 pub(crate) fn log_module_request(
     log: &SharedLogSink,
-    host: Option<&str>,
+    host: &str,
     peer_ip: IpAddr,
     module: &str,
 ) {
-    let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     // upstream: clientserver.c:787 - `rsync allowed access on module %s from %s (%s)`
-    let text = format!("rsync allowed access on module {module_display} from {display} ({peer_ip})");
+    let text = format!("rsync allowed access on module {module_display} from {host} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
@@ -42,16 +39,15 @@ pub(crate) fn log_module_request(
 /// refusal moment.
 pub(crate) fn log_module_limit(
     log: &SharedLogSink,
-    host: Option<&str>,
+    host: &str,
     peer_ip: IpAddr,
     module: &str,
     limit: i32,
     current: u32,
 ) {
-    let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "max-connections cap reached: which={module_display} peer={display} ({peer_ip}) cap={limit} current={current}"
+        "max-connections cap reached: which={module_display} peer={host} ({peer_ip}) cap={limit} current={current}"
     );
     let message = rsync_warning!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -59,15 +55,14 @@ pub(crate) fn log_module_limit(
 
 fn log_module_lock_error(
     log: &SharedLogSink,
-    host: Option<&str>,
+    host: &str,
     peer_ip: IpAddr,
     module: &str,
     error: &io::Error,
 ) {
-    let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "failed to update lock for module '{module_display}' requested from {display} ({peer_ip}): {error}"
+        "failed to update lock for module '{module_display}' requested from {host} ({peer_ip}): {error}"
     );
     let message = rsync_error!(FEATURE_UNAVAILABLE_EXIT_CODE, text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -75,15 +70,14 @@ fn log_module_lock_error(
 
 fn log_module_refused_option(
     log: &SharedLogSink,
-    host: Option<&str>,
+    host: &str,
     peer_ip: IpAddr,
     module: &str,
     refused: &str,
 ) {
-    let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "refusing option '{refused}' for module '{module_display}' from {display} ({peer_ip})"
+        "refusing option '{refused}' for module '{module_display}' from {host} ({peer_ip})"
     );
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -91,45 +85,42 @@ fn log_module_refused_option(
 
 pub(crate) fn log_module_auth_failure(
     log: &SharedLogSink,
-    host: Option<&str>,
+    host: &str,
     peer_ip: IpAddr,
     module: &str,
 ) {
-    let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     // upstream: authenticate.c:249 / :335 - `auth failed on module %s from %s (%s)`.
     // Upstream appends the specific reason (`: invalid challenge response`, or
     // ` for %s: %s`); the failure reason is not propagated to this emission point,
     // so only the invariant prefix is reproduced here.
-    let text = format!("auth failed on module {module_display} from {display} ({peer_ip})");
+    let text = format!("auth failed on module {module_display} from {host} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
 pub(crate) fn log_module_denied(
     log: &SharedLogSink,
-    host: Option<&str>,
+    host: &str,
     peer_ip: IpAddr,
     module: &str,
 ) {
-    let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     // upstream: clientserver.c:774 - `rsync denied on module %s from %s (%s)`
-    let text = format!("rsync denied on module {module_display} from {display} ({peer_ip})");
+    let text = format!("rsync denied on module {module_display} from {host} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
 pub(crate) fn log_unknown_module(
     log: &SharedLogSink,
-    host: Option<&str>,
+    host: &str,
     peer_ip: IpAddr,
     module: &str,
 ) {
-    let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     // upstream: clientserver.c:1568 - `unknown module '%s' tried from %s (%s)`
-    let text = format!("unknown module '{module_display}' tried from {display} ({peer_ip})");
+    let text = format!("unknown module '{module_display}' tried from {host} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }

--- a/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
@@ -214,16 +214,21 @@ impl HostPattern {
     /// Resolution is gated on `forward_lookup` (upstream `allow_forward_dns`
     /// from `lp_forward_lookup`, access.c:49) and applies only to the
     /// [`HostPattern::Hostname`] variant; address and CIDR variants are matched
-    /// numerically by [`HostPattern::matches`] and never forward-resolved. A
-    /// lookup that returns no records yields no match (fail-closed), mirroring
-    /// the NULL `gethostbyname` return at access.c:57-58.
-    fn forward_resolve_matches(&self, addr: IpAddr, forward_lookup: bool) -> bool {
+    /// numerically by [`HostPattern::matches`] and never forward-resolved.
+    ///
+    /// `deny` says which list is being scanned, and it is the whole of
+    /// CVE-2026-70452's sibling fix: a token the resolver cannot resolve
+    /// returns `deny` (access.c:57-63), so an unresolvable **deny** token
+    /// matches - we cannot prove the peer is not the denied host - while an
+    /// unresolvable **allow** token still does not. Both gates above return 0
+    /// regardless of `deny`, exactly as upstream does at access.c:49-53.
+    fn forward_resolve_matches(&self, addr: IpAddr, forward_lookup: bool, deny: bool) -> bool {
         if !forward_lookup {
             return false;
         }
 
         match self {
-            Self::Hostname(pattern) => pattern.forward_resolve_matches(addr),
+            Self::Hostname(pattern) => pattern.forward_resolve_matches(addr, deny),
             _ => false,
         }
     }
@@ -319,14 +324,19 @@ impl HostnamePattern {
     /// the connecting address (access.c:60-61). The eligibility gate is
     /// [`token_is_forward_resolvable`]; resolution goes through the shared
     /// [`module_state::forward_resolve`] seam so failures fail closed.
-    fn forward_resolve_matches(&self, addr: IpAddr) -> bool {
+    fn forward_resolve_matches(&self, addr: IpAddr, deny: bool) -> bool {
         if !token_is_forward_resolvable(&self.original) {
             return false;
         }
 
-        module_state::forward_resolve(&self.original)
-            .into_iter()
-            .any(|resolved| resolved == addr)
+        match module_state::forward_resolve(&self.original) {
+            // upstream: access.c:66-73 - a successful lookup matches only when
+            // one of the returned records IS the peer.
+            Some(resolved) => resolved.into_iter().any(|record| record == addr),
+            // upstream: access.c:57-63 - a token the resolver cannot resolve
+            // returns `deny`, so a deny rule fails CLOSED.
+            None => deny,
+        }
     }
 
     fn matches(&self, hostname: &str) -> bool {

--- a/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
@@ -148,8 +148,15 @@ impl HostPattern {
         })
     }
 
-    /// Returns whether the given IP address and optional hostname match this pattern.
-    fn matches(&self, addr: IpAddr, hostname: Option<&str>) -> bool {
+    /// Returns whether the given IP address and peer hostname match this
+    /// pattern.
+    ///
+    /// `hostname` is never empty - it is either a resolved name or one of
+    /// upstream's `UNKNOWN`/`UNDETERMINED` sentinels - which is why the
+    /// hostname and netgroup arms match it unconditionally. upstream:
+    /// access.c:37-38 refuses only a NULL or empty `host`, a state upstream
+    /// never reaches either.
+    fn matches(&self, addr: IpAddr, hostname: &str) -> bool {
         match (self, addr) {
             (Self::Any, _) => true,
             (Self::Ipv4 { network, prefix }, IpAddr::V4(candidate)) => {
@@ -170,18 +177,14 @@ impl HostPattern {
                     (u128::from(candidate) & mask) == u128::from(*network)
                 }
             }
-            (Self::Hostname(pattern), _) => {
-                hostname.is_some_and(|name| pattern.matches(name))
-            }
+            (Self::Hostname(pattern), _) => pattern.matches(hostname),
             // upstream: access.c:41-42 `innetgr(tok + 1, host, NULL, NULL)` -
             // the client's resolved hostname is tested for netgroup membership.
             // Like the reverse-DNS name match, this needs a resolved hostname;
             // without one (access.c:37-38 `if (!host || !*host) return 0`) it
             // never matches. Resolution goes through the `module_state`
             // netgroup seam, a no-op returning false on musl/Windows.
-            (Self::Netgroup(name), _) => {
-                hostname.is_some_and(|host| module_state::netgroup_contains(name, host))
-            }
+            (Self::Netgroup(name), _) => module_state::netgroup_contains(name, hostname),
             _ => false,
         }
     }
@@ -327,6 +330,15 @@ impl HostnamePattern {
     }
 
     fn matches(&self, hostname: &str) -> bool {
+        // Every pattern kind is lowercased at parse time (mirroring upstream's
+        // `strlower(list2)`, access.c:251), so the comparison must fold the HOST
+        // too - upstream's matcher is `iwildmatch`, the case-INSENSITIVE form
+        // (access.c:46). Comparing directly worked only while every host arrived
+        // pre-lowercased by `normalize_hostname_owned`, and failed silently for
+        // `UNKNOWN`/`UNDETERMINED`, which upstream documents as usable in a
+        // `hosts allow` line (clientname.c:93-95) and which are uppercase.
+        let folded = hostname.to_ascii_lowercase();
+        let hostname = folded.as_str();
         match &self.kind {
             HostnamePatternKind::Exact(expected) => hostname == expected,
             HostnamePatternKind::Suffix(suffix) => {

--- a/crates/daemon/src/daemon/sections/inetd.rs
+++ b/crates/daemon/src/daemon/sections/inetd.rs
@@ -94,7 +94,7 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
     }
 
     // Build a DaemonStream::Stdio from process stdin/stdout.
-    // upstream: clientserver.c:1559 - start_daemon(STDIN_FILENO, STDIN_FILENO)
+    // upstream: clientserver.c:1738 - start_daemon(STDIN_FILENO, STDIN_FILENO)
     // passes the same fd for both read and write. We use separate stdin/stdout
     // handles since Rust's std::io separates them.
     let stdin = io::stdin();
@@ -102,7 +102,7 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
     let pair = crate::daemon_stream::StdioPair::new(Box::new(stdin), Box::new(stdout));
     let stream = DaemonStream::stdio(pair);
 
-    // upstream: clientserver.c:1559 - `start_daemon(STDIN_FILENO, STDIN_FILENO)`.
+    // upstream: clientserver.c:1738 - `start_daemon(STDIN_FILENO, STDIN_FILENO)`.
     // Under inetd, fd 0 IS the connected socket, so `client_addr()` skips the
     // environment arm entirely and `client_sockaddr()` reads the real peer via
     // `getpeername` (clientname.c:37-45).

--- a/crates/daemon/src/daemon/sections/inetd.rs
+++ b/crates/daemon/src/daemon/sections/inetd.rs
@@ -141,7 +141,11 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
     };
 
     if let Some(log) = log_sink.as_ref() {
-        log_connection(log, peer_host.as_deref(), peer_addr);
+        log_connection(
+            log,
+            peer_host_display(peer_host.as_deref(), reverse_lookup),
+            peer_addr,
+        );
     }
 
     let outcome = handle_legacy_session(

--- a/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
@@ -268,7 +268,7 @@ fn read_and_log_client_args(
         let text = format!(
             "module '{}' from {} ({}): client args: {}",
             ctx.request,
-            ctx.effective_host().unwrap_or("unknown"),
+            ctx.host_display(),
             ctx.peer_ip,
             args_str
         );

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -112,11 +112,6 @@ fn log_message(log: &SharedLogSink, message: &Message) {
     }
 }
 
-/// Formats a host for logging, using the IP address as fallback.
-fn format_host(host: Option<&str>, fallback: IpAddr) -> String {
-    host.map_or_else(|| fallback.to_string(), str::to_string)
-}
-
 /// Returns a sanitised view of a module identifier suitable for diagnostics.
 ///
 /// Module names originate from user input (daemon operands) or configuration

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -24,6 +24,10 @@ struct ModuleRequestContext<'a> {
     peer_ip: IpAddr,
     session_peer_host: Option<&'a str>,
     module_peer_host: Option<&'a str>,
+    /// Whether a reverse lookup was in scope for this session (global default
+    /// OR the module override), which selects between upstream's two
+    /// no-name sentinels. upstream: clientserver.c:768 `lp_reverse_lookup(i)`.
+    reverse_lookup: bool,
     request: &'a str,
     log_sink: Option<&'a SharedLogSink>,
     messages: &'a LegacyMessageCache,
@@ -56,9 +60,18 @@ struct ModuleRequestContext<'a> {
 }
 
 impl<'a> ModuleRequestContext<'a> {
-    /// Returns the effective host for logging (module-specific or session-level).
-    fn effective_host(&self) -> Option<&str> {
-        self.module_peer_host.or(self.session_peer_host)
+    /// Returns the peer host string that every log escape, daemon log line and
+    /// `RSYNC_HOST_NAME` renders, in upstream's shape: the resolved name, else
+    /// `UNKNOWN` when a lookup was attempted, else `UNDETERMINED`.
+    ///
+    /// The module-level name wins over the session-level one because upstream
+    /// re-resolves per module when the session left the host undetermined
+    /// (clientserver.c:768-769).
+    fn host_display(&self) -> &str {
+        peer_host_display(
+            self.module_peer_host.or(self.session_peer_host),
+            self.reverse_lookup,
+        )
     }
 }
 
@@ -129,7 +142,7 @@ fn deny_module(
     stream: &mut DaemonStream,
     module: &ModuleDefinition,
     peer_ip: IpAddr,
-    host: Option<&str>,
+    host: &str,
     limiter: &mut Option<BandwidthLimiter>,
 ) -> io::Result<()> {
     let module_display = sanitize_module_identifier(&module.name);
@@ -137,12 +150,10 @@ fn deny_module(
         // upstream: clientserver.c:730 - hide module existence for non-listable modules.
         AtError::UnknownModule(module_display.into_owned())
     } else {
-        let addr_str = peer_ip.to_string();
-        let host_display = host.unwrap_or(&addr_str);
         AtError::AccessDenied {
             module: module_display.into_owned(),
-            host: host_display.to_owned(),
-            addr: addr_str,
+            host: host.to_owned(),
+            addr: peer_ip.to_string(),
         }
     };
     send_error(stream, limiter, &error)
@@ -185,7 +196,7 @@ fn handle_max_connections_exceeded(
             .load(std::sync::atomic::Ordering::Acquire);
         log_module_limit(
             log,
-            ctx.effective_host(),
+            ctx.host_display(),
             ctx.peer_ip,
             ctx.request,
             limit,
@@ -201,7 +212,7 @@ fn handle_max_connections_exceeded(
 fn handle_lock_error(ctx: &mut ModuleRequestContext<'_>, error: &io::Error) -> io::Result<()> {
     send_error(ctx.reader.get_mut(), ctx.limiter, &AtError::ModuleLockError)?;
     if let Some(log) = ctx.log_sink {
-        log_module_lock_error(log, ctx.effective_host(), ctx.peer_ip, ctx.request, error);
+        log_module_lock_error(log, ctx.host_display(), ctx.peer_ip, ctx.request, error);
     }
     Ok(())
 }
@@ -215,7 +226,7 @@ fn handle_refused_option(ctx: &mut ModuleRequestContext<'_>, refused: &str) -> i
     let error = AtError::message(format!("The server is configured to refuse {refused}"));
     send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
     if let Some(log) = ctx.log_sink {
-        log_module_refused_option(log, ctx.effective_host(), ctx.peer_ip, ctx.request, refused);
+        log_module_refused_option(log, ctx.host_display(), ctx.peer_ip, ctx.request, refused);
     }
     Ok(())
 }
@@ -256,7 +267,7 @@ fn handle_refused_option_post_handshake(
         FEATURE_UNAVAILABLE_EXIT_CODE,
     )?;
     if let Some(log) = ctx.log_sink {
-        log_module_refused_option(log, ctx.effective_host(), ctx.peer_ip, ctx.request, refused);
+        log_module_refused_option(log, ctx.host_display(), ctx.peer_ip, ctx.request, refused);
     }
     Ok(())
 }
@@ -479,7 +490,7 @@ fn handle_authentication(
         }
         AuthenticationStatus::Denied => {
             if let Some(log) = ctx.log_sink {
-                log_module_auth_failure(log, ctx.effective_host(), ctx.peer_ip, ctx.request);
+                log_module_auth_failure(log, ctx.host_display(), ctx.peer_ip, ctx.request);
             }
             // FSM: -> Closing on auth failure (session ends).
             ctx.conn_state = ctx
@@ -512,12 +523,18 @@ fn handle_unknown_module(
     request: &str,
     peer_ip: IpAddr,
     session_peer_host: Option<&str>,
+    reverse_lookup: bool,
     log_sink: Option<&SharedLogSink>,
 ) -> io::Result<()> {
     let error = AtError::UnknownModule(sanitize_module_identifier(request).into_owned());
 
     if let Some(log) = log_sink {
-        log_unknown_module(log, session_peer_host, peer_ip, request);
+        log_unknown_module(
+            log,
+            peer_host_display(session_peer_host, reverse_lookup),
+            peer_ip,
+            request,
+        );
     }
 
     send_error(stream, limiter, &error)
@@ -530,15 +547,15 @@ fn handle_module_denied(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleDefinition,
 ) -> io::Result<()> {
-    let host = ctx.module_peer_host.or(ctx.session_peer_host);
+    let host = ctx.host_display().to_owned();
     if let Some(log) = ctx.log_sink {
-        log_module_denied(log, host, ctx.peer_ip, ctx.request);
+        log_module_denied(log, &host, ctx.peer_ip, ctx.request);
     }
     deny_module(
         ctx.reader.get_mut(),
         module,
         ctx.peer_ip,
-        host,
+        &host,
         ctx.limiter,
     )
 }
@@ -579,6 +596,7 @@ fn respond_with_module_request(
             request,
             peer_ip,
             session_peer_host,
+            reverse_lookup,
             log_sink,
         );
     };
@@ -606,6 +624,7 @@ fn respond_with_module_request(
         peer_ip,
         session_peer_host,
         module_peer_host,
+        reverse_lookup: module_reverse_lookup,
         request,
         log_sink,
         messages,

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -634,7 +634,11 @@ fn respond_with_module_request(
         conn_state,
     };
 
-    if !module.permits(peer_ip, module_peer_host) {
+    // upstream: clientserver.c:773 `allow_access(addr, &host, i)` is handed the
+    // same never-empty host string the log lines use, sentinels included - so a
+    // `hosts allow = UNKNOWN` line works as clientname.c:93-95 documents.
+    let access_host = PeerHost::new(module_peer_host, module_reverse_lookup);
+    if !module.permits(peer_ip, access_host) {
         return handle_module_denied(&mut ctx, module);
     }
 

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -402,28 +402,41 @@ mod module_access_tests {
         assert!(message.contains("/var/lock/rsyncd.lock"));
     }
 
+    /// A resolved name is rendered verbatim, whatever the lookup setting.
     #[test]
-    fn format_host_returns_hostname_when_present() {
-        use std::net::IpAddr;
-        let host = Some("example.com");
-        let fallback: IpAddr = "192.168.1.1".parse().unwrap();
-        assert_eq!(format_host(host, fallback), "example.com");
+    fn peer_host_display_returns_the_resolved_name() {
+        assert_eq!(peer_host_display(Some("example.com"), true), "example.com");
+        assert_eq!(peer_host_display(Some("example.com"), false), "example.com");
     }
 
+    /// A lookup that was ATTEMPTED and produced nothing renders `UNKNOWN`.
+    ///
+    /// upstream: clientname.c:112 `strlcpy(name_buf, default_name, ...)`.
     #[test]
-    fn format_host_returns_ip_when_hostname_missing() {
-        use std::net::IpAddr;
-        let host: Option<&str> = None;
-        let fallback: IpAddr = "10.0.0.1".parse().unwrap();
-        assert_eq!(format_host(host, fallback), "10.0.0.1");
+    fn peer_host_display_reports_unknown_when_the_lookup_failed() {
+        assert_eq!(peer_host_display(None, true), "UNKNOWN");
     }
 
+    /// A lookup that was never attempted renders `UNDETERMINED`, a DIFFERENT
+    /// string. Collapsing the two is the divergence this replaces: oc printed
+    /// one lowercase `unknown` for both, and the bare IP in the access lines.
+    ///
+    /// upstream: clientserver.c:126 + :1525.
     #[test]
-    fn format_host_returns_ipv6_when_hostname_missing() {
-        use std::net::IpAddr;
-        let host: Option<&str> = None;
-        let fallback: IpAddr = "::1".parse().unwrap();
-        assert_eq!(format_host(host, fallback), "::1");
+    fn peer_host_display_reports_undetermined_when_no_lookup_ran() {
+        assert_eq!(peer_host_display(None, false), "UNDETERMINED");
+        assert_ne!(peer_host_display(None, false), peer_host_display(None, true));
+    }
+
+    /// The sentinels must never be an address: the daemon log renders
+    /// `<host> (<addr>)` and upstream keeps those two fields distinct even when
+    /// the host is unknown. oc previously printed `10.0.0.1 (10.0.0.1)`.
+    #[test]
+    fn peer_host_display_never_substitutes_the_peer_address() {
+        for reverse_lookup in [true, false] {
+            let rendered = peer_host_display(None, reverse_lookup);
+            assert!(rendered.parse::<std::net::IpAddr>().is_err(), "{rendered}");
+        }
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -17,7 +17,7 @@
 fn run_post_xfer_finalizer(
     ctx: &ModuleRequestContext<'_>,
     module: &ModuleRuntime,
-    host_name: Option<&str>,
+    host_name: &str,
     user_name: Option<&str>,
     client_args: &[String],
     exit_status: i32,
@@ -40,7 +40,7 @@ fn run_post_xfer_finalizer(
         module_name: &module.name,
         username: "",
         remote_addr: &addr_str,
-        hostname: host_name.unwrap_or(""),
+        hostname: host_name,
         pid: std::process::id(),
     };
     let expanded_command = expand_exec_command(command, &path_ctx);
@@ -77,7 +77,7 @@ fn process_approved_module(
     };
 
     if let Some(log) = ctx.log_sink {
-        log_module_request(log, ctx.effective_host(), ctx.peer_ip, ctx.request);
+        log_module_request(log, ctx.host_display(), ctx.peer_ip, ctx.request);
     }
 
     if let Some(refused) = refused_option(module, options) {
@@ -103,7 +103,7 @@ fn process_approved_module(
             }
         }
         let client_addr = ctx.peer_ip.to_string();
-        let client_host = ctx.effective_host().unwrap_or(&client_addr);
+        let client_host = ctx.host_display();
         expand_module_vars(&mut definition, &client_addr, client_host);
         ModuleRuntime::from(definition)
     };
@@ -140,7 +140,7 @@ fn process_approved_module(
                 module_name: &module.name,
                 username: auth_user.as_deref().unwrap_or(""),
                 remote_addr: &ctx.peer_ip.to_string(),
-                hostname: ctx.effective_host().unwrap_or(""),
+                hostname: ctx.host_display(),
                 pid: std::process::id(),
             };
             let expanded_command = expand_exec_command(command, &early_path_ctx);
@@ -148,7 +148,7 @@ fn process_approved_module(
                 module_name: &module.name,
                 module_path: &module.path,
                 host_addr: ctx.peer_ip,
-                host_name: ctx.effective_host(),
+                host_name: ctx.host_display(),
                 user_name: auth_user.as_deref(),
                 request: ctx.request,
                 // Early exec runs before client args are received.
@@ -168,11 +168,11 @@ fn process_approved_module(
                     // upstream: clientserver.c:945-949 - early exec runs after
                     // the post-xfer-exec fork point, so its failure is a
                     // child exit the waiting parent still observes.
-                    let host_owned = ctx.effective_host().map(str::to_owned);
+                    let host_owned = ctx.host_display().to_owned();
                     run_post_xfer_finalizer(
                         ctx,
                         module,
-                        host_owned.as_deref(),
+                        &host_owned,
                         auth_user.as_deref(),
                         &[],
                         MODULE_ABORT_EXIT_CODE,
@@ -185,11 +185,11 @@ fn process_approved_module(
                         ctx.request
                     ));
                     send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
-                    let host_owned = ctx.effective_host().map(str::to_owned);
+                    let host_owned = ctx.host_display().to_owned();
                     run_post_xfer_finalizer(
                         ctx,
                         module,
-                        host_owned.as_deref(),
+                        &host_owned,
                         auth_user.as_deref(),
                         &[],
                         MODULE_ABORT_EXIT_CODE,
@@ -211,11 +211,11 @@ fn process_approved_module(
     if !validate_module_path(ctx, module)? {
         // upstream: clientserver.c:992-993 - the change_dir() into the module
         // path is post-fork, so a missing/unreachable path still hooks.
-        let host_owned = ctx.effective_host().map(str::to_owned);
+        let host_owned = ctx.host_display().to_owned();
         run_post_xfer_finalizer(
             ctx,
             module,
-            host_owned.as_deref(),
+            &host_owned,
             auth_user.as_deref(),
             &[],
             MODULE_ABORT_EXIT_CODE,
@@ -242,11 +242,11 @@ fn process_approved_module(
                 ctx.limiter,
                 &AtError::message("daemon security issue -- contact admin"),
             )?;
-            let host_owned = ctx.effective_host().map(str::to_owned);
+            let host_owned = ctx.host_display().to_owned();
             run_post_xfer_finalizer(
                 ctx,
                 module,
-                host_owned.as_deref(),
+                &host_owned,
                 auth_user.as_deref(),
                 &[],
                 RERR_UNSUPPORTED_EXIT_CODE,
@@ -292,7 +292,7 @@ fn process_approved_module(
     // `MPLEX_BASE = 7`). upstream: clientserver.c:1169 io_start_multiplex_out
     // immediately followed by `rwrite(FERROR, ...)`.
     if let Some(refused) = refused_client_arg(module, &client_args) {
-        let host_owned = ctx.effective_host().map(str::to_owned);
+        let host_owned = ctx.host_display().to_owned();
         let result = handle_refused_option_post_handshake(
             ctx,
             &refused,
@@ -306,7 +306,7 @@ fn process_approved_module(
         run_post_xfer_finalizer(
             ctx,
             module,
-            host_owned.as_deref(),
+            &host_owned,
             auth_user.as_deref(),
             &client_args,
             RERR_UNSUPPORTED_EXIT_CODE,
@@ -347,7 +347,7 @@ fn process_approved_module(
     // rejection first (the child's `rprintf(FERROR, ...)` + `exit_cleanup`),
     // then run the post-xfer finalizer, matching that ordering.
     if effective_read_only && matches!(role, ServerRole::Receiver) {
-        let host_owned = ctx.effective_host().map(str::to_owned);
+        let host_owned = ctx.host_display().to_owned();
         let result = handle_access_denied_post_handshake(
             ctx,
             MODULE_READ_ONLY_PAYLOAD,
@@ -357,7 +357,7 @@ fn process_approved_module(
         run_post_xfer_finalizer(
             ctx,
             module,
-            host_owned.as_deref(),
+            &host_owned,
             auth_user.as_deref(),
             &client_args,
             RERR_SYNTAX_EXIT_CODE,
@@ -365,7 +365,7 @@ fn process_approved_module(
         return result;
     }
     if module.write_only && matches!(role, ServerRole::Generator) {
-        let host_owned = ctx.effective_host().map(str::to_owned);
+        let host_owned = ctx.host_display().to_owned();
         let result = handle_access_denied_post_handshake(
             ctx,
             MODULE_WRITE_ONLY_PAYLOAD,
@@ -375,7 +375,7 @@ fn process_approved_module(
         run_post_xfer_finalizer(
             ctx,
             module,
-            host_owned.as_deref(),
+            &host_owned,
             auth_user.as_deref(),
             &client_args,
             RERR_SYNTAX_EXIT_CODE,
@@ -411,7 +411,7 @@ fn process_approved_module(
             module_name: &module.name,
             username: auth_user.as_deref().unwrap_or(""),
             remote_addr: &ctx.peer_ip.to_string(),
-            hostname: ctx.effective_host().unwrap_or(""),
+            hostname: ctx.host_display(),
             pid: std::process::id(),
         };
         let expanded = expand_exec_command(cmd, &nc_path_ctx);
@@ -423,11 +423,11 @@ fn process_approved_module(
                 // upstream: clientserver.c:965-970 - the name-converter spawn
                 // runs after the post-xfer-exec fork point, so its failure
                 // is a child exit the waiting parent still observes.
-                let host_owned = ctx.effective_host().map(str::to_owned);
+                let host_owned = ctx.host_display().to_owned();
                 run_post_xfer_finalizer(
                     ctx,
                     module,
-                    host_owned.as_deref(),
+                    &host_owned,
                     auth_user.as_deref(),
                     &client_args,
                     MODULE_ABORT_EXIT_CODE,
@@ -467,11 +467,11 @@ fn process_approved_module(
             // upstream: clientserver.c - config assembly runs after the
             // post-xfer-exec fork point (post-chroot, post-args), so a
             // failure here is a child exit the waiting parent still hooks.
-            let host_owned = ctx.effective_host().map(str::to_owned);
+            let host_owned = ctx.host_display().to_owned();
             run_post_xfer_finalizer(
                 ctx,
                 module,
-                host_owned.as_deref(),
+                &host_owned,
                 auth_user.as_deref(),
                 &client_args,
                 MODULE_ABORT_EXIT_CODE,
@@ -488,11 +488,11 @@ fn process_approved_module(
         Err(err) => {
             let error = AtError::message(format!("failed to load module filter rules: {err}"));
             send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
-            let host_owned = ctx.effective_host().map(str::to_owned);
+            let host_owned = ctx.host_display().to_owned();
             run_post_xfer_finalizer(
                 ctx,
                 module,
-                host_owned.as_deref(),
+                &host_owned,
                 auth_user.as_deref(),
                 &client_args,
                 MODULE_ABORT_EXIT_CODE,
@@ -526,11 +526,11 @@ fn process_approved_module(
         .map(|p| p.as_path())
         .collect();
     if !engage_landlock_sandbox(ctx, module, &extra_allowed)? {
-        let host_owned = ctx.effective_host().map(str::to_owned);
+        let host_owned = ctx.host_display().to_owned();
         run_post_xfer_finalizer(
             ctx,
             module,
-            host_owned.as_deref(),
+            &host_owned,
             auth_user.as_deref(),
             &client_args,
             MODULE_ABORT_EXIT_CODE,
@@ -564,11 +564,11 @@ fn process_approved_module(
     let mut streams = match setup_transfer_streams(ctx, arm_drain, zero_copy_policy)? {
         Some(s) => s,
         None => {
-            let host_owned = ctx.effective_host().map(str::to_owned);
+            let host_owned = ctx.host_display().to_owned();
             run_post_xfer_finalizer(
                 ctx,
                 module,
-                host_owned.as_deref(),
+                &host_owned,
                 auth_user.as_deref(),
                 &client_args,
                 MODULE_ABORT_EXIT_CODE,
@@ -579,13 +579,13 @@ fn process_approved_module(
 
     // Extract host name before building structs that borrow ctx, so the
     // borrow is released before the FSM transition mutates ctx.conn_state.
-    let host_name_owned = ctx.effective_host().map(str::to_owned);
+    let host_name_owned = ctx.host_display().to_owned();
 
     let xfer_ctx = XferExecContext {
         module_name: &module.name,
         module_path: &module.path,
         host_addr: ctx.peer_ip,
-        host_name: host_name_owned.as_deref(),
+        host_name: &host_name_owned,
         user_name: auth_user.as_deref(),
         request: ctx.request,
         client_args: &client_args,
@@ -600,7 +600,7 @@ fn process_approved_module(
         module_name: &module.name,
         username: "",
         remote_addr: &addr_str_exec,
-        hostname: host_name_owned.as_deref().unwrap_or(""),
+        hostname: &host_name_owned,
         pid: std::process::id(),
     };
 
@@ -650,7 +650,7 @@ fn process_approved_module(
                 run_post_xfer_finalizer(
                     ctx,
                     module,
-                    host_name_owned.as_deref(),
+                    &host_name_owned,
                     auth_user.as_deref(),
                     &client_args,
                     RERR_UNSUPPORTED_EXIT_CODE,
@@ -673,7 +673,7 @@ fn process_approved_module(
                 run_post_xfer_finalizer(
                     ctx,
                     module,
-                    host_name_owned.as_deref(),
+                    &host_name_owned,
                     auth_user.as_deref(),
                     &client_args,
                     MODULE_ABORT_EXIT_CODE,

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -72,11 +72,11 @@ fn apply_privilege_restrictions_with_upstream_errors(
                     AtError::ChrootFailed
                 };
                 send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
-                let host_owned = ctx.effective_host().map(str::to_owned);
+                let host_owned = ctx.host_display().to_owned();
                 run_post_xfer_finalizer(
                     ctx,
                     module,
-                    host_owned.as_deref(),
+                    &host_owned,
                     auth_user,
                     client_args,
                     MODULE_ABORT_EXIT_CODE,
@@ -121,11 +121,11 @@ fn apply_privilege_restrictions_with_upstream_errors(
                     AtError::SetgidFailed
                 };
                 send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
-                let host_owned = ctx.effective_host().map(str::to_owned);
+                let host_owned = ctx.host_display().to_owned();
                 run_post_xfer_finalizer(
                     ctx,
                     module,
-                    host_owned.as_deref(),
+                    &host_owned,
                     auth_user,
                     client_args,
                     MODULE_ABORT_EXIT_CODE,
@@ -192,7 +192,7 @@ fn validate_module_path(
         let text = format!(
             "module '{}' path validation failed for {} ({}): path does not exist: {}",
             ctx.request,
-            ctx.effective_host().unwrap_or("unknown"),
+            ctx.host_display(),
             ctx.peer_ip,
             module.path.display()
         );

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -314,7 +314,7 @@ fn execute_transfer(
         let text = format!(
             "module '{}' from {} ({}): protocol {}, role: {:?}",
             ctx.request,
-            ctx.effective_host().unwrap_or("unknown"),
+            ctx.host_display(),
             ctx.peer_ip,
             final_protocol.as_u8(),
             role
@@ -369,7 +369,7 @@ fn execute_transfer(
 
                     let log_ctx = LogFormatContext {
                         operation,
-                        hostname: ctx.effective_host().unwrap_or("unknown"),
+                        hostname: ctx.host_display(),
                         remote_addr: &addr_str,
                         module_name: ctx.request,
                         username: "",
@@ -411,7 +411,7 @@ fn execute_transfer(
             if let Some(log) = ctx.log_sink {
                 let text = format!(
                     "transfer failed to {} ({}): module={} error={}",
-                    ctx.effective_host().unwrap_or("unknown"),
+                    ctx.host_display(),
                     ctx.peer_ip,
                     ctx.request,
                     err

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -100,7 +100,11 @@ fn handle_session(
         None
     };
     if let Some(log) = log_sink.as_ref() {
-        log_connection(log, peer_host.as_deref(), peer_addr);
+        log_connection(
+            log,
+            peer_host_display(peer_host.as_deref(), reverse_lookup),
+            peer_addr,
+        );
     }
 
     match style {
@@ -399,7 +403,11 @@ fn handle_legacy_session(
         // listing; capabilities are only sent after module selection
         // during the transfer handshake.
         if let Some(log) = log_sink.as_ref() {
-            log_list_request(log, peer_host.as_deref(), peer_addr);
+            log_list_request(
+                log,
+                peer_host_display(peer_host.as_deref(), reverse_lookup),
+                peer_addr,
+            );
         }
         respond_with_module_list(reader.get_mut(), &mut limiter, modules, messages)?;
         // FSM: -> Closing after sending the module list and EXIT.

--- a/crates/daemon/src/daemon/sections/xfer_exec.rs
+++ b/crates/daemon/src/daemon/sections/xfer_exec.rs
@@ -21,7 +21,7 @@ struct XferExecContext<'a> {
     module_name: &'a str,
     module_path: &'a Path,
     host_addr: IpAddr,
-    host_name: Option<&'a str>,
+    host_name: &'a str,
     user_name: Option<&'a str>,
     request: &'a str,
     /// Numbered client arguments for `RSYNC_ARG0`, `RSYNC_ARG1`, etc.
@@ -63,7 +63,7 @@ fn build_base_xfer_command(command: &str, ctx: &XferExecContext<'_>) -> ProcessC
     cmd.env("RSYNC_MODULE_NAME", ctx.module_name);
     cmd.env("RSYNC_MODULE_PATH", ctx.module_path);
     cmd.env("RSYNC_HOST_ADDR", ctx.host_addr.to_string());
-    cmd.env("RSYNC_HOST_NAME", ctx.host_name.unwrap_or_default());
+    cmd.env("RSYNC_HOST_NAME", ctx.host_name);
     cmd.env("RSYNC_USER_NAME", ctx.user_name.unwrap_or_default());
     cmd.env("RSYNC_PID", std::process::id().to_string());
 
@@ -316,7 +316,7 @@ mod xfer_exec_tests {
             module_name: "testmod",
             module_path: Path::new("/srv/testmod"),
             host_addr: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)),
-            host_name: Some("client.example.com"),
+            host_name: "client.example.com",
             user_name: Some("testuser"),
             request: "testmod/subdir",
             client_args: &TEST_ARGS,
@@ -361,12 +361,16 @@ mod xfer_exec_tests {
     }
 
     #[test]
-    fn build_xfer_command_handles_missing_optional_fields() {
+    /// upstream: clientserver.c:770 sets `RSYNC_HOST_NAME` from the same `host`
+    /// the ACL and `%h` use, which is never empty - it is `UNKNOWN` or
+    /// `UNDETERMINED` when no name was resolved. The previous assertion pinned
+    /// oc's empty-string divergence.
+    fn build_xfer_command_renders_the_unresolved_host_sentinel() {
         let ctx = XferExecContext {
             module_name: "mod",
             module_path: Path::new("/data"),
             host_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            host_name: None,
+            host_name: crate::daemon::module_state::UNKNOWN_HOSTNAME,
             user_name: None,
             request: "mod",
             client_args: &TEST_ARGS,
@@ -380,7 +384,7 @@ mod xfer_exec_tests {
                 .and_then(|(_, v)| v.map(|s| s.to_string_lossy().into_owned()))
         };
 
-        assert_eq!(find_env("RSYNC_HOST_NAME").as_deref(), Some(""));
+        assert_eq!(find_env("RSYNC_HOST_NAME").as_deref(), Some("UNKNOWN"));
         assert_eq!(find_env("RSYNC_USER_NAME").as_deref(), Some(""));
     }
 
@@ -633,7 +637,7 @@ mod xfer_exec_tests {
             module_name: "testmod",
             module_path: Path::new("/srv/testmod"),
             host_addr: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)),
-            host_name: Some("client.example.com"),
+            host_name: "client.example.com",
             user_name: Some("testuser"),
             request: "testmod/subdir",
             client_args: &args,
@@ -663,7 +667,7 @@ mod xfer_exec_tests {
             module_name: "testmod",
             module_path: Path::new("/srv/testmod"),
             host_addr: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)),
-            host_name: Some("client.example.com"),
+            host_name: "client.example.com",
             user_name: Some("testuser"),
             request: "testmod/subdir",
             client_args: &args,
@@ -730,7 +734,7 @@ mod xfer_exec_tests {
             module_name: "testmod",
             module_path: Path::new("/srv/testmod"),
             host_addr: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)),
-            host_name: Some("client.example.com"),
+            host_name: "client.example.com",
             user_name: Some("testuser"),
             request: "testmod/subdir",
             client_args: &args,
@@ -760,7 +764,7 @@ mod xfer_exec_tests {
             module_name: "testmod",
             module_path: Path::new("/srv/testmod"),
             host_addr: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)),
-            host_name: Some("client.example.com"),
+            host_name: "client.example.com",
             user_name: Some("testuser"),
             request: "testmod/subdir",
             client_args: &args,

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -161,6 +161,7 @@ include!("tests/chunks/module_hostname_allow_forward_resolves_token_to_peer.rs")
 include!("tests/chunks/module_hostname_allow_netgroup_admits_member.rs");
 include!("tests/chunks/module_hostname_deny_fails_closed_when_dns_unresolved.rs");
 include!("tests/chunks/module_hostname_deny_forward_resolves_token_to_peer.rs");
+include!("tests/chunks/module_hostname_deny_unresolvable_token_fails_closed.rs");
 include!("tests/chunks/module_hostname_forward_lookup_off_skips_token_resolution.rs");
 include!("tests/chunks/module_hostname_netgroup_deny_blocks_member.rs");
 include!("tests/chunks/module_hostname_netgroup_deny_fails_closed_without_hostname.rs");

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -27,6 +27,7 @@ use crate::daemon::{
     ModuleConnectionError,
     ModuleDefinition,
     ModuleRuntime,
+    PeerHost,
     // From sections/cli_args.rs
     ProgramName,
     RERR_SYNTAX_EXIT_CODE,

--- a/crates/daemon/src/tests/chunks/log_bodies_match_upstream_wording.rs
+++ b/crates/daemon/src/tests/chunks/log_bodies_match_upstream_wording.rs
@@ -9,7 +9,7 @@ fn log_bodies_match_upstream_wording() {
     let path = dir.path().join("daemon.log");
     let log = open_log_sink(&path, Brand::Oc).expect("open log");
 
-    let host = Some("client.example");
+    let host = "client.example";
     let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 17));
     let addr = std::net::SocketAddr::new(ip, 873);
 

--- a/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
+++ b/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
@@ -7,7 +7,7 @@ fn log_module_limit_logs_cap_reached() {
 
     log_module_limit(
         &log,
-        Some("client.example"),
+        "client.example",
         IpAddr::V4(Ipv4Addr::new(192, 0, 2, 17)),
         "docs",
         limit,

--- a/crates/daemon/src/tests/chunks/module_definition_empty_acls_allow_all.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_empty_acls_allow_all.rs
@@ -3,6 +3,6 @@ fn module_definition_empty_acls_allow_all() {
     // upstream: access.c - when neither hosts_allow nor hosts_deny is set,
     // all connections are permitted.
     let module = module_with_host_patterns(&[], &[]);
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), None));
-    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), PeerHost::new(None, true)));
+    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_allow_matches_exact.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_allow_matches_exact.rs
@@ -2,8 +2,8 @@
 fn module_definition_hostname_allow_matches_exact() {
     let module = module_with_host_patterns(&["trusted.example.com"], &[]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    assert!(module.permits(peer, Some("trusted.example.com")));
-    assert!(!module.permits(peer, Some("other.example.com")));
-    assert!(!module.permits(peer, None));
+    assert!(module.permits(peer, PeerHost::new(Some("trusted.example.com"), true)));
+    assert!(!module.permits(peer, PeerHost::new(Some("other.example.com"), true)));
+    assert!(!module.permits(peer, PeerHost::new(None, true)));
 }
 

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_deny_takes_precedence.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_deny_takes_precedence.rs
@@ -15,11 +15,23 @@ fn module_definition_hostname_deny_short_circuited_by_wildcard_allow() {
 /// Hostname deny rules engage when the peer matches no allow pattern.
 /// This pairs with the wildcard-allow case above: removing the wildcard
 /// allows the deny list to gate access by hostname.
+///
+/// The deny token is given a forward resolution deliberately. Upstream returns
+/// the caller's `deny` flag when a token will not resolve (access.c:57-63), so
+/// an unresolvable deny token blocks EVERY peer - and the second assertion
+/// below would then be asserting the absence of a security property rather
+/// than the presence of a matching rule. Resolving the token elsewhere isolates
+/// the reverse-name match, which is what this test is about.
 #[test]
 fn module_definition_hostname_deny_applies_without_allow_match() {
+    clear_test_hostname_overrides();
     let module = module_with_host_patterns(&[], &["bad.example.com"]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    set_test_forward_override("bad.example.com", &[IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9))]);
+
     assert!(!module.permits(peer, PeerHost::new(Some("bad.example.com"), true)));
     assert!(module.permits(peer, PeerHost::new(Some("good.example.com"), true)));
+
+    clear_test_hostname_overrides();
 }
 

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_deny_takes_precedence.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_deny_takes_precedence.rs
@@ -8,8 +8,8 @@
 fn module_definition_hostname_deny_short_circuited_by_wildcard_allow() {
     let module = module_with_host_patterns(&["*"], &["bad.example.com"]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    assert!(module.permits(peer, Some("bad.example.com")));
-    assert!(module.permits(peer, Some("good.example.com")));
+    assert!(module.permits(peer, PeerHost::new(Some("bad.example.com"), true)));
+    assert!(module.permits(peer, PeerHost::new(Some("good.example.com"), true)));
 }
 
 /// Hostname deny rules engage when the peer matches no allow pattern.
@@ -19,7 +19,7 @@ fn module_definition_hostname_deny_short_circuited_by_wildcard_allow() {
 fn module_definition_hostname_deny_applies_without_allow_match() {
     let module = module_with_host_patterns(&[], &["bad.example.com"]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    assert!(!module.permits(peer, Some("bad.example.com")));
-    assert!(module.permits(peer, Some("good.example.com")));
+    assert!(!module.permits(peer, PeerHost::new(Some("bad.example.com"), true)));
+    assert!(module.permits(peer, PeerHost::new(Some("good.example.com"), true)));
 }
 

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_suffix_matches.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_suffix_matches.rs
@@ -2,9 +2,9 @@
 fn module_definition_hostname_suffix_matches() {
     let module = module_with_host_patterns(&[".example.com"], &[]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    assert!(module.permits(peer, Some("node.example.com")));
-    assert!(module.permits(peer, Some("example.com")));
-    assert!(!module.permits(peer, Some("example.net")));
-    assert!(!module.permits(peer, Some("sampleexample.com")));
+    assert!(module.permits(peer, PeerHost::new(Some("node.example.com"), true)));
+    assert!(module.permits(peer, PeerHost::new(Some("example.com"), true)));
+    assert!(!module.permits(peer, PeerHost::new(Some("example.net"), true)));
+    assert!(!module.permits(peer, PeerHost::new(Some("sampleexample.com"), true)));
 }
 

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_collapses_consecutive_asterisks.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_collapses_consecutive_asterisks.rs
@@ -2,7 +2,7 @@
 fn module_definition_hostname_wildcard_collapses_consecutive_asterisks() {
     let module = module_with_host_patterns(&["**.example.com"], &[]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    assert!(module.permits(peer, Some("node.example.com")));
-    assert!(!module.permits(peer, Some("node.example.org")));
+    assert!(module.permits(peer, PeerHost::new(Some("node.example.com"), true)));
+    assert!(!module.permits(peer, PeerHost::new(Some("node.example.org"), true)));
 }
 

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_handles_multiple_asterisks.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_handles_multiple_asterisks.rs
@@ -2,8 +2,8 @@
 fn module_definition_hostname_wildcard_handles_multiple_asterisks() {
     let module = module_with_host_patterns(&["*build*node*.example.com"], &[]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    assert!(module.permits(peer, Some("fastbuild-node1.example.com")));
-    assert!(module.permits(peer, Some("build-node.example.com")));
-    assert!(!module.permits(peer, Some("build.example.org")));
+    assert!(module.permits(peer, PeerHost::new(Some("fastbuild-node1.example.com"), true)));
+    assert!(module.permits(peer, PeerHost::new(Some("build-node.example.com"), true)));
+    assert!(!module.permits(peer, PeerHost::new(Some("build.example.org"), true)));
 }
 

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_matches.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_matches.rs
@@ -2,8 +2,8 @@
 fn module_definition_hostname_wildcard_matches() {
     let module = module_with_host_patterns(&["build?.example.*"], &[]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    assert!(module.permits(peer, Some("build1.example.net")));
-    assert!(module.permits(peer, Some("builda.example.org")));
-    assert!(!module.permits(peer, Some("build12.example.net")));
+    assert!(module.permits(peer, PeerHost::new(Some("build1.example.net"), true)));
+    assert!(module.permits(peer, PeerHost::new(Some("builda.example.org"), true)));
+    assert!(!module.permits(peer, PeerHost::new(Some("build12.example.net"), true)));
 }
 

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_treats_question_as_single_character.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_treats_question_as_single_character.rs
@@ -2,8 +2,8 @@
 fn module_definition_hostname_wildcard_treats_question_as_single_character() {
     let module = module_with_host_patterns(&["app??.example.com"], &[]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    assert!(module.permits(peer, Some("app12.example.com")));
-    assert!(!module.permits(peer, Some("app1.example.com")));
-    assert!(!module.permits(peer, Some("app123.example.com")));
+    assert!(module.permits(peer, PeerHost::new(Some("app12.example.com"), true)));
+    assert!(!module.permits(peer, PeerHost::new(Some("app1.example.com"), true)));
+    assert!(!module.permits(peer, PeerHost::new(Some("app123.example.com"), true)));
 }
 

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
@@ -6,14 +6,14 @@ fn module_definition_ipv4_allow_short_circuits_deny() {
     // overlapping deny rule would otherwise match.
     let module = module_with_host_patterns(&["192.168.0.0/16"], &["192.168.1.0/24"]);
     // In the allowed subnet and outside the deny subnet - permitted by allow.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), PeerHost::new(None, true)));
     // In both the allowed and denied subnets - allow short-circuits the
     // deny rule, matching upstream.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), PeerHost::new(None, true)));
     // Outside both the allowed and denied subnets - admitted because
     // access.c:287 only refuses on a deny-list match; otherwise
     // access.c:291 falls through to "Allow all other access". The
     // allow-list non-match short-circuits to refuse only when the deny
     // list is empty (access.c:281-282).
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_matches_exact.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_matches_exact.rs
@@ -3,6 +3,6 @@ fn module_definition_ipv4_allow_matches_exact() {
     let module = module_with_host_patterns(&["192.168.1.1"], &[]);
     let allowed = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
     let denied = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2));
-    assert!(module.permits(allowed, None));
-    assert!(!module.permits(denied, None));
+    assert!(module.permits(allowed, PeerHost::new(None, true)));
+    assert!(!module.permits(denied, PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_24_boundary.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_24_boundary.rs
@@ -2,9 +2,9 @@
 fn module_definition_ipv4_cidr_24_boundary() {
     let module = module_with_host_patterns(&["192.168.1.0/24"], &[]);
     // First and last address in /24.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 0)), None));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 0)), PeerHost::new(None, true)));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255)), PeerHost::new(None, true)));
     // One address outside the /24 boundary on each side.
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 255)), None));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 0)), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 255)), PeerHost::new(None, true)));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 0)), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_allow_matches_subnet.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_allow_matches_subnet.rs
@@ -1,8 +1,8 @@
 #[test]
 fn module_definition_ipv4_cidr_allow_matches_subnet() {
     let module = module_with_host_patterns(&["10.0.0.0/8"], &[]);
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 255, 255, 255)), None));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(11, 0, 0, 1)), None));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), PeerHost::new(None, true)));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 255, 255, 255)), PeerHost::new(None, true)));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(11, 0, 0, 1)), PeerHost::new(None, true)));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_blocks_matching_ip.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_blocks_matching_ip.rs
@@ -3,6 +3,6 @@ fn module_definition_ipv4_deny_blocks_matching_ip() {
     let module = module_with_host_patterns(&[], &["192.168.1.100"]);
     let blocked = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100));
     let allowed = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 101));
-    assert!(!module.permits(blocked, None));
-    assert!(module.permits(allowed, None));
+    assert!(!module.permits(blocked, PeerHost::new(None, true)));
+    assert!(module.permits(allowed, PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_cidr_blocks_subnet.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_cidr_blocks_subnet.rs
@@ -1,8 +1,8 @@
 #[test]
 fn module_definition_ipv4_deny_cidr_blocks_subnet() {
     let module = module_with_host_patterns(&[], &["172.16.0.0/12"]);
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)), None));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(172, 31, 255, 254)), None));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(172, 32, 0, 1)), None));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)), PeerHost::new(None, true)));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(172, 31, 255, 254)), PeerHost::new(None, true)));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(172, 32, 0, 1)), PeerHost::new(None, true)));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv6_allow_matches_exact.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv6_allow_matches_exact.rs
@@ -1,8 +1,8 @@
 #[test]
 fn module_definition_ipv6_allow_matches_exact() {
     let module = module_with_host_patterns(&["::1"], &[]);
-    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), None));
-    assert!(!module.permits(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)), None));
+    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), PeerHost::new(None, true)));
+    assert!(!module.permits(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)), PeerHost::new(None, true)));
     // IPv4 peer does not match an IPv6 allow rule.
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::LOCALHOST), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::LOCALHOST), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv6_cidr_allow_matches_prefix.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv6_cidr_allow_matches_prefix.rs
@@ -2,15 +2,9 @@
 fn module_definition_ipv6_cidr_allow_matches_prefix() {
     let module = module_with_host_patterns(&["fd00::/8"], &[]);
     assert!(module.permits(
-        IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)),
-        None,
-    ));
+        IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)), PeerHost::new(None, true)));
     assert!(module.permits(
-        IpAddr::V6(Ipv6Addr::new(0xfdff, 0xffff, 0, 0, 0, 0, 0, 1)),
-        None,
-    ));
+        IpAddr::V6(Ipv6Addr::new(0xfdff, 0xffff, 0, 0, 0, 0, 0, 1)), PeerHost::new(None, true)));
     assert!(!module.permits(
-        IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
-        None,
-    ));
+        IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs
@@ -10,20 +10,16 @@ fn module_definition_mixed_ip_and_hostname_acl() {
         &["192.168.1.99"],
     );
     // IP in allowed range, not in deny list - permitted by allow.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), PeerHost::new(None, true)));
     // IP in allowed range and also in deny list - the allow match short-
     // circuits the deny check, matching upstream `allow_access`.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 99)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 99)), PeerHost::new(None, true)));
     // IP outside allowed range but hostname matches allow pattern - allow.
     assert!(module.permits(
-        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)),
-        Some("build.trusted.org"),
-    ));
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), PeerHost::new(Some("build.trusted.org"), true)));
     // IP outside allowed range, hostname not in allow, IP not in deny -
     // fall-through after a non-matching allow list with a non-empty deny
     // list admits the peer per upstream access.c:290.
     assert!(module.permits(
-        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)),
-        Some("build.untrusted.org"),
-    ));
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), PeerHost::new(Some("build.untrusted.org"), true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_only_allow_denies_non_matching.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_only_allow_denies_non_matching.rs
@@ -3,7 +3,7 @@ fn module_definition_only_allow_denies_non_matching() {
     // upstream: access.c - when only hosts_allow is set, anything not allowed
     // is denied.
     let module = module_with_host_patterns(&["192.168.1.0/24"], &[]);
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), None));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), None));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), PeerHost::new(None, true)));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), PeerHost::new(None, true)));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_only_deny_allows_non_matching.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_only_deny_allows_non_matching.rs
@@ -3,7 +3,7 @@ fn module_definition_only_deny_allows_non_matching() {
     // upstream: access.c - when only hosts_deny is set, anything not denied
     // is allowed.
     let module = module_with_host_patterns(&[], &["10.0.0.0/8"]);
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)), None));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), None));
-    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)), PeerHost::new(None, true)));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), PeerHost::new(None, true)));
+    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_wildcard_any_allows_all.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_wildcard_any_allows_all.rs
@@ -1,7 +1,7 @@
 #[test]
 fn module_definition_wildcard_any_allows_all() {
     let module = module_with_host_patterns(&["*"], &[]);
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), None));
-    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), None));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::LOCALHOST), Some("anything.example.com")));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), PeerHost::new(None, true)));
+    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), PeerHost::new(None, true)));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::LOCALHOST), PeerHost::new(Some("anything.example.com"), true)));
 }

--- a/crates/daemon/src/tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs
@@ -56,7 +56,7 @@ fn module_hostname_allow_fails_closed_under_chroot() {
     // hostname-only `hosts allow` list. The peer is refused even though
     // its IP is not explicitly denied.
     assert!(
-        !module.permits(peer, resolved),
+        !module.permits(peer, PeerHost::new(resolved, true)),
         "hostname-pattern `hosts allow` rule must refuse peers whose \
          reverse DNS fails under chroot (GHSA-rjfm-3w2m-jf4f Scenario B)"
     );
@@ -76,7 +76,7 @@ fn module_hostname_allow_fails_closed_under_chroot() {
         "override must surface the configured hostname for the positive case"
     );
     assert!(
-        module.permits(peer, resolved),
+        module.permits(peer, PeerHost::new(resolved, true)),
         "matching hostname must be admitted; the prior refusal is from \
          the DNS failure, not a pattern mismatch"
     );

--- a/crates/daemon/src/tests/chunks/module_hostname_allow_forward_resolve_failure_fails_closed.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_allow_forward_resolve_failure_fails_closed.rs
@@ -19,7 +19,7 @@ fn module_hostname_allow_forward_resolve_failure_fails_closed() {
     // No forward override is registered, so the token "does not resolve" and
     // the resolver returns an empty address set.
     assert!(
-        !module.permits(peer, None),
+        !module.permits(peer, PeerHost::new(None, true)),
         "an unresolvable hostname allow token must fail closed (deny)"
     );
 

--- a/crates/daemon/src/tests/chunks/module_hostname_allow_forward_resolve_non_matching_denies.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_allow_forward_resolve_non_matching_denies.rs
@@ -22,7 +22,7 @@ fn module_hostname_allow_forward_resolve_non_matching_denies() {
     );
 
     assert!(
-        !module.permits(peer, None),
+        !module.permits(peer, PeerHost::new(None, true)),
         "a hostname allow token resolving to a different address must not \
          admit an unrelated peer"
     );

--- a/crates/daemon/src/tests/chunks/module_hostname_allow_forward_resolves_token_to_peer.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_allow_forward_resolves_token_to_peer.rs
@@ -23,7 +23,7 @@ fn module_hostname_allow_forward_resolves_token_to_peer() {
     set_test_forward_override("trusted.example.com", &[peer]);
 
     assert!(
-        module.permits(peer, None),
+        module.permits(peer, PeerHost::new(None, true)),
         "a hostname allow token forward-resolving to the peer must admit it"
     );
 

--- a/crates/daemon/src/tests/chunks/module_hostname_allow_netgroup_admits_member.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_allow_netgroup_admits_member.rs
@@ -18,7 +18,7 @@ fn module_hostname_allow_netgroup_admits_member() {
     set_test_netgroup_members("trusted", &["client.example.com"]);
 
     assert!(
-        module.permits(peer, Some("client.example.com")),
+        module.permits(peer, PeerHost::new(Some("client.example.com"), true)),
         "a client whose hostname is a member of the @netgroup allow rule must be admitted"
     );
 

--- a/crates/daemon/src/tests/chunks/module_hostname_deny_fails_closed_when_dns_unresolved.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_deny_fails_closed_when_dns_unresolved.rs
@@ -45,7 +45,7 @@ fn module_hostname_deny_fails_closed_when_dns_unresolved() {
     // attacker who controls their PTR record (or simply blackholes reverse
     // DNS) cannot dodge the deny list.
     assert!(
-        !module.permits(peer, resolved),
+        !module.permits(peer, PeerHost::new(resolved, true)),
         "hostname-pattern deny rule must reject peers whose reverse DNS \
          fails (GHSA-rjfm-3w2m-jf4f)"
     );

--- a/crates/daemon/src/tests/chunks/module_hostname_deny_forward_resolves_token_to_peer.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_deny_forward_resolves_token_to_peer.rs
@@ -24,7 +24,7 @@ fn module_hostname_deny_forward_resolves_token_to_peer() {
 
     set_test_forward_override("blocked.example.com", &[peer]);
     assert!(
-        !module.permits(peer, reverse),
+        !module.permits(peer, PeerHost::new(reverse, true)),
         "a deny token forward-resolving to the peer must reject it"
     );
 
@@ -35,7 +35,7 @@ fn module_hostname_deny_forward_resolves_token_to_peer() {
         &[IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9))],
     );
     assert!(
-        module.permits(peer, reverse),
+        module.permits(peer, PeerHost::new(reverse, true)),
         "a deny token resolving to a different address must not block the peer"
     );
 

--- a/crates/daemon/src/tests/chunks/module_hostname_deny_unresolvable_token_fails_closed.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_deny_unresolvable_token_fails_closed.rs
@@ -1,0 +1,68 @@
+/// An unresolvable `hosts deny` hostname token must fail CLOSED, and an
+/// unresolvable `hosts allow` token must NOT.
+///
+/// upstream: access.c:57-63 - the forward-DNS branch of `match_hostname`
+/// returns the caller's `deny` flag when `gethostbyname` returns NULL:
+///
+/// ```c
+/// if (!(hp = gethostbyname(tok))) {
+///     /* A deny-list hostname token we cannot resolve must fail CLOSED:
+///      * we can't prove the peer isn't the denied host ... */
+///     return deny;
+/// }
+/// ```
+///
+/// The flag is threaded per call - 0 for the allow list (access.c:284), 1 for
+/// the deny list (access.c:293) - so ONE branch produces opposite answers for
+/// the two lists. Sibling of CVE-2026-70452, which fixed the reverse-lookup
+/// path only. oc previously returned "no match" for both, so a `hosts deny`
+/// naming a host whose DNS was unavailable admitted every peer.
+#[test]
+fn module_hostname_deny_unresolvable_token_fails_closed() {
+    clear_test_hostname_overrides();
+    let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 14));
+    // A resolved reverse name matching no token, so the sentinel fail-closed
+    // guard stays inactive and only the forward-resolution path is under test.
+    let reverse = Some("workstation.example.net");
+
+    // THE FIX. No override for the token means the lookup FAILS, and a deny
+    // token we cannot resolve must block.
+    let deny_only = module_with_host_patterns(&[], &["unresolvable.example.com"]);
+    assert!(
+        !deny_only.permits(peer, PeerHost::new(reverse, true)),
+        "an unresolvable `hosts deny` token must refuse the peer (access.c:57-63)"
+    );
+
+    // THE ASYMMETRY, and the reason `deny` is a parameter rather than a global
+    // rule: the identical unresolvable token on the ALLOW side must still not
+    // match. A fix that returned `true` from the failure branch unconditionally
+    // would admit every peer here and pass the assertion above.
+    let allow_only = module_with_host_patterns(&["unresolvable.example.com"], &[]);
+    assert!(
+        !allow_only.permits(peer, PeerHost::new(reverse, true)),
+        "an unresolvable `hosts allow` token must still not admit the peer"
+    );
+
+    // CONTROL: a deny token that DOES resolve, to some other address, must not
+    // block. Without this the whole table is satisfied by a build that refuses
+    // everything, which is the failure mode a fail-closed change invites.
+    clear_test_hostname_overrides();
+    set_test_forward_override(
+        "unresolvable.example.com",
+        &[IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9))],
+    );
+    assert!(
+        deny_only.permits(peer, PeerHost::new(reverse, true)),
+        "a deny token resolving elsewhere must leave the peer permitted"
+    );
+
+    // CONTROL: a deny token resolving TO the peer still blocks, so the
+    // successful-lookup arm is not collateral damage from the fix.
+    set_test_forward_override("unresolvable.example.com", &[peer]);
+    assert!(
+        !deny_only.permits(peer, PeerHost::new(reverse, true)),
+        "a deny token resolving to the peer must still block it"
+    );
+
+    clear_test_hostname_overrides();
+}

--- a/crates/daemon/src/tests/chunks/module_hostname_forward_lookup_off_skips_token_resolution.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_forward_lookup_off_skips_token_resolution.rs
@@ -23,7 +23,7 @@ fn module_hostname_forward_lookup_off_skips_token_resolution() {
     set_test_forward_override("trusted.example.com", &[peer]);
 
     assert!(
-        !module.permits(peer, None),
+        !module.permits(peer, PeerHost::new(None, true)),
         "forward lookup = no must skip forward resolution of hostname tokens"
     );
 
@@ -31,7 +31,7 @@ fn module_hostname_forward_lookup_off_skips_token_resolution() {
     // peer, confirming the deny above is due to the disabled parameter alone.
     let enabled = module_with_host_patterns(&["trusted.example.com"], &[]);
     assert!(
-        enabled.permits(peer, None),
+        enabled.permits(peer, PeerHost::new(None, true)),
         "forward lookup = yes (default) must admit via the same token"
     );
 

--- a/crates/daemon/src/tests/chunks/module_hostname_netgroup_deny_blocks_member.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_netgroup_deny_blocks_member.rs
@@ -16,11 +16,11 @@ fn module_hostname_netgroup_deny_blocks_member() {
     set_test_netgroup_members("blocked", &["bad.example.com"]);
 
     assert!(
-        !module.permits(peer, Some("bad.example.com")),
+        !module.permits(peer, PeerHost::new(Some("bad.example.com"), true)),
         "a member of the @netgroup deny rule must be blocked"
     );
     assert!(
-        module.permits(peer, Some("good.example.com")),
+        module.permits(peer, PeerHost::new(Some("good.example.com"), true)),
         "a non-member must not be caught by the @netgroup deny rule"
     );
 

--- a/crates/daemon/src/tests/chunks/module_hostname_netgroup_deny_fails_closed_without_hostname.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_netgroup_deny_fails_closed_without_hostname.rs
@@ -18,7 +18,7 @@ fn module_hostname_netgroup_deny_fails_closed_without_hostname() {
     let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 23));
 
     assert!(
-        !module.permits(peer, None),
+        !module.permits(peer, PeerHost::new(None, true)),
         "an @netgroup deny rule must fail closed when the peer has no resolved hostname"
     );
 

--- a/crates/daemon/src/tests/chunks/module_hostname_netgroup_non_member_falls_through.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_netgroup_non_member_falls_through.rs
@@ -20,7 +20,7 @@ fn module_hostname_netgroup_non_member_falls_through() {
     // musl/Windows no-op resolver that always reports no membership.
 
     assert!(
-        !module.permits(peer, Some("stranger.example.com")),
+        !module.permits(peer, PeerHost::new(Some("stranger.example.com"), true)),
         "a non-member (or the no-op netgroup platform) must not satisfy an @netgroup allow rule"
     );
 

--- a/crates/daemon/src/tests/chunks/module_hostname_wildcard_token_not_forward_resolved.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_wildcard_token_not_forward_resolved.rs
@@ -20,13 +20,13 @@ fn module_hostname_wildcard_token_not_forward_resolved() {
     // refused.
     set_test_forward_override("*.trusted.example.com", &[peer]);
     assert!(
-        !module.permits(peer, None),
+        !module.permits(peer, PeerHost::new(None, true)),
         "a wildcarded token must not be forward-resolved"
     );
 
     // The wildcard still matches a reverse-DNS name the normal way.
     assert!(
-        module.permits(peer, Some("node.trusted.example.com")),
+        module.permits(peer, PeerHost::new(Some("node.trusted.example.com"), true)),
         "a wildcarded token must still match a reverse-DNS name"
     );
 

--- a/crates/daemon/src/tests/chunks/module_ip_deny_unaffected_by_dns_failure.rs
+++ b/crates/daemon/src/tests/chunks/module_ip_deny_unaffected_by_dns_failure.rs
@@ -21,7 +21,7 @@ fn module_ip_deny_unaffected_by_dns_failure() {
 
     // Denied peer is still denied (IP rule matches regardless of hostname).
     assert!(
-        !module.permits(denied_peer, None),
+        !module.permits(denied_peer, PeerHost::new(None, true)),
         "IP-pattern deny rule must continue to match the peer IP even when \
          reverse DNS fails"
     );
@@ -30,7 +30,7 @@ fn module_ip_deny_unaffected_by_dns_failure() {
     // GHSA-rjfm-3w2m-jf4f only activates when at least one deny rule is
     // hostname-based; pure IP-rule modules retain their original semantics.
     assert!(
-        module.permits(allowed_peer, None),
+        module.permits(allowed_peer, PeerHost::new(None, true)),
         "IP-only deny rule must not fail closed on unresolved DNS for peers \
          outside the denied range"
     );

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_forward_confirm_rejects_spoofed_ptr.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_forward_confirm_rejects_spoofed_ptr.rs
@@ -29,7 +29,7 @@ fn module_peer_hostname_forward_confirm_rejects_spoofed_ptr() {
         "a PTR name that does not forward-resolve to the peer must be rejected"
     );
     assert!(
-        !module.permits(peer, resolved),
+        !module.permits(peer, PeerHost::new(resolved, true)),
         "spoofed PTR must not satisfy a hostname `hosts allow` rule"
     );
 
@@ -39,7 +39,7 @@ fn module_peer_hostname_forward_confirm_rejects_spoofed_ptr() {
     set_test_forward_override("trusted.example.com", &[peer]);
     let resolved = module_peer_hostname(&module, &mut cache, peer, true);
     assert_eq!(resolved, Some("trusted.example.com"));
-    assert!(module.permits(peer, resolved));
+    assert!(module.permits(peer, PeerHost::new(resolved, true)));
 
     clear_test_hostname_overrides();
 }

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_forward_lookup_off_restores_ptr_only.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_forward_lookup_off_restores_ptr_only.rs
@@ -30,7 +30,7 @@ fn module_peer_hostname_forward_lookup_off_restores_ptr_only() {
         Some("trusted.example.com"),
         "forward lookup = no must trust the PTR name without confirmation"
     );
-    assert!(module.permits(peer, resolved));
+    assert!(module.permits(peer, PeerHost::new(resolved, true)));
 
     clear_test_hostname_overrides();
 }

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_missing_resolution_denies_hostname_only_rules.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_missing_resolution_denies_hostname_only_rules.rs
@@ -8,6 +8,6 @@ fn module_peer_hostname_missing_resolution_denies_hostname_only_rules() {
     if let Some(host) = resolved {
         assert_ne!(host, "trusted.example.com");
     }
-    assert!(!module.permits(peer, resolved));
+    assert!(!module.permits(peer, PeerHost::new(resolved, true)));
 }
 

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_resolution_before_chroot_denies_unknown.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_resolution_before_chroot_denies_unknown.rs
@@ -46,7 +46,7 @@ fn module_peer_hostname_resolution_before_chroot_denies_unknown() {
     // The critical security property: with no resolved hostname, the
     // hostname-only allow rule cannot match, so access must be denied.
     assert!(
-        !module.permits(peer, resolved),
+        !module.permits(peer, PeerHost::new(resolved, true)),
         "module must deny access when hostname resolution fails and only \
          hostname-based allow rules are configured (CVE-2026-43617)"
     );

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_skips_lookup_when_disabled.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_skips_lookup_when_disabled.rs
@@ -7,7 +7,7 @@ fn module_peer_hostname_skips_lookup_when_disabled() {
     let mut cache = None;
     let resolved = module_peer_hostname(&module, &mut cache, peer, false);
     assert!(resolved.is_none());
-    assert!(!module.permits(peer, resolved));
+    assert!(!module.permits(peer, PeerHost::new(resolved, true)));
     clear_test_hostname_overrides();
 }
 

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_uses_override.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_uses_override.rs
@@ -10,7 +10,7 @@ fn module_peer_hostname_uses_override() {
     let mut cache = None;
     let resolved = module_peer_hostname(&module, &mut cache, peer, true);
     assert_eq!(resolved, Some("trusted.example.com"));
-    assert!(module.permits(peer, resolved));
+    assert!(module.permits(peer, PeerHost::new(resolved, true)));
     clear_test_hostname_overrides();
 }
 

--- a/crates/daemon/src/tests/chunks/runtime_options_module_definition_parses_inline_options.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_module_definition_parses_inline_options.rs
@@ -19,9 +19,7 @@ fn runtime_options_module_definition_parses_inline_options() {
     assert!(module.numeric_ids());
     assert!(!module.use_chroot());
     assert!(module.permits(
-        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 42)),
-        Some("host.example")
-    ));
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 42)), PeerHost::new(Some("host.example"), true)));
     assert_eq!(module.auth_users().len(), 2);
     assert_eq!(module.auth_users()[0].username, "alice");
     assert_eq!(module.auth_users()[1].username, "bob");

--- a/tests/daemon_hosts_allow_sentinel.rs
+++ b/tests/daemon_hosts_allow_sentinel.rs
@@ -1,0 +1,232 @@
+//! `hosts allow = UNKNOWN` / `UNDETERMINED` must match, as upstream documents.
+//!
+//! ```c
+//! /* clientname.c:91-94 - the sentinel is a documented affordance, not an
+//!    internal placeholder. */
+//! /* If anything goes wrong, including the name->addr->name check, then
+//!  * we just use "UNKNOWN", so you can use that value in hosts allow
+//!  * lines. */
+//! ```
+//!
+//! Upstream hands `allow_access()` the same never-empty host string its log
+//! lines print (clientserver.c:769-773), and `match_hostname` refuses only a
+//! NULL or empty name (access.c:37-38) - so a sentinel is matched like any
+//! other name. oc modelled the host as `Option<&str>` and passed `None`, making
+//! both sentinels unmatchable: `hosts allow = UNDETERMINED` refused every peer.
+//!
+//! TWO defects, and the first alone was INERT:
+//!
+//! 1. the sentinel never reached the matcher; and
+//! 2. `HostnamePattern::matches` compared case-SENSITIVELY against a pattern
+//!    lowercased at parse time. That held only because every host until now
+//!    arrived pre-lowercased from DNS. Upstream's matcher is `iwildmatch`, the
+//!    case-insensitive form (access.c:46), against a list lowercased by
+//!    `strlower` (access.c:251) - so `unknown` matches `UNKNOWN` upstream.
+//!
+//! Fixing only (1) left every row below still failing, which is why the table
+//! asserts the OUTCOME of a real connection rather than the shape of the call.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Loopback TCP is unavailable.
+//! - The cross-implementation cells additionally need a built upstream 3.5.0
+//!   binary; without it they report why they did not run.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn upstream_binary() -> Option<PathBuf> {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("target/interop/upstream-src/rsync-3.5.0/rsync");
+    path.is_file().then_some(path)
+}
+
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+/// One row of the access-control table.
+struct Case {
+    /// `hosts allow` value.
+    allow: &'static str,
+    /// `reverse lookup` value: "no" leaves the host `UNDETERMINED`; "yes"
+    /// resolves loopback to a real name on every platform CI runs.
+    reverse_lookup: &'static str,
+    /// Whether the peer must be admitted.
+    admitted: bool,
+    /// Why this row is in the table.
+    why: &'static str,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        allow: "UNDETERMINED",
+        reverse_lookup: "no",
+        admitted: true,
+        why: "the sentinel upstream documents as usable in a hosts allow line",
+    },
+    Case {
+        allow: "undetermined",
+        reverse_lookup: "no",
+        admitted: true,
+        why: "upstream lowercases the LIST and matches case-insensitively",
+    },
+    Case {
+        allow: "UNDETER*",
+        reverse_lookup: "no",
+        admitted: true,
+        why: "the wildcard arm folds case too, not just the exact arm",
+    },
+    // CONTROL: the fix must not admit everyone. A non-matching hostname rule
+    // still refuses - without this row, "always allow" would pass every row
+    // above.
+    Case {
+        allow: "other.example",
+        reverse_lookup: "no",
+        admitted: false,
+        why: "CONTROL: an unrelated hostname rule must still refuse",
+    },
+    // CONTROL: address rules are untouched. Without this row, "the hosts allow
+    // directive is being ignored entirely" would also produce a refusal above
+    // and look like a pass.
+    Case {
+        allow: "127.0.0.1",
+        reverse_lookup: "no",
+        admitted: true,
+        why: "CONTROL: an address rule still admits, so the directive is live",
+    },
+    // THE DISCRIMINATOR. When a name IS found, the sentinel must NOT match:
+    // a build that matched the sentinel unconditionally would pass every row
+    // above and fail only this one.
+    Case {
+        allow: "UNDETERMINED",
+        reverse_lookup: "yes",
+        admitted: false,
+        why: "a resolved peer is not UNDETERMINED, so the sentinel must not match",
+    },
+];
+
+struct Fixture {
+    root: tempfile::TempDir,
+    port: u16,
+}
+
+impl Fixture {
+    fn new(allow: &str, reverse_lookup: &str) -> Option<Self> {
+        let root = tempfile::tempdir().expect("temp dir");
+        let port = free_port()?;
+        fs::create_dir_all(root.path().join("mod")).expect("module dir");
+        fs::write(root.path().join("mod/f.txt"), b"hello\n").expect("module file");
+        let conf = format!(
+            "port = {port}\n\
+             use chroot = no\n\
+             log file = {log}\n\
+             reverse lookup = {reverse_lookup}\n\
+             hosts allow = {allow}\n\
+             \n\
+             [m]\n\
+             \tpath = {module}\n\
+             \tread only = yes\n",
+            log = root.path().join("daemon.log").display(),
+            module = root.path().join("mod").display(),
+        );
+        fs::write(root.path().join("rsyncd.conf"), conf).expect("config");
+        Some(Self { root, port })
+    }
+
+    fn conf(&self) -> PathBuf {
+        self.root.path().join("rsyncd.conf")
+    }
+
+    /// Runs one loopback pull and reports whether the peer was admitted.
+    fn admitted(&self, daemon_bin: &Path, client_bin: &Path) -> bool {
+        let mut daemon = spawn_daemon(daemon_bin, &self.conf(), self.port);
+        let dest = self.root.path().join("dest.txt");
+        let status = Command::new(client_bin)
+            .args([
+                "-q",
+                &format!("rsync://127.0.0.1:{}/m/f.txt", self.port),
+                &dest.display().to_string(),
+            ])
+            .status()
+            .expect("run client");
+        let _ = daemon.kill();
+        let _ = daemon.wait();
+        status.success() && dest.is_file()
+    }
+}
+
+/// Starts a daemon and waits until its port answers.
+///
+/// `stdin` is `/dev/null` deliberately: with an inherited terminal or pipe the
+/// daemon takes its single-connection path and never listens, and every row
+/// then reports "connection refused" - identical output for rows that must
+/// differ. That is a broken instrument, not a result.
+fn spawn_daemon(binary: &Path, conf: &Path, port: u16) -> Child {
+    let child = Command::new(binary)
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return child;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    child
+}
+
+fn assert_table(binary: &Path, label: &str) {
+    for case in CASES {
+        let Some(fixture) = Fixture::new(case.allow, case.reverse_lookup) else {
+            println!("SKIP: no loopback port available");
+            return;
+        };
+        let admitted = fixture.admitted(binary, binary);
+        assert_eq!(
+            admitted,
+            case.admitted,
+            "{label}: `hosts allow = {}` with `reverse lookup = {}` must {} - {}",
+            case.allow,
+            case.reverse_lookup,
+            if case.admitted { "ADMIT" } else { "REFUSE" },
+            case.why
+        );
+    }
+}
+
+#[test]
+fn oc_matches_the_host_sentinels_in_hosts_allow() {
+    assert_table(&oc_binary(), "oc");
+}
+
+/// CROSS-IMPLEMENTATION: the expected column is upstream's behaviour, so assert
+/// it against upstream rather than trusting the transcription.
+#[test]
+fn upstream_matches_the_host_sentinels_in_hosts_allow() {
+    let Some(upstream) = upstream_binary() else {
+        println!(
+            "SKIP: upstream 3.5.0 oracle not built \
+             (target/interop/upstream-src/rsync-3.5.0/rsync)"
+        );
+        return;
+    };
+    assert_table(&upstream, "upstream 3.5.0");
+}

--- a/tests/daemon_log_host_rendering.rs
+++ b/tests/daemon_log_host_rendering.rs
@@ -1,0 +1,277 @@
+//! The daemon's peer-host rendering must reproduce upstream's two sentinels.
+//!
+//! Upstream keeps ONE host string per connection and renders it everywhere the
+//! peer is named - the `%h` log escape, `RSYNC_HOST_NAME`, and the
+//! `connect from` / `rsync allowed access` / `rsync denied` lines:
+//!
+//! ```c
+//! /* clientserver.c:1524-1526 */
+//! addr = client_addr(f_in);
+//! host = lp_reverse_lookup(-1) ? client_name(addr) : undetermined_hostname;
+//! rprintf(FLOG, "connect from %s (%s)\n", host, addr);
+//! /* clientserver.c:770-771 */
+//! set_env_str("RSYNC_HOST_NAME", host);
+//! set_env_str("RSYNC_HOST_ADDR", addr);
+//! ```
+//!
+//! and that string is never empty: it is `UNDETERMINED` (clientserver.c:126)
+//! when reverse lookup is off, and `UNKNOWN` (clientname.c:34) when a lookup
+//! was attempted and produced nothing.
+//!
+//! oc had THREE disagreeing fallbacks for the same missing name - a lowercase
+//! `unknown` in the log format, the bare peer IP in the access lines, and an
+//! empty string in `RSYNC_HOST_NAME` - so a single session could print
+//! `rsync allowed access on module m from 127.0.0.1 (127.0.0.1)` immediately
+//! above `h=[unknown]`. This is the class test for that: one rule, rendered
+//! identically wherever the peer is named.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Loopback TCP is unavailable.
+//! - The cross-implementation cell additionally needs a built upstream 3.5.0
+//!   binary; without it that cell reports why it did not run.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// A log format naming every field this test reasons about, so one line
+/// carries the whole comparison.
+const PROBE_FORMAT: &str = "PROBE h=[%h] a=[%a] m=[%m]";
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Locates the built upstream 3.5.0 oracle, or `None` when the interop tree has
+/// not been fetched and built. The cross-implementation cell degrades to a
+/// printed skip rather than a silent pass.
+fn upstream_binary() -> Option<PathBuf> {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("target/interop/upstream-src/rsync-3.5.0/rsync");
+    path.is_file().then_some(path)
+}
+
+/// Claims a loopback port by binding and immediately dropping the listener.
+///
+/// The daemon binds the same port a moment later. A collision would surface as
+/// a failure to serve, which the assertions below report - it cannot turn into
+/// a false pass, because every assertion needs a log line the daemon writes.
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+struct Fixture {
+    root: tempfile::TempDir,
+    port: u16,
+}
+
+impl Fixture {
+    fn new(reverse_lookup: &str) -> Option<Self> {
+        let root = tempfile::tempdir().expect("temp dir");
+        let port = free_port()?;
+        fs::create_dir_all(root.path().join("mod")).expect("module dir");
+        fs::write(root.path().join("mod/f.txt"), b"hello\n").expect("module file");
+        let conf = format!(
+            "port = {port}\n\
+             use chroot = no\n\
+             log file = {log}\n\
+             reverse lookup = {reverse_lookup}\n\
+             \n\
+             [m]\n\
+             \tpath = {module}\n\
+             \tread only = yes\n\
+             \ttransfer logging = yes\n\
+             \tlog format = {PROBE_FORMAT}\n",
+            log = root.path().join("daemon.log").display(),
+            module = root.path().join("mod").display(),
+        );
+        fs::write(root.path().join("rsyncd.conf"), conf).expect("config");
+        Some(Self { root, port })
+    }
+
+    fn conf(&self) -> PathBuf {
+        self.root.path().join("rsyncd.conf")
+    }
+
+    fn log(&self) -> PathBuf {
+        self.root.path().join("daemon.log")
+    }
+
+    /// Runs one loopback pull against `daemon_bin` and returns the daemon log.
+    fn run(&self, daemon_bin: &Path, client_bin: &Path) -> String {
+        let mut daemon = spawn_daemon(daemon_bin, &self.conf());
+        let dest = self.root.path().join("dest.txt");
+        let status = Command::new(client_bin)
+            .args([
+                "-q",
+                &format!("rsync://127.0.0.1:{}/m/f.txt", self.port),
+                &dest.display().to_string(),
+            ])
+            .status()
+            .expect("run client");
+        let _ = daemon.kill();
+        let _ = daemon.wait();
+        assert!(status.success(), "pull failed against {daemon_bin:?}");
+        fs::read_to_string(self.log()).expect("read daemon log")
+    }
+}
+
+/// Starts a daemon and waits until its port answers, so the client never races
+/// the listener.
+fn spawn_daemon(binary: &Path, conf: &Path) -> Child {
+    let child = Command::new(binary)
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let port: u16 = fs::read_to_string(conf)
+        .expect("read config")
+        .lines()
+        .find_map(|line| line.strip_prefix("port = ")?.trim().parse().ok())
+        .expect("port directive");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return child;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    child
+}
+
+/// Extracts the single `PROBE ...` line the module's `log format` produced.
+fn probe_line(log: &str) -> String {
+    log.lines()
+        .find(|line| line.contains("PROBE "))
+        .map(|line| {
+            let start = line.find("PROBE ").expect("PROBE marker");
+            line[start..].to_owned()
+        })
+        .unwrap_or_else(|| panic!("no PROBE line in daemon log:\n{log}"))
+}
+
+/// Extracts the `rsync allowed access ... from <host> (<addr>)` line body.
+fn access_line(log: &str) -> String {
+    log.lines()
+        .find(|line| line.contains("rsync allowed access on module"))
+        .map(|line| {
+            let start = line
+                .find("rsync allowed access")
+                .expect("allowed-access marker");
+            line[start..].to_owned()
+        })
+        .unwrap_or_else(|| panic!("no allowed-access line in daemon log:\n{log}"))
+}
+
+/// With `reverse lookup = no` no name is ever sought, so upstream reports
+/// `UNDETERMINED` - not a lowercase `unknown`, and not the address.
+///
+/// upstream: clientserver.c:126 + :1525.
+#[test]
+fn reverse_lookup_off_renders_undetermined_everywhere() {
+    let Some(fixture) = Fixture::new("no") else {
+        println!("SKIP: no loopback port available");
+        return;
+    };
+    let oc = oc_binary();
+    let log = fixture.run(&oc, &oc);
+
+    let probe = probe_line(&log);
+    assert!(
+        probe.contains("h=[UNDETERMINED]"),
+        "%h must be upstream's no-lookup sentinel, got: {probe}"
+    );
+    assert!(
+        probe.contains("a=[127.0.0.1]"),
+        "%a must be the real peer address, got: {probe}"
+    );
+
+    // The access line names the peer with the SAME string. oc used to print the
+    // bare IP here while printing `unknown` in the line above.
+    let access = access_line(&log);
+    assert!(
+        access.contains("from UNDETERMINED (127.0.0.1)"),
+        "the access line must reuse the host string, got: {access}"
+    );
+}
+
+/// With reverse lookup ON, a loopback peer resolves on every platform CI runs,
+/// so `%h` carries a real name and `%a` the address.
+///
+/// This is the over-correction guard: a build that always emitted a sentinel
+/// would pass the test above and fail here.
+///
+/// ⚠ It does NOT discriminate on the fix itself: a resolvable peer produced a
+/// name before the change too, so this case passes on a pre-fix build. It is
+/// kept only to stop the fix being "print a sentinel unconditionally", which
+/// nothing else in the file would catch. Measured: with the pre-fix lowercase
+/// fallback restored, the other two cases fail and this one still passes.
+#[test]
+fn reverse_lookup_on_renders_a_resolved_name() {
+    let Some(fixture) = Fixture::new("yes") else {
+        println!("SKIP: no loopback port available");
+        return;
+    };
+    let oc = oc_binary();
+    let log = fixture.run(&oc, &oc);
+
+    let probe = probe_line(&log);
+    assert!(
+        probe.contains("a=[127.0.0.1]"),
+        "%a must be the real peer address, got: {probe}"
+    );
+    assert!(
+        !probe.contains("h=[UNDETERMINED]"),
+        "a resolvable peer must not report the no-lookup sentinel: {probe}"
+    );
+    assert!(
+        !probe.contains("h=[unknown]"),
+        "the lowercase oc-only fallback must be gone: {probe}"
+    );
+}
+
+/// CROSS-IMPLEMENTATION: the same config served by the real 3.5.0 binary must
+/// produce the same `%h` / `%a` rendering.
+///
+/// This is what makes the sentinels evidence rather than a guess - the strings
+/// `UNDETERMINED` and `UNKNOWN` come from the oracle, not from oc's own source.
+#[test]
+fn host_rendering_matches_the_real_upstream_daemon() {
+    let Some(upstream) = upstream_binary() else {
+        println!(
+            "SKIP: upstream 3.5.0 oracle not built \
+             (target/interop/upstream-src/rsync-3.5.0/rsync)"
+        );
+        return;
+    };
+    let oc = oc_binary();
+
+    for reverse_lookup in ["yes", "no"] {
+        let Some(oc_fixture) = Fixture::new(reverse_lookup) else {
+            println!("SKIP: no loopback port available");
+            return;
+        };
+        let oc_probe = probe_line(&oc_fixture.run(&oc, &oc));
+
+        let Some(up_fixture) = Fixture::new(reverse_lookup) else {
+            println!("SKIP: no loopback port available");
+            return;
+        };
+        let up_probe = probe_line(&up_fixture.run(&upstream, &upstream));
+
+        assert_eq!(
+            oc_probe, up_probe,
+            "daemon log format diverges from upstream at `reverse lookup = {reverse_lookup}`"
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #7303 - the first two commits are that PR's and this one should merge after it. The four commits here are all daemon peer-host naming and ACL evaluation, and the last two are security fixes. Each commit carries its own upstream citation, measurement table and non-vacuity note.

## 1. `fix(daemon): render the peer host like upstream, not three ways`

Upstream keeps one never-empty host string and hands the same value to `%h`, `RSYNC_HOST_NAME` and `allow_access()` (`clientserver.c:769-773`), using two sentinels: `UNDETERMINED` when reverse lookup is off (`clientserver.c:126`) and `UNKNOWN` when the lookup failed (`clientname.c:34`). oc named the peer three different ways depending on the consumer.

## 2. `fix(daemon): match the host sentinels in hosts allow, as upstream does`

Upstream documents `UNKNOWN` as a value an operator may put in a `hosts allow` line (`clientname.c:91-94`); `match_hostname` refuses only a NULL or empty name (`access.c:37-38`), so a sentinel matches like any other name. Measured with `reverse lookup = no` against a loopback peer, `hosts allow = UNDETERMINED` was ALLOWED on 3.5.0 and DENIED on oc.

**Two defects, and fixing the filed one alone was inert** - the end-to-end measurement still showed DENIED on every row. The sentinel never reached the matcher *and* `HostnamePattern::matches` compared case-**sensitively** against a pattern lowercased at parse time. That held only while every host arrived pre-lowercased from DNS. Upstream lowercases the list (`strlower`, `access.c:251`) and matches with the case-**insensitive** `iwildmatch` (`access.c:46`).

## 3. `refactor(daemon): make the fail-closed deny guard compiler-enforced`

The guard that refuses a peer when a hostname-based `hosts deny` rule cannot be evaluated asked `!host.is_resolved()`. Correct today, but resting on an unenforced biconditional over the two current `PeerHost` variants - a third variant would default a state nobody considered into "allowed", at the one site where being wrong is a security regression rather than a parity one. The guard now matches the enum exhaustively and `is_resolved()` is deleted, so adding a variant is `E0004` at the guard instead of an inherited default. Verified by adding a probe variant: two `E0004`s, at the guard and at `as_str()`. Behaviour unchanged.

## 4. `fix(daemon): hosts deny fails CLOSED on an unresolvable token`

CVE-2026-70452's sibling. Upstream returns the caller's `deny` flag when the forward lookup of a configured token fails (`access.c:57-63`). oc returned "no match" for both lists, so `hosts deny = host.example` **admitted every peer** whenever that name would not resolve - a fail-open on a deny rule, reachable by making the operator's DNS unavailable.

Measured with `reverse lookup = yes` against a loopback peer:

| config | 3.5.0 | oc before |
|---|---|---|
| `hosts deny = unresolvable.example.com` | DENIED | **ALLOWED** |
| `hosts deny = 203.0.113.9` (control) | ALLOWED | ALLOWED |
| `hosts deny = 127.0.0.1` (control) | DENIED | DENIED |

**Enumerated rather than generalised.** Upstream has ONE decision site and threads a per-call flag to it - `access_match(allow_list, .., 0)` (`access.c:284`), `access_match(deny_list, .., 1)` (`:293`), and `allow_proxy_protocol_peer` (`:305`), which is allow-shaped. So `deny` is a parameter, not module state.

The fix needed a distinction oc did not have: upstream separates a **failed** lookup (`NULL` from `gethostbyname` -> return deny) from a **successful** one whose records exclude the peer (falls out of the loop -> return 0). `forward_resolve` collapsed both into an empty `Vec`, and that collapse is precisely what made the deny side fail open. It now returns `Option<Vec<IpAddr>>`.

One existing test encoded the fail-open - it asserted a second peer was admitted while the deny token was unresolvable. Corrected by giving the token a resolution, which is what that test actually meant to isolate.

## Verification

Measured on this branch (`cce83d5ae`, on top of #7303's `d6bc4bab5`):

- `cargo fmt --all -- --check` - clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - exit 0
- `cargo nextest run -p daemon --all-features` - 1768 passed, 6 skipped (2 passed on retry)
- `daemon_hosts_allow_sentinel` + `daemon_log_host_rendering` - 5 passed

Both new integration tables assert against oc **and** against the real upstream 3.5.0 binary in the same cell. Each table carries controls that a blanket "refuse everything" or "admit everything" build would fail, and the deny fix additionally pins the allow-side **asymmetry**: the identical unresolvable token on the allow side must still not admit, so a change returning true unconditionally passes the first assertion and fails this one.
