### PR TITLE
docs(citations): retarget four constructs left on 3.4.4 lines

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -656,7 +656,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
                 if let Some(window) = s.strip_prefix("-@") {
                     flags.modify_window = Some(window.to_owned());
                 }
-                // upstream: options.c:2787-2790 - block_size arrives as a
+                // upstream: options.c:2953-2954 - block_size arrives as a
                 // standalone `-B%u` token (e.g. `-B131072`) after the compact
                 // flag string. Guard on trailing digits so only the block-size
                 // spelling is consumed here, never some other `-B...` token.
@@ -946,7 +946,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--usermap=")
         || arg.starts_with("--groupmap=")
         || arg.starts_with("--skip-compress=")
-        // upstream: options.c:2787-2790 - block_size arrives as a standalone
+        // upstream: options.c:2953-2954 - block_size arrives as a standalone
         // `-B%u` token. Guard on trailing digits so only that spelling matches.
         || (arg.starts_with("-B")
             && arg.len() > 2

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -1007,7 +1007,7 @@ fn long_flags_capture_skip_compress() {
     assert_eq!(flags.skip_compress.as_deref(), Some("gz/zip/jpg"));
 }
 
-// upstream: options.c:2787-2790 - block_size is forwarded as a standalone
+// upstream: options.c:2953-2954 - block_size is forwarded as a standalone
 // `-B%u` token (e.g. `-B131072`) after the compact flag string. Without
 // recognition the token leaked into the positional list and the receiver
 // failed with `failed to create destination root -B131072` (exit 12).
@@ -1030,7 +1030,7 @@ fn block_size_is_known_and_not_positional() {
     );
 }
 
-// upstream: options.c:2787-2790 - the forwarded block-size digits are captured.
+// upstream: options.c:2953-2954 - the forwarded block-size digits are captured.
 #[test]
 fn long_flags_capture_block_size() {
     let args = vec![OsString::from("--server"), OsString::from("-B131072")];

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -408,7 +408,7 @@ pub(super) fn build_full_daemon_args(
         ));
     }
 
-    // upstream: options.c:2787-2791 - `-B%u` (block_size). oc mirrors the SSH
+    // upstream: options.c:2953-2957 - `-B%u` (block_size). oc mirrors the SSH
     // builder's `--block-size=` spelling; both are accepted by the daemon's
     // option parser and carry the identical value, so the remote receiver's
     // generator sizes delta blocks exactly like the client requested.
@@ -1485,7 +1485,7 @@ mod server_option_fidelity_tests {
         assert!(flag.contains('p'), "perms on must pack 'p': {flag}");
     }
 
-    // upstream: options.c:2787-2791 - -B/block_size must reach the remote so its
+    // upstream: options.c:2953-2957 - -B/block_size must reach the remote so its
     // generator sizes delta blocks identically. Role-agnostic (both directions).
     #[test]
     fn block_size_forwarded_both_directions() {

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -356,7 +356,7 @@ impl<'a> CopyContext<'a> {
         if self.delete_pass_blocked_by_io_error() {
             // I/O errors occurred and --ignore-errors is not set; suppress
             // deletions to prevent data loss and emit the one-shot skip
-            // notice. upstream: generator.c:298-305.
+            // notice. upstream: generator.c:304-311.
             self.deferred_ops.deletions.clear();
             return Ok(());
         }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -1426,7 +1426,7 @@ impl<'a> CopyContext<'a> {
     /// neither the warning nor the skip fires in that case - matching
     /// upstream, where the flag both suppresses the notice and lets the
     /// delete pass run.
-    // upstream: generator.c:298-305 delete_in_dir() prints "IO error
+    // upstream: generator.c:304-311 delete_in_dir() prints "IO error
     // encountered -- skipping file deletion" once (guarded by a static
     // `already_warned`) and returns without deleting whenever
     // `io_error & IOERR_GENERAL && !ignore_errors`.

--- a/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
@@ -74,7 +74,7 @@ pub(super) fn apply_during_transfer_deletions(
 
     // When I/O errors occurred and --ignore-errors is not set, suppress
     // deletions to prevent data loss (upstream rsync behavior) and emit the
-    // one-shot skip notice. upstream: generator.c:298-305.
+    // one-shot skip notice. upstream: generator.c:304-311.
     if context.delete_pass_blocked_by_io_error() {
         return Ok(());
     }
@@ -119,7 +119,7 @@ pub(super) fn handle_post_transfer_deletions(
 
     // When I/O errors occurred and --ignore-errors is not set, suppress
     // deletions to prevent data loss (upstream rsync behavior) and emit the
-    // one-shot skip notice. upstream: generator.c:298-305.
+    // one-shot skip notice. upstream: generator.c:304-311.
     if context.delete_pass_blocked_by_io_error() {
         return Ok(());
     }

--- a/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
@@ -240,7 +240,7 @@ fn ignore_errors_option_independent_of_delete_timing() {
 #[cfg(unix)]
 #[test]
 fn delete_suppressed_when_io_errors_and_ignore_errors_not_set() {
-    // upstream: generator.c:298 - `delete_in_dir` skips ALL file deletion once
+    // upstream: generator.c:304 - `delete_in_dir` skips ALL file deletion once
     // `io_error & IOERR_GENERAL` is set and `--ignore-errors` is off, printing
     // "IO error encountered -- skipping file deletion". The general IO error is
     // raised while BUILDING the file list (e.g. an unreadable directory whose
@@ -287,7 +287,7 @@ fn delete_suppressed_when_io_errors_and_ignore_errors_not_set() {
     let _ = fs::set_permissions(source.join("baddir"), fs::Permissions::from_mode(0o755));
 
     // The extra file in the later directory must survive because the general IO
-    // error suppresses deletion (upstream generator.c:298).
+    // error suppresses deletion (upstream generator.c:304).
     assert!(
         dest.join("zsub/extra.txt").exists(),
         "zsub/extra.txt must survive when a directory-read IO error suppresses deletion"
@@ -304,7 +304,7 @@ fn io_error_skip_deletion_emits_upstream_notice() {
     // upstream prints "IO error encountered -- skipping file deletion" once
     // before abandoning the delete pass. This asserts the notice reaches the
     // diagnostic queue, not merely that the extra file survives.
-    // upstream: generator.c:298-305 delete_in_dir().
+    // upstream: generator.c:304-311 delete_in_dir().
     use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, init};
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -430,7 +430,7 @@ pub struct ReceiverContext {
     /// `delete_in_dir()`; skipping protects destination files that merely never
     /// made it into an incomplete file list from being unlinked as extraneous.
     ///
-    /// upstream: generator.c:298-305 - `delete_in_dir()` returns early (printing
+    /// upstream: generator.c:304-311 - `delete_in_dir()` returns early (printing
     /// once) whenever `io_error & IOERR_GENERAL && !ignore_errors`.
     pub(in crate::receiver) io_error_delete_warning_emitted: bool,
     /// True when this receiver is applying a recorded batch (`--read-batch`)

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -323,7 +323,7 @@ impl ReceiverContext {
     {
         use crate::generator::io_error_flags::IOERR_GENERAL;
 
-        // upstream: generator.c:298-305 delete_in_dir() - if the sender hit a
+        // upstream: generator.c:304-311 delete_in_dir() - if the sender hit a
         // general I/O error while scanning the source, its file list may be
         // incomplete, so deleting dest files that merely never got listed would
         // lose data. Skip the entire delete pass (both phases) and print the


### PR DESCRIPTION
Master's pin is rsync **3.5.0** (`PINNED_SOURCE_DIR`, `xtask/src/commands/citations.rs:64`). Four constructs were retargeted to **3.4.4** line numbers while 3.4.4 was the pin. Under 3.5.0 they name unrelated code.

## Evidence — read from the pinned 3.5.0 tree, not inferred

| cited | 3.5.0 line content | correct |
|---|---|---|
| `options.c:2787` | *(blank line)* | `options.c:2953-2954` |
| `generator.c:298` | `if (DEBUG_GTE(DEL, 2))` | `generator.c:304` |
| `generator.c:714` | unrelated | `generator.c:720-721` |

What the correct lines actually contain:

```c
/* options.c:2953-2957 */
if (block_size) {
    if (asprintf(&arg, "-B%u", (int)block_size) < 0)
        goto oom;
    args[ac++] = arg;
}

/* generator.c:304-311 */
if (io_error & IOERR_GENERAL && !ignore_errors) {
    if (already_warned)
        return;
    rprintf(FINFO, "IO error encountered -- skipping file deletion\n");
    already_warned = 1;
    return;
}

/* generator.c:720-721, sum_sizes_sqroot() */
if (block_size)
    blength = block_size;
```

Mappings applied: `2787-2790`→`2953-2954`, `2787-2791`→`2953-2957`, `298`→`304`, `298-305`→`304-311`, `714`→`720`, `714-715`→`720-721`.

## ⚠ The gate cannot catch this class, and stays green either way

`cargo xtask citations` checks that the cited **file exists** and the **line is in bounds** — not that the line says what the comment claims. Its own summary says so:

> every citation names a file rsync 3.5.0 has, at a line that file has. This does **NOT** mean the cited line says what the comment claims; nothing here checks that.

Every stale 3.4.4 number is comfortably in bounds for 3.5.0's longer files, so the gate passed before this change and passes after. **The evidence is the source lines above, not a green check.** This is distinct from the word-filter coverage hole already filed separately.

## Scope and safety

Nine files, comment-only. Zero non-comment lines change, and every replacement is the **same character count**, so nothing reflows.

Gates: `cargo fmt --all -- --check` clean; `cargo xtask citations` = 7766 names and 7766 line ranges across 4923 files, exit 0.

## Residual, stated rather than implied

This fixes the constructs for which the wrong-target claim is **measured**. It is not a full sweep of everything retargeted while 3.4.4 was the pin — that class is invisible to tooling by construction and needs its own pass. Two independent instances of it have now been found by two people; treat that as a lower bound, not a total.
