### PR TITLE
fix(server): landlock root must be the destination's directory

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -15,6 +15,33 @@ use super::parse::{
     parse_server_stop_after, parse_server_stop_at,
 };
 
+/// Resolves the Landlock allowlist root for a receiver's destination operand.
+///
+/// The root must be the **directory the receiver writes into**, never the
+/// operand itself. Upstream builds every temp name inside the destination's own
+/// directory - `get_tmpname()` (upstream: receiver.c:309) splits `fname` at its
+/// last `/` and prefixes the temp basename there - so that directory is always
+/// required, whether or not the destination file already exists.
+///
+/// Canonicalising the operand alone is not enough: when it names an **existing
+/// regular file** `canonicalize()` succeeds on the file, and Landlock's
+/// `PathBeneath` rule over a regular file grants that one file and nothing else.
+/// The receiver's `mkstemp` of a sibling temp then fails with `EACCES`. Taking
+/// the parent in that case makes an existing destination behave like one that
+/// does not exist yet, which already resolved to the parent.
+fn landlock_root_for_dest(dest: &std::path::Path) -> Option<std::path::PathBuf> {
+    dest.canonicalize()
+        .ok()
+        .and_then(|canonical| {
+            if canonical.is_dir() {
+                Some(canonical)
+            } else {
+                canonical.parent().map(std::path::Path::to_path_buf)
+            }
+        })
+        .or_else(|| dest.parent().and_then(|parent| parent.canonicalize().ok()))
+}
+
 /// Runs the native server implementation when `--server` is requested.
 pub(crate) fn run_server_mode<Out, Err>(
     args: &[OsString],
@@ -445,11 +472,7 @@ where
     if role == ServerRole::Receiver {
         if let Some(dest) = config.args.last() {
             let dest_path = std::path::PathBuf::from(dest);
-            if let Some(root) = dest_path
-                .canonicalize()
-                .ok()
-                .or_else(|| dest_path.parent().and_then(|p| p.canonicalize().ok()))
-            {
+            if let Some(root) = landlock_root_for_dest(&dest_path) {
                 use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
                 if is_supported() {
                     let canonical_root = root.clone();
@@ -856,6 +879,46 @@ mod log_format_itemize_tests {
     #[test]
     fn a_format_without_i_leaves_every_flag_clear() {
         assert_eq!(derive("%n%L"), InfoFlags::default());
+    }
+}
+
+#[cfg(test)]
+mod landlock_root_tests {
+    use std::fs;
+
+    use super::landlock_root_for_dest;
+
+    /// The receiver's `mkstemp` targets the destination's own directory, so the
+    /// allowlist root must be a directory in every shape the operand can take.
+    /// The existing-file row is the regression: `canonicalize()` succeeds on the
+    /// file, and a Landlock rule over a regular file grants that file alone, so
+    /// returning the operand there denies the sibling temp with `EACCES`.
+    #[test]
+    fn root_is_the_written_directory_for_every_operand_shape() {
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let dir = scratch.path().join("dest");
+        fs::create_dir(&dir).unwrap();
+        let existing_file = dir.join("f.bin");
+        fs::write(&existing_file, b"basis").unwrap();
+        let absent = dir.join("not-yet.bin");
+
+        let canonical_dir = fs::canonicalize(&dir).unwrap();
+
+        assert_eq!(
+            landlock_root_for_dest(&dir).as_ref(),
+            Some(&canonical_dir),
+            "a directory operand is its own root"
+        );
+        assert_eq!(
+            landlock_root_for_dest(&existing_file).as_ref(),
+            Some(&canonical_dir),
+            "an existing destination file must resolve to its parent directory"
+        );
+        assert_eq!(
+            landlock_root_for_dest(&absent).as_ref(),
+            Some(&canonical_dir),
+            "a not-yet-created destination keeps resolving to its parent"
+        );
     }
 }
 


### PR DESCRIPTION
## Root cause

The receiver-side `--server` Landlock allowlist takes the destination operand as its root:

```rust
dest_path.canonicalize().ok()
    .or_else(|| dest_path.parent().and_then(|p| p.canonicalize().ok()))
```

When the operand names an **existing regular file**, `canonicalize()` succeeds on the file and the parent fallback never runs. The ruleset then grants exactly that one file - `PathBeneath` over a regular file grants that file and does not widen to its parent (`crates/fast_io/src/landlock.rs`). The receiver's `mkstemp` of a sibling temp in the same directory fails with `EACCES` and the transfer dies.

When the destination does **not** exist, `canonicalize()` fails, the fallback runs, and the parent directory is allowlisted - which is correct. So the bug is confined to the already-exists case.

## Upstream

`get_tmpname()` (receiver.c:309) builds the temp name from the destination's own directory - it splits `fname` at its last `/` (receiver.c:321) and prefixes the temp basename there. That directory is therefore always required, whether or not the destination file exists.

## Fix

`landlock_root_for_dest()` resolves to the directory the receiver writes into: the canonicalised operand when it is a directory, its parent otherwise, keeping the existing not-yet-created fallback. This makes the existing-file case behave like the already-correct not-yet-exists case; no other shape changes.

## Scope

Linux only - Landlock does not exist on macOS or Windows, which is why those cells were green. Reachable from a plain `oc-rsync src/f.bin host:/path/to/existing-file` over a remote shell.

## Verification

- New unit test `root_is_the_written_directory_for_every_operand_shape` pins all three operand shapes (directory / existing file / absent).
- Non-vacuity proven: forcing the pre-fix branch (`if canonical.is_dir()` -> `if true`) makes the existing-file assertion fail with `left: .../dest/f.bin`, `right: .../dest`; restoring the fix makes it pass.
- MEASURED: `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`; `cargo nextest run -p cli --all-features -E 'test(landlock_root)'` (1 passed).
