### PR TITLE
fix(tools): exclude test-only modules and dev-only crates from the path sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,30 @@ jobs:
         run: python3 tools/audit/unsafe_safety_comment_audit.py
 
   # ===========================================================================
+  # tools/ Unit Tests
+  # ---------------------------------------------------------------------------
+  # `tools/tests/` held unittest modules that no workflow ran, so a regression
+  # in the helpers they cover was invisible - including the coverage gate and
+  # the path-site sweep whose output scopes the confinement work. The runner
+  # discovers by pattern rather than an enumerated list, because an enumerated
+  # list is how those modules became orphans in the first place, and it asserts
+  # a non-zero test count, because `unittest discover` exits 0 when it matches
+  # nothing. Blocking, not informational: an inert gate is the defect it is
+  # meant to catch.
+  # ===========================================================================
+  tools-tests:
+    name: tools unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run tools/tests
+        run: bash tools/ci/run_tools_tests.sh
+
+  # ===========================================================================
   # Test Job - Full test suite on Linux with toolchain matrix
   # ===========================================================================
   test:

--- a/tools/ci/path_site_sweep.py
+++ b/tools/ci/path_site_sweep.py
@@ -13,6 +13,18 @@ is not an attack surface, so counting it buries the real sites. That means
 `benches/`, `examples/`, and `build.rs`. Comments are excluded too - a doc
 comment naming `File::open` is documentation, not a call site.
 
+A whole FILE is test code when the `mod` declaration that pulls it in is
+cfg(test)-gated. The gate sits in the parent, so the file's own text carries no
+attribute and a line-scan inside it sees production code; matching file NAMES
+instead only works while every such file is called `tests.rs`. Resolving the
+declaration is exact and needs no naming convention. Exclusion propagates
+through the submodules such a file declares, since a module unreachable outside
+`cfg(test)` cannot make its children reachable.
+
+Crates depended on only from `[dev-dependencies]` are excluded for the same
+reason one level up: they are never linked into the shipped binary, so their
+call sites are not an attack surface either.
+
 What is deliberately NOT counted, so the number is not read as more than it is:
 bare `.metadata()`, because it is `File::metadata` (fd-based, already anchored)
 as often as `Path::metadata` (path-resolving), and the two are not
@@ -31,6 +43,7 @@ import collections
 import os
 import re
 import sys
+import tomllib
 
 # One pattern per operation class. The class matters because the confinement
 # obligation differs: a create/rename/link/unlink mutates the filesystem, an
@@ -70,6 +83,14 @@ _CFG_ATTR = re.compile(r"#\[cfg(?:_attr)?\((?P<pred>.*)\)\]")
 _QUOTED = re.compile(r'"[^"]*"')
 _BARE_TEST = re.compile(r"\btest\b")
 
+# A `mod foo;` declaration, with or without a visibility qualifier. Only the
+# `;` form matters: an inline `mod foo { .. }` body is already covered by the
+# cfg-attribute brace tracking in production_lines().
+_MOD_DECL = re.compile(
+    r"^\s*(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*;"
+)
+_ATTR_LINE = re.compile(r"^\s*#\[")
+
 SKIP_DIRS = frozenset({"tests", "benches", "examples"})
 SKIP_FILES = frozenset({"tests.rs", "build.rs"})
 
@@ -80,6 +101,115 @@ def is_test_cfg(line: str) -> bool:
     if not match:
         return False
     return bool(_BARE_TEST.search(_QUOTED.sub("", match.group("pred"))))
+
+
+def _module_targets(path: str, gated_only: bool):
+    """Yield the file each `mod NAME;` in `path` resolves to.
+
+    With `gated_only`, only declarations carrying a cfg(test) attribute count -
+    either inline or on one of the attribute lines directly above.
+    """
+    directory = os.path.dirname(path)
+    with open(path, errors="replace") as handle:
+        lines = handle.read().splitlines()
+    for index, line in enumerate(lines):
+        match = _MOD_DECL.match(line)
+        if not match:
+            continue
+        if gated_only and not _declared_under_test_cfg(lines, index):
+            continue
+        stem = match.group("name")
+        for candidate in (
+            os.path.join(directory, f"{stem}.rs"),
+            os.path.join(directory, stem, "mod.rs"),
+        ):
+            if os.path.isfile(candidate):
+                yield candidate
+
+
+def _declared_under_test_cfg(lines: list[str], index: int) -> bool:
+    """True when the `mod` declaration at `index` is gated on `test`."""
+    if is_test_cfg(lines[index]):
+        return True
+    cursor = index - 1
+    while cursor >= 0 and _ATTR_LINE.match(lines[cursor]):
+        if is_test_cfg(lines[cursor]):
+            return True
+        cursor -= 1
+    return False
+
+
+def test_only_files(root: str) -> set[str]:
+    """Return every file reachable only through a cfg(test)-gated `mod`.
+
+    Seeded from the gated declarations, then closed over the submodules those
+    files declare: a module the compiler only builds under `cfg(test)` cannot
+    make its children reachable in a production build.
+    """
+    pending = []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for filename in filenames:
+            if filename.endswith(".rs"):
+                path = os.path.join(dirpath, filename)
+                pending.extend(_module_targets(path, gated_only=True))
+
+    seen: set[str] = set()
+    while pending:
+        path = pending.pop()
+        if path in seen:
+            continue
+        seen.add(path)
+        pending.extend(_module_targets(path, gated_only=False))
+    return seen
+
+
+def _dependency_names(data: dict, sections: tuple[str, ...]) -> set[str]:
+    """Collect dependency names from `sections`, including per-target tables."""
+    names: set[str] = set()
+    for section in sections:
+        names.update(data.get(section, {}))
+    for target in data.get("target", {}).values():
+        for section in sections:
+            names.update(target.get(section, {}))
+    return names
+
+
+def dev_only_crates(root: str) -> set[str]:
+    """Return crate directory names depended on ONLY from dev-dependencies.
+
+    Such a crate is never linked into the shipped binary, so its call sites
+    carry no confinement obligation. Derived from the manifests rather than
+    from the crate's name, so a renamed helper crate stays excluded.
+
+    Two conditions, and both matter. A crate needs at least one dev edge: a
+    crate nothing depends on at all is unreferenced, which is a different
+    finding and not this function's to make. And the scan must include the
+    WORKSPACE ROOT manifest, which carries real `[target.'cfg(..)'.dependencies]`
+    edges - reading only `crates/*/Cargo.toml` misclassifies a platform-gated
+    runtime dependency as test-only.
+    """
+    manifests = {}
+    workspace_root = os.path.join(os.path.dirname(root) or ".", "Cargo.toml")
+    if os.path.isfile(workspace_root):
+        with open(workspace_root, "rb") as handle:
+            manifests[None] = tomllib.load(handle)
+    for entry in sorted(os.listdir(root)):
+        manifest = os.path.join(root, entry, "Cargo.toml")
+        if os.path.isfile(manifest):
+            with open(manifest, "rb") as handle:
+                manifests[entry] = tomllib.load(handle)
+
+    names = {
+        data.get("package", {}).get("name", entry): entry
+        for entry, data in manifests.items()
+        if entry is not None
+    }
+    non_dev: set[str] = set()
+    dev: set[str] = set()
+    for data in manifests.values():
+        non_dev |= _dependency_names(data, ("dependencies", "build-dependencies"))
+        dev |= _dependency_names(data, ("dev-dependencies",))
+    return {entry for name, entry in names.items() if name in dev - non_dev}
 
 
 def code_before_comment(line: str) -> str:
@@ -132,6 +262,8 @@ def production_lines(path: str):
 def sweep(root: str):
     """Return a list of (operation, crate, path, lineno, text) for every site."""
     sites = []
+    skip_paths = test_only_files(root)
+    skip_crates = dev_only_crates(root)
     for dirpath, dirnames, filenames in os.walk(root):
         # Prune in place so os.walk does not descend at all. The original
         # substring check on dirpath only caught "tests", so benches/ and
@@ -143,8 +275,15 @@ def sweep(root: str):
             if not filename.endswith(".rs") or filename in SKIP_FILES:
                 continue
             path = os.path.join(dirpath, filename)
-            parts = path.split(os.sep)
-            crate = parts[1] if len(parts) > 1 else "?"
+            if path in skip_paths:
+                continue
+            # Relative to `root`, so the crate is the first component whatever
+            # --root was given. Indexing the absolute path positionally only
+            # ever worked for the literal default.
+            parts = os.path.relpath(path, root).split(os.sep)
+            crate = parts[0] if len(parts) > 1 else "?"
+            if crate in skip_crates:
+                continue
             for lineno, code in production_lines(path):
                 match = _MATCHER.search(code)
                 if match:

--- a/tools/ci/run_tools_tests.sh
+++ b/tools/ci/run_tools_tests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Run the unittest modules under tools/tests/.
+#
+# Discovery is by pattern rather than an enumerated list. tools/tests/
+# accumulated three modules that no workflow ran, and an enumerated list is
+# precisely how a fourth would join them.
+#
+# The test count is asserted rather than inferred from the exit status. On
+# Python 3.12+ a run that collects nothing exits 5 ("NO TESTS RAN") and the
+# status check below catches it; on earlier versions it exits 0, which is
+# indistinguishable from a passing run. The count assertion is what makes this
+# script correct on both, and it does not depend on which Python the runner
+# happens to ship.
+#
+# The modules import their subjects as `tools.<module>`, so the repository root
+# has to be importable; the top-level directory is the test directory itself
+# because tools/ is a namespace package and `discover` cannot import it as a
+# start directory.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+output=$(PYTHONPATH=. python3 -m unittest discover \
+	--start-directory tools/tests \
+	--top-level-directory tools/tests \
+	--pattern 'test_*.py' 2>&1) && status=0 || status=$?
+
+# Some subjects under test print GitHub Actions workflow commands (`::error`)
+# on their failure paths, and asserting on those paths is the point of the
+# tests. Echoed raw, a passing run would decorate itself with red annotations,
+# so workflow-command parsing is suspended around the output.
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+	token="tools-tests-$RANDOM$RANDOM"
+	echo "::stop-commands::$token"
+	printf '%s\n' "$output"
+	echo "::$token::"
+else
+	printf '%s\n' "$output"
+fi
+
+if [ "$status" -ne 0 ]; then
+	exit "$status"
+fi
+
+if ! grep -qE '^Ran [1-9][0-9]* tests?' <<<"$output"; then
+	echo "error: unittest discover matched no tests under tools/tests/" >&2
+	echo "A pattern that matches nothing exits 0 and reads as success." >&2
+	exit 1
+fi

--- a/tools/tests/test_path_site_sweep.py
+++ b/tools/tests/test_path_site_sweep.py
@@ -1,0 +1,173 @@
+"""Unit tests for the production path-site sweep.
+
+The sweep's output feeds the confinement-resolver work (docs/design/
+upstream-3.5.0-path-confinement-model.md), so a site it wrongly counts becomes
+work that gets scoped and never needed. Each test below pins one reason a file
+is or is not production code; the negative cases matter as much as the
+positive ones, because a rule that excludes too much shrinks the number just as
+convincingly as a correct one.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.ci.path_site_sweep import dev_only_crates, sweep, test_only_files
+
+
+class SweepFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self._tempdir.name)
+        self.crates = self.root / "crates"
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def write(self, relative: str, text: str) -> Path:
+        path = self.crates / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+        return path
+
+    def site_paths(self) -> set[str]:
+        return {site[2] for site in sweep(str(self.crates))}
+
+
+class TestOnlyModuleTests(SweepFixture):
+    """A file is test code when its `mod` declaration is cfg(test)-gated."""
+
+    def test_file_behind_a_gated_mod_is_not_a_production_site(self) -> None:
+        self.write("demo/src/lib.rs", "#[cfg(test)]\nmod helper;\n")
+        self.write("demo/src/helper.rs", "fn f() { File::create(p); }\n")
+        self.assertEqual(set(), self.site_paths())
+
+    def test_file_behind_an_ungated_mod_is_still_counted(self) -> None:
+        """The control. Without it, a rule that excluded everything would pass."""
+        self.write("demo/src/lib.rs", "mod helper;\n")
+        self.write("demo/src/helper.rs", "fn f() { File::create(p); }\n")
+        self.assertEqual(1, len(self.site_paths()))
+
+    def test_the_all_test_unix_spelling_is_recognised(self) -> None:
+        """`#[cfg(test)]` is only the simplest spelling; the tree uses others."""
+        self.write("demo/src/lib.rs", "#[cfg(all(unix, test))]\nmod helper;\n")
+        self.write("demo/src/helper.rs", "fn f() { File::create(p); }\n")
+        self.assertEqual(set(), self.site_paths())
+
+    def test_an_intervening_attribute_does_not_hide_the_gate(self) -> None:
+        self.write(
+            "demo/src/lib.rs",
+            "#[cfg(test)]\n#[allow(clippy::pedantic)]\nmod helper;\n",
+        )
+        self.write("demo/src/helper.rs", "fn f() { File::create(p); }\n")
+        self.assertEqual(set(), self.site_paths())
+
+    def test_a_mod_rs_directory_module_resolves(self) -> None:
+        self.write("demo/src/lib.rs", "#[cfg(test)]\nmod helper;\n")
+        self.write("demo/src/helper/mod.rs", "fn f() { File::create(p); }\n")
+        self.assertEqual(set(), self.site_paths())
+
+    def test_exclusion_reaches_submodules_of_a_gated_module(self) -> None:
+        """A module the compiler only builds under cfg(test) cannot make its
+        children reachable, so the gate has to propagate."""
+        self.write("demo/src/lib.rs", "#[cfg(test)]\nmod helper;\n")
+        self.write("demo/src/helper/mod.rs", "mod deeper;\n")
+        self.write("demo/src/helper/deeper.rs", "fn f() { File::create(p); }\n")
+        self.assertEqual(set(), self.site_paths())
+
+    def test_a_visibility_qualifier_does_not_hide_the_declaration(self) -> None:
+        self.write("demo/src/lib.rs", "#[cfg(test)]\npub(crate) mod helper;\n")
+        self.write("demo/src/helper.rs", "fn f() { File::create(p); }\n")
+        self.assertEqual(set(), self.site_paths())
+
+    def test_a_quoted_test_feature_name_is_not_a_test_gate(self) -> None:
+        """`feature = "test-utils"` is a production feature, not cfg(test)."""
+        self.write("demo/src/lib.rs", '#[cfg(feature = "test-utils")]\nmod helper;\n')
+        self.write("demo/src/helper.rs", "fn f() { File::create(p); }\n")
+        self.assertEqual(1, len(self.site_paths()))
+
+    def test_only_the_declared_file_is_excluded(self) -> None:
+        self.write("demo/src/lib.rs", "#[cfg(test)]\nmod helper;\nmod real;\n")
+        self.write("demo/src/helper.rs", "fn f() { File::create(p); }\n")
+        self.write("demo/src/real.rs", "fn g() { fs::rename(a, b); }\n")
+        excluded = test_only_files(str(self.crates))
+        self.assertIn(str(self.crates / "demo/src/helper.rs"), excluded)
+        self.assertNotIn(str(self.crates / "demo/src/real.rs"), excluded)
+
+
+class DevOnlyCrateTests(SweepFixture):
+    """A crate reached only from dev-dependencies is never shipped."""
+
+    def manifest(self, relative: str, text: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+    def test_a_crate_used_only_as_a_dev_dependency_is_excluded(self) -> None:
+        self.manifest("Cargo.toml", "[workspace]\n")
+        self.manifest("crates/helper/Cargo.toml", '[package]\nname = "helper"\n')
+        self.manifest(
+            "crates/app/Cargo.toml",
+            '[package]\nname = "app"\n\n[dev-dependencies]\nhelper = { path = "../helper" }\n',
+        )
+        self.assertEqual({"helper"}, dev_only_crates(str(self.crates)))
+
+    def test_a_crate_also_used_as_a_real_dependency_is_kept(self) -> None:
+        self.manifest("Cargo.toml", "[workspace]\n")
+        self.manifest("crates/helper/Cargo.toml", '[package]\nname = "helper"\n')
+        self.manifest(
+            "crates/app/Cargo.toml",
+            '[package]\nname = "app"\n\n[dependencies]\nhelper = { path = "../helper" }\n'
+            '\n[dev-dependencies]\nhelper = { path = "../helper" }\n',
+        )
+        self.assertEqual(set(), dev_only_crates(str(self.crates)))
+
+    def test_a_root_manifest_target_dependency_keeps_the_crate(self) -> None:
+        """The measured false positive: a platform-gated runtime dependency is
+        declared in the WORKSPACE ROOT manifest and in no crate manifest.
+        Reading only crates/*/Cargo.toml classified it as test-only - and
+        because the crate happened to hold no path sites, the total did not
+        move, so the misclassification was invisible in the output.
+
+        The dev edge is deliberately placed in a CRATE manifest and the runtime
+        edge in the ROOT one. Putting both in the root makes the test pass even
+        when the root scan is removed - the crate then has no dev edge either,
+        so the dev-edge requirement alone suppresses it and the assertion holds
+        for the wrong reason.
+        """
+        self.manifest(
+            "Cargo.toml",
+            "[workspace]\n\n[target.'cfg(windows)'.dependencies]\n"
+            'shim = { path = "crates/shim" }\n',
+        )
+        self.manifest("crates/shim/Cargo.toml", '[package]\nname = "shim"\n')
+        self.manifest(
+            "crates/app/Cargo.toml",
+            '[package]\nname = "app"\n\n[dev-dependencies]\nshim = { path = "../shim" }\n',
+        )
+        self.assertEqual(set(), dev_only_crates(str(self.crates)))
+
+    def test_a_crate_nothing_depends_on_is_not_called_dev_only(self) -> None:
+        """Unreferenced is a different finding from test-only, and claiming the
+        latter would quietly drop a shipped crate that simply has no in-tree
+        dependents."""
+        self.manifest("Cargo.toml", "[workspace]\n")
+        self.manifest("crates/lonely/Cargo.toml", '[package]\nname = "lonely"\n')
+        self.assertEqual(set(), dev_only_crates(str(self.crates)))
+
+    def test_sites_in_a_dev_only_crate_are_not_swept(self) -> None:
+        self.manifest("Cargo.toml", "[workspace]\n")
+        self.manifest("crates/helper/Cargo.toml", '[package]\nname = "helper"\n')
+        self.manifest(
+            "crates/app/Cargo.toml",
+            '[package]\nname = "app"\n\n[dev-dependencies]\nhelper = { path = "../helper" }\n',
+        )
+        self.write("helper/src/lib.rs", "fn f() { File::create(p); }\n")
+        self.write("app/src/lib.rs", "fn g() { fs::rename(a, b); }\n")
+        self.assertEqual({str(self.crates / "app/src/lib.rs")}, self.site_paths())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The production path-site sweep (`tools/ci/path_site_sweep.py`) counts call sites that the 3.5.0 confinement resolver will have to cover. Its output scopes that work, so a site it wrongly counts becomes work that gets planned and never needed.

## The defect

A file whose `mod` declaration is cfg(test)-gated is test code, but the gate sits in the **parent**. The file's own text carries no attribute, so the existing line-scan reads it as production. `SKIP_FILES` compensated by matching the literal name `tests.rs` — which holds only while every such file is named that way.

The tool already has `is_test_cfg()`. It was applied to lines *inside* a file and never to the declaration that pulls the file in. **The defect is the scope the existing check runs at, not a missing name list.**

```
crates/metadata/src/chmod/mod.rs:20        #[cfg(all(test, unix))]
                              :21        mod matrix_tests;
crates/transfer/src/disk_commit/mod.rs:34  #[cfg(test)]
                                    :35  mod tests_partial_interrupt_parity;
crates/engine/src/concurrent_delta/spill/mod.rs:83  #[cfg(test)]
                                              :84  mod tests_per_knob;
```

## The fix

Resolve `mod NAME;` to `<dir>/NAME.rs` or `<dir>/NAME/mod.rs` and exclude it when the declaration is gated. Exclusion propagates through the submodules such a file declares — a module the compiler only builds under `cfg(test)` cannot make its children reachable. No naming convention involved, so future files are covered for free.

Second rule, same reasoning one level up: crates reached **only** from `[dev-dependencies]` are never linked into the shipped binary, so their call sites carry no confinement obligation either.

## Measured

Both rules independent and additive, on this tree:

| | TOTAL |
|---|---|
| neither rule (previous behaviour) | 564 |
| cfg(test) `mod` rule only | 553 (-11) |
| dev-only crate rule only | 556 (-8) |
| both | **545** (-19) |

Every count derived from this tool — 564, 255, 46, 263 — was overstated by these 19. The tool runs in no workflow, so nothing else moves.

## One trap worth recording

The dev-crate rule initially read only `crates/*/Cargo.toml` and classified `windows-gnu-eh` as test-only. It is a real platform-gated runtime dependency, declared in the **workspace root** manifest under `[target.'cfg(all(windows, target_env = "gnu"))'.dependencies]`. Because that crate happens to hold no path sites, **the total did not move and the misclassification was invisible in the output.** The rule now scans the root manifest and requires a dev edge as well as the absence of a non-dev edge — a crate nothing depends on is unreferenced, which is a different finding and not this function's to make.

Also fixed while here: crate attribution indexed the absolute path positionally, so it only ever resolved correctly for the literal default `--root`. Caught by a test running against a tempdir.

## Verification

`tools/tests/test_path_site_sweep.py`, 14 cases, following the existing `tools/tests/` unittest convention. Each pins one reason a file is or is not production code, and the negative controls are what distinguish a correct rule from one that simply excludes more.

Non-vacuity proven by mutation — five mutations, each killing exactly its own tests and leaving the controls green:

| mutation | tests killed |
|---|---|
| `test_only_files` returns nothing | the 7 gated-mod cases; ungated control stays **green** |
| every `mod` treated as gated | the 2 ungated controls + the mixed case |
| submodule propagation removed | the propagation case only |
| workspace-root manifest scan removed | the root-target case only |
| dev-edge requirement removed | all 4 dev-crate cases |

The root-manifest case initially survived its mutation — passing for the wrong reason, because putting both edges in the root manifest lets the dev-edge requirement suppress the crate on its own. The fixture now places the dev edge in a crate manifest and the runtime edge in the root, and the mutation kills it.

```
MEASURED: python3 -m unittest tools.tests.test_path_site_sweep   ->  Ran 14 tests, OK
MEASURED: python3 tools/ci/path_site_sweep.py --root crates      ->  TOTAL 545
MEASURED: python3 tools/ci/path_site_sweep.py --check-patterns   ->  exit 0
MEASURED: git show origin/master:tools/ci/path_site_sweep.py | python3 - --root crates -> TOTAL 564
```

Wiring `tools/tests/*.py` into CI is deliberately out of scope; it is separately tracked and covers the two pre-existing test modules as well.

---

## Second commit: the tests now actually run

`tools/tests/` held two unittest modules that **no workflow executed**, and the module above would have been the third. Shipping a guard nobody runs is the same defect one level up, so the wiring is folded in here rather than deferred.

```
git grep -n -e pytest -e unittest -e 'tools/tests' origin/master -- '.github/**'   ->  (no output)
```

A blocking `tools unit tests` job in `ci.yml`, which already lists `tools/**` in both its `push` and `pull_request` path filters — so the step fires on exactly the changes it covers, rather than existing and never triggering. Not `continue-on-error`.

**Discovery is by pattern, not an enumerated list**, because an enumerated list is how the existing two became orphans. The runner asserts a non-zero test count rather than trusting the exit status — and one premise there needed correcting mid-build: on **Python 3.12+ a run that collects nothing exits 5**, not 0, so the status check catches it on a modern runner; on earlier versions it exits 0 and is indistinguishable from success. The count assertion is what makes the script correct on both, independent of which Python the runner ships.

Also handled: the subjects under test print GitHub Actions workflow commands (`::error`) on their failure paths, and exercising those paths is the point of the tests. Echoed raw, a passing run would decorate itself with red annotations that read as failures, so workflow-command parsing is suspended around the captured output.

```
MEASURED green      bash tools/ci/run_tools_tests.sh  -> exit 0, "Ran 24 tests ... OK"
MEASURED red        one assertion inverted            -> exit 1, "FAILED (failures=1)"
MEASURED vacuity    count predicate REJECTS "Ran 0 tests in 0.000s",
                    ACCEPTS the real 24-test output
MEASURED shellcheck tools/ci/run_tools_tests.sh       -> clean
```

24 tests: 5 coverage-gate, 5 sha256, 14 path-site sweep. Both pre-existing modules pass unmodified — checked before wiring them in, since an orphan that had rotted would have turned this PR red for an unrelated reason.
