### PR TITLE
docs(protocol): retarget name.rs upstream citations at the 3.5.0 pin

### DIFF
--- a/crates/protocol/src/flist/read/name.rs
+++ b/crates/protocol/src/flist/read/name.rs
@@ -6,9 +6,9 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:recv_file_entry()` lines 760-800 for name reading
+//! - `flist.c:recv_file_entry()` lines 843-883 for name reading
 //! - `util1.c:943`: `clean_fname()` with `CFN_REFUSE_DOT_DOT_DIRS`
-//! - `flist.c:768-772`: pathname safety check
+//! - `flist.c:851-855`: pathname safety check
 
 use std::io::{self, Read};
 
@@ -53,7 +53,7 @@ impl FileListReader {
             0
         };
 
-        // upstream: flist.c:731-734 - XMIT_LONG_NAME uses read_varint30()
+        // upstream: flist.c:814-817 - XMIT_LONG_NAME uses read_varint30()
         // which dispatches to read_int (4-byte LE) for protocol < 30,
         // read_varint for protocol >= 30
         let suffix_len = if flags.long_name() {
@@ -139,7 +139,7 @@ impl FileListReader {
     ///
     /// # Upstream Reference
     ///
-    /// `flist.c:757-764` `recv_file_entry()` runs the freshly-read filename
+    /// `flist.c:840-847` `recv_file_entry()` runs the freshly-read filename
     /// through `iconvbufs(ic_recv, ..., ICB_INIT)` (strict). On failure upstream
     /// sets `io_error |= IOERR_GENERAL`, prints `[%s] cannot convert filename:
     /// %s (%s)` via `FERROR_UTF8`, and sets `outbuf.len = 0` so the name becomes
@@ -158,13 +158,13 @@ impl FileListReader {
         match converter.remote_to_local(&name) {
             Ok(converted) => Ok(converted.into_owned()),
             Err(_) => {
-                // upstream: flist.c:759-762 - the FERROR_UTF8 message, then
+                // upstream: flist.c:842-845 - the FERROR_UTF8 message, then
                 // `outbuf.len = 0` empties the name.
                 eprintln!(
                     "{}",
                     crate::iconv::cannot_convert_filename_message("receiver", &name)
                 );
-                // upstream: flist.c:758 sets `io_error |= IOERR_GENERAL` with
+                // upstream: flist.c:841 sets `io_error |= IOERR_GENERAL` with
                 // no `ignore_errors` check, so this is a LOCAL error and is
                 // never suppressed by --ignore-errors.
                 self.local_io_error |= crate::io_error::IOERR_GENERAL;
@@ -176,7 +176,7 @@ impl FileListReader {
     /// Cleans and validates a filename received from the sender.
     ///
     /// Mirrors upstream `clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS)` followed
-    /// by the leading-slash check at flist.c:768-772. Performs in-place on a byte
+    /// by the leading-slash check at flist.c:851-855. Performs in-place on a byte
     /// buffer to avoid allocations on the common (clean) path.
     ///
     /// Normalization:
@@ -193,7 +193,7 @@ impl FileListReader {
     /// # Upstream Reference
     ///
     /// - `util1.c:943`: `clean_fname()` with `CFN_REFUSE_DOT_DOT_DIRS`
-    /// - `flist.c:768-772`: pathname safety check after `clean_fname`
+    /// - `flist.c:851-855`: pathname safety check after `clean_fname`
     pub(super) fn clean_and_validate_name(&self, name: Vec<u8>) -> io::Result<Vec<u8>> {
         if name.is_empty() {
             return Ok(name);
@@ -202,7 +202,7 @@ impl FileListReader {
         // Fast path: most names from a well-behaved sender need no cleaning.
         if !needs_cleaning(&name) {
             if !self.relative_paths && name[0] == b'/' {
-                // upstream: flist.c:768 exit_cleanup(RERR_UNSUPPORTED); the
+                // upstream: flist.c:854 exit_cleanup(RERR_UNSUPPORTED); the
                 // `Unsupported` kind maps to exit 4, not StreamIo(12).
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
@@ -219,9 +219,9 @@ impl FileListReader {
         let mut out = Vec::with_capacity(name.len());
         let anchored = name[0] == b'/';
 
-        // upstream: flist.c:769 - reject absolute paths when not --relative
+        // upstream: flist.c:852 - reject absolute paths when not --relative
         if anchored && !self.relative_paths {
-            // upstream: flist.c:768 exit_cleanup(RERR_UNSUPPORTED) -> exit 4.
+            // upstream: flist.c:854 exit_cleanup(RERR_UNSUPPORTED) -> exit 4.
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 format!(
@@ -260,7 +260,7 @@ impl FileListReader {
                 if next == Some(b'.') {
                     let after = name.get(i + 2).copied();
                     if after == Some(b'/') || after.is_none() {
-                        // upstream: flist.c:768 exit_cleanup(RERR_UNSUPPORTED) -> exit 4.
+                        // upstream: flist.c:854 exit_cleanup(RERR_UNSUPPORTED) -> exit 4.
                         return Err(io::Error::new(
                             io::ErrorKind::Unsupported,
                             format!(


### PR DESCRIPTION
`crates/protocol/src/flist/read/name.rs` carried twelve `flist.c:` citations, all still naming 3.4.4 line numbers. The gate is pinned at 3.5.0, so all twelve were stale — but only one was **visible**.

## Why the pin is 3.5.0

```
xtask/src/commands/citations.rs:61  MANIFEST_PATH     = "tools/ci/upstream-3.5.0-lines.tsv"
xtask/src/commands/citations.rs:64  PINNED_SOURCE_DIR = "target/interop/upstream-src/rsync-3.5.0"
git ls-tree origin/master tools/ci/ | grep tsv  ->  upstream-3.5.0-lines.tsv   (the only one)
```

⚠ `.github/workflows/citations.yml:27` says the gate reads `tools/ci/upstream-3.4.4-lines.tsv`. **That file does not exist** — the comment is false and is what made this citation look correct. Worth fixing separately; it is not touched here.

## The retarget

The cited region shifts by a constant **+83** between releases and the constructs are otherwise byte-identical, so this is a pure retarget with no semantic change.

| construct | 3.4.4 | 3.5.0 |
|---|---|---|
| `recv_file_entry()` name reading | 760-800 | 843-883 |
| `XMIT_LONG_NAME` / `read_varint30` | 731-734 | 814-817 |
| iconv block | 757-764 | 840-847 |
| `io_error \|= IOERR_GENERAL` | 758 | **841** |
| `FERROR_UTF8` message | 759-762 | 842-845 |
| pathname safety check | 768-772 | 851-855 |
| `!relative_paths` absolute reject | 769 | 852 |

**841, not 1316.** Both are `iconvbufs(ic_recv, ...) < 0` inside `recv_file_entry` under the same `#ifdef ICONV_OPTION`, so a line number alone cannot separate them. The `rprintf` below each does: 841 is `FERROR_UTF8` / "cannot convert filename"; 1316 is `FERROR_XFER` / "cannot convert symlink data for", gated on `sender_symlink_iconv`. This site calls `cannot_convert_filename_message`, so it is the filename converter.

**One correction beyond the retarget:** three sites cited `flist.c:768 exit_cleanup(RERR_UNSUPPORTED)`, but 768 (now 851) is the block-opening `if`, not the `exit_cleanup`. They now name **854**, the call itself.

## Why a sweep and not a one-liner

Only the `io_error |= IOERR_GENERA` anchor is tracked by the drift gate. The other eleven have **no anchor string**, so patching just the flagged line would have left eleven known-wrong citations behind and reported success. That invisible class is task 652.

## Verification

```
MEASURED  tools/ci/citation_drift_audit.py
  before   protocol: string-anchored=56 suspected-drift=1 (2%) unresolved=24
  after    protocol: string-anchored=56 suspected-drift=0 (0%) unresolved=24
```

Each new target was read from the pinned 3.5.0 source rather than inferred from the offset:

```
814  if (xflags & XMIT_LONG_NAME)
841  io_error |= IOERR_GENERAL;
842  rprintf(FERROR_UTF8,
852  && (clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS) < 0 || (!relative_paths && *thisname == '/'))) {
854  exit_cleanup(RERR_UNSUPPORTED);
```

`unresolved=24` is unchanged and out of scope — those are anchors that resolve at no line in 3.5.0, task 652's third class.

Comments only; no code changes, so nothing to test beyond the gate.
