### PR TITLE
fix(transfer): name drop_devices in the server-flag classification guard

### DIFF
--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -1345,8 +1345,14 @@ mod delivery_classification {
             //    long arg so it is delivered, just not through these two.
             //    `parallel_delta_scan` is an oc extension with no upstream
             //    letter, so a bridge is its only possible route.
+            //    `drop_devices` needs no decision: it is deliberately
+            //    client-local, which is what makes the argv byte-identical.
+            //    The server decodes `--drop-D` only so a restricted shell can
+            //    inject it (upstream's rrsync forces it; see
+            //    cli/src/frontend/server/flags.rs:478).
             partial,
             parallel_delta_scan,
+            drop_devices,
             mkpath,
             incremental_recursion,
             msgs_to_stderr,


### PR DESCRIPTION
`ParsedServerFlags` gained a `drop_devices` field, but the exhaustive destructure in `every_parsed_server_flags_field_is_classified` never named it. That is a hard `E0027`, so `crates/transfer` fails to build under `--all-targets` and every open PR shows a red `fmt + clippy`.

Reproduced on pristine `origin/master` (`490134fc1`), not on a feature branch. Both contributing changes were green in isolation and red together — a stale-base merge-compile collision. The guard is `cfg(test)`, so only a build that compiles tests sees it; a plain `cargo build` stays green, which is why it reached master.

**Non-vacuity proven both directions** on `490134fc1`:

```
MEASURED: cargo check -p transfer --all-targets --all-features
  without this patch -> exit 101, error[E0027]: pattern does not mention field `drop_devices`
  with this patch    -> exit 0
```

## Why this group

`drop_devices` goes under "⚠ NEITHER MECHANISM": no compact letter, and `apply_common_server_flags` does not carry it (verified — no match in `crates/core/src/client/remote/flags.rs`).

Unlike its neighbours, that is not an open question needing a decision. The option is deliberately client-local: no client path emits `--drop-D` into the argv, which is exactly what made the argv byte-identical. The server decodes `--drop-D` only so a restricted shell can inject it, upstream's `rrsync` being the case that forces it. The comment says so, since the group's existing text would otherwise imply an unresolved gap.

The exhaustive pattern is a drift guard working as designed — it refused to let a new field be added without classifying how it reaches the server.
