### PR TITLE
docs(ci): correct two stale claims in the citations.yml header

### DIFF
--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -23,9 +23,21 @@
 #
 # The cost of running this on every pull request is small and was measured, not
 # assumed: `cargo xtask citations` builds 68 packages, where the workspace
-# nextest cell builds 490. It needs no upstream tarball either - the gate reads
-# the committed `tools/ci/upstream-3.4.4-lines.tsv` manifest, which is why the
-# manifest exists.
+# nextest cell builds 490. It needs no upstream tarball either - the gate reads a
+# committed line-count manifest, which is why the manifest exists.
+#
+# The manifest, and the upstream release it describes, are named by
+# `MANIFEST_PATH` and `PINNED_SOURCE_DIR` in `xtask/src/commands/citations.rs`.
+# Read those constants rather than a filename written here: this comment used to
+# name `tools/ci/upstream-3.4.4-lines.tsv`, survived the bump to the 3.5.0 pin,
+# and went on asserting a file that no longer exists. A comment sitting next to
+# the thing it describes reads as authoritative, so a stale one is worse than
+# none - it cost two readers a wrong diagnosis before anyone printed the constant.
+#
+# Note also that this job answers only "does the cited line exist in that file?".
+# Whether the line still *says* what the citation claims is a separate question,
+# answered by `tools/ci/citation_drift_audit.py`. A citation can pass here and
+# fail there, which is exactly how a stale citation rides in a green cell.
 #
 # This deliberately overlaps the copy that runs under nextest. The duplication is
 # cheap and the two have different trigger sets; the standalone job is the one
@@ -34,9 +46,14 @@
 # ADVISORY, NOT REQUIRED - a deliberate choice, not an oversight.
 #
 # `Upstream citations resolve` is not in the master ruleset's required-status-check
-# list and is not being added to it. Master enforces strict up-to-date merges, so
-# every additional required context lengthens the serial merge queue; a docs-typo
-# pull request should not have to round-trip that queue behind a comment checker.
+# list and is not being added to it. A docs-typo pull request should not have to
+# wait on a comment checker to merge.
+#
+# This paragraph used to add "Master enforces strict up-to-date merges, so every
+# additional required context lengthens the serial merge queue." That is no longer
+# true - `strict_required_status_checks_policy` is now `false` on the master
+# ruleset - so the queue-length argument is retired, not the decision. Check the
+# ruleset before reusing any claim about merge behaviour from a comment.
 # The failure being closed here is *invisibility* - a wrong citation currently
 # reaches master with nothing anywhere reporting on it - and an advisory red is
 # visible on the pull request, which is exactly what was missing.


### PR DESCRIPTION
Two claims in `citations.yml`'s header asserted repo state that had since drifted. Both sit **adjacent to the thing they describe**, which is what makes a stale comment expensive — it reads as authoritative.

## 1. A manifest that does not exist

```
# the gate reads the committed `tools/ci/upstream-3.4.4-lines.tsv` manifest
```

```
git ls-tree origin/master tools/ci/ | grep tsv   ->   upstream-3.5.0-lines.tsv   (only)
```

The gate reads whatever `MANIFEST_PATH` names in `xtask/src/commands/citations.rs`; `PINNED_SOURCE_DIR` beside it names the release. The sentence survived the bump to the 3.5.0 pin and went on naming a deleted file.

It cost two readers a wrong diagnosis in sequence — one cited it as authority for "the pin is still 3.4.4", the second built a "two version gates disagree by construction" theory on that report. Neither printed the constant. The replacement **points at the constants rather than restating a filename**, so it cannot drift out of sync with itself the way the sentence did.

## 2. A merge policy that has been turned off

```
# Master enforces strict up-to-date merges, so every additional required
# context lengthens the serial merge queue
```

```
gh api repos/oferchen/rsync/rulesets/... -> strict_required_status_checks_policy: false
```

Found while editing the same block. The **queue-length argument is retired, not the decision** — advisory-not-required still stands on its remaining reason, that a docs-typo PR should not wait on a comment checker. I corrected the fact without touching the choice.

## Also recorded

What this job actually answers — *does the cited line exist in that file?* — versus the drift audit's *does the line still say what we claim?*. A citation can pass the bounds check and fail the content check, and that asymmetry is precisely how a stale citation rides inside a green cell. Worth stating where the next reader will be standing.

Comments only; no workflow logic changed.

⚠ Verification note: my first check was `grep -c` for the two old strings, which reported both still present — a **false positive**, because the replacement quotes them in past tense as history. The real check is whether each occurrence is *asserted* or *quoted*, which needs the surrounding line, not a substring count.
