### PR TITLE
fix(citations): retarget the core crate's upstream citations at rsync 3.5.0

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -175,7 +175,7 @@ fn parse_protocol_from_greeting(greeting: &str) -> Result<ProtocolVersion, Clien
 /// Echoes a daemon `@ERROR` line to stderr and constructs the matching
 /// client error.
 ///
-/// Mirrors upstream `clientserver.c:382` - `rprintf(FERROR, "%s\n", line)` -
+/// Mirrors upstream `clientserver.c:425` - `rprintf(FERROR, "%s\n", line)` -
 /// which prints the raw `@ERROR` line verbatim to stderr before returning
 /// the fatal error to the caller. External tools (and the upstream
 /// testsuite/daemon-chroot-acl_test.py GHSA-rjfm-3w2m-jf4f regression

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -211,9 +211,10 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
 /// Sender-only `--super`/`--stats` server args, shared by the SSH and
 /// daemon-push argument builders.
 ///
-/// upstream: options.c:2852-2857 server_options() - inside the `if (am_sender)`
-/// block, `--super` is appended when `am_root > 1` (an explicit `--super`, never
-/// mere root) and `--stats` when `do_stats`. Both are forwarded only on a push,
+/// upstream: options.c:3018-3023 server_options() - `args[ac++] = "--super"`
+/// when `am_root > 1` (an explicit `--super`, never mere root) and
+/// `args[ac++] = "--stats"` when `do_stats`, both inside the am_sender block.
+/// Both are forwarded only on a push,
 /// where the remote receiver/generator performs the privileged operations and
 /// computes the transfer statistics. Callers invoke this only from their sender
 /// branch so both transports emit the same trailer in the same order.
@@ -538,7 +539,7 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // config (the wire-side sender conversion in build_wire_format_rules only
     // affects what the remote sender hides, not local delete protection).
     server_config.deletion.delete_excluded = config.delete_excluded();
-    // upstream: generator.c:298 delete_in_dir() - `io_error & IOERR_GENERAL &&
+    // upstream: generator.c:304 delete_in_dir() - `io_error & IOERR_GENERAL &&
     // !ignore_errors` skips the whole delete pass, so `--ignore-errors` is what
     // lets deletions proceed after a source-scan error. Like `--preallocate` and
     // `--remove-source-files` above, it is long-form-only with no compact letter,
@@ -909,7 +910,7 @@ mod tests {
     }
 
     /// `--ignore-errors` governs the receiver's delete pass
-    /// (upstream: generator.c:298 `io_error & IOERR_GENERAL && !ignore_errors`).
+    /// (upstream: generator.c:304 `io_error & IOERR_GENERAL && !ignore_errors`).
     /// On a pull the LOCAL client is the receiver, and the flag is long-form-only
     /// so it never rides the compact flag string this config is parsed from -
     /// exactly like `--preallocate` and `--remove-source-files`. Without this the

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -711,11 +711,11 @@ fn config_with_batch_mode(mode: engine::batch::BatchMode) -> ClientConfig {
         .build()
 }
 
-/// upstream: `options.c:2850-2851` - the sender half of `server_options()` emits
-/// the literal `--only-write-batch=X` placeholder. It is the only signal that
-/// puts the remote receiver into `dry_run` (`main.c:1839`), which is what stops
+/// upstream: `options.c:3016-3017` - the sender half of server_options() emits
+/// `args[ac++] = "--only-write-batch=X"`. It is the only signal that
+/// puts the remote receiver into `dry_run` (`main.c:1919`), which is what stops
 /// it from updating the destination and from waiting on a token stream the
-/// sender is diverting into its batch file (`sender.c:217`). Without this
+/// sender is diverting into its batch file (`sender.c:501`). Without this
 /// argument a `--only-write-batch` push writes the remote destination.
 #[test]
 fn only_write_batch_sender_emits_placeholder_arg() {
@@ -729,8 +729,9 @@ fn only_write_batch_sender_emits_placeholder_arg() {
     );
 }
 
-/// upstream: `options.c:2850-2851` sits inside the `if (am_sender)` block, so a
-/// PULL never forwards it. Leaking it would put the remote SENDER into dry-run
+/// upstream: `options.c:3016-3017` - `args[ac++] = "--only-write-batch=X"` sits
+/// inside the am_sender block, so a PULL never forwards it. Leaking it would
+/// put the remote SENDER into dry-run
 /// and it would stop sending file data entirely.
 #[test]
 fn only_write_batch_is_not_forwarded_on_a_pull() {

--- a/tools/ci/citation_drift_baseline.json
+++ b/tools/ci/citation_drift_baseline.json
@@ -10,7 +10,7 @@
   "checksums": 0,
   "cli": 3,
   "compress": 0,
-  "core": 3,
+  "core": 0,
   "daemon": 2,
   "engine": 0,
   "filters": 0,


### PR DESCRIPTION
Clears the `core` ratchet, which **five open PRs currently inherit** (#7301, #7304, #7313, #7314, #7315, #7316). Comment-only — no behaviour change.

```
before   FAIL: core suspected-drift rose 3 -> 4
after    core: suspected-drift=0
```

## Why these went stale

#7305 moved the pinned upstream source from 3.4.4 to 3.5.0. Ten PRs authored before that flip merged after it (`git log 21c46555b..master`), landing 3.4.4 line numbers in a tree the gate resolves against 3.5.0. **A pin move is not a one-changeset event** — it silently invalidates every branch already in flight.

## What changed

Every target verified against **both** tarballs. Only the first is a mechanical retarget.

| # | site | cited | → | how it was located |
|---|---|---|---|---|
| 1 | `flags.rs` | `generator.c:298` | `:304` | anchor unique; context byte-identical |
| 2 | `daemon_transfer/connection/mod.rs` | `clientserver.c:382` | `:425` | by the `@ERROR` handler |
| 3 | `flags.rs` | `options.c:2852-2857` | `:3018-3023` | by `args[ac++] = "--super"` |
| 4 | `invocation/tests.rs` (×2) | `options.c:2850-2851` | `:3016-3017` | by `args[ac++] = "--only-write-batch=X"` |
| 5 | `invocation/tests.rs` | `main.c:1839`, `sender.c:217` | `:1919`, `:501` | by construct — **not reported by the ratchet** |

### ⚠ Do not treat the audit's candidate column as a fix list

Rows 2-4 have **non-unique anchors** — `rprintf(FERROR, "` and `if (am_sender)` each resolve to three places in 3.5.0, and `io_error |= IOERR_GENERAL` occurs 19 times in `flist.c`. So the audit reports *candidates*, not answers.

It is worse than merely non-committal. For row 2 the audit offered:

```
clientserver.c:382 'rprintf(FERROR, "'  ->  3.5.0@[205, 211, 220]
```

The correct line is **425** — **not in that list at all**. Every candidate sits in the greeting/protocol-error block; the actual site is the `@ERROR` handler further down. Anyone retargeting to the first suggestion would have shipped a citation that resolves cleanly, passes the hard gate, and points at unrelated code — strictly worse than leaving it stale, because the next reader has no reason to doubt it.

Each site here was instead located by its **enclosing construct** and confirmed by byte-identical surrounding context.

Rows 3-4 were already correct 3.4.4 **ranges**; the audit flagged them only because it anchors on the range's prose (`if (am_sender)`), which is not on the cited line. Those comments are now re-anchored on strings that are unique in `options.c`, so the audit can resolve them rather than guess — this is the recurrence fix, not just the retarget.

### Row 5 is the one the gate could never have caught

`main.c:1839` and `sender.c:217` sit mid-sentence in a doc comment, on lines that do not contain the word `upstream` — the only lines the drift audit inspects. Both were stale. **`sender.c` moved by +284 where `options.c` moved by +166**, so a bulk offset would have been wrong; each was located by its construct (`if (write_batch < 0) dry_run = 1` and `f_xfer = write_batch < 0 ? batch_fd : f_out`).

## Baseline

`core` drops 4 → 0, so its baseline goes **3 → 0** in this commit. The baseline file requires lowering when citations are fixed: leaving it at 3 keeps accepting drift that no longer exists and hides the next regression under that headroom.

## Out of scope, deliberately

- **`protocol`** (`flist.c:758`) — the identical fix is already in #7318. Dropped from this PR to avoid two PRs editing one line.
- **`daemon`** (`clientserver.c:1559`) — same cohort, fixed on #7314.

## Verification

Measured on `ce8c63dd1`:

- `python3 tools/ci/citation_drift_audit.py --ratchet` — `core: suspected-drift=0`
- `cargo xtask citations` — 7826 citations, all resolve
- `cargo fmt --all -- --check` — clean

No `cargo build` needed, so master's `drop_devices` breakage (#7319) does not gate this.
