### PR TITLE
feat(fast_io): warn once when a deep path exhausts file descriptors

### DIFF
--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -209,6 +209,13 @@ tempfile = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
 
+[target.'cfg(unix)'.dev-dependencies]
+# The dir_sandbox descriptor-exhaustion test lowers RLIMIT_NOFILE to provoke a
+# real EMFILE from the kernel. rustix's `process` feature exposes a safe
+# setrlimit/getrlimit pair, so the test needs no `unsafe` libc call; the crate
+# is already a production dependency here under the `fs` feature.
+rustix = { workspace = true, features = ["process", "stdio"] }
+
 [[bench]]
 name = "io_optimizations"
 harness = false

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -67,6 +67,7 @@ use std::io;
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use dashmap::DashMap;
 
@@ -409,6 +410,39 @@ impl DirSandbox {
     }
 }
 
+/// Latch for the once-per-process descriptor-exhaustion hint.
+static FD_EXHAUSTION_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// The hint text, byte-for-byte as upstream prints it.
+///
+/// upstream: syscall.c:2930-2931 - a bare `rprintf(FWARNING, ...)`, which
+/// `rwrite()` routes to stderr verbatim (log.c:341). The
+/// `rsync warning: ... (code N) at FILE(LINE) [role=version]` envelope is
+/// **not** applied here; that wording is spelled out literally at its own
+/// call site (log.c:956) and adding it would print text upstream does not.
+const FD_EXHAUSTION_HINT: &str =
+    "out of file descriptors resolving a deep path; raise the open-file limit (e.g. `ulimit -n`)";
+
+/// Decide whether `err` is the first descriptor-exhaustion failure seen.
+///
+/// Returns `true` exactly once per `warned` latch, and only for `EMFILE`
+/// (per-process limit) or `ENFILE` (system-wide limit). `swap` makes the
+/// claim atomic, so concurrent rayon workers hitting the ceiling together
+/// still produce a single line.
+///
+/// The latch is a parameter rather than a direct read of
+/// [`FD_EXHAUSTION_WARNED`] so tests can exercise the first-time arm
+/// without the process-global static coupling them to each other.
+fn should_warn_fd_exhaustion(err: &io::Error, warned: &AtomicBool) -> bool {
+    use rustix::io::Errno;
+
+    let exhausted = err.raw_os_error().is_some_and(|raw| {
+        raw == Errno::MFILE.raw_os_error() || raw == Errno::NFILE.raw_os_error()
+    });
+
+    exhausted && !warned.swap(true, Ordering::Relaxed)
+}
+
 /// Descend one component beneath `parent_fd`, following an in-tree symlink
 /// and refusing an escape.
 ///
@@ -432,7 +466,35 @@ impl DirSandbox {
 /// component, which refuses in-tree symlinks the kernel path would follow.
 /// That is stricter than upstream and is the portable-fallback gap tracked
 /// for the rest of the sandbox.
+///
+/// # Descriptor exhaustion
+///
+/// The carrier holds one dirfd per live path component, so a deep descent
+/// can exhaust the open-file limit where a single path-based `open()`
+/// would not. Upstream prints a one-shot hint on `EMFILE`/`ENFILE` for
+/// exactly this reason (upstream: syscall.c:2924-2936); without it the
+/// bare "Too many open files" is opaque about which limit to raise.
+///
+/// Upstream brackets its `rprintf` with `int e = errno; ... errno = e;`
+/// because `rprintf` can itself clobber the global `errno`. Rust has no
+/// such hazard here: the failure is an owned [`io::Error`] moved through
+/// this function, so nothing the emit does can alter what the caller
+/// observes. The guarantee is pinned by test rather than by copying a
+/// save/restore dance that would be a no-op.
 fn openat_dir(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
+    let result = openat_dir_strict(parent_fd, child_name);
+
+    if let Err(err) = &result
+        && should_warn_fd_exhaustion(err, &FD_EXHAUSTION_WARNED)
+    {
+        eprintln!("{FD_EXHAUSTION_HINT}");
+    }
+
+    result
+}
+
+/// The resolution itself, with no diagnostics attached.
+fn openat_dir_strict(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
     #[cfg(target_os = "linux")]
     {
         if openat2_supported()

--- a/crates/fast_io/src/dir_sandbox/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/tests.rs
@@ -352,3 +352,209 @@ fn operator_trusted_policy_follows_a_relative_in_tree_symlink() {
         .lstat_at(std::ffi::OsStr::new("marker"))
         .expect("the sandbox must be anchored at real/, reached through sub");
 }
+
+/// The descriptor-exhaustion hint must fire for exactly the two errnos
+/// upstream tests for, and for nothing else.
+///
+/// The interesting negative is `ENOENT`: every descent that walks past a
+/// missing component produces one, so a predicate that fired on any error
+/// would print the hint on ordinary traffic. Testing only the positives
+/// would not catch that - the mutation `exhausted = true` survives a
+/// positives-only suite.
+///
+/// upstream: syscall.c:2924 `if (errno == EMFILE || errno == ENFILE)`.
+#[test]
+fn fd_exhaustion_predicate_matches_only_emfile_and_enfile() {
+    use rustix::io::Errno;
+
+    for errno in [Errno::MFILE, Errno::NFILE] {
+        let latch = std::sync::atomic::AtomicBool::new(false);
+        let err = std::io::Error::from_raw_os_error(errno.raw_os_error());
+        assert!(
+            super::should_warn_fd_exhaustion(&err, &latch),
+            "{errno:?} is a descriptor-exhaustion failure and must warn"
+        );
+    }
+
+    for errno in [
+        Errno::NOENT,
+        Errno::ACCESS,
+        Errno::LOOP,
+        Errno::XDEV,
+        Errno::NOTDIR,
+    ] {
+        let latch = std::sync::atomic::AtomicBool::new(false);
+        let err = std::io::Error::from_raw_os_error(errno.raw_os_error());
+        assert!(
+            !super::should_warn_fd_exhaustion(&err, &latch),
+            "{errno:?} is an ordinary resolution failure and must stay silent"
+        );
+        assert!(
+            !latch.load(std::sync::atomic::Ordering::Relaxed),
+            "{errno:?} must not consume the one-shot latch"
+        );
+    }
+}
+
+/// The hint is one-shot: a deep tree hits the ceiling once per component
+/// and would otherwise flood stderr with an identical line.
+///
+/// upstream: syscall.c:2926-2928 `static int warned = 0; if (!warned)`.
+#[test]
+fn fd_exhaustion_hint_is_emitted_at_most_once() {
+    use rustix::io::Errno;
+
+    let latch = std::sync::atomic::AtomicBool::new(false);
+    let err = std::io::Error::from_raw_os_error(Errno::MFILE.raw_os_error());
+
+    assert!(
+        super::should_warn_fd_exhaustion(&err, &latch),
+        "the first exhaustion must warn"
+    );
+    for attempt in 2..=16 {
+        assert!(
+            !super::should_warn_fd_exhaustion(&err, &latch),
+            "attempt {attempt} must stay silent once the latch is claimed"
+        );
+    }
+}
+
+/// Concurrent claimants still produce exactly one line.
+///
+/// The carrier hands `BorrowedFd` copies to rayon workers, so several
+/// threads can hit the ceiling in the same instant. A non-atomic
+/// load-then-store latch would let more than one through.
+#[test]
+fn fd_exhaustion_latch_admits_exactly_one_concurrent_claimant() {
+    use rustix::io::Errno;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let latch = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let claims = Arc::new(AtomicUsize::new(0));
+
+    let handles: Vec<_> = (0..16)
+        .map(|_| {
+            let latch = Arc::clone(&latch);
+            let claims = Arc::clone(&claims);
+            thread::spawn(move || {
+                let err = std::io::Error::from_raw_os_error(Errno::MFILE.raw_os_error());
+                if super::should_warn_fd_exhaustion(&err, &latch) {
+                    claims.fetch_add(1, Ordering::Relaxed);
+                }
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().expect("join claimant");
+    }
+
+    assert_eq!(
+        claims.load(Ordering::Relaxed),
+        1,
+        "the latch must admit exactly one claimant across all threads"
+    );
+}
+
+/// The hint text is upstream's, byte for byte, with no `rsync warning:`
+/// envelope.
+///
+/// `rprintf(FWARNING, ...)` is routed to stderr verbatim by `rwrite()`
+/// (log.c:341); the `rsync warning: ... (code N) at FILE(LINE)` wording is
+/// spelled out at its own call site (log.c:956) and does not apply here.
+/// Pinning the text is what stops a later "improvement" from wrapping it.
+///
+/// upstream: syscall.c:2930-2931.
+#[test]
+fn fd_exhaustion_hint_text_matches_upstream_verbatim() {
+    assert_eq!(
+        super::FD_EXHAUSTION_HINT,
+        "out of file descriptors resolving a deep path; raise the open-file limit (e.g. `ulimit -n`)"
+    );
+    assert!(
+        !super::FD_EXHAUSTION_HINT.contains("rsync warning:"),
+        "upstream's FWARNING at this site carries no envelope"
+    );
+    assert!(
+        !super::FD_EXHAUSTION_HINT.ends_with('\n'),
+        "the newline belongs to the emit, not the text"
+    );
+}
+
+/// Cross-check against a real kernel refusal: `enter()` must emit the hint
+/// on stderr and must still report `EMFILE` to its caller.
+///
+/// This is the only cell that exercises the wiring inside `openat_dir`
+/// rather than the predicate in isolation. Without the stderr half,
+/// deleting the `eprintln!` from `openat_dir` leaves every other test in
+/// this file green - the predicate stays correct and becomes dead code.
+///
+/// The errno half is the port's answer to upstream's `int e = errno; ...
+/// errno = e;`. Upstream needs the save/restore because `rprintf` can
+/// clobber the global `errno`; the Rust port owns the failure as a moved
+/// [`std::io::Error`], so nothing the emit does can reach it. Asserting
+/// the errno here is what makes that a checked claim rather than a stated
+/// one: a refactor that re-derives the error after the emit (from a fresh
+/// `Errno::last_os_error()`, say) changes what this sees.
+///
+/// Both the `RLIMIT_NOFILE` drop and the stderr redirect are
+/// process-global. That is safe because nextest runs each test in its own
+/// process. Every descriptor the test needs is allocated *before* the
+/// limit drops, and both globals are restored before the assertions so a
+/// failing assert can still allocate for its own output.
+///
+/// upstream: syscall.c:2924-2936.
+#[test]
+fn real_fd_exhaustion_warns_once_and_surfaces_emfile_to_the_caller() {
+    use rustix::io::dup;
+    use rustix::process::{Resource, Rlimit, getrlimit, setrlimit};
+    use rustix::stdio::{dup2_stderr, stderr};
+    use std::io::{Read, Seek, SeekFrom};
+
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("subdir")).expect("mkdir subdir");
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+
+    // Allocate every descriptor up front - none of this can succeed once
+    // the limit is down.
+    let mut captured = tempfile::tempfile().expect("stderr capture file");
+    let saved_stderr = dup(stderr()).expect("save stderr");
+    let original = getrlimit(Resource::Nofile);
+
+    dup2_stderr(&captured).expect("redirect stderr");
+
+    // Existing descriptors keep working; only new allocations are refused,
+    // because the kernel checks the limit when it picks an fd number.
+    setrlimit(
+        Resource::Nofile,
+        Rlimit {
+            current: Some(3),
+            maximum: original.maximum,
+        },
+    )
+    .expect("lower RLIMIT_NOFILE");
+
+    let outcome = sandbox.enter(std::ffi::OsStr::new("subdir"));
+
+    setrlimit(Resource::Nofile, original).expect("restore RLIMIT_NOFILE");
+    dup2_stderr(&saved_stderr).expect("restore stderr");
+
+    let mut emitted = String::new();
+    captured.seek(SeekFrom::Start(0)).expect("rewind capture");
+    captured
+        .read_to_string(&mut emitted)
+        .expect("read captured stderr");
+
+    assert_eq!(
+        emitted.matches(super::FD_EXHAUSTION_HINT).count(),
+        1,
+        "the descent must print the hint exactly once; got: {emitted:?}"
+    );
+
+    let err = outcome.expect_err("descent must fail once no descriptor can be allocated");
+    assert_eq!(
+        err.raw_os_error(),
+        Some(rustix::io::Errno::MFILE.raw_os_error()),
+        "the caller must still see EMFILE, not an error re-derived after the hint"
+    );
+}


### PR DESCRIPTION
Ports upstream 3.5.0's one-shot descriptor-exhaustion hint (`syscall.c:2924-2936`) into `openat_dir`, the single funnel both the `openat2` and the `openat(O_NOFOLLOW)` arms pass through.

The `DirSandbox` carrier holds one dirfd per live path component, so a deep descent can exhaust the open-file limit where a single path-based `open()` would not. Until now that surfaced only as a bare "Too many open files", which says nothing about which limit to raise.

**This ports ahead of the pin flip deliberately: 3.4.4 has no analogue at all** - it contains no reference to `EMFILE` anywhere in its C sources - so there is no 3.4.4 behaviour to diverge from.

## Two details worth naming

**The message is emitted bare.** Upstream's call is `rprintf(FWARNING, ...)`, which `rwrite()` routes to stderr verbatim (`log.c:341`). The `rsync warning: ... (code N) at FILE(LINE) [role=version]` envelope is spelled out literally at its own call site (`log.c:956`) and does not apply here, so wrapping it in `logging::format_rsync_warning` would print text upstream never emits.

**No errno save/restore, because the hazard does not exist in Rust.** Upstream brackets its `rprintf` with `int e = errno; ... errno = e;` because `rprintf` can clobber the *global* `errno`. Here the failure is an owned `io::Error` moved through the function, so the emit cannot reach it. Rather than copy a dance that would be a provable no-op, the guarantee is pinned by a test that drives a real `EMFILE` through `DirSandbox::enter` and asserts the caller still sees it - which stays falsifiable if a refactor ever re-derives the error after the emit.

## Tests

Five cells: both exhaustion errnos; five ordinary resolution failures that must stay silent (`ENOENT` is the load-bearing negative - every descent past a missing component makes one, so a predicate firing on any error would print the hint on ordinary traffic); the one-shot latch; a 16-thread race on it admitting exactly one claimant; the exact hint text; and a real-`EMFILE` cross-check under a lowered `RLIMIT_NOFILE` asserting **both** the stderr line and the propagated errno.

**Non-vacuity, measured:** deleting the `eprintln!` from `openat_dir` fails exactly one cell and only that one. Without its stderr half the other four stay green while the predicate becomes dead code, so that assertion exists specifically to close the hole.

## Scope note

The hint fires from `DirSandbox`'s own descent, so it is reachable exactly where `DirSandbox` is used - the receiver and delete paths - and not from a plain local copy, which constructs no `DirSandbox`. Upstream parity is the justification; I am not claiming a local-copy user will see it.

## Dependencies

No production dependency change - `rustix` and `libc` are already `cfg(unix)` production deps of `fast_io`. The only manifest edit adds `rustix` with `process` + `stdio` under `[target.'cfg(unix)'.dev-dependencies]`, so the test can call `setrlimit` and redirect fd 2 through safe wrappers. No `unsafe`.

## Inherited CI reds (reproduced on pristine master, not introduced here)

Rebased onto `965d11bc3`. Two failures on this PR are master's, both reproduced by checking out `965d11bc3` in the same worktree:

1. **`fmt + clippy`** - `error[E0027]: pattern does not mention field 'drop_devices'` in `crates/transfer/src/flags.rs`. Fixed by #7319, still open. This PR touches no file in `crates/transfer`.
2. **`macOS (stable)`** - three `fast_io` cells fail on macOS, all landed by #7304: `enter_follows_in_tree_symlink_child`, `enter_refuses_relative_symlink_that_escapes`, `operator_trusted_policy_follows_a_relative_in_tree_symlink`. Pristine `965d11bc3` reports `3 tests run: 0 passed, 3 failed`. They assume `openat2`'s `RESOLVE_BENEATH` follows in-tree symlinks, which is Linux-only; on macOS the `O_NOFOLLOW` fallback refuses them and returns `ENOTDIR` - exactly what `openat_dir`'s own doc predicts ("Where `openat2(2)` is unavailable the walk degrades to `O_NOFOLLOW` ... stricter than upstream").

`fast_io` on this branch: **670 tests run, 667 passed, 3 failed** - the three above. All five new cells pass.

## Relationship to the sibling PR

Reads as a pair with the `raise_fd_limit` PR (that one raises the ceiling; this one explains it when the raised ceiling is still hit), but the two are independent - different crates, no shared files - and either can land first.


## Is the ceiling actually reachable? Measured.

Per-component dirfd stacking is bounded by `PATH_MAX`, not by input size. With single-character components - the densest possible tree - a `/tmp`-rooted path tops out near **depth 460** before `ENAMETOOLONG`; a depth-480 tree fails to build at all, and a depth-300 tree copies cleanly. So the carrier can hold on the order of 460 concurrent dirfds at the extreme.

That makes upstream's numbers concrete rather than presumed:

- **OpenBSD's default soft limit of 128 is genuinely binding** - 460 is 3.6x over it, so the exhaustion upstream describes is reachable, not theoretical.
- **4096 is generous but correctly sized** - comfortably above the structural ceiling without adopting a 2^20 hard limit wholesale.

## Reachability today, and where it is heading

`DirSandbox` is constructed on the receiver and delete paths (`transfer/src/receiver/transfer/setup/sandbox.rs`, `engine/delete/context/core.rs`). `crates/engine/src/local_copy/` constructs none, so a plain local copy cannot exhaust descriptors by depth at any limit - measured: depth 300 under a soft limit of 64 succeeds with zero fd pressure.

That is a sequencing fact rather than a weakness. Tasks 603-607 (U350-4d) route substantially more sites onto the resolver - the daemon sender open, the leaf sinks (rename/link/symlink/rmdir/unlink), and the alt-dest and staging families - so this lands **ahead of** the surface that will need it, which is the correct order.
