### PR TITLE
feat(core): raise the soft file-descriptor limit at startup

### DIFF
--- a/crates/core/src/fd_limit.rs
+++ b/crates/core/src/fd_limit.rs
@@ -1,0 +1,196 @@
+//! Process file-descriptor limit management.
+//!
+//! upstream: `main.c:1793-1808` `raise_fd_limit()`, invoked as the first
+//! statement of `main()` (`main.c:1817`).
+
+/// Soft `RLIMIT_NOFILE` this process aims for.
+///
+/// upstream: `main.c:1795` - "covers a MAXPATHLEN-deep walk + cache +
+/// headroom". Deliberately not unbounded: some systems set an enormous
+/// hard limit (2^20 and up) that upstream declines to adopt wholesale.
+pub const FD_LIMIT_TARGET: u64 = 4096;
+
+/// Raise the soft `RLIMIT_NOFILE` toward [`FD_LIMIT_TARGET`].
+///
+/// The symlink-race-safe descent in `fast_io::dir_sandbox` holds one open
+/// dirfd per path component plus an ancestor cache, so it needs far more
+/// descriptors than a single path-based `open()`. On a host with a low
+/// default soft limit - upstream names OpenBSD's 128 - a deep tree hits
+/// `EMFILE` where legacy rsync would not.
+///
+/// Three properties, all upstream's:
+///
+/// - **Capped** at [`FD_LIMIT_TARGET`], not raised to the hard limit.
+/// - **Clamped** to the hard limit, which an unprivileged process cannot
+///   exceed. Asking for more makes `setrlimit` fail outright, which would
+///   leave the soft limit untouched - so the clamp is what keeps the
+///   mitigation working on a host with a low admin-set ceiling, not a
+///   politeness.
+/// - **Raise-only.** An operator or parent process that deliberately set a
+///   higher limit keeps it; one that set a *lower* one is overridden only
+///   up to the cap, never reduced.
+///
+/// Best-effort throughout: every failure path leaves the process running
+/// with whatever limit it already had. `main()` calls this before any
+/// thread or child process is spawned, so the raised limit is inherited by
+/// the sender, generator, receiver and daemon children.
+///
+/// upstream: `main.c:1793-1808`.
+#[cfg(unix)]
+pub fn raise_fd_limit() {
+    use rustix::process::{Resource, getrlimit, setrlimit};
+
+    let mut limit = getrlimit(Resource::Nofile);
+
+    // `None` encodes `RLIM_INFINITY`. An infinite hard limit clamps
+    // nothing, mirroring C's `want > rl.rlim_max` being false there.
+    let want = match limit.maximum {
+        Some(maximum) => FD_LIMIT_TARGET.min(maximum),
+        None => FD_LIMIT_TARGET,
+    };
+
+    // An infinite soft limit already exceeds any finite target, so there is
+    // nothing to raise - again matching `rl.rlim_cur < want` in C.
+    let Some(current) = limit.current else {
+        return;
+    };
+    if current >= want {
+        return;
+    }
+
+    limit.current = Some(want);
+    let _ = setrlimit(Resource::Nofile, limit);
+}
+
+/// No-op on platforms without `RLIMIT_NOFILE`.
+///
+/// Windows has no per-process descriptor rlimit to raise; the C runtime's
+/// file-handle ceiling is not settable through this interface. The
+/// `dir_sandbox` carrier this guards is itself `#[cfg(unix)]`.
+#[cfg(not(unix))]
+pub fn raise_fd_limit() {}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::{FD_LIMIT_TARGET, raise_fd_limit};
+    use rustix::process::{Resource, Rlimit, getrlimit, setrlimit};
+
+    /// Set the soft limit, leaving the hard limit alone.
+    fn set_soft(current: u64) {
+        let limit = getrlimit(Resource::Nofile);
+        setrlimit(
+            Resource::Nofile,
+            Rlimit {
+                current: Some(current),
+                maximum: limit.maximum,
+            },
+        )
+        .expect("set soft RLIMIT_NOFILE");
+    }
+
+    /// A soft limit below the target is raised to it.
+    ///
+    /// The starting limit is lowered explicitly rather than taken from the
+    /// ambient environment: macOS ships a soft limit far above
+    /// `FD_LIMIT_TARGET`, so a test that skipped this step would assert
+    /// nothing on the platform it runs on most often.
+    #[test]
+    fn raises_a_low_soft_limit_to_the_target() {
+        let original = getrlimit(Resource::Nofile);
+        let hard = original.maximum.unwrap_or(u64::MAX);
+        assert!(
+            hard >= FD_LIMIT_TARGET,
+            "environment cannot exercise this case: hard limit {hard} < target {FD_LIMIT_TARGET}"
+        );
+
+        set_soft(64);
+        raise_fd_limit();
+
+        assert_eq!(
+            getrlimit(Resource::Nofile).current,
+            Some(FD_LIMIT_TARGET),
+            "a soft limit below the target must be raised to it"
+        );
+    }
+
+    /// A soft limit already above the target is left alone.
+    ///
+    /// upstream: `main.c:1804` `if (rl.rlim_cur < want)` - raise-only. An
+    /// unconditional assignment would silently *lower* the limit of an
+    /// operator who raised it on purpose, which is a regression the
+    /// low-limit test above cannot see.
+    #[test]
+    fn never_lowers_a_soft_limit_above_the_target() {
+        let original = getrlimit(Resource::Nofile);
+        let hard = original.maximum.unwrap_or(u64::MAX);
+        let generous = FD_LIMIT_TARGET * 2;
+        assert!(
+            hard >= generous,
+            "environment cannot exercise this case: hard limit {hard} < {generous}"
+        );
+
+        set_soft(generous);
+        raise_fd_limit();
+
+        assert_eq!(
+            getrlimit(Resource::Nofile).current,
+            Some(generous),
+            "a soft limit above the target must survive untouched"
+        );
+    }
+
+    /// The request is clamped to the hard limit.
+    ///
+    /// This is the cell that matters most. `setrlimit` refuses a soft limit
+    /// above the hard limit outright, and the call site discards its error
+    /// deliberately (upstream does too), so an unclamped request would not
+    /// raise the limit *at all* and would do it silently - the mitigation
+    /// becomes inert on exactly the low-ceiling hosts it exists for.
+    ///
+    /// Lowering the hard limit is irreversible for the process, which is
+    /// safe here only because nextest runs each test in its own process.
+    ///
+    /// upstream: `main.c:1802` `if (want > rl.rlim_max) want = rl.rlim_max;`
+    #[test]
+    fn clamps_the_request_to_a_hard_limit_below_the_target() {
+        let ceiling = 256;
+        assert!(ceiling < FD_LIMIT_TARGET);
+
+        setrlimit(
+            Resource::Nofile,
+            Rlimit {
+                current: Some(64),
+                maximum: Some(ceiling),
+            },
+        )
+        .expect("lower the hard RLIMIT_NOFILE");
+
+        raise_fd_limit();
+
+        assert_eq!(
+            getrlimit(Resource::Nofile).current,
+            Some(ceiling),
+            "the raise must clamp to the hard limit, not fail silently at 64"
+        );
+    }
+
+    /// An equal soft and hard limit at the target is a no-op, not a failure.
+    #[test]
+    fn leaves_a_soft_limit_exactly_at_the_target_alone() {
+        let original = getrlimit(Resource::Nofile);
+        let hard = original.maximum.unwrap_or(u64::MAX);
+        assert!(
+            hard >= FD_LIMIT_TARGET,
+            "environment cannot exercise this case"
+        );
+
+        set_soft(FD_LIMIT_TARGET);
+        raise_fd_limit();
+
+        assert_eq!(
+            getrlimit(Resource::Nofile).current,
+            Some(FD_LIMIT_TARGET),
+            "an already-satisfied limit must be left as it is"
+        );
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,8 @@ pub mod auth;
 pub mod bandwidth;
 /// Centralized exit code definitions matching upstream rsync's `errcode.h`.
 pub mod exit_code;
+/// Process file-descriptor limit management.
+pub mod fd_limit;
 /// Signal handling for graceful shutdown and cleanup.
 pub mod signal;
 /// Timeout configuration and tracking for rsync connections and I/O operations.

--- a/src/bin/oc-rsync.rs
+++ b/src/bin/oc-rsync.rs
@@ -42,6 +42,14 @@ fn main() -> ExitCode {
     #[cfg(all(target_os = "windows", target_env = "gnu"))]
     windows_gnu_eh::force_link();
 
+    // Raised before any thread or child process exists, so the sender,
+    // generator, receiver and daemon children all inherit it. The placement
+    // is load-bearing rather than stylistic: raising it later would leave
+    // already-spawned workers on the old limit.
+    //
+    // upstream: main.c:1817 - the first statement of main().
+    core::fd_limit::raise_fd_limit();
+
     // Do NOT hold `StdoutLock`/`StderrLock` here. Both are process-wide
     // reentrant locks owned by the acquiring thread. In TCP-daemon mode `main`
     // parks in the accept loop for the process lifetime while each session runs


### PR DESCRIPTION
Ports upstream 3.5.0's `raise_fd_limit()` (`main.c:1793-1808`).

The symlink-race-safe descent in `fast_io::dir_sandbox` holds one open dirfd per live path component plus an ancestor cache, so it needs far more descriptors than a single path-based `open()`. Upstream states the case it is defending in a comment at `main.c:1788`: **on a host with a low default soft limit - it names OpenBSD's 128 - a deep tree can hit `EMFILE`** where legacy rsync would not.

**This ports ahead of the pin flip deliberately: 3.4.4 has no analogue at all** - it contains no reference to `EMFILE` anywhere in its C sources - so there is no 3.4.4 behaviour to diverge from.

## Three properties, all upstream's, each load-bearing

- **Capped at 4096** rather than raised to the hard limit, because some systems set an enormous hard limit (2^20 and up) that upstream declines to adopt wholesale.
- **Clamped to the hard limit.** This is not politeness. `setrlimit` *refuses* a soft limit above the hard limit outright, and the call discards its error the way upstream does - so an unclamped request would not overshoot, it would **raise nothing at all, silently, on exactly the low-ceiling hosts the mitigation exists for.**
- **Raise-only,** so an operator or parent process that deliberately set a higher limit keeps it.

## Call-site placement is load-bearing

The function lives in `core`; the **call** is the first statement of `main()` in `src/bin/oc-rsync.rs`, matching `main.c:1817`. That placement is not stylistic: it runs before any thread or child process exists, so the sender, generator, receiver and daemon children all inherit the raised limit. Inside `core::session()` it would run after CLI parsing and could miss daemon mode entirely, since daemon is a mode of this same binary.

## Tests

Four cells: the raise, the raise-only guard, the hard-limit clamp, and the already-satisfied no-op. The low-limit cell lowers the starting soft limit explicitly rather than reading the ambient one - macOS ships a soft limit far above the target, so the cell would otherwise assert nothing on the platform it most often runs on.

**Non-vacuity, measured.** Each of the three behavioural properties was mutated in turn and each killed exactly the cell that owns it:

| mutation | cells killed |
|---|---|
| clamp removed | `clamps_the_request_to_a_hard_limit_below_the_target` |
| raise-only guard removed | `never_lowers_a_soft_limit_above_the_target` |
| `setrlimit` removed (function inert) | the two behavioural cells; the raise-only and already-at-target cells correctly survive, since they assert *no change* |

Every sweep run with `--no-fail-fast` and `passed + failed == run` checked.

Lowering the hard limit is irreversible for the process, which is safe only because nextest runs each test in its own process.

## Known gap, stated rather than papered over

**The call site itself is unobserved.** Deleting `core::fd_limit::raise_fd_limit();` from `main()` kills none of the four cells. I tried to close that with a behavioural A/B - two binaries, with-call and without-call, deep tree under a lowered `RLIMIT_NOFILE` - and it could not discriminate: at depth 300 with a soft limit of 64, both succeed with zero fd pressure, because **`crates/engine/src/local_copy/` constructs no `DirSandbox`** and so never stacks per-component dirfds. The scenario is reachable only on the receiver/delete paths, which needs a live transfer harness. Tracked as a follow-up rather than claimed as covered.

## Dependencies

None added. `core` already carries `rustix` with the `process` feature under `cfg(unix)`. Non-unix gets a documented no-op - Windows has no per-process descriptor rlimit to raise, and the `dir_sandbox` carrier this guards is itself `#[cfg(unix)]`. No `unsafe`.

## Inherited CI reds (reproduced on pristine master, not introduced here)

Rebased onto `965d11bc3`. Two failures are master's, both reproduced by checking out `965d11bc3` in the same worktree:

1. **`fmt + clippy`** - `error[E0027]: pattern does not mention field 'drop_devices'` in `crates/transfer/src/flags.rs`. Fixed by #7319, still open. This PR touches no file in `crates/transfer`.
2. **`macOS (stable)`** - three `fast_io` cells landed by #7304 fail on macOS. Pristine `965d11bc3` reports `3 tests run: 0 passed, 3 failed`. This PR touches no file in `crates/fast_io`.

Verification on this branch: `clippy -p core -p bin --all-targets --all-features -D warnings` exit 0 with zero diagnostics (note `-p bin` - the root package is named `bin`, not `oc-rsync`; that cell is what proves the `main()` wiring compiles). `core` suite **2778 passed**.

## Relationship to the sibling PR

Reads as a pair with the fd-exhaustion-hint PR (this one raises the ceiling; that one explains it when the raised ceiling is still hit), but the two are independent - different crates, no shared files - and either can land first.


## Is the ceiling actually reachable? Measured.

Per-component dirfd stacking is bounded by `PATH_MAX`, not by input size. With single-character components - the densest possible tree - a `/tmp`-rooted path tops out near **depth 460** before `ENAMETOOLONG`; a depth-480 tree fails to build at all, and a depth-300 tree copies cleanly. So the carrier can hold on the order of 460 concurrent dirfds at the extreme.

That makes upstream's numbers concrete rather than presumed:

- **OpenBSD's default soft limit of 128 is genuinely binding** - 460 is 3.6x over it, so the exhaustion upstream describes is reachable, not theoretical.
- **4096 is generous but correctly sized** - comfortably above the structural ceiling without adopting a 2^20 hard limit wholesale.

## Reachability today, and where it is heading

`DirSandbox` is constructed on the receiver and delete paths (`transfer/src/receiver/transfer/setup/sandbox.rs`, `engine/delete/context/core.rs`). `crates/engine/src/local_copy/` constructs none, so a plain local copy cannot exhaust descriptors by depth at any limit - measured: depth 300 under a soft limit of 64 succeeds with zero fd pressure.

That is a sequencing fact rather than a weakness. Tasks 603-607 (U350-4d) route substantially more sites onto the resolver - the daemon sender open, the leaf sinks (rename/link/symlink/rmdir/unlink), and the alt-dest and staging families - so this lands **ahead of** the surface that will need it, which is the correct order.
