### PR TITLE
fix(generator): order io_error to RERR_* the way cleanup.c does

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -107,7 +107,10 @@ pub(super) fn convert_server_stats_to_summary(
         summary = summary.with_events(list_only_events);
     }
 
-    // upstream: log.c - log_exit() converts io_error bitfield to RERR_* codes.
+    // upstream: cleanup.c:210-218 - convert io_error bitfield to RERR_* codes.
+    // `log_exit()` only renders the chosen code; the selection rule lives in
+    // `_exit_cleanup`, and its three independent `if`s order the flags
+    // GENERAL > VANISHED > DEL_LIMIT.
     let exit_code = io_error_flags::to_exit_code(io_error);
     if exit_code != 0 {
         summary.set_io_error_exit_code(exit_code);

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -80,7 +80,10 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
 
     let mut summary = ClientSummary::from_summary(local_summary);
 
-    // upstream: log.c log_exit() - convert io_error bitfield to RERR_* codes.
+    // upstream: cleanup.c:210-218 - convert io_error bitfield to RERR_* codes.
+    // `log_exit()` only renders the chosen code; the selection rule lives in
+    // `_exit_cleanup`, and its three independent `if`s order the flags
+    // GENERAL > VANISHED > DEL_LIMIT.
     let exit_code = io_error_flags::to_exit_code(io_error);
     if exit_code != 0 {
         summary.set_io_error_exit_code(exit_code);

--- a/crates/transfer/src/generator/io_error_flags.rs
+++ b/crates/transfer/src/generator/io_error_flags.rs
@@ -5,7 +5,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `rsync.h:168-170` - `IOERR_GENERAL`, `IOERR_VANISHED`, `IOERR_DEL_LIMIT`
+//! - `rsync.h:191-193` - `IOERR_GENERAL`, `IOERR_VANISHED`, `IOERR_DEL_LIMIT`
 
 // The bit definitions and the peer-value mask live in `protocol` because they
 // are wire values shared with the file-list and multiplex decoders; re-exported
@@ -13,28 +13,96 @@
 pub use protocol::{IOERR_DEL_LIMIT, IOERR_GENERAL, IOERR_VALID_MASK, IOERR_VANISHED};
 
 /// Converts an accumulated `io_error` bitfield into the corresponding rsync
-/// exit code.
+/// exit code. Returns 0 when no error bits are set.
 ///
-/// Mirrors upstream `log.c` - `log_exit()` which maps the io_error flags to
-/// `RERR_*` exit codes. Returns 0 when no error bits are set.
+/// # Precedence
+///
+/// Upstream evaluates three INDEPENDENT `if`s - not an `if`/`else if` chain -
+/// and lets the last one that matches overwrite `exit_code`. Precedence is
+/// therefore **GENERAL > VANISHED > DEL_LIMIT**, the reverse of the source
+/// order. The assignment form below mirrors that structure directly so the
+/// precedence cannot be misread as source order:
+///
+/// ```c
+/// if (io_error & IOERR_DEL_LIMIT) exit_code = RERR_DEL_LIMIT;
+/// if (io_error & IOERR_VANISHED)  exit_code = RERR_VANISHED;
+/// if (io_error & IOERR_GENERAL || got_xfer_error) exit_code = RERR_PARTIAL;
+/// ```
+///
+/// A `--max-delete` stop that also hit a permission-denied file is a *partial
+/// transfer* (23), not a delete-limit stop (25): the caller needs to know data
+/// was missed, which the delete limit alone does not imply.
+///
+/// `got_xfer_error` is not an `io_error` bit and is applied by the caller.
 ///
 /// # Exit code mapping
 ///
-/// | Condition | Code | Upstream constant |
-/// |-----------|------|-------------------|
-/// | `IOERR_DEL_LIMIT` set | 25 | `RERR_DEL_LIMIT` |
-/// | `IOERR_VANISHED` set (only) | 24 | `RERR_VANISHED` |
-/// | `IOERR_GENERAL` set | 23 | `RERR_PARTIAL` |
-/// | No bits set | 0 | success |
+/// | Highest-precedence bit set | Code | Upstream constant |
+/// |----------------------------|------|-------------------|
+/// | `IOERR_GENERAL` | 23 | `RERR_PARTIAL` |
+/// | `IOERR_VANISHED` | 24 | `RERR_VANISHED` |
+/// | `IOERR_DEL_LIMIT` | 25 | `RERR_DEL_LIMIT` |
+/// | none | 0 | success |
+///
+/// # Upstream Reference
+///
+/// - `cleanup.c:210-218` - the three sequential assignments. Note the rule
+///   lives here and NOT in `log.c:log_exit()`, which does no io_error mapping.
 #[must_use]
 pub const fn to_exit_code(io_error: i32) -> i32 {
+    let mut exit_code = 0;
     if io_error & IOERR_DEL_LIMIT != 0 {
-        25 // RERR_DEL_LIMIT
-    } else if io_error & IOERR_GENERAL != 0 {
-        23 // RERR_PARTIAL
-    } else if io_error & IOERR_VANISHED != 0 {
-        24 // RERR_VANISHED
-    } else {
-        0
+        exit_code = 25; // RERR_DEL_LIMIT
+    }
+    if io_error & IOERR_VANISHED != 0 {
+        exit_code = 24; // RERR_VANISHED
+    }
+    if io_error & IOERR_GENERAL != 0 {
+        exit_code = 23; // RERR_PARTIAL
+    }
+    exit_code
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IOERR_DEL_LIMIT, IOERR_GENERAL, IOERR_VANISHED, to_exit_code};
+
+    /// The full truth table. Written out rather than derived so a future edit
+    /// to the precedence has to change these numbers deliberately.
+    ///
+    /// upstream: `cleanup.c:210-218`.
+    #[test]
+    fn every_flag_combination_matches_upstream_precedence() {
+        for (bits, expected) in [
+            (0, 0),
+            (IOERR_DEL_LIMIT, 25),
+            (IOERR_VANISHED, 24),
+            (IOERR_GENERAL, 23),
+            (IOERR_DEL_LIMIT | IOERR_VANISHED, 24),
+            (IOERR_DEL_LIMIT | IOERR_GENERAL, 23),
+            (IOERR_VANISHED | IOERR_GENERAL, 23),
+            (IOERR_DEL_LIMIT | IOERR_VANISHED | IOERR_GENERAL, 23),
+        ] {
+            assert_eq!(to_exit_code(bits), expected, "io_error bits {bits:#b}");
+        }
+    }
+
+    /// The case that regressed: an `else if` chain lets DEL_LIMIT short-circuit
+    /// and report 25, hiding the fact that data was actually missed. CI scripts
+    /// branch on 23 to detect a partial transfer.
+    ///
+    /// upstream: `cleanup.c:216-217` - the GENERAL assignment runs last and
+    /// overwrites the DEL_LIMIT one.
+    #[test]
+    fn general_error_outranks_delete_limit() {
+        assert_eq!(to_exit_code(IOERR_DEL_LIMIT | IOERR_GENERAL), 23);
+    }
+
+    /// Sibling of the above: VANISHED also outranks DEL_LIMIT.
+    ///
+    /// upstream: `cleanup.c:214-215`.
+    #[test]
+    fn vanished_outranks_delete_limit() {
+        assert_eq!(to_exit_code(IOERR_DEL_LIMIT | IOERR_VANISHED), 24);
     }
 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2783,12 +2783,18 @@ fn to_exit_code_del_limit_returns_25() {
 }
 
 #[test]
-fn to_exit_code_del_limit_overrides_all() {
-    // upstream: IOERR_DEL_LIMIT takes highest precedence
+fn to_exit_code_general_outranks_vanished_and_del_limit() {
+    // upstream: cleanup.c:210-218 - three INDEPENDENT `if`s assign in the order
+    // DEL_LIMIT, VANISHED, GENERAL, each overwriting the last, so the GENERAL
+    // arm is the one that survives when several flags are set.
+    //
+    // This test previously asserted 25 under the comment "IOERR_DEL_LIMIT takes
+    // highest precedence", which inverted the rule and pinned the defect it was
+    // meant to guard.
     let all = io_error_flags::IOERR_DEL_LIMIT
         | io_error_flags::IOERR_GENERAL
         | io_error_flags::IOERR_VANISHED;
-    assert_eq!(io_error_flags::to_exit_code(all), 25);
+    assert_eq!(io_error_flags::to_exit_code(all), 23);
 }
 
 #[test]


### PR DESCRIPTION
Orders the `io_error` -> `RERR_*` mapping the way upstream's `cleanup.c` does. Written for task 405 and tracked by task 439 ("SHIP PR2"), which had been sitting `pending` with the work finished and pushed but never proposed - one of the four branches task 675 surfaced.

Rebased from `8c68fdb46` (84 commits behind) onto `965d11bc3`. The rebase replayed cleanly with the footprint unchanged (4 files, +102/-22), which is the first evidence master does not already carry it.

## Verification

⚠ The `transfer` crate cannot be compiled on current master, because master carries `error[E0027]: pattern does not mention field 'drop_devices'` in `crates/transfer/src/flags.rs` (fixed by #7319, still open). Rather than ship unverified, I applied #7319's one-line fix **locally and uncommitted** to get real signal, then reverted it - it is not part of this branch.

With that local patch in place:

- `io_error` cells: **38 run, 38 passed**
- full `transfer` crate: **2732 run, 2730 passed, 2 failed**

The 2 failures are `receiver::transfer::setup::sandbox::symlink_race_tests::{anchored_mode_follows_an_in_tree_symlinked_subdirectory, anchored_mode_refuses_a_peer_tail_that_escapes_the_module}`. Both reproduce on pristine `965d11bc3` with only the same local `E0027` patch applied (`8 tests run: 6 passed, 2 failed`), so they are inherited, not introduced. They are the `transfer`-side members of the macOS `openat2`/`O_NOFOLLOW` class that #7325 is fixing.

## Inherited CI reds

1. **`fmt + clippy`** - the `E0027` above. This PR touches `crates/transfer/src/generator/` and `crates/core/src/client/remote/`, not `flags.rs`.
2. **`macOS (stable)`** - the symlink-race class described above, being fixed by #7325.
