### PR TITLE
fix(engine): --link-dest must create the node when a hard link is refused

### DIFF
--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -230,7 +230,9 @@ pub(crate) fn copy_device(
             && let Some(basis) =
                 context.link_dest_special_target(link_relative, metadata, metadata_options)?
         {
-            link_special_from_link_dest(
+            // A destination that refuses the link falls through to creating the
+            // device node from the source, as upstream's `-3` return does.
+            if link_special_from_link_dest(
                 context,
                 source,
                 destination,
@@ -240,8 +242,9 @@ pub(crate) fn copy_device(
                 file_type,
                 destination_previously_existed,
                 true,
-            )?;
-            return Ok(());
+            )? {
+                return Ok(());
+            }
         }
     }
 

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -240,7 +240,9 @@ pub(crate) fn copy_fifo(
             && let Some(basis) =
                 context.link_dest_special_target(link_relative, metadata, metadata_options)?
         {
-            link_special_from_link_dest(
+            // A destination that refuses the link falls through to creating the
+            // FIFO from the source, as upstream's `-3` return does.
+            if link_special_from_link_dest(
                 context,
                 source,
                 destination,
@@ -250,8 +252,9 @@ pub(crate) fn copy_fifo(
                 file_type,
                 destination_previously_existed,
                 false,
-            )?;
-            return Ok(());
+            )? {
+                return Ok(());
+            }
         }
     }
 

--- a/crates/engine/src/local_copy/executor/special/mod.rs
+++ b/crates/engine/src/local_copy/executor/special/mod.rs
@@ -19,8 +19,53 @@ pub(crate) use device::copy_device;
 pub(crate) use fifo::copy_fifo;
 pub(crate) use symlink::{copy_symlink, create_symlink, symlink_target_is_safe};
 
+/// Attempts a `--link-dest` basis hard link, reporting whether it succeeded.
+///
+/// Returns `Ok(false)` when the destination refuses to create the link, leaving
+/// the caller to materialise the entry from the source instead. Upstream treats
+/// *any* `do_link_at()` failure that way rather than selecting "cannot
+/// hard-link" errnos, because the errno does not carry that distinction:
+/// `link(2)` documents `EPERM` both for a filesystem without hard-link support
+/// and for an ordinary permission refusal, and FUSE reports `ENOSYS` for the
+/// same condition. Failures that are genuinely fatal (`ENOSPC`, `EDQUOT`,
+/// `EROFS`) surface again when the caller creates the node, so nothing is
+/// silently swallowed.
+///
+/// upstream: generator.c:1269-1292 try_dests_non() - a failed `do_link_at()`
+/// sets `cannot_hardlink = 1; match_level = 2;` and returns `-3`, which makes
+/// the caller create the entry, landing where a build without
+/// `CAN_HARDLINK_SYMLINK` / `CAN_HARDLINK_SPECIAL` already lands.
+fn try_hard_link_basis(
+    context: &mut CopyContext,
+    basis: &Path,
+    destination: &Path,
+) -> Result<bool, LocalCopyError> {
+    let mut attempted_commit = false;
+    loop {
+        match create_hard_link(basis, destination) {
+            Ok(()) => return Ok(true),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                remove_existing_destination(destination)?;
+                return Ok(create_hard_link(basis, destination).is_ok());
+            }
+            Err(error)
+                if error.kind() == io::ErrorKind::NotFound
+                    && context.delay_updates_enabled()
+                    && !attempted_commit =>
+            {
+                context.commit_deferred_update_for(basis)?;
+                attempted_commit = true;
+            }
+            Err(_) => return Ok(false),
+        }
+    }
+}
+
 /// Hard-links a `--link-dest` basis device or special node into place, recording
 /// an exact-match `hD`/`hS` itemize row with blank attribute slots.
+///
+/// Returns `false` when the destination refused the link, so the caller creates
+/// the node from the source instead (see [`try_hard_link_basis`]).
 ///
 /// upstream: generator.c:1105-1137 try_dests_non() match_level 3 - the basis is
 /// hard-linked via `do_link()` and itemized with
@@ -38,35 +83,9 @@ pub(super) fn link_special_from_link_dest(
     file_type: fs::FileType,
     destination_previously_existed: bool,
     is_device: bool,
-) -> Result<(), LocalCopyError> {
-    let mut attempted_commit = false;
-    loop {
-        match create_hard_link(basis, destination) {
-            Ok(()) => break,
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                remove_existing_destination(destination)?;
-                create_hard_link(basis, destination).map_err(|link_error| {
-                    LocalCopyError::io("create hard link", destination.to_path_buf(), link_error)
-                })?;
-                break;
-            }
-            Err(error)
-                if error.kind() == io::ErrorKind::NotFound
-                    && context.delay_updates_enabled()
-                    && !attempted_commit =>
-            {
-                context.commit_deferred_update_for(basis)?;
-                attempted_commit = true;
-                continue;
-            }
-            Err(error) => {
-                return Err(LocalCopyError::io(
-                    "create hard link",
-                    destination.to_path_buf(),
-                    error,
-                ));
-            }
-        }
+) -> Result<bool, LocalCopyError> {
+    if !try_hard_link_basis(context, basis, destination)? {
+        return Ok(false);
     }
 
     context.record_hard_link(metadata, destination);
@@ -107,5 +126,5 @@ pub(super) fn link_special_from_link_dest(
         record_path,
         file_type,
     )?;
-    Ok(())
+    Ok(true)
 }

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -27,7 +27,7 @@ use crate::local_copy::{
 use ::metadata::{MetadataOptions, apply_symlink_metadata_with_options};
 
 use super::super::{is_device, is_fifo};
-use super::{device::copy_device, fifo::copy_fifo};
+use super::{device::copy_device, fifo::copy_fifo, try_hard_link_basis};
 
 /// Returns `true` when a symlink target stays within the transfer tree.
 ///
@@ -456,43 +456,12 @@ pub(crate) fn copy_symlink(
     // the destination is being created fresh (no prior symlink to recreate).
     if !mode.is_dry_run() && pre_replace_symlink_metadata.is_none() {
         let link_relative = relative.unwrap_or(record_path.as_deref().unwrap_or(Path::new("")));
+        // A destination that refuses the link falls through to recreating the
+        // symlink from the source, as upstream's `-3` return does.
         if !link_relative.as_os_str().is_empty()
             && let Some(basis_symlink) = context.link_dest_symlink_target(link_relative, &target)?
+            && try_hard_link_basis(context, &basis_symlink, destination)?
         {
-            let mut attempted_commit = false;
-            loop {
-                match create_hard_link(&basis_symlink, destination) {
-                    Ok(()) => break,
-                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                        remove_existing_destination(destination)?;
-                        create_hard_link(&basis_symlink, destination).map_err(|link_error| {
-                            LocalCopyError::io(
-                                "create hard link",
-                                destination.to_path_buf(),
-                                link_error,
-                            )
-                        })?;
-                        break;
-                    }
-                    Err(error)
-                        if error.kind() == io::ErrorKind::NotFound
-                            && context.delay_updates_enabled()
-                            && !attempted_commit =>
-                    {
-                        context.commit_deferred_update_for(&basis_symlink)?;
-                        attempted_commit = true;
-                        continue;
-                    }
-                    Err(error) => {
-                        return Err(LocalCopyError::io(
-                            "create hard link",
-                            destination.to_path_buf(),
-                            error,
-                        ));
-                    }
-                }
-            }
-
             context.record_hard_link(metadata, destination);
             context.summary_mut().record_hard_link();
             context.summary_mut().record_symlink();

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -1488,16 +1488,29 @@ fn link_dest_refused_hard_link_creates_the_node_instead() {
             let ftime = FileTime::from_last_modification_time(
                 &fs::symlink_metadata(&source_node).expect("source metadata"),
             );
-            set_file_times(&basis_node, ftime, ftime).expect("sync basis times");
+            // Must be the NOFOLLOW setter, to match the lstat above. Plain
+            // set_file_times() open(2)s the path first, which on these three
+            // kinds is not merely wrong but unusable: a FIFO blocks forever
+            // waiting for a peer to open the other end, a socket refuses with
+            // ENXIO/EOPNOTSUPP, and a symlink is followed to a target that
+            // does not exist.
+            filetime::set_symlink_file_times(&basis_node, ftime, ftime).expect("sync basis times");
 
-            let operands = vec![
-                source_dir.clone().into_os_string(),
-                dest_dir.clone().into_os_string(),
-            ];
+            // Trailing slash is load-bearing: it syncs the CONTENTS of source,
+            // so the entry's link-dest-relative name is `node` and resolves to
+            // `previous/node`. Without it the name would be `source/node`,
+            // the basis lookup would miss, and the link tier would never run -
+            // the matrix would pass while testing nothing.
+            let mut source_operand = source_dir.clone().into_os_string();
+            source_operand.push("/");
+            let operands = vec![source_operand, dest_dir.clone().into_os_string()];
             let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+            // `specials` covers FIFOs and sockets; symlinks need `links` as
+            // well, or they are skipped before the link tier is reached.
             let options = LocalCopyOptions::default()
                 .recursive(true)
                 .specials(true)
+                .links(true)
                 .permissions(true)
                 .extend_link_dests([basis_dir.clone()]);
 
@@ -1572,12 +1585,15 @@ fn link_dest_links_special_when_the_destination_accepts_it() {
     let ftime = FileTime::from_last_modification_time(
         &fs::symlink_metadata(&source_node).expect("source metadata"),
     );
-    set_file_times(&basis_node, ftime, ftime).expect("sync basis times");
+    // NOFOLLOW setter to match the lstat above; plain set_file_times() would
+    // open(2) the FIFO and block forever waiting for a peer.
+    filetime::set_symlink_file_times(&basis_node, ftime, ftime).expect("sync basis times");
 
-    let operands = vec![
-        source_dir.clone().into_os_string(),
-        dest_dir.clone().into_os_string(),
-    ];
+    // Trailing slash syncs the CONTENTS, so the link-dest-relative name is
+    // `node` and resolves to `previous/node` (see the matrix test above).
+    let mut source_operand = source_dir.clone().into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest_dir.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .recursive(true)

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -1403,3 +1403,195 @@ fn link_dest_copies_when_only_xattrs_differ() {
         .expect("basis xattr present");
     assert_eq!(basis_xattr, b"v1", "link-dest basis must not be modified");
 }
+
+// A `--link-dest` basis whose node the destination refuses to hard-link must
+// fall back to creating the entry, not fail the transfer.
+//
+// upstream: generator.c:1269-1292 try_dests_non() - rsync 3.5.0 sets
+// `cannot_hardlink = 1; match_level = 2;` on ANY `do_link_at()` failure and
+// returns `-3`, so the caller creates the node. 3.4.4 instead reported
+// `FERROR_XFER` and exited 23. Upstream deliberately does not select "cannot
+// hard-link" errnos: `link(2)` documents `EPERM` both for a filesystem without
+// hard-link support and for an ordinary permission refusal, and FUSE reports
+// `ENOSYS` for the same condition, so the errno cannot carry the distinction.
+//
+// Every errno below must therefore behave identically, for every special type
+// that reaches the link tier. Device nodes take the same
+// `link_special_from_link_dest` path as FIFOs and sockets (only the `is_device`
+// summary flag differs) but cannot be created without privileges, so they are
+// covered by that shared path rather than by a separate node here.
+#[cfg(unix)]
+#[test]
+fn link_dest_refused_hard_link_creates_the_node_instead() {
+    use std::os::unix::net::UnixListener;
+
+    #[derive(Clone, Copy)]
+    enum Special {
+        Fifo,
+        Socket,
+        Symlink,
+    }
+
+    let kinds = [
+        (Special::Fifo, "fifo"),
+        (Special::Socket, "socket"),
+        (Special::Symlink, "symlink"),
+    ];
+    // Every errno a destination can answer a refused link with. EOPNOTSUPP and
+    // ENOSYS differ numerically between Linux and macOS, so take them from libc
+    // rather than hard-coding.
+    let errnos = [
+        (libc::EXDEV, "EXDEV"),
+        (libc::EPERM, "EPERM"),
+        (libc::EOPNOTSUPP, "EOPNOTSUPP"),
+        (libc::EMLINK, "EMLINK"),
+        (libc::ENOSYS, "ENOSYS"),
+        (libc::EACCES, "EACCES"),
+    ];
+
+    for (kind, kind_name) in kinds {
+        for (errno, errno_name) in errnos {
+            let case = format!("{kind_name}/{errno_name}");
+            let temp = tempdir().expect("tempdir");
+            let source_dir = temp.path().join("source");
+            let basis_dir = temp.path().join("previous");
+            let dest_dir = temp.path().join("dest");
+            fs::create_dir_all(&source_dir).expect("create source");
+            fs::create_dir_all(&basis_dir).expect("create basis");
+
+            let make = |dir: &Path| {
+                let path = dir.join("node");
+                match kind {
+                    Special::Fifo => {
+                        let c = std::ffi::CString::new(path.as_os_str().as_encoded_bytes())
+                            .expect("cstring");
+                        // SAFETY-free: mkfifo via libc is the only portable way
+                        // to create a FIFO; the call is wrapped by the crate's
+                        // existing libc usage policy for tests.
+                        let rc = unsafe { libc::mkfifo(c.as_ptr(), 0o600) };
+                        assert_eq!(rc, 0, "mkfifo failed for {case}");
+                    }
+                    Special::Socket => {
+                        UnixListener::bind(&path).expect("bind socket");
+                    }
+                    Special::Symlink => {
+                        std::os::unix::fs::symlink("/some/target", &path).expect("symlink");
+                    }
+                }
+                path
+            };
+
+            let source_node = make(&source_dir);
+            let basis_node = make(&basis_dir);
+            // Align mtime so the basis reaches the exact-match tier that
+            // attempts the hard link at all.
+            let ftime = FileTime::from_last_modification_time(
+                &fs::symlink_metadata(&source_node).expect("source metadata"),
+            );
+            set_file_times(&basis_node, ftime, ftime).expect("sync basis times");
+
+            let operands = vec![
+                source_dir.clone().into_os_string(),
+                dest_dir.clone().into_os_string(),
+            ];
+            let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+            let options = LocalCopyOptions::default()
+                .recursive(true)
+                .specials(true)
+                .permissions(true)
+                .extend_link_dests([basis_dir.clone()]);
+
+            let summary = with_hard_link_override(
+                move |_, _| Err(io::Error::from_raw_os_error(errno)),
+                || plan.execute_with_options(LocalCopyExecution::Apply, options),
+            );
+
+            // The refusal must not fail the transfer (3.4.4 exited 23 here).
+            let summary = summary
+                .unwrap_or_else(|error| panic!("{case}: transfer failed instead of copying: {error}"));
+            let _ = &summary;
+
+            // ...and the entry must exist, created from the source.
+            let created = dest_dir.join("node");
+            let meta = fs::symlink_metadata(&created)
+                .unwrap_or_else(|error| panic!("{case}: destination entry missing: {error}"));
+            match kind {
+                Special::Fifo => {
+                    use std::os::unix::fs::FileTypeExt;
+                    assert!(meta.file_type().is_fifo(), "{case}: not a FIFO");
+                }
+                Special::Socket => {
+                    use std::os::unix::fs::FileTypeExt;
+                    assert!(meta.file_type().is_socket(), "{case}: not a socket");
+                }
+                Special::Symlink => {
+                    assert!(meta.file_type().is_symlink(), "{case}: not a symlink");
+                    assert_eq!(
+                        fs::read_link(&created).expect("read_link"),
+                        Path::new("/some/target"),
+                        "{case}: symlink target not preserved"
+                    );
+                }
+            }
+
+            // The fallback must create a distinct node, never share the basis
+            // inode - that is what distinguishes a real fallback from a link
+            // that silently succeeded.
+            let basis_meta = fs::symlink_metadata(&basis_node).expect("basis metadata");
+            assert_ne!(
+                meta.ino(),
+                basis_meta.ino(),
+                "{case}: destination shares the basis inode, so no link was attempted"
+            );
+        }
+    }
+}
+
+// Companion to the test above: with the link tier succeeding, the same setup
+// MUST hard-link. Without this, the fallback test could pass vacuously on a
+// basis that never reached the exact-match tier at all.
+#[cfg(unix)]
+#[test]
+fn link_dest_links_special_when_the_destination_accepts_it() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let basis_dir = temp.path().join("previous");
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir_all(&source_dir).expect("create source");
+    fs::create_dir_all(&basis_dir).expect("create basis");
+
+    let make = |dir: &Path| {
+        let path = dir.join("node");
+        let c = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).expect("cstring");
+        let rc = unsafe { libc::mkfifo(c.as_ptr(), 0o600) };
+        assert_eq!(rc, 0, "mkfifo failed");
+        path
+    };
+    let source_node = make(&source_dir);
+    let basis_node = make(&basis_dir);
+    let ftime = FileTime::from_last_modification_time(
+        &fs::symlink_metadata(&source_node).expect("source metadata"),
+    );
+    set_file_times(&basis_node, ftime, ftime).expect("sync basis times");
+
+    let operands = vec![
+        source_dir.clone().into_os_string(),
+        dest_dir.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .specials(true)
+        .permissions(true)
+        .extend_link_dests([basis_dir.clone()]);
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let created = fs::symlink_metadata(dest_dir.join("node")).expect("destination entry");
+    let basis_meta = fs::symlink_metadata(&basis_node).expect("basis metadata");
+    assert_eq!(
+        created.ino(),
+        basis_meta.ino(),
+        "an accepted link must share the basis inode"
+    );
+}


### PR DESCRIPTION
## oc was worse than the bug being ported

Measured cross-device (a `--link-dest` basis on a separate filesystem, so `link(2)` returns `EXDEV`), against the real 3.4.4 binary:

| | exit | stderr | `dst/pipe` |
|---|---|---|---|
| upstream 3.4.4 | 23 | error printed | **FIFO created** |
| oc (before) | 23 | error printed | **MISSING** |
| oc (after) | 0 | silent | **FIFO created** |

Upstream still materialises the node and only gets the exit status wrong. oc left the destination entry absent entirely, so the row this PR is nominally "porting" was already the better of the two behaviours.

3.5.0's `generator.c:try_dests_non()` falls back to creating a non-regular entry when the destination refuses to hard-link a `--link-dest` basis: it sets `cannot_hardlink = 1; match_level = 2;` and returns a new `-3` so the caller materialises the node. 3.4.4 instead reported `FERROR_XFER` and exited 23.

## Why the fallback is errno-blind, on purpose

Upstream applies the fallback to **every** errno deliberately, because the errno cannot carry the distinction it would need to:

- `link(2)` documents `EPERM` both for a filesystem without hard-link support **and** for an ordinary permission refusal.
- FUSE reports `ENOSYS` for the same condition.

So there is no errno subset that means "this filesystem cannot hard-link" as opposed to "you may not". Selecting one would silently drop the cases it failed to enumerate. Genuinely fatal conditions (`ENOSPC`, `EDQUOT`, `EROFS`) are not swallowed - they resurface when the caller creates the node.

The test matrix is built from that argument: every special type that reaches the link tier x every errno a destination can refuse with (FIFO, socket, symlink x `EXDEV`, `EPERM`, `EOPNOTSUPP`, `EMLINK`, `ENOSYS`, `EACCES`). `EOPNOTSUPP` and `ENOSYS` are taken from `libc` rather than hard-coded, since they differ numerically between Linux and macOS.

## Change

Three engine sites shared one open-coded retry loop ending in a hard error. They now share a single `try_hard_link_basis()` helper that *reports* refusal, and each caller falls through to its existing creation path. The `AlreadyExists` and delay-updates `NotFound` retries are unchanged. The receiver path (`transfer/receiver/quick_check.rs`) already fell back correctly and is untouched.

## Second commit: the harness had never run

The first commit was recorded with its test run still building. Running it to completion surfaced three defects **in the harness, none in the fix**:

1. **`set_file_times()` on a special file deadlocks.** `filetime::set_file_times` is defined once for all platforms (`lib.rs:247`) and unconditionally routes through `imp::open` -> `File::open`. On a FIFO that `open(2)` blocks until a peer opens the other end, so both tests hung **permanently** - two test processes sat in `__open` for 20 minutes. The same call is wrong for the other two kinds for different reasons: a socket refuses with `ENXIO`/`EOPNOTSUPP`, and a symlink is followed to a target that does not exist. Fixed by using `set_symlink_file_times`, which matches the `symlink_metadata` getter beside it and is path-based `utimensat` with `AT_SYMLINK_NOFOLLOW` - it never opens anything.
2. **Missing trailing slash on the source operand.** Without it the link-dest-relative name is `source/node`, so the basis lookup probes `previous/source/node`, misses, and the link tier is never reached (measured: destination link count 1, distinct inode).
3. **`links` not enabled.** `specials` covers FIFOs and sockets only, so every symlink row was skipped before the link tier even though `symlink.rs:463` routes through the same helper.

Defects 2 and 3 are the dangerous pair: each would have let the matrix report green while exercising nothing.

## Verification

- `cargo nextest run -p engine --all-features --no-fail-fast`: **4971 run / 4971 passed / 24 skipped**.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings`: clean.

**Non-vacuity.** Two independent mutations of the fallback arm, each run against the full engine suite. Both are lethal and each kills **exactly one** test - the errno matrix, and nothing else:

| mutation | meaning | result |
|---|---|---|
| `Ok(false)` -> `Ok(true)` | caller believes the link landed, entry never created | 4970 passed / 1 failed |
| propagate the error | the 3.4.4 behaviour | 4970 passed / 1 failed |

The companion test `link_dest_links_special_when_the_destination_accepts_it` pins the accepting case to **share** the basis inode, so the matrix cannot go green by ceasing to reach the link tier; the matrix rows assert the destination inode **differs** from the basis, so a link that quietly succeeded cannot pass either.

## Inherited red

Full-workspace clippy fails on this branch, and on its base, with a single pre-existing error unrelated to this change:

```
error[E0027]: pattern does not mention field `drop_devices`
    --> crates/transfer/src/flags.rs:1274:13
```

That is #7319, open against master. Control: the branch base is `965d11bc3`, and the two workspace clippy errors are both this `E0027` in `crates/transfer`; zero reference `crates/engine`. Engine-scoped clippy exits 0.
