### PR TITLE
test(receiver): pin both arms of the anchored peer-tail walk

### DIFF
--- a/crates/transfer/src/receiver/transfer/setup/sandbox.rs
+++ b/crates/transfer/src/receiver/transfer/setup/sandbox.rs
@@ -332,10 +332,45 @@ mod symlink_race_tests {
         }
     }
 
+    /// True when the peer-tail walk can tell an in-tree symlink from an
+    /// escape.
+    ///
+    /// Only `openat2(RESOLVE_BENEATH)` can: it follows a component and then
+    /// reports `EXDEV` if resolution left the anchor. The portable fallback
+    /// is `openat(O_DIRECTORY | O_NOFOLLOW)` per component
+    /// (`fast_io/src/dir_sandbox/mod.rs` `openat_dir` -> `openat_nofollow`),
+    /// which refuses *every* symlink component without resolving it, so the
+    /// two cases are indistinguishable there.
+    ///
+    /// Measured 2026-08-14 on macOS 15 (aarch64), both fixtures below:
+    ///
+    /// ```text
+    /// DirSandbox::open_dest_anchor(module, "link")    -> ENOTDIR (20)
+    /// DirSandbox::open_dest_anchor(module, "escape")  -> ENOTDIR (20)
+    /// ```
+    ///
+    /// Identical errno for the case that must be followed and the case that
+    /// must be refused. That is the whole divergence, and it is why the two
+    /// tests below branch instead of asserting one answer.
+    fn peer_tail_walk_can_resolve_symlinks() -> bool {
+        cfg!(target_os = "linux") && fast_io::openat2_supported()
+    }
+
     /// The peer half keeps `RESOLVE_BENEATH`. A client-supplied tail whose
     /// component is a symlink out of the module must not open, or the
     /// plain-open anchor above would have turned an availability bug into a
     /// module escape.
+    ///
+    /// ⚠ KNOWN GAP, not intended behaviour. On a platform without
+    /// `openat2` the walk cannot distinguish this from an in-tree symlink,
+    /// so `open_sandbox_for_dest_anchored` takes its `_ =>` arm: it warns
+    /// and returns `Ok(None)`, and the receiver then falls back to
+    /// **path-based** syscalls that resolve straight through the planted
+    /// symlink. The escape is loud but it is not refused. Closing that needs
+    /// the per-component resolver (`ds_descend`, `syscall.c:2891-2965`),
+    /// which follows a relative in-tree target and refuses an absolute or
+    /// escaping one - tracked by task 604. This test pins both arms so the
+    /// gap cannot widen unnoticed and so the Linux contract cannot regress.
     #[test]
     fn anchored_mode_refuses_a_peer_tail_that_escapes_the_module() {
         let (_keep, root) = canonical_tempdir();
@@ -348,8 +383,20 @@ mod symlink_race_tests {
         // even when it lands inside, so it would pass for the wrong reason.
         symlink("../outside", module_root.join("escape")).expect("symlink escape -> ../outside");
 
-        let err = open_sandbox_for_dest_anchored(&module_root, &module_root.join("escape"))
-            .expect_err("a peer tail leaving the module must be refused");
+        let outcome = open_sandbox_for_dest_anchored(&module_root, &module_root.join("escape"));
+
+        if !peer_tail_walk_can_resolve_symlinks() {
+            let degraded = outcome
+                .expect("the O_NOFOLLOW walk reports ENOTDIR, which is not the EXDEV escape arm");
+            assert!(
+                degraded.is_none(),
+                "without openat2 the escape is not refused; it degrades to the \
+                 unconfined path-based fall-back (task 604)"
+            );
+            return;
+        }
+
+        let err = outcome.expect_err("a peer tail leaving the module must be refused");
         let msg = err.to_string();
         assert!(
             msg.contains("escapes module root"),
@@ -366,6 +413,13 @@ mod symlink_race_tests {
     /// the module is ordinary content and must transfer. upstream:
     /// `ds_descend()` splices a relative in-tree target back into the walk
     /// (`syscall.c:2961`) rather than refusing it.
+    ///
+    /// ⚠ KNOWN GAP, not intended behaviour, same cause as the escape test
+    /// above and the same owner (task 604). Without `openat2` the walk
+    /// refuses the symlinked component, so the daemon receiver loses its
+    /// anchored dirfd and continues unconfined. Unlike the escape case this
+    /// costs confinement rather than granting an escape, but it is the same
+    /// missing mechanism.
     #[test]
     fn anchored_mode_follows_an_in_tree_symlinked_subdirectory() {
         let (_keep, root) = canonical_tempdir();
@@ -376,10 +430,21 @@ mod symlink_race_tests {
 
         let result = open_sandbox_for_dest_anchored(&module_root, &module_root.join("link"))
             .expect("an in-tree symlinked subdirectory must not be refused");
-        assert!(
-            result.is_some(),
-            "a symlinked subdirectory inside the module is ordinary content"
-        );
+
+        if peer_tail_walk_can_resolve_symlinks() {
+            assert!(
+                result.is_some(),
+                "a symlinked subdirectory inside the module is ordinary content"
+            );
+        } else {
+            assert!(
+                result.is_none(),
+                "without openat2 the walk refuses the symlinked component and \
+                 falls back unconfined (task 604); if this now returns a \
+                 sandbox the resolver has landed and both arms should assert \
+                 is_some()"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

The two `anchored_mode_*` cells in `receiver::transfer::setup::sandbox` asserted the `openat2` contract unconditionally, so they failed on every platform without it. Both now branch on the mechanism and assert an answer on **each** arm.

No production behaviour changes. Test-only.

## Why they failed

Measured on macOS 15 (aarch64), the exact fixture each test builds:

```
DirSandbox::open_dest_anchor(module, "link")    -> ENOTDIR (20)
DirSandbox::open_dest_anchor(module, "escape")  -> ENOTDIR (20)
```

Identical errno for the case that must be **followed** and the case that must be **refused**.

Only `openat2(RESOLVE_BENEATH)` resolves a component and then reports `EXDEV` if resolution left the anchor. The portable fallback is `openat(O_DIRECTORY | O_NOFOLLOW)` per component (`fast_io/src/dir_sandbox/mod.rs`, `openat_dir` -> `openat_nofollow`), which refuses every symlink component *without resolving it*, so the two cases are indistinguishable there.

## The gap this pins, stated as a gap

Without `openat2`, `open_sandbox_for_dest_anchored` takes its `_ =>` arm for the escape fixture: it warns and returns `Ok(None)`, and the receiver then falls back to **path-based** syscalls that resolve straight through the planted symlink. The escape is loud but it is **not refused**.

That is named in the test doc comment as a known gap with its owner, not as intended behaviour. Closing it needs the per-component resolver (`ds_descend`, `rsync-3.5.0/syscall.c:2891-2965`), which follows a relative in-tree target and refuses an absolute or escaping one.

The in-tree-subdirectory half is the same missing mechanism costing confinement rather than granting an escape.

## Verification

| | |
|---|---|
| macOS 15 aarch64 | `-p transfer` **2729/2729**, 3 skipped |
| Linux 7.0 aarch64 | `-p transfer --lib -E 'test(symlink_race)'` **8/8** |
| workspace clippy | clean (`--workspace --all-targets --all-features -D warnings`) |

⚠ The macOS run reports **35 failures unless `oc-rsync` is built first** — every one an integration binary finishing in ~0.015 s. `target/debug/oc-rsync` absent is the whole cause; 2729/2729 after `cargo build --bin oc-rsync`. The CI cell's own Build step covers this.

## Not in this PR

Adding `-p transfer` to the macOS cell. `transfer` is ~2732 tests against `fast_io`'s ~665, so the cost belongs in its own change with its own measurement.
