### PR TITLE
ci: run the Windows metadata/fast_io/transfer cell unfiltered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
       # main Test step does not run.
       - name: Test crtime + sparse + iocp read parity + symlink junction (metadata, fast_io, transfer)
         shell: bash
-        run: cargo nextest run --locked -p metadata -p fast_io -p transfer -E 'test(crtime) | test(sparse) | test(iocp_read_parity) | test(junction) | test(file_symlink_reports) | test(windows_receiver_symlink)'
+        run: cargo nextest run --locked -p metadata -p fast_io -p transfer
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
The `Windows (stable)` cell selected its `metadata` / `fast_io` / `transfer` tests with a hand-maintained **test-name filter**. This removes it and runs the three packages whole.

Same class of defect as the macOS cell in #7325, one layer further in: there the cell omitted a *package*, here it ran the packages but filtered them down to a name list. A name list is the worse form — a newly added test is invisible by default, and nothing tells you.

## Measurement

Originally opened as a measurement-only probe, because "remove the filter" is only safe if the newly-visible tests actually pass. They do:

```
BEFORE  master 13979a49d, Windows (stable), job success
        -p metadata -p fast_io -p transfer \
          -E 'test(crtime) | test(sparse) | test(iocp_read_parity) | test(junction) | ...'
        128 tests run: 128 passed, 3137 skipped

AFTER   this PR, same cell
        -p metadata -p fast_io -p transfer
        3264 tests run: 3264 passed (1 slow), 1 skipped
```

**128 → 3264. The filter was selecting 3.9% of the available tests; 3136 were being skipped.**

Cross-check that the two runs cover the same universe, since "green both sides" would be meaningless otherwise:

```
before   128 + 3137 skipped = 3265
after   3264 +    1 skipped = 3265
```

Identical totals, only the selector changed. All Windows cells pass on this branch: `(stable)`, `(beta)`, `GNU cross-check`, `daemon`, `interop (best-effort)`, `DG-3 stress`, and the `tracing (windows-latest)` row.

⚠ **Baseline provenance.** The `before` figure is from master `13979a49d`, not current head — most recent master runs are `cancelled` from queue reclamation, and that is the newest one whose `Windows (stable)` job actually executed. The filter expression is unchanged on master between there and head (it is exactly what this PR changes), so the baseline is sound, but it is not from head.

## Why this is a separate PR from the macOS fix

| cell | change | blast radius |
|---|---|---|
| macOS (#7325) | add `-p fast_io` | 3 reds + 1 timing-fragile test, all needing code fixes |
| Windows (this) | remove the name filter | 3136 newly-run tests, **zero** reds |

Opposite outcomes for the same class of change, which is the argument against bundling them into one "fix the CI cells" sweep: the macOS half only lands with code fixes attached, this half needs none.

The branch is still named `measure/…` from its probe origin; renaming it would force a new PR and discard a queued run, so it stays.
