### PR TITLE
test(engine): cover archive-mode and force-replace on FIFOs on Apple

### DIFF
--- a/crates/engine/src/local_copy/tests/execute_force.rs
+++ b/crates/engine/src/local_copy/tests/execute_force.rs
@@ -403,15 +403,13 @@ fn force_disabled_symlink_cannot_replace_directory_in_recursive_copy() {
     assert!(dest_root.join("link").is_dir(), "directory should remain");
 }
 
-#[cfg(all(
-    unix,
-    not(any(
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "tvos",
-        target_os = "watchos"
-    ))
-))]
+// Creates no socket, so the Apple exclusion the neighbouring socket tests
+// carry does not apply: mkfifo_for_tests has an Apple arm and force-replacing
+// a populated directory is not platform-specific. Without this, replacing a
+// NON-EMPTY directory with a FIFO is covered on no Apple platform - the
+// macOS-running execute_fifo_replaces_directory_when_force_enabled uses an
+// empty one, so the recursive-removal half goes untested there.
+#[cfg(unix)]
 #[test]
 fn force_fifo_replaces_non_empty_directory() {
     use std::os::unix::fs::FileTypeExt;

--- a/crates/engine/src/local_copy/tests/execute_specials.rs
+++ b/crates/engine/src/local_copy/tests/execute_specials.rs
@@ -498,6 +498,85 @@ fn execute_archive_mode_copies_fifo_and_socket_together() {
     assert_eq!(summary.files_copied(), 1);
 }
 
+// FIFO-only counterpart to the two archive-mode tests above. Both of those
+// also create a socket, so both are excluded on Apple platforms, and the
+// FIFO half of what they assert goes with them: archive mode applied to a
+// special file has no coverage there at all. `mkfifo_for_tests` works on
+// every unix, so this runs everywhere.
+//
+// Unlike the socket tests this keeps times(true): utimensat returns ENXIO on
+// a socket on some Linux kernels, which is why they disable it, but a FIFO
+// takes timestamps normally. That makes this the only place the mtime VALUE
+// is asserted on a special file - the macOS-running
+// execute_fifo_preserves_type_under_times_and_perms passes --times but
+// checks only the type and mode.
+//
+// The mtime assertion is the load-bearing one: measured by mutation, forcing
+// times(false) fails it. The mode assertion is NOT a --perms test - forcing
+// permissions(false) still passes, because the executor hands the source mode
+// to mknod, so a special file carries its mode with or without --perms. It is
+// kept as a pin on that carried value, not as coverage of the flag.
+#[cfg(unix)]
+#[test]
+fn execute_archive_mode_copies_fifo_preserving_mode_and_mtime() {
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+
+    let temp = tempdir().expect("tempdir");
+    let source_root = temp.path().join("source");
+    fs::create_dir_all(&source_root).expect("create source");
+
+    let fifo = source_root.join("archive.pipe");
+    mkfifo_for_tests(&fifo, 0o640).expect("mkfifo");
+    fs::set_permissions(&fifo, PermissionsExt::from_mode(0o640))
+        .expect("set fifo permissions");
+
+    // Must be the NOFOLLOW setter. Plain set_file_times() open(2)s the path
+    // first, and open(2) on a FIFO blocks until a peer opens the other end -
+    // a permanent deadlock, not a slow test.
+    let atime = FileTime::from_unix_time(1_700_050_000, 0);
+    let mtime = FileTime::from_unix_time(1_700_060_000, 0);
+    filetime::set_symlink_file_times(&fifo, atime, mtime).expect("set fifo times");
+
+    fs::write(source_root.join("file.txt"), b"archive").expect("write file");
+
+    let dest_root = temp.path().join("dest");
+    let operands = vec![
+        source_root.into_os_string(),
+        dest_root.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // archive_options() minus owner/group: chown requires root.
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            test_helpers::presets::archive_options()
+                .owner(false)
+                .group(false),
+        )
+        .expect("archive copy succeeds");
+
+    let dest_fifo = dest_root.join("source").join("archive.pipe");
+    let fifo_meta = fs::symlink_metadata(&dest_fifo).expect("fifo meta");
+    assert!(
+        fifo_meta.file_type().is_fifo(),
+        "archive mode must recreate the FIFO as a FIFO"
+    );
+    assert_eq!(fifo_meta.permissions().mode() & 0o777, 0o640);
+    assert_eq!(
+        FileTime::from_last_modification_time(&fifo_meta).unix_seconds(),
+        1_700_060_000,
+        "archive mode must carry the FIFO's mtime, not stamp it with now()"
+    );
+
+    assert_eq!(
+        fs::read(dest_root.join("source").join("file.txt")).expect("read"),
+        b"archive"
+    );
+    assert_eq!(summary.fifos_created(), 1);
+    assert_eq!(summary.files_copied(), 1);
+}
+
 
 #[cfg(all(
     unix,


### PR DESCRIPTION
## The filed premise was too broad, and measuring it changed the deliverable

This started as "`execute_specials.rs` has zero macOS coverage of the specials copy path". The file half is true - 19 of its 24 tests are Apple-excluded and the 5 survivors are pure `LocalCopyOptions` getter/setter tests with no filesystem I/O. The path half is not:

```
FIFO tests by file          runs on macOS   Apple-excluded
execute_special.rs                     22                2
executor_file_operations.rs            11                0
execute_super.rs                        2                0
list_only.rs                            2                0
execute_copy_links.rs                   1*               1*
execute_force.rs                        0                1
execute_specials.rs                     0                3
                                       ---              ---
                                        38                8
   * two arms of the same test, one per platform - it runs everywhere
```

`execute_special.rs` (singular) already covers create / skip-without-specials / skip-event / within-directory / hard links / dry run / force-replace / replace-regular-file / recopy / delete-extraneous / FifoCopied event / multiple permissions / times-and-perms on macOS. Writing FIFO-only siblings for the 19 excluded socket tests would have duplicated an existing, already-running suite.

So the deliverable is the residual, not the original scope: **two behaviours with genuinely zero Apple coverage.**

## What is actually missing, and why

| behaviour | why it has no Apple coverage |
|---|---|
| archive mode applied to a special file | the only two tests combining `mkfifo_for_tests` with `archive_options()` also create a socket, so both are Apple-excluded and the FIFO half of what they assert goes with them |
| force-replacing a **non-empty** directory with a FIFO | `force_fifo_replaces_non_empty_directory` carries the Apple exclusion its socket neighbours need, but creates no socket. The macOS-running `execute_fifo_replaces_directory_when_force_enabled` uses an **empty** directory, so the recursive-removal half is untested there |

Two different causes, two different fixes. The first is an absence and is closed additively. The second is an unjustified gate and is closed by widening it.

**No socket gate is touched.** All 19 are correct: they need a Unix-domain socket, and macOS cannot bind one in a temp dir. Narrowing them would force socket tests onto a platform that cannot run them.

## The new test keeps `times(true)`, which the socket tests cannot

`utimensat` returns ENXIO on a socket on some Linux kernels - that is why the two archive tests disable times. A FIFO takes timestamps normally, so the FIFO-only test can assert the mtime **value**. That makes it the only place an mtime value is asserted on a special file: the macOS-running `execute_fifo_preserves_type_under_times_and_perms` passes `--times` but checks only type and mode.

## Non-vacuity, measured

| mutation | result |
|---|---|
| force `times(false)` | **FAIL** - the mtime assertion is load-bearing |
| force `permissions(false)` | **PASS** - the mode assertion does not discriminate on `--perms` |

The second mutation is the informative one. The executor hands the source mode to `mknod`, so a special file carries its mode with or without `--perms`. The mode assertion is kept as a pin on that carried value and the comment says so explicitly rather than implying flag coverage it does not provide. The same is true of the existing `--perms` assertions on the socket tests; not changed here, but worth knowing.

Both tests run on macOS in this change - verified by running them on macOS, not by reading the `cfg`.

## Verification

```
cargo nextest run -p engine --all-features -E '<the two tests>'
  Summary [0.034s] 2 tests run: 2 passed, 4993 skipped     (macOS, aarch64)

cargo fmt --all -- --check                                        exit 0
cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
  Finished dev profile in 8m09s                                   exit 0, zero error/warning lines
```

## Follow-up found, deliberately not folded in

`execute_copy_links.rs` carries `copy_links_follows_symlink_to_fifo_in_directory` **twice** - a non-Apple arm and an Apple arm with byte-identical bodies. The Apple arm's comment says "FIFOs are created differently; use the macOS-compatible helper", but `mkfifo_for_tests` already dispatches internally, so the split has been unnecessary since that helper grew its Apple arm. Coverage is unaffected either way; it is duplication, not a hole.
