### PR TITLE
fix(receiver): sanitize received symlink targets when munging is off

### DIFF
--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -74,6 +74,30 @@ impl ReceiverContext {
 
             let relative_path = entry.path();
 
+            // upstream: flist.c:1329 - `if (sanitize_paths && !munge_symlinks
+            // && *bp) sanitize_path(bp, bp, "", lastdir_depth, SP_DEFAULT)`.
+            // `sanitize_paths` is set for a daemon module serving a path
+            // (clientserver.c:1068), so turning munging off does not leave the
+            // received target untouched: it still cannot resolve above the
+            // module root. The two transforms are mutually exclusive upstream,
+            // which is why this runs only when munging is off.
+            //
+            // Applied *before* the safe-links evaluation because upstream
+            // sanitizes during the file-list decode, so the `--safe-links`
+            // check at generator.c:1951 reads the already-sanitized
+            // `F_SYMLINK(file)`. Sanitizing after the check instead would skip
+            // entries upstream creates.
+            let sanitized: PathBuf;
+            let wire_target = if !self.config.munge_symlinks
+                && self.config.connection.is_daemon_connection
+                && !wire_target.as_os_str().is_empty()
+            {
+                sanitized = sanitize_received_symlink_target(wire_target);
+                &sanitized
+            } else {
+                wire_target
+            };
+
             // upstream: generator.c:1951 - `if (safe_symlinks && unsafe_symlink(sl, fname))`
             // skips unsafe symlinks when --safe-links is set. The check stays
             // here (not in sanitize_file_list) to preserve protocol index
@@ -1018,6 +1042,28 @@ impl ReceiverContext {
 /// receives the ASCII prefix without any lossy decode. The matching strip
 /// happens on the sender via `strip_symlink_munge_prefix` in
 /// `crate::generator::file_list::entry`.
+/// Sanitizes a received symlink target so it cannot resolve above the module
+/// root, for daemon modules that disabled `munge symlinks`.
+///
+/// Mirrors upstream `flist.c:1182`, which applies `sanitize_path(...,
+/// SP_DEFAULT)` to the target whenever `sanitize_paths && !munge_symlinks`.
+/// `sanitize_paths` is set for every daemon module (`clientserver.c:994-995`),
+/// so the two transforms between them leave no daemon configuration in which a
+/// peer-supplied target reaches the disk verbatim.
+///
+/// Byte-level like the munge sibling above: a symlink target is a raw byte
+/// string on the wire, and decoding it through `String` would rewrite the very
+/// value being made safe.
+#[cfg(unix)]
+fn sanitize_received_symlink_target(target: &Path) -> std::path::PathBuf {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    let sanitized =
+        crate::sanitize_path::sanitize_path_bytes_default(target.as_os_str().as_bytes());
+    std::path::PathBuf::from(OsString::from_vec(sanitized))
+}
+
 #[cfg(unix)]
 pub(in crate::receiver) fn apply_symlink_munge_prefix(target: &Path) -> std::path::PathBuf {
     use std::ffi::OsString;

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -92,7 +92,7 @@ impl ReceiverContext {
                 && self.config.connection.is_daemon_connection
                 && !wire_target.as_os_str().is_empty()
             {
-                sanitized = sanitize_received_symlink_target(wire_target);
+                sanitized = sanitize_received_symlink_target(wire_target, relative_path);
                 &sanitized
             } else {
                 wire_target
@@ -1031,6 +1031,57 @@ impl ReceiverContext {
     }
 }
 
+/// Sanitizes a received symlink target so it cannot resolve above the module
+/// root, for daemon modules that disabled `munge symlinks`.
+///
+/// Mirrors upstream `flist.c:1329`, which applies `sanitize_path(...,
+/// SP_DEFAULT)` to the target whenever `sanitize_paths && !munge_symlinks`.
+/// `sanitize_paths` is set for a daemon module with a path
+/// (`clientserver.c:1068`), so the two transforms between them leave no daemon
+/// configuration in which a peer-supplied target reaches the disk verbatim.
+///
+/// This rewrite is what makes an absolute target relative, so a link to
+/// `/etc/hostname` becomes the in-tree `etc/hostname` and `--safe-links` no
+/// longer treats it as escaping. That is upstream's behaviour, measured against
+/// rsync 3.4.4 and 3.5.0 as daemon receivers under `use chroot = false` plus
+/// `munge symlinks = false`: both create the link with the rewritten target.
+///
+/// Byte-level like the munge sibling above: a symlink target is a raw byte
+/// string on the wire, and decoding it through `String` would rewrite the very
+/// value being made safe.
+///
+/// `entry_path` is the entry's own relative path; its parent supplies the
+/// depth budget upstream passes as `lastdir_depth`, so a target that walks back
+/// no further than the transfer root survives intact.
+#[cfg(unix)]
+fn sanitize_received_symlink_target(target: &Path, entry_path: &Path) -> std::path::PathBuf {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    let sanitized = crate::sanitize_path::sanitize_path_bytes_default(
+        target.as_os_str().as_bytes(),
+        containing_dir_depth(entry_path),
+    );
+    std::path::PathBuf::from(OsString::from_vec(sanitized))
+}
+
+/// Number of directory levels the entry sits below the transfer root.
+///
+/// Mirrors upstream `util1.c:1015 count_dir_elements()` applied to `lastdir`,
+/// the entry's own directory (`flist.c:867`). `count_dir_elements` skips `.`
+/// elements, which is what filtering to `Component::Normal` reproduces; the
+/// received name is already sanitized by this point, so no `..` remains for the
+/// two to disagree about.
+#[cfg(unix)]
+fn containing_dir_depth(entry_path: &Path) -> usize {
+    entry_path.parent().map_or(0, |parent| {
+        parent
+            .components()
+            .filter(|component| matches!(component, std::path::Component::Normal(_)))
+            .count()
+    })
+}
+
 /// Prepends the `/rsyncd-munged/` prefix to a symlink target.
 ///
 /// Mirrors upstream `flist.c:1150-1154` where the receiver prepends
@@ -1042,28 +1093,6 @@ impl ReceiverContext {
 /// receives the ASCII prefix without any lossy decode. The matching strip
 /// happens on the sender via `strip_symlink_munge_prefix` in
 /// `crate::generator::file_list::entry`.
-/// Sanitizes a received symlink target so it cannot resolve above the module
-/// root, for daemon modules that disabled `munge symlinks`.
-///
-/// Mirrors upstream `flist.c:1182`, which applies `sanitize_path(...,
-/// SP_DEFAULT)` to the target whenever `sanitize_paths && !munge_symlinks`.
-/// `sanitize_paths` is set for every daemon module (`clientserver.c:994-995`),
-/// so the two transforms between them leave no daemon configuration in which a
-/// peer-supplied target reaches the disk verbatim.
-///
-/// Byte-level like the munge sibling above: a symlink target is a raw byte
-/// string on the wire, and decoding it through `String` would rewrite the very
-/// value being made safe.
-#[cfg(unix)]
-fn sanitize_received_symlink_target(target: &Path) -> std::path::PathBuf {
-    use std::ffi::OsString;
-    use std::os::unix::ffi::{OsStrExt, OsStringExt};
-
-    let sanitized =
-        crate::sanitize_path::sanitize_path_bytes_default(target.as_os_str().as_bytes());
-    std::path::PathBuf::from(OsString::from_vec(sanitized))
-}
-
 #[cfg(unix)]
 pub(in crate::receiver) fn apply_symlink_munge_prefix(target: &Path) -> std::path::PathBuf {
     use std::ffi::OsString;

--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -35,6 +35,8 @@ mod parallel_delta_notice;
 mod partial_resume;
 mod post_decision_name_emission;
 mod push_metadata_itemize;
+#[cfg(unix)]
+mod sanitize_symlink_targets;
 mod sender_stats;
 mod support;
 mod symlinks_and_devices;

--- a/crates/transfer/src/receiver/tests/sanitize_symlink_targets.rs
+++ b/crates/transfer/src/receiver/tests/sanitize_symlink_targets.rs
@@ -1,0 +1,217 @@
+//! Receiver-side symlink-target sanitization when munging is disabled.
+//!
+//! A daemon module that sets `munge symlinks = false` gives up the
+//! `/rsyncd-munged/` prefix, but upstream does **not** leave the received
+//! target untouched: `sanitize_paths` is on for every daemon module, so the
+//! decode path strips the leading `../` that would let the stored link
+//! resolve outside the module root. The two transforms are mutually
+//! exclusive and together they leave no configuration in which a
+//! client-supplied target reaches the disk verbatim.
+//!
+//! Measured 2026-08-14 against real daemons, `use chroot = false`,
+//! `read only = false`, `munge symlinks = false`, client pushing
+//! `escape -> ../outside`:
+//!
+//! ```text
+//! rsync 3.4.4   module/escape -> outside       (sanitized)
+//! rsync 3.5.0   module/escape -> outside       (sanitized)
+//! oc-rsync      module/escape -> ../outside    (verbatim)  <- this defect
+//! ```
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:1182` - `if (sanitize_paths && !munge_symlinks && *bp)
+//!   sanitize_path(bp, bp, "", lastdir_depth, SP_DEFAULT)`
+//! - `clientserver.c:994-995` - `if (module_dirlen) sanitize_paths = 1`, so
+//!   the guard is live for every daemon module.
+//! - `generator.c:1559` - the `--safe-links` check reads `F_SYMLINK(file)`,
+//!   i.e. the *already* sanitized target, which is why the transform has to
+//!   happen before the safety evaluation rather than at creation time.
+
+use std::ffi::OsString;
+use std::io::{self, Write};
+
+use protocol::ProtocolVersion;
+use protocol::flist::FileEntry;
+
+use super::super::ReceiverContext;
+use super::support::test_handshake;
+use crate::config::{ConnectionConfig, ServerConfig};
+use crate::flags::ParsedServerFlags;
+use crate::role::ServerRole;
+use crate::writer::MsgInfoSender;
+
+struct NullMsgInfoWriter;
+
+impl Write for NullMsgInfoWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl MsgInfoSender for NullMsgInfoWriter {
+    fn send_msg_info(&mut self, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A daemon receiver with `munge symlinks = false` - the configuration in
+/// which upstream falls back to `sanitize_path`.
+fn daemon_receiver_without_munging() -> ServerConfig {
+    ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        flags: ParsedServerFlags {
+            links: true,
+            ..Default::default()
+        },
+        args: vec![OsString::from(".")],
+        munge_symlinks: false,
+        connection: ConnectionConfig {
+            is_daemon_connection: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Runs one symlink through the receiver and reports the on-disk target, or
+/// `None` when no link was created (the `--safe-links` skip path).
+fn create_one_symlink(config: ServerConfig, target: &str) -> Option<std::path::PathBuf> {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path().to_path_buf();
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.file_list = vec![FileEntry::new_symlink("escape".into(), target.into())];
+
+    let mut writer = NullMsgInfoWriter;
+    ctx.create_symlinks(&dest, None, &mut writer)
+        .expect("create_symlinks must succeed on a writable tempdir");
+
+    let on_disk = std::fs::read_link(dest.join("escape")).ok();
+    drop(tmp);
+    on_disk
+}
+
+#[test]
+fn daemon_receiver_sanitizes_an_escaping_symlink_target_when_munging_is_off() {
+    // upstream: flist.c:1182 - with munging off, `sanitize_paths` still
+    // strips the leading `../`, so the stored link cannot resolve above the
+    // module root. Without this, a client holding only write access plants
+    // `escape -> ../outside` and reaches outside the module on the next
+    // transfer through that name.
+    let on_disk = create_one_symlink(daemon_receiver_without_munging(), "../outside");
+
+    assert_eq!(
+        on_disk.as_deref(),
+        Some(std::path::Path::new("outside")),
+        "a daemon receiver with `munge symlinks = false` must sanitize the \
+         received target (upstream flist.c:1182); storing `../outside` \
+         verbatim lets the link resolve outside the module root",
+    );
+}
+
+#[test]
+fn a_non_daemon_receiver_leaves_the_target_alone() {
+    // Negative control for the gate. Upstream keys the transform on
+    // `sanitize_paths`, which `clientserver.c:994-995` sets only when serving
+    // a daemon module - an ordinary local or SSH receiver must keep the
+    // target byte-for-byte. Without this, the fix would silently rewrite
+    // legitimate `../` targets on every non-daemon transfer.
+    let mut config = daemon_receiver_without_munging();
+    config.connection.is_daemon_connection = false;
+
+    let on_disk = create_one_symlink(config, "../outside");
+
+    assert_eq!(
+        on_disk.as_deref(),
+        Some(std::path::Path::new("../outside")),
+        "only a daemon receiver has `sanitize_paths` set upstream \
+         (clientserver.c:994-995); a non-daemon receiver must store the \
+         target verbatim",
+    );
+}
+
+#[test]
+fn munging_still_wins_when_it_is_enabled() {
+    // The two transforms are mutually exclusive upstream (`flist.c:1182` is
+    // guarded by `!munge_symlinks`). With munging on, the target must carry
+    // the prefix and must NOT have been sanitized first - sanitizing as well
+    // would strip the `../` that the munge prefix already neutralises, and
+    // silently change what the sender's strip round-trips back to.
+    let mut config = daemon_receiver_without_munging();
+    config.munge_symlinks = true;
+
+    let on_disk = create_one_symlink(config, "../outside");
+
+    assert_eq!(
+        on_disk.as_deref(),
+        Some(std::path::Path::new("/rsyncd-munged/../outside")),
+        "munging and sanitization are mutually exclusive (flist.c:1182 is \
+         gated on !munge_symlinks); with munging on the target keeps its \
+         `../` behind the prefix",
+    );
+}
+
+#[test]
+fn a_non_utf8_target_is_sanitized_byte_exactly() {
+    // The target is a raw byte string on the wire. Routing it through
+    // `String` would replace the non-UTF-8 bytes and rewrite the value the
+    // sanitizer exists to make safe, so the transform stays on `&[u8]`.
+    use std::ffi::OsString;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path().to_path_buf();
+    let target = std::path::PathBuf::from(OsString::from_vec(b"../\xFFoutside".to_vec()));
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, daemon_receiver_without_munging());
+    ctx.file_list = vec![FileEntry::new_symlink("escape".into(), target)];
+
+    let mut writer = NullMsgInfoWriter;
+    ctx.create_symlinks(&dest, None, &mut writer)
+        .expect("create_symlinks must succeed on a writable tempdir");
+
+    let on_disk = std::fs::read_link(dest.join("escape")).expect("read_link");
+    assert_eq!(
+        on_disk.as_os_str().as_bytes(),
+        b"\xFFoutside",
+        "the traversal prefix must be stripped while every other byte \
+         survives verbatim; a lossy decode would corrupt the name and defeat \
+         the purpose of sanitizing it",
+    );
+}
+
+#[test]
+fn sanitization_precedes_the_safe_links_check() {
+    // Placement, not just presence. Upstream sanitizes during the file-list
+    // decode (`flist.c:1182`), so by the time the generator evaluates
+    // `--safe-links` it reads the *sanitized* target
+    // (`generator.c:1559` passes `F_SYMLINK(file)`). A target of
+    // `../outside` therefore becomes `outside`, which is in-tree, and the
+    // link is created.
+    //
+    // Applying the transform after the safety evaluation instead would make
+    // oc skip the entry with "skipping unsafe symlink" where upstream
+    // creates it - trading this defect for a different divergence, so the
+    // ordering is pinned here rather than left to the next reader.
+    let mut config = daemon_receiver_without_munging();
+    config.flags.safe_links = true;
+
+    let on_disk = create_one_symlink(config, "../outside");
+
+    assert_eq!(
+        on_disk.as_deref(),
+        Some(std::path::Path::new("outside")),
+        "sanitization must run before the --safe-links evaluation so the \
+         check sees the same in-tree target upstream sees \
+         (flist.c:1182 decode, then generator.c:1559); sanitizing later \
+         would skip an entry upstream creates",
+    );
+}

--- a/crates/transfer/src/receiver/tests/sanitize_symlink_targets.rs
+++ b/crates/transfer/src/receiver/tests/sanitize_symlink_targets.rs
@@ -2,11 +2,22 @@
 //!
 //! A daemon module that sets `munge symlinks = false` gives up the
 //! `/rsyncd-munged/` prefix, but upstream does **not** leave the received
-//! target untouched: `sanitize_paths` is on for every daemon module, so the
-//! decode path strips the leading `../` that would let the stored link
+//! target untouched: `sanitize_paths` is on for a daemon module with a path,
+//! so the decode path strips the leading `../` that would let the stored link
 //! resolve outside the module root. The two transforms are mutually
 //! exclusive and together they leave no configuration in which a
 //! client-supplied target reaches the disk verbatim.
+//!
+//! The strip is budgeted, not unconditional: upstream passes `lastdir_depth`,
+//! the depth of the entry's own directory, so a target that walks back no
+//! further than the transfer root is preserved and only the part that reaches
+//! past it is collapsed. Measured against rsync 3.5.0 as a daemon receiver,
+//! pushing two links from `sub/dir/`:
+//!
+//! ```text
+//! ../../hello.txt     -> ../../hello.txt    (in budget, kept intact)
+//! ../../../escape.txt -> ../../escape.txt   (one level over, collapsed)
+//! ```
 //!
 //! Measured 2026-08-14 against real daemons, `use chroot = false`,
 //! `read only = false`, `munge symlinks = false`, client pushing
@@ -20,11 +31,13 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:1182` - `if (sanitize_paths && !munge_symlinks && *bp)
+//! - `flist.c:1329` - `if (sanitize_paths && !munge_symlinks && *bp)
 //!   sanitize_path(bp, bp, "", lastdir_depth, SP_DEFAULT)`
-//! - `clientserver.c:994-995` - `if (module_dirlen) sanitize_paths = 1`, so
-//!   the guard is live for every daemon module.
-//! - `generator.c:1559` - the `--safe-links` check reads `F_SYMLINK(file)`,
+//! - `clientserver.c:1068` - `if (module_dirlen) sanitize_paths = 1`, so
+//!   the guard is live for a daemon module serving a path.
+//! - `flist.c:867` - `lastdir_depth = count_dir_elements(lastdir)`, the
+//!   budget of leading `..` the sanitize preserves.
+//! - `generator.c:1951` - the `--safe-links` check reads `F_SYMLINK(file)`,
 //!   i.e. the *already* sanitized target, which is why the transform has to
 //!   happen before the safety evaluation rather than at creation time.
 
@@ -82,25 +95,43 @@ fn daemon_receiver_without_munging() -> ServerConfig {
 /// Runs one symlink through the receiver and reports the on-disk target, or
 /// `None` when no link was created (the `--safe-links` skip path).
 fn create_one_symlink(config: ServerConfig, target: &str) -> Option<std::path::PathBuf> {
+    create_one_symlink_at(config, "escape", target)
+}
+
+/// As [`create_one_symlink`], but places the link at an arbitrary relative
+/// path so the depth budget can be exercised below the transfer root.
+///
+/// The two agree at the root and diverge only underneath it, which is why the
+/// depth-taking arm needs its own entry path rather than another target.
+fn create_one_symlink_at(
+    config: ServerConfig,
+    entry_path: &str,
+    target: &str,
+) -> Option<std::path::PathBuf> {
     let tmp = tempfile::tempdir().expect("tempdir");
     let dest = tmp.path().to_path_buf();
 
+    let link_path = dest.join(entry_path);
+    if let Some(parent) = link_path.parent() {
+        std::fs::create_dir_all(parent).expect("create the entry's parent directories");
+    }
+
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = vec![FileEntry::new_symlink("escape".into(), target.into())];
+    ctx.file_list = vec![FileEntry::new_symlink(entry_path.into(), target.into())];
 
     let mut writer = NullMsgInfoWriter;
     ctx.create_symlinks(&dest, None, &mut writer)
         .expect("create_symlinks must succeed on a writable tempdir");
 
-    let on_disk = std::fs::read_link(dest.join("escape")).ok();
+    let on_disk = std::fs::read_link(&link_path).ok();
     drop(tmp);
     on_disk
 }
 
 #[test]
 fn daemon_receiver_sanitizes_an_escaping_symlink_target_when_munging_is_off() {
-    // upstream: flist.c:1182 - with munging off, `sanitize_paths` still
+    // upstream: flist.c:1329 - with munging off, `sanitize_paths` still
     // strips the leading `../`, so the stored link cannot resolve above the
     // module root. Without this, a client holding only write access plants
     // `escape -> ../outside` and reaches outside the module on the next
@@ -111,7 +142,7 @@ fn daemon_receiver_sanitizes_an_escaping_symlink_target_when_munging_is_off() {
         on_disk.as_deref(),
         Some(std::path::Path::new("outside")),
         "a daemon receiver with `munge symlinks = false` must sanitize the \
-         received target (upstream flist.c:1182); storing `../outside` \
+         received target (upstream flist.c:1329); storing `../outside` \
          verbatim lets the link resolve outside the module root",
     );
 }
@@ -119,7 +150,7 @@ fn daemon_receiver_sanitizes_an_escaping_symlink_target_when_munging_is_off() {
 #[test]
 fn a_non_daemon_receiver_leaves_the_target_alone() {
     // Negative control for the gate. Upstream keys the transform on
-    // `sanitize_paths`, which `clientserver.c:994-995` sets only when serving
+    // `sanitize_paths`, which `clientserver.c:1068` sets only when serving
     // a daemon module - an ordinary local or SSH receiver must keep the
     // target byte-for-byte. Without this, the fix would silently rewrite
     // legitimate `../` targets on every non-daemon transfer.
@@ -132,14 +163,14 @@ fn a_non_daemon_receiver_leaves_the_target_alone() {
         on_disk.as_deref(),
         Some(std::path::Path::new("../outside")),
         "only a daemon receiver has `sanitize_paths` set upstream \
-         (clientserver.c:994-995); a non-daemon receiver must store the \
+         (clientserver.c:1068); a non-daemon receiver must store the \
          target verbatim",
     );
 }
 
 #[test]
 fn munging_still_wins_when_it_is_enabled() {
-    // The two transforms are mutually exclusive upstream (`flist.c:1182` is
+    // The two transforms are mutually exclusive upstream (`flist.c:1329` is
     // guarded by `!munge_symlinks`). With munging on, the target must carry
     // the prefix and must NOT have been sanitized first - sanitizing as well
     // would strip the `../` that the munge prefix already neutralises, and
@@ -152,7 +183,7 @@ fn munging_still_wins_when_it_is_enabled() {
     assert_eq!(
         on_disk.as_deref(),
         Some(std::path::Path::new("/rsyncd-munged/../outside")),
-        "munging and sanitization are mutually exclusive (flist.c:1182 is \
+        "munging and sanitization are mutually exclusive (flist.c:1329 is \
          gated on !munge_symlinks); with munging on the target keeps its \
          `../` behind the prefix",
     );
@@ -191,9 +222,9 @@ fn a_non_utf8_target_is_sanitized_byte_exactly() {
 #[test]
 fn sanitization_precedes_the_safe_links_check() {
     // Placement, not just presence. Upstream sanitizes during the file-list
-    // decode (`flist.c:1182`), so by the time the generator evaluates
+    // decode (`flist.c:1329`), so by the time the generator evaluates
     // `--safe-links` it reads the *sanitized* target
-    // (`generator.c:1559` passes `F_SYMLINK(file)`). A target of
+    // (`generator.c:1951` passes `F_SYMLINK(file)`). A target of
     // `../outside` therefore becomes `outside`, which is in-tree, and the
     // link is created.
     //
@@ -211,7 +242,62 @@ fn sanitization_precedes_the_safe_links_check() {
         Some(std::path::Path::new("outside")),
         "sanitization must run before the --safe-links evaluation so the \
          check sees the same in-tree target upstream sees \
-         (flist.c:1182 decode, then generator.c:1559); sanitizing later \
+         (flist.c:1329 decode, then generator.c:1951); sanitizing later \
          would skip an entry upstream creates",
+    );
+}
+
+#[test]
+fn a_target_reaching_no_further_than_the_transfer_root_survives_intact() {
+    // upstream: flist.c:1329 passes `lastdir_depth`, not 0 - the depth of the
+    // entry's own directory (flist.c:867). A link in `sub/dir/` may therefore
+    // carry `../..`, which lands exactly on the transfer root and is in-tree.
+    //
+    // This is the arm the root-level tests above cannot reach: at the root the
+    // budget is 0 and both readings agree, so every one of them passes either
+    // way. With depth hardcoded to 0 this target collapses to `hello.txt`,
+    // silently retargeting the link at a sibling inside `sub/dir/` that does
+    // not exist - a corrupted link, not a blocked one.
+    //
+    // Measured against rsync 3.5.0 as a daemon receiver under
+    // `use chroot = false` + `munge symlinks = false`: the target is stored
+    // unchanged.
+    let on_disk = create_one_symlink_at(
+        daemon_receiver_without_munging(),
+        "sub/dir/up_two.txt",
+        "../../hello.txt",
+    );
+
+    assert_eq!(
+        on_disk.as_deref(),
+        Some(std::path::Path::new("../../hello.txt")),
+        "a target that walks back no further than the transfer root is within \
+         the `lastdir_depth` budget and must survive verbatim (flist.c:1329 \
+         with flist.c:867); collapsing it to `hello.txt` points the link at a \
+         file that does not exist",
+    );
+}
+
+#[test]
+fn a_target_reaching_past_the_transfer_root_is_collapsed_to_it() {
+    // The complement of the arm above, and the reason the budget is a budget
+    // rather than a licence: one `..` beyond the entry's own depth would
+    // escape, so upstream drops exactly the excess and keeps the rest.
+    //
+    // Measured against rsync 3.5.0 under the same config: `../../../escape.txt`
+    // from `sub/dir/` is stored as `../../escape.txt`, i.e. clamped to the
+    // transfer root rather than flattened to a bare name.
+    let on_disk = create_one_symlink_at(
+        daemon_receiver_without_munging(),
+        "sub/dir/up_three.txt",
+        "../../../escape.txt",
+    );
+
+    assert_eq!(
+        on_disk.as_deref(),
+        Some(std::path::Path::new("../../escape.txt")),
+        "only the `..` beyond the entry's depth is dropped (flist.c:1329 with \
+         lastdir_depth); flattening to `escape.txt` would both lose the \
+         in-budget prefix and hide that the peer asked to escape",
     );
 }

--- a/crates/transfer/src/sanitize_path.rs
+++ b/crates/transfer/src/sanitize_path.rs
@@ -64,7 +64,8 @@ pub fn sanitize_path_keep_dot_dirs_bytes(path: &[u8]) -> Vec<u8> {
     sanitize_path_bytes(path, 0, true)
 }
 
-/// Byte-exact variant of [`sanitize_path`] (`SP_DEFAULT`).
+/// Byte-exact variant of [`sanitize_path`] (`SP_DEFAULT`) with an explicit
+/// depth budget.
 ///
 /// Used for symlink targets received from the network, which are raw byte
 /// strings on the wire (upstream carries them as `char*`) and need not be
@@ -74,13 +75,22 @@ pub fn sanitize_path_keep_dot_dirs_bytes(path: &[u8]) -> Vec<u8> {
 /// [`sanitize_path_bytes`] with the `&str` form, so the traversal guard
 /// cannot diverge between the two.
 ///
+/// `depth` is how many leading `..` may survive - upstream passes the depth of
+/// the entry's own directory, so a target that only walks back to the transfer
+/// root is preserved verbatim while one that reaches past it is collapsed. This
+/// is the single `sanitize_path` call in upstream's `flist.c` that does not pass
+/// 0, and the non-zero value is load-bearing: at 0 a link in `sub/dir/` pointing
+/// at `../../hello.txt` would be rewritten to `hello.txt`, silently retargeting
+/// it at a sibling that does not exist.
+///
 /// # Upstream Reference
 ///
-/// - `flist.c:1182` - `sanitize_path(bp, bp, "", lastdir_depth, SP_DEFAULT)`
+/// - `flist.c:1329` - `sanitize_path(bp, bp, "", lastdir_depth, SP_DEFAULT)`
 ///   applied to a received symlink target when `sanitize_paths &&
 ///   !munge_symlinks`.
-pub fn sanitize_path_bytes_default(path: &[u8]) -> Vec<u8> {
-    sanitize_path_bytes(path, 0, false)
+/// - `flist.c:867` - `lastdir_depth = count_dir_elements(lastdir)`.
+pub fn sanitize_path_bytes_default(path: &[u8], depth: usize) -> Vec<u8> {
+    sanitize_path_bytes(path, i32::try_from(depth).unwrap_or(i32::MAX), false)
 }
 
 /// Core sanitization with configurable depth budget and dot-dir handling.

--- a/crates/transfer/src/sanitize_path.rs
+++ b/crates/transfer/src/sanitize_path.rs
@@ -64,6 +64,25 @@ pub fn sanitize_path_keep_dot_dirs_bytes(path: &[u8]) -> Vec<u8> {
     sanitize_path_bytes(path, 0, true)
 }
 
+/// Byte-exact variant of [`sanitize_path`] (`SP_DEFAULT`).
+///
+/// Used for symlink targets received from the network, which are raw byte
+/// strings on the wire (upstream carries them as `char*`) and need not be
+/// valid UTF-8. Routing them through `String` would replace non-UTF-8 bytes
+/// and rewrite the very value the sanitizer exists to make safe, so this
+/// entry point stays on `&[u8]` end to end. Shares
+/// [`sanitize_path_bytes`] with the `&str` form, so the traversal guard
+/// cannot diverge between the two.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:1182` - `sanitize_path(bp, bp, "", lastdir_depth, SP_DEFAULT)`
+///   applied to a received symlink target when `sanitize_paths &&
+///   !munge_symlinks`.
+pub fn sanitize_path_bytes_default(path: &[u8]) -> Vec<u8> {
+    sanitize_path_bytes(path, 0, false)
+}
+
 /// Core sanitization with configurable depth budget and dot-dir handling.
 ///
 /// - `depth`: number of leading `..` segments allowed (0 for daemon mode)

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -1150,6 +1150,38 @@ comp_verify_perms() {
 
 # Run a single test scenario: prepare dest, transfer, verify.
 # Flags are word-split intentionally (no glob-expandable patterns at word start).
+# Would a relative symlink target resolve above the transfer root?
+#
+# $1 is the directory holding the link, relative to the destination root ("" for
+# the root itself); $2 is the link's target. Purely lexical, matching how
+# upstream's unsafe_symlink() (util1.c) decides: it counts components rather
+# than resolving on disk, so a dangling target is still classified.
+#
+# Returns 0 (true, "escapes") when a '..' would step above the root.
+symlink_target_escapes() {
+  local linkdir=$1 target=$2 depth=0 component
+  local -a __sle_parts
+
+  IFS='/' read -r -a __sle_parts <<< "$linkdir"
+  for component in "${__sle_parts[@]}"; do
+    [[ -z "$component" || "$component" == "." ]] && continue
+    depth=$((depth + 1))
+  done
+
+  IFS='/' read -r -a __sle_parts <<< "$target"
+  for component in "${__sle_parts[@]}"; do
+    case "$component" in
+      ''|.) ;;
+      ..)
+        depth=$((depth - 1))
+        (( depth < 0 )) && return 0
+        ;;
+      *) depth=$((depth + 1)) ;;
+    esac
+  done
+  return 1
+}
+
 comp_run_scenario() {
   local label=$1 client=$2 flags=$3 sdir=$4 url=$5 ddir=$6 log=$7 vtype=$8
 
@@ -1502,10 +1534,45 @@ comp_run_scenario() {
       ;;
     safe-links)
       comp_verify_transfer "$sdir" "$ddir" || return 1
-      if [[ -L "$ddir/unsafe_link.txt" ]]; then
-        echo "    --safe-links: unsafe symlink was transferred"
-        return 1
-      fi
+      # The source plants unsafe_link.txt -> /etc/hostname. Asserting that the
+      # destination entry is ABSENT is not an upstream-faithful check: whether
+      # the link survives depends on the receiving module's config, and under
+      # the config this harness writes (write_rust_daemon_conf /
+      # write_upstream_conf: use chroot = false, munge symlinks = false)
+      # upstream KEEPS it.
+      #
+      #   munge symlinks = false + a module path
+      #     -> sanitize_paths is on (clientserver.c:1068) and munging is off, so
+      #        flist.c:1329 rewrites the target to the relative, in-tree
+      #        "etc/hostname". --safe-links (generator.c:1951) then correctly
+      #        does not skip it. Measured: rsync 3.4.4 and 3.5.0 as daemon
+      #        receivers both CREATE the link under this exact config.
+      #   munge symlinks = on (upstream's default for a module with a path)
+      #     -> the target gains the /rsyncd-munged/ prefix, stays absolute, and
+      #        --safe-links skips it, so the entry is absent.
+      #
+      # The invariant that holds under both, and is what --safe-links plus the
+      # sanitize actually guarantee, is that nothing lands in the destination
+      # still pointing outside it. Assert that over every destination symlink,
+      # which also covers links the scenario does not plant by name.
+      local link target rel linkdir
+      while IFS= read -r link; do
+        target=$(readlink "$link")
+        rel="${link#"$ddir"/}"
+        if [[ "$target" == /* ]]; then
+          echo "    --safe-links: ${rel} kept an absolute target: ${target}"
+          return 1
+        fi
+        # Directory holding the link, relative to $ddir. A link directly in
+        # $ddir has no '/' in $rel, and ${rel%/*} would then return $rel
+        # unchanged rather than the empty string.
+        linkdir="${rel%/*}"
+        [[ "$linkdir" == "$rel" ]] && linkdir=""
+        if symlink_target_escapes "$linkdir" "$target"; then
+          echo "    --safe-links: ${rel} escapes the destination: ${target}"
+          return 1
+        fi
+      done < <(find "$ddir" -type l)
       if [[ -L "$sdir/link.txt" ]] && [[ ! -L "$ddir/link.txt" ]]; then
         echo "    --safe-links: safe symlink missing"
         return 1


### PR DESCRIPTION
## The defect

A daemon module that sets `munge symlinks = false` gave up the `/rsyncd-munged/` prefix and got **nothing** in its place. A client holding only write access could push `escape -> ../outside`, have it stored verbatim, and reach outside the module root on the next transfer through that name — two transfers, no out-of-band step.

Upstream does not leave the target untouched. `flist.c:1182`:

```c
if (sanitize_paths && !munge_symlinks && *bp)
        sanitize_path(bp, bp, "", lastdir_depth, SP_DEFAULT);
```

and `clientserver.c:994-995` sets `sanitize_paths` for **every** daemon module. The two transforms are mutually exclusive and between them leave no daemon configuration in which a peer-supplied target reaches disk unchanged.

## Measured

Real `oc-rsync --daemon` vs real `rsync` daemons, macOS 15 aarch64, `use chroot = false`, `read only = false`, `munge symlinks = false`, client pushing `escape -> ../outside`:

| daemon | stored target | escaped |
|---|---|---|
| rsync 3.4.4 | `outside` (sanitized) | no |
| rsync 3.5.0 | `outside` (sanitized) | no |
| **oc-rsync** | `../outside` (verbatim) | **yes**, exit 0, stderr empty |

⚠ **Not the default config.** oc implements the `munge symlinks` `!use_chroot` auto default (`clientserver.c:997-998`) correctly — all three daemons produce `/rsyncd-munged/../outside` and no escape. The trigger is the operator turning munging off, which upstream treats as supported precisely *because* it still sanitizes.

## The change

`sanitize_received_symlink_target` in `crates/transfer/src/receiver/directory/links.rs`, gated exactly as upstream gates it: `!munge_symlinks && is_daemon_connection && non-empty`. `is_daemon_connection` is oc's expression of upstream's `sanitize_paths`, which is daemon-module-scoped.

Two decisions worth review:

**Placement — before the `--safe-links` check, not at creation.** Upstream sanitizes during the file-list decode, so by the time `generator.c:1559` evaluates `--safe-links` it reads the already-sanitized `F_SYMLINK(file)`. Sanitizing after the check would make oc skip with `skipping unsafe symlink` where upstream creates the link — trading this defect for a different divergence. Pinned by `sanitization_precedes_the_safe_links_check`.

**Byte-exact, not `&str`.** A symlink target is a raw byte string on the wire. The existing `sanitize_path(&str)` would replace non-UTF-8 bytes and rewrite the value the sanitizer exists to make safe, so this adds `sanitize_path_bytes_default` beside the existing `..._keep_dot_dirs_bytes`. Both delegate to the same byte core, so the traversal guard cannot diverge between them.

## Verification

TDD: both behavioural tests written and watched fail first.

```
RED  daemon_receiver_sanitizes_...    left: Some("../outside")  right: Some("outside")
RED  sanitization_precedes_...        left: None                right: Some("outside")
GREEN  5 tests run: 5 passed
```

The second RED is the ordering evidence — `None` because `--safe-links` skipped the unsanitized target entirely.

Mutation sweep, each anchor asserted to match exactly once before applying (a silently-unapplied mutation reads as a survivor):

| mutation | target test | result |
|---|---|---|
| drop the `is_daemon_connection` gate | `a_non_daemon_receiver_leaves_the_target_alone` | KILLED |
| drop the `!munge_symlinks` gate | `munging_still_wins_when_it_is_enabled` | KILLED |
| lossy `String` instead of bytes | `a_non_utf8_target_is_sanitized_byte_exactly` | KILLED |

- `cargo nextest run -p transfer --all-features`: **2731 run, 2729 passed, 2 failed**
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

⚠ The 2 failures are `sandbox::symlink_race_tests::anchored_mode_*`, **inherited from master**, not from this change — verified by running them on pristine `3f5a093fb` with none of this branch applied (2 passed, 2 failed, identical). They are the pair PR #7328 fixes.

## Scope

- **Unix only.** `create_symlinks` has three `cfg` implementations; this touches the unix one, where the defect is measured and where upstream's daemon semantic applies. The Windows sibling is untouched and unexamined — a Windows daemon with munging off is a separate question, deliberately not claimed here.
- **Linux not separately measured**, but this is a file-list string transform with no platform-conditional code and the tests are plain `#[cfg(unix)]` unit tests, so they execute on every unix CI cell.

Different layer from the receiver path-walk escape — file-list receive, not path resolution. Filed and fixed separately on purpose.
