### PR TITLE
docs(receiver): correct the munge/safe-links ordering claim and its citations

### DIFF
--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -74,16 +74,25 @@ impl ReceiverContext {
 
             let relative_path = entry.path();
 
-            // upstream: generator.c:1547 - skip unsafe symlinks when --safe-links
-            // is set. Check stays here (not in sanitize_file_list) to preserve
-            // protocol index alignment with the sender. Safe-link evaluation
-            // runs against the wire target (pre-munge) so the policy decision
-            // matches upstream's `flist.c` ordering where the munge prefix is
-            // applied only after safety checks complete.
+            // upstream: generator.c:1951 - `if (safe_symlinks && unsafe_symlink(sl, fname))`
+            // skips unsafe symlinks when --safe-links is set. The check stays
+            // here (not in sanitize_file_list) to preserve protocol index
+            // alignment with the sender.
+            //
+            // Note the operand differs from upstream's. oc evaluates the wire
+            // target (pre-munge); upstream evaluates the already-munged one,
+            // because it applies the prefix during file-list decode and the
+            // generator then reads `F_SYMLINK(file)`. `unsafe_symlink()`
+            // rejects every absolute target, and munging makes every target
+            // absolute, so upstream under `munge symlinks = true` with
+            // --safe-links skips every symlink - safe ones included - while oc
+            // creates the safe ones. Measured against 3.4.4 and 3.5.0.
+            // Reordering to match is a behaviour change, not a comment fix.
             if self.config.flags.safe_links
                 && crate::symlink_safety::is_unsafe_symlink(wire_target.as_os_str(), relative_path)
             {
-                // upstream: generator.c:1554 - log skipped unsafe symlinks
+                // upstream: generator.c:1952 - `if (INFO_GTE(NAME, 1))` gates the
+                // skipped-symlink report at the first -v level.
                 info_log!(
                     Name,
                     1,


### PR DESCRIPTION
The comment above the `--safe-links` check in `links.rs` states that oc
"matches upstream's `flist.c` ordering where the munge prefix is applied only
after safety checks complete". **Upstream does the opposite.** It applies the
prefix during file-list decode, so `generator.c` evaluates `--safe-links`
against the already-munged target via `F_SYMLINK(file)`.

## Why the wrong sentence matters

It is load-bearing in the wrong direction, and it already misled one change:
the sanitize half of this same block was nearly placed after the safety check
on the strength of it, which would have made oc skip entries upstream creates.

`unsafe_symlink()` (`util1.c`) rejects **every absolute target**, and munging
makes every target absolute. So the two features cancel:

```
                      safe -> target.txt            escape -> ../outside
oc          CREATED as /rsyncd-munged/target.txt      skipped
3.4.4       SKIPPED                                   skipped
3.5.0       SKIPPED                                   skipped
```

macOS, daemon push, `use chroot = false`, `read only = false`,
`munge symlinks = true`, `-av --safe-links`. Upstream's own `-v` line prints
the value it fed to the predicate, which is the direct evidence:

```
ignoring unsafe symlink "safe" -> "/rsyncd-munged/target.txt"
```

Note the escaping symlink agrees across all three implementations and cannot
distinguish the orderings - it is unsafe before and after the transform. Only
the plain in-tree symlink separates them.

The comment now records what oc actually does, how it differs, and that
**reordering is a behaviour change rather than a comment fix**, so the next
reader does not "correct" the code to match a sentence. Whether to mirror
upstream here is a separate decision: matching it means oc creates no symlinks
at all under that option pair, which is faithful but removes working
behaviour. Not a security issue - the created link is `/rsyncd-munged/...`,
which resolves nowhere unless that directory exists.

## Both citations in the block were wrong, and unverifiable

```
generator.c:1547  ->  file->mode = dest_mode(...)   unrelated
generator.c:1554  ->  #endif                        unrelated
```

Retargeted at the 3.5.0 lines the audit tool pins (`VER = "3.5.0"`), and each
given a **single-line** quoted anchor. Previously the anchor spanned two source
lines, so the extractor produced `[]` and the drift audit silently checked
nothing - a citation that could not be wrong because it was never read.

Verified both directions rather than assuming:

```
anchor 'if (safe_symlinks && unsafe_symlink(sl, fname))' -> 3.5.0@[1951]  cited 1951  MATCH
anchor 'if (INFO_GTE(NAME, 1))'                          -> 3.5.0@[1952]  cited 1952  MATCH

deliberate off-by-one (1951 -> 1900) is now reported:
  links.rs: generator.c:1900 'if (safe_symlinks && uns' -> 3.5.0@[1951]
```

## Verification

- `cargo fmt --all -- --check` - exit 0
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - exit 0
- citation drift audit - exit 0, no findings for this file
- **No behaviour change**: every added and removed line is a `//` comment
  (`git diff` filtered for non-comment lines is empty), one file, +16/-7.

The two `receiver::transfer::setup::sandbox::symlink_race_tests::anchored_mode_*`
failures on macOS are master's, not this change's - a comment-only diff cannot
reach them, and they are the pair an open PR already fixes by keying on
`openat2_supported()`.
