### PR TITLE
docs(daemon): correct sanitize_path citations and the `..` claims

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -66,9 +66,15 @@ fn extract_module_relative_paths(client_args: &[String], module_name: &str) -> V
 /// no-op for every currently-valid destination path (a `..`-free tail is
 /// unaffected); the guard rejects the escape up front as defense-in-depth.
 ///
-/// upstream: util1.c:1035 `sanitize_path` collapses `..` against the module
-/// root depth on the receiver side, behind the chroot wall. oc-rsync mirrors
-/// the check explicitly because the daemon does not always chroot.
+/// This is deliberately STRICTER than upstream, not a mirror of it.
+/// `sanitize_path` (util1.c:1138) has no failure path for `..`: its contract
+/// is to ALWAYS collapse `..` elements beyond the allowed depth, dropping a
+/// leading `..` that has nothing to pop so the result clamps at the module
+/// root. With upstream's daemon depth of 0 an in-tree `sub/../other` is
+/// therefore rewritten to `other` and served. oc-rsync refuses the whole
+/// request instead, which is safe but rejects paths both 3.4.4 and 3.5.0
+/// accept; reconciling the two is tracked separately and needs the collapse,
+/// not the removal of this guard.
 fn resolve_receiver_dest(
     module_path: &std::path::Path,
     client_args: &[String],
@@ -152,9 +158,9 @@ fn resolve_sender_sources(
         }
         all_empty = false;
         // Reject `..` traversal segments so the joined path cannot escape the
-        // module root. Upstream rsync's sender-side `sanitize_path()` and the
-        // chroot wall it lives behind cover this; oc-rsync mirrors the check
-        // explicitly because the daemon does not always chroot.
+        // module root. Upstream collapses rather than refuses here - see the
+        // divergence note on `resolve_receiver_dest` - so this arm is the
+        // stricter of the two behaviours, not a mirror of upstream's.
         let trimmed = tail.trim_start_matches(['/', '\\']);
         for component in std::path::Path::new(trimmed).components() {
             if matches!(component, std::path::Component::ParentDir) {
@@ -293,7 +299,7 @@ fn expand_relative_glob(base: &std::path::Path, rel: &std::path::Path) -> Vec<st
         let segment = match component {
             std::path::Component::Normal(s) => s,
             // RootDir / Prefix should not appear in a stripped relative path,
-            // and ParentDir is rejected upstream. CurDir is a no-op.
+            // and `..` was already rejected by the caller. CurDir is a no-op.
             std::path::Component::CurDir => continue,
             _ => return Vec::new(),
         };
@@ -465,7 +471,7 @@ fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf {
 /// check_alt_basis_dirs` only warns, never aborts - and we must still apply
 /// the containment policy in that case.
 ///
-/// upstream: util1.c:1035 `sanitize_path` collapses `..` against the
+/// upstream: util1.c:1138 `sanitize_path` collapses `..` against the
 /// module root depth; main.c:1199-1206 `check_alt_basis_dirs` warns on
 /// out-of-tree basis. We mirror the silent-drop side of that contract
 /// instead of upstream's path-rewrite because our daemon does not chdir

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2339,7 +2339,7 @@ mod module_access_tests {
     //
     // Behavioural divergence from the upstream test: upstream's daemon never
     // emits a literal "outside the module" `@ERROR` for these scenarios. Its
-    // `util1.c:1035 sanitize_path` collapses `..` against the module root
+    // `util1.c:1138 sanitize_path` collapses `..` against the module root
     // depth (rewriting the path under the module) and `main.c:841
     // check_alt_basis_dirs` only warns when the resulting basis is missing.
     // PR #5778 aligned the oc-rsync daemon with that contract by switching

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -263,7 +263,7 @@ fn classify_client_path_against_module(
 /// access, so they must reach the Landlock allowlist or a default-on flip
 /// would EACCES legitimate writes (URV-5.b.REOPEN).
 ///
-/// upstream: util1.c:1035 `sanitize_path` collapses `..` against the
+/// upstream: util1.c:1138 `sanitize_path` collapses `..` against the
 /// module root depth; main.c:841 `check_alt_basis_dirs` warns but does not
 /// abort when the sanitised basis is missing or out-of-tree.
 ///

--- a/crates/transfer/src/sanitize_path.rs
+++ b/crates/transfer/src/sanitize_path.rs
@@ -11,7 +11,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `util1.c:1035` - `sanitize_path(dest, p, rootdir, depth, flags)`
+//! - `util1.c:1138` - `sanitize_path(dest, p, rootdir, depth, flags)`
 //! - `flist.c:774` - applied to received file names in daemon mode
 //! - `flist.c:2299` - applied to `--files-from` entries
 //! - `flist.c:1182` - applied to symlink targets when `sanitize_paths && !munge_symlinks`
@@ -30,7 +30,7 @@
 ///
 /// # Upstream Reference
 ///
-/// - `util1.c:1035-1108` - `sanitize_path()`
+/// - `util1.c:1138-1211` - `sanitize_path()`
 pub fn sanitize_path(path: &str) -> String {
     sanitize_path_with_depth(path, 0, false)
 }
@@ -74,7 +74,7 @@ pub fn sanitize_path_keep_dot_dirs_bytes(path: &[u8]) -> Vec<u8> {
 ///
 /// # Upstream Reference
 ///
-/// - `util1.c:1035-1108`
+/// - `util1.c:1138-1211`
 fn sanitize_path_with_depth(path: &str, depth: i32, keep_dot_dirs: bool) -> String {
     let out = sanitize_path_bytes(path.as_bytes(), depth, keep_dot_dirs);
     String::from_utf8(out).unwrap_or_else(|_| ".".to_string())
@@ -90,7 +90,7 @@ fn sanitize_path_with_depth(path: &str, depth: i32, keep_dot_dirs: bool) -> Stri
 ///
 /// # Upstream Reference
 ///
-/// - `util1.c:1035-1108`
+/// - `util1.c:1138-1211`
 fn sanitize_path_bytes(bytes: &[u8], mut depth: i32, keep_dot_dirs: bool) -> Vec<u8> {
     let mut p = 0usize;
 


### PR DESCRIPTION
Comment-only. Corrects three false statements about upstream behaviour in the daemon path-resolution code, and retargets eight drifted `util1.c` citations.

## The false claims

Three sites said oc "mirrors" upstream's `sanitize_path` check; one said outright that "ParentDir is rejected upstream". Both are the inverse of what upstream does.

Upstream's own header comment (`util1.c:1133-1137`, 3.5.0):

> ALWAYS collapses ".." elements (except for those at the start of the string up to "depth" deep). If the resulting name would be empty, change it into a ".".

`sanitize_path` has **no failure path for `..`** - its only `return NULL` is a `MAXPATHLEN` overflow in the `dest != p` branch. At the daemon's `depth = 0`, `depth <= 0` always selects the collapse branch, and a `..` with nothing left to pop is dropped (`p += 2; continue`), clamping at the module root.

So for `sub/../other`:

| | behaviour |
|---|---|
| upstream 3.4.4 / 3.5.0 | rewrites to `other`, serves it |
| oc-rsync | refuses the whole request |

oc is **stricter**, not equivalent. The comments now say so, and name the reconciliation as separate work. This matters because the old wording invited exactly the wrong fix: read "we mirror upstream", conclude the guard is redundant, delete it - and lose the refusal without gaining the collapse.

The same file implements **three different `..` rules** citing the same upstream function: reject (`resolve_receiver_dest`), reject (`resolve_sender_sources`), and collapse-but-preserve-the-un-poppable-`..` (`lexically_normalize`, whose caller then rejects via `starts_with`). Only the third is described accurately today, and it is left untouched here.

## The citation drift

Eight `util1.c:1035` -> `util1.c:1138` across four files. `:1035` was **correct for 3.4.4**, where `:1034` begins `sanitize_path`'s header comment. In 3.5.0 the function moved to `:1138`, and `:1035` now lands inside **`clean_fname`'s** header comment - which also says *"will also collapse '..' elements"*. The stale citation resolves to a plausible-looking wrong function, which is why spot-checking it would not have caught the drift.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy -p daemon -p transfer --all-targets --all-features -- -D warnings` clean.
- Line numbers verified by reading `util1.c` at both 3.4.4 and 3.5.0, not from memory.
- Zero `util1.c:1035` remain repo-wide.

⚠ **The citation drift gate does not cover these lines, in either direction.** Measured: the audit exits 0 both before and after this change and never mentions them. The anchor extractor needs a quoted run of 8-60 chars containing a space; the only quoted runs on these lines are `sanitize_path` (no space) and `..` (too short), so nothing is extracted and the lines are skipped. This is a live instance of the ~35% skip already filed, and it means the gate is not evidence for this PR - the C source is.

No behaviour change, so no new tests. The behavioural divergence is tracked separately and needs the collapse implemented, not the guard removed.
