### PR TITLE
test: capture the drop-D argv to a file, not the shared stderr

### DIFF
--- a/tests/drop_devices.rs
+++ b/tests/drop_devices.rs
@@ -233,7 +233,22 @@ fn drop_d_does_not_change_the_remote_argv() {
     let (src, _) = seed_specials(temp.path());
 
     let rsh = temp.path().join("capture-argv");
-    fs::write(&rsh, "#!/bin/sh\nprintf '%s\\n' \"$*\" >&2\nexit 0\n").expect("write fake rsh");
+    // The argv is captured to a FILE, not to stderr. The fake shell exits without
+    // speaking the protocol, so oc-rsync then fails the transfer and writes its own
+    // diagnostic - and which diagnostic it writes is a race: noticing EOF yields
+    // "connection unexpectedly closed" (code 12), losing the write race yields
+    // "handshake failed: Broken pipe" (code 5). Sharing one stream between the
+    // capture and the process's own output made this gate compare that race instead
+    // of the argv it exists to pin. Keep the two channels separate.
+    let capture = temp.path().join("argv-capture");
+    fs::write(
+        &rsh,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >>'{}'\nexit 0\n",
+            capture.display()
+        ),
+    )
+    .expect("write fake rsh");
     let mut perms = fs::metadata(&rsh).expect("stat rsh").permissions();
     {
         use std::os::unix::fs::PermissionsExt;
@@ -249,7 +264,9 @@ fn drop_d_does_not_change_the_remote_argv() {
         args.push(rsh.as_os_str());
         args.push(OsStr::new(&src_arg));
         args.push(OsStr::new("remote:/dst/"));
-        String::from_utf8_lossy(&run(&args).stderr).into_owned()
+        let _ = fs::remove_file(&capture);
+        let _ = run(&args);
+        fs::read_to_string(&capture).unwrap_or_default()
     };
 
     let without = argv_for(&[]);


### PR DESCRIPTION
Fixes a real flake that failed the **required** `Linux musl (stable)` check on #7328 — a PR that touches only `crates/transfer/src/receiver/transfer/setup/sandbox.rs` and cannot affect this test.

## Root cause

The wire-neutrality gate captured **all of stderr** from two `oc-rsync` runs and compared them. The fake remote shell writes the argv to stderr — but so does `oc-rsync`. The shell exits immediately without speaking the protocol, so the transfer then fails and the client appends its own diagnostic to the same stream.

**Which diagnostic it appends is a race:**

| outcome | message |
|---|---|
| notices EOF first | `connection unexpectedly closed (0 bytes received so far) (code 12)` |
| loses the write race | `handshake failed: Broken pipe (os error 32) (code 5)` |

The two runs can land differently. From the failing job:

```
left:  "remote rsync --server -logDtpre.iLsfxCIvu . /dst/\n
        oc-rsync error: connection unexpectedly closed ... (code 12) ..."
right: "remote rsync --server -logDtpre.iLsfxCIvu . /dst/\n
        oc-rsync error: handshake failed: Broken pipe ... (code 5) ..."
```

**The argv — the thing the gate exists to pin — is byte-identical on both sides.** The assertion was failing on the error tail. The property under test held the whole time.

## Fix

Give the capture its own channel. The fake shell appends the argv to a file; the helper reads that file and ignores the process's streams entirely. One concern per channel, so diagnostics can no longer contaminate the comparison.

The assertion, the non-vacuity guard (`!without.is_empty()`), and the not-forwarded check are all unchanged. This does **not** widen or relax anything — after the change both captures contain only the argv line, which is what the doc comment always claimed was being compared.

## Verification

`cargo fmt --all -- --check` clean; 3 consecutive clean runs of the test.

⚠ **Non-vacuity proven, not assumed.** Swapping `--drop-D` for `--no-D` — which by this test's own premise *must* alter the option letters — fails exactly as it should:

```
left:  "remote rsync --server -logtpre.iLsfxCIvu --specials . /dst/"   <- D letter GONE
right: "remote rsync --server -logDtpre.iLsfxCIvu . /dst/"             <- D present
```

That is precisely the regression the gate guards (`--drop-D` implemented by clearing `preserve_devices`/`preserve_specials` would drop `D` and desynchronise the file list's rdev fields). The mutation script asserted its anchor matched exactly once, so it cannot have silently no-op'd.

Note both mutated captures contain **only** the argv, no error tail — direct evidence the channel separation took effect.

## Scope

Test-only; no production code touched. Unblocks the required musl cell for every open PR, not just the one that happened to surface it.
