### PR TITLE
fix: resolve fast_io intra-doc links so the rustdoc build succeeds

### DIFF
--- a/crates/fast_io/src/confinement.rs
+++ b/crates/fast_io/src/confinement.rs
@@ -13,12 +13,12 @@
 //!
 //! | Question | Upstream | Here |
 //! |---|---|---|
-//! | Is the hardening opted out of? | `symlink_optout_allowed()` | [`Activation::optout_allowed`] |
-//! | Is path resolution hardened at all? | `secure_relpath_active()` | [`Activation::hardened`] |
-//! | What root must a path stay under? | `confinement_root()` | [`Activation::root`] |
-//! | Is *this* open subject to the root? | `operator_path_resolve` | [`PathKind`] |
+//! | Is the hardening opted out of? | `symlink_optout_allowed()` | [`Activation::optout_allowed`](crate::confinement::Activation::optout_allowed) |
+//! | Is path resolution hardened at all? | `secure_relpath_active()` | [`Activation::hardened`](crate::confinement::Activation::hardened) |
+//! | What root must a path stay under? | `confinement_root()` | [`Activation::root`](crate::confinement::Activation::root) |
+//! | Is *this* open subject to the root? | `operator_path_resolve` | [`PathKind`](crate::confinement::PathKind) |
 //!
-//! The first three are properties of the session and live on [`Activation`].
+//! The first three are properties of the session and live on [`Activation`](crate::confinement::Activation).
 //! The fourth is a property of the individual call.
 //!
 //! # Why `PathKind` is a parameter and not session state

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -140,7 +140,7 @@ impl DirSandbox {
     ///
     /// `anchor` is operator-supplied - a daemon module root from the config
     /// file, or the destination operand of a local/remote-shell run. It is
-    /// opened with ordinary resolution via [`open_trusted_dir`], so an
+    /// opened with ordinary resolution via [`open_trusted_dir`](crate::open_trusted_dir), so an
     /// operator layout like `/srv -> /mnt/srv` resolves normally.
     ///
     /// `peer_tail` is the module-relative remainder the *peer* asked for. It


### PR DESCRIPTION
## Master's `Pages` workflow is failing; this fixes it

`Build rustdoc (workspace, all features, no deps)` aborts, so `Deploy to GitHub Pages` is skipped and the published docs are stale.

`fast_io` sets `#![deny(rustdoc::broken_intra_doc_links)]` and six links no longer resolve:

```
error: unresolved link to `Activation::optout_allowed`
error: unresolved link to `Activation::hardened`
error: unresolved link to `Activation::root`
error: unresolved link to `PathKind`
error: unresolved link to `Activation`
error: unresolved link to `open_trusted_dir`
error: could not document `fast_io`
```

## Why same-module links failed

The interesting one. Five of the six are in `confinement.rs`'s own `//!` header table, linking to `Activation` and `PathKind` — types defined in *that same file*. That should resolve.

It doesn't, because `confinement` carries **two** doc sources: an outer `///` block on the `pub mod confinement;` declaration in `lib.rs`, and its own inner `//!` block. rustdoc concatenates them and resolves the merged doc at the **declaration site**, where bare `Activation` is not in scope. That is why every error points at `lib.rs:91` while the offending text lives in `confinement.rs:16-21`, and why "the item is in the same module" is not sufficient here.

`open_trusted_dir` is the ordinary case: it is re-exported at the crate root (`lib.rs:392`), so it was never in scope from inside `dir_sandbox`.

Fix: qualify all six with crate paths, keeping the rendered link text identical so the docs read the same.

## Verification

Measured with the same command the workflow runs, before and after:

| command | before | after |
|---|---|---|
| `cargo doc -p fast_io --all-features --no-deps` | exit 101, 6 errors | **exit 0, 0 errors** |
| `cargo doc --workspace --all-features --no-deps` | (blocked) | **exit 0, 0 errors, 29 crates generated** |

The workspace run is the point: it confirms `fast_io` was the only blocker, rather than fixing one crate and leaving the step red on another.

⚠ Two `private_intra_doc_links` warnings remain (`DS_MAXDEPTH`, `DEFAULT_IO_URING_DEPTH`). They are pre-existing, and warnings rather than denials, so they do not fail the build. Left alone to keep this change to the one defect.
