### PR TITLE
fix(daemon): collapse `..` in client paths instead of refusing the request

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -48,6 +48,49 @@ fn extract_module_relative_paths(client_args: &[String], module_name: &str) -> V
     out
 }
 
+/// Collapses a module-relative client tail the way upstream's `sanitize_path()`
+/// does for a daemon connection, returning a `/`-joined relative path.
+///
+/// upstream: `util1.c:1138 sanitize_path(dest, p, rootdir, depth, flags)`, whose
+/// documented contract is to "ALWAYS collapse `..` elements (except for those at
+/// the start of the string up to `depth` deep)". The daemon reaches it via
+/// `options.c:2405` `sanitize_path(NULL, argv[i], "", 0, SP_KEEP_DOT_DIRS)`,
+/// gated on `sanitize_paths`, which `clientserver.c:1068` sets for every daemon
+/// connection. **The depth there is 0**, so `util1.c:1183`'s
+/// `if (depth <= 0 || sanp != start)` arm always wins: a `..` either backs up
+/// over one already-emitted component or, with nothing to back up over, is
+/// discarded. There is no arm that refuses.
+///
+/// That is why collapsing is safe rather than permissive: the output is closed
+/// under the module root by construction. `a/../b` becomes `b`, and `../etc`
+/// becomes `etc` - both still resolve beneath the module directory. Upstream
+/// serves both; refusing them rejects requests that 3.4.4 and 3.5.0 both accept.
+///
+/// Joins with a literal `/` on every host, matching upstream's `pathjoin()`
+/// rather than `PathBuf::join`, which would emit `\` on Windows for a path that
+/// is about to be compared against module-relative wire names.
+///
+/// Deliberately NOT [`lexically_normalize`], which walks the same components but
+/// PRESERVES an unpoppable leading `..` so its caller's `starts_with` containment
+/// check can reject an escaping alt-basis path. Four differences - input type,
+/// output type, separator policy, leading-`..` policy - so they are two
+/// functions with two contracts, not one to be deduplicated.
+fn collapse_module_relative(tail: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for segment in tail.split(['/', '\\']) {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                // upstream util1.c:1183-1191 - back up one component, or drop
+                // the `..` outright when already at the start (depth 0).
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out.join("/")
+}
+
 /// Resolves the receiver's on-disk destination directory from the client's
 /// positional path args.
 ///
@@ -60,57 +103,36 @@ fn extract_module_relative_paths(client_args: &[String], module_name: &str) -> V
 /// Returns the module path itself when no positional was supplied or when
 /// the stripped tail is empty (push directly into the module root).
 ///
-/// Returns `None` when the destination tail contains a `..` traversal
-/// segment, symmetric to `resolve_sender_sources`. Downstream file-list
-/// sanitisation and the `DirSandbox` already confine the write, so this is a
-/// no-op for every currently-valid destination path (a `..`-free tail is
-/// unaffected); the guard rejects the escape up front as defense-in-depth.
-///
-/// This is deliberately STRICTER than upstream, not a mirror of it.
-/// `sanitize_path` (util1.c:1138) has no failure path for `..`: its contract
-/// is to ALWAYS collapse `..` elements beyond the allowed depth, dropping a
-/// leading `..` that has nothing to pop so the result clamps at the module
-/// root. With upstream's daemon depth of 0 an in-tree `sub/../other` is
-/// therefore rewritten to `other` and served. oc-rsync refuses the whole
-/// request instead, which is safe but rejects paths both 3.4.4 and 3.5.0
-/// accept; reconciling the two is tracked separately and needs the collapse,
-/// not the removal of this guard.
+/// `..` segments in the tail are COLLAPSED, never refused, mirroring
+/// upstream's `sanitize_path()` contract - see [`collapse_module_relative`]
+/// for the anchor table and why the collapse is closed under the module root.
 fn resolve_receiver_dest(
     module_path: &std::path::Path,
     client_args: &[String],
     module_name: &str,
-) -> Option<std::path::PathBuf> {
+) -> std::path::PathBuf {
     let positionals = extract_module_relative_paths(client_args, module_name);
     // upstream: main.c:1422-1423 - `local_name = get_local_name(flist, argv[0])`
     // uses the FIRST remaining positional (after the `.` placeholder has been
     // consumed by `do_server_recv` at lines 1174-1177). For a receiver that
     // translates to the last wire positional - the destination.
     let Some(last) = positionals.last() else {
-        return Some(module_path.to_path_buf());
+        return module_path.to_path_buf();
     };
     let tail = last.trim();
     if tail.is_empty() || tail == "." {
-        return Some(module_path.to_path_buf());
+        return module_path.to_path_buf();
     }
-    // Reject `..` traversal segments so the joined destination cannot escape
-    // the module root, symmetric to the sender-source guard below.
-    let trimmed_for_scan = tail.trim_start_matches(['/', '\\']);
-    for component in std::path::Path::new(trimmed_for_scan).components() {
-        if matches!(component, std::path::Component::ParentDir) {
-            return None;
-        }
+    // A leading separator is stripped first for the same reason upstream's
+    // `sanitize_path` consumes one before walking (`util1.c:1147` `p++`): an
+    // absolute client path is interpreted against the module root, not the
+    // host root. Collapsing then folds away every `.` and `..`, so the joined
+    // destination is under `module_path` by construction on any host.
+    let collapsed = collapse_module_relative(tail.trim_start_matches(['/', '\\']));
+    if collapsed.is_empty() {
+        return module_path.to_path_buf();
     }
-    // Defensive: a path arriving here that is absolute on the host OS
-    // (Unix `is_absolute()` or a leading `/` that Windows treats as
-    // drive-relative) cannot be allowed to escape the module root. Strip
-    // the leading separators and join the remainder so the destination is
-    // always under `module_path`. Tests cover both forms cross-platform.
-    let rel = std::path::Path::new(tail);
-    if rel.is_absolute() || tail.starts_with('/') || tail.starts_with('\\') {
-        let stripped = tail.trim_start_matches(['/', '\\']);
-        return Some(module_path.join(stripped));
-    }
-    Some(module_path.join(rel))
+    module_path.join(collapsed)
 }
 
 /// Resolves the sender's on-disk source paths from the client's positional
@@ -129,10 +151,12 @@ fn resolve_receiver_dest(
 /// stripped tail is empty, matching the pre-existing "pull from module root"
 /// behaviour exactly.
 ///
-/// Sub-paths that contain `..` segments or that resolve to a host-absolute
-/// path are rejected (returns `None`) so a malicious client cannot enumerate
-/// files outside the module root via a crafted `rsync://host/mod/../etc/...`
-/// URL. This is defense-in-depth on top of the chroot / Landlock sandbox.
+/// Sub-paths containing `..`, and host-absolute sub-paths, are COLLAPSED
+/// against the module root rather than refused - see
+/// [`collapse_module_relative`]. A crafted `rsync://host/mod/../etc/...` URL
+/// therefore resolves to `<module>/etc/...` and cannot enumerate outside the
+/// module root, which is the same containment upstream gets from
+/// `sanitize_path` at depth 0.
 ///
 /// # Upstream Reference
 ///
@@ -143,10 +167,10 @@ fn resolve_sender_sources(
     module_path: &std::path::Path,
     client_args: &[String],
     module_name: &str,
-) -> Option<Vec<std::path::PathBuf>> {
+) -> Vec<std::path::PathBuf> {
     let positionals = extract_module_relative_paths(client_args, module_name);
     if positionals.is_empty() {
-        return Some(vec![module_root_dotdir(module_path)]);
+        return vec![module_root_dotdir(module_path)];
     }
     let mut sources = Vec::with_capacity(positionals.len());
     let mut all_empty = true;
@@ -157,15 +181,14 @@ fn resolve_sender_sources(
             continue;
         }
         all_empty = false;
-        // Reject `..` traversal segments so the joined path cannot escape the
-        // module root. Upstream collapses rather than refuses here - see the
-        // divergence note on `resolve_receiver_dest` - so this arm is the
-        // stricter of the two behaviours, not a mirror of upstream's.
-        let trimmed = tail.trim_start_matches(['/', '\\']);
-        for component in std::path::Path::new(trimmed).components() {
-            if matches!(component, std::path::Component::ParentDir) {
-                return None;
-            }
+        // Collapse `.` and `..` exactly as upstream's `sanitize_path` does at
+        // depth 0 - see [`collapse_module_relative`]. The result cannot escape
+        // the module root, so there is nothing left to refuse.
+        let collapsed = collapse_module_relative(tail.trim_start_matches(['/', '\\']));
+        let trimmed = collapsed.as_str();
+        if trimmed.is_empty() {
+            sources.push(module_root_dotdir(module_path));
+            continue;
         }
         // Preserve the trailing slash so the sender can detect a dotdir-style
         // source (upstream flist.c:2312-2322 appends `.` and sets DOTDIR_NAME
@@ -195,7 +218,7 @@ fn resolve_sender_sources(
         sources.push(std::path::PathBuf::from(buf));
     }
     if all_empty {
-        return Some(vec![module_root_dotdir(module_path)]);
+        return vec![module_root_dotdir(module_path)];
     }
     // upstream: util1.c:804 `glob_expand_module()` runs each module-relative
     // positional through `glob_expand()` (util1.c:755) which in turn calls
@@ -219,9 +242,9 @@ fn resolve_sender_sources(
     //   * Expansion is rooted at the module path so the resulting absolute
     //     paths land inside the module's tree, the same containment
     //     guarantee that the chroot / Landlock allowlist enforces. The
-    //     `..` rejection above the loop runs before this, so a pattern
-    //     containing `..` is already rejected.
-    Some(expand_sender_source_globs(module_path, sources))
+    //     `..` collapse above the loop runs before this, so a pattern
+    //     reaching the globber is already confined to the module root.
+    expand_sender_source_globs(module_path, sources)
 }
 
 /// Returns the module root path with a trailing `/` appended (idempotent).

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -161,27 +161,19 @@ fn build_server_config(
     // sub-tree instead of the entire module root. The original argv[0] is
     // always the module root; legacy tests that push straight into the module
     // root keep that behaviour.
+    // Both resolvers are total: they collapse `..` the way upstream's
+    // `sanitize_path` does at depth 0, so the result is confined to the module
+    // root by construction and there is no "resolves outside module root"
+    // rejection to represent. Upstream has no such daemon error either - a
+    // traversing tail is rewritten and served (util1.c:1183).
     let positional_args: Vec<OsString> = if role == ServerRole::Receiver {
-        match resolve_receiver_dest(std::path::Path::new(&module.path), client_args, &module.name) {
-            Some(dest) => vec![OsString::from(dest.as_os_str())],
-            None => {
-                let error = AtError::message("requested path resolves outside module root");
-                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
-                return Ok(None);
-            }
-        }
+        let dest = resolve_receiver_dest(std::path::Path::new(&module.path), client_args, &module.name);
+        vec![OsString::from(dest.as_os_str())]
     } else {
-        match resolve_sender_sources(std::path::Path::new(&module.path), client_args, &module.name) {
-            Some(sources) => sources
-                .into_iter()
-                .map(|p| OsString::from(p.as_os_str()))
-                .collect(),
-            None => {
-                let error = AtError::message("requested path resolves outside module root");
-                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
-                return Ok(None);
-            }
-        }
+        resolve_sender_sources(std::path::Path::new(&module.path), client_args, &module.name)
+            .into_iter()
+            .map(|p| OsString::from(p.as_os_str()))
+            .collect()
     };
 
     match ServerConfig::from_flag_string_and_args(

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2118,7 +2118,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_joins_subpath_with_module_root() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
         assert_eq!(dest, std::path::Path::new("/srv/upload/realdir/"));
     }
 
@@ -2126,7 +2126,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_falls_back_to_module_root_for_bare_module() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
         assert_eq!(dest, std::path::Path::new("/srv/upload"));
     }
 
@@ -2134,7 +2134,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_falls_back_to_module_root_when_no_positional() {
         let module_path = std::path::Path::new("/srv/upload");
         let args: Vec<String> = vec![];
-        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
         assert_eq!(dest, std::path::Path::new("/srv/upload"));
     }
 
@@ -2149,7 +2149,7 @@ mod module_access_tests {
             "upload/srcB/".to_owned(),
             "upload/destdir/".to_owned(),
         ];
-        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
         assert_eq!(dest, std::path::Path::new("/srv/upload/destdir/"));
     }
 
@@ -2157,19 +2157,41 @@ mod module_access_tests {
     fn resolve_receiver_dest_rejoins_absolute_path_under_module_root() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "/etc/passwd".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
         // Absolute path is forced under the module root - no escape.
         assert_eq!(dest, std::path::Path::new("/srv/upload/etc/passwd"));
     }
 
     #[test]
-    fn resolve_receiver_dest_rejects_parent_dir_traversal() {
-        // Defense-in-depth: a `..` segment in the receiver destination is
-        // rejected up front, symmetric to `resolve_sender_sources`. Every
-        // valid (dotdot-free) tail is unaffected; this only fails the escape.
+    fn resolve_receiver_dest_collapses_parent_dir_under_module_root() {
+        // upstream util1.c:1183 with depth 0: a `..` with nothing to pop is
+        // DISCARDED, not refused, so the escape clamps at the module root and
+        // is served. Refusing here rejected a request both 3.4.4 and 3.5.0
+        // accept.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/../../etc/passwd".to_owned()];
-        assert!(resolve_receiver_dest(module_path, &args, "upload").is_none());
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest, std::path::Path::new("/srv/upload/etc/passwd"));
+    }
+
+    #[test]
+    fn resolve_receiver_dest_collapses_in_tree_parent_dir() {
+        // The case the old reject broke for legitimate clients: `a/../b` is an
+        // ordinary in-tree path that never leaves the module.
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/a/../b".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest, std::path::Path::new("/srv/upload/b"));
+    }
+
+    #[test]
+    fn resolve_receiver_dest_collapses_to_module_root_when_fully_consumed() {
+        // Every component popped: upstream's `if (sanp == dest) *sanp++ = '.'`
+        // (util1.c:1205) yields the module root itself.
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/a/../..".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest, module_path);
     }
 
     // URV-5.b.REOPEN: classify_client_path_against_module is the pure helper
@@ -2475,7 +2497,7 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args: Vec<String> = vec![];
         let sources = resolve_sender_sources(module_path, &args, "upload")
-            .expect("bare module request must resolve");
+            ;
         assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
     }
 
@@ -2488,7 +2510,7 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload")
-            .expect("empty sub-path must resolve");
+            ;
         assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
     }
 
@@ -2500,7 +2522,7 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload")
-            .expect("file sub-path must resolve");
+            ;
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
@@ -2515,7 +2537,7 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/d2/".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload")
-            .expect("sub-dir trailing-slash path must resolve");
+            ;
         let lossy: Vec<String> = sources
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
@@ -2524,20 +2546,47 @@ mod module_access_tests {
     }
 
     #[test]
-    fn resolve_sender_sources_rejects_parent_dir_traversal() {
-        // SEC-1.q defense-in-depth: a `..` segment escaping the module root
-        // must be rejected at argv-resolution time so chroot-less daemons
-        // cannot leak files via sub-path requests like `module/../etc/...`.
+    fn resolve_sender_sources_collapses_parent_dir_under_module_root() {
+        // The escape clamps at the module root instead of being refused, which
+        // is what upstream serves. Containment still holds: the resolved source
+        // is inside `/srv/upload`, so a chroot-less daemon leaks nothing.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/../etc/passwd".to_owned()];
-        assert!(resolve_sender_sources(module_path, &args, "upload").is_none());
+        let sources = resolve_sender_sources(module_path, &args, "upload");
+        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/etc/passwd")]);
     }
 
     #[test]
-    fn resolve_sender_sources_rejects_mid_path_parent_dir() {
+    fn resolve_sender_sources_collapses_mid_path_parent_dir() {
+        // `d1/../../secret`: `d1` is popped by the first `..`, the second has
+        // nothing to pop and is discarded - upstream util1.c:1183-1191.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/../../secret".to_owned()];
-        assert!(resolve_sender_sources(module_path, &args, "upload").is_none());
+        let sources = resolve_sender_sources(module_path, &args, "upload");
+        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/secret")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_collapse_never_escapes_the_module_root() {
+        // CLASS assertion, not a single case: no amount of `..` may produce a
+        // path outside the module root. This is the security property the old
+        // reject was protecting, restated so the collapse must uphold it.
+        let module_path = std::path::Path::new("/srv/upload");
+        for tail in [
+            "upload/..",
+            "upload/../..",
+            "upload/../../../../../../etc/shadow",
+            "upload/a/../../../b",
+            "upload/./../.././x",
+        ] {
+            let args = vec![".".to_owned(), tail.to_owned()];
+            for src in resolve_sender_sources(module_path, &args, "upload") {
+                assert!(
+                    src.starts_with(module_path),
+                    "{tail} resolved to {src:?}, which escapes {module_path:?}"
+                );
+            }
+        }
     }
 
     #[test]
@@ -2545,7 +2594,7 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload//d1/d2/f2".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload")
-            .expect("leading-slash sub-path must resolve");
+            ;
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
@@ -2572,7 +2621,7 @@ mod module_access_tests {
 
         let args = vec![".".to_owned(), "mod/f*".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "mod")
-            .expect("glob pattern must resolve");
+            ;
         assert_eq!(sources, vec![module_path.join("foo")]);
     }
 
@@ -2587,7 +2636,7 @@ mod module_access_tests {
 
         let args = vec![".".to_owned(), "mod/z*".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "mod")
-            .expect("non-matching glob must resolve to literal");
+            ;
         assert_eq!(sources, vec![module_path.join("z*")]);
     }
 
@@ -2602,7 +2651,7 @@ mod module_access_tests {
         // `?` matches exactly one character; `?b` must match only `ab`.
         let args = vec![".".to_owned(), "mod/?b".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "mod")
-            .expect("? glob must resolve");
+            ;
         assert_eq!(sources, vec![module_path.join("ab")]);
     }
 
@@ -2617,7 +2666,7 @@ mod module_access_tests {
         // `[ab]` matches `a` or `b` but not `c`.
         let args = vec![".".to_owned(), "mod/[ab]".to_owned()];
         let mut sources = resolve_sender_sources(module_path, &args, "mod")
-            .expect("[class] glob must resolve");
+            ;
         sources.sort();
         assert_eq!(sources, vec![module_path.join("a"), module_path.join("b")]);
     }
@@ -2633,7 +2682,7 @@ mod module_access_tests {
 
         let args = vec![".".to_owned(), "mod/*".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "mod")
-            .expect("* glob must resolve");
+            ;
         assert_eq!(sources, vec![module_path.join("visible")]);
     }
 
@@ -2647,7 +2696,7 @@ mod module_access_tests {
 
         let args = vec![".".to_owned(), "mod/missing/file".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "mod")
-            .expect("plain path must resolve");
+            ;
         assert_eq!(sources, vec![module_path.join("missing/file")]);
     }
 
@@ -2684,7 +2733,7 @@ mod module_access_tests {
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload")
-            .expect("Windows drive-letter sub-path must resolve");
+            ;
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from(r"C:\srv\upload/d1/d2/f2")]
@@ -2702,7 +2751,7 @@ mod module_access_tests {
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/d1/d2/".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload")
-            .expect("Windows drive-letter sub-dir trailing-slash must resolve");
+            ;
         let lossy: Vec<String> = sources
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
@@ -2722,7 +2771,7 @@ mod module_access_tests {
         let module_path = std::path::Path::new(r"C:\srv\upload\");
         let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload")
-            .expect("backslash-terminated module root must resolve");
+            ;
         // The exact emitted bytes are `C:\srv\upload\` + `d1/d2/f2` because
         // the resolver detects the trailing `\` as an existing separator and
         // suppresses its own `/` insertion. The result is still a valid
@@ -2735,13 +2784,17 @@ mod module_access_tests {
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn resolve_sender_sources_rejects_parent_dir_traversal_on_windows() {
-        // Defense-in-depth must work identically on every host: a `..`
-        // segment in the client positional rejects the entire request,
-        // regardless of whether the module root is Linux- or Windows-style.
+    fn resolve_sender_sources_collapses_parent_dir_on_windows() {
+        // The collapse must behave identically on every host, and must still
+        // join with a literal `/` (upstream pathjoin) rather than `\`, because
+        // the result is compared against module-relative wire names.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/../etc/passwd".to_owned()];
-        assert!(resolve_sender_sources(module_path, &args, "upload").is_none());
+        let sources = resolve_sender_sources(module_path, &args, "upload");
+        assert_eq!(
+            sources,
+            vec![std::path::PathBuf::from(r"C:\srv\upload/etc/passwd")]
+        );
     }
 
     #[cfg(target_os = "windows")]
@@ -2753,7 +2806,7 @@ mod module_access_tests {
         // the same way they do on Linux.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
         // Path::join uses the host separator on Windows, so a trailing
         // slash on the positional collapses into a backslash-terminated
         // PathBuf. The assertion compares via Path equality so the
@@ -2772,7 +2825,7 @@ mod module_access_tests {
         // containment guarantee on Windows hosts.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "/etc/passwd".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
         // After stripping the leading `/`, the resolver hands the bare
         // string `etc/passwd` to Path::join, which prepends the host
         // separator (`\` on Windows) but does not rewrite the embedded


### PR DESCRIPTION
A daemon client asking for `mod/a/../b` - or for `mod/../etc/passwd` - was
refused outright. Both upstream 3.4.4 and 3.5.0 serve both requests.

upstream's `sanitize_path()` (util1.c:1138) documents its contract as: "ALWAYS
collapses `..` elements (except for those at the start of the string up to
`depth` deep)". The daemon reaches it through options.c:2405,
`sanitize_path(NULL, argv[i], "", 0, SP_KEEP_DOT_DIRS)`, gated on
`sanitize_paths`, which clientserver.c:1068 sets for every daemon connection.

The depth there is 0, so util1.c:1183's `if (depth <= 0 || sanp != start)` arm
always wins: a `..` either backs up over one already-emitted component, or -
with nothing to back up over - is discarded. There is no arm that refuses.

That is why collapsing is the safe behaviour and not a relaxation: the output
is closed under the module root by construction. `a/../b` becomes `b`;
`../etc` becomes `etc`. Neither can leave the module directory, which is
exactly the property the old reject was there to guarantee. The reject bought
no containment the collapse does not already provide, and cost conformance.

Both resolvers become TOTAL as a result - every `return None` was a `..`
reject - so the `Option` wrappers and the two `@ERROR: requested path resolves
outside module root` sites are removed with them. Upstream has no such daemon
error either; a traversing tail is rewritten and served. Leaving the plumbing
would have kept an unreachable error path and a return type that can no longer
be None.

`collapse_module_relative` is deliberately NOT `lexically_normalize`, which
walks the same components but PRESERVES an unpoppable leading `..` so its
caller's `starts_with` containment check can reject an escaping alt-basis
path. They differ in input type, output type, separator policy and
leading-`..` policy - four contracts, not one function to deduplicate. Both
now say so in their doc comments.

Verification: 1774/1774 daemon tests pass. Mutation - making the collapse a
no-op (push `..` instead of popping) kills 5 of the 22 resolver tests, and
17 + 5 = 22 reconciles against the run count, so no fail-fast truncation is
hiding kills. fmt clean; clippy -D warnings clean.

The four tests that asserted the reject are rewritten to assert the collapse,
plus a class-level assertion that no quantity of `..` in any position produces
a path outside the module root.

One pre-existing flake observed, unrelated to this area and outside the
touched files: `daemon::tests::clap_command_creates_command` needed a retry.
