### PR TITLE
test(transfer): pin the umask uts_chmod_option depends on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3947,6 +3947,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 name = "test-support"
 version = "0.6.4"
 dependencies = [
+ "libc",
  "tempfile",
 ]
 

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -12,6 +12,11 @@ description = "Shared test utilities for the oc-rsync workspace"
 [dependencies]
 tempfile = { workspace = true }
 
+# `OcRsyncCliRunner::umask` pins the spawned child's umask via `pre_exec`, so
+# tests asserting mode bits do not silently inherit the caller's umask.
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 # Rust port of upstream `support/lsh.sh`. Built as a workspace binary so tests
 # can resolve its path via `CARGO_BIN_EXE_lsh-stub` and drive oc-rsync's
 # remote-shell code paths locally (design section 5).

--- a/crates/test-support/src/cli.rs
+++ b/crates/test-support/src/cli.rs
@@ -88,6 +88,8 @@ pub struct OcRsyncCliRunner {
     stdin: Option<Vec<u8>>,
     timeout: Duration,
     cwd: Option<PathBuf>,
+    #[cfg(unix)]
+    umask: Option<u32>,
 }
 
 impl Default for OcRsyncCliRunner {
@@ -113,6 +115,8 @@ impl OcRsyncCliRunner {
             stdin: None,
             timeout: DEFAULT_TIMEOUT,
             cwd: None,
+            #[cfg(unix)]
+            umask: None,
         }
     }
 
@@ -180,6 +184,33 @@ impl OcRsyncCliRunner {
         self
     }
 
+    /// Pins the umask the spawned `oc-rsync` runs under.
+    ///
+    /// Some rsync behaviour reads the ambient umask, so a test asserting the
+    /// resulting mode bits is only meaningful once the umask is pinned. The
+    /// clearest case is `--chmod` with a bare `+w`: `chmod.c:92` computes
+    /// `bits = (where * what) & ~orig_umask`, so under umask 022 a `+w` on an
+    /// already-user-writable directory adds *nothing* and the assertion holds
+    /// vacuously, while under 002 it adds group-write.
+    ///
+    /// upstream pins the umask for exactly this reason - suite-wide at
+    /// `testsuite/rsyncfns.py` (`os.umask(0o022)`, mirroring `rsync.fns`'s
+    /// `umask 022`), and narrowed per test where the subject is umask-sensitive
+    /// (`testsuite/chmod-option_test.py` uses `0o002`).
+    ///
+    /// ⚠ Applied to the CHILD ONLY, via `pre_exec`, rather than by mutating
+    /// this process's umask around the spawn. `umask(2)` is process-global, so
+    /// the mutate-and-restore form upstream uses in Python (where every test is
+    /// its own process) would be a race here the moment two runners are used
+    /// concurrently in one test binary. Scoping it to the child is race-free by
+    /// construction and needs no restore.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn umask(mut self, mask: u32) -> Self {
+        self.umask = Some(mask);
+        self
+    }
+
     /// Run synchronously, enforcing the timeout.
     ///
     /// Returns a [`CliOutput`] on any completed run (including non-zero exit).
@@ -206,6 +237,22 @@ impl OcRsyncCliRunner {
         });
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
+
+        #[cfg(unix)]
+        if let Some(mask) = self.umask {
+            use std::os::unix::process::CommandExt;
+            // SAFETY: runs in the forked child between fork and exec, where only
+            // async-signal-safe calls are permitted. `umask(2)` is one of them
+            // (POSIX.1-2017 async-signal-safe list) and touches no allocator,
+            // no lock, and no memory shared with the parent.
+            #[allow(unsafe_code)]
+            unsafe {
+                cmd.pre_exec(move || {
+                    libc::umask(mask as libc::mode_t);
+                    Ok(())
+                });
+            }
+        }
 
         let start = Instant::now();
         let mut child = cmd.spawn().map_err(RunnerError::Spawn)?;

--- a/crates/transfer/tests/uts_chmod_option.rs
+++ b/crates/transfer/tests/uts_chmod_option.rs
@@ -48,6 +48,23 @@ use std::path::Path;
 use test_support::{OcRsyncCliRunner, require_binaries, test_name};
 
 /// Low 12 permission bits (`0o7777`) of `path`, following the entry itself.
+/// Umask pinned for the `D+w` leg, matching upstream's own choice.
+///
+/// `--chmod`'s bare `+w` is masked by the process umask (`chmod.c:92`,
+/// `bits = (where * what) & ~orig_umask`), so this leg is only meaningful once
+/// the umask is fixed.
+///
+/// ⚠ 002 rather than the suite-wide 022, and the difference is the whole point.
+/// `dir1` starts 0700 and reaches 0755 after `a+rX`, so it is already
+/// user-writable: under umask 022 a bare `+w` adds NOTHING and the assertion
+/// would hold without exercising `+w` at all. Under 002 it adds group-write,
+/// which is observable. upstream pins the same value for the same reason -
+/// `testsuite/chmod-option_test.py` sets `os.umask(0o002)` while the suite
+/// baseline in `testsuite/rsyncfns.py` is 022 ("Individual tests may still
+/// narrow it (e.g. chmod-option uses 002)").
+#[cfg(unix)]
+const CHMOD_TEST_UMASK: u32 = 0o002;
+
 fn mode_bits(path: &Path) -> u32 {
     fs::symlink_metadata(path)
         .unwrap_or_else(|e| panic!("stat {}: {e}", path.display()))
@@ -101,12 +118,22 @@ fn chmod_strip_setid_and_add_rx_dir_write() {
 
     let out = OcRsyncCliRunner::new()
         .args(["-a", "--chmod", "ug-s,a+rX,D+w"])
+        .umask(CHMOD_TEST_UMASK)
         .arg(slash(&from))
         .arg(slash(&to))
         .run()
         .expect("run oc-rsync");
     out.assert_success();
 
+    // `D+w` is a bare `+w`, so `chmod.c:92` masks it with the process umask:
+    // `bits = (where * what) & ~orig_umask`. Derive the expectation from the
+    // pinned umask rather than writing the resulting octal literal, so the
+    // two can never drift apart.
+    // upstream: testsuite/chmod-option_test.py `plus_w = 0o222 & ~0o002`.
+    let plus_w = 0o222 & !CHMOD_TEST_UMASK;
+
+    // Files are untouched by `D+w` (the `D` qualifier selects directories), so
+    // these two are umask-independent.
     assert_eq!(
         mode_bits(&to.join("name1")),
         0o755,
@@ -119,13 +146,13 @@ fn chmod_strip_setid_and_add_rx_dir_write() {
     );
     assert_eq!(
         mode_bits(&to.join("dir1")),
-        0o755,
-        "dir1: a+rX then D+w (0755)",
+        0o755 | plus_w,
+        "dir1: 0700 -> a+rX -> 0755, then D+w adds {plus_w:#o} under umask {CHMOD_TEST_UMASK:#o}",
     );
     assert_eq!(
         mode_bits(&to.join("dir2")),
-        0o775,
-        "dir2: a+rX then D+w (0775)",
+        0o775 | plus_w,
+        "dir2: 0770 -> a+rX -> 0775, then D+w adds {plus_w:#o} under umask {CHMOD_TEST_UMASK:#o}",
     );
 }
 
@@ -146,6 +173,11 @@ fn chmod_file_only_clears_world_execute() {
     let to = root.path().join("to");
     fs::create_dir_all(&from).expect("mkdir from");
     fs::create_dir(from.join("foo")).expect("mkdir foo");
+    // `create_dir` yields `0o777 & ~umask`, so the asserted 0755 below would
+    // only hold under umask 022 and this fixture would read 0775 under 002.
+    // Pin it, exactly as `bar` is pinned just below - the assertion is about
+    // `--chmod=Fo-x` leaving directories alone, not about the ambient umask.
+    fs::set_permissions(from.join("foo"), fs::Permissions::from_mode(0o755)).expect("chmod foo");
     fs::write(from.join("bar"), b"").expect("touch bar");
     // Match upstream: `chmod o+x "$fromdir"/bar`. Start from 0644, add o+x.
     fs::set_permissions(from.join("bar"), fs::Permissions::from_mode(0o645)).expect("chmod bar");


### PR DESCRIPTION
Two tests in `uts_chmod_option` asserted mode bits that silently depended on the ambient umask. Both fail on any host running umask 002 - **including on pristine master**, which is how this was found (a full-suite run on a Linux host at umask 0002 reported 2748/2750 with exactly these two red).

## The two failures have different root causes

| Test | Layer | Why it depended on the umask | Fix |
|---|---|---|---|
| `chmod_strip_setid_and_add_rx_dir_write` | subject | `D+w` is a bare `+w`, and `chmod.c:92` masks it with the process umask: `bits = (where * what) & ~orig_umask`. The value read is the one the spawned `oc-rsync` inherits. | pin the child's umask, derive the expectation from it |
| `chmod_file_only_clears_world_execute` | fixture | `fs::create_dir` yields `0o777 & ~umask` **in the test process**, which a runner-level umask cannot affect. | chmod the fixture directory explicitly |

The second one matters: pinning the runner's umask does not fix it, so a single-mechanism fix would have left one test still umask-dependent.

## Upstream first

Upstream has this same test and pins the umask for the same reason. Its suite baseline is 022 (`testsuite/rsyncfns.py`, mirroring `rsync.fns`), and `testsuite/chmod-option_test.py` narrows to **002** - because `dir1` reaches 0755 after `a+rX` and is therefore already user-writable, so under 022 the `D+w` leg adds *nothing* and the assertion holds without exercising the subject at all. Upstream also *derives* its expectation (`plus_w = 0o222 & ~0o002`) instead of writing the resulting octal. This change mirrors both choices.

## One deliberate divergence from upstream's mechanism

Upstream mutates the process umask and restores it, which is safe in Python where every test is its own process. Here `umask(2)` is process-global, so mutate-and-restore would be a race the moment two runners are used concurrently in one test binary. `OcRsyncCliRunner::umask` scopes it to the child via `pre_exec` instead - race-free by construction and needing no restore. It sits alongside `env()`/`cwd()` as part of how the subject is invoked.

## Verification

Green at umask **022, 002, 077 and 000** (whole `uts_chmod_option` binary: 4/4). Each half is independently load-bearing:

| Mutation | umask 022 | umask 002 |
|---|---|---|
| drop the `.umask()` pin | **FAIL** | pass |
| drop the fixture chmod | pass | **FAIL** |

Each is killed exactly where the ambient umask diverges from what that half assumes; together they are umask-independent, which the four-umask matrix shows directly.

Also: `cargo fmt --all -- --check`, and full-workspace `cargo clippy --locked --all-targets --all-features --no-deps -- -D warnings`, both clean.

## Residual

Other test files across the workspace hardcode `0o755`/`0o775`/`0o750` and may carry the same latent dependency. Within `crates/transfer` the class is exhausted (the umask-002 host run had only these two failures); the wider sweep is tracked separately and is not folded in here.
