### PR TITLE
fix(sender): route the confined source open onto the shared resolver

### DIFF
--- a/crates/fast_io/src/confined_open.rs
+++ b/crates/fast_io/src/confined_open.rs
@@ -90,10 +90,10 @@ pub enum LeafPolicy {
 ///
 /// # Errors
 ///
-/// - `EINVAL` when `relative` is absolute, empty, or contains a `..`
-///   component (front-door validation, mirroring upstream
-///   `secure_relative_open`).
-/// - `EISDIR` when the final component names a directory rather than a file.
+/// - `EINVAL` when `relative` is absolute or contains a `..` component
+///   (front-door validation, mirroring upstream `secure_relative_open`).
+/// - `EISDIR` when `relative` names a directory rather than a file: it is
+///   empty, all slashes, or its final component is `.` or `..`.
 /// - `EXDEV` (Linux `openat2` path) when resolution would escape `root`.
 /// - `ELOOP` when a symlink is refused: a leaf symlink under
 ///   [`LeafPolicy::Nofollow`], an absolute or escaping target under
@@ -162,6 +162,14 @@ mod imp {
         leaf: LeafPolicy,
         noatime: bool,
     ) -> io::Result<File> {
+        // Classify the final component ONCE, before the platform split, and
+        // hand both arms the slash-trimmed path. Doing it per-arm let them
+        // disagree: `openat2` opens a directory named by a bare `.` and
+        // reports `ENOENT` for an empty path, where upstream's walk reports
+        // `EISDIR` for both. The classification is a property of the input,
+        // not of the kernel.
+        let (trimmed, _, _) = split_leaf(relative)?;
+
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // Open the module root as the anchoring dirfd. The root is an
@@ -174,15 +182,14 @@ mod imp {
                 .read(true)
                 .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
                 .open(root)?;
-            if let Some(file) = linux::openat2_confined(root_dir.as_fd(), relative, leaf, noatime)?
-            {
+            if let Some(file) = linux::openat2_confined(root_dir.as_fd(), trimmed, leaf, noatime)? {
                 return Ok(file);
             }
         }
 
         match leaf {
-            LeafPolicy::Nofollow => walk_then_open_leaf(root, relative, noatime),
-            LeafPolicy::FollowConfined => walk_following_leaf(root, relative, noatime),
+            LeafPolicy::Nofollow => walk_then_open_leaf(root, trimmed, noatime),
+            LeafPolicy::FollowConfined => walk_following_leaf(root, trimmed, noatime),
         }
     }
 
@@ -198,7 +205,7 @@ mod imp {
     /// - `rsync-3.5.0/sender.c:209-247` `sender_open_confined()`
     /// - `rsync-3.5.0/syscall.c:3037-3057` `secure_walk_at()`'s file-leaf arm
     fn walk_then_open_leaf(root: &Path, relative: &Path, noatime: bool) -> io::Result<File> {
-        let (dir, leaf) = split_leaf(relative)?;
+        let (_, dir, leaf) = split_leaf(relative)?;
         let parent = resolve_parent(root, dir)?;
         open_leaf(parent.root_dirfd(), leaf, noatime)
     }
@@ -217,7 +224,7 @@ mod imp {
     fn walk_following_leaf(root: &Path, relative: &Path, noatime: bool) -> io::Result<File> {
         let mut cur = relative.to_path_buf();
         for _ in 0..COPYLINKS_MAXHOPS {
-            let (dir, leaf) = split_leaf(&cur)?;
+            let (_, dir, leaf) = split_leaf(&cur)?;
             let parent = resolve_parent(root, dir)?;
             let target = match readlinkat(parent.root_dirfd(), leaf) {
                 Ok(target) => target,
@@ -248,36 +255,48 @@ mod imp {
         DirSandbox::open_dest_anchor_confined(root, dir, ConfinePolicy::operator_trusted())
     }
 
-    /// Split `relative` into its parent path and final component on raw `/`
-    /// bytes.
+    /// Split `relative` into `(trimmed, parent, leaf)` on raw `/` bytes.
     ///
     /// Deliberately not `Path::components()`: that normalises, and the rule
     /// being mirrored is a byte split. Trailing slashes are trimmed first so
-    /// the last-component test is exact.
+    /// the last-component test is exact - and `trimmed` is handed to the
+    /// kernel arm too, which would otherwise see `sub/data/` and report
+    /// `ENOTDIR` where upstream opens the file.
+    ///
+    /// # Errors
+    ///
+    /// `EISDIR` when there is no file leaf to open: an empty or all-slash
+    /// path, or a final `.` / `..`. Those name a directory, and upstream
+    /// reports `EISDIR` for a caller that did not ask for `O_DIRECTORY`.
     ///
     /// # Upstream Reference
     ///
     /// - `rsync-3.5.0/sender.c:212-226` `sender_open_confined()`'s `strrchr`
     /// - `rsync-3.5.0/syscall.c:3002-3006` `secure_walk_at()`'s slash trim
-    fn split_leaf(relative: &Path) -> io::Result<(&Path, &OsStr)> {
+    /// - `rsync-3.5.0/syscall.c:3025-3033` a final `.` / `..` -> `EISDIR`
+    /// - `rsync-3.5.0/syscall.c:3079-3086` no component at all -> `EISDIR`
+    fn split_leaf(relative: &Path) -> io::Result<(&Path, &Path, &OsStr)> {
         let bytes = relative.as_os_str().as_bytes();
         let end = bytes.iter().rposition(|byte| *byte != b'/');
         let bytes = match end {
             Some(last) => &bytes[..=last],
-            // Empty, or nothing but slashes: no leaf to open beneath the root.
-            None => return Err(io::Error::from_raw_os_error(libc::EINVAL)),
+            // Empty, or nothing but slashes: no leaf, so this names the anchor
+            // directory itself.
+            None => return Err(io::Error::from_raw_os_error(libc::EISDIR)),
         };
         let (dir, leaf) = match bytes.iter().rposition(|byte| *byte == b'/') {
             Some(slash) => (&bytes[..slash], &bytes[slash + 1..]),
             None => (&bytes[..0], bytes),
         };
         if leaf == b"." || leaf == b".." {
-            // A movement, not a name to open: the caller asked for a
-            // directory. upstream: syscall.c:3025-3033 reports EISDIR when
-            // O_DIRECTORY was not requested.
+            // A movement, not a name to open.
             return Err(io::Error::from_raw_os_error(libc::EISDIR));
         }
-        Ok((Path::new(OsStr::from_bytes(dir)), OsStr::from_bytes(leaf)))
+        Ok((
+            Path::new(OsStr::from_bytes(bytes)),
+            Path::new(OsStr::from_bytes(dir)),
+            OsStr::from_bytes(leaf),
+        ))
     }
 
     /// Opens the leaf `O_RDONLY | O_NOFOLLOW`, honouring `--open-noatime`
@@ -767,19 +786,53 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
     }
 
-    /// An empty or all-slash relative path has no leaf to open.
+    /// A path naming a directory is refused with `EISDIR`, and a trailing
+    /// slash is trimmed rather than being fatal - identically on both
+    /// platform arms.
+    ///
+    /// WHY: the final-component rule is a property of the input, not of the
+    /// kernel, but it was first written inside the portable arm only. The two
+    /// arms then disagreed on every input here: `openat2` reports `ENOENT`
+    /// for an empty path, opens the directory named by a bare `.`, and
+    /// reports `ENOTDIR` for `sub/data/` - where upstream's
+    /// `secure_walk_at()` reports `EISDIR`, `EISDIR`, and the file. Caught
+    /// only by running the suite on Linux; all four pass on macOS either way,
+    /// which is exactly why the classification now happens once, above the
+    /// platform split.
     #[test]
-    fn rejects_a_relative_path_with_no_leaf() {
+    fn the_leaf_classification_is_identical_on_both_platform_arms() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
-        for empty in ["", "/"] {
-            let err = open_source_confined(&root, Path::new(empty), LeafPolicy::Nofollow, false)
-                .expect_err("a path with no leaf must be rejected");
+        std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+        std::fs::write(root.join("sub/data"), b"payload").expect("write");
+
+        for directory in ["", ".", "sub/."] {
+            let err =
+                open_source_confined(&root, Path::new(directory), LeafPolicy::Nofollow, false)
+                    .expect_err("a path naming a directory must be refused");
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EISDIR),
+                "expected EISDIR for {directory:?}, got: {err}"
+            );
+        }
+
+        // A leading slash is still the front door's EINVAL, not EISDIR - it is
+        // tested before the leaf is classified, exactly as upstream tests
+        // `relpath[0] == '/'` before entering the walk (syscall.c:3105-3109).
+        for absolute in ["/", "///"] {
+            let err = open_source_confined(&root, Path::new(absolute), LeafPolicy::Nofollow, false)
+                .expect_err("an absolute path must be refused");
             assert_eq!(
                 err.raw_os_error(),
                 Some(libc::EINVAL),
-                "expected EINVAL for {empty:?}, got: {err}"
+                "expected EINVAL for {absolute:?}, got: {err}"
             );
         }
+
+        // Trailing slashes are trimmed, so the file still opens.
+        let file = open_source_confined(&root, Path::new("sub/data/"), LeafPolicy::Nofollow, false)
+            .expect("a trailing slash must be trimmed, not fatal");
+        assert_eq!(read_to_string(file), "payload");
     }
 }

--- a/crates/fast_io/src/confined_open.rs
+++ b/crates/fast_io/src/confined_open.rs
@@ -14,20 +14,36 @@
 //! between the file-list scan and the source open, redirecting the read to
 //! a file outside the module.
 //!
+//! # The leaf is a separate decision from the walk
+//!
+//! Upstream splits the confined sender open into two entry points that share
+//! the same confinement and differ only in how they treat the *final*
+//! component, so [`LeafPolicy`] carries that choice as a parameter rather
+//! than letting one arm silently answer for both:
+//!
+//! - `rsync-3.5.0/sender.c:209-247` `sender_open_confined()` - the default.
+//!   Intermediate in-tree symlinks are followed, the leaf is opened
+//!   `O_NOFOLLOW` so a raced leaf-symlink swap is refused.
+//! - `rsync-3.5.0/sender.c:250-330` `sender_open_copylinks_confined()` -
+//!   `--copy-links` / `--copy-unsafe-links` / `--copy-dirlinks`. The leaf
+//!   symlink is resolved deliberately, still beneath the root.
+//!
 //! # Platform behaviour
 //!
-//! upstream: `syscall.c:secure_relative_open` (called from
-//! `sender.c:secure_relative_open` when `use_secure_symlinks`, i.e. a
-//! non-chroot daemon).
+//! upstream: `sender.c:678-682`, which selects these helpers when
+//! `secure_relpath_active()` (a non-chroot daemon, or the `/./` inner-module
+//! chroot).
 //!
 //! - Linux 5.6+: `openat2(2)` with
 //!   `RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS` anchored at the module-root
-//!   dirfd. In-tree symlinks are followed; escapes fail with `EXDEV`.
-//! - Older Linux and every other Unix target: a per-component
-//!   `O_NOFOLLOW` walk from the module-root dirfd, mirroring upstream's
-//!   portable fallback. This is stricter than the kernel path - it refuses
-//!   *every* symlink component, in-tree or not - trading function for
-//!   safety exactly as upstream documents.
+//!   dirfd, plus `O_NOFOLLOW` under [`LeafPolicy::Nofollow`]. The kernel
+//!   applies `O_NOFOLLOW` to the final component only, so intermediate
+//!   in-tree symlinks are still followed - the same split upstream builds by
+//!   hand. Escapes fail with `EXDEV`.
+//! - Older Linux and every other Unix target: the shared per-component
+//!   resolver ([`crate::dir_sandbox::DirSandbox::open_dest_anchor_confined`])
+//!   walks the parent directories, mirroring upstream's `ds_descend()`, then
+//!   the leaf is opened against the resolved parent dirfd.
 //! - Non-Unix: unsupported. The oc daemon (the only caller) is Unix-only,
 //!   so this path is never reached; it returns an `Unsupported` error.
 
@@ -35,12 +51,37 @@ use std::fs::File;
 use std::io;
 use std::path::{Component, Path};
 
+/// How the final component of a confined source open is resolved.
+///
+/// The two variants are upstream's two entry points, not a tuning knob: the
+/// caller already knows whether the operator asked for symlink following, and
+/// making that an argument means neither platform arm can answer it by
+/// accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeafPolicy {
+    /// Refuse a symlinked leaf with `ELOOP`, so a leaf raced into a symlink
+    /// between the file-list scan and the open cannot redirect the read.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/sender.c:209-247` `sender_open_confined()`
+    Nofollow,
+    /// Resolve a symlinked leaf, still confined beneath the root: an absolute
+    /// target is refused, a relative one is re-resolved through the walk.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/sender.c:250-330` `sender_open_copylinks_confined()`
+    FollowConfined,
+}
+
 /// Opens `root`/`relative` for reading, confined beneath `root`.
 ///
 /// `root` is the operator-trusted module-root directory (an absolute path
 /// from the daemon config); it is opened with normal symlink resolution.
 /// `relative` is the module-relative source path; its resolution is
-/// confined so it cannot escape `root`.
+/// confined so it cannot escape `root`. `leaf` selects the final-component
+/// rule - see [`LeafPolicy`].
 ///
 /// When `noatime` is set the leaf open adds `O_NOATIME` on Linux/Android,
 /// falling back to a plain open if the kernel or filesystem rejects the
@@ -49,18 +90,29 @@ use std::path::{Component, Path};
 ///
 /// # Errors
 ///
-/// - `EINVAL` when `relative` is absolute or contains a `..` component
-///   (front-door validation, mirroring upstream `secure_relative_open`).
+/// - `EINVAL` when `relative` is absolute, empty, or contains a `..`
+///   component (front-door validation, mirroring upstream
+///   `secure_relative_open`).
+/// - `EISDIR` when the final component names a directory rather than a file.
 /// - `EXDEV` (Linux `openat2` path) when resolution would escape `root`.
-/// - `ELOOP` (portable fallback) when any component of `relative` is a
-///   symlink.
+/// - `ELOOP` when a symlink is refused: a leaf symlink under
+///   [`LeafPolicy::Nofollow`], an absolute or escaping target under
+///   [`LeafPolicy::FollowConfined`], or an exhausted hop budget.
 /// - `ENOENT` when the file does not exist beneath `root`.
 /// - Any other I/O error from the underlying syscalls, forwarded verbatim.
 ///
-/// upstream: sender.c:secure_relative_open
-pub fn open_source_confined(root: &Path, relative: &Path, noatime: bool) -> io::Result<File> {
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/sender.c:678-682` `send_files()` - the call site that picks
+///   between the two helpers this function's `leaf` argument names.
+pub fn open_source_confined(
+    root: &Path,
+    relative: &Path,
+    leaf: LeafPolicy,
+    noatime: bool,
+) -> io::Result<File> {
     validate_relative(relative)?;
-    imp::open_source_confined(root, relative, noatime)
+    imp::open_source_confined(root, relative, leaf, noatime)
 }
 
 /// Rejects an absolute `relative` or any `..` component up front with
@@ -90,69 +142,142 @@ const EINVAL: i32 = 22;
 #[cfg(unix)]
 mod imp {
     use super::*;
-    use std::os::fd::AsFd;
-    use std::os::unix::fs::OpenOptionsExt;
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
 
-    use crate::dir_sandbox::openat;
+    use crate::dir_sandbox::at_syscalls::readlinkat;
+    use crate::dir_sandbox::{ConfinePolicy, DirSandbox, openat};
+
+    /// Ceiling on the symlink chain [`LeafPolicy::FollowConfined`] will
+    /// resolve before giving up with `ELOOP`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/sender.c:258` `int hops = 32;`
+    const COPYLINKS_MAXHOPS: u32 = 32;
 
     pub(super) fn open_source_confined(
         root: &Path,
         relative: &Path,
+        leaf: LeafPolicy,
         noatime: bool,
     ) -> io::Result<File> {
-        // Open the module root as the anchoring dirfd. The root is an
-        // absolute, operator-trusted path, so a plain open (following any
-        // symlinks in the root itself) matches upstream's
-        // `openat(AT_FDCWD, basedir, O_RDONLY | O_DIRECTORY)`.
-        let root_dir = std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
-            .open(root)?;
-
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            if let Some(file) = linux::openat2_confined(root_dir.as_fd(), relative, noatime)? {
+            // Open the module root as the anchoring dirfd. The root is an
+            // absolute, operator-trusted path, so a plain open (following any
+            // symlinks in the root itself) matches upstream's
+            // `openat(AT_FDCWD, basedir, O_RDONLY | O_DIRECTORY)`.
+            use std::os::fd::AsFd;
+            use std::os::unix::fs::OpenOptionsExt;
+            let root_dir = std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
+                .open(root)?;
+            if let Some(file) = linux::openat2_confined(root_dir.as_fd(), relative, leaf, noatime)?
+            {
                 return Ok(file);
             }
         }
 
-        walk_nofollow(root_dir.as_fd(), relative, noatime)
+        match leaf {
+            LeafPolicy::Nofollow => walk_then_open_leaf(root, relative, noatime),
+            LeafPolicy::FollowConfined => walk_following_leaf(root, relative, noatime),
+        }
     }
 
-    /// Portable per-component `O_NOFOLLOW` walk from `root_fd`, mirroring
-    /// the fallback in upstream `secure_relative_open` for platforms
-    /// without kernel `RESOLVE_BENEATH`. Every component - directory and
-    /// leaf - is opened `O_NOFOLLOW`, so any symlink along the path is
-    /// refused with `ELOOP`.
-    fn walk_nofollow(
-        root_fd: std::os::fd::BorrowedFd<'_>,
-        relative: &Path,
-        noatime: bool,
-    ) -> io::Result<File> {
-        let mut components: Vec<&std::ffi::OsStr> = Vec::new();
-        for comp in relative.components() {
-            if let Component::Normal(part) = comp {
-                components.push(part);
+    /// Resolve `relative`'s parent through the shared confined resolver, then
+    /// open the leaf `O_NOFOLLOW` against it.
+    ///
+    /// The resolver follows in-tree directory symlinks and refuses absolute
+    /// targets, `..` above the anchor, and anything the oracle excludes -
+    /// exactly `ds_descend()`. `O_NOFOLLOW` then governs the leaf alone.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/sender.c:209-247` `sender_open_confined()`
+    /// - `rsync-3.5.0/syscall.c:3037-3057` `secure_walk_at()`'s file-leaf arm
+    fn walk_then_open_leaf(root: &Path, relative: &Path, noatime: bool) -> io::Result<File> {
+        let (dir, leaf) = split_leaf(relative)?;
+        let parent = resolve_parent(root, dir)?;
+        open_leaf(parent.root_dirfd(), leaf, noatime)
+    }
+
+    /// Resolve a symlinked leaf deliberately, still confined beneath `root`.
+    ///
+    /// Reads the link, refuses an absolute target (it names a path the module
+    /// does not contain, even when it happens to resolve back inside), and
+    /// re-resolves a relative target through the walk - which pops `..` on its
+    /// held-fd stack and refuses a pop above the anchor. The final open is
+    /// still `O_NOFOLLOW`, so a flip raced in at the resolved leaf is refused.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/sender.c:250-330` `sender_open_copylinks_confined()`
+    fn walk_following_leaf(root: &Path, relative: &Path, noatime: bool) -> io::Result<File> {
+        let mut cur = relative.to_path_buf();
+        for _ in 0..COPYLINKS_MAXHOPS {
+            let (dir, leaf) = split_leaf(&cur)?;
+            let parent = resolve_parent(root, dir)?;
+            let target = match readlinkat(parent.root_dirfd(), leaf) {
+                Ok(target) => target,
+                // EINVAL means "not a symlink", so this is the resolved
+                // target file. upstream: sender.c:308-317.
+                Err(error) if error.raw_os_error() == Some(libc::EINVAL) => {
+                    return open_leaf(parent.root_dirfd(), leaf, noatime);
+                }
+                Err(error) => return Err(error),
+            };
+            if target.as_os_str().is_empty() || target.is_absolute() {
+                return Err(io::Error::from_raw_os_error(libc::ELOOP));
             }
-            // `.` is skipped; `..`, root, and prefix were rejected by
-            // `validate_relative`.
+            cur = dir.join(target);
         }
+        Err(io::Error::from_raw_os_error(libc::ELOOP))
+    }
 
-        let Some((leaf, dirs)) = components.split_last() else {
-            // Empty relative path: nothing to open beneath the root.
-            return Err(io::Error::from_raw_os_error(libc::EINVAL));
+    /// Walk `dir` beneath `root` through the shared per-component resolver.
+    ///
+    /// The anchor *is* the confinement root here, and the walk already refuses
+    /// every pop above its anchor and every absolute symlink target, so the
+    /// exclude oracle would be redundant. Upstream carries one because
+    /// `secure_walk_at()` is shared with call sites anchored *inside* the
+    /// module (`basedir == NULL`, i.e. the cwd); this call site is not one of
+    /// them.
+    fn resolve_parent(root: &Path, dir: &Path) -> io::Result<DirSandbox> {
+        DirSandbox::open_dest_anchor_confined(root, dir, ConfinePolicy::operator_trusted())
+    }
+
+    /// Split `relative` into its parent path and final component on raw `/`
+    /// bytes.
+    ///
+    /// Deliberately not `Path::components()`: that normalises, and the rule
+    /// being mirrored is a byte split. Trailing slashes are trimmed first so
+    /// the last-component test is exact.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/sender.c:212-226` `sender_open_confined()`'s `strrchr`
+    /// - `rsync-3.5.0/syscall.c:3002-3006` `secure_walk_at()`'s slash trim
+    fn split_leaf(relative: &Path) -> io::Result<(&Path, &OsStr)> {
+        let bytes = relative.as_os_str().as_bytes();
+        let end = bytes.iter().rposition(|byte| *byte != b'/');
+        let bytes = match end {
+            Some(last) => &bytes[..=last],
+            // Empty, or nothing but slashes: no leaf to open beneath the root.
+            None => return Err(io::Error::from_raw_os_error(libc::EINVAL)),
         };
-
-        let dir_flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
-        let mut current: Option<File> = None;
-        for dir in dirs {
-            let parent = current.as_ref().map_or(root_fd, AsFd::as_fd);
-            let next = openat(parent, dir, dir_flags, 0)?;
-            current = Some(next);
+        let (dir, leaf) = match bytes.iter().rposition(|byte| *byte == b'/') {
+            Some(slash) => (&bytes[..slash], &bytes[slash + 1..]),
+            None => (&bytes[..0], bytes),
+        };
+        if leaf == b"." || leaf == b".." {
+            // A movement, not a name to open: the caller asked for a
+            // directory. upstream: syscall.c:3025-3033 reports EISDIR when
+            // O_DIRECTORY was not requested.
+            return Err(io::Error::from_raw_os_error(libc::EISDIR));
         }
-
-        let parent = current.as_ref().map_or(root_fd, AsFd::as_fd);
-        open_leaf(parent, leaf, noatime)
+        Ok((Path::new(OsStr::from_bytes(dir)), OsStr::from_bytes(leaf)))
     }
 
     /// Opens the leaf `O_RDONLY | O_NOFOLLOW`, honouring `--open-noatime`
@@ -175,7 +300,7 @@ mod imp {
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(super) mod linux {
-        use super::{noatime_flag, noatime_retryable};
+        use super::{LeafPolicy, noatime_flag, noatime_retryable};
         use std::ffi::CString;
         use std::fs::File;
         use std::io;
@@ -188,15 +313,24 @@ mod imp {
         /// Attempts `openat2(RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS)` for
         /// `relative` beneath `root_fd`.
         ///
+        /// `O_NOFOLLOW` is added for [`LeafPolicy::Nofollow`]. The kernel
+        /// applies it to the *final* component only, so intermediate in-tree
+        /// symlinks are still followed - the same division upstream builds by
+        /// hand out of `ds_descend()` plus an `O_NOFOLLOW` leaf open. Without
+        /// it, `RESOLVE_BENEATH` resolves the leaf symlink too, which is what
+        /// `LeafPolicy::FollowConfined` wants and refuses absolute targets on
+        /// the kernel's behalf.
+        ///
         /// Returns `Ok(Some(file))` on success, `Ok(None)` when the kernel
         /// lacks `openat2` (`ENOSYS`, cached by [`openat2_supported`]) so the
         /// caller falls back to the portable walk, and `Err(_)` for every
         /// other failure - including the deliberate confinement refusals
-        /// (`EXDEV` for an escape, `ELOOP` for a magic link) the caller must
-        /// surface.
+        /// (`EXDEV` for an escape, `ELOOP` for a magic link or a refused leaf
+        /// symlink) the caller must surface.
         pub(super) fn openat2_confined(
             root_fd: BorrowedFd<'_>,
             relative: &Path,
+            leaf: LeafPolicy,
             noatime: bool,
         ) -> io::Result<Option<File>> {
             if !openat2_supported() {
@@ -210,7 +344,10 @@ mod imp {
                 )
             })?;
 
-            let base = libc::O_RDONLY | libc::O_CLOEXEC;
+            let mut base = libc::O_RDONLY | libc::O_CLOEXEC;
+            if leaf == LeafPolicy::Nofollow {
+                base |= libc::O_NOFOLLOW;
+            }
             if let Some(extra) = noatime_flag(noatime) {
                 match raw_openat2(root_fd, &c_rel, base | extra) {
                     Ok(outcome) => return Ok(outcome),
@@ -306,6 +443,7 @@ mod imp {
     pub(super) fn open_source_confined(
         _root: &Path,
         _relative: &Path,
+        _leaf: LeafPolicy,
         _noatime: bool,
     ) -> io::Result<File> {
         Err(io::Error::new(
@@ -334,35 +472,180 @@ mod tests {
         std::fs::create_dir(root.join("sub")).expect("mkdir sub");
         std::fs::write(root.join("sub/data"), b"payload").expect("write");
 
-        let file = open_source_confined(&root, Path::new("sub/data"), false).expect("open");
+        let file = open_source_confined(&root, Path::new("sub/data"), LeafPolicy::Nofollow, false)
+            .expect("open");
         assert_eq!(read_to_string(file), "payload");
     }
 
+    /// An in-tree symlinked *directory* component is followed on every
+    /// platform.
+    ///
+    /// WHY: upstream's `ds_descend()` follows a relative in-tree symlink
+    /// (`rsync-3.5.0/syscall.c:2937-2961`) - the behaviour restored for issue
+    /// #715, so a module whose layout uses a symlinked subdirectory keeps
+    /// serving. Before this walk was routed through the shared resolver the
+    /// portable arm opened every component `O_NOFOLLOW` and refused, which
+    /// made an ordinary module unservable on macOS/BSD while Linux served it.
+    ///
+    /// The previous version of this test accepted refusal *or* success, so it
+    /// could not fail on either arm. It now pins one answer for both.
     #[test]
-    fn follows_in_tree_directory_symlink_on_kernel_path() {
-        // In-tree symlinks are allowed by the openat2 RESOLVE_BENEATH path
-        // (upstream #715 behaviour). On the portable fallback walk this is
-        // refused with ELOOP; accept either, since the security contract is
-        // "no escape", and the fallback is deliberately stricter.
+    fn an_in_tree_symlinked_directory_component_is_followed() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
         std::fs::create_dir(root.join("real")).expect("mkdir real");
         std::fs::write(root.join("real/data"), b"in-tree").expect("write");
         symlink("real", root.join("link")).expect("symlink");
 
-        match open_source_confined(&root, Path::new("link/data"), false) {
-            Ok(file) => assert_eq!(read_to_string(file), "in-tree"),
-            Err(error) => {
-                // The portable walk refuses the symlinked directory component:
-                // ELOOP on Linux, ENOTDIR on macOS/BSD (O_DIRECTORY evaluated
-                // before O_NOFOLLOW).
-                let code = error.raw_os_error();
-                assert!(
-                    code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
-                    "fallback walk must refuse the symlink component, got: {error}"
-                );
-            }
-        }
+        let file = open_source_confined(&root, Path::new("link/data"), LeafPolicy::Nofollow, false)
+            .expect("an in-tree symlinked directory component must be followed");
+        assert_eq!(read_to_string(file), "in-tree");
+    }
+
+    /// A symlinked *leaf* is refused under the default policy even when its
+    /// target is in-tree.
+    ///
+    /// WHY: upstream opens the file leaf `O_NOFOLLOW`
+    /// (`rsync-3.5.0/syscall.c:3050`, `sender.c:245`) so an attacker who wins
+    /// the race between the file-list scan and the content open cannot swap
+    /// the leaf for a symlink and redirect the read. Confinement alone does
+    /// not close that: the swapped target may be a *different in-module file*
+    /// the peer was never authorised to see.
+    ///
+    /// This is the arm that regressed silently: `openat2(RESOLVE_BENEATH)`
+    /// without `O_NOFOLLOW` follows the leaf, so on Linux the defence was
+    /// absent while the portable walk refused - and no test looked at the
+    /// distinction.
+    #[test]
+    fn a_symlinked_leaf_is_refused_under_nofollow() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        std::fs::write(root.join("real"), b"in-tree").expect("write");
+        symlink("real", root.join("link")).expect("symlink");
+
+        let err = open_source_confined(&root, Path::new("link"), LeafPolicy::Nofollow, false)
+            .expect_err("O_NOFOLLOW must refuse the leaf even for an in-tree target");
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ELOOP),
+            "expected ELOOP for a refused leaf symlink, got: {err}"
+        );
+    }
+
+    /// `--copy-links` resolves that same leaf, still beneath the root.
+    ///
+    /// WHY: upstream keeps a second entry point rather than dropping the
+    /// `O_NOFOLLOW` (`rsync-3.5.0/sender.c:250-330`
+    /// `sender_open_copylinks_confined`), because a symlink-following mode is
+    /// an operator instruction that must not be silently downgraded. Collapse
+    /// the two and either `-L` stops working or the raced-leaf defence above
+    /// disappears.
+    #[test]
+    fn a_symlinked_leaf_is_resolved_under_follow_confined() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+        std::fs::write(root.join("sub/real"), b"followed").expect("write");
+        symlink("real", root.join("sub/link")).expect("symlink");
+
+        let file = open_source_confined(
+            &root,
+            Path::new("sub/link"),
+            LeafPolicy::FollowConfined,
+            false,
+        )
+        .expect("copy-links must resolve an in-tree leaf symlink");
+        assert_eq!(read_to_string(file), "followed");
+    }
+
+    /// A symlink chain is resolved to its end, then opened.
+    ///
+    /// WHY: upstream loops rather than resolving one hop
+    /// (`rsync-3.5.0/sender.c:265-330`), and each hop is re-anchored, so a
+    /// chain cannot walk out of the module one link at a time.
+    #[test]
+    fn follow_confined_resolves_a_symlink_chain() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        std::fs::create_dir(root.join("a")).expect("mkdir a");
+        std::fs::write(root.join("a/target"), b"end-of-chain").expect("write");
+        symlink("target", root.join("a/mid")).expect("symlink mid");
+        symlink("a/mid", root.join("head")).expect("symlink head");
+
+        let file =
+            open_source_confined(&root, Path::new("head"), LeafPolicy::FollowConfined, false)
+                .expect("a chain of in-tree links must resolve");
+        assert_eq!(read_to_string(file), "end-of-chain");
+    }
+
+    /// An absolute leaf target is refused under `--copy-links`.
+    ///
+    /// WHY: upstream refuses an absolute target outright
+    /// (`rsync-3.5.0/sender.c:320-323`) rather than testing where it lands -
+    /// it names a path the module does not contain, even when it happens to
+    /// resolve back inside.
+    #[test]
+    fn follow_confined_refuses_an_absolute_leaf_target() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let root = base.join("module");
+        std::fs::create_dir(&root).expect("mkdir module");
+        std::fs::write(base.join("secret"), b"do-not-leak").expect("write secret");
+        symlink(base.join("secret"), root.join("leak")).expect("symlink leak");
+
+        let err = open_source_confined(&root, Path::new("leak"), LeafPolicy::FollowConfined, false)
+            .expect_err("an absolute leaf target must be refused");
+        let code = err.raw_os_error();
+        assert!(
+            code == Some(libc::ELOOP) || code == Some(libc::EXDEV),
+            "expected ELOOP or EXDEV for an absolute leaf target, got: {err}"
+        );
+    }
+
+    /// A relative leaf target that climbs out of the module is refused.
+    ///
+    /// WHY: this is the case an absolute-target check alone would miss, and
+    /// the one a naive "join and open" would let through. The walk resolves
+    /// `..` by popping its held-fd stack and refuses a pop above the anchor
+    /// (`rsync-3.5.0/syscall.c:2896-2901`), so the climb cannot be laundered
+    /// through a symlink.
+    #[test]
+    fn follow_confined_refuses_a_relative_leaf_target_that_climbs_out() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let root = base.join("module");
+        std::fs::create_dir(&root).expect("mkdir module");
+        std::fs::write(base.join("secret"), b"do-not-leak").expect("write secret");
+        symlink("../secret", root.join("leak")).expect("symlink leak");
+
+        let err = open_source_confined(&root, Path::new("leak"), LeafPolicy::FollowConfined, false)
+            .expect_err("a climbing relative leaf target must be refused");
+        let code = err.raw_os_error();
+        assert!(
+            code == Some(libc::ELOOP) || code == Some(libc::EXDEV),
+            "expected ELOOP or EXDEV for a climbing leaf target, got: {err}"
+        );
+    }
+
+    /// A self-referential symlink terminates instead of spinning.
+    ///
+    /// WHY: upstream caps the chain at 32 hops (`rsync-3.5.0/sender.c:258`).
+    /// Without the cap a module operator - or an attacker with write access
+    /// to the tree - hangs the daemon's sender with two symlinks.
+    #[test]
+    fn follow_confined_bounds_the_symlink_chain() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        symlink("pong", root.join("ping")).expect("symlink ping");
+        symlink("ping", root.join("pong")).expect("symlink pong");
+
+        let err = open_source_confined(&root, Path::new("ping"), LeafPolicy::FollowConfined, false)
+            .expect_err("a symlink cycle must terminate with an error");
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ELOOP),
+            "expected ELOOP for an exhausted hop budget, got: {err}"
+        );
     }
 
     #[test]
@@ -380,15 +663,21 @@ mod tests {
         // `<root>/escape` -> the absolute `outside` dir (outside the module).
         symlink(&outside, root.join("escape")).expect("symlink escape");
 
-        let err = open_source_confined(&root, Path::new("escape/secret"), false)
-            .expect_err("escape must be refused");
-        // openat2 rejects the escape with EXDEV; the portable walk rejects the
-        // symlinked directory component with ELOOP (Linux) or ENOTDIR
-        // (macOS/BSD). Any of the three proves confinement.
+        let err = open_source_confined(
+            &root,
+            Path::new("escape/secret"),
+            LeafPolicy::Nofollow,
+            false,
+        )
+        .expect_err("escape must be refused");
+        // openat2 rejects the escape with EXDEV; the resolver refuses the
+        // absolute symlink target with ELOOP. ENOTDIR is deliberately no
+        // longer accepted - that was the old `O_NOFOLLOW`-every-component
+        // walk, which refused the component for the wrong reason.
         let code = err.raw_os_error();
         assert!(
-            code == Some(libc::EXDEV) || code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
-            "expected EXDEV, ELOOP, or ENOTDIR for an escape, got: {err}"
+            code == Some(libc::EXDEV) || code == Some(libc::ELOOP),
+            "expected EXDEV or ELOOP for an escape, got: {err}"
         );
     }
 
@@ -403,7 +692,7 @@ mod tests {
         // Absolute symlink leaf targeting a file outside the module.
         symlink(base.join("secret"), root.join("leak")).expect("symlink leak");
 
-        let err = open_source_confined(&root, Path::new("leak"), false)
+        let err = open_source_confined(&root, Path::new("leak"), LeafPolicy::Nofollow, false)
             .expect_err("symlinked leaf pointing outside must be refused");
         let code = err.raw_os_error();
         assert!(
@@ -416,8 +705,9 @@ mod tests {
     fn rejects_absolute_relative_path() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
-        let err = open_source_confined(&root, Path::new("/etc/passwd"), false)
-            .expect_err("absolute relative path must be rejected");
+        let err =
+            open_source_confined(&root, Path::new("/etc/passwd"), LeafPolicy::Nofollow, false)
+                .expect_err("absolute relative path must be rejected");
         assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
     }
 
@@ -425,8 +715,46 @@ mod tests {
     fn rejects_dotdot_component() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
-        let err = open_source_confined(&root, Path::new("../secret"), false)
+        let err = open_source_confined(&root, Path::new("../secret"), LeafPolicy::Nofollow, false)
             .expect_err("dotdot component must be rejected");
+        assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+    }
+
+    /// The front-door `..` rejection applies to the *caller's* input only.
+    ///
+    /// WHY: upstream skips it for a path it re-anchored itself
+    /// (`rsync-3.5.0/syscall.c:3153-3167`, the `reanchored` guard) because a
+    /// followed symlink's target legitimately contains parent-relative
+    /// components - `secure_relative_open_at_beneath()` exists for exactly
+    /// that. Applying the front-door check to a derived path would make
+    /// ordinary in-module links unfollowable.
+    #[test]
+    fn a_followed_target_may_contain_dotdot_while_caller_input_may_not() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        std::fs::create_dir(root.join("here")).expect("mkdir here");
+        std::fs::create_dir(root.join("there")).expect("mkdir there");
+        std::fs::write(root.join("there/data"), b"sibling").expect("write");
+        // Climbs to the module root and back down - inside the whole way.
+        symlink("../there/data", root.join("here/link")).expect("symlink");
+
+        let file = open_source_confined(
+            &root,
+            Path::new("here/link"),
+            LeafPolicy::FollowConfined,
+            false,
+        )
+        .expect("an in-module `..` target must resolve");
+        assert_eq!(read_to_string(file), "sibling");
+
+        // The same `..` written by the caller is still rejected up front.
+        let err = open_source_confined(
+            &root,
+            Path::new("here/../there/data"),
+            LeafPolicy::FollowConfined,
+            false,
+        )
+        .expect_err("caller-supplied dotdot must still be rejected");
         assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
     }
 
@@ -434,8 +762,24 @@ mod tests {
     fn missing_file_reports_not_found() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
-        let err = open_source_confined(&root, Path::new("nope"), false)
+        let err = open_source_confined(&root, Path::new("nope"), LeafPolicy::Nofollow, false)
             .expect_err("missing file must fail");
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    /// An empty or all-slash relative path has no leaf to open.
+    #[test]
+    fn rejects_a_relative_path_with_no_leaf() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        for empty in ["", "/"] {
+            let err = open_source_confined(&root, Path::new(empty), LeafPolicy::Nofollow, false)
+                .expect_err("a path with no leaf must be rejected");
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EINVAL),
+                "expected EINVAL for {empty:?}, got: {err}"
+            );
+        }
     }
 }

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -365,7 +365,7 @@ pub use traits::{FileReader, FileWriter};
 pub use gcd::{GcdQueue, GcdReader, GcdWriter};
 
 #[cfg(unix)]
-pub use confined_open::open_source_confined;
+pub use confined_open::{LeafPolicy, open_source_confined};
 #[cfg(unix)]
 pub use dir_sandbox::{
     AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,

--- a/crates/transfer/src/generator/open_source.rs
+++ b/crates/transfer/src/generator/open_source.rs
@@ -3,10 +3,14 @@
 //! The sender opens every source file through [`SourceOpen::open`], which
 //! mirrors the branch upstream `sender.c` takes before reading a file:
 //!
-//! - **Daemon, non-chroot** (`use_secure_symlinks`): the file is opened
+//! - **Daemon, non-chroot** (`secure_relpath_active`): the file is opened
 //!   confined beneath the module root via [`fast_io::open_source_confined`],
 //!   so a swapped directory symlink cannot redirect the read outside the
-//!   module (TOCTOU escape). upstream: `sender.c:secure_relative_open`.
+//!   module (TOCTOU escape). The *leaf* rule still follows the operator's
+//!   symlink mode, which is why the confined open takes a
+//!   [`fast_io::LeafPolicy`] rather than one arm answering for both.
+//!   upstream: `rsync-3.5.0/sender.c:678-682`, choosing between
+//!   `sender_open_confined()` and `sender_open_copylinks_confined()`.
 //! - **Everything else** (`do_open_checklinks`): the file is opened with
 //!   `O_NOFOLLOW` on the leaf so a symlinked final component is refused,
 //!   UNLESS `--copy-links` / `--copy-unsafe-links` is set (then the symlink
@@ -60,17 +64,26 @@ impl SourceOpen {
 
     /// Opens `path` under this policy.
     ///
-    /// upstream: sender.c - `secure_relative_open` (daemon, confined) vs
-    /// `do_open_checklinks` (`O_NOFOLLOW` leaf unless copy-links).
+    /// upstream: `rsync-3.5.0/sender.c:678-682` - the confined pair
+    /// (`sender_open_confined` / `sender_open_copylinks_confined`) for a
+    /// daemon, `do_open_checklinks` otherwise.
     pub(crate) fn open(&self, path: &Path) -> io::Result<fs::File> {
         #[cfg(unix)]
         if let Some(root) = self.confine_root.as_deref() {
-            // upstream: sender.c:secure_relative_open - reconstruct the
-            // module-relative path and open it confined beneath the module
-            // root. oc keeps absolute source paths, so the module-relative
-            // component is the source path with the module root stripped.
+            // Reconstruct the module-relative path and open it confined
+            // beneath the module root. oc keeps absolute source paths, so the
+            // module-relative component is the source path with the module
+            // root stripped.
             if let Ok(relative) = path.strip_prefix(root) {
-                return fast_io::open_source_confined(root, relative, self.noatime);
+                // A symlink-following mode is an operator instruction, so it
+                // survives confinement rather than being downgraded to the
+                // O_NOFOLLOW leaf. upstream: sender.c:680-682.
+                let leaf = if self.follow_symlinks {
+                    fast_io::LeafPolicy::FollowConfined
+                } else {
+                    fast_io::LeafPolicy::Nofollow
+                };
+                return fast_io::open_source_confined(root, relative, leaf, self.noatime);
             }
             // A source path that is not beneath the module root should never
             // happen for a legitimate daemon transfer; fail safe by falling
@@ -323,9 +336,46 @@ mod tests {
             .expect_err("confined open must refuse the escape");
         let code = err.raw_os_error();
         assert!(
-            code == Some(libc::EXDEV) || code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
-            "expected EXDEV, ELOOP, or ENOTDIR for a confined escape, got: {err}"
+            code == Some(libc::EXDEV) || code == Some(libc::ELOOP),
+            "expected EXDEV or ELOOP for a confined escape, got: {err}"
         );
+    }
+
+    /// Confinement must not silently downgrade `--copy-links`.
+    ///
+    /// WHY: upstream keeps a separate confined entry point for the
+    /// symlink-following modes (`rsync-3.5.0/sender.c:680-682` selecting
+    /// `sender_open_copylinks_confined`). If the daemon arm answered the leaf
+    /// question by itself, a module served with `-L` would either stop
+    /// following links the operator asked it to follow, or - the direction oc
+    /// actually had on Linux - follow a leaf symlink even at the default,
+    /// losing the raced-leaf defence.
+    #[cfg(unix)]
+    #[test]
+    fn daemon_confined_policy_still_honours_copy_links() {
+        use std::io::Read as _;
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("target"), b"followed").unwrap();
+        symlink("target", root.path().join("leaf")).unwrap();
+        let leaf = root.path().join("leaf");
+
+        // Default: the leaf symlink is refused even though it is in-module.
+        let strict = SourceOpen::new(Some(root.path().to_path_buf()), false, false);
+        let err = strict
+            .open(&leaf)
+            .expect_err("the default confined policy must refuse a leaf symlink");
+        assert_eq!(err.raw_os_error(), Some(libc::ELOOP));
+
+        // --copy-links: the same leaf resolves, still confined.
+        let following = SourceOpen::new(Some(root.path().to_path_buf()), true, false);
+        let mut file = following
+            .open(&leaf)
+            .expect("copy-links must still follow an in-module leaf");
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).unwrap();
+        assert_eq!(buf, "followed");
     }
 
     /// The confined daemon policy still opens a legitimate in-module file.


### PR DESCRIPTION
Routes the daemon sender's confined source open onto the shared per-component resolver, and makes the two platform arms agree with upstream 3.5.0 and with each other.

## The defect: two arms, diverging from upstream in *opposite* directions

The confined open had a bespoke per-component walk that opened every directory component `O_NOFOLLOW`, plus a Linux `openat2` arm that opened the leaf with plain `O_RDONLY`. Upstream 3.5.0 does neither: it descends intermediate components through `ds_descend()`, which **follows** a relative in-tree symlink (`syscall.c:2937-2961`), and opens the file leaf **`O_NOFOLLOW`** (`syscall.c:3050`) so a leaf raced into a symlink is refused.

| input | upstream 3.5.0 | oc Linux (openat2) | oc portable walk |
|---|---|---|---|
| in-tree symlinked **directory** component | follows | follows | **REFUSED** (over-strict) |
| in-tree symlinked **leaf**, default mode | refuses (ELOOP) | **FOLLOWED** (defence absent) | refuses |

So each arm was wrong on a different input, and they disagreed with each other - meaning the same source tree behaved differently depending on the kernel.

## Measured against the syscall before changing anything

On Linux 7.0:
- `openat2(RESOLVE_BENEATH|RESOLVE_NO_MAGICLINKS, O_RDONLY)` on a relative in-tree leaf symlink **returns the target**
- adding `O_NOFOLLOW` gives **ELOOP**
- `O_NOFOLLOW` still lets an in-tree symlinked **directory** component resolve, because the kernel applies it to the final component only

That last point is what makes the fix small: the kernel already expresses upstream's follow-the-path / refuse-the-leaf split in a single call.

## Changes

1. **Linux arm** - add `O_NOFOLLOW` when the leaf must not be followed.
2. **Portable arm** - walk the parent through the shared resolver (`DirSandbox::open_dest_anchor_confined`), then open the leaf `O_NOFOLLOW` against the resolved parent dirfd. The bespoke `walk_nofollow` is gone.

This is **not** contract-free: upstream splits the confined sender open into two entry points, so the leaf rule had to become a parameter (`LeafPolicy`) rather than a constant.

## Second commit: classify the leaf *once*, above the platform split

The final-component rule was applied inside the portable walk only, so the arms disagreed on every input naming a directory rather than a file. Measured on Linux 7.0, `openat2` reports ENOENT for an empty relative path, opens the directory named by a bare `.`, and reports ENOTDIR for `sub/data/` - where upstream's `secure_walk_at()` reports EISDIR, EISDIR, and the file (`syscall.c:3002-3006` trims trailing slashes; `:3025-3033` and `:3079-3086` report EISDIR).

`split_leaf` now also returns the trimmed path and is called once *before* the platform split, so the kernel arm sees the same classification and the same trimmed input. Its no-leaf error changes EINVAL -> EISDIR to match upstream. A **leading** slash is still the front door's EINVAL, tested before the leaf is classified.

That divergence was found only by running the suite on Linux - every one of those cases passes on macOS either way, which is what the new test's name records.

## Verification

- macOS: `-p fast_io -p transfer --all-features` **3462/3462** (3 skipped), with `oc-rsync` built first
- `cargo fmt --all -- --check` clean; full-workspace `cargo clippy --locked --all-targets --all-features --no-deps -- -D warnings` clean

Base is current master; the resolver this depends on landed in #7325.

## Scope note

This does **not** close the separate macOS/non-`openat2` daemon refusal gap (tracked as task 604): on a platform without `openat2`, `open_dest_anchor` cannot distinguish "follow" from "refuse" for an in-tree symlink vs an escape. That is its own change and is deliberately not folded in here.
