### PR TITLE
docs: correct stale upstream-version and CI-gate claims

### DIFF
--- a/docs/contributing/ONBOARDING.md
+++ b/docs/contributing/ONBOARDING.md
@@ -136,7 +136,7 @@ Explicit states with validated transitions:
 
 ## How to Add a Feature
 
-1. **Read upstream C source first.** The C code at `target/interop/upstream-src/rsync-3.4.1/` is the only source of truth for protocol behavior. Do not rely on man pages or third-party descriptions.
+1. **Read upstream C source first.** The C code at `target/interop/upstream-src/rsync-3.4.4/` - the release `workspace.metadata.oc_rsync.upstream_version` pins - is the only source of truth for protocol behavior. Do not rely on man pages or third-party descriptions.
 
 2. **Create a feature branch:**
    ```sh
@@ -171,13 +171,17 @@ All of these must pass before a PR can merge:
 
 | Check | What it validates |
 |-------|-------------------|
-| fmt+clippy | `cargo fmt --check` and `cargo clippy` with `-D warnings` |
+| fmt + clippy | `cargo fmt --check` and `cargo clippy` with `-D warnings` |
 | nextest (stable) | Full workspace test suite on Linux |
 | Windows (stable) | Platform-specific compilation and targeted tests |
 | macOS (stable) | Platform-specific compilation and targeted tests |
 | Linux musl (stable) | Static linking compatibility |
+| interop / interop with upstream rsync | Wire compatibility against every pinned upstream release |
+| upstream-testsuite / upstream testsuite | Upstream's own testsuite, unprivileged |
+| upstream-testsuite / upstream testsuite (root) | Upstream's own testsuite, privileged (ownership, devices) |
 
-PRs require one approving review (admin can bypass).
+Master is protected, so every change lands through a pull request. No approving
+review is required - the checks above are the gate.
 
 ## Upstream Rsync Reference
 
@@ -187,10 +191,14 @@ The upstream C source is the authoritative reference for all protocol behavior.
 
 ```sh
 mkdir -p target/interop/upstream-src && cd target/interop/upstream-src
-curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.1.tar.gz | tar xz
+curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz | tar xz
 ```
 
-Or run the interop harness which downloads all tested versions (3.0.9, 3.1.3, 3.4.1, 3.4.2):
+`3.4.4` is the version `workspace.metadata.oc_rsync.upstream_version` pins, and the
+one every `// upstream:` citation resolves against.
+
+Or run the interop harness, which downloads every tested version - the set lives in
+`versions=(...)` at `tools/ci/run_interop.sh:74`:
 
 ```sh
 bash tools/ci/run_interop.sh

--- a/docs/contributing/TESTING.md
+++ b/docs/contributing/TESTING.md
@@ -9,7 +9,8 @@ Tests are layered by scope and purpose:
 
 1. **Property tests** - verify algorithmic correctness with randomized inputs (proptest/quickcheck).
 2. **Golden byte tests** - pin exact wire format against captured upstream byte sequences.
-3. **Interop tests** - run oc-rsync against upstream rsync binaries (3.0.9, 3.1.3, 3.4.1, 3.4.2, 3.4.3).
+3. **Interop tests** - run oc-rsync against upstream rsync binaries; the version set is
+   `versions=(...)` in `tools/ci/run_interop.sh`.
 4. **Integration tests** - exercise end-to-end transfer pipelines using tempfile fixtures.
 5. **Fuzz targets** - find parser crashes and logic errors via cargo-fuzz.
 6. **SIMD parity tests** - ensure scalar and SIMD implementations produce identical output.
@@ -140,8 +141,10 @@ only the crates you changed.
 | interop (macOS) | macOS | Homebrew rsync smoke | Yes |
 | interop (Windows) | Windows | MSYS2 rsync smoke | No (best-effort) |
 
-Branch protection requires: fmt+clippy, nextest (stable), Windows (stable),
-macOS (stable), Linux musl (stable).
+Branch protection requires eight contexts: `fmt + clippy`, `nextest (stable)`,
+`Windows (stable)`, `macOS (stable)`, `Linux musl (stable)`,
+`interop / interop with upstream rsync`, `upstream-testsuite / upstream testsuite`,
+and `upstream-testsuite / upstream testsuite (root)`.
 
 ### Nextest configuration
 
@@ -155,7 +158,8 @@ macOS (stable), Linux musl (stable).
 
 The interop harness lives at `tools/ci/run_interop.sh`. It:
 
-1. Downloads and builds upstream rsync for versions 3.0.9, 3.1.3, 3.4.1, 3.4.2, and 3.4.3.
+1. Downloads and builds upstream rsync for every version in its own `versions=(...)`
+   list, plus the extra build-only and source-only sets declared beside it.
 2. Starts an oc-rsync daemon on a non-privileged port.
 3. Runs push and pull scenarios (initial sync, delta update, checksums, compression,
    hardlinks, delete modes, numeric-ids, excludes, inplace, batch) against each

--- a/docs/contributing/upstream-cross-references.md
+++ b/docs/contributing/upstream-cross-references.md
@@ -216,7 +216,8 @@ pub const NDX_DONE: i32 = -1;
 
 When adding new protocol features:
 
-1. Read the upstream C source first (at `target/interop/upstream-src/rsync-3.4.1/`).
+1. Read the upstream C source first (at `target/interop/upstream-src/rsync-3.4.4/`,
+   the release `workspace.metadata.oc_rsync.upstream_version` pins).
 2. Add `// upstream:` on every non-obvious line that mirrors C behavior.
 3. Run `grep -rn "// upstream:" crates/<crate>/src/ | wc -l` to verify coverage
    trends upward, not downward, with new code.


### PR DESCRIPTION
Four claims in the contributor docs contradict the repository. Each was checked
against the thing it describes, not against another document.

## 1. The required-check list was missing three gates

`ONBOARDING.md` listed five required checks. The ruleset returns eight:

```
$ gh api repos/:owner/:repo/rulesets/12911634 \
    --jq '.rules[] | select(.type=="required_status_checks")
          | .parameters.required_status_checks[].context'
fmt + clippy
nextest (stable)
Windows (stable)
macOS (stable)
Linux musl (stable)
interop / interop with upstream rsync
upstream-testsuite / upstream testsuite
upstream-testsuite / upstream testsuite (root)
```

The three that were missing are the slow behavioural gates - the ones most
likely to fail after a contributor believes they are done. Check names now match
the ruleset contexts verbatim, so a red check can be mapped to a row without
guessing. `TESTING.md` repeated the same five-item list and is corrected too.

## 2. The stated review requirement does not exist

`ONBOARDING.md` said "PRs require one approving review (admin can bypass)".

```
$ gh api repos/:owner/:repo/rulesets/12911634 \
    --jq '.rules[] | select(.type=="pull_request") | .parameters.required_approving_review_count'
0
```

Master is protected and changes do land via PR, but no approving review is
required; CI is the gate. Advertising a review requirement that is not enforced
invites contributors to block on one that will never arrive.

## 3. Three sites named the wrong upstream release

`ONBOARDING.md` (twice) and `upstream-cross-references.md` pointed at
`rsync-3.4.1`. The pin is 3.4.4:

```
$ grep -n upstream_version Cargo.toml
461:upstream_version = "3.4.4"
```

That is the tree every `// upstream:` citation resolves against, so following
the old instruction produces citations the drift gate then rejects. Each site
now names 3.4.4 and says which key pins it, so the next bump has one obvious
place to look.

## 4. The interop version list had drifted

`TESTING.md` hardcoded `3.0.9, 3.1.3, 3.4.1, 3.4.2, 3.4.3` in two places. The
harness declares:

```
$ grep -n 'versions=(' tools/ci/run_interop.sh
74:versions=(3.0.9 3.1.3 3.4.4 3.5.0)
78:extra_build_versions=(2.6.9)
85:source_only_versions=(2.6.9 3.4.4 3.5.0)
```

Neither documented list was right, and one named 3.4.2/3.4.3 which the harness
never builds. Both sites now point at the `versions=(...)` declaration rather
than copying it - the copy is precisely what drifted, so a second copy would
just drift again.

## Deliberately not changed

`CONTRIBUTING.md:194` also says `rsync-3.4.1/`, and it is correct. It cites that
path as an example of a citation qualified by a version that is *not* the pinned
release, to illustrate what falls out of scope. Retargeting it at 3.4.4 would
make it name the pin and destroy the example.

The `## CI Matrix` job table in `TESTING.md` is also left alone: its `Required`
column is per-job, and the mapping from jobs to the eight required *contexts*
was not verified here. Only the branch-protection sentence beneath it, which
states the context list directly, is corrected.

Documentation only - no code, no test, no workflow changes.
