### PR TITLE
fix(cli): emit the non-regular skip notice once, not twice at -v

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -1121,13 +1121,15 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
             ClientEventKind::SkippedNonRegular => {
-                writeln_wrapped(
-                    stdout,
-                    "skipping non-regular file \"",
-                    event.relative_path(),
-                    escape,
-                    "\"",
-                )?;
+                // Deliberately silent here. The `skipping non-regular file`
+                // notice is emitted on the NONREG info channel by the engine
+                // (context_impl/reporting.rs). Upstream gates it on
+                // INFO_GTE(NONREG, 1), and NONREG sits in info_verbosity[0]
+                // (options.c), so it prints once at DEFAULT verbosity. Writing
+                // it again from this renderer produced a second copy at -v and
+                // above - and, because this arm has no info gate at all while
+                // every sibling checks InfoFlag::Skip, `--info=nononreg` could
+                // not suppress it.
                 continue;
             }
             ClientEventKind::SkippedDirectory => {

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -8,7 +8,7 @@ impl<'a> CopyContext<'a> {
     /// byte-for-byte: `skipping non-regular file "%s"`.
     pub(super) fn record_skipped_non_regular(&mut self, relative: Option<&Path>) {
         if let Some(path) = relative {
-            info_log!(Nonreg, 1, "skipping non-regular file \"{}\"", path.display());
+            self.note_skipped_non_regular(path);
             self.record(LocalCopyRecord::new(
                 path.to_path_buf(),
                 LocalCopyAction::SkippedNonRegular,
@@ -18,6 +18,22 @@ impl<'a> CopyContext<'a> {
                 None,
             ));
         }
+    }
+
+    /// Emits the NONREG notice alone, without recording a transfer entry.
+    ///
+    /// This is the single owner of the message text and of its `INFO_GTE`
+    /// gate. Callers that build their own `SkippedNonRegular` record - the
+    /// symlink path needs one carrying a link-target snapshot - must call
+    /// this, or the entry is reported only through the verbose renderer and
+    /// therefore vanishes at default verbosity, where upstream still prints.
+    pub(super) fn note_skipped_non_regular(&mut self, relative: &Path) {
+        info_log!(
+            Nonreg,
+            1,
+            "skipping non-regular file \"{}\"",
+            relative.display()
+        );
     }
 
     /// Records a skip event for a symbolic link whose creation the platform

--- a/crates/engine/src/local_copy/executor/sources/handlers.rs
+++ b/crates/engine/src/local_copy/executor/sources/handlers.rs
@@ -34,6 +34,11 @@ fn record_skipped_symlink(
     if let Some(relative_path) = record_path {
         match fs::read_link(source_path) {
             Ok(target) => {
+                // Same NONREG notice record_skipped_non_regular would emit; only
+                // the record differs, since this one carries a link-target
+                // snapshot. Without this the notice would exist solely as a
+                // verbose-renderer event and never appear at default verbosity.
+                context.note_skipped_non_regular(relative_path);
                 let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, Some(target));
                 let record = LocalCopyRecord::new(
                     relative_path.to_path_buf(),

--- a/tests/drop_devices.rs
+++ b/tests/drop_devices.rs
@@ -220,6 +220,63 @@ fn skipped_entries_are_reported_as_non_regular_at_verbose() {
     }
 }
 
+/// Counts whole occurrences of the skip line for `name` in `rendered`.
+fn skip_line_count(rendered: &str, name: &str) -> usize {
+    let needle = format!("skipping non-regular file \"{name}\"");
+    rendered.matches(needle.as_str()).count()
+}
+
+/// EXACTLY ONE notice per entry, at EVERY verbosity.
+///
+/// upstream emits this from a single site - `recv_generator()`,
+/// generator.c:2110-2115 - gated on `INFO_GTE(NONREG, 1)`. NONREG lives in
+/// `info_verbosity[0]` (options.c), so upstream prints it once at default
+/// verbosity and still once at `-v`; raising verbosity does not multiply it.
+///
+/// oc reached the same text through two independent channels: the engine's
+/// NONREG info notice, and a `SkippedNonRegular` arm in the verbose renderer
+/// that had no info gate at all. Both fired for one entry, so `-v` printed the
+/// line twice - the second copy landing *after* the summary block, since the
+/// info queue drains once `execute()` returns.
+///
+/// The pre-existing assertion above cannot catch that: `contains` is satisfied
+/// by one occurrence and by five. Counting is the whole point of this test, and
+/// both verbosities are checked because the two channels differ in exactly that
+/// dimension - the renderer copy is unreachable at verbosity 0, so a
+/// default-verbosity-only test would have seen nothing wrong either.
+#[test]
+fn non_regular_skip_notice_is_emitted_exactly_once_per_entry() {
+    for verbosity in ["-a", "-av"] {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (src, seeded) = seed_specials(temp.path());
+        let dest = temp.path().join("dest");
+        fs::create_dir_all(&dest).expect("create dest");
+
+        let src_arg = format!("{}/", src.display());
+        let dest_arg = format!("{}/", dest.display());
+        let output = run(&[
+            OsStr::new(verbosity),
+            OsStr::new("--drop-D"),
+            OsStr::new(&src_arg),
+            OsStr::new(&dest_arg),
+        ]);
+
+        let rendered = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        for name in &seeded {
+            assert_eq!(
+                skip_line_count(&rendered, name),
+                1,
+                "`{verbosity}`: expected exactly one skip notice for {name}, \
+                 upstream emits one at every verbosity; got:\n{rendered}"
+            );
+        }
+    }
+}
+
 /// THE WIRE-NEUTRALITY GATE.
 ///
 /// `--drop-D` is not forwarded (`rsync.1.md:1786`), and unlike `--no-D` it must


### PR DESCRIPTION
fix(cli): emit the non-regular skip notice once, not twice at -v

`skipping non-regular file "x"` printed twice per entry at `-v` and above.
Measured on a FIFO with `-av --drop-D`: 2 lines, where upstream prints 1.

upstream has one emit site - recv_generator(), generator.c - gated on
INFO_GTE(NONREG, 1). NONREG lives in info_verbosity[0], so upstream prints
the notice once at DEFAULT verbosity and still once at -v; raising verbosity
does not multiply it.

oc reached the same text through two channels, both fed by one call to
record_skipped_non_regular:

  A  context_impl/reporting.rs - info_log!(Nonreg, 1, ..), which mirrors the
     upstream gate exactly and fires at default verbosity.
  B  progress/render.rs - a SkippedNonRegular arm in the verbose renderer
     that wrote the same literal with NO info gate, while all five sibling
     Skipped* arms check info_gte(InfoFlag::Skip, 1). So `--info=nononreg`
     could not suppress it either.

B is removed. It cannot reproduce upstream's contract - it is unreachable at
verbosity 0 by construction, so keeping it and dropping A would have silenced
the notice at default verbosity, a worse divergence than the duplicate. The
measured output also showed B's copy landing before the file list and A's
after the summary block, since the info queue drains once execute() returns.

Removing B alone would have introduced a regression, though.
record_skipped_symlink (executor/sources/handlers.rs) builds its own
SkippedNonRegular record on the read_link success branch - it needs one
carrying a link-target snapshot - and only falls back to
record_skipped_non_regular when read_link FAILS. That branch therefore
reported solely through B, and deleting B would have made it silent at every
verbosity. The notice emission is now a named helper,
note_skipped_non_regular, which is the single owner of the message text and
its gate, and that branch calls it.

⚠ I could not construct an input that reaches the success branch: `-r` with a
symlink reports once before and after (so it takes a different path), and
`-a --no-links` reports nothing either way. The hunk is therefore unproven by
measurement. It is kept because it is not a speculative addition - it is what
stops the B removal from silencing a path that today produces a record, and
the helper makes that invariant explicit rather than implicit.

The pre-existing assertion could not catch any of this: drop_devices.rs runs
at exactly `-av --drop-D`, the duplicating condition, and asserts
`rendered.contains(...)`. Containment holds for one occurrence and for five.
The new test COUNTS, at both `-a` and `-av`, because the two channels differ
in precisely that dimension - a default-verbosity-only test would also have
seen nothing wrong.

Verified: fmt clean; clippy -p engine -p cli --all-targets --all-features
clean; drop_devices 7/7. Non-vacuity proven by restoring only the render.rs
arm and re-running - the new test fails `left: 2, right: 1`.

