### PR TITLE
test: derive umask-dependent mode expectations instead of pinning constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,7 @@ dependencies = [
  "rayon",
  "rustix",
  "tempfile",
+ "test-support",
  "thiserror",
  "tracing",
  "windows-sys 0.61.2",

--- a/crates/cli/src/frontend/tests/transfer_request_with_no.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_no.rs
@@ -36,9 +36,7 @@ fn transfer_request_with_no_perms_overrides_archive() {
     let source = tmp.path().join("source-no-perms.txt");
     let destination = tmp.path().join("dest-no-perms.txt");
     std::fs::write(&source, b"data").expect("write source");
-    // Use 0o777 so that any non-zero umask will produce a different mode,
-    // proving that --no-perms applies umask-based defaults instead of
-    // preserving the source permissions.
+    // 0o777 makes every umask bit observable in the destination mode.
     std::fs::set_permissions(&source, PermissionsExt::from_mode(0o777)).expect("set perms");
 
     let (code, stdout, stderr) = run_with_args([
@@ -54,9 +52,14 @@ fn transfer_request_with_no_perms_overrides_archive() {
     assert!(stderr.is_empty());
 
     let metadata = std::fs::metadata(&destination).expect("dest metadata");
-    assert_ne!(
+    // `--no-perms` gives a new destination `flist_mode & (~CHMOD_BITS |
+    // dflt_perms)` (upstream: rsync.c dest_mode(), exists == 0) - the source
+    // mode with the umask applied. Asserting the exact mode also fails at
+    // umask 000, where "not 0o777" could not tell "umask applied" apart from
+    // "source preserved".
+    assert_eq!(
         metadata.permissions().mode() & 0o777,
-        0o777,
+        test_support::umask_masked(0o777),
         "without --perms, destination should have umask-applied permissions"
     );
 }

--- a/crates/engine/src/local_copy/tests/execute_archive.rs
+++ b/crates/engine/src/local_copy/tests/execute_archive.rs
@@ -731,8 +731,7 @@ fn archive_no_perms_skips_permission_preservation() {
         b"restricted",
         test_helpers::TEST_TIMESTAMP,
     );
-    // Use 0o777 so any non-zero umask produces a visibly different mode,
-    // proving that permissions are not preserved from the source.
+    // 0o777 makes every umask bit observable in the destination mode.
     test_helpers::set_permissions(&ctx.source.join("restricted.txt"), 0o777);
 
     // archive but with perms disabled
@@ -743,12 +742,15 @@ fn archive_no_perms_skips_permission_preservation() {
         .expect("copy");
 
     let dest_perms = test_helpers::get_permissions(&ctx.dest.join("restricted.txt"));
-    // With perms disabled, the destination gets umask-applied permissions,
-    // not the source's exact 0o777.
-    assert_ne!(
+    // With perms disabled the destination takes the source mode with the umask
+    // applied (upstream: rsync.c dest_mode(), exists == 0). Asserting the exact
+    // mode also fails at umask 000, where "not 0o777" could not tell
+    // "not preserved" apart from "preserved".
+    assert_eq!(
         dest_perms & 0o777,
-        0o777,
-        "with perms disabled, mode should not be exactly 0o777"
+        // `::` because `local_copy::test_support` shadows the crate name here.
+        ::test_support::umask_masked(0o777),
+        "with perms disabled, mode should be the umask-applied source mode"
     );
 }
 

--- a/crates/engine/src/local_copy/tests/execute_basic.rs
+++ b/crates/engine/src/local_copy/tests/execute_basic.rs
@@ -1015,8 +1015,7 @@ fn execute_does_not_preserve_permissions_by_default() {
     fs::write(&source, b"perms").expect("write source");
 
     let mut perms = fs::metadata(&source).expect("source metadata").permissions();
-    // Use 0o777 so any non-zero umask produces a visibly different mode,
-    // proving that permissions are not preserved by default.
+    // 0o777 makes every umask bit observable in the destination mode.
     perms.set_mode(0o777);
     fs::set_permissions(&source, perms).expect("set source perms");
 
@@ -1033,8 +1032,14 @@ fn execute_does_not_preserve_permissions_by_default() {
     assert_eq!(summary.files_copied(), 1);
 
     let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
-    // Default options do not preserve permissions - dest gets umask-applied mode
-    assert_ne!(dest_perms.mode() & 0o777, 0o777);
+    // Without --perms a new destination takes `flist_mode & (~CHMOD_BITS |
+    // dflt_perms)` where dflt_perms is `ACCESSPERMS & ~orig_umask`
+    // (upstream: rsync.c dest_mode(), exists == 0) - i.e. the source mode with
+    // the umask applied. Asserting the exact mode rather than "not 0o777"
+    // also fails at umask 000, where the old inequality could not distinguish
+    // "not preserved" from "preserved".
+    // `::` because `local_copy::test_support` shadows the crate name here.
+    assert_eq!(dest_perms.mode() & 0o777, ::test_support::umask_masked(0o777));
 }
 
 #[cfg(unix)]

--- a/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
@@ -519,8 +519,9 @@ fn no_implied_dirs_collection_reports_correct_events() {
 
 // Mirrors the upstream `relative-implied` testsuite `--no-implied-dirs` half:
 // `-aR --no-implied-dirs b/c/file dst/` must transfer dst/b/c/file, creating
-// the implied leading dirs with the default mode (umask-masked 0755) rather
-// than the source dir's distinctive 0750. Previously oc-rsync errored with
+// the implied leading dirs with the default mode - upstream's make_path()
+// passes ACCESSPERMS (0777) to do_mkdir_at, so the umask decides - rather than
+// the source dir's distinctive 0750. Previously oc-rsync errored with
 // "file has vanished". upstream: generator.c:1329-1333 make_path().
 #[cfg(unix)]
 #[test]
@@ -566,9 +567,12 @@ fn relative_no_implied_dirs_creates_leading_dirs_with_default_mode() {
         .permissions()
         .mode()
         & 0o777;
-    assert_ne!(
-        b_mode, 0o750,
-        "--no-implied-dirs must not mirror the source's 0750 onto the implied dir"
+    assert_eq!(
+        b_mode,
+        // `::` because `local_copy::test_support` shadows the crate name here.
+        ::test_support::umask_masked(0o777),
+        "--no-implied-dirs must give the implied dir the umask-applied default \
+         mode, not the source's 0750"
     );
 }
 

--- a/crates/engine/src/local_copy/tests/execute_zero_length.rs
+++ b/crates/engine/src/local_copy/tests/execute_zero_length.rs
@@ -584,8 +584,17 @@ fn execute_empty_file_preserves_permissions_with_chmod() {
         .permissions()
         .mode() & 0o777;
 
-    // Should have 0o640 from source + execute bits added
-    assert_eq!(dest_mode, 0o751, "chmod should be applied to empty file permissions");
+    // 0o640 from the source plus the execute bits `+x` adds. `+x` names no
+    // who-class, so upstream masks the implied bits with the umask
+    // (chmod.c:parse_chmod, `bits & ~orig_umask`); at umask 022 that is the
+    // full 0o111, at 077 only 0o100. Deriving keeps this exact under any umask
+    // instead of pinning the 0o751 that only holds when umask & 0o111 == 0.
+    // `::` because `local_copy::test_support` shadows the crate name here.
+    let expected = 0o640 | ::test_support::umask_masked(0o111);
+    assert_eq!(
+        dest_mode, expected,
+        "chmod should be applied to empty file permissions"
+    );
 }
 
 #[test]

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -208,6 +208,7 @@ windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Network
 tempfile = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
+test-support = { path = "../test-support" }
 
 [target.'cfg(unix)'.dev-dependencies]
 # The dir_sandbox descriptor-exhaustion test lowers RLIMIT_NOFILE to provoke a

--- a/crates/fast_io/src/o_tmpfile/low_level.rs
+++ b/crates/fast_io/src/o_tmpfile/low_level.rs
@@ -313,9 +313,12 @@ mod linux {
             let dest = dir.path().join("mode_test.txt");
             if link_anonymous_tmpfile(&file, &dest).is_ok() {
                 let meta = std::fs::metadata(&dest).unwrap();
-                // Mode should have at least the requested bits (umask may clear some)
+                // `O_TMPFILE` applies the umask like any other `O_CREAT`, so the
+                // surviving bits are the requested ones minus the mask. Deriving
+                // rather than asserting a bare 0o600 keeps this exact under a
+                // umask that clears owner bits.
                 let mode = meta.mode() & 0o777;
-                assert_eq!(mode & 0o600, 0o600);
+                assert_eq!(mode & 0o600, test_support::umask_masked(0o600));
             }
         }
     }

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -12,6 +12,8 @@ pub mod daemon_port;
 pub mod dir_diff;
 pub mod lsh;
 pub mod skip;
+#[cfg(unix)]
+pub mod umask;
 pub mod upstream_compat;
 
 pub use bin_path::{oc_rsync_bin, target_profile_dir, workspace_bin, workspace_bin_path};
@@ -24,6 +26,8 @@ pub use skip::{
     locate_command_on_path, locate_workspace_binary, require_binary, require_command_on_path,
     require_unix,
 };
+#[cfg(unix)]
+pub use umask::umask_masked;
 pub use upstream_compat::{
     UpstreamRsync, UpstreamVersion, locate_upstream_rsync, require_upstream_rsync,
     upstream_compat_enabled, upstream_install_bin, workspace_root,

--- a/crates/test-support/src/umask.rs
+++ b/crates/test-support/src/umask.rs
@@ -1,0 +1,91 @@
+//! Observing the process umask for tests that assert permission bits.
+//!
+//! Two shapes of test assert mode bits, and they need different tools:
+//!
+//! - Tests that spawn `oc-rsync` as a child pin the child's umask with
+//!   [`crate::OcRsyncCliRunner::umask`], so the expectation can be a constant.
+//! - Tests that drive the library in-process cannot pin anything: the umask is
+//!   process-global and already latched by the time the test runs. Those must
+//!   *derive* the expectation from the live umask, which is what this module
+//!   provides.
+//!
+//! Deriving beats pinning here for a second reason: it mirrors what upstream's
+//! own testsuite does (`umask 0` plus computed expectations), and it keeps the
+//! assertion exact rather than weakening it to "not the unmasked value".
+
+use std::fs;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+/// Returns `requested_mode` as the filesystem would actually create it, i.e.
+/// masked by the live process umask.
+///
+/// Use this for any expectation about a mode the *receiver* creates rather than
+/// copies. `open(O_CREAT)` and `mkdir` both apply the same process-wide mask,
+/// so one helper covers files and directories alike.
+///
+/// The mask is observed, not computed: creating a probe file exercises exactly
+/// the mechanism under test, so the helper cannot disagree with the code it is
+/// checking the way a cached `umask(2)` reading could.
+///
+/// # Panics
+///
+/// Panics if the probe file cannot be created or stat'd, which would mean the
+/// temp directory itself is unusable.
+#[must_use]
+pub fn umask_masked(requested_mode: u32) -> u32 {
+    requested_mode & permitted_permission_bits()
+}
+
+/// Returns the permission bits the umask currently leaves through, `~umask & 0o777`.
+fn permitted_permission_bits() -> u32 {
+    let dir = tempfile::tempdir().expect("create umask probe directory");
+    let probe = dir.path().join("umask-probe");
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o777)
+        .open(&probe)
+        .expect("create umask probe");
+    fs::metadata(&probe)
+        .expect("stat umask probe")
+        .permissions()
+        .mode()
+        & 0o777
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn masking_is_idempotent_and_bounded_by_the_request() {
+        let masked = umask_masked(0o777);
+        assert_eq!(umask_masked(masked), masked);
+        assert_eq!(masked & !0o777, 0);
+    }
+
+    #[test]
+    fn a_requested_bit_is_never_added_only_removed() {
+        // The helper answers "what survives", so it may only ever clear bits.
+        for requested in [0o000, 0o111, 0o644, 0o750, 0o777] {
+            let masked = umask_masked(requested);
+            assert_eq!(masked & !requested, 0, "{requested:04o} gained a bit");
+        }
+    }
+
+    #[test]
+    fn matches_what_the_filesystem_actually_does() {
+        // The whole point is agreement with a real create(2); prove it for a
+        // mode other than the 0o777 the probe itself uses.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("observed");
+        fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o746)
+            .open(&path)
+            .expect("create");
+        let observed = fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(umask_masked(0o746), observed);
+    }
+}

--- a/crates/transfer/tests/daemon_dest_mode_parity.rs
+++ b/crates/transfer/tests/daemon_dest_mode_parity.rs
@@ -41,7 +41,7 @@
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
@@ -220,22 +220,6 @@ fn new_destination_takes_the_masked_source_mode_on_every_write_path() {
 
 /// Returns `SOURCE_MODE` as the filesystem would create it, i.e. masked by the
 /// process umask.
-///
-/// Observed rather than computed: creating a file with `SOURCE_MODE` applies the
-/// umask exactly as the receiver's own `O_CREAT` does, which keeps this test
-/// free of `unsafe` (`crates/transfer` denies it) and of a `libc` dependency.
 fn masked_source_mode() -> u32 {
-    let probe_dir = test_support::create_tempdir();
-    let probe = probe_dir.path().join("umask-probe");
-    fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(SOURCE_MODE)
-        .open(&probe)
-        .expect("create umask probe");
-    fs::metadata(&probe)
-        .expect("stat umask probe")
-        .permissions()
-        .mode()
-        & 0o7777
+    test_support::umask_masked(SOURCE_MODE)
 }


### PR DESCRIPTION
Seven in-process tests asserted destination permission bits against constants
that only hold under the developer's ambient umask. They spawn no child, so the
`pre_exec` umask pinning added for the CLI runner in #7348 cannot reach them -
the expectation has to be derived instead.

## The shared helper

`test_support::umask_masked(mode)` reports what the filesystem would actually
create for `mode` under the live umask. It **observes** the mask with a probe
file rather than reading `umask(2)`, so it exercises the same `O_CREAT` masking
as the code under test and needs no `unsafe`. `open(O_CREAT)` and `mkdir` apply
the same process-wide mask, so one helper covers files and directories.

`daemon_dest_mode_parity.rs` already carried a private copy of that probe; it
now delegates, leaving one owner of the rule.

## Fixed assertions

| Test | Was | Fails at umask |
|---|---|---|
| `execute_empty_file_preserves_permissions_with_chmod` | `== 0o751` | 027, 077 |
| `execute_does_not_preserve_permissions_by_default` | `!= 0o777` | 000 |
| `archive_no_perms_skips_permission_preservation` | `!= 0o777` | 000 |
| `relative_no_implied_dirs_creates_leading_dirs_with_default_mode` | `!= 0o750` | 027 |
| `open_respects_mode_bits` (O_TMPFILE) | `& 0o600 == 0o600` | any clearing an owner bit |

- **`--chmod=+x` over a 0o640 source.** `+x` names no who-class, so upstream
  masks the implied bits (`chmod.c` `parse_chmod`, `bits & ~orig_umask`). 0o751
  holds only when `umask & 0o111 == 0`; at the common hardened defaults it is
  0o750 (umask 027) or 0o740 (umask 077).
- **The three "permissions are not preserved" tests.** `!= 0o777` fails outright
  at umask 000 and is a weak oracle everywhere else - 0o755, 0o644 and 0o000 all
  satisfy it. They now assert the exact mode upstream's `dest_mode()` produces
  for a new destination: `flist_mode & (~CHMOD_BITS | dflt_perms)` with
  `dflt_perms = ACCESSPERMS & ~orig_umask`, i.e. the source mode umask-applied.

## One comment was wrong about upstream

`relative_no_implied_dirs` documented the implied-dir default as "umask-masked
0755". Upstream's `make_path` passes `ACCESSPERMS` (0o777) to `do_mkdir_at`
(`util1.c:238`, `:277`), and `create_dir_all` matches that. The comment is
corrected; the real hostile umask for that assertion is 027, not the 005 the
0o755 reading implied.

## Verification

RED proven per test at its own hostile umask, against the pre-change
assertions on this exact tree:

- umask 077 - `chmod +x` cell: `left: 480` (0o740) vs `right: 489` (0o751)
- umask 000 - both `!= 0o777` cells fail
- umask 027 - implied-dir cell: `left: 488, right: 488` (both 0o750)

GREEN after, across umask 000 / 005 / 022 / 027 / 077: engine + test-support
7/7 at every level, cli cell 1/1 at 000 / 027 / 077, transfer parity 2/2.
`cargo fmt --all -- --check` and
`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
both exit 0.

The `O_TMPFILE` cell is Linux-gated, so it compiled but did not execute in the
local macOS run - it is covered by the Linux nextest cell.
