### PR TITLE
fix(batch): local --write-batch must encode the flist the reader decodes

### DIFF
--- a/crates/batch/src/lib.rs
+++ b/crates/batch/src/lib.rs
@@ -446,6 +446,24 @@ pub struct BatchConfig {
     /// (`numeric_ids <= 0 && !inc_recurse`) and `uidlist.c:465,473`
     /// (`numeric_ids <= 0`).
     pub numeric_ids: bool,
+
+    /// Whether `--atimes` was active for the batch invocation.
+    ///
+    /// Like [`Self::numeric_ids`], and for the same reason, this is not a
+    /// recorded stream flag: upstream's `batch.c:59-76 flag_ptr[]` has no bit
+    /// for it, because upstream's batch file is a byte tee of a real wire
+    /// stream and the replaying receiver takes `preserve_atimes` from the
+    /// replay script's argv. It gates the per-entry atime field, which the
+    /// flist writer emits under `preserve_atimes` (`flist.c:625`), so a reader
+    /// that does not know about it decodes the next entry's flag byte as an
+    /// atime and desynchronises the stream.
+    pub preserve_atimes: bool,
+
+    /// Whether `--crtimes` was active for the batch invocation.
+    ///
+    /// Same rationale as [`Self::preserve_atimes`]: no `flag_ptr[]` bit, comes
+    /// from the replay invocation, gates the per-entry crtime field.
+    pub preserve_crtimes: bool,
 }
 
 impl BatchConfig {
@@ -501,6 +519,8 @@ impl BatchConfig {
             active_flags: BatchFlags::default(),
             eol_nulls: false,
             numeric_ids: false,
+            preserve_atimes: false,
+            preserve_crtimes: false,
         }
     }
 
@@ -692,6 +712,48 @@ impl BatchConfig {
     /// ```
     pub const fn with_numeric_ids(mut self, numeric_ids: bool) -> Self {
         self.numeric_ids = numeric_ids;
+        self
+    }
+
+    /// Set whether `--atimes` was active for the batch invocation.
+    ///
+    /// Gates the per-entry atime field, which the flist writer emits under
+    /// `preserve_atimes` (`flist.c:625`). Like `--numeric-ids`, this has no
+    /// `batch.c:59-76 flag_ptr[]` bit and must come from the replay
+    /// invocation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use batch::{BatchConfig, BatchMode};
+    ///
+    /// let config = BatchConfig::new(BatchMode::Read, "/tmp/batch".to_string(), 31)
+    ///     .with_preserve_atimes(true);
+    ///
+    /// assert!(config.preserve_atimes);
+    /// ```
+    pub const fn with_preserve_atimes(mut self, preserve_atimes: bool) -> Self {
+        self.preserve_atimes = preserve_atimes;
+        self
+    }
+
+    /// Set whether `--crtimes` was active for the batch invocation.
+    ///
+    /// Same rationale as [`Self::with_preserve_atimes`]: no `flag_ptr[]` bit,
+    /// gates the per-entry crtime field.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use batch::{BatchConfig, BatchMode};
+    ///
+    /// let config = BatchConfig::new(BatchMode::Read, "/tmp/batch".to_string(), 31)
+    ///     .with_preserve_crtimes(true);
+    ///
+    /// assert!(config.preserve_crtimes);
+    /// ```
+    pub const fn with_preserve_crtimes(mut self, preserve_crtimes: bool) -> Self {
+        self.preserve_crtimes = preserve_crtimes;
         self
     }
 

--- a/crates/batch/src/reader/flist.rs
+++ b/crates/batch/src/reader/flist.rs
@@ -84,6 +84,16 @@ impl BatchReader {
         // the stream flags, numeric_ids is not recorded in the batch header
         // (batch.c:59-76); it is carried in from the --read-batch invocation.
         let numeric_ids = self.config.numeric_ids;
+        // Same reason as numeric_ids: `batch.c:59-76 flag_ptr[]` has no bit for
+        // --atimes or --crtimes, so the recorded stream flags cannot describe
+        // them. Upstream does not need a bit because its batch file is a byte
+        // tee of a real wire stream and the replaying receiver takes
+        // preserve_atimes/preserve_crtimes from the replay script's argv. Both
+        // gate a per-entry field (`flist.c:625`, `flist.c:634`), so a reader
+        // that does not know about them decodes the following entry's flag
+        // byte as a timestamp and desynchronises the stream.
+        let preserve_atimes = self.config.preserve_atimes;
+        let preserve_crtimes = self.config.preserve_crtimes;
 
         let header = self.header.as_ref().expect("header checked above");
         let flags = header.stream_flags;
@@ -123,7 +133,9 @@ impl BatchReader {
             .with_preserve_specials(flags.preserve_devices)
             .with_preserve_hard_links(flags.preserve_hard_links)
             .with_preserve_acls(flags.preserve_acls)
-            .with_preserve_xattrs(flags.preserve_xattrs);
+            .with_preserve_xattrs(flags.preserve_xattrs)
+            .with_preserve_atimes(preserve_atimes)
+            .with_preserve_crtimes(preserve_crtimes);
 
         // upstream: flist.c:162 - when always_checksum is set, each regular file
         // entry in the flist carries a trailing checksum of flist_csum_len bytes.
@@ -294,7 +306,11 @@ impl BatchReader {
 /// # Upstream Reference
 ///
 /// - `checksum.c:csum_len_for_type()` - MD4=16, MD5=16, XXH3_128=16, XXH64=8
-pub(crate) fn default_flist_csum_len(protocol_version: i32) -> usize {
+///
+/// Public because the local `--write-batch` flist writer must emit exactly the
+/// number of bytes this reader will consume; sharing one function is what keeps
+/// the two from drifting.
+pub fn default_flist_csum_len(protocol_version: i32) -> usize {
     // All supported protocols (27-32) default to MD4 or MD5, both 16 bytes.
     // If XXH3-128 is negotiated via checksum seeds, it is also 16 bytes.
     // XXH64 and XXH3-64 are 8 bytes but require explicit negotiation which

--- a/crates/batch/src/reader/mod.rs
+++ b/crates/batch/src/reader/mod.rs
@@ -10,6 +10,8 @@
 
 mod delta;
 mod flist;
+
+pub use flist::default_flist_csum_len;
 mod stats;
 
 #[cfg(test)]

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -366,7 +366,12 @@ fn replay_batch(
     let replay_cfg = batch_cfg
         .clone()
         .with_active_flags(config_batch_flags(config))
-        .with_numeric_ids(config.numeric_ids());
+        .with_numeric_ids(config.numeric_ids())
+        // --atimes / --crtimes have no flag_ptr[] bit either (batch.c:59-76),
+        // and each gates a per-entry flist field, so they must reach the
+        // reader from the replay invocation or the entry decode desyncs.
+        .with_preserve_atimes(config.preserve_atimes())
+        .with_preserve_crtimes(config.preserve_crtimes());
 
     let result = engine::batch::replay::replay(&replay_cfg, &dest_root, config.verbosity().into())
         .map_err(|e| match e {

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -49,6 +49,16 @@ impl<'a> CopyContext<'a> {
             let guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
             let proto_version = guard.config().protocol_version;
             let compat_flags_val = guard.config().compat_flags;
+            let checksum_seed = guard.config().checksum_seed;
+            // The preserve flags come from the header this same writer already
+            // recorded, not from `options`, because the header is what the
+            // reader configures itself from (batch/src/reader/flist.rs). Unlike
+            // upstream - whose batch file is a byte tee of one real stream, so
+            // a writer/reader disagreement is unspellable - the local
+            // --write-batch path re-encodes the flist with a second encoder,
+            // and deriving it from anything but the recorded flags lets the two
+            // sides drift into an undecodable batch.
+            let stream_flags = *guard.stream_flags();
             drop(guard);
             let protocol = protocol::ProtocolVersion::try_from(proto_version as u8)
                 .unwrap_or(protocol::ProtocolVersion::NEWEST);
@@ -62,20 +72,43 @@ impl<'a> CopyContext<'a> {
             } else {
                 protocol::flist::FileListWriter::new(protocol)
             };
-            writer
-                .with_preserve_uid(options.preserve_owner())
-                .with_preserve_gid(options.preserve_group())
-                .with_preserve_links(options.links_enabled())
-                .with_preserve_devices(options.devices_enabled())
-                .with_preserve_specials(options.specials_enabled())
-                .with_preserve_hard_links(options.hard_links_enabled())
+            let writer = writer
+                .with_preserve_uid(stream_flags.preserve_uid)
+                .with_preserve_gid(stream_flags.preserve_gid)
+                .with_preserve_links(stream_flags.preserve_links)
+                .with_preserve_devices(stream_flags.preserve_devices)
+                // upstream: batch.c flag_ptr[] bit 4 is `preserve_devices` and
+                // covers --specials too (upstream `-D` = both), so the reader
+                // derives specials from that one bit. Deriving it here from
+                // `options.specials_enabled()` instead would desync a
+                // `--specials --no-devices` batch.
+                .with_preserve_specials(stream_flags.preserve_devices)
+                .with_preserve_hard_links(stream_flags.preserve_hard_links)
+                .with_preserve_acls(stream_flags.preserve_acls)
+                .with_preserve_xattrs(stream_flags.preserve_xattrs)
+                // --atimes / --crtimes have no flag_ptr[] bit; the reader takes
+                // them from the replay invocation instead (reader/flist.rs), so
+                // the writer keeps using the live options here.
                 .with_preserve_atimes(options.preserve_atimes())
                 .with_preserve_crtimes(options.preserve_crtimes())
                 // The batch id-list trailer (write_batch_id_lists) emits bare
                 // terminators without names, so owner names must ride inline in
                 // every entry regardless of inc_recurse. Keep XMIT_*_NAME_FOLLOWS
                 // always enabled for the batch flist writer.
-                .with_name_follows(true)
+                .with_name_follows(true);
+
+            // upstream: flist.c:162 - under always_checksum every regular-file
+            // entry carries a trailing digest. The reader re-derives the length
+            // from the protocol version (batch/src/reader/flist.rs
+            // default_flist_csum_len), so the two must agree or the reader
+            // walks off the end of each entry.
+            if stream_flags.always_checksum {
+                writer
+                    .with_always_checksum(batch::reader::default_flist_csum_len(proto_version))
+                    .with_checksum_seed(checksum_seed)
+            } else {
+                writer
+            }
         });
 
         // upstream: batch.c:68 - stream-flag bit 8 records `do_compression`, and

--- a/crates/test-support/src/capabilities.rs
+++ b/crates/test-support/src/capabilities.rs
@@ -1,0 +1,190 @@
+//! Compile-time capability discovery for the binary under test.
+//!
+//! Several options are gated behind Cargo features that are off in some CI
+//! cells - the musl and `no-incremental-flist` cells build without `acl` and
+//! `xattr`, and `oc-rsync -A` there exits 1 at preflight with "POSIX ACLs are
+//! not supported on this client". A test that hard-codes such an option is red
+//! on those cells for a reason that has nothing to do with the behaviour under
+//! test.
+//!
+//! The fix is neither to delete the option nor to blanket-skip the test: it is
+//! to ask the binary what it supports and to record what was consequently not
+//! exercised. Upstream's own testsuite does exactly this - `acl-symlink-race`
+//! greps `--version` output and calls `test_skipped()` when ACLs are absent
+//! (`testsuite/acl-symlink-race_test.py:50`).
+//!
+//! A skipped row must stay visible. [`Capabilities::skip_reason`] returns the
+//! reason so the caller can print it, and callers are expected to assert that
+//! the unconditional rows still ran - otherwise a build with every optional
+//! feature off would pass the test vacuously.
+
+use std::collections::BTreeSet;
+use std::process::Command;
+use std::sync::OnceLock;
+
+use crate::bin_path::oc_rsync_bin;
+
+/// Capability names as printed in the `Capabilities:` block of `--version`.
+///
+/// These are the strings the binary itself emits, not an independent list, so
+/// they cannot drift from what the build actually supports.
+pub mod names {
+    /// POSIX ACL support, gated by the `acl` Cargo feature. Required by `-A`.
+    pub const ACLS: &str = "ACLs";
+    /// Extended-attribute support, gated by the `xattr` feature. Required by `-X`.
+    pub const XATTRS: &str = "xattrs";
+    /// Access-time preservation. Required by `-U`.
+    pub const ATIMES: &str = "atimes";
+    /// Creation-time preservation. Required by `-N`.
+    pub const CRTIMES: &str = "crtimes";
+}
+
+/// The capability set advertised by the `oc-rsync` binary under test.
+///
+/// Probed once per process and cached; the binary cannot change underneath a
+/// single test run.
+#[derive(Debug, Clone)]
+pub struct Capabilities {
+    advertised: BTreeSet<String>,
+}
+
+impl Capabilities {
+    /// Returns the cached capability set, probing the binary on first use.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `oc-rsync --version` cannot be run or exits non-zero, which
+    /// would mean the binary under test is unusable - a condition that must
+    /// fail loudly rather than degrade into "no capabilities".
+    pub fn probe() -> &'static Self {
+        static CAPABILITIES: OnceLock<Capabilities> = OnceLock::new();
+        CAPABILITIES.get_or_init(|| {
+            let bin = oc_rsync_bin();
+            let output = Command::new(&bin)
+                .arg("--version")
+                .output()
+                .unwrap_or_else(|e| panic!("run {} --version: {e}", bin.display()));
+            assert!(
+                output.status.success(),
+                "{} --version exited {}",
+                bin.display(),
+                output.status
+            );
+            Self::from_version_output(&String::from_utf8_lossy(&output.stdout))
+        })
+    }
+
+    /// Parses the `Capabilities:` block out of `--version` output.
+    ///
+    /// The block is an indented, comma-separated list that wraps across lines
+    /// and ends at the next unindented heading, so parsing keys on indentation
+    /// rather than on a fixed line count.
+    fn from_version_output(stdout: &str) -> Self {
+        let mut advertised = BTreeSet::new();
+        let mut in_block = false;
+        for line in stdout.lines() {
+            if line.starts_with("Capabilities:") {
+                in_block = true;
+                continue;
+            }
+            if in_block {
+                // The block ends at the next unindented line, which is the
+                // following heading ("Optimizations:", etc.).
+                if !line.starts_with(char::is_whitespace) {
+                    break;
+                }
+                advertised.extend(
+                    line.split(',')
+                        .map(|item| item.trim().to_owned())
+                        .filter(|item| !item.is_empty()),
+                );
+            }
+        }
+        assert!(
+            !advertised.is_empty(),
+            "no Capabilities: block in --version output; the probe would \
+             silently report every capability as absent:\n{stdout}"
+        );
+        Self { advertised }
+    }
+
+    /// Reports whether the binary advertises `name`.
+    #[must_use]
+    pub fn has(&self, name: &str) -> bool {
+        self.advertised.contains(name)
+    }
+
+    /// Returns a printable reason when any of `required` is missing.
+    ///
+    /// `None` means every requirement is met and the caller should run the
+    /// case. `Some(reason)` is intended to be printed, so a skipped case leaves
+    /// a trace in the test log rather than vanishing.
+    #[must_use]
+    pub fn skip_reason(&self, required: &[&str]) -> Option<String> {
+        let missing: Vec<&str> = required
+            .iter()
+            .copied()
+            .filter(|name| !self.has(name))
+            .collect();
+        if missing.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "binary lacks {} (build without the matching Cargo feature)",
+            missing.join(", ")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+oc-rsync v0.6.4 (revision #deadbeef) protocol version 32
+Capabilities:
+    64-bit files, symlinks, atimes, batchfiles, inplace, append, ACLs,
+    xattrs, iconv, crtimes
+Optimizations:
+    SIMD-roll, jemalloc
+";
+
+    #[test]
+    fn parses_a_wrapped_capability_block() {
+        let caps = Capabilities::from_version_output(SAMPLE);
+        for expected in [names::ACLS, names::XATTRS, names::ATIMES, names::CRTIMES] {
+            assert!(caps.has(expected), "{expected} should be advertised");
+        }
+        // Proves the block terminates at the next heading rather than running on.
+        assert!(
+            !caps.has("SIMD-roll"),
+            "parsing must stop at Optimizations:"
+        );
+    }
+
+    #[test]
+    fn absent_capability_yields_a_reason_naming_it() {
+        let caps = Capabilities::from_version_output(SAMPLE);
+        assert!(caps.skip_reason(&[names::ACLS]).is_none());
+        let reason = caps
+            .skip_reason(&["no-such-capability"])
+            .expect("missing capability must produce a reason");
+        assert!(
+            reason.contains("no-such-capability"),
+            "the reason must name what is missing, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn a_version_without_the_block_is_an_error_not_an_empty_set() {
+        // The dangerous failure mode: silently reporting every capability
+        // absent, which would skip every gated case and pass vacuously.
+        let result = std::panic::catch_unwind(|| {
+            Capabilities::from_version_output("oc-rsync v0.6.4\nOptimizations:\n    none\n")
+        });
+        assert!(
+            result.is_err(),
+            "a missing block must panic, not yield {{}}"
+        );
+    }
+}

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -6,6 +6,7 @@
 //! duplicated retry logic and setup boilerplate across crates.
 
 pub mod bin_path;
+pub mod capabilities;
 pub mod clean_fname;
 pub mod cli;
 pub mod daemon_port;
@@ -15,6 +16,7 @@ pub mod skip;
 pub mod upstream_compat;
 
 pub use bin_path::{oc_rsync_bin, target_profile_dir, workspace_bin, workspace_bin_path};
+pub use capabilities::Capabilities;
 pub use clean_fname::COLLAPSE_CASES;
 pub use cli::{CliOutput, OcRsyncCliRunner, RunnerError};
 pub use daemon_port::{daemon_listen_port, spawn_daemon_on_free_port};

--- a/tests/batch_local_write_flag_roundtrip.rs
+++ b/tests/batch_local_write_flag_roundtrip.rs
@@ -33,8 +33,38 @@ struct FieldGatingCase {
     ///
     /// The per-entry rdev field only appears for an entry that *is* special, so
     /// a `--specials` case over plain files would pass for want of a FIFO
-    /// rather than for want of a bug.
+    /// rather than for want of a bug. On a platform that cannot create one the
+    /// case is skipped for that reason rather than run vacuously.
     needs_special_file: bool,
+}
+
+/// Whether this platform can create the FIFO a `needs_special_file` case wants.
+///
+/// `cfg!` rather than `#[cfg]` deliberately: the field must be read on every
+/// platform, otherwise the Windows build sees a never-read field.
+const PLATFORM_HAS_FIFO: bool = cfg!(unix);
+
+impl FieldGatingCase {
+    /// Returns why this case cannot run here, or `None` if it can.
+    ///
+    /// Two independent reasons - a capability the binary was not built with,
+    /// and a fixture this platform cannot create - reported through one
+    /// accessor so callers cannot honour only one of them.
+    fn skip_reason(&self, capabilities: &Capabilities) -> Option<String> {
+        if self.needs_special_file && !PLATFORM_HAS_FIFO {
+            return Some(
+                "platform cannot create a FIFO, so the rdev field \
+                         would never be exercised"
+                    .to_owned(),
+            );
+        }
+        capabilities.skip_reason(self.requires)
+    }
+
+    /// Reports whether the case runs everywhere, so it can anchor non-vacuity.
+    const fn is_unconditional(&self) -> bool {
+        self.requires.is_empty() && (!self.needs_special_file || PLATFORM_HAS_FIFO)
+    }
 }
 
 /// Options that each gate a per-entry flist field on the local write path.
@@ -89,7 +119,7 @@ fn local_write_batch_replays_under_every_field_gating_option() {
     let mut ran = 0usize;
 
     for case in FIELD_GATING_CASES {
-        if let Some(reason) = capabilities.skip_reason(case.requires) {
+        if let Some(reason) = case.skip_reason(capabilities) {
             // Printed, not silent: a skipped row must leave a trace, or a build
             // with the feature off looks identical to one that passed.
             println!("skipping {:?}: {reason}", case.options);
@@ -99,13 +129,22 @@ fn local_write_batch_replays_under_every_field_gating_option() {
         ran += 1;
     }
 
-    // The unconditional cases (`-c`, `--specials`) require no optional feature,
-    // so this can only fail if the case table itself was gutted - which is the
-    // failure mode a "0 tests ran, success" outcome would otherwise hide.
+    // Derived, not a magic number: every case that needs no optional feature
+    // and no fixture this platform lacks must have run. That is what makes a
+    // "0 tests ran, success" outcome impossible, and it stays correct when the
+    // table grows or when a platform loses a capability.
+    let unconditional = FIELD_GATING_CASES
+        .iter()
+        .filter(|case| case.is_unconditional())
+        .count();
     assert!(
-        ran >= 2,
-        "only {ran} of {} cases ran; the unconditional cases must always \
-         execute or this test proves nothing",
+        unconditional >= 1,
+        "the case table has no unconditional case left, so this test could \
+         pass without exercising anything"
+    );
+    assert!(
+        ran >= unconditional,
+        "only {ran} of {} cases ran but {unconditional} are unconditional here",
         FIELD_GATING_CASES.len()
     );
 }
@@ -127,10 +166,10 @@ fn run_round_trip(case: &FieldGatingCase) {
             .write_file(&format!("src/{name}"), name.as_bytes())
             .expect("write source file");
     }
-    #[cfg(unix)]
     if case.needs_special_file {
         // Same `mkfifo(1)` shell-out as tests/drop_devices.rs, rather than a new
-        // dependency for one fixture.
+        // dependency for one fixture. Unreachable where `PLATFORM_HAS_FIFO` is
+        // false, so no `#[cfg]` is needed and the field stays read everywhere.
         let status = std::process::Command::new("mkfifo")
             .arg(src.join("fifo"))
             .status()

--- a/tests/batch_local_write_flag_roundtrip.rs
+++ b/tests/batch_local_write_flag_roundtrip.rs
@@ -4,11 +4,11 @@
 //! upstream's is (`io.c:1962-1963`, armed at `io.c:2528-2529`; upstream forks a
 //! real `local_child` server at `main.c:648-654` precisely so a stream exists to
 //! tee). oc re-encodes the file list with a second `FileListWriter`, which must
-//! agree with the reader entry field for entry field. Every option below gates a
-//! per-entry field, so any disagreement makes the reader decode the following
-//! entry's flag byte as payload and desynchronise the whole stream - the
+//! agree with the reader entry field for entry field. Every option exercised
+//! here gates a per-entry field, so a disagreement makes the reader decode the
+//! following entry's flag byte as payload and desynchronise the stream - the
 //! observable symptom being `xattr index N out of range (cache size 0)` under
-//! `-X`, and a silent garbage decode under the rest.
+//! `-X`, and a silent garbage decode or an empty replay under the rest.
 //!
 //! These are round-trips on purpose. A unit test over the writer's builder chain
 //! would pass against a chain that still disagrees with the reader; only feeding
@@ -17,6 +17,25 @@
 mod integration;
 
 use integration::helpers::{RsyncCommand, TestDir};
+use test_support::Capabilities;
+use test_support::capabilities::names;
+
+/// One option combination whose flist encoding must survive a round-trip.
+struct FieldGatingCase {
+    /// Options passed to both the recording and the replaying invocation.
+    options: &'static [&'static str],
+    /// Capabilities the binary must advertise, or the case cannot run.
+    ///
+    /// Empty means unconditional: those cases are what keeps the test from
+    /// passing vacuously on a build with every optional feature disabled.
+    requires: &'static [&'static str],
+    /// Whether the fixture needs a special file for the case to mean anything.
+    ///
+    /// The per-entry rdev field only appears for an entry that *is* special, so
+    /// a `--specials` case over plain files would pass for want of a FIFO
+    /// rather than for want of a bug.
+    needs_special_file: bool,
+}
 
 /// Options that each gate a per-entry flist field on the local write path.
 ///
@@ -24,107 +43,155 @@ use integration::helpers::{RsyncCommand, TestDir};
 /// them from the recorded header. `-U`/`-N` have no bit - upstream does not need
 /// one because its replaying receiver reads them off the replay script's argv -
 /// so oc carries them into the reader from the `--read-batch` invocation.
-const FIELD_GATING_OPTIONS: &[&[&str]] = &[
-    &["-X"],
-    &["-A"],
-    &["-c"],
-    &["-U"],
-    &["-N"],
-    &["--specials"],
-    &["-X", "-A", "-c", "-U", "-N"],
+const FIELD_GATING_CASES: &[FieldGatingCase] = &[
+    FieldGatingCase {
+        options: &["-X"],
+        requires: &[names::XATTRS],
+        needs_special_file: false,
+    },
+    FieldGatingCase {
+        options: &["-A"],
+        requires: &[names::ACLS],
+        needs_special_file: false,
+    },
+    FieldGatingCase {
+        options: &["-c"],
+        requires: &[],
+        needs_special_file: false,
+    },
+    FieldGatingCase {
+        options: &["-U"],
+        requires: &[names::ATIMES],
+        needs_special_file: false,
+    },
+    FieldGatingCase {
+        options: &["-N"],
+        requires: &[names::CRTIMES],
+        needs_special_file: false,
+    },
+    FieldGatingCase {
+        options: &["--specials"],
+        requires: &[],
+        needs_special_file: true,
+    },
+    FieldGatingCase {
+        options: &["-X", "-A", "-c", "-U", "-N"],
+        requires: &[names::XATTRS, names::ACLS, names::ATIMES, names::CRTIMES],
+        needs_special_file: false,
+    },
 ];
 
 /// A local `--write-batch` under any per-entry-field option must replay into a
 /// byte-identical tree.
-///
-/// Multiple files are required: a single-entry flist cannot reveal a desync,
-/// because the reader only runs off the end of an entry when another entry
-/// follows it.
 #[test]
 fn local_write_batch_replays_under_every_field_gating_option() {
-    for extra in FIELD_GATING_OPTIONS {
-        let test_dir = TestDir::new().expect("create test dir");
-        let src = test_dir.mkdir("src").expect("create src");
+    let capabilities = Capabilities::probe();
+    let mut ran = 0usize;
 
-        for name in ["alpha.txt", "beta.txt", "gamma.txt"] {
-            test_dir
-                .write_file(&format!("src/{name}"), name.as_bytes())
-                .expect("write source file");
+    for case in FIELD_GATING_CASES {
+        if let Some(reason) = capabilities.skip_reason(case.requires) {
+            // Printed, not silent: a skipped row must leave a trace, or a build
+            // with the feature off looks identical to one that passed.
+            println!("skipping {:?}: {reason}", case.options);
+            continue;
         }
+        run_round_trip(case);
+        ran += 1;
+    }
+
+    // The unconditional cases (`-c`, `--specials`) require no optional feature,
+    // so this can only fail if the case table itself was gutted - which is the
+    // failure mode a "0 tests ran, success" outcome would otherwise hide.
+    assert!(
+        ran >= 2,
+        "only {ran} of {} cases ran; the unconditional cases must always \
+         execute or this test proves nothing",
+        FIELD_GATING_CASES.len()
+    );
+}
+
+/// Records a batch with `case.options`, replays it, and compares the replayed
+/// tree against the one the same invocation wrote directly.
+///
+/// Multiple files are required: a single-entry flist cannot reveal a desync,
+/// because the reader only runs off the end of an entry when another follows it.
+fn run_round_trip(case: &FieldGatingCase) {
+    const PAYLOAD_FILES: &[&str] = &["alpha.txt", "beta.txt", "gamma.txt", "nested/delta.txt"];
+
+    let options = case.options;
+    let test_dir = TestDir::new().expect("create test dir");
+    let src = test_dir.mkdir("src").expect("create src");
+
+    for name in PAYLOAD_FILES {
         test_dir
-            .write_file("src/nested/delta.txt", b"nested payload")
-            .expect("write nested source file");
+            .write_file(&format!("src/{name}"), name.as_bytes())
+            .expect("write source file");
+    }
+    #[cfg(unix)]
+    if case.needs_special_file {
+        // Same `mkfifo(1)` shell-out as tests/drop_devices.rs, rather than a new
+        // dependency for one fixture.
+        let status = std::process::Command::new("mkfifo")
+            .arg(src.join("fifo"))
+            .status()
+            .expect("spawn mkfifo");
+        assert!(status.success(), "mkfifo failed: {status}");
+    }
 
-        // A special file must exist or the `--specials` row is vacuous: the
-        // per-entry rdev field only appears for an entry that is one, so a
-        // fixture of plain files could never expose a specials disagreement.
-        #[cfg(unix)]
-        if extra.contains(&"--specials") {
-            // Same `mkfifo(1)` shell-out as tests/drop_devices.rs, rather than a
-            // new dependency for one fixture.
-            let status = std::process::Command::new("mkfifo")
-                .arg(src.join("fifo"))
-                .status()
-                .expect("spawn mkfifo");
-            assert!(status.success(), "mkfifo failed: {status}");
-        }
+    let direct = test_dir.mkdir("direct").expect("create direct");
+    let replayed = test_dir.mkdir("replayed").expect("create replayed");
+    let batch_path = test_dir.path().join("BATCH");
 
-        let direct = test_dir.mkdir("direct").expect("create direct");
-        let replayed = test_dir.mkdir("replayed").expect("create replayed");
-        let batch_path = test_dir.path().join("BATCH");
+    // Record. This also performs the transfer into `direct/`, which is the
+    // reference tree the replay must reproduce.
+    let mut record = RsyncCommand::new();
+    record.arg("-a");
+    for opt in options {
+        record.arg(opt);
+    }
+    record
+        .arg(format!("--write-batch={}", batch_path.display()))
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", direct.display()));
+    record.assert_success();
 
-        // Record. This also performs the transfer into `direct/`, which is the
-        // reference tree the replay must reproduce.
-        let mut record = RsyncCommand::new();
-        record.arg("-a");
-        for opt in *extra {
-            record.arg(opt);
-        }
-        record
-            .arg(format!("--write-batch={}", batch_path.display()))
-            .arg(format!("{}/", src.display()))
-            .arg(format!("{}/", direct.display()));
-        record.assert_success();
+    assert!(
+        batch_path.exists(),
+        "{options:?}: --write-batch must create '{}'",
+        batch_path.display()
+    );
 
+    // Replay. The same options ride the replay invocation, mirroring the
+    // generated BATCH.sh, which is where --atimes/--crtimes reach the reader.
+    let mut replay = RsyncCommand::new();
+    replay.arg("-a");
+    for opt in options {
+        replay.arg(opt);
+    }
+    replay
+        .arg(format!("--read-batch={}", batch_path.display()))
+        .arg(format!("{}/", replayed.display()));
+    let output = replay.assert_success();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("out of range"),
+        "{options:?}: replay reported a decode error, so the writer and reader \
+         disagree about the entry layout: {stderr}"
+    );
+
+    for name in PAYLOAD_FILES {
+        let want = direct.join(name);
+        let got = replayed.join(name);
         assert!(
-            batch_path.exists(),
-            "{extra:?}: --write-batch must create '{}'",
-            batch_path.display()
+            got.exists(),
+            "{options:?}: replay did not produce '{}' (stderr: {stderr})",
+            got.display()
         );
-
-        // Replay. The same options ride the replay invocation, mirroring the
-        // generated BATCH.sh, which is where --atimes/--crtimes reach the
-        // reader.
-        let mut replay = RsyncCommand::new();
-        replay.arg("-a");
-        for opt in *extra {
-            replay.arg(opt);
-        }
-        replay
-            .arg(format!("--read-batch={}", batch_path.display()))
-            .arg(format!("{}/", replayed.display()));
-        let output = replay.assert_success();
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(
-            !stderr.contains("out of range"),
-            "{extra:?}: replay reported a decode error, so the writer and reader \
-             disagree about the entry layout: {stderr}"
+        assert_eq!(
+            std::fs::read(&want).expect("read reference"),
+            std::fs::read(&got).expect("read replayed"),
+            "{options:?}: replayed '{name}' differs from the directly-copied tree"
         );
-
-        for name in ["alpha.txt", "beta.txt", "gamma.txt", "nested/delta.txt"] {
-            let want = direct.join(name);
-            let got = replayed.join(name);
-            assert!(
-                got.exists(),
-                "{extra:?}: replay did not produce '{}' (stderr: {stderr})",
-                got.display()
-            );
-            assert_eq!(
-                std::fs::read(&want).expect("read reference"),
-                std::fs::read(&got).expect("read replayed"),
-                "{extra:?}: replayed '{name}' differs from the directly-copied tree"
-            );
-        }
     }
 }

--- a/tests/batch_local_write_flag_roundtrip.rs
+++ b/tests/batch_local_write_flag_roundtrip.rs
@@ -1,0 +1,130 @@
+//! Local `--write-batch` must produce a batch its own `--read-batch` can decode.
+//!
+//! The local write-batch path is not a byte tee of a real wire stream the way
+//! upstream's is (`io.c:1962-1963`, armed at `io.c:2528-2529`; upstream forks a
+//! real `local_child` server at `main.c:648-654` precisely so a stream exists to
+//! tee). oc re-encodes the file list with a second `FileListWriter`, which must
+//! agree with the reader entry field for entry field. Every option below gates a
+//! per-entry field, so any disagreement makes the reader decode the following
+//! entry's flag byte as payload and desynchronise the whole stream - the
+//! observable symptom being `xattr index N out of range (cache size 0)` under
+//! `-X`, and a silent garbage decode under the rest.
+//!
+//! These are round-trips on purpose. A unit test over the writer's builder chain
+//! would pass against a chain that still disagrees with the reader; only feeding
+//! the bytes back through the real reader proves the two agree.
+
+mod integration;
+
+use integration::helpers::{RsyncCommand, TestDir};
+
+/// Options that each gate a per-entry flist field on the local write path.
+///
+/// `-X`/`-A`/`-c` have a `batch.c:59-76 flag_ptr[]` bit, so the writer derives
+/// them from the recorded header. `-U`/`-N` have no bit - upstream does not need
+/// one because its replaying receiver reads them off the replay script's argv -
+/// so oc carries them into the reader from the `--read-batch` invocation.
+const FIELD_GATING_OPTIONS: &[&[&str]] = &[
+    &["-X"],
+    &["-A"],
+    &["-c"],
+    &["-U"],
+    &["-N"],
+    &["--specials"],
+    &["-X", "-A", "-c", "-U", "-N"],
+];
+
+/// A local `--write-batch` under any per-entry-field option must replay into a
+/// byte-identical tree.
+///
+/// Multiple files are required: a single-entry flist cannot reveal a desync,
+/// because the reader only runs off the end of an entry when another entry
+/// follows it.
+#[test]
+fn local_write_batch_replays_under_every_field_gating_option() {
+    for extra in FIELD_GATING_OPTIONS {
+        let test_dir = TestDir::new().expect("create test dir");
+        let src = test_dir.mkdir("src").expect("create src");
+
+        for name in ["alpha.txt", "beta.txt", "gamma.txt"] {
+            test_dir
+                .write_file(&format!("src/{name}"), name.as_bytes())
+                .expect("write source file");
+        }
+        test_dir
+            .write_file("src/nested/delta.txt", b"nested payload")
+            .expect("write nested source file");
+
+        // A special file must exist or the `--specials` row is vacuous: the
+        // per-entry rdev field only appears for an entry that is one, so a
+        // fixture of plain files could never expose a specials disagreement.
+        #[cfg(unix)]
+        if extra.contains(&"--specials") {
+            // Same `mkfifo(1)` shell-out as tests/drop_devices.rs, rather than a
+            // new dependency for one fixture.
+            let status = std::process::Command::new("mkfifo")
+                .arg(src.join("fifo"))
+                .status()
+                .expect("spawn mkfifo");
+            assert!(status.success(), "mkfifo failed: {status}");
+        }
+
+        let direct = test_dir.mkdir("direct").expect("create direct");
+        let replayed = test_dir.mkdir("replayed").expect("create replayed");
+        let batch_path = test_dir.path().join("BATCH");
+
+        // Record. This also performs the transfer into `direct/`, which is the
+        // reference tree the replay must reproduce.
+        let mut record = RsyncCommand::new();
+        record.arg("-a");
+        for opt in *extra {
+            record.arg(opt);
+        }
+        record
+            .arg(format!("--write-batch={}", batch_path.display()))
+            .arg(format!("{}/", src.display()))
+            .arg(format!("{}/", direct.display()));
+        record.assert_success();
+
+        assert!(
+            batch_path.exists(),
+            "{extra:?}: --write-batch must create '{}'",
+            batch_path.display()
+        );
+
+        // Replay. The same options ride the replay invocation, mirroring the
+        // generated BATCH.sh, which is where --atimes/--crtimes reach the
+        // reader.
+        let mut replay = RsyncCommand::new();
+        replay.arg("-a");
+        for opt in *extra {
+            replay.arg(opt);
+        }
+        replay
+            .arg(format!("--read-batch={}", batch_path.display()))
+            .arg(format!("{}/", replayed.display()));
+        let output = replay.assert_success();
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("out of range"),
+            "{extra:?}: replay reported a decode error, so the writer and reader \
+             disagree about the entry layout: {stderr}"
+        );
+
+        for name in ["alpha.txt", "beta.txt", "gamma.txt", "nested/delta.txt"] {
+            let want = direct.join(name);
+            let got = replayed.join(name);
+            assert!(
+                got.exists(),
+                "{extra:?}: replay did not produce '{}' (stderr: {stderr})",
+                got.display()
+            );
+            assert_eq!(
+                std::fs::read(&want).expect("read reference"),
+                std::fs::read(&got).expect("read replayed"),
+                "{extra:?}: replayed '{name}' differs from the directly-copied tree"
+            );
+        }
+    }
+}


### PR DESCRIPTION
`oc-rsync -aX --write-batch=B src/ dst/` writes a batch that its own
`--read-batch` cannot decode:

```
oc-rsync error: batch replay failed: I/O error: Failed to read protocol
flist entry: xattr index 8344 out of range (cache size 0)
```

The recorded artifact is permanently undecodable, including by upstream rsync.

## Root cause

The filed hypothesis - replay skipping a cache-population step - is refuted:
`receive_xattr` is self-populating (`cache.rs:388`, upstream
`xattrs.c:538 rsync_xal_store()`). `cache size 0` means the *first* xattr field
decoded yielded `ndx >= 1`, i.e. the reader read a varint from bytes that are
not an xattr field. Stream desync.

The desync is manufactured on the **local** `--write-batch` path only. Network
`--write-batch` is a genuine byte tee (`remote/batch_support.rs:82-88`, upstream
`io.c:1962-1963`) and cannot disagree with itself. Upstream never needs to: it
forks a real `local_child` server (`main.c:648-654`) precisely so a protocol
stream exists to tee, which makes a writer/reader disagreement unspellable.

oc's local path instead **re-encodes** the file list with a second
`FileListWriter` built from `options`, while the reader configures itself from
the recorded header flags. Two vocabularies, kept in sync by hand, drifted.

## Scope is six options, not one

Each gates a per-entry field, so any disagreement makes the reader consume the
next entry's flag byte as payload. All four failures below were reproduced
against the pre-change tree:

| option | disagreement | observed failure |
|---|---|---|
| `-X` | writer never set `preserve_xattrs` | `xattr index 8344 out of range (cache size 0)` |
| `-A` | writer never set `preserve_acls` | `recv_acl_index: access ACL index 8343 > 0` |
| `-c` | writer never set `always_checksum` | **exit 0, zero files replayed** |
| `-N` | reader never configured crtimes | `invalid file mode 00` |
| `--specials` | writer used `specials_enabled()`, reader `preserve_devices` | (structural) |
| `-U` | reader never configured atimes | **not reproduced - see below** |

The `-c` cell is the worst: the replay reports success and silently produces
nothing.

## The fix

The writer now derives its preserve flags from `BatchWriter::stream_flags()` -
the header it recorded itself, and the same value the reader reads - instead of
from `options`. **That accessor already existed for exactly this purpose**; its
field doc says it is captured so downstream regions can gate on the same
predicates. Specials rides `preserve_devices` on both sides now, matching
upstream's `batch.c:59-76 flag_ptr[]`, which has one bit for both because
upstream `-D` is both. `default_flist_csum_len` becomes public so the two sides
cannot disagree about digest length either.

`--atimes` / `--crtimes` have no `flag_ptr[]` bit and cannot get one without
diverging from upstream's batch header format. They follow the `numeric_ids`
precedent already in this code - carried into the reader from the
`--read-batch` invocation, which is where upstream's replaying receiver gets
them too.

## Verification

Round-trip against the real binary, per option and all together. RED on the
pre-change tree reproduces the reported message verbatim; GREEN after.
`cargo fmt` and full-workspace `clippy --all-targets --all-features` both exit
0; `-p batch` 82/82.

Two corrections to my own scoping, both measured rather than reasoned:

- **`-U` (atimes) does NOT desync** on this fixture. The reader-side threading
  is kept because it makes the contract explicit and matches how upstream gets
  the value, but it is not claimed as a bug fix.
- **A `--specials` row over plain files is vacuous** - the rdev field only
  appears for an entry that *is* special. The fixture creates a FIFO, or that
  row would be a false pass.

## Filed separately

The local `--write-batch` re-encoder is a **second flist encoder oc maintains
that upstream does not have at all**. These six are instances; the second
encoder is the class defect. It belongs in the `--read-batch` reunification
design note as a further deliverable - note it is on the **record** path, so
replacing the replay engine does not address it.
