### PR TITLE
fix(engine): honour --safe-links before the backup fast path

### DIFF
--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -853,6 +853,57 @@ impl<'a> CopyContext<'a> {
     /// (backup.c:352) under `INFO_GTE(BACKUP, 1)` once the backup has been
     /// placed successfully. The wording matches upstream byte-for-byte:
     /// `backed up <fname> to <buf>`.
+    /// Reports whether `--safe-links` forbids backing up `destination`,
+    /// emitting upstream's `SYMSAFE,1` notice when it does.
+    ///
+    /// upstream: `backup.c:289-310` gates the hard-link/rename fast path and
+    /// `backup.c:368-375` gates the copy fallback on the same rule. Upstream
+    /// carries both because `link_or_rename()` would otherwise hard-link an
+    /// escaping symlink into the backup area and `goto success`, never reaching
+    /// the copy path's check - its own comment at `backup.c:282-288` says so.
+    /// Routing both oc sites through one predicate is what stops them drifting
+    /// apart again, which is exactly how the fast path came to be unguarded.
+    ///
+    /// A `readlink` failure refuses the backup rather than permitting it:
+    /// upstream fails closed at `backup.c:295-300` on the same reasoning, that
+    /// an unverifiable target must not be preserved into the backup area.
+    fn backup_refused_by_safe_links(&self, destination: &Path, file_type: fs::FileType) -> bool {
+        if !(file_type.is_symlink()
+            && self.options.links_enabled()
+            && self.options.safe_links_enabled())
+        {
+            return false;
+        }
+
+        let Ok(target) = fs::read_link(destination) else {
+            // upstream: backup.c:296-297
+            info_log!(
+                Symsafe,
+                1,
+                "not backing up symlink with unreadable target \"{}\"",
+                destination.display()
+            );
+            return true;
+        };
+
+        let safety_rel = destination
+            .strip_prefix(self.destination_root())
+            .unwrap_or(destination);
+        if symlink_target_is_safe(&target, safety_rel) {
+            return false;
+        }
+
+        // upstream: backup.c:303-306
+        info_log!(
+            Symsafe,
+            1,
+            "not backing up unsafe symlink \"{}\" -> \"{}\"",
+            destination.display(),
+            target.display()
+        );
+        true
+    }
+
     pub(super) fn backup_existing_entry(
         &mut self,
         destination: &Path,
@@ -894,6 +945,14 @@ impl<'a> CopyContext<'a> {
                 parent,
                 &self.metadata_options(),
             )?;
+        }
+
+        // upstream: backup.c:289-310 - honour --safe-links BEFORE the
+        // hard-link/rename fast path. Without this the fast path preserves an
+        // escaping symlink in the backup area and returns successfully, so the
+        // cross-device check further down is never consulted.
+        if self.backup_refused_by_safe_links(destination, file_type) {
+            return Ok(());
         }
 
         // upstream: backup.c:200-207 link_or_rename() - try a hard link into
@@ -953,27 +1012,12 @@ impl<'a> CopyContext<'a> {
                 BackupStrategy::Rename
             }
             Err(error) if error.kind() == io::ErrorKind::CrossesDevices => {
-                // upstream: backup.c:290 - when copying across devices, the
-                // symlink fallback honours --safe-links. Unsafe symlinks are
-                // not recreated at the backup location and SYMSAFE,1 fires.
-                if file_type.is_symlink()
-                    && self.options.safe_links_enabled()
-                    && let Ok(target) = fs::read_link(destination)
-                {
-                    let safety_rel = destination
-                        .strip_prefix(self.destination_root())
-                        .unwrap_or(destination);
-                    if !symlink_target_is_safe(&target, safety_rel) {
-                        // upstream: backup.c:291 - INFO_GTE(SYMSAFE, 1)
-                        info_log!(
-                            Symsafe,
-                            1,
-                            "not backing up unsafe symlink \"{}\" -> \"{}\"",
-                            destination.display(),
-                            target.display()
-                        );
-                        return Ok(());
-                    }
+                // upstream: backup.c:368-375 - the copy fallback re-checks
+                // --safe-links before recreating the symlink. Upstream keeps
+                // this alongside the fast-path check above; both go through the
+                // one predicate so they cannot implement different rules.
+                if self.backup_refused_by_safe_links(destination, file_type) {
+                    return Ok(());
                 }
                 match copy_entry_to_backup(
                     destination,

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -2322,6 +2322,69 @@ fn symsafe_skip_backup_wording_matches_upstream() {
     );
 }
 
+/// The hard-link/rename fast path must not preserve an unsafe destination
+/// symlink into the backup area.
+///
+/// upstream: `backup.c:289-310` runs the `--safe-links` check BEFORE
+/// `link_or_rename()`, and its own comment at `backup.c:282-288` explains why:
+/// the fast path would otherwise hard-link an escaping symlink into the backup
+/// area and `goto success`, never reaching the copy path's check at
+/// `backup.c:368-375`. oc only had the second check, so the escaping link
+/// survived as `link~`.
+///
+/// This drives a real copy rather than asserting the message format, because a
+/// format-only assertion passes against a build where the check never runs.
+/// The oracle is real rsync 3.5.0, which on this fixture prints
+/// `not backing up unsafe symlink "d/link" -> "../../etc/passwd"` and leaves no
+/// `link~`; oc before this fix printed nothing and created
+/// `link~ -> ../../etc/passwd`.
+///
+/// The DESTINATION entry carries the unsafe target on purpose. A source-side
+/// unsafe link never reaches the backup path at all, because `--safe-links`
+/// drops it earlier - so a fixture built the other way round passes with or
+/// without the fix and proves nothing.
+#[cfg(unix)]
+#[test]
+fn safe_links_blocks_backup_of_unsafe_destination_symlink() {
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+
+    let source_dir = ctx.source.join("d");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    std::os::unix::fs::symlink("sibling", source_dir.join("link")).expect("safe source link");
+
+    let dest_dir = ctx.dest.join("source").join("d");
+    fs::create_dir_all(&dest_dir).expect("create dest dir");
+    // Four levels up from `<dest>/source/d/link` (depth 3) genuinely leaves the
+    // destination tree. Counting matters: `../../outside` from this depth still
+    // lands inside it, so a shallower target makes the case pass whether or not
+    // the check runs.
+    let dest_link = dest_dir.join("link");
+    std::os::unix::fs::symlink("../../../../outside", &dest_link).expect("unsafe dest link");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .links(true)
+        .safe_links(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let backup = dest_dir.join("link~");
+    assert!(
+        !backup.exists() && fs::symlink_metadata(&backup).is_err(),
+        "--safe-links must not preserve the escaping symlink into the backup \
+         area; found {} -> {:?}",
+        backup.display(),
+        fs::read_link(&backup).ok()
+    );
+}
+
 /// Verifies the default verbosity (no `--info=SYMSAFE`) suppresses the
 /// notice, matching upstream's `INFO_GTE(SYMSAFE, 1)` gate at
 /// `backup.c:291`. SYMSAFE is in `info_verbosity[1]`, so it stays silent


### PR DESCRIPTION
## What

`--backup --safe-links` preserved an escaping destination symlink into the backup area. Both rsync 3.4.4 and 3.5.0 refuse it, so oc was **more permissive than upstream**.

## Measured

Destination entry `d/link -> ../../etc/passwd` replaced by a safe source link; oracle is real rsync 3.5.0:

| | stderr | `dst/d` |
|---|---|---|
| rsync 3.5.0 | `not backing up unsafe symlink "d/link" -> "../../etc/passwd"` | `link` |
| oc before | *(silent)* | `link`, `link~ -> ../../etc/passwd` |
| oc after | `not backing up unsafe symlink "<dest>/d/link" -> "../../etc/passwd"` | `link` |

## Root cause

Upstream runs the check at **two** sites and explains why at `backup.c:282-288`: the hard-link/rename fast path would otherwise link the escaping symlink into the backup area and `goto success`, never reaching the copy path's check.

- `backup.c:289-310` — before `link_or_rename()`
- `backup.c:368-375` — copy fallback

oc had only the second, and only inside its `CrossesDevices` arm, leaving the fast path unguarded.

## Approach

Both oc sites now call one predicate instead of carrying the rule twice — two copies drifting apart is exactly how the fast path came to be unguarded. The predicate also **fails closed** when `readlink` fails, matching `backup.c:295-300`; the previous inline check used `if let Ok(target)` and fell through to the copy on error.

## Note on the fixture

The destination entry carries the unsafe target deliberately. A source-side unsafe link never reaches this code because `--safe-links` drops it earlier, so a fixture built the other way round passes with or without the fix. My first fixture had that flaw, and a second used `../../outside` from depth 3 — which still resolves *inside* the tree. Both agreed pre- and post-fix. The committed target escapes by a counted margin, and the test comment records why the count matters.

## Verification

- RED/GREEN by removing only the new fast-path guard: fails with `link~ -> ../../../../outside` present, passes when restored.
- `cargo fmt`, workspace `clippy --all-targets --all-features`, engine 4974/4974.

Related: the sender-side `--safe-links` filter oc carries with no upstream counterpart is a separate, opposite-direction divergence and is not touched here.
