### PR TITLE
fix(logging): escape log-file lines in the sink, not the CLI renderer

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -389,7 +389,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         .with_id_preservation(preserve_owner, preserve_group)
         .with_emit_unchanged(emit_unchanged)
         .with_itemize_repeated(itemize_repeated)
-        .with_escape_style(EscapeStyle::log_file())
+        .with_escape_style(EscapeStyle::passthrough())
         .with_preserve_links(preserve_links)
         .with_full_checksum(full_checksum_algorithm, always_checksum);
     // upstream: log.c:290-305 - FLOG messages are written to the log file
@@ -434,7 +434,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         // that `--8-bit-output` does not reach, so a name carrying `ESC`, a
         // newline or an 8-bit CSI cannot forge a log line (CWE-117) while DEL
         // and 0xA0-0xFF stay verbatim.
-        EscapeStyle::log_file(),
+        EscapeStyle::passthrough(),
         &mut log.file,
     )?;
     // upstream: cleanup.c:222-226 gates log_exit() on

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -82,7 +82,10 @@ use std::io::{self, Write};
 /// CLI argument parsing for the rsync frontend.
 pub mod arguments;
 mod command_builder;
-pub(crate) mod escape;
+// The escaper lives in `logging-sink` so the log-file sink can apply it
+// without depending on the CLI: upstream escapes inside `log.c:126 logit()`,
+// the single writer to `logfile_fp`, which is what makes it unbypassable.
+pub(crate) use logging_sink::escape;
 mod execution;
 pub(crate) mod outbuf;
 

--- a/crates/logging-sink/src/escape.rs
+++ b/crates/logging-sink/src/escape.rs
@@ -20,11 +20,18 @@ use std::path::Path;
 ///   - the log-file sink gets `use_isprint = 0, escape_c1 = 1` (log.c:132),
 ///     which is deliberately *not* gated on `--8-bit-output`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct EscapeStyle {
+pub struct EscapeStyle {
     /// Escape every byte libc `isprint()` rejects (upstream `use_isprint`).
     use_isprint: bool,
     /// Escape the C1 control range 0x80-0x9F (upstream `escape_c1`).
     escape_c1: bool,
+    /// Escape the C0 controls below 0x20, tab excepted.
+    ///
+    /// Upstream has no switch for this: every `filtered_fwrite` call site
+    /// escapes them (log.c:250 `*fp < ' '`). oc-rsync needs the switch because
+    /// it has a sink upstream does not - [`EscapeStyle::passthrough`], for a
+    /// producer whose own sink escapes.
+    escape_controls: bool,
 }
 
 impl Default for EscapeStyle {
@@ -42,10 +49,11 @@ impl EscapeStyle {
     /// which covers DEL (0x7F) and the whole high range 0x80-0xFF; with `-8`
     /// only the sub-0x20 controls (tab excepted) are.
     #[must_use]
-    pub(crate) const fn terminal(allow_8bit: bool) -> Self {
+    pub const fn terminal(allow_8bit: bool) -> Self {
         Self {
             use_isprint: !allow_8bit,
             escape_c1: false,
+            escape_controls: true,
         }
     }
 
@@ -58,10 +66,29 @@ impl EscapeStyle {
     /// 8-bit `CSI` can forge a log line or drive the operator's terminal. The
     /// pair does not depend on `--8-bit-output`.
     #[must_use]
-    pub(crate) const fn log_file() -> Self {
+    pub const fn log_file() -> Self {
         Self {
             use_isprint: false,
             escape_c1: true,
+            escape_controls: true,
+        }
+    }
+
+    /// Leaves every byte alone, for a producer whose sink already escapes.
+    ///
+    /// upstream has no `filtered_fwrite` call in `log_formatted()` at all: the
+    /// renderer builds the line and escaping happens later, once, in the
+    /// writer - `log.c:132 logit()` for the log file, `log.c:425 rwrite()` for
+    /// the terminal. [`LogFileWriter`](crate::logfile::LogFileWriter) now owns
+    /// the log-file half, so a renderer feeding it must select this style;
+    /// applying [`EscapeStyle::log_file`] there too would escape the backslash
+    /// of an already-emitted `\#033` and corrupt the line.
+    #[must_use]
+    pub const fn passthrough() -> Self {
+        Self {
+            use_isprint: false,
+            escape_c1: false,
+            escape_controls: false,
         }
     }
 }
@@ -84,7 +111,7 @@ fn is_c_print(byte: u8) -> bool {
 fn should_escape_byte(byte: u8, style: EscapeStyle) -> bool {
     byte != b'\t'
         && ((style.use_isprint && !is_c_print(byte))
-            || byte < b' '
+            || (style.escape_controls && byte < b' ')
             || (style.escape_c1 && (0x80..=0x9F).contains(&byte)))
 }
 
@@ -103,7 +130,14 @@ fn should_escape_byte(byte: u8, style: EscapeStyle) -> bool {
 /// must survive verbatim. A `String` cannot hold arbitrary invalid UTF-8, so
 /// returning `Vec<u8>` and writing it directly to a byte sink is the only way
 /// to reach byte-for-byte parity with upstream on that edge case.
-pub(crate) fn escape_for_output(input: &[u8], style: EscapeStyle) -> Vec<u8> {
+pub fn escape_for_output(input: &[u8], style: EscapeStyle) -> Vec<u8> {
+    // A producer feeding a sink that escapes must not pre-escape anything: the
+    // `\#ddd` guard below would otherwise fire on the sink's own output the
+    // moment it re-entered this function, turning `\#033` into `\#134#033`.
+    if style == EscapeStyle::passthrough() {
+        return input.to_vec();
+    }
+
     // Fast path: all bytes ASCII-printable or tab (0x09, 0x20-0x7E) -> no byte
     // needs escaping under any style and there is no literal `\#ddd` to guard,
     // so return the bytes verbatim.
@@ -197,7 +231,7 @@ fn escape_bytes_slow(input: &[u8], style: EscapeStyle) -> Vec<u8> {
 /// transcode of otherwise-representable filenames: stable std offers no API to
 /// recover the raw WTF-8 bytes, so full byte-fidelity for lone surrogates is
 /// unreachable on Windows today.
-pub(crate) fn escape_path(path: &Path, style: EscapeStyle) -> Vec<u8> {
+pub fn escape_path(path: &Path, style: EscapeStyle) -> Vec<u8> {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;

--- a/crates/logging-sink/src/lib.rs
+++ b/crates/logging-sink/src/lib.rs
@@ -71,8 +71,9 @@
 //! - [`core::message`] for message construction and formatting helpers.
 //! - `logging` crate for verbosity flags and the `info_log!`/`debug_log!` macros.
 
-mod line_mode;
 /// Upstream `logit()`-compatible log-file line formatting.
+pub mod escape;
+mod line_mode;
 pub mod logfile;
 mod sink;
 /// Syslog backend for daemon-mode logging.

--- a/crates/logging-sink/src/logfile.rs
+++ b/crates/logging-sink/src/logfile.rs
@@ -11,6 +11,8 @@
 use std::io::{self, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::escape::{EscapeStyle, escape_for_output};
+
 /// Maximum epoch seconds accepted for timestamp formatting.
 ///
 /// Corresponds to 9999-12-31 23:59:59 UTC - the last representable date in a
@@ -115,32 +117,58 @@ impl<W: Write> LogFileWriter<W> {
     }
 }
 
+impl<W: Write> LogFileWriter<W> {
+    /// Writes one line body through the log-file escape filter.
+    ///
+    /// upstream: log.c:126 `logit()` is the only function that writes to
+    /// `logfile_fp`, and it hands every line to `filtered_fwrite(logfile_fp,
+    /// buf, len, 0, 1, trailing)` (log.c:132). Escaping there rather than in
+    /// each producer is what makes it unbypassable - a caller cannot forget it,
+    /// because there is no other way to reach the file.
+    ///
+    /// The timestamp/pid prefix and the line terminator are written raw, as
+    /// upstream does: `logit()` `fprintf`s the prefix before the call and
+    /// passes the stripped trailing newline to `filtered_fwrite` as `end_char`.
+    fn write_escaped(&mut self, body: &[u8]) -> io::Result<()> {
+        if body.is_empty() {
+            return Ok(());
+        }
+        self.inner
+            .write_all(&escape_for_output(body, EscapeStyle::log_file()))
+    }
+}
+
 impl<W: Write> Write for LogFileWriter<W> {
+    /// upstream: log.c:128-129 - `logit()` strips exactly ONE trailing newline
+    /// and hands everything before it to `filtered_fwrite`. A newline *inside*
+    /// the message is therefore escaped as `\#012` and stays on one log line;
+    /// only the newline that ends the message closes the record. That is the
+    /// whole CWE-117 defence: were an embedded newline to start a fresh line,
+    /// it would be stamped with a genuine timestamp/pid prefix and a filename
+    /// could forge an authentic-looking log entry.
+    ///
+    /// The message boundary is the `write` call, so a producer must deliver one
+    /// message per call - which both `MessageSink` and the CLI's `writeln!`
+    /// sites do. A partial write (a message split across calls) is carried by
+    /// `at_line_start`, so only the first fragment is prefixed.
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        // Copy line segments through in batches, stamping the prefix whenever
-        // a non-empty line starts and dropping FCLIENT-style blank separators
-        // (log.c:288-289 - FCLIENT never reaches the log file).
-        let mut rest = buf;
-        while !rest.is_empty() {
-            if self.at_line_start && rest[0] == b'\n' {
-                rest = &rest[1..];
-                continue;
-            }
-            if self.at_line_start {
-                self.inner.write_all(log_line_prefix_now().as_bytes())?;
-                self.at_line_start = false;
-            }
-            match rest.iter().position(|&byte| byte == b'\n') {
-                Some(newline) => {
-                    self.inner.write_all(&rest[..=newline])?;
-                    self.at_line_start = true;
-                    rest = &rest[newline + 1..];
-                }
-                None => {
-                    self.inner.write_all(rest)?;
-                    rest = &[];
-                }
-            }
+        let (body, terminated) = match buf.split_last() {
+            Some((b'\n', head)) => (head, true),
+            _ => (buf, false),
+        };
+        // log.c:288-289 - FCLIENT blank separators never reach the log file, so
+        // an empty message must vanish rather than emit a bare prefix.
+        if body.is_empty() && self.at_line_start {
+            return Ok(buf.len());
+        }
+        if self.at_line_start {
+            self.inner.write_all(log_line_prefix_now().as_bytes())?;
+            self.at_line_start = false;
+        }
+        self.write_escaped(body)?;
+        if terminated {
+            self.inner.write_all(b"\n")?;
+            self.at_line_start = true;
         }
         Ok(buf.len())
     }
@@ -232,7 +260,10 @@ mod tests {
     fn writer_prefixes_every_line() {
         let mut writer = LogFileWriter::new(Vec::new());
         writer.write_all(b"building file list\n").unwrap();
-        writer.write_all(b"first\nsecond\n").unwrap();
+        // One message per call: that is the boundary `logit()` works on, and
+        // the shape every real producer (MessageSink, `writeln!`) delivers.
+        writer.write_all(b"first\n").unwrap();
+        writer.write_all(b"second\n").unwrap();
         let output = String::from_utf8(writer.into_inner()).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(lines.len(), 3);
@@ -268,7 +299,8 @@ mod tests {
     fn writer_drops_blank_lines() {
         let mut writer = LogFileWriter::new(Vec::new());
         writer.write_all(b"\n").unwrap();
-        writer.write_all(b"totals\n\n").unwrap();
+        writer.write_all(b"totals\n").unwrap();
+        writer.write_all(b"\n").unwrap();
         let output = String::from_utf8(writer.into_inner()).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(
@@ -277,5 +309,82 @@ mod tests {
             "blank lines must not reach the log: {output:?}"
         );
         assert!(lines[0].ends_with("totals"));
+    }
+
+    /// Returns the body of the single logged line, prefix stripped.
+    fn single_line_body(raw: &[u8]) -> Vec<u8> {
+        assert_eq!(
+            raw.iter().filter(|&&byte| byte == b'\n').count(),
+            1,
+            "expected exactly one line: {raw:?}"
+        );
+        let body_start = raw
+            .windows(2)
+            .position(|pair| pair == b"] ")
+            .expect("prefix ends with `] `")
+            + 2;
+        assert_eq!(*raw.last().expect("non-empty"), b'\n', "newline is raw");
+        raw[body_start..raw.len() - 1].to_vec()
+    }
+
+    /// upstream: log.c:132 - `logit()` hands every line to `filtered_fwrite`,
+    /// so a control byte that reached the log through *any* producer is
+    /// escaped. Escaping in the sink rather than in a renderer is what makes
+    /// this unbypassable: the daemon's log writers never touch the CLI's
+    /// out-format renderer, yet must not be able to emit a raw `ESC` that
+    /// forges a log line on the operator's terminal (CWE-117).
+    #[test]
+    fn writer_escapes_control_bytes_in_the_body() {
+        let mut writer = LogFileWriter::new(Vec::new());
+        writer.write_all(b"recv nope\x1b[31mX\n").unwrap();
+        let body = single_line_body(&writer.into_inner());
+        assert_eq!(
+            body,
+            b"recv nope\\#033[31mX".to_vec(),
+            "ESC must be escaped exactly once, as \\#033"
+        );
+    }
+
+    /// A line with nothing escapable must reach the file byte-identical. This
+    /// is the non-vacuity control for the test above: without it, an escaper
+    /// that mangled every line would still satisfy "the ESC is gone".
+    #[test]
+    fn writer_leaves_printable_lines_byte_identical() {
+        let mut writer = LogFileWriter::new(Vec::new());
+        writer.write_all(b"recv plain/name.txt\tok\n").unwrap();
+        let body = single_line_body(&writer.into_inner());
+        assert_eq!(body, b"recv plain/name.txt\tok".to_vec());
+    }
+
+    /// A newline inside the message must not open a second log record.
+    ///
+    /// This is the injection itself, not a cosmetic detail: every line the
+    /// sink emits is stamped with a real timestamp and pid, so a filename
+    /// carrying `\n` would otherwise produce a second, entirely authentic-
+    /// looking entry under the attacker's control. upstream: log.c:128-129
+    /// strips only the message's own trailing newline.
+    #[test]
+    fn writer_escapes_a_newline_inside_the_message() {
+        let mut writer = LogFileWriter::new(Vec::new());
+        writer
+            .write_all(b"recv a\n2026/01/01 00:00:00 [1] forged\n")
+            .unwrap();
+        let body = single_line_body(&writer.into_inner());
+        assert_eq!(
+            body,
+            b"recv a\\#0122026/01/01 00:00:00 [1] forged".to_vec(),
+            "an embedded newline must stay on one line as \\#012"
+        );
+    }
+
+    /// upstream: log.c:132 passes `use_isprint = 0` and `escape_c1 = 1`, so a
+    /// UTF-8 filename survives verbatim while the 8-bit CSI (0x9B) - which can
+    /// drive a terminal just as an `ESC [` pair does - is escaped.
+    #[test]
+    fn writer_escapes_c1_but_passes_utf8_through() {
+        let mut writer = LogFileWriter::new(Vec::new());
+        writer.write_all(b"recv caf\xc3\xa9\x9b31m\n").unwrap();
+        let body = single_line_body(&writer.into_inner());
+        assert_eq!(body, b"recv caf\xc3\xa9\\#23331m".to_vec());
     }
 }

--- a/tests/daemon_log_file_escaping.rs
+++ b/tests/daemon_log_file_escaping.rs
@@ -1,0 +1,145 @@
+//! Peer-supplied text reaching the daemon's log file is escaped (CWE-117).
+//!
+//! Upstream escapes in the *sink*, not in any renderer: `logit()` is the only
+//! function that writes `logfile_fp`, and it hands every line to
+//! `filtered_fwrite(logfile_fp, buf, len, 0, 1, trailing)` (log.c:126-132).
+//! Nothing that reaches the log file can skip it.
+//!
+//! oc-rsync used to escape in the CLI out-format renderer instead. That
+//! covered `--log-file` on the client, and nothing else: the daemon writes its
+//! log through an entirely different path and so recorded a raw `ESC` where
+//! rsync 3.5.0 writes `\#033`. This test pins the daemon half, which is the
+//! half a renderer-side escaper cannot reach by construction.
+//!
+//! The vector is the client's argument vector, logged verbatim at
+//! `module '%s' from %s: client args: ...` - it carries an operand the peer
+//! chose, before the module has resolved anything, so no fixture can launder
+//! it.
+//!
+//! Skip condition (test passes with a printed reason): loopback TCP is
+//! unavailable, or the daemon does not answer.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// A requested path carrying the two bytes that forge log output: `ESC`, which
+/// starts a terminal control sequence, and `LF`, which would otherwise open a
+/// second - fully prefix-stamped, therefore authentic-looking - log record.
+const HOSTILE_OPERAND: &str = "A\x1bB\nC";
+
+/// The same operand as the log file must render it. 0x1B is octal 033, 0x0A is
+/// octal 012; every other byte is ASCII-printable and survives verbatim.
+const ESCAPED_OPERAND: &str = "A\\#033B\\#012C";
+
+/// A wholly printable operand, used as the run's non-vacuity control: it must
+/// reach the log unchanged, so a sink that mangled or dropped every operand
+/// could not satisfy both assertions.
+const PLAIN_OPERAND: &str = "plain-name";
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+/// Starts a daemon and waits until its port answers, so the client never races
+/// the listener.
+fn spawn_daemon(conf: &Path, port: u16) -> Option<Child> {
+    let mut child = Command::new(oc_binary())
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return Some(child);
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    None
+}
+
+/// Pulls `operand` from the module. The file does not exist, so the transfer
+/// fails - the log line under test is written before the lookup, and a failing
+/// pull keeps the fixture from having to create a file whose name the host
+/// filesystem may refuse.
+fn request(port: u16, operand: &str, dest: &Path) {
+    let _ = Command::new(oc_binary())
+        .arg("-q")
+        .arg(format!("rsync://127.0.0.1:{port}/m/{operand}"))
+        .arg(dest)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run client");
+}
+
+#[test]
+fn daemon_log_file_escapes_a_peer_supplied_operand() {
+    let Some(port) = free_port() else {
+        println!("skipping: loopback TCP unavailable");
+        return;
+    };
+    let root = tempfile::tempdir().expect("temp dir");
+    let log = root.path().join("daemon.log");
+    let module = root.path().join("mod");
+    fs::create_dir_all(&module).expect("module dir");
+    let conf = root.path().join("rsyncd.conf");
+    fs::write(
+        &conf,
+        format!(
+            "port = {port}\n\
+             use chroot = no\n\
+             log file = {log}\n\
+             \n\
+             [m]\n\
+             \tpath = {module}\n\
+             \tread only = yes\n",
+            log = log.display(),
+            module = module.display(),
+        ),
+    )
+    .expect("write config");
+
+    let Some(mut daemon) = spawn_daemon(&conf, port) else {
+        println!("skipping: daemon did not answer on 127.0.0.1:{port}");
+        return;
+    };
+    let dest = root.path().join("dest");
+    request(port, HOSTILE_OPERAND, &dest);
+    request(port, PLAIN_OPERAND, &dest);
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+
+    let logged = fs::read(&log).expect("read daemon log");
+    let text = String::from_utf8_lossy(&logged);
+    assert!(
+        text.contains(PLAIN_OPERAND),
+        "the control operand never reached the log, so the assertions below \
+         would be vacuous:\n{text}"
+    );
+    assert!(
+        !logged.contains(&0x1b),
+        "a raw ESC reached the daemon log file:\n{text}"
+    );
+    assert!(
+        text.contains(ESCAPED_OPERAND),
+        "expected {ESCAPED_OPERAND:?} in the daemon log:\n{text}"
+    );
+}


### PR DESCRIPTION
## Problem

Upstream rsync has exactly one writer to the log file: `logit()` (`log.c:126`), which hands every line to `filtered_fwrite(logfile_fp, buf, len, 0, 1, trailing)` at `log.c:132`. Escaping in the **sink** is what makes it unbypassable - a producer cannot forget it, because there is no other way to reach the file.

oc-rsync escaped in the CLI out-format **renderer** instead. That covered `--log-file` on the client and nothing else. The daemon writes its log through an entirely different path, so a peer-supplied operand reached the log with a raw `ESC` where rsync 3.5.0 writes `\#033`:

```
module 'm' from localhost (127.0.0.1): client args: --server --sender ... m/no<ESC>pe
```

Every line the sink emits carries a genuine timestamp and pid, so a name carrying a newline could open a second, entirely authentic-looking record (CWE-117).

## Change

Move the escaper from `crates/cli/src/frontend/escape.rs` down to `crates/logging-sink/src/escape.rs`, and apply it inside `LogFileWriter` - the one type both the CLI (`summary.rs`) and the daemon (`daemon.rs`, `privilege.rs`, `hardening.rs`, `module_access`) construct for a log file. `logging-sink` was already a dependency of both, so nothing new enters the crate graph.

The renderer switches to a new `EscapeStyle::passthrough`. Applying both would double-escape: the sink's `\#ddd` guard (`log.c:252-254`) fires on the renderer's own output and turns `\#033` into `\#134#033` - which is exactly what the existing oracle test reported when only half the change was in place.

Two consequences fall out of putting it in the sink:

- **`EscapeStyle` gains an `escape_controls` switch.** Upstream has no such switch because every `filtered_fwrite` call site escapes C0 controls. oc-rsync needs one because it now has a sink upstream does not - the passthrough style, whose whole job is to leave the bytes alone.
- **The `Write` adapter treats a newline as a record terminator only when it ends the write.** A newline *inside* the message is escaped as `\#012`, matching `log.c:128-129`, which strips exactly one trailing newline. The previous byte-stream splitting turned an embedded newline into a second prefixed line - the injection this defends against. Producers already deliver one message per call (`MessageSink`, and `writeln!` on the CLI side), so this is the boundary upstream works on.

## Verification

- New `tests/daemon_log_file_escaping.rs` pins the half a renderer-side escaper cannot reach: a peer-supplied operand carrying `ESC` and `LF`, asserted byte-exactly as `A\#033B\#012C`, with a printable control operand in the same run so the assertions cannot pass vacuously.
- **RED proven**: reverting only the sink escaping (`write_escaped` -> raw `write_all`) fails the new test with `a raw ESC reached the daemon log file`.
- The existing 3.5.0 oracle test `crates/cli/tests/log_file_control_char_escape.rs` passes unchanged - that is what proves the move did not perturb the client half.
- `cargo fmt --all -- --check` clean; `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- `cargo nextest run -p logging-sink -p cli --all-features`: 3974 passed. `-p daemon --all-features`: 1797 passed.

Closes the residual filed when the log-file escaping port was reviewed.
