### PR TITLE
fix(metadata): an installed name converter must replace the host database

### DIFF
--- a/crates/metadata/src/id_lookup/converter.rs
+++ b/crates/metadata/src/id_lookup/converter.rs
@@ -27,6 +27,26 @@ pub trait NameConverterCallbacks: Send {
     fn name_to_gid(&mut self, name: &str) -> Option<u32>;
 }
 
+/// Runs `query` against the installed name converter, if there is one.
+///
+/// `Some(answer)` means a converter is installed and `answer` is its verdict -
+/// including `Some(None)` for "the converter does not recognise this id or
+/// name". `None` means no converter is installed, and only then may the caller
+/// consult the host user database.
+///
+/// upstream: uidlist.c:114-121, :131-138, :154-163, :180-189 - every lookup is
+/// `if (namecvt_pid) { namecvt_call(...) } else { getpw*()/getgr*() }`. The
+/// converter exists to isolate a session from the host database: a chrooted
+/// daemon module resolves names through the operator's script, not through
+/// `/etc/passwd`. Falling back to the host on "unknown" would defeat the reason
+/// the directive is configured, so the two arms are mutually exclusive and this
+/// helper is the single place that says so.
+pub(super) fn with_name_converter<T>(
+    query: impl FnOnce(&mut dyn NameConverterCallbacks) -> Option<T>,
+) -> Option<Option<T>> {
+    NAME_CONVERTER_SLOT.with(|slot| slot.borrow_mut().as_mut().map(|nc| query(&mut **nc)))
+}
+
 thread_local! {
     pub(super) static NAME_CONVERTER_SLOT: RefCell<Option<Box<dyn NameConverterCallbacks>>> =
         const { RefCell::new(None) };

--- a/crates/metadata/src/id_lookup/nss.rs
+++ b/crates/metadata/src/id_lookup/nss.rs
@@ -1,14 +1,15 @@
 //! POSIX NSS lookup functions for UID/GID name resolution.
 //!
 //! Wraps the thread-safe `_r` variants of `getpwuid`, `getpwnam`, `getgrgid`,
-//! and `getgrnam`. Each function checks the thread-local name converter first
-//! and falls back to the libc call only when no converter is installed.
+//! and `getgrnam`. A thread-local name converter, when installed, *replaces*
+//! the libc call rather than being tried ahead of it - see
+//! [`with_name_converter`](super::converter::with_name_converter).
 //!
 //! upstream: uidlist.c - getpwuid_r / getpwnam_r / getgrgid_r / getgrnam_r usage
 
 #![allow(unsafe_code)]
 
-use super::converter::NAME_CONVERTER_SLOT;
+use super::converter::with_name_converter;
 use rustix::process::{RawGid, RawUid};
 use std::ffi::{CStr, CString};
 use std::io;
@@ -21,14 +22,9 @@ use std::ptr;
 /// Uses `getpwuid_r` for thread-safe lookup. When a name converter is
 /// installed via [`super::set_name_converter`], delegates to it instead.
 pub fn lookup_user_name(uid: RawUid) -> Result<Option<Vec<u8>>, io::Error> {
-    // upstream: uidlist.c:110-116 - name_converter replaces getpwuid
-    let converted = NAME_CONVERTER_SLOT.with(|slot| {
-        slot.borrow_mut()
-            .as_mut()
-            .and_then(|nc| nc.uid_to_name(uid))
-    });
-    if let Some(name) = converted {
-        return Ok(Some(name.into_bytes()));
+    // upstream: uidlist.c:114-121 - the converter replaces getpwuid outright.
+    if let Some(answer) = with_name_converter(|nc| nc.uid_to_name(uid)) {
+        return Ok(answer.map(String::into_bytes));
     }
 
     let mut buffer = vec![0_u8; 1024];
@@ -75,16 +71,17 @@ pub fn lookup_user_name(uid: RawUid) -> Result<Option<Vec<u8>>, io::Error> {
 /// Uses `getpwnam_r` for thread-safe lookup. When a name converter is
 /// installed via [`super::set_name_converter`], delegates to it instead.
 pub fn lookup_user_by_name(name: &[u8]) -> Result<Option<RawUid>, io::Error> {
-    // upstream: uidlist.c:138-144 - name_converter replaces getpwnam
-    if let Ok(name_str) = std::str::from_utf8(name) {
-        let converted = NAME_CONVERTER_SLOT.with(|slot| {
-            slot.borrow_mut()
-                .as_mut()
-                .and_then(|nc| nc.name_to_uid(name_str))
-        });
-        if let Some(uid) = converted {
-            return Ok(Some(uid as RawUid));
-        }
+    // upstream: uidlist.c:146 `user_to_uid()` - an empty name is "no id",
+    // decided before the converter or the host database is consulted.
+    if name.is_empty() {
+        return Ok(None);
+    }
+
+    // upstream: uidlist.c:131-138 - the converter replaces getpwnam outright.
+    if let Ok(name_str) = std::str::from_utf8(name)
+        && let Some(answer) = with_name_converter(|nc| nc.name_to_uid(name_str))
+    {
+        return Ok(answer.map(|uid| uid as RawUid));
     }
 
     let Ok(c_name) = CString::new(name) else {
@@ -134,14 +131,9 @@ pub fn lookup_user_by_name(name: &[u8]) -> Result<Option<RawUid>, io::Error> {
 /// Uses `getgrgid_r` for thread-safe lookup. When a name converter is
 /// installed via [`super::set_name_converter`], delegates to it instead.
 pub fn lookup_group_name(gid: RawGid) -> Result<Option<Vec<u8>>, io::Error> {
-    // upstream: uidlist.c:153-159 - name_converter replaces getgrgid
-    let converted = NAME_CONVERTER_SLOT.with(|slot| {
-        slot.borrow_mut()
-            .as_mut()
-            .and_then(|nc| nc.gid_to_name(gid))
-    });
-    if let Some(name) = converted {
-        return Ok(Some(name.into_bytes()));
+    // upstream: uidlist.c:154-163 - the converter replaces getgrgid outright.
+    if let Some(answer) = with_name_converter(|nc| nc.gid_to_name(gid)) {
+        return Ok(answer.map(String::into_bytes));
     }
 
     let mut buffer = vec![0_u8; 1024];
@@ -188,16 +180,17 @@ pub fn lookup_group_name(gid: RawGid) -> Result<Option<Vec<u8>>, io::Error> {
 /// Uses `getgrnam_r` for thread-safe lookup. When a name converter is
 /// installed via [`super::set_name_converter`], delegates to it instead.
 pub fn lookup_group_by_name(name: &[u8]) -> Result<Option<RawGid>, io::Error> {
-    // upstream: uidlist.c:175-181 - name_converter replaces getgrnam
-    if let Ok(name_str) = std::str::from_utf8(name) {
-        let converted = NAME_CONVERTER_SLOT.with(|slot| {
-            slot.borrow_mut()
-                .as_mut()
-                .and_then(|nc| nc.name_to_gid(name_str))
-        });
-        if let Some(gid) = converted {
-            return Ok(Some(gid as RawGid));
-        }
+    // upstream: uidlist.c:172 `group_to_gid()` - an empty name is "no id",
+    // decided before the converter or the host database is consulted.
+    if name.is_empty() {
+        return Ok(None);
+    }
+
+    // upstream: uidlist.c:180-189 - the converter replaces getgrnam outright.
+    if let Ok(name_str) = std::str::from_utf8(name)
+        && let Some(answer) = with_name_converter(|nc| nc.name_to_gid(name_str))
+    {
+        return Ok(answer.map(|gid| gid as RawGid));
     }
 
     let Ok(c_name) = CString::new(name) else {

--- a/crates/metadata/src/id_lookup/nss_stub.rs
+++ b/crates/metadata/src/id_lookup/nss_stub.rs
@@ -3,8 +3,15 @@
 //! On platforms without POSIX NSS (Windows, etc.), lookups succeed only when
 //! a name converter is installed via [`super::set_name_converter`]. Without
 //! a converter, all lookups return `Ok(None)`.
+//!
+//! These share
+//! [`with_name_converter`](super::converter::with_name_converter) with the
+//! POSIX path. There is no host database to fall back to here, so the
+//! helper's "converter installed" and "converter answered" arms collapse to
+//! the same `Ok(None)` - but going through it keeps one description of how a
+//! converter is consulted instead of four copies of the slot dance.
 
-use super::converter::NAME_CONVERTER_SLOT;
+use super::converter::with_name_converter;
 use std::io;
 
 /// Looks up the username for a given UID.
@@ -12,12 +19,9 @@ use std::io;
 /// Delegates to the thread-local name converter if installed, otherwise
 /// returns `Ok(None)`.
 pub fn lookup_user_name(uid: u32) -> Result<Option<Vec<u8>>, io::Error> {
-    let converted = NAME_CONVERTER_SLOT.with(|slot| {
-        slot.borrow_mut()
-            .as_mut()
-            .and_then(|nc| nc.uid_to_name(uid))
-    });
-    Ok(converted.map(String::into_bytes))
+    Ok(with_name_converter(|nc| nc.uid_to_name(uid))
+        .flatten()
+        .map(String::into_bytes))
 }
 
 /// Looks up the UID for a given username.
@@ -28,12 +32,7 @@ pub fn lookup_user_by_name(name: &[u8]) -> Result<Option<u32>, io::Error> {
     let Ok(name_str) = std::str::from_utf8(name) else {
         return Ok(None);
     };
-    let converted = NAME_CONVERTER_SLOT.with(|slot| {
-        slot.borrow_mut()
-            .as_mut()
-            .and_then(|nc| nc.name_to_uid(name_str))
-    });
-    Ok(converted)
+    Ok(with_name_converter(|nc| nc.name_to_uid(name_str)).flatten())
 }
 
 /// Looks up the group name for a given GID.
@@ -41,12 +40,9 @@ pub fn lookup_user_by_name(name: &[u8]) -> Result<Option<u32>, io::Error> {
 /// Delegates to the thread-local name converter if installed, otherwise
 /// returns `Ok(None)`.
 pub fn lookup_group_name(gid: u32) -> Result<Option<Vec<u8>>, io::Error> {
-    let converted = NAME_CONVERTER_SLOT.with(|slot| {
-        slot.borrow_mut()
-            .as_mut()
-            .and_then(|nc| nc.gid_to_name(gid))
-    });
-    Ok(converted.map(String::into_bytes))
+    Ok(with_name_converter(|nc| nc.gid_to_name(gid))
+        .flatten()
+        .map(String::into_bytes))
 }
 
 /// Looks up the GID for a given group name.
@@ -57,12 +53,7 @@ pub fn lookup_group_by_name(name: &[u8]) -> Result<Option<u32>, io::Error> {
     let Ok(name_str) = std::str::from_utf8(name) else {
         return Ok(None);
     };
-    let converted = NAME_CONVERTER_SLOT.with(|slot| {
-        slot.borrow_mut()
-            .as_mut()
-            .and_then(|nc| nc.name_to_gid(name_str))
-    });
-    Ok(converted)
+    Ok(with_name_converter(|nc| nc.name_to_gid(name_str)).flatten())
 }
 
 #[cfg(test)]

--- a/crates/metadata/src/id_lookup/tests.rs
+++ b/crates/metadata/src/id_lookup/tests.rs
@@ -493,3 +493,95 @@ fn cached_lookup_bypasses_cache_when_converter_installed() {
 
     clear_name_converter();
 }
+
+/// A converter that answers exactly one name and disclaims everything else.
+///
+/// The disclaimed answers are the point: they are what a real converter emits
+/// for a name outside the operator's mapping, and what a dead converter's
+/// caller sees.
+struct DisclaimingConverter;
+
+impl NameConverterCallbacks for DisclaimingConverter {
+    fn uid_to_name(&mut self, _uid: u32) -> Option<String> {
+        None
+    }
+
+    fn gid_to_name(&mut self, _gid: u32) -> Option<String> {
+        None
+    }
+
+    fn name_to_uid(&mut self, name: &str) -> Option<u32> {
+        (name == "mapped-only").then_some(4242)
+    }
+
+    fn name_to_gid(&mut self, name: &str) -> Option<u32> {
+        (name == "mapped-only").then_some(4243)
+    }
+}
+
+/// An installed converter REPLACES the host user database; it is not merely
+/// consulted ahead of it.
+///
+/// upstream: uidlist.c:114-121, :131-138, :154-163, :180-189 - each lookup is
+/// `if (namecvt_pid) { namecvt_call(...) } else { getpw*()/getgr*() }`. The
+/// directive exists to isolate a session from the host database, so answering
+/// "unknown" must mean unknown, not "now go ask /etc/passwd".
+///
+/// The probe name is deliberately one the host DOES resolve. A bogus name such
+/// as `no_such_user_zzz` returns `None` whether or not the fall-through exists,
+/// so a test using one would pass with the bug intact.
+#[cfg(unix)]
+#[test]
+fn installed_converter_replaces_the_host_database() {
+    clear_name_converter();
+    let host_uid = lookup_user_by_name(b"root").expect("host lookup");
+    // Non-vacuity: `root` really is resolvable without a converter, so a `None`
+    // below is the converter's verdict and not simply an absent user.
+    assert!(
+        host_uid.is_some(),
+        "this host cannot resolve `root`, so the fall-through would be \
+         unobservable and this test cannot discriminate"
+    );
+
+    set_name_converter(Box::new(DisclaimingConverter));
+
+    // Non-vacuity: the converter is genuinely installed and genuinely answering.
+    assert_eq!(
+        lookup_user_by_name(b"mapped-only").expect("lookup"),
+        Some(4242),
+        "the converter is not installed, so the assertions below prove nothing"
+    );
+
+    assert_eq!(
+        lookup_user_by_name(b"root").expect("lookup"),
+        None,
+        "the converter disclaimed `root`, so the lookup must fail - falling \
+         through to the host database would return {host_uid:?} and defeat the \
+         isolation the directive exists for"
+    );
+    assert_eq!(
+        lookup_user_name(0).expect("lookup"),
+        None,
+        "the converter disclaimed uid 0; the host name must not leak through"
+    );
+
+    clear_name_converter();
+}
+
+/// upstream: uidlist.c:146 `user_to_uid()` / :172 `group_to_gid()` -
+/// `if (!name || !*name) return 0;`. An empty name is decided before either the
+/// converter or the host database is consulted, so no request is framed for it.
+#[cfg(unix)]
+#[test]
+fn an_empty_name_resolves_to_nothing_without_consulting_the_converter() {
+    set_name_converter(Box::new(DisclaimingConverter));
+    assert_eq!(lookup_user_by_name(b"").expect("lookup"), None);
+    assert_eq!(lookup_group_by_name(b"").expect("lookup"), None);
+    // Non-vacuity: the same converter still answers a real name, so the two
+    // `None`s above are the empty-name rule and not a broken fixture.
+    assert_eq!(
+        lookup_user_by_name(b"mapped-only").expect("lookup"),
+        Some(4242)
+    );
+    clear_name_converter();
+}

--- a/crates/metadata/src/id_lookup/tests.rs
+++ b/crates/metadata/src/id_lookup/tests.rs
@@ -499,8 +499,13 @@ fn cached_lookup_bypasses_cache_when_converter_installed() {
 /// The disclaimed answers are the point: they are what a real converter emits
 /// for a name outside the operator's mapping, and what a dead converter's
 /// caller sees.
+///
+/// Scoped to Unix because both its consumers are: the host-database contrast
+/// they assert only exists where there IS a host database to leak from.
+#[cfg(unix)]
 struct DisclaimingConverter;
 
+#[cfg(unix)]
 impl NameConverterCallbacks for DisclaimingConverter {
     fn uid_to_name(&mut self, _uid: u32) -> Option<String> {
         None


### PR DESCRIPTION
## Problem

Upstream's four id lookups are a strict either/or:

```c
if (namecvt_pid) { namecvt_call(...) } else { getpwuid()/getgrnam()/... }
```

(`uidlist.c:114-121`, `:131-138`, `:154-163`, `:180-189`.) The `name converter` directive exists to **isolate** a session from the host user database - a chrooted daemon module resolves names through the operator's script, not through `/etc/passwd` - so upstream never consults NSS once a converter is installed.

oc tried the converter *first* and fell through to `getpwnam_r` / `getgrnam_r` / `getpwuid_r` / `getgrgid_r` whenever it answered "unknown". The isolation was therefore only as good as the converter's coverage: any name outside the operator's mapping silently resolved against the host, and a converter that **died** resolved *everything* against the host from then on, with no diagnostic and no non-zero exit.

The comment above each site already read `name_converter replaces getpwnam`. The code did the opposite - the comment described the intent, not the behaviour.

## Change

One helper owns the rule, and its return type states it:

```rust
fn with_name_converter<T>(query: ...) -> Option<Option<T>>
```

`Some(answer)` = a converter is installed and this is its verdict, including `Some(None)` for "unknown". `None` = no converter installed, and only then may the caller consult the host. Four call sites, one place that says what the rule is - which is what stops them drifting apart again.

Also adds upstream's empty-name guard (`uidlist.c:146` `user_to_uid`, `:172` `group_to_gid`: `if (!name || !*name) return 0;`), decided before either the converter or the host is consulted.

## Not in scope, because it is already present

An earlier analysis claimed oc had no converter-token validation. That is **false on current master**: `namecvt_safe_token` (`clientserver.c:1362-1370`) is already mirrored at `name_converter.rs:110` as `is_safe_token`, byte-for-byte (`< 0x20 || == 0x7f`), along with the 1024-byte request limit and the strict all-digit reply parse that rejects a leading `+`. Nothing there needed changing and nothing there was touched.

## Verification

- `root` is the probe name **on purpose**: it is one the host resolves. A bogus name like `no_such_user_zzz` returns `None` whether or not the fall-through exists, so a test using one passes with the bug intact.
- The test reads the host's answer first and asserts it is present, so a `None` afterwards is provably the converter's verdict and not an absent user. It also asserts the converter answers a name it *does* map, so "converter never installed" cannot masquerade as a pass.
- **RED proven**: restoring the fall-through fails with ``the converter disclaimed `root`, so the lookup must fail - falling through to the host database would return Some(0)``.
- `cargo nextest run -p metadata --all-features`: 606 passed. fmt + full-workspace clippy clean.

## Residual, filed not fixed

`NameConverter::query` still collapses four distinct outcomes into one `None`: request-too-large and write/flush failure are **fatal** upstream (`RERR_UNSUPPORTED` / `RERR_SOCKETIO`, `clientserver.c:1324-1334`) but are reported here as "name not found". Read-EOF-as-not-found is *correct* and matches `clientserver.c:1336-1337` - a fix that made EOF fatal would diverge. Distinguishing the other three needs an `io::Result<Option<T>>` signature change across the callback trait and its call sites; kept out of this change deliberately.
