### PR TITLE
fix(receiver): fold peer io_error before the late delete sweep

### DIFF
--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -327,6 +327,24 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.finalize_delayed_updates_and_hardlinks(&setup.dest_dir, &all_delayed_updates, writer)?;
 
+        // upstream: io.c:1702-1712 - the receiver ORs each MSG_IO_ERROR into the
+        // global `io_error` and forwards it to the generator, so by the time the
+        // generator runs its late sweep the bits are already visible to
+        // `delete_in_dir`'s guard (generator.c:304-311). oc has no generator
+        // peer - the receive path is unified - so the equivalent is to drain the
+        // reader's accumulator here, BEFORE the sweep consults `stats.io_error`.
+        //
+        // The sender emits MSG_IO_ERROR immediately before the phase-1 NDX_DONE
+        // (sender.c:809-817), which the pipeline loop above must consume to
+        // return, so the bits are already accumulated by this point. Draining
+        // only after `finalize_transfer` (below) would let --delete-after remove
+        // destination entries that upstream preserves.
+        //
+        // `take_io_error` is destructive, and both drains OR into the same field,
+        // so the later one still folds in anything that arrives during the
+        // goodbye handshake without double-counting these bits.
+        stats.io_error |= reader.take_io_error();
+
         // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
         // the sweep only after every file (including each destination
         // `.rsync-filter` and any --delay-updates staged file committed just

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -361,6 +361,13 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.finalize_delayed_updates_and_hardlinks(&setup.dest_dir, &all_delayed_updates, writer)?;
 
+        // upstream: io.c:1702-1712 - see the matching drain in `pipelined.rs`.
+        // The sender's MSG_IO_ERROR arrives before the phase-1 NDX_DONE
+        // (sender.c:809-817), so folding it in here is what lets the late sweep
+        // honour `delete_in_dir`'s IOERR_GENERAL guard (generator.c:304-311)
+        // instead of deleting entries upstream preserves.
+        stats.io_error |= reader.take_io_error();
+
         // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
         // the sweep only after every file (including each destination
         // `.rsync-filter` and any --delay-updates staged file committed just


### PR DESCRIPTION
## Problem

`--delete-after` consulted `stats.io_error` **before** the sender's
`MSG_IO_ERROR` bits had been folded into it, so the late sweep decided against a
zero value and removed destination entries upstream preserves.

`crates/transfer/src/receiver/transfer/pipelined.rs` (same inversion in
`pipelined_incremental.rs`):

| line | statement |
|---|---|
| ~222-241 | pipeline loop consumes through phase-1 `NDX_DONE` — the sender's bits are already accumulated here |
| **~338** | `run_receiver_delete_pass(DeletePassPhase::Late, …, &mut stats)` ← decides from `stats.io_error` |
| **~366** | `stats.io_error \|= reader.take_io_error();` ← 28 lines too late |

The gate that reads it is `receiver/transfer.rs:331`:
`stats.io_error & IOERR_GENERAL != 0 && !ignore_errors`.

## Upstream

`generator.c:304-311` — `delete_in_dir()` refuses to delete when
`io_error & IOERR_GENERAL` is set and `--ignore-errors` is off:

```c
if (io_error & IOERR_GENERAL && !ignore_errors) {
        if (already_warned)
                return;
        rprintf(FINFO, "IO error encountered -- skipping file deletion\n");
        already_warned = 1;
        return;
}
```

The receiver ORs each `MSG_IO_ERROR` into the global `io_error` and forwards it
to the generator (`io.c:1702-1712`), so the bits are already visible when the
generator's late sweep runs. oc has no generator peer — the receive path is
unified — so the equivalent is to drain the reader's accumulator before the
sweep reads `stats.io_error`.

The sender emits `MSG_IO_ERROR` immediately before the phase-1 `NDX_DONE`
(`sender.c:809-817`), which the pipeline loop must consume in order to return,
so the bits are provably already accumulated at that point.

## Why a second drain rather than moving the existing one

Hoisting line ~366 above ~338 would drop bits that arrive during
`finalize_transfer`'s goodbye handshake from the exit code. `take_io_error` is
destructive and both drains OR into the same field, so the later drain still
folds in anything late without double-counting.

## Observable

Exit code is **23 either way**, so exit code cannot detect this — the surviving
destination entry is the only observable. Scope: `--delete-after` /
`--delete-delay` (`delete_pass_is_late()`), protocol >= 30, remote transfer,
a source file becoming unreadable between flist build and send, without
`--ignore-errors`.

`--delete-before` / `--delete-during` are unaffected: upstream also decides
those before the post-`send_files` message arrives.

## Test status — deliberately deferred, not forgotten

No behavioural regression test ships with this. Every remote trigger for this
gate goes through the sender's `MSG_NO_SEND` branch, and oc currently
**deadlocks** there: the receiver decodes `MSG_NO_SEND` and records the index
(`reader/multiplex.rs:730` → `handle_no_send_msg` → `no_send_indices.push`) but
`take_no_send_indices` has zero production callers, so the receiver waits for
data the sender has already declined while the sender waits for the next
request. Measured against upstream 3.5.0, which exits 23 on the same fixture.

A test written today would **hang rather than fail**, which is worse than no
test. It is tracked separately along with the shared fix — one marker-aware NDX
read that can surface the decline to its caller, mirroring upstream's
`got_flist_entry_status(FES_NO_SEND, ndx)`.

`pipelined.rs` also gained a local-path guard test in an earlier PR for the
scan-time channel (`tests/delete_io_error_gate_timing.rs`); this change covers
the distinct post-`send_files` channel.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- rebased on current master (post-#7362), replayed clean
