### PR TITLE
fix(sender): reject stray negative NDX instead of skipping it

### DIFF
--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -11,10 +11,7 @@ use std::io::{self, Read, Write};
 use std::path::Path;
 
 use logging::{debug_log, info_log};
-use protocol::codec::{
-    MonotonicNdxWriter, NDX_DEL_STATS, NDX_DONE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec,
-    create_ndx_codec,
-};
+use protocol::codec::{MonotonicNdxWriter, NDX_DEL_STATS, NDX_DONE, NdxCodec, create_ndx_codec};
 use protocol::stats::DeleteStats;
 
 use super::super::delta::{
@@ -539,11 +536,6 @@ impl GeneratorContext {
                         }
                         continue;
                     }
-                    NDX_FLIST_EOF => {
-                        // End of incremental file lists (upstream io.c:1738-1741)
-                        debug_log!(Flist, 2, "received NDX_FLIST_EOF, file list complete");
-                        continue;
-                    }
                     NDX_DEL_STATS => {
                         // Deletion statistics (upstream main.c:238-247).
                         // During dry-run the connection may drop mid-read.
@@ -563,15 +555,24 @@ impl GeneratorContext {
                         );
                         continue;
                     }
-                    _ if ndx <= NDX_FLIST_OFFSET => {
-                        // Incremental file list directory index (upstream flist.c)
-                        debug_log!(Flist, 2, "received NDX_FLIST_OFFSET {}, not supported", ndx);
-                        continue;
-                    }
+                    // upstream: rsync.c:343-353 - `if (!inc_recurse || am_sender)`
+                    // rejects EVERY remaining negative index with
+                    // "Invalid file index: %d (%d - %d) [%s]" and
+                    // exit_cleanup(RERR_PROTOCOL). The gate sits ABOVE the
+                    // NDX_FLIST_EOF branch (:354) and the sub-list branch
+                    // (:360), so for a sender those are protocol violations
+                    // too, not markers to skip: only a receiver inside the
+                    // INC_RECURSE window may grow its list from the stream.
+                    // Continuing here instead would let a peer desync this
+                    // loop silently.
                     _ => {
-                        // Unknown negative NDX - log and continue
-                        debug_log!(Flist, 1, "received unknown negative NDX value {}", ndx);
-                        continue;
+                        return Err(crate::receiver::ndx_stream::invalid_file_index(
+                            ndx,
+                            // Mirrors GoodbyeNdxSink::last_file_ndx (goodbye.rs),
+                            // upstream rsync.c:345-348.
+                            self.file_list().len() as i32 - 1,
+                            crate::receiver::ndx_stream::StreamRole::Sender,
+                        ));
                     }
                 }
             }
@@ -1887,6 +1888,82 @@ mod phase2_guard_tests {
         let mut itemize: Option<&mut dyn crate::ItemizeCallback> = None;
         ctx.run_transfer_loop(&mut reader, &mut writer, &mut progress, &mut itemize)
             .map(|_| ())
+    }
+
+    /// Every negative NDX the sender does not itself define is a protocol
+    /// violation, not a marker to skip.
+    ///
+    /// upstream: rsync.c:343-353 - the `if (!inc_recurse || am_sender)` gate
+    /// runs BEFORE the NDX_FLIST_EOF branch (:354) and the sub-list branch
+    /// (:360), so a sender rejects all three with
+    /// `exit_cleanup(RERR_PROTOCOL)`. Only a receiver inside the INC_RECURSE
+    /// window may grow its file list from the stream.
+    ///
+    /// Each case previously logged at debug level and `continue`d, so a peer
+    /// could desync this loop with no diagnostic and no exit code. The whole
+    /// suite passed either way, which is why the divergence survived.
+    fn assert_sender_rejects_negative_ndx(marker: i32, case: &str) {
+        let (_dir, mut ctx) = generator_with_one_file();
+
+        let mut ndx = MonotonicNdxWriter::new(32);
+        let mut wire = Vec::new();
+        ndx.write_ndx(&mut wire, marker).expect("write marker");
+
+        let err = drive(&mut ctx, wire).expect_err(case);
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(&format!("Invalid file index: {marker}")),
+            "{case}: expected upstream's rejection text, got {rendered}"
+        );
+    }
+
+    #[test]
+    fn sender_rejects_flist_eof_as_protocol_violation() {
+        assert_sender_rejects_negative_ndx(
+            protocol::codec::NDX_FLIST_EOF,
+            "NDX_FLIST_EOF reaches a sender only from a broken peer",
+        );
+    }
+
+    #[test]
+    fn sender_rejects_sublist_index_as_protocol_violation() {
+        // A directory sub-list request: upstream's dir_ndx encoding, which only
+        // an INC_RECURSE receiver may consume.
+        assert_sender_rejects_negative_ndx(
+            protocol::codec::NDX_FLIST_OFFSET - 3,
+            "a sub-list index reaches a sender only from a broken peer",
+        );
+    }
+
+    #[test]
+    fn sender_rejects_unknown_negative_ndx_as_protocol_violation() {
+        assert_sender_rejects_negative_ndx(-42, "unknown negative NDX");
+    }
+
+    /// Non-vacuity companion: the rejection must not swallow the one negative
+    /// marker upstream DOES handle above the gate (rsync.c:337-342), or the
+    /// fix would turn a legitimate frame into a fatal.
+    #[test]
+    fn sender_still_accepts_del_stats_then_done() {
+        let (_dir, mut ctx) = generator_with_one_file();
+
+        let mut ndx = MonotonicNdxWriter::new(32);
+        let mut wire = Vec::new();
+        ndx.write_ndx(&mut wire, protocol::codec::NDX_DEL_STATS)
+            .expect("write del stats marker");
+        protocol::DeleteStats {
+            files: 2,
+            dirs: 1,
+            symlinks: 0,
+            devices: 0,
+            specials: 0,
+        }
+        .write_to(&mut wire)
+        .expect("write del stats");
+        ndx.write_ndx_done(&mut wire).expect("write done");
+        ndx.write_ndx_done(&mut wire).expect("write done");
+
+        drive(&mut ctx, wire).expect("NDX_DEL_STATS is handled above the gate");
     }
 
     #[test]

--- a/crates/transfer/src/receiver/ndx_stream.rs
+++ b/crates/transfer/src/receiver/ndx_stream.rs
@@ -241,7 +241,7 @@ pub(crate) enum NdxFrame {
 /// `who_am_i()`. Tagged as a protocol violation so the exit-code mapper yields
 /// `RERR_PROTOCOL` (2), matching `exit_cleanup(RERR_PROTOCOL)` at
 /// `rsync.c:351`.
-fn invalid_file_index(ndx: i32, last: i32, role: StreamRole) -> io::Error {
+pub(crate) fn invalid_file_index(ndx: i32, last: i32, role: StreamRole) -> io::Error {
     protocol::protocol_violation(format!(
         "Invalid file index: {ndx} ({NDX_DONE} - {last}) {}{}",
         crate::role_trailer::error_location!(),


### PR DESCRIPTION
## Upstream

`read_ndx_and_attrs`'s read_loop (`rsync.c:329-381`) handles negative indices in a fixed order:

```c
if (ndx == NDX_DONE) return ndx;                       /* :335 */
if (ndx == NDX_DEL_STATS) { read_del_stats(f_in); ... } /* :337 */
if (!inc_recurse || am_sender) {                        /* :343  <-- the gate */
        rprintf(FERROR, "Invalid file index: %d (%d - %d) [%s]\n", ...);
        exit_cleanup(RERR_PROTOCOL);
}
if (ndx == NDX_FLIST_EOF) { ... }                       /* :354 */
/* sub-list branch */                                   /* :360 */
```

The gate is **above** the `NDX_FLIST_EOF` and sub-list branches. For a sender (`am_sender`) it is unconditional — those are not markers to skip, they are protocol violations. Only a receiver inside the INC_RECURSE window may grow its file list from the stream.

## The defect

`run_transfer_loop` is oc's `send_files` analogue (its own comments cite `sender.c:256-261`/`:267-272`, and upstream reads its NDX via the same `read_ndx_and_attrs` at `sender.c:236`). It open-coded the classifier and **failed open** on three arms:

| oc arm | oc did | upstream does |
|---|---|---|
| `NDX_FLIST_EOF` | `debug_log!` + `continue` | exit 2 |
| `_ if ndx <= NDX_FLIST_OFFSET` | `debug_log!` + `continue` | exit 2 |
| `_` (unknown negative) | `debug_log!` + `continue` | exit 2 |

A peer could desync the send loop with no diagnostic and no exit code.

## Change

The three arms collapse into one, because upstream rejects them at one site. The error comes from `ndx_stream::invalid_file_index`, which already renders upstream's exact wording and is tagged as a protocol violation → `RERR_PROTOCOL` (2), so the message keeps a single owner rather than gaining a second copy. `last` mirrors `GoodbyeNdxSink::last_file_ndx` (`rsync.c:345-348`).

`NDX_DEL_STATS` deliberately keeps its own arm — upstream drains it at `:337`, *above* the gate — as does `NDX_DONE`, which carries oc's phase-transition logic.

This is **not** a behaviour-neutral refactor: it converts three silent-continue arms into hard exits. That is the point.

## Why it survived

The full suite passed before *and* after the fix — nothing exercised these arms. That is the signature of a silent fail-open, and it is why the tests below assert the new behaviour directly rather than relying on the suite.

## Verification

- 3 rejection tests, one per arm, asserting upstream's message text.
- **RED proven**: restoring the fail-open `continue` ahead of the rejection makes all three fail.
- **Non-vacuity companion** `sender_still_accepts_del_stats_then_done`: feeds a real `NDX_DEL_STATS` frame plus its five varints and asserts the loop still completes. It passes both before and after — it exists to catch a fix that turns a legitimate frame fatal.
- `cargo nextest run -p transfer --all-features`: **2753 run, 2753 passed**
- `cargo fmt --all -- --check`: clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`: clean

## Context

This is the fourth and last open copy of the NDX classifier. The other three (`read_next_frame`, `read_ndx_skipping_del_stats`, the goodbye loop) were already collapsed onto the shared `ndx_stream` primitive by #7228 — this one was missed, and it is the only one that ever had a contract divergence rather than being a pure duplicate.
