### PR TITLE
test(daemon): gate readiness on IPv4 reachability, not any listener

### DIFF
--- a/crates/core/tests/daemon_listen_port_reachability.rs
+++ b/crates/core/tests/daemon_listen_port_reachability.rs
@@ -1,0 +1,79 @@
+//! Readiness must mean "reachable the way the client will dial", not merely
+//! "listening on that port".
+//!
+//! `spawn_daemon_on_free_port` allocates a candidate port, spawns the daemon on
+//! it, and polls `daemon_listen_port(pid)` until it reports that port. Every
+//! daemon fixture then connects to `rsync://127.0.0.1:<port>/`.
+//!
+//! On its default bind the daemon opens one socket per address family and,
+//! mirroring upstream `socket.c:463-465`, treats a per-family `bind` failure as
+//! a warning and serves on whichever families succeeded. Under parallel test
+//! load a concurrently-allocated candidate can take the IPv4 half of the port
+//! first, leaving the daemon alive and listening on IPv6 only - on the right
+//! port, yet refusing the IPv4 connection the test is about to make. A probe
+//! that reports any listening port therefore declares readiness for a daemon
+//! the client cannot reach, and the connect fails with ECONNREFUSED *after* the
+//! readiness wait succeeded - so the bounded retry that exists for exactly this
+//! race never fires.
+//!
+//! These tests pin the discriminating property directly, without a daemon: the
+//! probe reports a port only when an IPv4 loopback client could reach it. They
+//! rely on nextest's process-per-test isolation, so the only listening sockets
+//! in the process are the ones each test creates.
+
+#![cfg(any(target_os = "linux", target_os = "macos"))]
+
+use std::net::{Ipv4Addr, Ipv6Addr, TcpListener};
+
+use test_support::daemon_listen_port;
+
+/// The bug this file exists for. An IPv6-only listener holds the port but
+/// cannot serve `127.0.0.1`: the daemon sets `IPV6_V6ONLY` on every IPv6 socket
+/// it opens, so not even an IPv4-mapped connection reaches it. Reporting it
+/// would let `spawn_daemon_on_free_port` accept a daemon whose next client
+/// connection is refused.
+#[test]
+fn an_ipv6_only_listener_is_not_reported() {
+    let Ok(listener) = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)) else {
+        eprintln!("skipping: no IPv6 loopback on this host");
+        return;
+    };
+    let port = listener.local_addr().expect("local_addr").port();
+
+    assert_ne!(
+        daemon_listen_port(std::process::id()),
+        Some(port),
+        "an IPv6-only listener must not satisfy readiness: the client dials \
+         127.0.0.1 and would be refused",
+    );
+}
+
+/// Non-vacuity for the case above, and the shape that matters in practice: the
+/// daemon's default bind is the IPv4 **wildcard**, which `lsof` renders as
+/// `*:<port>` - the same text it prints for the IPv6 wildcard. If this stopped
+/// being reported, every daemon fixture would time out instead.
+#[test]
+fn a_wildcard_ipv4_listener_is_reported() {
+    let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0)).expect("bind IPv4 wildcard");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    assert_eq!(
+        daemon_listen_port(std::process::id()),
+        Some(port),
+        "a wildcard IPv4 listener serves 127.0.0.1 and must satisfy readiness",
+    );
+}
+
+/// The other reachable form: a daemon started with `--address=127.0.0.1` binds
+/// loopback explicitly rather than the wildcard.
+#[test]
+fn a_loopback_ipv4_listener_is_reported() {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind IPv4 loopback");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    assert_eq!(
+        daemon_listen_port(std::process::id()),
+        Some(port),
+        "a loopback IPv4 listener is exactly what the client dials",
+    );
+}

--- a/crates/test-support/src/daemon_port.rs
+++ b/crates/test-support/src/daemon_port.rs
@@ -7,21 +7,27 @@
 //! time-of-check / time-of-use window: between the drop and the daemon's own
 //! `bind`, a concurrently-running test can be handed the same ephemeral port.
 //!
-//! The oc-rsync daemon binds its default single listener with `SO_REUSEADDR`
-//! only (matching upstream `socket.c:447`), so such a collision is a **clean
-//! `EADDRINUSE` daemon-startup failure** - never a silent co-bind. (Only the
-//! opt-in `acceptor threads > 1` multi-acceptor daemon sets `SO_REUSEPORT`, for
-//! its own replica sockets.) That means a losing daemon simply exits, and the
-//! winner owns the port exclusively - no two daemons ever share a port and no
-//! cross-connection load-balancing is possible.
+//! The oc-rsync daemon binds its listeners with `SO_REUSEADDR` only (matching
+//! upstream `socket.c:447`), so such a collision is a **clean `EADDRINUSE` bind
+//! failure** - never a silent co-bind. (Only the opt-in `acceptor threads > 1`
+//! multi-acceptor daemon sets `SO_REUSEPORT`, for its own replica sockets.) No
+//! two daemons ever share a port and no cross-connection load-balancing is
+//! possible.
 //!
-//! [`spawn_daemon_on_free_port`] turns that into a bounded retry: allocate a
-//! candidate port, spawn the daemon on it, and confirm the spawned process
-//! itself is listening on that port (matched by pid via [`daemon_listen_port`]).
-//! If the daemon lost the bind race it exits and we retry with a fresh port.
-//! Matching by pid - rather than merely connecting to the port - is what closes
-//! the window: it never mistakes a *different* winning daemon on the same port
-//! for our own.
+//! Losing that race does **not** necessarily stop the daemon, though. On its
+//! default bind it opens one socket per address family and, mirroring upstream
+//! `socket.c:463-465`, treats a per-family failure as a warning and serves on
+//! whichever families did bind. So a daemon that loses only the IPv4 half stays
+//! alive listening on IPv6 - on the requested port, yet unreachable to a client
+//! dialling `127.0.0.1`.
+//!
+//! [`spawn_daemon_on_free_port`] therefore allocates a candidate port, spawns
+//! the daemon on it, and confirms the spawned process is listening on that port
+//! *at an address that client will actually reach* ([`daemon_listen_port`],
+//! matched by pid). A total or partial bind loss both fail that check, and the
+//! attempt retries with a fresh port. Matching by pid - rather than merely
+//! connecting to the port - is what closes the window: it never mistakes a
+//! *different* winning daemon on the same port for our own.
 
 use std::io;
 use std::net::{Ipv4Addr, TcpListener};
@@ -107,14 +113,30 @@ where
     Err(last_err.unwrap_or_else(|| io::Error::other("could not allocate a free daemon port")))
 }
 
-/// Returns the TCP port that process `pid` is listening on (loopback), or
-/// `None` if it has no `LISTEN` TCP socket yet.
+/// Whether a listener bound to `addr` can serve a client dialling
+/// `127.0.0.1` - the address every daemon test connects to.
+///
+/// Only IPv4 sockets are candidates: the daemon sets `IPV6_V6ONLY` on every
+/// IPv6 socket it opens (`daemon/sections/server_runtime/listener.rs`, keeping
+/// each family's socket independent per upstream `socket.c:447-465`), so an
+/// IPv6 listener never accepts an IPv4 connection - not even a mapped one. Of
+/// the IPv4 sockets, the wildcard and loopback addresses serve that client; a
+/// socket bound to some other interface address does not.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn serves_ipv4_loopback(addr: Ipv4Addr) -> bool {
+    addr.is_unspecified() || addr.is_loopback()
+}
+
+/// Returns the TCP port that process `pid` is listening on at an address
+/// reachable from the IPv4 loopback, or `None` if it has no such socket yet.
 ///
 /// Used by [`spawn_daemon_on_free_port`] to confirm a specific daemon process
-/// owns its port. Only the daemon's own socket table is consulted (matched by
-/// the socket inodes it owns on Linux, or scoped to the pid by `lsof` on
-/// macOS), so an unrelated process listening on loopback is never mistaken for
-/// the daemon.
+/// owns its port *and* can answer the connection the test is about to make.
+/// Only the daemon's own socket table is consulted (matched by the socket
+/// inodes it owns on Linux, or scoped to the pid by `lsof` on macOS), so an
+/// unrelated process listening on loopback is never mistaken for the daemon.
+/// A daemon that bound only its IPv6 socket is deliberately *not* reported:
+/// see [`serves_ipv4_loopback`] and this module's header.
 #[cfg(target_os = "linux")]
 #[must_use]
 pub fn daemon_listen_port(pid: u32) -> Option<u16> {
@@ -137,33 +159,56 @@ pub fn daemon_listen_port(pid: u32) -> Option<u16> {
         return None;
     }
 
-    // `/proc/<pid>/net/tcp{,6}` columns: sl local_address rem_address st ...
-    // inode. `st == 0A` is TCP_LISTEN; `local_address` is HEXIP:HEXPORT.
-    for family in ["tcp", "tcp6"] {
-        let Ok(table) = fs::read_to_string(format!("/proc/{pid}/net/{family}")) else {
+    // `/proc/<pid>/net/tcp` columns: sl local_address rem_address st ... inode.
+    // `st == 0A` is TCP_LISTEN; `local_address` is HEXIP:HEXPORT. Only the IPv4
+    // table is read - `tcp6` holds the daemon's `IPV6_V6ONLY` sockets, which
+    // cannot serve the IPv4 loopback client.
+    let table = fs::read_to_string(format!("/proc/{pid}/net/tcp")).ok()?;
+    for line in table.lines().skip(1) {
+        let cols: Vec<&str> = line.split_whitespace().collect();
+        if cols.len() < 10 || cols[3] != "0A" || !inodes.contains(cols[9]) {
+            continue;
+        }
+        let Some((addr_hex, port_hex)) = cols[1].split_once(':') else {
             continue;
         };
-        for line in table.lines().skip(1) {
-            let cols: Vec<&str> = line.split_whitespace().collect();
-            if cols.len() < 10 || cols[3] != "0A" || !inodes.contains(cols[9]) {
-                continue;
-            }
-            if let Some((_, port_hex)) = cols[1].rsplit_once(':') {
-                if let Ok(port) = u16::from_str_radix(port_hex, 16) {
-                    if port != 0 {
-                        return Some(port);
-                    }
-                }
-            }
+        let (Ok(addr), Ok(port)) = (
+            u32::from_str_radix(addr_hex, 16),
+            u16::from_str_radix(port_hex, 16),
+        ) else {
+            continue;
+        };
+        // The kernel prints `local_address` as a native-endian word holding the
+        // network-order address, so its native bytes are the address octets on
+        // either endianness.
+        if port != 0 && serves_ipv4_loopback(Ipv4Addr::from(addr.to_ne_bytes())) {
+            return Some(port);
         }
     }
     None
+}
+
+/// Parses the endpoint in an `lsof -Fn` name line for an IPv4 socket, which is
+/// either `*:<port>` (wildcard) or `<dotted quad>:<port>`.
+#[cfg(target_os = "macos")]
+fn parse_lsof_ipv4_endpoint(name: &str) -> Option<(Ipv4Addr, u16)> {
+    let (addr, port) = name.rsplit_once(':')?;
+    let addr = if addr == "*" {
+        Ipv4Addr::UNSPECIFIED
+    } else {
+        addr.parse().ok()?
+    };
+    Some((addr, port.parse().ok()?))
 }
 
 /// macOS variant backed by `lsof`, which is present by default.
 #[cfg(target_os = "macos")]
 #[must_use]
 pub fn daemon_listen_port(pid: u32) -> Option<u16> {
+    // `-Ft` emits each socket's address family (`tIPv4` / `tIPv6`) immediately
+    // before its `-Fn` name. That field is what separates the families here:
+    // lsof renders BOTH wildcard sockets as `*:<port>`, so the name alone
+    // cannot tell an IPv4 listener from an IPv6-only one.
     let output = std::process::Command::new("lsof")
         .args([
             "-nP",
@@ -172,17 +217,23 @@ pub fn daemon_listen_port(pid: u32) -> Option<u16> {
             &pid.to_string(),
             "-iTCP",
             "-sTCP:LISTEN",
-            "-Fn",
+            "-Fnt",
         ])
         .output()
         .ok()?;
+    let mut is_ipv4 = false;
     for line in String::from_utf8_lossy(&output.stdout).lines() {
-        // e.g. "n127.0.0.1:52345" or "n[::1]:52345".
-        if let Some((_, port)) = line.strip_prefix('n').and_then(|a| a.rsplit_once(':')) {
-            if let Ok(p) = port.parse::<u16>() {
-                if p != 0 {
-                    return Some(p);
-                }
+        if let Some(family) = line.strip_prefix('t') {
+            is_ipv4 = family == "IPv4";
+        } else if let Some(name) = line.strip_prefix('n') {
+            if !is_ipv4 {
+                continue;
+            }
+            let Some((addr, port)) = parse_lsof_ipv4_endpoint(name) else {
+                continue;
+            };
+            if port != 0 && serves_ipv4_loopback(addr) {
+                return Some(port);
             }
         }
     }


### PR DESCRIPTION
## Problem

A daemon fixture intermittently fails its very first client connection:

```
oc-rsync error: failed to read daemon greeting from 127.0.0.1:50342:
  Connection refused (61) (code 10) at error.rs(423) [client=0.6.4]
```

ECONNREFUSED *after* the readiness wait already succeeded. This is not
spawn-and-hope: `spawn_daemon_on_free_port` polls `daemon_listen_port(pid)`
until it reports the candidate port. The probe just answered a different
question from the one the fixture goes on to ask.

## Root cause (measured, not inferred)

`daemon_listen_port` accepted a `LISTEN` socket of **any address family**, so
"ready" did not imply "reachable by the client", which always dials
`rsync://127.0.0.1:<port>/`.

That gap is reachable because of two upstream-faithful behaviours meeting:

1. On its default bind the daemon opens **one socket per address family** and,
   mirroring `socket.c:463-465`, treats a per-family `bind` failure as a warning
   and serves on whichever families succeeded.
2. It sets `IPV6_V6ONLY` on every IPv6 socket, so an IPv6 listener never
   accepts an IPv4 connection - not even a mapped one.

`candidate_port()` reserves the port on IPv4 loopback only, so under parallel
test load a concurrently-allocated candidate can win the IPv4 half. The daemon
then stays **alive** on IPv6 only - holding the requested port, refusing the
IPv4 connect. Readiness passed, and the bounded retry that exists for exactly
this race never fired, because nothing observed the loss.

Measured on macOS by squatting `0.0.0.0:P` and starting the daemon on `P`:

```
=== daemon alive? ===       RUNNING
=== readiness probe sees === n*:54322          <- probe says "ready on 54322"
=== human ===                IPv6 ... TCP *:54322 (LISTEN)   <- IPv4 socket absent
rsync warning: IPv4 bind for 0.0.0.0:54322 failed: Address already in use
  (os error 48); continuing with remaining address families
```

The module header asserted the opposite ("a losing daemon simply exits"). That
holds for a *total* bind loss, not a partial one; the doc is corrected here.

## Fix

The daemon is upstream-correct, so the **predicate** changes, not the daemon.
`daemon_listen_port` now reports a port only when the pid owns a `LISTEN`
socket at an address an IPv4 loopback client actually reaches. A partial bind
loss now fails readiness and the pre-existing retry proceeds to a fresh port -
no new retry, no backoff, no sleep.

`serves_ipv4_loopback` is the single owner of that policy; both platform arms
decode to an `Ipv4Addr` and defer to it.

- **macOS** now reads `lsof`'s `-Ft` family field. This is load-bearing: `-Fn`
  renders *both* wildcard sockets as `*:<port>`, so the name alone cannot tell
  an IPv4 listener from an IPv6-only one.
- **Linux** reads only `/proc/<pid>/net/tcp`; `tcp6` holds the `V6ONLY` sockets,
  which cannot serve this client. The address word is decoded with
  `to_ne_bytes()`, which is correct on either endianness.

## Tests

Three cases in `crates/core/tests/`, using in-process listeners (nextest gives
process-per-test isolation, so each process owns exactly one socket).

They live in `core` deliberately: `test-support` is in **no** macOS CI cell
(`iconv` runs `-p protocol -p transfer -p engine -p core -p cli -p daemon`;
the toolchain cell runs `-p core -p engine -p cli -p metadata -p apple-fs
-p fast_io`), and the arm being fixed is macOS-specific - a unit test there
would have had zero macOS coverage.

- `an_ipv6_only_listener_is_not_reported` - the pin.
- `a_wildcard_ipv4_listener_is_reported` - the daemon's actual default shape,
  and the guard that keeps the `*:<port>` parse from regressing every fixture.
- `a_loopback_ipv4_listener_is_reported` - the `--address=127.0.0.1` shape.

**RED proven** by restoring the old family-blind scan: `3 tests run: 2 passed,
1 failed`, with the old code returning `Some(49371)` for the IPv6-only
listener. The mutation kills exactly the pin; the two positive cases survive,
so they are not passing vacuously.

## Verification

- `cargo fmt --all -- --check` clean; workspace clippy (`--all-targets
  --all-features -D warnings`) clean.
- All 10 daemon fixtures that consume the probe, plus the two root-level
  INC_RECURSE oracles and the sibling port-retry tests: **46 tests, 0 failures**.
