### PR TITLE
fix(receiver): surface MSG_NO_SEND so a declined file cannot hang the pull

### DIFF
--- a/crates/transfer/src/reader/mod.rs
+++ b/crates/transfer/src/reader/mod.rs
@@ -13,8 +13,8 @@ mod server;
 mod tests;
 
 pub(crate) use counting::CountingReader;
-pub use multiplex::RemoteExitError;
 pub(crate) use multiplex::{DeletedRender, MultiplexReader};
+pub use multiplex::{FileDeclinedError, RemoteExitError};
 pub use server::ServerReader;
 
 /// Reports whether the next `Read` call is serviceable entirely from an

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -111,8 +111,10 @@ impl DeletedRender {
 /// accumulated value via [`MultiplexReader::take_io_error`].
 ///
 /// When `MSG_NO_SEND` frames are received, the 4-byte little-endian file index
-/// is accumulated into an internal queue. Callers drain the queue via
-/// [`MultiplexReader::take_no_send_indices`].
+/// is queued and then surfaced as a [`FileDeclinedError`] from the very next
+/// read, one index per read. It cannot be delivered as a value the caller polls
+/// for: the sender writes no response for a declined file, so the read that
+/// awaits it would block forever before any poll could happen.
 ///
 /// When a `batch_recorder` is attached, all demuxed `MSG_DATA` payloads are
 /// copied to the recorder. This mirrors upstream rsync's `write_batch_monitor_in`
@@ -225,6 +227,40 @@ impl std::fmt::Display for RemoteExitError {
 }
 
 impl std::error::Error for RemoteExitError {}
+
+/// The sender declined to send a file it had already been asked for.
+///
+/// Carried as the inner error of an [`io::ErrorKind::Other`] `io::Error` so the
+/// receiver's response reader can `downcast_ref` it, retire the outstanding
+/// request, and carry on with the next file.
+///
+/// # Why this must interrupt a read rather than accumulate silently
+///
+/// The sender answers `MSG_NO_SEND` and moves straight on to the next file
+/// (`sender.c:723`, and `:669` / `:751` for the other two refusal cases), so no
+/// response for this index will ever arrive. Recording the index and continuing
+/// to wait for a frame is therefore an unconditional hang: the message is
+/// consumed *inside* the very read it needs to abort.
+///
+/// Upstream never faces this because the message lands on the generator's
+/// channel and the generator retires the entry (`io.c:1809-1818` ->
+/// `got_flist_entry_status(FES_NO_SEND, ndx)`), while its receiver is
+/// NDX-addressed and simply never awaits the file (`rsync.c:322-431`). oc fuses
+/// those two roles into one loop, so the decline has to be able to unwind an
+/// in-flight positional read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileDeclinedError {
+    /// File index the sender refused to send.
+    pub ndx: i32,
+}
+
+impl std::fmt::Display for FileDeclinedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "sender declined to send file index {}", self.ndx)
+    }
+}
+
+impl std::error::Error for FileDeclinedError {}
 
 /// Default buffer capacity for `MultiplexReader`.
 ///
@@ -361,16 +397,6 @@ impl<R> MultiplexReader<R> {
     /// - `main.c:1630-1631`: `if (got_xfer_error) _exit(RERR_PARTIAL);`
     pub(super) fn xfer_error_count(&self) -> u32 {
         self.xfer_error_count
-    }
-
-    /// Returns and drains the accumulated `MSG_NO_SEND` file indices.
-    ///
-    /// # Upstream Reference
-    ///
-    /// - `io.c:1618-1627`: `MSG_NO_SEND` handling.
-    /// - `sender.c:367-368`: sender sends `MSG_NO_SEND` when `protocol_version >= 30`.
-    pub(super) fn take_no_send_indices(&mut self) -> Vec<i32> {
-        std::mem::take(&mut self.no_send_indices)
     }
 
     /// Returns and drains the accumulated `MSG_REDO` file indices.
@@ -636,6 +662,35 @@ impl<R> MultiplexReader<R> {
     /// control frame (`MSG_IO_ERROR`/`MSG_REDO`/`MSG_NO_SEND`/`MSG_SUCCESS`) is
     /// fatal (`exit_cleanup(RERR_STREAMIO)`); oc surfaces it as an `InvalidData`
     /// error so the read loop aborts the transfer instead of dropping the frame.
+    /// Surfaces the oldest pending `MSG_NO_SEND` as an error, one file per call.
+    ///
+    /// Drains a single index rather than the whole ledger: consecutive
+    /// unreadable files produce consecutive declines, and each has to unwind
+    /// the read that awaits *that* file. Draining them together would report
+    /// the first and silently strand the rest.
+    ///
+    /// Called at the top of the read loop so an index recorded during a
+    /// previous read fires without first blocking for a frame that is not
+    /// coming.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1809-1818` - `MSG_NO_SEND` retires the entry on the generator.
+    /// - `sender.c:669,723,751` - each emitter `continue`s without a response.
+    fn check_file_declined(&mut self) -> io::Result<()> {
+        if self.no_send_indices.is_empty() {
+            return Ok(());
+        }
+        // The frame that carried this index is still staged in `buffer`. The
+        // read loop normally retires a non-data frame by overwriting it on the
+        // next `next_frame()`, so leaving the loop early has to retire it here
+        // instead: otherwise the next `read` takes the buffered-bytes shortcut
+        // and hands the caller the 4-byte MSG_NO_SEND payload AS FILE DATA.
+        self.pos = self.buffer.len();
+        let ndx = self.no_send_indices.remove(0);
+        Err(io::Error::other(FileDeclinedError { ndx }))
+    }
+
     fn check_control_msg(&self) -> io::Result<()> {
         if self.invalid_control_msg {
             return Err(io::Error::new(
@@ -806,6 +861,9 @@ impl<R: Read> MultiplexReader<R> {
         // deliverable payload until the frame completes.
         if self.frames.in_progress() || self.pos >= self.buffer.len() {
             loop {
+                // See the sibling check in `Read::read`: a declined file has no
+                // frame coming, so this must fire before blocking.
+                self.check_file_declined()?;
                 let code = self.next_frame()?;
 
                 if self.dispatch_message(code) {
@@ -898,6 +956,9 @@ impl<R: Read> Read for MultiplexReader<R> {
 
         // Loop until we get a MSG_DATA message
         loop {
+            // Checked before blocking: a file the sender already declined will
+            // never produce a frame, so waiting for one is a hang.
+            self.check_file_declined()?;
             let code = self.next_frame()?;
 
             if self.dispatch_message(code) {

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -246,30 +246,6 @@ impl<R: Read> ServerReader<R> {
         }
     }
 
-    /// Returns and drains accumulated `MSG_NO_SEND` file indices from the sender.
-    ///
-    /// When the sender cannot open a file it was asked to transfer, it sends
-    /// `MSG_NO_SEND` with the 4-byte little-endian file index (protocol >= 30).
-    /// The receiver accumulates these indices during normal reads and drains
-    /// them via this method.
-    ///
-    /// Returns an empty `Vec` for plain-mode readers.
-    ///
-    /// # Upstream Reference
-    ///
-    /// - `io.c:1618-1627`: `MSG_NO_SEND` dispatches to `got_flist_entry_status(FES_NO_SEND, val)`
-    ///   on the generator side, or forwards to the generator if on the receiver side.
-    /// - `sender.c:367-368`: sender sends `MSG_NO_SEND` for protocol >= 30 when file open fails.
-    pub fn take_no_send_indices(&mut self) -> Vec<i32> {
-        match &mut self.inner {
-            ServerReaderInner::Multiplex(mux) => mux.take_no_send_indices(),
-            ServerReaderInner::Compressed(compressed) => {
-                compressed.get_mut().take_no_send_indices()
-            }
-            ServerReaderInner::Plain(_) => Vec::new(),
-        }
-    }
-
     /// Returns and drains accumulated `MSG_REDO` file indices from the receiver.
     ///
     /// When the receiver detects a whole-file checksum failure, it sends

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -512,10 +512,18 @@ fn msg_io_error_round_trip_through_multiplex_layer() {
 }
 
 #[test]
-fn multiplex_reader_accumulates_msg_no_send() {
-    // upstream: io.c:1618-1627, sender.c:367-368
+fn multiplex_reader_surfaces_each_msg_no_send_before_the_data_after_it() {
+    // The sender emits MSG_NO_SEND and moves straight on to the next file
+    // without answering, so the decline must INTERRUPT the read that awaits
+    // that file. Recording it and continuing to wait is an unconditional hang.
+    //
+    // Consecutive declines surface one per read, in order: a receiver awaits
+    // exactly one file at a time, so draining them together would report the
+    // first and silently strand the rest.
+    //
+    // upstream: io.c:1809-1818 - MSG_NO_SEND retires the entry on the generator
+    // upstream: sender.c:669,723,751 - each emitter `continue`s, writing no response
     let mut stream = Vec::new();
-
     let ndx1: i32 = 42;
     protocol::send_msg(
         &mut stream,
@@ -523,9 +531,7 @@ fn multiplex_reader_accumulates_msg_no_send() {
         &ndx1.to_le_bytes(),
     )
     .unwrap();
-
     protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"hello").unwrap();
-
     let ndx2: i32 = 99;
     protocol::send_msg(
         &mut stream,
@@ -533,27 +539,39 @@ fn multiplex_reader_accumulates_msg_no_send() {
         &ndx2.to_le_bytes(),
     )
     .unwrap();
-
     protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"world").unwrap();
 
     let mut mux = MultiplexReader::new(Cursor::new(stream));
-
     let mut buf = [0u8; 5];
-    let n = mux.read(&mut buf).unwrap();
-    assert_eq!(n, 5);
+
+    let err = mux
+        .read(&mut buf)
+        .expect_err("the first decline must surface, not be swallowed");
+    assert_eq!(declined_ndx(&err), 42);
+
+    // The decline is consumed, so the data behind it is now deliverable.
+    assert_eq!(mux.read(&mut buf).unwrap(), 5);
     assert_eq!(&buf, b"hello");
 
-    assert_eq!(mux.no_send_indices, vec![42]);
+    let err = mux
+        .read(&mut buf)
+        .expect_err("the second decline must surface independently");
+    assert_eq!(declined_ndx(&err), 99);
 
-    let n = mux.read(&mut buf).unwrap();
-    assert_eq!(n, 5);
+    assert_eq!(mux.read(&mut buf).unwrap(), 5);
     assert_eq!(&buf, b"world");
 
-    assert_eq!(mux.no_send_indices, vec![42, 99]);
-
-    let taken = mux.take_no_send_indices();
-    assert_eq!(taken, vec![42, 99]);
+    // Each index is reported exactly once and leaves no residue behind.
     assert!(mux.no_send_indices.is_empty());
+}
+
+/// Extracts the declined file index from a surfaced `MSG_NO_SEND` error,
+/// asserting the typed inner error survives the `io::Error` wrapper.
+fn declined_ndx(err: &std::io::Error) -> i32 {
+    err.get_ref()
+        .and_then(|inner| inner.downcast_ref::<multiplex::FileDeclinedError>())
+        .expect("inner FileDeclinedError must survive the io::Error wrapper")
+        .ndx
 }
 
 #[test]
@@ -578,13 +596,9 @@ fn multiplex_reader_no_send_wrong_payload_length_aborts() {
 }
 
 #[test]
-fn server_reader_take_no_send_indices_plain_returns_empty() {
-    let mut reader = ServerReader::new_plain(Cursor::new(vec![]));
-    assert!(reader.take_no_send_indices().is_empty());
-}
-
-#[test]
-fn server_reader_take_no_send_indices_multiplex_accumulates() {
+fn server_reader_surfaces_msg_no_send_through_the_multiplex_arm() {
+    // The same contract must hold through `ServerReader`, which is the type
+    // the receiver actually reads from.
     let mut stream = Vec::new();
     let ndx: i32 = 7;
     protocol::send_msg(
@@ -600,14 +614,13 @@ fn server_reader_take_no_send_indices_multiplex_accumulates() {
         .unwrap();
 
     let mut buf = [0u8; 4];
-    let n = reader.read(&mut buf).unwrap();
-    assert_eq!(n, 4);
+    let err = reader
+        .read(&mut buf)
+        .expect_err("the decline must surface through ServerReader too");
+    assert_eq!(declined_ndx(&err), 7);
+
+    assert_eq!(reader.read(&mut buf).unwrap(), 4);
     assert_eq!(&buf, b"data");
-
-    let indices = reader.take_no_send_indices();
-    assert_eq!(indices, vec![7]);
-
-    assert!(reader.take_no_send_indices().is_empty());
 }
 
 #[test]
@@ -706,8 +719,10 @@ fn server_reader_take_redo_indices_multiplex_accumulates() {
 
 #[test]
 fn multiplex_reader_redo_and_no_send_interleaved() {
+    // A redo index is still accumulated for later collection; only the
+    // no-send decline interrupts the read, because only it means a response
+    // the caller is waiting for will never arrive.
     let mut stream = Vec::new();
-
     let redo_ndx: i32 = 3;
     protocol::send_msg(
         &mut stream,
@@ -715,7 +730,6 @@ fn multiplex_reader_redo_and_no_send_interleaved() {
         &redo_ndx.to_le_bytes(),
     )
     .unwrap();
-
     let no_send_ndx: i32 = 7;
     protocol::send_msg(
         &mut stream,
@@ -723,17 +737,17 @@ fn multiplex_reader_redo_and_no_send_interleaved() {
         &no_send_ndx.to_le_bytes(),
     )
     .unwrap();
-
     protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"x").unwrap();
 
     let mut mux = MultiplexReader::new(Cursor::new(stream));
     let mut buf = [0u8; 1];
-    let n = mux.read(&mut buf).unwrap();
-    assert_eq!(n, 1);
-    assert_eq!(&buf, b"x");
 
+    let err = mux.read(&mut buf).expect_err("the decline must surface");
+    assert_eq!(declined_ndx(&err), 7);
     assert_eq!(mux.redo_indices, vec![3]);
-    assert_eq!(mux.no_send_indices, vec![7]);
+
+    assert_eq!(mux.read(&mut buf).unwrap(), 1);
+    assert_eq!(&buf, b"x");
 }
 
 #[test]

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -28,6 +28,67 @@ use crate::transfer_ops::{
     send_file_request_xattr,
 };
 
+/// Per-file state the response handler needs for an in-flight request: the
+/// flat file-list index, destination path, the owned entry (Stage 0 clones it
+/// so the loop holds no borrow into `self.file_list`) and the generator's
+/// base iflags.
+type InFlightFile = (usize, PathBuf, FileEntry, u32);
+
+/// The receiver's in-flight request window - wire state and per-file state
+/// held as one unit.
+///
+/// [`PipelineState`] tracks the outstanding wire requests, while the response
+/// handler additionally needs an [`InFlightFile`] per request. Upstream needs
+/// no such pairing: its receiver is NDX-ADDRESSED, reading the index off the
+/// wire and then looking the file up by it (`rsync.c:322-431`), so the two can
+/// never disagree. oc's pipelined driver is instead FIFO-POSITIONAL, which
+/// makes two parallel queues a standing hazard - and a live one, because an
+/// entry can be dropped out of band when the sender declines a file
+/// (`MSG_NO_SEND`). A single missed drop does not fail loudly; it silently
+/// pairs every later response with the wrong file.
+///
+/// Owning push, pop and eviction here is what makes that unrepresentable at a
+/// call site, rather than a rule each of the three sites has to remember.
+struct InFlightRequests {
+    wire: PipelineState,
+    files: VecDeque<InFlightFile>,
+}
+
+impl InFlightRequests {
+    fn new(config: PipelineConfig) -> Self {
+        let wire = PipelineState::new(config);
+        let files = VecDeque::with_capacity(wire.window_size());
+        Self { wire, files }
+    }
+
+    fn push(&mut self, pending: crate::pipeline::PendingTransfer, file: InFlightFile) {
+        self.wire.push(pending);
+        self.files.push_back(file);
+    }
+
+    /// Removes the oldest request together with its file state.
+    fn pop(&mut self) -> Option<(crate::pipeline::PendingTransfer, InFlightFile)> {
+        let pending = self.wire.pop()?;
+        let file = self
+            .files
+            .pop_front()
+            .expect("in-flight queues are only ever pushed and popped together");
+        Some((pending, file))
+    }
+
+    fn is_empty(&self) -> bool {
+        self.wire.is_empty()
+    }
+
+    fn outstanding(&self) -> usize {
+        self.wire.outstanding()
+    }
+
+    fn available_slots(&self) -> usize {
+        self.wire.available_slots()
+    }
+}
+
 /// Result type for the pipelined transfer closure:
 /// `(files_transferred, transferred_file_size, bytes, literal, matched, redo_indices,
 /// delayed_updates)`. `transferred_file_size` mirrors upstream `receiver.c:784`
@@ -332,13 +393,11 @@ impl ReceiverContext {
         // stream), so the reader is built once and reused for the session.
         let mut token_reader = request_config.create_token_reader()?;
 
-        let mut pipeline = PipelineState::new(pipeline_config);
-        let mut file_iter = files_to_transfer.into_iter();
         // Stage 0: the in-flight window OWNS its FileEntry (cloned at push,
         // bounded to the pipeline window = O(window)), so the loop no longer
         // holds a borrow into `self.file_list`.
-        let mut pending_files_info: VecDeque<(usize, PathBuf, FileEntry, u32)> =
-            VecDeque::with_capacity(pipeline.window_size());
+        let mut pipeline = InFlightRequests::new(pipeline_config);
+        let mut file_iter = files_to_transfer.into_iter();
         let mut files_transferred = 0usize;
         // upstream: receiver.c:784 stats.total_transferred_size += F_LENGTH(file),
         // summed at the same point as files_transferred.
@@ -544,7 +603,6 @@ impl ReceiverContext {
                                     writer,
                                     &mut *ndx_write_codec,
                                     &mut pipeline,
-                                    &mut pending_files_info,
                                     file_idx,
                                     file_entry,
                                     file_path,
@@ -578,13 +636,7 @@ impl ReceiverContext {
                                 xattr_request.as_ref(),
                             )?;
 
-                            pipeline.push(pending);
-                            pending_files_info.push_back((
-                                file_idx,
-                                file_path,
-                                file_entry,
-                                base_iflags,
-                            ));
+                            pipeline.push(pending, (file_idx, file_path, file_entry, base_iflags));
                         }
                     }
                 }
@@ -600,10 +652,9 @@ impl ReceiverContext {
                 }
 
                 // Process one response from a previously flushed request.
-                let pending = pipeline.pop().expect("pipeline not empty");
+                let (pending, (file_idx, file_path, file_entry, base_iflags)) =
+                    pipeline.pop().expect("pipeline not empty");
                 flushed_pending = flushed_pending.saturating_sub(1);
-                let (file_idx, file_path, file_entry, base_iflags) =
-                    pending_files_info.pop_front().expect("pipeline not empty");
 
                 // upstream: sender.c:292-294 - a non-transfer item is logged by
                 // the sender and echoed back via write_ndx_and_attrs(); consume
@@ -632,7 +683,7 @@ impl ReceiverContext {
 
                 let xattr_list = self.resolve_xattr_list(&file_entry);
                 let is_device_target = self.config.write.write_devices && file_entry.is_device();
-                let result = process_file_response_streaming(
+                let response = process_file_response_streaming(
                     reader,
                     &mut *ndx_read_codec,
                     pending,
@@ -645,7 +696,44 @@ impl ReceiverContext {
                     is_device_target,
                     xattr_list,
                     &mut token_reader,
-                )?;
+                );
+                let result = match response {
+                    Ok(result) => result,
+                    Err(err) => {
+                        // upstream: io.c:1809-1818 - the sender declined this
+                        // file and moved on, so no response is coming. The
+                        // sender has already reported why (FERROR_XFER,
+                        // sender.c:719) and set io_error, which is what makes
+                        // the run exit 23; the receiver simply drops the file,
+                        // exactly as upstream's generator retires the entry via
+                        // got_flist_entry_status(FES_NO_SEND).
+                        let declined = err
+                            .get_ref()
+                            .and_then(|inner| {
+                                inner.downcast_ref::<crate::reader::FileDeclinedError>()
+                            })
+                            .copied();
+                        let awaited = self.flat_to_wire_ndx(file_idx);
+                        match declined {
+                            // The sender answers requests in NDX order and the
+                            // window pops in the same order, so a decline can
+                            // only ever name the file being awaited. Anything
+                            // else means the two have drifted apart.
+                            Some(d) if d.ndx == awaited => continue,
+                            Some(d) => {
+                                return Err(io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    format!(
+                                        "sender declined NDX {} while the receiver awaited NDX \
+                                         {awaited} - request stream desynchronised",
+                                        d.ndx
+                                    ),
+                                ));
+                            }
+                            None => return Err(err),
+                        }
+                    }
+                };
 
                 pipelined_receiver.note_commit_sent(
                     result.expected_checksum,
@@ -814,8 +902,7 @@ impl ReceiverContext {
         &self,
         writer: &mut W,
         ndx_write_codec: &mut impl protocol::codec::NdxCodec,
-        pipeline: &mut PipelineState,
-        pending_files_info: &mut VecDeque<(usize, PathBuf, FileEntry, u32)>,
+        pipeline: &mut InFlightRequests,
         file_idx: usize,
         file_entry: FileEntry,
         file_path: PathBuf,
@@ -824,12 +911,10 @@ impl ReceiverContext {
         let wire_ndx = self.flat_to_wire_ndx(file_idx);
         ndx_write_codec.write_ndx(&mut *writer, wire_ndx)?;
         writer.write_all(&((base_iflags & 0xFFFF) as u16).to_le_bytes())?;
-        pipeline.push(crate::pipeline::PendingTransfer::new_full_transfer(
-            wire_ndx,
-            file_path.clone(),
-            0,
-        ));
-        pending_files_info.push_back((file_idx, file_path, file_entry, base_iflags));
+        pipeline.push(
+            crate::pipeline::PendingTransfer::new_full_transfer(wire_ndx, file_path.clone(), 0),
+            (file_idx, file_path, file_entry, base_iflags),
+        );
         Ok(())
     }
 

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -48,7 +48,8 @@ use std::path::Path;
 use protocol::ProtocolVersion;
 
 use crate::reader::ServerReader;
-use crate::receiver::{SenderAttrs, SumHead};
+use crate::receiver::SumHead;
+use crate::receiver::ndx_stream::StreamRole;
 
 pub use self::request::{send_file_request, send_file_request_xattr};
 pub use self::response::process_file_response;
@@ -279,12 +280,42 @@ fn read_response_header<R: Read>(
 ) -> io::Result<ResponseHeader> {
     let expected_ndx = pending.ndx();
 
-    let (echoed_ndx, sender_attrs) = SenderAttrs::read_with_codec_xattr(
+    // upstream: rsync.c:322-431 `read_ndx_and_attrs()`. The NDX must be read
+    // through the marker-aware primitive, not the combined
+    // `read_with_codec_xattr` helper: `rsync.c:334-335` returns at `NDX_DONE`
+    // *before* consuming any attribute byte, and `NDX_DONE` is a single 0x00 at
+    // protocol >= 30. Reading the tail unconditionally would block in
+    // `read_exact` for two `iflags` bytes the peer never sends - see the note on
+    // `SenderAttrs::read_attrs_after_ndx`, which was split out for exactly this.
+    //
+    // `NoLazyFlist` keeps the previous semantics rather than widening them: its
+    // `inc_recurse()` is false, so every file-list marker stays a protocol
+    // violation via `rsync.c:343`, which is what this driver already did - it
+    // cannot consume sub-lists. `last_file_ndx` is diagnostic context for that
+    // error only; it is not a classification input.
+    let mut flist_sink =
+        crate::receiver::ndx_stream::NoLazyFlist::new(StreamRole::Receiver, expected_ndx);
+    let (echoed_ndx, sender_attrs) = crate::receiver::ndx_stream::read_ndx_and_attrs(
         reader,
         ndx_codec,
+        &mut flist_sink,
         ctx.config.preserve_xattrs,
         ctx.config.want_xattr_optim,
-    )?;
+    )?
+    .ok_or_else(|| {
+        // upstream: rsync.c:334-335 - `NDX_DONE` ends the phase. Reaching it
+        // with a transfer still outstanding means the sender dropped a file
+        // without the receiver retiring it (e.g. an unconsumed `MSG_NO_SEND`,
+        // io.c:1639 -> got_flist_entry_status(), io.c:1089). Fail loudly here
+        // rather than reading attributes that were never sent.
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "sender ended the phase (NDX_DONE) while the response for NDX {expected_ndx} \
+                 was still outstanding - protocol violation"
+            ),
+        )
+    })?;
 
     // upstream: sender.c emits responses in NDX order; out-of-order is a protocol violation.
     if echoed_ndx != expected_ndx {
@@ -356,6 +387,7 @@ struct ResponseHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::receiver::SenderAttrs;
 
     #[test]
     fn resolve_use_inplace_writes_to_destination_for_inplace() {

--- a/crates/transfer/tests/msg_no_send_unsendable_file.rs
+++ b/crates/transfer/tests/msg_no_send_unsendable_file.rs
@@ -1,0 +1,379 @@
+//! Regression coverage for `MSG_NO_SEND` on the pipelined receiver.
+//!
+//! # Background
+//!
+//! When the sender cannot open a file it has already been asked for, it does
+//! not answer the request. It emits `MSG_NO_SEND` carrying the file's index and
+//! moves on to the next file (`sender.c:723`, plus `:669` for an over-long path
+//! and `:751` for a diminished file under `--append`). Upstream's generator
+//! retires the entry on receipt (`io.c:1809-1818` ->
+//! `got_flist_entry_status(FES_NO_SEND, ndx)`), and its receiver is unaffected
+//! because it is *NDX-addressed*: it reads whatever index arrives and looks the
+//! file up by it (`rsync.c:322-431`).
+//!
+//! oc's pipelined receiver is instead *FIFO-positional* - it pops the oldest
+//! outstanding request to interpret each response. A declined file therefore
+//! has to be evicted from that window explicitly, or the request stays queued
+//! forever waiting for a reply the sender already decided not to send.
+//!
+//! # Why this matters (Rule 9)
+//!
+//! The contract is: a source file the sender cannot open is skipped, the rest
+//! of the transfer completes, and the run reports the I/O error. The failure
+//! mode this pins is not a wrong byte - it is a **hang**. Two independent
+//! defects produced it, and each alone is sufficient:
+//!
+//! 1. The response reader called the *combined* NDX+attributes helper, so on
+//!    reaching `NDX_DONE` (a single `0x00` at protocol >= 30) it blocked in
+//!    `read_exact` for two `iflags` bytes the peer never sends. Upstream
+//!    returns at that point *before* consuming any attribute byte
+//!    (`rsync.c:334-335`).
+//! 2. The `MSG_NO_SEND` ledger was decoded and accumulated but never drained,
+//!    so the declined file's request was never evicted from the in-flight
+//!    window.
+//!
+//! Because either defect alone hangs the client, the test asserts on a
+//! **bounded** run: a timeout is a failure, not an inconclusive result.
+//!
+//! # Fixture design
+//!
+//! The unreadable file is named to sort **last**. rsync transfers in sorted
+//! order, so an unreadable file sorting first would be declined while the
+//! window is still empty - the positional desync could not be observed and the
+//! test would pass vacuously against both defects. Sorting it last guarantees
+//! readable requests are outstanding when the decline arrives.
+//!
+//! # Skip semantics
+//!
+//! Self-skips when the binary or a loopback port is unavailable, and when the
+//! running user can read a mode-000 file - which is the real precondition, so
+//! it is probed behaviourally rather than inferred from a uid. A hang, a wrong
+//! exit code, or a missing readable file are real regressions.
+//!
+//! # Upstream References
+//!
+//! - `sender.c:583-585` - non-transfer items are echoed and `continue`d
+//!   *above* every `MSG_NO_SEND` emitter, so the message only ever names a
+//!   transfer item.
+//! - `sender.c:669,723,751` - the three emitters; each `continue`s without
+//!   writing a response.
+//! - `io.c:1809-1818` - `MSG_NO_SEND` -> `got_flist_entry_status(FES_NO_SEND)`.
+//! - `sender.c:668,719` - `io_error |= IOERR_GENERAL`, which is what makes the
+//!   run exit 23; the exit code travels via `MSG_IO_ERROR`, not `MSG_NO_SEND`.
+//! - `rsync.c:334-335` - `NDX_DONE` returns before any attribute byte.
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io::{self, Read};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+use tempfile::{TempDir, tempdir};
+
+/// Upper bound on the client run. The transfer moves a few kilobytes over
+/// loopback; anything approaching this is the hang under test, not slowness.
+const RUN_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Upstream `RERR_PARTIAL`: "some files could not be transferred".
+const EXIT_PARTIAL_TRANSFER: i32 = 23;
+
+/// Write an `rsyncd.conf` exposing one read-only module rooted at
+/// `module_root`. `use chroot = false` keeps the unprivileged test process from
+/// needing `CAP_SYS_CHROOT`.
+fn write_daemon_config(
+    config_path: &Path,
+    pid_path: &Path,
+    log_path: &Path,
+    module_root: &Path,
+) -> io::Result<()> {
+    let body = format!(
+        "pid file = {pid}\n\
+         log file = {log}\n\
+         use chroot = false\n\
+         max connections = 4\n\
+         \n\
+         [nosendmod]\n\
+         path = {root}\n\
+         comment = MSG_NO_SEND regression\n\
+         read only = true\n\
+         list = true\n",
+        pid = pid_path.display(),
+        log = log_path.display(),
+        root = module_root.display(),
+    );
+    fs::write(config_path, body)
+}
+
+/// Kills the daemon child on drop so a panicking test never leaks the listener.
+struct DaemonGuard {
+    child: Child,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
+}
+
+/// Run one `oc-rsync` invocation under a deadline, returning `None` if it had
+/// to be killed.
+///
+/// Both pipes are drained by dedicated threads *before* waiting. Polling
+/// `try_wait()` while output accumulates in a pipe buffer is itself a hang: the
+/// child blocks writing, the parent blocks waiting, and the deadline is the
+/// only thing that ends it - which would report the hang under test even after
+/// it is fixed.
+fn run_under_deadline(bin: &Path, args: &[&OsStr]) -> io::Result<Option<(ExitStatus, String)>> {
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdout = child.stdout.take().expect("stdout piped");
+    let mut stderr = child.stderr.take().expect("stderr piped");
+    let out_reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout.read_to_string(&mut buf);
+        buf
+    });
+    let err_reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stderr.read_to_string(&mut buf);
+        buf
+    });
+
+    let deadline = Instant::now() + RUN_TIMEOUT;
+    let status = loop {
+        match child.try_wait()? {
+            Some(status) => break Some(status),
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    };
+
+    let combined = format!(
+        "{}{}",
+        out_reader.join().unwrap_or_default(),
+        err_reader.join().unwrap_or_default()
+    );
+    Ok(status.map(|s| (s, combined)))
+}
+
+/// Per-test scratch state.
+struct Scratch {
+    _tmp: TempDir,
+    root: PathBuf,
+    config: PathBuf,
+    log: PathBuf,
+    pid: PathBuf,
+}
+
+impl Scratch {
+    fn new() -> Option<Self> {
+        let tmp = tempdir().ok()?;
+        let root = tmp.path().to_path_buf();
+        Some(Self {
+            config: root.join("rsyncd.conf"),
+            log: root.join("rsyncd.log"),
+            pid: root.join("rsyncd.pid"),
+            root,
+            _tmp: tmp,
+        })
+    }
+}
+
+/// Whether this user is subject to file permissions at all.
+///
+/// Probed rather than derived from a uid: root reads a mode-000 file happily,
+/// and so does any user holding `CAP_DAC_OVERRIDE`. The precondition the
+/// fixture needs is exactly "opening this file fails", so that is what is
+/// measured.
+fn mode_000_is_unreadable(probe: &Path) -> bool {
+    fs::write(probe, b"probe").is_ok()
+        && fs::set_permissions(probe, fs::Permissions::from_mode(0o000)).is_ok()
+        && fs::File::open(probe).is_err()
+}
+
+/// The three source names. `zz_unreadable.bin` sorts last so that requests for
+/// the readable files are still outstanding when the decline arrives - see the
+/// fixture note in the module docs.
+const READABLE: [&str; 2] = ["a_first.bin", "b_second.bin"];
+const UNREADABLE: &str = "zz_unreadable.bin";
+
+/// Seed the module root. Every file gets a distinct size so a quick-check
+/// cannot skip it on a re-run.
+fn seed_module(module_root: &Path) {
+    fs::create_dir_all(module_root).expect("create module root");
+    for (i, name) in READABLE.iter().enumerate() {
+        let body: Vec<u8> = (0..(4096 + i * 512)).map(|b| (b % 251) as u8).collect();
+        fs::write(module_root.join(name), &body).expect("seed readable source");
+    }
+    let body: Vec<u8> = (0..8192).map(|b| (b % 241) as u8).collect();
+    fs::write(module_root.join(UNREADABLE), &body).expect("seed unreadable source");
+}
+
+fn pull_args<'a>(src: &'a OsStr, dest: &'a OsStr) -> Vec<&'a OsStr> {
+    vec![OsStr::new("--recursive"), OsStr::new("--times"), src, dest]
+}
+
+/// A source file the sender cannot open must be skipped, the rest of the
+/// transfer must complete, and the run must report the I/O error - not hang.
+#[test]
+fn daemon_pull_skips_a_file_the_sender_cannot_open() {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(scratch) = Scratch::new() else {
+        eprintln!("skipping: tempdir allocation failed");
+        return;
+    };
+
+    if !mode_000_is_unreadable(&scratch.root.join("perm_probe")) {
+        eprintln!("skipping: this user can read a mode-000 file (root or CAP_DAC_OVERRIDE)");
+        return;
+    }
+
+    let module_root = scratch.root.join("source");
+    let dest_dir = scratch.root.join("dest");
+    seed_module(&module_root);
+    fs::set_permissions(
+        module_root.join(UNREADABLE),
+        fs::Permissions::from_mode(0o000),
+    )
+    .expect("make source unreadable");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+
+    write_daemon_config(&scratch.config, &scratch.pid, &scratch.log, &module_root)
+        .expect("write daemon config");
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return;
+        }
+    };
+
+    let src = OsString::from(format!("rsync://127.0.0.1:{port}/nosendmod/"));
+    let mut dest_arg = dest_dir.clone().into_os_string();
+    dest_arg.push("/");
+    let args = pull_args(&src, &dest_arg);
+
+    let outcome = run_under_deadline(&oc_bin, &args).expect("spawn client");
+
+    // The primary assertion. Before the fix the client blocked forever: either
+    // in `read_exact` on NDX_DONE, or waiting on a response for the declined
+    // file that the sender never sends.
+    let Some((status, output)) = outcome else {
+        panic!(
+            "client did not exit within {RUN_TIMEOUT:?} - the receiver is waiting on a response \
+             the sender declined to send (MSG_NO_SEND)"
+        );
+    };
+
+    assert_eq!(
+        status.code(),
+        Some(EXIT_PARTIAL_TRANSFER),
+        "unreadable source must exit {EXIT_PARTIAL_TRANSFER} (RERR_PARTIAL); output:\n{output}"
+    );
+
+    // The readable files must still arrive: a skip must cost exactly the one
+    // file, not the remainder of the transfer.
+    for name in READABLE {
+        let landed = dest_dir.join(name);
+        assert!(
+            landed.is_file(),
+            "readable source {name} must still transfer after the skip; output:\n{output}"
+        );
+        assert_eq!(
+            fs::read(&landed).expect("read transferred file").len(),
+            fs::metadata(module_root.join(name))
+                .expect("stat source")
+                .len() as usize,
+            "{name} transferred with the wrong length"
+        );
+    }
+
+    assert!(
+        !dest_dir.join(UNREADABLE).exists(),
+        "the file the sender could not open must not be created at the destination; \
+         output:\n{output}"
+    );
+}
+
+/// Non-vacuity companion: the identical fixture with every file readable must
+/// transfer all three and exit 0.
+///
+/// Without this, the pin above would also pass if the module were simply
+/// unreachable, the daemon refused every file, or the fixture could not
+/// transfer anything at all.
+#[test]
+fn daemon_pull_transfers_every_file_when_all_are_readable() {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(scratch) = Scratch::new() else {
+        eprintln!("skipping: tempdir allocation failed");
+        return;
+    };
+
+    let module_root = scratch.root.join("source");
+    let dest_dir = scratch.root.join("dest");
+    seed_module(&module_root);
+    fs::create_dir_all(&dest_dir).expect("create dest");
+
+    write_daemon_config(&scratch.config, &scratch.pid, &scratch.log, &module_root)
+        .expect("write daemon config");
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return;
+        }
+    };
+
+    let src = OsString::from(format!("rsync://127.0.0.1:{port}/nosendmod/"));
+    let mut dest_arg = dest_dir.clone().into_os_string();
+    dest_arg.push("/");
+    let args = pull_args(&src, &dest_arg);
+
+    let outcome = run_under_deadline(&oc_bin, &args).expect("spawn client");
+    let Some((status, output)) = outcome else {
+        panic!("client did not exit within {RUN_TIMEOUT:?} on the all-readable fixture");
+    };
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "all-readable fixture must exit 0; output:\n{output}"
+    );
+    for name in READABLE.iter().chain(std::iter::once(&UNREADABLE)) {
+        assert!(
+            dest_dir.join(name).is_file(),
+            "{name} must transfer when readable; output:\n{output}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

A source file the sender cannot open hangs the pull. Measured against a
loopback daemon, three files, one of them mode-000:

```
receiving incremental file list
a_first.bin
b_second.bin
rsync: [sender] send_files failed to open "zz_unreadable.bin" (in nosendmod): Permission denied (13)
<client never exits>
```

The two readable files transfer, the sender reports the failure, and the
client then blocks forever. A stack sample puts it in `read_ndx_step` ->
`ModernNdxCodec::read_ndx` -> `read_exact` on the socket: waiting for a
response the sender already decided not to write.

## Root cause

`MSG_NO_SEND` was decoded and pushed onto `no_send_indices`, and nothing
ever read it - `take_no_send_indices` had zero production callers.

Upstream does not hit this. The message lands on the **generator's** channel
and the generator retires the entry (`io.c:1809-1818` ->
`got_flist_entry_status(FES_NO_SEND, ndx)`), while upstream's receiver is
**NDX-addressed**: it reads whichever index arrives and looks the file up by
it (`rsync.c:322-431`). It never positionally awaits a file that was
dropped. oc's pipelined driver fuses both roles into one loop and is
**FIFO-positional**, so a decline has to unwind an in-flight read.

**Polling the ledger cannot work.** The `MSG_NO_SEND` frame is consumed
*inside* the very read that needs to abort, so a check placed around that
read always runs while the ledger is still empty. That is why this is
surfaced as a value returned *from* the read rather than one the caller asks
for afterwards.

## Fix

`MSG_NO_SEND` becomes a first-class read outcome: a typed
`FileDeclinedError` carrying the index, one per read, checked at the top of
the frame loop so an already-queued decline fires without blocking first.
The receiver drops that file and continues. The exit code is untouched - it
still comes from `io_error |= IOERR_GENERAL` on the sender
(`sender.c:668`, `:719`) travelling via `MSG_IO_ERROR`, which is what makes
the run exit 23.

Retiring the frame on the early-exit path is load-bearing, and the test
caught it: the loop normally discards a non-data frame by overwriting it on
the next `next_frame()`, so leaving early must discard it explicitly.
Without that, the next read takes the buffered-bytes shortcut and returns
the **4-byte `MSG_NO_SEND` payload as file data** - silent corruption. The
unit test asserts the byte count and fails (`left: 4, right: 5`) if the
retire is dropped.

`take_no_send_indices` is removed with its `ServerReader` wrapper; it has no
possible production caller under the new contract.

### Supporting changes

- **`read_response_header` routes through the tested `ndx_stream`
  primitive** instead of the combined NDX+attributes helper, mapping
  `NDX_DONE` to a typed error. `rsync.c:334-335` returns at `NDX_DONE`
  *before* consuming any attribute byte, so the combined call blocks for two
  `iflags` bytes the peer never sends. (Closes the `A3a` receiver-epic item.)
- **The in-flight window is now one owner.** It was two parallel FIFOs
  popped by two adjacent `.expect()` calls and pushed from two sites - a
  standing desync hazard on a path where entries can be dropped out of band.

## Upstream invariant relied on

`sender.c:583-585` gates non-transfer items into `write_ndx_and_attrs` +
`continue` **above** all three `MSG_NO_SEND` emitters, so the message can
only ever name a *transfer* item. The non-transfer echo arm therefore needs
no decline handling.

## Tests

`crates/transfer/tests/msg_no_send_unsendable_file.rs` (new, `#![cfg(unix)]`):

- `daemon_pull_skips_a_file_the_sender_cannot_open` - the pin. Bounded run:
  a timeout is a failure, not an inconclusive result. Asserts exit 23, both
  readable files landed at the right length, the unreadable one absent.
- `daemon_pull_transfers_every_file_when_all_are_readable` - non-vacuity
  companion. Without it the pin would also pass if the module were simply
  unreachable or the fixture could transfer nothing.

Fixture notes that must survive any rewrite: the unreadable file sorts
**last**, because one sorting first would be declined while the window is
empty and the positional desync could not be observed. Root /
`CAP_DAC_OVERRIDE` is detected **behaviourally** (can this user open a
mode-000 file?) rather than inferred from a uid. The deadline runner drains
both pipes on dedicated threads before waiting - polling `try_wait()` while
a pipe fills is itself a hang.

Three reader unit tests that pinned the old accumulate-and-poll contract now
pin the surfacing contract.

## Mutation results

- **M2** (remove both surfacing call sites): kills the integration pin -
  it hangs to the 60s deadline - **and** the three reader unit tests
  instantly. Both halves proven.
- **M3** (drop the frame-retire line): kills
  `multiplex_reader_surfaces_each_msg_no_send_before_the_data_after_it` with
  `left: 4, right: 5`. Found organically - the test caught the defect during
  development.
- **M1** (revert the `read_response_header` routing): **does NOT kill the
  pin.** Stated plainly rather than left to look proven: the live block in
  this scenario is the NDX read, not the attribute read, so that change
  rests on upstream fidelity (`rsync.c:334-335`) and on routing the site
  onto the already-tested primitive - not on this test. The primitive itself
  carries 10 existing tests.

## Verification

`cargo fmt --all -- --check` clean; `cargo clippy -p transfer --all-targets
--all-features -D warnings` clean. `cargo nextest run -p transfer
--all-features --no-fail-fast`: **2757 run, 2757 passed, 3 skipped** (counts
reconcile - no truncated kill list).
