### PR TITLE
fix(filters): accept the `x` dir-merge modifier without inheriting XATTR

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
@@ -108,7 +108,7 @@ pub(super) fn split_short_merge_modifiers(text: &str) -> Result<(&str, &str), In
     scan_modifiers(text, |ch| {
         matches!(
             ch.to_ascii_lowercase(),
-            '+' | '-' | 'c' | 'w' | 's' | 'r' | 'p' | '/' | 'e' | 'n'
+            '+' | '-' | 'c' | 'w' | 's' | 'r' | 'p' | '/' | 'e' | 'n' | 'x'
         )
     })
 }

--- a/crates/cli/src/frontend/filter_rules/parsing/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/merge.rs
@@ -104,6 +104,13 @@ pub(crate) fn parse_merge_modifiers(
             '/' => {
                 options = options.anchor_root(true);
             }
+            // upstream: exclude.c:1438 - `x` carries no guard and is legal on
+            // every prefix, `.` and `:` included. It is consumed and then
+            // deliberately dropped: FILTRULES_FROM_CONTAINER (exclude.c:1229)
+            // is ABS_PATH|INCLUDE|DIRECTORY|NEGATE|PERISHABLE, so XATTR is NOT
+            // inherited by the merged rules. Marking the container xattr-only
+            // would silently turn every rule in the file into an xattr rule.
+            'x' => {}
             _ => {
                 let message = rsync_error!(
                     1,
@@ -317,7 +324,9 @@ mod tests {
 
     #[test]
     fn parse_merge_modifiers_unknown() {
-        let result = parse_merge_modifiers("x", ":x file", true);
+        // `z` is outside upstream's modifier set `- + / ! C e n p r s w x`
+        // (exclude.c:1381-1441); `x` is in it and must parse.
+        let result = parse_merge_modifiers("z", ":z file", true);
         assert!(result.is_err());
     }
 

--- a/crates/cli/src/frontend/tests/parse_filter.rs
+++ b/crates/cli/src/frontend/tests/parse_filter.rs
@@ -322,7 +322,9 @@ fn parse_filter_directive_accepts_merge_anchor_and_whitespace_modifiers() {
 
 #[test]
 fn parse_filter_directive_rejects_merge_with_unknown_modifier() {
-    let error = parse_filter_directive(OsStr::new("merge,x rules"))
+    // `z` is outside upstream's modifier set `- + / ! C e n p r s w x`
+    // (exclude.c:1381-1441); `x` is in it and must parse.
+    let error = parse_filter_directive(OsStr::new("merge,z rules"))
         .expect_err("merge with unsupported modifier should error");
     let rendered = error.to_string();
     assert!(rendered.contains("uses unsupported modifier"));

--- a/crates/cli/tests/dir_merge_x_modifier.rs
+++ b/crates/cli/tests/dir_merge_x_modifier.rs
@@ -1,0 +1,149 @@
+//! The `x` filter modifier is legal on a dir-merge prefix and does not make the
+//! merged rules xattr rules.
+//!
+//! Upstream's modifier loop is `- + / ! C e n p r s w x`. Most arms open with a
+//! `goto invalid` guard restricting them to certain rule kinds; exactly three -
+//! `/`, `p` and `x` - have none:
+//!
+//! ```c
+//! case 'x':
+//!         rule->rflags |= FILTRULE_XATTR;
+//!         saw_xattr_filter = 1;
+//!         break;
+//! ```
+//!
+//! (`exclude.c:1438`). Nothing restricts it to a rule prefix, so `:x FILE` and
+//! `.x FILE` parse exactly like `: FILE` and `. FILE` plus the XATTR bit on the
+//! *container* rule.
+//!
+//! The bit is deliberately not inherited by the rules read out of the merged
+//! file. Upstream computes what a container passes down as
+//!
+//! ```c
+//! #define FILTRULES_FROM_CONTAINER (FILTRULE_ABS_PATH | FILTRULE_INCLUDE \
+//!                                 | FILTRULE_DIRECTORY | FILTRULE_NEGATE \
+//!                                 | FILTRULE_PERISHABLE)
+//! ```
+//!
+//! (`exclude.c:1229`) - `FILTRULE_XATTR` is absent. Propagating it would turn
+//! every rule in the merged file into an xattr rule, which matches attribute
+//! names rather than paths, so a `- FOO` inside the file would stop excluding
+//! the file `FOO`.
+//!
+//! Both expectations below were captured from rsync 3.5.0 run over the same
+//! trees: `.rules KEEP` for the flat fixture (with and without the `x`) and
+//! `.rules .rules2 KEEP` for the nested one, each at exit 0.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+use test_support::oc_rsync_bin;
+
+/// Source tree whose `.rules` is itself the rule file: `- FOO`.
+///
+/// Reached through a `--filter` directive, so this fixture exercises the
+/// command-line filter parser.
+fn flat_tree() -> TempDir {
+    let tmp = new_tree();
+    fs::write(tmp.path().join("src/.rules"), b"- FOO\n").expect("rule file");
+    tmp
+}
+
+/// Source tree whose `.rules` carries its own `:x` dir-merge directive.
+///
+/// The `x` therefore appears in the *contents* of a merged file rather than on
+/// the command line, which is a separate parser from the one `flat_tree`
+/// reaches.
+fn nested_tree() -> TempDir {
+    let tmp = new_tree();
+    fs::write(tmp.path().join("src/.rules"), b":x .rules2\n").expect("outer rule file");
+    fs::write(tmp.path().join("src/.rules2"), b"- FOO\n").expect("inner rule file");
+    tmp
+}
+
+/// `src/` holding the file the rules exclude plus one they do not, and `dst/`.
+///
+/// `KEEP` is what makes the assertions non-vacuous: without it an empty
+/// destination would satisfy every expectation below, including the one where
+/// the client fails to start at all.
+fn new_tree() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join("src")).expect("source root");
+    fs::create_dir_all(tmp.path().join("dst")).expect("destination root");
+    fs::write(tmp.path().join("src/FOO"), b"foo\n").expect("excluded file");
+    fs::write(tmp.path().join("src/KEEP"), b"keep\n").expect("retained file");
+    tmp
+}
+
+/// Runs `oc-rsync -r --filter=<rule> src/ dst/` and returns the exit code with
+/// the sorted destination listing.
+///
+/// The exit code is returned alongside the listing because the listing alone
+/// cannot tell a working exclusion from a client that refused to parse the
+/// rule - both leave `FOO` out of the destination.
+fn transfer(root: &Path, filter: &str) -> (i32, Vec<String>) {
+    let mut source = root.join("src").into_os_string();
+    source.push("/");
+    let mut destination = root.join("dst").into_os_string();
+    destination.push("/");
+
+    let status = Command::new(oc_rsync_bin())
+        .arg("-r")
+        .arg(format!("--filter={filter}"))
+        .arg(source)
+        .arg(destination)
+        .status()
+        .expect("run oc-rsync");
+
+    let mut entries: Vec<String> = fs::read_dir(root.join("dst"))
+        .expect("read destination")
+        .map(|entry| {
+            entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    entries.sort();
+
+    (status.code().expect("exit code"), entries)
+}
+
+#[test]
+fn directive_x_modifier_is_accepted_and_merges_the_named_file() {
+    let tmp = flat_tree();
+    assert_eq!(
+        transfer(tmp.path(), ":x .rules"),
+        (0, vec![".rules".to_string(), "KEEP".to_string()]),
+    );
+}
+
+#[test]
+fn directive_x_modifier_does_not_change_what_the_merged_rules_match() {
+    let with_x = flat_tree();
+    let without_x = flat_tree();
+    assert_eq!(
+        transfer(with_x.path(), ":x .rules"),
+        transfer(without_x.path(), ": .rules"),
+        "FILTRULES_FROM_CONTAINER omits XATTR, so `x` must not reach the merged rules",
+    );
+}
+
+#[test]
+fn nested_x_modifier_is_accepted_inside_a_merged_file() {
+    let tmp = nested_tree();
+    assert_eq!(
+        transfer(tmp.path(), ": .rules"),
+        (
+            0,
+            vec![
+                ".rules".to_string(),
+                ".rules2".to_string(),
+                "KEEP".to_string(),
+            ],
+        ),
+    );
+}

--- a/crates/engine/src/local_copy/dir_merge/parse/modifiers.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/modifiers.rs
@@ -75,7 +75,10 @@ pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (
         }
 
         let lower = ch.to_ascii_lowercase();
-        let base_modifier = matches!(lower, '+' | '-' | 'c' | 'w' | 's' | 'r' | 'p' | '/');
+        // upstream: exclude.c:1438 - `x` is unguarded and legal on every
+        // prefix, so it must be consumed here or it terminates the scan and the
+        // remainder is misread as the merge filename.
+        let base_modifier = matches!(lower, '+' | '-' | 'c' | 'w' | 's' | 'r' | 'p' | '/' | 'x');
         let extended_modifier = matches!(lower, 'e' | 'n');
 
         if base_modifier || (allow_extended && extended_modifier) {
@@ -215,6 +218,13 @@ pub(super) fn parse_merge_modifiers(
                     return Err(FilterParseError::new(message));
                 }
             }
+            // upstream: exclude.c:1438 - `x` carries no guard and is legal on
+            // every prefix. Consumed and then deliberately dropped:
+            // FILTRULES_FROM_CONTAINER (exclude.c:1229) is
+            // ABS_PATH|INCLUDE|DIRECTORY|NEGATE|PERISHABLE, so XATTR is NOT
+            // inherited by the merged rules - marking the container xattr-only
+            // would silently turn every rule in the file into an xattr rule.
+            'x' => {}
             _ => {
                 let message = format!(
                     "{label} directive '{directive}' uses unsupported modifier '{modifier}'"
@@ -477,7 +487,9 @@ mod tests {
 
         #[test]
         fn unknown_modifier_is_error() {
-            let result = parse_merge_modifiers("x", ".", true);
+            // `z` is outside upstream's modifier set `- + / ! C e n p r s w x`
+            // (exclude.c:1381-1441); `x` is in it and must parse.
+            let result = parse_merge_modifiers("z", ".", true);
             assert!(result.is_err());
         }
 


### PR DESCRIPTION
## Problem

`:x .rules` and `.x .rules` do not work. Measured against rsync 3.5.0 on the
same tree (`src/` holding `FOO`, `KEEP` and a `.rules` reading `- FOO`):

| | upstream 3.5.0 | oc before |
|---|---|---|
| `--filter=':x .rules'` | `.rules KEEP`, exit 0 | **exit 1**, `invalid modifier 'x' at position 1` |
| `.rules` containing `:x .rules2` | `.rules .rules2 KEEP`, exit 0 | **`.rules .rules2 FOO KEEP`, exit 0** |

The second row is the dangerous one: no error, exit 0, and a file upstream
excludes lands in the destination. The modifier is eaten into the filename, so
the merge reads a file that does not exist and the rules inside it never apply.

## Root cause

Upstream's modifier table is `- + / ! C e n p r s w x`. Most arms open with a
`goto invalid` guard restricting them to certain rule kinds; exactly three -
`/`, `p` and `x` - have none:

```c
case 'x':
        rule->rflags |= FILTRULE_XATTR;
        saw_xattr_filter = 1;
        break;
```

(`exclude.c:1381-1441`). Nothing restricts it to a rule prefix, so it is legal on
every prefix including the two dir-merge prefixes `.` and `:`. oc rejected it
in two of its filter parsers - the CLI directive parser and the engine's
merge-file-contents parser - which are the two that see a dir-merge prefix.

## Fix

Accept `x` at both parsers, and deliberately **do not propagate** it into the
merged rules. Upstream computes what a container hands down as

```c
#define FILTRULES_FROM_CONTAINER (FILTRULE_ABS_PATH | FILTRULE_INCLUDE \
                                | FILTRULE_DIRECTORY | FILTRULE_NEGATE \
                                | FILTRULE_PERISHABLE)
```

(`exclude.c:1229`) - `FILTRULE_XATTR` is absent from that set. Propagating it
would turn every rule in the merged file into an xattr rule, which matches
attribute names rather than paths, so the `- FOO` inside the file would stop
excluding the file `FOO`. That is why both new arms are `'x' => {}` with the
citation on them rather than a flag assignment: the modifier must be
*consumed* so it stops corrupting the filename, and *dropped* so it stops
there.

## Tests

`crates/cli/tests/dir_merge_x_modifier.rs`, three cases run against the real
binary, each asserting **exit code and destination listing together**.

Asserting the listing alone would not have worked. An empty destination
satisfies both "the exclusion works" and "the client refused to parse the
rule", which is why every fixture also carries a `KEEP` file that must arrive,
and why the exit code is part of the compared tuple.

- `directive_x_modifier_is_accepted_and_merges_the_named_file` - the flat
  fixture, reaching the CLI parser.
- `nested_x_modifier_is_accepted_inside_a_merged_file` - `.rules` carrying its
  own `:x .rules2`, so the `x` appears in the *contents* of a merged file and
  reaches the engine parser. A flat fixture cannot exercise this half.
- `directive_x_modifier_does_not_change_what_the_merged_rules_match` -
  compares `:x .rules` against `: .rules` and requires them equal. This is the
  `FILTRULES_FROM_CONTAINER` claim stated as a test; it fails if the XATTR bit
  is ever inherited.

Expectations were captured from rsync 3.5.0 run over the same trees, not
derived from oc's own output.

## Mutation results

Each half is killed only by its own fixture, which is what proves neither edit
is decoration:

- **Revert the CLI half** - both CLI tests fail, `left: (1, [])` vs
  `right: (0, [".rules", "KEEP"])`. Killed by the exit code.
- **Revert the engine half** - only the nested test fails,
  `left: (0, [".rules", ".rules2", "FOO", "KEEP"])` vs
  `right: (0, [".rules", ".rules2", "KEEP"])`. Exit code is 0 on both sides,
  so this one is killed by the listing alone.

Both assertion components are therefore load-bearing, each for a different
half.

## Collateral

Three existing unit tests used `x` as their sample "unknown modifier" and so
encoded the bug. They now use `z`, which is outside upstream's set; the
"unknown modifiers are rejected" contract they were written for (PR #7361) is
unchanged.

## Scope

This is the dir-merge half only. `x` is also over-rejected on other rule types
by other parsers; those need the `--filter` short-form routing and the
Protect/Risk mapping to move together, so they are deliberately not folded in
here - shipping the acceptance without that mapping would make a Protect rule
panic in debug and a Risk rule silently deny where upstream allows.
