### PR TITLE
fix(filters): accept the `x` modifier on hide/show/protect/risk rules

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
@@ -1,4 +1,4 @@
-use core::client::{FilterRuleKind, FilterRuleSpec};
+use core::client::FilterRuleSpec;
 use core::message::{Message, Role};
 use core::rsync_error;
 
@@ -103,7 +103,6 @@ pub(super) fn parse_rule_modifiers(
 pub(super) fn apply_rule_modifiers(
     mut rule: FilterRuleSpec,
     modifiers: RuleModifierState,
-    directive: &str,
 ) -> Result<FilterRuleSpec, Message> {
     if modifiers.anchor_root {
         rule = rule.with_anchor();
@@ -125,24 +124,14 @@ pub(super) fn apply_rule_modifiers(
         rule = rule.with_negate(true);
     }
 
+    // upstream: exclude.c:1438 - `case 'x': rule->rflags |= FILTRULE_XATTR;`.
+    // The modifier sets one bit and touches nothing else; in particular it does
+    // not bind a side. `+`/`-` already default to both sides, so forcing them
+    // here was a no-op there while silently erasing the one-sided semantics of
+    // the H/S/P/R prefixes (hide/show/protect/risk), which exist precisely to
+    // express a side (exclude.c:1345-1358).
     if modifiers.xattr_only {
-        if !matches!(
-            rule.kind(),
-            FilterRuleKind::Include | FilterRuleKind::Exclude
-        ) {
-            let message = rsync_error!(
-                1,
-                format!(
-                    "filter rule '{directive}' cannot combine 'x' modifiers with this directive"
-                )
-            )
-            .with_role(Role::Client);
-            return Err(message);
-        }
-        rule = rule
-            .with_xattr_only(true)
-            .with_sender(true)
-            .with_receiver(true);
+        rule = rule.with_xattr_only(true);
     }
 
     Ok(rule)
@@ -287,7 +276,7 @@ mod tests {
             xattr_only: false,
             negate: false,
         };
-        let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
+        let result = apply_rule_modifiers(rule, modifiers).expect("apply");
         assert!(result.pattern().starts_with('/'));
     }
 
@@ -302,7 +291,7 @@ mod tests {
             xattr_only: false,
             negate: false,
         };
-        let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
+        let result = apply_rule_modifiers(rule, modifiers).expect("apply");
         assert!(result.applies_to_sender());
     }
 
@@ -317,7 +306,7 @@ mod tests {
             xattr_only: false,
             negate: false,
         };
-        let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
+        let result = apply_rule_modifiers(rule, modifiers).expect("apply");
         assert!(result.applies_to_receiver());
     }
 
@@ -332,7 +321,7 @@ mod tests {
             xattr_only: false,
             negate: false,
         };
-        let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
+        let result = apply_rule_modifiers(rule, modifiers).expect("apply");
         assert!(result.is_perishable());
     }
 
@@ -347,7 +336,7 @@ mod tests {
             xattr_only: true,
             negate: false,
         };
-        let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
+        let result = apply_rule_modifiers(rule, modifiers).expect("apply");
         assert!(result.is_xattr_only());
         assert!(result.applies_to_sender());
         assert!(result.applies_to_receiver());
@@ -364,12 +353,17 @@ mod tests {
             xattr_only: true,
             negate: false,
         };
-        let result = apply_rule_modifiers(rule, modifiers, "-").expect("apply");
+        let result = apply_rule_modifiers(rule, modifiers).expect("apply");
         assert!(result.is_xattr_only());
     }
 
     #[test]
-    fn apply_rule_modifiers_xattr_only_for_non_include_exclude_fails() {
+    fn xattr_modifier_keeps_a_protect_rule_receiver_only() {
+        // upstream: exclude.c:1355-1357 - `P` sets FILTRULE_RECEIVER_SIDE, and
+        // :1438 `case 'x'` sets only FILTRULE_XATTR. The two are independent, so
+        // `Px` stays receiver-only. Forcing both sides here would erase exactly
+        // the distinction the `P` prefix exists to express, and upstream
+        // ACCEPTS `Px` (measured against rsync 3.5.0: exit 0).
         let rule = FilterRuleSpec::protect("*.rs".to_owned());
         let modifiers = RuleModifierState {
             anchor_root: false,
@@ -379,8 +373,15 @@ mod tests {
             xattr_only: true,
             negate: false,
         };
-        let result = apply_rule_modifiers(rule, modifiers, "P");
-        assert!(result.is_err());
+        let result = apply_rule_modifiers(rule, modifiers).expect("upstream accepts `Px`");
+        assert!(
+            result.is_xattr_only(),
+            "the x modifier must set the xattr bit"
+        );
+        assert!(
+            !result.applies_to_sender() && result.applies_to_receiver(),
+            "P binds receiver-only; the x modifier must not widen it"
+        );
     }
 
     #[test]
@@ -394,7 +395,7 @@ mod tests {
             xattr_only: false,
             negate: true,
         };
-        let result = apply_rule_modifiers(rule, modifiers, "-").expect("apply");
+        let result = apply_rule_modifiers(rule, modifiers).expect("apply");
         assert!(result.is_negated());
     }
 
@@ -402,7 +403,7 @@ mod tests {
     fn apply_rule_modifiers_empty_state() {
         let rule = FilterRuleSpec::include("*.rs".to_owned());
         let modifiers = RuleModifierState::default();
-        let result = apply_rule_modifiers(rule.clone(), modifiers, "+").expect("apply");
+        let result = apply_rule_modifiers(rule.clone(), modifiers).expect("apply");
         assert_eq!(result.pattern(), rule.pattern());
     }
 }

--- a/crates/cli/src/frontend/filter_rules/parsing/rules.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/rules.rs
@@ -103,7 +103,7 @@ pub(super) fn parse_short_include_rule(
     }
 
     let rule = builder(pattern.to_owned());
-    let rule = match apply_rule_modifiers(rule, modifiers, trimmed) {
+    let rule = match apply_rule_modifiers(rule, modifiers) {
         Ok(rule) => rule,
         Err(error) => return Some(Err(error)),
     };
@@ -142,7 +142,7 @@ pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Messa
             prefix_specifies_side,
         )?;
         let rule = builder(pattern.to_owned());
-        let rule = apply_rule_modifiers(rule, modifiers, trimmed)?;
+        let rule = apply_rule_modifiers(rule, modifiers)?;
         Ok(FilterDirective::Rule(rule))
     };
 
@@ -166,19 +166,19 @@ pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Messa
     // prefixes that set prefix_specifies_side, so `s`/`r` are invalid while `p`
     // (perishable) stays valid.
     if keyword == "show" {
-        return build_rule(FilterRuleSpec::show, true, false, true);
+        return build_rule(FilterRuleSpec::show, true, true, true);
     }
 
     if keyword == "hide" {
-        return build_rule(FilterRuleSpec::hide, true, false, true);
+        return build_rule(FilterRuleSpec::hide, true, true, true);
     }
 
     if keyword == "protect" {
-        return build_rule(FilterRuleSpec::protect, true, false, true);
+        return build_rule(FilterRuleSpec::protect, true, true, true);
     }
 
     if keyword == "risk" {
-        return build_rule(FilterRuleSpec::risk, true, false, true);
+        return build_rule(FilterRuleSpec::risk, true, true, true);
     }
 
     let message = rsync_error!(

--- a/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
@@ -3,7 +3,8 @@ use core::message::{Message, Role};
 use core::rsync_error;
 
 use super::super::directive::FilterDirective;
-use super::helpers::consume_rule_separator;
+use super::helpers::split_short_rule_modifiers;
+use super::modifiers::{apply_rule_modifiers, parse_rule_modifiers};
 
 /// Parses a single-character rule prefix (`short`) followed by a separator and
 /// a pattern, building the rule via `builder`. Returns `None` when `short` does
@@ -33,22 +34,36 @@ pub(super) fn parse_filter_shorthand(
         return Some(Err(message));
     }
 
-    if !remainder
-        .chars()
-        .next()
-        .is_some_and(|ch| ch.is_ascii_whitespace() || ch == '_')
-    {
-        return None;
-    }
+    // upstream: exclude.c:1330-1445 - the modifier loop runs for EVERY rule
+    // prefix, `H`/`S`/`P`/`R` included, so these accept a modifier run before
+    // the separator exactly as `+`/`-` do. Character validity is left to
+    // `parse_rule_modifiers`, matching `split_short_rule_modifiers`' contract,
+    // so an unknown letter reports "invalid modifier" rather than falling
+    // through to the unrelated "unsupported filter rule" diagnostic.
+    let (modifier_text, pattern) = match split_short_rule_modifiers(remainder) {
+        Ok(split) => split,
+        Err(invalid) => return Some(Err(invalid.into_message(short.len_utf8(), trimmed))),
+    };
 
-    let pattern = consume_rule_separator(remainder);
+    // `prefix_specifies_side = true`: H/S/P/R already bind a side, so upstream
+    // rejects a redundant `s`/`r` modifier on them (exclude.c:1423-1432) while
+    // leaving `p` and `x` unguarded (exclude.c:1421, :1438).
+    let modifiers = match parse_rule_modifiers(modifier_text, trimmed, true, true, true) {
+        Ok(state) => state,
+        Err(error) => return Some(Err(error)),
+    };
+
     if pattern.is_empty() {
         let text = format!("filter rule '{trimmed}' is missing a pattern after '{label}'");
         let message = rsync_error!(1, text).with_role(Role::Client);
         return Some(Err(message));
     }
 
-    Some(Ok(FilterDirective::Rule(builder(pattern.to_owned()))))
+    let rule = builder(pattern.to_owned());
+    match apply_rule_modifiers(rule, modifiers) {
+        Ok(rule) => Some(Ok(FilterDirective::Rule(rule))),
+        Err(error) => Some(Err(error)),
+    }
 }
 
 #[cfg(test)]
@@ -66,9 +81,18 @@ mod tests {
     }
 
     #[test]
-    fn returns_none_without_separator() {
+    fn no_separator_reports_an_invalid_modifier() {
+        // MEASURED against rsync 3.5.0: `Ppattern` -> "invalid modifier 'a' at
+        // position 2". With no separator the whole remainder is scanned as
+        // modifiers (helpers.rs scan_modifiers, upstream exclude.c:1214-1287),
+        // so the first non-modifier byte is reported - it is NOT an unknown
+        // rule, and it must not fall through to the keyword parser.
         let result = parse_filter_shorthand("epattern", 'e', "exclude", mock_builder);
-        assert!(result.is_none());
+        assert!(
+            result
+                .expect("prefix matched, so the parser must not decline")
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/cli/src/frontend/tests/parse_filter.rs
+++ b/crates/cli/src/frontend/tests/parse_filter.rs
@@ -254,16 +254,45 @@ fn parse_filter_directive_accepts_xattr_only_rules() {
 }
 
 #[test]
-fn parse_filter_directive_rejects_xattr_on_unsupported_keywords() {
-    let protect_error =
-        parse_filter_directive(OsStr::new("protect,x secrets")).expect_err("protect,x should fail");
-    let rendered = protect_error.to_string();
-    assert!(rendered.contains("uses unsupported modifier 'x'"));
+fn parse_filter_directive_accepts_xattr_on_side_bound_rules_keeping_the_side() {
+    // MEASURED against rsync 3.5.0: `protect,x`, `show,x`, `Px`, `Sx` all exit 0.
+    // upstream: exclude.c:1438 `case 'x'` carries no guard, so it is legal on every
+    // prefix, and :1345-1358 shows H/S/P/R are nothing but (include|exclude) x
+    // (sender|receiver) - the `x` bit is orthogonal and must not widen the side.
+    let protect = parse_filter_directive(OsStr::new("protect,x secrets"))
+        .expect("upstream accepts protect,x");
+    assert_eq!(
+        protect,
+        FilterDirective::Rule(FilterRuleSpec::protect("secrets".to_owned()).with_xattr_only(true))
+    );
 
-    let show_error =
-        parse_filter_directive(OsStr::new("show,x meta")).expect_err("show,x should fail");
-    let rendered = show_error.to_string();
-    assert!(rendered.contains("uses unsupported modifier 'x'"));
+    let show = parse_filter_directive(OsStr::new("show,x meta")).expect("upstream accepts show,x");
+    assert_eq!(
+        show,
+        FilterDirective::Rule(FilterRuleSpec::show("meta".to_owned()).with_xattr_only(true))
+    );
+
+    // The single-letter forms must agree with their long spellings; upstream
+    // erases the distinction before transmission (exclude.c:1824-1881
+    // get_rule_prefix never emits H/S/P/R).
+    assert_eq!(
+        parse_filter_directive(OsStr::new("Px secrets")).expect("upstream accepts Px"),
+        parse_filter_directive(OsStr::new("protect,x secrets")).expect("long form"),
+    );
+    assert_eq!(
+        parse_filter_directive(OsStr::new("Sx meta")).expect("upstream accepts Sx"),
+        parse_filter_directive(OsStr::new("show,x meta")).expect("long form"),
+    );
+}
+
+#[test]
+fn parse_filter_directive_still_rejects_a_redundant_side_modifier() {
+    // Non-vacuity companion: `x` became legal on these rules, but `s`/`r` must
+    // stay rejected because the prefix already binds the side
+    // (upstream exclude.c:1423-1432, measured: `Ps user.a` exits 1).
+    let error = parse_filter_directive(OsStr::new("Ps secrets"))
+        .expect_err("s is redundant once P binds the side");
+    assert!(error.to_string().contains("unsupported modifier 's'"));
 }
 
 #[test]

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -20,6 +20,7 @@ pub(crate) use clear::apply_clear_rule;
 use pattern::{compile_patterns, normalise_pattern};
 pub(crate) use rule::CompiledRule;
 pub(crate) use xattr::CompiledXattrRule;
+pub use xattr::XattrSide;
 
 impl CompiledRule {
     /// Compiles a [`FilterRule`] into optimised glob matchers.

--- a/crates/filters/src/compiled/xattr.rs
+++ b/crates/filters/src/compiled/xattr.rs
@@ -14,6 +14,25 @@ use std::path::Path;
 use super::pattern::{CompiledPattern, compile_patterns};
 use crate::{FilterAction, FilterError, FilterRule};
 
+/// Which end of the transfer is consulting the xattr chain.
+///
+/// This is upstream's `am_sender`. Upstream expresses the same distinction
+/// indirectly: `send_rules()` stamps each rule's `elide` field from its side
+/// flags and `am_sender` (exclude.c:1903-1911), and `rule_matches()` then skips
+/// any rule whose `elide` equals `cur_elide_value` (exclude.c:1010). Working
+/// the four combinations through, that reduces to one rule - a side-flagged
+/// rule participates only on its own side - which is what this enum selects.
+/// The `LOCAL_RULE`/`REMOTE_RULE` encoding exists upstream because `elide` also
+/// doubles as "do not transmit this rule to the peer" (exclude.c:1913); oc has
+/// no such double duty here, so the side is named directly.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum XattrSide {
+    /// Upstream's `am_sender != 0`: the file-list builder reading source xattrs.
+    Sender,
+    /// Upstream's `am_sender == 0`: the generator and every receiver-side read.
+    Receiver,
+}
+
 /// A compiled `x`-modifier filter rule matched against xattr names only.
 ///
 /// Only include/exclude actions carry meaning for xattr-name filtering; the
@@ -24,6 +43,12 @@ pub(crate) struct CompiledXattrRule {
     action: FilterAction,
     matchers: Vec<CompiledPattern>,
     negate: bool,
+    /// Mirrors `FILTRULE_SENDER_SIDE` / `FILTRULE_RECEIVER_SIDE`. A rule with
+    /// no side prefix carries both, so it participates on either end exactly as
+    /// an unflagged upstream rule does (its `elide` stays 0, which never equals
+    /// `cur_elide_value`).
+    applies_to_sender: bool,
+    applies_to_receiver: bool,
 }
 
 impl CompiledXattrRule {
@@ -47,12 +72,26 @@ impl CompiledXattrRule {
             action: rule.action,
             matchers,
             negate: rule.negate,
+            applies_to_sender: rule.applies_to_sender,
+            applies_to_receiver: rule.applies_to_receiver,
         })
     }
 
     /// Returns the rule's action, used to resolve the first-match-wins decision.
     pub(crate) const fn action(&self) -> FilterAction {
         self.action
+    }
+
+    /// Whether this rule participates on `side`.
+    ///
+    /// upstream: exclude.c:1010 - `if (!*name || ex->elide == cur_elide_value)
+    /// return 0;`. A rule carrying the opposite side's flag is elided before
+    /// its pattern is ever consulted.
+    pub(crate) const fn applies_to(&self, side: XattrSide) -> bool {
+        match side {
+            XattrSide::Sender => self.applies_to_sender,
+            XattrSide::Receiver => self.applies_to_receiver,
+        }
     }
 
     /// Tests whether `name` matches this rule, honouring the `!` negate modifier.

--- a/crates/filters/src/compiled/xattr.rs
+++ b/crates/filters/src/compiled/xattr.rs
@@ -33,11 +33,41 @@ pub enum XattrSide {
     Receiver,
 }
 
+/// Resolves a rule's action to the include/exclude decision upstream stores.
+///
+/// upstream: exclude.c:1345-1358 - the four side-bound prefixes are nothing but
+/// (include|exclude) x (sender|receiver) bit pairs:
+///
+/// | prefix    | upstream rflags                     | decision |
+/// |-----------|-------------------------------------|----------|
+/// | `S`/show  | `FILTRULE_INCLUDE\|SENDER_SIDE`     | include  |
+/// | `H`/hide  | `FILTRULE_SENDER_SIDE`              | exclude  |
+/// | `R`/risk  | `FILTRULE_INCLUDE\|RECEIVER_SIDE`   | include  |
+/// | `P`/protect | `FILTRULE_RECEIVER_SIDE`          | exclude  |
+///
+/// There is no distinct protect/risk *action* upstream. oc models the two
+/// receiver-side spellings as their own [`FilterAction`] variants because its
+/// delete pass needs them separable on the PATH chain, and that stays as it is;
+/// but an xattr name is never deleted, so on this chain the extra variants have
+/// no meaning and must collapse back onto upstream's two-value decision. Doing
+/// otherwise drops the rule: `protect,x user.drop` would parse and then match
+/// nothing, which is the silent-no-op shape this chain exists to avoid.
+const fn xattr_decision(action: FilterAction) -> Option<FilterAction> {
+    match action {
+        FilterAction::Include | FilterAction::Risk => Some(FilterAction::Include),
+        FilterAction::Exclude | FilterAction::Protect => Some(FilterAction::Exclude),
+        // Meta actions carry no xattr decision. `!`/clear is handled by the
+        // set's clear pass, and the merge prefixes consume `x` and drop it
+        // (upstream: exclude.c:1229 FILTRULES_FROM_CONTAINER omits XATTR), so
+        // no merge rule can reach here carrying the flag.
+        FilterAction::Clear | FilterAction::Merge | FilterAction::DirMerge => None,
+    }
+}
+
 /// A compiled `x`-modifier filter rule matched against xattr names only.
 ///
-/// Only include/exclude actions carry meaning for xattr-name filtering; the
-/// deletion (protect/risk) and meta (clear/merge) actions never reach this list
-/// because upstream's xattr filter dispatch is a plain include/exclude decision.
+/// The action is normalised to include/exclude on construction via
+/// [`xattr_decision`]; the meta (clear/merge) actions never reach this list.
 #[derive(Debug)]
 pub(crate) struct CompiledXattrRule {
     action: FilterAction,
@@ -60,21 +90,26 @@ impl CompiledXattrRule {
     /// rules (via [`compile_patterns`]) is used so wildcard semantics stay in
     /// lockstep with the path chain.
     ///
+    /// Returns `Ok(None)` for a meta action, which carries no xattr decision.
+    ///
     /// # Errors
     ///
     /// Returns [`FilterError`] if the pattern is not a valid glob.
-    pub(crate) fn new(rule: FilterRule) -> Result<Self, FilterError> {
+    pub(crate) fn new(rule: FilterRule) -> Result<Option<Self>, FilterError> {
         debug_assert!(rule.xattr_only, "non-xattr rule compiled as xattr rule");
+        let Some(action) = xattr_decision(rule.action) else {
+            return Ok(None);
+        };
         let mut patterns = std::collections::HashSet::with_capacity(1);
         patterns.insert(rule.pattern.clone());
         let matchers = compile_patterns(patterns, false)?;
-        Ok(Self {
-            action: rule.action,
+        Ok(Some(Self {
+            action,
             matchers,
             negate: rule.negate,
             applies_to_sender: rule.applies_to_sender,
             applies_to_receiver: rule.applies_to_receiver,
-        })
+        }))
     }
 
     /// Returns the rule's action, used to resolve the first-match-wins decision.

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -4,7 +4,7 @@ use logging::debug_log;
 
 use crate::{
     FilterAction,
-    compiled::{CompiledRule, CompiledXattrRule},
+    compiled::{CompiledRule, CompiledXattrRule, XattrSide},
 };
 
 /// Internal rule storage shared by [`FilterSet`](crate::FilterSet) instances.
@@ -32,8 +32,15 @@ impl FilterSetInner {
     /// rule's include/exclude verdict; with no match the name is included by
     /// default. Mirrors upstream `exclude.c:name_is_excluded(name,
     /// NAME_IS_XATTR, ALL_FILTERS)` consulted from `xattrs.c:250`.
-    pub(crate) fn xattr_name_allowed(&self, name: &str) -> bool {
+    pub(crate) fn xattr_name_allowed(&self, name: &str, side: XattrSide) -> bool {
         for rule in &self.xattr {
+            // Side elision precedes the pattern test, as upstream's
+            // `ex->elide == cur_elide_value` guard precedes the match body
+            // (exclude.c:1010). A `P`/`H`-prefixed xattr rule must not decide
+            // anything on the end it does not name.
+            if !rule.applies_to(side) {
+                continue;
+            }
             if rule.matches(name) {
                 return matches!(rule.action(), FilterAction::Include);
             }

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -129,6 +129,7 @@ pub use apple_double::{
 pub use chain::{DirFilterGuard, DirMergeConfig, FilterChain, FilterChainError};
 pub use clean_fname::collapse_dot_dot_dirs;
 pub use clear_token::{ClearToken, classify_clear_token};
+pub use compiled::XattrSide;
 pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -16,6 +16,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::compiled::XattrSide;
 use crate::{
     FilterAction, FilterError, FilterRule, MergeFileError,
     apple_double::default_patterns as apple_double_default_patterns,
@@ -176,8 +177,8 @@ impl FilterSet {
     /// `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)` (exclude.c:914,
     /// consulted from xattrs.c:250).
     #[must_use]
-    pub fn xattr_name_allowed(&self, name: &str) -> bool {
-        self.inner.xattr_name_allowed(name)
+    pub fn xattr_name_allowed(&self, name: &str, side: XattrSide) -> bool {
+        self.inner.xattr_name_allowed(name, side)
     }
 
     /// Returns `true` if the path should be included in the transfer.
@@ -838,9 +839,9 @@ mod tests {
 
         assert!(set.has_xattr_rules());
         // The named xattr is excluded...
-        assert!(!set.xattr_name_allowed("user.foo"));
+        assert!(!set.xattr_name_allowed("user.foo", XattrSide::Receiver));
         // ...while an unrelated xattr name is still allowed (default include).
-        assert!(set.xattr_name_allowed("user.bar"));
+        assert!(set.xattr_name_allowed("user.bar", XattrSide::Receiver));
         // ...and the rule must NOT leak into path matching: a *file* called
         // "user.foo" is unaffected by the xattr-only rule.
         assert!(set.allows(Path::new("user.foo"), false));
@@ -856,8 +857,8 @@ mod tests {
         ])
         .unwrap();
 
-        assert!(set.xattr_name_allowed("user.keep"));
-        assert!(!set.xattr_name_allowed("user.drop"));
+        assert!(set.xattr_name_allowed("user.keep", XattrSide::Receiver));
+        assert!(!set.xattr_name_allowed("user.drop", XattrSide::Receiver));
     }
 
     /// upstream: exclude.c:914 - a rule WITHOUT the `x` modifier never
@@ -870,7 +871,7 @@ mod tests {
         // The plain rule excludes the *file* path "user.foo"...
         assert!(!set.allows(Path::new("user.foo"), false));
         // ...but leaves the xattr NAME "user.foo" allowed - no `x` modifier.
-        assert!(set.xattr_name_allowed("user.foo"));
+        assert!(set.xattr_name_allowed("user.foo", XattrSide::Receiver));
     }
 
     /// An empty set (or one with only path rules) allows every xattr name and
@@ -880,6 +881,6 @@ mod tests {
     fn xattr_name_allowed_defaults_to_true() {
         let set = FilterSet::default();
         assert!(!set.has_xattr_rules());
-        assert!(set.xattr_name_allowed("user.anything"));
+        assert!(set.xattr_name_allowed("user.anything", XattrSide::Receiver));
     }
 }

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -102,8 +102,12 @@ impl FilterSet {
             // chain instead of dropping it so `--filter='-x user.foo'` can be
             // honoured by xattr-name matching (upstream: xattrs.c:250).
             if rule.is_xattr_only() {
-                if matches!(rule.action, FilterAction::Include | FilterAction::Exclude) {
-                    xattr.push(CompiledXattrRule::new(rule)?);
+                // `CompiledXattrRule` owns which actions carry an xattr
+                // decision: the four side-bound spellings all collapse onto
+                // upstream's include/exclude pair (exclude.c:1345-1358), and a
+                // meta action yields None.
+                if let Some(compiled) = CompiledXattrRule::new(rule)? {
+                    xattr.push(compiled);
                 }
                 continue;
             }

--- a/crates/filters/tests/edge_cases.rs
+++ b/crates/filters/tests/edge_cases.rs
@@ -6,6 +6,7 @@
 //!
 //! Reference: rsync 3.4.1 exclude.c for pattern handling edge cases.
 
+use filters::XattrSide;
 use filters::{FilterAction, FilterRule, FilterSet};
 use std::path::Path;
 
@@ -522,8 +523,8 @@ fn xattr_only_rules_apply_to_names_not_paths() {
     // The xattr-only rule does not affect file (path) matching...
     assert!(set.allows(Path::new("file.xattr"), false));
     // ...but it does exclude a matching xattr NAME.
-    assert!(!set.xattr_name_allowed("user.xattr"));
-    assert!(set.xattr_name_allowed("user.keep"));
+    assert!(!set.xattr_name_allowed("user.xattr", XattrSide::Receiver));
+    assert!(set.xattr_name_allowed("user.keep", XattrSide::Receiver));
 }
 
 /// Verifies Unicode patterns.

--- a/crates/filters/tests/edge_cases.rs
+++ b/crates/filters/tests/edge_cases.rs
@@ -527,6 +527,49 @@ fn xattr_only_rules_apply_to_names_not_paths() {
     assert!(set.xattr_name_allowed("user.keep", XattrSide::Receiver));
 }
 
+/// Verifies a side-flagged xattr rule participates only on its own side.
+///
+/// upstream: exclude.c:1903-1912 send_rules() stamps `elide` from the rule's
+/// side flags and `am_sender`; exclude.c:1010 rule_matches() then returns 0 for
+/// any rule whose `elide` equals `cur_elide_value`, two lines before the
+/// NAME_IS_XATTR test at :1013. So the side is decided BEFORE the pattern is
+/// consulted, and `hide,x` (SENDER_SIDE, exclude.c:1349) must be inert on the
+/// receiver while `protect,x` (RECEIVER_SIDE, :1357) is inert on the sender.
+#[test]
+fn side_flagged_xattr_rules_participate_only_on_their_own_side() {
+    let hide = FilterRule::hide("user.sender").with_xattr_only(true);
+    let protect = FilterRule::protect("user.receiver").with_xattr_only(true);
+    let set = FilterSet::from_rules([hide, protect]).unwrap();
+
+    // `hide` carries SENDER_SIDE: it excludes on the sender and is elided on
+    // the receiver, where the name must survive.
+    assert!(!set.xattr_name_allowed("user.sender", XattrSide::Sender));
+    assert!(set.xattr_name_allowed("user.sender", XattrSide::Receiver));
+
+    // `protect` carries RECEIVER_SIDE: the mirror image.
+    assert!(!set.xattr_name_allowed("user.receiver", XattrSide::Receiver));
+    assert!(set.xattr_name_allowed("user.receiver", XattrSide::Sender));
+}
+
+/// Non-vacuity companion to the side test: an unflagged rule keeps both sides.
+///
+/// Without this, dropping the side dimension entirely - making every rule apply
+/// everywhere - would still leave a passing suite for the unflagged case, and
+/// the side test above could not be distinguished from a broken matcher that
+/// simply never matches anything.
+///
+/// upstream: exclude.c:1903-1912 - a rule with neither side flag never has
+/// `elide` assigned, so it stays 0, which never equals `cur_elide_value`
+/// (`LOCAL_RULE` = 1 / `REMOTE_RULE` = 2, exclude.c:180).
+#[test]
+fn an_unflagged_xattr_rule_participates_on_both_sides() {
+    let rule = FilterRule::exclude("user.both").with_xattr_only(true);
+    let set = FilterSet::from_rules([rule]).unwrap();
+
+    assert!(!set.xattr_name_allowed("user.both", XattrSide::Sender));
+    assert!(!set.xattr_name_allowed("user.both", XattrSide::Receiver));
+}
+
 /// Verifies Unicode patterns.
 #[test]
 fn unicode_patterns() {

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -185,7 +185,9 @@ fn apply_metadata_acls_and_xattrs(
 
     // upstream: xattrs.c:set_xattr() - apply xattrs after metadata and ACLs
     if let Some(xattr_list) = xattr_list {
-        let filter = xattr_filter.map(|set| move |name: &str| set.xattr_name_allowed(name));
+        let filter = xattr_filter.map(|set| {
+            move |name: &str| set.xattr_name_allowed(name, filters::XattrSide::Receiver)
+        });
         let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
         // upstream: rsync_xal_set(fname, ..., fnamecmp) resolves an abbreviated
         // value against the basis file - the pre-transfer destination, which

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -349,8 +349,9 @@ impl GeneratorContext {
                 // Follow symlinks only for non-symlink entries (lgetxattr for symlinks)
                 let follow = !file_type.is_symlink();
                 let xattr_filter = self.xattr_name_filter();
-                let predicate =
-                    xattr_filter.map(|set| move |name: &str| set.xattr_name_allowed(name));
+                let predicate = xattr_filter.map(|set| {
+                    move |name: &str| set.xattr_name_allowed(name, filters::XattrSide::Sender)
+                });
                 let opts = metadata::XattrSendOptions {
                     role: metadata::XattrRole::Sender,
                     follow_symlinks: follow,

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -515,9 +515,9 @@ impl ReceiverContext {
                 }
                 // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
                 if let Some(ref xattr_list) = xattr_list {
-                    let filter = xattr_filter
-                        .as_ref()
-                        .map(|set| move |name: &str| set.xattr_name_allowed(name));
+                    let filter = xattr_filter.as_ref().map(|set| {
+                        move |name: &str| set.xattr_name_allowed(name, filters::XattrSide::Receiver)
+                    });
                     let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
                     // upstream: rsync_xal_set resolves an abbreviated value
                     // against fnamecmp; a directory is its own basis.
@@ -885,9 +885,9 @@ impl ReceiverContext {
             }
         } else if let Some(ref xattr_list) = self.resolve_xattr_list(entry) {
             // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
-            let filter = self
-                .xattr_name_filter()
-                .map(|set| move |name: &str| set.xattr_name_allowed(name));
+            let filter = self.xattr_name_filter().map(|set| {
+                move |name: &str| set.xattr_name_allowed(name, filters::XattrSide::Receiver)
+            });
             let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
             // upstream: rsync_xal_set resolves an abbreviated value against
             // fnamecmp; a directory is its own basis.

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -956,9 +956,9 @@ impl ReceiverContext {
         // screens names through the same `x`-modifier rules the sender applied
         // to its side. Without it an excluded name survives on the destination
         // list alone and flips the itemize `x` column upstream leaves clear.
-        let filter = self
-            .xattr_name_filter()
-            .map(|set| move |name: &str| set.xattr_name_allowed(name));
+        let filter = self.xattr_name_filter().map(|set| {
+            move |name: &str| set.xattr_name_allowed(name, filters::XattrSide::Receiver)
+        });
         let opts = self.generator_xattr_opts(filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool));
         let sender = self.resolve_xattr_list(entry).unwrap_or_default();
         match path {
@@ -1041,9 +1041,9 @@ impl ReceiverContext {
             return None;
         }
 
-        let filter = self
-            .xattr_name_filter()
-            .map(|set| move |name: &str| set.xattr_name_allowed(name));
+        let filter = self.xattr_name_filter().map(|set| {
+            move |name: &str| set.xattr_name_allowed(name, filters::XattrSide::Receiver)
+        });
         let opts = self.generator_xattr_opts(filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool));
 
         // upstream: xattrs.c:967 get_xattr_data(fnamecmp, ...) - the diff reads
@@ -1283,9 +1283,9 @@ impl ReceiverContext {
         // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
         if has_xattrs {
             if let Some(ref xattr_list) = self.resolve_xattr_list(entry) {
-                let filter = self
-                    .xattr_name_filter()
-                    .map(|set| move |name: &str| set.xattr_name_allowed(name));
+                let filter = self.xattr_name_filter().map(|set| {
+                    move |name: &str| set.xattr_name_allowed(name, filters::XattrSide::Receiver)
+                });
                 let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
                 // upstream: rsync_xal_set resolves an abbreviated value against
                 // fnamecmp; the file is its own basis for the in-place case.

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -554,9 +554,9 @@ impl ReceiverContext {
                 metadata_errors.push((file_path.clone(), meta_err.to_string()));
             } else if let Some(ref xattr_list) = self.resolve_xattr_list(file_entry) {
                 // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
-                let filter = self
-                    .xattr_name_filter()
-                    .map(|set| move |name: &str| set.xattr_name_allowed(name));
+                let filter = self.xattr_name_filter().map(|set| {
+                    move |name: &str| set.xattr_name_allowed(name, filters::XattrSide::Receiver)
+                });
                 let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
                 // upstream: rsync_xal_set resolves an abbreviated value against
                 // fnamecmp; the file is its own basis for the in-place case.


### PR DESCRIPTION
## Problem

`--filter='protect,x user.drop'` and its seven siblings did not work. Measured
against rsync 3.5.0 on identical trees, oc rejected the `x` modifier on all
four side-bound rule spellings, in both their keyword and single-letter forms:

| filter rule | upstream 3.5.0 | oc before |
|---|---|---|
| `protect,x user.drop` / `Px user.drop` | accepted, exit 0 | **exit 1**, `unsupported modifier 'x'` |
| `risk,x` / `Rx`, `hide,x` / `Hx`, `show,x` / `Sx` | accepted, exit 0 | **exit 1** |

And behind the parser sat a second defect that would have made a fix inert:
even once accepted, a `protect,x` rule was **dropped on the floor** by the
filter-set compiler. It would have parsed cleanly, exited 0, and matched
nothing.

## What upstream does

There is no protect/risk *action* in rsync. `exclude.c:1345-1358` encodes all
four side-bound prefixes as (include|exclude) x (sender|receiver) bit pairs on
a single rule type:

```
S / show    = FILTRULE_INCLUDE | FILTRULE_SENDER_SIDE
H / hide    = FILTRULE_SENDER_SIDE
R / risk    = FILTRULE_INCLUDE | FILTRULE_RECEIVER_SIDE
P / protect = FILTRULE_RECEIVER_SIDE
```

The modifier loop (`exclude.c:1330-1445`) runs for **every** rule prefix. Its
full set is `- + / ! C e n p r s w x`, and exactly three arms carry no
`goto invalid` guard restricting them to particular prefixes: `/`, `p`, and
`x`. The `x` arm is one line:

```c
case 'x':
        rule->rflags |= FILTRULE_XATTR;
        saw_xattr_filter = 1;
        break;
```

(`exclude.c:1438`.) It binds no side. By contrast `s` and `r` **are** guarded
(`exclude.c:1423-1432`) - they are refused when an H/S/P/R prefix has already
set `prefix_specifies_side`. That asymmetry is the whole rule: `x` is legal
everywhere, a redundant side modifier is not.

The side itself is decided *before* the pattern is consulted. `send_rules()`
stamps each rule's `elide` from its side flags and `am_sender`
(`exclude.c:1903-1912`); `rule_matches()` then returns 0 for any rule whose
`elide` equals `cur_elide_value` (`exclude.c:1010`) - two lines above the
`NAME_IS_XATTR` biconditional at `:1013`. Worked through, that reduces to one
sentence: **a side-flagged rule participates only on its own side.**

## Fix

Three commits, each a separate concern.

**1. `refactor(filters)` - give xattr rules the side dimension.** The xattr
chain had no notion of which end was asking, so it could not express the
`elide` rule at all. Adds `XattrSide::{Sender, Receiver}` (upstream's
`am_sender`), threads it through `xattr_name_allowed`, and elides by side
*before* testing the pattern, mirroring the order in `rule_matches`. Eight
production call sites threaded: one Sender (the file-list builder, which
already carried `XattrRole::Sender` citing `xattrs.c:237`), seven Receiver.
Behaviour-neutral on its own - nothing could yet spell a one-sided xattr rule.

**2. `fix(filters)` - accept `x` on the four spellings.** The CLI parser held
a guard-plus-clobber that both rejected `x` on side-bound rules and, on the
paths where it did run, forced the rule back to both-sides. That collapses to
upstream's single line. `+`/`-` already default to both sides, so the clobber
was a no-op there while silently erasing the one-sided semantics that H/S/P/R
exist to express. The short-form parser gained the modifier scan it was
missing - it previously looked for a bare separator, so `Px user.drop` never
reached the modifier loop at all.

**3. `fix(filters)` - resolve the actions.** `xattr_decision` collapses
Protect -> Exclude and Risk -> Include, which is just upstream's table read
back. oc keeps `FilterAction::Protect`/`Risk` as distinct variants on the
**path** chain because its delete pass needs them separable, and that is
untouched; but an xattr name is never deleted, so on the xattr chain the extra
variants have no meaning. `CompiledXattrRule::new` now returns `Option`, so the
meta actions are declined by the type that owns the encoding rather than by a
`matches!` guard at the call site.

## Wire neutrality

Established by construction, not by hoping. Upstream never puts H/S/P/R on the
wire: `get_rule_prefix()` (`exclude.c:1824-1881`) emits only
`- + / ! C n w e x s r p`, and a P/R rule is assigned `elide = LOCAL_RULE`
(`exclude.c:1913`), so it is not transmitted at all. oc's encoder already
normalises Protect/Risk to `-r`/`+r` and hide/show to `-s`/`+s`. Confirmed by
TCP capture against 3.5.0: `Hx user.drop` goes out as `-xs user.drop`, `Sx` as
`+xs`, and `hide,x user.drop` vs `Hx user.drop` are **byte-identical** - the
wire erases the spelling. No golden-byte fixture changes.

## Verification

**18-cell conformance matrix**, oc against the real rsync 3.5.0 binary on
identical trees, comparing exit code *and* accept/reject together (an exit code
alone cannot separate "parsed and matched nothing" from "refused to parse"):

```
RULE                       oc-rsync       upstream 3.5.0 VERDICT
protect,x user.drop        0/ACCEPT       0/ACCEPT       match
risk,x user.drop           0/ACCEPT       0/ACCEPT       match
hide,x user.drop           0/ACCEPT       0/ACCEPT       match
show,x user.drop           0/ACCEPT       0/ACCEPT       match
Px user.drop               0/ACCEPT       0/ACCEPT       match
Rx user.drop               0/ACCEPT       0/ACCEPT       match
Hx user.drop               0/ACCEPT       0/ACCEPT       match
Sx user.drop               0/ACCEPT       0/ACCEPT       match
-x user.drop               0/ACCEPT       0/ACCEPT       match
+x user.drop               0/ACCEPT       0/ACCEPT       match
:x .rules                  0/ACCEPT       0/ACCEPT       match
.x .rules                  11/ACCEPT      11/ACCEPT      match
Pq user.drop               1/REJECT       1/REJECT       match
protect,q user.drop        1/REJECT       1/REJECT       match
Ps user.drop               1/REJECT       1/REJECT       match
Pr user.drop               1/REJECT       1/REJECT       match
Pp user.drop               0/ACCEPT       0/ACCEPT       match
Ppattern                   1/REJECT       1/REJECT       match
cells: 18  divergent: 0
```

The last six rows are negative controls and are what make the other twelve mean
something. `Pq` must still be refused (unknown modifier); `Ps`/`Pr` must still
be refused as a *redundant side* on an already-side-bound prefix
(`exclude.c:1423-1432`); `Pp` must be **accepted**, because `p` is one of the
three unguarded arms; and `Ppattern` with no separator reports
`invalid modifier 'a' at position 2` on both implementations rather than
falling through to the unknown-rule diagnostic. A blanket "accept every
modifier" change fails four of these.

**Mutation results.** Each half is killed only by its own cells, on disjoint
sets - so neither edit is decoration and neither subsumes the other:

- Restore `allow_xattr = false` on the four keywords -> 4 divergent
  (`protect,x`, `risk,x`, `hide,x`, `show,x`), the other 14 unaffected.
- Restore `allow_xattr = false` in the short form -> 4 divergent
  (`Px`, `Rx`, `Hx`, `Sx`), the other 14 unaffected.
- Make `applies_to` return `true` unconditionally (erase the side dimension) ->
  `side_flagged_xattr_rules_participate_only_on_their_own_side` fails, and its
  non-vacuity companion stays green, as designed.

Commit 3 was **RED by construction**: the side test was written first and
failed on `assertion failed: !set.xattr_name_allowed("user.receiver", Receiver)`
- that failure *is* the report of the silent-drop defect. The mapping turned it
green.

**Suites**, all on the rebased base with a freshly built binary:
`cargo fmt --all -- --check` clean; full-workspace
`clippy --all-targets --all-features -D warnings` clean; `filters` 1445/1445;
workspace-wide sweep over `xattr|filter|modifier|shorthand|protect|risk|hide|show`
**2106/2106 across 504 binaries, 0 failed** (run with `--no-fail-fast`, and
`passed + skipped == total`, so no kill list was truncated).

## Collateral

Three existing unit tests used `x` as their sample "unknown modifier" and so
encoded the bug. They now use `z`, which is outside upstream's set; the
"unknown modifiers are rejected" contract they were written for is unchanged
and still covered.

`returns_none_without_separator` encoded non-upstream behaviour - it asserted
the parser *declines* a prefix with no separator. Measured against 3.5.0:
`Ppattern` -> `invalid modifier 'a' at position 2`, `Pxfoo` ->
`invalid modifier 'f' at position 2`, `Pq user.a` ->
`invalid modifier 'q' at position 1`. Renamed to
`no_separator_reports_an_invalid_modifier` and re-pointed at the measured
behaviour.

## Scope

The dir-merge half of the `x` story shipped separately in #7372. What remains
outside this PR: the merge-file parser and the engine dir-merge line parser
still pass `allow_xattr = false` on their own single-letter and long-keyword
forms. Those are a distinct parser pair and are deliberately not folded in
here.
