### PR TITLE
fix(filters): lift the x-modifier gate and unstack it from the namespace screen

### DIFF
--- a/crates/core/src/client/run/filters.rs
+++ b/crates/core/src/client/run/filters.rs
@@ -21,7 +21,7 @@ pub(crate) fn compile_filter_program(
 
     let mut entries = Vec::new();
     for rule in rules {
-        // upstream: exclude.c:1330-1332 add_rule() applies an implicit
+        // upstream: exclude.c:1478-1481 parse_rule_tok() applies an implicit
         // FILTRULE_SENDER_SIDE when --delete-excluded is active and the
         // rule carries neither FILTRULES_SIDES nor merge/dir-merge.
         let mut rule = rule.clone();

--- a/crates/core/src/client/run/filters.rs
+++ b/crates/core/src/client/run/filters.rs
@@ -45,16 +45,23 @@ pub(crate) fn compile_filter_program(
                     .with_negate(rule.is_negated()),
             )),
             FilterRuleKind::Clear => entries.push(FilterProgramEntry::Clear),
+            // `P`/`R` carry the `x` modifier exactly as `-`/`+` do: upstream's
+            // modifier loop runs for EVERY prefix (exclude.c:1365-1443) and
+            // `x` (:1438) has no side guard. Dropping the flag here turned
+            // `Px user.foo` into an ordinary PATH protect rule, so the xattr
+            // chain never saw it and the destination prune ran unfiltered.
             FilterRuleKind::Protect => entries.push(FilterProgramEntry::Rule(
                 EngineFilterRule::protect(rule.pattern().to_owned())
                     .with_sides(rule.applies_to_sender(), rule.applies_to_receiver())
                     .with_perishable(rule.is_perishable())
+                    .with_xattr_only(rule.is_xattr_only())
                     .with_negate(rule.is_negated()),
             )),
             FilterRuleKind::Risk => entries.push(FilterProgramEntry::Rule(
                 EngineFilterRule::risk(rule.pattern().to_owned())
                     .with_sides(rule.applies_to_sender(), rule.applies_to_receiver())
                     .with_perishable(rule.is_perishable())
+                    .with_xattr_only(rule.is_xattr_only())
                     .with_negate(rule.is_negated()),
             )),
             FilterRuleKind::DirMerge => {

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -288,6 +288,20 @@ impl<'a> CopyContext<'a> {
                 // the transfer root: `pre_len = dirbuf_len - module_dirlen - 1`
                 // prepends the dir prefix. Mirror that so `- /file1` in `foo/.filt`
                 // matches `foo/file1`, not a top-level `file1`.
+                // upstream: exclude.c:1013 - `if (!(name_flags & NAME_IS_XATTR)
+                // ^ !(ex->rflags & FILTRULE_XATTR)) return 0;`. An `x` rule
+                // matches xattr names and NOTHING else, so it must never join
+                // the path chain. Measured against rsync 3.5.0: with
+                // `-x user.foo` in a `.rsync-filter`, upstream transfers a FILE
+                // named `user.foo` while oc silently dropped it.
+                //
+                // oc has no per-directory xattr chain yet, so such a rule is
+                // inert here rather than applied to xattr names - strictly
+                // closer to upstream than deleting the wrong file. The residual
+                // is named in the PR body, not hidden.
+                if compiled.is_xattr_only() {
+                    continue;
+                }
                 let compiled = anchor_dir_merge_rule(compiled, relative_dir);
                 if let Err(error) = segment.push_rule(compiled) {
                     ephemeral_stack.pop();

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -23,25 +23,41 @@ fn unsupported_modifier_error(directive: &str, modifier: impl fmt::Display) -> F
     ))
 }
 
+/// Parses the `,modifier` run that may follow a rule prefix.
+///
+/// `prefix_specifies_side` mirrors upstream's variable of the same name, set by
+/// the four side-bound prefixes (exclude.c:1345-1358 for `S`/`H`/`R`/`P`, and
+/// the long keywords that map onto them). When it is set, a further `s` or `r`
+/// is a redundant side and upstream refuses the rule (exclude.c:1423-1432).
 fn parse_rule_modifiers(
     modifiers: &str,
     directive: &str,
     allow_perishable: bool,
     allow_xattr: bool,
+    prefix_specifies_side: bool,
 ) -> Result<RuleModifierState, FilterParseError> {
     let mut state = RuleModifierState::default();
 
+    // upstream: exclude.c:1365 - the modifier loop switches on the raw byte.
+    // `R`/`S`/`P`/`X` are not modifiers at all; they reach the default arm and
+    // raise RERR_SYNTAX (exclude.c:1371-1379). Case-folding them here silently
+    // applied a side or perishable restriction the rule never asked for.
     for modifier in modifiers.chars() {
-        let lower = modifier.to_ascii_lowercase();
-        match lower {
+        match modifier {
             '/' => state.anchor_root = true,
             's' => {
+                if prefix_specifies_side {
+                    return Err(unsupported_modifier_error(directive, modifier));
+                }
                 state.sender = Some(true);
                 if state.receiver.is_none() {
                     state.receiver = Some(false);
                 }
             }
             'r' => {
+                if prefix_specifies_side {
+                    return Err(unsupported_modifier_error(directive, modifier));
+                }
                 state.receiver = Some(true);
                 if state.sender.is_none() {
                     state.sender = Some(false);
@@ -94,10 +110,11 @@ fn apply_rule_modifiers(
     if modifiers.xattr_only {
         match rule.action() {
             filters::FilterAction::Include | filters::FilterAction::Exclude => {
-                rule = rule
-                    .with_xattr_only(true)
-                    .with_sender(true)
-                    .with_receiver(true);
+                // upstream: exclude.c:1438 - `case 'x': rule->rflags |=
+                // FILTRULE_XATTR;`. The modifier sets one bit and binds no
+                // side, so forcing both sides here erased whatever `s`/`r`
+                // had already selected: `-sx pat` became a both-sides rule.
+                rule = rule.with_xattr_only(true);
             }
             _ => {
                 return Err(FilterParseError::new(format!(
@@ -181,7 +198,7 @@ pub(crate) fn parse_filter_directive_line(
 
     if let Some(remainder) = trimmed.strip_prefix('+') {
         let (modifier_text, remainder) = split_short_rule_modifiers(remainder);
-        let modifiers = parse_rule_modifiers(modifier_text, trimmed, true, true)?;
+        let modifiers = parse_rule_modifiers(modifier_text, trimmed, true, true, false)?;
         let pattern = remainder.trim_start();
         if pattern.is_empty() {
             return Err(FilterParseError::new("filter rule '+' requires a pattern"));
@@ -193,7 +210,7 @@ pub(crate) fn parse_filter_directive_line(
 
     if let Some(remainder) = trimmed.strip_prefix('-') {
         let (modifier_text, remainder) = split_short_rule_modifiers(remainder);
-        let modifiers = parse_rule_modifiers(modifier_text, trimmed, true, true)?;
+        let modifiers = parse_rule_modifiers(modifier_text, trimmed, true, true, false)?;
         let pattern = remainder.trim_start();
         if pattern.is_empty() {
             return Err(FilterParseError::new("filter rule '-' requires a pattern"));
@@ -211,13 +228,19 @@ pub(crate) fn parse_filter_directive_line(
     let handle_keyword = |pattern: &str,
                           builder: fn(String) -> FilterRule,
                           allow_perishable: bool,
-                          allow_xattr: bool|
+                          allow_xattr: bool,
+                          prefix_specifies_side: bool|
      -> Result<Option<ParsedFilterDirective>, FilterParseError> {
         if pattern.is_empty() {
             return Err(FilterParseError::new("filter directive missing pattern"));
         }
-        let modifiers =
-            parse_rule_modifiers(keyword_modifiers, trimmed, allow_perishable, allow_xattr)?;
+        let modifiers = parse_rule_modifiers(
+            keyword_modifiers,
+            trimmed,
+            allow_perishable,
+            allow_xattr,
+            prefix_specifies_side,
+        )?;
         let rule = builder(pattern.to_owned());
         let rule = apply_rule_modifiers(rule, modifiers, trimmed)?;
         Ok(Some(ParsedFilterDirective::Rule(rule)))
@@ -229,51 +252,49 @@ pub(crate) fn parse_filter_directive_line(
             .next()
             .expect("keyword has exactly one char")
             .to_ascii_lowercase();
+        // upstream: exclude.c:1365 - the modifier loop runs after EVERY rule
+        // prefix, so `P`/`R` take a modifier run exactly as `S`/`H` do. The
+        // blanket refusal that used to sit on these two arms had no upstream
+        // counterpart; per-modifier validity is `parse_rule_modifiers`' job.
         match shorthand {
             'p' => {
-                if !keyword_modifiers.is_empty() {
-                    return Err(unsupported_modifier_error(trimmed, keyword_modifiers));
-                }
-                return handle_keyword(remainder, FilterRule::protect, false, false);
+                return handle_keyword(remainder, FilterRule::protect, true, false, true);
             }
             'r' => {
-                if !keyword_modifiers.is_empty() {
-                    return Err(unsupported_modifier_error(trimmed, keyword_modifiers));
-                }
-                return handle_keyword(remainder, FilterRule::risk, false, false);
+                return handle_keyword(remainder, FilterRule::risk, true, false, true);
             }
             's' => {
-                return handle_keyword(remainder, FilterRule::show, false, false);
+                return handle_keyword(remainder, FilterRule::show, true, false, true);
             }
             'h' => {
-                return handle_keyword(remainder, FilterRule::hide, false, false);
+                return handle_keyword(remainder, FilterRule::hide, true, false, true);
             }
             _ => {}
         }
     }
 
     if keyword.eq_ignore_ascii_case("include") {
-        return handle_keyword(remainder, FilterRule::include, true, true);
+        return handle_keyword(remainder, FilterRule::include, true, true, false);
     }
 
     if keyword.eq_ignore_ascii_case("exclude") {
-        return handle_keyword(remainder, FilterRule::exclude, true, true);
+        return handle_keyword(remainder, FilterRule::exclude, true, true, false);
     }
 
     if keyword.eq_ignore_ascii_case("show") {
-        return handle_keyword(remainder, FilterRule::show, false, false);
+        return handle_keyword(remainder, FilterRule::show, true, false, true);
     }
 
     if keyword.eq_ignore_ascii_case("hide") {
-        return handle_keyword(remainder, FilterRule::hide, false, false);
+        return handle_keyword(remainder, FilterRule::hide, true, false, true);
     }
 
     if keyword.eq_ignore_ascii_case("protect") {
-        return handle_keyword(remainder, FilterRule::protect, false, false);
+        return handle_keyword(remainder, FilterRule::protect, true, false, true);
     }
 
     if keyword.eq_ignore_ascii_case("risk") {
-        return handle_keyword(remainder, FilterRule::risk, false, false);
+        return handle_keyword(remainder, FilterRule::risk, true, false, true);
     }
 
     Err(FilterParseError::new(format!(
@@ -284,6 +305,120 @@ pub(crate) fn parse_filter_directive_line(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rule_of(line: &str) -> FilterRule {
+        match parse_filter_directive_line(line) {
+            Ok(Some(ParsedFilterDirective::Rule(rule))) => rule,
+            other => panic!("expected a rule from {line:?}, got {other:?}"),
+        }
+    }
+
+    /// MEASURED against rsync 3.5.0: `-R FOO` / `-S FOO` / `-P FOO` / `-X FOO`
+    /// all exit 1. oc case-folded the modifier byte, so they parsed as
+    /// receiver / sender / perishable / xattr and applied a restriction the
+    /// rule never expressed - at exit 0. `-S FOO` dropped FOO while `-R FOO`
+    /// kept it, which is what made this a silent wrong transfer rather than a
+    /// cosmetic difference.
+    ///
+    /// upstream: exclude.c:1365 switches on the raw byte; the uppercase forms
+    /// reach the default arm at :1371 and raise RERR_SYNTAX.
+    #[test]
+    fn uppercase_modifier_letters_are_not_modifiers() {
+        for line in ["-R FOO", "-S FOO", "-P FOO", "-X FOO", "+R FOO"] {
+            assert!(
+                parse_filter_directive_line(line).is_err(),
+                "{line:?} must be refused: upstream has no uppercase modifiers"
+            );
+        }
+    }
+
+    /// Non-vacuity companion to the case test: the LOWERCASE letters must still
+    /// work. Without this, deleting the whole modifier match arm would also
+    /// make the test above pass.
+    #[test]
+    fn lowercase_modifier_letters_are_still_accepted() {
+        assert!(rule_of("-s FOO").applies_to_sender());
+        assert!(!rule_of("-s FOO").applies_to_receiver());
+        assert!(rule_of("-r FOO").applies_to_receiver());
+        assert!(!rule_of("-r FOO").applies_to_sender());
+        assert!(rule_of("-x user.drop").is_xattr_only());
+    }
+
+    /// upstream: exclude.c:1423-1432 - `s`/`r` are refused once a prefix has
+    /// already bound a side, which the four side-bound spellings all do
+    /// (exclude.c:1345-1358). oc accepted `protect,s`, building a SENDER-side
+    /// protect rule - a rule upstream cannot express.
+    #[test]
+    fn a_side_bound_prefix_refuses_a_redundant_side_modifier() {
+        for line in [
+            "protect,s FOO",
+            "protect,r FOO",
+            "risk,s FOO",
+            "show,r FOO",
+            "hide,r FOO",
+            "Ps FOO",
+            "Hr FOO",
+        ] {
+            assert!(
+                parse_filter_directive_line(line).is_err(),
+                "{line:?} must be refused: the prefix already binds a side"
+            );
+        }
+    }
+
+    /// Non-vacuity companion: `p` is one of the three arms upstream leaves
+    /// unguarded (exclude.c:1420), so it must be accepted on exactly the
+    /// prefixes that reject `s`/`r`. Without this the guard above could be
+    /// implemented as "side-bound prefixes take no modifiers at all", which is
+    /// what oc previously did for `P`/`R` and is equally wrong.
+    #[test]
+    fn a_side_bound_prefix_still_accepts_the_unguarded_perishable_modifier() {
+        for line in ["protect,p FOO", "risk,p FOO", "show,p FOO", "P,p FOO"] {
+            assert!(
+                parse_filter_directive_line(line).is_ok(),
+                "{line:?} must parse: upstream's `p` arm has no prefix guard"
+            );
+        }
+    }
+
+    /// MEASURED divergence this change does NOT close, pinned so it cannot be
+    /// mistaken for intended behaviour: upstream takes the modifier run
+    /// adjacent to a single-letter prefix (`Pp FOO`, `Px user.drop`), while
+    /// this parser only reaches its modifier scan when a comma separates them
+    /// (`P,p FOO`). Upstream 3.5.0 accepts `Pp FOO` at exit 0; oc exits 1.
+    ///
+    /// This is a parse-SHAPE gap, distinct from the `x` gate below it - which
+    /// is why `Px` fails for two independent reasons today.
+    #[test]
+    fn adjacent_modifiers_after_a_single_letter_prefix_are_not_yet_parsed() {
+        assert!(
+            parse_filter_directive_line("Pp FOO").is_err(),
+            "pin the known gap: adjacent-modifier support is not implemented"
+        );
+        assert!(
+            parse_filter_directive_line("P,p FOO").is_ok(),
+            "the comma form is what oc supports today"
+        );
+    }
+
+    /// upstream: exclude.c:1438 - the `x` arm sets `FILTRULE_XATTR` and nothing
+    /// else. oc forced both sides on, so `-sx` silently widened a sender-only
+    /// xattr rule to both ends.
+    #[test]
+    fn the_x_modifier_does_not_clobber_an_explicit_side() {
+        let sender_only = rule_of("-sx user.drop");
+        assert!(sender_only.is_xattr_only());
+        assert!(sender_only.applies_to_sender());
+        assert!(
+            !sender_only.applies_to_receiver(),
+            "`x` must not re-enable the receiver side that `s` switched off"
+        );
+
+        let receiver_only = rule_of("-rx user.drop");
+        assert!(receiver_only.is_xattr_only());
+        assert!(receiver_only.applies_to_receiver());
+        assert!(!receiver_only.applies_to_sender());
+    }
 
     #[test]
     fn split_keyword_modifiers_no_modifiers() {

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -15,6 +15,7 @@ struct RuleModifierState {
     receiver: Option<bool>,
     perishable: bool,
     xattr_only: bool,
+    negate: bool,
 }
 
 fn unsupported_modifier_error(directive: &str, modifier: impl fmt::Display) -> FilterParseError {
@@ -32,8 +33,6 @@ fn unsupported_modifier_error(directive: &str, modifier: impl fmt::Display) -> F
 fn parse_rule_modifiers(
     modifiers: &str,
     directive: &str,
-    allow_perishable: bool,
-    allow_xattr: bool,
     prefix_specifies_side: bool,
 ) -> Result<RuleModifierState, FilterParseError> {
     let mut state = RuleModifierState::default();
@@ -63,19 +62,20 @@ fn parse_rule_modifiers(
                     state.sender = Some(false);
                 }
             }
-            'p' => {
-                if allow_perishable {
-                    state.perishable = true;
-                } else {
-                    return Err(unsupported_modifier_error(directive, modifier));
-                }
-            }
+            // upstream: exclude.c:1395-1401 - `!` sets FILTRULE_NEGATE and is
+            // refused only on a merge rule. Merge prefixes never reach this
+            // function (they are dispatched to the merge/dir-merge parsers
+            // above), so the guard has no expressible case here.
+            '!' => state.negate = true,
+            // upstream: exclude.c:1420 (`p`) and exclude.c:1438 (`x`) are the
+            // only modifiers besides `/` that carry NO guard at all - not the
+            // merge-file test that gates `- + e n w`, not the `!`-on-merge
+            // test, and not the `prefix_specifies_side` test that `C`, `r` and
+            // `s` consult. Both are therefore legal after every prefix,
+            // including the four side-bound ones.
+            'p' => state.perishable = true,
             'x' => {
-                if allow_xattr {
-                    state.xattr_only = true;
-                } else {
-                    return Err(unsupported_modifier_error(directive, modifier));
-                }
+                state.xattr_only = true;
             }
             _ => {
                 return Err(unsupported_modifier_error(directive, modifier));
@@ -107,33 +107,72 @@ fn apply_rule_modifiers(
         rule = rule.with_perishable(true);
     }
 
+    if modifiers.negate {
+        rule = rule.with_negate(true);
+    }
+
     if modifiers.xattr_only {
-        match rule.action() {
-            filters::FilterAction::Include | filters::FilterAction::Exclude => {
-                // upstream: exclude.c:1438 - `case 'x': rule->rflags |=
-                // FILTRULE_XATTR;`. The modifier sets one bit and binds no
-                // side, so forcing both sides here erased whatever `s`/`r`
-                // had already selected: `-sx pat` became a both-sides rule.
-                rule = rule.with_xattr_only(true);
-            }
-            _ => {
-                return Err(FilterParseError::new(format!(
-                    "filter directive '{directive}' cannot combine 'x' modifiers with this directive"
-                )));
-            }
+        // upstream: exclude.c:1438 - `case 'x': rule->rflags |=
+        // FILTRULE_XATTR;`. The modifier sets one bit and binds no side, so
+        // forcing both sides here erased whatever `s`/`r` had already
+        // selected: `-sx pat` became a both-sides rule.
+        //
+        // Every prefix that carries an include/exclude decision accepts it.
+        // Restricting the set to oc's `Include`/`Exclude` variants excluded
+        // `protect`/`risk`, which upstream stores as the same two decisions
+        // with a receiver-side bit (exclude.c:1352-1358) - so `protect,x` was
+        // refused where upstream builds an ordinary receiver-side xattr rule.
+        // [`FilterAction::xattr_decision`] is the shared owner of that table.
+        if rule.action().xattr_decision().is_none() {
+            return Err(FilterParseError::new(format!(
+                "filter directive '{directive}' cannot combine 'x' modifiers with this directive"
+            )));
         }
+        rule = rule.with_xattr_only(true);
     }
 
     Ok(rule)
 }
 
+/// Splits a rule token into its prefix and the modifier run that follows.
+///
+/// upstream: exclude.c:1325-1329 - the prefix switch's `default:` arm takes
+/// `ch = *s` and advances past only an OPTIONAL comma, leaving the modifier
+/// loop at :1365 to read from the very next byte. So for a single-letter
+/// prefix the comma is decoration: `Px pat` and `P,x pat` parse identically,
+/// and the pattern cannot start until a space or `_` (:1365 loop exit).
+///
+/// A long keyword is different: `rule_strcmp` (exclude.c:1218-1227) accepts it
+/// only when followed by space/`_`/NUL or `,`, so `protect,x` is valid and
+/// `protectx` is not. Splitting on the comma alone - the whole rule oc used to
+/// apply - therefore handled the keyword form and silently rejected the
+/// adjacent single-letter form as an unknown rule.
 fn split_keyword_modifiers(keyword: &str) -> (&str, &str) {
+    let mut chars = keyword.chars();
+    if let Some(first) = chars.next() {
+        if SINGLE_LETTER_PREFIXES.contains(first) {
+            let rest = chars.as_str();
+            return (
+                &keyword[..first.len_utf8()],
+                rest.strip_prefix(',').unwrap_or(rest),
+            );
+        }
+    }
     if let Some((name, modifiers)) = keyword.split_once(',') {
         (name, modifiers)
     } else {
         (keyword, "")
     }
 }
+
+/// The single-character rule prefixes this parser dispatches, upper case only.
+///
+/// upstream: exclude.c:1288-1330 - the long-keyword switch matches lower-case
+/// initials and the `default:` arm passes the raw byte through, so `S H R P`
+/// are prefixes while `s h r p` fail `RULE_STRCMP` and fall to
+/// `filter_rule_err("Unknown filter rule")` at :1362-1363. Case-folding the
+/// prefix accepted four spellings upstream rejects.
+const SINGLE_LETTER_PREFIXES: &str = "SHRP";
 
 /// Parses a single line of a per-directory merge file.
 ///
@@ -198,7 +237,7 @@ pub(crate) fn parse_filter_directive_line(
 
     if let Some(remainder) = trimmed.strip_prefix('+') {
         let (modifier_text, remainder) = split_short_rule_modifiers(remainder);
-        let modifiers = parse_rule_modifiers(modifier_text, trimmed, true, true, false)?;
+        let modifiers = parse_rule_modifiers(modifier_text, trimmed, false)?;
         let pattern = remainder.trim_start();
         if pattern.is_empty() {
             return Err(FilterParseError::new("filter rule '+' requires a pattern"));
@@ -210,7 +249,7 @@ pub(crate) fn parse_filter_directive_line(
 
     if let Some(remainder) = trimmed.strip_prefix('-') {
         let (modifier_text, remainder) = split_short_rule_modifiers(remainder);
-        let modifiers = parse_rule_modifiers(modifier_text, trimmed, true, true, false)?;
+        let modifiers = parse_rule_modifiers(modifier_text, trimmed, false)?;
         let pattern = remainder.trim_start();
         if pattern.is_empty() {
             return Err(FilterParseError::new("filter rule '-' requires a pattern"));
@@ -227,20 +266,12 @@ pub(crate) fn parse_filter_directive_line(
 
     let handle_keyword = |pattern: &str,
                           builder: fn(String) -> FilterRule,
-                          allow_perishable: bool,
-                          allow_xattr: bool,
                           prefix_specifies_side: bool|
      -> Result<Option<ParsedFilterDirective>, FilterParseError> {
         if pattern.is_empty() {
             return Err(FilterParseError::new("filter directive missing pattern"));
         }
-        let modifiers = parse_rule_modifiers(
-            keyword_modifiers,
-            trimmed,
-            allow_perishable,
-            allow_xattr,
-            prefix_specifies_side,
-        )?;
+        let modifiers = parse_rule_modifiers(keyword_modifiers, trimmed, prefix_specifies_side)?;
         let rule = builder(pattern.to_owned());
         let rule = apply_rule_modifiers(rule, modifiers, trimmed)?;
         Ok(Some(ParsedFilterDirective::Rule(rule)))
@@ -250,51 +281,50 @@ pub(crate) fn parse_filter_directive_line(
         let shorthand = keyword
             .chars()
             .next()
-            .expect("keyword has exactly one char")
-            .to_ascii_lowercase();
+            .expect("keyword has exactly one char");
         // upstream: exclude.c:1365 - the modifier loop runs after EVERY rule
         // prefix, so `P`/`R` take a modifier run exactly as `S`/`H` do. The
         // blanket refusal that used to sit on these two arms had no upstream
         // counterpart; per-modifier validity is `parse_rule_modifiers`' job.
         match shorthand {
-            'p' => {
-                return handle_keyword(remainder, FilterRule::protect, true, false, true);
+            'P' => {
+                return handle_keyword(remainder, FilterRule::protect, true);
             }
-            'r' => {
-                return handle_keyword(remainder, FilterRule::risk, true, false, true);
+            'R' => {
+                return handle_keyword(remainder, FilterRule::risk, true);
             }
-            's' => {
-                return handle_keyword(remainder, FilterRule::show, true, false, true);
+            'S' => {
+                return handle_keyword(remainder, FilterRule::show, true);
             }
-            'h' => {
-                return handle_keyword(remainder, FilterRule::hide, true, false, true);
+            'H' => {
+                return handle_keyword(remainder, FilterRule::hide, true);
             }
             _ => {}
         }
     }
 
     if keyword.eq_ignore_ascii_case("include") {
-        return handle_keyword(remainder, FilterRule::include, true, true, false);
+        return handle_keyword(remainder, FilterRule::include, false);
     }
 
     if keyword.eq_ignore_ascii_case("exclude") {
-        return handle_keyword(remainder, FilterRule::exclude, true, true, false);
+        return handle_keyword(remainder, FilterRule::exclude, false);
     }
 
     if keyword.eq_ignore_ascii_case("show") {
-        return handle_keyword(remainder, FilterRule::show, true, false, true);
+        return handle_keyword(remainder, FilterRule::show, true);
     }
 
     if keyword.eq_ignore_ascii_case("hide") {
-        return handle_keyword(remainder, FilterRule::hide, true, false, true);
+        return handle_keyword(remainder, FilterRule::hide, true);
     }
 
     if keyword.eq_ignore_ascii_case("protect") {
-        return handle_keyword(remainder, FilterRule::protect, true, false, true);
+        return handle_keyword(remainder, FilterRule::protect, true);
     }
 
     if keyword.eq_ignore_ascii_case("risk") {
-        return handle_keyword(remainder, FilterRule::risk, true, false, true);
+        return handle_keyword(remainder, FilterRule::risk, true);
     }
 
     Err(FilterParseError::new(format!(
@@ -381,23 +411,73 @@ mod tests {
         }
     }
 
-    /// MEASURED divergence this change does NOT close, pinned so it cannot be
-    /// mistaken for intended behaviour: upstream takes the modifier run
-    /// adjacent to a single-letter prefix (`Pp FOO`, `Px user.drop`), while
-    /// this parser only reaches its modifier scan when a comma separates them
-    /// (`P,p FOO`). Upstream 3.5.0 accepts `Pp FOO` at exit 0; oc exits 1.
+    /// For a single-letter prefix the comma is decoration.
     ///
-    /// This is a parse-SHAPE gap, distinct from the `x` gate below it - which
-    /// is why `Px` fails for two independent reasons today.
+    /// upstream: exclude.c:1325-1329 - the prefix switch's `default:` arm
+    /// advances past only an OPTIONAL comma, so the modifier loop at :1365
+    /// starts at the same byte either way. `Pp FOO` and `P,p FOO` are the same
+    /// rule. A long keyword is the opposite: `rule_strcmp` (exclude.c:1218)
+    /// requires the comma, so `protect,x` parses and `protectx` does not.
     #[test]
-    fn adjacent_modifiers_after_a_single_letter_prefix_are_not_yet_parsed() {
-        assert!(
-            parse_filter_directive_line("Pp FOO").is_err(),
-            "pin the known gap: adjacent-modifier support is not implemented"
+    fn a_single_letter_prefix_takes_adjacent_modifiers_the_keyword_form_needs_a_comma() {
+        for line in ["Pp FOO", "P,p FOO", "Px user.drop", "P,x user.drop"] {
+            assert!(
+                parse_filter_directive_line(line).is_ok(),
+                "{line:?} must parse: the comma is optional after a one-letter prefix"
+            );
+        }
+        assert_eq!(
+            rule_of("Pp FOO").is_perishable(),
+            rule_of("P,p FOO").is_perishable(),
+            "the two spellings must produce the same rule, not merely both parse"
         );
         assert!(
-            parse_filter_directive_line("P,p FOO").is_ok(),
-            "the comma form is what oc supports today"
+            parse_filter_directive_line("protectx user.drop").is_err(),
+            "a long keyword still requires the comma (rule_strcmp, exclude.c:1218)"
+        );
+    }
+
+    /// Lower-case single letters are NOT prefixes.
+    ///
+    /// upstream: exclude.c:1288-1330 - the first switch matches lower-case
+    /// keyword initials, so `p`/`r`/`s`/`h` enter `RULE_STRCMP`, fail it, leave
+    /// `ch == 0` and reach `filter_rule_err("Unknown filter rule")` at :1362.
+    /// Only `S H R P` reach the `default:` arm as prefixes. Measured against
+    /// rsync 3.5.0: `p *.tmp` in a dir-merge file exits 1.
+    #[test]
+    fn lower_case_single_letters_are_not_rule_prefixes() {
+        for line in ["p *.tmp", "r *.tmp", "s *.tmp", "h *.tmp"] {
+            assert!(
+                parse_filter_directive_line(line).is_err(),
+                "{line:?} must be refused: upstream has no lower-case prefix"
+            );
+        }
+        for line in ["P *.tmp", "R *.tmp", "S *.tmp", "H *.tmp"] {
+            assert!(
+                parse_filter_directive_line(line).is_ok(),
+                "{line:?} is the upper-case prefix upstream does accept"
+            );
+        }
+    }
+
+    /// upstream: exclude.c:1395-1401 - `!` sets FILTRULE_NEGATE after any
+    /// non-merge prefix. Measured against 3.5.0: `-! *.tmp` transfers only the
+    /// `*.tmp` files (the sense is inverted), where oc used to exit 1.
+    #[test]
+    fn the_negate_modifier_is_accepted_after_every_non_merge_prefix() {
+        for line in ["-! *.tmp", "+! *.tmp", "P! *.tmp", "R! *.tmp"] {
+            assert!(
+                parse_filter_directive_line(line).is_ok(),
+                "{line:?} must parse: `!` carries no prefix guard upstream"
+            );
+        }
+        assert!(
+            rule_of("-! *.tmp").is_negated(),
+            "the modifier must reach the rule, not merely be tolerated"
+        );
+        assert!(
+            !rule_of("- *.tmp").is_negated(),
+            "and the same rule without `!` must not be negated"
         );
     }
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -275,12 +275,21 @@ fn reconcile_copied_ads(
     // filter admits, so a filtered-out source stream `CopyFileExW` pre-copied
     // does not survive on the destination.
     ::metadata::strip_source_xattrs(source, destination, false).map_err(map_metadata_error)?;
-    // Receiver side, like every live caller of upstream's copy_xattrs
-    // (generator.c:1599, generator.c:2430, util1.c:513): a `H`/`S` rule is
-    // elided here and only a `P`/`R` rule participates. upstream: exclude.c:1010.
-    let filter = |name: &str| program.allows_xattr(name, filters::XattrSide::Receiver);
-    ::metadata::sync_xattrs(source, destination, false, Some(&filter))
-        .map_err(map_metadata_error)?;
+    // Source read is upstream's sender, destination prune its generator - see
+    // `metadata::XattrSyncFilters`. upstream: exclude.c:1010 elides a
+    // side-flagged rule on the other side before its pattern is consulted.
+    let sender = |name: &str| program.allows_xattr(name, filters::XattrSide::Sender);
+    let receiver = |name: &str| program.allows_xattr(name, filters::XattrSide::Receiver);
+    ::metadata::sync_xattrs(
+        source,
+        destination,
+        false,
+        ::metadata::XattrSyncFilters {
+            source: Some(&sender),
+            destination: Some(&receiver),
+        },
+    )
+    .map_err(map_metadata_error)?;
     Ok(())
 }
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -275,7 +275,10 @@ fn reconcile_copied_ads(
     // filter admits, so a filtered-out source stream `CopyFileExW` pre-copied
     // does not survive on the destination.
     ::metadata::strip_source_xattrs(source, destination, false).map_err(map_metadata_error)?;
-    let filter = |name: &str| program.allows_xattr(name);
+    // Receiver side, like every live caller of upstream's copy_xattrs
+    // (generator.c:1599, generator.c:2430, util1.c:513): a `H`/`S` rule is
+    // elided here and only a `P`/`R` rule participates. upstream: exclude.c:1010.
+    let filter = |name: &str| program.allows_xattr(name, filters::XattrSide::Receiver);
     ::metadata::sync_xattrs(source, destination, false, Some(&filter))
         .map_err(map_metadata_error)?;
     Ok(())

--- a/crates/engine/src/local_copy/filter_program/program.rs
+++ b/crates/engine/src/local_copy/filter_program/program.rs
@@ -355,6 +355,11 @@ struct XattrRule {
     /// and therefore never equals `cur_elide_value` (exclude.c:1010).
     applies_to_sender: bool,
     applies_to_receiver: bool,
+    /// upstream: exclude.c:1005 - `ret_match = FILTRULE_NEGATE ? 0 : 1`, so `!`
+    /// inverts the verdict on an xattr chain exactly as on a path chain. The
+    /// filters crate's `CompiledXattrRule` already carried this; omitting it
+    /// here made `-x! user.keep` mean the opposite on the two chains.
+    negate: bool,
 }
 
 #[cfg(all(any(unix, windows), feature = "xattr"))]
@@ -384,6 +389,7 @@ impl XattrRule {
             matcher: glob.compile_matcher(),
             applies_to_sender: rule.applies_to_sender(),
             applies_to_receiver: rule.applies_to_receiver(),
+            negate: rule.is_negated(),
         }))
     }
 
@@ -399,8 +405,9 @@ impl XattrRule {
         }
     }
 
+    /// upstream: exclude.c:1005 - the `!` modifier inverts the verdict.
     fn matches(&self, name: &str) -> bool {
-        self.matcher.is_match(name)
+        self.matcher.is_match(name) ^ self.negate
     }
 }
 
@@ -712,6 +719,33 @@ mod tests {
         assert!(
             !receiver_only.allows_xattr("user.secret", XattrSide::Receiver),
             "`P` is a plain exclude on its own side (exclude.c:1358)"
+        );
+    }
+
+    /// The `!` modifier inverts an xattr rule exactly as it inverts a path rule.
+    ///
+    /// upstream: exclude.c:1005 - `ret_match = FILTRULE_NEGATE ? 0 : 1` is
+    /// applied before the xattr/path partition at :1013, so the flag is not
+    /// specific to either chain. The filters crate's `CompiledXattrRule`
+    /// carried it while this one did not, which made `-x! user.keep` mean
+    /// opposite things on the network and local-copy chains.
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
+    #[test]
+    fn the_negate_modifier_inverts_an_xattr_rule() {
+        let program = FilterProgram::new([FilterProgramEntry::Rule(
+            FilterRule::exclude("user.keep")
+                .with_xattr_only(true)
+                .with_negate(true),
+        )])
+        .unwrap();
+
+        assert!(
+            program.allows_xattr("user.keep", XattrSide::Receiver),
+            "`!` inverts the match, so the NAMED xattr is the one that survives"
+        );
+        assert!(
+            !program.allows_xattr("user.other", XattrSide::Receiver),
+            "and every other name is excluded - without the flag this is backwards"
         );
     }
 

--- a/crates/engine/src/local_copy/filter_program/program.rs
+++ b/crates/engine/src/local_copy/filter_program/program.rs
@@ -4,9 +4,9 @@
 
 use std::path::Path;
 
-#[cfg(all(any(unix, windows), feature = "xattr"))]
-use filters::FilterAction;
 use filters::FilterRule;
+#[cfg(all(any(unix, windows), feature = "xattr"))]
+use filters::{FilterAction, XattrSide};
 #[cfg(all(any(unix, windows), feature = "xattr"))]
 use globset::{GlobBuilder, GlobMatcher};
 use thiserror::Error;
@@ -84,8 +84,9 @@ impl FilterProgram {
                     #[cfg(all(any(unix, windows), feature = "xattr"))]
                     {
                         if rule.is_xattr_only() {
-                            let compiled = XattrRule::new(&rule)?;
-                            xattr_rules.push(compiled);
+                            if let Some(compiled) = XattrRule::new(&rule)? {
+                                xattr_rules.push(compiled);
+                            }
                         } else {
                             current_segment.push_rule(rule)?;
                         }
@@ -288,12 +289,18 @@ impl FilterProgram {
     }
 
     #[cfg(all(any(unix, windows), feature = "xattr"))]
-    pub(crate) fn allows_xattr(&self, name: &str) -> bool {
+    pub(crate) fn allows_xattr(&self, name: &str, side: XattrSide) -> bool {
         // upstream: exclude.c:check_filter() evaluates rules first-match-wins,
         // returning on the FIRST matching rule (include -> allow, exclude ->
         // deny). A later rule never overrides an earlier match, so `+x
         // user.keep` before `-x user.*` keeps user.keep.
         for rule in &self.xattr_rules {
+            // upstream: exclude.c:1010 - a rule flagged for the opposite side is
+            // elided before its pattern is consulted, so it can neither match
+            // nor shadow a later rule that does apply here.
+            if !rule.applies_to(side) {
+                continue;
+            }
             if rule.matches(name) {
                 return matches!(rule.action, FilterAction::Include);
             }
@@ -343,12 +350,28 @@ impl FilterProgramError {
 struct XattrRule {
     action: FilterAction,
     matcher: GlobMatcher,
+    /// Mirrors `FILTRULE_SENDER_SIDE` / `FILTRULE_RECEIVER_SIDE`. A rule with no
+    /// side prefix carries both, matching an upstream rule whose `elide` stays 0
+    /// and therefore never equals `cur_elide_value` (exclude.c:1010).
+    applies_to_sender: bool,
+    applies_to_receiver: bool,
 }
 
 #[cfg(all(any(unix, windows), feature = "xattr"))]
 impl XattrRule {
-    fn new(rule: &FilterRule) -> Result<Self, FilterProgramError> {
+    /// Returns `Ok(None)` for a meta action, which carries no xattr decision.
+    fn new(rule: &FilterRule) -> Result<Option<Self>, FilterProgramError> {
         debug_assert!(rule.is_xattr_only());
+
+        // upstream: exclude.c:1345-1358 via `FilterAction::xattr_decision` - the
+        // shared owner of the (include|exclude) x (sender|receiver) table. Left
+        // un-normalised, `risk,x` fell through `matches!(.., Include)` below and
+        // was treated as an EXCLUDE, inverting upstream's
+        // `R = FILTRULE_INCLUDE|RECEIVER_SIDE`.
+        let Some(action) = rule.action().xattr_decision() else {
+            return Ok(None);
+        };
+
         let pattern = rule.pattern().to_owned();
         let glob = GlobBuilder::new(&pattern)
             .literal_separator(true)
@@ -356,16 +379,24 @@ impl XattrRule {
             .build()
             .map_err(|error| FilterProgramError::new(pattern.clone(), error))?;
 
-        let action = rule.action();
-        debug_assert!(matches!(
-            action,
-            FilterAction::Include | FilterAction::Exclude
-        ));
-
-        Ok(Self {
+        Ok(Some(Self {
             action,
             matcher: glob.compile_matcher(),
-        })
+            applies_to_sender: rule.applies_to_sender(),
+            applies_to_receiver: rule.applies_to_receiver(),
+        }))
+    }
+
+    /// Whether this rule participates on `side`.
+    ///
+    /// upstream: exclude.c:1010 - `if (!*name || ex->elide == cur_elide_value)
+    /// return 0;`, which sits two lines above the `NAME_IS_XATTR` test at
+    /// :1013. The side is decided BEFORE the pattern is consulted.
+    const fn applies_to(&self, side: XattrSide) -> bool {
+        match side {
+            XattrSide::Sender => self.applies_to_sender,
+            XattrSide::Receiver => self.applies_to_receiver,
+        }
     }
 
     fn matches(&self, name: &str) -> bool {
@@ -637,12 +668,74 @@ mod tests {
         let program = FilterProgram::new(entries).unwrap();
 
         assert!(
-            program.allows_xattr("user.keep"),
+            program.allows_xattr("user.keep", XattrSide::Receiver),
             "earlier include rule must win under first-match-wins"
         );
         assert!(
-            !program.allows_xattr("user.other"),
+            !program.allows_xattr("user.other", XattrSide::Receiver),
             "later exclude rule must drop non-matching user.* xattrs"
+        );
+    }
+
+    /// A side-flagged rule participates only on its own side.
+    ///
+    /// upstream: exclude.c:1903-1913 stamps `elide` from the rule's side flags
+    /// and `am_sender`, and exclude.c:1010 returns 0 when `ex->elide ==
+    /// cur_elide_value` - two lines ABOVE the `NAME_IS_XATTR` biconditional at
+    /// :1013, so the side decision precedes the pattern entirely. Without this
+    /// dimension `allows_xattr` could return the same answer for both sides and
+    /// every other xattr test would still pass.
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
+    #[test]
+    fn a_side_flagged_xattr_rule_is_elided_on_the_opposite_side() {
+        let sender_only = FilterProgram::new([FilterProgramEntry::Rule(
+            FilterRule::hide("user.secret").with_xattr_only(true),
+        )])
+        .unwrap();
+        assert!(
+            !sender_only.allows_xattr("user.secret", XattrSide::Sender),
+            "`H`/hide carries FILTRULE_SENDER_SIDE, so it must exclude on the sender"
+        );
+        assert!(
+            sender_only.allows_xattr("user.secret", XattrSide::Receiver),
+            "the same rule is elided on the receiver and cannot exclude there"
+        );
+
+        let receiver_only = FilterProgram::new([FilterProgramEntry::Rule(
+            FilterRule::protect("user.secret").with_xattr_only(true),
+        )])
+        .unwrap();
+        assert!(
+            receiver_only.allows_xattr("user.secret", XattrSide::Sender),
+            "`P`/protect carries FILTRULE_RECEIVER_SIDE and is elided on the sender"
+        );
+        assert!(
+            !receiver_only.allows_xattr("user.secret", XattrSide::Receiver),
+            "`P` is a plain exclude on its own side (exclude.c:1358)"
+        );
+    }
+
+    /// `R`/risk is `FILTRULE_INCLUDE|RECEIVER_SIDE` (exclude.c:1355), so on an
+    /// xattr chain it is an INCLUDE - the inverse of `P`. Modelling protect and
+    /// risk as distinct oc actions makes it possible to treat both as
+    /// "not Include" and silently invert this row, which is what
+    /// [`FilterAction::xattr_decision`] exists to prevent.
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
+    #[test]
+    fn risk_resolves_to_include_on_an_xattr_chain() {
+        let program = FilterProgram::new([
+            FilterProgramEntry::Rule(FilterRule::risk("user.keep").with_xattr_only(true)),
+            FilterProgramEntry::Rule(FilterRule::exclude("user.*").with_xattr_only(true)),
+        ])
+        .unwrap();
+
+        assert!(
+            program.allows_xattr("user.keep", XattrSide::Receiver),
+            "`R` must resolve to include and win first-match against the later exclude"
+        );
+        assert!(
+            !program.allows_xattr("user.other", XattrSide::Receiver),
+            "the trailing exclude still drops every other user.* name"
         );
     }
 }

--- a/crates/engine/src/local_copy/filter_program_internal_tests.rs
+++ b/crates/engine/src/local_copy/filter_program_internal_tests.rs
@@ -54,9 +54,13 @@ fn filter_program_xattr_rules_control_allowance() {
     .expect("compile program");
 
     assert!(program.has_xattr_rules());
-    assert!(!program.allows_xattr("user.skip"));
-    assert!(program.allows_xattr("user.keep"));
-    assert!(program.allows_xattr("user.other"));
+    for side in [filters::XattrSide::Sender, filters::XattrSide::Receiver] {
+        // Neither rule carries a side prefix, so both participate on either end
+        // exactly as an upstream rule with `elide == 0` does (exclude.c:1010).
+        assert!(!program.allows_xattr("user.skip", side));
+        assert!(program.allows_xattr("user.keep", side));
+        assert!(program.allows_xattr("user.other", side));
+    }
 }
 
 #[test]

--- a/crates/engine/src/local_copy/metadata_sync.rs
+++ b/crates/engine/src/local_copy/metadata_sync.rs
@@ -18,6 +18,9 @@ use super::LocalCopyExecution;
 #[cfg(all(any(unix, windows), feature = "xattr"))]
 use super::FilterProgram;
 
+#[cfg(all(unix, feature = "xattr"))]
+use ::filters::XattrSide;
+
 #[cfg(all(any(unix, windows), feature = "acl"))]
 use ::metadata::{sync_acls, sync_acls_via_fake_super};
 
@@ -48,7 +51,15 @@ pub(crate) fn sync_xattrs_if_requested(
     if preserve_xattrs && !mode.is_dry_run() {
         if let Some(program) = filter_program {
             if program.has_xattr_rules() {
-                let filter = |name: &str| program.allows_xattr(name);
+                // upstream: copy_xattrs (xattrs.c:358) is this function's
+                // analogue, and every live caller is generator-side -
+                // gen_entry_copy_xattrs (generator.c:1599), the backup copy
+                // (generator.c:2430) and copy_file (util1.c:513). Its
+                // `user_only = am_sender ? 0 : am_root <= 0` therefore always
+                // evaluates with `am_sender == 0`, so the filter is consulted
+                // with receiver semantics even though the names are read from
+                // the SOURCE.
+                let filter = |name: &str| program.allows_xattr(name, XattrSide::Receiver);
                 sync_xattrs(source, destination, follow_symlinks, Some(&filter))
                     .map_err(map_metadata_error)?;
             } else {
@@ -89,9 +100,17 @@ pub(crate) fn xattrs_differ_from_source(
     fake_super: bool,
     filter_program: Option<&FilterProgram>,
 ) -> bool {
-    let filter = filter_program
-        .filter(|program| program.has_xattr_rules())
-        .map(|program| move |name: &str| program.allows_xattr(name));
+    // The two sides read their lists with different `am_sender`, so they must
+    // also consult the xattr chain with different sides: upstream elides a
+    // side-flagged rule before its pattern is consulted (exclude.c:1010), so a
+    // `H`/`S` rule shapes only the sender's list and a `P`/`R` rule only the
+    // generator's. Sharing one closure across both reads would compare
+    // asymmetrically filtered lists and manufacture a spurious `x` column.
+    let rules = filter_program.filter(|program| program.has_xattr_rules());
+    let sender_filter =
+        rules.map(|program| move |name: &str| program.allows_xattr(name, XattrSide::Sender));
+    let receiver_filter =
+        rules.map(|program| move |name: &str| program.allows_xattr(name, XattrSide::Receiver));
     let sender_opts = ::metadata::XattrSendOptions {
         role: ::metadata::XattrRole::Sender,
         follow_symlinks,
@@ -100,7 +119,7 @@ pub(crate) fn xattrs_differ_from_source(
         // strip always applies on the sender side. upstream: xattrs.c:260-267.
         preserve_xattrs: 1,
         fake_super,
-        filter: filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool),
+        filter: sender_filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool),
         // Both lists are read from local disk with full values, so the
         // abbreviation digest is never consulted. upstream: xattrs.c:584-594.
         checksum_seed: 0,
@@ -113,6 +132,7 @@ pub(crate) fn xattrs_differ_from_source(
         destination,
         &::metadata::XattrSendOptions {
             role: ::metadata::XattrRole::Generator,
+            filter: receiver_filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool),
             ..sender_opts
         },
     )

--- a/crates/engine/src/local_copy/metadata_sync.rs
+++ b/crates/engine/src/local_copy/metadata_sync.rs
@@ -21,6 +21,9 @@ use super::FilterProgram;
 #[cfg(all(unix, feature = "xattr"))]
 use ::filters::XattrSide;
 
+#[cfg(all(unix, feature = "xattr"))]
+use ::metadata::XattrSyncFilters;
+
 #[cfg(all(any(unix, windows), feature = "acl"))]
 use ::metadata::{sync_acls, sync_acls_via_fake_super};
 
@@ -51,23 +54,37 @@ pub(crate) fn sync_xattrs_if_requested(
     if preserve_xattrs && !mode.is_dry_run() {
         if let Some(program) = filter_program {
             if program.has_xattr_rules() {
-                // upstream: copy_xattrs (xattrs.c:358) is this function's
-                // analogue, and every live caller is generator-side -
-                // gen_entry_copy_xattrs (generator.c:1599), the backup copy
-                // (generator.c:2430) and copy_file (util1.c:513). Its
-                // `user_only = am_sender ? 0 : am_root <= 0` therefore always
-                // evaluates with `am_sender == 0`, so the filter is consulted
-                // with receiver semantics even though the names are read from
-                // the SOURCE.
-                let filter = |name: &str| program.allows_xattr(name, XattrSide::Receiver);
-                sync_xattrs(source, destination, follow_symlinks, Some(&filter))
+                // The two halves of this call are upstream's two sides - see
+                // [`XattrSyncFilters`]. Reading the source names is the
+                // sender's `rsync_xal_get()`, deleting the extraneous
+                // destination names is the generator's prune in
+                // `rsync_xal_set()`, and a side-flagged rule participates in
+                // exactly one of them (exclude.c:1010).
+                let sender = |name: &str| program.allows_xattr(name, XattrSide::Sender);
+                let receiver = |name: &str| program.allows_xattr(name, XattrSide::Receiver);
+                let filters = XattrSyncFilters {
+                    source: Some(&sender),
+                    destination: Some(&receiver),
+                };
+                sync_xattrs(source, destination, follow_symlinks, filters)
                     .map_err(map_metadata_error)?;
             } else {
-                sync_xattrs(source, destination, follow_symlinks, None)
-                    .map_err(map_metadata_error)?;
+                sync_xattrs(
+                    source,
+                    destination,
+                    follow_symlinks,
+                    XattrSyncFilters::default(),
+                )
+                .map_err(map_metadata_error)?;
             }
         } else {
-            sync_xattrs(source, destination, follow_symlinks, None).map_err(map_metadata_error)?;
+            sync_xattrs(
+                source,
+                destination,
+                follow_symlinks,
+                XattrSyncFilters::default(),
+            )
+            .map_err(map_metadata_error)?;
         }
     }
     Ok(())

--- a/crates/engine/src/local_copy/tests/filters.rs
+++ b/crates/engine/src/local_copy/tests/filters.rs
@@ -78,13 +78,23 @@ fn parse_filter_directive_keyword_with_xattr_modifier() {
     assert_eq!(rule.pattern(), "user.keep");
 }
 
+/// upstream: exclude.c:1438 - `case 'x'` carries no guard, so it is legal after
+/// the side-bound prefixes too. `show,x` is upstream's
+/// `FILTRULE_INCLUDE|SENDER_SIDE|XATTR`: a sender-side xattr include.
 #[test]
-fn parse_filter_directive_rejects_xattr_on_show_keyword() {
-    let error = parse_filter_directive_line("show,x user.skip")
-        .expect_err("show keyword should reject xattr modifier");
-    assert!(error
-        .to_string()
-        .contains("uses unsupported modifier 'x'"));
+fn parse_filter_directive_accepts_xattr_on_show_keyword() {
+    let rule = match parse_filter_directive_line("show,x user.skip").expect("parse") {
+        Some(ParsedFilterDirective::Rule(rule)) => rule,
+        other => panic!("expected rule, got {other:?}"),
+    };
+
+    assert!(rule.is_xattr_only());
+    assert!(rule.applies_to_sender());
+    assert!(
+        !rule.applies_to_receiver(),
+        "`show` binds the sender side (exclude.c:1345-1351)"
+    );
+    assert_eq!(rule.pattern(), "user.skip");
 }
 
 #[test]

--- a/crates/filters/src/action.rs
+++ b/crates/filters/src/action.rs
@@ -62,6 +62,52 @@ pub enum FilterAction {
     DirMerge,
 }
 
+impl FilterAction {
+    /// Resolves this action to the include/exclude decision upstream stores for
+    /// an xattr-name rule, or `None` for a meta action that carries none.
+    ///
+    /// upstream: exclude.c:1345-1358 - the four side-bound prefixes are nothing
+    /// but (include|exclude) x (sender|receiver) bit pairs:
+    ///
+    /// | prefix      | upstream rflags                   | decision |
+    /// |-------------|-----------------------------------|----------|
+    /// | `S`/show    | `FILTRULE_INCLUDE\|SENDER_SIDE`   | include  |
+    /// | `H`/hide    | `FILTRULE_SENDER_SIDE`            | exclude  |
+    /// | `R`/risk    | `FILTRULE_INCLUDE\|RECEIVER_SIDE` | include  |
+    /// | `P`/protect | `FILTRULE_RECEIVER_SIDE`          | exclude  |
+    ///
+    /// There is no distinct protect/risk *action* upstream. oc models the two
+    /// receiver-side spellings as their own variants because its delete pass
+    /// needs them separable on the PATH chain; but an xattr name is never
+    /// deleted, so on an xattr chain the extra variants have no meaning and
+    /// must collapse back onto upstream's two-value decision.
+    ///
+    /// This is the single owner of that table: both the [`crate`] xattr chain
+    /// and the engine's local-copy chain resolve through it, so the two cannot
+    /// drift apart.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use filters::FilterAction;
+    /// assert_eq!(FilterAction::Protect.xattr_decision(), Some(FilterAction::Exclude));
+    /// assert_eq!(FilterAction::Risk.xattr_decision(), Some(FilterAction::Include));
+    /// assert_eq!(FilterAction::Clear.xattr_decision(), None);
+    /// ```
+    #[must_use]
+    pub const fn xattr_decision(self) -> Option<Self> {
+        match self {
+            Self::Include | Self::Risk => Some(Self::Include),
+            Self::Exclude | Self::Protect => Some(Self::Exclude),
+            // `!`/clear is handled by the set's clear pass, and the merge
+            // prefixes consume `x` and drop it (upstream: exclude.c:1229
+            // FILTRULES_FROM_CONTAINER omits XATTR), so no merge rule reaches
+            // an xattr chain carrying the flag.
+            Self::Clear | Self::Merge | Self::DirMerge => None,
+        }
+    }
+}
+
 impl fmt::Display for FilterAction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/filters/src/compiled/xattr.rs
+++ b/crates/filters/src/compiled/xattr.rs
@@ -33,41 +33,12 @@ pub enum XattrSide {
     Receiver,
 }
 
-/// Resolves a rule's action to the include/exclude decision upstream stores.
-///
-/// upstream: exclude.c:1345-1358 - the four side-bound prefixes are nothing but
-/// (include|exclude) x (sender|receiver) bit pairs:
-///
-/// | prefix    | upstream rflags                     | decision |
-/// |-----------|-------------------------------------|----------|
-/// | `S`/show  | `FILTRULE_INCLUDE\|SENDER_SIDE`     | include  |
-/// | `H`/hide  | `FILTRULE_SENDER_SIDE`              | exclude  |
-/// | `R`/risk  | `FILTRULE_INCLUDE\|RECEIVER_SIDE`   | include  |
-/// | `P`/protect | `FILTRULE_RECEIVER_SIDE`          | exclude  |
-///
-/// There is no distinct protect/risk *action* upstream. oc models the two
-/// receiver-side spellings as their own [`FilterAction`] variants because its
-/// delete pass needs them separable on the PATH chain, and that stays as it is;
-/// but an xattr name is never deleted, so on this chain the extra variants have
-/// no meaning and must collapse back onto upstream's two-value decision. Doing
-/// otherwise drops the rule: `protect,x user.drop` would parse and then match
-/// nothing, which is the silent-no-op shape this chain exists to avoid.
-const fn xattr_decision(action: FilterAction) -> Option<FilterAction> {
-    match action {
-        FilterAction::Include | FilterAction::Risk => Some(FilterAction::Include),
-        FilterAction::Exclude | FilterAction::Protect => Some(FilterAction::Exclude),
-        // Meta actions carry no xattr decision. `!`/clear is handled by the
-        // set's clear pass, and the merge prefixes consume `x` and drop it
-        // (upstream: exclude.c:1229 FILTRULES_FROM_CONTAINER omits XATTR), so
-        // no merge rule can reach here carrying the flag.
-        FilterAction::Clear | FilterAction::Merge | FilterAction::DirMerge => None,
-    }
-}
-
 /// A compiled `x`-modifier filter rule matched against xattr names only.
 ///
 /// The action is normalised to include/exclude on construction via
-/// [`xattr_decision`]; the meta (clear/merge) actions never reach this list.
+/// [`FilterAction::xattr_decision`] - the single owner of upstream's
+/// `exclude.c:1345-1358` table, shared with the engine's local-copy chain so
+/// the two cannot drift. The meta (clear/merge) actions never reach this list.
 #[derive(Debug)]
 pub(crate) struct CompiledXattrRule {
     action: FilterAction,
@@ -97,7 +68,7 @@ impl CompiledXattrRule {
     /// Returns [`FilterError`] if the pattern is not a valid glob.
     pub(crate) fn new(rule: FilterRule) -> Result<Option<Self>, FilterError> {
         debug_assert!(rule.xattr_only, "non-xattr rule compiled as xattr rule");
-        let Some(action) = xattr_decision(rule.action) else {
+        let Some(action) = rule.action.xattr_decision() else {
             return Ok(None);
         };
         let mut patterns = std::collections::HashSet::with_capacity(1);

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -313,7 +313,7 @@ pub use special::{
     create_fifo, create_fifo_node_from_parts, create_fifo_with_fake_super,
 };
 
-pub use xattr_send::{XattrRole, XattrSendOptions, dest_xattrs_differ};
+pub use xattr_send::{XattrRole, XattrSendOptions, XattrSyncFilters, dest_xattrs_differ};
 
 #[cfg(all(feature = "xattr", any(unix, windows)))]
 pub use xattr::{

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -22,6 +22,7 @@
 
 use crate::error::MetadataError;
 use crate::xattr_send::XattrSendOptions;
+use crate::xattr_send::XattrSyncFilters;
 use protocol::xattr::XattrList;
 use std::collections::HashSet;
 use std::io;
@@ -347,8 +348,12 @@ pub fn sync_xattrs(
     source: &Path,
     destination: &Path,
     follow_symlinks: bool,
-    filter: Option<&dyn Fn(&str) -> bool>,
+    filters: XattrSyncFilters<'_>,
 ) -> Result<(), MetadataError> {
+    let XattrSyncFilters {
+        source: source_filter,
+        destination: destination_filter,
+    } = filters;
     let source_attrs = list_attributes(source, follow_symlinks, receiver_screen())?;
     let mut retained: HashSet<Vec<u8>> = HashSet::with_capacity(source_attrs.len());
     let dest = DestinationXattrs::open(destination, follow_symlinks);
@@ -361,7 +366,7 @@ pub fn sync_xattrs(
             continue;
         }
         retained.insert(name.clone());
-        let allow = filter.is_none_or(|predicate| predicate(&name_str));
+        let allow = source_filter.is_none_or(|predicate| predicate(&name_str));
 
         if !allow {
             continue;
@@ -387,7 +392,7 @@ pub fn sync_xattrs(
             continue;
         }
 
-        let allow = filter.is_none_or(|predicate| predicate(&name_str));
+        let allow = destination_filter.is_none_or(|predicate| predicate(&name_str));
 
         if allow {
             dest.remove(name)?;
@@ -894,7 +899,7 @@ mod tests {
         write_attribute(&source, &attr1, b"value1", false).expect("write attr1");
         write_attribute(&source, &attr2, b"value2", false).expect("write attr2");
 
-        sync_xattrs(&source, &destination, false, None).expect("sync");
+        sync_xattrs(&source, &destination, false, XattrSyncFilters::default()).expect("sync");
 
         assert_eq!(
             read_attribute(&destination, &attr1, false)
@@ -968,7 +973,7 @@ mod tests {
         write_attribute(&destination, &attr1, b"old_value1", false).expect("write dest attr1");
         write_attribute(&destination, &attr2, b"extra_value", false).expect("write dest attr2");
 
-        sync_xattrs(&source, &destination, false, None).expect("sync");
+        sync_xattrs(&source, &destination, false, XattrSyncFilters::default()).expect("sync");
 
         // attr1 should be updated
         assert_eq!(
@@ -1017,7 +1022,7 @@ mod tests {
         write_attribute(&destination, &stat_name, b"100000 0,0 2:2", false)
             .expect("write dest %stat");
 
-        sync_xattrs(&source, &destination, false, None).expect("sync");
+        sync_xattrs(&source, &destination, false, XattrSyncFilters::default()).expect("sync");
 
         // The destination's fake-super %stat must be preserved verbatim - not
         // overwritten by the source copy nor deleted by the removal pass.
@@ -1410,7 +1415,13 @@ mod tests {
 
         // Filter that only allows attrs NOT containing "blocked"
         let filter = |name: &str| !name.contains("blocked");
-        sync_xattrs(&source, &destination, false, Some(&filter)).expect("sync");
+        sync_xattrs(
+            &source,
+            &destination,
+            false,
+            XattrSyncFilters::uniform(&filter),
+        )
+        .expect("sync");
 
         // allowed should be synced
         assert_eq!(
@@ -1505,7 +1516,13 @@ mod tests {
 
         // Filter that blocks "preserved" - it should NOT be touched
         let filter = |name: &str| !name.contains("preserved");
-        sync_xattrs(&source, &destination, false, Some(&filter)).expect("sync");
+        sync_xattrs(
+            &source,
+            &destination,
+            false,
+            XattrSyncFilters::uniform(&filter),
+        )
+        .expect("sync");
 
         // src_attr should be synced
         assert_eq!(
@@ -1521,6 +1538,100 @@ mod tests {
                 .expect("preserved"),
             b"keep_me"
         );
+    }
+
+    /// The source read and the destination prune consult DIFFERENT filters.
+    ///
+    /// upstream: the source read is the sender's `rsync_xal_get()`
+    /// (xattrs.c:262) and the prune is the generator's sweep in
+    /// `rsync_xal_set()` (xattrs.c:1078); `rule_matches()` elides a
+    /// side-flagged rule before its pattern is consulted (exclude.c:1010), so
+    /// an `H`/`S` rule reaches only the first and a `P`/`R` rule only the
+    /// second.
+    ///
+    /// Each half is asserted in BOTH directions. With a single shared
+    /// predicate the two rows of each pair collapse onto the same answer, so
+    /// the inverse row is what makes this non-vacuous rather than decoration.
+    #[test]
+    fn sync_xattrs_consults_each_side_filter_for_its_own_half() {
+        let dir = tempdir().expect("create temp dir");
+        let source = dir.path().join("source.txt");
+        let destination = dir.path().join("dest.txt");
+        fs::write(&source, "source").expect("write source");
+        fs::write(&destination, "dest").expect("write dest");
+
+        if !xattrs_supported(&source) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let from_source = test_xattr_name("from_source");
+        let dest_only = test_xattr_name("dest_only");
+        let name_of = |raw: &[u8]| String::from_utf8_lossy(raw).into_owned();
+        let blocked = |target: String| move |name: &str| name != target;
+        let allow_all = |_: &str| true;
+
+        // Source-read half: only `filters.source` may suppress the copy.
+        for (block_source, expect_copied) in [(true, false), (false, true)] {
+            let _ = fs::remove_file(&destination);
+            fs::write(&destination, "dest").expect("write dest");
+            write_attribute(&source, &from_source, b"v", false).expect("write source attr");
+
+            let deny = blocked(name_of(&from_source));
+            let filters = if block_source {
+                XattrSyncFilters {
+                    source: Some(&deny),
+                    destination: Some(&allow_all),
+                }
+            } else {
+                XattrSyncFilters {
+                    source: Some(&allow_all),
+                    destination: Some(&deny),
+                }
+            };
+            sync_xattrs(&source, &destination, false, filters).expect("sync");
+
+            let copied = read_attribute(&destination, &from_source, false)
+                .expect("read")
+                .is_some();
+            assert_eq!(
+                copied, expect_copied,
+                "a source name is gated by `filters.source` alone \
+                 (block_source = {block_source})"
+            );
+        }
+
+        // Destination-prune half: only `filters.destination` may spare it.
+        let _ = fs::remove_file(&source);
+        fs::write(&source, "source").expect("rewrite source");
+        for (block_destination, expect_survives) in [(true, true), (false, false)] {
+            let _ = fs::remove_file(&destination);
+            fs::write(&destination, "dest").expect("write dest");
+            write_attribute(&destination, &dest_only, b"v", false).expect("write dest attr");
+
+            let deny = blocked(name_of(&dest_only));
+            let filters = if block_destination {
+                XattrSyncFilters {
+                    source: Some(&allow_all),
+                    destination: Some(&deny),
+                }
+            } else {
+                XattrSyncFilters {
+                    source: Some(&deny),
+                    destination: Some(&allow_all),
+                }
+            };
+            sync_xattrs(&source, &destination, false, filters).expect("sync");
+
+            let survives = read_attribute(&destination, &dest_only, false)
+                .expect("read")
+                .is_some();
+            assert_eq!(
+                survives, expect_survives,
+                "an extraneous destination name is gated by `filters.destination` \
+                 alone (block_destination = {block_destination})"
+            );
+        }
     }
 
     #[test]
@@ -1676,7 +1787,8 @@ mod tests {
 
         // sync_xattrs: copies the source set, then removes destination strays.
         let (source, destination) = readonly_pair("sync");
-        sync_xattrs(&source, &destination, false, None).expect("sync_xattrs on read-only dest");
+        sync_xattrs(&source, &destination, false, XattrSyncFilters::default())
+            .expect("sync_xattrs on read-only dest");
         assert_mode_restored(&destination, "sync_xattrs");
 
         // strip_source_xattrs: removes only names the source also carries. This

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -133,6 +133,20 @@ fn list_attributes(
         .collect())
 }
 
+/// Selects the namespace screen for one read.
+///
+/// upstream: xattrs.c:250-257 (`rsync_xal_get`) and :375-382 (`copy_xattrs`) -
+/// the namespace test is the `else` of the `saw_xattr_filter` branch, so an
+/// `x`-modifier filter REPLACES it rather than stacking with it. Both readers
+/// make that same decision, so the rule has a single owner.
+const fn namespace_screen(filter_governs: bool, user_only: bool) -> NamespaceScreen {
+    if filter_governs {
+        NamespaceScreen::Bypass
+    } else {
+        NamespaceScreen::Apply { user_only }
+    }
+}
+
 /// Shorthand for the receiver/local-copy namespace screen.
 fn receiver_screen() -> NamespaceScreen {
     NamespaceScreen::Apply {
@@ -192,21 +206,12 @@ pub fn read_xattrs_for_wire(
 ) -> Result<XattrList, MetadataError> {
     use protocol::xattr::{XattrEntry, is_fake_super_store_attr, is_rsync_internal, local_to_wire};
 
-    // upstream: xattrs.c:250-257 - the filter branch and the namespace branch
-    // are mutually exclusive, so a transfer carrying `x`-modifier rules never
-    // evaluates the namespace test at all.
-    let screen = if opts.filter.is_some() {
-        NamespaceScreen::Bypass
-    } else {
-        // upstream: xattrs.c:249 - `user_only = am_sender ? 0 : !am_root`. The
-        // sender skips only the system.* namespace and still transmits user.*,
-        // security.* (e.g. SELinux labels), and trusted.*; a non-root
-        // generator reading the destination to diff it keeps user.* alone, so
-        // a namespace it could never store cannot flip the itemize `x` column.
-        NamespaceScreen::Apply {
-            user_only: opts.user_only(),
-        }
-    };
+    // upstream: xattrs.c:249 - `user_only = am_sender ? 0 : !am_root`. The
+    // sender skips only the system.* namespace and still transmits user.*,
+    // security.* (e.g. SELinux labels), and trusted.*; a non-root generator
+    // reading the destination to diff it keeps user.* alone, so a namespace it
+    // could never store cannot flip the itemize `x` column.
+    let screen = namespace_screen(opts.filter.is_some(), opts.user_only());
     let attrs = list_attributes(path, opts.follow_symlinks, screen)?;
     let mut entries = Vec::with_capacity(attrs.len());
 
@@ -350,11 +355,15 @@ pub fn sync_xattrs(
     follow_symlinks: bool,
     filters: XattrSyncFilters<'_>,
 ) -> Result<(), MetadataError> {
+    // Screening first and filtering second dropped `--filter='+x trusted.foo'`
+    // for a non-root receiver on Linux: the name never survived to reach the
+    // rule that was meant to admit it.
+    let screen = namespace_screen(filters.governs_selection(), receiver_user_only());
     let XattrSyncFilters {
         source: source_filter,
         destination: destination_filter,
     } = filters;
-    let source_attrs = list_attributes(source, follow_symlinks, receiver_screen())?;
+    let source_attrs = list_attributes(source, follow_symlinks, screen)?;
     let mut retained: HashSet<Vec<u8>> = HashSet::with_capacity(source_attrs.len());
     let dest = DestinationXattrs::open(destination, follow_symlinks);
 
@@ -365,12 +374,20 @@ pub fn sync_xattrs(
             retained.insert(name.clone());
             continue;
         }
-        retained.insert(name.clone());
+        // Retain ONLY what the source side actually transfers. upstream's
+        // prune (xattrs.c:1074-1094) walks the destination list and removes any
+        // name absent from the sender's `xalp`; a name the sender's
+        // `rsync_xal_get` screened out (xattrs.c:262-264) never enters `xalp`,
+        // so upstream DELETES the destination copy. Inserting before the filter
+        // exempted it instead, leaving a stale value behind - measured against
+        // rsync 3.5.0 with `--filter='Hx user.shared'` present on both sides:
+        // upstream removes it, oc kept it.
         let allow = source_filter.is_none_or(|predicate| predicate(&name_str));
 
         if !allow {
             continue;
         }
+        retained.insert(name.clone());
 
         if let Some(value) = read_attribute(source, name, follow_symlinks)? {
             dest.write(name, &value)?;
@@ -379,7 +396,7 @@ pub fn sync_xattrs(
         }
     }
 
-    let destination_attrs = list_attributes(destination, follow_symlinks, receiver_screen())?;
+    let destination_attrs = list_attributes(destination, follow_symlinks, screen)?;
     for name in &destination_attrs {
         if retained.contains(name) {
             continue;
@@ -1438,6 +1455,43 @@ mod tests {
         );
     }
 
+    /// An `x`-modifier filter REPLACES the namespace screen, it does not stack
+    /// with it: upstream reaches the namespace test only through the `else` of
+    /// the `saw_xattr_filter` branch (xattrs.c:250-257, :375-382). Screening
+    /// first and filtering second made `--filter='+x trusted.foo'` inert for a
+    /// non-root Linux receiver - the name was gone before its rule ran.
+    ///
+    /// The decision is pinned here rather than through a real xattr because no
+    /// unprivileged fixture can express it: writing `trusted.*` needs
+    /// CAP_SYS_ADMIN on Linux, and off Linux `is_xattr_permitted` is constantly
+    /// true, so `Apply` and `Bypass` are indistinguishable by observation.
+    #[test]
+    fn a_filter_replaces_the_namespace_screen_rather_than_stacking() {
+        assert!(matches!(
+            namespace_screen(true, true),
+            NamespaceScreen::Bypass
+        ));
+        assert!(matches!(
+            namespace_screen(true, false),
+            NamespaceScreen::Bypass
+        ));
+    }
+
+    /// Non-vacuity companion: without a filter the screen still applies, and
+    /// carries `user_only` through unchanged. Without this row the rule above
+    /// would also hold for a `namespace_screen` that returned `Bypass` always.
+    #[test]
+    fn without_a_filter_the_namespace_screen_applies_verbatim() {
+        assert!(matches!(
+            namespace_screen(false, true),
+            NamespaceScreen::Apply { user_only: true }
+        ));
+        assert!(matches!(
+            namespace_screen(false, false),
+            NamespaceScreen::Apply { user_only: false }
+        ));
+    }
+
     #[test]
     fn is_xattr_permitted_allows_user_namespace() {
         // user.* should always be permitted regardless of platform or mode.
@@ -1598,6 +1652,41 @@ mod tests {
                 copied, expect_copied,
                 "a source name is gated by `filters.source` alone \
                  (block_source = {block_source})"
+            );
+        }
+
+        // The row that discriminates a REAL fork from a half fork: a name
+        // present on BOTH sides. `retained` must be keyed on what the source
+        // side actually transfers, so a source-denied name still reaches the
+        // prune loop and is deleted from the destination - upstream's
+        // xattrs.c:1074-1094 removes any destination name absent from the
+        // sender's `xalp`. With `retained.insert` above the source filter this
+        // row is the only one that fails; the two disjoint fixtures below
+        // cannot see it, which is why they are not sufficient on their own.
+        // Measured against rsync 3.5.0 with `--filter='Hx user.shared'`.
+        {
+            let _ = fs::remove_file(&destination);
+            fs::write(&destination, "dest").expect("write dest");
+            write_attribute(&source, &from_source, b"src", false).expect("source attr");
+            write_attribute(&destination, &from_source, b"dst", false).expect("dest attr");
+
+            let deny = blocked(name_of(&from_source));
+            sync_xattrs(
+                &source,
+                &destination,
+                false,
+                XattrSyncFilters {
+                    source: Some(&deny),
+                    destination: Some(&allow_all),
+                },
+            )
+            .expect("sync");
+
+            assert!(
+                read_attribute(&destination, &from_source, false)
+                    .expect("read")
+                    .is_none(),
+                "a source-denied name is not transferred, so the destination copy                  must be pruned - not exempted by having existed on the source"
             );
         }
 

--- a/crates/metadata/src/xattr_send.rs
+++ b/crates/metadata/src/xattr_send.rs
@@ -231,7 +231,32 @@ fn without_macos_auto_xattrs(list: &XattrList) -> XattrList {
 
 #[cfg(test)]
 mod tests {
-    use super::{XattrRole, XattrSendOptions};
+    use super::{XattrRole, XattrSendOptions, XattrSyncFilters};
+
+    /// The filter chain governs the selection as soon as EITHER half carries a
+    /// rule: upstream's `saw_xattr_filter` (exclude.c:1440) is a process-wide
+    /// latch set by any `x` rule, not a per-side one, and it is what suppresses
+    /// the namespace screen for the whole read.
+    #[test]
+    fn governs_selection_when_either_half_carries_a_rule() {
+        let admit_all = |_: &str| true;
+        assert!(!XattrSyncFilters::default().governs_selection());
+        assert!(
+            XattrSyncFilters {
+                source: Some(&admit_all),
+                destination: None,
+            }
+            .governs_selection()
+        );
+        assert!(
+            XattrSyncFilters {
+                source: None,
+                destination: Some(&admit_all),
+            }
+            .governs_selection()
+        );
+        assert!(XattrSyncFilters::uniform(&admit_all).governs_selection());
+    }
 
     /// `user_only` is a function of the role first and privilege second.
     ///
@@ -331,15 +356,20 @@ mod macos_provenance_tests {
     }
 }
 
-/// The two xattr-name filters [`sync_xattrs`] consults, one per upstream side.
+/// The two xattr-name filters `sync_xattrs` consults, one per upstream side.
 ///
-/// A local copy is upstream's forked sender + generator, and the two halves of
-/// this function are exactly that fork:
+/// `sync_xattrs` is oc's analogue of upstream `copy_xattrs` (xattrs.c:358),
+/// whose two halves consult the filter chain for two different decisions:
 ///
-/// - reading the SOURCE names is the sender's `rsync_xal_get()`
-///   (xattrs.c:250-267), which runs with `am_sender = 1`;
-/// - deleting the extraneous DESTINATION names is the generator's prune in
-///   `rsync_xal_set()` (xattrs.c:1078-1082), which runs with `am_sender = 0`.
+/// - reading the SOURCE names decides what is COPIED (xattrs.c:375);
+/// - the caller's prune of extraneous DESTINATION names, mirroring
+///   `rsync_xal_set` (xattrs.c:1078), decides what is DELETED.
+///
+/// ⚠ Both run with the generator's `user_only` - `copy_xattrs` computes
+/// `am_sender ? 0 : am_root <= 0` (xattrs.c:364) and every live caller is
+/// generator-side (generator.c:1599, generator.c:2430, util1.c:513), so
+/// `am_sender == 0` throughout. The SIDE below is about which filter RULES
+/// participate, which is a separate axis from the namespace screen.
 ///
 /// `rule_matches()` elides a side-flagged rule before it consults the pattern
 /// (exclude.c:1010), so the two halves genuinely see different rule sets: an
@@ -359,6 +389,20 @@ pub struct XattrSyncFilters<'a> {
 }
 
 impl<'a> XattrSyncFilters<'a> {
+    /// Whether an `x`-modifier filter governs the selection on either side.
+    ///
+    /// upstream: `saw_xattr_filter` (exclude.c:1440) is a process-wide latch set
+    /// by ANY `x` rule, and both `rsync_xal_get` (xattrs.c:262-269) and
+    /// `copy_xattrs` (xattrs.c:375-382) read it as
+    /// `if (saw_xattr_filter) { ...filter... } else if (namespace screen)`. The
+    /// namespace screen is the ELSE, so a filter suppresses it entirely - "when
+    /// you specify an xattr-affecting filter rule, rsync requires that you do
+    /// your own system/user filtering" (rsync.1.md).
+    #[must_use]
+    pub const fn governs_selection(&self) -> bool {
+        self.source.is_some() || self.destination.is_some()
+    }
+
     /// Applies one predicate to both sides.
     ///
     /// Correct only where the caller has no side distinction to make - a rule

--- a/crates/metadata/src/xattr_send.rs
+++ b/crates/metadata/src/xattr_send.rs
@@ -330,3 +330,54 @@ mod macos_provenance_tests {
         );
     }
 }
+
+/// The two xattr-name filters [`sync_xattrs`] consults, one per upstream side.
+///
+/// A local copy is upstream's forked sender + generator, and the two halves of
+/// this function are exactly that fork:
+///
+/// - reading the SOURCE names is the sender's `rsync_xal_get()`
+///   (xattrs.c:250-267), which runs with `am_sender = 1`;
+/// - deleting the extraneous DESTINATION names is the generator's prune in
+///   `rsync_xal_set()` (xattrs.c:1078-1082), which runs with `am_sender = 0`.
+///
+/// `rule_matches()` elides a side-flagged rule before it consults the pattern
+/// (exclude.c:1010), so the two halves genuinely see different rule sets: an
+/// `H`/`S` rule shapes only the source read and a `P`/`R` rule only the
+/// destination prune. Sharing one predicate across both collapses that
+/// distinction - and measured against rsync 3.5.0 it is observable, e.g.
+/// `--filter='Hx user.foo'` must not copy the attribute while
+/// `--filter='Px user.foo'` must not delete an extraneous one.
+///
+/// [`Default`] leaves both sides unfiltered, which is `-X` with no `x` rules.
+#[derive(Clone, Copy, Default)]
+pub struct XattrSyncFilters<'a> {
+    /// Consulted with each name read from the source, upstream's sender side.
+    pub source: Option<&'a dyn Fn(&str) -> bool>,
+    /// Consulted with each extraneous destination name, upstream's generator side.
+    pub destination: Option<&'a dyn Fn(&str) -> bool>,
+}
+
+impl<'a> XattrSyncFilters<'a> {
+    /// Applies one predicate to both sides.
+    ///
+    /// Correct only where the caller has no side distinction to make - a rule
+    /// set with no side-flagged rules, or a test fixture. Production callers
+    /// that own a filter chain should build the two sides separately.
+    #[must_use]
+    pub const fn uniform(filter: &'a dyn Fn(&str) -> bool) -> Self {
+        Self {
+            source: Some(filter),
+            destination: Some(filter),
+        }
+    }
+}
+
+impl std::fmt::Debug for XattrSyncFilters<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("XattrSyncFilters")
+            .field("source", &self.source.is_some())
+            .field("destination", &self.destination.is_some())
+            .finish()
+    }
+}

--- a/crates/metadata/src/xattr_stub.rs
+++ b/crates/metadata/src/xattr_stub.rs
@@ -7,6 +7,7 @@
 
 use crate::error::MetadataError;
 use crate::xattr_send::XattrSendOptions;
+use crate::xattr_send::XattrSyncFilters;
 use protocol::xattr::XattrList;
 use std::path::Path;
 use std::sync::Once;
@@ -29,7 +30,7 @@ pub fn sync_xattrs(
     _source: &Path,
     _destination: &Path,
     _follow_symlinks: bool,
-    _filter: Option<&dyn Fn(&str) -> bool>,
+    _filters: XattrSyncFilters<'_>,
 ) -> Result<(), MetadataError> {
     warn_xattr_unsupported();
     Ok(())
@@ -91,7 +92,7 @@ mod tests {
     fn sync_xattrs_returns_ok() {
         let src = Path::new("/nonexistent/src");
         let dst = Path::new("/nonexistent/dst");
-        let result = sync_xattrs(src, dst, false, None);
+        let result = sync_xattrs(src, dst, false, XattrSyncFilters::default());
         assert!(result.is_ok());
     }
 
@@ -100,7 +101,7 @@ mod tests {
         let src = Path::new("/nonexistent/src");
         let dst = Path::new("/nonexistent/dst");
         let filter = |_name: &str| true;
-        let result = sync_xattrs(src, dst, true, Some(&filter));
+        let result = sync_xattrs(src, dst, true, XattrSyncFilters::uniform(&filter));
         assert!(result.is_ok());
     }
 

--- a/crates/metadata/tests/security_selinux_roundtrip.rs
+++ b/crates/metadata/tests/security_selinux_roundtrip.rs
@@ -36,7 +36,7 @@
 use std::fs;
 use std::path::Path;
 
-use metadata::{apply_xattrs_from_list, sync_xattrs};
+use metadata::{XattrSyncFilters, apply_xattrs_from_list, sync_xattrs};
 use protocol::xattr::{XattrEntry, XattrList};
 use tempfile::tempdir;
 

--- a/crates/metadata/tests/security_selinux_roundtrip.rs
+++ b/crates/metadata/tests/security_selinux_roundtrip.rs
@@ -99,7 +99,7 @@ fn security_selinux_xattr_round_trips() {
 
     xattr::set(&source, "security.selinux", FIXTURE_LABEL).expect("seed source label");
 
-    sync_xattrs(&source, &destination, false, None).expect("sync xattrs");
+    sync_xattrs(&source, &destination, false, XattrSyncFilters::default()).expect("sync xattrs");
 
     let landed = xattr::get(&destination, "security.selinux")
         .expect("read dest label")

--- a/tests/dir_merge_xattr_rule_is_not_a_path_rule.rs
+++ b/tests/dir_merge_xattr_rule_is_not_a_path_rule.rs
@@ -1,0 +1,50 @@
+//! An `x` rule in a per-directory merge file must not filter FILE names.
+//!
+//! upstream: exclude.c:1013 - `if (!(name_flags & NAME_IS_XATTR) ^
+//! !(ex->rflags & FILTRULE_XATTR)) return 0;`. A rule carrying `FILTRULE_XATTR`
+//! matches xattr names and nothing else, so it can never exclude a path.
+//!
+//! Measured against rsync 3.5.0: with `- x user.foo` (i.e. `-x user.foo`) in a
+//! `.rsync-filter`, upstream transfers a FILE named `user.foo`; oc routed the
+//! rule onto the path chain and silently dropped the file. `anchor_dir_merge_rule`
+//! even prefixed the merge file's directory, so the "xattr name" became
+//! `sub/user.foo`.
+//!
+//! ⚠ oc has no per-directory xattr chain, so such a rule is currently inert
+//! rather than applied to xattr names. That residual is named in the PR; this
+//! test pins only the half that was actively wrong - deleting the wrong file.
+
+use std::fs;
+use std::process::Command;
+
+use tempfile::TempDir;
+use test_support::oc_rsync_bin;
+
+#[test]
+fn a_dir_merge_xattr_rule_does_not_exclude_a_same_named_file() {
+    let temp = TempDir::new().expect("tempdir");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    fs::create_dir_all(&src).expect("create src");
+    fs::create_dir_all(&dst).expect("create dst");
+    fs::write(src.join("user.foo"), b"payload\n").expect("write user.foo");
+    fs::write(src.join("other.txt"), b"payload\n").expect("write other.txt");
+    fs::write(src.join(".rsync-filter"), b"-x user.foo\n").expect("write filter");
+
+    let status = Command::new(oc_rsync_bin())
+        .arg("-rF")
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dst.display()))
+        .status()
+        .expect("run oc-rsync");
+    assert!(status.success(), "transfer must succeed, got {status:?}");
+
+    assert!(
+        dst.join("user.foo").exists(),
+        "an `x` rule matches xattr names only; the FILE named user.foo must transfer"
+    );
+    assert!(
+        dst.join("other.txt").exists(),
+        "non-vacuity: the transfer really ran and carried an unrelated file"
+    );
+}


### PR DESCRIPTION
## Summary

oc gated the filter-rule `x` modifier on the same booleans as the side modifiers, so `x` was rejected on four rule types and silently misrouted on a fifth. Upstream's modifier loop (`exclude.c:1365-1443`) runs for **every** prefix, and `x` (`:1438`) carries no guard at all - only `C`/`r`/`s` test `prefix_specifies_side`, and only `- + e n w !` test the merge-file context.

Fixing that exposed two further divergences on the same path: the xattr chain had no side dimension, and the namespace screen was stacked on top of the filter instead of replaced by it.

## The upstream sites, and what oc did

| upstream | rule | oc before |
|---|---|---|
| `exclude.c:1438` | `x` has no side guard | rejected on `P`/`R`/`S`/`H` |
| `exclude.c:1420` | `p` has no side guard | gated on the side booleans |
| `exclude.c:1005` | `!` inverts the verdict | absent from the engine chain |
| `exclude.c:1325-1329` | a one-letter prefix takes **adjacent** modifiers (`Px` == `P,x`) | comma required |
| `exclude.c:1218-1227` | a long keyword **requires** the comma | comma optional |
| `exclude.c:1362` | only `S H R P` are prefixes; a lowercase initial is "Unknown filter rule" | matched case-insensitively |
| `exclude.c:1013` | `FILTRULE_XATTR` is a biconditional with `NAME_IS_XATTR` | dir-merge `x` rules joined the **path** chain |
| `exclude.c:1010` | a side-flagged rule is elided **before** its pattern is consulted | one filter served both sides |
| `xattrs.c:250-257`, `:375-382` | the namespace screen is the `else` of the filter branch | screen applied first, filter second |
| `xattrs.c:1074-1094` | the prune deletes any destination name absent from the sender's `xalp` | a screened-out name was exempted, not deleted |

## Measured against the real 3.5.0 binary

| matrix | before | after |
|---|---|---|
| xattr side (`S`/`H`/`R`/`P` x sender/receiver) | 10/12 | 12/12 |
| both-sides retained ordering | 5/6 | 6/6 |
| dir-merge modifier cells | 9 divergent | 32/32 |
| dir-merge `x` rule on a file named `user.foo` | oc dropped the file | transferred, as upstream does |

Two of those were user-visible data divergences, not cosmetics: a dir-merge `-x user.foo` rule made oc **drop a file** upstream transfers, and `Hx user.shared` left a stale destination xattr upstream deletes.

## Design

Three rules each got a single owner rather than a second hand-written copy:

- `Action::xattr_decision()` (`crates/filters/src/action.rs`) is the sole encoding of upstream's prefix table - `S`/`R` resolve to include, `H`/`P` to exclude, and the merge/clear arms are the only rejections. The dir-merge parser derives its reject condition from it instead of listing letters again.
- `XattrSide` gives the chain a side dimension, so a local copy consults it twice - once as upstream's sender and once as its generator - exactly as `exclude.c:1010` elides a side-flagged rule before the pattern is tested.
- `namespace_screen(filter_governs, user_only)` is the one place the screen-versus-filter decision is made; both readers call it.

## Tests

Every fix carries a pin, and every pin was mutation-tested. The screen pins are unit-level by necessity and say so: no unprivileged fixture can distinguish `Apply` from `Bypass`, since writing `trusted.*` needs `CAP_SYS_ADMIN` on Linux and the screen is constantly true off Linux. Each pin has an explicit non-vacuity companion - the `Bypass` rule is paired with a row that fails if the function became constant, and `governs_selection` is checked on all four combinations.

Two existing tests encoded the pre-fix behaviour (`adjacent_modifiers_after_a_single_letter_prefix_are_not_yet_parsed`, `parse_filter_directive_rejects_xattr_on_show_keyword`). Both were rewritten to the upstream contract rather than waived.
