### PR TITLE
fix(engine): match dir-merge modifiers case-sensitively, per upstream

### DIFF
--- a/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
@@ -52,10 +52,21 @@ pub(super) fn parse_dir_merge_directive(
     let mut saw_minus = false;
     let mut used_cvs_default = false;
 
+    // upstream: exclude.c:1365-1444 (`parse_rule_tok`) scans modifiers
+    // case-sensitively - `C` is the CVS modifier, `c` is not a modifier at all.
     for modifier in modifiers.chars() {
-        let lower = modifier.to_ascii_lowercase();
-        match lower {
+        match modifier {
+            // upstream: exclude.c:1381-1390 - `-`/`+` require
+            // BITS_SETnUNSET(FILTRULE_MERGE_FILE, FILTRULE_NO_PREFIXES), and `C`
+            // sets NO_PREFIXES, so a `C` scanned earlier in the same run
+            // invalidates them. Order matters: `:-C` is legal, `:C-` is not.
             '-' => {
+                if used_cvs_default {
+                    let message = format!(
+                        "{label} directive '{text}' cannot combine '-' with the 'C' modifier"
+                    );
+                    return Err(FilterParseError::new(message));
+                }
                 if saw_plus {
                     let message =
                         format!("{label} directive '{text}' cannot combine '+' and '-' modifiers");
@@ -65,6 +76,12 @@ pub(super) fn parse_dir_merge_directive(
                 options = options.with_enforced_kind(Some(DirMergeEnforcedKind::Exclude));
             }
             '+' => {
+                if used_cvs_default {
+                    let message = format!(
+                        "{label} directive '{text}' cannot combine '+' with the 'C' modifier"
+                    );
+                    return Err(FilterParseError::new(message));
+                }
                 if saw_minus {
                     let message =
                         format!("{label} directive '{text}' cannot combine '+' and '-' modifiers");
@@ -92,7 +109,19 @@ pub(super) fn parse_dir_merge_directive(
             '/' => {
                 options = options.anchor_root(true);
             }
-            'c' => {
+            // upstream: exclude.c:1419-1421 - `p` is unguarded, and
+            // FILTRULE_PERISHABLE is in FILTRULES_FROM_CONTAINER (exclude.c:1229)
+            // so it propagates to the rules read out of the merged file.
+            'p' => {
+                options = options.mark_perishable();
+            }
+            // upstream: exclude.c:1402-1409 - `C` is invalid once NO_PREFIXES is
+            // already set, which a preceding `C` in the same run does.
+            'C' => {
+                if used_cvs_default {
+                    let message = format!("{label} directive '{text}' repeats the 'C' modifier");
+                    return Err(FilterParseError::new(message));
+                }
                 used_cvs_default = true;
                 options = options.with_enforced_kind(Some(DirMergeEnforcedKind::Exclude));
                 options = options.use_whitespace();
@@ -269,7 +298,7 @@ mod tests {
 
     #[test]
     fn parse_dir_merge_c_modifier_defaults_cvsignore() {
-        let result = parse_dir_merge_directive("dir-merge,c");
+        let result = parse_dir_merge_directive("dir-merge,C");
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
@@ -279,6 +308,80 @@ mod tests {
             }
             _ => panic!("expected DirMerge directive"),
         }
+    }
+
+    /// upstream: exclude.c:1365-1444 - the modifier scan is case-sensitive, so
+    /// the lower-case spelling of a modifier letter is not that modifier.
+    /// `c` is the case that mattered: it used to be accepted as an alias for `C`.
+    #[test]
+    fn parse_dir_merge_modifier_letters_are_case_sensitive() {
+        for directive in [
+            "dir-merge,c",
+            "dir-merge,N f",
+            "dir-merge,E f",
+            "dir-merge,P f",
+        ] {
+            assert!(
+                parse_dir_merge_directive(directive).is_err(),
+                "{directive} must be rejected - upstream matches modifiers case-sensitively"
+            );
+        }
+    }
+
+    /// Non-vacuity companion for the case-sensitivity pin: without it, that test
+    /// would also pass if the parser simply rejected every one of these letters.
+    #[test]
+    fn parse_dir_merge_upper_and_lower_case_letters_are_not_interchangeable() {
+        for directive in [
+            "dir-merge,C",
+            "dir-merge,n f",
+            "dir-merge,e f",
+            "dir-merge,p f",
+        ] {
+            assert!(
+                parse_dir_merge_directive(directive).is_ok(),
+                "{directive} is the correctly-cased spelling and must parse"
+            );
+        }
+    }
+
+    /// upstream: exclude.c:1419-1421 - `p` sets FILTRULE_PERISHABLE, which is in
+    /// FILTRULES_FROM_CONTAINER (exclude.c:1229) and so reaches the merged rules.
+    #[test]
+    fn parse_dir_merge_p_modifier_marks_rules_perishable() {
+        let directive = parse_dir_merge_directive("dir-merge,p .rsync-filter")
+            .expect("parses")
+            .expect("directive");
+        match directive {
+            ParsedFilterDirective::DirMerge { options, .. } => {
+                assert!(options.perishable());
+            }
+            _ => panic!("expected DirMerge directive"),
+        }
+        // Without `p` the flag must stay clear, or the assertion above holds for
+        // the wrong reason.
+        let plain = parse_dir_merge_directive("dir-merge .rsync-filter")
+            .expect("parses")
+            .expect("directive");
+        match plain {
+            ParsedFilterDirective::DirMerge { options, .. } => {
+                assert!(!options.perishable());
+            }
+            _ => panic!("expected DirMerge directive"),
+        }
+    }
+
+    /// upstream: exclude.c:1381-1390 - `-`/`+` require NO_PREFIXES to be unset,
+    /// and `C` (exclude.c:1402-1409) sets it. The scan is left-to-right, so the
+    /// rejection is order-dependent: `:-C` is legal, `:C-` is not.
+    #[test]
+    fn parse_dir_merge_cvs_modifier_forbids_a_later_sign_modifier() {
+        assert!(parse_dir_merge_directive("dir-merge,C- f").is_err());
+        assert!(parse_dir_merge_directive("dir-merge,C+ f").is_err());
+        assert!(parse_dir_merge_directive("dir-merge,CC f").is_err());
+        // The reverse order is accepted upstream - `C` only guards what follows it.
+        assert!(parse_dir_merge_directive("dir-merge,-C f").is_ok());
+        assert!(parse_dir_merge_directive("dir-merge,+C f").is_ok());
     }
 
     #[test]

--- a/crates/engine/src/local_copy/tests/filters.rs
+++ b/crates/engine/src/local_copy/tests/filters.rs
@@ -189,7 +189,7 @@ fn parse_filter_directive_dir_merge_with_modifiers() {
 
 #[test]
 fn parse_filter_directive_dir_merge_cvs_default_path() {
-    let directive = parse_filter_directive_line("dir-merge,c")
+    let directive = parse_filter_directive_line("dir-merge,C")
         .expect("parse")
         .expect("directive");
 


### PR DESCRIPTION
## What

The local-copy dir-merge parser lower-cased every modifier letter before
matching it. Upstream's scan is case-sensitive (`parse_rule_tok`,
`exclude.c:1365-1444`), so oc accepted `dir-merge,c` as a synonym for the CVS
modifier `C` — a spelling upstream rejects outright with
`exit_cleanup(RERR_SYNTAX)`.

## Why these three changes ship together

They interact, and the middle one is unsafe on its own:

| Change | Upstream anchor |
|---|---|
| Drop the case fold; spell the CVS arm `C` | `exclude.c:1365-1444` |
| Accept `p` (perishable) | `exclude.c:1419-1421` |
| `-`/`+` invalid after `C`; `C` invalid after `C` | `exclude.c:1381-1390`, `:1402-1409` |

Adding `p` to a **still-folded** loop would newly accept `P`, converting an
accidentally-correct rejection into a fresh divergence. The fold has to go
first or in the same change.

`FILTRULE_PERISHABLE` is in `FILTRULES_FROM_CONTAINER` (`exclude.c:1229`), so
`p` propagates to the rules read out of the merged file — it is not a
container-only marker.

The `C` guard is **order-dependent**, because upstream scans left to right and
`C` is what sets `FILTRULE_NO_PREFIXES`: `dir-merge,-C` is legal,
`dir-merge,C-` is not. Both directions are pinned.

## Deliberately not fixed here: `x`

`x` stays rejected. Upstream's `x` arm sets the global `saw_xattr_filter`,
which *replaces* the xattr namespace screen rather than stacking with it, and
`DirMergeOptions` has no channel to that decision. Accepting `x` and dropping
it would trade a loud divergence for a silent weakening of xattr selection.
`FILTRULE_XATTR` is **not** in `FILTRULES_FROM_CONTAINER`, so its propagation
scope is a separate question, tracked with the rest of the xattr side
dimension.

## Verification

- `engine` dir-merge selector: **209 run, 209 passed** on base `4e6b485ef`.
- `cargo fmt --all -- --check`: exit 0.
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`: exit 0, zero `error` lines.
- **Mutation-tested, 3/3 lethal**, each killing only its own pin:
  - restore the case fold → `parse_dir_merge_modifier_letters_are_case_sensitive` fails
  - delete the `p` arm → `parse_dir_merge_p_modifier_marks_rules_perishable` fails
  - delete the `C` guard on `-` → `parse_dir_merge_cvs_modifier_forbids_a_later_sign_modifier` fails
- The case-sensitivity pin ships with a **non-vacuity companion** asserting the
  correctly-cased spellings still parse. Without it the pin would also hold if
  the parser simply rejected all four letters.

Two pre-existing tests asserted `dir-merge,c` parses — i.e. they encoded the
bug. Both are re-based on `C`.
