### PR TITLE
fix(protocol): clear filter rule must go on the wire as one byte

### DIFF
--- a/crates/protocol/src/filters/prefix.rs
+++ b/crates/protocol/src/filters/prefix.rs
@@ -186,7 +186,16 @@ fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -
         prefix.push('p');
     }
 
-    prefix.push(' ');
+    // upstream: exclude.c:1880 `get_rule_prefix` appends the separating space
+    // that divides the prefix from the pattern. A clear rule has no pattern, and
+    // upstream's own parser refuses one: for a `!` rule with any trailing byte,
+    // exclude.c:1467-1473 raises `'!' rule has trailing characters` and
+    // exit_cleanup(RERR_SYNTAX). MEASURED against rsync 3.5.0 - `--filter='! '`
+    // exits 1 with that message while `--filter='!'` exits 0 - so emitting the
+    // space here made every clear rule oc sent abort a real upstream peer.
+    if !matches!(rule.rule_type, RuleType::Clear) {
+        prefix.push(' ');
+    }
 
     prefix
 }
@@ -382,7 +391,28 @@ mod tests {
         };
 
         let prefix = build_rule_prefix(&rule, protocol).unwrap();
-        assert_eq!(prefix, "! ");
+        // Exactly one byte: real rsync 3.5.0 aborts on `"! "` with
+        // `'!' rule has trailing characters` (exclude.c:1467-1473).
+        assert_eq!(prefix, "!");
+    }
+
+    /// Non-vacuity companion: the separating space is still emitted for every
+    /// rule type that carries a pattern, so the assertion above is pinning the
+    /// clear-rule exception rather than a blanket removal.
+    #[test]
+    fn non_clear_rules_keep_the_separating_space() {
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        for rule_type in [RuleType::Exclude, RuleType::Include, RuleType::DirMerge] {
+            let rule = FilterRuleWireFormat {
+                rule_type,
+                ..FilterRuleWireFormat::default()
+            };
+            let prefix = build_rule_prefix(&rule, protocol).unwrap();
+            assert!(
+                prefix.ends_with(' '),
+                "{rule_type:?} must keep the prefix/pattern separator, got {prefix:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/protocol/tests/filter_rule_wire_roundtrip.rs
+++ b/crates/protocol/tests/filter_rule_wire_roundtrip.rs
@@ -434,15 +434,18 @@ fn dir_merge_all_merge_modifiers_roundtrip() {
 
 #[test]
 fn clear_rule_roundtrips() {
-    // upstream: exclude.c:1208-1210 / 1315-1323 - a bare `!` (with the trailing
-    // separator space) is FILTRULE_CLEAR_LIST and carries no pattern.
+    // upstream: exclude.c:1208-1210 / 1315-1323 - a bare `!` is
+    // FILTRULE_CLEAR_LIST and carries no pattern, so it takes NO separator
+    // space. exclude.c:1467-1473 rejects a `!` rule with any trailing byte
+    // (`'!' rule has trailing characters`, exit_cleanup(RERR_SYNTAX)), which
+    // real rsync 3.5.0 was measured doing - so the encoding is exactly one byte.
     assert_roundtrips_to_self(
         FilterRuleWireFormat {
             rule_type: RuleType::Clear,
             ..FilterRuleWireFormat::default()
         },
         proto(32),
-        b"! ",
+        b"!",
     );
 }
 


### PR DESCRIPTION
## The bug

`build_rule_prefix` (crates/protocol/src/filters/prefix.rs) appended the
prefix/pattern separator space unconditionally, so oc encoded a **clear** rule
as `"! "`. A clear rule carries no pattern, and upstream's parser refuses a
trailing byte after `!`:

> `exclude.c:1467-1473` — for a clear rule with `!NO_PREFIXES && !OLD_PREFIXES && len`:
> `filter_rule_err("'!' rule has trailing characters")` → `exit_cleanup(RERR_SYNTAX)`

## Measured, not inferred

Against **real rsync 3.5.0** — the tarball build and the packaged binary
independently agree:

| input | exit | stderr |
|---|---|---|
| `--filter='!'` | 0 | — |
| `--filter='! '` | **1** | `'!' rule has trailing characters: ! ` |

So **every clear rule oc put on the wire aborted a conforming upstream peer.**
Reachable from plain `--filter='!'` against an `rsync://` or ssh remote, via
`FilterRuleKind::Clear` on the remote flag builder.

## Why no interop test caught it

Upstream never *sends* a clear rule. `parse_filter_str` pops the list and
`goto free_continue`s (`exclude.c:1542-1551`) before the rule can enter
`filter_list`, so `send_rules` never sees one. These bytes are **oc-only wire
traffic** — the only authority on them is upstream's *parser*, which rejects
them. No amount of oc↔oc testing could surface this; it needed the real binary.

## Decoder unchanged — and that is deliberate

With the emitter fixed, `b"!"` decodes to a Clear rule with an empty pattern
and re-encodes to `b"!"`. The round-trip is now idempotent; **previously it was
not** (`"! "` → empty pattern → would re-encode to 3 bytes).

An earlier draft of this change also made the decoder skip the modifier scan
for Clear. That was **refuted**: it breaks `clear_rule_roundtrips` and
`heterogeneous_rule_list_roundtrips_in_order`, and it is the wrong half of the
rule — the defect is on the emitter, not the decoder.

## Verification

- `protocol` filter/prefix/clear selector: **298 run, 298 passed**.
- `-p protocol -p filters -p core --all-features`: **10268 run, 10268 passed**.
- `cargo fmt --all -- --check`: exit 0.
- **Mutation-tested**: restoring the unconditional `prefix.push(' ')` fails
  exactly `clear_rule_prefix` and `clear_rule_roundtrips`, while
  `non_clear_rules_keep_the_separating_space` stays green — proving the
  companion is independent, not a copy of the pin.

Two committed fixtures encoded the defective bytes — including a comment that
asserted the trailing space was *correct*. Both re-based on the measured
encoding, and the comment now carries the upstream anchor.
