### PR TITLE
fix(protocol): bound the peer-supplied filter-rule record length

### DIFF
--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -249,6 +249,25 @@ fn wire_bytes_to_pattern(bytes: &[u8]) -> OsString {
     OsString::from(String::from_utf8_lossy(bytes).into_owned())
 }
 
+/// Largest filter-rule record accepted from a peer, in bytes.
+///
+/// upstream: rsync.h:765-769 defines
+/// `BIGPATHBUFLEN = MAXPATHLEN < 4096 ? 4096+1024 : MAXPATHLEN+1024`, and
+/// `recv_filter_list` sizes its receive buffer with it (exclude.c:1973).
+///
+/// The value is 5120 on every platform oc supports, but not for the same
+/// reason on each: rsync.h:761 defines `MAXPATHLEN 1024` only `#ifndef`, and
+/// rsync.h:389 includes `<sys/param.h>` first, so the system value wins - 4096
+/// on Linux, 1024 on macOS. Linux takes the `MAXPATHLEN+1024` arm and macOS
+/// takes the `4096+1024` arm, and both land on 5120.
+///
+/// This is the WIRE-FRAME bound and is deliberately not the only one upstream
+/// applies: `parse_filter_str` separately discards an individual rule whose
+/// pattern reaches `MAXPATHLEN` with a non-fatal "discarding over-long filter"
+/// warning (exclude.c:1533-1537). That second, smaller limit is per-pattern and
+/// platform-dependent; this one is per-record and fixed.
+const MAX_FILTER_RULE_LEN: u32 = 5120;
+
 /// Reads filter list from wire format.
 ///
 /// Reads a sequence of filter rules terminated by a 4-byte integer 0.
@@ -268,7 +287,13 @@ pub fn read_filter_list(
             break;
         }
 
-        if len < 0 {
+        // upstream: exclude.c:1980-1981 - `recv_filter_list` reads into
+        // `char line[BIGPATHBUFLEN]` (:1973) and calls `overflow_exit("recv_rules")`
+        // for `len >= sizeof line`. Its `len` is an `unsigned int`, so a negative
+        // wire value widens to a huge unsigned and takes the SAME branch; casting
+        // to u32 here reproduces that, which is why this one bound also subsumes
+        // the old negative-length arm.
+        if u32::from_ne_bytes(len.to_ne_bytes()) >= MAX_FILTER_RULE_LEN {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("invalid filter rule length: {len}"),
@@ -326,7 +351,13 @@ where
             break;
         }
 
-        if len < 0 {
+        // upstream: exclude.c:1980-1981 - `recv_filter_list` reads into
+        // `char line[BIGPATHBUFLEN]` (:1973) and calls `overflow_exit("recv_rules")`
+        // for `len >= sizeof line`. Its `len` is an `unsigned int`, so a negative
+        // wire value widens to a huge unsigned and takes the SAME branch; casting
+        // to u32 here reproduces that, which is why this one bound also subsumes
+        // the old negative-length arm.
+        if u32::from_ne_bytes(len.to_ne_bytes()) >= MAX_FILTER_RULE_LEN {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("invalid filter rule length: {len}"),

--- a/crates/protocol/tests/adversarial_stream_corpus.rs
+++ b/crates/protocol/tests/adversarial_stream_corpus.rs
@@ -543,16 +543,38 @@ fn filter_list_negative_length_rejected() {
 }
 
 #[test]
-fn filter_list_oversized_length_truncates_to_eof() {
-    // Bug it catches: an attacker-controlled length must surface EOF
-    // (truncated read) rather than allocate the full claimed payload.
-    // Length here is 1 MiB but no payload follows.
+fn filter_list_oversized_length_rejected_before_allocation() {
+    // Bug it catches: an attacker-controlled length must be refused against the
+    // frame bound BEFORE any buffer is sized from it.
+    //
+    // This test previously asserted UnexpectedEof and was named
+    // `..._truncates_to_eof`. That outcome did not mean what its comment
+    // claimed: the 1 MiB buffer WAS allocated, and the EOF only followed
+    // because no payload happened to be present. A peer that sent the payload
+    // got the allocation. upstream refuses first - exclude.c:1980-1981
+    // `overflow_exit("recv_rules")` precedes the `read_sbuf` at :1982 - so the
+    // rejection, not the truncation, is the behaviour to pin.
     let mut bytes = Vec::new();
     bytes.extend_from_slice(&(1_024_i32 * 1_024).to_le_bytes());
     let mut cursor = Cursor::new(&bytes[..]);
     let protocol = ProtocolVersion::from_supported(32).expect("v32 supported");
     let err = read_filter_list(&mut cursor, protocol)
-        .expect_err("oversized length without payload must surface EOF");
+        .expect_err("oversized length must be refused against the frame bound");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn filter_list_length_within_the_bound_still_reaches_the_read() {
+    // Non-vacuity companion. Without it, the assertion above would also hold if
+    // the bound rejected every non-zero length. A record just inside the frame
+    // bound must still be attempted, and then fail on the absent payload -
+    // proving the guard discriminates on size rather than refusing outright.
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&5_119_i32.to_le_bytes());
+    let mut cursor = Cursor::new(&bytes[..]);
+    let protocol = ProtocolVersion::from_supported(32).expect("v32 supported");
+    let err = read_filter_list(&mut cursor, protocol)
+        .expect_err("in-bound length with no payload must surface EOF");
     assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
 }
 


### PR DESCRIPTION
## The hole

Both filter-list readers validated only the sign of the peer-supplied 4-byte
length, then sized a buffer from it:

```rust
if len < 0 { /* reject */ }
let mut buf = vec![0u8; len as usize];
```

Any positive `i32` was accepted, so **two wire bytes bought a ~2 GB allocation
per record**, repeatable for as long as the peer kept sending.

`read_filter_list_async` carried the **identical** hole. Fixing only the sync
reader would have left half the surface open — worth stating because the two
functions are ~40 lines apart and easy to treat as one.

## What upstream does

It bounds the frame *before* it reads. `recv_filter_list` declares
`char line[BIGPATHBUFLEN]` (`exclude.c:1973`) and calls
`overflow_exit("recv_rules")` for `len >= sizeof line` (`:1980-1981`) — the
refusal precedes the `read_sbuf` at `:1982`.

## Why 5120, and why that is not obvious

The value is 5120 everywhere oc runs, **but not by the same route on each
platform**:

| | `MAXPATHLEN` | arm taken (`rsync.h:765-769`) | result |
|---|---|---|---|
| Linux | 4096 | `MAXPATHLEN + 1024` | 5120 |
| macOS | 1024 | `4096 + 1024` | 5120 |

`rsync.h:761` defines `MAXPATHLEN 1024` only `#ifndef`, and `rsync.h:389`
includes `<sys/param.h>` first — so the *system* value wins and the two
platforms take opposite arms to the same number. Recorded in the constant's
doc comment so nobody "simplifies" it to `MAXPATHLEN + 1024` later.

## One comparison replaces two arms

Upstream's `len` is an `unsigned int`, so a negative wire value widens to a
huge unsigned and takes the **same** overflow branch. Casting to `u32` here
reproduces that exactly — which is why the negative-length arm collapses into
the bound rather than sitting beside it. `filter_list_negative_length_rejected`
still passes unchanged, from the new guard.

## Deliberately NOT included

Upstream's **second, smaller** limit. `parse_filter_str` separately discards an
individual rule whose pattern reaches `MAXPATHLEN` with a *non-fatal*
`"discarding over-long filter"` warning (`exclude.c:1533-1537`). That is
per-pattern, platform-dependent and non-fatal — a different rule at a different
layer. Folding it in here would conflate the two.

## The test was asserting the wrong thing

`filter_list_oversized_length_truncates_to_eof` asserted `UnexpectedEof`, and
its comment claimed this meant the payload was not allocated. It did not: the
1 MiB buffer **was** allocated, and the EOF only followed because no payload
happened to be present. A peer that sent the payload still got the allocation.

Re-based on the rejection, and given a companion — `..._within_the_bound_still_reaches_the_read` — asserting that a length just
inside the bound is still attempted and then fails on the absent payload.
Without it, the main assertion would also hold if the guard refused every
non-zero length.

## Verification

- `-p protocol` filter selector: **53 run, 53 passed**.
- `cargo fmt --all -- --check`: exit 0.
- **Mutation-tested**: restoring `if len < 0` in *both* readers fails exactly
  `filter_list_oversized_length_rejected_before_allocation` — 7 passed, 1
  failed — while the in-bound companion and the negative-length test stay
  green. The guard discriminates on size, not blanket refusal.
- Constants grepped from `rsync.h`, not recalled.
