### PR TITLE
fix(protocol): mirror upstream parse_rule_tok on the filter-rule wire decoder

### DIFF
--- a/crates/protocol/src/filters/prefix.rs
+++ b/crates/protocol/src/filters/prefix.rs
@@ -186,9 +186,14 @@ fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -
         prefix.push('p');
     }
 
-    // upstream: exclude.c:1880 `get_rule_prefix` appends the separating space
-    // that divides the prefix from the pattern. A clear rule has no pattern, and
-    // upstream's own parser refuses one: for a `!` rule with any trailing byte,
+    // upstream: exclude.c:1880-1881 `get_rule_prefix` appends the separating
+    // space that divides the prefix from the pattern, gated only on `legal_len`
+    // (zeroed at :1841 for the protocol<29 bare-pattern form). It has no
+    // clear-rule branch at all, because upstream never emits one: parse_filter_str
+    // pops the list and `goto free_continue`s at exclude.c:1542-1551 before a `!`
+    // rule can enter filter_list, so send_rules never sees it. That makes this
+    // oc-only traffic, judged by upstream's PARSER rather than its emitter: for a
+    // `!` rule with any trailing byte,
     // exclude.c:1467-1473 raises `'!' rule has trailing characters` and
     // exit_cleanup(RERR_SYNTAX). MEASURED against rsync 3.5.0 - `--filter='! '`
     // exits 1 with that message while `--filter='!'` exits 0 - so emitting the

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -480,12 +480,7 @@ fn parse_wire_rule_old_prefix(buf: &[u8]) -> io::Result<FilterRuleWireFormat> {
         ..FilterRuleWireFormat::default()
     };
 
-    if let Some(stripped) = pattern_bytes.strip_suffix(b"/".as_slice()) {
-        rule.directory_only = true;
-        rule.pattern = wire_bytes_to_pattern(stripped);
-    } else {
-        rule.pattern = wire_bytes_to_pattern(pattern_bytes);
-    }
+    strip_directory_suffix(&mut rule, pattern_bytes);
 
     Ok(rule)
 }
@@ -682,14 +677,25 @@ fn parse_wire_rule_modern(buf: &[u8]) -> io::Result<FilterRuleWireFormat> {
         pattern_bytes = &pattern_bytes[1..];
     }
 
-    if let Some(stripped) = pattern_bytes.strip_suffix(b"/".as_slice()) {
-        rule.directory_only = true;
-        rule.pattern = wire_bytes_to_pattern(stripped);
-    } else {
-        rule.pattern = wire_bytes_to_pattern(pattern_bytes);
-    }
+    strip_directory_suffix(&mut rule, pattern_bytes);
 
     Ok(rule)
+}
+
+/// Splits a trailing `/` off the pattern, marking the rule directory-only.
+///
+/// upstream: exclude.c:287 `add_rule` - `if (pat_len > 1 && pat[pat_len-1] == '/')`.
+/// The length guard is load-bearing: a pattern of exactly `/` is left intact and
+/// is NOT directory-only, because stripping it would leave no pattern at all.
+/// Both decode paths share this so they cannot drift apart.
+fn strip_directory_suffix(rule: &mut FilterRuleWireFormat, pattern_bytes: &[u8]) {
+    match pattern_bytes.strip_suffix(b"/".as_slice()) {
+        Some(stripped) if pattern_bytes.len() > 1 => {
+            rule.directory_only = true;
+            rule.pattern = wire_bytes_to_pattern(stripped);
+        }
+        _ => rule.pattern = wire_bytes_to_pattern(pattern_bytes),
+    }
 }
 
 /// Serializes a filter rule to wire format bytes.

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -420,7 +420,7 @@ fn parse_wire_rule(buf: &[u8], protocol: ProtocolVersion) -> io::Result<FilterRu
         return parse_wire_rule_old_prefix(buf);
     }
 
-    parse_wire_rule_modern(buf, protocol)
+    parse_wire_rule_modern(buf)
 }
 
 /// Parses a wire rule using old-style prefix rules (protocol < 29).
@@ -490,14 +490,46 @@ fn parse_wire_rule_old_prefix(buf: &[u8]) -> io::Result<FilterRuleWireFormat> {
     Ok(rule)
 }
 
+/// Builds the diagnostic for a modifier byte upstream refuses.
+///
+/// upstream: exclude.c:1371-1379 - the `invalid:` label formats
+/// `" '%c' at position %d"` into `"invalid modifier%s in filter rule: %s"` and
+/// then calls `exit_cleanup(RERR_SYNTAX)`. `position` is the byte offset into
+/// the rule text, which is exactly the loop index.
+///
+/// Every rejection in the modifier scan funnels through here, matching
+/// upstream's own control flow: each `goto invalid` targets this one label.
+///
+/// The error is a plain `InvalidData`, like the two sibling diagnostics in this
+/// file, so it maps to `RERR_STREAMIO` (12) where upstream exits `RERR_SYNTAX`
+/// (1). Reaching 1 from an `io::Error` needs a marker type that
+/// `ExitCode::from_io_error` can downcast, which is a separate decision from
+/// this conformance change; because every rejection funnels through this one
+/// helper it is a single-site swap once that lands.
+fn invalid_modifier(buf: &[u8], byte: u8, position: usize) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "invalid modifier '{}' at position {position} in filter rule: {}",
+            byte as char,
+            String::from_utf8_lossy(buf)
+        ),
+    )
+}
+
 /// Parses a wire rule using modern prefix rules (protocol >= 29).
 ///
-/// Supports full modifier parsing including `/`, `!`, `C`, `n`, `w`, `e`,
-/// `x`, `s`, `r`, `p` flags.
-fn parse_wire_rule_modern(
-    buf: &[u8],
-    protocol: ProtocolVersion,
-) -> io::Result<FilterRuleWireFormat> {
+/// Mirrors upstream `parse_rule_tok()` (exclude.c:1241-1489). `recv_filter_list()`
+/// (exclude.c:1971-1984) feeds peer bytes through that same parser with
+/// `xflags = 0` at protocol >= 29, so every guard below applies to a wire rule
+/// exactly as it does to a command-line one.
+///
+/// Upstream applies no `protocol_version` test anywhere in the modifier switch,
+/// which is why this function takes no protocol argument. The `p`-requires-30
+/// and `s`/`r`-require-29 rules are SENDER rules living in `get_rule_prefix`
+/// (exclude.c:1871-1876); applying them here made `-p foo` at protocol 29
+/// decode to the pattern `"p foo"`.
+fn parse_wire_rule_modern(buf: &[u8]) -> io::Result<FilterRuleWireFormat> {
     // The rule-type prefix is always a single ASCII byte, so decode it as a
     // char without validating the rest of the buffer as UTF-8.
     let first = *buf
@@ -516,89 +548,120 @@ fn parse_wire_rule_modern(
         ..FilterRuleWireFormat::default()
     };
 
-    let mut pattern_start = 1;
-    // Every modifier byte is ASCII; scan them directly and stop at the first
-    // non-modifier byte, which begins the (possibly non-UTF-8) pattern body.
-    for (i, &c) in buf[1..].iter().enumerate() {
-        match c {
-            b'/' if i == 0 => {
-                rule.anchored = true;
-                pattern_start += 1;
-            }
-            b'!' => {
-                rule.negate = true;
-                pattern_start += 1;
-            }
-            b'C' => {
-                // upstream: exclude.c:1248-1255 parse_rule_tok() case 'C' sets
-                // FILTRULE_NO_PREFIXES | FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT
-                // | FILTRULE_CVS_IGNORE together, so a `C` rule carries all the
-                // flags it implies. Re-derive them here so a `:C` dir-merge from
-                // an upstream peer keeps its no-inherit/word-split/no-prefixes
-                // semantics (the receiver gates DirMergeConfig::with_inherit on
-                // no_inherit). The serializer collapses these back to a bare `C`
-                // (get_rule_prefix emits only `C` and suppresses the implied
-                // flags, exclude.c:1548-1561), so re-encoding a decoded `:C`
-                // stays `:C` - no double-application.
-                rule.cvs_exclude = true;
-                rule.no_inherit = true;
-                rule.word_split = true;
-                rule.no_prefixes = true;
-                pattern_start += 1;
-            }
-            b'n' => {
-                rule.no_inherit = true;
-                pattern_start += 1;
-            }
-            b'w' => {
-                rule.word_split = true;
-                pattern_start += 1;
-            }
-            b'e' => {
-                rule.exclude_from_merge = true;
-                pattern_start += 1;
-            }
-            b'x' => {
-                rule.xattr_only = true;
-                pattern_start += 1;
-            }
-            // upstream: exclude.c:1227-1237 - `-` and `+` set FILTRULE_NO_PREFIXES
-            // on merge/dir-merge rules. `+` additionally sets FILTRULE_INCLUDE.
-            // Acceptance is gated on Merge/DirMerge to mirror upstream's
-            // FILTRULE_MERGE_FILE precondition; on other rule types these
-            // characters fall through to `_` and terminate modifier parsing.
-            b'-' if matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) => {
-                rule.no_prefixes = true;
-                pattern_start += 1;
-            }
-            b'+' if matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) => {
-                rule.no_prefixes = true;
-                rule.no_prefixes_include = true;
-                pattern_start += 1;
-            }
-            b's' if protocol.supports_sender_receiver_modifiers() => {
-                rule.sender_side = true;
-                pattern_start += 1;
-            }
-            b'r' if protocol.supports_sender_receiver_modifiers() => {
-                rule.receiver_side = true;
-                pattern_start += 1;
-            }
-            b'p' if protocol.supports_perishable_modifier() => {
-                rule.perishable = true;
-                pattern_start += 1;
-            }
-            b' ' => {
-                // Trailing space terminates the modifier section per upstream
-                // exclude.c parser.
-                pattern_start += 1;
+    // upstream: exclude.c:1332-1338 - `:` and `.` both set FILTRULE_MERGE_FILE
+    // by fall-through.
+    let merge_file = matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge);
+    // upstream: exclude.c:1345-1358 - `S`/`H`/`R`/`P` set prefix_specifies_side.
+    // oc's wire RuleType spells only the `P`/`R` pair; `H`/`S` are refused by
+    // from_prefix_char above and so cannot reach this predicate.
+    let prefix_specifies_side = matches!(rule.rule_type, RuleType::Protect | RuleType::Risk);
+    let is_clear = matches!(rule.rule_type, RuleType::Clear);
+
+    // upstream: exclude.c:1325-1329 - `default: ch = *s; if (s[1] == ',') s++;`
+    // A comma directly after the rule-type byte is a legal separator, so
+    // `-,p foo` and `:,C f` parse as `-p foo` and `:C f`.
+    let mut idx = if buf.get(1) == Some(&b',') { 2 } else { 1 };
+
+    // upstream: exclude.c:1365 - the `ch != '!'` term short-circuits before the
+    // first `*++s`, so a clear rule never enters the modifier run at all.
+    if !is_clear {
+        while idx < buf.len() {
+            let c = buf[idx];
+            // upstream: exclude.c:1365 - BOTH ' ' and '_' terminate the run, and
+            // exclude.c:1444 `if (*s) s++` consumes whichever one ended it.
+            // Missing the '_' arm left the underscore in the pattern body, so
+            // `-p_foo` excluded `_foo` where upstream excludes `foo`.
+            if c == b' ' || c == b'_' {
+                idx += 1;
                 break;
             }
-            _ => break,
+            match c {
+                // upstream: exclude.c:1381-1390 - BITS_SETnUNSET requires
+                // MERGE_FILE set AND NO_PREFIXES not yet set, so both `:C-` and
+                // `:--` are invalid.
+                b'-' if merge_file && !rule.no_prefixes => rule.no_prefixes = true,
+                b'+' if merge_file && !rule.no_prefixes => {
+                    rule.no_prefixes = true;
+                    rule.no_prefixes_include = true;
+                }
+                // upstream: exclude.c:1392-1394 - FILTRULE_ABS_PATH. There is no
+                // position gate: `/` is legal anywhere in the run, not only first.
+                b'/' => rule.anchored = true,
+                // upstream: exclude.c:1395-1400 - negation belongs to the
+                // pattern, so it is invalid as a merge-file default.
+                b'!' if !merge_file => rule.negate = true,
+                // upstream: exclude.c:1402-1409 - `C` sets NO_PREFIXES |
+                // WORD_SPLIT | NO_INHERIT | CVS_IGNORE together, and is refused
+                // once NO_PREFIXES is set or the prefix already picked a side.
+                // Re-deriving the implied flags keeps an upstream peer's `:C`
+                // no-inherit/word-split semantics; get_rule_prefix collapses them
+                // back to a bare `C` (exclude.c:1846-1848), so a decoded `:C`
+                // re-encodes as `:C` with no double application.
+                b'C' if !rule.no_prefixes && !prefix_specifies_side => {
+                    rule.cvs_exclude = true;
+                    rule.no_inherit = true;
+                    rule.word_split = true;
+                    rule.no_prefixes = true;
+                }
+                // upstream: exclude.c:1410-1414
+                b'e' if merge_file => rule.exclude_from_merge = true,
+                // upstream: exclude.c:1415-1419
+                b'n' if merge_file => rule.no_inherit = true,
+                // upstream: exclude.c:1420-1422 - `p` carries no guard.
+                b'p' => rule.perishable = true,
+                // upstream: exclude.c:1423-1427
+                b'r' if !prefix_specifies_side => rule.receiver_side = true,
+                // upstream: exclude.c:1428-1432
+                b's' if !prefix_specifies_side => rule.sender_side = true,
+                // upstream: exclude.c:1433-1437
+                b'w' if merge_file => rule.word_split = true,
+                // upstream: exclude.c:1438-1441 - no guard.
+                b'x' => rule.xattr_only = true,
+                // upstream: exclude.c:1371-1379 - `default: goto invalid`. Every
+                // failed guard above falls here, which is exactly upstream's
+                // control flow: each `goto invalid` targets this same label.
+                _ => return Err(invalid_modifier(buf, c, idx)),
+            }
+            idx += 1;
         }
     }
 
-    let mut pattern_bytes = &buf[pattern_start..];
+    let mut pattern_bytes = &buf[idx.min(buf.len())..];
+
+    if is_clear {
+        // upstream: exclude.c:1467-1471 - with modern prefixes and no
+        // FILTRULE_NO_PREFIXES on the template, any text after `!` is fatal.
+        // Pairs with the encoder: a clear rule is exactly one byte on the wire,
+        // so a conformant peer never produces text here.
+        if !pattern_bytes.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "'!' rule has trailing characters: {}",
+                    String::from_utf8_lossy(buf)
+                ),
+            ));
+        }
+        return Ok(rule);
+    }
+
+    // upstream: exclude.c:1474-1475 - an empty pattern is fatal unless the rule
+    // carries FILTRULE_CVS_IGNORE, whose pattern is filled in downstream.
+    //
+    // This MUST stay above the trailing-`/` strip below. Upstream computes its
+    // length on the raw remainder (exclude.c:1462-1465) and never strips, so
+    // `- /` is a legal one-byte pattern there. Checking after the strip would
+    // reject bytes upstream accepts, and would desynchronise this decoder from
+    // serialize_rule, which still emits `- /` for the decoded rule.
+    if pattern_bytes.is_empty() && !rule.cvs_exclude {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unexpected end of filter rule: {}",
+                String::from_utf8_lossy(buf)
+            ),
+        ));
+    }
 
     // Non-merge rules encode the anchor as a leading `/` in the pattern body
     // (upstream keeps it in ent->pattern with FILTRULE_ABS_PATH unset). Fold it
@@ -948,18 +1011,46 @@ mod tests {
     #[test]
     fn no_prefixes_modifier_rejected_on_non_merge_rule() {
         let protocol = ProtocolVersion::from_supported(32).unwrap();
-        // Raw wire bytes: "--foo" - the leading `-` is the rule type prefix
-        // (Exclude); the second `-` is not a legal modifier on Exclude rules
-        // and must fall through to the pattern.
-        let rules = read_filter_list(
+        // Raw wire bytes: "--foo". The leading `-` is the rule-type prefix
+        // (Exclude); the second `-` is a modifier whose guard fails, because
+        // upstream requires FILTRULE_MERGE_FILE for `-` (exclude.c:1381-1388).
+        //
+        // This test previously asserted the byte FELL THROUGH into the pattern,
+        // yielding `-foo`. That encoded oc's own bug: upstream's failed guard is
+        // `goto invalid`, landing on the same label as an unknown byte, and it
+        // exits RERR_SYNTAX (exclude.c:1371-1379). Falling through produced a
+        // rule upstream never creates, silently and at exit 0.
+        let err = read_filter_list(
             &mut &[5u8, 0, 0, 0, b'-', b'-', b'f', b'o', b'o', 0, 0, 0, 0][..],
             protocol,
         )
-        .unwrap();
+        .expect_err("`-` on a non-merge rule must be refused, not folded into the pattern");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string()
+                .contains("invalid modifier '-' at position 1"),
+            "the diagnostic must name the byte and its offset, got: {err}"
+        );
+    }
+
+    /// Non-vacuity companion for the test above: the same modifier byte in the
+    /// same slot is ACCEPTED where upstream's guard passes, so the rejection
+    /// pins the guard rather than a blanket refusal of `-`.
+    #[test]
+    fn no_prefixes_modifier_accepted_on_a_dir_merge_rule() {
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        // ":- .excl" - `-` on a DirMerge, where FILTRULE_MERGE_FILE is set.
+        let rules = read_filter_list(
+            &mut &[
+                8u8, 0, 0, 0, b':', b'-', b' ', b'.', b'e', b'x', b'c', b'l', 0, 0, 0, 0,
+            ][..],
+            protocol,
+        )
+        .expect("`-` on a dir-merge is upstream-legal");
         assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].rule_type, RuleType::Exclude);
-        assert!(!rules[0].no_prefixes);
-        assert_eq!(rules[0].pattern, "-foo");
+        assert_eq!(rules[0].rule_type, RuleType::DirMerge);
+        assert!(rules[0].no_prefixes);
+        assert_eq!(rules[0].pattern, ".excl");
     }
 
     #[test]

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -527,8 +527,9 @@ fn invalid_modifier(buf: &[u8], byte: u8, position: usize) -> io::Error {
 /// Upstream applies no `protocol_version` test anywhere in the modifier switch,
 /// which is why this function takes no protocol argument. The `p`-requires-30
 /// and `s`/`r`-require-29 rules are SENDER rules living in `get_rule_prefix`
-/// (exclude.c:1871-1876); applying them here made `-p foo` at protocol 29
-/// decode to the pattern `"p foo"`.
+/// (exclude.c:1865-1877 - `s` at :1865-1867, `r` at :1868-1871, `p` at
+/// :1872-1877); applying them here made `-p foo` at protocol 29 decode to the
+/// pattern `"p foo"`.
 fn parse_wire_rule_modern(buf: &[u8]) -> io::Result<FilterRuleWireFormat> {
     // The rule-type prefix is always a single ASCII byte, so decode it as a
     // char without validating the rest of the buffer as UTF-8.
@@ -568,7 +569,7 @@ fn parse_wire_rule_modern(buf: &[u8]) -> io::Result<FilterRuleWireFormat> {
         while idx < buf.len() {
             let c = buf[idx];
             // upstream: exclude.c:1365 - BOTH ' ' and '_' terminate the run, and
-            // exclude.c:1444 `if (*s) s++` consumes whichever one ended it.
+            // exclude.c:1444-1445 `if (*s) s++;` consumes whichever one ended it.
             // Missing the '_' arm left the underscore in the pattern body, so
             // `-p_foo` excluded `_foo` where upstream excludes `foo`.
             if c == b' ' || c == b'_' {
@@ -595,7 +596,9 @@ fn parse_wire_rule_modern(buf: &[u8]) -> io::Result<FilterRuleWireFormat> {
                 // once NO_PREFIXES is set or the prefix already picked a side.
                 // Re-deriving the implied flags keeps an upstream peer's `:C`
                 // no-inherit/word-split semantics; get_rule_prefix collapses them
-                // back to a bare `C` (exclude.c:1846-1848), so a decoded `:C`
+                // back to a bare `C` (exclude.c:1847-1860 - the `C` arm emits
+                // just `C`, and the `else` branch that would have emitted
+                // `n`/`w`/`-`/`+` is skipped entirely), so a decoded `:C`
                 // re-encodes as `:C` with no double application.
                 b'C' if !rule.no_prefixes && !prefix_specifies_side => {
                     rule.cvs_exclude = true;

--- a/crates/protocol/tests/filter_rule_wire_conformance.rs
+++ b/crates/protocol/tests/filter_rule_wire_conformance.rs
@@ -1,0 +1,321 @@
+//! Conformance of the filter-rule wire decoder against upstream `parse_rule_tok`.
+//!
+//! `recv_filter_list()` (exclude.c:1971-1984) feeds peer-supplied bytes through
+//! the same `parse_rule_tok()` that parses a command-line rule, with
+//! `xflags = 0` at protocol >= 29. Every guard upstream applies to a filter rule
+//! therefore applies to a rule arriving over the wire.
+//!
+//! Each rejection below is paired with the byte-adjacent acceptance it must NOT
+//! swallow. Without that companion a row would also pass against a decoder that
+//! refused everything, which is the failure mode these tests exist to exclude.
+
+use protocol::ProtocolVersion;
+use protocol::filters::{FilterRuleWireFormat, RuleType, read_filter_list};
+use std::io;
+
+/// Frames one rule the way `recv_filter_list()` reads it: 4-byte LE length,
+/// body, 4-byte LE zero terminator (upstream: exclude.c:1979-1984).
+fn decode(payload: &[u8], version: u8) -> io::Result<Vec<FilterRuleWireFormat>> {
+    let protocol = ProtocolVersion::from_supported(version).expect("supported version");
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&(payload.len() as i32).to_le_bytes());
+    buf.extend_from_slice(payload);
+    buf.extend_from_slice(&0i32.to_le_bytes());
+    read_filter_list(&mut &buf[..], protocol)
+}
+
+fn one(payload: &[u8], version: u8) -> FilterRuleWireFormat {
+    let mut rules = decode(payload, version).expect("payload must decode");
+    assert_eq!(rules.len(), 1, "expected exactly one rule from {payload:?}");
+    rules.pop().expect("one rule")
+}
+
+/// Asserts the payload is refused AND that the diagnostic names the offending
+/// byte at its offset. Checking the position is what distinguishes "the guard
+/// fired on the byte I meant" from "something else failed first".
+fn err_at(payload: &[u8], position: usize, byte: char) {
+    let err = decode(payload, 32).expect_err("payload must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains(&format!("'{byte}' at position {position}")),
+        "expected modifier '{byte}' at position {position}, got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unknown byte. upstream: exclude.c:1371-1379 `default: goto invalid`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_unknown_modifier_byte_is_refused() {
+    err_at(b"-q foo", 1, 'q');
+}
+
+#[test]
+fn a_known_modifier_in_the_same_slot_is_accepted() {
+    let rule = one(b"-p foo", 32);
+    assert!(rule.perishable);
+    assert_eq!(rule.pattern, "foo");
+}
+
+// ---------------------------------------------------------------------------
+// Comma form. upstream: exclude.c:1325-1329 `if (s[1] == ',') s++;`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_comma_may_separate_the_prefix_from_its_modifiers() {
+    let rule = one(b"-,p foo", 32);
+    assert!(rule.perishable);
+    assert_eq!(rule.pattern, "foo");
+}
+
+#[test]
+fn the_comma_is_skipped_rather_than_consumed_as_a_modifier() {
+    // Discriminator: if the comma were eaten AS a modifier, the bad byte would
+    // be reported at position 1. Reporting position 2 proves it was skipped.
+    err_at(b"-,q foo", 2, 'q');
+}
+
+#[test]
+fn the_comma_form_and_the_plain_form_decode_identically() {
+    assert_eq!(one(b":,C f", 32), one(b":C f", 32));
+}
+
+// ---------------------------------------------------------------------------
+// Underscore separator. upstream: exclude.c:1365 terminator + :1444 consume.
+// Documented in rsync.1.md: "You can use an underscore instead of a space".
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_underscore_terminates_the_modifier_run_and_is_consumed() {
+    // Before the fix oc had no `_` arm at all: the byte hit the catch-all,
+    // which did NOT advance the pattern start, so the underscore survived into
+    // the pattern body. oc excluded `_foo` where upstream excludes `foo` -
+    // a different file set, at exit 0 on both sides.
+    let rule = one(b"-p_foo", 32);
+    assert!(rule.perishable);
+    assert_eq!(
+        rule.pattern, "foo",
+        "the '_' separator must not survive into the pattern"
+    );
+}
+
+#[test]
+fn an_underscore_and_a_space_are_the_same_separator() {
+    assert_eq!(one(b"-p_foo", 32), one(b"-p foo", 32));
+}
+
+// ---------------------------------------------------------------------------
+// `/` has no position gate. upstream: exclude.c:1392-1394.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_anchor_modifier_is_accepted_after_another_modifier() {
+    let rule = one(b":n/ .f", 32);
+    assert!(rule.no_inherit && rule.anchored);
+    assert_eq!(rule.pattern, ".f");
+}
+
+#[test]
+fn modifier_order_does_not_change_the_decoded_rule() {
+    assert_eq!(one(b":n/ .f", 32), one(b":/n .f", 32));
+}
+
+// ---------------------------------------------------------------------------
+// Merge-file guards. upstream: exclude.c:1395-1400 / :1410-1419 / :1433-1437.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn negation_is_refused_on_a_merge_rule() {
+    err_at(b":! .f", 1, '!');
+}
+
+#[test]
+fn negation_is_accepted_on_a_plain_exclude() {
+    assert!(one(b"-! core", 32).negate);
+}
+
+#[test]
+fn merge_only_modifiers_are_refused_on_an_exclude() {
+    for (payload, byte) in [
+        (b"-e f".as_slice(), 'e'),
+        (b"-n f".as_slice(), 'n'),
+        (b"-w f".as_slice(), 'w'),
+    ] {
+        err_at(payload, 1, byte);
+    }
+}
+
+#[test]
+fn merge_only_modifiers_are_accepted_on_a_dir_merge() {
+    assert!(one(b":e .f", 32).exclude_from_merge);
+    assert!(one(b":n .f", 32).no_inherit);
+    assert!(one(b":w .f", 32).word_split);
+}
+
+// ---------------------------------------------------------------------------
+// `-`/`+` need MERGE_FILE set AND NO_PREFIXES unset.
+// upstream: exclude.c:1381-1390 BITS_SETnUNSET.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_no_prefixes_modifier_is_refused_on_a_plain_exclude() {
+    err_at(b"-- foo", 1, '-');
+}
+
+#[test]
+fn the_no_prefixes_modifier_is_refused_twice_on_the_same_rule() {
+    err_at(b":-- .f", 2, '-');
+}
+
+#[test]
+fn the_no_prefixes_modifier_is_accepted_once_on_a_dir_merge() {
+    let minus = one(b":- .excl", 32);
+    assert!(minus.no_prefixes && !minus.no_prefixes_include);
+    let plus = one(b":+ .incl", 32);
+    assert!(plus.no_prefixes && plus.no_prefixes_include);
+}
+
+// ---------------------------------------------------------------------------
+// `C` guards. upstream: exclude.c:1402-1409.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_cvs_modifier_is_refused_after_no_prefixes() {
+    err_at(b":-C .f", 2, 'C');
+}
+
+#[test]
+fn the_cvs_modifier_is_refused_on_a_side_specifying_prefix() {
+    err_at(b"PC f", 1, 'C');
+}
+
+#[test]
+fn the_cvs_modifier_is_accepted_on_a_dir_merge_and_implies_four_flags() {
+    let rule = one(b":C f", 32);
+    assert_eq!(rule.rule_type, RuleType::DirMerge);
+    assert!(rule.cvs_exclude && rule.no_inherit && rule.word_split && rule.no_prefixes);
+}
+
+// ---------------------------------------------------------------------------
+// Side modifiers vs a side-specifying prefix. upstream: exclude.c:1423-1432.
+//
+// Only `P`/`R` can reach this guard: oc's RuleType has no Hide/Show, and
+// from_prefix_char refuses `H`/`S` outright, so `Hs`/`Ss` are unspellable.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn side_modifiers_are_refused_after_a_side_specifying_prefix() {
+    err_at(b"Pr f", 1, 'r');
+    err_at(b"Ps f", 1, 's');
+    err_at(b"Rr f", 1, 'r');
+}
+
+#[test]
+fn side_modifiers_are_accepted_on_a_plain_exclude() {
+    let rule = one(b"-sr shared", 32);
+    assert!(rule.sender_side && rule.receiver_side);
+}
+
+// ---------------------------------------------------------------------------
+// Empty pattern. upstream: exclude.c:1474-1475, with the CVS_IGNORE carve-out.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_empty_pattern_is_refused() {
+    let err = decode(b"- ", 32).expect_err("an empty pattern must be refused");
+    assert!(
+        err.to_string().contains("unexpected end of filter rule"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn a_cvs_rule_may_carry_an_empty_pattern() {
+    // The `!CVS_IGNORE` half of upstream's condition. Without it the check
+    // would break `:C `, whose pattern upstream fills in downstream.
+    let rule = one(b":C ", 32);
+    assert!(rule.cvs_exclude);
+    assert!(rule.pattern.is_empty());
+    // ...and the non-CVS sibling of the same shape is still refused, so the
+    // carve-out is specific rather than a hole.
+    assert!(decode(b":n ", 32).is_err());
+}
+
+#[test]
+fn a_bare_slash_is_a_legal_one_byte_pattern() {
+    // Pins the empty-pattern check ABOVE the trailing-`/` strip. Upstream
+    // computes its length on the raw remainder (exclude.c:1462-1465), so `- /`
+    // has length 1 and is legal. If the check moved below the strip this would
+    // error while serialize_rule still emits `- /` - an encoder/decoder
+    // asymmetry the fuzz round-trip oracle asserts against.
+    let rule = one(b"- /", 32);
+    assert!(rule.directory_only);
+    assert!(rule.pattern.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Clear rule. upstream: exclude.c:1365 (loop skipped) + :1467-1471.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_clear_rule_refuses_trailing_text() {
+    let err = decode(b"!keep", 32).expect_err("trailing text after `!` must be refused");
+    assert!(
+        err.to_string().contains("'!' rule has trailing characters"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn a_bare_clear_rule_is_accepted() {
+    assert_eq!(one(b"!", 32).rule_type, RuleType::Clear);
+}
+
+#[test]
+fn a_clear_rule_takes_no_modifiers_at_all() {
+    // Discriminator: the message must be "trailing characters", NOT "invalid
+    // modifier". Upstream's `ch != '!'` term short-circuits before the first
+    // `*++s`, so `x` is never examined as a modifier byte.
+    let err = decode(b"!x", 32).expect_err("`!x` must be refused");
+    let msg = err.to_string();
+    assert!(msg.contains("trailing characters"), "got: {msg}");
+    assert!(
+        !msg.contains("invalid modifier"),
+        "the modifier loop must be skipped entirely, got: {msg}"
+    );
+}
+
+#[test]
+fn the_same_byte_is_a_valid_modifier_on_a_non_clear_rule() {
+    assert!(one(b"-x user.*", 32).xattr_only);
+}
+
+// ---------------------------------------------------------------------------
+// Protocol gates removed from the DECODER.
+//
+// Upstream has no protocol test in the modifier switch; the `p`-requires-30
+// and `s`/`r`-require-29 rules live in the SENDER (get_rule_prefix,
+// exclude.c:1871-1876).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn perishable_is_accepted_at_protocol_29() {
+    // Before the fix this decoded to the pattern "p foo" - a live silent
+    // misparse, not a pedantic gate.
+    let rule = one(b"-p foo", 29);
+    assert!(rule.perishable);
+    assert_eq!(rule.pattern, "foo");
+}
+
+#[test]
+fn side_modifiers_are_accepted_at_protocol_29() {
+    let rule = one(b"-sr shared", 29);
+    assert!(rule.sender_side && rule.receiver_side);
+}
+
+#[test]
+fn protocol_29_and_32_decode_the_same_bytes_identically() {
+    assert_eq!(one(b"-p foo", 29), one(b"-p foo", 32));
+    assert_eq!(one(b"-sr shared", 29), one(b"-sr shared", 32));
+}

--- a/crates/protocol/tests/filter_rule_wire_conformance.rs
+++ b/crates/protocol/tests/filter_rule_wire_conformance.rs
@@ -243,15 +243,29 @@ fn a_cvs_rule_may_carry_an_empty_pattern() {
 }
 
 #[test]
-fn a_bare_slash_is_a_legal_one_byte_pattern() {
-    // Pins the empty-pattern check ABOVE the trailing-`/` strip. Upstream
-    // computes its length on the raw remainder (exclude.c:1462-1465), so `- /`
-    // has length 1 and is legal. If the check moved below the strip this would
-    // error while serialize_rule still emits `- /` - an encoder/decoder
-    // asymmetry the fuzz round-trip oracle asserts against.
+fn a_bare_slash_is_a_legal_one_byte_pattern_and_is_not_directory_only() {
+    // Two upstream rules meet on this input.
+    //
+    // 1. The empty-pattern check sits ABOVE the trailing-`/` strip: upstream
+    //    measures length on the raw remainder (exclude.c:1462-1465), so `- /`
+    //    has length 1 and is legal.
+    // 2. The strip itself is guarded - `if (pat_len > 1 && pat[pat_len-1] ==
+    //    '/')` (exclude.c:287) - so a pattern of exactly `/` is NOT stripped
+    //    and NOT directory-only. Without the guard oc produced an empty
+    //    pattern plus directory_only, a rule upstream cannot express.
     let rule = one(b"- /", 32);
+    assert_eq!(rule.pattern, "/");
+    assert!(!rule.directory_only);
+}
+
+#[test]
+fn a_two_byte_pattern_ending_in_slash_still_strips() {
+    // Non-vacuity for the length guard: at the very next length up, the strip
+    // must still fire. A guard of `>= 1` and a guard of `> 1` differ on exactly
+    // one input, so this pair is what discriminates them.
+    let rule = one(b"- */", 32);
+    assert_eq!(rule.pattern, "*");
     assert!(rule.directory_only);
-    assert!(rule.pattern.is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/protocol/tests/filter_rule_wire_conformance.rs
+++ b/crates/protocol/tests/filter_rule_wire_conformance.rs
@@ -296,7 +296,7 @@ fn the_same_byte_is_a_valid_modifier_on_a_non_clear_rule() {
 //
 // Upstream has no protocol test in the modifier switch; the `p`-requires-30
 // and `s`/`r`-require-29 rules live in the SENDER (get_rule_prefix,
-// exclude.c:1871-1876).
+// exclude.c:1865-1877).
 // ---------------------------------------------------------------------------
 
 #[test]


### PR DESCRIPTION
Upstream feeds peer-supplied filter rules through the *same* parser it uses for
a command-line rule. `recv_filter_list()` (exclude.c:1971-1984) calls
`parse_filter_str(..., xflags = 0)` at protocol >= 29, so every guard
`parse_rule_tok()` (exclude.c:1241-1487) applies to `--filter` applies to a rule
arriving over the wire. oc's `parse_wire_rule_modern` had drifted from it in
five ways. Two are silent misparses - oc accepts bytes upstream rejects and
transfers a *different file set* at exit 0.

## Divergences

| # | Input | upstream 3.5.0 | oc before | Class |
|---|---|---|---|---|
| 1 | `-p_foo` | pattern `foo` | pattern `_foo` | **silent misparse** |
| 2 | `-p foo` at proto 29 | perishable + `foo` | pattern `p foo` | **silent misparse** |
| 3 | `-q foo` | exit 1 | pattern `-foo`, rule kept | accept-invalid |
| 4 | `!keep` | exit 1 | Clear, trailing text dropped | accept-invalid |
| 5 | `- ` | exit 1 | empty pattern accepted | accept-invalid |

**1 - the underscore separator.** The modifier loop terminates on *both* space
and underscore - `while (ch != '!' && *++s && *s != ' ' && *s != '_')`
(exclude.c:1365) - and `if (*s) s++` (:1444) consumes whichever one stopped it.
oc had no `_` arm, so the byte fell to the catch-all, which did not advance the
pattern start. `-p_foo` excluded `_foo` where upstream excludes `foo`.

**2 - the protocol gates were on the wrong side.** oc gated `p` on protocol >= 30
and `s`/`r` on >= 29 *while decoding*. There is no `protocol_version` test
anywhere in upstream's modifier switch: those are **sender** rules, in
`get_rule_prefix` (exclude.c:1865-1877), which is about what you may *emit*. On
decode the gate turned a valid rule into the pattern `"p foo"`.

**3-5.** Unknown bytes, trailing text after `!`, and an empty pattern are each
`goto invalid` upstream (exclude.c:1371-1379, :1467-1471, :1474-1475), landing on
the same label - `exit_cleanup(RERR_SYNTAX)`.

## Two half-rules that had to come with them

The empty-pattern check carries a `!CVS_IGNORE` half upstream (exclude.c:1474):
`:C ` legitimately has no pattern, filled in downstream. And it must sit *above*
the trailing-`/` strip - upstream measures length on the raw remainder
(:1462-1465), so `- /` is a legal one-byte pattern. Placing the check below the
strip would have made the decoder reject bytes `serialize_rule` still emits.

The clear rule takes **no** modifiers at all, rather than an empty set: the
`ch != '!'` term short-circuits before the first `*++s`, so the loop is never
entered. `!x` must report trailing characters, not an invalid modifier - the
tests assert on *which* message, since both would be a non-zero exit.

## Scope note

Rejections currently surface as `ErrorKind::InvalidData` -> exit 12, where
upstream exits 1 (`RERR_SYNTAX`). `ExitCode::from_io_error`
(crates/core/src/exit_code/codes.rs:368) has no constructor that reaches 1 from a
wire-decode path; adding one needs a new tagged error type and is deliberately
**not** in this PR. Every rejection here funnels through a single
`invalid_modifier()` helper, so that is a one-line swap when the type lands.

## Tests

31 rows in `crates/protocol/tests/filter_rule_wire_conformance.rs`. Every
rejection is paired with the byte-adjacent acceptance it must not swallow -
without those companions a row would also pass against a decoder that refused
everything.

Mutation-tested; each mutation killed exactly its own rows and no companion:

| Mutation | Killed |
|---|---|
| restore `_ => break` | 9 - exactly the 9 rejection rows |
| drop the `_` terminator | 2 - both underscore rows |
| drop the empty-pattern check | 2 |
| drop the clear trailing-text check | 2 |

`protocol` 6065 passed / 0 failed / 2 skipped. `cargo fmt --check` and
workspace `clippy -D warnings` clean.

Depends on the emitter fix in #7376 (already merged): before it, the committed
`b"! "` fixture made the new clear-rule check fail.



## Follow-up applied on this branch

A citation audit against 3.5.0 found four drifted references in this area
(sender gates `:1865-1877` not `:1871-1876`; `if (*s) s++;` spans `:1444-1445`;
the `C` collapse is `:1847-1860`; `get_rule_prefix` emits the separating space at
`:1880-1881` gated on `legal_len`, and has no clear-rule branch at all because
`parse_filter_str` pops a clear rule at `:1542-1551` before `send_rules` sees it).
All corrected here.

It also surfaced a defect in this PR's own test: `add_rule` strips a trailing `/`
only when `pat_len > 1` (exclude.c:287), so a pattern of exactly `/` is kept and
is NOT directory-only. The original test asserted oc's unguarded behaviour as if
correct. Both decode sites now share a guarded `strip_directory_suffix`, and the
row is paired with `- */` - the two inputs that discriminate `>= 1` from `> 1`.
