### PR TITLE
fix(engine): match filter-rule keywords case-sensitively

### DIFF
--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -1,4 +1,6 @@
-use super::parse::{FilterParseError, ParsedFilterDirective, parse_filter_directive_line};
+use super::parse::{
+    FilterParseError, ParsedFilterDirective, directive_takes_argument, parse_filter_directive_line,
+};
 use crate::local_copy::LocalCopyError;
 use crate::local_copy::filter_program::{
     DirMergeEnforcedKind, DirMergeOptions, DirMergeParser, ExcludeIfPresentRule, FilterProgramError,
@@ -244,17 +246,15 @@ pub(crate) fn load_dir_merge_rules_recursive(
                     continue;
                 }
 
-                let token_lower = token.to_ascii_lowercase();
-                if token == "!" || token_lower == "clear" {
+                if token == "!" || token == "clear" {
                     if options.list_clear_allowed() {
                         entries.rules.clear();
                         entries.exclude_if_present.clear();
                         entries.clear_inherited = true;
                         continue;
                     }
-                    let directive = if token == "!" { "!" } else { token };
                     return Err(map_error(FilterParseError::new(format!(
-                        "list-clearing '{directive}' is not permitted in this filter file"
+                        "list-clearing '{token}' is not permitted in this filter file"
                     ))));
                 }
 
@@ -272,19 +272,9 @@ pub(crate) fn load_dir_merge_rules_recursive(
                 }
 
                 let mut directive = token.to_owned();
-                let lower = directive.to_ascii_lowercase();
-                let needs_argument = matches!(
-                    lower.as_str(),
-                    "merge"
-                        | "include"
-                        | "exclude"
-                        | "show"
-                        | "hide"
-                        | "protect"
-                        | "exclude-if-present"
-                ) || lower.starts_with("dir-merge");
-
-                if needs_argument && let Some(next) = iter.next() {
+                if directive_takes_argument(token)
+                    && let Some(next) = iter.next()
+                {
                     directive.push(' ');
                     directive.push_str(next);
                 }
@@ -373,7 +363,7 @@ pub(crate) fn load_dir_merge_rules_recursive(
                     continue;
                 }
 
-                if trimmed == "!" || trimmed.eq_ignore_ascii_case("clear") {
+                if trimmed == "!" || trimmed == "clear" {
                     if options.list_clear_allowed() {
                         entries.rules.clear();
                         entries.exclude_if_present.clear();

--- a/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
@@ -21,7 +21,12 @@ pub(super) fn parse_dir_merge_directive(
             continue;
         }
 
-        if text[..alias.len()].eq_ignore_ascii_case(alias) {
+        // upstream: exclude.c:1294 `RULE_STRCMP(s, "dir-merge")` under
+        // `case 'd':`; `rule_strcmp` is `strncmp` (:1218), so the keyword is
+        // matched exactly and `Dir-Merge` is an unknown rule. `per-dir` has no
+        // upstream counterpart at all; it is held to the same rule for
+        // consistency with its sibling alias.
+        if &text[..alias.len()] == alias {
             matched = Some((&text[..alias.len()], &text[alias.len()..]));
             break;
         }
@@ -206,11 +211,27 @@ mod tests {
         }
     }
 
+    /// upstream: exclude.c:1294 - `RULE_STRCMP(s, "dir-merge")` is `strncmp`
+    /// (:1218), so the keyword is lower case only. MEASURED against rsync
+    /// 3.5.0: `--filter='DIR-MERGE .rsync-filter'` reports
+    /// `Unknown filter rule` and exits 1.
     #[test]
-    fn parse_dir_merge_case_insensitive() {
-        let result = parse_dir_merge_directive("DIR-MERGE .rsync-filter");
-        assert!(result.is_ok());
-        let directive = result.unwrap().unwrap();
+    fn parse_dir_merge_keyword_is_case_sensitive() {
+        assert!(
+            parse_dir_merge_directive("DIR-MERGE .rsync-filter")
+                .expect("uppercase is not a parse error, just not a dir-merge")
+                .is_none()
+        );
+    }
+
+    /// Non-vacuity companion for `parse_dir_merge_keyword_is_case_sensitive`:
+    /// without it the case test would also pass if the parser recognised no
+    /// spelling at all.
+    #[test]
+    fn parse_dir_merge_lower_case_keyword_still_parses() {
+        let directive = parse_dir_merge_directive("dir-merge .rsync-filter")
+            .expect("parse")
+            .expect("dir-merge directive");
         match directive {
             ParsedFilterDirective::DirMerge { pattern, .. } => {
                 assert_eq!(pattern, PathBuf::from(".rsync-filter"));

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -165,6 +165,51 @@ fn split_keyword_modifiers(keyword: &str) -> (&str, &str) {
     }
 }
 
+/// The list-clearing keyword, lower case only.
+///
+/// upstream: exclude.c:1290 `RULE_STRCMP(s, "clear")`, reached only from the
+/// `case 'c':` arm of the switch at :1288. `CLEAR` takes the `default:` arm and
+/// is reported as an unknown rule.
+const CLEAR_KEYWORD: &str = "clear";
+
+/// The oc-only `exclude-if-present` keyword.
+///
+/// Upstream has no such directive, so there is no upstream case rule to mirror.
+/// The spelling stays case-insensitive to match the CLI option of the same name
+/// (`crates/cli/src/frontend/filters/parsing/rules.rs`), which accepts any case.
+const EXCLUDE_IF_PRESENT_PREFIX: &str = "exclude-if-present";
+
+/// Reports whether `token` names a directive whose pattern arrives as the next
+/// whitespace-delimited word in a word-split filter file.
+///
+/// ⚠ This table has NO upstream counterpart, and it is not a reconstruction of
+/// one. Upstream's word-split *file reader* ends every token at the first
+/// whitespace before any keyword parsing runs (exclude.c:1772,
+/// `if (word_split && isspace(ch)) break;`), so `exclude foo` in a `merge,w`
+/// file is two tokens and the bare `exclude` is a fatal
+/// `unexpected end of filter rule`. MEASURED against rsync 3.5.0: that input
+/// exits 1, while `exclude_foo` excludes `foo` and exits 0.
+///
+/// oc instead glues the following token on, accepting a form upstream rejects.
+/// Removing the glue is upstream parity but changes accepted input, so it is
+/// deliberately left for its own change rather than folded in here; this
+/// function only preserves the pre-existing set verbatim so the keyword-case
+/// fix stays behaviour-neutral apart from case. In particular `risk` and
+/// `per-dir` are absent because they were absent before - adding them would
+/// widen the divergence, not narrow it.
+///
+/// The case policy is shared with [`parse_filter_directive_line`]: the upstream
+/// keywords match exactly (`rule_strcmp` is `strncmp`, exclude.c:1218), while
+/// the oc-only `exclude-if-present` keeps the case-insensitive spelling its own
+/// parser accepts.
+pub(crate) fn directive_takes_argument(token: &str) -> bool {
+    matches!(
+        token,
+        "merge" | "include" | "exclude" | "show" | "hide" | "protect"
+    ) || token.starts_with("dir-merge")
+        || token.eq_ignore_ascii_case(EXCLUDE_IF_PRESENT_PREFIX)
+}
+
 /// The single-character rule prefixes this parser dispatches, upper case only.
 ///
 /// upstream: exclude.c:1288-1330 - the long-keyword switch matches lower-case
@@ -195,7 +240,7 @@ pub(crate) fn parse_filter_directive_line(
 
     let trimmed = trimmed.trim_end();
 
-    if trimmed == "!" || trimmed.eq_ignore_ascii_case("clear") {
+    if trimmed == "!" || trimmed == CLEAR_KEYWORD {
         return Ok(Some(ParsedFilterDirective::Clear));
     }
 
@@ -210,8 +255,6 @@ pub(crate) fn parse_filter_directive_line(
     if let Some(directive) = parse_dir_merge_directive(trimmed)? {
         return Ok(Some(directive));
     }
-
-    const EXCLUDE_IF_PRESENT_PREFIX: &str = "exclude-if-present";
 
     if trimmed.len() >= EXCLUDE_IF_PRESENT_PREFIX.len()
         && trimmed[..EXCLUDE_IF_PRESENT_PREFIX.len()]
@@ -303,28 +346,18 @@ pub(crate) fn parse_filter_directive_line(
         }
     }
 
-    if keyword.eq_ignore_ascii_case("include") {
-        return handle_keyword(remainder, FilterRule::include, false);
-    }
-
-    if keyword.eq_ignore_ascii_case("exclude") {
-        return handle_keyword(remainder, FilterRule::exclude, false);
-    }
-
-    if keyword.eq_ignore_ascii_case("show") {
-        return handle_keyword(remainder, FilterRule::show, true);
-    }
-
-    if keyword.eq_ignore_ascii_case("hide") {
-        return handle_keyword(remainder, FilterRule::hide, true);
-    }
-
-    if keyword.eq_ignore_ascii_case("protect") {
-        return handle_keyword(remainder, FilterRule::protect, true);
-    }
-
-    if keyword.eq_ignore_ascii_case("risk") {
-        return handle_keyword(remainder, FilterRule::risk, true);
+    // upstream: exclude.c:1288-1327 - the keyword switch dispatches on the raw
+    // first byte (only lower-case initials `c d e h i m p r s` have arms) and
+    // compares with `rule_strcmp`, which is `strncmp` (:1218). `EXCLUDE` falls
+    // to `default: ch = *s` and then to the `Unknown filter rule` arm (:1362).
+    match keyword {
+        "include" => return handle_keyword(remainder, FilterRule::include, false),
+        "exclude" => return handle_keyword(remainder, FilterRule::exclude, false),
+        "show" => return handle_keyword(remainder, FilterRule::show, true),
+        "hide" => return handle_keyword(remainder, FilterRule::hide, true),
+        "protect" => return handle_keyword(remainder, FilterRule::protect, true),
+        "risk" => return handle_keyword(remainder, FilterRule::risk, true),
+        _ => {}
     }
 
     Err(FilterParseError::new(format!(
@@ -458,6 +491,83 @@ mod tests {
                 "{line:?} is the upper-case prefix upstream does accept"
             );
         }
+    }
+
+    /// upstream: exclude.c:1288-1327 - the long-keyword switch dispatches on
+    /// the raw first byte and has arms only for the lower-case initials
+    /// `c d e h i m p r s`, and `rule_strcmp` is `strncmp` (:1218). An
+    /// upper-case spelling therefore takes `default: ch = *s` and lands on
+    /// `filter_rule_err("Unknown filter rule")` at :1362.
+    ///
+    /// Every upper-case spelling is refused, but in one of TWO ways, and which
+    /// one depends on whether the keyword's first letter is itself a rule
+    /// prefix. `show`/`hide`/`protect`/`risk` begin with `S`/`H`/`P`/`R`, so
+    /// upstream consumes that byte as the prefix and the modifier loop
+    /// (exclude.c:1365) then fails on the SECOND letter. `include`/`exclude`
+    /// begin with `I`/`E`, which are not prefixes, so they reach the unknown-
+    /// rule arm instead.
+    ///
+    /// MEASURED against rsync 3.5.0, one cell per row:
+    ///   `INCLUDE foo` -> `Unknown filter rule: INCLUDE foo`
+    ///   `EXCLUDE foo` -> `Unknown filter rule: EXCLUDE foo`
+    ///   `Show foo`    -> `invalid modifier 'h' at position 1`
+    ///   `Hide foo`    -> `invalid modifier 'i' at position 1`
+    ///   `PROTECT foo` -> `invalid modifier 'R' at position 1`
+    ///   `Risk foo`    -> `invalid modifier 'i' at position 1`
+    /// all exit 1.
+    #[test]
+    fn the_long_keywords_are_case_sensitive() {
+        for (line, expected_fragment) in [
+            ("INCLUDE foo", "Unknown filter rule"),
+            ("EXCLUDE foo", "Unknown filter rule"),
+            ("Show foo", "modifier 'h'"),
+            ("Hide foo", "modifier 'i'"),
+            ("PROTECT foo", "modifier 'R'"),
+            ("Risk foo", "modifier 'i'"),
+        ] {
+            let error = parse_filter_directive_line(line)
+                .expect_err("an upper-case keyword is not a filter directive");
+            assert!(
+                error.to_string().contains(expected_fragment),
+                "{line:?} should be refused with {expected_fragment:?}, got: {error}"
+            );
+        }
+    }
+
+    /// Non-vacuity companion for `the_long_keywords_are_case_sensitive`:
+    /// without it that test would also pass if the parser rejected every
+    /// keyword form.
+    #[test]
+    fn the_long_keywords_still_parse_in_lower_case() {
+        for line in [
+            "include foo",
+            "exclude foo",
+            "show foo",
+            "hide foo",
+            "protect foo",
+            "risk foo",
+        ] {
+            assert!(
+                parse_filter_directive_line(line).is_ok(),
+                "{line:?} is the spelling upstream accepts"
+            );
+        }
+    }
+
+    /// `SHOW foo` is the sharpest cell: `S` IS a valid prefix, so upstream
+    /// consumes it and then runs the modifier loop over `HOW`, failing on the
+    /// first byte. MEASURED against rsync 3.5.0: `--filter='SHOW foo'` prints
+    /// `invalid modifier 'H' at position 1` and exits 1 - a different error
+    /// from the `Unknown filter rule` the other five produce.
+    #[test]
+    fn an_upper_case_keyword_starting_with_a_prefix_letter_fails_in_the_modifier_run() {
+        let error = parse_filter_directive_line("SHOW foo")
+            .expect_err("S is a prefix, so HOW is scanned as modifiers");
+        let message = error.to_string();
+        assert!(
+            message.contains("modifier") && message.contains('H'),
+            "expected a modifier error naming 'H', got: {message}"
+        );
     }
 
     /// upstream: exclude.c:1395-1401 - `!` sets FILTRULE_NEGATE after any

--- a/crates/engine/src/local_copy/dir_merge/parse/merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/merge.rs
@@ -20,8 +20,11 @@ pub(super) fn parse_merge_directive(
         return Ok(None);
     }
 
+    // upstream: exclude.c:1310 `RULE_STRCMP(s, "merge")` under `case 'm':`, and
+    // `rule_strcmp` is `strncmp` (:1218) - `Merge` reaches `default:` and is
+    // reported as an unknown rule, not parsed as a merge directive.
     let (prefix, rest) = text.split_at(MERGE_PREFIX.len());
-    if !prefix.eq_ignore_ascii_case(MERGE_PREFIX) {
+    if prefix != MERGE_PREFIX {
         return Ok(None);
     }
 
@@ -164,11 +167,26 @@ mod tests {
         }
     }
 
+    /// upstream: exclude.c:1310 - `RULE_STRCMP(s, "merge")` is `strncmp`
+    /// (:1218), so the keyword is lower case only. MEASURED against rsync
+    /// 3.5.0: `--filter='Merge f'` reports `Unknown filter rule` and exits 1.
     #[test]
-    fn parse_merge_directive_case_insensitive() {
-        let result = parse_merge_directive("MERGE .rsync-filter");
-        assert!(result.is_ok());
-        let directive = result.unwrap().unwrap();
+    fn parse_merge_keyword_is_case_sensitive() {
+        assert!(
+            parse_merge_directive("MERGE .rsync-filter")
+                .expect("uppercase is not a parse error, just not a merge")
+                .is_none()
+        );
+    }
+
+    /// Non-vacuity companion for `parse_merge_keyword_is_case_sensitive`:
+    /// without it the case test would also pass if the parser recognised no
+    /// spelling at all.
+    #[test]
+    fn parse_merge_lower_case_keyword_still_parses() {
+        let directive = parse_merge_directive("merge .rsync-filter")
+            .expect("parse")
+            .expect("merge directive");
         match directive {
             ParsedFilterDirective::Merge { path, .. } => {
                 assert_eq!(path, PathBuf::from(".rsync-filter"));

--- a/crates/engine/src/local_copy/dir_merge/parse/mod.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/mod.rs
@@ -11,5 +11,5 @@ mod merge;
 mod modifiers;
 mod types;
 
-pub(crate) use line::parse_filter_directive_line;
+pub(crate) use line::{directive_takes_argument, parse_filter_directive_line};
 pub(crate) use types::{FilterParseError, ParsedFilterDirective};

--- a/crates/engine/src/local_copy/tests/filters.rs
+++ b/crates/engine/src/local_copy/tests/filters.rs
@@ -113,11 +113,27 @@ fn parse_filter_directive_clear_keyword() {
     let directive = parse_filter_directive_line("clear").expect("parse clear");
     assert!(matches!(directive, Some(ParsedFilterDirective::Clear)));
 
-    let uppercase = parse_filter_directive_line("  CLEAR  ").expect("parse uppercase");
-    assert!(matches!(uppercase, Some(ParsedFilterDirective::Clear)));
-
     let bang = parse_filter_directive_line("!").expect("parse bang");
     assert!(matches!(bang, Some(ParsedFilterDirective::Clear)));
+}
+
+/// upstream: exclude.c:1290 - `RULE_STRCMP(s, "clear")` sits under `case 'c':`
+/// of the switch at :1288, which has only lower-case initials, and
+/// `rule_strcmp` is `strncmp` (:1218). `CLEAR` therefore takes the `default:`
+/// arm at :1324 and is reported as an unknown rule.
+///
+/// MEASURED against rsync 3.5.0: `--filter=CLEAR` prints
+/// `Unknown filter rule: CLEAR` and exits 1; `--filter=clear` exits 0.
+#[test]
+fn parse_filter_directive_clear_keyword_is_case_sensitive() {
+    for spelling in ["CLEAR", "Clear", "  CLEAR  "] {
+        let error = parse_filter_directive_line(spelling)
+            .expect_err("an upper-case clear is not a filter rule oc knows");
+        assert!(
+            error.to_string().contains("Unknown filter rule"),
+            "unexpected error for {spelling:?}: {error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/filters_runtime.rs
+++ b/crates/engine/src/local_copy/tests/filters_runtime.rs
@@ -299,6 +299,83 @@ fn dir_merge_clear_keyword_discards_rules_in_whitespace_mode() {
     assert!(entries.exclude_if_present.is_empty());
 }
 
+/// The two list-clear checks in `load_dir_merge_rules_recursive` short-circuit
+/// before `parse_filter_directive_line` runs, so they carry their own copy of
+/// the keyword rule and a parser-level test cannot reach them.
+///
+/// upstream: exclude.c:1290 - `clear` is matched with `strncmp` (:1218) under
+/// the lower-case-only `case 'c':`, so `CLEAR` reaches the unknown-rule arm
+/// (:1362). A merge file carries no `FILTRULE_NO_PREFIXES`, so there is no
+/// bare-pattern fallback: the line is a hard error, not an exclude.
+///
+/// MEASURED against rsync 3.5.0, with `- keep` / `CLEAR` in a `.rsync-filter`
+/// read via `-rF`:
+///   `Unknown filter rule: <rule from .../.rsync-filter line 2>`
+///   `rsync error: syntax or usage error (code 1) at exclude.c(136)`
+#[test]
+fn dir_merge_clear_keyword_is_case_sensitive_in_both_parser_modes() {
+    let temp = tempdir().expect("tempdir");
+
+    for (name, body, options) in [
+        (
+            "lines.rules",
+            &b"- keep\nCLEAR\n"[..],
+            DirMergeOptions::default(),
+        ),
+        (
+            "words.rules",
+            &b"-_keep CLEAR"[..],
+            DirMergeOptions::default()
+                .use_whitespace()
+                .allow_list_clearing(true),
+        ),
+    ] {
+        let filter = temp.path().join(name);
+        fs::write(&filter, body).expect("write filter");
+        let mut visited = Vec::new();
+        match load_dir_merge_rules_recursive(&filter, &options, false, &mut visited) {
+            Ok(_) => panic!("{name}: an upper-case CLEAR is neither a directive nor a pattern"),
+            Err(error) => assert!(
+                error.to_string().contains("Unknown filter rule"),
+                "unexpected error for {name}: {error}"
+            ),
+        }
+    }
+}
+
+/// Non-vacuity companion for the test above: the same two fixtures with the
+/// lower-case spelling DO clear the list, so the case test cannot pass merely
+/// because the loader rejects the fixture shape.
+#[test]
+fn dir_merge_lower_case_clear_still_clears_in_both_parser_modes() {
+    let temp = tempdir().expect("tempdir");
+
+    for (name, body, options) in [
+        (
+            "lines.ok",
+            &b"- keep\nclear\n"[..],
+            DirMergeOptions::default(),
+        ),
+        (
+            "words.ok",
+            &b"-_keep clear"[..],
+            DirMergeOptions::default()
+                .use_whitespace()
+                .allow_list_clearing(true),
+        ),
+    ] {
+        let filter = temp.path().join(name);
+        fs::write(&filter, body).expect("write filter");
+        let mut visited = Vec::new();
+        let entries = load_dir_merge_rules_recursive(&filter, &options, false, &mut visited)
+            .unwrap_or_else(|error| panic!("{name} must parse: {error}"));
+        assert!(
+            entries.rules.is_empty() && entries.clear_inherited,
+            "{name}: lower-case clear must discard the earlier rule"
+        );
+    }
+}
+
 /// Nested `dir-merge` inside a per-directory merge file should register the
 /// referenced filename for lookup in each visited subdirectory, NOT load it
 /// eagerly against the enclosing file's directory.


### PR DESCRIPTION
Upstream matches every filter-rule keyword with `rule_strcmp` (exclude.c:1218),
which is `strncmp` - and the switch that dispatches to it (`switch (*s)`,
exclude.c:1288) has arms only for the lower-case initials `c d e h i m p r s`.
An upper-case spelling can never reach a keyword branch. oc was folding case at
six sites, so `CLEAR`, `EXCLUDE foo`, `MERGE f` and `DIR-MERGE f` were accepted
as directives where upstream refuses them.

## Upstream refuses in two different ways, and the split is not obvious

Every upper-case spelling exits 1, but *which* error depends on whether the
keyword's first letter happens to be a rule prefix. `S`, `H`, `P` and `R` are
the shorthand prefixes for show/hide/protect/risk, so upstream consumes that
byte and the modifier loop (exclude.c:1365) then fails on the *second* letter.
`I` and `E` are not prefixes, so they fall to the unknown-rule arm at :1362.

MEASURED against rsync 3.5.0, one command per row:

| rule | exit | first stderr line |
|---|---|---|
| `INCLUDE foo` | 1 | `Unknown filter rule: INCLUDE foo` |
| `EXCLUDE foo` | 1 | `Unknown filter rule: EXCLUDE foo` |
| `Show foo` | 1 | `invalid modifier 'h' at position 1 in filter rule: Show foo` |
| `Hide foo` | 1 | `invalid modifier 'i' at position 1 in filter rule: Hide foo` |
| `PROTECT foo` | 1 | `invalid modifier 'R' at position 1 in filter rule: PROTECT foo` |
| `Risk foo` | 1 | `invalid modifier 'i' at position 1 in filter rule: Risk foo` |
| `clear` / `exclude foo` | 0 | *(none)* |

oc already reproduced this split exactly, including the specific letter. The
first version of the test asserted `Unknown filter rule` for all six and failed
on four of them - the table above is what the code was doing all along.

## Sites

Six, and three of them are not in the parser:

- `parse/line.rs` - the `clear` keyword and the six long keywords.
- `parse/merge.rs`, `parse/dir_merge.rs` - the `merge` and `dir-merge` aliases.
- `load.rs` x3 - two list-clear checks that short-circuit **before**
  `parse_filter_directive_line` runs, and the word-split argument table. Fixing
  only the parser would have left `CLEAR` still clearing the list from a
  `.rsync-filter` file, because the loader never consults the parser for it.

`exclude-if-present` stays case-insensitive: it is an oc extension with no
upstream keyword to mirror, and the CLI option of the same name accepts any
case, so tightening one side alone would create a new internal divergence.
`per-dir` is likewise oc-only; it is held to the same exact-match rule as its
`dir-merge` sibling for consistency, not on upstream authority.

## A non-upstream table left deliberately untouched

`load.rs`'s word-split arm glues the next whitespace token onto a keyword. That
has no upstream counterpart at all: upstream's word-split *file reader* ends
every token at the first whitespace before any keyword parsing runs
(exclude.c:1772, `if (word_split && isspace(ch)) break;`). MEASURED - a file
containing `exclude foo` read via `merge,w` gives `unexpected end of filter
rule` and exit 1, while the same file via plain `merge` exits 0, and
`exclude_foo` via `merge,w` correctly excludes `foo`.

So oc accepts a form upstream rejects. Removing the glue is upstream parity but
changes which filter files are accepted, so it belongs in its own change rather
than riding along here. This PR keeps the pre-existing keyword set verbatim and
documents why. An earlier draft of this branch *added* `risk` and `per-dir` to
that table on the theory that it had drifted from the parser; that was wrong one
level down - the table should not exist for upstream fidelity, so extending it
widens the divergence. The addition is reverted.

The CVS path is unaffected either way: `-C`, `--cvs-exclude`, `.cvsignore`,
`:C` and `,C` all set an enforced include/exclude kind that short-circuits into
the bare-pattern branch before the glue is reached, and upstream sets
`FILTRULE_NO_PREFIXES` for CVS so it structurally cannot express a keyword rule
there (exclude.c:1273-1275).

## Tests

Three tests encoded the old behaviour - their names said `_case_insensitive` -
and are re-based onto measured upstream tables. Each rejection is paired with a
lower-case non-vacuity companion, without which the case test would also pass if
the parser simply recognised nothing.

Two on-disk `.rsync-filter` tests cover the `load.rs` sites, which no unit test
reaches. Their expectation is also measured: a bare `CLEAR` in a lines-mode
merge file is a hard `Unknown filter rule` + exit 1 upstream, not a demotion to
a literal pattern - a merge file carries no `FILTRULE_NO_PREFIXES`, so there is
no bare-pattern fallback. My first draft asserted the demotion and failed.

Mutation sweep over all six fixed sites, one site at a time, `--no-fail-fast`:
every mutation lethal, and `passed + failed == run` on each row (5003+2, then
5004+1 five times) so no kill list was truncated.

engine 5005/5005. `cargo fmt --all -- --check` clean; workspace
`clippy --all-targets --all-features -D warnings` clean.
