### PR TITLE
fix(filters): a receiver must not refuse a perishable rule below protocol 30

### DIFF
--- a/crates/protocol/src/filters/prefix.rs
+++ b/crates/protocol/src/filters/prefix.rs
@@ -44,7 +44,26 @@ fn build_old_prefix(rule: &FilterRuleWireFormat) -> Option<String> {
         return None;
     }
 
-    // upstream: exclude.c:1530 - any modifier exceeds legal_len = 1 and is unsendable
+    // upstream: exclude.c:1829 - `legal_len = 1`, and the final length test at
+    // :1878 rejects any prefix that outgrew it. Every flag listed here is written
+    // to the buffer unconditionally (:1845-1864), so each one overflows and makes
+    // the rule unsendable.
+    //
+    // `perishable` is deliberately ABSENT. Upstream never writes `p` below
+    // protocol 30 (:1872-1874), so it cannot contribute to the overflow; the only
+    // perishable NULL is the separate `else if (am_sender) return NULL` at :1875,
+    // which oc owns at the call site (`perishable_rules_too_modern`, transfer)
+    // where the sending role is known - this function is role-blind. A receiver
+    // omits the modifier and keeps the rule, exactly as the protocol >= 29 path
+    // already does via `supports_perishable_modifier`. Including it here made a
+    // receiving client abort a pre-29 pull that upstream completes.
+    //
+    // `sender_side` / `receiver_side` are still listed even though upstream also
+    // gates their emission (:1865-1871): the `r` gate has a third arm
+    // (`delete_excluded && am_sender`) under which upstream DOES write the byte
+    // and DOES overflow, and neither input reaches this function today. Relaxing
+    // them needs that plumbing, so they stay conservative here rather than
+    // becoming half-right.
     let has_modifiers = rule.anchored
         || rule.negate
         || rule.cvs_exclude
@@ -54,7 +73,6 @@ fn build_old_prefix(rule: &FilterRuleWireFormat) -> Option<String> {
         || rule.xattr_only
         || rule.sender_side
         || rule.receiver_side
-        || rule.perishable
         || rule.no_prefixes;
 
     if has_modifiers {
@@ -342,12 +360,33 @@ mod tests {
         assert!(build_rule_prefix(&rule, protocol).is_none());
     }
 
+    /// upstream: exclude.c:1872-1876 - below protocol 30 the `p` byte is never
+    /// written, so a perishable rule does NOT overflow `legal_len` and is not
+    /// unsendable. The only perishable refusal is `else if (am_sender)`, which
+    /// this role-blind builder cannot make; `perishable_rules_too_modern`
+    /// (transfer) owns it. Here the rule keeps its bare-pattern form, matching
+    /// what upstream's receiver puts on the wire.
+    ///
+    /// MEASURED against rsync 3.5.0: a protocol-28 PULL with `--filter='-p f'`
+    /// exits 0 and transfers, while the same rule on a PUSH exits 2.
     #[test]
-    fn v28_cannot_represent_perishable() {
+    fn v28_omits_perishable_instead_of_refusing_the_rule() {
         let protocol = ProtocolVersion::from_supported(28).unwrap();
         let rule = FilterRuleWireFormat::exclude("test".to_owned()).with_perishable(true);
 
-        // v28 uses old prefixes which cannot encode modifiers - returns None
+        assert_eq!(build_rule_prefix(&rule, protocol).as_deref(), Some(""));
+    }
+
+    /// Non-vacuity companion: a modifier upstream DOES write at protocol 28
+    /// still overflows `legal_len` and is refused, so the test above is not
+    /// passing merely because the builder stopped refusing anything.
+    #[test]
+    fn v28_still_refuses_a_modifier_upstream_actually_emits() {
+        let protocol = ProtocolVersion::from_supported(28).unwrap();
+        // `!` is written unconditionally at exclude.c:1846, so it overflows.
+        let mut rule = FilterRuleWireFormat::exclude("test".to_owned());
+        rule.negate = true;
+
         assert!(build_rule_prefix(&rule, protocol).is_none());
     }
 

--- a/crates/protocol/tests/filter_legal_len_parity.rs
+++ b/crates/protocol/tests/filter_legal_len_parity.rs
@@ -80,13 +80,18 @@ fn serialize_rule_errors_with_too_modern_for_dir_merge_at_protocol_28() {
     );
 }
 
-/// Every modifier flag is independently unsendable at protocol 28.
+/// Every modifier upstream WRITES at protocol 28 is independently unsendable.
 ///
-/// Upstream `exclude.c:1530` budgets one prefix byte, so each modifier
-/// (anchored, negate, cvs_exclude, no_inherit, word_split, exclude_from_merge,
-/// xattr_only, sender_side, receiver_side, perishable) pushes the prefix
-/// length past `legal_len=1` and triggers the `RERR_PROTOCOL` exit at
-/// `send_rules:1623-1627`. The parameterised loop pins all ten flags.
+/// Upstream `exclude.c:1829` budgets one prefix byte and the length test at
+/// `:1878` rejects anything longer, so each of these modifiers pushes the
+/// prefix past `legal_len=1` and triggers the `RERR_PROTOCOL` exit at
+/// `send_rules:1922-1927`.
+///
+/// `perishable` is NOT in this list, and its absence is the point: upstream
+/// never writes `p` below protocol 30 (`:1872-1874`), so it cannot overflow.
+/// Its refusal is a separate, sender-only branch - see
+/// `perishable_is_omitted_not_refused_at_protocol_28` below. Listing it here
+/// made a receiving client abort a pre-29 pull that upstream completes.
 #[test]
 fn each_modifier_unsendable_at_protocol_28() {
     type Setter = fn(&mut FilterRuleWireFormat);
@@ -100,7 +105,6 @@ fn each_modifier_unsendable_at_protocol_28() {
         ("xattr_only", |r| r.xattr_only = true),
         ("sender_side", |r| r.sender_side = true),
         ("receiver_side", |r| r.receiver_side = true),
-        ("perishable", |r| r.perishable = true),
     ];
 
     for (name, setter) in cases {
@@ -125,6 +129,38 @@ fn each_modifier_unsendable_at_protocol_28() {
             "modifier '{name}': error must match upstream send_rules:1623-1627 wording; got {err}",
         );
     }
+}
+
+/// A perishable rule is OMITTED at protocol 28, not refused.
+///
+/// Upstream `get_rule_prefix` (`exclude.c:1872-1876`) writes `p` only at
+/// protocol >= 30. Below that it emits nothing and returns NULL solely when
+/// `am_sender` - a role this serializer does not know. So the wire form is the
+/// receiver's: the rule survives with a bare pattern and no modifier byte.
+///
+/// The sender's abort lives at the transfer call site
+/// (`perishable_rules_too_modern`), which runs before `write_filter_list`.
+/// Duplicating it here refused BOTH roles and broke pre-29 pulls that upstream
+/// completes - MEASURED against rsync 3.5.0, which exits 0 and transfers on a
+/// protocol-28 pull with `--filter='-p f'` while exiting 2 on the push.
+#[test]
+fn perishable_is_omitted_not_refused_at_protocol_28() {
+    let mut rule = FilterRuleWireFormat::exclude("pattern".to_owned());
+    rule.perishable = true;
+
+    assert_eq!(
+        build_rule_prefix(&rule, proto(PROTO_28)).as_deref(),
+        Some(""),
+        "perishable must not overflow legal_len - upstream never writes `p` below protocol 30",
+    );
+
+    let mut buf = Vec::new();
+    write_filter_list(&mut buf, std::slice::from_ref(&rule), proto(PROTO_28))
+        .expect("a perishable rule is serializable at protocol 28");
+    assert!(
+        !buf.is_empty(),
+        "the rule must reach the wire rather than being silently dropped",
+    );
 }
 
 /// The wire parser treats a `:`-prefixed payload at protocol 28 as a bare

--- a/tests/perishable_filter_too_modern_gate.rs
+++ b/tests/perishable_filter_too_modern_gate.rs
@@ -1,0 +1,204 @@
+//! A perishable (`p`) filter rule must NOT make a receiver refuse a pre-30 peer.
+//!
+//! ```c
+//! /* exclude.c:1872-1877, get_rule_prefix() */
+//! if (rule->rflags & FILTRULE_PERISHABLE) {
+//!     if (!for_xfer || protocol_version >= 30)
+//!         *op++ = 'p';
+//!     else if (am_sender)
+//!         return NULL;
+//! }
+//! ```
+//!
+//! Below protocol 30 upstream never writes the `p` byte, so a perishable rule
+//! cannot overflow `legal_len` and cannot be "too modern" on its own. The only
+//! NULL is the sender-only `else if (am_sender)`.
+//!
+//! oc listed `perishable` among the modifiers that overflow `legal_len` in
+//! `build_old_prefix`, which is role-blind - so a RECEIVING client refused a
+//! pre-29 pull that upstream completes. This file pins the receiver side.
+//!
+//! MEASURED against rsync 3.5.0 (`--filter='-p bar.txt'`, remote via an rsh
+//! shim, no `--delete`):
+//!
+//! ```text
+//! pull --protocol=28  exit 0   foo.txt transferred   (oc exited 2 before)
+//! pull --protocol=32  exit 0   foo.txt transferred
+//! push --protocol=32  exit 0   foo.txt transferred
+//! ```
+//!
+//! ⚠ THE SENDER HALF IS DELIBERATELY NOT TESTED HERE, because it is NOT
+//! implemented. oc does not abort a protocol-28 PUSH carrying a perishable
+//! rule where upstream would. Making it abort is NOT a one-line hoist: see
+//! `send_rules` (exclude.c:1905-1912), where a rule elided as `LOCAL_RULE`
+//! `continue`s BEFORE `get_rule_prefix` is ever called, and exclude.c:1499,
+//! where upstream marks a rule perishable ONLY when `protocol_version >= 30`.
+//! An earlier revision of this branch hoisted the sender check without either
+//! condition and regressed the upstream `symlink-dirlink-basis` testsuite
+//! case: `--partial-dir` at protocol 28 aborted where upstream exits 0.
+//! That is tracked separately; do not "restore" the hoist without both gates.
+//!
+//! The protocol-32 rows are non-vacuity controls: without them a build that
+//! refused every perishable rule, or refused on both sides, would still pass
+//! the protocol-28 pull row alone.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the remote-shell shim uses `/bin/sh`).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// A remote-shell stand-in: drops the leading options and the host token, then
+/// execs the server command, so the "remote" is this same binary running for
+/// real as `--server`.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    Push,
+    Pull,
+}
+
+struct Outcome {
+    code: Option<i32>,
+    stderr: String,
+    dest_entries: Vec<String>,
+}
+
+/// Runs one cell: a perishable exclude over the rsh shim at `protocol`.
+///
+/// Deliberately passes NO `--delete` and NO `--prune-empty-dirs` - those are
+/// exactly the flags that make oc's write-suppression flag true and would have
+/// masked the defect this test exists for.
+fn run_cell(protocol: u32, direction: Direction) -> Outcome {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(src.join("foo.txt"), b"a\n").expect("write foo");
+    fs::write(src.join("bar.txt"), b"b\n").expect("write bar");
+    let dest = root.join("dest");
+
+    let shim = write_rsh_shim(root);
+    let bin = oc_binary();
+    let mut command = Command::new(&bin);
+    command
+        .arg("-r")
+        .arg(format!("--protocol={protocol}"))
+        .arg("-e")
+        .arg(&shim)
+        .arg("--rsync-path")
+        .arg(&bin)
+        .arg("--filter=-p bar.txt");
+
+    match direction {
+        Direction::Push => {
+            command
+                .arg(format!("{}/", src.display()))
+                .arg(format!("lh:{}/", dest.display()));
+        }
+        Direction::Pull => {
+            command
+                .arg(format!("lh:{}/", src.display()))
+                .arg(format!("{}/", dest.display()));
+        }
+    }
+
+    let output = command.output().expect("spawn oc-rsync");
+    let mut dest_entries: Vec<String> = fs::read_dir(&dest)
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .collect()
+        })
+        .unwrap_or_default();
+    dest_entries.sort();
+
+    Outcome {
+        code: output.status.code(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        dest_entries,
+    }
+}
+
+/// Non-vacuity across the PROTOCOL dimension: at 30 and above the `p` is
+/// representable, so there is nothing to refuse.
+#[test]
+fn perishable_rule_transfers_on_push_at_protocol_32() {
+    let outcome = run_cell(32, Direction::Push);
+    assert_eq!(
+        outcome.code,
+        Some(0),
+        "push at protocol 32 must succeed; stderr: {}",
+        outcome.stderr
+    );
+    assert_eq!(
+        outcome.dest_entries,
+        vec!["foo.txt".to_string()],
+        "the perishable exclude must still drop bar.txt"
+    );
+}
+
+/// Non-vacuity across the SIDE dimension: upstream's refusal is gated on
+/// `am_sender`, so a receiving client keeps the rule locally and transfers.
+#[test]
+fn perishable_rule_transfers_on_pull_below_protocol_30() {
+    let outcome = run_cell(28, Direction::Pull);
+    assert_eq!(
+        outcome.code,
+        Some(0),
+        "pull at protocol 28 must succeed - the abort is sender-only; stderr: {}",
+        outcome.stderr
+    );
+    assert_eq!(
+        outcome.dest_entries,
+        vec!["foo.txt".to_string()],
+        "the perishable exclude must still drop bar.txt"
+    );
+}
+
+/// The remaining cell of the 2x2, so the table is complete rather than
+/// three points chosen to fit.
+#[test]
+fn perishable_rule_transfers_on_pull_at_protocol_32() {
+    let outcome = run_cell(32, Direction::Pull);
+    assert_eq!(
+        outcome.code,
+        Some(0),
+        "pull at protocol 32 must succeed; stderr: {}",
+        outcome.stderr
+    );
+    assert_eq!(
+        outcome.dest_entries,
+        vec!["foo.txt".to_string()],
+        "the perishable exclude must still drop bar.txt"
+    );
+}


### PR DESCRIPTION
`get_rule_prefix` (exclude.c:1872-1877):

    if (rule->rflags & FILTRULE_PERISHABLE) {
        if (!for_xfer || protocol_version >= 30)
            *op++ = 'p';
        else if (am_sender)
            return NULL;
    }

Below protocol 30 the `p` byte is never written, so a perishable rule cannot
overflow `legal_len` and is not "too modern" by itself. The only NULL is the
sender-only `else if (am_sender)`.

`build_old_prefix` listed `perishable` among the modifiers that overflow
`legal_len`. Every other flag in that list IS written unconditionally
(exclude.c:1845-1864) and so genuinely overflows; `p` is not. Because the
function is role-blind, a RECEIVING client refused a pre-29 pull that upstream
completes.

MEASURED against rsync 3.5.0, `--filter='-p bar.txt'` over an rsh shim:

| direction | protocol | upstream | oc before |
|---|---|---|---|
| pull | 28 | exit 0, transfers | exit 2, aborts |
| pull | 32 | exit 0 | exit 0 |
| push | 32 | exit 0 | exit 0 |

`sender_side`/`receiver_side` stay in the list even though upstream also gates
their emission (:1865-1871): the `r` gate has a third arm
(`delete_excluded && am_sender`) under which upstream DOES write the byte and
DOES overflow, and neither input reaches this function today. Relaxing them
needs that plumbing, so they stay conservative rather than half-right.

## The sender half is deliberately NOT included

An earlier revision of this branch also hoisted `perishable_rules_too_modern`
out of the `should_send_filter_list` gate so a protocol-28 PUSH would abort.
That was WRONG and is reverted. It regressed the upstream testsuite case
`symlink-dirlink-basis`: `--partial-dir` at protocol 28 aborted where upstream
exits 0, reproduced locally as

    oc  --protocol=28 --partial-dir=.rp   exit 2
    upstream                              exit 0

Two upstream conditions that hoist missed:

- `send_rules` (exclude.c:1905-1912) `continue`s on `elide == LOCAL_RULE`
  BEFORE calling `get_rule_prefix`, so a locally-elided rule never reaches the
  refusal at all.
- compat.c:803-807 (`setup_protocol`) marks the implicit `--partial-dir` rule
  perishable only when `!am_sender || protocol_version >= 30`:

      if (partial_dir && *partial_dir != '/' && (!am_server || local_server)) {
          int rflags = FILTRULE_NO_PREFIXES | FILTRULE_DIRECTORY;
          if (!am_sender || protocol_version >= 30)
              rflags |= FILTRULE_PERISHABLE;

  On a SENDER below protocol 30 both disjuncts are false, so upstream
  deliberately does NOT mark it - there is nothing for the abort to refuse.
  oc's `push_implicit_partial_dir_filter`
  (crates/core/src/client/config/builder/filters.rs:96) sets
  `with_perishable(true)` unconditionally, so oc has a perishable rule exactly
  where upstream has none. Note upstream sets this in `setup_protocol`, i.e.
  AFTER negotiation, where `protocol_version` is known; oc builds the rule in
  the config builder, so mirroring the gate is a sequencing change, not a
  one-line condition.

So the sender-side abort cannot be added until the perishable marking itself
is keyed on the negotiated protocol. Tracked separately; the test file records
this so the hoist is not "restored" without both gates.

## Tests

`tests/perishable_filter_too_modern_gate.rs` spawns the real binary over an
rsh shim and pins the three measured cells. The protocol-32 rows are
non-vacuity controls: without them a build that refused every perishable rule,
or refused on both sides, would still satisfy the protocol-28 pull row alone.

Two existing tests encoded the pre-fix behaviour and are re-based onto the
measured table rather than flipped: `v28_cannot_represent_perishable` becomes
`v28_omits_perishable_instead_of_refusing_the_rule`, with a companion pinning
that a modifier upstream *does* emit (`!`) is still refused; and `perishable`
moves out of the `each_modifier_unsendable_at_protocol_28` loop into its own
cased test stating why it is not in that set.

protocol 6069/6069. fmt clean. `--partial-dir` and `--backup` at protocol 28
re-measured against the rebuilt binary: both exit 0, matching upstream.

