### PR TITLE
fix(cli): track --delete-excluded distinctly in the server arg parse

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -144,6 +144,20 @@ pub(super) struct ServerLongFlags {
     ///
     /// [`late_delete`]: Self::late_delete
     pub(super) delete_after: bool,
+    /// Also delete destination entries the filter list excludes (upstream:
+    /// `--delete-excluded`, long-form only).
+    ///
+    /// Tracked apart from [`delete`] because it is an input to
+    /// `receiver_wants_filter_list`, which BOTH ends must compute identically:
+    /// `prune_empty_dirs || (delete_mode && (!delete_excluded || protocol >= 29))`
+    /// (upstream exclude.c:1947-1948 `send_filter_list` / :1976-1977
+    /// `recv_filter_list`). Folding it into [`delete`] left this side reading
+    /// `false`, so below protocol 29 the client correctly sent no list while the
+    /// server still tried to read one and consumed the file list as a rule
+    /// length.
+    ///
+    /// [`delete`]: Self::delete
+    pub(super) delete_excluded: bool,
     /// Remove source files after a successful transfer.
     ///
     /// upstream: options.c:2964-2965 - `server_options()` emits
@@ -415,6 +429,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         delete: false,
         late_delete: false,
         delete_after: false,
+        delete_excluded: false,
         remove_source_files: false,
         copy_devices: false,
         stats: false,
@@ -563,8 +578,22 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // upstream: --numeric-ids is long-form only (options.c:2887-2888)
             "--numeric-ids" => flags.numeric_ids = true,
             // upstream: --delete variants are long-form only (options.c:2818-2827)
-            "--delete" | "--delete-before" | "--delete-during" | "--delete-excluded" => {
+            "--delete" | "--delete-before" | "--delete-during" => {
                 flags.delete = true;
+            }
+            // upstream: options.c:3010-3013 server_options() emits `--delete`
+            // only in the `else if (delete_mode && !delete_excluded)` arm, then
+            // adds `--delete-excluded` separately - so `--delete-excluded`
+            // arrives INSTEAD of `--delete`, not alongside it, and setting
+            // `delete` here is what carries delete_mode over. That matches
+            // options.c:2334, where `delete_mode || delete_excluded` turns
+            // `--delete-excluded` alone into a delete mode.
+            //
+            // Keeping only `delete` made the server disagree with the client
+            // about `receiver_wants_filter_list`.
+            "--delete-excluded" => {
+                flags.delete = true;
+                flags.delete_excluded = true;
             }
             // upstream: generator.c:124 EARLY_DELETE_DONE_MSG = !(delete_during==2
             // || delete_after). --delete-delay defers only the goodbye del-stats

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -296,6 +296,12 @@ where
     // merge files it just received protect matching destination entries at delete
     // time. --delete-delay decides during the walk and only defers the unlink.
     config.deletion.delete_after = long_flags.delete_after;
+    // upstream: exclude.c:1947-1948 / :1976-1977 - both ends compute
+    // `receiver_wants_list` from the same four inputs, so a server that reads
+    // `delete_excluded` as false while the client reads it as true will try to
+    // read a filter list the client never sent, consuming the file list as a
+    // rule length. Below protocol 29 that is the whole difference.
+    config.deletion.delete_excluded = long_flags.delete_excluded;
     // upstream: options.c:2964-2965 - `--remove-source-files` is forwarded
     // long-form when the client requested sender-side removal. The flag is
     // consumed by the sender's `successful_send()` after each transferred

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -405,6 +405,41 @@ fn parse_server_args_skips_append_flag() {
     );
 }
 
+/// `--delete-excluded` must be recorded distinctly, not folded into `delete`.
+///
+/// It is an input to `receiver_wants_filter_list` (exclude.c:1947-1948), which
+/// both ends compute independently, so losing it here desynced the filter-list
+/// exchange below protocol 29. `delete` is also set because upstream emits
+/// `--delete-excluded` INSTEAD of `--delete` (options.c:3010-3013, the
+/// `else if (delete_mode && !delete_excluded)` arm), and `--delete-excluded`
+/// alone implies a delete mode (options.c:2334).
+#[test]
+fn long_flags_captures_delete_excluded_distinctly() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--delete-excluded"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert!(
+        flags.delete,
+        "--delete-excluded alone must still imply a delete mode"
+    );
+    assert!(
+        flags.delete_excluded,
+        "--delete-excluded must be tracked apart from the generic delete flag"
+    );
+}
+
+/// Non-vacuity companion: a plain `--delete` must NOT set `delete_excluded`,
+/// so the test above cannot pass by the field being unconditionally true.
+#[test]
+fn long_flags_plain_delete_leaves_delete_excluded_unset() {
+    let args = vec![OsString::from("--server"), OsString::from("--delete")];
+    let flags = parse_server_long_flags(&args);
+    assert!(flags.delete);
+    assert!(!flags.delete_excluded);
+}
+
 /// `parse_server_long_flags` records a single `--append` as `append_mode == 1`
 /// (plain append, prefix trusted) and never sets `append_verify`.
 #[test]

--- a/tests/server_delete_excluded_filter_list_agreement.rs
+++ b/tests/server_delete_excluded_filter_list_agreement.rs
@@ -1,0 +1,192 @@
+//! `--delete-excluded` must survive the `--server` argv parse.
+//!
+//! Both ends of a transfer compute the same predicate before either touches the
+//! filter list:
+//!
+//! ```c
+//! /* exclude.c:1947-1948, send_filter_list()  */
+//! /* exclude.c:1976-1977, recv_filter_list()  */
+//! int receiver_wants_list = prune_empty_dirs
+//!     || (delete_mode && (!delete_excluded || protocol_version >= 29));
+//! ```
+//!
+//! It is a pure function of four inputs, so the two ends agree only while they
+//! agree on every input. `--delete-excluded` was collapsed into the generic
+//! `delete` flag by the real subprocess argv parser and never reached
+//! `config.deletion.delete_excluded`, which therefore stayed `false` on the
+//! server. Below protocol 29 that flips exactly one operand:
+//!
+//! - client, true  delete_excluded: `!true  || 28 >= 29` -> false, sends nothing
+//! - server, false delete_excluded: `!false || 28 >= 29` -> true, reads a list
+//!
+//! The server then consumed the start of the file list as a 4-byte rule length,
+//! producing a nonsense count and a truncated stream. At protocol 29 and above
+//! the `protocol_version >= 29` disjunct makes the predicate true on both ends
+//! regardless, which is why this only ever broke legacy peers.
+//!
+//! NOTE: this has nothing to do with filter rules - no `--filter` is involved
+//! in any cell below. The defect reproduces on the bare option pair.
+//!
+//! MEASURED against rsync 3.5.0 and oc over an rsh shim, pushing a two-file
+//! tree with no filter:
+//!
+//! ```text
+//!                                   upstream        oc (before)
+//! --protocol=28 --delete --delete-excluded   exit 0, 2 files   exit 12, 0 files
+//! --protocol=28 --delete                     exit 0, 2 files   exit 0,  2 files
+//! --protocol=32 --delete --delete-excluded   exit 0, 2 files   exit 0,  2 files
+//! ```
+//!
+//! Exactly one cell diverged. Both agreeing rows are kept as controls and each
+//! isolates one variable: dropping `--delete-excluded` at the same protocol
+//! shows the option is the trigger, and keeping it at protocol 32 shows the
+//! protocol is. Without them a build that broke every `--delete` push, or every
+//! protocol, would still satisfy the failing row alone.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the remote-shell shim uses `/bin/sh`).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// A remote-shell stand-in: drops the leading options and the host token, then
+/// execs the server command, so the "remote" is this same binary running for
+/// real as `--server`. The defect lives in that subprocess argv parser, so an
+/// in-process harness cannot reach it.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+struct Outcome {
+    code: Option<i32>,
+    stderr: String,
+    dest_entries: Vec<String>,
+}
+
+/// Pushes a two-file tree over the rsh shim at `protocol` with `delete_flags`.
+fn push(protocol: u32, delete_flags: &[&str]) -> Outcome {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(src.join("foo.txt"), b"a\n").expect("write foo");
+    fs::write(src.join("bar.txt"), b"b\n").expect("write bar");
+    let dest = root.join("dest");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let shim = write_rsh_shim(root);
+    let bin = oc_binary();
+    let mut command = Command::new(&bin);
+    command
+        .arg("-r")
+        .arg(format!("--protocol={protocol}"))
+        .arg("-e")
+        .arg(&shim)
+        .arg("--rsync-path")
+        .arg(&bin)
+        .args(delete_flags)
+        .arg(format!("{}/", src.display()))
+        .arg(format!("lh:{}/", dest.display()));
+
+    let output = command.output().expect("spawn oc-rsync");
+    let mut dest_entries: Vec<String> = fs::read_dir(&dest)
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .collect()
+        })
+        .unwrap_or_default();
+    dest_entries.sort();
+
+    Outcome {
+        code: output.status.code(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        dest_entries,
+    }
+}
+
+fn both_files() -> Vec<String> {
+    vec!["bar.txt".to_string(), "foo.txt".to_string()]
+}
+
+/// The defect: the two ends disagreed about `receiver_wants_list`, so the
+/// server read a filter list the client never sent.
+#[test]
+fn delete_excluded_push_below_protocol_29_transfers() {
+    let outcome = push(28, &["--delete", "--delete-excluded"]);
+    assert_eq!(
+        outcome.code,
+        Some(0),
+        "protocol 28 --delete --delete-excluded must succeed; stderr: {}",
+        outcome.stderr
+    );
+    assert_eq!(
+        outcome.dest_entries,
+        both_files(),
+        "nothing is excluded here - both files must land"
+    );
+    // The failure mode was a desynced stream, not a clean refusal. Pinning the
+    // symptom keeps a future regression recognisable even if the exit code
+    // changes.
+    assert!(
+        !outcome.stderr.contains("invalid filter rule length"),
+        "the server must not read the file list as a filter-rule length; stderr: {}",
+        outcome.stderr
+    );
+}
+
+/// Control isolating the OPTION: the same protocol without
+/// `--delete-excluded` agrees on both ends even with the defect present, so a
+/// build that broke every `--delete` push would fail here too.
+#[test]
+fn plain_delete_push_below_protocol_29_transfers() {
+    let outcome = push(28, &["--delete"]);
+    assert_eq!(
+        outcome.code,
+        Some(0),
+        "protocol 28 --delete must succeed; stderr: {}",
+        outcome.stderr
+    );
+    assert_eq!(outcome.dest_entries, both_files());
+}
+
+/// Control isolating the PROTOCOL: at 29 and above the `protocol_version >= 29`
+/// disjunct makes the predicate true on both ends regardless of
+/// `delete_excluded`, so this cell was always green.
+#[test]
+fn delete_excluded_push_at_protocol_32_transfers() {
+    let outcome = push(32, &["--delete", "--delete-excluded"]);
+    assert_eq!(
+        outcome.code,
+        Some(0),
+        "protocol 32 --delete --delete-excluded must succeed; stderr: {}",
+        outcome.stderr
+    );
+    assert_eq!(outcome.dest_entries, both_files());
+}


### PR DESCRIPTION
Both ends of a transfer independently compute the same predicate before
either touches the filter list:

    /* exclude.c:1947-1948 send_filter_list, :1976-1977 recv_filter_list */
    int receiver_wants_list = prune_empty_dirs
        || (delete_mode && (!delete_excluded || protocol_version >= 29));

It is a pure function of four inputs, so the ends stay in lockstep only
while they agree on every input. The real `--server` argv parser collapsed
`--delete-excluded` into the generic `delete` bool - `ServerLongFlags` had
no `delete_excluded` field at all - so on the server it read `false` no
matter what the client sent.

Below protocol 29 that flips exactly one operand:

    client, delete_excluded=true:   !true  || 28 >= 29  -> false, sends nothing
    server, delete_excluded=false:  !false || 28 >= 29  -> true,  reads a list

The client sends no filter list; the server calls `read_filter_list` anyway
and consumes the start of the file list as a 4-byte rule length. At protocol
29 and above the `protocol_version >= 29` disjunct makes the predicate true
on both ends regardless, so only legacy peers were affected.

MEASURED, pushing a two-file tree over an rsh shim with NO `--filter`:

| flags                       | proto | upstream 3.5.0 | oc before |
|---|---|---|---|
| `--delete --delete-excluded` | 28 | exit 0, 2 files | exit 12, 0 files |
| `--delete`                   | 28 | exit 0, 2 files | exit 0,  2 files |
| `--delete --delete-excluded` | 32 | exit 0, 2 files | exit 0,  2 files |

oc's failure was:

    server error: failed to read filter list: invalid filter rule length: -2144468711
    transfer failed: multiplexed frame truncated: expected 4 bytes but received 0

⚠ This has nothing to do with filter rules. It reproduces with no `--filter`
argument at all - the bare option pair is enough. Any framing of it as a
filter-parsing defect is wrong.

## Scope

Only the subprocess `--server` parser is affected. The in-process embedded
path already does this correctly (`core/src/client/remote/flags.rs:546`) -
two parsers, one gap. `DeletionConfig::delete_excluded` already existed as a
public field and was simply never assigned here, the same unwired-setter
shape as the `--ignore-errors` bridge.

`--delete-excluded` also sets `delete`, and that line is load-bearing rather
than redundant: upstream emits `--delete` only in the
`else if (delete_mode && !delete_excluded)` arm and adds `--delete-excluded`
separately (options.c:3010-3013), so `--delete-excluded` arrives INSTEAD of
`--delete`, never alongside it. That matches options.c:2334, where
`delete_mode || delete_excluded` turns `--delete-excluded` alone into a
delete mode.

## Tests

`tests/server_delete_excluded_filter_list_agreement.rs` spawns the real
binary over an rsh shim and pins all three measured cells. The two agreeing
rows are controls, and each isolates one variable: dropping
`--delete-excluded` at the same protocol shows the option is the trigger,
and keeping it at protocol 32 shows the protocol is. Without them a build
that broke every `--delete` push, or every protocol, would still satisfy the
failing row alone.

The end-to-end shape is required, not preferred: the defect lives in the
subprocess argv parser, which no in-process harness reaches.

Two parser unit tests cover the flag itself, including a companion asserting
a plain `--delete` leaves `delete_excluded` unset so the first cannot pass by
the field being unconditionally true.

Verified against the freshly built binary: all three cells now match
upstream exactly. `cargo build -p cli -p bin --all-features` clean.

