### PR TITLE
fix(filters): refuse a sided rule inside a sided merge file

### DIFF
--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -224,6 +224,24 @@ pub(crate) fn process_merge_directive(
 ) -> Result<(), Message> {
     match parse_filter_directive(OsStr::new(directive)) {
         Ok(FilterDirective::Rule(mut rule)) => {
+            // upstream: exclude.c:1447-1456 - when the merge directive named a
+            // side and the rule inside the file names one too, the inherit is
+            // "dodgy (and won't work correctly if the template is a one-sided
+            // per-dir merge rule)", so upstream refuses the whole run via
+            // filter_rule_err -> exit_cleanup(RERR_SYNTAX). The check sits
+            // ABOVE the `rule->rflags |= template->rflags & FILTRULES_SIDES`
+            // inherit, so the conflicting side is never applied.
+            if options.specifies_side() && rule.specifies_side() {
+                // Exit 1 is upstream's RERR_SYNTAX, the code filter_rule_err
+                // passes to exit_cleanup (exclude.c:133-137).
+                return Err(rsync_error!(
+                    1,
+                    format!(
+                        "specified-side merge file contains specified-side filter: {directive}"
+                    )
+                )
+                .with_role(Role::Client));
+            }
             rule.apply_dir_merge_overrides(options);
             destination.push(rule);
         }

--- a/crates/core/src/client/config/filters.rs
+++ b/crates/core/src/client/config/filters.rs
@@ -261,6 +261,20 @@ impl FilterRuleSpec {
         true
     }
 
+    /// Reports whether the rule itself names a side.
+    ///
+    /// upstream: exclude.c:1448 `rule->rflags & FILTRULES_SIDES`. oc spells
+    /// "no side bit set" as *both* sides applying, so any rule that is not
+    /// both-sided has named one. That deliberately includes `P`/`R`
+    /// (protect/risk), which default to receiver-only here and set
+    /// `FILTRULE_RECEIVER_SIDE` upstream - measured against rsync 3.5.0, a
+    /// `P` or `R` line inside a sided merge file is refused exactly like an
+    /// explicit `-r`/`-s`.
+    #[must_use]
+    pub const fn specifies_side(&self) -> bool {
+        !(self.applies_to_sender && self.applies_to_receiver)
+    }
+
     /// Applies dir-merge style overrides (anchor, side modifiers) to the rule.
     pub fn apply_dir_merge_overrides(&mut self, options: &DirMergeOptions) {
         if matches!(self.kind, FilterRuleKind::Clear) {

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -64,6 +64,27 @@ pub(crate) fn resolve_dir_merge_path(base: &Path, pattern: &Path) -> PathBuf {
 /// built-in `get_cvs_excludes()` patterns. Only the wrapper merge/dir-merge
 /// directives themselves are skipped (FILTRULE_MERGE_FILE /
 /// FILTRULE_PERDIR_MERGE bits), not the per-token rules they expand into.
+/// Reports upstream's "dodgy" side conflict between a merge template and a
+/// rule read out of the merge file.
+///
+/// upstream: exclude.c:1447-1456
+///
+/// ```c
+/// if (template->rflags & FILTRULES_SIDES) {
+///     if (rule->rflags & FILTRULES_SIDES)
+///         filter_rule_err("specified-side merge file contains specified-side filter", ...);
+///     rule->rflags |= template->rflags & FILTRULES_SIDES;
+/// }
+/// ```
+///
+/// The refusal sits ABOVE the inherit, so the conflicting side is never
+/// applied. oc spells "the rule has no side bit" as *both* sides applying, so
+/// any rule that is not both-sided has named one - `P`/`R` included, matching
+/// measured rsync 3.5.0 behaviour.
+pub(crate) fn dir_merge_side_conflict(rule: &FilterRule, options: &DirMergeOptions) -> bool {
+    options.specifies_side() && !(rule.applies_to_sender() && rule.applies_to_receiver())
+}
+
 pub(crate) fn apply_dir_merge_rule_defaults(
     mut rule: FilterRule,
     options: &DirMergeOptions,
@@ -281,6 +302,11 @@ pub(crate) fn load_dir_merge_rules_recursive(
 
                 match parse_filter_directive_line(&directive) {
                     Ok(Some(ParsedFilterDirective::Rule(rule))) => {
+                        if dir_merge_side_conflict(&rule, options) {
+                            return Err(map_error(FilterParseError::new(format!(
+                                "specified-side merge file contains specified-side filter: {directive}"
+                            ))));
+                        }
                         entries.push_rule(apply_dir_merge_rule_defaults(
                             rule,
                             options,
@@ -390,6 +416,11 @@ pub(crate) fn load_dir_merge_rules_recursive(
 
                 match parse_filter_directive_line(trimmed) {
                     Ok(Some(ParsedFilterDirective::Rule(rule))) => {
+                        if dir_merge_side_conflict(&rule, options) {
+                            return Err(map_error(FilterParseError::new(format!(
+                                "specified-side merge file contains specified-side filter: {trimmed}"
+                            ))));
+                        }
                         entries.push_rule(apply_dir_merge_rule_defaults(
                             rule,
                             options,

--- a/crates/engine/src/local_copy/filter_program/options.rs
+++ b/crates/engine/src/local_copy/filter_program/options.rs
@@ -289,6 +289,20 @@ impl DirMergeOptions {
         }
     }
 
+    /// Reports whether the merge directive itself named a side.
+    ///
+    /// upstream: exclude.c:1447 `template->rflags & FILTRULES_SIDES`, where
+    /// `FILTRULES_SIDES` is `FILTRULE_SENDER_SIDE | FILTRULE_RECEIVER_SIDE`
+    /// (rsync.h:1050-1057). `SideState::Unspecified` is oc's spelling of "the
+    /// bit is clear", so a side counts as named whenever either state moved
+    /// off `Unspecified` - including the `Disabled` direction, which upstream
+    /// also records by setting the opposite side's bit.
+    #[must_use]
+    pub const fn specifies_side(&self) -> bool {
+        !matches!(self.sender_side, SideState::Unspecified)
+            || !matches!(self.receiver_side, SideState::Unspecified)
+    }
+
     /// Reports whether patterns should be anchored to the transfer root.
     #[must_use]
     pub const fn anchor_root_enabled(&self) -> bool {

--- a/tests/sided_merge_file_side_conflict.rs
+++ b/tests/sided_merge_file_side_conflict.rs
@@ -1,0 +1,164 @@
+//! A merge directive that names a side must refuse a rule inside the file that
+//! also names one.
+//!
+//! upstream: exclude.c:1447-1456
+//!
+//! ```c
+//! if (template->rflags & FILTRULES_SIDES) {
+//!     if (rule->rflags & FILTRULES_SIDES) {
+//!         /* The filter and template both specify side(s).  This
+//!          * is dodgy (and won't work correctly if the template is
+//!          * a one-sided per-dir merge rule), so reject it. */
+//!         filter_rule_err("specified-side merge file contains specified-side filter",
+//!                         *rulestr_ptr);
+//!     }
+//!     rule->rflags |= template->rflags & FILTRULES_SIDES;
+//! }
+//! ```
+//!
+//! `filter_rule_err` is fatal - it calls `exit_cleanup(RERR_SYNTAX)`
+//! (exclude.c:133-137), i.e. exit 1. The refusal sits ABOVE the inherit, so a
+//! conflicting side is never applied.
+//!
+//! Every expectation below was MEASURED against a real rsync 3.5.0 binary
+//! before the fix was written; oc exited 0 and silently applied the rule in
+//! the three conflict rows.
+//!
+//! ⚠ oc reaches this condition through TWO independent code paths, because it
+//! re-implements the template-to-rule side inheritance where upstream has a
+//! single `parse_rule_tok` site: `.s FILE` (merge) goes through
+//! `cli/frontend/filter_rules/merge.rs`, while `:s FILE` (dir-merge) goes
+//! through `engine/local_copy/dir_merge/load.rs`. Fixing only one leaves the
+//! other silently accepting, which is why both shapes are pinned here rather
+//! than just the one the bug was filed against.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::process::Command;
+
+struct Fixture {
+    dir: tempfile::TempDir,
+}
+
+impl Fixture {
+    /// Builds `src/{foo,bar}` plus a rules file holding `rule_line`, written
+    /// both at the top level (for `.` merge) and inside `src/` (for `:`
+    /// dir-merge, which is read per-directory during traversal).
+    fn new(rules_name: &str, rule_line: &str) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).expect("mkdir src");
+        fs::create_dir_all(root.join("dst")).expect("mkdir dst");
+        fs::write(root.join("src/foo"), b"hello\n").expect("write foo");
+        fs::write(root.join("src/bar"), b"world\n").expect("write bar");
+        let body = format!("{rule_line}\n");
+        fs::write(root.join(rules_name), &body).expect("write rules");
+        fs::write(root.join("src").join(rules_name), &body).expect("write src rules");
+        Self { dir }
+    }
+
+    fn run(&self, filter: &str) -> (i32, String) {
+        let output = Command::new(env!("CARGO_BIN_EXE_oc-rsync"))
+            .current_dir(self.dir.path())
+            .arg("-r")
+            .arg(format!("--filter={filter}"))
+            .arg("src/")
+            .arg("dst/")
+            .output()
+            .expect("spawn oc-rsync");
+        let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+        text.push_str(&String::from_utf8_lossy(&output.stderr));
+        (output.status.code().unwrap_or(-1), text)
+    }
+}
+
+const MESSAGE: &str = "specified-side merge file contains specified-side filter";
+
+fn assert_refused(filter: &str, rules_name: &str, rule_line: &str) {
+    let fixture = Fixture::new(rules_name, rule_line);
+    let (code, text) = fixture.run(filter);
+    assert_eq!(
+        code, 1,
+        "--filter={filter} with '{rule_line}' must exit 1 (upstream RERR_SYNTAX); got {code}, output: {text}"
+    );
+    assert!(
+        text.contains(MESSAGE),
+        "--filter={filter} with '{rule_line}' must report upstream's wording; got: {text}"
+    );
+}
+
+fn assert_accepted(filter: &str, rules_name: &str, rule_line: &str) {
+    let fixture = Fixture::new(rules_name, rule_line);
+    let (code, text) = fixture.run(filter);
+    assert_eq!(
+        code, 0,
+        "--filter={filter} with '{rule_line}' must succeed; got {code}, output: {text}"
+    );
+    assert!(
+        !text.contains(MESSAGE),
+        "--filter={filter} with '{rule_line}' must not trip the side-conflict guard; got: {text}"
+    );
+}
+
+#[test]
+fn sided_merge_refuses_a_receiver_sided_rule() {
+    assert_refused(".s f.rules", "f.rules", "-r foo");
+}
+
+#[test]
+fn receiver_sided_merge_refuses_a_sender_sided_rule() {
+    // The mirror direction: upstream's test is on the SIDES mask, not on one
+    // particular side, so `.r` + `-s` must refuse exactly like `.s` + `-r`.
+    assert_refused(".r f.rules", "f.rules", "-s foo");
+}
+
+#[test]
+fn sided_dir_merge_refuses_a_sided_rule() {
+    // Distinct code path from the `.` merge above: the per-directory file is
+    // read during traversal by the local-copy dir-merge loader.
+    assert_refused(":s .rules", ".rules", "-r foo");
+}
+
+#[test]
+fn sided_merge_refuses_a_protect_rule() {
+    // `P` sets FILTRULE_RECEIVER_SIDE upstream, so it counts as a specified
+    // side even though no `s`/`r` modifier is typed. Measured: rsync 3.5.0
+    // exits 1 here.
+    assert_refused(".s f.rules", "f.rules", "P foo");
+}
+
+#[test]
+fn sided_merge_refuses_a_risk_rule() {
+    assert_refused(".s f.rules", "f.rules", "R foo");
+}
+
+// --- non-vacuity controls -------------------------------------------------
+//
+// Without these a build that refused EVERY merge rule, or refused on any
+// merge at all, would still satisfy every row above.
+
+#[test]
+fn sided_merge_accepts_an_unsided_rule() {
+    assert_accepted(".s f.rules", "f.rules", "- foo");
+}
+
+#[test]
+fn sided_dir_merge_accepts_an_unsided_rule() {
+    assert_accepted(":s .rules", ".rules", "- foo");
+}
+
+#[test]
+fn unsided_merge_accepts_a_sided_rule() {
+    // The template carries no side, so upstream's outer `if` never fires and
+    // the rule's own side is simply honoured.
+    assert_accepted(". f.rules", "f.rules", "-r foo");
+}
+
+#[test]
+fn perishable_modifier_is_not_a_side() {
+    // `p` is the perishable modifier, not a side. Measured: rsync 3.5.0 exits
+    // 0. This pins the guard against keying on "the directive has modifiers"
+    // instead of "the directive names a side".
+    assert_accepted(":p .rules", ".rules", "-r foo");
+}


### PR DESCRIPTION
`get_rule_prefix`'s caller in upstream rejects the combination outright
(exclude.c:1447-1456):

    if (template->rflags & FILTRULES_SIDES) {
        if (rule->rflags & FILTRULES_SIDES) {
            /* The filter and template both specify side(s).  This
             * is dodgy (and won't work correctly if the template is
             * a one-sided per-dir merge rule), so reject it. */
            filter_rule_err("specified-side merge file contains specified-side filter",
                            *rulestr_ptr);
        }
        rule->rflags |= template->rflags & FILTRULES_SIDES;
    }

`filter_rule_err` is fatal - `exit_cleanup(RERR_SYNTAX)` at
exclude.c:133-137, i.e. exit 1 - and the check sits ABOVE the inherit, so
the conflicting side is never applied. oc had no analogue anywhere:
`grep -rn "specified-side" crates/` returned nothing.

MEASURED against rsync 3.5.0 over a local copy, before the fix:

| --filter        | rule in file | upstream | oc before |
|---|---|---|---|
| `.s f.rules`    | `-r foo`     | exit 1   | exit 0    |
| `.r f.rules`    | `-s foo`     | exit 1   | exit 0    |
| `:s .rules`     | `-r foo`     | exit 1   | exit 0    |
| `.s f.rules`    | `P foo`      | exit 1   | exit 0    |
| `.s f.rules`    | `R foo`      | exit 1   | exit 0    |
| `.s f.rules`    | `- foo`      | exit 0   | exit 0    |
| `:s .rules`     | `- foo`      | exit 0   | exit 0    |
| `. f.rules`     | `-r foo`     | exit 0   | exit 0    |
| `:p .rules`     | `-r foo`     | exit 0   | exit 0    |

The last four rows are controls and were already in agreement; they are
what makes the fixture discriminating rather than a build that refuses
every merge rule.

## The predicate

Upstream tests a bitmask (`FILTRULES_SIDES` = SENDER|RECEIVER,
rsync.h:1050-1057). oc spells "no side bit set" as *both* sides applying,
so "the rule names a side" is exactly `!(applies_to_sender &&
applies_to_receiver)`.

That deliberately includes `P`/`R`, which default to receiver-only here and
set `FILTRULE_RECEIVER_SIDE` upstream - rows 4 and 5 above confirm rsync
3.5.0 refuses them, so keying the guard on a typed `s`/`r` modifier instead
of on the resulting sides would have missed both.

`:p` is the control in the other direction: `p` is the perishable modifier,
not a side, and neither implementation fires. Keying on "the directive has
modifiers" rather than "the directive names a side" would have broken it.

## Two sites, because oc has two implementations

Upstream inherits the template's sides at a single point inside
`parse_rule_tok`. oc re-implements that inheritance separately for merge
and dir-merge, so a one-site fix leaves the other silently accepting:

- `.s FILE` - `process_merge_directive`
  (cli/frontend/filter_rules/merge.rs), where a rule parsed out of the file
  meets the enclosing `DirMergeOptions`.
- `:s FILE` - `apply_dir_merge_rule_defaults`'s two parsed-rule call sites
  (engine/local_copy/dir_merge/load.rs), reached when the per-directory
  file is read during traversal.

The two synthetic-rule call sites in each file (exclude-self, enforced
kind) are deliberately NOT guarded: those rules are constructed locally and
cannot carry a side of their own, so a guard there would be unreachable.

The shared decision is expressed once per crate - `FilterRuleSpec::
specifies_side` / `dir_merge_side_conflict` - against a new
`DirMergeOptions::specifies_side`, so the template half has a single owner.

## Tests

`tests/sided_merge_file_side_conflict.rs` drives the real binary and pins
all nine measured rows: five refusals (both merge and dir-merge, both side
directions, plus `P` and `R`) and four non-vacuity controls.

RED PROVEN by neutralising both guards: 9 run, 5 failed, 4 passed - exactly
the five refusal rows, with every control still green. Run under
`--no-fail-fast`, because fail-fast reports a single failure and truncates
the kill list.

core+engine+filters 9238/9238; cli+bin 4278/4278; fmt and full-workspace
clippy clean.

