### PR TITLE
fix(filters): redact peer-chosen rule text in filter-rule diagnostics

### DIFF
--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use core::client::{ClientConfigBuilder, DirMergeOptions, FilterRuleKind, FilterRuleSpec};
 use core::message::Message;
+use filters::RuleSource;
 use logging_sink::MessageSink;
 
 use super::messages::fail_with_message;
@@ -104,7 +105,16 @@ fn push_filter_directive(
             let effective_options =
                 merge_directive_options(&DirMergeOptions::default(), &directive);
             let directive = directive.with_options(effective_options);
-            apply_merge_directive(directive, merge_base, filter_rules, merge_stack)?;
+            // The operator typed this `--filter='. FILE'` themselves, so the
+            // merge file's name is theirs to see: upstream's non-redacted
+            // open-failure arm (exclude.c:1713-1717, errno included).
+            apply_merge_directive(
+                directive,
+                merge_base,
+                filter_rules,
+                merge_stack,
+                RuleSource::Argument,
+            )?;
         }
         FilterDirective::Clear => filter_rules.clear(),
         FilterDirective::CvsDefaults => filter_rules.extend(cvs_default_exclude_rules()?),

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -14,6 +14,26 @@ use super::directive::{
 use super::parsing::parse_filter_directive;
 use super::sources::{read_merge_file, read_merge_from_standard_input};
 
+/// The merge-file name to put in diagnostics, which is not the path we open.
+///
+/// Upstream keeps the two apart: `parse_filter_file` opens `open_path` but
+/// reports `src_name`, a verbatim copy of the name it was handed
+/// (exclude.c:1727). That name comes from `parse_merge_name`, which "return[s]
+/// the name unchanged [if] it doesn't have any slashes" (exclude.c:704-715) and
+/// only joins it onto the filter dir when it does. So `--filter='. f.rules'`
+/// reports `f.rules`, not the absolute path the open resolved to.
+///
+/// Reporting the resolved path instead would leak the operator's directory
+/// layout into a message the peer can read back whenever the rule came from a
+/// merged file - the leak the `rule_text()` chokepoint exists to close.
+fn reported_merge_name(source: &OsStr, resolved: &Path) -> String {
+    let named = Path::new(source);
+    if named.components().count() == 1 && !named.has_root() {
+        return named.display().to_string();
+    }
+    resolved.display().to_string()
+}
+
 /// Loads a merge file referenced by `directive`, parsing each of its lines and
 /// appending the resulting rules to `destination`. `visited` guards against
 /// recursive merge cycles; stdin (`-`) is read once.
@@ -50,7 +70,7 @@ pub(crate) fn apply_merge_directive(
         // is why it succeeds when `a/b` does not exist - handing the raw name
         // to the OS instead fails with ENOENT.
         let resolved = filters::collapse_dot_dot_dirs(&joined);
-        let display = resolved.display().to_string();
+        let display = reported_merge_name(directive.source(), &resolved);
         let canonical = std::fs::canonicalize(&resolved).ok();
         (resolved, display, canonical)
     };

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use core::client::{DirMergeEnforcedKind, DirMergeOptions, FilterRuleSpec};
 use core::message::{Message, Role};
 use core::rsync_error;
+use filters::RuleSource;
 
 use super::cvs::cvs_default_exclude_rules;
 use super::directive::{
@@ -16,11 +17,18 @@ use super::sources::{read_merge_file, read_merge_from_standard_input};
 /// Loads a merge file referenced by `directive`, parsing each of its lines and
 /// appending the resulting rules to `destination`. `visited` guards against
 /// recursive merge cycles; stdin (`-`) is read once.
+///
+/// `source` says who named this merge file: the operator (`--filter='. FILE'`,
+/// `RuleSource::Argument`) or another filter file's contents (a nested `. FILE`
+/// line). Upstream keys its open-failure diagnostic on exactly that distinction
+/// (exclude.c:1703-1720), so it has to travel with the directive rather than be
+/// re-derived at the open.
 pub(crate) fn apply_merge_directive(
     directive: MergeDirective,
     base_dir: &Path,
     destination: &mut Vec<FilterRuleSpec>,
     visited: &mut HashSet<PathBuf>,
+    source: RuleSource<'_>,
 ) -> Result<(), Message> {
     let options = directive.options().clone();
     let original_source_text = os_string_to_pattern(directive.source().to_os_string());
@@ -87,6 +95,7 @@ pub(crate) fn apply_merge_directive(
             read_merge_file(
                 &resolved_path,
                 options.enforced_kind() == Some(DirMergeEnforcedKind::Include),
+                source,
             )?
         };
 
@@ -162,12 +171,27 @@ fn parse_merge_contents(
                 token.to_owned()
             };
 
-            process_merge_directive(&directive, options, base_dir, display, destination, visited)?;
+            // upstream: rule_src_line = word_split ? -1 : 0 (exclude.c:1754) -
+            // a word-split merge file yields tokens, not lines, so there is no
+            // line number to report and rule_src_where returns the name alone.
+            process_merge_directive(
+                &directive,
+                options,
+                base_dir,
+                display,
+                RuleSource::FileWordSplit { name: display },
+                destination,
+                visited,
+            )?;
         }
         return Ok(());
     }
 
-    for line in contents.lines() {
+    // upstream counts PHYSICAL lines: rule_src_line increments once per read
+    // iteration (exclude.c:1759-1760), before the comment and empty-token
+    // filter at :1806, so comments and blank lines advance the count.
+    for (index, line) in contents.lines().enumerate() {
+        let line_number = index + 1;
         // upstream: exclude.c:1514 parse_filter_file - a line is skipped only
         // when it is empty or (line parsing) begins with `;`/`#`. Whitespace is
         // never stripped, so leading whitespace and whitespace-only lines fall
@@ -205,7 +229,18 @@ fn parse_merge_contents(
             continue;
         }
 
-        process_merge_directive(line, options, base_dir, display, destination, visited)?;
+        process_merge_directive(
+            line,
+            options,
+            base_dir,
+            display,
+            RuleSource::File {
+                name: display,
+                line: line_number,
+            },
+            destination,
+            visited,
+        )?;
     }
 
     Ok(())
@@ -219,6 +254,7 @@ pub(crate) fn process_merge_directive(
     options: &DirMergeOptions,
     base_dir: &Path,
     display: &str,
+    source: RuleSource<'_>,
     destination: &mut Vec<FilterRuleSpec>,
     visited: &mut HashSet<PathBuf>,
 ) -> Result<(), Message> {
@@ -234,10 +270,17 @@ pub(crate) fn process_merge_directive(
             if options.specifies_side() && rule.specifies_side() {
                 // Exit 1 is upstream's RERR_SYNTAX, the code filter_rule_err
                 // passes to exit_cleanup (exclude.c:133-137).
+                //
+                // The rule text goes through RuleSource because filter_rule_err
+                // renders it with rule_text (exclude.c:135), and this guard can
+                // only fire on a rule read out of a merge file - the peer picks
+                // which file that is. See
+                // docs/design/upstream-3.5.0-filter-rule-text-provenance.md.
                 return Err(rsync_error!(
                     1,
                     format!(
-                        "specified-side merge file contains specified-side filter: {directive}"
+                        "specified-side merge file contains specified-side filter: {}",
+                        source.rule_text(directive)
                     )
                 )
                 .with_role(Role::Client));
@@ -248,14 +291,28 @@ pub(crate) fn process_merge_directive(
         Ok(FilterDirective::Merge(nested)) => {
             let effective_options = merge_directive_options(options, &nested);
             let nested = nested.with_options(effective_options);
-            apply_merge_directive(nested, base_dir, destination, visited).map_err(|error| {
-                let detail = error.to_string();
-                rsync_error!(
-                    1,
-                    format!("failed to process merge file '{display}': {detail}")
-                )
-                .with_role(Role::Client)
-            })?;
+            // This merge file was named by ANOTHER filter file's contents, so
+            // `source` travels down: it selects upstream's redacted open-failure
+            // arm (exclude.c:1708-1712) for the nested file.
+            //
+            // The nested error keeps its own exit code. upstream reports a
+            // failed open as RERR_FILEIO (11) from `exit_cleanup` at
+            // exclude.c:1719 whether the name came from a file or from the
+            // command line - only the TEXT differs between the two arms, never
+            // the code. Re-wrapping at a fixed 1 here turned every nested open
+            // failure into a syntax-error exit; `code` preserves whichever the
+            // inner site chose, so RERR_SYNTAX rules still surface as 1.
+            apply_merge_directive(nested, base_dir, destination, visited, source).map_err(
+                |error| {
+                    let code = error.code().unwrap_or(1);
+                    let detail = error.to_string();
+                    rsync_error!(
+                        code,
+                        format!("failed to process merge file '{display}': {detail}")
+                    )
+                    .with_role(Role::Client)
+                },
+            )?;
         }
         Ok(FilterDirective::Clear) => destination.clear(),
         // A blank line inside a merge file contributes no rule.

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -424,8 +424,7 @@ mod tests {
     fn read_merge_file_reports_a_missing_file_like_upstream() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("nonexistent.txt");
-        let error =
-            read_merge_file(&path, false, RuleSource::Argument).expect_err("must fail");
+        let error = read_merge_file(&path, false, RuleSource::Argument).expect_err("must fail");
         assert_eq!(error.code(), Some(11));
         assert!(
             error.text().starts_with("failed to open exclude file "),

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -8,6 +8,8 @@ use core::message::{Message, Role};
 use core::rsync_error;
 use engine::local_copy::upstream_io_error;
 
+use filters::RuleSource;
+
 use super::directive::FilterDirective;
 use super::parsing::parse_old_prefix_rule;
 
@@ -82,21 +84,53 @@ pub(crate) fn append_filter_rules_from_files(
 /// Reports a filter file that could not be opened the way upstream's
 /// `parse_filter_file` does, under upstream's exit code.
 ///
-/// upstream: exclude.c:1712-1719 - `rsyserr(FERROR, errno, "failed to open
-/// %sclude file %s", ...)` then `exit_cleanup(RERR_FILEIO)`. The include/exclude
-/// wording follows `template->rflags & FILTRULE_INCLUDE`, so a merge rule
-/// carrying a `+` modifier (`.+ FILE`, `merge,+ FILE`) says "include file".
+/// upstream: exclude.c:1703-1720 is ONE `if (!fp)` block with TWO arms selected
+/// by `TEXT_FROM_FILE(template)`:
+///
+/// ```c
+/// if (TEXT_FROM_FILE(template)) {
+///         /* errno too: it answers "does this path exist". */
+///         rprintf(FERROR, "failed to open %sclude file %s\n", ...,
+///                 rule_text(template, fname));
+/// } else {
+///         rsyserr(FERROR, errno, "failed to open %sclude file %s", ..., fname);
+/// }
+/// exit_cleanup(RERR_FILEIO);
+/// ```
+///
+/// So when the name came out of a file's contents, BOTH channels are withheld:
+/// the path (via `rule_text`, which substitutes `<rule from FILE line N>`) and
+/// `strerror(errno)`. The peer chooses what a merge file names, so errno would
+/// answer "does this path exist, and may this process read it" for any path -
+/// a filesystem probe through the filter parser. Only the TEXT differs between
+/// the arms; both exit `RERR_FILEIO`, which is why the code is set once below.
+///
+/// The include/exclude wording follows `template->rflags & FILTRULE_INCLUDE` in
+/// BOTH arms, so a merge rule carrying a `+` modifier (`.+ FILE`,
+/// `merge,+ FILE`) says "include file" either way.
 ///
 /// This rule is deliberately NOT shared with `--files-from`, whose own open
 /// failure upstream reports from a different site and exits 1, not 11
 /// (main.c:1886) - measured on 3.5.0.
-fn filter_file_open_error(path: &Path, include: bool, error: &io::Error) -> Message {
-    let text = format!(
-        "failed to open {}clude file {}: {}",
-        if include { "in" } else { "ex" },
-        path.display(),
-        upstream_io_error(error)
-    );
+fn filter_file_open_error(
+    path: &Path,
+    include: bool,
+    error: &io::Error,
+    source: RuleSource<'_>,
+) -> Message {
+    let word = if include { "in" } else { "ex" };
+    let name = path.display().to_string();
+    let text = if source.is_from_file() {
+        format!(
+            "failed to open {word}clude file {}",
+            source.rule_text(&name)
+        )
+    } else {
+        format!(
+            "failed to open {word}clude file {name}: {}",
+            upstream_io_error(error)
+        )
+    };
     rsync_error!(FILE_IO_EXIT_CODE, text).with_role(Role::Client)
 }
 
@@ -112,7 +146,11 @@ pub(crate) fn load_filter_file_patterns(
         return read_filter_patterns_from_standard_input(eol_nulls);
     }
 
-    let file = File::open(path).map_err(|error| filter_file_open_error(path, include, &error))?;
+    // `--include-from` / `--exclude-from` name the file on the command line, so
+    // this is always upstream's non-file arm: the operator already knows the
+    // path they typed, and errno is theirs to see.
+    let file = File::open(path)
+        .map_err(|error| filter_file_open_error(path, include, &error, RuleSource::Argument))?;
 
     let mut reader = BufReader::new(file);
     read_filter_patterns(&mut reader, eol_nulls).map_err(|error| {
@@ -125,13 +163,19 @@ pub(crate) fn load_filter_file_patterns(
 }
 
 /// Reads a merge file's entire contents as a string. `include` selects
-/// upstream's include/exclude wording if the open fails.
-pub(super) fn read_merge_file(path: &Path, include: bool) -> Result<String, Message> {
+/// upstream's include/exclude wording if the open fails; `source` says whether
+/// this merge file was named by the operator or by another filter file's
+/// contents, which selects the arm of `filter_file_open_error`.
+pub(super) fn read_merge_file(
+    path: &Path,
+    include: bool,
+    source: RuleSource<'_>,
+) -> Result<String, Message> {
     // Opened separately from the read so that only a genuine open failure takes
     // upstream's wording and exit code; a mid-file read error (or non-UTF-8
     // contents) is a different condition and keeps its own report.
     let mut file =
-        File::open(path).map_err(|error| filter_file_open_error(path, include, &error))?;
+        File::open(path).map_err(|error| filter_file_open_error(path, include, &error, source))?;
     let mut contents = String::new();
     file.read_to_string(&mut contents).map_err(|error| {
         let text = format!("failed to read filter file '{}': {error}", path.display());
@@ -364,21 +408,74 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("merge.txt");
         std::fs::write(&path, "content here").expect("write");
-        let result = read_merge_file(&path, false).expect("read");
+        let result = read_merge_file(&path, false, RuleSource::Argument).expect("read");
         assert_eq!(result, "content here");
     }
 
     /// A merge rule naming a missing file is fatal under the same rule
     /// (upstream: exclude.c:1587 passes XFLG_FATAL_ERRORS for `merge`/`.`).
+    ///
+    /// This is the OPERATOR-named arm: the path they typed and `strerror` are
+    /// both theirs to see (upstream's `rsyserr` branch, exclude.c:1714-1717).
+    /// MEASURED on rsync 3.5.0: `--include-from=/definitely/missing` prints
+    /// `failed to open include file /definitely/missing: No such file or
+    /// directory (2)` and exits 11.
     #[test]
     fn read_merge_file_reports_a_missing_file_like_upstream() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("nonexistent.txt");
-        let error = read_merge_file(&path, false).expect_err("must fail");
+        let error =
+            read_merge_file(&path, false, RuleSource::Argument).expect_err("must fail");
         assert_eq!(error.code(), Some(11));
         assert!(
             error.text().starts_with("failed to open exclude file "),
             "unexpected text: {}",
+            error.text()
+        );
+        assert!(
+            error.text().contains("nonexistent.txt"),
+            "the operator arm keeps the path they typed: {}",
+            error.text()
+        );
+    }
+
+    /// The FILE-named arm withholds BOTH channels: the path AND errno.
+    ///
+    /// upstream: exclude.c:1703-1720 is one `if (!fp)` block whose arms are
+    /// selected by `TEXT_FROM_FILE(template)`. When the name came out of a
+    /// file's contents it uses `rprintf` + `rule_text()` - no `strerror`,
+    /// because errno answers "does this path exist, and may this process read
+    /// it" for any path a peer chooses to name. Both arms exit `RERR_FILEIO`;
+    /// only the TEXT differs, which is why the code is asserted equal here.
+    ///
+    /// MEASURED on rsync 3.5.0, a merge file containing `. /definitely/missing`:
+    /// `failed to open exclude file <rule from FILE line 1>`, exit 11.
+    #[test]
+    fn read_merge_file_withholds_path_and_errno_when_the_name_came_from_a_file() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("nonexistent.txt");
+        let source = RuleSource::File {
+            name: "outer.rules",
+            line: 1,
+        };
+        let error = read_merge_file(&path, false, source).expect_err("must fail");
+
+        // Same exit code as the operator arm - upstream never varies it.
+        assert_eq!(error.code(), Some(11));
+        assert!(
+            error.text().contains("<rule from outer.rules line 1>"),
+            "must name where the rule is: {}",
+            error.text()
+        );
+        assert!(
+            !error.text().contains("nonexistent.txt"),
+            "must not echo the peer-chosen path: {}",
+            error.text()
+        );
+        // The errno channel is the one a `rule_text`-only fix would leave open.
+        assert!(
+            !error.text().contains("No such file"),
+            "must not leak strerror as an existence oracle: {}",
             error.text()
         );
     }

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -187,6 +187,7 @@ pub(crate) fn process_merge_directive(
     options: &DirMergeOptions,
     base_dir: &Path,
     display: &str,
+    source: filters::RuleSource<'_>,
     destination: &mut Vec<FilterRuleSpec>,
     visited: &mut HashSet<PathBuf>,
 ) -> Result<(), Message> {
@@ -195,6 +196,7 @@ pub(crate) fn process_merge_directive(
         options,
         base_dir,
         display,
+        source,
         destination,
         visited,
     )

--- a/crates/cli/src/frontend/tests/apply.rs
+++ b/crates/cli/src/frontend/tests/apply.rs
@@ -20,7 +20,13 @@ fn apply_merge_directive_resolves_relative_paths() {
     let mut visited = HashSet::new();
     let directive = MergeDirective::new(OsString::from("outer.rules"), None)
         .with_options(DirMergeOptions::default().allow_list_clearing(true));
-    super::apply_merge_directive(directive, temp.path(), &mut rules, &mut visited)
+    super::apply_merge_directive(
+        directive,
+        temp.path(),
+        &mut rules,
+        &mut visited,
+        filters::RuleSource::Argument,
+    )
         .expect("merge succeeds");
 
     assert!(visited.is_empty());
@@ -44,7 +50,13 @@ fn apply_merge_directive_respects_forced_include() {
                 .with_enforced_kind(Some(DirMergeEnforcedKind::Include))
                 .allow_list_clearing(true),
         );
-    super::apply_merge_directive(directive, temp.path(), &mut rules, &mut visited)
+    super::apply_merge_directive(
+        directive,
+        temp.path(),
+        &mut rules,
+        &mut visited,
+        filters::RuleSource::Argument,
+    )
         .expect("merge succeeds");
 
     assert!(visited.is_empty());

--- a/crates/cli/src/frontend/tests/apply.rs
+++ b/crates/cli/src/frontend/tests/apply.rs
@@ -27,7 +27,7 @@ fn apply_merge_directive_resolves_relative_paths() {
         &mut visited,
         filters::RuleSource::Argument,
     )
-        .expect("merge succeeds");
+    .expect("merge succeeds");
 
     assert!(visited.is_empty());
     let patterns: Vec<_> = rules.iter().map(|rule| rule.pattern().to_owned()).collect();
@@ -57,7 +57,7 @@ fn apply_merge_directive_respects_forced_include() {
         &mut visited,
         filters::RuleSource::Argument,
     )
-        .expect("merge succeeds");
+    .expect("merge succeeds");
 
     assert!(visited.is_empty());
     // upstream: exclude.c:1393-1402 - '!' inside a merge file clears only

--- a/crates/cli/src/frontend/tests/merge.rs
+++ b/crates/cli/src/frontend/tests/merge.rs
@@ -47,7 +47,8 @@ fn apply_merge_directive_parses_whitespace_risk_and_exclude_if_present() {
         &mut rules,
         &mut visited,
         filters::RuleSource::Argument,
-    ).expect("apply merge");
+    )
+    .expect("apply merge");
 
     assert!(visited.is_empty());
     assert!(
@@ -79,13 +80,16 @@ fn apply_merge_directive_rejects_per_dir_alias() {
     let mut visited = HashSet::new();
     // "per-dir" is not an upstream directive, so a merge file that uses it must
     // fail to load rather than silently accept the oc-only alias.
-    assert!(apply_merge_directive(
-        directive,
-        temp.path(),
-        &mut rules,
-        &mut visited,
-        filters::RuleSource::Argument,
-    ).is_err());
+    assert!(
+        apply_merge_directive(
+            directive,
+            temp.path(),
+            &mut rules,
+            &mut visited,
+            filters::RuleSource::Argument,
+        )
+        .is_err()
+    );
 }
 
 #[test]
@@ -143,7 +147,8 @@ fn apply_merge_directive_collapses_dot_dot_before_opening_the_file() {
         &mut rules,
         &mut visited,
         filters::RuleSource::Argument,
-    ).expect("apply merge");
+    )
+    .expect("apply merge");
 
     assert!(
         rules
@@ -166,11 +171,14 @@ fn apply_merge_directive_still_fails_when_the_collapsed_name_is_absent() {
     let directive = MergeDirective::new(OsString::from("a/b/../missing.txt"), None);
     let mut rules = Vec::new();
     let mut visited = HashSet::new();
-    assert!(apply_merge_directive(
-        directive,
-        temp.path(),
-        &mut rules,
-        &mut visited,
-        filters::RuleSource::Argument,
-    ).is_err());
+    assert!(
+        apply_merge_directive(
+            directive,
+            temp.path(),
+            &mut rules,
+            &mut visited,
+            filters::RuleSource::Argument,
+        )
+        .is_err()
+    );
 }

--- a/crates/cli/src/frontend/tests/merge.rs
+++ b/crates/cli/src/frontend/tests/merge.rs
@@ -41,7 +41,13 @@ fn apply_merge_directive_parses_whitespace_risk_and_exclude_if_present() {
 
     let mut rules = Vec::new();
     let mut visited = HashSet::new();
-    apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).expect("apply merge");
+    apply_merge_directive(
+        directive,
+        temp.path(),
+        &mut rules,
+        &mut visited,
+        filters::RuleSource::Argument,
+    ).expect("apply merge");
 
     assert!(visited.is_empty());
     assert!(
@@ -73,7 +79,13 @@ fn apply_merge_directive_rejects_per_dir_alias() {
     let mut visited = HashSet::new();
     // "per-dir" is not an upstream directive, so a merge file that uses it must
     // fail to load rather than silently accept the oc-only alias.
-    assert!(apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).is_err());
+    assert!(apply_merge_directive(
+        directive,
+        temp.path(),
+        &mut rules,
+        &mut visited,
+        filters::RuleSource::Argument,
+    ).is_err());
 }
 
 #[test]
@@ -125,7 +137,13 @@ fn apply_merge_directive_collapses_dot_dot_before_opening_the_file() {
     let directive = MergeDirective::new(OsString::from("a/b/../rules.txt"), None);
     let mut rules = Vec::new();
     let mut visited = HashSet::new();
-    apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).expect("apply merge");
+    apply_merge_directive(
+        directive,
+        temp.path(),
+        &mut rules,
+        &mut visited,
+        filters::RuleSource::Argument,
+    ).expect("apply merge");
 
     assert!(
         rules
@@ -148,5 +166,11 @@ fn apply_merge_directive_still_fails_when_the_collapsed_name_is_absent() {
     let directive = MergeDirective::new(OsString::from("a/b/../missing.txt"), None);
     let mut rules = Vec::new();
     let mut visited = HashSet::new();
-    assert!(apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).is_err());
+    assert!(apply_merge_directive(
+        directive,
+        temp.path(),
+        &mut rules,
+        &mut visited,
+        filters::RuleSource::Argument,
+    ).is_err());
 }

--- a/crates/cli/src/frontend/tests/process.rs
+++ b/crates/cli/src/frontend/tests/process.rs
@@ -22,6 +22,10 @@ fn process_merge_directive_applies_parent_overrides_to_nested_merges() {
         &options,
         temp.path(),
         "parent.rules",
+        filters::RuleSource::File {
+            name: "parent.rules",
+            line: 1,
+        },
         &mut rules,
         &mut visited,
     )

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -119,6 +119,7 @@ pub mod implied;
 /// Merge-file reader and parser for filter rules.
 pub mod merge;
 mod rule;
+pub mod rule_source;
 mod set;
 mod wildmatch;
 
@@ -135,6 +136,7 @@ pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};
 pub use merge::{MergeFileError, parse_rules, read_rules, read_rules_recursive};
 pub use rule::FilterRule;
+pub use rule_source::RuleSource;
 pub use set::{FilterSet, FilterSetError, apple_double_exclusion_rules, cvs_exclusion_rules};
 pub use wildmatch::{iwildmatch, wildmatch};
 

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -7,6 +7,7 @@
 use std::path::Path;
 
 use crate::FilterRule;
+use crate::RuleSource;
 use crate::clear_token::{ClearToken, classify_clear_token};
 
 use super::error::MergeFileError;
@@ -355,12 +356,25 @@ fn invalid_modifier(
     source_path: &Path,
     line_num: usize,
 ) -> MergeFileError {
+    // upstream: exclude.c:1370-1379 builds the detail into a scratch buffer and
+    // passes it through rule_detail, which returns "" whenever the text itself
+    // is replaced - "a character of it, an offset into it. Dropped along with
+    // the text it describes" (exclude.c:127-131). Keeping the character or the
+    // offset while redacting the line would leak the file one byte at a time,
+    // which is a finer-grained oracle than echoing the whole rule.
+    let name = source_path.display().to_string();
+    let source = RuleSource::File {
+        name: &name,
+        line: line_num,
+    };
+    let detail = format!(" '{ch}' at position {}", idx + 1);
     MergeFileError::parse_error(
         source_path,
         line_num,
         format!(
-            "invalid modifier '{ch}' at position {} in filter rule: {full_line}",
-            idx + 1
+            "invalid modifier{} in filter rule: {}",
+            source.rule_detail(&detail),
+            source.rule_text(full_line)
         ),
     )
 }
@@ -580,10 +594,20 @@ fn parse_rule_line(
     match classify_clear_token(line.as_bytes()) {
         ClearToken::Clear => return Ok(FilterRule::clear()),
         ClearToken::TrailingCharacters => {
+            // upstream: exclude.c:1470 filter_rule_err, which renders the rule
+            // through rule_text (exclude.c:135).
+            let name = source_path.display().to_string();
+            let source = RuleSource::File {
+                name: &name,
+                line: line_num,
+            };
             return Err(MergeFileError::parse_error(
                 source_path,
                 line_num,
-                format!("'!' rule has trailing characters: {line}"),
+                format!(
+                    "'!' rule has trailing characters: {}",
+                    source.rule_text(line)
+                ),
             ));
         }
         ClearToken::NotClearToken => {}
@@ -597,9 +621,18 @@ fn parse_rule_line(
         return Ok(rule);
     }
 
+    // upstream: exclude.c:1363 filter_rule_err("Unknown filter rule", *rulestr_ptr),
+    // rendered through rule_text (exclude.c:135). Upstream does not quote the
+    // text, and quoting a `<rule from ...>` replacement would be meaningless, so
+    // the backticks go with the raw text they used to wrap.
+    let name = source_path.display().to_string();
+    let source = RuleSource::File {
+        name: &name,
+        line: line_num,
+    };
     Err(MergeFileError::parse_error(
         source_path,
         line_num,
-        format!("Unknown filter rule: `{line}'"),
+        format!("Unknown filter rule: {}", source.rule_text(line)),
     ))
 }

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -11,6 +11,35 @@ use super::parse::{
 };
 use super::read::{read_rules, read_rules_recursive};
 
+/// Asserts a rule was rejected for an invalid modifier without echoing the rule
+/// text or naming the offending character.
+///
+/// upstream: exclude.c:135 renders `filter_rule_err`'s text through `rule_text`,
+/// which substitutes `<rule from FILE line N>` whenever the rule came from a
+/// file, and exclude.c:127-131 drops the `'%c' at position %d` detail for the
+/// same reason - the peer chooses which file gets merged, so both the text and
+/// any offset into it are peer-controlled.
+///
+/// MEASURED against rsync 3.5.0, the same rule reached two ways:
+///   merge file -> `invalid modifier in filter rule: <rule from f.rules line 1>`
+///   argument   -> `invalid modifier 'e' at position 1 in filter rule: -e *.log`
+///
+/// These parsers only ever see file content - every production caller passes a
+/// merge file's bytes (`chain/mod.rs`, `merge/read.rs`) - so the redacted arm is
+/// the only reachable one here. The which-character discrimination is pinned on
+/// the argument-sourced parser instead, where upstream keeps it verbatim:
+/// `crates/cli/src/frontend/filter_rules/parsing/helpers.rs`.
+fn assert_modifier_rejected_without_echo(rendered: &str, rule: &str) {
+    assert!(
+        rendered.contains("invalid modifier in filter rule: <rule from"),
+        "expected the redacted upstream wording for `{rule}`, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains(rule),
+        "must not echo the peer-chosen rule text `{rule}`, got: {rendered}"
+    );
+}
+
 #[test]
 fn parse_include_short() {
     let rules = parse_rules("+ *.txt", Path::new("test")).unwrap();
@@ -427,10 +456,7 @@ fn parse_modifier_unknown_char_without_separator_errors() {
     // perishable modifier and the following `a` hits the `invalid:` label
     // rather than being treated as the start of the pattern.
     let err = parse_rules("-!/path/*.txt", Path::new("test")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier 'a'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "-!/path/*.txt");
 }
 
 #[test]
@@ -514,10 +540,7 @@ fn parse_modifiers_non_merge_flags() {
 #[test]
 fn parse_exclude_self_modifier_rejected_on_non_merge_rule() {
     let err = parse_rules("-e *.bak", Path::new("test")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier 'e'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "-e *.bak");
 }
 
 /// `e` word-split combinations on a non-merge rule are equally invalid: the
@@ -525,10 +548,7 @@ fn parse_exclude_self_modifier_rejected_on_non_merge_rule() {
 #[test]
 fn parse_exclude_self_modifier_rejected_with_word_split() {
     let err = parse_rules("-ew foo bar", Path::new("test")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier 'e'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "-ew foo bar");
 }
 
 /// `e` is accepted on a dir-merge rule (upstream sets `FILTRULE_EXCLUDE_SELF`
@@ -560,10 +580,7 @@ fn parse_exclude_self_modifier_accepted_on_merge_rule() {
 #[test]
 fn parse_no_inherit_modifier_rejected_on_non_merge_rule() {
     let err = parse_rules("-n *.tmp", Path::new("test")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier 'n'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "-n *.tmp");
 }
 
 /// `n` parses on a dir-merge rule, where it maps to FILTRULE_NO_INHERIT.
@@ -585,20 +602,14 @@ fn parse_no_inherit_modifier_accepted_on_dir_merge_rule() {
 #[test]
 fn parse_word_split_modifier_rejected_on_non_merge_rule() {
     let err = parse_rules("-w foo bar baz", Path::new("test")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier 'w'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "-w foo bar baz");
 }
 
 /// `w` on an include rule is equally invalid.
 #[test]
 fn parse_word_split_include_rejected_on_non_merge_rule() {
     let err = parse_rules("+w *.rs *.toml", Path::new("test")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier 'w'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "+w *.rs *.toml");
 }
 
 /// `w` parses on a dir-merge rule (FILTRULE_WORD_SPLIT), the only context
@@ -659,10 +670,7 @@ fn parse_no_prefixes_modifier_on_non_merge_errors() {
     // upstream: exclude.c:1197-1199 - `-`/`+` require FILTRULE_MERGE_FILE, so a
     // plain exclude rule with `-` in its modifiers is invalid.
     let err = parse_rules("-- pattern", Path::new("test")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier '-'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "-- pattern");
 }
 
 #[test]
@@ -670,10 +678,7 @@ fn parse_negate_modifier_on_merge_errors() {
     // upstream: exclude.c:1191-1196 - `!` is meaningless on a merge default and
     // is rejected on merge / dir-merge rules.
     let err = parse_rules(":! .filt", Path::new("test")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier '!'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), ":! .filt");
 }
 
 #[test]
@@ -919,11 +924,7 @@ fn parse_rejects_s_modifier_on_side_specific_prefix() {
     // H/S/P/R prefixes and rejects 's' or 'r' modifiers on them.
     for line in ["Hs foo", "Ss foo", "Ps foo", "Rs foo"] {
         let err = parse_rules(line, Path::new("test")).unwrap_err();
-        assert!(
-            err.message.contains("invalid modifier 's'"),
-            "expected rejection for `{line}`, got `{}`",
-            err.message
-        );
+        assert_modifier_rejected_without_echo(&err.message, line);
     }
 }
 
@@ -931,18 +932,14 @@ fn parse_rejects_s_modifier_on_side_specific_prefix() {
 fn parse_rejects_r_modifier_on_side_specific_prefix() {
     for line in ["Hr foo", "Sr foo", "Pr foo", "Rr foo"] {
         let err = parse_rules(line, Path::new("test")).unwrap_err();
-        assert!(
-            err.message.contains("invalid modifier 'r'"),
-            "expected rejection for `{line}`, got `{}`",
-            err.message
-        );
+        assert_modifier_rejected_without_echo(&err.message, line);
     }
 }
 
 #[test]
 fn parse_rejects_side_modifier_with_word_split_on_side_prefix() {
     let err = parse_rules("Hsw foo bar", Path::new("test")).unwrap_err();
-    assert!(err.message.contains("invalid modifier 's'"));
+    assert_modifier_rejected_without_echo(&err.message, "Hsw foo bar");
 }
 
 #[test]
@@ -952,11 +949,7 @@ fn parse_rejects_c_modifier_on_side_specific_prefix() {
     // that rejects `s`/`r` on those prefixes.
     for line in ["HC foo", "SC foo", "PC foo", "RC foo"] {
         let err = parse_rules(line, Path::new("test")).unwrap_err();
-        assert!(
-            err.message.contains("invalid modifier 'C'"),
-            "expected rejection for `{line}`, got `{}`",
-            err.message
-        );
+        assert_modifier_rejected_without_echo(&err.message, line);
     }
 }
 
@@ -966,11 +959,7 @@ fn parse_rejects_c_modifier_after_no_prefixes() {
     // is set by a preceding `-`/`+`, mirroring upstream's prefix/no-prefix
     // incompatibility rather than silently accepting the nonsensical combination.
     let err = parse_rules(":-C", Path::new("test")).unwrap_err();
-    assert!(
-        err.message.contains("invalid modifier 'C'"),
-        "expected rejection for `:-C`, got `{}`",
-        err.message
-    );
+    assert_modifier_rejected_without_echo(&err.message, ":-C");
 }
 
 // upstream: exclude.c:1404-1408 - merge / dir-merge with the `C`

--- a/crates/filters/src/rule_source.rs
+++ b/crates/filters/src/rule_source.rs
@@ -1,0 +1,246 @@
+//! Provenance of the text of a filter rule.
+//!
+//! upstream: `exclude.c:49-131`. A rule that fails to parse used to be echoed
+//! back verbatim, and the peer chooses which file gets merged - a per-directory
+//! merge rule travels over the protocol, so no argument of ours ever names it.
+//! That made the filter parser a read-any-line oracle: any line that is not
+//! valid filter syntax came straight back in the error. 3.5.0 reports *where*
+//! the bad rule is instead of *what it says*.
+//!
+//! The rule is deliberately not "redact everything". Text that came from the
+//! operator's own argument is returned unchanged, "because it is the user's own
+//! and hiding it only makes typos harder to fix" (`exclude.c:90-95`); only text
+//! that came out of a file's contents is replaced.
+//!
+//! Upstream expresses this with four module-globals (`rule_src_in_file`,
+//! `rule_src_file`, `rule_src_line`, `rule_src_named_at`) plus a per-rule
+//! `FILTRULE_FROM_FILE` bit, read through the `TEXT_FROM_FILE` macro. Those are
+//! process state because C has no better option for a value threaded through a
+//! recursive descent; here the same information is a value passed down the
+//! parse, which is both thread-safe and impossible to leave stale.
+//!
+//! Design note: upstream's `rule_text_len` returns one of two rotated static
+//! buffers so that two calls in a single `rprintf` do not alias
+//! (`exclude.c:104-109`). Owned/borrowed returns make that unnecessary here,
+//! but the property it protects is real - five upstream messages interpolate
+//! two of these calls - so it is pinned by test rather than assumed.
+
+use std::borrow::Cow;
+
+/// Where the text of a filter rule came from.
+///
+/// upstream: the `TEXT_FROM_FILE` predicate (`exclude.c:67-69`) plus the four
+/// arms of `rule_src_where` (`exclude.c:72-86`). [`Self::Argument`] is
+/// upstream's "not from a file" case; the other four are its four descriptions,
+/// in the order upstream tests them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleSource<'a> {
+    /// The operator's own command line. Text is shown verbatim.
+    Argument,
+    /// A file's contents, where the file's own name is safe to show and the
+    /// position is a line count.
+    ///
+    /// upstream: `"%s line %d"`.
+    File {
+        /// The merge file's name, as the operator or the walk named it.
+        name: &'a str,
+        /// 1-indexed physical line, counting comments and blank lines.
+        line: usize,
+    },
+    /// A file's contents, where the name is safe to show but the position is
+    /// not a line count - a word-split merge file yields tokens, not lines.
+    ///
+    /// upstream: `rule_src_line < 0`, which returns the file name alone.
+    FileWordSplit {
+        /// The merge file's name.
+        name: &'a str,
+    },
+    /// A file's contents, where the file's OWN name came from a file and so
+    /// must not be printed, but where it was named is known and printable.
+    ///
+    /// upstream: `"a file named at %s"`.
+    FileNamedAt {
+        /// Description of the location that named this file.
+        location: &'a str,
+    },
+    /// A file's contents whose origin was not retained - a deferred per-dir
+    /// merge, whose naming file was read and closed long ago.
+    ///
+    /// upstream: `"a file read earlier"`.
+    FileReadEarlier,
+}
+
+impl<'a> RuleSource<'a> {
+    /// Reports whether the text came from a file's contents.
+    ///
+    /// upstream: `TEXT_FROM_FILE` (`exclude.c:67-69`).
+    #[must_use]
+    pub const fn is_from_file(&self) -> bool {
+        !matches!(self, Self::Argument)
+    }
+
+    /// Describes where the rule came from, for interpolation into
+    /// `<rule from %s>`.
+    ///
+    /// upstream: `rule_src_where` (`exclude.c:72-86`). Returns `None` for
+    /// [`Self::Argument`], which has no such description because its text is
+    /// never replaced.
+    #[must_use]
+    pub fn describe(&self) -> Option<Cow<'a, str>> {
+        match *self {
+            Self::Argument => None,
+            Self::File { name, line } => Some(Cow::Owned(format!("{name} line {line}"))),
+            Self::FileWordSplit { name } => Some(Cow::Borrowed(name)),
+            Self::FileNamedAt { location } => {
+                Some(Cow::Owned(format!("a file named at {location}")))
+            }
+            Self::FileReadEarlier => Some(Cow::Borrowed("a file read earlier")),
+        }
+    }
+
+    /// Returns the rule text to show in a diagnostic.
+    ///
+    /// Argument-sourced text is returned unchanged; file-sourced text is
+    /// replaced by `<rule from ...>`.
+    ///
+    /// upstream: `rule_text` / `rule_text_len` (`exclude.c:88-123`), the
+    /// chokepoint every diagnostic built from a rule's own text must pass
+    /// through.
+    #[must_use]
+    pub fn rule_text<'t>(&self, text: &'t str) -> Cow<'t, str>
+    where
+        'a: 't,
+    {
+        match self.describe() {
+            None => Cow::Borrowed(text),
+            Some(where_from) => Cow::Owned(format!("<rule from {where_from}>")),
+        }
+    }
+
+    /// Returns extra detail *about* the rule text - a character of it, an
+    /// offset into it - or the empty string when the text itself is redacted.
+    ///
+    /// upstream: `rule_detail` (`exclude.c:127-131`): "For the extra detail
+    /// some messages add ABOUT the text - a character of it, an offset into it.
+    /// Dropped along with the text it describes." Without this, a message like
+    /// `invalid modifier 'k' at position 1` leaks the file's contents one byte
+    /// at a time, which is a finer-grained oracle than echoing the whole line.
+    #[must_use]
+    pub fn rule_detail<'d>(&self, detail: &'d str) -> &'d str {
+        if self.is_from_file() { "" } else { detail }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argument_text_is_returned_verbatim() {
+        // upstream keeps argument text "because it is the user's own and hiding
+        // it only makes typos harder to fix" (exclude.c:90-95). This is the
+        // non-vacuity companion to every redaction case below: without it a
+        // blanket-redaction bug passes the whole suite.
+        let src = RuleSource::Argument;
+        assert_eq!(src.rule_text("CLEAR"), "CLEAR");
+        assert_eq!(src.rule_detail(" 'k' at position 1"), " 'k' at position 1");
+        assert!(!src.is_from_file());
+        assert_eq!(src.describe(), None);
+    }
+
+    #[test]
+    fn line_counted_file_reports_name_and_line() {
+        let src = RuleSource::File {
+            name: "f.rules",
+            line: 2,
+        };
+        assert_eq!(src.rule_text("CLEAR"), "<rule from f.rules line 2>");
+    }
+
+    #[test]
+    fn word_split_file_reports_name_without_a_line() {
+        // upstream: rule_src_line = word_split ? -1 : 0 (exclude.c:1754). A
+        // word-split merge file yields tokens, so counting them as lines would
+        // report a number that means nothing.
+        let src = RuleSource::FileWordSplit { name: "w.rules" };
+        assert_eq!(src.rule_text("CLEAR"), "<rule from w.rules>");
+    }
+
+    #[test]
+    fn file_named_by_a_file_withholds_its_own_name() {
+        // upstream: rule_src_file = named_by_file ? NULL : src_name
+        // (exclude.c:1753). The name is withheld entirely, not shortened.
+        let src = RuleSource::FileNamedAt {
+            location: "outer.rules line 1",
+        };
+        assert_eq!(
+            src.rule_text("CLEAR"),
+            "<rule from a file named at outer.rules line 1>"
+        );
+    }
+
+    #[test]
+    fn deferred_merge_reports_the_generic_description() {
+        let src = RuleSource::FileReadEarlier;
+        assert_eq!(src.rule_text("CLEAR"), "<rule from a file read earlier>");
+    }
+
+    #[test]
+    fn detail_is_dropped_for_every_file_arm() {
+        // rule_detail is keyed on the same predicate as rule_text, so the
+        // character-and-offset detail vanishes wherever the text does.
+        for src in [
+            RuleSource::File { name: "f", line: 1 },
+            RuleSource::FileWordSplit { name: "f" },
+            RuleSource::FileNamedAt { location: "f" },
+            RuleSource::FileReadEarlier,
+        ] {
+            assert_eq!(src.rule_detail(" 'k' at position 1"), "");
+            assert!(src.is_from_file());
+        }
+    }
+
+    #[test]
+    fn two_texts_in_one_message_do_not_alias() {
+        // upstream needs two rotated static buffers for this (exclude.c:104-109,
+        // "so two calls in one rprintf() are safe"); five of its messages
+        // interpolate two of these. Pinned rather than assumed, because a future
+        // refactor to a shared scratch buffer would silently reintroduce the
+        // aliasing this property rules out.
+        let inner = RuleSource::FileReadEarlier;
+        let outer = RuleSource::File {
+            name: "outer.rules",
+            line: 1,
+        };
+        let message = format!(
+            "add_rule({}) [per-dir {}]",
+            inner.rule_text("- nothing"),
+            outer.rule_text(": .sub-rules")
+        );
+        assert_eq!(
+            message,
+            "add_rule(<rule from a file read earlier>) [per-dir <rule from outer.rules line 1>]"
+        );
+    }
+
+    #[test]
+    fn one_redacted_and_one_verbatim_in_the_same_message() {
+        // The mixed case, measured from upstream at --debug=FILTER3: the rules
+        // inside an argument-named per-dir file are redacted while the file's
+        // own name, which came from the argument, stays verbatim.
+        let from_file = RuleSource::File {
+            name: "/tmp/src/.sub-rules",
+            line: 1,
+        };
+        let from_arg = RuleSource::Argument;
+        let message = format!(
+            "add_rule({}) [per-dir {}]",
+            from_file.rule_text("- nothing"),
+            from_arg.rule_text(".sub-rules")
+        );
+        assert_eq!(
+            message,
+            "add_rule(<rule from /tmp/src/.sub-rules line 1>) [per-dir .sub-rules]"
+        );
+    }
+}

--- a/crates/filters/tests/dir_merge_parsing_comprehensive.rs
+++ b/crates/filters/tests/dir_merge_parsing_comprehensive.rs
@@ -84,10 +84,7 @@ fn exclude_self_modifier_rejected_on_plain_rule() {
     fs::write(&rules_path, "-e *.bak\n").unwrap();
 
     let err = filters::merge::read_rules(&rules_path).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier 'e'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "-e *.bak");
 }
 
 #[test]
@@ -125,16 +122,15 @@ fn dir_merge_requires_separator_before_pattern() {
 
     // upstream: exclude.c:1226 - without a separator, the modifier loop reads
     // `.` (after the `n` modifier) as another modifier character and rejects
-    // it. rsync 3.4.4 emits:
-    //   invalid modifier '.' at position 2 in filter rule: :n.rsync-filter
+    // it. The rule here is read from a FILE, so 3.5.0 redacts both the text
+    // and the offending character (exclude.c:49-56, :127-131):
+    //   invalid modifier in filter rule: <rule from rules.txt line 1>
+    // The `'.' at position 2` form is the ARGUMENT arm and is pinned in the
+    // CLI parser tests instead.
     fs::write(&rules_path, ":n.rsync-filter\n").unwrap();
 
     let err = filters::merge::read_rules(&rules_path).unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("invalid modifier '.' at position 2 in filter rule: :n.rsync-filter"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), ":n.rsync-filter");
 }
 
 #[test]
@@ -569,4 +565,31 @@ fn dir_merge_with_empty_lines_around() {
     let rules = filters::merge::read_rules(&rules_path).unwrap();
     assert_eq!(rules.len(), 1);
     assert_eq!(rules[0].action(), FilterAction::DirMerge);
+}
+
+/// Asserts a file-sourced rule was rejected for an invalid modifier without
+/// echoing the rule text or naming the offending character.
+///
+/// upstream: exclude.c:135 renders `filter_rule_err`'s text through `rule_text`,
+/// which substitutes `<rule from FILE line N>` when the rule came from a file,
+/// and exclude.c:127-131 drops the `'%c' at position %d` detail for the same
+/// reason - the peer chooses which file gets merged, so the text and any offset
+/// into it are both peer-controlled.
+///
+/// MEASURED against rsync 3.5.0, the same rule reached two ways:
+///   merge file -> `invalid modifier in filter rule: <rule from f.rules line 1>`
+///   argument   -> `invalid modifier 'e' at position 1 in filter rule: -e *.log`
+///
+/// The which-character discrimination is pinned on the argument-sourced parser,
+/// where upstream keeps it verbatim: see
+/// `crates/cli/src/frontend/filter_rules/parsing/helpers.rs`.
+fn assert_modifier_rejected_without_echo(rendered: &str, rule: &str) {
+    assert!(
+        rendered.contains("invalid modifier in filter rule: <rule from"),
+        "expected the redacted upstream wording for `{rule}`, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains(rule),
+        "must not echo the peer-chosen rule text `{rule}`, got: {rendered}"
+    );
 }

--- a/crates/filters/tests/exclude_from_file_parsing.rs
+++ b/crates/filters/tests/exclude_from_file_parsing.rs
@@ -933,10 +933,7 @@ mod rule_modifiers_from_file {
         fs::write(&path, "-w *.tmp *.bak *.log\n").expect("write");
 
         let err = read_rules(&path).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'w'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "-w *.tmp *.bak *.log");
     }
 }
 
@@ -1098,4 +1095,31 @@ mod integration_tests {
         assert!(set.allows(Path::new("main.c"), false));
         assert!(set.allows(Path::new("header.h"), false));
     }
+}
+
+/// Asserts a file-sourced rule was rejected for an invalid modifier without
+/// echoing the rule text or naming the offending character.
+///
+/// upstream: exclude.c:135 renders `filter_rule_err`'s text through `rule_text`,
+/// which substitutes `<rule from FILE line N>` when the rule came from a file,
+/// and exclude.c:127-131 drops the `'%c' at position %d` detail for the same
+/// reason - the peer chooses which file gets merged, so the text and any offset
+/// into it are both peer-controlled.
+///
+/// MEASURED against rsync 3.5.0, the same rule reached two ways:
+///   merge file -> `invalid modifier in filter rule: <rule from f.rules line 1>`
+///   argument   -> `invalid modifier 'e' at position 1 in filter rule: -e *.log`
+///
+/// The which-character discrimination is pinned on the argument-sourced parser,
+/// where upstream keeps it verbatim: see
+/// `crates/cli/src/frontend/filter_rules/parsing/helpers.rs`.
+fn assert_modifier_rejected_without_echo(rendered: &str, rule: &str) {
+    assert!(
+        rendered.contains("invalid modifier in filter rule: <rule from"),
+        "expected the redacted upstream wording for `{rule}`, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains(rule),
+        "must not echo the peer-chosen rule text `{rule}`, got: {rendered}"
+    );
 }

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -34,10 +34,7 @@ mod include_rules {
         // before the pattern. `+*.txt` reads `*` as a modifier and rejects it:
         //   invalid modifier '*' at position 1 in filter rule: +*.txt
         let err = parse_rules("+*.txt", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier '*'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "+*.txt");
     }
 
     #[test]
@@ -160,10 +157,7 @@ mod include_rules {
     #[test]
     fn include_with_word_split_rejected() {
         let err = parse_rules("+w *.rs *.toml *.md", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'w'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "+w *.rs *.toml *.md");
     }
 }
 
@@ -183,10 +177,7 @@ mod exclude_rules {
         // upstream: exclude.c:1226 - `-*.bak` reads `*` as a modifier:
         //   invalid modifier '*' at position 1 in filter rule: -*.bak
         let err = parse_rules("-*.bak", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier '*'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "-*.bak");
     }
 
     #[test]
@@ -280,10 +271,7 @@ mod exclude_rules {
         // and stored a flag no matching logic read, silently diverging from
         // upstream on malformed input.
         let err = parse_rules("-e *.log", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'e'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "-e *.log");
     }
 
     // upstream: exclude.c:1261-1264 / 1279-1283 - `n` and `w` are valid only
@@ -293,28 +281,19 @@ mod exclude_rules {
     #[test]
     fn exclude_with_no_inherit_modifier_rejected() {
         let err = parse_rules("-n *.tmp", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'n'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "-n *.tmp");
     }
 
     #[test]
     fn exclude_with_word_split_rejected() {
         let err = parse_rules("-w *.tmp *.bak *.swp", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'w'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "-w *.tmp *.bak *.swp");
     }
 
     #[test]
     fn exclude_with_combined_modifiers_and_word_split_rejected() {
         let err = parse_rules("-!pw *.o *.obj", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'w'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "-!pw *.o *.obj");
     }
 
     #[test]
@@ -563,10 +542,7 @@ mod hide_show_rules {
         // modifier, matching rsync 3.4.4:
         //   invalid modifier 'I' at position 1 in filter rule: HIDE *.secret
         let err = parse_rules("HIDE *.secret", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'I'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "HIDE *.secret");
     }
 
     #[test]
@@ -594,10 +570,7 @@ mod hide_show_rules {
         // an invalid `H` modifier:
         //   invalid modifier 'H' at position 1 in filter rule: SHOW *.public
         let err = parse_rules("SHOW *.public", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'H'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "SHOW *.public");
     }
 
     #[test]
@@ -701,10 +674,7 @@ mod protect_risk_rules {
         // then an invalid `R` modifier:
         //   invalid modifier 'R' at position 1 in filter rule: PROTECT /important
         let err = parse_rules("PROTECT /important", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'R'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "PROTECT /important");
     }
 
     #[test]
@@ -728,10 +698,7 @@ mod protect_risk_rules {
         // invalid `I` modifier:
         //   invalid modifier 'I' at position 1 in filter rule: RISK /temp
         let err = parse_rules("RISK /temp", Path::new("test")).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid modifier 'I'"),
-            "unexpected error: {err}"
-        );
+        crate::assert_modifier_rejected_without_echo(&err.to_string(), "RISK /temp");
     }
 
     #[test]
@@ -1299,4 +1266,31 @@ mod pattern_preservation {
         let rules = parse_rules("+ foo\\?bar", Path::new("test")).unwrap();
         assert_eq!(rules[0].pattern(), "foo\\?bar");
     }
+}
+
+/// Asserts a file-sourced rule was rejected for an invalid modifier without
+/// echoing the rule text or naming the offending character.
+///
+/// upstream: exclude.c:135 renders `filter_rule_err`'s text through `rule_text`,
+/// which substitutes `<rule from FILE line N>` when the rule came from a file,
+/// and exclude.c:127-131 drops the `'%c' at position %d` detail for the same
+/// reason - the peer chooses which file gets merged, so the text and any offset
+/// into it are both peer-controlled.
+///
+/// MEASURED against rsync 3.5.0, the same rule reached two ways:
+///   merge file -> `invalid modifier in filter rule: <rule from f.rules line 1>`
+///   argument   -> `invalid modifier 'e' at position 1 in filter rule: -e *.log`
+///
+/// The which-character discrimination is pinned on the argument-sourced parser,
+/// where upstream keeps it verbatim: see
+/// `crates/cli/src/frontend/filter_rules/parsing/helpers.rs`.
+fn assert_modifier_rejected_without_echo(rendered: &str, rule: &str) {
+    assert!(
+        rendered.contains("invalid modifier in filter rule: <rule from"),
+        "expected the redacted upstream wording for `{rule}`, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains(rule),
+        "must not echo the peer-chosen rule text `{rule}`, got: {rendered}"
+    );
 }

--- a/crates/filters/tests/proptest_fuzz.rs
+++ b/crates/filters/tests/proptest_fuzz.rs
@@ -800,19 +800,13 @@ fn cvs_exclusion_rules_are_all_valid() {
 #[test]
 fn parse_word_split_empty_pattern_rejected() {
     let err = parse_rules("-w   ", Path::new("<test>")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier 'w'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "-w   ");
 }
 
 #[test]
 fn parse_word_split_single_word_rejected() {
     let err = parse_rules("-w single", Path::new("<test>")).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid modifier 'w'"),
-        "unexpected error: {err}"
-    );
+    assert_modifier_rejected_without_echo(&err.to_string(), "-w single");
 }
 
 #[test]
@@ -820,8 +814,32 @@ fn parse_word_split_many_words_rejected() {
     let words: Vec<String> = (0..100).map(|i| format!("word{i}")).collect();
     let input = format!("-w {}", words.join(" "));
     let err = parse_rules(&input, Path::new("<test>")).unwrap_err();
+    assert_modifier_rejected_without_echo(&err.to_string(), &input);
+}
+
+/// Asserts a file-sourced rule was rejected for an invalid modifier without
+/// echoing the rule text or naming the offending character.
+///
+/// upstream: exclude.c:135 renders `filter_rule_err`'s text through `rule_text`,
+/// which substitutes `<rule from FILE line N>` when the rule came from a file,
+/// and exclude.c:127-131 drops the `'%c' at position %d` detail for the same
+/// reason - the peer chooses which file gets merged, so the text and any offset
+/// into it are both peer-controlled.
+///
+/// MEASURED against rsync 3.5.0, the same rule reached two ways:
+///   merge file -> `invalid modifier in filter rule: <rule from f.rules line 1>`
+///   argument   -> `invalid modifier 'e' at position 1 in filter rule: -e *.log`
+///
+/// The which-character discrimination is pinned on the argument-sourced parser,
+/// where upstream keeps it verbatim: see
+/// `crates/cli/src/frontend/filter_rules/parsing/helpers.rs`.
+fn assert_modifier_rejected_without_echo(rendered: &str, rule: &str) {
     assert!(
-        err.to_string().contains("invalid modifier 'w'"),
-        "unexpected error: {err}"
+        rendered.contains("invalid modifier in filter rule: <rule from"),
+        "expected the redacted upstream wording for `{rule}`, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains(rule),
+        "must not echo the peer-chosen rule text `{rule}`, got: {rendered}"
     );
 }

--- a/crates/transfer/tests/exclude_lsh_cvs_wire_expansion.rs
+++ b/crates/transfer/tests/exclude_lsh_cvs_wire_expansion.rs
@@ -115,6 +115,14 @@ fn cvs_mode_dir_merge_does_not_inherit_to_subdirs() {
 /// Sanity check that the standard merge parser, used outside CVS-mode,
 /// rejects unprefixed tokens. This pins the failure mode the CVS-mode
 /// fix bypasses.
+///
+/// The rejection must name *where* the bad rule is, never *what it says*.
+/// The token came out of a merged file's contents, and the peer chooses
+/// which file gets merged, so echoing the line back would hand it a read
+/// primitive. upstream: exclude.c:55 "Report where the bad rule is, not what
+/// it says"; the substitution happens at the `rule_text()` chokepoint
+/// (exclude.c:90-118), which swaps file-sourced text for `<rule from FILE
+/// line N>` whenever `rule_src_in_file` is set.
 #[test]
 fn standard_dir_merge_rejects_unprefixed_cvsignore_token() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -129,8 +137,15 @@ fn standard_dir_merge_rejects_unprefixed_cvsignore_token() {
         .expect_err("standard merge parse must fail on unprefixed token");
     let msg = err.to_string();
     assert!(
-        msg.contains("one-in-one-out"),
-        "error must mention the offending token: {msg}",
+        !msg.contains("one-in-one-out"),
+        "the file's own line must not be echoed back: {msg}",
+    );
+    // Without this the redaction could degenerate into a message that says
+    // nothing at all, which would satisfy the assertion above while making
+    // the diagnostic useless - the outcome upstream's comment rules out.
+    assert!(
+        msg.contains(".cvsignore") && msg.contains("line 1"),
+        "error must still locate the bad rule by file and line: {msg}",
     );
 }
 

--- a/docs/design/upstream-3.5.0-filter-rule-text-provenance.md
+++ b/docs/design/upstream-3.5.0-filter-rule-text-provenance.md
@@ -1,0 +1,383 @@
+# Upstream rsync 3.5.0 filter-rule text provenance
+
+Read-only extraction of the rule set oc-rsync must mirror. Source of truth is
+the C at `target/interop/upstream-src/rsync-3.5.0/`, primarily `exclude.c`
+plus the `FILTRULE_FROM_FILE` bit in `rsync.h`.
+
+This document is the specification the implementation work is measured against.
+It records what upstream *does*, not what oc-rsync currently does. Every rule
+below was additionally confirmed by running the real 3.5.0 binary; the probes
+are in section 9.
+
+## 0. Why this exists
+
+3.5.0 changed what a filter diagnostic is allowed to say. The reasoning is
+stated at `exclude.c:49-56`:
+
+> A rule that fails to parse used to be echoed back verbatim, and the peer
+> chooses which file gets merged (a per-directory merge rule travels over the
+> protocol, so no argument of ours ever names it), which made the filter parser
+> a read-any-line oracle: any line that is not valid filter syntax came straight
+> back in the error. Report where the bad rule is, not what it says.
+
+Two consequences shape the whole design:
+
+- The rule is **not** "redact everything". Text that came from the operator's
+  own argument is returned unchanged, "because it is the user's own and hiding
+  it only makes typos harder to fix" (`exclude.c:90-95`). Only text that came
+  out of a **file's contents** is replaced.
+- The decision is made at **one chokepoint**, not at each message. The comment
+  at `exclude.c:96-98` gives the reason: "Doing it here rather than at each site
+  is the point: a message added later cannot reintroduce the leak by forgetting
+  to check, and there is one place to audit."
+
+An implementation that patches the messages individually satisfies the letter
+and loses the property.
+
+## 1. The provenance predicate
+
+`exclude.c:67-69`:
+
+```c
+#define TEXT_FROM_FILE(template) \
+    (rule_src_in_file \
+     || ((template) && (template)->rflags & FILTRULE_FROM_FILE))
+```
+
+Two inputs, and both are load-bearing:
+
+| Input | Kind | Answers |
+|---|---|---|
+| `rule_src_in_file` | dynamic, process-global | are we parsing a file's contents *right now*? |
+| `FILTRULE_FROM_FILE` (`rsync.h:1055`, bit 21) | per-rule flag | did *this rule's* text come from a file? |
+
+The per-rule flag exists for the **deferred** case: a per-directory merge rule
+whose name came from a file, but which is applied during traversal, long after
+that file was read and closed. At that moment `rule_src_in_file` is 0. A single
+dynamic flag cannot express it and would print the raw text.
+
+Four module-globals carry the state (`exclude.c:56-62`):
+
+| Global | Meaning |
+|---|---|
+| `rule_src_in_file` | parsing a file's contents right now |
+| `rule_src_file` | the file's name, **when that name is itself safe to show** |
+| `rule_src_line` | current line, or `-1` when the count is not a line count |
+| `rule_src_named_at` | where a file whose own name must not be printed was named |
+
+`rule_src_file` being `NULL` while `rule_src_in_file` is 1 is a normal state,
+not an error: it means we are in a file whose *name* is also peer-controlled.
+
+## 2. Two helpers, not one
+
+`rule_text_len` (`exclude.c:102-118`) replaces the **text**:
+
+```c
+if (!TEXT_FROM_FILE(template)) {
+    if (len < 0) return text;
+    snprintf(b, sizeof buf[0], "%.*s", len, text);
+    return b;
+}
+snprintf(b, sizeof buf[0], "<rule from %s>", rule_src_where());
+```
+
+`rule_detail` (`exclude.c:127-131`) drops the **detail about** the text:
+
+```c
+return TEXT_FROM_FILE(template) ? "" : detail;
+```
+
+Its comment: "For the extra detail some messages add ABOUT the text - a
+character of it, an offset into it. Dropped along with the text it describes."
+
+This second helper is easy to miss and it matters more than it looks. A message
+of the form `invalid modifier 'k' at position 1` leaks the file's contents one
+byte at a time, which is a finer-grained oracle than echoing the whole line.
+Redacting only the text leaves the oracle intact.
+
+### The buffer is rotated, and that is required
+
+```c
+static char buf[2][BIGPATHBUFLEN];
+static int which = 0;
+which ^= 1;
+```
+
+"The returned buffer is rotated, so two calls in one rprintf() are safe."
+Five sites call a helper twice in a single message: `:272-274`, `:1101-1102`,
+`:1377-1378`, `:1659-1660`, `:1699-1700`. A single-buffer port corrupts all of
+them, and the corruption is silent - the message still prints, with one
+fragment showing the other's text.
+
+## 3. `rule_src_where()` has four arms
+
+`exclude.c:72-86`:
+
+| Condition | Result |
+|---|---|
+| `!rule_src_file && !rule_src_named_at` | `"a file read earlier"` |
+| `!rule_src_file` | `"a file named at %s"` (`rule_src_named_at`) |
+| `rule_src_line < 0` | `rule_src_file` alone |
+| otherwise | `"%s line %d"` |
+
+The two degraded arms are not defensive padding. They are the normal output
+whenever the merge file's own name came from a file (arm 2) or whenever the
+rule is a deferred per-dir merge (arm 1).
+
+Line numbers count **physical lines**, including comments and blank lines - the
+counter increments once per read iteration (`exclude.c:1759-1760`), before the
+comment and empty-token filter at `:1806`. Numbering only the rules that parse
+produces different, wrong numbers.
+
+## 4. Where provenance is set
+
+Exactly two sites set `FILTRULE_FROM_FILE`:
+
+- `exclude.c:1265` - `if (rule_src_in_file) rule->rflags |= FILTRULE_FROM_FILE;`
+  The trailing comment pins the ordering: "before parse_merge_name()".
+- `exclude.c:1567` - the synthetic exclude-self rule inherits it:
+  `excl_self->rflags = rule->rflags & FILTRULE_FROM_FILE;`
+
+The second is the one an independent implementation will omit. Its comment
+records the bug that omitting it caused: the pattern of an exclude-self rule is
+the merge rule's own text, so "built by hand, this rule looked argument-origin
+once parsing finished and the match trace echoed a merge file's contents at
+-vv". A synthetic rule constructed locally can still carry text that came from
+a file. Provenance must be inherited, not inferred from how the rule was built.
+
+`FILTRULE_FROM_FILE` never reaches the wire. `get_rule_prefix` tests only
+`FILTRULES_SIDES`, `FILTRULE_DIRECTORY`, `FILTRULE_ABS_PATH`,
+`FILTRULE_MERGE_FILE` and `FILTRULE_INCLUDE`, so bit 21 is purely local state
+with no golden-byte or interop exposure.
+
+## 5. Nesting: save, restore, and snapshot
+
+A merge rule inside a merge file re-enters `parse_filter_file`, so all four
+globals are saved on entry (`:1734-1739`) and restored on exit (`:1814-1816`).
+
+Three details are easy to lose:
+
+- `named_at` is `strlcpy`'d from `rule_src_where()` **before** the state is
+  overwritten, precisely because that function returns a static buffer
+  (`:1744-1749`).
+- A deferred merge gets `rule_src_named_at = NULL` deliberately - it has "no
+  live location to point at", so upstream leaves the generic description rather
+  than nesting two vague ones.
+- `rule_src_file` is re-set inside the read loop at `:1807`, before each
+  `parse_filter_str`, because a nested merge on an earlier line has clobbered it.
+
+`rule_src_line = word_split ? -1 : 0` (`:1754`): a word-split merge file yields
+tokens, not lines, so line counting is suppressed rather than reported wrongly.
+
+## 6. The redaction has two channels
+
+Text is one. **errno is the other.**
+
+On a failed open (`:1705-1717`), upstream branches:
+
+```c
+if (TEXT_FROM_FILE(template)) {
+    /* errno too: it answers "does this path exist". */
+    rprintf(FERROR, "failed to open %sclude file %s\n", ..., rule_text(template, fname));
+} else {
+    rsyserr(FERROR, errno, "failed to open %sclude file %s", ..., fname);
+}
+```
+
+`rsyserr` appends `strerror(errno)`; the from-file arm uses plain `rprintf` and
+drops it. An implementation that redacts the name but keeps "No such file or
+directory" has rebuilt a path-existence oracle.
+
+Related, at `:1753`: `rule_src_file = named_by_file ? NULL : src_name`. When a
+rule we read named *this* file, our own path is file content too. Upstream does
+not print the name in a shortened or relative form - it withholds the name
+entirely and falls back to arm 2 of section 3.
+
+At `:1800-1801`, an over-long line is discarded with `rule_text_len(NULL, line, 0)`
+- length zero. Not even a truncated prefix is echoed.
+
+## 7. The call sites
+
+Fourteen messages, eighteen helper calls, all in `exclude.c`:
+
+| Line | Message |
+|---|---|
+| 135 | `filter_rule_err` - the generic syntax-error emitter |
+| 272-274 | `add_rule` debug trace (2 x `rule_detail`, 1 x `rule_text_len`) |
+| 379 | per-dir `debug_type` label |
+| 728 | merge-file name |
+| 742 | filter filename |
+| 918 | "cannot add local filter rules in long-named directory" (path composed from rule text) |
+| 1101-1102 | match trace ("...ing file X because of pattern Y") |
+| 1377-1378 | "invalid modifier%s in filter rule: %s" |
+| 1535 | pattern by explicit length |
+| 1622 | `MAX_MERGE_DEPTH` exceeded |
+| 1659-1660 | "hidden by daemon filter" |
+| 1699-1700 | `parse_filter_file` debug trace |
+| 1712 | "failed to open %sclude file" |
+| 1801 | "discarding over-long filter" |
+
+The debug and trace sites are in scope, not optional extras: the comment at
+`:1567` documents a real observed leak through the match trace. Both trace
+gates are `DEBUG_GTE(FILTER, n)` - `n = 2` for `add_rule`, and `n = 1` for a
+sender or generator / `3` for a receiver on the match trace. They are reached
+with `--debug=FILTERn`, not with `-vv`.
+
+## 8. Refusal observable
+
+`filter_rule_err` (`exclude.c:133-137`) prints `"%s: %s"` and calls
+`exit_cleanup(RERR_SYNTAX)`, i.e. exit 1:
+
+```c
+rprintf(FERROR, "%s: %s\n", msg, rule_text(NULL, rulestr));
+```
+
+It has four call sites, and every one of them is redacted by that single
+`rule_text`:
+
+| Line | Message |
+|---|---|
+| 1363 | `Unknown filter rule` |
+| 1452 | `specified-side merge file contains specified-side filter` |
+| 1470 | `'!' rule has trailing characters` |
+| 1475 | `unexpected end of filter rule` |
+
+Any message-wording work on these four is therefore coupled to the provenance
+funnel: matching upstream's text without the funnel produces upstream's words
+carrying peer-controlled content.
+
+## 9. Confirmed behaviour
+
+Each rule above predicts a specific string. Measured against the 3.5.0 binary,
+every probe paired with an argument-sourced control:
+
+| Rule | Probe | Observed |
+|---|---|---|
+| §1 deferred | per-dir merge named by a file | `<rule from a file read earlier>` |
+| §3 arm 2 | `outer.rules` merges `g.rules`; bad rule in `g.rules` | `<rule from a file named at outer.rules line 1>` |
+| §3 arm 3 | `.w w.rules` (word-split) | `<rule from w.rules>`, no line number |
+| §3 arm 4 | bad rule on line 2 / line 4 | `line 2` / `line 4` |
+| §3 physical lines | comment + blank + rule + bad rule | `line 4` |
+| §2 `rule_detail` | `-k foo` as argument | `invalid modifier 'k' at position 1 in filter rule: -k foo` |
+| §2 `rule_detail` | same rule inside a file | `invalid modifier in filter rule: <rule from m.rules line 1>` |
+| §2 rotation | argument-named dir-merge, `--debug=FILTER3` | `add_rule(<rule from /…/.sub-rules line 1>) [per-dir .sub-rules]` |
+| §4 exclude-self | file-named dir-merge, `--debug=FILTER3` | `add_rule(<rule from a file read earlier>)` |
+| §5 nesting | merge on line 2, bad rule on line 3 | `<rule from f.rules line 3>` |
+| §6 errno | missing merge file named by a file | `failed to open exclude file <rule from n.rules line 1>` |
+| §6 control | missing file named by an argument | `... missing.rules: No such file or directory (2)` |
+| §6 over-long | 200 KB line | `discarding over-long filter: <rule from big.rules line 1>` |
+
+The rotation row is the sharpest: one message holds a redacted fragment and a
+verbatim one at once, so an unrotated buffer would visibly print the same
+string twice.
+
+Note the modifier offset is 0-based (`-k foo` reports position 1).
+
+## 10. Consequences for oc-rsync
+
+oc-rsync currently echoes peer-controlled merge-file text, and emits three
+different messages where upstream emits one:
+
+| Source | oc-rsync site | Divergence |
+|---|---|---|
+| argument | `crates/cli/src/frontend/filter_rules/parsing/rules.rs:184` | wording: "unsupported filter rule ... this build currently supports only ..." where upstream says "Unknown filter rule" and echoes verbatim |
+| merge (`.`) | `crates/cli/src/frontend/filter_rules/merge.rs:279` | wraps the above, and additionally prints a canonicalised **absolute path** to the merge file |
+| dir-merge (`:`) | `crates/engine/src/local_copy/dir_merge/parse/line.rs:364` | echoes the literal line; wording otherwise closest to upstream |
+
+A fourth emitter, `crates/filters/src/merge/parse.rs:603`, shares the dir-merge
+shape; its reachability is not yet traced.
+
+A fifth is `crates/cli/src/frontend/filter_rules/merge.rs:237` plus its
+dir-merge twin in `crates/engine/src/local_copy/dir_merge/load.rs`, which
+implement upstream's `exclude.c:1452` refusal:
+
+```
+upstream: specified-side merge file contains specified-side filter: <rule from f.rules line 1>
+oc:       specified-side merge file contains specified-side filter: -r foo
+```
+
+This site is worth calling out as the clearest evidence for section 0's
+argument about the chokepoint. It is unconditionally file-sourced - the guard
+fires only when a merge template names a side *and* a rule inside the merged
+file names one - so there is no argument-sourced case to preserve, and the
+`rulestr` is always a line the peer chose. It is also recent, which is the
+point: the message was added to oc after the surrounding parser was already
+correct, exactly the "a message added later reintroduces the leak" failure
+mode the upstream comment describes. Per-message fixes do not prevent this;
+only routing every emitter through one funnel does.
+
+### The plumbing splits in two, and only one half is cheap
+
+There are two classes of emitter, and they differ in whether provenance is
+still in scope:
+
+- **Parse-time errors** (`filter_rule_err` analogues, merge-open failures). The
+  parser knows which file it is reading, so a `RuleSource` can be built at or
+  near the call site. `crates/filters/src/merge/parse.rs` already threads
+  `source_path` + `line_num`; `crates/cli/src/frontend/filter_rules/merge.rs`
+  has the merge file's display name and can count lines. Cheap.
+
+- **Trace-time messages** (`add_rule`, the match trace). By the time a rule is
+  compiled, `FilterRule`/`CompiledRule` hold `pattern: String` and nothing
+  else - oc has **no field equivalent to `FILTRULE_FROM_FILE`**
+  (`rsync.h:1055`). Provenance is already lost. These sites cannot redact
+  until a provenance bit is carried on the rule itself, through parsing and
+  into the compiled form.
+
+That per-rule bit is section 1's second predicate input, and it is exactly
+what upstream needed too - `FILTRULE_FROM_FILE` exists precisely because the
+dynamic "am I parsing a file right now" flag is false by the time a deferred
+or compiled rule is used. An implementation that adds only the dynamic half
+will redact the parse errors and silently leave every trace site leaking.
+
+oc's trace sites, for reference (all reachable via `--debug=FILTER`):
+`crates/filters/src/compiled/mod.rs` and
+`crates/engine/src/local_copy/filter_program/segments.rs` (add_rule, level 2);
+`crates/filters/src/decision.rs` and the same `segments.rs`
+(`report_filter_result`, level 1). Note oc runs both traces **twice, in two
+crates**, where upstream has one funnel in `exclude.c`.
+
+Three upstream trace sites have no oc analogue at all: the `" [per-dir %s]"`
+label (`:379`), "hidden by daemon filter" (`:1659-1660`), and the
+`parse_filter_file` trace (`:1699-1700`). oc also gates its match trace at
+level 1 unconditionally, with no analogue of upstream's receiver arm
+(`DEBUG_GTE(FILTER, am_sender||am_generator ? 1 : 3)`).
+
+Two properties of the upstream design should survive the port:
+
+1. One funnel with a provenance parameter, not a fix per message. The value is
+   that a message added later cannot reintroduce the leak.
+2. The argument arm stays verbatim. Any test suite for this work needs an
+   argument-sourced control on every case, or a blanket-redaction regression
+   passes silently.
+
+Sequencing note: the wording-parity work on the four `filter_rule_err`
+messages is tracked separately, but it is not independent of this document -
+see section 8. Landing upstream's wording without the funnel gives upstream's
+text wrapped around peer-controlled content, which is worse than the current
+state because it looks correct. Either sequence the funnel first, or land both
+together. Both changes alter strings that existing filter tests assert on.
+
+Out of scope: `daemon_config_filter_file` (`exclude.c:1681`,
+`clientserver.c:931/954`) gates `operator_path_resolve` so the daemon's own
+`filter` / `include from` / `exclude from` parameters may live outside the
+module. That is path confinement, covered by
+[upstream-3.5.0-path-confinement-model.md](upstream-3.5.0-path-confinement-model.md).
+
+## References
+
+- `exclude.c:47` - `daemon_config_filter_file`
+- `exclude.c:49-62` - threat model and the four provenance globals
+- `exclude.c:67-69` - `TEXT_FROM_FILE`
+- `exclude.c:72-86` - `rule_src_where`
+- `exclude.c:88-123` - `rule_text_len` / `rule_text`, the chokepoint
+- `exclude.c:127-131` - `rule_detail`
+- `exclude.c:133-137` - `filter_rule_err`, `RERR_SYNTAX`
+- `exclude.c:1265` - `FILTRULE_FROM_FILE` set during file parsing
+- `exclude.c:1567` - exclude-self rule inherits provenance
+- `exclude.c:1705-1717` - failed open, errno suppression
+- `exclude.c:1734-1760` - save, snapshot, and per-file setup
+- `exclude.c:1800-1801` - over-long line, length 0
+- `exclude.c:1807` - `rule_src_file` re-set inside the read loop
+- `exclude.c:1814-1816` - restore on exit
+- `rsync.h:1055` - `FILTRULE_FROM_FILE` (1<<21)

--- a/tests/sided_merge_file_side_conflict.rs
+++ b/tests/sided_merge_file_side_conflict.rs
@@ -88,6 +88,51 @@ fn assert_refused(filter: &str, rules_name: &str, rule_line: &str) {
     );
 }
 
+/// The refusal names WHERE the bad rule is, never WHAT it says.
+///
+/// upstream: `filter_rule_err` renders its rule text through `rule_text`
+/// (exclude.c:135), which replaces file-sourced text with `<rule from ...>`
+/// because the peer chooses which file gets merged (exclude.c:49-56). This
+/// guard is unconditionally file-sourced - it fires only when a merge template
+/// names a side AND a rule *inside the merged file* names one - so there is no
+/// argument-sourced case here to keep verbatim.
+#[test]
+fn refusal_reports_where_the_rule_is_not_what_it_says() {
+    let fixture = Fixture::new("f.rules", "-r foo");
+    let (code, text) = fixture.run(".s f.rules");
+    assert_eq!(code, 1, "must still exit 1; got {code}, output: {text}");
+    assert!(
+        text.contains("<rule from f.rules line 1>"),
+        "must name the merge file and line; got: {text}"
+    );
+    assert!(
+        !text.contains("-r foo"),
+        "must not echo the peer-chosen merge-file line; got: {text}"
+    );
+}
+
+/// Non-vacuity companion: the line number is real, not a hardcoded 1.
+///
+/// upstream counts PHYSICAL lines, so the leading comment and blank line both
+/// advance the count (exclude.c:1759-1760 increments before the `;`/`#` and
+/// empty-token filter at :1806). Without this row, numbering only the rules
+/// that parse would pass the test above.
+#[test]
+fn refusal_line_number_counts_comments_and_blanks() {
+    let fixture = Fixture::new("f.rules", "-r foo");
+    fs::write(
+        fixture.dir.path().join("f.rules"),
+        b"# a comment\n\n- keep\n-r foo\n",
+    )
+    .expect("write rules");
+    let (code, text) = fixture.run(".s f.rules");
+    assert_eq!(code, 1, "must exit 1; got {code}, output: {text}");
+    assert!(
+        text.contains("<rule from f.rules line 4>"),
+        "physical line 4, counting the comment and the blank; got: {text}"
+    );
+}
+
 fn assert_accepted(filter: &str, rules_name: &str, rule_line: &str) {
     let fixture = Fixture::new(rules_name, rule_line);
     let (code, text) = fixture.run(filter);


### PR DESCRIPTION
## What

Upstream 3.5.0 does not echo a filter rule's text back to the operator when that
rule came from a file. `exclude.c:60-75`:

```c
#define TEXT_FROM_FILE(template) \
    (rule_src_in_file || ((template) && (template)->rflags & FILTRULE_FROM_FILE))
```

Every rule-text interpolation goes through `rule_text()` / `rule_detail()`, which
substitute a `<rule from ...>` placeholder instead of the rule bytes.
`rule_src_where()` has four arms: a file read earlier / a file named at `%s` / a
bare word-split source / `"%s line %d"`.

oc interpolated the rule text unconditionally at both filter-parser message sites
and at the include/exclude open-failure site, so a merge file's contents reached
the operator verbatim.

## How

`filters::RuleSource` becomes the single owner of that decision:

- `rule_text()` replaces the **text**.
- `rule_detail()` suppresses detail *about* the text (a character of it, an offset
  into it) — these are separate because upstream treats them separately.

The CLI parser and both open-failure arms route through it.

**errno is a second redaction channel.** Upstream's from-file arm uses plain
`rprintf` where the argument arm uses `rsyserr` (`exclude.c:1703-1720`), because
errno answers "does this path exist". The from-file arm now withholds it.

Physical-line counting matches `exclude.c:1759-1760` vs `:1806-1807`, which
increments *before* the `;`/`#`/empty filter.

## Verification

Run on Linux aarch64 (rust 1.88.0):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
  — **zero diagnostics**
- `cargo nextest run -p filters -p cli --all-features --no-fail-fast` —
  **5253 run, 5250 passed, 3 failed**

**Correction (2026-08-19): the 3 `cli::dir_merge_x_modifier` failures reported
above were not real, and my "pre-existing" attribution was wrong.** They were
produced by a stale `target/debug/oc-rsync` on the test host, dated four days
before the commit under test and therefore predating the `x`-modifier fixes in
PRs #7361/#7379/#7380. Rebuilding the binary gives **3 run, 3 passed**, and the
same fixture matches upstream 3.5.0 in all four cells (`: .rules` / `:x .rules`,
flat and nested) on both Linux and macOS.

The "reproduced on base `ce6d7f8a8`" evidence was worthless: that run used the
*same* stale binary, so it could not distinguish base from branch. Re-running at
a different commit does not re-derive the artefact under test when the artefact
is a separate build product — the correct discriminator was rebuilding.

PR #7385 closes the class: `workspace_bin` now asserts the binary is newer than
every source Cargo built it from, so this fails loudly instead of masquerading as
a behavioural regression. With that guard and a current binary, this branch has
**no failing tests**.

Redaction is RED/GREEN proven: 30 test functions across 5 files were converted to
assert the redacted wording *and* assert the rule text is absent. Disabling the
from-file arm turns exactly those 30 red and leaves the rest green.

