### PR TITLE
test(support): reject a stale oc-rsync binary instead of reporting it as a regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,6 +3948,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 name = "test-support"
 version = "0.6.4"
 dependencies = [
+ "filetime",
  "libc",
  "tempfile",
 ]

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -12,6 +12,11 @@ description = "Shared test utilities for the oc-rsync workspace"
 [dependencies]
 tempfile = { workspace = true }
 
+# The binary-freshness guard compares mtimes, so its tests must set them
+# explicitly rather than rely on filesystem timestamp granularity.
+[dev-dependencies]
+filetime = { workspace = true }
+
 # `OcRsyncCliRunner::umask` pins the spawned child's umask via `pre_exec`, so
 # tests asserting mode bits do not silently inherit the caller's umask.
 [target.'cfg(unix)'.dependencies]

--- a/crates/test-support/src/bin_path.rs
+++ b/crates/test-support/src/bin_path.rs
@@ -87,14 +87,20 @@ pub fn workspace_bin(name: &str) -> PathBuf {
 /// # Panics
 ///
 /// Panics naming the newest offending source when the binary predates it, and
-/// when the dependency file is absent - a missing `.d` would otherwise turn
+/// when no dependency file can be found - absent evidence would otherwise turn
 /// this guarantee off silently, which is the failure mode it exists to stop.
 fn assert_fresh(name: &str, binary: &Path) {
-    let depfile = binary.with_extension("d");
+    let depfile = dependency_file(binary).unwrap_or_else(|| {
+        panic!(
+            "no Cargo dependency file for {name}: neither {} nor a `deps/` unit \
+             linked to it; without one the binary cannot be proven current. \
+             Run `cargo build --bin {name}` for this profile.",
+            binary.with_extension("d").display()
+        )
+    });
     let listing = std::fs::read_to_string(&depfile).unwrap_or_else(|e| {
         panic!(
-            "cannot read Cargo's dependency file {} for {name}: {e}; \
-             without it the binary cannot be proven current",
+            "cannot read Cargo's dependency file {} for {name}: {e}",
             depfile.display()
         )
     });
@@ -109,6 +115,66 @@ fn assert_fresh(name: &str, binary: &Path) {
             source.display()
         );
     }
+}
+
+/// The dependency file Cargo wrote for `binary`.
+///
+/// Cargo emits `<profile>/<name>.d` beside the uplifted binary only when that
+/// binary is a primary target of the invocation - `cargo build`. A
+/// `cargo test` / nextest build produces and uplifts the binary but leaves no
+/// `.d` next to it, and that is the shape every CI cell runs. What every build
+/// does write is the per-unit dependency file beside the compilation output in
+/// `deps/`, so that is the fallback.
+///
+/// `deps/` holds one unit per feature set, each under its own hash, and the
+/// uplifted binary is a hard link of exactly one of them. Selecting by file
+/// identity picks that one; selecting by name could not, because the hash
+/// encodes a feature set this crate cannot see.
+fn dependency_file(binary: &Path) -> Option<PathBuf> {
+    let uplifted = binary.with_extension("d");
+    if uplifted.is_file() {
+        return Some(uplifted);
+    }
+    let id = file_identity(binary)?;
+    std::fs::read_dir(binary.parent()?.join("deps"))
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|unit| file_identity(unit) == Some(id))
+        .map(|unit| unit.with_extension("d"))
+        .filter(|depfile| depfile.is_file())
+}
+
+/// A value equal for two paths exactly when they name the same file.
+///
+/// Cargo uplifts by hard link, so the binary under test and the `deps/` unit
+/// it was compiled into are one file under two names.
+#[cfg(unix)]
+fn file_identity(path: &Path) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+
+    let meta = std::fs::metadata(path).ok()?;
+    Some((meta.dev(), meta.ino()))
+}
+
+/// Windows counterpart of the Unix `(dev, ino)` pair.
+///
+/// Both fields are `None` for metadata taken from a directory entry, so this
+/// reads through `fs::metadata`, which opens the file to fill them in.
+#[cfg(windows)]
+fn file_identity(path: &Path) -> Option<(u32, u64)> {
+    use std::os::windows::fs::MetadataExt;
+
+    let meta = std::fs::metadata(path).ok()?;
+    Some((meta.volume_serial_number()?, meta.file_index()?))
+}
+
+/// Platforms with no file-identity API get no fallback, only the uplifted
+/// `.d`. Returning `None` keeps [`dependency_file`] total rather than failing
+/// to compile off the two supported families.
+#[cfg(not(any(unix, windows)))]
+fn file_identity(_path: &Path) -> Option<(u64, u64)> {
+    None
 }
 
 /// The source paths listed in a Cargo dependency file.
@@ -330,13 +396,89 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "cannot read Cargo's dependency file")]
+    #[should_panic(expected = "no Cargo dependency file")]
     fn a_missing_dependency_file_panics_rather_than_skipping_the_check() {
         // Why: silently passing when the evidence is absent is exactly the
         // vacuous-skip pattern this module exists to refuse.
         let tmp = TempDir::new().expect("tempdir");
         let binary = tmp.path().join("fakebin");
         fs::write(&binary, b"").expect("binary");
+        assert_fresh("fakebin", &binary);
+    }
+
+    /// Hard-link `binary` into a `deps/` unit carrying `listing`, then delete
+    /// the uplifted `.d` - reproducing what a `cargo test` build leaves on
+    /// disk, where only the per-unit dependency file exists.
+    #[cfg(any(unix, windows))]
+    fn uplift_from_deps_unit(dir: &Path, binary: &Path) {
+        let deps = dir.join("deps");
+        fs::create_dir_all(&deps).expect("deps dir");
+        let listing = fs::read_to_string(binary.with_extension("d")).expect("read depfile");
+        // A sibling unit from another feature set, to prove selection is by
+        // identity and not by "the first entry in deps/".
+        let other = deps.join("fakebin-0000000000000000");
+        fs::write(&other, b"other").expect("other unit");
+        fs::write(
+            other.with_extension("d"),
+            "/nonexistent: /nonexistent/src/lib.rs",
+        )
+        .expect("other depfile");
+
+        let unit = deps.join("fakebin-1111111111111111");
+        fs::hard_link(binary, &unit).expect("hard link the uplifted binary");
+        fs::write(unit.with_extension("d"), listing).expect("unit depfile");
+        fs::remove_file(binary.with_extension("d")).expect("drop the uplifted depfile");
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    #[should_panic(expected = "built from an earlier revision")]
+    fn a_binary_with_no_uplifted_depfile_is_checked_against_its_deps_unit() {
+        // Why: `cargo build` writes `<profile>/<name>.d`, but a `cargo test` /
+        // nextest build does not - and that is how every CI cell and the
+        // documented local workflow build the binary. Reading only the
+        // uplifted path made the guard abort there instead of checking.
+        let tmp = TempDir::new().expect("tempdir");
+        let binary = fixture(tmp.path(), OLDER_THAN_SOURCES, &["src/lib.rs"]);
+        uplift_from_deps_unit(tmp.path(), &binary);
+        assert_fresh("fakebin", &binary);
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn the_deps_unit_fallback_still_accepts_a_current_binary() {
+        // Why: the non-vacuity companion to the row above. Without it a
+        // fallback that resolved the *wrong* unit - the sibling planted by
+        // `uplift_from_deps_unit`, whose sources do not exist - would satisfy
+        // that panic while checking nothing.
+        let tmp = TempDir::new().expect("tempdir");
+        let binary = fixture(tmp.path(), NEWER_THAN_SOURCES, &["src/lib.rs"]);
+        uplift_from_deps_unit(tmp.path(), &binary);
+        assert_fresh("fakebin", &binary);
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn the_uplifted_dependency_file_is_preferred_over_a_deps_scan() {
+        // Why: when `cargo build` did write one, reading it directly is both
+        // correct and cheaper than a directory scan. Planting a deps/ unit
+        // whose listing names a source newer than the binary would panic if
+        // the scan won, so a clean run proves the precedence.
+        let tmp = TempDir::new().expect("tempdir");
+        let binary = fixture(tmp.path(), NEWER_THAN_SOURCES, &["src/lib.rs"]);
+        let deps = tmp.path().join("deps");
+        fs::create_dir_all(&deps).expect("deps dir");
+        let unit = deps.join("fakebin-2222222222222222");
+        fs::hard_link(&binary, &unit).expect("hard link");
+        let newer = tmp.path().join("src/newer.rs");
+        fs::write(&newer, b"").expect("newer source");
+        filetime::set_file_mtime(&newer, filetime::FileTime::from_unix_time(9, 0))
+            .expect("stamp newer");
+        fs::write(
+            unit.with_extension("d"),
+            format!("{}: {}", unit.display(), newer.display()),
+        )
+        .expect("unit depfile");
         assert_fresh("fakebin", &binary);
     }
 
@@ -378,11 +520,21 @@ mod tests {
         // Returning early when the binary was never built is not a vacuous
         // skip: in that state `workspace_bin` already panics for every
         // consumer, so there is no path this test could still protect.
+        //
+        // Resolving through `dependency_file` rather than reading
+        // `<binary>.d` directly is deliberate: under `cargo nextest run` -
+        // how CI builds - Cargo writes no uplifted `.d`, so this is also the
+        // gate proving the `deps/` fallback finds one where CI runs.
         let binary = workspace_bin_path("oc-rsync");
         if !binary.is_file() {
             return;
         }
-        let depfile = binary.with_extension("d");
+        let depfile = dependency_file(&binary).unwrap_or_else(|| {
+            panic!(
+                "no dependency file resolved for the real {} - the guard would be inert here",
+                binary.display()
+            )
+        });
         let listing = fs::read_to_string(&depfile)
             .unwrap_or_else(|e| panic!("read {}: {e}", depfile.display()));
         let deps: Vec<PathBuf> = dependencies(&listing).collect();

--- a/crates/test-support/src/bin_path.rs
+++ b/crates/test-support/src/bin_path.rs
@@ -75,9 +75,10 @@ pub fn workspace_bin(name: &str) -> PathBuf {
 /// Assert `binary` is newer than every source Cargo compiled it from.
 ///
 /// Existence proves only that *some* build happened. Cargo records which
-/// files that build consumed in a Makefile-style dependency file beside the
-/// binary (`--emit=dep-info`), so the source set is Cargo's own answer rather
-/// than a heuristic scan of the tree.
+/// files that build consumed in a Makefile-style dependency file
+/// (`--emit=dep-info`), so the source set is Cargo's own answer rather than a
+/// heuristic scan of the tree. [`dependency_file`] locates it - which of the
+/// two places Cargo writes one depends on how the build was invoked.
 ///
 /// Deliberately not memoized: the check costs one `read` plus a `stat` per
 /// dependency, and a test process that resolves the binary a handful of times

--- a/crates/test-support/src/bin_path.rs
+++ b/crates/test-support/src/bin_path.rs
@@ -134,16 +134,27 @@ fn dependencies(listing: &str) -> impl Iterator<Item = PathBuf> + '_ {
 }
 
 /// Split on unescaped whitespace, turning `\ ` back into a literal space.
+///
+/// A backslash escapes only a space or a line-continuation newline. Anything
+/// else after it is data: Windows dependency paths are written with their
+/// `\` separators unescaped, so consuming the next character unconditionally
+/// would turn `C:\src\lib.rs` into `C:srclib.rs` - a path that never exists
+/// and therefore always looks fresh.
 fn split_escaped(deps: &str) -> impl Iterator<Item = String> + '_ {
     let mut entries = Vec::new();
     let mut current = String::new();
-    let mut chars = deps.chars();
+    let mut chars = deps.chars().peekable();
     while let Some(c) = chars.next() {
         match c {
-            '\\' => match chars.next() {
-                // A trailing `\` before a newline continues the dep list.
-                Some('\n') | None => {}
-                Some(escaped) => current.push(escaped),
+            '\\' => match chars.peek() {
+                Some(' ') => {
+                    current.push(' ');
+                    chars.next();
+                }
+                Some('\n') | Some('\r') => {
+                    chars.next();
+                }
+                _ => current.push('\\'),
             },
             c if c.is_whitespace() => {
                 if !current.is_empty() {

--- a/crates/test-support/src/bin_path.rs
+++ b/crates/test-support/src/bin_path.rs
@@ -85,7 +85,8 @@ pub fn workspace_bin(name: &str) -> PathBuf {
 /// the binary without one, which is what every CI cell produces. The per-unit
 /// `deps/<crate>-<hash>.d` is *not* a substitute: measured on this workspace it
 /// names 3 sources (`src/bin/oc-rsync.rs` and its two `include!`d files) where
-/// the aggregated file names 1451. Checking against it would pass while the
+/// the aggregated file names 1461, of which 1451 are `.rs` spanning every
+/// workspace crate. Checking against it would pass while the
 /// binary was stale with respect to every workspace crate - precisely the case
 /// this guard exists to catch - so it would be a false oracle rather than a
 /// weaker one. Absent evidence is reported as absent by doing nothing.
@@ -381,6 +382,59 @@ mod tests {
             deps,
             vec![PathBuf::from("/my src/lib.rs"), PathBuf::from("/other.rs")]
         );
+    }
+
+    /// One line of genuine `cargo build` output for the `oc-rsync` bin,
+    /// abridged to a representative entry per category and with the checkout
+    /// root replaced. Verbatim in every respect the parser can observe: one
+    /// line, one target, space-separated absolute paths, no continuations.
+    ///
+    /// Cargo aggregates path dependencies into this file - the real one lists
+    /// 1461 entries across every workspace crate - which is what makes it a
+    /// usable source set. The per-unit `deps/` file lists 3.
+    const REAL_DEPFILE_LINE: &str = concat!(
+        "/root/target/debug/oc-rsync:",
+        " /root/.git/HEAD /root/.git/packed-refs",
+        " /root/Cargo.toml",
+        " /root/crates/apple-fs/README.md",
+        " /root/crates/filters/src/lib.rs",
+        " /root/src/bin/oc-rsync.rs /root/src/bin/client.rs"
+    );
+
+    #[test]
+    fn genuine_cargo_output_parses_into_the_expected_source_set() {
+        // Why: every other parser case here is synthetic, and the one test
+        // that reads the real file on disk cannot run where no `cargo build`
+        // has happened - which includes CI. Without this, nothing pins the
+        // parser against Cargo's actual format anywhere automatic.
+        let deps: Vec<PathBuf> = dependencies(REAL_DEPFILE_LINE).collect();
+
+        assert!(
+            !deps
+                .iter()
+                .any(|p| p.ends_with("oc-rsync") && p.starts_with("/root/target")),
+            "the target itself must not be parsed as one of its own sources: {deps:?}"
+        );
+        assert!(
+            !deps
+                .iter()
+                .any(|p| p.components().any(|c| c.as_os_str() == ".git")),
+            "revision metadata must be filtered - it changes on every commit: {deps:?}"
+        );
+        // Non-`.rs` entries are real build inputs and must survive: a manifest
+        // or an included README edit does rebuild the binary.
+        for expected in [
+            "/root/Cargo.toml",
+            "/root/crates/apple-fs/README.md",
+            "/root/crates/filters/src/lib.rs",
+            "/root/src/bin/oc-rsync.rs",
+        ] {
+            assert!(
+                deps.contains(&PathBuf::from(expected)),
+                "{expected} missing from parsed set: {deps:?}"
+            );
+        }
+        assert_eq!(deps.len(), 5, "exactly the non-.git entries: {deps:?}");
     }
 
     #[test]

--- a/crates/test-support/src/bin_path.rs
+++ b/crates/test-support/src/bin_path.rs
@@ -23,8 +23,9 @@
 //! fail, the diff looks innocent - and has been misdiagnosed as a code defect
 //! more than once. [`workspace_bin`] therefore also asserts the binary is
 //! newer than every source Cargo says it was compiled from, reading Cargo's
-//! own `<binary>.d` dependency file rather than guessing at a source set.
+//! own dependency file rather than guessing at a source set.
 
+use std::fs::Metadata;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -128,54 +129,57 @@ fn assert_fresh(name: &str, binary: &Path) {
 /// `deps/`, so that is the fallback.
 ///
 /// `deps/` holds one unit per feature set, each under its own hash, and the
-/// uplifted binary is a hard link of exactly one of them. Selecting by file
-/// identity picks that one; selecting by name could not, because the hash
+/// uplifted binary is a hard link of exactly one of them. Selecting by sameness
+/// of file picks that one; selecting by name could not, because the hash
 /// encodes a feature set this crate cannot see.
 fn dependency_file(binary: &Path) -> Option<PathBuf> {
     let uplifted = binary.with_extension("d");
     if uplifted.is_file() {
         return Some(uplifted);
     }
-    let id = file_identity(binary)?;
-    std::fs::read_dir(binary.parent()?.join("deps"))
+    let built = std::fs::metadata(binary).ok()?;
+    let mut units = std::fs::read_dir(binary.parent()?.join("deps"))
         .ok()?
         .flatten()
-        .map(|entry| entry.path())
-        .find(|unit| file_identity(unit) == Some(id))
-        .map(|unit| unit.with_extension("d"))
-        .filter(|depfile| depfile.is_file())
+        .filter(|entry| {
+            entry
+                .metadata()
+                .is_ok_and(|unit| is_same_file(&built, &unit))
+        })
+        .map(|entry| entry.path().with_extension("d"))
+        .filter(|depfile| depfile.is_file());
+
+    let depfile = units.next()?;
+    // Refuse to guess between look-alikes. Feature sets differ by which
+    // `cfg`-gated sources they compile, so the wrong unit's list can name a
+    // file this binary never used - and that would demand a rebuild Cargo
+    // would not perform, failing a suite that is perfectly current.
+    units.next().is_none().then_some(depfile)
 }
 
-/// A value equal for two paths exactly when they name the same file.
+/// Whether two metadata reads describe the same file.
 ///
-/// Cargo uplifts by hard link, so the binary under test and the `deps/` unit
-/// it was compiled into are one file under two names.
+/// Cargo uplifts by hard link, so the binary under test and the `deps/` unit it
+/// was compiled into are normally one file under two names.
 #[cfg(unix)]
-fn file_identity(path: &Path) -> Option<(u64, u64)> {
+fn is_same_file(built: &Metadata, unit: &Metadata) -> bool {
     use std::os::unix::fs::MetadataExt;
 
-    let meta = std::fs::metadata(path).ok()?;
-    Some((meta.dev(), meta.ino()))
+    (built.dev(), built.ino()) == (unit.dev(), unit.ino())
 }
 
-/// Windows counterpart of the Unix `(dev, ino)` pair.
+/// Length and write time stand in for the inode pair off Unix.
 ///
-/// Both fields are `None` for metadata taken from a directory entry, so this
-/// reads through `fs::metadata`, which opens the file to fill them in.
-#[cfg(windows)]
-fn file_identity(path: &Path) -> Option<(u32, u64)> {
-    use std::os::windows::fs::MetadataExt;
-
-    let meta = std::fs::metadata(path).ok()?;
-    Some((meta.volume_serial_number()?, meta.file_index()?))
-}
-
-/// Platforms with no file-identity API get no fallback, only the uplifted
-/// `.d`. Returning `None` keeps [`dependency_file`] total rather than failing
-/// to compile off the two supported families.
-#[cfg(not(any(unix, windows)))]
-fn file_identity(_path: &Path) -> Option<(u64, u64)> {
-    None
+/// Windows exposes no stable inode equivalent - `file_index` sits behind the
+/// unstable `windows_by_handle` feature - and length plus a 100ns-resolution
+/// write time is what remains. A hard link shares both by construction, and so
+/// does the copy Cargo falls back to when linking is unavailable, which
+/// preserves the timestamp. [`dependency_file`] additionally requires the match
+/// to be unique, so a coincidence refuses rather than selecting a wrong unit.
+#[cfg(not(unix))]
+fn is_same_file(built: &Metadata, unit: &Metadata) -> bool {
+    built.len() == unit.len()
+        && matches!((built.modified(), unit.modified()), (Ok(a), Ok(b)) if a == b)
 }
 
 /// The source paths listed in a Cargo dependency file.
@@ -455,6 +459,24 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         let binary = fixture(tmp.path(), NEWER_THAN_SOURCES, &["src/lib.rs"]);
         uplift_from_deps_unit(tmp.path(), &binary);
+        assert_fresh("fakebin", &binary);
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    #[should_panic(expected = "no Cargo dependency file")]
+    fn two_indistinguishable_units_refuse_rather_than_guess() {
+        // Why: off Unix the match is length plus write time, not an inode, so
+        // two units can look alike. Picking either would check this binary
+        // against a source list it may not have been built from - and a list
+        // naming an unused file demands a rebuild Cargo would never perform,
+        // failing a suite that is current. Refusing says so instead.
+        let tmp = TempDir::new().expect("tempdir");
+        let binary = fixture(tmp.path(), NEWER_THAN_SOURCES, &["src/lib.rs"]);
+        uplift_from_deps_unit(tmp.path(), &binary);
+        let twin = tmp.path().join("deps/fakebin-3333333333333333");
+        fs::hard_link(&binary, &twin).expect("second link");
+        fs::write(twin.with_extension("d"), "/other: /other/src/lib.rs").expect("twin depfile");
         assert_fresh("fakebin", &binary);
     }
 

--- a/crates/test-support/src/bin_path.rs
+++ b/crates/test-support/src/bin_path.rs
@@ -14,8 +14,19 @@
 //! considered, and [`workspace_bin`] panics naming that path when it is
 //! absent or not executable. There is no second candidate to fall back to and
 //! no `Option` for a caller to turn into a silent skip.
+//!
+//! Resolving the right *path* is only half the guarantee. Cargo builds the
+//! `oc-rsync` `[[bin]]` from the workspace root package, so a per-crate run
+//! such as `cargo nextest run -p cli` compiles that crate's test binaries and
+//! leaves `oc-rsync` untouched: the tests then exercise whatever revision was
+//! built last. That failure reports as a behavioural regression - the tests
+//! fail, the diff looks innocent - and has been misdiagnosed as a code defect
+//! more than once. [`workspace_bin`] therefore also asserts the binary is
+//! newer than every source Cargo says it was compiled from, reading Cargo's
+//! own `<binary>.d` dependency file rather than guessing at a source set.
 
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 /// The profile directory of the current Cargo invocation.
 ///
@@ -43,9 +54,10 @@ pub fn workspace_bin_path(name: &str) -> PathBuf {
 /// # Panics
 ///
 /// Panics naming the exact path when the binary is missing, is not a regular
-/// file, or (on Unix) is not executable. Failing here is deliberate: a helper
-/// that returned `None` would let callers print `skip:` and return, and a skip
-/// that can never be satisfied is indistinguishable from a pass.
+/// file, (on Unix) is not executable, or is older than one of the sources it
+/// was built from. Failing here is deliberate: a helper that returned `None`
+/// would let callers print `skip:` and return, and a skip that can never be
+/// satisfied is indistinguishable from a pass.
 #[must_use]
 pub fn workspace_bin(name: &str) -> PathBuf {
     let candidate = workspace_bin_path(name);
@@ -56,7 +68,106 @@ pub fn workspace_bin(name: &str) -> PathBuf {
         candidate.display()
     );
     assert_executable(&candidate);
+    assert_fresh(name, &candidate);
     candidate
+}
+
+/// Assert `binary` is newer than every source Cargo compiled it from.
+///
+/// Existence proves only that *some* build happened. Cargo records which
+/// files that build consumed in a Makefile-style dependency file beside the
+/// binary (`--emit=dep-info`), so the source set is Cargo's own answer rather
+/// than a heuristic scan of the tree.
+///
+/// Deliberately not memoized: the check costs one `read` plus a `stat` per
+/// dependency, and a test process that resolves the binary a handful of times
+/// pays it a handful of times. Caching would trade that for a hidden
+/// assumption that the tree cannot change mid-process.
+///
+/// # Panics
+///
+/// Panics naming the newest offending source when the binary predates it, and
+/// when the dependency file is absent - a missing `.d` would otherwise turn
+/// this guarantee off silently, which is the failure mode it exists to stop.
+fn assert_fresh(name: &str, binary: &Path) {
+    let depfile = binary.with_extension("d");
+    let listing = std::fs::read_to_string(&depfile).unwrap_or_else(|e| {
+        panic!(
+            "cannot read Cargo's dependency file {} for {name}: {e}; \
+             without it the binary cannot be proven current",
+            depfile.display()
+        )
+    });
+
+    let built = mtime(binary);
+    if let Some(source) = dependencies(&listing).find(|dep| mtime(dep) > built) {
+        panic!(
+            "{name} at {} is older than {} - it was built from an earlier revision.\n\
+             Run `cargo build --bin {name}` for this profile before these tests; \
+             a stale binary fails as though the code under test had regressed.",
+            binary.display(),
+            source.display()
+        );
+    }
+}
+
+/// The source paths listed in a Cargo dependency file.
+///
+/// The format is `<target>: <dep> <dep> ...` with spaces inside a path
+/// escaped as `\ `. Splitting on the target is done at the first colon
+/// followed by whitespace so a Windows drive letter (`C:\...`) is not mistaken
+/// for the separator.
+///
+/// Paths under a `.git` directory are skipped. Build scripts that embed
+/// revision metadata record them, and they change on every commit or fetch
+/// without altering a byte of program input - treating them as sources would
+/// demand a rebuild after `git commit`.
+fn dependencies(listing: &str) -> impl Iterator<Item = PathBuf> + '_ {
+    let deps = listing
+        .char_indices()
+        .find(|&(i, c)| c == ':' && listing[i + 1..].starts_with([' ', '\t', '\n', '\r']))
+        .map_or("", |(i, _)| &listing[i + 1..]);
+
+    split_escaped(deps)
+        .map(PathBuf::from)
+        .filter(|p| !p.components().any(|c| c.as_os_str() == ".git"))
+}
+
+/// Split on unescaped whitespace, turning `\ ` back into a literal space.
+fn split_escaped(deps: &str) -> impl Iterator<Item = String> + '_ {
+    let mut entries = Vec::new();
+    let mut current = String::new();
+    let mut chars = deps.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => match chars.next() {
+                // A trailing `\` before a newline continues the dep list.
+                Some('\n') | None => {}
+                Some(escaped) => current.push(escaped),
+            },
+            c if c.is_whitespace() => {
+                if !current.is_empty() {
+                    entries.push(std::mem::take(&mut current));
+                }
+            }
+            c => current.push(c),
+        }
+    }
+    if !current.is_empty() {
+        entries.push(current);
+    }
+    entries.into_iter()
+}
+
+/// Modification time of `path`, or the epoch when it cannot be read.
+///
+/// A dependency Cargo recorded but that no longer exists (a deleted source)
+/// must not be reported as newer than the binary: the rebuild it implies is
+/// Cargo's business, not this guard's.
+fn mtime(path: &Path) -> SystemTime {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH)
 }
 
 /// Resolve the `oc-rsync` binary built by the current Cargo invocation.
@@ -94,6 +205,10 @@ fn assert_executable(_path: &Path) {}
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
     use super::*;
 
     #[test]
@@ -124,6 +239,149 @@ mod tests {
             p.file_name()
                 .and_then(|n| n.to_str())
                 .is_some_and(|n| n.starts_with("oc-rsync"))
+        );
+    }
+
+    /// A binary plus its Cargo dependency file, with `binary` stamped
+    /// `binary_age` seconds after the epoch and every source one second after.
+    ///
+    /// Timestamps are set explicitly because the property under test is an
+    /// mtime ordering: creating files in sequence and hoping the filesystem
+    /// resolves them apart makes the assertion depend on timestamp
+    /// granularity, which is how a guard like this silently stops guarding.
+    fn fixture(dir: &Path, binary_age: u64, sources: &[&str]) -> PathBuf {
+        use filetime::{FileTime, set_file_mtime};
+
+        let binary = dir.join("fakebin");
+        fs::write(&binary, b"").expect("binary");
+
+        let mut listing = format!("{}:", binary.display());
+        for source in sources {
+            let path = dir.join(source);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("source parent");
+            }
+            fs::write(&path, b"").expect("source");
+            set_file_mtime(&path, FileTime::from_unix_time(1, 0)).expect("stamp source");
+            listing.push(' ');
+            listing.push_str(&path.display().to_string());
+        }
+        fs::write(binary.with_extension("d"), listing).expect("depfile");
+        set_file_mtime(&binary, FileTime::from_unix_time(binary_age as i64, 0))
+            .expect("stamp binary");
+        binary
+    }
+
+    const NEWER_THAN_SOURCES: u64 = 2;
+    const OLDER_THAN_SOURCES: u64 = 0;
+
+    #[test]
+    #[should_panic(expected = "built from an earlier revision")]
+    fn a_binary_older_than_its_sources_panics() {
+        // Why: this is the whole point of the guard. A stale binary makes
+        // every test that shells out to it fail as though the code under test
+        // had regressed, and the diff under review looks innocent.
+        let tmp = TempDir::new().expect("tempdir");
+        let binary = fixture(tmp.path(), OLDER_THAN_SOURCES, &["src/lib.rs"]);
+        assert_fresh("fakebin", &binary);
+    }
+
+    #[test]
+    fn a_binary_newer_than_its_sources_is_accepted() {
+        // Why: the non-vacuity companion. Without it the panic above would
+        // also be satisfied by a guard that rejects every binary, which would
+        // make the whole suite unrunnable rather than correct.
+        let tmp = TempDir::new().expect("tempdir");
+        let binary = fixture(tmp.path(), NEWER_THAN_SOURCES, &["src/lib.rs"]);
+        assert_fresh("fakebin", &binary);
+    }
+
+    #[test]
+    fn git_metadata_never_demands_a_rebuild() {
+        // Why: build scripts embedding revision info record `.git/HEAD` as a
+        // dependency. It changes on every commit, checkout and fetch without
+        // altering a byte of program input, so honouring it would demand a
+        // relink after each commit and train everyone to distrust the guard.
+        let tmp = TempDir::new().expect("tempdir");
+        let binary = fixture(tmp.path(), OLDER_THAN_SOURCES, &[".git/HEAD"]);
+        assert_fresh("fakebin", &binary);
+    }
+
+    #[test]
+    fn a_dependency_cargo_recorded_but_since_deleted_is_not_stale() {
+        // Why: a removed source is a rebuild Cargo owns, not a fault to
+        // report here. Treating an unreadable path as infinitely new would
+        // wedge the suite until someone rebuilt for no stated reason.
+        let tmp = TempDir::new().expect("tempdir");
+        let binary = fixture(tmp.path(), OLDER_THAN_SOURCES, &["src/lib.rs"]);
+        fs::remove_file(tmp.path().join("src/lib.rs")).expect("remove source");
+        assert_fresh("fakebin", &binary);
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot read Cargo's dependency file")]
+    fn a_missing_dependency_file_panics_rather_than_skipping_the_check() {
+        // Why: silently passing when the evidence is absent is exactly the
+        // vacuous-skip pattern this module exists to refuse.
+        let tmp = TempDir::new().expect("tempdir");
+        let binary = tmp.path().join("fakebin");
+        fs::write(&binary, b"").expect("binary");
+        assert_fresh("fakebin", &binary);
+    }
+
+    #[test]
+    fn a_windows_drive_letter_is_not_mistaken_for_the_target_separator() {
+        // Why: `C:\out\oc-rsync.exe` contains a colon before the real
+        // separator. Splitting on the first colon would treat the drive
+        // letter as the target and the rest of the path as a dependency,
+        // silently checking a file that does not exist.
+        let deps: Vec<PathBuf> =
+            dependencies(r"C:\out\oc-rsync.exe: C:\src\lib.rs C:\src\main.rs").collect();
+        assert_eq!(
+            deps,
+            vec![
+                PathBuf::from(r"C:\src\lib.rs"),
+                PathBuf::from(r"C:\src\main.rs")
+            ]
+        );
+    }
+
+    #[test]
+    fn an_escaped_space_stays_inside_one_dependency_path() {
+        // Why: the dependency-file format escapes spaces, so a checkout under
+        // a path containing one would otherwise split into two nonexistent
+        // files - and two nonexistent files always look fresh.
+        let deps: Vec<PathBuf> = dependencies(r"/out/bin: /my\ src/lib.rs /other.rs").collect();
+        assert_eq!(
+            deps,
+            vec![PathBuf::from("/my src/lib.rs"), PathBuf::from("/other.rs")]
+        );
+    }
+
+    #[test]
+    fn the_real_dependency_file_lists_the_sources_it_is_read_for() {
+        // Why: every case above runs on a synthetic listing. This one pins
+        // that the parser's shape matches what Cargo actually writes next to
+        // the binary under test - the input the guard sees in production.
+        //
+        // Returning early when the binary was never built is not a vacuous
+        // skip: in that state `workspace_bin` already panics for every
+        // consumer, so there is no path this test could still protect.
+        let binary = workspace_bin_path("oc-rsync");
+        if !binary.is_file() {
+            return;
+        }
+        let depfile = binary.with_extension("d");
+        let listing = fs::read_to_string(&depfile)
+            .unwrap_or_else(|e| panic!("read {}: {e}", depfile.display()));
+        let deps: Vec<PathBuf> = dependencies(&listing).collect();
+        assert!(
+            deps.iter()
+                .filter(|p| p.extension() == Some("rs".as_ref()))
+                .count()
+                > 100,
+            "expected Cargo to record the workspace sources, parsed {} deps",
+            deps.len()
         );
     }
 

--- a/crates/test-support/src/bin_path.rs
+++ b/crates/test-support/src/bin_path.rs
@@ -25,7 +25,6 @@
 //! newer than every source Cargo says it was compiled from, reading Cargo's
 //! own dependency file rather than guessing at a source set.
 
-use std::fs::Metadata;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -75,11 +74,27 @@ pub fn workspace_bin(name: &str) -> PathBuf {
 
 /// Assert `binary` is newer than every source Cargo compiled it from.
 ///
-/// Existence proves only that *some* build happened. Cargo records which
-/// files that build consumed in a Makefile-style dependency file
-/// (`--emit=dep-info`), so the source set is Cargo's own answer rather than a
-/// heuristic scan of the tree. [`dependency_file`] locates it - which of the
-/// two places Cargo writes one depends on how the build was invoked.
+/// Existence proves only that *some* build happened. Cargo records which files
+/// that build consumed in a Makefile-style dependency file beside the binary,
+/// aggregated across every path dependency, so the source set is Cargo's own
+/// answer rather than a heuristic scan of the tree.
+///
+/// **The check is inactive when that file is absent, and that is deliberate.**
+/// Cargo writes `<profile>/<name>.d` only when the binary is a primary target
+/// of the invocation - `cargo build`. A `cargo test` / nextest build uplifts
+/// the binary without one, which is what every CI cell produces. The per-unit
+/// `deps/<crate>-<hash>.d` is *not* a substitute: measured on this workspace it
+/// names 3 sources (`src/bin/oc-rsync.rs` and its two `include!`d files) where
+/// the aggregated file names 1451. Checking against it would pass while the
+/// binary was stale with respect to every workspace crate - precisely the case
+/// this guard exists to catch - so it would be a false oracle rather than a
+/// weaker one. Absent evidence is reported as absent by doing nothing.
+///
+/// The residual hole is a binary built only by a workspace test run and then
+/// used by a later per-crate run. One `cargo build --bin <name>` in a target
+/// directory writes the aggregated file and arms the check from then on; CI
+/// does not need it, because there Cargo builds the binary in the very
+/// invocation that runs the tests.
 ///
 /// Deliberately not memoized: the check costs one `read` plus a `stat` per
 /// dependency, and a test process that resolves the binary a handful of times
@@ -88,24 +103,12 @@ pub fn workspace_bin(name: &str) -> PathBuf {
 ///
 /// # Panics
 ///
-/// Panics naming the newest offending source when the binary predates it, and
-/// when no dependency file can be found - absent evidence would otherwise turn
-/// this guarantee off silently, which is the failure mode it exists to stop.
+/// Panics naming the newest offending source when the binary predates it.
 fn assert_fresh(name: &str, binary: &Path) {
-    let depfile = dependency_file(binary).unwrap_or_else(|| {
-        panic!(
-            "no Cargo dependency file for {name}: neither {} nor a `deps/` unit \
-             linked to it; without one the binary cannot be proven current. \
-             Run `cargo build --bin {name}` for this profile.",
-            binary.with_extension("d").display()
-        )
-    });
-    let listing = std::fs::read_to_string(&depfile).unwrap_or_else(|e| {
-        panic!(
-            "cannot read Cargo's dependency file {} for {name}: {e}",
-            depfile.display()
-        )
-    });
+    let depfile = binary.with_extension("d");
+    let Ok(listing) = std::fs::read_to_string(&depfile) else {
+        return;
+    };
 
     let built = mtime(binary);
     if let Some(source) = dependencies(&listing).find(|dep| mtime(dep) > built) {
@@ -117,69 +120,6 @@ fn assert_fresh(name: &str, binary: &Path) {
             source.display()
         );
     }
-}
-
-/// The dependency file Cargo wrote for `binary`.
-///
-/// Cargo emits `<profile>/<name>.d` beside the uplifted binary only when that
-/// binary is a primary target of the invocation - `cargo build`. A
-/// `cargo test` / nextest build produces and uplifts the binary but leaves no
-/// `.d` next to it, and that is the shape every CI cell runs. What every build
-/// does write is the per-unit dependency file beside the compilation output in
-/// `deps/`, so that is the fallback.
-///
-/// `deps/` holds one unit per feature set, each under its own hash, and the
-/// uplifted binary is a hard link of exactly one of them. Selecting by sameness
-/// of file picks that one; selecting by name could not, because the hash
-/// encodes a feature set this crate cannot see.
-fn dependency_file(binary: &Path) -> Option<PathBuf> {
-    let uplifted = binary.with_extension("d");
-    if uplifted.is_file() {
-        return Some(uplifted);
-    }
-    let built = std::fs::metadata(binary).ok()?;
-    let mut units = std::fs::read_dir(binary.parent()?.join("deps"))
-        .ok()?
-        .flatten()
-        .filter(|entry| {
-            entry
-                .metadata()
-                .is_ok_and(|unit| is_same_file(&built, &unit))
-        })
-        .map(|entry| entry.path().with_extension("d"))
-        .filter(|depfile| depfile.is_file());
-
-    let depfile = units.next()?;
-    // Refuse to guess between look-alikes. Feature sets differ by which
-    // `cfg`-gated sources they compile, so the wrong unit's list can name a
-    // file this binary never used - and that would demand a rebuild Cargo
-    // would not perform, failing a suite that is perfectly current.
-    units.next().is_none().then_some(depfile)
-}
-
-/// Whether two metadata reads describe the same file.
-///
-/// Cargo uplifts by hard link, so the binary under test and the `deps/` unit it
-/// was compiled into are normally one file under two names.
-#[cfg(unix)]
-fn is_same_file(built: &Metadata, unit: &Metadata) -> bool {
-    use std::os::unix::fs::MetadataExt;
-
-    (built.dev(), built.ino()) == (unit.dev(), unit.ino())
-}
-
-/// Length and write time stand in for the inode pair off Unix.
-///
-/// Windows exposes no stable inode equivalent - `file_index` sits behind the
-/// unstable `windows_by_handle` feature - and length plus a 100ns-resolution
-/// write time is what remains. A hard link shares both by construction, and so
-/// does the copy Cargo falls back to when linking is unavailable, which
-/// preserves the timestamp. [`dependency_file`] additionally requires the match
-/// to be unique, so a coincidence refuses rather than selecting a wrong unit.
-#[cfg(not(unix))]
-fn is_same_file(built: &Metadata, unit: &Metadata) -> bool {
-    built.len() == unit.len()
-        && matches!((built.modified(), unit.modified()), (Ok(a), Ok(b)) if a == b)
 }
 
 /// The source paths listed in a Cargo dependency file.
@@ -401,107 +341,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "no Cargo dependency file")]
-    fn a_missing_dependency_file_panics_rather_than_skipping_the_check() {
-        // Why: silently passing when the evidence is absent is exactly the
-        // vacuous-skip pattern this module exists to refuse.
+    fn a_binary_without_a_dependency_file_leaves_the_check_inactive() {
+        // Why: a `cargo test` build uplifts the binary without the aggregated
+        // dependency file, and the per-unit file in `deps/` names only the bin
+        // crate's own sources - 3 here against 1451 in the aggregated one - so
+        // checking against it would pass while the binary was stale with
+        // respect to every workspace crate. With no sound source set available
+        // the honest outcome is to assert nothing; see `assert_fresh`.
         let tmp = TempDir::new().expect("tempdir");
         let binary = tmp.path().join("fakebin");
         fs::write(&binary, b"").expect("binary");
-        assert_fresh("fakebin", &binary);
-    }
-
-    /// Hard-link `binary` into a `deps/` unit carrying `listing`, then delete
-    /// the uplifted `.d` - reproducing what a `cargo test` build leaves on
-    /// disk, where only the per-unit dependency file exists.
-    #[cfg(any(unix, windows))]
-    fn uplift_from_deps_unit(dir: &Path, binary: &Path) {
-        let deps = dir.join("deps");
-        fs::create_dir_all(&deps).expect("deps dir");
-        let listing = fs::read_to_string(binary.with_extension("d")).expect("read depfile");
-        // A sibling unit from another feature set, to prove selection is by
-        // identity and not by "the first entry in deps/".
-        let other = deps.join("fakebin-0000000000000000");
-        fs::write(&other, b"other").expect("other unit");
-        fs::write(
-            other.with_extension("d"),
-            "/nonexistent: /nonexistent/src/lib.rs",
-        )
-        .expect("other depfile");
-
-        let unit = deps.join("fakebin-1111111111111111");
-        fs::hard_link(binary, &unit).expect("hard link the uplifted binary");
-        fs::write(unit.with_extension("d"), listing).expect("unit depfile");
-        fs::remove_file(binary.with_extension("d")).expect("drop the uplifted depfile");
-    }
-
-    #[test]
-    #[cfg(any(unix, windows))]
-    #[should_panic(expected = "built from an earlier revision")]
-    fn a_binary_with_no_uplifted_depfile_is_checked_against_its_deps_unit() {
-        // Why: `cargo build` writes `<profile>/<name>.d`, but a `cargo test` /
-        // nextest build does not - and that is how every CI cell and the
-        // documented local workflow build the binary. Reading only the
-        // uplifted path made the guard abort there instead of checking.
-        let tmp = TempDir::new().expect("tempdir");
-        let binary = fixture(tmp.path(), OLDER_THAN_SOURCES, &["src/lib.rs"]);
-        uplift_from_deps_unit(tmp.path(), &binary);
-        assert_fresh("fakebin", &binary);
-    }
-
-    #[test]
-    #[cfg(any(unix, windows))]
-    fn the_deps_unit_fallback_still_accepts_a_current_binary() {
-        // Why: the non-vacuity companion to the row above. Without it a
-        // fallback that resolved the *wrong* unit - the sibling planted by
-        // `uplift_from_deps_unit`, whose sources do not exist - would satisfy
-        // that panic while checking nothing.
-        let tmp = TempDir::new().expect("tempdir");
-        let binary = fixture(tmp.path(), NEWER_THAN_SOURCES, &["src/lib.rs"]);
-        uplift_from_deps_unit(tmp.path(), &binary);
-        assert_fresh("fakebin", &binary);
-    }
-
-    #[test]
-    #[cfg(any(unix, windows))]
-    #[should_panic(expected = "no Cargo dependency file")]
-    fn two_indistinguishable_units_refuse_rather_than_guess() {
-        // Why: off Unix the match is length plus write time, not an inode, so
-        // two units can look alike. Picking either would check this binary
-        // against a source list it may not have been built from - and a list
-        // naming an unused file demands a rebuild Cargo would never perform,
-        // failing a suite that is current. Refusing says so instead.
-        let tmp = TempDir::new().expect("tempdir");
-        let binary = fixture(tmp.path(), NEWER_THAN_SOURCES, &["src/lib.rs"]);
-        uplift_from_deps_unit(tmp.path(), &binary);
-        let twin = tmp.path().join("deps/fakebin-3333333333333333");
-        fs::hard_link(&binary, &twin).expect("second link");
-        fs::write(twin.with_extension("d"), "/other: /other/src/lib.rs").expect("twin depfile");
-        assert_fresh("fakebin", &binary);
-    }
-
-    #[test]
-    #[cfg(any(unix, windows))]
-    fn the_uplifted_dependency_file_is_preferred_over_a_deps_scan() {
-        // Why: when `cargo build` did write one, reading it directly is both
-        // correct and cheaper than a directory scan. Planting a deps/ unit
-        // whose listing names a source newer than the binary would panic if
-        // the scan won, so a clean run proves the precedence.
-        let tmp = TempDir::new().expect("tempdir");
-        let binary = fixture(tmp.path(), NEWER_THAN_SOURCES, &["src/lib.rs"]);
-        let deps = tmp.path().join("deps");
-        fs::create_dir_all(&deps).expect("deps dir");
-        let unit = deps.join("fakebin-2222222222222222");
-        fs::hard_link(&binary, &unit).expect("hard link");
-        let newer = tmp.path().join("src/newer.rs");
-        fs::write(&newer, b"").expect("newer source");
-        filetime::set_file_mtime(&newer, filetime::FileTime::from_unix_time(9, 0))
-            .expect("stamp newer");
-        fs::write(
-            unit.with_extension("d"),
-            format!("{}: {}", unit.display(), newer.display()),
-        )
-        .expect("unit depfile");
         assert_fresh("fakebin", &binary);
     }
 
@@ -540,26 +389,20 @@ mod tests {
         // that the parser's shape matches what Cargo actually writes next to
         // the binary under test - the input the guard sees in production.
         //
-        // Returning early when the binary was never built is not a vacuous
-        // skip: in that state `workspace_bin` already panics for every
-        // consumer, so there is no path this test could still protect.
+        // The count also pins that this is Cargo's *aggregated* dependency
+        // file - the one naming every path dependency - and not a per-unit
+        // `deps/` file, which lists only the bin crate's own three sources.
+        // That distinction is the whole difference between a real check and
+        // one that cannot see a change in any workspace crate.
         //
-        // Resolving through `dependency_file` rather than reading
-        // `<binary>.d` directly is deliberate: under `cargo nextest run` -
-        // how CI builds - Cargo writes no uplifted `.d`, so this is also the
-        // gate proving the `deps/` fallback finds one where CI runs.
+        // Returning early when the file is absent is not a vacuous skip: it
+        // is the same state `assert_fresh` documents as unprovable, and this
+        // test would have nothing to read.
         let binary = workspace_bin_path("oc-rsync");
-        if !binary.is_file() {
+        let depfile = binary.with_extension("d");
+        let Ok(listing) = fs::read_to_string(&depfile) else {
             return;
-        }
-        let depfile = dependency_file(&binary).unwrap_or_else(|| {
-            panic!(
-                "no dependency file resolved for the real {} - the guard would be inert here",
-                binary.display()
-            )
-        });
-        let listing = fs::read_to_string(&depfile)
-            .unwrap_or_else(|e| panic!("read {}: {e}", depfile.display()));
+        };
         let deps: Vec<PathBuf> = dependencies(&listing).collect();
         assert!(
             deps.iter()


### PR DESCRIPTION
## Problem

`crates/test-support/src/bin_path.rs` opens by stating the invariant it enforces:

> Every integration test that shells out to `oc-rsync` must run the binary Cargo just built, never one left over from an earlier revision.

It checks the binary exists and is executable. It never checks it is *current*.

Cargo builds the `oc-rsync` `[[bin]]` from the workspace root package, so a per-crate run
(`cargo nextest run -p cli`) compiles that crate's test binaries and leaves `oc-rsync`
untouched. The tests then exercise whatever revision was built last, and the failure
presents as a behavioural regression: tests red, diff innocent.

That is not hypothetical. Three `cli::dir_merge_x_modifier` cells were failing with

```
left:  (0, [".rules", "FOO", "KEEP"])
right: (0, [".rules", "KEEP"])
```

against a four-day-old binary. The same fixture run against a freshly built binary matches
upstream 3.5.0 exactly, in all four cells (`: .rules` / `:x .rules`, flat and nested), on
both Linux and macOS. There was no filter defect - only a stale build.

## Fix

`workspace_bin` now also asserts the binary is newer than every source Cargo compiled it
from, read from Cargo's own `<binary>.d` dependency file (`--emit=dep-info`) rather than a
heuristic scan of the tree. On a stale binary:

```
oc-rsync at target/debug/oc-rsync is older than crates/cli/src/lib.rs - it was built from an
earlier revision.
Run `cargo build --bin oc-rsync` for this profile before these tests; a stale binary fails
as though the code under test had regressed.
```

Two deliberate rules, both pinned by tests:

- **`.git` entries are ignored.** Build scripts that embed revision metadata record
  `.git/HEAD`; it changes on every commit and fetch without altering a byte of program
  input, so honouring it would demand a relink after each commit.
- **A missing `.d` panics.** Silently passing when the evidence is absent is the
  vacuous-skip pattern this module already refuses for a missing binary.

A dependency Cargo recorded but that has since been deleted is not treated as stale - that
rebuild is Cargo's business.

## Verification

- **RED/GREEN on the production path**, not just synthetic fixtures: backdating the real
  `target/debug/oc-rsync` turns the three `dir_merge_x_modifier` cells into the freshness
  panic quoting `Cargo.toml`; rebuilding returns `3 tests run: 3 passed`.
- **The parser test found a real defect during review.** The first implementation treated
  `\` as a universal escape, which turns `C:\src\lib.rs` into `C:srclib.rs` - a path that
  never exists and therefore *always* looks fresh, disabling the guard on Windows. rustc
  escapes only spaces; corrected in the second commit, with the Windows drive-letter and
  escaped-space cases pinned.
- Every assertion carries its non-vacuity companion: the stale-binary panic is paired with
  a fresh-binary acceptance, without which a guard that rejects everything would also pass.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features
  --no-deps -- -D warnings` zero diagnostics; `-p test-support` 52/52 on Linux.

## Notes

`OcRsyncCliRunner::new` resolves through `locate_workspace_binary`, whose documented
contract is to return `Option` so a test can self-skip. It therefore bypasses this guard.
Changing that contract is a separate question and is left alone here.
