### PR TITLE
fix(output): print `skipping directory` at default verbosity

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -282,6 +282,13 @@ where
 
     let verbosity_config = VerbosityConfig::from_verbose_level(verbosity);
     logging::init(verbosity_config);
+    // The parser already folded `--quiet` into `verbosity = 0`, which is what
+    // silences every verbosity-gated line. Upstream additionally keeps `quiet`
+    // as its own global and consults it in the `FINFO` arm of `rwrite()`
+    // (log.c:344-345), so a notice it prints at DEFAULT verbosity - `skipping
+    // directory %s` (flist.c:1484) - still disappears under `-q`. Carrying the
+    // flag past the parser is what makes those two states distinguishable.
+    logging::set_quiet(quiet);
 
     let rayon_thread_count = rayon_threads.and_then(|n| NonZeroUsize::new(n as usize));
     let tokio_thread_count = tokio_threads.and_then(|n| NonZeroUsize::new(n as usize));

--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -79,11 +79,15 @@ pub fn render_diagnostic_events<O: Write, E: Write>(
         // rule; a second copy here is what made #352 and #357 two separate
         // bugs instead of one.
         let ctx = logging::StreamContext {
-            // This renderer runs after the CLI has already folded `--quiet`
-            // into the verbosity level, so the events that reach it are
-            // pre-filtered; passing `quiet: false` keeps that behaviour
-            // unchanged. Wiring the real flag through is task #346.
-            quiet: false,
+            // upstream: log.c:345 `if (quiet)` - the FINFO arm of rwrite()
+            // returns without writing when quiet is set. Folding
+            // `--quiet` into `verbose = 0` at parse time silences only the
+            // verbosity-gated events; a notice upstream prints at DEFAULT
+            // verbosity - `skipping non-regular file "%s"` under
+            // `INFO_GTE(NONREG, 1)`, which `info_verbosity[0]` enables - still
+            // reaches this renderer and must be suppressed here, where
+            // upstream suppresses it.
+            quiet: logging::finfo_suppressed(),
             // `Never` and `Default` select the same stream (log.c:253 keys on
             // `== 1`), so a caller that only knows the boolean loses nothing
             // here. The tri-state is available for callers that have it.
@@ -334,56 +338,62 @@ mod tests {
     fn test_renderer_delegates_every_code_to_the_shared_funnel() {
         for code in LogCode::ALL {
             for msgs2stderr in [false, true] {
-                let ctx = logging::StreamContext {
-                    quiet: false,
-                    msgs2stderr: if msgs2stderr {
-                        logging::Msgs2Stderr::Always
-                    } else {
-                        logging::Msgs2Stderr::Default
-                    },
-                    log_destination: false,
-                };
-                let events = vec![DiagnosticEvent::Info {
-                    flag: InfoFlag::Misc,
-                    level: 1,
-                    code,
-                    message: "probe".to_owned(),
-                }];
-                let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
-                let result =
-                    render_diagnostic_events(&events, &mut stdout, &mut stderr, msgs2stderr);
+                for quiet in [false, true] {
+                    logging::set_quiet(quiet);
+                    let ctx = logging::StreamContext {
+                        quiet,
+                        msgs2stderr: if msgs2stderr {
+                            logging::Msgs2Stderr::Always
+                        } else {
+                            logging::Msgs2Stderr::Default
+                        },
+                        log_destination: false,
+                    };
+                    let events = vec![DiagnosticEvent::Info {
+                        flag: InfoFlag::Misc,
+                        level: 1,
+                        code,
+                        message: "probe".to_owned(),
+                    }];
+                    let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+                    let result =
+                        render_diagnostic_events(&events, &mut stdout, &mut stderr, msgs2stderr);
 
-                match logging::message_stream(code, ctx) {
-                    Ok(logging::MessageStream::Stdout) => {
-                        assert!(result.is_ok(), "{code} must render");
-                        assert!(
-                            String::from_utf8_lossy(&stdout).contains("probe"),
-                            "{code} belongs on stdout with msgs2stderr={msgs2stderr}",
-                        );
-                        assert!(stderr.is_empty(), "{code} must not also hit stderr");
-                    }
-                    Ok(logging::MessageStream::Stderr) => {
-                        assert!(result.is_ok(), "{code} must render");
-                        assert!(
-                            String::from_utf8_lossy(&stderr).contains("probe"),
-                            "{code} belongs on stderr with msgs2stderr={msgs2stderr}",
-                        );
-                        assert!(stdout.is_empty(), "{code} must not also hit stdout");
-                    }
-                    Ok(logging::MessageStream::LogOnly | logging::MessageStream::Suppressed) => {
-                        assert!(result.is_ok(), "{code} must render");
-                        assert!(
-                            stdout.is_empty() && stderr.is_empty(),
-                            "{code} must emit nothing"
-                        );
-                    }
-                    Err(_) => {
-                        assert!(result.is_err(), "{code} must be rejected, not rendered");
-                        assert!(stdout.is_empty(), "a rejected code must not reach stdout");
+                    match logging::message_stream(code, ctx) {
+                        Ok(logging::MessageStream::Stdout) => {
+                            assert!(result.is_ok(), "{code} must render");
+                            assert!(
+                                String::from_utf8_lossy(&stdout).contains("probe"),
+                                "{code} belongs on stdout with msgs2stderr={msgs2stderr}",
+                            );
+                            assert!(stderr.is_empty(), "{code} must not also hit stderr");
+                        }
+                        Ok(logging::MessageStream::Stderr) => {
+                            assert!(result.is_ok(), "{code} must render");
+                            assert!(
+                                String::from_utf8_lossy(&stderr).contains("probe"),
+                                "{code} belongs on stderr with msgs2stderr={msgs2stderr}",
+                            );
+                            assert!(stdout.is_empty(), "{code} must not also hit stdout");
+                        }
+                        Ok(
+                            logging::MessageStream::LogOnly | logging::MessageStream::Suppressed,
+                        ) => {
+                            assert!(result.is_ok(), "{code} must render");
+                            assert!(
+                                stdout.is_empty() && stderr.is_empty(),
+                                "{code} must emit nothing"
+                            );
+                        }
+                        Err(_) => {
+                            assert!(result.is_err(), "{code} must be rejected, not rendered");
+                            assert!(stdout.is_empty(), "a rejected code must not reach stdout");
+                        }
                     }
                 }
             }
         }
+        logging::set_quiet(false);
     }
 
     /// `--msgs-to-stderr` moves the stdout-bound codes only; a warning was

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -1167,17 +1167,17 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
             ClientEventKind::SkippedDirectory => {
-                // upstream: flist.c:1338 and flist.c:2452 -
-                // `rprintf(FINFO, "skipping directory %s\n", ...)`: the bare
-                // relative name with no surrounding quotes and no trailing
-                // "(no recursion)" suffix.
-                writeln_wrapped(
-                    stdout,
-                    "skipping directory ",
-                    event.relative_path(),
-                    escape,
-                    "",
-                )?;
+                // Deliberately silent here, for the same reason as
+                // `SkippedNonRegular` above. Upstream gates the notice on
+                // `!xfer_dirs` and nothing else - no INFO_GTE, no verbosity
+                // test - so it prints at DEFAULT verbosity, where this
+                // renderer never runs: the event log itself is only collected
+                // when `verbosity > 0 || progress || list_only`
+                // (core: client/config/client/output.rs `collect_events`), so
+                // at `-q` and at the default the record never reaches here.
+                // The engine emits it on the info channel instead
+                // (context_impl/reporting.rs), which is where `--quiet` can
+                // still suppress it via `message_stream`.
                 continue;
             }
             ClientEventKind::SkippedUnsafeSymlink => {
@@ -1503,7 +1503,7 @@ mod tests {
     }
 
     #[test]
-    fn skipped_directory_matches_upstream_bare_message() {
+    fn skipped_directory_renders_nothing_because_the_engine_owns_the_notice() {
         let event = ClientEvent::for_test(
             PathBuf::from("subdir"),
             ClientEventKind::SkippedDirectory,
@@ -1511,11 +1511,20 @@ mod tests {
             Some(ClientEntryMetadata::for_test(ClientEntryKind::Directory)),
             LocalCopyChangeSet::new(),
         );
-        // upstream: flist.c:1338 and flist.c:2452 emit
-        // `rprintf(FINFO, "skipping directory %s\n", ...)` - a bare relative
-        // name with no surrounding quotes and no "(no recursion)" suffix. Byte
-        // fidelity with upstream requires exactly this form.
-        assert_eq!(render_verbose(event), "skipping directory subdir\n");
+        // Upstream gates `skipping directory %s` on `!xfer_dirs` alone, so it
+        // prints at DEFAULT verbosity - but this renderer only ever runs over a
+        // collected event log, and collection requires
+        // `verbosity > 0 || progress || list_only`. Rendering the notice here
+        // therefore emitted it at `-v` and above while staying silent in
+        // exactly the case upstream prints. The notice now comes from
+        // `record_skipped_directory` in the engine; a second copy here would
+        // duplicate it at `-v`.
+        //
+        // The upstream byte form - bare relative name, no quotes, no
+        // "(no recursion)" suffix - is pinned end to end against the real
+        // binary's stdout by `skipping_directory_prints_without_name_output`,
+        // which compares whole lines, not by this unit.
+        assert_eq!(render_verbose(event), "");
     }
 
     /// Renders the summary trailer for an empty (default) transfer at the given

--- a/crates/cli/src/frontend/tests/transfer_request_skips_directories_without_recursion.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_skips_directories_without_recursion.rs
@@ -81,6 +81,82 @@ fn non_trailing_slash_source_without_recursion_skips_directory() {
     );
 }
 
+/// Runs `oc-rsync <flags> <src-dir> <dst>/` on a fresh tree and returns stdout.
+///
+/// The source is a bare directory operand with no `-r`/`-d`, which is the only
+/// shape that reaches upstream's `!xfer_dirs` guard.
+fn skip_notice_stdout(flags: &[&str]) -> String {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("subdir");
+    std::fs::create_dir(&source_dir).expect("create source");
+    std::fs::write(source_dir.join("child.txt"), b"payload").expect("write child");
+    let dest_dir = tmp.path().join("dst");
+    std::fs::create_dir(&dest_dir).expect("create dest");
+
+    let mut args = vec![OsString::from(RSYNC)];
+    args.extend(flags.iter().map(OsString::from));
+    args.push(source_dir.into_os_string());
+    args.push(dest_dir.into_os_string());
+
+    let (code, stdout, _stderr) = run_with_args(args);
+    assert_eq!(code, 0, "skipping a directory operand is a success");
+    String::from_utf8(stdout).expect("stdout is utf-8")
+}
+
+fn skip_notice_count(stdout: &str) -> usize {
+    stdout
+        .lines()
+        .filter(|line| *line == "skipping directory subdir")
+        .count()
+}
+
+/// The notice is printed at DEFAULT verbosity, and `--info=name0` does not
+/// silence it.
+///
+/// upstream's condition is `!xfer_dirs` and nothing else - there is no
+/// `INFO_GTE` and no verbosity test at either call site (flist.c:1484 in
+/// `send_file_name`, flist.c:2724 in `send_file_list`). The only suppressor is
+/// `quiet` inside `rwrite()` (log.c:344-345). Routing it through the NAME
+/// output level, as the per-file listing is, hides it from every operator who
+/// did not pass `-v` - and from one who explicitly disabled NAME, which is what
+/// makes `--info=name0` the discriminating cell rather than a variation on the
+/// default.
+///
+/// Measured against rsync 3.5.0: it prints the line in all three cells below.
+#[test]
+fn skipping_directory_prints_without_name_output() {
+    for flags in [&[][..], &["--info=name0"][..], &["--info=skip1"][..]] {
+        assert_eq!(
+            skip_notice_count(&skip_notice_stdout(flags)),
+            1,
+            "`skipping directory subdir` must print exactly once with {flags:?}"
+        );
+    }
+}
+
+/// `-q` is the one thing that does suppress it, and the notice must not
+/// duplicate at `-v`.
+///
+/// Without the `-q` half this pin would also pass on a renderer that simply
+/// printed the line unconditionally, so the two cells are a pair: one proves
+/// the notice escapes the NAME gate, the other proves it still answers to
+/// upstream's actual suppressor.
+#[test]
+fn quiet_suppresses_the_notice_and_verbose_does_not_duplicate_it() {
+    assert_eq!(
+        skip_notice_count(&skip_notice_stdout(&["-q"])),
+        0,
+        "upstream's rwrite() returns early for FINFO under --quiet (log.c:344-345)"
+    );
+    assert_eq!(
+        skip_notice_count(&skip_notice_stdout(&["-v"])),
+        1,
+        "-v must not add a second copy of the notice"
+    );
+}
+
 /// Verifies that `-r` re-enables the recursive copy that the default would have
 /// skipped. Guards against an over-broad fix that disables recursion entirely.
 #[test]

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -73,8 +73,21 @@ impl<'a> CopyContext<'a> {
     }
 
     /// Records a skip event for a directory (when `-r` is not enabled).
+    ///
+    /// Emits the notice here, not from the verbose renderer. Upstream's guard
+    /// is `S_ISDIR(st.st_mode) && !xfer_dirs` and nothing else - there is no
+    /// `INFO_GTE` and no verbosity test at either call site - so the line
+    /// prints at DEFAULT verbosity. The event log this record joins is only
+    /// collected when `verbosity > 0 || progress || list_only`, so a renderer
+    /// arm alone is unreachable in exactly the case upstream prints. `--quiet`
+    /// still suppresses it, at `rwrite()`'s FINFO arm, which
+    /// `logging::message_stream` owns.
+    // upstream: flist.c:1338 and flist.c:2452 -
+    // `rprintf(FINFO, "skipping directory %s\n", ...)`: the bare relative name
+    // with no surrounding quotes and no trailing "(no recursion)" suffix.
     pub(super) fn record_skipped_directory(&mut self, relative: Option<&Path>) {
         if let Some(path) = relative {
+            info_log!(Misc, 0, "skipping directory {}", path.display());
             self.record(LocalCopyRecord::new(
                 path.to_path_buf(),
                 LocalCopyAction::SkippedDirectory,

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -102,7 +102,7 @@ pub use stream::{BadLogCode, MessageStream, Msgs2Stderr, StreamContext, message_
 pub use thread_local::{
     DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events,
     drain_events_coded, drain_events_for_peer, emit_debug, emit_debug_coded, emit_info,
-    emit_info_coded, emit_warning, info_gte, init,
+    emit_info_coded, emit_warning, finfo_suppressed, info_gte, init, set_quiet,
 };
 pub use verify_failure::{VerifyFailure, verification_failure};
 

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -18,10 +18,11 @@
 use super::config::VerbosityConfig;
 use super::levels::{DebugFlag, InfoFlag};
 use super::log_code::LogCode;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 thread_local! {
     static VERBOSITY: RefCell<VerbosityConfig> = RefCell::new(VerbosityConfig::default());
+    static QUIET: Cell<bool> = const { Cell::new(false) };
     #[allow(clippy::missing_const_for_thread_local)]
     static EVENTS: RefCell<Vec<DiagnosticEvent>> = RefCell::new(Vec::new());
 }
@@ -76,6 +77,28 @@ pub fn init(config: VerbosityConfig) {
     VERBOSITY.with(|v| {
         *v.borrow_mut() = config;
     });
+}
+
+/// Record whether `-q` / `--quiet` was requested, for the current thread.
+///
+/// Upstream keeps `quiet` as a global of its own, separate from `verbose` and
+/// from `info_levels[]`, and consults it in exactly one place: the `FINFO` arm
+/// of `rwrite()` returns without writing (upstream: log.c:344-345). Anything
+/// that only folds `--quiet` into `verbose = 0` cannot express a notice
+/// upstream prints at default verbosity and suppresses only under `-q` - the
+/// two states become indistinguishable.
+pub fn set_quiet(quiet: bool) {
+    QUIET.with(|q| q.set(quiet));
+}
+
+/// Whether `FINFO` output is suppressed on this thread.
+///
+/// The single question a producer or renderer should ask before emitting an
+/// upstream `rprintf(FINFO, ...)` that carries no `INFO_GTE` gate of its own.
+// upstream: log.c:345 rwrite() `if (quiet)` - the FINFO arm's early return.
+#[must_use]
+pub fn finfo_suppressed() -> bool {
+    QUIET.with(Cell::get)
 }
 
 /// Check if the info flag is at or above the specified level.


### PR DESCRIPTION
Upstream gates the notice on `S_ISDIR(st.st_mode) && !xfer_dirs` and
nothing else - there is no `INFO_GTE` and no verbosity test at either
call site (flist.c:1338 in send_file_name, flist.c:2452 in
send_file_list). It therefore prints at DEFAULT verbosity, and the only
thing that suppresses it is `quiet` inside `rwrite()` (log.c:345).

oc emitted it from the verbose renderer instead. That renderer only ever
runs over a collected event log, and collection is gated on
`force_event_collection || verbosity > 0 || progress || list_only`
(core: client/config/client/output.rs `collect_events`). At the default
every disjunct is false, so `LocalCopyContext::events` is `None`,
`record()` never stores the entry, and the renderer iterates an empty
slice. The notice was reachable only at `-v` and above - the exact
inverse of upstream, which prints at the default and hides it under -q.

Move the emission to the decision site in `record_skipped_directory`,
and make the renderer arm a `continue`. This is the shape already used
for `skipping non-regular file` in the same file, whose doc comment
records the identical failure mode. `--quiet` still suppresses the line,
via `logging::message_stream`, which owns upstream's
`case FINFO: if (quiet) return;` rule.

`--quiet` reaches that funnel for the first time here: the parser folds
`-q` into `verbosity = 0`, which cannot express "default verbosity but
quiet", and the renderer's `StreamContext` had `quiet` hardcoded to
`false`. Give quiet its own thread-local, mirroring upstream's global,
and feed it to the funnel.

`record_skipped_directory` is the single owner: all three producers
(sources/handlers.rs twice, sources/orchestration.rs) call it, and
`ClientEventKind::SkippedDirectory` is only ever built from
`LocalCopyAction::SkippedDirectory`, so the renderer arm served local
copy alone and removing it cannot silence a network path.

Tests count occurrences rather than asserting containment, since
containment holds for one copy and for five. `--info=name0` is the
discriminating cell: it disables NAME output while upstream still
prints. The `-q` and `-v` cells are the non-vacuity companions - without
`-q` the pin would also pass on a renderer that printed
unconditionally, and `-v` is the only cell that catches a re-introduced
duplicate.
