### PR TITLE
fix(server): honour --confine-root instead of taking it for the destination

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -92,6 +92,19 @@ pub(super) struct ServerLongFlags {
     pub(super) stop_at: Option<String>,
     pub(super) stop_after: Option<String>,
     pub(super) files_from: Option<String>,
+    /// `--confine-root=DIR` - the root every operator/peer-supplied path this
+    /// server resolves must stay under.
+    ///
+    /// A wrapper serving a restricted directory over a remote shell appends
+    /// this to the server argv whenever its restricted dir is not "/"
+    /// (upstream `support/rrsync` main():637-644), because a wrapper can vet
+    /// the argv it is handed but filter rules travel over the protocol where
+    /// it cannot see them (rsync.1.md:1420-1429).
+    ///
+    /// upstream: options.c:64-65 (`confine_root`/`confine_rootlen`), :690 (the
+    /// popt entry), :2382-2399 (validation), syscall.c:136
+    /// `confinement_root()` - `am_daemon ? module_dir : confine_root`.
+    pub(super) confine_root: Option<String>,
     pub(super) from0: bool,
     pub(super) inplace: bool,
     /// Append data onto shorter destination files (upstream: `--append`).
@@ -418,6 +431,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         stop_at: None,
         stop_after: None,
         files_from: None,
+        confine_root: None,
         from0: false,
         inplace: false,
         append: false,
@@ -786,6 +800,8 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.stop_after = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--files-from=") {
         flags.files_from = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--confine-root=") {
+        flags.confine_root = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--max-delete=") {
         flags.max_delete = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--suffix=") {
@@ -973,6 +989,15 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--stop-at=")
         || arg.starts_with("--stop-after=")
         || arg.starts_with("--files-from=")
+        // upstream: options.c:690 - `--confine-root` is POPT_ARG_STRING, and a
+        // restricted-directory wrapper appends the JOINED `--confine-root=DIR`
+        // form to the server argv (support/rrsync main():637-644). Without this
+        // entry the token is not recognised as a flag at all and leaks into the
+        // positional list, where it becomes the destination root: MEASURED as
+        // `failed to create destination root --confine-root=/...: No such file
+        // or directory`, rc=12. Same allow-list-drift class as the alt-dest and
+        // --backup-dir/--temp-dir joined forms above.
+        || arg.starts_with("--confine-root=")
         // upstream: options.c:2966-2967 - server_options() emits `--bwlimit=%d`
         // (whole KiB) as a JOINED long flag. Recognise it so the value is not
         // mistaken for a positional destination path; a separate pass captures

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -225,6 +225,12 @@ where
     config.trust_sender = true;
     config.qsort = long_flags.qsort;
     config.file_selection.files_from_path = long_flags.files_from;
+    // upstream: options.c:2382-2399 - a restricted-directory wrapper appends
+    // `--confine-root=DIR` to the server argv, and the server honours it for
+    // every path it resolves. The daemon arm is handled where the root is READ
+    // (`GeneratorContext::source_open`), which prefers the module directory, so
+    // a peer-supplied value cannot widen a module even if one arrives here.
+    config.connection.confine_root = long_flags.confine_root.map(std::path::PathBuf::from);
     config.file_selection.from0 = long_flags.from0;
     config.write.inplace = long_flags.inplace;
     // upstream: options.c:2400-2411 - append mode implies inplace. The promotion

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -290,6 +290,63 @@ fn parse_server_args_skips_known_long_args() {
     assert_eq!(pos_args, vec![OsString::from("src/")]);
 }
 
+/// A restricted-directory wrapper's exact server argv must not turn
+/// `--confine-root=DIR` into the destination path.
+///
+/// This is the half that actually broke. MEASURED against the 3.5.0 suite
+/// before the fix: `--confine-root=` was in neither `is_known_server_long_flag`
+/// nor `is_two_arg_server_long_flag` (which only covers the space-separated
+/// `safe_arg("", value)` pairs), so the joined single-slot form fell through to
+/// the positional list and became the destination root -
+/// `failed to create destination root --confine-root=/...: No such file or
+/// directory`, rc=12, on every `rrsync-*` test that serves a non-"/" dir.
+///
+/// upstream: `support/rrsync` main():637-644 appends it; options.c:690 is the
+/// POPT_ARG_STRING entry that consumes it.
+#[test]
+fn parse_server_args_does_not_leak_confine_root_into_the_destination() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpre.iLsfxCIvu"),
+        OsString::from("--confine-root=/srv/restricted"),
+        OsString::from("."),
+        OsString::from("dest"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpre.iLsfxCIvu");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("dest")],
+        "--confine-root=DIR must be consumed as a flag, never left in the \
+         positional list where it is taken for the destination root"
+    );
+}
+
+/// The value must also survive to the config, not merely be swallowed.
+///
+/// Paired with the operand test above on purpose: they exercise DIFFERENT
+/// functions (`parse_server_flag_string_and_args` vs
+/// `parse_server_long_flags`), and recognising the flag in only one of them
+/// leaves either a positional leak or a silently dropped confinement root.
+#[test]
+fn long_flags_capture_confine_root() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--confine-root=/srv/restricted"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.confine_root.as_deref(), Some("/srv/restricted"));
+}
+
+/// Absent by default - the option is opt-in, and a server that never receives
+/// it must not invent a confinement root.
+#[test]
+fn long_flags_default_confine_root_is_absent() {
+    let args = vec![OsString::from("--server")];
+    let flags = parse_server_long_flags(&args);
+    assert!(flags.confine_root.is_none());
+}
+
 #[test]
 fn parse_server_args_skips_secluded_flag() {
     let args = vec![

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -187,6 +187,24 @@ pub struct ConnectionConfig {
     /// - `clientserver.c:993` - `change_dir(module_chdir, CD_NORMAL)`
     /// - `util1.c:1285` - `p1 = curr_dir + module_dirlen`
     pub daemon_module_root: Option<PathBuf>,
+    /// `--confine-root=DIR`: the confinement root for a NON-daemon server.
+    ///
+    /// Upstream keeps one `confinement_root()` accessor and picks the root by
+    /// role - `am_daemon ? module_dir : confine_root` - so the two never apply
+    /// at once. A daemon deliberately ignores `--confine-root`: its module
+    /// directory is already the boundary, and the option arrives in a
+    /// peer-supplied argv, where honouring it could only *widen* the module
+    /// (options.c:2382-2386). Mirrored by
+    /// [`GeneratorContext::source_open`](crate::generator::GeneratorContext),
+    /// which reads [`daemon_module_root`](Self::daemon_module_root) for a
+    /// daemon and this field otherwise.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:64-65` - `confine_root` / `confine_rootlen`
+    /// - `options.c:2382-2399` - daemon-ignores / absolute / normalize rules
+    /// - `syscall.c:128-143` - `confinement_root()`
+    pub confine_root: Option<PathBuf>,
     /// Filter rules to send to remote daemon (client_mode only).
     pub filter_rules: Vec<FilterRuleWireFormat>,
     /// Optional filename encoding converter for `--iconv` support.

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -663,10 +663,16 @@ impl GeneratorContext {
     /// - `clientserver.c:1345-1357` - why the daemon chroot does not set it
     /// - `sender.c:359-383` - `secure_relative_open` vs `do_open_checklinks`
     pub(crate) fn source_open(&self) -> open_source::SourceOpen {
+        // upstream: syscall.c:136 `confinement_root()` -
+        // `am_daemon ? module_dir : confine_root`. The daemon arm wins
+        // unconditionally: its module directory is already the boundary, and
+        // `--confine-root` arrives in a peer-supplied argv where honouring it
+        // could only WIDEN the module (options.c:2382-2386 nulls it out for a
+        // daemon before it is ever read).
         let confine_root = if self.config.connection.is_daemon_connection {
             self.config.connection.daemon_module_root.clone()
         } else {
-            None
+            self.config.connection.confine_root.clone()
         };
         let follow_symlinks = self.config.flags.copy_links || self.config.flags.copy_unsafe_links;
         open_source::SourceOpen::new(


### PR DESCRIPTION
rsync 3.5.0 added `--confine-root=DIR` (`options.c:64-65`, `:690`). oc's `--server`
operand parser did not know the option, so an incoming `--confine-root=/some/dir`
fell through `is_known_server_long_flag` into the positional list and became the
destination path.

MEASURED against the real upstream 3.5.0 testsuite, the server side reported:

```
rsync: [receiver] link_stat "--confine-root=/tmp/.../to" failed: No such file or directory (2)
```

The filed claim for this gap said oc "rejects `--confine-root` with exit 1"; that is
not what happens. It is not silently ignored either. It leaks into the operand list
and breaks the transfer by redirecting the destination. Same class as the earlier
`--bwlimit=` and `--block-size` operand leaks.

## Change

- `crates/cli/src/frontend/server/flags.rs` - capture `--confine-root=VALUE` into
  `ServerLongFlags`, and add it to the server-mode allow-list so it can never reach
  the positional list.
- `crates/cli/src/frontend/server/run.rs` - carry the captured value into
  `ConnectionConfig`, next to `files_from_path`.
- `crates/transfer/src/config/mod.rs` - new `ConnectionConfig::confine_root`.
- `crates/transfer/src/generator/context.rs` - `source_open()` picks the confinement
  anchor per `syscall.c:136 confinement_root()`:
  `am_daemon ? module_dir : confine_root`. The daemon arm wins unconditionally - its
  module directory is already the boundary, and `--confine-root` arrives in a
  peer-supplied argv where honouring it could only widen the module.
  `options.c:2382-2386` nulls the option out for a daemon before it is ever read, so
  mirroring that precedence here is the same rule, not a new one.

## Tests

Three tests in `crates/cli/src/frontend/server/tests.rs`, deliberately spanning two
different functions so a fix to one half cannot make the other pass vacuously:

- `parse_server_args_does_not_leak_confine_root_into_the_destination` - the operand
  half, i.e. the half that actually broke. Fails on the pre-fix parser.
- `long_flags_capture_confine_root` - the value half.
- `long_flags_default_confine_root_is_absent` - non-vacuity companion; without it the
  capture test would also pass if the field were unconditionally populated.

## Verification (Linux aarch64)

- `cargo nextest run -p cli --all-features -E 'test(confine_root)'` - 3 passed.
- `cargo fmt --all -- --check` - clean.
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - clean.
