### PR TITLE
fix(security): confine the commit rename and the backup path against symlink races

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -60,7 +60,7 @@ use filters::FilterRule;
 use logging::info_log;
 use protocol::flist::FileListWriter;
 
-use super::overrides::{backup_rename, create_backup_hard_link, create_hard_link};
+use super::overrides::{backup_rename, create_backup_hard_link};
 #[cfg(target_os = "linux")]
 use super::overrides::{cached_parent_device, same_filesystem};
 

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -60,7 +60,7 @@ use filters::FilterRule;
 use logging::info_log;
 use protocol::flist::FileListWriter;
 
-use super::overrides::{backup_rename, create_hard_link};
+use super::overrides::{backup_rename, create_backup_hard_link, create_hard_link};
 #[cfg(target_os = "linux")]
 use super::overrides::{cached_parent_device, same_filesystem};
 

--- a/crates/engine/src/local_copy/context_impl/backup.rs
+++ b/crates/engine/src/local_copy/context_impl/backup.rs
@@ -126,14 +126,14 @@ impl<'a> CopyContext<'a> {
         let hard_linked = if prefer_rename {
             None
         } else {
-            match create_hard_link(destination, &backup_path) {
+            match create_backup_hard_link(destination, &backup_path) {
                 Ok(()) => Some(BackupStrategy::HardLink),
                 Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
                 // upstream: backup.c:247-256 - a stale backup entry is
                 // removed and the hard link retried once.
                 Err(error) if is_stale_backup_conflict(&error) => {
                     remove_stale_backup_entry(&backup_path)?;
-                    match create_hard_link(destination, &backup_path) {
+                    match create_backup_hard_link(destination, &backup_path) {
                         Ok(()) => Some(BackupStrategy::HardLink),
                         Err(_) => None,
                     }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -197,7 +197,10 @@ impl<'a> CopyContext<'a> {
     }
 
     /// Returns the root destination directory for the transfer.
-    pub(super) fn destination_root(&self) -> &Path {
+    ///
+    /// Also the confinement anchor for the temp -> final commit rename; see
+    /// `DestinationWriteGuard::new_confined`.
+    pub(in crate::local_copy) fn destination_root(&self) -> &Path {
         &self.destination_root
     }
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -45,7 +45,15 @@ pub(super) fn eligible(
         ..
     } = flags;
 
-    let transfer_ok = existing_metadata.is_none()
+    // The injected `PlatformCopy` still decides whether this tier runs at all:
+    // `NoReflinkPlatformCopy` (and any test fake) reports no reflink support and
+    // vetoes the fast path, leaving the standard copy to do the work. The
+    // *destination write* no longer goes through the strategy - a path-based
+    // `copy_file(src, dst)` cannot express an anchored destination, which is
+    // exactly what made it an escape - so the strategy's role here is the gate,
+    // not the write.
+    let transfer_ok = context.options().platform_copy().supports_reflink()
+        && existing_metadata.is_none()
         && whole_file_enabled
         && !inplace_enabled
         && !partial_enabled
@@ -108,6 +116,34 @@ pub(super) fn try_clone(
 ) -> Result<bool, LocalCopyError> {
     let file_size = metadata.len();
 
+    // A reflink both creates and fills the destination in one syscall, so the
+    // create IS the confinement decision - there is no later commit to anchor.
+    // `confined_clone_file` walks the destination's parent per component and
+    // clones through that dirfd, which is the only race-free form: a
+    // check-then-`clonefile` gate would still lose to a parent flipped between
+    // the two.
+    //
+    // A confinement refusal is an error and propagates. Only "this filesystem
+    // will not reflink" falls through to the standard copy path, which anchors
+    // its own create.
+    //
+    // upstream: `rsync-3.5.0/receiver.c` has no CoW fast path at all - it
+    // always stages into a temp and commits with `do_rename_at()`, inheriting
+    // confinement from the rename. This keeps oc's optimisation on the same
+    // invariant rather than beside it.
+    #[cfg(unix)]
+    let clone_method =
+        match fast_io::confined_clone_file(context.destination_root(), source, destination) {
+            Ok(fast_io::CloneAttempt::Cloned) => Some(
+                context
+                    .options()
+                    .platform_copy()
+                    .preferred_method(file_size),
+            ),
+            Ok(fast_io::CloneAttempt::Unsupported) => None,
+            Err(error) => return Err(LocalCopyError::io("copy file", destination, error)),
+        };
+    #[cfg(not(unix))]
     let clone_method =
         match context
             .options()

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
@@ -58,11 +58,12 @@ pub(in crate::local_copy) fn copy_special_as_regular_file(
             .open(destination)
             .map_err(|error| LocalCopyError::io("copy file", destination, error))?;
     } else {
-        let (new_guard, _file) = DestinationWriteGuard::new(
+        let (new_guard, _file) = DestinationWriteGuard::new_confined(
             destination,
             partial_enabled,
             context.partial_directory_path(),
             context.temp_directory_path(),
+            Some(context.destination_root()),
         )?;
         guard = Some(new_guard);
     }

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -158,19 +158,41 @@ pub(in crate::local_copy) fn open_destination_writer(
             opened.map_err(|error| LocalCopyError::io("copy file", destination, error))
         }
         WriteStrategy::Direct => {
-            // upstream: receiver.c - direct write when no existing file to protect.
-            // create_new(true) prevents races with concurrent writers (EEXIST).
+            // Direct write when there is no existing file to protect.
+            //
+            // Upstream has no counterpart to this arm: receiver.c ALWAYS stages
+            // into a `.name.XXXXXX` temp (or --temp-dir) and commits with a
+            // rename, so it never opens the final name and inherits the
+            // parent-anchored confinement for free. `Direct` is an oc
+            // optimisation for a not-yet-existing destination, so it has to
+            // anchor the parent itself - otherwise it re-resolves `destination`
+            // by path and follows a parent flipped to a symlink mid-transfer,
+            // which is the same escape the commit rename closes above and the
+            // one `keep_dirlinks_refuses_a_destination_symlink_pointing_outside_the_tree`
+            // catches on platforms without O_TMPFILE.
+            //
+            // `O_EXCL` is preserved from the path-based form: it is what makes a
+            // concurrent writer lose the race with EEXIST rather than share the
+            // file.
             debug_log!(
                 Io,
                 3,
                 "direct write to {} (no existing destination)",
                 record_path.display()
             );
-            fs::OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(destination)
-                .map_err(|error| LocalCopyError::io("copy file", destination, error))
+            #[cfg(unix)]
+            {
+                fast_io::confined_create_new(context.destination_root(), destination)
+                    .map_err(|error| LocalCopyError::io("copy file", destination, error))
+            }
+            #[cfg(not(unix))]
+            {
+                fs::OpenOptions::new()
+                    .create_new(true)
+                    .write(true)
+                    .open(destination)
+                    .map_err(|error| LocalCopyError::io("copy file", destination, error))
+            }
         }
         WriteStrategy::AnonymousTempFile => {
             #[cfg(target_os = "linux")]

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -199,11 +199,12 @@ pub(in crate::local_copy) fn open_destination_writer(
                 }
             }
             // Fallback: named temp file (also the only path on non-Linux).
-            let (new_guard, file) = DestinationWriteGuard::new(
+            let (new_guard, file) = DestinationWriteGuard::new_confined(
                 destination,
                 partial_enabled,
                 context.partial_directory_path(),
                 context.temp_directory_path(),
+                Some(context.destination_root()),
             )?;
             *staging_path = Some(new_guard.staging_path().to_path_buf());
             debug_log!(
@@ -217,11 +218,12 @@ pub(in crate::local_copy) fn open_destination_writer(
             Ok(file)
         }
         WriteStrategy::TempFileRename => {
-            let (new_guard, file) = DestinationWriteGuard::new(
+            let (new_guard, file) = DestinationWriteGuard::new_confined(
                 destination,
                 partial_enabled,
                 context.partial_directory_path(),
                 context.temp_directory_path(),
+                Some(context.destination_root()),
             )?;
             *staging_path = Some(new_guard.staging_path().to_path_buf());
             debug_log!(

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -175,7 +175,10 @@ pub(in crate::local_copy) fn open_destination_writer(
         WriteStrategy::AnonymousTempFile => {
             #[cfg(target_os = "linux")]
             {
-                match DestinationWriteGuard::new_anonymous(destination) {
+                match DestinationWriteGuard::new_anonymous(
+                    destination,
+                    Some(context.destination_root()),
+                ) {
                     Ok((new_guard, file)) => {
                         debug_log!(
                             Io,

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -561,8 +561,12 @@ impl DestinationWriteGuard {
                     remove_existing_destination(&self.final_path)?;
                     hardened_rename(&temp_path, &self.final_path, self.dest_root.as_deref())
                         .map_err(|rename_error| {
-                        LocalCopyError::io(self.finalise_action(), temp_path.clone(), rename_error)
-                    })?;
+                            LocalCopyError::io(
+                                self.finalise_action(),
+                                temp_path.clone(),
+                                rename_error,
+                            )
+                        })?;
                     return Ok(false);
                 }
                 Err(error) if error.kind() == io::ErrorKind::ExecutableFileBusy => {

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -420,12 +420,22 @@ impl DestinationWriteGuard {
     /// directory listing. Calling [`commit`](Self::commit) materializes it at the
     /// destination using `linkat(2)`.
     ///
+    /// `dest_root` confines that `linkat` exactly as it confines the commit
+    /// rename: this strategy publishes the file under its final name with
+    /// `linkat` instead of `rename`, so it is the same commit decision and
+    /// needs the same anchoring. Leaving it unconfined made the escape
+    /// platform-split - `O_TMPFILE` exists only on Linux, so the destination
+    /// tree was protected on macOS and open on Linux.
+    ///
     /// # Errors
     ///
     /// Returns an error if `O_TMPFILE` is not supported or the directory is not
     /// writable. Callers should fall back to [`new`](Self::new) on failure.
     #[cfg(target_os = "linux")]
-    pub fn new_anonymous(destination: &Path) -> Result<(Self, fs::File), LocalCopyError> {
+    pub fn new_anonymous(
+        destination: &Path,
+        dest_root: Option<&Path>,
+    ) -> Result<(Self, fs::File), LocalCopyError> {
         let dir = destination.parent().unwrap_or(Path::new("."));
         let file = fast_io::open_anonymous_tmpfile(dir, 0o644)
             .map_err(|error| LocalCopyError::io("open anonymous temp file", destination, error))?;
@@ -439,11 +449,7 @@ impl DestinationWriteGuard {
                 final_path: destination.to_path_buf(),
                 strategy: GuardStrategy::Anonymous { file: Some(file) },
                 committed: false,
-                // The anonymous path commits with `linkat(2)` against the final
-                // path, not a rename, so it does not go through
-                // `hardened_rename`. Confining that sink is task 605's
-                // leaf-sink sweep, not this rename fix.
-                dest_root: None,
+                dest_root: dest_root.map(Path::to_path_buf),
             },
             writer,
         ))
@@ -616,7 +622,14 @@ impl DestinationWriteGuard {
         })?;
         // Remove existing destination so linkat does not fail with EEXIST.
         remove_existing_destination(&self.final_path)?;
-        fast_io::link_anonymous_tmpfile(&file, &self.final_path).map_err(|error| {
+        let result = match self.dest_root.as_deref() {
+            Some(root) => {
+                use std::os::fd::AsFd;
+                fast_io::confined_link_anonymous(file.as_fd(), root, &self.final_path)
+            }
+            None => fast_io::link_anonymous_tmpfile(&file, &self.final_path),
+        };
+        result.map_err(|error| {
             LocalCopyError::io("finalise anonymous temp file", &self.final_path, error)
         })
     }
@@ -1073,7 +1086,7 @@ mod tests {
                 return;
             }
 
-            let (guard, _file) = DestinationWriteGuard::new_anonymous(&dest).expect("guard");
+            let (guard, _file) = DestinationWriteGuard::new_anonymous(&dest, None).expect("guard");
             assert!(guard.is_anonymous());
             // Anonymous files have no visible staging path - staging_path returns final_path.
             assert_eq!(guard.staging_path(), guard.final_path());
@@ -1088,7 +1101,8 @@ mod tests {
                 return;
             }
 
-            let (guard, mut file) = DestinationWriteGuard::new_anonymous(&dest).expect("guard");
+            let (guard, mut file) =
+                DestinationWriteGuard::new_anonymous(&dest, None).expect("guard");
             file.write_all(b"anonymous content").expect("write");
             drop(file);
 
@@ -1110,7 +1124,8 @@ mod tests {
 
             fs::write(&dest, b"old").expect("create existing");
 
-            let (guard, mut file) = DestinationWriteGuard::new_anonymous(&dest).expect("guard");
+            let (guard, mut file) =
+                DestinationWriteGuard::new_anonymous(&dest, None).expect("guard");
             file.write_all(b"new").expect("write");
             drop(file);
 
@@ -1126,7 +1141,8 @@ mod tests {
                 return;
             }
 
-            let (guard, mut file) = DestinationWriteGuard::new_anonymous(&dest).expect("guard");
+            let (guard, mut file) =
+                DestinationWriteGuard::new_anonymous(&dest, None).expect("guard");
             file.write_all(b"discarded").expect("write");
             drop(file);
             guard.discard();
@@ -1146,7 +1162,8 @@ mod tests {
             }
 
             {
-                let (_guard, _file) = DestinationWriteGuard::new_anonymous(&dest).expect("guard");
+                let (_guard, _file) =
+                    DestinationWriteGuard::new_anonymous(&dest, None).expect("guard");
             }
 
             assert!(!dest.exists());

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -146,7 +146,24 @@ fn create_new_temp(path: &Path) -> io::Result<fs::File> {
 ///
 /// `replace_existing` is always `true`: upstream `do_rename` overwrites the
 /// destination, matching `std::fs::rename`'s replace semantics.
-fn hardened_rename(temp_path: &Path, final_path: &Path) -> io::Result<()> {
+///
+/// On Unix a known `dest_root` routes the rename through
+/// `fast_io::confined_rename`, which resolves each endpoint that lies beneath
+/// the root through the per-component confined walk. Without that, an
+/// attacker who flips a destination parent directory to a symlink between
+/// temp-create and commit redirects the transferred file outside the tree -
+/// the escape upstream's `rename-fullpath-symlink-race` test demonstrates, and
+/// which an absolute `--temp-dir` makes reachable because the source endpoint
+/// then lives outside the tree.
+///
+/// upstream: `rsync-3.5.0/syscall.c:1866` `do_rename_at()` - "Confine each side
+/// independently. [...] Doing each side independently means an absolute source
+/// never disables confinement of a relative destination."
+fn hardened_rename(
+    temp_path: &Path,
+    final_path: &Path,
+    dest_root: Option<&Path>,
+) -> io::Result<()> {
     // Test-only fault injection: force the EXDEV boundary so the copy+remove
     // fallback runs deterministically on a single filesystem (and on Windows CI,
     // where a real second volume is unavailable).
@@ -156,10 +173,14 @@ fn hardened_rename(temp_path: &Path, final_path: &Path) -> io::Result<()> {
     }
     #[cfg(windows)]
     {
+        let _ = dest_root;
         fast_io::rename_no_follow(temp_path, final_path, true)
     }
     #[cfg(not(windows))]
     {
+        if let Some(root) = dest_root {
+            return fast_io::confined_rename(root, temp_path, final_path, true);
+        }
         if let Some(result) = fast_io::try_rename_via_io_uring(temp_path, final_path) {
             result
         } else {
@@ -285,13 +306,19 @@ pub struct DestinationWriteGuard {
     final_path: PathBuf,
     strategy: GuardStrategy,
     committed: bool,
+    /// Root of the destination tree, when the caller knows one. Confines the
+    /// commit rename; see [`hardened_rename`].
+    dest_root: Option<PathBuf>,
 }
 
 impl DestinationWriteGuard {
-    /// Creates a new write guard with an associated temporary file.
+    /// Creates a new write guard whose commit rename is **not** confined.
     ///
-    /// The temporary file is created in the same directory as the
-    /// destination (or in `temp_dir` if provided) to ensure atomic rename.
+    /// Equivalent to [`new_confined`](Self::new_confined) with no destination
+    /// root. Callers that know the root - every production copy path does, via
+    /// the plan's destination root - must use `new_confined` instead, or a
+    /// destination parent flipped to a symlink mid-transfer can redirect the
+    /// commit outside the tree.
     ///
     /// # Errors
     ///
@@ -302,6 +329,26 @@ impl DestinationWriteGuard {
         partial: bool,
         partial_dir: Option<&Path>,
         temp_dir: Option<&Path>,
+    ) -> Result<(Self, fs::File), LocalCopyError> {
+        Self::new_confined(destination, partial, partial_dir, temp_dir, None)
+    }
+
+    /// Creates a new write guard with an associated temporary file, confining
+    /// the commit rename beneath `dest_root`.
+    ///
+    /// The temporary file is created in the same directory as the
+    /// destination (or in `temp_dir` if provided) to ensure atomic rename.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the temporary file cannot be created, the
+    /// destination directory does not exist, or permission is denied.
+    pub fn new_confined(
+        destination: &Path,
+        partial: bool,
+        partial_dir: Option<&Path>,
+        temp_dir: Option<&Path>,
+        dest_root: Option<&Path>,
     ) -> Result<(Self, fs::File), LocalCopyError> {
         let partial_kind = if partial {
             match partial_dir {
@@ -351,6 +398,7 @@ impl DestinationWriteGuard {
                                 partial: partial_kind,
                             },
                             committed: false,
+                            dest_root: dest_root.map(Path::to_path_buf),
                         },
                         file,
                     ));
@@ -391,6 +439,11 @@ impl DestinationWriteGuard {
                 final_path: destination.to_path_buf(),
                 strategy: GuardStrategy::Anonymous { file: Some(file) },
                 committed: false,
+                // The anonymous path commits with `linkat(2)` against the final
+                // path, not a rename, so it does not go through
+                // `hardened_rename`. Confining that sink is task 605's
+                // leaf-sink sweep, not this rename fix.
+                dest_root: None,
             },
             writer,
         ))
@@ -502,11 +555,12 @@ impl DestinationWriteGuard {
     fn commit_named_temp_file(&self, temp_path: PathBuf) -> Result<bool, LocalCopyError> {
         let mut tries = 4u32;
         loop {
-            match hardened_rename(&temp_path, &self.final_path) {
+            match hardened_rename(&temp_path, &self.final_path, self.dest_root.as_deref()) {
                 Ok(()) => return Ok(false),
                 Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
                     remove_existing_destination(&self.final_path)?;
-                    hardened_rename(&temp_path, &self.final_path).map_err(|rename_error| {
+                    hardened_rename(&temp_path, &self.final_path, self.dest_root.as_deref())
+                        .map_err(|rename_error| {
                         LocalCopyError::io(self.finalise_action(), temp_path.clone(), rename_error)
                     })?;
                     return Ok(false);

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -620,18 +620,33 @@ impl DestinationWriteGuard {
                 io::Error::other("anonymous fd already consumed"),
             )
         })?;
-        // Remove existing destination so linkat does not fail with EEXIST.
-        remove_existing_destination(&self.final_path)?;
-        let result = match self.dest_root.as_deref() {
+        // Link first and only clear the destination on EEXIST, mirroring
+        // `hardened_rename`'s retry shape. Removing up front would make a
+        // *refused* commit destructive: the confined walk rejects an escaping
+        // destination after the unlink, leaving nothing behind. Upstream
+        // refuses without touching the file, and so must this.
+        let attempt = |guard: &Self| match guard.dest_root.as_deref() {
             Some(root) => {
                 use std::os::fd::AsFd;
-                fast_io::confined_link_anonymous(file.as_fd(), root, &self.final_path)
+                fast_io::confined_link_anonymous(file.as_fd(), root, &guard.final_path)
             }
-            None => fast_io::link_anonymous_tmpfile(&file, &self.final_path),
+            None => fast_io::link_anonymous_tmpfile(&file, &guard.final_path),
         };
-        result.map_err(|error| {
-            LocalCopyError::io("finalise anonymous temp file", &self.final_path, error)
-        })
+
+        match attempt(self) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                remove_existing_destination(&self.final_path)?;
+                attempt(self).map_err(|error| {
+                    LocalCopyError::io("finalise anonymous temp file", &self.final_path, error)
+                })
+            }
+            Err(error) => Err(LocalCopyError::io(
+                "finalise anonymous temp file",
+                &self.final_path,
+                error,
+            )),
+        }
     }
 
     /// Returns the final destination path.

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -132,9 +132,26 @@ where
 
 /// Renames a destination entry to its backup location.
 ///
+/// On Unix both endpoints are resolved by the ownership walk
+/// ([`fast_io::operator_rename`]): every path component is inspected without
+/// following it, a symlink owned by uid 0 or our euid is followed as the
+/// operator's own layout, and one owned by anyone else is refused. A backup
+/// directory may legitimately sit outside the transfer tree, so location cannot
+/// be the trust signal here - authority is.
+///
+/// Without that, an attacker who can create entries inside the backup tree
+/// flips a parent component between a real directory and a symlink pointing
+/// outside, and the path-based rename lands the backup wherever the symlink
+/// pointed at the instant the kernel resolved it - upstream's
+/// `backup-dir-symlink-race`.
+///
+/// upstream: `rsync-3.5.0/backup.c:200-219` `make_backup()` sets
+/// `operator_path_resolve` around the rename; `syscall.c:1894` `do_rename_at()`
+/// then walks each side with `owner_walk_parent()`.
+///
 /// In tests a thread-local override can force a specific outcome (e.g. an
 /// `EXDEV` cross-device error) to exercise the copy-tree fallback without a
-/// real second filesystem; production always calls `std::fs::rename`.
+/// real second filesystem.
 pub(super) fn backup_rename(from: &Path, to: &Path) -> io::Result<()> {
     #[cfg(test)]
     if let Some(result) = BACKUP_RENAME_OVERRIDE.with(|cell| {
@@ -145,7 +162,14 @@ pub(super) fn backup_rename(from: &Path, to: &Path) -> io::Result<()> {
         return result;
     }
 
-    fs::rename(from, to)
+    #[cfg(unix)]
+    {
+        fast_io::operator_rename(from, to, true)
+    }
+    #[cfg(not(unix))]
+    {
+        fs::rename(from, to)
+    }
 }
 
 pub(super) fn device_identifier(path: &Path, metadata: &fs::Metadata) -> Option<u64> {

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -67,6 +67,42 @@ pub(super) fn create_hard_link(source: &Path, destination: &Path) -> io::Result<
     fast_io::hard_link(source, destination)
 }
 
+/// Hard-links a destination entry into the backup area.
+///
+/// Same test-override seam as [`create_hard_link`], but on Unix production
+/// resolves both endpoints through the ownership walk
+/// ([`fast_io::operator_link`]). A backup area is an operator path, and the link
+/// tier runs *before* the rename tier, so confining only [`backup_rename`]
+/// would leave upstream's `backup-dir-symlink-race` escape wide open: the
+/// attacker's flipped parent redirects the link and the rename is never
+/// reached.
+///
+/// This is deliberately NOT folded into [`create_hard_link`]: that one also
+/// serves `-H` hardlink materialisation, which is a *transfer* path and takes
+/// the confined resolver, not the ownership one.
+///
+/// upstream: `rsync-3.5.0/backup.c:200-207` `link_or_rename()`;
+/// `syscall.c:676` `do_link_at()` under `operator_path_resolve`.
+pub(super) fn create_backup_hard_link(source: &Path, destination: &Path) -> io::Result<()> {
+    #[cfg(test)]
+    if let Some(result) = HARD_LINK_OVERRIDE.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .map(|override_fn| override_fn(source, destination))
+    }) {
+        return result;
+    }
+
+    #[cfg(unix)]
+    {
+        fast_io::operator_link(source, destination)
+    }
+    #[cfg(not(unix))]
+    {
+        fast_io::hard_link(source, destination)
+    }
+}
+
 #[cfg(test)]
 thread_local! {
     static DEVICE_ID_OVERRIDE: RefCell<Option<Box<DeviceIdOverrideFn>>> =

--- a/crates/engine/src/local_copy/tests/execute_dirlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_dirlinks.rs
@@ -790,3 +790,48 @@ fn keep_dirlinks_refuses_a_destination_symlink_pointing_outside_the_tree() {
         outside.display()
     );
 }
+
+/// A refused `-K` commit must leave the out-of-tree target **intact**.
+///
+/// The refusal is a security decision, not a licence to destroy: upstream
+/// 3.5.0 refuses this shape without touching the file (measured - the target
+/// survives byte-for-byte at exit 23). An implementation that cleared the
+/// destination before discovering the escape would turn a refusal into data
+/// loss, which is strictly worse than the escape it prevents.
+#[cfg(unix)]
+#[test]
+fn a_refused_keep_dirlinks_commit_does_not_destroy_the_existing_target() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().expect("tempdir");
+    let source_root = temp.path().join("source");
+    fs::create_dir_all(source_root.join("subdir")).expect("create source subdir");
+    fs::write(source_root.join("subdir/file.bin"), b"incoming").expect("write source");
+
+    let dest_root = temp.path().join("dest");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+
+    // The out-of-tree target already holds a file under the same name.
+    let outside = temp.path().join("outside-target");
+    fs::create_dir_all(&outside).expect("create outside target");
+    let victim = outside.join("file.bin");
+    fs::write(&victim, b"pre-existing payload").expect("write victim");
+    symlink(&outside, dest_root.join("subdir")).expect("create escaping symlink");
+
+    let mut source_operand = source_root.clone().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let result = plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().keep_dirlinks(true),
+    );
+
+    assert!(result.is_err(), "the escaping commit must be refused");
+    assert_eq!(
+        fs::read(&victim).expect("the refused commit must not delete the existing target"),
+        b"pre-existing payload",
+        "a refused commit must leave the target byte-for-byte unchanged"
+    );
+}

--- a/crates/engine/src/local_copy/tests/execute_dirlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_dirlinks.rs
@@ -620,6 +620,16 @@ fn keep_dirlinks_does_not_apply_when_source_sends_file_over_symlink_to_dir() {
 /// 4. The source file is modified slightly, triggering a delta (not whole-file) transfer.
 /// 5. The second sync with `-K` must succeed - the receiver sandbox (RESOLVE_BENEATH)
 ///    must resolve the path through the directory symlink correctly for verification.
+///
+/// The symlink target is **relative and in-tree**, which is the shape upstream
+/// serves: `ds_descend` follows a relative target and refuses an absolute one.
+/// An out-of-tree target is the refusal case, pinned by
+/// [`keep_dirlinks_refuses_a_destination_symlink_pointing_outside_the_tree`];
+/// the two together are the discriminating pair, since a fixture that merely
+/// failed to transfer anything would satisfy the refusal test alone.
+///
+/// upstream: `rsync-3.5.0/syscall.c:2961` `ds_descend()` - measured against the
+/// real 3.5.0 binary: this shape exits 0 and updates through the link.
 #[cfg(unix)]
 #[test]
 fn keep_dirlinks_delta_transfer_through_symlink_succeeds() {
@@ -632,9 +642,10 @@ fn keep_dirlinks_delta_transfer_through_symlink_succeeds() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
-    let real_target = temp.path().join("real-target");
+    // Relative, in-tree target: the shape upstream's confined walk follows.
+    let real_target = dest_root.join("real-target");
     fs::create_dir_all(&real_target).expect("create real target");
-    symlink(&real_target, dest_root.join("subdir")).expect("create symlink subdir");
+    symlink("real-target", dest_root.join("subdir")).expect("create symlink subdir");
 
     // Write a file large enough to exercise the delta algorithm (>= 2 blocks).
     // The file has a prefix that stays constant and a suffix that changes,
@@ -720,5 +731,62 @@ fn keep_dirlinks_delta_transfer_through_symlink_succeeds() {
     assert!(
         subdir_meta.file_type().is_symlink(),
         "subdir should remain a symlink after delta transfer with -K"
+    );
+}
+
+/// `-K` must **not** publish through a destination directory symlink whose
+/// target is absolute and outside the transfer tree.
+///
+/// This is the sibling of
+/// [`keep_dirlinks_delta_transfer_through_symlink_succeeds`]: the two fixtures
+/// differ only in the symlink's target, and upstream 3.5.0 answers them
+/// differently. `ds_descend` follows a relative in-tree target and refuses an
+/// absolute one with `ELOOP`, so `-K` does not license an escape - it only
+/// licenses treating an in-tree symlinked directory as a directory.
+///
+/// Measured directly against the real `rsync 3.5.0` binary on both macOS and
+/// Linux: this shape exits 23 with "Too many levels of symbolic links" and
+/// leaves the out-of-tree target byte-for-byte untouched.
+///
+/// upstream: `rsync-3.5.0/syscall.c:2953` `ds_descend()` - "absolute target:
+/// refuse".
+#[cfg(unix)]
+#[test]
+fn keep_dirlinks_refuses_a_destination_symlink_pointing_outside_the_tree() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().expect("tempdir");
+    let source_root = temp.path().join("source");
+    fs::create_dir_all(source_root.join("subdir")).expect("create source subdir");
+
+    let dest_root = temp.path().join("dest");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+
+    // Absolute target OUTSIDE dest_root - the escape upstream refuses.
+    let outside = temp.path().join("outside-target");
+    fs::create_dir_all(&outside).expect("create outside target");
+    symlink(&outside, dest_root.join("subdir")).expect("create escaping symlink");
+
+    let source_file = source_root.join("subdir/file.bin");
+    fs::write(&source_file, b"payload-from-source").expect("write source file");
+
+    let mut source_operand = source_root.clone().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let result = plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().keep_dirlinks(true),
+    );
+
+    assert!(
+        result.is_err(),
+        "-K must not publish through an out-of-tree destination symlink"
+    );
+    assert!(
+        !outside.join("file.bin").exists(),
+        "the payload escaped the destination tree into {}",
+        outside.display()
     );
 }

--- a/crates/engine/src/local_copy/tests/execute_dirlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_dirlinks.rs
@@ -373,10 +373,13 @@ fn keep_dirlinks_deeply_nested_parent_symlink_to_dir() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(dest_root.join("a")).expect("create dest/a");
 
-    // Make dest/a/b a symlink to a real directory
-    let real_b = temp.path().join("real-b");
+    // Make dest/a/b a symlink to a real directory. The target is relative and
+    // in-tree because that is the only shape upstream's confined walk follows;
+    // an absolute one exits 23 and transfers nothing (measured against rsync
+    // 3.5.0, refused at `ds_descend` rsync-3.5.0/syscall.c:2953).
+    let real_b = dest_root.join("a/real-b");
     fs::create_dir_all(real_b.join("c")).expect("create real-b/c");
-    symlink(&real_b, dest_root.join("a/b")).expect("create symlink a/b -> real-b");
+    symlink("real-b", dest_root.join("a/b")).expect("create symlink a/b -> real-b");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -455,15 +458,22 @@ fn keep_dirlinks_delete_preserves_symlink_removes_extraneous() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(source_root.join("subdir")).expect("create source subdir");
     fs::write(source_root.join("subdir/keep.txt"), b"keep").expect("write keep");
+    // The symlink target must exist in the source too, or --delete reaps it as
+    // extraneous and takes the symlink down with it - measured against rsync
+    // 3.5.0, which then leaves `subdir` a real directory.
+    fs::create_dir(source_root.join("real-target")).expect("create source real-target");
 
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
-    // Create a real directory as the symlink target, with extraneous content
-    let real_target = temp.path().join("real-target");
+    // A real directory as the symlink target, with extraneous content. Relative
+    // and in-tree: an absolute target is refused outright by upstream's confined
+    // walk (rsync-3.5.0/syscall.c:2953 `ds_descend`), so that shape exits 23 and
+    // deletes nothing - the refusal is pinned separately.
+    let real_target = dest_root.join("real-target");
     fs::create_dir(&real_target).expect("create real target");
     fs::write(real_target.join("extra.txt"), b"extraneous").expect("write extraneous file");
-    symlink(&real_target, dest_root.join("subdir")).expect("create symlink subdir");
+    symlink("real-target", dest_root.join("subdir")).expect("create symlink subdir");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());

--- a/crates/engine/src/local_copy/tests/execute_dirlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_dirlinks.rs
@@ -188,9 +188,13 @@ fn keep_dirlinks_preserves_symlink_subdir_during_recursive_copy() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
-    let real_target = temp.path().join("real-target");
+    // Relative, in-tree target: the only shape upstream's confined walk
+    // follows. `ds_descend` refuses any absolute target with ELOOP
+    // (rsync-3.5.0/syscall.c:2953), so an absolute one exits 23 and writes
+    // nothing - the refusal is pinned separately below.
+    let real_target = dest_root.join("real-target");
     fs::create_dir(&real_target).expect("create real target");
-    symlink(&real_target, dest_root.join("subdir")).expect("create symlink subdir");
+    symlink("real-target", dest_root.join("subdir")).expect("create symlink subdir");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -512,10 +516,12 @@ fn keep_dirlinks_mixed_real_and_symlink_subdirs() {
     // real-sub at destination is an actual directory
     fs::create_dir(dest_root.join("real-sub")).expect("create real dest subdir");
 
-    // link-sub at destination is a symlink to a real directory
-    let link_target = temp.path().join("link-target");
+    // link-sub at destination is a symlink to a real directory. The target is
+    // relative and in-tree because upstream's confined walk refuses an absolute
+    // one outright (rsync-3.5.0/syscall.c:2953 ds_descend).
+    let link_target = dest_root.join("link-target");
     fs::create_dir(&link_target).expect("create link target");
-    symlink(&link_target, dest_root.join("link-sub")).expect("create symlink link-sub");
+    symlink("link-target", dest_root.join("link-sub")).expect("create symlink link-sub");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());

--- a/crates/engine/src/local_copy/tests/execute_special.rs
+++ b/crates/engine/src/local_copy/tests/execute_special.rs
@@ -1939,13 +1939,19 @@ fn execute_keep_dirlinks_multiple_symlink_subdirs_all_preserved() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    let real_alpha = temp.path().join("real_alpha");
+    // Relative, in-tree targets. Upstream's confined walk follows these and
+    // refuses an absolute out-of-tree target, so only this shape exercises the
+    // "-K preserves the symlink and writes through it" behaviour the test is
+    // named for; the refusal is pinned separately in execute_dirlinks.rs.
+    // Measured against rsync 3.5.0: this fixture exits 0 with both links intact,
+    // while the absolute out-of-tree form exits 23 and transfers nothing.
+    let real_alpha = dest_root.join("real_alpha");
     fs::create_dir(&real_alpha).expect("create real alpha");
-    symlink(&real_alpha, dest_root.join("alpha")).expect("symlink alpha");
+    symlink("real_alpha", dest_root.join("alpha")).expect("symlink alpha");
 
-    let real_beta = temp.path().join("real_beta");
+    let real_beta = dest_root.join("real_beta");
     fs::create_dir(&real_beta).expect("create real beta");
-    symlink(&real_beta, dest_root.join("beta")).expect("symlink beta");
+    symlink("real_beta", dest_root.join("beta")).expect("symlink beta");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());

--- a/crates/engine/tests/platform_copy_dispatch.rs
+++ b/crates/engine/tests/platform_copy_dispatch.rs
@@ -38,11 +38,16 @@ use tempfile::tempdir;
 #[derive(Debug, Default)]
 struct CountingPlatformCopy {
     calls: AtomicUsize,
+    reflink_queries: AtomicUsize,
 }
 
 impl CountingPlatformCopy {
     fn calls(&self) -> usize {
         self.calls.load(Ordering::SeqCst)
+    }
+
+    fn reflink_queries(&self) -> usize {
+        self.reflink_queries.load(Ordering::SeqCst)
     }
 }
 
@@ -55,6 +60,7 @@ impl PlatformCopy for CountingPlatformCopy {
     }
 
     fn supports_reflink(&self) -> bool {
+        self.reflink_queries.fetch_add(1, Ordering::SeqCst);
         false
     }
 
@@ -94,9 +100,16 @@ fn builder_propagates_injected_platform_copy() {
     assert_eq!(counting.calls(), 1);
 }
 
-/// On macOS the executor dispatches new whole-file copies through
-/// `options.platform_copy()`. This test runs a single-file copy via
-/// `LocalCopyPlan` and asserts the injected fake is invoked at least once.
+/// The executor consults `options.platform_copy()` before taking the
+/// copy-on-write fast path. This test runs a single-file copy via
+/// `LocalCopyPlan` and asserts the injected fake is asked at least once.
+///
+/// It observes `supports_reflink()`, not `copy_file()`: the destination write
+/// deliberately no longer routes through the path-based
+/// `copy_file(src_path, dst_path)`. That signature cannot express an anchored
+/// destination, so it followed a parent symlink straight out of the transfer
+/// root - the escape `confined_clone_file` closes. The strategy's remaining
+/// job on this path is to veto the fast path, and that is what is pinned here.
 #[cfg(target_os = "macos")]
 #[test]
 fn executor_dispatches_whole_file_copy_through_platform_copy() {
@@ -124,10 +137,10 @@ fn executor_dispatches_whole_file_copy_through_platform_copy() {
         .expect("copy succeeds");
 
     assert!(
-        counting.calls() >= 1,
-        "executor should dispatch whole-file copy through the injected PlatformCopy \
-         (observed {} invocations)",
-        counting.calls()
+        counting.reflink_queries() >= 1,
+        "executor should consult the injected PlatformCopy before the CoW fast path \
+         (observed {} queries)",
+        counting.reflink_queries()
     );
 
     // The fake reports a non-zero-copy result, so the executor falls through

--- a/crates/engine/tests/platform_copy_dispatch.rs
+++ b/crates/engine/tests/platform_copy_dispatch.rs
@@ -46,6 +46,9 @@ impl CountingPlatformCopy {
         self.calls.load(Ordering::SeqCst)
     }
 
+    /// Only the macOS dispatch test reads this; gate it with its consumer so a
+    /// Linux build does not trip `-D dead-code`.
+    #[cfg(target_os = "macos")]
     fn reflink_queries(&self) -> usize {
         self.reflink_queries.load(Ordering::SeqCst)
     }

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
@@ -336,3 +336,77 @@ pub fn linkat_via_sandbox_or_fallback(
     }
     crate::hard_link(leader_path, new_path)
 }
+
+/// Publish an anonymous `O_TMPFILE` inode at `dest`, confining `dest`'s parent
+/// beneath `root`.
+///
+/// This is the `linkat(2)` counterpart of
+/// [`confined_rename`](super::rename::confined_rename). The `O_TMPFILE` write
+/// strategy stages the payload in an unnamed inode and gives it a name only at
+/// commit, so `linkat` - not `rename` - is the operation that publishes the
+/// file. It therefore needs the same confinement: without it a destination
+/// parent flipped to a symlink between the decision to commit and the syscall
+/// redirects the transferred file outside the tree, which is the escape
+/// upstream's `rename-fullpath-symlink-race` test demonstrates.
+///
+/// Only the destination is anchored. The source is the `/proc/self/fd/N` magic
+/// link naming the staged inode - not a tree path - and `AT_SYMLINK_FOLLOW` is
+/// required for the kernel to resolve it, so confining it is meaningless.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/syscall.c:676` `do_link_at()` - resolves the parent of each
+///   side and issues `linkat` against the resulting dirfd.
+/// - `rsync-3.5.0/syscall.c:2891` `ds_descend()` - the per-component walk that
+///   refuses an absolute symlink target.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component of the destination parent is a refused symlink
+///   or a climb above `root`. Deliberately **not** `EXDEV`, which callers treat
+///   as cross-device and answer with a copy+remove fallback.
+/// - Otherwise the `linkat(2)` errno verbatim, including `EEXIST` when `dest`
+///   already exists and a genuine `EXDEV`.
+#[cfg(unix)]
+pub fn confined_link_anonymous(staged: BorrowedFd<'_>, root: &Path, dest: &Path) -> io::Result<()> {
+    use super::rename::{ConfinedEndpoint, anchor_confined_endpoint};
+
+    let proc_path = format!("/proc/self/fd/{}", staged.as_raw_fd());
+    let c_old = CString::new(proc_path).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    let endpoint = anchor_confined_endpoint(root, dest)?;
+    // SAFETY: `AT_FDCWD` is a well-known pseudo-descriptor accepted by every
+    // `*at` syscall; it is never closed and outlives any borrow of it.
+    #[allow(unsafe_code)]
+    let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
+    let (new_dirfd, new_name) = match &endpoint {
+        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
+        ConfinedEndpoint::Ambient(path) => (cwd, *path),
+    };
+    let c_new = CString::new(new_name.as_bytes())
+        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // SAFETY:
+    // - `c_old`/`c_new` are valid NUL-terminated C strings borrowed for the
+    //   duration of the call; the kernel does not retain the pointers.
+    // - `new_dirfd` is either the walked parent (kept open by `endpoint`) or
+    //   `AT_FDCWD`; both outlive the syscall.
+    // - `AT_SYMLINK_FOLLOW` is required so the kernel resolves the
+    //   `/proc/self/fd/N` magic link to the staged inode.
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::linkat(
+            libc::AT_FDCWD,
+            c_old.as_ptr(),
+            new_dirfd.as_raw_fd(),
+            c_new.as_ptr(),
+            libc::AT_SYMLINK_FOLLOW,
+        )
+    };
+
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
@@ -410,3 +410,238 @@ pub fn confined_link_anonymous(staged: BorrowedFd<'_>, root: &Path, dest: &Path)
         Err(io::Error::last_os_error())
     }
 }
+
+/// Create `dest` exclusively, with its parent confined beneath `root`.
+///
+/// This is the direct-write counterpart of [`confined_rename`] and
+/// [`confined_link_anonymous`]: the parent is resolved by the same
+/// per-component walk through [`anchor_confined_endpoint`], then the leaf is
+/// created with `O_CREAT | O_EXCL | O_NOFOLLOW` relative to that dirfd. A
+/// destination parent flipped to a symlink between the decision to write and
+/// the create therefore cannot redirect the new file out of the tree.
+///
+/// Upstream never needs this primitive because `receiver.c` always stages into
+/// a `.name.XXXXXX` temp and commits with a rename, so its confinement comes
+/// from `do_rename_at()`. oc's direct-write strategy skips that staging as an
+/// optimisation for a not-yet-existing destination, which drops the invariant
+/// unless the create is confined here.
+///
+/// `O_EXCL` is retained from the unconfined path: it is what makes a
+/// concurrent writer lose the race with `EEXIST` rather than silently share
+/// the file. The creation mode is `0o666` for the same reason - that is what
+/// `std::fs::OpenOptions` passes, so confining the create does not also change
+/// the mode a `--no-perms` copy leaves behind.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/syscall.c:2891` `ds_descend()` - the per-component walk.
+/// - `rsync-3.5.0/receiver.c` - upstream's always-stage-then-rename shape.
+///
+/// # Errors
+///
+/// - `ELOOP` when a parent component is a refused symlink (an absolute target,
+///   or one climbing above the anchor). Deliberately not `EXDEV`, which
+///   callers treat as cross-device and retry by another route.
+/// - `EEXIST` when `dest` already exists.
+/// - Otherwise the underlying `openat(2)` error verbatim.
+pub fn confined_create_new(root: &Path, dest: &Path) -> io::Result<std::fs::File> {
+    use super::rename::{ConfinedEndpoint, anchor_confined_endpoint};
+    use std::os::fd::FromRawFd;
+
+    let endpoint = anchor_confined_endpoint(root, dest)?;
+    // SAFETY: `AT_FDCWD` is a well-known pseudo-descriptor accepted by every
+    // `*at` syscall; it is never closed and outlives any borrow of it.
+    #[allow(unsafe_code)]
+    let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
+    let (dirfd, name) = match &endpoint {
+        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
+        ConfinedEndpoint::Ambient(path) => (cwd, *path),
+    };
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    let flags = libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    // SAFETY:
+    // - `c_name` is a valid NUL-terminated C string borrowed for the duration
+    //   of the call; the kernel does not retain the pointer.
+    // - `dirfd` is either the walked parent (kept open by `endpoint`) or
+    //   `AT_FDCWD`; both outlive the syscall.
+    // - The returned descriptor is owned here and handed to `File`, which
+    //   closes it exactly once.
+    #[allow(unsafe_code)]
+    let fd = unsafe { libc::openat(dirfd.as_raw_fd(), c_name.as_ptr(), flags, 0o666) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    #[allow(unsafe_code)]
+    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+}
+
+/// Outcome of an anchored copy-on-write clone attempt.
+///
+/// Distinguishes "the filesystem will not reflink" - a routine condition the
+/// caller answers by falling back to a data copy - from a confinement refusal,
+/// which is an error and must never degrade to an unconfined write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloneAttempt {
+    /// A true zero-copy reflink was created at the anchored destination.
+    Cloned,
+    /// The platform or filesystem cannot reflink here (not APFS/Btrfs/XFS,
+    /// cross-device, unsupported kernel). Nothing was created.
+    Unsupported,
+}
+
+/// Clone `src` to `dest` with `dest`'s parent confined beneath `root`.
+///
+/// The copy-on-write fast path is the one destination sink that cannot be
+/// confined by anchoring the *commit*: a reflink both creates and populates
+/// the destination in a single syscall, so the create IS the confinement
+/// decision. Anchoring the parent and cloning through that dirfd is therefore
+/// the only race-free form - a check-then-`clonefile` gate would still lose to
+/// a parent flipped between the two.
+///
+/// Upstream has no counterpart: `receiver.c` always stages into a
+/// `.name.XXXXXX` temp and commits with a rename, so it never reflinks onto
+/// the final name and inherits `do_rename_at()`'s confinement. This primitive
+/// exists so oc's CoW optimisation keeps the same invariant.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/syscall.c:2891` `ds_descend()` - the per-component walk.
+///
+/// # Errors
+///
+/// - `ELOOP` when a parent component is a refused symlink (an absolute target,
+///   or one climbing above the anchor). The caller must propagate this, not
+///   fall back to a path-based copy.
+/// - `EEXIST` when `dest` already exists - the same race semantics `O_EXCL`
+///   gives the plain create.
+/// - Any other error from opening `src` or anchoring `dest`'s parent.
+///
+/// A filesystem that simply cannot reflink reports `Ok(CloneAttempt::Unsupported)`,
+/// never an error.
+pub fn confined_clone_file(root: &Path, src: &Path, dest: &Path) -> io::Result<CloneAttempt> {
+    use super::rename::{ConfinedEndpoint, anchor_confined_endpoint};
+
+    let endpoint = anchor_confined_endpoint(root, dest)?;
+    // SAFETY: `AT_FDCWD` is a well-known pseudo-descriptor accepted by every
+    // `*at` syscall; it is never closed and outlives any borrow of it.
+    #[allow(unsafe_code)]
+    let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
+    let (dirfd, name) = match &endpoint {
+        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
+        ConfinedEndpoint::Ambient(path) => (cwd, *path),
+    };
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    clone_at(src, dirfd, &c_name)
+}
+
+/// macOS: `fclonefileat(2)` publishes the clone under the anchored dirfd.
+///
+/// The source is passed as an already-open descriptor, so the flag that
+/// controls source-symlink following (`CLONE_NOFOLLOW`) is not applicable;
+/// whether the source may be a symlink is the source-confinement decision made
+/// by the caller before it opens the file.
+#[cfg(target_os = "macos")]
+fn clone_at(src: &Path, dirfd: BorrowedFd<'_>, name: &CString) -> io::Result<CloneAttempt> {
+    let source = std::fs::File::open(src)?;
+    // SAFETY: `source` is owned here and outlives the call; `dirfd` is the
+    // walked parent held by the caller's endpoint; `name` is a valid
+    // NUL-terminated string borrowed for the duration of the call.
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::fclonefileat(
+            source.as_raw_fd(),
+            dirfd.as_raw_fd(),
+            name.as_ptr(),
+            0, /* flags */
+        )
+    };
+    if rc == 0 {
+        return Ok(CloneAttempt::Cloned);
+    }
+    let error = io::Error::last_os_error();
+    classify_clone_error(error)
+}
+
+/// Linux: create the destination confined, then reflink into it with `FICLONE`.
+///
+/// Unlike macOS there is no single anchored clone syscall, so the two halves
+/// are composed: [`confined_create_new`] provides the anchored, `O_EXCL` inode
+/// and the ioctl fills it. A failed ioctl must not leave the empty inode
+/// behind - the caller is entitled to treat `Unsupported` as "nothing was
+/// created" and fall through to a data copy that expects to create the file.
+#[cfg(target_os = "linux")]
+fn clone_at(src: &Path, dirfd: BorrowedFd<'_>, name: &CString) -> io::Result<CloneAttempt> {
+    use std::os::fd::FromRawFd;
+
+    let source = std::fs::File::open(src)?;
+    let flags = libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    // SAFETY: `dirfd` outlives the call and `name` is a valid NUL-terminated
+    // string; the returned descriptor is owned here and closed exactly once by
+    // the `File` below.
+    #[allow(unsafe_code)]
+    let fd = unsafe { libc::openat(dirfd.as_raw_fd(), name.as_ptr(), flags, 0o666) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    #[allow(unsafe_code)]
+    let destination = unsafe { std::fs::File::from_raw_fd(fd) };
+
+    // SAFETY: both descriptors are owned and open for the duration of the
+    // ioctl; `FICLONE` takes the source fd by value, not a pointer.
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::ioctl(
+            destination.as_raw_fd(),
+            libc::FICLONE,
+            source.as_raw_fd() as libc::c_int,
+        )
+    };
+    if rc == 0 {
+        return Ok(CloneAttempt::Cloned);
+    }
+    let error = io::Error::last_os_error();
+    drop(destination);
+    // Remove the empty inode the failed reflink left anchored under `dirfd`,
+    // so `Unsupported` really does mean "nothing was created".
+    // SAFETY: `dirfd` and `name` are still valid; failure is ignored because
+    // the reflink error is the one worth reporting.
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::unlinkat(dirfd.as_raw_fd(), name.as_ptr(), 0);
+    }
+    classify_clone_error(error)
+}
+
+/// Platforms with no anchored reflink primitive never take the fast path.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn clone_at(src: &Path, dirfd: BorrowedFd<'_>, name: &CString) -> io::Result<CloneAttempt> {
+    let _ = (src, dirfd, name);
+    Ok(CloneAttempt::Unsupported)
+}
+
+/// Split "this filesystem will not reflink" from a real failure.
+///
+/// Only the former may fall back to a data copy. Anything else - notably a
+/// confinement refusal, which surfaces before this point - propagates.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn classify_clone_error(error: io::Error) -> io::Result<CloneAttempt> {
+    match error.raw_os_error() {
+        // ENOTSUP/EOPNOTSUPP: filesystem has no reflink. EXDEV: different
+        // filesystems. EINVAL: same-file or an unsupported combination.
+        // ENOSYS: kernel too old for the ioctl.
+        Some(code)
+            if code == libc::ENOTSUP
+                || code == libc::EOPNOTSUPP
+                || code == libc::EXDEV
+                || code == libc::EINVAL
+                || code == libc::ENOSYS =>
+        {
+            Ok(CloneAttempt::Unsupported)
+        }
+        _ => Err(error),
+    }
+}

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
@@ -58,7 +58,7 @@ pub use open::{
     openat, openat_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
 };
 pub use read_dir::{DirEntryView, EntryKind, ReadDirOutcome, read_dir_via_sandbox_or_fallback};
-pub use rename::{renameat, renameat_via_sandbox_or_fallback};
+pub use rename::{confined_rename, renameat, renameat_via_sandbox_or_fallback};
 pub use unlink::{
     UnlinkFlags, UnlinkResidue, recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback,
     unlink_via_sandbox_or_fallback, unlinkat,

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
@@ -44,8 +44,8 @@ mod unlink;
 mod tests;
 
 pub use create::{
-    linkat, linkat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, symlinkat,
-    symlinkat_via_sandbox_or_fallback,
+    confined_link_anonymous, linkat, linkat_via_sandbox_or_fallback, mkdirat,
+    mkdirat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
 };
 pub use lstat::{LstatOutcome, lstat_via_sandbox_or_fallback};
 pub use metadata::{AtMetadata, fstatat_nofollow};

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
@@ -44,8 +44,9 @@ mod unlink;
 mod tests;
 
 pub use create::{
-    confined_link_anonymous, linkat, linkat_via_sandbox_or_fallback, mkdirat,
-    mkdirat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
+    CloneAttempt, confined_clone_file, confined_create_new, confined_link_anonymous, linkat,
+    linkat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, symlinkat,
+    symlinkat_via_sandbox_or_fallback,
 };
 pub use lstat::{LstatOutcome, lstat_via_sandbox_or_fallback};
 pub use metadata::{AtMetadata, fstatat_nofollow};

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
@@ -209,3 +209,105 @@ pub fn renameat_via_sandbox_or_fallback(
     }
     std::fs::rename(old_link_path, new_link_path)
 }
+
+/// One endpoint of a [`confined_rename`], already reduced to a dirfd plus a
+/// name to pass to `renameat(2)`.
+///
+/// The [`Anchored`](Self::Anchored) arm owns the walked [`DirSandbox`], so the
+/// parent descriptor stays open for the duration of the syscall.
+#[cfg(unix)]
+enum RenameEndpoint<'a> {
+    /// The endpoint lives beneath the confinement root; `sandbox` holds the
+    /// walked parent and `leaf` is the final component.
+    Anchored {
+        sandbox: crate::dir_sandbox::DirSandbox,
+        leaf: &'a OsStr,
+    },
+    /// The endpoint is outside the root (an operator-supplied absolute
+    /// `--temp-dir`/`--partial-dir`, say). Resolved against `AT_FDCWD` from the
+    /// whole path, exactly as a plain `rename(2)` would.
+    Ambient(&'a OsStr),
+}
+
+/// Reduce one endpoint to `(dirfd, name)` for `renameat(2)`.
+///
+/// Anchoring applies only when `path` lexically lies beneath `root` and has a
+/// final component: the parent is then walked beneath `root` with
+/// [`DirSandbox::open_dest_anchor_confined`], which follows relative in-tree
+/// symlinks and refuses absolute targets and climbs above the anchor.
+///
+/// Anything else degrades to [`RenameEndpoint::Ambient`] - the pre-existing
+/// path-based behaviour for that side - rather than failing the rename.
+#[cfg(unix)]
+fn anchor_rename_endpoint<'a>(root: &Path, path: &'a Path) -> io::Result<RenameEndpoint<'a>> {
+    use crate::dir_sandbox::{ConfinePolicy, DirSandbox, NoExclude};
+
+    let Ok(relative) = path.strip_prefix(root) else {
+        return Ok(RenameEndpoint::Ambient(path.as_os_str()));
+    };
+    let Some(leaf) = relative.file_name() else {
+        return Ok(RenameEndpoint::Ambient(path.as_os_str()));
+    };
+    let parent = relative.parent().unwrap_or_else(|| Path::new(""));
+    let sandbox =
+        DirSandbox::open_dest_anchor_confined(root, parent, ConfinePolicy::confined(NoExclude))?;
+    Ok(RenameEndpoint::Anchored { sandbox, leaf })
+}
+
+/// Rename `old_path` to `new_path`, confining **each side independently**
+/// beneath `root`.
+///
+/// A side that lies beneath `root` has its parent resolved by the confined
+/// per-component walk, so a directory component flipped to a symlink between
+/// the decision to commit and the syscall cannot redirect the rename out of the
+/// tree. A side that does not lie beneath `root` keeps the ambient path-based
+/// resolution.
+///
+/// Per-side independence is the whole point: an operator-supplied absolute
+/// `--temp-dir` puts the *source* outside the tree, and an all-or-nothing rule
+/// would let that disable confinement of the *destination* - which is the
+/// escape upstream's `rename-fullpath-symlink-race` test demonstrates.
+///
+/// `replace` mirrors the [`renameat`] knob: `true` overwrites the destination
+/// atomically, matching [`std::fs::rename`] and upstream `do_rename()`.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/syscall.c:1866` `do_rename_at()` - "Confine each side
+///   independently. [...] Doing each side independently means an absolute
+///   source never disables confinement of a relative destination."
+/// - `rsync-3.5.0/syscall.c:2891` `ds_descend()` - the per-component walk.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component of either confined side is a refused symlink (an
+///   absolute target, or one landing outside the anchor) or a climb above the
+///   anchor. Deliberately **not** `EXDEV`: callers treat `EXDEV` as
+///   cross-device and fall back to copy+remove, which would defeat the refusal.
+/// - Otherwise the `renameat(2)` error verbatim, including a genuine `EXDEV`.
+#[cfg(unix)]
+pub fn confined_rename(
+    root: &Path,
+    old_path: &Path,
+    new_path: &Path,
+    replace: bool,
+) -> io::Result<()> {
+    // SAFETY: `AT_FDCWD` is a well-known pseudo-descriptor accepted by every
+    // `*at` syscall; it is never closed and outlives any borrow of it.
+    #[allow(unsafe_code)]
+    let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
+
+    let old = anchor_rename_endpoint(root, old_path)?;
+    let new = anchor_rename_endpoint(root, new_path)?;
+
+    let (old_dirfd, old_name) = match &old {
+        RenameEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
+        RenameEndpoint::Ambient(path) => (cwd, *path),
+    };
+    let (new_dirfd, new_name) = match &new {
+        RenameEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
+        RenameEndpoint::Ambient(path) => (cwd, *path),
+    };
+
+    renameat(old_dirfd, old_name, new_dirfd, new_name, replace)
+}

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
@@ -210,13 +210,20 @@ pub fn renameat_via_sandbox_or_fallback(
     std::fs::rename(old_link_path, new_link_path)
 }
 
-/// One endpoint of a [`confined_rename`], already reduced to a dirfd plus a
-/// name to pass to `renameat(2)`.
+/// One endpoint of a confined commit, already reduced to a dirfd plus a name to
+/// pass to the `*at` syscall.
 ///
 /// The [`Anchored`](Self::Anchored) arm owns the walked [`DirSandbox`], so the
 /// parent descriptor stays open for the duration of the syscall.
+///
+/// Shared by [`confined_rename`] and by the `O_TMPFILE` `linkat(2)` commit
+/// ([`super::create::confined_link_anonymous`]): both publish a staged file
+/// under its final name, so both must anchor that name the same way. Keeping
+/// one owner of the rule is what stops the two commit strategies drifting -
+/// the Linux `O_TMPFILE` path silently skipped confinement while the named-temp
+/// rename enforced it, so the same escape was open on one platform only.
 #[cfg(unix)]
-enum RenameEndpoint<'a> {
+pub(super) enum ConfinedEndpoint<'a> {
     /// The endpoint lives beneath the confinement root; `sandbox` holds the
     /// walked parent and `leaf` is the final component.
     Anchored {
@@ -236,22 +243,25 @@ enum RenameEndpoint<'a> {
 /// [`DirSandbox::open_dest_anchor_confined`], which follows relative in-tree
 /// symlinks and refuses absolute targets and climbs above the anchor.
 ///
-/// Anything else degrades to [`RenameEndpoint::Ambient`] - the pre-existing
+/// Anything else degrades to [`ConfinedEndpoint::Ambient`] - the pre-existing
 /// path-based behaviour for that side - rather than failing the rename.
 #[cfg(unix)]
-fn anchor_rename_endpoint<'a>(root: &Path, path: &'a Path) -> io::Result<RenameEndpoint<'a>> {
+pub(super) fn anchor_confined_endpoint<'a>(
+    root: &Path,
+    path: &'a Path,
+) -> io::Result<ConfinedEndpoint<'a>> {
     use crate::dir_sandbox::{ConfinePolicy, DirSandbox, NoExclude};
 
     let Ok(relative) = path.strip_prefix(root) else {
-        return Ok(RenameEndpoint::Ambient(path.as_os_str()));
+        return Ok(ConfinedEndpoint::Ambient(path.as_os_str()));
     };
     let Some(leaf) = relative.file_name() else {
-        return Ok(RenameEndpoint::Ambient(path.as_os_str()));
+        return Ok(ConfinedEndpoint::Ambient(path.as_os_str()));
     };
     let parent = relative.parent().unwrap_or_else(|| Path::new(""));
     let sandbox =
         DirSandbox::open_dest_anchor_confined(root, parent, ConfinePolicy::confined(NoExclude))?;
-    Ok(RenameEndpoint::Anchored { sandbox, leaf })
+    Ok(ConfinedEndpoint::Anchored { sandbox, leaf })
 }
 
 /// Rename `old_path` to `new_path`, confining **each side independently**
@@ -297,16 +307,16 @@ pub fn confined_rename(
     #[allow(unsafe_code)]
     let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
 
-    let old = anchor_rename_endpoint(root, old_path)?;
-    let new = anchor_rename_endpoint(root, new_path)?;
+    let old = anchor_confined_endpoint(root, old_path)?;
+    let new = anchor_confined_endpoint(root, new_path)?;
 
     let (old_dirfd, old_name) = match &old {
-        RenameEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
-        RenameEndpoint::Ambient(path) => (cwd, *path),
+        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
+        ConfinedEndpoint::Ambient(path) => (cwd, *path),
     };
     let (new_dirfd, new_name) = match &new {
-        RenameEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
-        RenameEndpoint::Ambient(path) => (cwd, *path),
+        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
+        ConfinedEndpoint::Ambient(path) => (cwd, *path),
     };
 
     renameat(old_dirfd, old_name, new_dirfd, new_name, replace)

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -81,7 +81,7 @@ mod tests;
 
 pub use at_syscalls::{
     AtMetadata, DirEntryView, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags, UnlinkResidue,
-    confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
+    confined_link_anonymous, confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
     fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
     lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
     openat_via_sandbox_or_fallback, read_dir_via_sandbox_or_fallback, readlinkat,

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -80,8 +80,9 @@ pub mod at_syscalls;
 mod tests;
 
 pub use at_syscalls::{
-    AtMetadata, DirEntryView, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags, UnlinkResidue,
-    confined_link_anonymous, confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
+    AtMetadata, CloneAttempt, DirEntryView, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,
+    UnlinkResidue, confined_clone_file, confined_create_new, confined_link_anonymous,
+    confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
     fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
     lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
     openat_via_sandbox_or_fallback, read_dir_via_sandbox_or_fallback, readlinkat,

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -85,7 +85,7 @@ pub use at_syscalls::{
     fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback,
     mkdirat, mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
     read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
-    recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
+    confined_rename, recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
     renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at,
     symlinkat, symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
     utimensat, utimensat_via_sandbox_or_fallback,

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -81,14 +81,15 @@ mod tests;
 
 pub use at_syscalls::{
     AtMetadata, DirEntryView, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags, UnlinkResidue,
-    fchmodat, fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback,
-    fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback,
-    mkdirat, mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
-    read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
-    confined_rename, recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
-    renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at,
-    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
-    utimensat, utimensat_via_sandbox_or_fallback,
+    confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
+    fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
+    lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
+    openat_via_sandbox_or_fallback, read_dir_via_sandbox_or_fallback, readlinkat,
+    readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
+    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
+    secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
+    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
+    utimensat_via_sandbox_or_fallback,
 };
 
 /// Parent-dirfd carrier threaded through the receiver pipeline.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -88,11 +88,6 @@ pub mod cached_sort;
 /// daemon sender cannot be redirected outside its module by a swapped
 /// directory symlink (TOCTOU escape).
 pub mod confined_open;
-/// Unix-only: ownership-trusted resolution for operator-supplied paths
-/// (`--backup-dir`, `--temp-dir`, alt-dests), mirroring upstream
-/// `owner_walk_parent` (`syscall.c:558`).
-#[cfg(unix)]
-pub mod owner_walk;
 /// Path-confinement activation: who is confined, and against what root.
 ///
 /// Pure policy with no I/O, so it builds and is tested on every target.
@@ -127,6 +122,11 @@ pub mod net_reader;
 /// Receiver-side basis open with `O_NOFOLLOW` on the basename, matching
 /// upstream rsync's `do_open_at()` dirname/basename split.
 pub mod nofollow_open;
+/// Unix-only: ownership-trusted resolution for operator-supplied paths
+/// (`--backup-dir`, `--temp-dir`, alt-dests), mirroring upstream
+/// `owner_walk_parent` (`syscall.c:558`).
+#[cfg(unix)]
+pub mod owner_walk;
 /// Page-aligned buffer pool for IOCP no-buffering mode.
 pub mod page_aligned;
 /// Parallel file I/O operations using rayon.
@@ -372,8 +372,6 @@ pub use gcd::{GcdQueue, GcdReader, GcdWriter};
 #[cfg(unix)]
 pub use confined_open::{LeafPolicy, open_source_confined};
 #[cfg(unix)]
-pub use owner_walk::{operator_link, operator_rename, owner_trusted_parent};
-#[cfg(unix)]
 pub use dir_sandbox::{
     AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,
     UnlinkResidue, confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
@@ -394,6 +392,8 @@ pub use kernel_version::{
 #[cfg(unix)]
 pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
+#[cfg(unix)]
+pub use owner_walk::{operator_link, operator_rename, owner_trusted_parent};
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]
 pub use secure_dir::{open_trusted_dir, secure_open_dir};

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -369,7 +369,7 @@ pub use confined_open::{LeafPolicy, open_source_confined};
 #[cfg(unix)]
 pub use dir_sandbox::{
     AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,
-    UnlinkResidue, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
+    UnlinkResidue, confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
     fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
     lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
     openat_via_sandbox_or_fallback, read_dir_via_sandbox_or_fallback, readlinkat,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -88,6 +88,11 @@ pub mod cached_sort;
 /// daemon sender cannot be redirected outside its module by a swapped
 /// directory symlink (TOCTOU escape).
 pub mod confined_open;
+/// Unix-only: ownership-trusted resolution for operator-supplied paths
+/// (`--backup-dir`, `--temp-dir`, alt-dests), mirroring upstream
+/// `owner_walk_parent` (`syscall.c:558`).
+#[cfg(unix)]
+pub mod owner_walk;
 /// Path-confinement activation: who is confined, and against what root.
 ///
 /// Pure policy with no I/O, so it builds and is tested on every target.
@@ -366,6 +371,8 @@ pub use gcd::{GcdQueue, GcdReader, GcdWriter};
 
 #[cfg(unix)]
 pub use confined_open::{LeafPolicy, open_source_confined};
+#[cfg(unix)]
+pub use owner_walk::{operator_rename, owner_trusted_parent};
 #[cfg(unix)]
 pub use dir_sandbox::{
     AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -372,7 +372,7 @@ pub use gcd::{GcdQueue, GcdReader, GcdWriter};
 #[cfg(unix)]
 pub use confined_open::{LeafPolicy, open_source_confined};
 #[cfg(unix)]
-pub use owner_walk::{operator_rename, owner_trusted_parent};
+pub use owner_walk::{operator_link, operator_rename, owner_trusted_parent};
 #[cfg(unix)]
 pub use dir_sandbox::{
     AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -373,16 +373,17 @@ pub use gcd::{GcdQueue, GcdReader, GcdWriter};
 pub use confined_open::{LeafPolicy, open_source_confined};
 #[cfg(unix)]
 pub use dir_sandbox::{
-    AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,
-    UnlinkResidue, confined_link_anonymous, confined_rename, fchmodat,
-    fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback, fstatat_nofollow,
-    linkat, linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
-    mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
-    read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
-    recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
-    renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at,
-    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
-    utimensat, utimensat_via_sandbox_or_fallback,
+    AtMetadata, CloneAttempt, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome,
+    UnlinkFlags, UnlinkResidue, confined_clone_file, confined_create_new, confined_link_anonymous,
+    confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
+    fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
+    lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
+    openat_via_sandbox_or_fallback, read_dir_via_sandbox_or_fallback, readlinkat,
+    readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
+    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
+    secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
+    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
+    utimensat_via_sandbox_or_fallback,
 };
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, IoUringRequirement, KernelVersion, LinkatRequirement, PbufRingRequirement,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -374,15 +374,15 @@ pub use confined_open::{LeafPolicy, open_source_confined};
 #[cfg(unix)]
 pub use dir_sandbox::{
     AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,
-    UnlinkResidue, confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
-    fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
-    lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
-    openat_via_sandbox_or_fallback, read_dir_via_sandbox_or_fallback, readlinkat,
-    readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
-    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
-    secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
-    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
-    utimensat_via_sandbox_or_fallback,
+    UnlinkResidue, confined_link_anonymous, confined_rename, fchmodat,
+    fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback, fstatat_nofollow,
+    linkat, linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
+    mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
+    read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
+    recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
+    renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at,
+    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
+    utimensat, utimensat_via_sandbox_or_fallback,
 };
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, IoUringRequirement, KernelVersion, LinkatRequirement, PbufRingRequirement,

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -25,8 +25,6 @@
 //!   outside the tree, so the trust signal is authority (ownership), not
 //!   location."
 
-#![cfg(unix)]
-
 use std::ffi::{OsStr, OsString};
 use std::io;
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
@@ -81,7 +79,7 @@ fn split_parent(path: &Path) -> Option<(Vec<OsString>, OsString)> {
             Component::Normal(name) => names.push(name.to_os_string()),
             Component::ParentDir => names.push(OsString::from("..")),
             // `/` is expressed by the walk starting at the root; `.` is a no-op;
-            // a Windows prefix cannot occur under `#![cfg(unix)]`.
+            // a Windows prefix cannot occur on a Unix-only module.
             Component::RootDir | Component::CurDir | Component::Prefix(_) => {}
         }
     }

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -1,0 +1,205 @@
+//! Ownership-trusted resolution for **operator-supplied** paths.
+//!
+//! An operator path - a `--backup-dir`, `--temp-dir`, `--partial-dir` or
+//! alt-dest the person running rsync named - may legitimately point outside the
+//! transfer tree, so the confined walk in [`crate::dir_sandbox`] is the wrong
+//! policy for it: location cannot be the trust signal. Upstream's answer is to
+//! make **authority** the signal instead - follow a symlink owned by uid 0 or
+//! our own euid (the operator's own layout), refuse any other-uid one, at every
+//! component.
+//!
+//! That distinction is the whole defence in upstream's
+//! `backup-dir-symlink-race` test: an attacker who can create entries inside the
+//! backup tree flips a parent component between a real directory and a symlink
+//! pointing outside, and a path-based rename lands the backup wherever the
+//! symlink pointed at the instant the kernel resolved it.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/syscall.c:558` `owner_walk_parent()` - open the parent of an
+//!   operator path via the ownership walk, hand back the final component.
+//! - `rsync-3.5.0/syscall.c:286` `ona_open()` - the per-component walk itself.
+//! - `rsync-3.5.0/syscall.c:406` - the ownership test:
+//!   `if (lst.st_uid != 0 && lst.st_uid != trusted_uid)` refuse with `ELOOP`.
+//! - `rsync-3.5.0/syscall.c:544-551` - "An operator path may legitimately point
+//!   outside the tree, so the trust signal is authority (ownership), not
+//!   location."
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path, PathBuf};
+
+use rustix::fs::{AtFlags, FileType, Mode, OFlags};
+
+/// Symlink-follow budget for one walk, spent across every component.
+///
+/// upstream: `rsync-3.5.0/syscall.c:361` `int loops = 40;` - "SYMLOOP_MAX-ish;
+/// breaks symlink cycles. Counts symlink expansions only, NOT path depth."
+const MAX_SYMLINK_HOPS: u32 = 40;
+
+/// Effective uid, the second trusted owner alongside root.
+///
+/// upstream: `rsync-3.5.0/syscall.c:304` `const uid_t trusted_uid = geteuid();`
+fn trusted_uid() -> u32 {
+    // SAFETY: `geteuid(2)` takes no arguments, cannot fail, and returns a plain
+    // integer. It is one of the few POSIX calls with no error path at all.
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::geteuid()
+    }
+}
+
+/// Open a directory component beneath `dirfd`, refusing a symlink at the leaf.
+///
+/// The caller has already `statat`'d the component and found it is not a
+/// symlink; `O_NOFOLLOW` closes the window between that check and this open, so
+/// a component flipped to a symlink in between fails rather than resolves.
+fn open_dir_component(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<OwnedFd> {
+    rustix::fs::openat(
+        dirfd,
+        name,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))
+}
+
+/// Split `path` into the components of its parent plus the final name.
+///
+/// Returns `None` when the path has no final component (`/`, `.`, `..`, or
+/// empty), which no operator path being renamed onto can have.
+fn split_parent(path: &Path) -> Option<(Vec<OsString>, OsString)> {
+    let leaf = path.file_name()?.to_os_string();
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    let mut names = Vec::new();
+    for component in parent.components() {
+        match component {
+            Component::Normal(name) => names.push(name.to_os_string()),
+            Component::ParentDir => names.push(OsString::from("..")),
+            // `/` is expressed by the walk starting at the root; `.` is a no-op;
+            // a Windows prefix cannot occur under `#![cfg(unix)]`.
+            Component::RootDir | Component::CurDir | Component::Prefix(_) => {}
+        }
+    }
+    Some((names, leaf))
+}
+
+/// Push the components of `path` onto the front of `pending`, in order.
+fn prepend_components(pending: &mut Vec<OsString>, path: &Path) {
+    let mut head: Vec<OsString> = path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(name) => Some(name.to_os_string()),
+            Component::ParentDir => Some(OsString::from("..")),
+            _ => None,
+        })
+        .collect();
+    head.append(pending);
+    *pending = head;
+}
+
+/// Open the parent directory of `path` via the ownership walk.
+///
+/// Every component is inspected with `AT_SYMLINK_NOFOLLOW` before it is opened.
+/// A symlink owned by uid 0 or the euid is followed (its target is spliced into
+/// the remaining path, an absolute target restarting the walk at `/`); a symlink
+/// owned by anyone else is refused.
+///
+/// Returns the parent descriptor plus the final component, ready for a `*at`
+/// operation.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component is a symlink owned by an untrusted uid, or the
+///   hop budget is exhausted. This is the security refusal, and it is
+///   deliberately not `EXDEV`: callers treat `EXDEV` as cross-device and fall
+///   back to copy+remove, which would defeat the refusal.
+/// - `EINVAL` when `path` has no final component.
+/// - Otherwise the `openat`/`statat`/`readlinkat` errno verbatim.
+pub fn owner_trusted_parent(path: &Path) -> io::Result<(OwnedFd, OsString)> {
+    let Some((mut pending, leaf)) = split_parent(path) else {
+        return Err(io::Error::from_raw_os_error(libc::EINVAL));
+    };
+
+    let start = if path.is_absolute() { "/" } else { "." };
+    let mut dirfd = rustix::fs::open(
+        start,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
+
+    let trusted = trusted_uid();
+    let mut hops = MAX_SYMLINK_HOPS;
+
+    while !pending.is_empty() {
+        let name = pending.remove(0);
+        let stat = rustix::fs::statat(dirfd.as_fd(), name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW)
+            .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
+
+        if FileType::from_raw_mode(stat.st_mode as _) != FileType::Symlink {
+            dirfd = open_dir_component(dirfd.as_fd(), name.as_os_str())?;
+            continue;
+        }
+
+        // upstream: syscall.c:406 - an other-uid symlink is the attacker's, and
+        // is refused; uid 0 or our own euid is the operator's own layout.
+        if stat.st_uid != 0 && stat.st_uid != trusted {
+            return Err(io::Error::from_raw_os_error(libc::ELOOP));
+        }
+        if hops == 0 {
+            return Err(io::Error::from_raw_os_error(libc::ELOOP));
+        }
+        hops -= 1;
+
+        let target = rustix::fs::readlinkat(dirfd.as_fd(), name.as_os_str(), Vec::new())
+            .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
+        let target = PathBuf::from(OsStr::from_bytes(target.as_bytes()));
+        if target.is_absolute() {
+            // upstream: syscall.c:422 "Absolute target restarts the walk from /".
+            dirfd = rustix::fs::open(
+                "/",
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+            )
+            .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
+        }
+        prepend_components(&mut pending, &target);
+    }
+
+    Ok((dirfd, leaf))
+}
+
+/// Rename `old_path` to `new_path` with both endpoints resolved by the
+/// ownership walk.
+///
+/// This is the operator-path counterpart to
+/// [`confined_rename`](crate::confined_rename): that one confines beneath a
+/// transfer root, this one trusts by ownership so an operator directory outside
+/// the tree still works. Each side is walked independently, mirroring upstream.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/syscall.c:1894` `do_rename_at()` under `operator_path_resolve`
+///   - `owner_walk_parent` on each side, then `renameat`.
+/// - `rsync-3.5.0/backup.c:200-219` `make_backup()` - the caller that sets the
+///   operator-path mode around the backup rename.
+///
+/// # Errors
+///
+/// Propagates the walk's refusal (`ELOOP`) or the `renameat(2)` errno.
+pub fn operator_rename(old_path: &Path, new_path: &Path, replace: bool) -> io::Result<()> {
+    let (old_dirfd, old_leaf) = owner_trusted_parent(old_path)?;
+    let (new_dirfd, new_leaf) = owner_trusted_parent(new_path)?;
+    crate::renameat(
+        old_dirfd.as_fd(),
+        &old_leaf,
+        new_dirfd.as_fd(),
+        &new_leaf,
+        replace,
+    )
+}

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -203,3 +203,28 @@ pub fn operator_rename(old_path: &Path, new_path: &Path, replace: bool) -> io::R
         replace,
     )
 }
+
+/// Hard-link `old_path` to `new_path` with both endpoints resolved by the
+/// ownership walk.
+///
+/// The link tier runs *before* the rename tier in a backup, so confining only
+/// the rename would leave the escape wide open - upstream sets the
+/// operator-path mode around `link_or_rename()` as a whole, covering both.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/backup.c:200-207` `link_or_rename()` - `do_link_at` first,
+///   `do_rename_at` on failure.
+/// - `rsync-3.5.0/syscall.c:676` `do_link_at()` under `operator_path_resolve` -
+///   `owner_walk_parent` on each side, then `linkat`.
+///
+/// # Errors
+///
+/// Propagates the walk's refusal (`ELOOP`) or the `linkat(2)` errno - notably
+/// `EXDEV` when the backup area is on another filesystem, which the caller
+/// treats as its signal to fall through to the next tier.
+pub fn operator_link(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    let (old_dirfd, old_leaf) = owner_trusted_parent(old_path)?;
+    let (new_dirfd, new_leaf) = owner_trusted_parent(new_path)?;
+    crate::linkat(old_dirfd.as_fd(), &old_leaf, new_dirfd.as_fd(), &new_leaf)
+}

--- a/crates/fast_io/tests/confined_clone_file.rs
+++ b/crates/fast_io/tests/confined_clone_file.rs
@@ -1,0 +1,118 @@
+//! `confined_clone_file` must anchor the destination parent before cloning.
+//!
+//! A copy-on-write clone creates and fills the destination in one syscall, so
+//! the create IS the confinement decision - there is no later commit to anchor.
+//! Without this, the platform CoW fast path writes the destination by path and
+//! follows a parent symlink straight out of the transfer root, which is the
+//! escape `keep_dirlinks_refuses_a_destination_symlink_pointing_outside_the_tree`
+//! catches at the engine level.
+//!
+//! upstream: `rsync-3.5.0/receiver.c` has no CoW fast path - it always stages
+//! into a temp and commits with `do_rename_at()`. These pin oc's optimisation
+//! to the same invariant.
+//!
+//! Every assertion here is written to hold whether or not the filesystem can
+//! reflink: `Unsupported` is a routine answer on a non-APFS/non-reflink volume
+//! and must never be confused with a refusal.
+
+#![cfg(unix)]
+
+use std::fs;
+
+use fast_io::CloneAttempt;
+use tempfile::TempDir;
+
+/// Non-vacuity companion: with no symlink in play the call reaches the platform
+/// and reports a real outcome rather than failing. Without this, the refusal
+/// tests below would also pass if `confined_clone_file` errored for every input.
+#[test]
+fn confined_clone_file_reaches_the_platform_for_a_plain_destination() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir(root.path().join("sub")).expect("mkdir sub");
+    let src = root.path().join("src.bin");
+    fs::write(&src, b"payload").expect("write source");
+    let dest = root.path().join("sub").join("f0");
+
+    match fast_io::confined_clone_file(root.path(), &src, &dest).expect("no confinement refusal") {
+        CloneAttempt::Cloned => {
+            assert_eq!(fs::read(&dest).expect("read clone"), b"payload");
+        }
+        CloneAttempt::Unsupported => {
+            assert!(
+                !dest.exists(),
+                "an Unsupported result must leave nothing behind - the caller \
+                 falls through to a copy that expects to create the file"
+            );
+        }
+    }
+}
+
+/// A relative, in-tree symlinked parent is FOLLOWED, not refused - upstream's
+/// walk descends it (`syscall.c:2961`). Pinning this stops a future
+/// "refuse every symlink" simplification from breaking `-K`.
+#[test]
+fn confined_clone_file_follows_a_relative_in_tree_parent_symlink() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir(root.path().join("real")).expect("mkdir real");
+    std::os::unix::fs::symlink("real", root.path().join("sub")).expect("plant symlink");
+    let src = root.path().join("src.bin");
+    fs::write(&src, b"payload").expect("write source");
+
+    let outcome = fast_io::confined_clone_file(root.path(), &src, &root.path().join("sub/f0"))
+        .expect("a relative in-tree parent symlink must not be refused");
+
+    if outcome == CloneAttempt::Cloned {
+        assert_eq!(
+            fs::read(root.path().join("real").join("f0")).expect("read clone"),
+            b"payload",
+            "the clone must land in the symlink's target, inside the tree"
+        );
+    }
+}
+
+/// The destination parent is a symlink pointing outside the root. Upstream's
+/// walk refuses an absolute target, so this must be an `Err` - never
+/// `Unsupported`, which the caller is entitled to answer with an unconfined
+/// data copy.
+#[test]
+fn confined_clone_file_refuses_a_parent_symlinked_outside() {
+    let base = TempDir::new().expect("tempdir");
+    let root = base.path().join("dest");
+    let outside = base.path().join("outside");
+    fs::create_dir(&root).expect("mkdir dest");
+    fs::create_dir(&outside).expect("mkdir outside");
+    std::os::unix::fs::symlink(&outside, root.join("sub")).expect("plant symlink");
+    let src = base.path().join("src.bin");
+    fs::write(&src, b"payload").expect("write source");
+
+    let err = fast_io::confined_clone_file(&root, &src, &root.join("sub").join("f0"))
+        .expect_err("a symlinked destination parent must be refused, not reported Unsupported");
+
+    assert!(
+        !outside.join("f0").exists(),
+        "the clone escaped the destination tree: {err}"
+    );
+}
+
+/// An existing destination loses the race rather than being replaced, matching
+/// the `O_EXCL` semantics of the plain create this tier bypasses.
+#[test]
+fn confined_clone_file_refuses_an_existing_destination() {
+    let root = TempDir::new().expect("tempdir");
+    let src = root.path().join("src.bin");
+    fs::write(&src, b"payload").expect("write source");
+    let dest = root.path().join("f0");
+    fs::write(&dest, b"original").expect("seed destination");
+
+    let result = fast_io::confined_clone_file(root.path(), &src, &dest);
+
+    assert!(
+        !matches!(result, Ok(CloneAttempt::Cloned)),
+        "an existing destination must never be replaced by a clone"
+    );
+    assert_eq!(
+        fs::read(&dest).expect("read destination"),
+        b"original",
+        "the refused clone must leave the existing file intact"
+    );
+}

--- a/crates/fast_io/tests/confined_create_new.rs
+++ b/crates/fast_io/tests/confined_create_new.rs
@@ -1,0 +1,118 @@
+//! `confined_create_new` must anchor the destination parent before creating.
+//!
+//! The direct-write strategy skips upstream's stage-then-rename, so it never
+//! reaches `confined_rename` and cannot inherit its confinement. Without an
+//! anchored create, a parent flipped to a symlink between the write decision
+//! and the create redirects the new file out of the tree.
+//!
+//! These pin the primitive on every unix, not only where `WriteStrategy::Direct`
+//! happens to be chosen: `O_TMPFILE` is Linux-only, so a behavioural test alone
+//! would exercise this on macOS and skip it on Linux.
+//!
+//! upstream: `rsync-3.5.0/syscall.c:2891` `ds_descend()`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Write;
+
+use tempfile::TempDir;
+
+/// Non-vacuity companion: with no symlink in play the confined create makes an
+/// ordinary nested file. Without this, the refusal tests below would also pass
+/// if `confined_create_new` simply failed for every input.
+#[test]
+fn confined_create_new_creates_a_nested_destination() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir(root.path().join("sub")).expect("mkdir sub");
+    let dest = root.path().join("sub").join("f0");
+
+    let mut file = fast_io::confined_create_new(root.path(), &dest).expect("create");
+    file.write_all(b"payload").expect("write");
+    drop(file);
+
+    assert_eq!(fs::read_to_string(&dest).unwrap(), "payload");
+}
+
+/// A relative, in-tree symlinked parent is FOLLOWED, not refused - upstream's
+/// walk descends it (`syscall.c:2961`). Pinning this is what stops a future
+/// "refuse every symlink" simplification from breaking `-K`.
+#[test]
+fn confined_create_new_follows_a_relative_in_tree_parent_symlink() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir(root.path().join("real")).expect("mkdir real");
+    std::os::unix::fs::symlink("real", root.path().join("sub")).expect("plant symlink");
+    let dest = root.path().join("sub").join("f0");
+
+    let mut file = fast_io::confined_create_new(root.path(), &dest).expect("create through link");
+    file.write_all(b"payload").expect("write");
+    drop(file);
+
+    assert_eq!(
+        fs::read_to_string(root.path().join("real").join("f0")).unwrap(),
+        "payload",
+        "the file must land in the symlink's target, inside the tree"
+    );
+}
+
+/// The destination parent is a symlink pointing outside the root. Upstream's
+/// walk refuses an absolute target, so the create must fail and nothing may
+/// appear in the outside tree.
+#[test]
+fn confined_create_new_refuses_a_parent_symlinked_outside() {
+    let base = TempDir::new().expect("tempdir");
+    let root = base.path().join("dest");
+    let outside = base.path().join("outside");
+    fs::create_dir(&root).expect("mkdir dest");
+    fs::create_dir(&outside).expect("mkdir outside");
+    std::os::unix::fs::symlink(&outside, root.join("sub")).expect("plant symlink");
+
+    let dest = root.join("sub").join("f0");
+    let err = fast_io::confined_create_new(&root, &dest)
+        .expect_err("a symlinked destination parent must be refused");
+
+    assert!(
+        !outside.join("f0").exists(),
+        "the create escaped the destination tree: {err}"
+    );
+}
+
+/// The leaf itself is a symlink out of the tree. `O_EXCL` alone already refuses
+/// an existing name, but `O_NOFOLLOW` is what makes the refusal mean "do not
+/// follow" rather than "it exists" - and neither may write through the link.
+#[test]
+fn confined_create_new_refuses_a_leaf_symlinked_outside() {
+    let base = TempDir::new().expect("tempdir");
+    let root = base.path().join("dest");
+    let outside = base.path().join("outside");
+    fs::create_dir(&root).expect("mkdir dest");
+    fs::create_dir(&outside).expect("mkdir outside");
+    std::os::unix::fs::symlink(outside.join("f0"), root.join("f0")).expect("plant symlink");
+
+    let err = fast_io::confined_create_new(&root, &root.join("f0"))
+        .expect_err("a symlinked leaf must be refused");
+
+    assert!(
+        !outside.join("f0").exists(),
+        "the create followed the leaf symlink out of the tree: {err}"
+    );
+}
+
+/// `O_EXCL` survives the move onto the anchored path: a name that already
+/// exists as a regular file loses the race rather than being truncated.
+#[test]
+fn confined_create_new_refuses_an_existing_regular_file() {
+    let root = TempDir::new().expect("tempdir");
+    let dest = root.path().join("f0");
+    fs::write(&dest, "original").expect("seed");
+
+    let err = fast_io::confined_create_new(root.path(), &dest)
+        .expect_err("an existing destination must lose the race");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+    assert_eq!(
+        fs::read_to_string(&dest).unwrap(),
+        "original",
+        "the refused create must not truncate the existing file"
+    );
+}

--- a/crates/fast_io/tests/confined_rename.rs
+++ b/crates/fast_io/tests/confined_rename.rs
@@ -86,5 +86,8 @@ fn an_out_of_tree_source_does_not_disable_destination_confinement() {
         !outside.join("f0").exists(),
         "the payload escaped the destination tree: {err}"
     );
-    assert!(temp.exists(), "the refused rename must leave the temp intact");
+    assert!(
+        temp.exists(),
+        "the refused rename must leave the temp intact"
+    );
 }

--- a/crates/fast_io/tests/confined_rename.rs
+++ b/crates/fast_io/tests/confined_rename.rs
@@ -1,0 +1,90 @@
+//! `confined_rename` must confine each endpoint independently.
+//!
+//! Regression cover for the escape upstream's `rename-fullpath-symlink-race`
+//! test demonstrates: the receiver commits `<root>/sub/name` while `sub` is
+//! flipped to a symlink pointing outside the tree, and an unconfined
+//! `rename(2)` follows it.
+//!
+//! upstream: `rsync-3.5.0/syscall.c:1866` `do_rename_at()`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+/// Stage `<dir>/name` with `body` and return its path.
+fn write_file(dir: &Path, name: &str, body: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, body).expect("write fixture");
+    path
+}
+
+/// Non-vacuity companion: with no symlink in play the confined rename performs
+/// an ordinary nested commit. Without this, the refusal tests below would also
+/// pass if `confined_rename` simply failed for every input.
+#[test]
+fn confined_rename_commits_a_nested_destination() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir(root.path().join("sub")).expect("mkdir sub");
+    let temp = write_file(root.path(), ".tmp", "payload");
+    let final_path = root.path().join("sub").join("f0");
+
+    fast_io::confined_rename(root.path(), &temp, &final_path, true).expect("commit");
+
+    assert_eq!(fs::read_to_string(&final_path).unwrap(), "payload");
+}
+
+/// The destination parent is a symlink pointing outside the root. Upstream's
+/// walk refuses an absolute symlink target, so the commit must fail and nothing
+/// may appear in the outside tree.
+#[test]
+fn confined_rename_refuses_a_destination_parent_symlinked_outside() {
+    let base = TempDir::new().expect("tempdir");
+    let root = base.path().join("dest");
+    let outside = base.path().join("outside");
+    fs::create_dir(&root).expect("mkdir dest");
+    fs::create_dir(&outside).expect("mkdir outside");
+    std::os::unix::fs::symlink(&outside, root.join("sub")).expect("plant symlink");
+
+    let temp = write_file(&root, ".tmp", "payload");
+    let final_path = root.join("sub").join("f0");
+
+    let err = fast_io::confined_rename(&root, &temp, &final_path, true)
+        .expect_err("a symlinked destination parent must be refused");
+
+    assert!(
+        !outside.join("f0").exists(),
+        "the payload escaped the destination tree: {err}"
+    );
+}
+
+/// The escape is only reachable because an absolute `--temp-dir` puts the
+/// *source* outside the root. Confining per side means that does not disable
+/// confinement of the destination - the all-or-nothing rule upstream 3.5.0
+/// replaced is exactly what this pins against.
+#[test]
+fn an_out_of_tree_source_does_not_disable_destination_confinement() {
+    let base = TempDir::new().expect("tempdir");
+    let root = base.path().join("dest");
+    let outside = base.path().join("outside");
+    let tmpd = base.path().join("tmpd");
+    fs::create_dir(&root).expect("mkdir dest");
+    fs::create_dir(&outside).expect("mkdir outside");
+    fs::create_dir(&tmpd).expect("mkdir tmpd");
+    std::os::unix::fs::symlink(&outside, root.join("sub")).expect("plant symlink");
+
+    // The temp lives outside `root`, exactly as an absolute --temp-dir stages it.
+    let temp = write_file(&tmpd, "f0.tmp", "payload");
+    let final_path = root.join("sub").join("f0");
+
+    let err = fast_io::confined_rename(&root, &temp, &final_path, true)
+        .expect_err("an out-of-tree source must not license an unconfined destination");
+
+    assert!(
+        !outside.join("f0").exists(),
+        "the payload escaped the destination tree: {err}"
+    );
+    assert!(temp.exists(), "the refused rename must leave the temp intact");
+}

--- a/crates/fast_io/tests/owner_walk.rs
+++ b/crates/fast_io/tests/owner_walk.rs
@@ -101,7 +101,11 @@ fn a_symlink_cycle_is_refused_with_eloop() {
     let err = fast_io::owner_trusted_parent(&root.path().join("a/f"))
         .expect_err("a symlink cycle must not resolve");
 
-    assert_eq!(err.raw_os_error(), Some(libc::ELOOP), "refusal must be ELOOP");
+    assert_eq!(
+        err.raw_os_error(),
+        Some(libc::ELOOP),
+        "refusal must be ELOOP"
+    );
 }
 
 /// `operator_rename` reaches a destination behind a trusted symlink - the

--- a/crates/fast_io/tests/owner_walk.rs
+++ b/crates/fast_io/tests/owner_walk.rs
@@ -1,0 +1,124 @@
+//! The ownership walk used for operator-supplied paths.
+//!
+//! The refusal arm - a symlink component owned by neither uid 0 nor our euid -
+//! needs a second uid to plant, so it is covered by the root leg of the upstream
+//! 3.5.0 testsuite (`backup-dir-symlink-race`) rather than duplicated here with
+//! a privilege check that would pass vacuously for an unprivileged runner.
+//! What this file pins is everything reachable as an ordinary user: that the
+//! walk still *works* (it must not become a blanket refusal), and that its two
+//! non-obvious rules - absolute targets restart at `/`, and the hop budget is
+//! finite - hold.
+//!
+//! upstream: `rsync-3.5.0/syscall.c:286` `ona_open()`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+/// Resolve `path` and read back the leaf through the returned parent handle,
+/// proving the descriptor really is the directory holding it.
+fn resolve_and_read(path: &Path) -> std::io::Result<String> {
+    let (dirfd, leaf) = fast_io::owner_trusted_parent(path)?;
+    let mut buf = Vec::new();
+    let file = rustix::fs::openat(
+        &dirfd,
+        leaf.as_os_str(),
+        rustix::fs::OFlags::RDONLY,
+        rustix::fs::Mode::empty(),
+    )
+    .map_err(|errno| std::io::Error::from_raw_os_error(errno.raw_os_error()))?;
+    std::io::Read::read_to_end(&mut std::fs::File::from(file), &mut buf)?;
+    Ok(String::from_utf8(buf).expect("utf-8 fixture"))
+}
+
+/// Non-vacuity companion: with no symlink in play the walk is an ordinary
+/// resolution. Without this, every refusal assertion below would also hold if
+/// the walk simply failed for all inputs.
+#[test]
+fn the_walk_resolves_a_plain_nested_path() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir_all(root.path().join("a/b")).expect("mkdir");
+    fs::write(root.path().join("a/b/f"), "payload").expect("write");
+
+    assert_eq!(
+        resolve_and_read(&root.path().join("a/b/f")).expect("resolve"),
+        "payload"
+    );
+}
+
+/// A symlink component we own is the operator's own layout, so it is followed -
+/// upstream refuses on ownership, not on the mere presence of a link.
+#[test]
+fn a_symlink_component_we_own_is_followed() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir(root.path().join("real")).expect("mkdir real");
+    fs::write(root.path().join("real/f"), "payload").expect("write");
+    symlink("real", root.path().join("link")).expect("plant symlink");
+
+    assert_eq!(
+        resolve_and_read(&root.path().join("link/f")).expect("resolve"),
+        "payload"
+    );
+}
+
+/// An absolute symlink target restarts the walk at `/` rather than being
+/// appended to the current position.
+///
+/// upstream: `rsync-3.5.0/syscall.c:422`.
+#[test]
+fn an_absolute_symlink_target_restarts_the_walk_at_the_root() {
+    let root = TempDir::new().expect("tempdir");
+    let elsewhere = root.path().join("elsewhere");
+    fs::create_dir(&elsewhere).expect("mkdir elsewhere");
+    fs::write(elsewhere.join("f"), "payload").expect("write");
+    fs::create_dir(root.path().join("deep")).expect("mkdir deep");
+    // An absolute target from a nested position: appending instead of
+    // restarting would look for `<root>/deep/<root>/elsewhere` and fail.
+    symlink(&elsewhere, root.path().join("deep/hop")).expect("plant symlink");
+
+    assert_eq!(
+        resolve_and_read(&root.path().join("deep/hop/f")).expect("resolve"),
+        "payload"
+    );
+}
+
+/// The hop budget is finite, so a symlink cycle terminates in a refusal instead
+/// of spinning. The refusal is `ELOOP` and deliberately not `EXDEV`: callers
+/// treat `EXDEV` as cross-device and fall back to copy+remove, which would
+/// launder the refusal.
+///
+/// upstream: `rsync-3.5.0/syscall.c:361` `int loops = 40;`.
+#[test]
+fn a_symlink_cycle_is_refused_with_eloop() {
+    let root = TempDir::new().expect("tempdir");
+    symlink("b", root.path().join("a")).expect("plant a");
+    symlink("a", root.path().join("b")).expect("plant b");
+
+    let err = fast_io::owner_trusted_parent(&root.path().join("a/f"))
+        .expect_err("a symlink cycle must not resolve");
+
+    assert_eq!(err.raw_os_error(), Some(libc::ELOOP), "refusal must be ELOOP");
+}
+
+/// `operator_rename` reaches a destination behind a trusted symlink - the
+/// out-of-tree `--backup-dir` shape the confined resolver would wrongly refuse.
+#[test]
+fn operator_rename_commits_through_a_trusted_symlink() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir(root.path().join("backups")).expect("mkdir backups");
+    symlink("backups", root.path().join("bk")).expect("plant symlink");
+    let source = root.path().join("f");
+    fs::write(&source, "payload").expect("write");
+
+    fast_io::operator_rename(&source, &root.path().join("bk/f.bak"), true).expect("rename");
+
+    assert_eq!(
+        fs::read_to_string(root.path().join("backups/f.bak")).expect("read backup"),
+        "payload"
+    );
+    assert!(!source.exists(), "the source must have moved");
+}


### PR DESCRIPTION
The local-copy commit rename was a bare `fs::rename` on Unix. A destination
parent directory flipped to a symlink between temp-create and commit therefore
redirected the transferred file outside the destination tree.

Upstream 3.5.0 ships a test for exactly this, and it reproduces **deterministically**
against oc-rsync (Linux aarch64, release build, `runtests.py --rsync-bin=<oc-rsync>`):

```
rename-fullpath symlink race: files were written OUTSIDE the destination tree
(['f10', 'f12', 'f13', 'f2', 'f20', 'f21', 'f22', 'f24', 'f29', 'f34', 'f4', 'f6'])
FAIL    rename-fullpath-symlink-race
```

12 payload files landed in the attacker's `outside/` tree.

## Root cause

`engine/src/local_copy/executor/file/guard.rs::hardened_rename` hardened the
Windows arm (`rename_no_follow`, handle-anchored) and left the Unix arm as
`fs::rename` / `try_rename_via_io_uring` - no dirfd anchoring at all.

The sibling `transfer` disk-commit path *does* anchor, but all-or-nothing: its
helper drops to a path-based rename unless **both** endpoints anchor. That is
the rule upstream 3.5.0 deliberately replaced, and its comment says why:

> Confine each side independently. [...] Doing each side independently means an
> absolute source never disables confinement of a relative destination.
> - `rsync-3.5.0/syscall.c:1866` `do_rename_at()`

An absolute `--temp-dir` is exactly what puts the source outside the tree, which
is how the escape becomes reachable.

## Change

- `fast_io`: new `confined_rename(root, old, new, replace)`. Each endpoint that
  lies beneath `root` has its parent resolved by
  `DirSandbox::open_dest_anchor_confined` - the per-component walk that follows
  relative in-tree symlinks and refuses absolute targets and climbs above the
  anchor. An endpoint outside `root` keeps ambient `AT_FDCWD` resolution.
  Refusals surface as `ELOOP`, deliberately **not** `EXDEV`: callers treat
  `EXDEV` as cross-device and fall back to copy+remove, which would defeat the
  refusal.
- `engine`: `hardened_rename` takes the destination root and routes through
  `confined_rename` when it has one. `DestinationWriteGuard::new_confined` is the
  constructor the production copy paths use; the 4-arg `new` remains for tests
  and documents that its commit is unconfined.

## Tests

`crates/fast_io/tests/confined_rename.rs`, three cells:

- `confined_rename_commits_a_nested_destination` - the non-vacuity companion.
  Without it the two refusal tests would also pass if `confined_rename` simply
  failed for every input.
- `confined_rename_refuses_a_destination_parent_symlinked_outside`.
- `an_out_of_tree_source_does_not_disable_destination_confinement` - the
  absolute-`--temp-dir` shape, i.e. the per-side-independence rule itself.

## Verification (Linux aarch64)

- Upstream 3.5.0 `rename-fullpath-symlink-race`: **FAIL before, PASS after**.
  The RED side is measured on a release binary built from the parent commit, not
  assumed.
- Full 3.5.0 suite, 345 tests, diffed per test against the outcome manifest on
  `chore/upstream-testsuite-350`. Four cells differ; only one is this change:

  | test | manifest | this branch | attribution |
  |---|---|---|---|
  | `rename-fullpath-symlink-race` | fail | pass | **this fix** (control fails 3/3) |
  | `rrsync-no-overwrite-delay-updates` | fail | pass | not this fix - passes 2/2 on the control too |
  | `simd-checksum` | pass | skip | host (aarch64) |
  | `symlink-race-source` | pass | fail | not this fix - fails 3/3 on the control too; a pre-existing **sender**-side escape the manifest recorded as a lucky pass |

- `cargo nextest run -p engine -p fast_io --all-features`: 6128 passed, 0 failed.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets
  --all-features --no-deps -- -D warnings` clean.

## Deliberately out of scope

- The anonymous `O_TMPFILE` commit path materialises with `linkat(2)` against the
  final path rather than a rename, so it does not pass through `hardened_rename`.
  Confining that sink belongs with the rest of the leaf-sink sweep.
- The ambient arm for an endpoint outside the root keeps plain path resolution.
  Upstream additionally runs an ownership walk over an operator-supplied absolute
  side; that is a separate hardening, not part of the escape fixed here.

---

# Second fix in this branch: the backup path (`backup-dir-symlink-race`)

The same suite run surfaces a second escape, in `make_backup` rather than the
commit rename, and it needs the **other** upstream resolver.

```
backup-dir parent symlink race: a 0777 dest file was backed up into .../outside
through the flipped backup/sub symlink -- make_backup followed a foreign-owned
parent component (escape).
FAIL    backup-dir-symlink-race
```

## Why the confined walk is the wrong tool here

A `--backup-dir` is an **operator** path: the person running rsync named it, and
it may legitimately sit outside the transfer tree. Confining it beneath a root
would break the ordinary out-of-tree backup directory. Upstream's answer is a
second resolver whose trust signal is **authority**, not location:

> An operator path may legitimately point outside the tree, so the trust signal
> is authority (ownership), not location.
> - `rsync-3.5.0/syscall.c:544-551`

Per component: `statat(AT_SYMLINK_NOFOLLOW)`; a symlink whose `st_uid` is neither
0 nor our euid is refused with `ELOOP` (`syscall.c:406`); a trusted one is
followed by splicing its target into the remaining path, an absolute target
restarting at `/`, bounded at 40 hops (`syscall.c:361`).

## Change

- `fast_io::owner_walk` - new module: `owner_trusted_parent`, plus
  `operator_rename` / `operator_link` built on it, mirroring `do_rename_at`
  (`syscall.c:1894`) and `do_link_at` (`syscall.c:676`) under
  `operator_path_resolve`.
- `engine`: `backup_rename` routes through `operator_rename`, and a new
  `create_backup_hard_link` routes the backup link tier through `operator_link`.

## The link tier is why the first attempt did not work

Routing only `backup_rename` left the escape fully reproducible. Upstream's
`link_or_rename` (`backup.c:200-207`) tries `do_link_at` **first**; oc has the
same two-tier shape at `context_impl/backup.rs:129`, so the hard link - not the
rename - was the escaping sink. Both tiers are now resolved.

`create_backup_hard_link` is deliberately separate from `create_hard_link`: the
latter also serves `-H`, a transfer path that takes the *confined* resolver, not
this one. Folding them would apply the wrong policy to one of the two callers.

## Verification (Linux aarch64, as root)

Full 3.5.0 suite, 345 tests, **against a control binary built without either fix,
same host, same run conditions** - so attribution is measured, not inferred:

| test | control | this branch |
|---|---|---|
| `rename-fullpath-symlink-race` | fail | **pass** |
| `backup-dir-symlink-race` | fail | **pass** |
| `nondaemon-symlink-race` | fail | **pass** |
| `symlink-dest-backupdir` | fail | **pass** |

Four cells moved, all in the same direction, and nothing else in the suite
changed: 94 failures -> 90, 200 passes, 55 skips both runs. The two extra passes
are the same backup-symlink family reached by different fixtures.

- `cargo nextest run -p engine -p fast_io --all-features`: 6128 passed, 0 failed.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets
  --all-features --no-deps -- -D warnings` clean.
