### PR TITLE
fix(security): confine the local-copy source read beneath the transfer root

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -145,6 +145,16 @@ pub(crate) struct CopyContext<'a> {
     stop_at: Option<SystemTime>,
     last_progress: Instant,
     destination_root: PathBuf,
+    /// Confinement anchor for source-file content reads: the directory the
+    /// sender would `chdir` into for the operand currently being walked.
+    ///
+    /// `None` before the first operand and for any operand whose anchor cannot
+    /// be determined, in which case the open degrades to the `O_NOFOLLOW` leaf
+    /// rule alone. Set per operand because each source argument has its own
+    /// transfer root. upstream: `rsync-3.5.0/sender.c` opens file content
+    /// through the confined held-ancestor-dirfd stack anchored at the transfer
+    /// root, so a parent component flipped to a symlink is refused.
+    source_anchor: Option<PathBuf>,
     /// Number of leading path components in `relative` that represent the
     /// transfer root name (e.g. the source directory name when copying
     /// without a trailing slash).  These components inflate the depth

--- a/crates/engine/src/local_copy/context_impl/link_dest.rs
+++ b/crates/engine/src/local_copy/context_impl/link_dest.rs
@@ -40,7 +40,13 @@ impl<'a> CopyContext<'a> {
         let mut best: Option<(PathBuf, u8)> = None;
         for entry in self.options.link_dest_entries() {
             let candidate = entry.resolve(self.destination_root(), relative);
-            let candidate_metadata = match fs::metadata(&candidate) {
+            // upstream: generator.c try_dests_reg() -
+            // `if (basis_link_stat(cmpbuf, &sxp->st) < 0 || !S_ISREG(sxp->st.st_mode)) continue;`
+            // basis_link_stat resolves the leaf with `link_stat_at(dfd, leaf, stp, 0)`, i.e. an
+            // LSTAT, so a basis entry that is itself a symlink reports S_IFLNK and is skipped
+            // rather than followed. Using a following stat here would accept a symlink-to-regular
+            // candidate and then hard-link or read THROUGH it - the read oracle upstream closed.
+            let candidate_metadata = match fs::symlink_metadata(&candidate) {
                 Ok(metadata) => metadata,
                 Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
                 Err(error) => {

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -53,13 +53,20 @@ impl<'a> CopyContext<'a> {
     /// Whether a symlinked source *leaf* should be followed when its content is
     /// opened.
     ///
-    /// upstream: `sender.c:do_open_checklinks` follows the leaf with a plain
-    /// `do_open` under `--copy-links` / `--copy-unsafe-links` and otherwise
-    /// uses `do_open_nofollow`. This is a separate decision from the ancestor
-    /// confinement: a symlink-following mode is an operator instruction and
-    /// survives confinement rather than being downgraded.
+    /// upstream: `sender.c:685` gates the confined open on
+    /// `!copy_links && !copy_unsafe_links && !copy_dirlinks && !insecure_links`
+    /// and lets every other case fall through to the unconfined
+    /// `do_open_checklinks`, which follows the leaf. All three link-following
+    /// options belong in the predicate: `-k` follows a symlinked *parent*, so
+    /// confining beneath the transfer root would refuse exactly the traversal
+    /// the operator asked for.
+    ///
+    /// `--insecure-links` is upstream's fourth term; oc does not implement that
+    /// option yet, so it cannot be spelled here.
     pub(super) const fn follow_source_symlinks(&self) -> bool {
-        self.options.copy_links_enabled() || self.options.copy_unsafe_links_enabled()
+        self.options.copy_links_enabled()
+            || self.options.copy_unsafe_links_enabled()
+            || self.options.copy_dirlinks_enabled()
     }
 
     pub(super) const fn sparse_enabled(&self) -> bool {

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -50,6 +50,18 @@ impl<'a> CopyContext<'a> {
         self.options.open_noatime_enabled()
     }
 
+    /// Whether a symlinked source *leaf* should be followed when its content is
+    /// opened.
+    ///
+    /// upstream: `sender.c:do_open_checklinks` follows the leaf with a plain
+    /// `do_open` under `--copy-links` / `--copy-unsafe-links` and otherwise
+    /// uses `do_open_nofollow`. This is a separate decision from the ancestor
+    /// confinement: a symlink-following mode is an operator instruction and
+    /// survives confinement rather than being downgraded.
+    pub(super) const fn follow_source_symlinks(&self) -> bool {
+        self.options.copy_links_enabled() || self.options.copy_unsafe_links_enabled()
+    }
+
     pub(super) const fn sparse_enabled(&self) -> bool {
         self.options.sparse_enabled()
     }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -58,6 +58,7 @@ impl<'a> CopyContext<'a> {
             stop_at: stop_at_wallclock,
             last_progress: Instant::now(),
             destination_root,
+            source_anchor: None,
             safety_depth_offset: 0,
             use_buffer_pool: true,
             buffer_pool,
@@ -194,6 +195,20 @@ impl<'a> CopyContext<'a> {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     pub(in crate::local_copy) const fn has_bandwidth_limiter(&self) -> bool {
         self.limiter.is_some()
+    }
+
+    /// Sets the source-tree confinement anchor for the operand about to be
+    /// walked.
+    ///
+    /// upstream: `rsync-3.5.0/sender.c` - the sender's content opens are
+    /// confined beneath the transfer root, which is per source argument.
+    pub(in crate::local_copy) fn set_source_anchor(&mut self, anchor: Option<PathBuf>) {
+        self.source_anchor = anchor;
+    }
+
+    /// Returns the source-tree confinement anchor for the current operand.
+    pub(in crate::local_copy) fn source_anchor(&self) -> Option<&Path> {
+        self.source_anchor.as_deref()
     }
 
     /// Returns the root destination directory for the transfer.

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -332,7 +332,12 @@ pub(in crate::local_copy) fn execute_transfer_once(
         return Ok(TransferOutcome::Complete);
     }
 
-    let mut reader = open_source_file(source, context.open_noatime_enabled())
+    let mut reader = open_source_file(
+        source,
+        context.open_noatime_enabled(),
+        context.source_anchor(),
+        context.follow_source_symlinks(),
+    )
         .map_err(|error| LocalCopyError::io("copy file", source, error))?;
     let append_mode = determine_append_mode(
         append_allowed,
@@ -399,7 +404,17 @@ pub(in crate::local_copy) fn execute_transfer_once(
     };
 
     let (mut reader, copy_source) = if let Some(ref override_path) = copy_source_override {
-        let file = match open_source_file(override_path, context.open_noatime_enabled()) {
+        // The override is an ALT-BASE candidate (`--copy-dest` / `--link-dest`
+        // after a cross-device degrade), i.e. an operator-named path outside the
+        // source tree. It takes the operator-path resolver, not the transfer-root
+        // confinement, so no anchor is passed here; that routing is the alt-dest
+        // family's own change.
+        let file = match open_source_file(
+            override_path,
+            context.open_noatime_enabled(),
+            None,
+            context.follow_source_symlinks(),
+        ) {
             Ok(file) => file,
             Err(error) => {
                 // upstream: generator.c:931 - rsyserr(FINFO, errno,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -338,7 +338,7 @@ pub(in crate::local_copy) fn execute_transfer_once(
         context.source_anchor(),
         context.follow_source_symlinks(),
     )
-        .map_err(|error| LocalCopyError::io("copy file", source, error))?;
+    .map_err(|error| LocalCopyError::io("copy file", source, error))?;
     let append_mode = determine_append_mode(
         append_allowed,
         append_verify,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/open.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/open.rs
@@ -1,4 +1,23 @@
-//! Source file opening with optional `O_NOATIME` support.
+//! Source file opening: symlink-race confinement plus optional `O_NOATIME`.
+//!
+//! Every content read goes through [`open_source_file`], which mirrors the
+//! branch upstream's sender takes before reading a file:
+//!
+//! - the leaf is opened `O_NOFOLLOW` so a final component swapped for a symlink
+//!   is refused, unless `--copy-links` / `--copy-unsafe-links` asked for links
+//!   to be followed. upstream: `sender.c:do_open_checklinks`, which picks
+//!   between `do_open` and `do_open_nofollow`;
+//! - when the operand's transfer root is known, the *parent* components are
+//!   walked confined beneath it, so a directory flipped to a symlink pointing
+//!   outside the source tree between scan and read cannot redirect the read.
+//!   upstream 3.5.0's `symlink-race-source` test covers exactly this: "the
+//!   sender now opens each file's content through the confined
+//!   held-ancestor-dirfd stack anchored at the transfer root".
+//!
+//! The leaf rule is a separate decision from the ancestor rule, which is why
+//! the confined open takes a [`fast_io::LeafPolicy`]: a symlink-following mode
+//! is an operator instruction and survives confinement rather than being
+//! downgraded.
 //!
 //! On Linux/Android, files are opened with `O_NOATIME` when requested to avoid
 //! updating access times during transfers. This mirrors upstream rsync behavior
@@ -15,7 +34,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -44,14 +63,106 @@ static FSYNC_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
 pub(in crate::local_copy) fn open_source_file(
     path: &Path,
     use_noatime: bool,
+    anchor: Option<&Path>,
+    follow_symlinks: bool,
 ) -> io::Result<fs::File> {
-    let file = if use_noatime && let Some(file) = try_open_noatime(path)? {
-        file
-    } else {
-        fs::File::open(path)?
-    };
+    let file = open_source_handle(path, use_noatime, anchor, follow_symlinks)?;
     apply_macos_read_hint(&file);
     Ok(file)
+}
+
+/// Opens the source handle under the confinement and leaf policies, before the
+/// platform read hint is applied.
+#[cfg(unix)]
+fn open_source_handle(
+    path: &Path,
+    use_noatime: bool,
+    anchor: Option<&Path>,
+    follow_symlinks: bool,
+) -> io::Result<fs::File> {
+    if let Some(root) = anchor
+        && let Ok(relative) = path.strip_prefix(root)
+    {
+        let leaf = if follow_symlinks {
+            fast_io::LeafPolicy::FollowConfined
+        } else {
+            fast_io::LeafPolicy::Nofollow
+        };
+        return fast_io::open_source_confined(root, relative, leaf, use_noatime);
+    }
+    // No anchor, or a source outside it (an absolute operand reached through a
+    // path the anchor does not prefix): fall back to the leaf rule alone rather
+    // than anchoring somewhere the operand does not live.
+    open_source_leaf(path, use_noatime, follow_symlinks)
+}
+
+/// Non-Unix: `O_NOFOLLOW` and the confined walk are Unix concepts, so the open
+/// degrades to the plain read, matching the upstream limitation that its
+/// `do_open_nofollow` guarantee is `O_NOFOLLOW`-platform only.
+#[cfg(not(unix))]
+fn open_source_handle(
+    path: &Path,
+    use_noatime: bool,
+    _anchor: Option<&Path>,
+    _follow_symlinks: bool,
+) -> io::Result<fs::File> {
+    open_plain(path, use_noatime)
+}
+
+/// Opens `path` applying only the leaf rule: `O_NOFOLLOW` unless a
+/// symlink-following mode is active.
+///
+/// upstream: `sender.c:do_open_checklinks`.
+#[cfg(unix)]
+fn open_source_leaf(
+    path: &Path,
+    use_noatime: bool,
+    follow_symlinks: bool,
+) -> io::Result<fs::File> {
+    if follow_symlinks {
+        return open_plain(path, use_noatime);
+    }
+    let nofollow = libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    if use_noatime && let Some(extra) = noatime_flag() {
+        let mut options = fs::OpenOptions::new();
+        options.read(true).custom_flags(nofollow | extra);
+        match options.open(path) {
+            Ok(file) => return Ok(file),
+            Err(error) if noatime_retryable(&error) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    let mut options = fs::OpenOptions::new();
+    options.read(true).custom_flags(nofollow);
+    options.open(path)
+}
+
+/// Opens `path` following symlinks, honouring `--open-noatime`.
+fn open_plain(path: &Path, use_noatime: bool) -> io::Result<fs::File> {
+    if use_noatime && let Some(file) = try_open_noatime(path)? {
+        return Ok(file);
+    }
+    fs::File::open(path)
+}
+
+/// Returns `O_NOATIME` on Linux/Android, `None` where the flag is undefined.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const fn noatime_flag() -> Option<i32> {
+    Some(libc::O_NOATIME)
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+const fn noatime_flag() -> Option<i32> {
+    None
+}
+
+/// Whether an `O_NOATIME` open failure should be retried without the flag.
+#[cfg(unix)]
+fn noatime_retryable(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(libc::EPERM | libc::EACCES | libc::EINVAL | libc::ENOTSUP | libc::EROFS)
+    )
 }
 
 /// Applies the macOS `F_NOCACHE` advisory hint for sequential source reads.
@@ -125,7 +236,7 @@ mod tests {
         let path = dir.path().join("source.bin");
         std::fs::write(&path, b"payload").unwrap();
 
-        let mut file = open_source_file(&path, false).expect("open source");
+        let mut file = open_source_file(&path, false, None, false).expect("open source");
         let mut contents = Vec::new();
         file.read_to_end(&mut contents).unwrap();
         assert_eq!(contents, b"payload");
@@ -142,7 +253,7 @@ mod tests {
         let payload = vec![0xABu8; (fast_io::F_NOCACHE_THRESHOLD + 16) as usize];
         std::fs::write(&path, &payload).unwrap();
 
-        let mut file = open_source_file(&path, false).expect("open large source");
+        let mut file = open_source_file(&path, false, None, false).expect("open large source");
         let mut contents = Vec::new();
         file.read_to_end(&mut contents).unwrap();
         assert_eq!(contents.len(), payload.len());

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/open.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/open.rs
@@ -244,6 +244,94 @@ mod tests {
         assert_eq!(contents, b"payload");
     }
 
+    /// Non-vacuity companion for the confinement cells below: with the anchor
+    /// set and no symlink in play, a nested in-tree source opens normally.
+    /// Without this, the refusal test would also pass if the confined open
+    /// simply failed for every input.
+    #[cfg(unix)]
+    #[test]
+    fn anchored_open_reads_a_nested_in_tree_source() {
+        use std::io::Read as _;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("sub")).unwrap();
+        std::fs::write(root.path().join("sub/data"), b"in-tree").unwrap();
+
+        let mut file = open_source_file(
+            &root.path().join("sub/data"),
+            false,
+            Some(root.path()),
+            false,
+        )
+        .expect("in-tree source must open");
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).unwrap();
+        assert_eq!(buf, "in-tree");
+    }
+
+    /// Default symlink handling must refuse a source whose PARENT component is
+    /// a symlink pointing outside the transfer root.
+    ///
+    /// WHY: this is the sink upstream 3.5.0's `symlink-race-source` test
+    /// exercises. An attacker who controls a subtree of the source races a
+    /// parent directory between a real directory (seen at scan time) and a
+    /// symlink pointing outside (followed at read time), and an unconfined
+    /// open copies a file from outside the tree into the output. The race is
+    /// timing-dependent; this pins the same decision deterministically by
+    /// handing the open the flipped state directly.
+    #[cfg(unix)]
+    #[test]
+    fn anchored_open_refuses_a_parent_symlinked_outside() {
+        use std::os::unix::fs::symlink;
+
+        let base = tempfile::tempdir().unwrap();
+        let root = base.path().join("src");
+        let outside = base.path().join("outside");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("secret"), b"do-not-leak").unwrap();
+        symlink(&outside, root.join("sub")).unwrap();
+
+        let error = open_source_file(&root.join("sub/secret"), false, Some(&root), false)
+            .expect_err("a parent symlinked outside the root must be refused");
+        assert_ne!(
+            std::fs::read(root.join("sub/secret")).ok(),
+            None,
+            "fixture sanity: the path does resolve without confinement"
+        );
+        let _ = error;
+    }
+
+    /// A symlink-following mode keeps the legacy unconfined open, so the same
+    /// out-of-tree target IS read.
+    ///
+    /// WHY: upstream `sender.c:685` gates the confined open on
+    /// `!copy_links && !copy_unsafe_links && !copy_dirlinks`, falling through to
+    /// `do_open_checklinks`. `--copy-unsafe-links` exists precisely to
+    /// materialise links pointing outside the tree; confining it would break the
+    /// option outright. This is the cell that discriminates the gate from a
+    /// blanket confinement.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_following_mode_still_reads_through_the_escape() {
+        use std::io::Read as _;
+        use std::os::unix::fs::symlink;
+
+        let base = tempfile::tempdir().unwrap();
+        let root = base.path().join("src");
+        let outside = base.path().join("outside");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("payload"), b"followed").unwrap();
+        symlink(&outside, root.join("sub")).unwrap();
+
+        let mut file = open_source_file(&root.join("sub/payload"), false, Some(&root), true)
+            .expect("a symlink-following mode must not be confined");
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).unwrap();
+        assert_eq!(buf, "followed");
+    }
+
     #[test]
     fn open_source_file_large_file_succeeds_with_hint() {
         // The macOS `F_NOCACHE` hint runs through `apply_macos_read_hint` for

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/open.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/open.rs
@@ -3,21 +3,26 @@
 //! Every content read goes through [`open_source_file`], which mirrors the
 //! branch upstream's sender takes before reading a file:
 //!
-//! - the leaf is opened `O_NOFOLLOW` so a final component swapped for a symlink
-//!   is refused, unless `--copy-links` / `--copy-unsafe-links` asked for links
-//!   to be followed. upstream: `sender.c:do_open_checklinks`, which picks
-//!   between `do_open` and `do_open_nofollow`;
-//! - when the operand's transfer root is known, the *parent* components are
-//!   walked confined beneath it, so a directory flipped to a symlink pointing
-//!   outside the source tree between scan and read cannot redirect the read.
-//!   upstream 3.5.0's `symlink-race-source` test covers exactly this: "the
-//!   sender now opens each file's content through the confined
-//!   held-ancestor-dirfd stack anchored at the transfer root".
+//! - **Default symlink handling** - no `-L` / `--copy-unsafe-links` / `-k`: the
+//!   parent components are walked confined beneath the operand's transfer root
+//!   and the leaf is opened `O_NOFOLLOW`. A directory flipped to a symlink
+//!   pointing outside the source tree between scan and read cannot redirect the
+//!   read, and a raced leaf symlink is refused. upstream: `sender.c:685-705`
+//!   `sender_open_confined(NULL, fname, O_RDONLY)` - a NULL anchor means
+//!   relative-to-cwd, and upstream chdirs to the transfer root, so the two
+//!   anchors name the same directory.
+//! - **A symlink-following mode** - `-L` / `--copy-unsafe-links` / `-k`: the
+//!   legacy open, following the leaf, NOT confined. upstream: `sender.c:706`
+//!   falls through to `do_open_checklinks(fname)`. Confining here would break
+//!   the option outright: `--copy-unsafe-links` exists precisely to materialise
+//!   links whose targets lie OUTSIDE the tree.
 //!
-//! The leaf rule is a separate decision from the ancestor rule, which is why
-//! the confined open takes a [`fast_io::LeafPolicy`]: a symlink-following mode
-//! is an operator instruction and survives confinement rather than being
-//! downgraded.
+//! The confined/copy-links pairing upstream also keeps (`sender.c:682`
+//! `sender_open_copylinks_confined`) belongs to the DAEMON branch only, where
+//! the anchor is the module root and leaving it is a module escape. The
+//! non-daemon sender this module implements takes the plain
+//! `do_open_checklinks` branch instead. `--insecure-links` joins the same
+//! escape hatch upstream; oc does not implement that option yet.
 //!
 //! On Linux/Android, files are opened with `O_NOATIME` when requested to avoid
 //! updating access times during transfers. This mirrors upstream rsync behavior
@@ -80,20 +85,25 @@ fn open_source_handle(
     anchor: Option<&Path>,
     follow_symlinks: bool,
 ) -> io::Result<fs::File> {
+    if follow_symlinks {
+        // upstream: sender.c:706 - a symlink-following mode takes
+        // do_open_checklinks, an unconfined open that follows the leaf.
+        return open_plain(path, use_noatime);
+    }
     if let Some(root) = anchor
         && let Ok(relative) = path.strip_prefix(root)
     {
-        let leaf = if follow_symlinks {
-            fast_io::LeafPolicy::FollowConfined
-        } else {
-            fast_io::LeafPolicy::Nofollow
-        };
-        return fast_io::open_source_confined(root, relative, leaf, use_noatime);
+        return fast_io::open_source_confined(
+            root,
+            relative,
+            fast_io::LeafPolicy::Nofollow,
+            use_noatime,
+        );
     }
     // No anchor, or a source outside it (an absolute operand reached through a
     // path the anchor does not prefix): fall back to the leaf rule alone rather
     // than anchoring somewhere the operand does not live.
-    open_source_leaf(path, use_noatime, follow_symlinks)
+    open_source_nofollow_leaf(path, use_noatime)
 }
 
 /// Non-Unix: `O_NOFOLLOW` and the confined walk are Unix concepts, so the open
@@ -109,19 +119,11 @@ fn open_source_handle(
     open_plain(path, use_noatime)
 }
 
-/// Opens `path` applying only the leaf rule: `O_NOFOLLOW` unless a
-/// symlink-following mode is active.
+/// Opens `path` with `O_NOFOLLOW` on the leaf, honouring `--open-noatime`.
 ///
-/// upstream: `sender.c:do_open_checklinks`.
+/// upstream: `syscall.c:do_open_nofollow`.
 #[cfg(unix)]
-fn open_source_leaf(
-    path: &Path,
-    use_noatime: bool,
-    follow_symlinks: bool,
-) -> io::Result<fs::File> {
-    if follow_symlinks {
-        return open_plain(path, use_noatime);
-    }
+fn open_source_nofollow_leaf(path: &Path, use_noatime: bool) -> io::Result<fs::File> {
     let nofollow = libc::O_NOFOLLOW | libc::O_CLOEXEC;
     if use_noatime && let Some(extra) = noatime_flag() {
         let mut options = fs::OpenOptions::new();

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -499,6 +499,7 @@ pub(crate) fn copy_sources(
 
             let mut first_io_error: Option<LocalCopyError> = None;
             for source in &worklist {
+                context.set_source_anchor(source_confinement_anchor(source));
                 let result = process_single_source(
                     context,
                     plan,
@@ -636,6 +637,28 @@ pub(crate) fn copy_sources(
 }
 
 /// Processes a single source entry in the copy operation.
+/// The directory the sender would `chdir` into for `source`, used as the
+/// confinement anchor for that operand's content reads.
+///
+/// upstream: `rsync-3.5.0/main.c` chdirs to the transfer root before the
+/// sender runs, and `sender.c` opens file content confined beneath it. A
+/// trailing-slash operand (`src/`) transfers the directory's *contents*, so the
+/// operand itself is the root; otherwise the operand is the first entry and its
+/// parent is the root.
+///
+/// Returns `None` when the operand has no parent (a bare relative name, or
+/// `/`), leaving the open to the `O_NOFOLLOW` leaf rule alone rather than
+/// anchoring somewhere arbitrary.
+fn source_confinement_anchor(source: &SourceSpec) -> Option<PathBuf> {
+    let path = source.path();
+    if source.copy_contents() {
+        return Some(path.to_path_buf());
+    }
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+}
+
 fn process_single_source(
     context: &mut CopyContext,
     plan: &LocalCopyPlan,

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -1045,9 +1045,16 @@ fn link_dest_skips_symlink_in_reference() {
 
     let link_dest_dir = temp.path().join("previous");
     fs::create_dir_all(&link_dest_dir).expect("create link-dest");
-    // Create a symlink in link-dest instead of a regular file
+    // The link-dest entry is a symlink, not a regular file. Its target is made
+    // to match the source in size AND mtime, so the entry would sail through
+    // the quick check and be hard-linked if the symlink were followed - that is
+    // what makes the assertions below discriminating rather than vacuous.
     let real_file = temp.path().join("real_target.txt");
     fs::write(&real_file, b"real content").expect("write real target");
+    let source_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(&source_file).expect("source metadata"),
+    );
+    set_file_times(&real_file, source_mtime, source_mtime).expect("sync target mtime");
     let link_dest_file = link_dest_dir.join("file.txt");
     std::os::unix::fs::symlink(&real_file, &link_dest_file).expect("create symlink");
 
@@ -1067,11 +1074,26 @@ fn link_dest_skips_symlink_in_reference() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Should not hard link because link-dest entry is a symlink
+    // Measured against rsync 3.5.0: exit 0 with a plain copy - the symlink
+    // basis is skipped, never linked and never read through.
     assert!(dest_file.exists());
     assert_eq!(fs::read(&dest_file).expect("read dest"), b"real content");
-    // File should be copied, not linked - verify content is correct
-    // (files_copied counter may not increment for single-file operands)
+
+    // The discriminating assertions: a followed symlink basis would have
+    // hard-linked the destination onto real_target.txt, sharing its inode and
+    // raising its link count. A skipped basis leaves a fresh inode.
+    let dest_meta = fs::metadata(&dest_file).expect("dest metadata");
+    let target_meta = fs::metadata(&real_file).expect("target metadata");
+    assert_ne!(
+        (dest_meta.dev(), dest_meta.ino()),
+        (target_meta.dev(), target_meta.ino()),
+        "destination must not be hard-linked to the symlink basis's target"
+    );
+    assert_eq!(
+        target_meta.nlink(),
+        1,
+        "the symlink basis's target must not gain a link"
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
The local-copy source read was a bare `fs::File::open` - no `O_NOFOLLOW` on the
leaf and no confinement of the parent components. A source directory flipped to
a symlink between scan and read therefore redirected the read outside the
transfer tree.

Upstream 3.5.0 ships a test for exactly this, and it reproduces
**deterministically** against oc-rsync (Linux aarch64, release build):

```
source-tree TOCTOU: content from outside the source tree
('OUTSIDE-SECRET-do-not-copy') was copied into the output -- the sender
followed a parent-component symlink it should have confined.
FAIL    symlink-race-source
```

## Root cause

`engine/.../copy/transfer/open.rs::open_source_file` opened the source with
`fs::File::open` (or the `O_NOATIME` variant). Two gaps against upstream, not
one: no `O_NOFOLLOW` leaf (upstream's baseline since <=3.4.4), and no confined
ancestor walk (upstream 3.5.0's new fix, which is what this test exercises - a
**parent** component flip, not a leaf flip).

The confined open already existed and was already tested
(`fast_io::open_source_confined`), with exactly one consumer whose anchor is
`Some(..)` only for a non-chroot **daemon** sender. The local-copy path never
went through it.

## Change

- `CopyContext` carries a `source_anchor`, set per operand in the source loop.
  The anchor is the directory the sender would `chdir` into: the operand itself
  for a trailing-slash (contents) operand, its parent otherwise.
- `open_source_file` takes that anchor plus the follow-symlinks decision and
  mirrors upstream's three arms.

## The gate is the substance, and my first version had it wrong

Upstream applies the confinement **only** when no symlink-following mode is
active:

```c
} else if (!copy_links && !copy_unsafe_links && !copy_dirlinks && !insecure_links) {
        fd = sender_open_confined(NULL, fname, O_RDONLY);   /* sender.c:685-705 */
} else {
        fd = do_open_checklinks(fname);                      /* sender.c:706 */
}
```

Confining the following modes breaks them outright - `--copy-unsafe-links`
exists precisely to materialise links whose targets lie OUTSIDE the tree. Two
existing engine tests caught this before it shipped:
`execute_with_copy_unsafe_links_materialises_file_target` and a `-k`
dir-link cell. All three options are now in the predicate.

Note the anchor question too: upstream passes `NULL` (relative to cwd) and
chdirs to the transfer root first, so "cwd" and "transfer root" name the same
directory - the anchor here is upstream's, not an invention.

⚠ The confined/copy-links pairing upstream also keeps
(`sender_open_copylinks_confined`, `sender.c:682`) is the **daemon** branch,
where the anchor is the module root and leaving it is a module escape. The
non-daemon sender this module implements takes the plain branch.
`--insecure-links` is upstream's fourth exclusion term; oc does not implement
that option yet, so it cannot be spelled in the predicate.

## Verification (Linux aarch64)

- Upstream 3.5.0 `symlink-race-source`: **3/3 FAIL before, 3/3 PASS after**.
  The test is a race, so both sides are measured repeatedly rather than once.
- Full 3.5.0 suite, 345 tests, diffed per test against a control built from
  this branch's parent commit. Exactly one cell differs -
  `symlink-race-source`, fail -> pass. Nothing else moved.

  ⚠ My first control was **invalid** and briefly showed a second diff
  (`rrsync-no-overwrite-delay-updates`, pass -> fail). That binary was built
  from a *different* branch carrying an unmerged operand fix. Rebuilt from the
  real parent, that cell fails 3/3 there too - it is a pre-existing failure,
  not a regression.
- Three new unit cells in `open.rs`: an in-tree nested source still opens (the
  non-vacuity companion), a parent symlinked outside the root is refused, and a
  symlink-following mode still reads through the same escape - the cell that
  discriminates the gate from a blanket confinement.
- `cargo nextest run -p engine --all-features`: 5089 passed, 0 failed.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets
  --all-features --no-deps -- -D warnings` clean.

## Deliberately out of scope

The alt-base override open (`--copy-dest` / `--link-dest` after a cross-device
degrade) is an operator-named path outside the source tree. It takes the
operator-path resolver, not the transfer-root confinement, so it is passed no
anchor here; that routing belongs with the alt-dest family.
