### PR TITLE
test(ci): pass the 3.5.0 expect manifests to the badge testsuites

### DIFF
--- a/.github/workflows/upstream-testsuite-root.yml
+++ b/.github/workflows/upstream-testsuite-root.yml
@@ -4,6 +4,13 @@ name: Upstream Testsuite root (rsync 3.5.0)
 # pass/fail status is visible as a README badge. This re-runs the same 3.5.0
 # runtests.py corpus under passwordless sudo so root-only tests execute
 # (device nodes, ownership, etc.). Scheduled daily plus on-demand.
+#
+# It must pass the SAME --expect-result manifest ci.yml passes, and its OWN
+# one: the two legs run the same 345 tests at different privilege and 40 of
+# them resolve to a different outcome, so the non-root manifest would be wrong
+# for those 40. Without a manifest, runtests.py runs the whole corpus and fails
+# on any failure, so the badge would be permanently red against the known 3.5.0
+# divergences and would stop carrying information.
 on:
   workflow_dispatch:
   schedule:
@@ -22,3 +29,4 @@ jobs:
     with:
       upstream_rsync_version: '3.5.0'
       variant: 'root'
+      expect_result_root: tools/ci/upstream-3.5.0-expect.root.txt

--- a/.github/workflows/upstream-testsuite.yml
+++ b/.github/workflows/upstream-testsuite.yml
@@ -4,6 +4,12 @@ name: Upstream Testsuite (rsync 3.5.0)
 # pass/fail status is visible as a README badge. This is the same suite that
 # CI gates on as the required "upstream testsuite" check, run against upstream
 # rsync 3.5.0's own runtests.py testsuite corpus. Scheduled daily plus on-demand.
+#
+# It must pass the SAME --expect-result manifest ci.yml passes. Without one,
+# runtests.py runs the whole corpus and fails on any failure, so the badge
+# would be permanently red against the known 3.5.0 divergences and would stop
+# carrying information. With it, only a CHANGE in outcome - a regression or an
+# unexpected pass - turns the badge red.
 on:
   workflow_dispatch:
   schedule:
@@ -22,3 +28,4 @@ jobs:
     with:
       upstream_rsync_version: '3.5.0'
       variant: 'nonroot'
+      expect_result_nonroot: tools/ci/upstream-3.5.0-expect.nonroot.txt


### PR DESCRIPTION
The two standalone badge workflows (`upstream-testsuite.yml`, `upstream-testsuite-root.yml`) were flipped to `upstream_rsync_version: '3.5.0'` but kept `expect_result_*` empty.

Per `_upstream-testsuite.yml`'s own input contract, empty means *"run the whole suite and fail on any failure"*. Against the known 3.5.0 divergences that makes both badges structurally red — a badge that cannot be green carries no signal, and a permanently red one trains readers to ignore it.

They now pass the same committed manifests the **required** `upstream testsuite` / `(root)` contexts already pass (`ci.yml:915-916`), so only a *change* in outcome — a regression, or an unexpected pass — reddens them.

The root leg takes its own manifest deliberately: the two legs run the same 345 tests at different privilege and 40 resolve to a different outcome, so the non-root file would be wrong for those 40.

**Not inert, and cannot shrink coverage silently.** `run_upstream_testsuite.sh` refuses a manifest that is missing (:770), lists no tests (:776), or covers fewer than the full suite (:793) — the last is the whole-suite coverage guard, so a truncated manifest fails rather than quietly testing less.