### PR TITLE
fix(daemon): refuse a client-sent --insecure-links

### DIFF
--- a/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
@@ -415,7 +415,14 @@ fn is_option_refused(
     //     server-side logging.
     //   - `iconv` (options.c:1007-1008) is refused only when the module has no
     //     `charset` configured (`!*lp_charset(module_id)`).
+    //   - `insecure-links` (options.c:1087, new in 3.5.0) is a LOCAL-ONLY
+    //     opt-out, so a client must never be able to switch off the daemon's
+    //     symlink confinement by sending it. The daemon's own opt-out is the
+    //     `insecure links` module parameter, never this flag.
     if long_name.starts_with("log-file") {
+        return true;
+    }
+    if long_name == "insecure-links" {
         return true;
     }
     if long_name == "iconv"

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -401,6 +401,47 @@ fn default_log_file_refusal_survives_negation() {
 }
 
 #[test]
+fn default_refuses_client_insecure_links() {
+    // upstream: options.c:1087 (new in 3.5.0) - a daemon always appends
+    // `insecure-links` to the refuse list. The flag is a LOCAL-ONLY opt-out, so
+    // a client must never be able to switch off the daemon's symlink
+    // confinement by sending it; the daemon's own opt-out is the `insecure
+    // links` module parameter.
+    let module = ModuleDefinition::default();
+    assert_eq!(
+        refused_option(&module, &["--insecure-links".to_owned()]),
+        Some("--insecure-links")
+    );
+}
+
+#[test]
+fn insecure_links_refusal_survives_negation() {
+    // upstream: options.c:1077-1088 - the unconditional daemon refusals are
+    // appended AFTER the module's own `refuse options` rules, so an operator
+    // cannot re-enable the client flag with `!insecure-links` even by mistake.
+    // Without this the confinement opt-out would be one config typo away from
+    // being client-controllable.
+    let module = module_with_refuse(vec!["!insecure-links".to_owned()]);
+    assert_eq!(
+        refused_option(&module, &["--insecure-links".to_owned()]),
+        Some("--insecure-links")
+    );
+}
+
+#[test]
+fn insecure_links_refusal_does_not_catch_unrelated_options() {
+    // Non-vacuity companion: the refusal is an EXACT name match, not a prefix
+    // sweep. Without this, a stray `starts_with` would pass both tests above
+    // while silently refusing every option beginning with "insecure".
+    let module = ModuleDefinition::default();
+    assert_eq!(refused_option(&module, &["--insecure".to_owned()]), None);
+    assert_eq!(
+        refused_option(&module, &["--insecure-links-extra".to_owned()]),
+        None
+    );
+}
+
+#[test]
 fn iconv_refused_when_module_has_no_charset() {
     // upstream: options.c:1007-1008 - `if (!*lp_charset(module_id))
     // parse_one_refuse_match(0, "iconv", ...)`: a daemon module with no


### PR DESCRIPTION
## What

A daemon must refuse a client-sent `--insecure-links`.

`--insecure-links` is a **local-only** opt-out of symlink confinement. A client
must never be able to switch a daemon's confinement off, so upstream appends the
option to the daemon's refuse list unconditionally - after the module's own
`refuse options` rules have been applied, so no `!insecure-links` negation can
re-enable it. A daemon's own opt-out is the `insecure links` module parameter,
never the client flag.

## Why this one was missing

oc already mirrors the two sibling unconditional refusals from that same
`am_daemon` block - `log-file*` and the charset-gated `iconv` - but not this
third one, which 3.5.0 added. A client forwarding `-M--insecure-links` was
therefore not refused.

upstream: `options.c:1077-1088`, with
`parse_one_refuse_match(0, "insecure-links", list_end)` at `:1087`.

## Scope

The refuse evaluator already canonicalises raw client option strings without
consulting a known-option table, so the new clause needs nothing else wired up.
No behaviour changes for any other option.

## Tests

Three, alongside the existing `log-file*` / `iconv` pins:

- `default_refuses_client_insecure_links` - the refusal itself.
- `insecure_links_refusal_survives_negation` - `!insecure-links` in a module's
  `refuse options` cannot re-enable it, matching upstream's ordering.
- `insecure_links_refusal_does_not_catch_unrelated_options` - non-vacuity
  companion: the match is exact, not a prefix sweep, so `--insecure` and
  `--insecure-links-extra` stay allowed. Without it a stray `starts_with` would
  pass the first two while silently refusing a family of options.

RED proven by removing the clause: the two pins fail, the companion stays green
(1 passed, 2 failed).

## Verification

- `cargo fmt --all -- --check` - exit 0
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - exit 0
- `cargo nextest run -p daemon --all-features` - 1800 passed, 6 skipped

Covered end-to-end by upstream's `testsuite/operator-path-insecure-links-refused`.
