### PR TITLE
fix(fast_io): resolve an absolute operator rename endpoint by ownership

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
@@ -369,20 +369,13 @@ pub fn linkat_via_sandbox_or_fallback(
 ///   already exists and a genuine `EXDEV`.
 #[cfg(unix)]
 pub fn confined_link_anonymous(staged: BorrowedFd<'_>, root: &Path, dest: &Path) -> io::Result<()> {
-    use super::rename::{ConfinedEndpoint, anchor_confined_endpoint};
+    use super::rename::anchor_confined_endpoint;
 
     let proc_path = format!("/proc/self/fd/{}", staged.as_raw_fd());
     let c_old = CString::new(proc_path).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 
     let endpoint = anchor_confined_endpoint(root, dest)?;
-    // SAFETY: `AT_FDCWD` is a well-known pseudo-descriptor accepted by every
-    // `*at` syscall; it is never closed and outlives any borrow of it.
-    #[allow(unsafe_code)]
-    let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
-    let (new_dirfd, new_name) = match &endpoint {
-        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
-        ConfinedEndpoint::Ambient(path) => (cwd, *path),
-    };
+    let (new_dirfd, new_name) = endpoint.resolved();
     let c_new = CString::new(new_name.as_bytes())
         .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 
@@ -445,18 +438,11 @@ pub fn confined_link_anonymous(staged: BorrowedFd<'_>, root: &Path, dest: &Path)
 /// - `EEXIST` when `dest` already exists.
 /// - Otherwise the underlying `openat(2)` error verbatim.
 pub fn confined_create_new(root: &Path, dest: &Path) -> io::Result<std::fs::File> {
-    use super::rename::{ConfinedEndpoint, anchor_confined_endpoint};
+    use super::rename::anchor_confined_endpoint;
     use std::os::fd::FromRawFd;
 
     let endpoint = anchor_confined_endpoint(root, dest)?;
-    // SAFETY: `AT_FDCWD` is a well-known pseudo-descriptor accepted by every
-    // `*at` syscall; it is never closed and outlives any borrow of it.
-    #[allow(unsafe_code)]
-    let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
-    let (dirfd, name) = match &endpoint {
-        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
-        ConfinedEndpoint::Ambient(path) => (cwd, *path),
-    };
+    let (dirfd, name) = endpoint.resolved();
     let c_name =
         CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 
@@ -521,17 +507,10 @@ pub enum CloneAttempt {
 /// A filesystem that simply cannot reflink reports `Ok(CloneAttempt::Unsupported)`,
 /// never an error.
 pub fn confined_clone_file(root: &Path, src: &Path, dest: &Path) -> io::Result<CloneAttempt> {
-    use super::rename::{ConfinedEndpoint, anchor_confined_endpoint};
+    use super::rename::anchor_confined_endpoint;
 
     let endpoint = anchor_confined_endpoint(root, dest)?;
-    // SAFETY: `AT_FDCWD` is a well-known pseudo-descriptor accepted by every
-    // `*at` syscall; it is never closed and outlives any borrow of it.
-    #[allow(unsafe_code)]
-    let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
-    let (dirfd, name) = match &endpoint {
-        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
-        ConfinedEndpoint::Ambient(path) => (cwd, *path),
-    };
+    let (dirfd, name) = endpoint.resolved();
     let c_name =
         CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
@@ -7,9 +7,9 @@
 //! final-name commit, selecting the sandbox fast path when both leaves
 //! are single components under the same destination parent.
 
-use std::ffi::{CString, OsStr};
+use std::ffi::{CString, OsStr, OsString};
 use std::io;
-use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
@@ -178,10 +178,9 @@ pub fn renameat_via_sandbox_or_fallback(
         let dirfd = sandbox.current_dirfd();
         return renameat(dirfd, old_leaf, dirfd, new_leaf, replace);
     }
-    // Nested paths: confine each side independently beneath the root. An
-    // endpoint that lies under the root is anchored by the per-component
-    // confined walk; one that does not (an operator-supplied absolute
-    // `--temp-dir`/`--partial-dir`) keeps ambient resolution.
+    // Nested paths: resolve each side independently. An endpoint under the root
+    // is anchored by the per-component confined walk; an absolute one outside it
+    // (an operator-supplied `--temp-dir`/`--partial-dir`) by the ownership walk.
     //
     // Anchoring is deliberately NOT all-or-nothing. Requiring both sides to
     // anchor let an absolute `--temp-dir` source - which can never anchor -
@@ -219,21 +218,58 @@ pub(super) enum ConfinedEndpoint<'a> {
         sandbox: crate::dir_sandbox::DirSandbox,
         leaf: &'a OsStr,
     },
-    /// The endpoint is outside the root (an operator-supplied absolute
-    /// `--temp-dir`/`--partial-dir`, say). Resolved against `AT_FDCWD` from the
-    /// whole path, exactly as a plain `rename(2)` would.
+    /// The endpoint is an **operator** path outside the root (an absolute
+    /// `--temp-dir`/`--partial-dir`, say). Its parent is resolved by the
+    /// ownership walk, which follows uid-0/euid symlinks and refuses any
+    /// other-uid one, so a foreign-owned component flipped between the decision
+    /// to commit and the syscall cannot redirect the operation.
+    OwnerWalked { parent: OwnedFd, leaf: OsString },
+    /// The endpoint is neither beneath the root nor absolute - a bare relative
+    /// name. Resolved against `AT_FDCWD` from the whole path, exactly as a plain
+    /// `rename(2)` would, mirroring upstream's slashless arm.
     Ambient(&'a OsStr),
+}
+
+#[cfg(unix)]
+impl ConfinedEndpoint<'_> {
+    /// Reduce the endpoint to the `(dirfd, name)` pair every `*at` syscall wants.
+    ///
+    /// The single owner of that mapping. Each consumer having its own `match`
+    /// is what let them drift once already - the `O_TMPFILE` `linkat` commit
+    /// skipped confinement while the named-temp rename enforced it - so a new
+    /// arm must be impossible to handle in only some of them.
+    pub(super) fn resolved(&self) -> (BorrowedFd<'_>, &OsStr) {
+        match self {
+            Self::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), leaf),
+            Self::OwnerWalked { parent, leaf } => (parent.as_fd(), leaf.as_os_str()),
+            // SAFETY: `AT_FDCWD` is a well-known pseudo-descriptor accepted by
+            // every `*at` syscall; it is never closed and outlives any borrow.
+            #[allow(unsafe_code)]
+            Self::Ambient(path) => (unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) }, path),
+        }
+    }
 }
 
 /// Reduce one endpoint to `(dirfd, name)` for `renameat(2)`.
 ///
-/// Anchoring applies only when `path` lexically lies beneath `root` and has a
-/// final component: the parent is then walked beneath `root` with
-/// [`DirSandbox::open_dest_anchor_confined`], which follows relative in-tree
-/// symlinks and refuses absolute targets and climbs above the anchor.
+/// Three arms, mirroring upstream's three:
 ///
-/// Anything else degrades to [`ConfinedEndpoint::Ambient`] - the pre-existing
-/// path-based behaviour for that side - rather than failing the rename.
+/// | endpoint | resolver | upstream |
+/// |---|---|---|
+/// | beneath `root` | confined per-component walk | `secure_relative_open()`, `syscall.c:1945` |
+/// | absolute, outside `root` | ownership walk | `owner_walk_parent()`, `syscall.c:1926` |
+/// | otherwise | `AT_FDCWD` + whole path | `syscall.c:1949` |
+///
+/// The split matters because location cannot be the trust signal for an
+/// operator path - it may legitimately point outside the tree - so authority
+/// (ownership) is used instead. Keying the first arm on "beneath `root`" rather
+/// than on "relative" is oc's equivalent of upstream's test: upstream has
+/// already `chdir`'d the receiver into the destination, so its transfer paths
+/// are relative where oc's are absolute-but-beneath-root.
+///
+/// Deliberately **not** applied to the destination of a transfer: the ownership
+/// rule is more permissive than the confined walk, so widening it to a path
+/// beneath `root` would weaken that side rather than strengthen this one.
 #[cfg(unix)]
 pub(super) fn anchor_confined_endpoint<'a>(
     root: &Path,
@@ -242,6 +278,10 @@ pub(super) fn anchor_confined_endpoint<'a>(
     use crate::dir_sandbox::{ConfinePolicy, DirSandbox, NoExclude};
 
     let Ok(relative) = path.strip_prefix(root) else {
+        if path.is_absolute() {
+            let (parent, leaf) = crate::owner_walk::owner_trusted_parent(path)?;
+            return Ok(ConfinedEndpoint::OwnerWalked { parent, leaf });
+        }
         return Ok(ConfinedEndpoint::Ambient(path.as_os_str()));
     };
     let Some(leaf) = relative.file_name() else {
@@ -253,19 +293,22 @@ pub(super) fn anchor_confined_endpoint<'a>(
     Ok(ConfinedEndpoint::Anchored { sandbox, leaf })
 }
 
-/// Rename `old_path` to `new_path`, confining **each side independently**
-/// beneath `root`.
+/// Rename `old_path` to `new_path`, resolving **each side independently** by
+/// the resolver its provenance calls for (see [`anchor_confined_endpoint`]).
 ///
-/// A side that lies beneath `root` has its parent resolved by the confined
-/// per-component walk, so a directory component flipped to a symlink between
-/// the decision to commit and the syscall cannot redirect the rename out of the
-/// tree. A side that does not lie beneath `root` keeps the ambient path-based
-/// resolution.
+/// A side beneath `root` has its parent resolved by the confined per-component
+/// walk; an absolute side outside `root` - an operator path - by the ownership
+/// walk. Either way no component can be flipped to a symlink between the
+/// decision to commit and the syscall and redirect the rename out of the tree.
 ///
-/// Per-side independence is the whole point: an operator-supplied absolute
-/// `--temp-dir` puts the *source* outside the tree, and an all-or-nothing rule
-/// would let that disable confinement of the *destination* - which is the
-/// escape upstream's `rename-fullpath-symlink-race` test demonstrates.
+/// Per-side independence is the whole point, in both directions: an
+/// operator-supplied absolute `--temp-dir` puts the *source* outside the tree,
+/// and an all-or-nothing rule would let that disable confinement of the
+/// *destination* - the escape upstream's `rename-fullpath-symlink-race` test
+/// demonstrates. Leaving that source unresolved is the mirror-image escape,
+/// which `temp-dir-symlink-injection` demonstrates: the temp file's *creation*
+/// is confined, but re-resolving its path at commit time lets a flipped
+/// foreign-owned parent substitute attacker content into the destination.
 ///
 /// `replace` mirrors the [`renameat`] knob: `true` overwrites the destination
 /// atomically, matching [`std::fs::rename`] and upstream `do_rename()`.
@@ -291,22 +334,11 @@ pub fn confined_rename(
     new_path: &Path,
     replace: bool,
 ) -> io::Result<()> {
-    // SAFETY: `AT_FDCWD` is a well-known pseudo-descriptor accepted by every
-    // `*at` syscall; it is never closed and outlives any borrow of it.
-    #[allow(unsafe_code)]
-    let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
-
     let old = anchor_confined_endpoint(root, old_path)?;
     let new = anchor_confined_endpoint(root, new_path)?;
 
-    let (old_dirfd, old_name) = match &old {
-        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
-        ConfinedEndpoint::Ambient(path) => (cwd, *path),
-    };
-    let (new_dirfd, new_name) = match &new {
-        ConfinedEndpoint::Anchored { sandbox, leaf } => (sandbox.root_dirfd(), *leaf),
-        ConfinedEndpoint::Ambient(path) => (cwd, *path),
-    };
+    let (old_dirfd, old_name) = old.resolved();
+    let (new_dirfd, new_name) = new.resolved();
 
     renameat(old_dirfd, old_name, new_dirfd, new_name, replace)
 }

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
@@ -1843,3 +1843,64 @@ fn single_component_symlinkat_unchanged_by_nested_path() {
         "single-component symlink must still be created"
     );
 }
+
+/// `anchor_confined_endpoint` must pick the resolver by the endpoint's
+/// provenance, mirroring upstream's three arms in `do_rename_at()`.
+///
+/// The absolute-outside-root arm is the one that was missing: it degraded to
+/// `Ambient` (`AT_FDCWD` + the whole path), which re-resolves an operator
+/// `--temp-dir` at commit time and lets a flipped foreign-owned parent
+/// substitute attacker content into the destination. Its refusal needs a
+/// second uid to observe, so the behavioural proof is the root leg of the
+/// upstream 3.5.0 suite (`temp-dir-symlink-injection`); what is pinned here is
+/// that the ownership walk is *selected* at all.
+///
+/// upstream: `rsync-3.5.0/syscall.c:1926` (absolute -> `owner_walk_parent`),
+/// `:1945` (relative-with-slash -> `secure_relative_open`), `:1949` (slashless
+/// -> `AT_FDCWD`).
+mod endpoint_provenance {
+    use super::super::rename::{ConfinedEndpoint, anchor_confined_endpoint};
+    use super::canonical_tempdir;
+    use std::path::Path;
+
+    #[test]
+    fn an_endpoint_beneath_the_root_takes_the_confined_walk() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::create_dir(root.join("sub")).expect("mkdir");
+
+        let path = root.join("sub/f");
+        let endpoint = anchor_confined_endpoint(&root, &path).expect("anchor");
+
+        assert!(
+            matches!(endpoint, ConfinedEndpoint::Anchored { .. }),
+            "a transfer path must be confined beneath the root, not owner-walked"
+        );
+    }
+
+    #[test]
+    fn an_absolute_endpoint_outside_the_root_takes_the_ownership_walk() {
+        let (_keep, root) = canonical_tempdir();
+        let (_keep_out, outside) = canonical_tempdir();
+
+        let path = outside.join("f0.tmp");
+        let endpoint = anchor_confined_endpoint(&root, &path).expect("anchor");
+
+        assert!(
+            matches!(endpoint, ConfinedEndpoint::OwnerWalked { .. }),
+            "an absolute operator path must be resolved by the ownership walk, \
+             not left to ambient path resolution"
+        );
+    }
+
+    #[test]
+    fn a_bare_relative_endpoint_stays_ambient() {
+        let (_keep, root) = canonical_tempdir();
+
+        let endpoint = anchor_confined_endpoint(&root, Path::new("f0.tmp")).expect("anchor");
+
+        assert!(
+            matches!(endpoint, ConfinedEndpoint::Ambient(_)),
+            "a slashless name resolves against AT_FDCWD, as upstream does"
+        );
+    }
+}

--- a/crates/fast_io/tests/confined_rename.rs
+++ b/crates/fast_io/tests/confined_rename.rs
@@ -91,3 +91,41 @@ fn an_out_of_tree_source_does_not_disable_destination_confinement() {
         "the refused rename must leave the temp intact"
     );
 }
+
+/// The absolute `--temp-dir` source is resolved by the ownership walk, not left
+/// to ambient path resolution - so a foreign-owned parent flipped between the
+/// decision to commit and the syscall cannot substitute attacker content into
+/// the destination.
+///
+/// Planting a foreign-owned component needs a second uid, so the refusal itself
+/// is proven by the root leg of the upstream 3.5.0 suite
+/// (`temp-dir-symlink-injection`). What an unprivileged run can prove - and what
+/// this pins - is the direction that a blanket refusal would break: the walk
+/// must still *follow* a component the operator owns, because an operator path
+/// may legitimately live behind their own symlink.
+///
+/// upstream: `rsync-3.5.0/syscall.c:1926` `do_rename_at()`.
+#[test]
+fn an_out_of_tree_source_behind_an_owned_symlink_still_commits() {
+    let base = TempDir::new().expect("tempdir");
+    let root = base.path().join("dest");
+    let staging = base.path().join("staging");
+    fs::create_dir(&root).expect("mkdir dest");
+    fs::create_dir(&staging).expect("mkdir staging");
+    // The operator's own layout: an absolute --temp-dir reached through a
+    // symlink they own. The ownership walk follows it; a refuse-all walk would
+    // break this legitimate shape.
+    std::os::unix::fs::symlink(&staging, base.path().join("tmpd")).expect("plant symlink");
+
+    let temp = write_file(&base.path().join("tmpd"), "f0.tmp", "payload");
+    let final_path = root.join("f0");
+
+    fast_io::confined_rename(&root, &temp, &final_path, true)
+        .expect("an operator-owned symlink must be followed, not refused");
+
+    assert_eq!(fs::read_to_string(&final_path).unwrap(), "payload");
+    assert!(
+        !staging.join("f0.tmp").exists(),
+        "the staged temp must have moved out of the staging directory"
+    );
+}


### PR DESCRIPTION
## What

`confined_rename` resolved an **absolute endpoint outside the confinement root**
with `AT_FDCWD` and the whole path. That is the temp file staged by an absolute
`--temp-dir`: its *creation* is confined, but the commit re-resolves its path,
so a parent component flipped to a foreign-owned symlink in between redirects
the rename source and lands attacker content in the destination.

That is the escape upstream's `temp-dir-symlink-injection` test demonstrates. On
master it fails intermittently on the root leg - it loops for a race budget, so
it passes only when the flipper misses the window.

## Upstream rule

`do_rename_at()` (`syscall.c:1866-1990`) resolves **each side independently**,
by three arms, not two:

| endpoint | resolver | upstream |
|---|---|---|
| relative with a slash | `secure_relative_open()` - confined beneath the tree | `:1945` |
| absolute | `owner_walk_parent()` - the **ownership** walk | `:1926` |
| slashless | `AT_FDCWD` + the name | `:1949` |

The split exists because location cannot be the trust signal for an operator
path - it may legitimately point outside the tree - so authority (ownership)
is used instead: follow a symlink owned by uid 0 or our euid, refuse any other.

oc had the first and third arms and folded the second into the third.
`crates/fast_io/src/owner_walk.rs` already implements the walk; it was wired
only into the backup path (`engine/src/local_copy/overrides.rs`).

Keying oc's first arm on *beneath the root* rather than on *relative* is the
equivalent test: upstream has already `chdir`'d the receiver into the
destination, so its transfer paths are relative where oc's are
absolute-but-beneath-root.

## The trap this deliberately avoids

The ownership rule is **more permissive** than the confined walk. Applying it to
both sides - or to any endpoint beneath the root - would *weaken* the
destination while fixing the source. Upstream does not set
`operator_path_resolve` for this call, and neither does this change: the arm is
selected by provenance, and the destination keeps the confined walk.

## Design

`ConfinedEndpoint` gains an `OwnerWalked` arm, and the `(dirfd, name)` mapping
moves onto the type as `resolved()`. There were **four** copies of that match,
and the compiler found a fourth consumer I had not accounted for
(`confined_clone_file`) precisely because the enum is exhaustive. Those copies
are how the two commit strategies drifted apart once before - the `O_TMPFILE`
`linkat` path skipped confinement while the named-temp rename enforced it - so a
new arm must now be impossible to handle in only some of them.

## Tests

- `endpoint_provenance::*` - three cases pinning which resolver each provenance
  selects. The absolute-outside-root case is the fix.
- `an_out_of_tree_source_behind_an_owned_symlink_still_commits` - the direction a
  blanket refusal would break: an operator path may legitimately live behind a
  symlink they own, and the walk must follow it.

**RED/GREEN measured.** Removing only the absolute arm, leaving everything else:

| | absolute-arm test | owned-symlink follow | 3 destination-confinement tests | total |
|---|---|---|---|---|
| with the arm | pass | pass | pass | 7 passed |
| without | **FAIL** | pass | pass | 6 passed, 1 failed |

Exactly one test flips, and it is the discriminator.

**The cross-uid refusal is not duplicated here.** Planting a foreign-owned
component needs a second uid, so an unprivileged assertion would pass
vacuously; the refusal is proven by the root leg of the upstream 3.5.0 suite.
This is the same division `crates/fast_io/tests/owner_walk.rs` already documents
for the backup path.

## Known gap, pre-existing, not introduced

Upstream gates the ownership walk on `symlink_optout_allowed()`
(`--insecure-links` / the `insecure links` module directive). oc has that
predicate - `fast_io::confinement::Activation`, truth-tabled - with **zero
production constructors**, so no site consults it. The sibling operator-path
call (`backup_rename` -> `operator_link`/`operator_rename`) applies the walk
unconditionally on Unix for the same reason. This change follows that
precedent rather than inventing a second policy; wiring the opt-out belongs to
both sites at once and is tracked separately.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - exit 0, zero warnings
- `cargo nextest run -p fast_io --all-features` - 746 passed
- `cargo nextest run -p engine --all-features` - 5008 passed

Full-workspace and cross-platform coverage is left to the required CI contexts.

## Behavioural proof, with a negative control

The cross-uid refusal cannot be observed unprivileged, so it was measured
directly: upstream 3.5.0's own `temp-dir-symlink-injection` test, run as root
on aarch64 Linux against two `--release` binaries that differ only by this
commit. Same host, same harness, same built helper programs, same loop.

| binary | runs | failures |
|---|---|---|
| parent commit `6c88fca` (pre-fix) | 5 | **2** |
| this branch `24280b3` | 20 | **0** |

The control's failures carry the escape verbatim:

```
absolute --temp-dir rename injection: attacker out-of-tree content was renamed
into the destination (f23) -- the temp->final rename followed a flipped
foreign-owned temp-dir parent symlink.
```

The test loops for a race budget, so a single pass proves nothing - which is
why the control matters. At the control's ~40% per-run failure rate, 20
consecutive passes would occur by chance with probability ~4e-5.

That budget is also why this test is worth closing rather than baselining: a
`fail` row in the expect manifest would make a required CI context a coin flip,
and a `pass` row would have waived a live escape.
