### PR TITLE
fix(core): re-port SHELL_CHARS to 3.5.0 and stop escaping daemon path operands

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -53,13 +53,23 @@ pub(crate) fn send_daemon_arguments<W: Write>(
     } else {
         // upstream: options.c:2608-3015 server_options() wraps every emitted
         // option-with-value through `safe_arg()` before it enters the wire
-        // path. Under non-protect_args the daemon (rsync 3.4.4) responds with
+        // path. Under non-protect_args the daemon responds with
         // `unbackslash_arg()` on its side. We mirror both halves here so a
         // value such as `--groupmap=*:1234;foo` round-trips through the
         // remote shell-like text protocol without losing its wildcards.
-        full_args
+        //
+        // The path operands are deliberately excluded. Upstream escapes them
+        // with `safe_arg(NULL, ...)` only under `if (!daemon_connection)`
+        // (main.c:619), and its daemon agrees: `read_args()` un-escapes just
+        // the args preceding the `.` and routes everything after it through
+        // `glob_expand()` untouched (io.c:1500-1506). Escaping an operand here
+        // would ship literal backslashes that no peer removes - upstream 3.5.0
+        // then splits the name on them, so `a b.txt` arrives as `/a/ b.txt`.
+        let (options, operands) = split_at_operands(&full_args);
+        options
             .iter()
             .map(|arg| safe_arg_for_daemon(arg))
+            .chain(operands.iter().cloned())
             .collect()
     };
 
@@ -797,7 +807,7 @@ pub(super) fn build_full_daemon_args(
     }
 
     // upstream: dummy argument representing CWD.
-    args.push(".".to_owned());
+    args.push(DAEMON_ARG_SEPARATOR.to_owned());
 
     let module_path = format!("{}/{}", request.module, request.path);
     args.push(module_path);
@@ -880,6 +890,26 @@ const WILD_CHARS: &str = "*?[]";
 /// Option flag args that contain neither `=` nor any escapable character
 /// (e.g., `--server`, `--sender`, `--numeric-ids`) are returned verbatim
 /// to avoid allocation.
+/// The lone `.` that upstream pushes after `server_options()`
+/// (`clientserver.c:303`) to stand for the remote CWD. It is also the marker
+/// that separates option args from path operands on the wire: the daemon's
+/// `read_args()` switches behaviour the moment it sees it (`io.c:1500-1506`).
+const DAEMON_ARG_SEPARATOR: &str = ".";
+
+/// Splits a daemon argument vector into `(option args, path operands)` at
+/// [`DAEMON_ARG_SEPARATOR`], which stays with the options because the daemon
+/// un-escapes it alongside them.
+///
+/// A vector with no separator is all options - that is the shape
+/// `build_minimal_daemon_args` produces, and it carries no operands to protect.
+fn split_at_operands(args: &[String]) -> (&[String], &[String]) {
+    let operands_start = args
+        .iter()
+        .position(|arg| arg == DAEMON_ARG_SEPARATOR)
+        .map_or(args.len(), |dot| dot + 1);
+    args.split_at(operands_start)
+}
+
 fn safe_arg_for_daemon(arg: &str) -> String {
     let (prefix, value, escapes, is_filename_arg) = match arg.find('=') {
         Some(eq_pos) if arg.starts_with("--") => {

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -855,9 +855,10 @@ fn strip_client_only_batch_flags(args: &mut Vec<String>) {
 }
 
 /// Characters that the remote shell wrapper (or upstream `unbackslash_arg`)
-/// will interpret unless escaped. Mirrors upstream `options.c:2541`
-/// `SHELL_CHARS`. Backslash is included so a literal `\` round-trips intact.
-const SHELL_CHARS: &str = "!#$&;|<>(){}\"'` \t\\";
+/// will interpret unless escaped. Mirrors upstream `options.c:2695`
+/// `SHELL_CHARS`. Backslash is included so a literal `\` round-trips intact,
+/// and `\n`/`\r` so a newline cannot terminate the command and start a second.
+const SHELL_CHARS: &str = "!#$&;|<>(){}\"'` \t\n\r\\";
 
 /// Wildcard characters that the remote shell would expand. Mirrors upstream
 /// `options.c:2542` `WILD_CHARS`.

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -1210,10 +1210,14 @@ impl<'a> RemoteInvocationBuilder<'a> {
 
 /// Shell metacharacters that upstream rsync escapes in filename arguments.
 ///
-/// upstream: options.c `SHELL_CHARS` - characters requiring backslash escaping
-/// when passing filename arguments through a remote shell that evaluates them
-/// via `eval "$@"`.
-const SHELL_CHARS: &str = "!#$&;|<>(){}\"'` \t\\";
+/// upstream: options.c:2695 `SHELL_CHARS` - characters requiring backslash
+/// escaping when passing filename arguments through a remote shell that
+/// evaluates them via `eval "$@"`.
+///
+/// `\n` and `\r` are load-bearing: without them a newline inside a filename
+/// argument reaches the remote shell unescaped and terminates the command,
+/// so everything after it is executed as a second command.
+const SHELL_CHARS: &str = "!#$&;|<>(){}\"'` \t\n\r\\";
 
 /// Wildcard characters recognized by upstream rsync.
 ///

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -3869,6 +3869,29 @@ fn shell_safe_simple_path_unchanged() {
     assert_eq!(shell_safe("/simple/path"), "/simple/path");
 }
 
+/// A newline in a filename argument must be backslash-escaped, so the remote
+/// shell's `eval "$@"` sees one literal token instead of a command terminator
+/// followed by a second command.
+///
+/// upstream: options.c:2695 `SHELL_CHARS` includes `\n` and `\r`. oc's set was
+/// a byte-exact port of 3.4.4's, which has neither, so `needs_escaping` was
+/// false and the raw newline reached the argv verbatim.
+#[test]
+fn shell_safe_escapes_newline_and_carriage_return() {
+    // The injection shape: everything after the newline would run as its own
+    // command if the newline survived unescaped.
+    assert_eq!(shell_safe("/tmp/a\ntouch pwned"), "/tmp/a\\\ntouch\\ pwned");
+    assert_eq!(shell_safe("/tmp/a\rb"), "/tmp/a\\\rb");
+}
+
+/// Non-vacuity companion for `shell_safe_escapes_newline_and_carriage_return`:
+/// a name carrying no metacharacter at all must still pass through untouched,
+/// so the test above cannot pass merely because escaping became unconditional.
+#[test]
+fn shell_safe_leaves_a_metacharacter_free_name_alone() {
+    assert_eq!(shell_safe("/tmp/plain-name.txt"), "/tmp/plain-name.txt");
+}
+
 /// A non-UTF-8 operand round-trips byte-identically through
 /// `determine_transfer_role` -> `shell_safe_filename_arg`: the raw path byte
 /// (`0xFF`, a legal Unix filename byte rsync carries as `char*`) survives, and

--- a/tests/daemon_operand_metacharacters.rs
+++ b/tests/daemon_operand_metacharacters.rs
@@ -1,0 +1,192 @@
+//! A shell metacharacter in a filename survives an `rsync://` transfer.
+//!
+//! Upstream backslash-escapes filename operands with `safe_arg(NULL, ...)` only
+//! under `if (!daemon_connection)` (main.c:619) - that escaping exists for a
+//! remote shell that will `eval` the argv, and a daemon connection has no
+//! shell. Its daemon agrees: `read_args()` un-escapes just the args preceding
+//! the `.` and routes everything after it through `glob_expand()` untouched
+//! (io.c:1500-1506).
+//!
+//! oc-rsync escaped the operands on both transports, so every character in
+//! `SHELL_CHARS` reached the peer as a literal backslash that no peer removes.
+//! Measured against rsync 3.5.0 before the fix, `a b.txt` arrived as the split
+//! path `/a/ b.txt` and the transfer exited 23.
+//!
+//! This is a class test, not a single regression: the defect was one escape set
+//! applied to one argument vector, so every member of that set failed together
+//! and any future re-broadening fails here as a group.
+//!
+//! `CONTROL_NAME` carries no metacharacter and must transfer too - without it a
+//! harness that transferred nothing at all would satisfy every other assertion
+//! vacuously.
+//!
+//! Deliberately absent: a filename containing a literal backslash. Measured on
+//! this same harness, oc's *client* drives a real upstream 3.5.0 daemon
+//! correctly for that name while oc's own daemon still fails it, so the
+//! residual is in the daemon's post-dot operand handling, not in the escaping
+//! fixed here. It is tracked separately rather than silently dropped.
+//!
+//! Skip condition (test passes with a printed reason): loopback TCP is
+//! unavailable, or the daemon does not answer.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// `SHELL_CHARS` (options.c:2693) minus `WILD_CHARS`, which `glob_expand()`
+/// legitimately expands on the daemon side, and minus the backslash covered by
+/// the module note above. Tab and newline are included because they are the
+/// two bytes 3.5.0 added to the set, so they are the least-exercised members.
+const METACHARACTER_NAMES: &[&str] = &[
+    "sp ace",
+    "dol$lar",
+    "semi;colon",
+    "amp&ersand",
+    "hash#mark",
+    "paren(open",
+    "paren)close",
+    "brace{open",
+    "brace}close",
+    "single'quote",
+    "double\"quote",
+    "back`tick",
+    "pipe|bar",
+    "lt<gt",
+    "gt>lt",
+    "bang!mark",
+    "tab\tchar",
+    "new\nline",
+];
+
+/// The non-vacuity control: no metacharacter, so it must transfer whatever the
+/// escaping rule is.
+const CONTROL_NAME: &str = "control-plain";
+
+const PAYLOAD: &[u8] = b"metacharacter payload\n";
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+/// Starts a daemon and waits until its port answers, so the client never races
+/// the listener.
+fn spawn_daemon(conf: &Path, port: u16) -> Option<Child> {
+    let mut child = Command::new(oc_binary())
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return Some(child);
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    None
+}
+
+/// Pulls one name out of the module into a fresh directory and reports whether
+/// it arrived intact. Both halves matter: an escaped operand can either fail
+/// the lookup outright or resolve to a *different* name, and only comparing
+/// the landed bytes catches the second.
+fn pull(port: u16, name: &str, dest: &Path) -> Result<(), String> {
+    let status = Command::new(oc_binary())
+        .arg("-q")
+        .arg(format!("rsync://127.0.0.1:{port}/m/{name}"))
+        .arg(dest)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run client");
+    if !status.success() {
+        return Err(format!("client exited {:?}", status.code()));
+    }
+    match fs::read(dest.join(name)) {
+        Ok(bytes) if bytes == PAYLOAD => Ok(()),
+        Ok(bytes) => Err(format!(
+            "landed {} bytes, expected {}",
+            bytes.len(),
+            PAYLOAD.len()
+        )),
+        Err(err) => Err(format!("no file at that exact name: {err}")),
+    }
+}
+
+#[test]
+fn daemon_operands_keep_shell_metacharacters_intact() {
+    let Some(port) = free_port() else {
+        println!("skipping: loopback TCP unavailable");
+        return;
+    };
+    let root = tempfile::tempdir().expect("temp dir");
+    let module = root.path().join("mod");
+    fs::create_dir_all(&module).expect("module dir");
+
+    let mut names: Vec<&str> = vec![CONTROL_NAME];
+    names.extend_from_slice(METACHARACTER_NAMES);
+    for name in &names {
+        fs::write(module.join(name), PAYLOAD).expect("seed source file");
+    }
+
+    let conf = root.path().join("rsyncd.conf");
+    fs::write(
+        &conf,
+        format!(
+            "port = {port}\n\
+             use chroot = no\n\
+             \n\
+             [m]\n\
+             \tpath = {module}\n\
+             \tread only = yes\n",
+            module = module.display(),
+        ),
+    )
+    .expect("write config");
+
+    let Some(mut daemon) = spawn_daemon(&conf, port) else {
+        println!("skipping: daemon did not answer on 127.0.0.1:{port}");
+        return;
+    };
+
+    // A destination per name, so one mangled operand cannot land under a name
+    // a later pull would then find already present.
+    let failures: Vec<String> = names
+        .iter()
+        .enumerate()
+        .filter_map(|(i, name)| {
+            let dest = root.path().join(format!("dest{i}"));
+            fs::create_dir_all(&dest).expect("dest dir");
+            pull(port, name, &dest)
+                .err()
+                .map(|why| format!("{name:?}: {why}"))
+        })
+        .collect();
+
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+
+    assert!(
+        failures.is_empty(),
+        "operands were mangled in transit ({} of {}):\n{}",
+        failures.len(),
+        names.len(),
+        failures.join("\n")
+    );
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -265,7 +265,7 @@ relative-mkpath-dir-symlink fail
 relative-mkpath-symlink fail
 relative-symlinked-parent pass
 relative-symlinked-parent-dotdot pass
-remote-shell-newline-escaping fail
+remote-shell-newline-escaping pass
 rename-fullpath-symlink-race pass
 rename-mixed-parent-escape-poc pass
 rename-mixed-parent-symlink-race pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -265,7 +265,7 @@ relative-mkpath-dir-symlink fail
 relative-mkpath-symlink fail
 relative-symlinked-parent pass
 relative-symlinked-parent-dotdot pass
-remote-shell-newline-escaping fail
+remote-shell-newline-escaping pass
 rename-fullpath-symlink-race pass
 rename-mixed-parent-escape-poc pass
 rename-mixed-parent-symlink-race pass


### PR DESCRIPTION
Two escaping defects in the same argument vector, found because fixing the
first exposed the second.

## 1. `SHELL_CHARS` was a 3.4.4 port

`options.c:2693`:

```c
#define SHELL_CHARS "!#$&;|<>(){}\"\'` \t\n\r\\"
```

oc's constant was byte-exact for **3.4.4**, which has neither `\n` nor `\r`;
3.5.0 added them. `needs_escaping` consults only that set, so a newline in a
filename argument reached the remote shell unescaped, terminated the command,
and everything after it ran as a second command.

The constant is duplicated at the SSH-invocation and daemon builders; both are
corrected and both citations retargeted at `options.c:2695`.

## 2. The operands were escaped on a transport that has no shell

`safe_arg()`'s escaping exists for a remote shell that will `eval` the argv.
Upstream applies it to filename operands only under `if (!daemon_connection)`
(`main.c:619`), and its daemon agrees: `read_args()` un-escapes just the args
preceding the `.` and routes everything after it through `glob_expand()`
untouched (`io.c:1500-1506`).

oc escaped operands on **both** transports, so every `SHELL_CHARS` member
reached the peer as a literal backslash no peer removes. Measured against a
real rsync 3.5.0 daemon before the fix:

| | oc | upstream 3.5.0 |
|---|---|---|
| `rsync://host/m/a b.txt` | `link_stat "/a/ b.txt"`, exit 23 | transfers, exit 0 |

The backslash did not merely survive - it **split the path**. This predates the
`\n` change; a space was already enough. Escaping of the pre-dot option values
is unchanged, since that half is real and oc's daemon already mirrors
`unbackslash_arg` for it.

## Tests

`daemon_operands_keep_shell_metacharacters_intact` is a class test, not a
single regression: the defect was one escape set applied to one argument
vector, so all 18 members failed together and any re-broadening fails as a
group. `control-plain` is the non-vacuity companion - without it a harness that
transferred nothing would satisfy every other assertion.

**RED proven** by restoring the pre-fix escaping: 18 of 19 fail, and the
control still passes - which places the defect in the escaping rather than in a
broken fixture.

## Known residual (not silently dropped)

A filename containing a **literal backslash** still fails - but against oc's
*daemon*, not its client: oc's client drives a real upstream 3.5.0 daemon
correctly for that name on this same harness. The residual is in the daemon's
post-dot operand handling, a different component from the escaping fixed here,
and is tracked separately rather than folded into a client-side change.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - zero warnings
- `cargo nextest run -p bin -p core --all-features` - 3289 passed, 0 failed
- Oracle: upstream 3.5.0 daemon, 16/16 names including the control

The `remote-shell-newline-escaping` expect row flips `fail` -> `pass` on both
legs: the newline addition makes that test pass, and `--expect-result` fails on
an unexpected pass exactly as it does on a failure.
