### PR TITLE
fix(cli): don't log attribute-only changes under a non-itemizing --out-format

### DIFF
--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -67,7 +67,11 @@ impl OutFormat {
 /// upstream: generator.c:582-583 - emit when `iflags & (SIGNIFICANT_ITEM_FLAGS
 /// | ITEM_REPORT_XATTR) || INFO_GTE(NAME, 2) || stdout_format_has_i > 1
 /// || (xname && *xname)`.
-fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> bool {
+fn should_suppress_event(
+    event: &ClientEvent,
+    context: &OutFormatContext,
+    format_itemizes: bool,
+) -> bool {
     if event.itemize_override().is_some() {
         // A remote transfer supplies a row only when the sender's own emit gate
         // fired (generator.c:582-583 on the remote side), and it has no local
@@ -85,6 +89,28 @@ fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> boo
     if matches!(event.kind(), ClientEventKind::MetadataReused)
         && !event.was_created()
         && !event.change_set().has_any_change()
+    {
+        return true;
+    }
+
+    // upstream: log.c:875-890 `maybe_log_item()` - `see_item` is gated on
+    // `itemizing`, so a format without `%i` reports only entries that actually
+    // moved data. An attribute-only change (a chmod against an otherwise
+    // up-to-date file) is announced solely when the format itemizes.
+    //
+    // Measured against rsync 3.5.0 on a chmod-only second run:
+    //   --out-format='%n'      -> silent      (oc printed `a`)
+    //   --out-format='%%i %n'  -> silent      (oc printed `%i a`)
+    //   --out-format='%i %n'   -> `.f...p..... a`  (oc already matched)
+    // The new-file and content-change rows print under every one of those
+    // formats, which is why this narrows to `MetadataReused` rather than
+    // gating the whole emit on `format_itemizes`.
+    //
+    // Placed below the `-vv` / `-ii` arms above so their existing
+    // force-emission precedence is unchanged.
+    if !format_itemizes
+        && matches!(event.kind(), ClientEventKind::MetadataReused)
+        && !event.was_created()
     {
         return true;
     }
@@ -188,7 +214,7 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
             }
             continue;
         }
-        if should_suppress_event(event, context) {
+        if should_suppress_event(event, context, format.itemizes()) {
             continue;
         }
         format.render(event, context, writer)?;

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -26,6 +26,23 @@ impl OutFormat {
         self.tokens.iter()
     }
 
+    /// Returns `true` when the format renders the itemized-changes string.
+    ///
+    /// upstream: options.c:2354 - `stdout_format_has_i` is derived from the
+    /// resolved format string, and it is what puts the client into itemizing
+    /// mode. Read it from the parsed tokens rather than re-scanning the raw
+    /// text so the emit gate and the renderer cannot disagree about whether a
+    /// given `%i` is a real directive or the literal produced by `%%i`.
+    pub(super) fn itemizes(&self) -> bool {
+        self.tokens().any(|token| {
+            matches!(
+                token,
+                OutFormatToken::Placeholder(placeholder)
+                    if matches!(placeholder.kind, OutFormatPlaceholder::ItemizedChanges)
+            )
+        })
+    }
+
     /// Returns `true` when no tokens were parsed from the format string.
     #[cfg(test)]
     pub(crate) const fn is_empty(&self) -> bool {

--- a/tests/out_format_attribute_only.rs
+++ b/tests/out_format_attribute_only.rs
@@ -1,0 +1,126 @@
+//! A non-itemizing `--out-format` does not announce attribute-only changes.
+//!
+//! upstream: log.c:875-890 `maybe_log_item()` gates `see_item` on `itemizing`,
+//! so a format without `%i` reports only entries that actually moved data. An
+//! attribute-only change - a chmod against an otherwise up-to-date file - is
+//! announced solely when the format itemizes.
+//!
+//! The table below was measured against the real rsync 3.5.0 binary before the
+//! fix; oc diverged in exactly one cell of twelve (attr-only under a
+//! non-itemizing format, which `%n` and `%%i %n` both are):
+//!
+//! | --out-format | new  | content | attr-only | no change |
+//! |--------------|------|---------|-----------|-----------|
+//! | `%n`         | name | name    | SILENT    | SILENT    |
+//! | `%%i %n`     | name | name    | SILENT    | SILENT    |
+//! | `%i %n`      | row  | row     | row       | SILENT    |
+//!
+//! This is a table test rather than a single regression because the obvious
+//! narrow fix - suppressing whenever the format does not itemize - would also
+//! silence the `new` and `content` rows, which upstream prints. Those rows are
+//! therefore the non-vacuity companions: they must keep printing, or the pin
+//! would pass for a build that emitted nothing at all.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Runs one sync and returns stdout with the trailing newline trimmed.
+fn sync(out_format: &str, src: &Path, dst: &Path) -> String {
+    let output = Command::new(oc_binary())
+        .arg("-a")
+        .arg(format!("--out-format={out_format}"))
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dst.display()))
+        .output()
+        .expect("run oc-rsync");
+    assert!(
+        output.status.success(),
+        "transfer failed ({:?}): {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_owned()
+}
+
+/// Drives one format through the four transfer states in order and returns
+/// `(new, content, attribute_only, unchanged)` stdout.
+fn four_states(out_format: &str) -> (String, String, String, String) {
+    let root = tempfile::tempdir().expect("temp dir");
+    let src = root.path().join("src");
+    let dst = root.path().join("dst");
+    fs::create_dir_all(&src).expect("src");
+    fs::create_dir_all(&dst).expect("dst");
+    let file = src.join("a");
+
+    fs::write(&file, b"one\n").expect("seed");
+    let new = sync(out_format, &src, &dst);
+
+    // A longer payload so the quick check sees a size difference and cannot
+    // skip the transfer on a same-second mtime.
+    fs::write(&file, b"two-longer\n").expect("rewrite");
+    let content = sync(out_format, &src, &dst);
+
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o600)).expect("chmod");
+    let attribute_only = sync(out_format, &src, &dst);
+
+    let unchanged = sync(out_format, &src, &dst);
+    (new, content, attribute_only, unchanged)
+}
+
+#[test]
+fn non_itemizing_out_format_is_silent_for_an_attribute_only_change() {
+    for format in ["%n", "%%i %n"] {
+        let (new, content, attribute_only, unchanged) = four_states(format);
+
+        assert!(
+            attribute_only.is_empty(),
+            "{format:?} announced an attribute-only change: {attribute_only:?}"
+        );
+        assert!(
+            unchanged.is_empty(),
+            "{format:?} announced an unchanged entry: {unchanged:?}"
+        );
+
+        // Non-vacuity: without these the assertions above would also hold for a
+        // build that printed nothing under any circumstance.
+        assert!(
+            new.contains('a'),
+            "{format:?} dropped the new-file row: {new:?}"
+        );
+        assert!(
+            content.contains('a'),
+            "{format:?} dropped the content-change row: {content:?}"
+        );
+    }
+}
+
+#[test]
+fn an_itemizing_out_format_still_announces_an_attribute_only_change() {
+    let (new, content, attribute_only, unchanged) = four_states("%i %n");
+
+    // The discriminator: the same chmod that stays silent above must surface
+    // here, with the `p` column set (upstream renders `.f...p..... a`).
+    assert!(
+        attribute_only.contains('p') && attribute_only.contains('a'),
+        "%i dropped the attribute-only row: {attribute_only:?}"
+    );
+    assert!(new.contains('+'), "%i dropped the new-file row: {new:?}");
+    assert!(
+        content.contains('s'),
+        "%i dropped the content-change row: {content:?}"
+    );
+    assert!(
+        unchanged.is_empty(),
+        "%i announced an unchanged entry: {unchanged:?}"
+    );
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -171,7 +171,7 @@ itemize pass
 iwildmatch-fold pass
 keep-dirlinks-rule fail
 keep-dirlinks-symlinked-dest pass
-ki58-log-format-percent fail
+ki58-log-format-percent pass
 ki62-io-error-mask skip
 ki72-safe-links-backup pass
 ki73-cvs-clear-list pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -171,7 +171,7 @@ itemize pass
 iwildmatch-fold pass
 keep-dirlinks-rule fail
 keep-dirlinks-symlinked-dest pass
-ki58-log-format-percent fail
+ki58-log-format-percent pass
 ki62-io-error-mask skip
 ki72-safe-links-backup pass
 ki73-cvs-clear-list pass


### PR DESCRIPTION
## Problem

`ki58-log-format-percent` in the upstream 3.5.0 testsuite fails on both legs. Its
diagnostic says `'%%i' misdetected as itemizing`, but that is not what oc does:
`%%i` renders as the literal `%i` correctly, and the format scanner already
reports "no `%i` here". The failure is one layer further on - the *emission*
decision ignores the itemizing predicate entirely.

`upstream: log.c:875-890` - `maybe_log_item()` gates `see_item` on `itemizing`,
so a format without `%i` reports only entries that actually moved data. An
attribute-only change - a chmod against an otherwise up-to-date file - is
announced solely when the format itemizes. oc announced it under every format.

## Oracle

Measured against the real `rsync 3.5.0` binary on a chmod-only second run.
Twelve cells; oc diverged in exactly one.

| `--out-format` | new | content | attr-only | no change |
|---|---|---|---|---|
| `%n` | name | name | **SILENT** | SILENT |
| `%%i %n` | name | name | **SILENT** | SILENT |
| `%i %n` | row | row | row | SILENT |

The bolded cell is the divergence: oc printed `a` and `%i a` respectively.

## Fix

One rule in the `--out-format` emit gate, suppressing `MetadataReused` events
that were not created when the format does not itemize.

It deliberately does **not** gate the whole emit on `format_itemizes`: the
new-file and content-change rows print under all three formats above, so the
broader rule would silence output upstream produces. Scope is the one cell that
moved.

The itemizing predicate is read from the *parsed tokens* (`OutFormat::itemizes`,
mirroring `options.c:2354`'s `stdout_format_has_i`) rather than by re-scanning
the raw format text, so the emit gate and the renderer cannot disagree about
whether a given `%i` is a real directive or the literal produced by `%%i`. That
disagreement is precisely what the test is built to catch.

Placement is below the existing `-vv` / `-ii` force-emission arms, so their
precedence is unchanged.

## Verification

- **RED proven**: with only the new gate neutralised, `non_itemizing_out_format_is_silent_for_an_attribute_only_change` fails (`"%n" announced an attribute-only change: "a"`) while its companion stays green.
- **Blast radius re-measured against 3.5.0 after the change**: `-v`, `-i` and `-ii` attribute-only output all still match upstream byte for byte. (`-vv` has a separate pre-existing divergence - `a is uptodate` where upstream prints `a` - present identically before and after this change; filed, not touched here.)
- `ki58-log-format-percent`: **PASS**, `overall result is 0`.
- `cargo fmt --all -- --check` clean; full-workspace `cargo clippy --all-targets --all-features -D warnings` clean.
- `cargo nextest run -p cli -p bin --all-features`: **4296 passed, 0 failed**.

## Tests

`tests/out_format_attribute_only.rs` is a table test, not a single regression,
because the tempting narrow fix (suppress whenever the format lacks `%i`) also
silences the `new` and `content` rows. Those rows are asserted as the
non-vacuity companions - without them the pin would also pass for a build that
printed nothing at all. A second test pins that `%i %n` still *does* announce
the chmod, with the `p` column set.

## Manifest

`ki58-log-format-percent` flips `fail` -> `pass` in both expect manifests
(nonroot 56 -> 55 failing, root 76 -> 75). The test has no platform or privilege
dependence - it is chmod plus format assertions with a single `forced_protocol()`
branch - so the local pass carries to both CI legs.
