### PR TITLE
docs: fix the three broken intra-doc links failing the Pages build

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
@@ -406,9 +406,9 @@ pub fn confined_link_anonymous(staged: BorrowedFd<'_>, root: &Path, dest: &Path)
 
 /// Create `dest` exclusively, with its parent confined beneath `root`.
 ///
-/// This is the direct-write counterpart of [`confined_rename`] and
-/// [`confined_link_anonymous`]: the parent is resolved by the same
-/// per-component walk through [`anchor_confined_endpoint`], then the leaf is
+/// This is the direct-write counterpart of [`confined_rename`](super::confined_rename)
+/// and [`confined_link_anonymous`]: the parent is resolved by the same
+/// per-component walk through `anchor_confined_endpoint`, then the leaf is
 /// created with `O_CREAT | O_EXCL | O_NOFOLLOW` relative to that dirfd. A
 /// destination parent flipped to a symlink between the decision to write and
 /// the create therefore cannot redirect the new file out of the tree.

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
@@ -294,7 +294,7 @@ pub(super) fn anchor_confined_endpoint<'a>(
 }
 
 /// Rename `old_path` to `new_path`, resolving **each side independently** by
-/// the resolver its provenance calls for (see [`anchor_confined_endpoint`]).
+/// the resolver its provenance calls for (see `anchor_confined_endpoint`).
 ///
 /// A side beneath `root` has its parent resolved by the confined per-component
 /// walk; an absolute side outside `root` - an operator path - by the ownership

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -903,7 +903,7 @@ impl DirSandbox {
     /// - `ELOOP` - a refused symlink (absolute, empty, or landing outside the
     ///   confinement), a `..` that would rise above the anchor, or an
     ///   exhausted hop budget.
-    /// - `ENOMEM` - the path is deeper than [`DS_MAXDEPTH`].
+    /// - `ENOMEM` - the path is deeper than `DS_MAXDEPTH`.
     /// - Otherwise the underlying `openat`/`readlinkat` errno.
     #[cfg(unix)]
     pub fn open_dest_anchor_confined<O: ConfinementOracle>(

--- a/crates/fast_io/src/io_uring_stub/per_thread_ring.rs
+++ b/crates/fast_io/src/io_uring_stub/per_thread_ring.rs
@@ -14,7 +14,7 @@ use std::io;
 /// Default submission queue depth declared for cross-platform API parity.
 ///
 /// Re-exported from the single source of truth in
-/// [`crate::io_uring_depth::DEFAULT_IO_URING_DEPTH`] so the stub and the Linux
+/// `crate::io_uring_depth::DEFAULT_IO_URING_DEPTH` so the stub and the Linux
 /// backend cannot drift. On non-Linux targets the constant is retained so
 /// callers compile against the same surface; the stub `with_ring` always
 /// returns [`io::ErrorKind::Unsupported`].

--- a/crates/logging-sink/src/escape.rs
+++ b/crates/logging-sink/src/escape.rs
@@ -4,7 +4,12 @@
 //! Upstream rsync escapes non-printable bytes in filenames as `\#ooo`
 //! (backslash, hash, three octal digits). Which bytes qualify depends on the
 //! destination, so `filtered_fwrite` takes two independent switches - see
-//! [`EscapeStyle`].
+//! [`EscapeStyle`](crate::escape::EscapeStyle).
+//!
+//! The path is spelled out because `lib.rs` puts a `///` comment on
+//! `pub mod escape;`: rustdoc concatenates that with this `//!` block and
+//! resolves the result in the CRATE ROOT's scope, where a bare `EscapeStyle`
+//! does not exist.
 
 use std::io::Write;
 use std::path::Path;


### PR DESCRIPTION
The `Pages` workflow has been failing on master. `fast_io/src/lib.rs:79` carries
`#![deny(rustdoc::broken_intra_doc_links)]`, and the Pages job additionally
passes `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links`, so an unresolvable
link is a hard error:

  error: unresolved link to `confined_rename`
  error: unresolved link to `anchor_confined_endpoint`
  error: could not document `fast_io`

Three links, three different reasons:

- `confined_rename` IS public, re-exported at `at_syscalls/mod.rs:62`, but is
  not in scope inside `create.rs`. Given a path so the link resolves and still
  renders as the bare name.
- `anchor_confined_endpoint` is `pub(super)` and `DS_MAXDEPTH` is a private
  const: neither can ever resolve in a public-docs build, so both become plain
  backticks. `per_thread_ring.rs` had the same shape against a private const;
  it only reproduces off-Linux, which is why the Linux CI log never showed it.
- `EscapeStyle` is the subtle one. The link is written in `escape.rs`'s own
  `//!` header, where the type is local - but `lib.rs` puts a `///` comment on
  `pub mod escape;`, rustdoc CONCATENATES the two and resolves the result in the
  CRATE ROOT's scope, where a bare `EscapeStyle` does not exist. rustdoc reports
  it against `lib.rs:74`, not against the file that contains it. Spelled out as
  `crate::escape::EscapeStyle`, with a comment recording why.

⚠ The CI log named only `fast_io`, because cargo stops at the first crate that
fails to document ("build failed, waiting for other jobs to finish"). Running
the whole workspace locally showed `logging-sink` failing too, so fixing
`fast_io` alone would have moved the error rather than cleared it.

VERIFIED by reproducing the exact Pages invocation locally (pinned 1.88.0,
`RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links`, `cargo doc --workspace
--all-features --no-deps`): exit 101 -> exit 0. Re-run after `rm -rf
target/doc` so the pass is not an incremental artifact: 28 crates documented,
0 unresolved links, 0 "could not document".

⚠ RESIDUAL, deliberately not fixed here: 19 `links to private item` WARNINGS
remain across core(1), engine(6), logging(2), protocol(2), rsync_io(1) and
transfer(7). They are the same shape but are NOT part of this failure - the
gate denies only `broken_intra_doc_links`, so they do not affect the build.
Left alone to keep this change scoped to the red.