### PR TITLE
fix(output): report an attribute-only change by name, not "is uptodate"

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -846,6 +846,34 @@ fn is_uptodate_event(event: &ClientEvent) -> bool {
     event.is_uptodate()
 }
 
+/// Returns `true` when `"is uptodate"` is the right notice for an entry whose
+/// contents were not transferred, and `false` when upstream prints the bare
+/// name instead.
+///
+/// The discriminator is NOT "did the data move" - it is "did `set_file_attrs`
+/// change anything at all":
+///
+/// ```c
+/// /* rsync.c:823-828 */
+/// if (INFO_GTE(NAME, 2) && flags & ATTRS_REPORT) {
+///     if (updated)
+///         rprintf(FCLIENT, "%s\n", fname);
+///     else
+///         rprintf(FCLIENT, "%s is uptodate\n", fname);
+/// }
+/// ```
+///
+/// `updated` accumulates `UPDATED_MODE` / `_OWNER` / `_TIMES` / `_ACLS` /
+/// `_XATTRS`, so a chmod against a file whose content already matches reports
+/// the BARE NAME - it was updated, just not transferred. `change_set()` is oc's
+/// analogue, and it is the same source the itemize renderer derives
+/// `.f...p.....` from, so the two agree by construction.
+///
+/// upstream: rsync.c:823-828 `set_file_attrs()`.
+fn reports_uptodate_wording(event: &ClientEvent) -> bool {
+    !event.change_set().has_any_change()
+}
+
 /// Returns `true` for the per-file skip notices that upstream's `recv_generator`
 /// emits during the generator phase (`"exists"`, `"not creating new"`, `"is
 /// newer"`, `"is over max-size"`, `"is under min-size"`), ahead of the receiver
@@ -1030,8 +1058,14 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 {
                     continue;
                 }
-                writeln_wrapped(stdout, "", event.relative_path(), escape, " is uptodate")?;
-                continue;
+                // rsync.c:823-828 keys the wording on `updated`, so an entry
+                // whose attributes DID change falls through to the bare-name
+                // rendering below. The hardlink notice is a different upstream
+                // site (hlink.c:218-224) whose wording is unconditional.
+                if event.is_hardlink_uptodate() || reports_uptodate_wording(event) {
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, " is uptodate")?;
+                    continue;
+                }
             }
 
             let mut rendered = verbose_listing_name(event, escape);
@@ -1196,7 +1230,15 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                     continue;
                 }
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln_wrapped(stdout, "", event.relative_path(), escape, " is uptodate")?;
+                    // Same `fname`, different trailer - rsync.c:824 prints the
+                    // bare name when `set_file_attrs` updated anything, and
+                    // rsync.c:826 the `is uptodate` notice only when it did not.
+                    let trailer = if reports_uptodate_wording(event) {
+                        " is uptodate"
+                    } else {
+                        ""
+                    };
+                    writeln_wrapped(stdout, "", event.relative_path(), escape, trailer)?;
                 }
                 continue;
             }

--- a/tests/verbose_attr_only_name_row.rs
+++ b/tests/verbose_attr_only_name_row.rs
@@ -1,0 +1,135 @@
+//! An attribute-only change reports the BARE NAME, not `"is uptodate"`.
+//!
+//! Upstream decides the wording inside `set_file_attrs()` from its own
+//! `updated` bitmask - not from whether the file's DATA moved:
+//!
+//! ```c
+//! /* rsync.c:823-828 */
+//! if (INFO_GTE(NAME, 2) && flags & ATTRS_REPORT) {
+//!     if (updated)
+//!         rprintf(FCLIENT, "%s\n", fname);
+//!     else
+//!         rprintf(FCLIENT, "%s is uptodate\n", fname);
+//! }
+//! ```
+//!
+//! `updated` accumulates `UPDATED_MODE` / `_OWNER` / `_TIMES` / `_ACLS` /
+//! `_XATTRS`, so a chmod against a file whose contents already match is
+//! "updated, just not transferred" and prints the bare name. oc reported
+//! `"a is uptodate"` for that case because it keyed the wording on the event
+//! KIND (`MetadataReused`) rather than on whether anything actually changed.
+//!
+//! Measured against the real rsync 3.5.0 binary on this fixture:
+//!
+//! | flags            | upstream | oc (pre-fix)    |
+//! |------------------|----------|-----------------|
+//! | `-a`, `-a -v`    | silent   | silent          |
+//! | `-a -vv`         | `a`      | `a is uptodate` |
+//! | `-a --info=name2`| `a`      | `a is uptodate` |
+//!
+//! Both verbosity spellings are exercised deliberately: `--info=name2` reaches
+//! the renderer's verbosity-0 branch while `-vv` reaches the verbose branch,
+//! and before the fix each carried its own copy of the defect. A test covering
+//! only one of them would leave the other site unpinned.
+//!
+//! `unchanged_file_still_reports_is_uptodate` is the non-vacuity companion: it
+//! is the case upstream DOES phrase as `"is uptodate"`, so a build that simply
+//! stopped emitting the notice - or emitted it always - fails exactly one of
+//! the two tests. Neither test is meaningful without the other.
+
+#![cfg(unix)]
+
+use std::fs::{self, File, FileTimes};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Builds `src/a` and `dst/a` with identical contents and identical mtimes, so
+/// rsync's quick check reports the contents as already up to date. `dst_mode`
+/// decides whether anything is left for `set_file_attrs` to change.
+///
+/// Equal size AND equal mtime is what makes the quick check pass
+/// (upstream generator.c `quick_check_ok()`), which is the precondition for
+/// reaching the notice under test at all.
+fn fixture(root: &Path, dst_mode: u32) -> (PathBuf, PathBuf) {
+    let src = root.join("src");
+    let dst = root.join("dst");
+    fs::create_dir_all(&src).expect("create src");
+    fs::create_dir_all(&dst).expect("create dst");
+    fs::write(src.join("a"), b"hello\n").expect("write src/a");
+    fs::write(dst.join("a"), b"hello\n").expect("write dst/a");
+
+    fs::set_permissions(src.join("a"), fs::Permissions::from_mode(0o644)).expect("chmod src/a");
+    fs::set_permissions(dst.join("a"), fs::Permissions::from_mode(dst_mode)).expect("chmod dst/a");
+
+    // Copy the source mtime onto the destination so the quick check sees an
+    // identical (size, mtime) pair. Writing both files "at the same time" is
+    // not enough - sub-second timestamps make that a race.
+    let modified = fs::metadata(src.join("a"))
+        .expect("stat src/a")
+        .modified()
+        .expect("src mtime");
+    File::options()
+        .write(true)
+        .open(dst.join("a"))
+        .expect("open dst/a")
+        .set_times(FileTimes::new().set_modified(modified))
+        .expect("set dst/a mtime");
+
+    (src, dst)
+}
+
+/// Runs one local copy and returns the line the notice under test would occupy,
+/// or `None` when nothing was printed for the entry.
+fn name_row(root: &Path, dst_mode: u32, verbosity_flag: &str) -> Option<String> {
+    let (src, dst) = fixture(root, dst_mode);
+    let output = Command::new(env!("CARGO_BIN_EXE_oc-rsync"))
+        .arg("-a")
+        .arg(verbosity_flag)
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dst.display()))
+        .output()
+        .expect("run oc-rsync");
+    assert!(
+        output.status.success(),
+        "transfer failed ({}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find(|line| *line == "a" || *line == "a is uptodate")
+        .map(str::to_owned)
+}
+
+/// A chmod against an otherwise-identical file: upstream counts that as
+/// `updated`, so the row is the bare name.
+///
+/// upstream: rsync.c:823-828 `set_file_attrs()`.
+#[test]
+fn attribute_only_change_reports_the_bare_name() {
+    for flag in ["-vv", "--info=name2"] {
+        let temp = tempfile::tempdir().expect("temp dir");
+        assert_eq!(
+            name_row(temp.path(), 0o600, flag).as_deref(),
+            Some("a"),
+            "an attribute-only change must print the bare name at `{flag}`"
+        );
+    }
+}
+
+/// Nothing changed at all, so `updated` stays zero and the `is uptodate`
+/// wording is correct. Without this cell, "never say uptodate" would pass.
+///
+/// upstream: rsync.c:826 `set_file_attrs()`.
+#[test]
+fn unchanged_file_still_reports_is_uptodate() {
+    for flag in ["-vv", "--info=name2"] {
+        let temp = tempfile::tempdir().expect("temp dir");
+        assert_eq!(
+            name_row(temp.path(), 0o644, flag).as_deref(),
+            Some("a is uptodate"),
+            "a fully unchanged entry must keep the uptodate wording at `{flag}`"
+        );
+    }
+}


### PR DESCRIPTION
## What

At `-vv` (and `--info=name2`), an **attribute-only** change was reported as
`a is uptodate` while oc was simultaneously changing the file's mode. Upstream
prints the bare name for that case.

## Upstream rule

The wording is decided inside `set_file_attrs()` from its own `updated`
bitmask - **not** from whether the file's data moved:

```c
/* rsync.c:823-828 */
if (INFO_GTE(NAME, 2) && flags & ATTRS_REPORT) {
    if (updated)
        rprintf(FCLIENT, "%s\n", fname);
    else
        rprintf(FCLIENT, "%s is uptodate\n", fname);
}
```

`updated` accumulates `UPDATED_MODE` / `_OWNER` / `_TIMES` / `_ACLS` /
`_XATTRS`. A chmod against a file whose contents already match is therefore
"updated, just not transferred", and prints the bare name.

oc keyed the wording on the event **kind** (`MetadataReused`) instead, so any
entry that skipped the data transfer was announced as up to date regardless of
what changed.

## Measured against the real rsync 3.5.0 binary

Fixture: identical contents, identical mtime, destination mode `0600` vs source
`0644` - so the quick check passes and only attributes remain.

| flags | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| `-a` | *(silent)* | *(silent)* | *(silent)* |
| `-a -v` | *(silent)* | *(silent)* | *(silent)* |
| `-a -vv` | `a` | `a is uptodate` | `a` |
| `-a --info=name2` | `a` | `a is uptodate` | `a` |

Control (nothing changed at all) - unchanged by this PR, and upstream agrees:

| flags | upstream 3.5.0 | oc after |
|---|---|---|
| `-a -vv` | `a is uptodate` | `a is uptodate` |

The itemize row was already byte-identical to upstream on this fixture
(`.f...p..... a` on both). That is what identifies `change_set()` as oc's
analogue of `updated`: the notice and the itemize row now derive from one
source instead of disagreeing about the same file.

## Scope

- One shared predicate, `reports_uptodate_wording()`, owns the rule; both
  emitters call it rather than carrying a copy each.
- **Both** verbosity spellings are fixed. `--info=name2` reaches the renderer's
  verbosity-0 branch and `-vv` the verbose branch; each had its own copy of the
  defect, so fixing one would have left the other live.
- Directories stay suppressed - upstream passes no `ATTRS_REPORT` for them
  (generator.c:1503).
- The hardlink notice is deliberately left unconditional: it is a different
  upstream site (hlink.c:218-224) with its own rule.

## Tests

`tests/verbose_attr_only_name_row.rs`, both spellings per case:

- `attribute_only_change_reports_the_bare_name` - the fix.
- `unchanged_file_still_reports_is_uptodate` - its non-vacuity companion.

The pair is mutually discriminating on purpose: a build that never emits the
notice fails the second, one that always emits it fails the first.

**RED proven.** With the predicate mutated back to the pre-fix behaviour
(always "uptodate"), nextest reports `2 tests run: 1 passed, 1 failed` - the
attr-only test fails with `left: Some("a is uptodate"), right: Some("a")` while
the companion stays green.

## Verification

- `cargo fmt --all -- --check` - clean.
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -D warnings` - clean.
- `cargo nextest run -p cli --all-features --no-fail-fast` - 3813 passed, 0 failed.
- Workspace sweep `-E 'test(uptodate) or test(itemize) or test(metadata_reused)'` - 432 passed, 0 failed.
