### PR TITLE
ci: run the 3.5.0 testsuite over loopback TCP on every pull request

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -91,3 +91,14 @@ jobs:
 
   upstream-testsuite:
     uses: ./.github/workflows/_ci-skip-upstream-testsuite.yml
+
+  # ci.yml calls the same reusable testsuite workflow a second time under this
+  # job id for the loopback-TCP transport, so it publishes a second PAIR of
+  # contexts (`upstream-testsuite-tcp / upstream testsuite` and
+  # `... (root)`). The stand-in is the SAME stub workflow: the job id supplies
+  # the differing prefix, and the two job names it declares are exactly the two
+  # that need mirroring. Reusing it rather than copying keeps one file as the
+  # owner of "which contexts the testsuite publishes" - a copy is what drifts
+  # when a third leg is added.
+  upstream-testsuite-tcp:
+    uses: ./.github/workflows/_ci-skip-upstream-testsuite.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -916,6 +916,46 @@ jobs:
       expect_result_root: tools/ci/upstream-3.5.0-expect.root.txt
 
   # ===========================================================================
+  # Upstream Testsuite over a real loopback TCP daemon
+  # ---------------------------------------------------------------------------
+  # The same 3.5.0 corpus as the job above, run with `transport: tcp`. The two
+  # transports are NOT redundant: the job above uses upstream's secure default,
+  # a stdio socketpair with no listening socket, so it never exercises accept(),
+  # the `hosts allow`/`hosts deny` decision, or the peer-address resolution that
+  # only a real bound socket can reach. Those are exactly the surfaces the 3.5.0
+  # daemon CVEs live on, so a pipe-only gate cannot see a regression in them.
+  #
+  # `tcp` also passes --daemon-tests-only, which is the pairing upstream ships
+  # the option for - the dropped tests never call start_test_daemon(), so they
+  # cannot observe --use-tcp and would only repeat the pipe leg. That is why
+  # this leg runs 155 tests, not 345, and why it carries its OWN manifests
+  # rather than reusing the pipe ones.
+  #
+  # Reported as `upstream-testsuite-tcp / upstream testsuite` and
+  # `... / upstream testsuite (root)` - the job id below supplies the prefix
+  # that distinguishes them from the pipe leg, which is why the reusable
+  # workflow's own job names are literals rather than expressions.
+  #
+  # Not yet a required status check: registering a context in branch protection
+  # is a repo-admin action. Until that happens these run and report on every PR
+  # but do not block, so a regression is visible rather than silently unmeasured
+  # - which is the state this replaces, where the TCP legs ran only on
+  # workflow_dispatch and cron and no pull request ever validated them.
+  # ===========================================================================
+  upstream-testsuite-tcp:
+    needs: lint
+    uses: ./.github/workflows/_upstream-testsuite.yml
+    with:
+      cache_version: ${{ vars.CACHE_VERSION || 'v1' }}
+      upstream_rsync_version: ${{ vars.UPSTREAM_TESTSUITE_VERSION || '3.5.0' }}
+      transport: 'tcp'
+      # Separate from the pipe manifests by measurement, not by convention: the
+      # tcp legs select a different (smaller) test set, so a shared file would
+      # fail the driver's own coverage guard.
+      expect_result_nonroot: tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+      expect_result_root: tools/ci/upstream-3.5.0-expect.root.tcp.txt
+
+  # ===========================================================================
   # DG-3.e: concurrent_register_and_dispatch stress (#2694)
   # ---------------------------------------------------------------------------
   # Runs the 1000-thread x 10K-iter stress in


### PR DESCRIPTION
## Problem

The 3.5.0 conformance suite has four legs - `{nonroot,root} x {pipe,tcp}` - but
only the two **pipe** legs ran on pull requests. The tcp legs existed solely as
standalone badge workflows on `workflow_dispatch` + cron, so no pull request
ever validated them: a regression could only surface the next morning, already
merged.

The two transports are not redundant. The pipe leg uses upstream's secure
default - a stdio socketpair with no listening socket - so it never reaches
`accept()`, the `hosts allow`/`hosts deny` decision, or peer-address
resolution. Those are precisely the surfaces the 3.5.0 daemon fixes live on,
which is the axis a pipe-only gate cannot see.

## Change

Call the existing reusable workflow a second time with `transport: tcp` under
job id `upstream-testsuite-tcp`, and add the matching pair of `ci-skip` stubs.

Published contexts go from 2 to 4:

| | pipe | tcp |
|---|---|---|
| non-root | `upstream-testsuite / upstream testsuite` | `upstream-testsuite-tcp / upstream testsuite` |
| root | `upstream-testsuite / upstream testsuite (root)` | `upstream-testsuite-tcp / upstream testsuite (root)` |

The tcp legs pass `--daemon-tests-only`, which is the pairing upstream ships
the option for, so they select the 155 transport-observing tests rather than
all 345 and carry their own manifests sized to match. The driver derives that
expected size from upstream's own `select_daemon_tests()`, so a short manifest
is still refused.

`ci-skip.yml` reuses the **same** stub workflow rather than a copy - the job id
supplies the differing prefix, and one file stays the owner of "which contexts
the testsuite publishes". A copy is what drifts when a third leg is added.

Both halves ship in one commit deliberately: a new context in `ci.yml` without
its skip-path stand-in leaves any doc-only pull request waiting forever on a
context that never arrives.

## Verification

Validated by extracting the committed YAML back out with `yaml.safe_load` and
computing the published contexts from both files, rather than eyeballing the
diff:

- `ci.yml` and `ci-skip.yml` publish the **same 4 contexts**, exact string match.
- **Non-vacuity proven**: renaming the skip job to `...-TYPO` makes the parity
  check report a mismatch, so it can actually fail.
- No job `name:` in the reusable workflow is an expression - a skipped job would
  otherwise report the raw expression text and the context would never arrive.
- Every `with:` key the caller passes is a declared input of the callee.
- All four manifest paths exist; the tcp pair is 155 rows vs the pipe pair's
  345, confirming the daemon-only set is wired and not a copy of the pipe files.

## Scope

Not registered as required status checks - that is a separate repo-admin
action. Until then these report without blocking, which still replaces "never
measured on a pull request" with "visible on every pull request".
