### PR TITLE
fix(daemon): treat a backslash in a requested path as a filename byte

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -77,7 +77,16 @@ fn extract_module_relative_paths(client_args: &[String], module_name: &str) -> V
 /// functions with two contracts, not one to be deduplicated.
 fn collapse_module_relative(tail: &str) -> String {
     let mut out: Vec<&str> = Vec::new();
-    for segment in tail.split(['/', '\\']) {
+    // Splits on `/` ONLY. `tail` is a peer-supplied wire path, and the wire is
+    // `/`-separated on every host (upstream `pathjoin()`); upstream's own
+    // `sanitize_path` tests `== '/'` at every separator check and has no `\`
+    // arm at all, so a `\` is copied through as an ordinary byte of the
+    // component. On Unix `\` is a legal filename byte: treating it as a
+    // separator silently relocates a legitimately-named file - `a\b` becomes
+    // `a/b` - and strips a trailing one. Contrast the `module_path` checks
+    // below, which DO accept `\` because they inspect an operator-configured
+    // LOCAL path that may legitimately be Windows-style.
+    for segment in tail.split('/') {
         match segment {
             "" | "." => {}
             ".." => {
@@ -128,7 +137,7 @@ fn resolve_receiver_dest(
     // absolute client path is interpreted against the module root, not the
     // host root. Collapsing then folds away every `.` and `..`, so the joined
     // destination is under `module_path` by construction on any host.
-    let collapsed = collapse_module_relative(tail.trim_start_matches(['/', '\\']));
+    let collapsed = collapse_module_relative(tail.trim_start_matches('/'));
     if collapsed.is_empty() {
         return module_path.to_path_buf();
     }
@@ -184,7 +193,7 @@ fn resolve_sender_sources(
         // Collapse `.` and `..` exactly as upstream's `sanitize_path` does at
         // depth 0 - see [`collapse_module_relative`]. The result cannot escape
         // the module root, so there is nothing left to refuse.
-        let collapsed = collapse_module_relative(tail.trim_start_matches(['/', '\\']));
+        let collapsed = collapse_module_relative(tail.trim_start_matches('/'));
         let trimmed = collapsed.as_str();
         if trimmed.is_empty() {
             sources.push(module_root_dotdir(module_path));
@@ -197,7 +206,9 @@ fn resolve_sender_sources(
         // so build the result the same way instead of going through
         // PathBuf::join, which on Windows inserts `\` and on macOS leaves
         // a trailing `/` that doubles when we re-append.
-        let trailing = tail.ends_with('/') || tail.ends_with('\\');
+        // upstream flist.c tests `fbuf[len-1] == '/'` only - a trailing `\` is
+        // part of the NAME on Unix, not a dotdir marker.
+        let trailing = tail.ends_with('/');
         let mut buf = module_path.as_os_str().to_owned();
         let needs_leading_sep = !buf
             .as_encoded_bytes()

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2122,6 +2122,54 @@ mod module_access_tests {
         assert_eq!(dest, std::path::Path::new("/srv/upload/realdir/"));
     }
 
+    // A `\` in a peer-requested path is an ordinary filename byte on Unix, not
+    // a separator. Upstream's `sanitize_path` (util1.c) tests `== '/'` at every
+    // separator check and has no `\` arm, so it copies the byte through as part
+    // of the component. oc used to split on it, which relocated the file: with
+    // `a` present the request landed at `a/b`, and without it the open failed
+    // ENOENT and the connection died. MEASURED against real upstream 3.5.0.
+    #[test]
+    fn resolve_receiver_dest_keeps_a_backslash_as_a_filename_byte() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/a\\b".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        // The whole `a\b` is ONE component. Splitting would give `/srv/upload/a/b`.
+        assert_eq!(dest, std::path::Path::new("/srv/upload/a\\b"));
+    }
+
+    #[test]
+    fn resolve_receiver_dest_keeps_a_trailing_backslash() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/sub\\".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        // Treating the trailing `\` as a separator silently stripped it,
+        // yielding `/srv/upload/sub` for a peer that asked for `sub\`.
+        assert_eq!(dest, std::path::Path::new("/srv/upload/sub\\"));
+    }
+
+    // Non-vacuity companion: `/` MUST still split, and `..` must still collapse
+    // per upstream's depth-0 sanitize_path. Without this a fix that stopped
+    // splitting on every separator would also pass the two tests above.
+    #[test]
+    fn resolve_receiver_dest_still_splits_and_collapses_on_slash() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/x/../y/z".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest, std::path::Path::new("/srv/upload/y/z"));
+    }
+
+    // A `\` must not smuggle a traversal past the `..` collapse either: the
+    // collapse sees ONE component named `..\..`, which is not `..`, so it is
+    // kept as a literal name rather than popping two levels.
+    #[test]
+    fn resolve_receiver_dest_backslash_does_not_form_a_dotdot_component() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/..\\..\\etc".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest, std::path::Path::new("/srv/upload/..\\..\\etc"));
+        assert!(dest.starts_with(module_path));
+    }
+
     #[test]
     fn resolve_receiver_dest_falls_back_to_module_root_for_bare_module() {
         let module_path = std::path::Path::new("/srv/upload");


### PR DESCRIPTION
## Problem

The daemon split the peer-requested destination path on `\` as well as `/`. On
Unix a backslash is a legal filename byte, and the wire is `/`-separated on
every host, so this silently reinterpreted the path the peer asked for.

Upstream's `sanitize_path` (`util1.c`) tests `== '/'` at every separator check
and has **no `\` arm at all** — a backslash is copied through as an ordinary
byte of the component.

Measured against the real 3.5.0 binary, with the **same upstream client driving
both daemons** so the client is controlled for and only the daemon differs.

One root cause, three symptoms:

| requested dest | upstream 3.5.0 | oc (before) |
|---|---|---|
| `a\b`, no `a` dir | creates `a\b` | **connection dies** — synthesized parent missing, ENOENT |
| `a\b`, `a` dir present | creates `a\b` | rc=0, **silently written to `a/b`** |
| `sub\` | creates `sub\` | rc=0, **backslash stripped** → `sub` |

The middle row is the worst: no error, wrong path.

## Change

Four sites, all on the peer-supplied `tail`: the component split, the two
leading-separator strips, and the trailing-separator (dotdir) test.

**Three sites deliberately do NOT change.** They inspect the
operator-configured `module_path` buffer to decide whether it already ends in a
separator, and a Windows module root such as `C:\srv\data\` legitimately ends
with `\`. A blanket removal of every `\` in the file would have introduced a
*new* divergence there. The split is by **which variable is being examined**,
not by the character.

## Confinement is unaffected

Measured before and after: `..\pwned` and `sub\..\..\pwned` both resolve
**inside** the module, because a `\`-joined component is not the string `..`
and so never pops a level. `..\OUTSIDE\pwned` fails ENOENT. This is a fidelity
fix, not a traversal fix — no escape was possible either way.

## Verification

- **4 of 5** A/B cells against the real upstream daemon now match, including
  the discriminating cell (directory `a` pre-created), which yields the literal
  `a\b` rather than `a/b`. That cell is what distinguishes "kept as a byte"
  from "split as a separator" — a fix that merely rejected the input would fail it.
- **The 5th cell is a separate pre-existing defect, not a regression.** `a\b/`
  still differs, but the control shows plain `ab/` — no backslash anywhere —
  mismatches identically (oc writes a file, upstream makes a directory). Filed
  separately; neither caused nor fixed here.
- **RED proven** by restoring the old split: `12 tests run, 9 passed, 3 failed`
  — exactly the three backslash pins, while the slash/`..` companion stays
  green, so the pins discriminate backslash handling rather than separator
  handling in general. (`passed + failed == run`, so no fail-fast truncation.)
- Scope control: a backslash in a **source operand or transferred filename** was
  measured correct in 24/24 cells across all four client×daemon combinations ×
  {default, `--secluded-args`, `--old-args`} and is untouched.
- daemon **1805/1805**; `cargo fmt` and `cargo clippy` clean.
