### PR TITLE
docs(ci): state which file actually selects the testsuite runner

### DIFF
--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -47,11 +47,21 @@
 # WHICH RUNNER: chosen from what the extracted tree ships, not from the version
 # string. rsync moved its testsuite from shell `*.test` scripts to Python
 # (runtests.py + testsuite/*_test.py) between 3.4.4 and 3.5.0, so one
-# release-tarball path has to serve both. A tree with runtests.py delegates to
-# upstream's own runner (keeping the oracle upstream's, and unlocking
-# --rsync-bin2 version mixing and --expect-result manifests); a tree with
-# `*.test` takes the shell loop below. Neither can select zero tests silently:
-# the shell loop refuses an empty match, and an empty manifest is refused too.
+# release-tarball path has to serve both. A tree shipping `testsuite/*_test.py`
+# delegates to upstream's own runner (keeping the oracle upstream's, and
+# unlocking --rsync-bin2 version mixing and --expect-result manifests); a tree
+# with `*.test` takes the shell loop below. Neither can select zero tests
+# silently: the shell loop refuses an empty match, and an empty manifest is
+# refused too.
+#
+# ⚠ The `*_test.py` half of `python_suite_available` is LOAD-BEARING, and the
+# `runtests.py` half alone would be WRONG. 3.4.4 ALSO ships a runtests.py - its
+# own docstring says "Invokes test scripts from testsuite/", i.e. it is the
+# older shell-script driver, same filename and a different contract. Measured:
+# 3.4.4 = runtests.py + 57 `*.test` + 0 `*_test.py`; 3.5.0 = runtests.py + 0
+# `*.test` + 345 `*_test.py`. So do NOT "simplify" the predicate to a bare
+# `[[ -f runtests.py ]]`: that routes 3.4.4 into the Python runner, which
+# cannot drive it.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Problem

The runner-dispatch header in `tools/ci/run_upstream_testsuite.sh` said:

> A tree with runtests.py delegates to upstream's own runner

That is **false for 3.4.4**, which ships a `runtests.py` of its own — the older
shell-script driver, whose docstring reads *"Invokes test scripts from
testsuite/"*. Same filename, different contract.

## Why it matters

The live predicate is already correct:

```sh
python_suite_available() {
    [[ -f "${upstream_src_dir}/runtests.py" ]] || return 1
    compgen -G "${upstream_src_dir}/testsuite/*_test.py" >/dev/null 2>&1
}
```

Measured on the extracted trees:

| release | `runtests.py` | `*.test` | `*_test.py` | selects |
|---|---|---|---|---|
| 3.4.4 | yes | 57 | 0 | shell loop |
| 3.5.0 | yes | 0 | 345 | Python runner |

The **first condition is true for both releases** and cannot discriminate — the
`*_test.py` conjunct is the one doing the work. The prose named the wrong half.

The risk is a plausible simplification: someone reading the old sentence and
tightening the predicate to a bare `[[ -f runtests.py ]]` would route the 3.4.4
gate into the Python runner, which cannot drive it. This names the load-bearing
conjunct and records the measurement so that edit isn't made.

## Verification

Verified by extracting the real `python_suite_available` from the committed
script and running it against both actual extracted trees — 3.4.4 selects the
shell loop, 3.5.0 selects Python. (The dispatch itself is unchanged; this only
documents it.)

**Comment-only.** `git diff` filtered to non-comment lines is empty — the
predicate body and every other executable line are byte-identical. `bash -n`
clean.

Closes the verification half of the 3.5.0 CI cluster: the 3.4.4 shell-loop path
is confirmed unperturbed by the shape dispatch, and the loop's existing
zero-test guard (`exit 1` when nothing was considered) means a future misroute
would fail loudly rather than report a vacuous green.
