### PR TITLE
fix(daemon): keep the trailing slash that marks the dest a directory

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -141,6 +141,33 @@ fn resolve_receiver_dest(
     if collapsed.is_empty() {
         return module_path.to_path_buf();
     }
+    // Preserve a trailing `/`. upstream main.c:741 `get_local_name()` computes
+    // `trailing_slash = cp && !cp[1]` from the dest arg and takes the
+    // make-a-directory branch on `file_total > 1 || trailing_slash`: it mkdirs
+    // the dest, chdirs into it and returns a NULL local_name, so a single
+    // source file lands INSIDE. Without the slash the dest names the file
+    // itself. `collapse_module_relative` splits on `/` and drops the empty
+    // trailing segment, so the signal dies here unless it is re-appended -
+    // and the receiver then silently writes a FILE where the peer asked for a
+    // directory. oc's local path already implements the upstream rule
+    // correctly (measured); only the daemon was losing the input to it.
+    //
+    // Built by pushing onto the OsString rather than `PathBuf::join`, which
+    // normalises a trailing separator away, for the same reason
+    // `resolve_sender_sources` below does it by hand.
+    if tail.ends_with('/') {
+        let mut buf = module_path.as_os_str().to_owned();
+        if !buf
+            .as_encoded_bytes()
+            .last()
+            .is_some_and(|b| *b == b'/' || *b == b'\\')
+        {
+            buf.push("/");
+        }
+        buf.push(&collapsed);
+        buf.push("/");
+        return std::path::PathBuf::from(buf);
+    }
     module_path.join(collapsed)
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2128,6 +2128,44 @@ mod module_access_tests {
     // of the component. oc used to split on it, which relocated the file: with
     // `a` present the request landed at `a/b`, and without it the open failed
     // ENOENT and the connection died. MEASURED against real upstream 3.5.0.
+    // upstream main.c:741 `get_local_name()`: `trailing_slash = cp && !cp[1]`,
+    // and `file_total > 1 || trailing_slash` takes the make-a-directory branch
+    // (mkdir + chdir + NULL local_name), so a single source file lands INSIDE.
+    // Without the slash the dest names the file itself. oc's local path already
+    // honours that rule; the daemon was dropping the slash before the receiver
+    // could see it, so a peer asking for a DIRECTORY silently got a FILE.
+    //
+    // ⚠ Asserts on the raw OsStr, NOT on Path equality: `Path::new("a/") ==
+    // Path::new("a")` is TRUE because Path compares components and discards a
+    // trailing separator. A Path-equality assertion here would pass both before
+    // and after the fix - it cannot see the thing under test.
+    #[test]
+    fn resolve_receiver_dest_preserves_a_trailing_slash() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest.as_os_str(), std::ffi::OsStr::new("/srv/upload/realdir/"));
+    }
+
+    // Non-vacuity companion: the SAME tail without the slash must NOT gain one,
+    // or the fix would just be appending a slash unconditionally.
+    #[test]
+    fn resolve_receiver_dest_does_not_invent_a_trailing_slash() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/realdir".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest.as_os_str(), std::ffi::OsStr::new("/srv/upload/realdir"));
+    }
+
+    // The slash must survive `..` collapsing, which is what strips it.
+    #[test]
+    fn resolve_receiver_dest_keeps_the_slash_through_a_dotdot_collapse() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/x/../y/".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest.as_os_str(), std::ffi::OsStr::new("/srv/upload/y/"));
+    }
+
     #[test]
     fn resolve_receiver_dest_keeps_a_backslash_as_a_filename_byte() {
         let module_path = std::path::Path::new("/srv/upload");

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2149,12 +2149,19 @@ mod module_access_tests {
 
     // Non-vacuity companion: the SAME tail without the slash must NOT gain one,
     // or the fix would just be appending a slash unconditionally.
+    //
+    // The expectation is built with `join` rather than spelled out, because this
+    // arm returns `module_path.join(collapsed)` and `join` inserts the PLATFORM
+    // separator - a literal "/srv/upload/realdir" would be right on Unix and
+    // wrong on Windows, where `join` yields a backslash. Comparing against the
+    // same construction keeps the assertion about the trailing separator, which
+    // is what the test is for.
     #[test]
     fn resolve_receiver_dest_does_not_invent_a_trailing_slash() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir".to_owned()];
         let dest = resolve_receiver_dest(module_path, &args, "upload");
-        assert_eq!(dest.as_os_str(), std::ffi::OsStr::new("/srv/upload/realdir"));
+        assert_eq!(dest.as_os_str(), module_path.join("realdir").as_os_str());
     }
 
     // The slash must survive `..` collapsing, which is what strips it.


### PR DESCRIPTION
## Problem

A daemon push to `module/dir/` created a **file** named `dir` where upstream
creates a **directory** `dir` and puts the source file inside it. `rc=0` either
way, no diagnostic — the peer asked for a directory and silently got a file.

`upstream main.c:741 get_local_name()` derives `trailing_slash = cp && !cp[1]`
from the destination arg and takes the make-a-directory branch on
`file_total > 1 || trailing_slash`: mkdir the dest, chdir into it, return a NULL
`local_name` so a single source file lands inside. Without the slash the dest
names the file itself.

## Why the fix is at the daemon layer (and is not inert)

oc's **local** path already implements the upstream rule correctly — measured
against real 3.5.0, `out/ab/` yields `out/ab/` + `out/ab/f` on both. Only the
daemon was losing the input to it: `collapse_module_relative` splits the peer
tail on `/` and drops the empty trailing segment, so the slash died in the
resolver and the receiver never saw it.

That ordering matters: the consumer is proven present and working, so restoring
the signal is sufficient. Had the receiver-side rule been missing, this change
would have been inert and the real work would be elsewhere.

## Verification

Against a **real upstream daemon**, with the same upstream client driving both
ends so only the daemon differs:

| dest | upstream | oc before | oc after |
|---|---|---|---|
| `ab/` | `./ab` + `./ab/f` | `./ab` (a file) | `./ab` + `./ab/f` ✅ |
| `ab` | `./ab` | `./ab` | `./ab` ✅ |
| *(empty)* | `./f` | `./f` | `./f` ✅ |
| `a\b` | `./a\b` | `./a\b` | `./a\b` ✅ |

**RED proven** by removing the preservation: `15 tests run, 13 passed, 2 failed`
— exactly the two slash pins — while the no-slash companion stays green, so the
pins discriminate *preservation* from *unconditionally appending a slash*.

daemon **1808/1808**; `cargo fmt` and `cargo clippy` clean.

## Two things deliberately called out

**The tests assert on the raw `OsStr`, not on `Path` equality.**
`Path::new("a/") == Path::new("a")` is **true** — `Path` compares components and
discards a trailing separator — so a `Path`-equality assertion cannot see the
thing under test. The pre-existing
`resolve_receiver_dest_joins_subpath_with_module_root` is a `Path` comparison
and was passing both before and after.

**One cell still differs and is not this rule.** `sub/deep/` where `sub` does
not exist: both sides *refuse* — the slash is honoured and the mkdir is
attempted — but oc exits 12 where upstream exits 11 (`RERR_FILEIO` from
`do_mkdir`). That is exit-code mapping for a missing intermediate parent,
pre-existing and independent; not fixed here.
