### PR TITLE
fix(cli): mirror upstream parse_output_words for --info/--debug tokens

### DIFF
--- a/crates/cli/src/frontend/execution/flags/debug.rs
+++ b/crates/cli/src/frontend/execution/flags/debug.rs
@@ -5,6 +5,8 @@ use core::{
     rsync_error,
 };
 
+use super::output_words::{self, OutputWord};
+
 /// Parsed `--debug` flag settings controlling diagnostic output levels.
 #[derive(Debug, Default)]
 pub(crate) struct DebugFlagSettings {
@@ -39,10 +41,6 @@ pub(crate) struct DebugFlagSettings {
     pub(crate) iocp: Option<u8>,
     pub(crate) help_requested: bool,
 }
-
-/// Maximum debug output level. Levels above this are clamped rather than rejected.
-/// upstream: options.c:245 - #define MAX_OUT_LEVEL 4
-const MAX_OUT_LEVEL: u8 = 4;
 
 impl DebugFlagSettings {
     /// Returns an iterator over all flag (name, level) pairs that are set.
@@ -114,64 +112,20 @@ impl DebugFlagSettings {
         self.iocp = Some(level);
     }
 
-    const fn disable_all(&mut self) {
-        self.acl = Some(0);
-        self.backup = Some(0);
-        self.bind = Some(0);
-        self.chdir = Some(0);
-        self.connect = Some(0);
-        self.cmd = Some(0);
-        self.del = Some(0);
-        self.deltasum = Some(0);
-        self.dup = Some(0);
-        self.exit = Some(0);
-        self.filter = Some(0);
-        self.flist = Some(0);
-        self.fuzzy = Some(0);
-        self.genr = Some(0);
-        self.hash = Some(0);
-        self.hlink = Some(0);
-        self.iconv = Some(0);
-        self.io = Some(0);
-        self.nstr = Some(0);
-        self.own = Some(0);
-        self.proto = Some(0);
-        self.recv = Some(0);
-        self.send = Some(0);
-        self.time = Some(0);
-        self.iouring = Some(0);
-        self.clone = Some(0);
-        self.sockopt = Some(0);
-        self.iocp = Some(0);
-    }
-
     pub(super) fn apply(&mut self, token: &str, display: &str) -> Result<(), Message> {
         let lower = token.to_ascii_lowercase();
 
-        // upstream: options.c:450-453 - "none" sets all to 0;
-        // "all" with optional numeric suffix sets all flags to min(suffix, MAX_OUT_LEVEL).
-        if lower == "0" || lower == "none" {
-            self.disable_all();
-            return Ok(());
-        }
-
-        if lower == "1"
-            || lower == "all"
-            || (lower.starts_with("all") && lower[3..].bytes().all(|b| b.is_ascii_digit()))
-        {
-            let level = if lower == "1" || lower == "all" {
-                1
-            } else {
-                lower[3..].parse::<u8>().unwrap_or(1).min(MAX_OUT_LEVEL)
-            };
-            self.set_all(level);
-            return Ok(());
-        }
-
-        let (normalized, level) = self.parse_flag_and_level(&lower);
-
-        // upstream: options.c:444-445 - clamp to MAX_OUT_LEVEL rather than reject
-        let level = level.min(MAX_OUT_LEVEL);
+        let (normalized, level) = match output_words::classify(&lower) {
+            OutputWord::Help => {
+                self.help_requested = true;
+                return Ok(());
+            }
+            OutputWord::Every(level) => {
+                self.set_all(level);
+                return Ok(());
+            }
+            OutputWord::Named { name, level } => (name, level),
+        };
 
         match normalized {
             "acl" => self.acl = Some(level),
@@ -207,39 +161,6 @@ impl DebugFlagSettings {
 
         Ok(())
     }
-
-    /// Known debug flag names for disambiguating `no-` prefix vs flag names
-    /// that might start with "no".
-    const KNOWN_FLAGS: &'static [&'static str] = &[
-        "acl", "backup", "bind", "chdir", "connect", "cmd", "del", "deltasum", "dup", "exit",
-        "filter", "flist", "fuzzy", "genr", "hash", "hlink", "iconv", "io", "nstr", "own", "proto",
-        "recv", "send", "time", "iouring", "clone", "sockopt", "iocp",
-    ];
-
-    pub(super) fn parse_flag_and_level<'a>(&self, input: &'a str) -> (&'a str, u8) {
-        let base = input.trim_end_matches(|c: char| c.is_ascii_digit());
-        if base != input {
-            if Self::KNOWN_FLAGS.contains(&base) {
-                let suffix = &input[base.len()..];
-                let level = suffix.parse::<u8>().unwrap_or(1);
-                return (base, level);
-            }
-        } else if Self::KNOWN_FLAGS.contains(&input) {
-            return (input, 1);
-        }
-
-        let stripped = input.strip_prefix("no").or_else(|| input.strip_prefix('-'));
-
-        if let Some(stripped) = stripped {
-            return (stripped, 0);
-        }
-
-        (input, 1)
-    }
-}
-
-fn debug_flag_empty_error() -> Message {
-    rsync_error!(1, "--debug flag must not be empty").with_role(Role::Client)
 }
 
 fn debug_flag_error(display: &str) -> Message {
@@ -256,24 +177,7 @@ pub(crate) fn parse_debug_flags(values: &[OsString]) -> Result<DebugFlagSettings
 
     for value in values {
         let text = value.to_string_lossy();
-        let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
-
-        if trimmed.is_empty() {
-            return Err(debug_flag_empty_error());
-        }
-
-        for token in trimmed.split(',') {
-            let token = token.trim_matches(|ch: char| ch.is_ascii_whitespace());
-            if token.is_empty() {
-                return Err(debug_flag_empty_error());
-            }
-
-            if token.eq_ignore_ascii_case("help") {
-                settings.help_requested = true;
-            } else {
-                settings.apply(token, token)?;
-            }
-        }
+        output_words::for_each_token(&text, |token| settings.apply(token, token))?;
     }
 
     Ok(settings)

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -6,12 +6,13 @@ use core::{
 };
 
 use super::super::super::progress::{NameOutputLevel, ProgressSetting};
+use super::output_words::{self, OutputWord};
 
 /// Per-flag descriptor for an `--info=` token.
 ///
 /// upstream: options.c `output_struct` (rsync-3.4.1:259-266) plus the
 /// `info_verbosity[]` grouping at options.c:239-243. `max_level` is the
-/// per-flag ceiling used when `--info=all<N>` or `--info=N` fans out
+/// per-flag ceiling used when `--info=all<N>` fans out
 /// across every flag (it caps each flag at its highest meaningful level,
 /// mirroring upstream's runtime `INFO_GTE(...)` checks). `priority`
 /// records the upstream verbosity group at which the flag is auto-enabled
@@ -19,9 +20,6 @@ use super::super::super::progress::{NameOutputLevel, ProgressSetting};
 /// STATS/SYMSAFE=1, level-2 group covers BACKUP/MOUNT/REMOVE/SKIP=2). It
 /// is currently informational, exposed for the daemon-side limit handling
 /// tracked by audit I16 (`limit_output_verbosity()`, options.c:527-552).
-/// `strict_cap` controls whether a per-token level above `max_level` is
-/// rejected (`--info=flist3`) or silently capped (`--info=backup5`),
-/// preserving oc-rsync's historical usability split.
 #[derive(Clone, Copy)]
 pub(crate) struct InfoFlagSpec {
     pub(crate) name: &'static str,
@@ -31,30 +29,29 @@ pub(crate) struct InfoFlagSpec {
     // than priority, mirroring upstream's `parse_output_words` behavior.
     #[allow(dead_code)]
     pub(crate) priority: u8,
-    pub(crate) strict_cap: bool,
 }
 
 // upstream: options.c info_verbosity[] (rsync-3.4.1:239-243) - priority is
 // the verbosity-group index. NONREG sits in group 0 (always-on default),
 // the level-1 group covers COPY/DEL/FLIST/MISC/NAME/STATS/SYMSAFE, and the
 // level-2 group covers BACKUP/MOUNT/REMOVE/SKIP. PROGRESS has no upstream
-// verbosity-group entry; oc-rsync treats it as priority 1 so `--info=1`
+// verbosity-group entry; oc-rsync treats it as priority 1 so `--info=all1`
 // enables per-file progress, matching upstream `-v` parity for `--info`.
 #[rustfmt::skip]
 pub(crate) const INFO_FLAG_SPECS: &[InfoFlagSpec] = &[
-    InfoFlagSpec { name: "backup",   max_level: 1, priority: 2, strict_cap: false },
-    InfoFlagSpec { name: "copy",     max_level: 1, priority: 1, strict_cap: false },
-    InfoFlagSpec { name: "del",      max_level: 1, priority: 1, strict_cap: false },
-    InfoFlagSpec { name: "flist",    max_level: 2, priority: 1, strict_cap: true  },
-    InfoFlagSpec { name: "misc",     max_level: 2, priority: 1, strict_cap: true  },
-    InfoFlagSpec { name: "mount",    max_level: 1, priority: 2, strict_cap: false },
-    InfoFlagSpec { name: "name",     max_level: 2, priority: 1, strict_cap: false },
-    InfoFlagSpec { name: "nonreg",   max_level: 1, priority: 0, strict_cap: false },
-    InfoFlagSpec { name: "progress", max_level: 2, priority: 1, strict_cap: true  },
-    InfoFlagSpec { name: "remove",   max_level: 1, priority: 2, strict_cap: false },
-    InfoFlagSpec { name: "skip",     max_level: 2, priority: 2, strict_cap: true  },
-    InfoFlagSpec { name: "stats",    max_level: 3, priority: 1, strict_cap: true  },
-    InfoFlagSpec { name: "symsafe",  max_level: 1, priority: 1, strict_cap: false },
+    InfoFlagSpec { name: "backup",   max_level: 1, priority: 2 },
+    InfoFlagSpec { name: "copy",     max_level: 1, priority: 1 },
+    InfoFlagSpec { name: "del",      max_level: 1, priority: 1 },
+    InfoFlagSpec { name: "flist",    max_level: 2, priority: 1 },
+    InfoFlagSpec { name: "misc",     max_level: 2, priority: 1 },
+    InfoFlagSpec { name: "mount",    max_level: 1, priority: 2 },
+    InfoFlagSpec { name: "name",     max_level: 2, priority: 1 },
+    InfoFlagSpec { name: "nonreg",   max_level: 1, priority: 0 },
+    InfoFlagSpec { name: "progress", max_level: 2, priority: 1 },
+    InfoFlagSpec { name: "remove",   max_level: 1, priority: 2 },
+    InfoFlagSpec { name: "skip",     max_level: 2, priority: 2 },
+    InfoFlagSpec { name: "stats",    max_level: 3, priority: 1 },
+    InfoFlagSpec { name: "symsafe",  max_level: 1, priority: 1 },
 ];
 
 /// Parsed `--info` flag settings controlling informational output levels.
@@ -77,10 +74,6 @@ pub(crate) struct InfoFlagSettings {
 }
 
 impl InfoFlagSettings {
-    fn enable_all(&mut self) {
-        self.enable_all_at_level(1);
-    }
-
     // upstream: options.c parse_output_words - the "all<N>" token sets every
     // flag to level `min(N, spec.max_level)`. The `priority` field on each
     // spec records the upstream verbosity-group ordering (NONREG=0, level-1
@@ -90,12 +83,6 @@ impl InfoFlagSettings {
         for spec in INFO_FLAG_SPECS {
             let effective = level.min(spec.max_level);
             self.assign(spec.name, effective);
-        }
-    }
-
-    fn disable_all(&mut self) {
-        for spec in INFO_FLAG_SPECS {
-            self.assign(spec.name, 0);
         }
     }
 
@@ -252,82 +239,28 @@ impl InfoFlagSettings {
     ) -> Result<(), Message> {
         let lower = token.to_ascii_lowercase();
 
-        if lower == "help" {
-            self.help_requested = true;
-            return Ok(());
-        }
-
-        if lower == "all" {
-            self.enable_all();
-            return Ok(());
-        }
-
-        if lower == "none" {
-            self.disable_all();
-            return Ok(());
-        }
-
-        // upstream: options.c parse_output_words accepts "all<N>" (e.g. "all2")
-        // to set every flag to level N. As a usability extension, oc-rsync
-        // also accepts a bare integer token like "--info=2" with the same
-        // semantics. Per-flag caps are applied by `enable_all_at_level`.
-        if !lower.is_empty() && lower.bytes().all(|b| b.is_ascii_digit()) {
-            let level = lower.parse::<u8>().unwrap_or(u8::MAX);
-            self.enable_all_at_level(level);
-            return Ok(());
-        }
-
-        let (normalized, level) = self.parse_flag_and_level(&lower);
-
-        // upstream: options.c output_msg / parse_output_words clamps levels to
-        // MAX_OUT_LEVEL=4 but never rejects them. oc-rsync rejects only when the
-        // spec's `strict_cap` is set (progress/stats/flist/misc/skip) and the
-        // user-supplied level exceeds `max_level`; other flags accept any level
-        // verbatim for forward-compatibility with hypothetical future emit sites.
-        // The `!am_server` branch for missing specs mirrors upstream's
-        // parse_output_words server-mode tolerance: a newer client may forward
-        // info tokens this build does not know, and the server must not reject.
-        let Some(spec) = Self::spec_for(normalized) else {
-            return if am_server {
-                Ok(())
-            } else {
-                Err(info_flag_error(display))
-            };
-        };
-        if spec.strict_cap && level > spec.max_level {
-            return Err(info_flag_error(display));
-        }
-        self.assign(spec.name, level);
-        Ok(())
-    }
-
-    // Internal-only extension: `no<flag>` and `-<flag>` are accepted as a
-    // negation form mapping to level 0 (e.g. `noprogress` == `progress0`).
-    // Upstream rsync 3.4.1's `parse_output_words` (`options.c:427`) does NOT
-    // implement this prefix; it relies on the `flag0` suffix instead. The
-    // forms remain accepted for backwards compatibility and to tolerate
-    // server-mode token forwarding, but they are intentionally not advertised
-    // in `--info=help` (see `INFO_HELP_TEXT`) so users do not rely on a
-    // non-portable spelling. New code should prefer the suffix form.
-    pub(super) fn parse_flag_and_level<'a>(&self, input: &'a str) -> (&'a str, u8) {
-        let base = input.trim_end_matches(|c: char| c.is_ascii_digit());
-        if base != input {
-            if Self::spec_for(base).is_some() {
-                let suffix = &input[base.len()..];
-                let level = suffix.parse::<u8>().unwrap_or(1);
-                return (base, level);
+        match output_words::classify(&lower) {
+            OutputWord::Help => self.help_requested = true,
+            OutputWord::Every(level) => self.enable_all_at_level(level),
+            OutputWord::Named { name, level } => {
+                // The `am_server` branch mirrors upstream's
+                // `if (len && !words[j].name && !am_server)` guard: a newer
+                // client may forward info words this build does not know, and
+                // the server must accept them so the connection survives the
+                // version skew. The client still rejects, so a typo surfaces
+                // at the source.
+                let Some(spec) = Self::spec_for(name) else {
+                    return if am_server {
+                        Ok(())
+                    } else {
+                        Err(info_flag_error(display))
+                    };
+                };
+                self.assign(spec.name, level);
             }
-        } else if Self::spec_for(input).is_some() {
-            return (input, 1);
         }
 
-        let stripped = input.strip_prefix("no").or_else(|| input.strip_prefix('-'));
-
-        if let Some(stripped) = stripped {
-            return (stripped, 0);
-        }
-
-        (input, 1)
+        Ok(())
     }
 }
 
@@ -364,22 +297,9 @@ fn parse_info_flags_inner(
     let mut settings = InfoFlagSettings::default();
     for value in values {
         let text = value.to_string_lossy();
-        let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
-
-        if trimmed.is_empty() {
-            return Err(rsync_error!(1, "--info flag must not be empty").with_role(Role::Client));
-        }
-
-        for token in trimmed.split(',') {
-            let token = token.trim_matches(|ch: char| ch.is_ascii_whitespace());
-            if token.is_empty() {
-                return Err(
-                    rsync_error!(1, "--info flag must not be empty").with_role(Role::Client)
-                );
-            }
-
-            settings.apply_with_mode(token, token, am_server)?;
-        }
+        output_words::for_each_token(&text, |token| {
+            settings.apply_with_mode(token, token, am_server)
+        })?;
     }
 
     Ok(settings)

--- a/crates/cli/src/frontend/execution/flags/mod.rs
+++ b/crates/cli/src/frontend/execution/flags/mod.rs
@@ -1,5 +1,6 @@
 mod debug;
 mod info;
+mod output_words;
 
 #[cfg(test)]
 mod tests;

--- a/crates/cli/src/frontend/execution/flags/output_words.rs
+++ b/crates/cli/src/frontend/execution/flags/output_words.rs
@@ -1,0 +1,83 @@
+//! Shared token grammar for `--info=` and `--debug=` values.
+//!
+//! upstream: options.c `parse_output_words()`. Upstream has ONE tokenizer and
+//! passes the word table in as a parameter (`parse_output_words(words, levels,
+//! str, priority)`), which is why `--info` and `--debug` accept exactly the
+//! same syntax and differ only in which names they recognise. This module is
+//! that tokenizer; each caller keeps its own table and applies the result.
+
+/// Largest level any `word<N>` token may select.
+///
+/// upstream: options.c `#define MAX_OUT_LEVEL 4`. Upstream clamps to this
+/// bound (`if (lev > MAX_OUT_LEVEL || lev < 0) lev = MAX_OUT_LEVEL;`) and
+/// never rejects an out-of-range level.
+pub(super) const MAX_OUT_LEVEL: u8 = 4;
+
+/// One classified token from a `--info=` / `--debug=` list.
+pub(super) enum OutputWord<'a> {
+    /// `help`, with or without a level suffix. upstream prints the word table
+    /// and calls `exit_cleanup(0)`.
+    Help,
+    /// `all<N>`, `none`, or `none<N>`: apply this level to every word in the
+    /// caller's table. upstream expresses both by setting the compared length
+    /// to 0 so the table loop matches every entry, with `none` additionally
+    /// forcing the level to 0 regardless of any suffix.
+    Every(u8),
+    /// A category name and its level. The caller resolves the name against its
+    /// own table and reports an unknown name.
+    Named { name: &'a str, level: u8 },
+}
+
+/// Classifies one already-trimmed token.
+///
+/// upstream: options.c `parse_output_words()`. The trailing-digit scan is
+/// skipped when the token itself starts with a digit (`if (!isDigit(str))`),
+/// so a bare integer such as `2` stays its own name and falls through to the
+/// unknown-item error rather than selecting a level.
+pub(super) fn classify(token: &str) -> OutputWord<'_> {
+    let base = if token.starts_with(|c: char| c.is_ascii_digit()) {
+        token
+    } else {
+        token.trim_end_matches(|c: char| c.is_ascii_digit())
+    };
+
+    // A suffix that overflows `u8` is clamped, not rejected: upstream notes
+    // that `atoi()` of an overflowing digit string can return a negative int
+    // and folds that into the same `lev = MAX_OUT_LEVEL` clamp.
+    let level = match &token[base.len()..] {
+        "" => 1,
+        digits => digits.parse::<u8>().unwrap_or(MAX_OUT_LEVEL),
+    }
+    .min(MAX_OUT_LEVEL);
+
+    if base.eq_ignore_ascii_case("help") {
+        return OutputWord::Help;
+    }
+    if base.eq_ignore_ascii_case("none") {
+        return OutputWord::Every(0);
+    }
+    if base.eq_ignore_ascii_case("all") {
+        return OutputWord::Every(level);
+    }
+
+    OutputWord::Named { name: base, level }
+}
+
+/// Splits one `--info=`/`--debug=` value into tokens, dropping empty ones.
+///
+/// upstream: options.c `parse_output_words()` walks the comma list and does
+/// `if (!len) continue;`, so `--info=`, `--info=,` and `--info=name,` are all
+/// accepted no-ops rather than errors.
+pub(super) fn for_each_token<E>(
+    value: &str,
+    mut apply: impl FnMut(&str) -> Result<(), E>,
+) -> Result<(), E> {
+    for token in value.split(',') {
+        let token = token.trim_matches(|ch: char| ch.is_ascii_whitespace());
+        if token.is_empty() {
+            continue;
+        }
+        apply(token)?;
+    }
+    Ok(())
+}

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -1,39 +1,64 @@
 use super::debug::DebugFlagSettings;
 use super::info::{INFO_FLAG_SPECS, InfoFlagSettings};
+use super::output_words::{OutputWord, classify};
 use super::*;
 use crate::frontend::progress::{NameOutputLevel, ProgressSetting};
 use std::ffi::OsString;
 
-#[test]
-fn info_flag_parse_flag_and_level_default() {
-    let settings = InfoFlagSettings::default();
-    let (name, level) = settings.parse_flag_and_level("progress");
-    assert_eq!(name, "progress");
-    assert_eq!(level, 1);
+fn named(token: &str) -> (String, u8) {
+    match classify(token) {
+        OutputWord::Named { name, level } => (name.to_owned(), level),
+        OutputWord::Help => ("<help>".to_owned(), 0),
+        OutputWord::Every(level) => ("<all>".to_owned(), level),
+    }
 }
 
 #[test]
-fn info_flag_parse_flag_and_level_with_number() {
-    let settings = InfoFlagSettings::default();
-    let (name, level) = settings.parse_flag_and_level("progress2");
-    assert_eq!(name, "progress");
-    assert_eq!(level, 2);
+fn output_word_without_a_suffix_is_level_one() {
+    assert_eq!(named("progress"), ("progress".to_owned(), 1));
 }
 
 #[test]
-fn info_flag_parse_flag_and_level_no_prefix() {
-    let settings = InfoFlagSettings::default();
-    let (name, level) = settings.parse_flag_and_level("noprogress");
-    assert_eq!(name, "progress");
-    assert_eq!(level, 0);
+fn output_word_takes_its_level_from_a_trailing_digit() {
+    assert_eq!(named("progress2"), ("progress".to_owned(), 2));
+}
+
+// upstream: options.c parse_output_words has no negation prefix - `no<word>`
+// and `-<word>` are ordinary (unknown) names and exit RERR_SYNTAX. The
+// portable spelling for silencing a word is the `<word>0` suffix, which
+// `output_word_level_zero_silences_a_word` pins as the surviving mechanism.
+#[test]
+fn a_no_prefixed_word_is_not_a_negation() {
+    assert_eq!(named("noprogress"), ("noprogress".to_owned(), 1));
+    let err = parse_info_flags(&[OsString::from("noprogress")])
+        .expect_err("`noprogress` is an unknown info word, not a negation");
+    assert!(
+        err.to_string().contains("noprogress"),
+        "error must name the rejected token: {err}"
+    );
 }
 
 #[test]
-fn info_flag_parse_flag_and_level_dash_prefix() {
-    let settings = InfoFlagSettings::default();
-    let (name, level) = settings.parse_flag_and_level("-progress");
-    assert_eq!(name, "progress");
-    assert_eq!(level, 0);
+fn a_dash_prefixed_word_is_not_a_negation() {
+    assert_eq!(named("-progress"), ("-progress".to_owned(), 1));
+    let _ = parse_info_flags(&[OsString::from("-progress")])
+        .expect_err("`-progress` is an unknown info word, not a negation");
+}
+
+#[test]
+fn output_word_level_zero_silences_a_word() {
+    let settings = parse_info_flags(&[OsString::from("progress0")]).expect("progress0 parses");
+    assert_eq!(settings.progress, ProgressSetting::Disabled);
+}
+
+// upstream: options.c parse_output_words skips the trailing-digit scan when
+// the token starts with a digit (`if (!isDigit(str))`), so a bare integer is
+// its own name and reaches the unknown-item error.
+#[test]
+fn a_bare_integer_is_a_word_name_not_a_level() {
+    assert_eq!(named("2"), ("2".to_owned(), 1));
+    let _ =
+        parse_info_flags(&[OsString::from("2")]).expect_err("a bare integer is not an info word");
 }
 
 #[test]
@@ -83,10 +108,9 @@ fn info_flag_apply_invalid() {
 }
 
 #[test]
-fn parse_info_flags_empty_value() {
+fn parse_info_flags_empty_value_is_a_no_op() {
     let values = vec![OsString::from("")];
-    let result = parse_info_flags(&values);
-    assert!(result.is_err());
+    parse_info_flags(&values).expect("upstream skips empty items rather than erroring");
 }
 
 #[test]
@@ -135,19 +159,11 @@ fn parse_info_flags_server_mixes_known_and_unknown() {
 }
 
 #[test]
-fn debug_flag_parse_flag_and_level_default() {
-    let settings = DebugFlagSettings::default();
-    let (name, level) = settings.parse_flag_and_level("io");
-    assert_eq!(name, "io");
-    assert_eq!(level, 1);
-}
-
-#[test]
-fn debug_flag_parse_flag_and_level_with_number() {
-    let settings = DebugFlagSettings::default();
-    let (name, level) = settings.parse_flag_and_level("io3");
-    assert_eq!(name, "io");
-    assert_eq!(level, 3);
+fn a_debug_word_shares_the_info_token_grammar() {
+    assert_eq!(named("io"), ("io".to_owned(), 1));
+    assert_eq!(named("io3"), ("io".to_owned(), 3));
+    let _ = parse_debug_flags(&[OsString::from("noio")])
+        .expect_err("`noio` is an unknown debug word, not a negation");
 }
 
 #[test]
@@ -191,10 +207,9 @@ fn debug_flag_apply_invalid() {
 }
 
 #[test]
-fn parse_debug_flags_empty_value() {
+fn parse_debug_flags_empty_value_is_a_no_op() {
     let values = vec![OsString::from("")];
-    let result = parse_debug_flags(&values);
-    assert!(result.is_err());
+    parse_debug_flags(&values).expect("upstream skips empty items rather than erroring");
 }
 
 #[test]
@@ -222,13 +237,6 @@ fn info_flag_progress0_disables() {
 }
 
 #[test]
-fn info_flag_progress3_rejected() {
-    let mut settings = InfoFlagSettings::default();
-    let result = settings.apply("progress3", "progress3");
-    assert!(result.is_err());
-}
-
-#[test]
 fn info_flag_stats2() {
     let mut settings = InfoFlagSettings::default();
     settings.apply("stats2", "stats2").unwrap();
@@ -240,13 +248,6 @@ fn info_flag_stats3() {
     let mut settings = InfoFlagSettings::default();
     settings.apply("stats3", "stats3").unwrap();
     assert_eq!(settings.stats, Some(3));
-}
-
-#[test]
-fn info_flag_stats4_rejected() {
-    let mut settings = InfoFlagSettings::default();
-    let result = settings.apply("stats4", "stats4");
-    assert!(result.is_err());
 }
 
 #[test]
@@ -292,24 +293,10 @@ fn info_flag_flist2() {
 }
 
 #[test]
-fn info_flag_flist3_rejected() {
-    let mut settings = InfoFlagSettings::default();
-    let result = settings.apply("flist3", "flist3");
-    assert!(result.is_err());
-}
-
-#[test]
 fn info_flag_misc2() {
     let mut settings = InfoFlagSettings::default();
     settings.apply("misc2", "misc2").unwrap();
     assert_eq!(settings.misc, Some(2));
-}
-
-#[test]
-fn info_flag_misc3_rejected() {
-    let mut settings = InfoFlagSettings::default();
-    let result = settings.apply("misc3", "misc3");
-    assert!(result.is_err());
 }
 
 #[test]
@@ -320,19 +307,13 @@ fn info_flag_skip2() {
 }
 
 #[test]
-fn info_flag_skip3_rejected() {
-    let mut settings = InfoFlagSettings::default();
-    let result = settings.apply("skip3", "skip3");
-    assert!(result.is_err());
-}
-
-#[test]
 fn info_flag_backup_any_level() {
     let mut settings = InfoFlagSettings::default();
     settings.apply("backup", "backup").unwrap();
     assert_eq!(settings.backup, Some(1));
+    // upstream clamps every explicit level to MAX_OUT_LEVEL (4).
     settings.apply("backup5", "backup5").unwrap();
-    assert_eq!(settings.backup, Some(5));
+    assert_eq!(settings.backup, Some(4));
 }
 
 #[test]
@@ -380,100 +361,9 @@ fn info_flag_symsafe_any_level() {
 }
 
 #[test]
-fn info_flag_no_prefix_copy() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("nocopy", "nocopy").unwrap();
-    assert_eq!(settings.copy, Some(0));
-}
-
-#[test]
-fn info_flag_dash_prefix_copy() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("-copy", "-copy").unwrap();
-    assert_eq!(settings.copy, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_del() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("nodel", "nodel").unwrap();
-    assert_eq!(settings.del, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_stats() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("nostats", "nostats").unwrap();
-    assert_eq!(settings.stats, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_name() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("noname", "noname").unwrap();
-    assert_eq!(settings.name, Some(NameOutputLevel::Disabled));
-}
-
-#[test]
-fn info_flag_no_prefix_skip() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("noskip", "noskip").unwrap();
-    assert_eq!(settings.skip, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_flist() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("noflist", "noflist").unwrap();
-    assert_eq!(settings.flist, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_misc() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("nomisc", "nomisc").unwrap();
-    assert_eq!(settings.misc, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_backup() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("nobackup", "nobackup").unwrap();
-    assert_eq!(settings.backup, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_mount() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("nomount", "nomount").unwrap();
-    assert_eq!(settings.mount, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_nonreg() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("nononreg", "nononreg").unwrap();
-    assert_eq!(settings.nonreg, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_remove() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("noremove", "noremove").unwrap();
-    assert_eq!(settings.remove, Some(0));
-}
-
-#[test]
-fn info_flag_no_prefix_symsafe() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("nosymsafe", "nosymsafe").unwrap();
-    assert_eq!(settings.symsafe, Some(0));
-}
-
-#[test]
 fn info_flag_numeric_1_enables_all() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("1", "1").unwrap();
+    settings.apply("all1", "all1").unwrap();
     assert_eq!(settings.progress, ProgressSetting::PerFile);
     assert_eq!(settings.stats, Some(1));
     assert_eq!(settings.name, Some(NameOutputLevel::UpdatedOnly));
@@ -493,7 +383,7 @@ fn info_flag_numeric_1_enables_all() {
 fn info_flag_numeric_0_disables_all() {
     let mut settings = InfoFlagSettings::default();
     settings.apply("all", "all").unwrap();
-    settings.apply("0", "0").unwrap();
+    settings.apply("all0", "all0").unwrap();
     assert_eq!(settings.progress, ProgressSetting::Disabled);
     assert_eq!(settings.stats, Some(0));
     assert_eq!(settings.name, Some(NameOutputLevel::Disabled));
@@ -746,27 +636,9 @@ fn debug_flag_all_with_level() {
 }
 
 #[test]
-fn debug_flag_no_prefix_all_flags() {
-    let keywords = [
-        "acl", "backup", "bind", "chdir", "connect", "cmd", "del", "deltasum", "dup", "exit",
-        "filter", "flist", "fuzzy", "genr", "hash", "hlink", "iconv", "io", "nstr", "own", "proto",
-        "recv", "send", "time",
-    ];
-    for keyword in &keywords {
-        let mut settings = DebugFlagSettings::default();
-        let negated = format!("no{keyword}");
-        let result = settings.apply(&negated, &negated);
-        assert!(
-            result.is_ok(),
-            "negated debug keyword 'no{keyword}' should be accepted but got: {result:?}"
-        );
-    }
-}
-
-#[test]
 fn debug_flag_numeric_1_enables_all() {
     let mut settings = DebugFlagSettings::default();
-    settings.apply("1", "1").unwrap();
+    settings.apply("all1", "all1").unwrap();
     assert_eq!(settings.io, Some(1));
     assert_eq!(settings.proto, Some(1));
     assert_eq!(settings.flist, Some(1));
@@ -777,7 +649,7 @@ fn debug_flag_numeric_1_enables_all() {
 fn debug_flag_numeric_0_disables_all() {
     let mut settings = DebugFlagSettings::default();
     settings.apply("all", "all").unwrap();
-    settings.apply("0", "0").unwrap();
+    settings.apply("all0", "all0").unwrap();
     assert_eq!(settings.io, Some(0));
     assert_eq!(settings.proto, Some(0));
     assert_eq!(settings.flist, Some(0));
@@ -891,20 +763,6 @@ fn info_help_text_does_not_advertise_no_or_dash_prefix() {
 // for backwards compatibility and server-mode token forwarding even though
 // they are no longer advertised in `--info=help`.
 #[test]
-fn info_flag_no_prefix_still_accepted_after_help_scrub() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("noprogress", "noprogress").unwrap();
-    assert_eq!(settings.progress, ProgressSetting::Disabled);
-}
-
-#[test]
-fn info_flag_dash_prefix_still_accepted_after_help_scrub() {
-    let mut settings = InfoFlagSettings::default();
-    settings.apply("-progress", "-progress").unwrap();
-    assert_eq!(settings.progress, ProgressSetting::Disabled);
-}
-
-#[test]
 fn debug_help_text_lists_all_keywords() {
     let keywords = [
         "ACL", "BACKUP", "BIND", "CHDIR", "CONNECT", "CMD", "DEL", "DELTASUM", "DUP", "EXIT",
@@ -962,7 +820,7 @@ fn debug_help_text_includes_opt_preface() {
 #[test]
 fn info_flag_numeric_2_enables_all_at_level_2() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("2", "2").unwrap();
+    settings.apply("all2", "all2").unwrap();
     assert_eq!(settings.progress, ProgressSetting::Overall);
     assert_eq!(settings.stats, Some(2));
     assert_eq!(settings.name, Some(NameOutputLevel::UpdatedAndUnchanged));
@@ -982,7 +840,7 @@ fn info_flag_numeric_2_enables_all_at_level_2() {
 #[test]
 fn info_flag_numeric_3_clamps_per_flag() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("3", "3").unwrap();
+    settings.apply("all3", "all3").unwrap();
     // STATS supports level 3.
     assert_eq!(settings.stats, Some(3));
     // PROGRESS, NAME, FLIST, MISC, SKIP clamp at 2.
@@ -998,7 +856,7 @@ fn info_flag_numeric_3_clamps_per_flag() {
 #[test]
 fn info_flag_numeric_then_named_override() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("2", "2").unwrap();
+    settings.apply("all2", "all2").unwrap();
     settings.apply("name0", "name0").unwrap();
     assert_eq!(settings.name, Some(NameOutputLevel::Disabled));
     // Other flags retained from the numeric pre-fill.
@@ -1007,7 +865,7 @@ fn info_flag_numeric_then_named_override() {
 
 #[test]
 fn parse_info_flags_numeric_then_named_in_one_arg() {
-    let values = vec![OsString::from("2,name0")];
+    let values = vec![OsString::from("all2,name0")];
     let result = parse_info_flags(&values).unwrap();
     assert_eq!(result.name, Some(NameOutputLevel::Disabled));
     assert_eq!(result.stats, Some(2));
@@ -1018,7 +876,7 @@ fn parse_info_flags_numeric_then_named_in_one_arg() {
 fn info_flag_numeric_high_value_saturates() {
     // Out-of-range integers saturate at per-flag caps rather than erroring.
     let mut settings = InfoFlagSettings::default();
-    settings.apply("99", "99").unwrap();
+    settings.apply("all99", "all99").unwrap();
     assert_eq!(settings.stats, Some(3));
     assert_eq!(settings.flist, Some(2));
     assert_eq!(settings.copy, Some(1));
@@ -1029,7 +887,7 @@ fn info_flag_numeric_overflow_does_not_panic() {
     // A value that overflows u8 falls back to u8::MAX inside the parser,
     // which still saturates to per-flag caps.
     let mut settings = InfoFlagSettings::default();
-    settings.apply("999", "999").unwrap();
+    settings.apply("all999", "all999").unwrap();
     assert_eq!(settings.stats, Some(3));
 }
 
@@ -1061,7 +919,7 @@ fn info_flag_numeric_n_caps_each_priority_group_at_per_flag_max() {
     // `--info=2` enables every priority<=2 flag; per-flag caps still apply
     // (stats caps at 3, flist/misc/skip/name/progress at 2, others at 1).
     let mut settings = InfoFlagSettings::default();
-    settings.apply("2", "2").unwrap();
+    settings.apply("all2", "all2").unwrap();
     for spec in INFO_FLAG_SPECS {
         if spec.priority > 2 {
             continue;
@@ -1170,7 +1028,7 @@ fn apply_to_thread_local_numeric_level() {
     logging::init(logging::VerbosityConfig::default());
 
     let mut settings = InfoFlagSettings::default();
-    settings.apply("2", "2").unwrap();
+    settings.apply("all2", "all2").unwrap();
     settings.apply_to_thread_local();
 
     // Level 2 enables all flags, capped by per-flag max_level
@@ -1252,4 +1110,94 @@ fn apply_to_thread_local_unset_flags_not_touched() {
     // Other flags from verbose level 2 should remain untouched
     assert!(logging::info_gte(logging::InfoFlag::Mount, 1));
     assert!(logging::info_gte(logging::InfoFlag::Copy, 1));
+}
+
+// upstream: options.c parse_output_words matches a word by exact length
+// against the table, so `no<word>` and `-<word>` are simply unknown names.
+// Covering every word in the table rather than a sample keeps a future word
+// from silently reintroducing the removed prefix.
+#[test]
+fn no_info_word_accepts_a_negation_prefix() {
+    for spec in INFO_FLAG_SPECS {
+        for token in [format!("no{}", spec.name), format!("-{}", spec.name)] {
+            let _ = parse_info_flags(&[OsString::from(token.clone())]).expect_err(&format!(
+                "`{token}` must be rejected, not read as a negation"
+            ));
+        }
+    }
+}
+
+// Non-vacuity companion: the portable spelling upstream DOES accept must keep
+// working for every word, or the test above would pass on a parser that
+// rejects everything.
+#[test]
+fn every_info_word_accepts_the_level_zero_suffix() {
+    for spec in INFO_FLAG_SPECS {
+        let token = format!("{}0", spec.name);
+        parse_info_flags(&[OsString::from(token.clone())])
+            .unwrap_or_else(|e| panic!("`{token}` must parse: {e}"));
+    }
+}
+
+#[test]
+fn no_debug_word_accepts_a_negation_prefix() {
+    for word in [
+        "acl", "backup", "bind", "chdir", "connect", "cmd", "del", "deltasum", "dup", "exit",
+        "filter", "flist", "fuzzy", "genr", "hash", "hlink", "iconv", "io", "nstr", "own", "proto",
+        "recv", "send", "time", "iouring", "clone", "sockopt", "iocp",
+    ] {
+        for token in [format!("no{word}"), format!("-{word}")] {
+            let _ = parse_debug_flags(&[OsString::from(token.clone())]).expect_err(&format!(
+                "`{token}` must be rejected, not read as a negation"
+            ));
+        }
+        let zero = format!("{word}0");
+        parse_debug_flags(&[OsString::from(zero.clone())])
+            .unwrap_or_else(|e| panic!("`{zero}` must parse: {e}"));
+    }
+}
+
+#[test]
+fn info_flag_progress3_is_clamped_not_rejected() {
+    let mut settings = InfoFlagSettings::default();
+    settings
+        .apply("progress3", "progress3")
+        .expect("upstream clamps an out-of-range level, it never rejects one");
+    assert_eq!(settings.progress, ProgressSetting::Overall);
+}
+
+#[test]
+fn info_flag_stats4_is_clamped_not_rejected() {
+    let mut settings = InfoFlagSettings::default();
+    settings
+        .apply("stats4", "stats4")
+        .expect("upstream clamps an out-of-range level, it never rejects one");
+    assert_eq!(settings.stats, Some(4));
+}
+
+#[test]
+fn info_flag_flist3_is_clamped_not_rejected() {
+    let mut settings = InfoFlagSettings::default();
+    settings
+        .apply("flist3", "flist3")
+        .expect("upstream clamps an out-of-range level, it never rejects one");
+    assert_eq!(settings.flist, Some(3));
+}
+
+#[test]
+fn info_flag_misc3_is_clamped_not_rejected() {
+    let mut settings = InfoFlagSettings::default();
+    settings
+        .apply("misc3", "misc3")
+        .expect("upstream clamps an out-of-range level, it never rejects one");
+    assert_eq!(settings.misc, Some(3));
+}
+
+#[test]
+fn info_flag_skip3_is_clamped_not_rejected() {
+    let mut settings = InfoFlagSettings::default();
+    settings
+        .apply("skip3", "skip3")
+        .expect("upstream clamps an out-of-range level, it never rejects one");
+    assert_eq!(settings.skip, Some(3));
 }

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -136,9 +136,9 @@ fn info_backup_flag_parsing() {
     let settings = parse_info_flags(&flags).expect("flags parse");
     assert_eq!(settings.backup, Some(0));
 
-    let flags = vec![OsString::from("nobackup")];
-    let settings = parse_info_flags(&flags).expect("flags parse");
-    assert_eq!(settings.backup, Some(0));
+    // `nobackup` is not an upstream word; `backup0` above is the silencer.
+    let _ = parse_info_flags(&[OsString::from("nobackup")])
+        .expect_err("a negation prefix is not an upstream info word");
 }
 
 #[test]
@@ -151,9 +151,10 @@ fn info_flist_levels() {
     let settings = parse_info_flags(&flags).expect("flags parse");
     assert_eq!(settings.flist, Some(2));
 
+    // upstream clamps to MAX_OUT_LEVEL rather than rejecting an over-range level.
     let flags = vec![OsString::from("flist3")];
-    let error = parse_info_flags(&flags).expect_err("should reject level 3");
-    assert!(error.to_string().contains("invalid --info flag"));
+    let settings = parse_info_flags(&flags).expect("an over-range level is clamped, not rejected");
+    assert_eq!(settings.flist, Some(3));
 }
 
 #[test]
@@ -171,30 +172,36 @@ fn info_stats_levels() {
     assert_eq!(settings.stats, Some(3));
 
     let flags = vec![OsString::from("stats4")];
-    let error = parse_info_flags(&flags).expect_err("should reject level 4");
-    assert!(error.to_string().contains("invalid --info flag"));
+    let settings = parse_info_flags(&flags).expect("an over-range level is clamped, not rejected");
+    assert_eq!(settings.stats, Some(4));
+
+    // MAX_OUT_LEVEL is the ceiling: anything above it lands on 4.
+    let flags = vec![OsString::from("stats9")];
+    let settings = parse_info_flags(&flags).expect("flags parse");
+    assert_eq!(settings.stats, Some(4));
 }
 
 #[test]
-fn info_negation_forms() {
-    let flags = vec![OsString::from("nodel")];
-    let settings = parse_info_flags(&flags).expect("flags parse");
-    assert_eq!(settings.del, Some(0));
+fn info_negation_prefixes_are_rejected() {
+    // upstream: options.c parse_output_words - `no<word>` / `-<word>` are
+    // unknown names and exit RERR_SYNTAX; `<word>0` is the portable silencer.
+    for token in ["nodel", "-skip"] {
+        let _ = parse_info_flags(&[OsString::from(token)])
+            .expect_err("a negation prefix is not an upstream info word");
+    }
 
-    let flags = vec![OsString::from("-skip")];
-    let settings = parse_info_flags(&flags).expect("flags parse");
-    assert_eq!(settings.skip, Some(0));
-
-    let flags = vec![OsString::from("copy0")];
-    let settings = parse_info_flags(&flags).expect("flags parse");
+    let settings = parse_info_flags(&[OsString::from("copy0")]).expect("flags parse");
     assert_eq!(settings.copy, Some(0));
 }
 
 #[test]
-fn info_rejects_empty_segments() {
+fn info_skips_empty_segments() {
+    // upstream: options.c parse_output_words does `if (!len) continue;`, so an
+    // empty item is skipped and the surrounding words still apply.
     let flags = vec![OsString::from("progress,,stats")];
-    let error = parse_info_flags(&flags).expect_err("parse should fail");
-    assert!(error.to_string().contains("--info flag must not be empty"));
+    let settings = parse_info_flags(&flags).expect("an empty item is skipped, not an error");
+    assert_eq!(settings.progress, ProgressSetting::PerFile);
+    assert_eq!(settings.stats, Some(1));
 }
 
 #[test]
@@ -273,17 +280,13 @@ fn debug_io_levels() {
 }
 
 #[test]
-fn debug_negation_forms() {
-    let flags = vec![OsString::from("nodel")];
-    let settings = parse_debug_flags(&flags).expect("flags parse");
-    assert_eq!(settings.del, Some(0));
+fn debug_negation_prefixes_are_rejected() {
+    for token in ["nodel", "-filter"] {
+        let _ = parse_debug_flags(&[OsString::from(token)])
+            .expect_err("a negation prefix is not an upstream debug word");
+    }
 
-    let flags = vec![OsString::from("-filter")];
-    let settings = parse_debug_flags(&flags).expect("flags parse");
-    assert_eq!(settings.filter, Some(0));
-
-    let flags = vec![OsString::from("recv0")];
-    let settings = parse_debug_flags(&flags).expect("flags parse");
+    let settings = parse_debug_flags(&[OsString::from("recv0")]).expect("flags parse");
     assert_eq!(settings.recv, Some(0));
 }
 
@@ -303,10 +306,11 @@ fn debug_all_and_none() {
 }
 
 #[test]
-fn debug_rejects_empty_segments() {
+fn debug_skips_empty_segments() {
     let flags = vec![OsString::from("deltasum,,io")];
-    let error = parse_debug_flags(&flags).expect_err("parse should fail");
-    assert!(error.to_string().contains("--debug flag must not be empty"));
+    let settings = parse_debug_flags(&flags).expect("an empty item is skipped, not an error");
+    assert_eq!(settings.deltasum, Some(1));
+    assert_eq!(settings.io, Some(1));
 }
 
 #[test]
@@ -677,56 +681,26 @@ fn info_all_upstream_keywords_with_level_0() {
 }
 
 #[test]
-fn info_all_upstream_keywords_with_negation() {
-    let keywords = [
-        "nobackup",
-        "nocopy",
-        "nodel",
-        "noflist",
-        "nomisc",
-        "nomount",
-        "noname",
-        "nononreg",
-        "noprogress",
-        "noremove",
-        "noskip",
-        "nostats",
-        "nosymsafe",
-    ];
-    for keyword in &keywords {
-        let flags = vec![OsString::from(*keyword)];
-        let result = parse_info_flags(&flags);
-        assert!(
-            result.is_ok(),
-            "info keyword '{keyword}' with no-prefix should be accepted"
-        );
+fn info_all_upstream_keywords_reject_a_no_prefix() {
+    for word in [
+        "backup", "copy", "del", "flist", "misc", "mount", "name", "nonreg", "progress", "remove",
+        "skip", "stats", "symsafe",
+    ] {
+        let token = format!("no{word}");
+        let _ = parse_info_flags(&[OsString::from(token.clone())])
+            .expect_err(&format!("`{token}` is not an upstream info word"));
     }
 }
 
 #[test]
-fn info_all_upstream_keywords_with_dash_negation() {
-    let keywords = [
-        "-backup",
-        "-copy",
-        "-del",
-        "-flist",
-        "-misc",
-        "-mount",
-        "-name",
-        "-nonreg",
-        "-progress",
-        "-remove",
-        "-skip",
-        "-stats",
-        "-symsafe",
-    ];
-    for keyword in &keywords {
-        let flags = vec![OsString::from(*keyword)];
-        let result = parse_info_flags(&flags);
-        assert!(
-            result.is_ok(),
-            "info keyword '{keyword}' with dash-prefix should be accepted"
-        );
+fn info_all_upstream_keywords_reject_a_dash_prefix() {
+    for word in [
+        "backup", "copy", "del", "flist", "misc", "mount", "name", "nonreg", "progress", "remove",
+        "skip", "stats", "symsafe",
+    ] {
+        let token = format!("-{word}");
+        let _ = parse_info_flags(&[OsString::from(token.clone())])
+            .expect_err(&format!("`{token}` is not an upstream info word"));
     }
 }
 

--- a/crates/logging/QUICK_REFERENCE.md
+++ b/crates/logging/QUICK_REFERENCE.md
@@ -38,7 +38,7 @@ oc-rsync --info=help
 --info=copy          # Show file copies
 
 # Disable flags
---info=nocopy        # Don't show copies
+--info=copy0         # Don't show copies
 --info=name0         # Don't show names
 
 # Combine flags
@@ -299,7 +299,7 @@ total size is 1.23M  speedup is 6.49
 ### Too much output
 
 - Reduce verbosity level
-- Disable specific flags: `--info=nomisc,noskip`
+- Disable specific flags: `--info=misc0,skip0`
 - Use `--quiet --info=stats` for summary only
 
 ### Missing debug information

--- a/crates/logging/TRACING.md
+++ b/crates/logging/TRACING.md
@@ -83,7 +83,7 @@ Info flags control informational messages. Use `--info=help` to see all availabl
 --info=stats3       # Maximum statistics detail
 
 # Disable specific flags
---info=nocopy       # or -copy or copy0
+--info=copy0        # Silence a single category
 --info=progress0
 
 # Special keywords
@@ -152,7 +152,7 @@ Debug flags provide detailed diagnostic output for development and troubleshooti
 --debug=io4         # Maximum I/O debugging
 
 # Disable specific flags
---debug=noproto     # or -proto or proto0
+--debug=proto0      # Silence a single category
 
 # Special keywords
 --debug=all         # Enable all debug flags at level 1
@@ -276,7 +276,7 @@ Reduce verbosity or disable specific flags:
 oc-rsync -vv src/ dest/
 
 # Disable noisy flags
-oc-rsync -v --info=nomisc,noskip src/ dest/
+oc-rsync -v --info=misc0,skip0 src/ dest/
 ```
 
 ### Debug specific issues

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -968,7 +968,7 @@ mod info_copy_emission_tests {
         );
     }
 
-    /// Verifies that `--info=nocopy` (level 0) suppresses the emission,
+    /// Verifies that `--info=copy0` (level 0) suppresses the emission,
     /// mirroring upstream's `INFO_GTE(COPY, 1)` gate.
     #[test]
     fn nocopy_suppresses_info_copy_notice() {

--- a/docs/audits/info-flags-verbosity-matrix.md
+++ b/docs/audits/info-flags-verbosity-matrix.md
@@ -78,7 +78,7 @@ unconditionally, which is why `NONREG` is on at level 1 by default.
   to 1; it also lifts `FLIST` to 2.
 
 These lifts run at `DEFAULT_PRIORITY`, so an explicit `--info=stats0` or
-`--info=noname` overrides them per the priority test at
+`--info=name0` overrides them per the priority test at
 `options.c:457-460`.
 
 ### 1.4 Token grammar


### PR DESCRIPTION
## Problem

`--info` and `--debug` share one token grammar upstream: `parse_output_words()` takes the
word table as a parameter, so both options accept exactly the same syntax and differ only
in which names they recognise. oc reimplemented that grammar twice - once in `info.rs`,
once in `debug.rs` - and the two copies had drifted from upstream and from each other.

Measured against real `rsync 3.5.0` (fresh dest per cell, exit codes):

| form | upstream 3.5.0 | oc before |
|---|---|---|
| `--info=` , `--info=,` , `--info=name,` | 0 (empty item skipped) | **1** |
| `--info=all2` / `all4` / `all0` | 0 (every word at level N) | **1** |
| `--info=none2` / `help2` | 0 | **1** |
| `--info=stats9` `progress9` `flist9` `misc9` `skip9` | 0 (clamped to 4) | **1** |
| `--info=noname` , `--info=-name` , `--debug=nodeltasum` | **1** | 0 |
| `--info=2` (bare integer) | **1** | 0 |

`--info=help` already advertised `ALL   Set all --info options (e.g. all4)` - a form oc
rejected.

## Fix

Extract the grammar into one `output_words` module mirroring the upstream function, and
route both parsers through it:

- an empty item is skipped, not an error (`if (!len) continue;`)
- `all<N>` / `none<N>` / `help<N>` carry a level
- a level above `MAX_OUT_LEVEL` is clamped to 4, never rejected
- `no<word>` / `-<word>` and a bare integer are ordinary names, so they reach the
  unknown-item error exactly as upstream reports it

The last point removes two oc-only spellings. Neither added capability: upstream already
expresses them as `<word>0` and `all<N>`, and both remain supported - including for the
four oc-specific debug categories (`IOURING`, `CLONE`, `SOCKOPT`, `IOCP`), which are
table entries and so were never affected by this change. Docs that advertised the removed
spellings are updated to the portable form.

## Verification

- **Exit-code parity vs rsync 3.5.0: 26/26** - the 10 divergent forms above plus 16
  controls (`name`, `name0`, `none`, `all`, `name99`, `bogus`, `name,bogus`, ...) that
  must *not* move.
- **RED proven by mutation**: restoring the negation prefix in the shared classifier fails
  32 tests.
- Per-word coverage replaces the previous 17 near-identical per-word tests: every info
  word rejects both prefixes, and a non-vacuity companion asserts every word still accepts
  `<word>0` (without it, a parser that rejected everything would pass).
- The `all<N>` fan-out tests were retargeted from the removed bare-integer spelling onto
  upstream's `all<N>`, which previously had **no** coverage.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets
  --all-features --no-deps -- -D warnings` clean.
- `cargo nextest run -p cli -p logging -p transfer --all-features`: **6913 passed, 0 failed**.

## Notes

Two things I filed earlier are **refuted** by this measurement and are not part of the
problem: an unknown item *does* already exit 1, and server-mode tolerance for unknown
words already works (`parse_info_flags_server` is wired at `frontend/server/run.rs:188`).
