### PR TITLE
fix(cli): reject a -M value that does not start with a dash

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -114,6 +114,35 @@ fn check_quic_feature(matches: &clap::ArgMatches) -> Result<(), clap::Error> {
     ))
 }
 
+/// Rejects a `-M` / `--remote-option` value that does not begin with a dash.
+///
+/// upstream: options.c `case 'M'` - `if (*arg != '-') { ... "Remote option
+/// must start with a dash: %s" ... goto cleanup; }`. The guard is
+/// unconditional and sits in the argument parser, so it fires before rsync
+/// knows whether the transfer is local or remote and, in particular, before
+/// any connection is attempted. Without it a bad value survives parsing and
+/// the first sign of trouble is whatever the transport reports - oc used to
+/// dial the daemon and surface a connection error instead of the real cause.
+///
+/// The dash is tested on the raw bytes rather than a lossy string so a
+/// non-UTF-8 value is judged by what the user actually passed. An empty value
+/// has no first byte and is rejected, matching upstream, where `*arg` reads
+/// the NUL terminator.
+fn check_remote_option_dashes(remote_options: &[OsString]) -> Result<(), clap::Error> {
+    for option in remote_options {
+        if option.as_encoded_bytes().first() != Some(&b'-') {
+            return Err(clap::Error::raw(
+                clap::error::ErrorKind::ValueValidation,
+                format!(
+                    "Remote option must start with a dash: {}\n",
+                    option.to_string_lossy()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Parses command-line arguments into a structured [`ParsedArgs`] representation.
 ///
 /// This function accepts an iterator of arguments (typically from `std::env::args_os()`)
@@ -198,10 +227,11 @@ where
         .remove_one::<OsString>("quic-ca")
         .filter(|value| !value.is_empty())
         .map(std::path::PathBuf::from);
-    let remote_options = matches
+    let remote_options: Vec<OsString> = matches
         .remove_many::<OsString>("remote-option")
         .map(Iterator::collect)
         .unwrap_or_default();
+    check_remote_option_dashes(&remote_options)?;
     let protect_args = if matches.get_flag("no-protect-args") {
         Some(false)
     } else if matches.get_flag("protect-args") {

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1756,6 +1756,53 @@ mod option_values {
         assert_eq!(parsed.remote_options, vec![OsString::from("--bwlimit=100")]);
     }
 
+    // upstream: options.c `case 'M'` rejects a value that does not start with a
+    // dash, with this exact wording, during argument parsing. The tests below
+    // pin both halves of "during parsing": that the value is refused at all,
+    // and that it is refused for a remote target too - where the refusal has to
+    // beat the transport, or the user sees a connection error instead of the
+    // real cause.
+    #[test]
+    fn remote_option_without_leading_dash_is_rejected() {
+        let error =
+            parse_test_args(["-M", "nodash", "src/", "dst/"]).expect_err("parse should fail");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("Remote option must start with a dash: nodash"),
+            "error should carry upstream's wording, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn remote_option_without_leading_dash_is_rejected_for_a_remote_target() {
+        let error = parse_test_args(["-M", "nodash", "src/", "host::module/"])
+            .expect_err("parse should fail before any transport is chosen");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("Remote option must start with a dash: nodash"),
+            "error should carry upstream's wording, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn empty_remote_option_is_rejected() {
+        let error = parse_test_args(["-M", "", "src/", "dst/"]).expect_err("parse should fail");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("Remote option must start with a dash:"),
+            "an empty value has no leading dash either, got: {rendered}"
+        );
+    }
+
+    // Non-vacuity companion: without this, the two tests above would still pass
+    // if the dash check rejected every `-M` value.
+    #[test]
+    fn remote_option_with_a_leading_dash_is_accepted_for_a_remote_target() {
+        let parsed = parse_test_args(["-M", "--fake-super", "src/", "host::module/"])
+            .expect("a dashed remote option must parse");
+        assert_eq!(parsed.remote_options, vec![OsString::from("--fake-super")]);
+    }
+
     #[test]
     fn multiple_remote_options() {
         let parsed = parse_test_args(["-M", "--bwlimit=100", "-M", "--compress", "src/", "dst/"])


### PR DESCRIPTION
## What

Upstream `options.c` `case 'M'` refuses a `--remote-option` / `-M` value whose first character is not a dash:

```c
arg = poptGetOptArg(pc);
if (*arg != '-') {
    snprintf(err_buf, sizeof err_buf,
             "Remote option must start with a dash: %s\n", arg);
    goto cleanup;
}
```

The guard is unconditional and sits in the argument parser, so it fires before rsync knows whether the transfer is local or remote - and, crucially, before any connection is attempted.

oc-rsync had no such check.

## Measured divergence (real rsync 3.5.0 vs oc, before this change)

| Cell | upstream 3.5.0 | oc (before) |
|---|---|---|
| `-M nodash src/ dst/` | rc=1 `Remote option must start with a dash: nodash` | rc=1, but the **wrong reason** - the value fell through to the remote-only guard and was reported as "may only be used with remote connections" |
| `-M nodash src/ host::module/` | rc=1 at parse time | **rc=10** - the value survived parsing, so the client dialled the peer and the user saw a connection failure instead of the cause |
| `-M --fake-super src/ host::module/` (control) | rc=10 connect-fail | rc=10 connect-fail |

After this change both `nodash` cells report rc=1 with upstream's wording.

## How

One validation at the `remote-option` collection site in `crates/cli/src/frontend/arguments/parser/entry.rs`, raised through the file's existing `clap::Error::raw` idiom so it fires at parse time on both the local and the remote path.

Two details worth naming:

- The dash is tested on the **raw bytes**, not a lossy string, so a non-UTF-8 value is judged by what the user actually passed.
- An empty value (`-M ''`) has no first byte and is refused, matching upstream, where `*arg` reads the NUL terminator.

## Tests

Three rejection pins (local spelling, remote spelling, empty value) plus a **non-vacuity companion** - `-M --fake-super` against a remote target must still parse. Without the companion, all three pins would also pass if the check simply rejected every `-M` value.

RED proven by mutation. With the check removed and `--no-fail-fast` (so the kill list is not truncated):

```
FAIL empty_remote_option_is_rejected
FAIL remote_option_without_leading_dash_is_rejected
FAIL remote_option_without_leading_dash_is_rejected_for_a_remote_target
Summary  8 tests run: 5 passed, 3 failed
```

`5 + 3 = 8 = run`, so nothing was dropped from the list. Exactly the three pins die; the companion and the four pre-existing acceptance tests survive. Restored: 8/8 green.

## Scope

Deliberately narrow. This is only the value-validation half of the `-M` gap. Applying `-M` to a **local** receiver is a separate, entangled question: `remote_options` currently has zero local consumers, so removing oc's remote-only guard on its own would convert a loud refusal into a silent no-op (e.g. `--fake-super` would leave mode 0777 where upstream produces 0755). That half is untouched here, and the control row in the table above shows it unchanged.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p cli --all-features -E 'test(remote_option)'` 8/8
- End-to-end against the real 3.5.0 binary, table above
