### PR TITLE
fix(protocol): gate the end-of-flist io_error on both wire encodings

### DIFF
--- a/crates/protocol/src/flist/write/encoding.rs
+++ b/crates/protocol/src/flist/write/encoding.rs
@@ -383,21 +383,32 @@ impl FileListWriter {
     /// - Safe file list with error: two-byte sentinel + varint error code
     /// - Normal: single zero byte
     ///
-    /// upstream: flist.c:send_file_list() end-of-list write
+    /// upstream: flist.c `write_end_of_flist(int f, int send_io_error)`. There
+    /// the two encodings are governed by ONE `send_io_error` flag - the varint
+    /// arm writes `send_io_error ? io_error : 0` and the legacy arm is guarded
+    /// by `else if (send_io_error)` - and every caller computes that flag with
+    /// the same rule, whose peer-facing half is `use_safe_inc_flist`.
+    ///
+    /// A peer that never negotiated a safe file list cannot carry the error, so
+    /// upstream sends 0 rather than a value that peer would misread. That
+    /// clause therefore binds BOTH arms. It used to sit inside the legacy arm
+    /// here, which left the varint arm leaking a scan error to a protocol-30
+    /// peer without CF_SAFE_FLIST; hoisting it to the top makes it impossible
+    /// for one encoding to be updated without the other.
     pub fn write_end<W: Write + ?Sized>(
         &self,
         writer: &mut W,
         io_error: Option<i32>,
     ) -> io::Result<()> {
+        let send_io_error = io_error.filter(|_| self.use_safe_file_list());
+
         if self.use_varint_flags() {
             write_varint(writer, 0)?;
-            write_varint(writer, io_error.unwrap_or(0))?;
+            write_varint(writer, send_io_error.unwrap_or(0))?;
             return Ok(());
         }
 
-        if let Some(error) = io_error
-            && self.use_safe_file_list()
-        {
+        if let Some(error) = send_io_error {
             let marker_lo = XMIT_EXTENDED_FLAGS;
             let marker_hi = XMIT_IO_ERROR_ENDLIST;
             writer.write_all(&[marker_lo, marker_hi])?;

--- a/crates/protocol/src/flist/write/tests/basic.rs
+++ b/crates/protocol/src/flist/write/tests/basic.rs
@@ -91,6 +91,56 @@ fn write_end_without_safe_file_list_writes_normal_marker_even_with_error() {
     assert_eq!(buf, vec![0u8]);
 }
 
+// The `use_safe_inc_flist` clause binds BOTH end-of-list encodings, not just
+// the legacy one. Upstream passes a single `send_io_error` flag into
+// `write_end_of_flist` and the varint arm reads it too
+// (`write_varint(f, send_io_error ? io_error : 0)`), so a protocol-30 peer that
+// negotiated VARINT_FLIST_FLAGS but not SAFE_FILE_LIST must still see a zero.
+//
+// This is the arm that used to leak: the gate lived inside the legacy branch,
+// so the varint branch wrote the scan error to a peer that never agreed to
+// carry it. The sibling above pins the legacy arm on the same rule.
+#[test]
+fn write_end_varint_without_safe_file_list_sends_zero_even_with_error() {
+    let protocol = ProtocolVersion::try_from(30u8).unwrap();
+    let writer =
+        FileListWriter::with_compat_flags(protocol, CompatibilityFlags::VARINT_FLIST_FLAGS);
+    assert!(
+        writer.use_varint_flags(),
+        "fixture must reach the varint arm"
+    );
+    assert!(
+        !writer.use_safe_file_list(),
+        "fixture must be the un-negotiated peer this test is about"
+    );
+
+    let mut buf = Vec::new();
+    writer.write_end(&mut buf, Some(23)).unwrap();
+
+    // Zero varint (end of list) followed by a zero varint error code.
+    assert_eq!(buf, vec![0u8, 0u8]);
+}
+
+// Non-vacuity companion: without this, the test above would also pass if the
+// varint arm had stopped emitting the error to ANY peer.
+#[test]
+fn write_end_varint_with_safe_file_list_sends_the_error() {
+    let protocol = ProtocolVersion::try_from(30u8).unwrap();
+    let writer = FileListWriter::with_compat_flags(
+        protocol,
+        CompatibilityFlags::VARINT_FLIST_FLAGS | CompatibilityFlags::SAFE_FILE_LIST,
+    );
+    assert!(
+        writer.use_varint_flags(),
+        "fixture must reach the varint arm"
+    );
+
+    let mut buf = Vec::new();
+    writer.write_end(&mut buf, Some(23)).unwrap();
+
+    assert_eq!(buf, vec![0u8, 23u8]);
+}
+
 #[test]
 fn write_end_with_protocol_31_enables_safe_mode_automatically() {
     let protocol = ProtocolVersion::try_from(31u8).unwrap();


### PR DESCRIPTION
## What

Upstream's end-of-list writer takes the send/suppress decision as a **parameter** and applies it to **both** wire encodings:

```c
static void write_end_of_flist(int f, int send_io_error)
{
	if (xfer_flags_as_varint) {
		write_varint(f, 0);
		write_varint(f, send_io_error ? io_error : 0);   /* <- consults it */
	} else if (send_io_error) {                          /* <- consults it */
		write_shortint(f, XMIT_EXTENDED_FLAGS|XMIT_IO_ERROR_ENDLIST);
		write_varint(f, io_error);
	} else
		write_byte(f, 0);
}
```

Every caller computes that flag the same way, and its peer-facing half is `use_safe_inc_flist`:

```c
if (io_error == 0 || ignore_errors)  write_end_of_flist(f, 0);
else if (use_safe_inc_flist)         write_end_of_flist(f, 1);
else { ...                           write_end_of_flist(f, 0); }
```

oc applied the `use_safe_inc_flist` clause **inside the legacy arm only**:

```rust
if self.use_varint_flags() {
    write_varint(writer, 0)?;
    write_varint(writer, io_error.unwrap_or(0))?;   // <- ungated
    return Ok(());
}

if let Some(error) = io_error
    && self.use_safe_file_list()                    // <- gated
{ ... }
```

So a peer that negotiated `VARINT_FLIST_FLAGS` but **not** `SAFE_FILE_LIST` — protocol 30 without CF_SAFE_FLIST, i.e. rsync 3.0.0-3.0.6 — received a scan error it never agreed to carry. Upstream's message for exactly this situation names the affected peers: *"dying to avoid a --delete-%s issue with a pre-3.0.7 receiver"*.

## How

One expression above the branch, so both arms are governed by the same flag and neither encoding can be updated without the other:

```rust
let send_io_error = io_error.filter(|_| self.use_safe_file_list());
```

Observable wire is unchanged for every case already covered by tests. The only cell that moves is varint-without-`SAFE_FILE_LIST`, and it moves toward upstream.

## The golden tests placed this fix

My first attempt moved the decision to the *caller*, mirroring upstream's two-argument signature more literally. Four protocol-28/29 **golden wire tests** went red:

```
golden_v28_end_marker_ignores_io_error       left: [4, 16, 5]   right: [0]
golden_v29_end_of_list_ignores_io_error      left: [4, 16, 5]   right: [0]
golden_v29_end_marker_ignores_io_error       left: [4, 16, 42]  right: [0]
write_end_without_safe_file_list_...          left: [4, 16, 23]  right: [0]
```

Those goldens are **right** about the wire — at proto 28/29 the end marker is a bare zero byte even when a scan error occurred. Moving the gate to the caller would have required re-baselining four correct wire goldens and would have distributed the obligation to every present and future `write_end` call site. Hoisting it above the branch keeps one owner, keeps all four goldens byte-identical, and still fixes the leak. That is the version shipped here.

## Tests

Two new pins on the previously-uncovered arm:

- `write_end_varint_without_safe_file_list_sends_zero_even_with_error` — the fix
- `write_end_varint_with_safe_file_list_sends_the_error` — **non-vacuity companion**; without it the first would also pass if the varint arm had stopped emitting the error to *any* peer

Both assert their fixture actually reaches the varint arm, so neither can pass by landing in the legacy branch by accident.

RED proven by restoring the pre-fix shape (gate back inside the legacy arm only), with `--no-fail-fast` so the kill list is not truncated:

```
FAIL write_end_varint_without_safe_file_list_sends_zero_even_with_error
Summary  66 tests run: 65 passed, 1 failed
```

`65 + 1 = 66 = run`. Exactly the new pin dies; the companion and all four goldens stay green.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p protocol -p transfer -p engine -p batch --all-features` — **14069 passed, 0 failed**

## Residual, filed not fixed

Upstream's third clause aborts rather than proceeding when the peer cannot carry the error and a delete pass is active:

```c
if (delete_during) fatal_unsafe_io_error();   /* FERROR_XFER + RERR_UNSUPPORTED */
```

oc has **no** equivalent — `fatal_unsafe_io_error` has no counterpart anywhere in the tree. That is a distinct behaviour gap (a new fatal path, exit 4) and is deliberately **not** bundled into a wire-correctness fix. It is unreachable against every version in the interop matrix, since CF_SAFE_FLIST landed in 3.0.7 and the oldest tested peer is 3.0.9.
