### PR TITLE
fix(engine): decide each implied parent level on its own

### DIFF
--- a/crates/engine/src/local_copy/context_impl/options/dirs.rs
+++ b/crates/engine/src/local_copy/context_impl/options/dirs.rs
@@ -75,7 +75,25 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
     false
 }
 
-    /// Dry-run replacement policy: remove destination (logically) and either
+    /// Removes a non-directory occupying a level where a directory must exist.
+    ///
+    /// upstream: `generator.c:1839-1842` `recv_generator()` - a directory entry
+    /// that finds a non-directory in its place runs `delete_item(fname, ..,
+    /// del_opts | DEL_FOR_DIR)` and carries on. `--force` contributes only
+    /// `DEL_RECURSE` (`generator.c:1629`), which governs recursing into a
+    /// non-empty *directory*, so clearing a non-directory is unconditional.
+    /// Callers reach this only after establishing that `existing` is not a
+    /// directory.
+    fn clear_obstructing_non_directory(
+        &mut self,
+        parent: &Path,
+        existing: &fs::Metadata,
+    ) -> Result<(), LocalCopyError> {
+        let relative = self.parent_relative_to_destination(parent);
+        self.force_remove_destination(parent, relative, existing)
+    }
+
+    /// Dry-run replacement policy: clear the obstruction (logically) and either
     /// allow creation (Ok) or synthesize a "NotFound" error.
     fn replace_parent_entry_dry_run(
         &mut self,
@@ -83,45 +101,25 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
         existing: &fs::Metadata,
         allow_creation: bool,
     ) -> Result<(), LocalCopyError> {
-        if self.force_replacements_enabled() {
-            let relative = self.parent_relative_to_destination(parent);
-            self.force_remove_destination(parent, relative, existing)?;
-            if allow_creation {
-                Ok(())
-            } else {
-                Err(LocalCopyError::io(
-                    "create parent directory",
-                    parent.to_path_buf(),
-                    io::Error::from(io::ErrorKind::NotFound),
-                ))
-            }
-        } else {
-            Err(LocalCopyError::invalid_argument(
-                LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
-            ))
+        if allow_creation {
+            return self.clear_obstructing_non_directory(parent, existing);
         }
+        self.replace_parent_entry_forbidden(parent, existing)
     }
 
     /// Creation policy when creation is allowed and side effects are real
-    /// (non-dry-run): replace destination, create directory, and register progress.
+    /// (non-dry-run): clear the obstruction, create the directory, and register
+    /// progress.
     fn replace_parent_entry_create(
         &mut self,
         parent: &Path,
         existing: &fs::Metadata,
     ) -> Result<(), LocalCopyError> {
-        if self.force_replacements_enabled() {
-            let relative = self.parent_relative_to_destination(parent);
-            self.force_remove_destination(parent, relative, existing)?;
-            fs::create_dir_all(parent).map_err(|error| {
-                LocalCopyError::io("create parent directory", parent, error)
-            })?;
-            self.register_progress();
-            Ok(())
-        } else {
-            Err(LocalCopyError::invalid_argument(
-                LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
-            ))
-        }
+        self.clear_obstructing_non_directory(parent, existing)?;
+        fs::create_dir_all(parent)
+            .map_err(|error| LocalCopyError::io("create parent directory", parent, error))?;
+        self.register_progress();
+        Ok(())
     }
 
     /// Policy when creation is forbidden: replace destination and always return

--- a/crates/engine/src/local_copy/context_impl/options/dirs.rs
+++ b/crates/engine/src/local_copy/context_impl/options/dirs.rs
@@ -146,14 +146,58 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
         }
     }
 
+    /// Lists the destination-tree directories that must exist before `parent`
+    /// can, ordered outermost first and excluding `parent` itself.
+    ///
+    /// Empty when `parent` lies outside the destination root: that prefix is
+    /// the operator's own `--mkpath` argument rather than a path derived from
+    /// the transferred names, and keeps its single-step handling.
+    fn destination_ancestors(&self, parent: &Path) -> Vec<PathBuf> {
+        let root = self.destination_root();
+        let Ok(relative) = parent.strip_prefix(root) else {
+            return Vec::new();
+        };
+
+        let mut ancestors = Vec::new();
+        let mut current = root.to_path_buf();
+        if current != parent {
+            ancestors.push(current.clone());
+        }
+        for component in relative.components() {
+            current.push(component);
+            if current == parent {
+                break;
+            }
+            ancestors.push(current.clone());
+        }
+        ancestors
+    }
+
     /// Ensures the parent directory exists, creating it if `--implied-dirs` or
     /// `--mkpath` is enabled, or replacing a non-directory obstacle when
     /// `--force` is set.
+    ///
+    /// Each destination-tree level is decided on its own, outermost first.
+    /// upstream: `generator.c:1839-1842` `recv_generator()` receives every
+    /// implied parent as its own file-list entry, so an in-the-way
+    /// non-directory is found at the level that holds it. Resolving the whole
+    /// path in one step would instead traverse such a level, and a symlink
+    /// there would place the new directories wherever it points - outside the
+    /// destination tree.
     pub(super) fn prepare_parent_directory(&mut self, parent: &Path) -> Result<(), LocalCopyError> {
         if parent.as_os_str().is_empty() {
             return Ok(());
         }
 
+        for ancestor in self.destination_ancestors(parent) {
+            self.prepare_directory_component(&ancestor)?;
+        }
+        self.prepare_directory_component(parent)
+    }
+
+    /// Ensures one directory level exists, applying the replacement policy to
+    /// whatever currently occupies it.
+    fn prepare_directory_component(&mut self, parent: &Path) -> Result<(), LocalCopyError> {
         // Fast path: skip stat if this parent was already verified as a directory.
         // With 10K files in one directory, this avoids 9,999 redundant statx calls.
         if self.verified_parents.contains_key(parent) {

--- a/crates/engine/src/local_copy/tests/execute_relative_implied_parents.rs
+++ b/crates/engine/src/local_copy/tests/execute_relative_implied_parents.rs
@@ -1,10 +1,10 @@
 // Tests for --relative implied-parent creation across an in-the-way symlink.
 //
 // upstream: generator.c:1839-1842 recv_generator() receives each implied parent
-// as its own file-list entry and decides that level on its own, so a symlink
-// occupying one of them is found rather than traversed. Creating the whole
-// parent path in one step instead follows the symlink, and the directories land
-// wherever it points.
+// as its own file-list entry and decides that level on its own: a non-directory
+// found in its place is removed and a real directory created there. Resolving
+// the whole parent path in one step instead follows such a component, and the
+// directories land wherever it points.
 
 /// Builds `src/a/b/f` plus a destination root whose `a` component is a symlink
 /// pointing outside the destination tree, and returns the `-R`-style operands.
@@ -28,57 +28,24 @@ fn escaping_implied_parent_fixture(temp: &Path) -> (Vec<OsString>, PathBuf, Path
     (operands, destination_root, outside)
 }
 
+/// The implied parents must be created inside the destination tree, replacing
+/// the symlink rather than following it.
+///
+/// The two halves are load-bearing together: "nothing outside" alone would hold
+/// if the transfer never reached parent creation, so the landed file pins that
+/// both levels really were created through the obstructed component.
 #[cfg(unix)]
 #[test]
-fn relative_implied_parents_do_not_follow_a_symlinked_component() {
-    let temp = create_tempdir();
-    let (operands, _destination_root, outside) = escaping_implied_parent_fixture(temp.path());
-    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-
-    let error = plan
-        .execute_with_options(
-            LocalCopyExecution::Apply,
-            LocalCopyOptions::default().relative_paths(true),
-        )
-        .expect_err("a non-directory occupying an implied parent is refused");
-
-    assert!(
-        matches!(
-            error.kind(),
-            LocalCopyErrorKind::InvalidArgument(
-                LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory
-            )
-        ),
-        "unexpected error kind: {:?}",
-        error.kind()
-    );
-    assert_eq!(
-        fs::read_dir(&outside)
-            .expect("read outside tree")
-            .count(),
-        0,
-        "implied parents must not be created through the symlink"
-    );
-}
-
-/// Non-vacuity companion: on the same fixture, `--force` clears the symlink and
-/// the transfer completes wholly inside the destination tree. Without this the
-/// pin above would also hold if the fixture never reached parent creation at
-/// all.
-#[cfg(unix)]
-#[test]
-fn forced_relative_implied_parents_replace_the_symlink_in_place() {
+fn relative_implied_parents_replace_a_symlinked_component_in_place() {
     let temp = create_tempdir();
     let (operands, destination_root, outside) = escaping_implied_parent_fixture(temp.path());
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default()
-            .relative_paths(true)
-            .force_replacements(true),
+        LocalCopyOptions::default().relative_paths(true),
     )
-    .expect("forced replacement succeeds");
+    .expect("implied parents are created inside the destination tree");
 
     let copied = destination_root.join("a").join("b").join("f");
     assert_eq!(fs::read(&copied).expect("read copied"), b"payload");
@@ -92,10 +59,39 @@ fn forced_relative_implied_parents_replace_the_symlink_in_place() {
         "the in-the-way symlink must be replaced by a real directory"
     );
     assert_eq!(
-        fs::read_dir(&outside)
-            .expect("read outside tree")
-            .count(),
+        fs::read_dir(&outside).expect("read outside tree").count(),
         0,
-        "nothing may be written outside the destination tree"
+        "implied parents must not be created through the symlink"
+    );
+}
+
+/// Dry run must report the same outcome without touching either tree - in
+/// particular without creating the implied parents through the symlink.
+#[cfg(unix)]
+#[test]
+fn relative_implied_parents_dry_run_touches_neither_tree() {
+    let temp = create_tempdir();
+    let (operands, destination_root, outside) = escaping_implied_parent_fixture(temp.path());
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(
+        LocalCopyExecution::DryRun,
+        LocalCopyOptions::default().relative_paths(true),
+    )
+    .expect("dry run succeeds");
+
+    assert!(
+        destination_root
+            .join("a")
+            .symlink_metadata()
+            .expect("stat component")
+            .file_type()
+            .is_symlink(),
+        "dry run must leave the symlink in place"
+    );
+    assert_eq!(
+        fs::read_dir(&outside).expect("read outside tree").count(),
+        0,
+        "dry run must not create anything through the symlink"
     );
 }

--- a/crates/engine/src/local_copy/tests/execute_relative_implied_parents.rs
+++ b/crates/engine/src/local_copy/tests/execute_relative_implied_parents.rs
@@ -1,0 +1,101 @@
+// Tests for --relative implied-parent creation across an in-the-way symlink.
+//
+// upstream: generator.c:1839-1842 recv_generator() receives each implied parent
+// as its own file-list entry and decides that level on its own, so a symlink
+// occupying one of them is found rather than traversed. Creating the whole
+// parent path in one step instead follows the symlink, and the directories land
+// wherever it points.
+
+/// Builds `src/a/b/f` plus a destination root whose `a` component is a symlink
+/// pointing outside the destination tree, and returns the `-R`-style operands.
+#[cfg(unix)]
+fn escaping_implied_parent_fixture(temp: &Path) -> (Vec<OsString>, PathBuf, PathBuf) {
+    let source_root = temp.join("src");
+    fs::create_dir_all(source_root.join("a").join("b")).expect("create source tree");
+    fs::write(source_root.join("a").join("b").join("f"), b"payload").expect("write source");
+
+    let destination_root = temp.join("dst");
+    fs::create_dir_all(&destination_root).expect("create destination root");
+    let outside = temp.join("outside");
+    fs::create_dir_all(&outside).expect("create outside tree");
+    std::os::unix::fs::symlink(&outside, destination_root.join("a")).expect("plant symlink");
+
+    let operand = source_root.join(".").join("a").join("b").join("f");
+    let operands = vec![
+        operand.into_os_string(),
+        destination_root.clone().into_os_string(),
+    ];
+    (operands, destination_root, outside)
+}
+
+#[cfg(unix)]
+#[test]
+fn relative_implied_parents_do_not_follow_a_symlinked_component() {
+    let temp = create_tempdir();
+    let (operands, _destination_root, outside) = escaping_implied_parent_fixture(temp.path());
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let error = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().relative_paths(true),
+        )
+        .expect_err("a non-directory occupying an implied parent is refused");
+
+    assert!(
+        matches!(
+            error.kind(),
+            LocalCopyErrorKind::InvalidArgument(
+                LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory
+            )
+        ),
+        "unexpected error kind: {:?}",
+        error.kind()
+    );
+    assert_eq!(
+        fs::read_dir(&outside)
+            .expect("read outside tree")
+            .count(),
+        0,
+        "implied parents must not be created through the symlink"
+    );
+}
+
+/// Non-vacuity companion: on the same fixture, `--force` clears the symlink and
+/// the transfer completes wholly inside the destination tree. Without this the
+/// pin above would also hold if the fixture never reached parent creation at
+/// all.
+#[cfg(unix)]
+#[test]
+fn forced_relative_implied_parents_replace_the_symlink_in_place() {
+    let temp = create_tempdir();
+    let (operands, destination_root, outside) = escaping_implied_parent_fixture(temp.path());
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default()
+            .relative_paths(true)
+            .force_replacements(true),
+    )
+    .expect("forced replacement succeeds");
+
+    let copied = destination_root.join("a").join("b").join("f");
+    assert_eq!(fs::read(&copied).expect("read copied"), b"payload");
+    assert!(
+        destination_root
+            .join("a")
+            .symlink_metadata()
+            .expect("stat replaced component")
+            .file_type()
+            .is_dir(),
+        "the in-the-way symlink must be replaced by a real directory"
+    );
+    assert_eq!(
+        fs::read_dir(&outside)
+            .expect("read outside tree")
+            .count(),
+        0,
+        "nothing may be written outside the destination tree"
+    );
+}

--- a/crates/engine/src/local_copy/tests/mod.rs
+++ b/crates/engine/src/local_copy/tests/mod.rs
@@ -1019,6 +1019,7 @@ include!("execute_delay_updates_delete.rs");
 include!("execute_ignore_times.rs");
 include!("execute_inplace.rs");
 include!("execute_no_implied_dirs.rs");
+include!("execute_relative_implied_parents.rs");
 include!("execute_permissions.rs");
 include!("execute_remove_source.rs");
 include!("execute_temp_dir.rs");

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -261,8 +261,8 @@ relative pass
 relative-content pass
 relative-implied pass
 relative-implied-symlink pass
-relative-mkpath-dir-symlink fail
-relative-mkpath-symlink fail
+relative-mkpath-dir-symlink pass
+relative-mkpath-symlink pass
 relative-symlinked-parent pass
 relative-symlinked-parent-dotdot pass
 remote-shell-newline-escaping pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -261,8 +261,8 @@ relative pass
 relative-content pass
 relative-implied pass
 relative-implied-symlink pass
-relative-mkpath-dir-symlink fail
-relative-mkpath-symlink fail
+relative-mkpath-dir-symlink pass
+relative-mkpath-symlink pass
 relative-symlinked-parent pass
 relative-symlinked-parent-dotdot pass
 remote-shell-newline-escaping pass


### PR DESCRIPTION
Two commits, both measured against real upstream 3.5.0 and against pristine
master `823f388e7`.

## 1. Decide each implied parent level on its own

`prepare_parent_directory` resolved the whole implied-parent path in one step:
one `symlink_metadata` on the deepest parent, then `create_dir_all`. A symlink
at an intermediate level resolved *past*, so `create_dir_all` followed it and
the directories landed wherever it pointed - outside the destination tree.

upstream `generator.c:1839-1842` `recv_generator()` receives every implied
parent as its own file-list entry, so each level is decided on its own and an
in-the-way non-directory is found rather than traversed. The walk now goes
outermost-first over the destination-tree levels. Levels *above* the
destination root are the operator's own `--mkpath` prefix and keep their
single-step handling.

## 2. Clear an obstructing non-directory without `--force`

Making those levels visible exposed the second half: oc's replacement policy
refused a non-directory where upstream replaces it, so commit 1 alone closed
the escape but still failed a transfer upstream completes.

upstream runs `delete_item(fname, .., del_opts | DEL_FOR_DIR)` unconditionally
there; `--force` contributes only `DEL_RECURSE` (`generator.c:1629`), which
governs recursing into a non-empty *directory*. Measured against 3.5.0 on
regular-file and symlink obstructions, with and without `--force`: rc=0 and
replaced in all four cells. The three replacement policies now route through
one owner, `clear_obstructing_non_directory()`, reached only after the caller
establishes the entry is not a directory. Creation-forbidden paths are
unchanged.

## Measured outcome

`-R -a src/./a/b/f dst/` with `dst/a` a symlink pointing outside the tree:

| | rc | outside the tree | destination tree |
|---|---|---|---|
| upstream 3.5.0 | 0 | *(empty)* | `dst/a dst/a/b dst/a/b/f` |
| master `823f388e7` | 23 | **`outside/b`** | `dst/a` |
| this branch | 0 | *(empty)* | `dst/a dst/a/b dst/a/b/f` |

The escape is confirmed on pristine master, and the branch is byte-identical to
upstream on all three columns.

## Verification

- Two mutations, each killing the parity pin, each `2 passed + 1 failed == 3
  run` so no fail-fast truncation:
  - drop the per-level walk (restores one-shot resolution) -> escape returns;
  - restore the `--force` gate on obstruction removal -> refusal returns.
- The pin's two halves are load-bearing together: "nothing outside" alone would
  hold if the transfer never reached parent creation, so the landed file pins
  that both levels really were created through the obstructed component.
- A dry-run guard asserts neither tree is touched. It survives both mutations by
  design - it guards a separate property, not the fix.
- `cargo fmt --all -- --check` clean; workspace clippy `-D warnings` clean;
  `cargo nextest run -p engine --all-features` 5013/5013.

## Note on the earlier CI red

The first push failed `upstream testsuite` and `upstream testsuite (root)`. That
commit had commit 1 without commit 2, i.e. it converted a silently-followed
intermediate symlink into a refusal - which is what commit 2 corrects. Rechecking
now that both are in.
