### PR TITLE
fix(engine): clearing a directory obstruction is not --force's job

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/destination.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/destination.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::local_copy::{
-    CopyContext, LocalCopyAction, LocalCopyArgumentError, LocalCopyError, LocalCopyMetadata,
-    LocalCopyRecord, follow_symlink_metadata,
+    CopyContext, LocalCopyAction, LocalCopyError, LocalCopyMetadata, LocalCopyRecord,
+    follow_symlink_metadata,
 };
 
 /// Result of checking destination directory state.
@@ -47,8 +47,15 @@ impl DestinationState {
 /// Handles various cases:
 /// - Destination is already a directory: returns `Ready`
 /// - Destination is a symlink to a directory with `--keep-dirlinks`: returns `Ready`
-/// - Destination exists but is not a directory: removes it if force is enabled
+/// - Destination exists but is not a directory: removes it and returns `Missing`
 /// - Destination doesn't exist: returns `Missing`
+///
+/// upstream: `generator.c:1839-1842` `recv_generator()` - a directory entry
+/// that finds a non-directory in its place runs `delete_item(fname, ..,
+/// del_opts | DEL_FOR_DIR)` and carries on. `--force` contributes only
+/// `DEL_RECURSE` (`generator.c:1629`), which governs recursing into a
+/// non-empty *directory*, so clearing a non-directory is unconditional.
+/// `force_remove_destination` elides the removal under `--dry-run`.
 #[inline]
 pub(super) fn check_destination_state(
     context: &mut CopyContext,
@@ -60,27 +67,16 @@ pub(super) fn check_destination_state(
             let file_type = existing.file_type();
             if file_type.is_dir() {
                 // Directory already present; nothing to do.
-                Ok(DestinationState::Ready(Some(existing)))
-            } else if file_type.is_symlink() && context.keep_dirlinks_enabled() {
+                return Ok(DestinationState::Ready(Some(existing)));
+            }
+            if file_type.is_symlink() && context.keep_dirlinks_enabled() {
                 let target_metadata = follow_symlink_metadata(destination)?;
                 if target_metadata.file_type().is_dir() {
-                    Ok(DestinationState::Ready(Some(target_metadata)))
-                } else if context.force_replacements_enabled() {
-                    context.force_remove_destination(destination, relative, &existing)?;
-                    Ok(DestinationState::Missing)
-                } else {
-                    Err(LocalCopyError::invalid_argument(
-                        LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
-                    ))
+                    return Ok(DestinationState::Ready(Some(target_metadata)));
                 }
-            } else if context.force_replacements_enabled() {
-                context.force_remove_destination(destination, relative, &existing)?;
-                Ok(DestinationState::Missing)
-            } else {
-                Err(LocalCopyError::invalid_argument(
-                    LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
-                ))
             }
+            context.force_remove_destination(destination, relative, &existing)?;
+            Ok(DestinationState::Missing)
         }
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(DestinationState::Missing),
         Err(error) => Err(LocalCopyError::io(

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -419,21 +419,18 @@ pub(crate) fn copy_sources(
                 && fs::symlink_metadata(source.path()).is_ok_and(|meta| meta.is_dir())
                 && fs::read_dir(source.path()).is_ok_and(|mut entries| entries.next().is_some())
             {
-                // A pre-existing non-directory destination blocks the mkdir.
-                // When force replacements are enabled, remove it first (mirrors
-                // the per-entry force-replace path in handlers.rs) so the
-                // source name is preserved as `dest/<source>/`. Without force,
-                // refuse to replace the existing file with a directory, mirroring
-                // the recursive executor's error for the same conflict.
+                // A pre-existing non-directory destination blocks the mkdir, so
+                // clear it first and let the source name land as
+                // `dest/<source>/`. upstream: generator.c:1839-1842
+                // recv_generator() removes it with `delete_item(fname, ..,
+                // del_opts | DEL_FOR_DIR)` regardless of `--force`, which
+                // contributes only DEL_RECURSE (generator.c:1629) and so
+                // governs recursing into a non-empty *directory*, not this.
                 if destination_state.exists && !destination_state.is_dir {
-                    if context.force_replacements_enabled() && !context.mode().is_dry_run() {
+                    if !context.mode().is_dry_run() {
                         remove_existing_destination(destination_path)?;
-                        destination_state.exists = false;
-                    } else {
-                        return Err(LocalCopyError::invalid_argument(
-                            LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
-                        ));
                     }
+                    destination_state.exists = false;
                 }
                 destination_root_created |= ensure_destination_directory(
                     destination_path,

--- a/crates/engine/src/local_copy/tests/execute_directories.rs
+++ b/crates/engine/src/local_copy/tests/execute_directories.rs
@@ -1034,8 +1034,12 @@ fn execute_directory_nested_already_exists_merges_content() {
     assert_eq!(fs::read(dest_nested.join("existing.txt")).expect("read existing"), b"existing content");
 }
 
+/// upstream: `generator.c:1839-1842` `recv_generator()` clears a non-directory
+/// standing where a directory belongs and carries on. `--force` contributes
+/// only `DEL_RECURSE` (`generator.c:1629`), which governs recursing into a
+/// non-empty *directory*, so this replacement needs no flag.
 #[test]
-fn execute_directory_errors_when_destination_is_file_without_force() {
+fn execute_directory_replaces_destination_file_without_force() {
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source dir");
@@ -1050,14 +1054,13 @@ fn execute_directory_errors_when_destination_is_file_without_force() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let error = plan.execute().expect_err("should fail to replace file with directory");
+    plan.execute().expect("obstructing file is cleared, not refused");
 
-    match error.kind() {
-        LocalCopyErrorKind::InvalidArgument(reason) => {
-            assert_eq!(*reason, LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory);
-        }
-        other => panic!("unexpected error kind: {other:?}"),
-    }
+    assert!(destination.is_dir(), "destination file replaced by a directory");
+    assert_eq!(
+        fs::read(destination.join("source").join("child.txt")).expect("read copied child"),
+        b"content"
+    );
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_dirlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_dirlinks.rs
@@ -136,9 +136,13 @@ fn execute_with_keep_dirlinks_allows_destination_directory_symlink() {
     assert!(summary.directories_created() >= 1);
 }
 
+/// Without `--keep-dirlinks` a destination symlink is an obstruction, so it is
+/// removed and a real directory takes its place - the link is never followed.
+/// upstream: `generator.c:1839-1842` `delete_item(.., DEL_FOR_DIR)`; only
+/// `--keep-dirlinks` makes a symlink-to-directory count as a directory.
 #[cfg(unix)]
 #[test]
-fn execute_without_keep_dirlinks_rejects_destination_directory_symlink() {
+fn execute_without_keep_dirlinks_replaces_destination_symlink_in_place() {
     use std::os::unix::fs::symlink;
 
     let temp = tempdir().expect("tempdir");
@@ -157,22 +161,24 @@ fn execute_without_keep_dirlinks_rejects_destination_directory_symlink() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let result = plan.execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default());
+    plan.execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
+        .expect("obstructing symlink is cleared, not refused");
 
-    let error = result.expect_err("keep-dirlinks disabled should reject destination symlink");
-    assert!(matches!(
-        error.kind(),
-        LocalCopyErrorKind::InvalidArgument(
-            LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory
-        )
-    ));
     assert!(
-        fs::symlink_metadata(&destination_link)
-            .expect("destination link metadata")
+        !fs::symlink_metadata(&destination_link)
+            .expect("destination metadata")
             .file_type()
-            .is_symlink()
+            .is_symlink(),
+        "symlink replaced by a real directory"
     );
-    assert!(!actual_destination.join("src-dir").join("file.txt").exists());
+    assert_eq!(
+        fs::read(destination_link.join("src-dir").join("file.txt")).expect("read copied file"),
+        b"payload"
+    );
+    assert!(
+        !actual_destination.join("src-dir").exists(),
+        "the link target must not be written through"
+    );
 }
 
 #[cfg(unix)]
@@ -272,9 +278,13 @@ fn without_keep_dirlinks_force_replaces_symlink_subdir_with_real_directory() {
     );
 }
 
+/// `--keep-dirlinks` only spares a symlink whose target is a *directory*. A
+/// symlink to a regular file is an ordinary obstruction: it is removed and a
+/// real directory replaces it, leaving the link target untouched.
+/// upstream: `generator.c:1839-1842` `delete_item(.., DEL_FOR_DIR)`.
 #[cfg(unix)]
 #[test]
-fn keep_dirlinks_with_symlink_to_file_errors() {
+fn keep_dirlinks_replaces_symlink_to_file_without_force() {
     use std::os::unix::fs::symlink;
 
     let temp = tempdir().expect("tempdir");
@@ -295,22 +305,23 @@ fn keep_dirlinks_with_symlink_to_file_errors() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let error = plan
-        .execute_with_options(
-            LocalCopyExecution::Apply,
-            LocalCopyOptions::default().keep_dirlinks(true),
-        )
-        .expect_err("should fail when symlink target is a file, not a directory");
-
-    assert!(matches!(
-        error.kind(),
-        LocalCopyErrorKind::InvalidArgument(
-            LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory
-        )
-    ));
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().keep_dirlinks(true),
+    )
+    .expect("symlink-to-file is an obstruction, not a dirlink");
 
     let meta = fs::symlink_metadata(dest_root.join("subdir")).expect("subdir metadata");
-    assert!(meta.file_type().is_symlink(), "symlink should remain");
+    assert!(meta.file_type().is_dir(), "symlink replaced by a real directory");
+    assert_eq!(
+        fs::read(dest_root.join("subdir").join("child.txt")).expect("read copied child"),
+        b"data"
+    );
+    assert_eq!(
+        fs::read(&file_target).expect("read link target"),
+        b"not-a-dir",
+        "the link target must not be written through"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/engine/src/local_copy/tests/execute_force.rs
+++ b/crates/engine/src/local_copy/tests/execute_force.rs
@@ -126,8 +126,13 @@ fn force_directory_replaces_file() {
     );
 }
 
+/// Companion to `force_replaces_file_with_directory_during_recursive_copy`:
+/// clearing a non-directory that obstructs a directory is not `--force`'s job.
+/// upstream: `generator.c:1839-1842` runs `delete_item(.., DEL_FOR_DIR)`
+/// unconditionally; `--force` only adds `DEL_RECURSE` (`generator.c:1629`),
+/// which governs recursing into a non-empty *directory*.
 #[test]
-fn force_disabled_directory_cannot_replace_file() {
+fn force_disabled_directory_still_replaces_file() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("srcdir");
     fs::create_dir_all(&source_root).expect("create source dir");
@@ -142,23 +147,17 @@ fn force_disabled_directory_cannot_replace_file() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let error = plan
-        .execute_with_options(
-            LocalCopyExecution::Apply,
-            LocalCopyOptions::default().force_replacements(false),
-        )
-        .expect_err("should fail without force");
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().force_replacements(false),
+    )
+    .expect("obstruction cleared without --force");
 
-    match error.kind() {
-        LocalCopyErrorKind::InvalidArgument(reason) => {
-            assert_eq!(
-                *reason,
-                LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory
-            );
-        }
-        other => panic!("unexpected error kind: {other:?}"),
-    }
-    assert!(destination.is_file(), "file should remain");
+    assert!(destination.is_dir(), "file replaced by a directory");
+    assert_eq!(
+        fs::read(destination.join("srcdir").join("file.txt")).expect("read copied file"),
+        b"content"
+    );
 }
 
 #[test]

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -169,7 +169,7 @@ io-nosend-flood-recursion skip
 io-readargs-argv-nullwrite skip
 itemize pass
 iwildmatch-fold pass
-keep-dirlinks-rule fail
+keep-dirlinks-rule pass
 keep-dirlinks-symlinked-dest pass
 ki58-log-format-percent pass
 ki62-io-error-mask skip

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -169,7 +169,7 @@ io-nosend-flood-recursion skip
 io-readargs-argv-nullwrite skip
 itemize pass
 iwildmatch-fold pass
-keep-dirlinks-rule fail
+keep-dirlinks-rule pass
 keep-dirlinks-symlinked-dest pass
 ki58-log-format-percent pass
 ki62-io-error-mask skip


### PR DESCRIPTION
## What

Clearing a non-directory that stands where a directory belongs is not `--force`'s job. Two local-copy sites still gated that removal on `--force` and refused instead.

## Upstream rule

`generator.c:1839-1842` `recv_generator()`:

```c
if (statret == 0 && stype != FT_DIR) {
    if (delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_DIR) != 0)
        goto skipping_dir_contents;
    statret = -1;
}
```

`del_opts` is `delete_mode || force_delete ? DEL_RECURSE : 0` (`generator.c:1629`, `:2481`). `DEL_RECURSE` governs recursing into a non-empty *directory*, so `--force` never gates clearing a non-directory - that removal is unconditional.

## Measured against rsync 3.5.0

`-a src/ dst/`, with `dst/sub` obstructed four ways. Master is the merge-base (`5f039cefb`), built fresh.

| `dst/sub` is | upstream 3.5.0 | master | this branch |
|---|---|---|---|
| symlink to an in-tree dir | rc=0, replaced | **rc=23, refused** | rc=0, replaced |
| symlink escaping the tree | rc=0, replaced | **rc=23, refused** | rc=0, replaced |
| regular file | rc=0, replaced | **rc=23, refused** | rc=0, replaced |
| symlink to a file, under `-K` | rc=0, replaced | **rc=23, refused** | rc=0, replaced |

4/4 now byte-identical to upstream. In the symlink rows the link is *removed*, not followed - the target tree is verified untouched in every cell.

## Sites

| Site | Path shape | Change |
|---|---|---|
| `executor/directory/recursive/destination.rs` | recursive descent | two `--force`-gated arms collapse to one unconditional `force_remove_destination` |
| `executor/sources/orchestration.rs` | named destination operand | drop the `force_replacements_enabled()` conjunct only |

The dry-run guard is **kept** at the orchestration site: it calls the raw `remove_existing_destination` helper. The recursive site delegates to `force_remove_destination`, which already elides the removal under `--dry-run` (`context_impl/backup.rs:384`) - verified rather than assumed.

`replace_parent_entry_forbidden` (`context_impl/options/dirs.rs:142`) is **deliberately unchanged**: when creation is disallowed upstream never reaches the removal, so `ReplaceNonDirectoryWithDirectory` stays live and reachable.

## Tests

Four tests asserted the old refusal - their names stated the behaviour being changed. Each is rebased onto upstream's measured outcome and *strengthened* to assert the link target is not written through, which is the property the refusal was standing in for and which nothing previously checked.

Mutation kill matrix, each site restored independently, `--no-fail-fast`, `passed + failed == run` verified both times:

| Mutation | Killed |
|---|---|
| restore the gate in `destination.rs` | `keep_dirlinks_replaces_symlink_to_file_without_force` (1 of 5013) |
| restore the gate in `orchestration.rs` | the other 3 (3 of 5013) |

Disjoint - each site has its own covering test, so neither can regress silently.

`-p engine` 5013/5013. `cargo fmt --all -- --check` and full-workspace `clippy -D warnings` clean. The `ReplaceNonDirectoryWithDirectory` variant has no remaining test-only assertions anywhere in the workspace, so no root-level integration cell is left encoding the old behaviour.

## CI follow-up: one ledger row moved (second commit)

The 3.5.0 conformance gate reddened on an **unexpected PASS**, which is the gate working as designed: `--expect-result` fails on a test that starts passing, so the divergence set can only shrink deliberately.

`keep-dirlinks-rule` is the row, and it pins exactly the rule this change implements — quoting the test's own docstring:

> sender has a non-dir (file) of that name -> `-K` does not apply, the dest symlink is replaced by the file;
> default (no `-K`) -> the dest symlink is deleted and recreated as a real dir.

Measured on the same fixture, all three binaries:

| binary | result |
|---|---|
| upstream 3.5.0 | PASS |
| master | FAIL |
| this branch | PASS |

Corroborated by the CI shape: both **pipe** legs (nonroot and root) went red while both **TCP** legs stayed green — and the row exists only in the two pipe manifests. That is the exact footprint of this single row moving, and it also confirms nothing else regressed.

Re-baselined to `pass` in the two pipe manifests, two lines total. Flipping an observed pass back to `fail` would be the waiver; recording it is the honest ledger update.

`no-implied-dirs-symlink` is deliberately **left at `fail`**: it fails identically on master and this branch, and its failing arm is the `--no-implied-dirs` case, which this change intentionally does not touch.
