### PR TITLE
fix(receiver): apply the daemon filter to the destination argument

### DIFF
--- a/crates/transfer/src/receiver/dest_root.rs
+++ b/crates/transfer/src/receiver/dest_root.rs
@@ -85,9 +85,16 @@ pub(in crate::receiver) fn dest_arg_has_trailing_slash(arg: &OsStr) -> bool {
 ///   once here, then the sandbox locks every subsequent open below that
 ///   resolved fd.
 /// - The daemon module-containment check is performed by the daemon module
-///   loader, not by this helper. A symlinked dest cannot escape the module
-///   root because the daemon already chroots / restricts `module.path` at
-///   the module-config layer.
+///   loader, not by this helper.
+///
+/// ⚠ Containment alone is *not* sufficient on a `path = /` module: upstream's
+/// `abspath_outside_confinement` short-circuits when the confinement root is
+/// `/` (`rootlen <= 1`, `syscall.c:206-207`), so nothing about `module.path`
+/// constrains a peer-supplied `..` traversal there. What upstream relies on in
+/// that configuration is the module's NAME-based `exclude`, applied to the
+/// destination argument in `get_local_name()` (`main.c:718-737`). oc mirrors
+/// that in `ReceiverContext::reject_daemon_excluded_destination`, which runs
+/// before this helper.
 ///
 /// [`DirSandbox`]: fast_io::DirSandbox
 ///

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
@@ -176,3 +176,91 @@ fn refused_directory_swallows_its_contents_without_a_second_report() {
         "an allowed tree must not be swallowed"
     );
 }
+
+/// Builds a receiver whose daemon module excludes `secret`, the shape the
+/// `operator-path-traversal-*-daemon` conformance cells use.
+fn ctx_excluding(pattern: &str) -> ReceiverContext {
+    use protocol::filters::{FilterRuleWireFormat, RuleType};
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.daemon_filter_rules = vec![FilterRuleWireFormat {
+        rule_type: RuleType::Exclude,
+        pattern: pattern.into(),
+        ..FilterRuleWireFormat::default()
+    }];
+    ReceiverContext::new_for_test(&handshake, config)
+}
+
+fn refusal(ctx: &ReceiverContext, dest: &str) -> Option<String> {
+    ctx.reject_daemon_excluded_destination(std::path::Path::new(dest))
+        .err()
+        .map(|e| e.to_string())
+}
+
+/// THE ESCAPE (task 819): on a `path = /` module the daemon `exclude` is the
+/// only thing stopping a peer-supplied `..` traversal, because upstream's
+/// `abspath_outside_confinement` short-circuits at `rootlen <= 1`
+/// (`syscall.c:206-207`). The name check must therefore run on the collapsed
+/// path, so `pub/../secret` is refused exactly as a bare `secret` is.
+///
+/// upstream: `main.c:718-737` `get_local_name()`.
+#[test]
+fn daemon_excluded_destination_is_refused_after_dot_dot_collapse() {
+    let ctx = ctx_excluding("secret");
+
+    let direct = refusal(&ctx, "secret").expect("a directly excluded dest must be refused");
+    assert!(
+        direct.contains("daemon has excluded destination"),
+        "upstream wording expected, got: {direct}"
+    );
+
+    let traversed =
+        refusal(&ctx, "pub/../secret").expect("a '..' traversal into the excluded subtree escapes");
+    assert!(
+        traversed.contains("daemon has excluded destination"),
+        "upstream wording expected, got: {traversed}"
+    );
+    // upstream quotes the ORIGINAL argument, not the collapsed copy.
+    assert!(
+        traversed.contains("\"pub/../secret\""),
+        "the original operand must be quoted, got: {traversed}"
+    );
+}
+
+/// Non-vacuity companion: without this the refusal test would still pass if
+/// the check simply refused everything.
+#[test]
+fn daemon_allows_a_destination_no_rule_excludes() {
+    let ctx = ctx_excluding("secret");
+    assert!(
+        refusal(&ctx, "public/data").is_none(),
+        "an unexcluded destination must be accepted"
+    );
+    assert!(
+        refusal(&ctx, ".").is_none(),
+        "upstream skips the check entirely for a bare '.'"
+    );
+}
+
+/// A receiver with no daemon filter must not gain a new refusal path.
+#[test]
+fn destination_check_is_inert_without_a_daemon_filter() {
+    let handshake = test_handshake();
+    let ctx = ReceiverContext::new_for_test(&handshake, test_config());
+    assert!(refusal(&ctx, "anything/at/all").is_none());
+}
+
+/// The trailing-slash rule form must keep its `XFLG_DIR2WILD3` meaning
+/// (`exclude.c:308-313`): `/excluded/` becomes `<pat>/***`, matching the
+/// directory and its contents. Testing BOTH `is_dir` values is why upstream
+/// ORs its two `check_filter()` calls - a dir-only rule is invisible to a
+/// file-only probe.
+#[test]
+fn daemon_excluded_destination_honours_dir_only_rules() {
+    let ctx = ctx_excluding("excluded/");
+    assert!(
+        refusal(&ctx, "excluded").is_some(),
+        "a dir-only rule must still refuse the directory itself"
+    );
+}

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -7,7 +7,7 @@
 //! forwarding helpers live alongside it.
 
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use logging::debug_log;
@@ -335,6 +335,66 @@ impl ReceiverContext {
             .with_group_mapping(self.config.group_mapping.clone())
     }
 
+    /// Refuses a destination argument that the daemon module's own filter list
+    /// excludes.
+    ///
+    /// upstream: `main.c:718-737` `get_local_name()` - when
+    /// `daemon_filter_list.head` is set, the destination argument is checked by
+    /// NAME against the daemon filter and the transfer is aborted with
+    /// `RERR_FILESELECT` if it matches. The check runs before the destination
+    /// is stat'ed or rewritten, which is why it sits here rather than beside
+    /// the pre-flight mkdir.
+    ///
+    /// The match is performed on a `..`-collapsed *copy* so a `../excluded`
+    /// destination is caught by name; upstream leaves the real path alone for
+    /// the resolver. This is deliberately a name-based filter decision and not
+    /// a confinement one: on a `path = /` module upstream's
+    /// `abspath_outside_confinement` short-circuits (`rootlen <= 1`,
+    /// `syscall.c:206-207`), so the module `exclude` is the *only* thing
+    /// standing between a peer-supplied `..` traversal and the excluded
+    /// subtree.
+    ///
+    /// Both `is_dir` values are tested because upstream ORs the two
+    /// `check_filter()` calls: a rule written `/excluded/` only matches as a
+    /// directory (`XFLG_DIR2WILD3`, `exclude.c:308-313`), while a bare
+    /// `/excluded` only matches as a file.
+    ///
+    /// `crates/transfer` sits below `crates/core`, so `ExitCode::FileSelect`
+    /// is not nameable here; `ErrorKind::PermissionDenied` is what
+    /// `ExitCode::from_io_error` maps to that code.
+    pub(in crate::receiver) fn reject_daemon_excluded_destination(
+        &self,
+        dest: &Path,
+    ) -> io::Result<()> {
+        let Some(filters) = self.daemon_filter_set() else {
+            return Ok(());
+        };
+        let cleaned = filters::collapse_dot_dot_dirs(dest);
+        // upstream: main.c:729-730 - a trailing `/` or `/.` component is
+        // lopped off before matching, and a bare `.` is not checked at all.
+        let cleaned = match cleaned.file_name() {
+            Some(name) if name == "." => {
+                cleaned.parent().map_or(cleaned.clone(), Path::to_path_buf)
+            }
+            _ => cleaned,
+        };
+        if cleaned.as_os_str().is_empty() || cleaned == Path::new(".") {
+            return Ok(());
+        }
+        if filters.allows(&cleaned, false) && filters.allows(&cleaned, true) {
+            return Ok(());
+        }
+        // upstream: main.c:734-735 quotes the ORIGINAL argument, not the
+        // collapsed copy used for matching.
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "ERROR: daemon has excluded destination \"{}\"",
+                dest.display()
+            ),
+        ))
+    }
+
     fn build_pipeline_setup(&mut self, file_count: usize) -> io::Result<(usize, PipelineSetup)> {
         let removed = self.sanitize_file_list();
         let file_count = file_count - removed;
@@ -366,6 +426,8 @@ impl ReceiverContext {
         let dest_arg = self.config.args.first();
         let trailing_slash = dest_arg.is_some_and(|arg| dest_arg_has_trailing_slash(arg));
         let dest_dir = dest_arg.map_or_else(|| PathBuf::from("."), PathBuf::from);
+
+        self.reject_daemon_excluded_destination(&dest_dir)?;
 
         // upstream: main.c:805-832 get_local_name() - single-file rename
         // semantics. When the transfer is exactly one non-directory entry,


### PR DESCRIPTION
## What

A peer-supplied `..` traversal in the destination argument reaches a subtree the daemon module `exclude`s, and writes there. oc never applied the module filter to the destination.

Observed on the `operator-path-traversal-dest-dir-daemon` and `operator-path-traversal-backup-dir-daemon` conformance cells, where upstream reports "did not escape" for both:

```
escaped: a dest '..' traversal reached the excluded subtree
         (.../secret/f0 is now 'NEW-PUSHED-CONTENT\n')
escaped: a --backup-dir '..' traversal reached the excluded subtree
         (.../secret/f0 is now 'OLD-DESTINATION-FILE-CONTENT\n')
```

`grep -rn "daemon has excluded" crates/` returned nothing on master.

## ⚠ Confinement is not what stops upstream — this does not belong in the resolver

On a `path = /` module the confinement root is `/`, so `abspath_outside_confinement` short-circuits (`if (rootlen <= 1) return 0;`, `syscall.c:206-207`). Nothing about `module.path` constrains the traversal there. What upstream relies on is the module's **name-based** `exclude`, applied to the destination argument in `get_local_name()` (`main.c:718-737`) — which is why the fix is a filter application, not a confinement change.

Upstream's own comment gives the rationale: the daemon exclude is name-based, so a symlink whose *name* is not excluded is still followed (`rsyncd.conf` "munge symlinks").

## The rule, mirrored exactly

| upstream | mirrored |
|---|---|
| gated on `daemon_filter_list.head` | gated on `daemon_filter_set()` |
| matches a `..`-collapsed **copy**, real path left for the resolver | `filters::collapse_dot_dot_dirs` on a copy |
| strips a trailing `/` or `/.`; skips a bare `.` | same |
| `check_filter(.., 0) < 0 \|\| check_filter(.., 1) < 0` — **both** `is_dir` values | `!allows(p,false) \|\| !allows(p,true)` |
| quotes the **original** argument, not the collapsed copy | same |
| `exit_cleanup(RERR_FILESELECT)` = 3 | see below |

Both `is_dir` values matter: `XFLG_DIR2WILD3` (`exclude.c:308-313`) rewrites a trailing-`/` exclude into `<pat>/***`, so `/excluded/` matches only as a directory while bare `/excluded` matches only as a file. A single-`is_dir` probe would silently miss half the rule forms.

## Placement and layering

Placed immediately after the destination operand is read and **before** `apply_single_file_rename` or the pre-flight mkdir — matching upstream, where the check precedes the `do_stat`.

⚠ **`crates/transfer` has no `core` dependency** (it sits below core), so `ExitCode::FileSelect` is not nameable at this site. The refusal is raised as `ErrorKind::PermissionDenied`, which `ExitCode::from_io_error` maps to 3. Naming the constant directly would not compile.

It could not go inside `ensure_dest_root_exists` either — that is a free function with no access to the filter set.

## A comment that documented the defeated premise

`dest_root.rs:87-90` asserted that module containment protects the destination "because the daemon already chroots / restricts `module.path`". That is precisely the argument that does not hold for `path = /`, and is plausibly why the gap survived review. Corrected in the same change rather than left standing.

## Tests

RED proven by neutering the check — the kill matrix is exactly right:

| | result |
|---|---|
| `daemon_excluded_destination_is_refused_after_dot_dot_collapse` | **FAIL** |
| `daemon_excluded_destination_honours_dir_only_rules` | **FAIL** |
| `daemon_allows_a_destination_no_rule_excludes` (non-vacuity) | stays green |
| `destination_check_is_inert_without_a_daemon_filter` (non-vacuity) | stays green |

`2 passed + 2 failed = 4 run`. Without the two companions the refusal tests would still pass if the check simply refused everything, or if it fired where no daemon filter exists.

`-p transfer` 2761/2761, `cargo fmt --all -- --check` clean, full-workspace `clippy -D warnings` exit 0 with zero diagnostics.

⚠ Method note: the suite first reported 37 failures, all at ~0.01s — the vacuity signature of binary-dependent integration tests with no `oc-rsync` built in the worktree. Building the binary first returned 2761/2761, confirming they were unrelated rather than assuming so.
