### PR TITLE
fix(sender): read a source symlink target through the confined parent

### DIFF
--- a/crates/fast_io/src/confined_open.rs
+++ b/crates/fast_io/src/confined_open.rs
@@ -181,6 +181,45 @@ pub fn pin_dest_leaf_confined(
     imp::pin_dest_leaf_confined(root, relative, kind)
 }
 
+/// Reads the symlink target of `root`/`relative` with the parent components
+/// resolved confined beneath `root`.
+///
+/// This is the file-list counterpart to [`open_source_confined`]: the sender
+/// records a symlink's target in the flist, and a path-based `readlink` re-walks
+/// every parent component at call time, so a parent raced into a symlink
+/// pointing out of the module redirects the read and the *outside* link's target
+/// is what goes on the wire. Resolving the parent once through the confined walk
+/// and reading the leaf with `readlinkat` against the held fd closes that window:
+/// the fd cannot be redirected after the fact.
+///
+/// The leaf is never followed - a `readlink` reads the link itself - so unlike
+/// the source open there is no leaf policy to choose.
+///
+/// # Errors
+///
+/// - `EINVAL` when `relative` is absolute, contains a `..` component, or names
+///   something that is not a symlink (the `readlink` contract).
+/// - `EISDIR` when `relative` has no leaf: it is empty, all slashes, or its
+///   final component is `.` or `..`.
+/// - `ELOOP` when the parent walk refuses a symlink - an absolute or escaping
+///   target, or an exhausted hop budget.
+/// - `ENOENT` when the leaf does not exist beneath `root`.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/flist.c:247-255` `scan_readlink()` - reads the leaf with
+///   `do_readlink_atfd(scan_dirfd, ...)` against the already-open scan dir.
+/// - `rsync-3.5.0/flist.c:2028-2059` `secure_opendir()` - the daemon arm that
+///   obtains that dirfd through `secure_relative_open_at()`, which is what makes
+///   the subsequent `readlinkat` race-free.
+/// - `rsync-3.5.0/util1.c:1216` `change_dir()` - the same confinement applied to
+///   the per-argument directory descent, so a named `dir/link` operand is
+///   covered even when no directory scan is running.
+pub fn read_link_confined(root: &Path, relative: &Path) -> io::Result<std::path::PathBuf> {
+    validate_relative(relative)?;
+    imp::read_link_confined(root, relative)
+}
+
 /// Rejects an absolute `relative` or any `..` component up front with
 /// `EINVAL`, matching upstream `secure_relative_open`'s portable front-door
 /// check (`path_has_dotdot_component`). `.` and normal components are
@@ -283,6 +322,15 @@ mod imp {
             flags |= libc::O_DIRECTORY;
         }
         openat(parent.root_dirfd(), leaf, flags, 0)
+    }
+
+    pub(super) fn read_link_confined(
+        root: &Path,
+        relative: &Path,
+    ) -> io::Result<std::path::PathBuf> {
+        let (_, dir, leaf) = split_leaf(relative)?;
+        let parent = resolve_parent(root, dir)?;
+        readlinkat(parent.root_dirfd(), leaf)
     }
 
     /// Resolve `relative`'s parent through the shared confined resolver, then
@@ -571,6 +619,16 @@ mod imp {
         Err(io::Error::new(
             io::ErrorKind::Unsupported,
             "confined destination leaf pin is Unix-only (it exists for fd-based xattr/ACL writes)",
+        ))
+    }
+
+    pub(super) fn read_link_confined(
+        _root: &Path,
+        _relative: &Path,
+    ) -> io::Result<std::path::PathBuf> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "confined readlink is Unix-only (the daemon sender is Unix-only)",
         ))
     }
 }
@@ -1056,6 +1114,84 @@ mod tests {
             DestLeafKind::NonDirectory,
         )
         .expect_err("`..` must be rejected");
+        assert_eq!(error.raw_os_error(), Some(libc::EINVAL), "got {error:?}");
+    }
+
+    /// A symlink read through the confined helper must return the in-module
+    /// target, so the escape tests below discriminate rather than pass because
+    /// the helper refuses everything.
+    #[test]
+    fn read_link_confined_reads_an_in_module_link() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        std::fs::create_dir(root.join("real")).expect("mkdir real");
+        symlink("inside-target", root.join("real/link")).expect("symlink");
+
+        let target = read_link_confined(&root, Path::new("real/link")).expect("read the link");
+        assert_eq!(target, PathBuf::from("inside-target"));
+    }
+
+    /// THE DEFECT: a parent component raced into a symlink pointing out of the
+    /// module must not redirect the read.
+    ///
+    /// WHY: the sender records this target in the file list, so following the
+    /// raced parent puts the *outside* link's target on the wire - an
+    /// information leak from a tree the module does not contain. Upstream
+    /// resolves the parent once through `secure_relative_open()` and reads the
+    /// leaf against the held fd (`flist.c:247-255`, `util1.c:1216`); a
+    /// path-based `readlink` re-walks the parent on every call and has no such
+    /// window closed.
+    #[test]
+    fn read_link_confined_refuses_a_parent_symlink_escaping_the_root() {
+        let base = tempfile::tempdir().expect("tempdir");
+        let base = std::fs::canonicalize(base.path()).expect("canonicalize");
+        let root = base.join("module");
+        std::fs::create_dir(&root).expect("mkdir module");
+        let outside = base.join("outside");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        symlink("OUTSIDE-LINK-TARGET", outside.join("link")).expect("outside link");
+        // The raced flip: the module's `real` directory becomes a symlink out.
+        symlink(&outside, root.join("real")).expect("plant the escape");
+
+        let error = read_link_confined(&root, Path::new("real/link"))
+            .expect_err("the confined read must refuse the escaping parent");
+        let code = error.raw_os_error();
+        assert!(
+            code == Some(libc::EXDEV) || code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
+            "expected a confinement refusal, got: {error:?}"
+        );
+    }
+
+    /// An in-tree directory symlink is still followed, so a legitimate module
+    /// layout keeps working.
+    ///
+    /// WHY: upstream's walk refuses escapes, not symlinks (`ds_descend`,
+    /// `syscall.c:2961`). A helper that refused every symlinked parent would
+    /// break ordinary modules while passing the escape test above - which is
+    /// exactly the over-refusal this pins against.
+    #[test]
+    fn read_link_confined_follows_an_in_tree_directory_symlink() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        std::fs::create_dir(root.join("real")).expect("mkdir real");
+        symlink("in-module-target", root.join("real/link")).expect("symlink");
+        symlink("real", root.join("alias")).expect("in-tree dir symlink");
+
+        let target = read_link_confined(&root, Path::new("alias/link"))
+            .expect("an in-tree directory symlink must still be followed");
+        assert_eq!(target, PathBuf::from("in-module-target"));
+    }
+
+    /// A non-symlink leaf reports `EINVAL`, the `readlink(2)` contract the
+    /// callers' error handling is written against.
+    #[test]
+    fn read_link_confined_reports_einval_for_a_non_symlink() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        std::fs::write(root.join("plain"), b"not a link").expect("write");
+
+        let error = read_link_confined(&root, Path::new("plain"))
+            .expect_err("a regular file is not a symlink");
         assert_eq!(error.raw_os_error(), Some(libc::EINVAL), "got {error:?}");
     }
 }

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -371,7 +371,9 @@ pub use traits::{FileReader, FileWriter};
 pub use gcd::{GcdQueue, GcdReader, GcdWriter};
 
 #[cfg(unix)]
-pub use confined_open::{DestLeafKind, LeafPolicy, open_source_confined, pin_dest_leaf_confined};
+pub use confined_open::{
+    DestLeafKind, LeafPolicy, open_source_confined, pin_dest_leaf_confined, read_link_confined,
+};
 pub use confined_readdir::read_dir_confined;
 #[cfg(unix)]
 pub use dir_sandbox::{

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -715,7 +715,15 @@ impl GeneratorContext {
     ///   produces `scan_dirfd` for a daemon.
     /// - `util1.c:1216` `change_dir()` - the per-argument descent, confined
     ///   with `secure_relative_open()` for a non-chrooted daemon.
+    ///
+    /// The confined branch is Unix-only, matching
+    /// [`SourceOpen::open`](crate::generator::open_source::SourceOpen::open):
+    /// `fast_io` re-exports the confined helpers under `#[cfg(unix)]` because
+    /// the walk is built on `openat`/`readlinkat`, and the oc daemon - the only
+    /// producer of a module confinement root - is itself Unix-only. On non-Unix
+    /// this is the plain `read_link` it has always been.
     pub(in crate::generator) fn read_source_link(&self, full_path: &Path) -> io::Result<PathBuf> {
+        #[cfg(unix)]
         if let Some(root) = self.confine_root() {
             // oc keeps absolute source paths, so the confinement-relative
             // component is the source path with the root stripped - the same

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -6,6 +6,7 @@
 //! Construction-time setup happens in [`GeneratorContext::new`]; the full send
 //! workflow is driven by the `transfer` submodule via `GeneratorContext::run`.
 
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
@@ -663,23 +664,71 @@ impl GeneratorContext {
     /// - `clientserver.c:1345-1357` - why the daemon chroot does not set it
     /// - `sender.c:359-383` - `secure_relative_open` vs `do_open_checklinks`
     pub(crate) fn source_open(&self) -> open_source::SourceOpen {
-        // upstream: syscall.c:136 `confinement_root()` -
-        // `am_daemon ? module_dir : confine_root`. The daemon arm wins
-        // unconditionally: its module directory is already the boundary, and
-        // `--confine-root` arrives in a peer-supplied argv where honouring it
-        // could only WIDEN the module (options.c:2382-2386 nulls it out for a
-        // daemon before it is ever read).
-        let confine_root = if self.config.connection.is_daemon_connection {
-            self.config.connection.daemon_module_root.clone()
-        } else {
-            self.config.connection.confine_root.clone()
-        };
         let follow_symlinks = self.config.flags.copy_links || self.config.flags.copy_unsafe_links;
         open_source::SourceOpen::new(
-            confine_root,
+            self.confine_root(),
             follow_symlinks,
             self.config.write.open_noatime,
         )
+    }
+
+    /// The absolute directory every source-side path resolution is confined
+    /// beneath, or `None` when this transfer applies no confinement.
+    ///
+    /// Sole owner of the confinement-root decision for the sender: the source
+    /// open ([`Self::source_open`]) and the file-list symlink read
+    /// ([`Self::read_source_link`]) must agree on the boundary, and one
+    /// function answering for both is what makes that structural rather than
+    /// coincidental.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `syscall.c:136` `confinement_root()` - `am_daemon ? module_dir :
+    ///   confine_root`. The daemon arm wins unconditionally: its module
+    ///   directory is already the boundary, and `--confine-root` arrives in a
+    ///   peer-supplied argv where honouring it could only WIDEN the module
+    ///   (`options.c:2382-2386` nulls it out for a daemon before it is read).
+    pub(crate) fn confine_root(&self) -> Option<PathBuf> {
+        if self.config.connection.is_daemon_connection {
+            self.config.connection.daemon_module_root.clone()
+        } else {
+            self.config.connection.confine_root.clone()
+        }
+    }
+
+    /// Reads a source symlink's target with the parent components resolved
+    /// beneath [`Self::confine_root`].
+    ///
+    /// A plain `read_link` re-walks every parent component at call time, so a
+    /// parent raced into a symlink pointing out of the module redirects the
+    /// read and the *outside* link's target is what the sender records in the
+    /// file list. Upstream closes that window by resolving the parent once -
+    /// through `secure_relative_open()` in `change_dir()` for a named
+    /// `dir/link` operand, or `secure_opendir()` for a directory scan - and
+    /// then reading the leaf against the held fd. This is the same shape.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:247-255` `scan_readlink()` - `do_readlink_atfd(scan_dirfd,
+    ///   basename)` when the leaf sits directly inside the scanned directory.
+    /// - `flist.c:2028-2059` `secure_opendir()` - the confined open that
+    ///   produces `scan_dirfd` for a daemon.
+    /// - `util1.c:1216` `change_dir()` - the per-argument descent, confined
+    ///   with `secure_relative_open()` for a non-chrooted daemon.
+    pub(in crate::generator) fn read_source_link(&self, full_path: &Path) -> io::Result<PathBuf> {
+        if let Some(root) = self.confine_root() {
+            // oc keeps absolute source paths, so the confinement-relative
+            // component is the source path with the root stripped - the same
+            // reconstruction `SourceOpen::open` performs.
+            if let Ok(relative) = full_path.strip_prefix(&root) {
+                return fast_io::read_link_confined(&root, relative);
+            }
+            // A source path outside the confinement root is not something a
+            // legitimate daemon transfer produces. There is no hardened
+            // readlink to fall back to, so this preserves the previous
+            // behaviour rather than adding a defence - it is not one.
+        }
+        std::fs::read_link(full_path)
     }
 
     /// Whether the source open must apply confinement or `O_NOFOLLOW`, which

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -194,13 +194,17 @@ impl GeneratorContext {
                 Some(metadata::windows::ReparseKind::Symlink)
                 | Some(metadata::windows::ReparseKind::Junction)
                 | Some(metadata::windows::ReparseKind::MountPoint)
-                | None => std::fs::read_link(full_path).unwrap_or_else(|_| PathBuf::from("")),
+                | None => self
+                    .read_source_link(full_path)
+                    .unwrap_or_else(|_| PathBuf::from("")),
                 Some(metadata::windows::ReparseKind::OneDrive)
                 | Some(metadata::windows::ReparseKind::AfUnix)
                 | Some(metadata::windows::ReparseKind::Other(_)) => PathBuf::from(""),
             };
             #[cfg(not(windows))]
-            let raw_target = std::fs::read_link(full_path).unwrap_or_else(|_| PathBuf::from(""));
+            let raw_target = self
+                .read_source_link(full_path)
+                .unwrap_or_else(|_| PathBuf::from(""));
 
             // upstream: flist.c:222-226 - sender strips the `/rsyncd-munged/`
             // prefix from the readlink result when the daemon module has

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -264,7 +264,7 @@ impl GeneratorContext {
         // Sender-side filtering ensures unsafe symlinks never reach the receiver,
         // matching the belt-and-suspenders approach for daemon push interop.
         if self.config.flags.safe_links && metadata.file_type().is_symlink() {
-            if let Ok(target) = std::fs::read_link(&path) {
+            if let Ok(target) = self.read_source_link(&path) {
                 if super::super::super::symlink_safety::is_unsafe_symlink(
                     target.as_os_str(),
                     &relative,
@@ -483,7 +483,7 @@ impl GeneratorContext {
                         && self.config.flags.copy_unsafe_links
                         && meta.file_type().is_symlink()
                     {
-                        if let Ok(target) = std::fs::read_link(&path) {
+                        if let Ok(target) = self.read_source_link(&path) {
                             let relative = path.strip_prefix(base).unwrap_or(&path);
                             if super::super::super::symlink_safety::is_unsafe_symlink(
                                 target.as_os_str(),
@@ -606,7 +606,7 @@ impl GeneratorContext {
 
         // upstream: flist.c:215 - follow unsafe symlinks when --copy-unsafe-links
         if self.config.flags.copy_unsafe_links && meta.file_type().is_symlink() {
-            let target = std::fs::read_link(path)?;
+            let target = self.read_source_link(path)?;
             let relative = path.strip_prefix(base).unwrap_or(path);
             if super::super::super::symlink_safety::is_unsafe_symlink(target.as_os_str(), relative)
             {

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -144,7 +144,7 @@ rsync-ssl-stunnel-ca-required pass
 rsync-ssl-stunnel-hostname-check pass
 scanner-daemon-log-checksum pass
 sender-flist-symlink-leak pass
-sender-readlink-atfd fail
+sender-readlink-atfd pass
 sender-remove-source-secure pass
 symlink-exclude pass
 symlink-exclude-chdir-alias pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -304,7 +304,7 @@ scanner-daemon-log-checksum pass
 scanner-delete-delay-overread pass
 secure-relpath-validation pass
 sender-flist-symlink-leak pass
-sender-readlink-atfd fail
+sender-readlink-atfd pass
 sender-remove-source-relative-anchor pass
 sender-remove-source-root-anchor skip
 sender-remove-source-secure pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -144,7 +144,7 @@ rsync-ssl-stunnel-ca-required pass
 rsync-ssl-stunnel-hostname-check pass
 scanner-daemon-log-checksum pass
 sender-flist-symlink-leak pass
-sender-readlink-atfd fail
+sender-readlink-atfd pass
 sender-remove-source-secure pass
 symlink-exclude pass
 symlink-exclude-chdir-alias pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -304,7 +304,7 @@ scanner-daemon-log-checksum pass
 scanner-delete-delay-overread pass
 secure-relpath-validation pass
 sender-flist-symlink-leak pass
-sender-readlink-atfd fail
+sender-readlink-atfd pass
 sender-remove-source-relative-anchor pass
 sender-remove-source-root-anchor pass
 sender-remove-source-secure pass


### PR DESCRIPTION
The daemon sender recorded a symlink's target with a path-based
`std::fs::read_link`, which re-walks every parent component at call time.
A parent raced into a symlink pointing out of the module redirects that
read, and the *outside* link's target is what goes on the wire.

Observed on the 3.5.0 conformance cell `sender-readlink-atfd`, which flips
`<module>/real` between a real directory and a symlink to an outside tree
while a client pulls `real/link`:

    daemon sender readlink followed a raced parent symlink
    and sent the outside symlink target

Upstream is unaffected, and the log names its mechanism:

    rsync: [sender] change_dir "real" (in src) failed: No such file or directory (2)

The protection is not in `readlink` at all - `do_readlink` is a plain
`readlink(2)`. It comes from resolving the parent ONCE through a confined
walk and reading the leaf against the held fd:

  - `util1.c:1216` `change_dir()` - a non-chrooted daemon resolves a relative
    directory with `secure_relative_open()` and `fchdir()`s to the result, so
    the raced parent is refused outright. This is the arm the failing cell
    exercises (a named `dir/link` operand, no directory scan running).
  - `flist.c:2028-2059` `secure_opendir()` + `flist.c:247-255`
    `scan_readlink()` - during a directory scan the same guarantee comes from
    `do_readlink_atfd(scan_dirfd, basename)` against the confined scan fd.

oc keeps absolute source paths rather than chdir'ing, so the equivalent is a
confined `readlinkat`: `fast_io::read_link_confined` walks the parent with the
shared per-component resolver (the same `ds_descend` rule `open_source_confined`
already uses) and reads the leaf with `readlinkat` against the resulting dirfd.
An fd cannot be redirected after the fact.

FOUR call sites, not one. Upstream reads this link through a single
`scan_readlink()` inside `readlink_stat()`, and oc had it open-coded four
times: the flist entry's recorded target plus three `--safe-links` /
`--copy-unsafe-links` safety decisions. Confining only the recorded target
would leave a *decision* reading a raced link, so all four now route through
one owner, `GeneratorContext::read_source_link`.

The confinement-root decision was already made in `source_open()`; it is
extracted to `GeneratorContext::confine_root` so the source open and the
symlink read cannot drift apart on which boundary they mean.

Tests: four in `fast_io`, of which three are non-vacuity companions - an
in-module link still reads, an in-tree directory symlink is still FOLLOWED
(upstream refuses escapes, not symlinks; a helper that refused every symlinked
parent would pass the escape test and break ordinary modules), and a
non-symlink still reports EINVAL.

RED proven twice:

  - Neutering the primitive to a plain `read_link`: nextest reports
    `4 tests run: 3 passed, 1 failed` and the failure carries the leaked
    value - `the confined read must refuse the escaping parent:
    "OUTSIDE-LINK-TARGET"`. Only the escape test dies.
  - Neutering the transfer-side wiring: the conformance cell goes back to
    FAIL, so the call site is load-bearing rather than decorative.

Measured after the fix: `sender-readlink-atfd` PASSES on both the pipe and
TCP legs, and the neighbouring `sender-flist-symlink-leak`,
`daemon-copy-links-symlink` and `symlink-race-source` cells stay green. All
four 3.5.0 expect-manifests re-baselined `fail` -> `pass`; leaving them would
redden the gate as an unexpected pass.

fmt + full-workspace clippy clean; `-p fast_io -p transfer` 3512/3512.
