### PR TITLE
test(flist): gate the symlink-follow test on unix, not its body

### DIFF
--- a/crates/flist/src/batched_stat/tests.rs
+++ b/crates/flist/src/batched_stat/tests.rs
@@ -245,26 +245,27 @@ fn test_get_or_fetch_error_not_cached() {
     assert_eq!(cache.len(), 0);
 }
 
+// Gated on the test rather than its body: with the gate inside, `cache` and
+// `temp` are bound but unused on Windows, which is a hard error under the
+// cross-check's `-D warnings`. Matches the three sibling unix-only tests.
+#[cfg(unix)]
 #[test]
 fn test_follow_symlinks_option() {
     let cache = BatchedStatCache::new();
     let temp = create_test_tree();
 
-    #[cfg(unix)]
-    {
-        let target = temp.path().join("file1.txt");
-        let link = temp.path().join("link.txt");
-        std::os::unix::fs::symlink(&target, &link).unwrap();
+    let target = temp.path().join("file1.txt");
+    let link = temp.path().join("link.txt");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
 
-        let result_nofollow = cache.get_or_fetch(&link, false);
-        assert!(result_nofollow.is_ok());
+    let result_nofollow = cache.get_or_fetch(&link, false);
+    assert!(result_nofollow.is_ok());
 
-        cache.clear();
-        let result_follow = cache.get_or_fetch(&link, true);
-        assert!(result_follow.is_ok());
+    cache.clear();
+    let result_follow = cache.get_or_fetch(&link, true);
+    assert!(result_follow.is_ok());
 
-        assert!(cache.get(&link).is_some());
-    }
+    assert!(cache.get(&link).is_some());
 }
 
 #[cfg(feature = "parallel")]


### PR DESCRIPTION
## Problem

`test_follow_symlinks_option` puts `#[cfg(unix)]` on the test *body* while
binding `cache` and `temp` outside it. On Windows both bindings are unused, and
under `-D warnings` that is a hard error:

```
error: unused variable: `cache`
  --> crates/flist/src/batched_stat/tests.rs:250:9
error: unused variable: `temp`
  --> crates/flist/src/batched_stat/tests.rs:251:9
error: could not compile `flist` (lib test) due to 2 previous errors
```

## Why CI is green anyway

The `Windows GNU cross-check` job runs `cargo check --locked --workspace
--target x86_64-pc-windows-gnu` with **no `--all-targets`**, so it never builds
test targets. The defect is real but structurally invisible to the gate that
exists to catch it.

Reproduced and cleared with the job's own target plus `--all-targets`:

```
RUSTFLAGS="-D warnings" cargo check --locked -p flist \
    --all-targets --all-features --target x86_64-pc-windows-gnu
```

RED before the change (the two errors above), clean after.

## Change

Move the gate from the body onto the test, matching the three sibling unix-only
tests already in the same file (`:126`, `:334`, `:345`) — that shape is the
file's existing convention, and this test was the only one departing from it.

**No coverage is lost.** The body was already inert on Windows, so the test was
passing without asserting anything there. It now reads as honestly absent rather
than vacuously green.

## Scope

A full-workspace run of the same command reports **no other instance** of this
shape, so this is the complete set rather than the first of many.

That run also surfaces four pre-existing `unresolved import criterion` errors in
`crates/engine/benches/`. Those are **not** from this change — they reproduce
identically on the pristine base (4 occurrences both before and after), and they
only appear because `--all-targets` cross-compiles benches, which CI does not do.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p flist --all-features` - 546 run, 546 passed
- Windows GNU cross-check of `-p flist --all-targets` clean
