### PR TITLE
fix(receiver): stat alt-dest basis via the ownership walk

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/metadata.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/metadata.rs
@@ -192,3 +192,41 @@ pub fn fstatat_nofollow(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<AtMet
         Err(io::Error::last_os_error())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::fstatat_nofollow;
+    use std::os::fd::AsFd;
+    use std::os::unix::fs::MetadataExt;
+
+    /// [`AtMetadata`](super::AtMetadata) and [`std::fs::Metadata`] must agree on
+    /// the identity and comparison fields for the same file.
+    ///
+    /// This is not a tautology across platforms. `fstatat_nofollow` calls
+    /// `libc::fstatat`, while `std::fs::symlink_metadata` on Linux goes through
+    /// `statx` and reconstructs `st_dev` from the returned major/minor pair. Any
+    /// caller that stats a file both ways and then compares the two results -
+    /// which is how the receiver's alt-dest basis lookup verifies that a
+    /// path-based stat landed on the inode the confined stat saw - is silently
+    /// broken if those reconstructions differ on any target.
+    ///
+    /// Kept as a standing invariant rather than a one-off probe: it costs two
+    /// syscalls and it fails loudly on the platform where it stops holding.
+    #[test]
+    fn at_metadata_agrees_with_std_metadata_on_the_same_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("probe.bin");
+        std::fs::write(&path, b"probe payload").expect("write probe file");
+
+        let dir = std::fs::File::open(temp.path()).expect("open temp dir");
+        let at = fstatat_nofollow(dir.as_fd(), std::ffi::OsStr::new("probe.bin"))
+            .expect("fstatat the probe file");
+        let std_meta = std::fs::symlink_metadata(&path).expect("symlink_metadata");
+
+        assert_eq!(at.dev(), std_meta.dev(), "st_dev disagrees");
+        assert_eq!(at.ino(), std_meta.ino(), "st_ino disagrees");
+        assert_eq!(at.size(), std_meta.len(), "size disagrees");
+        assert_eq!(at.mode(), std_meta.mode(), "st_mode disagrees");
+        assert_eq!(at.uid(), std_meta.uid(), "st_uid disagrees");
+    }
+}

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -255,6 +255,60 @@ struct ReferenceMatch<'a> {
     level: MatchLevel,
 }
 
+/// Stats an alt-dest basis entry without traversing an attacker-owned symlink.
+///
+/// The tail of `path` comes from the peer's file list, so on a pull the peer
+/// chooses which name is looked up inside the operator's basis directory. A
+/// plain path stat walks every component at call time, so a symlink anywhere
+/// along that tail - one the peer itself could have planted during an earlier
+/// run into the same tree, which is exactly what `--link-dest=../prev` points
+/// at - redirects the stat outside the basis and turns the basis directory into
+/// a read oracle. The ownership walk resolves each component itself, following
+/// only symlinks owned by root or our euid and refusing the rest with `ELOOP`.
+///
+/// Only the parent is walked. The leaf is `fstatat`'d with
+/// `AT_SYMLINK_NOFOLLOW`, never opened and never resolved, because upstream
+/// reaches it through `link_stat_at()` - a symlink sitting at the basis name
+/// must report *as a symlink* so the `!S_ISREG` filter drops it, even when the
+/// link is trusted-owned. Opening the leaf instead would both follow that
+/// symlink and require read permission the `--link-dest` hard-link path does
+/// not need.
+///
+/// The returned [`fs::Metadata`] comes from a second, path-based stat so the
+/// attribute comparisons downstream keep their `std` type; it is accepted only
+/// when it names the same `(dev, ino)` the confined stat saw. A parent flipped
+/// between the two calls therefore lands on a different inode and is refused,
+/// which is what makes the path stat safe to use as the carrier.
+///
+/// Any failure is reported as "no basis here", the same outcome upstream
+/// produces when `link_stat` fails: the file transfers normally.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/generator.c:979-990` `basis_link_stat()` - the non-daemon
+///   receiver arm: `owner_walk_parent()` for the parent components, then
+///   `link_stat_at()` on the leaf through the returned descriptor.
+/// - `rsync-3.5.0/syscall.c:558` `owner_walk_parent()` - the walk itself.
+#[cfg(unix)]
+fn basis_stat(path: &Path) -> Option<fs::Metadata> {
+    use std::os::fd::AsFd;
+    use std::os::unix::fs::MetadataExt;
+
+    let (parent, leaf) = fast_io::owner_walk::owner_trusted_parent(path).ok()?;
+    let confined = fast_io::fstatat_nofollow(parent.as_fd(), &leaf).ok()?;
+    let meta = fs::symlink_metadata(path).ok()?;
+    (meta.dev() == confined.dev() && meta.ino() == confined.ino()).then_some(meta)
+}
+
+/// Non-Unix fallback: the ownership walk is a dirfd construction with no
+/// Windows analogue, so the basis is stat'd by path. `symlink_metadata` still
+/// refuses to follow a symlink at the leaf, which is what keeps a symlinked
+/// basis entry from being consumed; only the parent components are unguarded.
+#[cfg(not(unix))]
+fn basis_stat(path: &Path) -> Option<fs::Metadata> {
+    fs::symlink_metadata(path).ok()
+}
+
 /// Scans every reference directory and returns the strongest basis match,
 /// mirroring upstream's `best_match` selection in `try_dests_reg`.
 ///
@@ -294,8 +348,8 @@ fn best_reference_match<'a>(
     let mut best: Option<ReferenceMatch<'a>> = None;
     for ref_dir in reference_directories {
         let ref_path = ref_dir.path.join(relative_path);
-        let ref_meta = match fs::symlink_metadata(&ref_path) {
-            Ok(m) if m.file_type().is_file() => m,
+        let ref_meta = match basis_stat(&ref_path) {
+            Some(m) if m.file_type().is_file() => m,
             _ => continue,
         };
 
@@ -1071,11 +1125,25 @@ mod symlink_basis_tests {
         ref_dir: &std::path::Path,
         dest_dir: &std::path::Path,
     ) -> bool {
-        let entry = FileEntry::new_file(
-            PathBuf::from("payload.bin"),
+        run_named(
+            kind,
+            ref_dir,
+            dest_dir,
+            "payload.bin",
             b"basis payload".len() as u64,
-            0o644,
-        );
+        )
+    }
+
+    /// `run` with the peer-supplied entry name spelled out, so a test can probe
+    /// a multi-component name whose leading component the basis resolves.
+    fn run_named(
+        kind: ReferenceDirectoryKind,
+        ref_dir: &std::path::Path,
+        dest_dir: &std::path::Path,
+        entry_name: &str,
+        entry_size: u64,
+    ) -> bool {
+        let entry = FileEntry::new_file(PathBuf::from(entry_name), entry_size, 0o644);
         let reference = ReferenceDirectory {
             kind,
             path: ref_dir.to_path_buf(),
@@ -1143,6 +1211,84 @@ mod symlink_basis_tests {
         assert!(
             !handled,
             "compare-dest must not treat symlink basis as up-to-date"
+        );
+    }
+
+    /// A symlinked parent component the invoking user OWNS is still traversed.
+    ///
+    /// The basis stat runs through the ownership walk, whose rule is ownership
+    /// and not location: uid 0 or our euid is the operator's own layout (the
+    /// `--link-dest=/backup` where `backup -> /mnt/disk` pattern) and is
+    /// followed; any other uid is refused with `ELOOP`. Routing the basis onto
+    /// that walk must not break the followed half, which is the half real
+    /// deployments depend on.
+    ///
+    /// MEASURED against real rsync 3.5.0: with `basis/sub -> ../outside` owned
+    /// by the invoking user, upstream consumes the basis and does not transfer
+    /// `sub/payload.bin`. The refusing half needs a foreign-owned symlink and so
+    /// needs root to construct; it is pinned at the predicate instead, by
+    /// `fast_io::owner_walk`'s `refuses_an_owner_that_is_neither_root_nor_the_euid`.
+    ///
+    /// upstream: `generator.c:979-990` `basis_link_stat()` ARM 1 resolves the
+    /// basis parent with `owner_walk_parent()`; `syscall.c:406` is the
+    /// `st_uid != 0 && st_uid != trusted_uid` refusal this cell stays clear of.
+    #[test]
+    fn copy_dest_traverses_a_self_owned_symlinked_parent() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&outside).expect("create outside dir");
+        fs::write(outside.join("payload.bin"), b"basis payload").expect("write outside file");
+
+        // The basis dir reaches its content through a symlink the test - and so
+        // the invoking euid - owns, which is the trusted case.
+        let ref_dir = temp.path().join("basis");
+        fs::create_dir_all(&ref_dir).expect("create basis dir");
+        unix::fs::symlink("../outside", ref_dir.join("sub")).expect("create parent symlink");
+
+        let dest_dir = temp.path().join("dest");
+        fs::create_dir_all(&dest_dir).expect("create dest dir");
+
+        let handled = run_named(
+            ReferenceDirectoryKind::Copy,
+            &ref_dir,
+            &dest_dir,
+            "sub/payload.bin",
+            b"basis payload".len() as u64,
+        );
+
+        assert!(
+            handled,
+            "a self-owned symlinked parent is trusted and must still be walked"
+        );
+    }
+
+    /// Non-vacuity companion for the parent-walk cases: with `sub` a real
+    /// directory the very same entry name matches, proving the fixture can
+    /// reach the basis without any symlink in play.
+    #[test]
+    fn copy_dest_matches_through_a_real_parent_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let ref_dir = temp.path().join("basis");
+        fs::create_dir_all(ref_dir.join("sub")).expect("create basis subdir");
+        fs::write(ref_dir.join("sub/payload.bin"), b"escaped payload").expect("write basis file");
+
+        let dest_dir = temp.path().join("dest");
+        fs::create_dir_all(&dest_dir).expect("create dest dir");
+
+        let handled = run_named(
+            ReferenceDirectoryKind::Copy,
+            &ref_dir,
+            &dest_dir,
+            "sub/payload.bin",
+            b"escaped payload".len() as u64,
+        );
+
+        assert!(handled, "a real parent directory must still be walked");
+        assert_eq!(
+            fs::read(dest_dir.join("sub/payload.bin")).expect("dest file"),
+            b"escaped payload"
         );
     }
 

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -255,6 +255,73 @@ struct ReferenceMatch<'a> {
     level: MatchLevel,
 }
 
+/// Which of upstream's `basis_link_stat()` arms resolves an alt-dest basis entry.
+///
+/// Upstream selects between an ownership-walked stat and a plain `link_stat()`
+/// from `am_daemon`; a daemon receiver deliberately keeps the plain stat because
+/// its confinement comes from elsewhere (chroot, the module-root resolver, and
+/// the `../` clamp `sanitize_path` already applied to a dest-relative basis).
+/// The distinction is spelled as a type rather than a `bool` so neither arm can
+/// be selected by accident at a call site.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/generator.c:962` `basis_link_stat()` - the arm selection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum BasisTrust {
+    /// Non-daemon receiver: resolve the parent through the ownership walk.
+    ///
+    /// upstream: `generator.c:978` - the `!am_daemon && am_root >= 0 &&
+    /// !symlink_optout_allowed()` arm.
+    OwnerWalk,
+    /// Daemon receiver: stat the basis by path, as upstream's fall-through does.
+    ///
+    /// upstream: `generator.c:1010` - the trailing plain `link_stat()`.
+    PlainStat,
+}
+
+impl BasisTrust {
+    /// Picks the arm for a receiver, from the one fact upstream branches on.
+    ///
+    /// upstream: `generator.c:978` - `!am_daemon` selects the ownership walk.
+    #[must_use]
+    pub(super) const fn for_receiver(is_daemon_connection: bool) -> Self {
+        if is_daemon_connection {
+            Self::PlainStat
+        } else {
+            Self::OwnerWalk
+        }
+    }
+}
+
+#[cfg(test)]
+mod basis_trust_tests {
+    use super::BasisTrust;
+
+    /// A daemon receiver must NOT take the ownership walk.
+    ///
+    /// This is the arm upstream selects, and taking the other one is not merely
+    /// stricter - the walk opens every component from `/` downward, which a
+    /// confined daemon worker cannot do, so the basis vanishes and every file
+    /// is re-transferred. That is the `link-dest-relative-basis` cell
+    /// (upstream #915/#930), whose manifest row is `pass` on both pipe legs.
+    ///
+    /// upstream: `rsync-3.5.0/generator.c:978` - the ownership-walk arm is
+    /// guarded by `!am_daemon`; `generator.c:1010` is the plain `link_stat()`
+    /// a daemon receiver falls through to.
+    #[test]
+    fn a_daemon_receiver_stats_the_basis_by_path() {
+        assert_eq!(BasisTrust::for_receiver(true), BasisTrust::PlainStat);
+    }
+
+    /// Non-vacuity companion: the walk is still selected off the daemon path,
+    /// so the mapping is a real branch and not a constant.
+    #[test]
+    fn a_non_daemon_receiver_walks_the_basis_parent() {
+        assert_eq!(BasisTrust::for_receiver(false), BasisTrust::OwnerWalk);
+    }
+}
+
 /// Stats an alt-dest basis entry without traversing an attacker-owned symlink.
 ///
 /// The tail of `path` comes from the peer's file list, so on a pull the peer
@@ -283,16 +350,31 @@ struct ReferenceMatch<'a> {
 /// Any failure is reported as "no basis here", the same outcome upstream
 /// produces when `link_stat` fails: the file transfers normally.
 ///
+/// [`BasisTrust::PlainStat`] takes the path-based stat instead. That is not a
+/// weakening: it is the arm upstream itself takes for a daemon receiver, whose
+/// basis is confined by the module resolver rather than by ownership. Walking
+/// there would also be actively wrong - the walk opens every component starting
+/// at `/`, and a daemon worker is confined (chroot, or a Landlock ruleset rooted
+/// at the module) precisely so that the ancestors of the module are *not*
+/// openable, so the walk fails with `EACCES` and the basis silently disappears.
+///
 /// # Upstream Reference
 ///
 /// - `rsync-3.5.0/generator.c:979-990` `basis_link_stat()` - the non-daemon
 ///   receiver arm: `owner_walk_parent()` for the parent components, then
 ///   `link_stat_at()` on the leaf through the returned descriptor.
+/// - `rsync-3.5.0/generator.c:1010` - the plain `link_stat()` fall-through a
+///   daemon receiver reaches for a dest-relative basis (`--link-dest=../01`),
+///   whose `../` `sanitize_path` has already clamped to the module root.
 /// - `rsync-3.5.0/syscall.c:558` `owner_walk_parent()` - the walk itself.
 #[cfg(unix)]
-fn basis_stat(path: &Path) -> Option<fs::Metadata> {
+fn basis_stat(path: &Path, trust: BasisTrust) -> Option<fs::Metadata> {
     use std::os::fd::AsFd;
     use std::os::unix::fs::MetadataExt;
+
+    if trust == BasisTrust::PlainStat {
+        return fs::symlink_metadata(path).ok();
+    }
 
     let (parent, leaf) = fast_io::owner_walk::owner_trusted_parent(path).ok()?;
     let confined = fast_io::fstatat_nofollow(parent.as_fd(), &leaf).ok()?;
@@ -301,11 +383,12 @@ fn basis_stat(path: &Path) -> Option<fs::Metadata> {
 }
 
 /// Non-Unix fallback: the ownership walk is a dirfd construction with no
-/// Windows analogue, so the basis is stat'd by path. `symlink_metadata` still
-/// refuses to follow a symlink at the leaf, which is what keeps a symlinked
-/// basis entry from being consumed; only the parent components are unguarded.
+/// Windows analogue, so the basis is stat'd by path regardless of `trust`.
+/// `symlink_metadata` still refuses to follow a symlink at the leaf, which is
+/// what keeps a symlinked basis entry from being consumed; only the parent
+/// components are unguarded.
 #[cfg(not(unix))]
-fn basis_stat(path: &Path) -> Option<fs::Metadata> {
+fn basis_stat(path: &Path, _trust: BasisTrust) -> Option<fs::Metadata> {
     fs::symlink_metadata(path).ok()
 }
 
@@ -344,11 +427,12 @@ fn best_reference_match<'a>(
     always_checksum: Option<protocol::ChecksumAlgorithm>,
     modify_window: ModifyWindow,
     metadata_opts: &MetadataOptions,
+    trust: BasisTrust,
 ) -> Option<ReferenceMatch<'a>> {
     let mut best: Option<ReferenceMatch<'a>> = None;
     for ref_dir in reference_directories {
         let ref_path = ref_dir.path.join(relative_path);
-        let ref_meta = match basis_stat(&ref_path) {
+        let ref_meta = match basis_stat(&ref_path, trust) {
             Some(m) if m.file_type().is_file() => m,
             _ => continue,
         };
@@ -434,6 +518,7 @@ pub(super) fn try_reference_dest(
     metadata_errors: &mut Vec<(PathBuf, String)>,
     acl_cache: Option<&AclCache>,
     acl_id_map: Option<&AclIdMapper>,
+    trust: BasisTrust,
 ) -> bool {
     if reference_directories.is_empty() {
         return false;
@@ -449,6 +534,7 @@ pub(super) fn try_reference_dest(
         always_checksum,
         modify_window,
         metadata_opts,
+        trust,
     ) else {
         return false;
     };
@@ -930,7 +1016,7 @@ mod info_copy_emission_tests {
     use metadata::MetadataOptions;
     use protocol::flist::FileEntry;
 
-    use super::{ModifyWindow, try_reference_dest};
+    use super::{BasisTrust, ModifyWindow, try_reference_dest};
     use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
 
     fn copy_messages() -> Vec<String> {
@@ -997,6 +1083,7 @@ mod info_copy_emission_tests {
             &mut metadata_errors,
             None,
             None,
+            BasisTrust::OwnerWalk,
         );
 
         // Restore writable permissions so tempdir cleanup succeeds.
@@ -1057,6 +1144,7 @@ mod info_copy_emission_tests {
             &mut metadata_errors,
             None,
             None,
+            BasisTrust::OwnerWalk,
         );
 
         let mut restore = fs::metadata(&dest_dir).expect("dest meta").permissions();
@@ -1096,7 +1184,7 @@ mod symlink_basis_tests {
     use metadata::MetadataOptions;
     use protocol::flist::FileEntry;
 
-    use super::{ModifyWindow, try_reference_dest};
+    use super::{BasisTrust, ModifyWindow, try_reference_dest};
     use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
 
     fn setup_symlink_basis() -> (tempfile::TempDir, PathBuf, PathBuf) {
@@ -1165,6 +1253,7 @@ mod symlink_basis_tests {
             &mut metadata_errors,
             None,
             None,
+            BasisTrust::OwnerWalk,
         )
     }
 
@@ -1659,7 +1748,7 @@ mod alt_dest_match_level_tests {
     use metadata::MetadataOptions;
     use protocol::flist::FileEntry;
 
-    use super::{ModifyWindow, try_reference_dest};
+    use super::{BasisTrust, ModifyWindow, try_reference_dest};
     use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
 
     /// A fixed mtime shared by basis files and source entries so the quick-check
@@ -1705,6 +1794,7 @@ mod alt_dest_match_level_tests {
             &mut errs,
             None,
             None,
+            BasisTrust::OwnerWalk,
         )
     }
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -21,8 +21,8 @@ use protocol::flist::FileEntry;
 
 use crate::receiver::directory::FailedDirectories;
 use crate::receiver::quick_check::{
-    dest_mtime_newer, dest_type_matches_source, is_hardlink_follower, quick_check_matches,
-    try_reference_dest,
+    BasisTrust, dest_mtime_newer, dest_type_matches_source, is_hardlink_follower,
+    quick_check_matches, try_reference_dest,
 };
 use crate::receiver::stats::{ListOnlyEntry, TransferStats};
 use crate::receiver::{ReceiverContext, apply_acls_from_receiver_cache};
@@ -467,6 +467,7 @@ impl ReceiverContext {
                         metadata_errors,
                         acl_cache,
                         acl_id_map,
+                        BasisTrust::for_receiver(self.config.connection.is_daemon_connection),
                     )
                 {
                     continue;


### PR DESCRIPTION
## What

The receiver resolved a `--compare-dest` / `--copy-dest` / `--link-dest` basis
entry with a plain `fs::symlink_metadata`, which re-walks every component of a
**peer-supplied** entry name at call time. Upstream reaches the same entry
through `owner_walk_parent()` + `link_stat_at()` (`generator.c:979-990`), so a
symlink component owned by neither root nor our euid is refused with `ELOOP`
rather than traversed.

This routes the basis stat onto `fast_io::owner_walk` - the same primitive the
sibling operator-path families already use for `--temp-dir` (#7398) and
`--backup-dir` (#7404).

## Why this shape

Only the **parent** is walked. The leaf is `fstatat(AT_SYMLINK_NOFOLLOW)`'d and
never opened:

- upstream must report a symlink at the basis name **as a symlink** so its
  `!S_ISREG` filter drops it. Opening the leaf resolves it, which measurably
  re-opens the hole #7419 just closed - the existing
  `link_dest_skips_symlink_basis_entry` cell caught exactly that while this was
  being built.
- opening would also demand read permission that the `--link-dest` hard-link
  path does not need.

The `fs::Metadata` handed downstream comes from a second path stat, accepted
only when it names the same `(dev, ino)` the confined stat saw. That keeps
`quick_check_matches` / `metadata_unchanged` on their `std` types while making
a parent flipped between the two calls refusable rather than silently followed.

## Scope, stated plainly

The ownership walk's rule is ownership, not location: uid 0 or our euid is the
operator's own layout (`--link-dest=/backup` where `backup -> /mnt/disk`) and is
followed; any other uid is refused.

**Measured against real rsync 3.5.0**: with `basis/sub -> ../outside` owned by
the invoking user, upstream consumes the basis and does not transfer
`sub/payload.bin`. oc did the same before this change, so the traversing half is
unchanged - and it is now pinned, because breaking it would break the deployments
that rely on it.

The half that changes behaviour needs a **foreign-owned** symlink and therefore
root to construct, so it is not reachable from a non-root `nextest` cell. It
stays pinned at the predicate, by `owner_walk`'s existing
`refuses_an_owner_that_is_neither_root_nor_the_euid`.

## Verification

- `symlink_basis_tests` 6/6, including the three `--copy-dest` / `--link-dest` /
  `--compare-dest` leaf cells from #7419 as the regression guard.
- full `-p transfer --all-features`: 2762 run, 2762 passed, 3 skipped.
- `cargo fmt --all -- --check` clean; `clippy -p transfer -p fast_io
  --all-targets --all-features -D warnings` clean.
- oracle script comparing oc against the built `rsync-3.5.0` binary on the
  symlinked-parent and real-parent cells.

Closes the alt-dest half of the operator-path confinement family.
