### PR TITLE
fix(daemon): read operator-named aux files through the ownership walk

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -72,6 +72,7 @@ use crate::{
 
 mod at_error;
 mod help;
+pub(crate) mod operator_file;
 pub(crate) mod peer_address;
 pub(crate) mod tracing_stream;
 

--- a/crates/daemon/src/daemon/operator_file.rs
+++ b/crates/daemon/src/daemon/operator_file.rs
@@ -1,0 +1,38 @@
+//! Reading the daemon's operator-supplied auxiliary files.
+//!
+//! The daemon reads several files named by the operator rather than by a peer -
+//! the config file itself, any `&include`/`&merge` it pulls in, `motd file`, and
+//! `secrets file`. All of them are read by a process that is typically root and
+//! before (or during) the privilege drop, so a symlink planted at any component
+//! of those paths redirects a privileged read to a file the operator never
+//! named. Upstream closes this with one primitive applied at every such open.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/syscall.c:538` `open_no_attacker_symlinks()` - walk each
+//!   component without following it; follow a symlink only when it is owned by
+//!   uid 0 or our euid, refuse any other-uid one (`syscall.c:406`).
+//! - `rsync-3.5.0/params.c:586` - the config file (and its includes).
+//! - `rsync-3.5.0/clientserver.c:188` - `motd`.
+//! - `rsync-3.5.0/authenticate.c:159` - `secrets file`.
+
+use std::io;
+use std::path::Path;
+
+/// Read an operator-named daemon file, refusing an attacker-owned symlink.
+///
+/// Wraps [`fast_io::operator_read_to_string`] so the single platform seam lives
+/// here rather than at each call site. On non-Unix targets the ownership walk
+/// has no meaning (there is no `st_uid` to trust) and this degrades to a plain
+/// read, matching how the rest of the tree gates `fast_io`'s operator-path
+/// helpers.
+pub(crate) fn read_to_string(path: &Path) -> io::Result<String> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_read_to_string(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::read_to_string(path)
+    }
+}

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -90,7 +90,11 @@ fn apply_global_directive(
             }
 
             let motd_path = resolve_config_relative_path(path, trimmed);
-            let contents = fs::read_to_string(&motd_path).map_err(|error| {
+            // upstream: clientserver.c:188 reads the motd through
+            // `open_no_attacker_symlinks()`. The daemon is typically root here,
+            // so a symlink planted at any component of an operator-named motd
+            // path would otherwise splice an arbitrary file into the greeting.
+            let contents = crate::daemon::operator_file::read_to_string(&motd_path).map_err(|error| {
                 let motd_display = motd_path.display();
                 config_parse_error(
                     path,

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -75,7 +75,12 @@ fn parse_config_modules_inner(
         ));
     }
 
-    let contents = fs::read_to_string(&canonical)
+    // upstream: params.c:586 opens the config file with
+    // `open_no_attacker_symlinks()` - the path as *given*, walked component by
+    // component. Read `path`, not `canonical`: `canonicalize()` follows every
+    // symlink, so reading the resolved path is precisely the redirect this
+    // guards against. `canonical` stays the cycle-detection key only.
+    let contents = crate::daemon::operator_file::read_to_string(path)
         .map_err(|error| config_io_error("read", &canonical, error))?;
     stack.push(canonical.clone());
 

--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -371,7 +371,13 @@ fn verify_secret_response(
         return Ok(false);
     }
 
-    let contents = match fs::read_to_string(secrets_path) {
+    // upstream: authenticate.c:159 opens the secrets file through
+    // `open_no_attacker_symlinks()`. Without the walk, a symlink planted at any
+    // component redirects the daemon's privileged read - and because the
+    // strict-modes `fstat` above inspects the *target* inode, a link to a
+    // root-owned 0600 file passes the mode check while feeding an
+    // attacker-chosen file to the password comparison.
+    let contents = match crate::daemon::operator_file::read_to_string(secrets_path) {
         Ok(contents) => contents,
         Err(_) => return Ok(false),
     };

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -399,8 +399,8 @@ pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
-    operator_link, operator_open_append, operator_open_read, operator_rename, owner_trusted_parent,
-    symlink_owner_is_trusted,
+    operator_link, operator_open_append, operator_open_read, operator_read_to_string,
+    operator_rename, owner_trusted_parent, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -393,9 +393,86 @@ pub fn operator_open_append(path: &Path, mode: u32) -> io::Result<std::fs::File>
     )
 }
 
+/// Read an operator-supplied file to a `String` through the ownership walk.
+///
+/// The `read_to_string` counterpart to [`operator_open_read`], for the auxiliary
+/// files rsync consumes whole as text rather than streaming: the daemon config
+/// and `secrets file`, `motd`, `--password-file`, and the filter/`--files-from`
+/// lists. Reading these with a plain path-based `std::fs::read_to_string` lets a
+/// symlink planted at *any* component redirect a privileged read to a file the
+/// operator never named.
+///
+/// Opening and reading is one operation here on purpose: a caller that resolved
+/// the path first and read it second would reintroduce exactly the window the
+/// walk exists to close.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/params.c:586` - the daemon config file.
+/// - `rsync-3.5.0/authenticate.c:159` / `:245` - `secrets file` and
+///   `--password-file`.
+/// - `rsync-3.5.0/clientserver.c:188` - `motd`.
+///
+///   Each opens with `open_no_attacker_symlinks()` and reads from the returned
+///   descriptor; none of them resolves the path independently first.
+///
+/// # Errors
+///
+/// See [`operator_open_with`]. Additionally surfaces any read error, including
+/// `InvalidData` when the file is not valid UTF-8.
+pub fn operator_read_to_string(path: &Path) -> io::Result<String> {
+    use std::io::Read as _;
+
+    let mut file = operator_open_read(path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(contents)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{operator_open_append, operator_open_read, symlink_owner_is_trusted, trusted_uid};
+    use super::{
+        operator_open_append, operator_open_read, operator_read_to_string,
+        symlink_owner_is_trusted, trusted_uid,
+    };
+
+    /// The whole point of the helper: content comes back, and it comes back
+    /// through the walk rather than a path-based read.
+    #[test]
+    fn operator_read_to_string_returns_the_file_contents() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("rsyncd.conf");
+        std::fs::write(&path, "[mod]\n    path = /srv\n").expect("write");
+
+        assert_eq!(
+            operator_read_to_string(&path).expect("read the operator file"),
+            "[mod]\n    path = /srv\n"
+        );
+    }
+
+    /// A symlink the caller itself owns is the operator's own layout
+    /// (`/etc/rsyncd.conf -> /srv/conf/rsyncd.conf`) and must still be
+    /// followed - refusing every leaf symlink would break the ordinary
+    /// administrative arrangement this resolver exists to preserve.
+    ///
+    /// The refusing half needs a foreign-owned symlink and therefore root, so
+    /// it is pinned at the predicate by
+    /// `refuses_an_owner_that_is_neither_root_nor_the_euid`; this cell pins the
+    /// half a careless "confine it" change would silently break.
+    #[test]
+    fn operator_read_to_string_follows_a_self_owned_symlink() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target = temp.path().join("real.conf");
+        std::fs::write(&target, "motd line\n").expect("write");
+
+        let link = temp.path().join("link.conf");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+        assert_eq!(
+            operator_read_to_string(&link).expect("follow a euid-owned symlink"),
+            "motd line\n"
+        );
+    }
     use std::io::{Read, Write};
     use std::os::unix::fs::symlink;
     use tempfile::TempDir;

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -74,7 +74,7 @@ daemon-refuse-compress-threads-alias fail
 daemon-refuse-delete-alias fail
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass
-daemon-secrets-file-symlink fail
+daemon-secrets-file-symlink pass
 daemon-size-arg-overflow fail
 daemon-standalone-detach fail
 daemon-strict-modes-matrix pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -70,7 +70,7 @@ daemon-chroot skip
 daemon-chroot-acl skip
 daemon-chroot-munge-default fail
 daemon-config pass
-daemon-config-symlink fail
+daemon-config-symlink pass
 daemon-copy-links-symlink pass
 daemon-copylinks-intree pass
 daemon-copylinks-parent-escape pass
@@ -113,7 +113,7 @@ daemon-refuse-compress-threads-alias skip
 daemon-refuse-delete-alias fail
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass
-daemon-secrets-file-symlink fail
+daemon-secrets-file-symlink pass
 daemon-size-arg-overflow fail
 daemon-standalone-detach skip
 daemon-strict-modes-matrix fail


### PR DESCRIPTION
The daemon reads `motd file`, `secrets file`, and its config file with a plain
path-based read, as a process that is typically root. A symlink planted at any
path component therefore redirects a privileged read to a file the operator
never named.

Upstream routes every one of these through a single primitive,
`open_no_attacker_symlinks()` (`syscall.c:538`): walk each component without
following it, follow a symlink only when owned by uid 0 or our euid, refuse any
other-uid one (`syscall.c:406`). Its call sites are exactly these files -
`clientserver.c:188` (motd), `authenticate.c:159` (secrets), `params.c:586`
(config).

**oc already had that primitive**, as `fast_io::operator_open_read` - tested,
documented for precisely these consumers, and unused outside six call sites in
three files. This is routing, not new machinery: a `operator_read_to_string`
counterpart plus one platform seam, so call sites stay cfg-free.

## Measured

Linux, as root - both cells self-skip without it, which is why they had never
actually executed.

| | daemon-config-symlink | daemon-secrets-file-symlink |
|---|---|---|
| master (`d2f1414c4`) | FAIL | FAIL |
| this branch | **PASS** | **PASS** |
| real upstream 3.5.0 | PASS | PASS |

The upstream control matters: it makes these genuine oc divergences rather than
fixture artifacts.

## Per-site mutation

Each mutation rebuilt and re-ran both cells, so the attribution is measured, not
assumed:

| reverted site | daemon-config-symlink | daemon-secrets-file-symlink |
|---|---|---|
| motd (`dispatch.rs`) | **FAIL** | PASS |
| secrets (`authentication.rs`) | PASS | **FAIL** |
| config parser (`parser.rs`) | PASS | PASS |

Two things that correction surfaced, both worth stating plainly:

- The cell named `daemon-config-symlink` plants at the **motd** path (and the
  lock-file path) and asserts on the motd leak. It does not exercise the config
  file. My first attribution said otherwise; the mutation refuted it.
- The **config-parser hunk is covered by no suite cell** - reverting it leaves
  both cells green. It is kept because the defect is real and upstream guards it:
  `parse_config_modules_inner` called `path.canonicalize()`, which resolves every
  symlink, then read the resolved path - the redirect happened before any check
  could matter. It now reads the path as given and keeps `canonical` only as the
  recursion-detection key.
- The lock-file half of that cell is also untested here: oc never opens a
  per-module lock file at all, so there is nothing to redirect yet.

## Gates

`cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets
--all-features -D warnings` clean on both changed crates; two new `fast_io` unit
tests (content round-trip, and a self-owned symlink still followed - the half a
careless "confine it" change would break).
