### PR TITLE
docs: refresh README, SECURITY and the changelog against measured state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,74 @@ oc-rsync is wire-compatible with upstream rsync 3.5.0 and the 3.4.x series
 
 ## [Unreleased]
 
+This cycle is dominated by the move to upstream rsync 3.5.0 as the reference
+implementation: retargeting the source-of-truth citations, adopting the new
+3.5.0 option and directive surface, closing the path-confinement and daemon CVE
+families, and putting the 3.5.0 test suite in front of every pull request.
+
+### Security
+
+**Path confinement (CVE-2026-53795 family)**
+- Confine the destination write and the source read against symlink races, and
+  route the confined source open onto one shared per-component resolver instead
+  of two platform arms that had drifted in opposite directions (#7393, #7349)
+- Never follow a symlinked alt-dest basis entry, and read a source symlink
+  target through the confined parent rather than the raw path (#7419, #7418)
+- Resolve an absolute operator rename endpoint by ownership, closing an absolute
+  `--temp-dir` rename injection (#7398)
+- Resolve `--log-file` through the ownership walk (#7404)
+- Decide each `--relative` implied parent level on its own, so a planted
+  intermediate symlink cannot capture the rest of the path (#7415)
+- Open a daemon module root plainly and confine only the peer-supplied tail;
+  applying `RESOLVE_NO_SYMLINKS` to the fused whole made legitimate module roots
+  unreachable without adding confinement (#7304)
+- Apply the daemon filter to the destination argument, and honour
+  `--confine-root` on the server instead of taking it for the destination
+  (#7417, #7388)
+- Add the path-confinement activation predicate as four explicit decisions
+  (opt-out / hardened / root / path kind) rather than one boolean (#7322)
+
+**Daemon**
+- Resolve the real peer address on both stdio paths. The inetd and remote-shell
+  entry points fabricated `127.0.0.1`, which made every `hosts allow` /
+  `hosts deny` rule evaluate against a synthetic localhost (#7303)
+- Match upstream's peer-host naming and ACL evaluation; `hosts deny` no longer
+  fails open when a configured hostname does not resolve (CVE-2026-70452,
+  #7314)
+- Honour the leading-comma separator form in `auth users` and `gid`
+  (CVE-2026-70463, #7345)
+- Add the `auth digest` minimum-digest floor (#7350)
+- Refuse control bytes in a name-converter request, closing a newline-injection
+  desync of the converter stream (#7346)
+- Name the user and the rule in auth-failure log lines (#7395)
+- Treat a backslash in a requested path as a filename byte, not a path separator
+  (#7409)
+
+**Peer-supplied input bounds**
+- Bound peer-supplied xattr bytes and the CONNECT host (#7297)
+- Bound the peer-supplied filter-rule record length (#7377)
+- Bound the equal-weak-checksum chain in the delta matcher (CVE-2026-70453,
+  #7293)
+- Mask peer-supplied `io_error` to the defined `IOERR_*` bits (#7291)
+- Reject stray negative NDX instead of skipping it (#7365)
+- Reject `--max-alloc=0` instead of disabling the guard (#7285)
+- Sanitize received symlink targets when munging is off (#7333)
+- Escape control characters in log-file output, in the sink rather than the CLI
+  renderer so remote-controlled writes cannot reach the terminal raw (#7296,
+  #7357)
+- Redact peer-chosen rule text in filter-rule diagnostics (#7384)
+
+### Added
+
+- `--confine-root=DIR`, `--insecure-links` / `--no-insecure-links`, and
+  `--drop-D` / `--no-drop-D`, matching the new 3.5.0 option surface. Like
+  upstream, `--confine-root` and `--drop-D` are deliberately not forwarded to
+  the remote side (#7396, #7299)
+- `--chmod` now supports chmod(1)-style permission copies (`u=g`, `g=o`) (#7295)
+- The `auth digest` daemon directive (#7350)
+- The soft file-descriptor limit is raised at startup, and a deep path that
+  exhausts descriptors warns once instead of failing silently (#7324, #7323)
+
 ### Changed
 
 - Tracked upstream reference moved to rsync 3.5.0 (released 13 Aug 2026) in
@@ -17,19 +85,135 @@ oc-rsync is wire-compatible with upstream rsync 3.5.0 and the 3.4.x series
   protocol as 3.4.4 (`PROTOCOL_VERSION` 32, `SUBPROTOCOL_VERSION` 0, unchanged
   `errcode.h`), so wire compatibility is unaffected; the release is behavioural,
   covering 33 CVEs in path handling and the daemon.
+- Upstream source citations across the workspace retargeted at the 3.5.0 line
+  numbers, with the citation gate extended to run on docs-only changes and to
+  fail when a cited file does not exist (#7305, #7321, #7331, #7315, #7318,
+  #7308, #7286)
+- rsync 3.5.0 now runs the full interop scenario matrix as a gating peer,
+  alongside 3.0.9, 3.1.3 and 3.4.4 (#7290, #7337)
+- The required upstream-testsuite gate runs the rsync 3.5.0 Python corpus
+  instead of the 3.4.4 shell corpus, as four legs: privilege {non-root, root} x
+  daemon transport {stdio pipe, loopback TCP}. Each leg carries an expected-
+  outcome manifest generated from a real run, so only a change in outcome - a
+  regression, or an unexpected pass - fails the gate (#7387, #7339, #7405,
+  #7408, #7392, #7391)
 - Release benchmarks now compare against upstream rsync 3.5.0 and report **peak
   RSS alongside elapsed time for every mode**. The measurement was already being
   collected for each run and discarded for all but the memory mode, so a speed
   win paid for in memory was invisible in the published numbers.
-- Added rsync 3.5.0 to the interop harness as a built-and-cached oracle binary.
-  The "this release has no distro package, build from source" fact is now stated
-  once in a shared list instead of being duplicated across two dispatch tables.
+- Interop failures name the peer version that broke, via `--only-version`
+  (#7341)
+- The local-copy context state module is split by concern (#7358)
 
-### Added
+### Fixed
 
+**Filters**
+- Reject invalid filter-rule modifiers instead of stopping at the first one
+  (#7361)
+- Match dir-merge modifiers and filter-rule keywords case-sensitively, per
+  upstream `parse_rule_tok` (#7375, #7380, #7379, #7378)
+- Accept the `x` modifier on dir-merge and on hide/show/protect/risk rules
+  without inheriting XATTR, and unstack it from the namespace screen (#7372,
+  #7373, #7374)
+- A clear filter rule goes on the wire as one byte (#7376)
+- Collapse a merge-file name's `..` before opening it (#7288)
+- Fold the pattern inside brackets for case-insensitive matching (#7292)
+- Mirror upstream's clear-list token boundary exactly (#7298)
+- Refuse a sided rule inside a sided merge file, reporting the merge file by the
+  given name rather than its resolved absolute path (#7383)
+- Terminate a self-referential dir-merge instead of hanging (#7362)
+- A receiver must not refuse a perishable rule below protocol 30 (#7381)
+- Track `--delete-excluded` distinctly in the server arg parse (#7382)
+
+**Transfer and receiver**
+- Honour `-B` / `--block-size` on every wire transport; three decoders parsed the
+  value and dropped it (#7301)
+- Surface `MSG_NO_SEND` so a declined file cannot hang a pull (#7371)
+- Frame server-side warnings to the peer instead of dropping them (#7366)
+- A daemon `MSG_IO_TIMEOUT` of 0 must not disable the client's `--timeout`
+  (#7347)
+- Gate the end-of-flist `io_error` on both wire encodings, and honour
+  `--ignore-errors` in the marker (#7414, #7309, #7300)
+- Carry `--ignore-errors` onto the local receiver and local copy (#7302)
+- Fold peer `io_error` before the late delete sweep, order `io_error` to
+  `RERR_*` the way `cleanup.c` does, and drop the redundant re-check from the
+  delayed-deletion flush (#7363, #7326, #7359)
+- Resolve a relative `--temp-dir` against the destination (#7397)
+- Local `--write-batch` must encode the flist the reader decodes (#7355)
+
+**Local copy and engine**
+- Size a local copy from the opened file, not the flist record, and clamp the
+  read to the declared length so a growing source cannot silently truncate
+  (#7403)
+- `--backup` must not override the quick check; it was applying `--checksum`
+  semantics and reading both trees on every run (#7364)
+- Honour `--safe-links` before the backup fast path (#7356)
+- `--link-dest` must create the node when a hard link is refused (#7327)
+- Clearing a directory obstruction is not `--force`'s job (#7416)
+
+**Daemon**
+- Collapse `..` in client paths instead of refusing the request (#7343)
+- Keep the trailing slash that marks the destination a directory (#7411)
+- Probe `nobody` then `nogroup` for the default privilege-drop group (#7342)
+- The Landlock root must be the destination's directory (#7316)
+
+**CLI and output**
+- Honour the `--` end-of-options marker in server-mode argv (#7402)
+- Mirror upstream `parse_output_words` for `--info` / `--debug` tokens (#7412)
+- Bound the out-format width scan like upstream 3.5.0, and treat `%%` as a
+  literal percent in `log_format_has` (#7400, #7344)
+- Report an attribute-only change by name, not "is uptodate" - two independent
+  sites, `--info=name2` and `-vv`, each carried its own copy (#7407)
+- Don't log attribute-only changes under a non-itemizing `--out-format` (#7401)
+- Emit the non-regular skip notice once, not twice at `-v` (#7353)
+- `--iconv` with an unopenable charset must exit 4 rather than transfer (#7311)
+- Reject a `-M` value that does not start with a dash (#7413)
+- Re-port `SHELL_CHARS` to 3.5.0 and stop escaping daemon path operands (#7399)
+- `--chmod=a+s` must set both setuid and setgid (#7287)
+
+**Metadata**
+- An installed name converter must replace the host database (#7360)
+
+### Testing and CI
+
+- The 3.5.0 expect-manifest gate is proven non-vacuous on outcomes, with a
+  whole-suite coverage guard so a silently deleted row cannot pass (#7387)
+- Guard-page over-read harness for the SIMD rolling checksum, carrying its own
+  negative control (#7294)
+- Confined-walk resolver suite; fixes three macOS failures and the CI gap that
+  hid them - the macOS cell omitted `fast_io`, the one crate whose entire
+  purpose is platform-specific I/O (#7325)
+- `test-support` rejects a stale `oc-rsync` binary instead of reporting it as a
+  regression, asserting freshness from Cargo's own depfile (#7385)
+- Umask-dependent mode expectations are derived rather than pinned to constants
+  (#7354, #7348)
+- Daemon test readiness is gated on IPv4 reachability, not any listener (#7370)
+- The required interop context no longer reports a vacuous green: a duplicated
+  copy of the upstream test suite that could only ever hide a failure was
+  deleted, and the two non-blocking 2.6.9 parity cells now report their
+  pre-`continue-on-error` outcome to the job summary (#7352)
+- CI triggers on `merge_group` so a merge queue can validate (#7312)
 - Regression tests for the benchmark report renderer, covering the peak-RSS
   columns, the missing-measurement fallback, and the requirement that a bytes
   metric is not described in duration language ("higher", not "slower").
+
+### Documentation
+
+- Corrected stale upstream-version and CI-gate claims across the contributor
+  docs: five required checks where the ruleset returns eight, a claim of one
+  approving review where the count is zero, three sites naming rsync 3.4.1 as
+  the source of truth, and a hardcoded interop version list that had drifted
+  from the one the harness actually reads (#7351)
+- The upstream 3.5.0 rrsync rule set extracted into a spec; it forces `--drop-D`,
+  not `--no-D` (#7283)
+- Path-confinement resolver API design note, and a spec for the receiver
+  peer-tail confinement fail-open (#7310, #7330)
+- Corrected several upstream claims that were stated backwards or cited the
+  wrong construct: `RESOLVE_BENEATH` where the code omits it, the munge /
+  safe-links ordering, the daemon `sanitize_path` `..` behaviour, and the 3.5.0
+  new-option count (#7307, #7334, #7335, #7284)
+- Fixed the intra-doc links breaking the rustdoc and Pages builds (#7338,
+  #7406)
 
 ## [0.6.4] - 2026-07-18
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict
 
 **Release:** 0.6.4 - Wire-compatible drop-in replacement for rsync 3.5.0 and the 3.4.x series (protocols 28-32).
 
-All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop scenarios run in CI against upstream rsync 3.0.9, 3.1.3, and 3.4.4, with 2.6.9 and 3.5.0 built and cached; 3.4.4 represents the whole 3.4.x series (3.4.1/3.4.2/3.4.3 share protocol 32 and are superseded by it). Upstream rsync's own testsuite runs in CI against `oc-rsync` as `$RSYNC`; against the 3.4.4 corpus all tests pass and the known-failures roster is empty.
+All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop scenarios run in CI against upstream rsync 3.0.9, 3.1.3, 3.4.4 and 3.5.0, with 2.6.9 built and cached; 3.4.4 represents the whole 3.4.x series (3.4.1/3.4.2/3.4.3 share protocol 32 and are superseded by it). Upstream rsync's own testsuite runs in CI against `oc-rsync` as `$RSYNC`: against the 3.4.4 corpus all tests pass and the known-failures roster is empty, and against the newer 3.5.0 corpus **64 of 345 tests currently diverge** (see below).
 
 **Tracking rsync 3.5.0.** Upstream released 3.5.0 on 13 Aug 2026. It is wire-identical to 3.4.4 - `PROTOCOL_VERSION` 32, `SUBPROTOCOL_VERSION` 0, unchanged `errcode.h` - so protocol compatibility carries over unchanged and is what the "wire-compatible" claim above rests on. What 3.5.0 changes is *behaviour*: 33 CVEs concentrated in path handling and the daemon, a rewritten path resolver, five new options (`--confine-root`, `--drop-D`, `--no-drop-D`, `--insecure-links`, `--no-insecure-links`), three new daemon directives (`proxy protocol hosts`, `auth digest`, `insecure links`), and a test suite rebuilt from shell scripts into Python. Aligning oc-rsync to those behaviours is in progress and tracked openly.
 
@@ -30,7 +30,18 @@ The 3.5.0 **release** testsuite runs as four flows, one per cell of privilege x 
 | non-root | [nonroot, pipe](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite.yml) | [nonroot, tcp](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite-tcp.yml) |
 | root     | [root, pipe](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite-root.yml) | [root, tcp](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite-root-tcp.yml) |
 
-The pipe legs run the whole 345-test corpus. The tcp legs add `--daemon-tests-only`, which is what upstream ships that option for - the tests it drops never call `start_test_daemon()`, so they cannot observe the transport - and so run the 155 tests that can. Every leg carries its own expected-outcome manifest, generated from a real run, so only a *change* in outcome (a regression, or an unexpected pass) turns a badge red. The `upstream testsuite` and `upstream testsuite (root)` checks that gate every PR run this same 3.5.0 corpus.
+The pipe legs run the whole 345-test corpus. The tcp legs add `--daemon-tests-only`, which is what upstream ships that option for - the tests it drops never call `start_test_daemon()`, so they cannot observe the transport - and so run the 155 tests that can. The `upstream testsuite` and `upstream testsuite (root)` checks that gate every PR run this same 3.5.0 corpus.
+
+Current outcomes, as recorded in each leg's committed manifest:
+
+| leg | pass | fail | skip | corpus |
+|---|---:|---:|---:|---:|
+| non-root, pipe | 217 | 43 | 85 | 345 |
+| root, pipe | 229 | 62 | 54 | 345 |
+| non-root, tcp | 80 | 42 | 33 | 155 |
+| root, tcp | 87 | 55 | 13 | 155 |
+
+**64 distinct tests** diverge across the two full-corpus legs, and 89 across all four. Every leg carries its own expected-outcome manifest, generated from a real run rather than hand-written, so only a *change* in outcome turns a badge red - and that includes an unexpected **pass**, which is what stops a divergence being quietly re-baselined instead of fixed. A fix flips its manifest rows in the same commit. The divergences are genuine and tracked openly: each was re-run against the real upstream 3.5.0 binary as a negative control, so they are oc-rsync behaviour gaps, not harness artefacts.
 
 Separately, [Upstream Testsuite 3.5.0dev](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml) is a **development** tracker, not a gate and not the 3.5.0 release: it builds RsyncProject git master (`version.h` == `3.5.0dev`), a moving target, and is deliberately non-blocking so an upstream-side break can never fail a PR here.
 
@@ -49,6 +60,7 @@ Separately, [Upstream Testsuite 3.5.0dev](https://github.com/oferchen/rsync/acti
 | **Filtering** | `--filter`, `--exclude`, `--include`, `.rsync-filter`, `--files-from` |
 | **Reference dirs** | `--compare-dest`, `--link-dest`, `--copy-dest` |
 | **Options** | `--delay-updates`, `--inplace`, `--partial`, `--iconv`, fuzzy matching |
+| **3.5.0 surface** | `--confine-root`, `--drop-D` / `--no-drop-D`, `--insecure-links` / `--no-insecure-links`, daemon `auth digest` |
 | **I/O** | io_uring (Linux 5.6+), `copy_file_range`, `clonefile` (macOS), adaptive buffers |
 | **Memory** | Flat file list (contiguous `Vec<FileEntry>`) for efficient scaling at high file counts |
 | **Platforms** | Linux, macOS (full); Windows (NTFS DACL partial, xattrs via NTFS ADS, IOCP file + socket I/O, symlinks with junction fallback; no POSIX device nodes) |
@@ -88,7 +100,7 @@ See the [CHANGELOG](./CHANGELOG.md) for the full, per-release change history.
 
 ### Interop Testing
 
-Tested against upstream rsync **2.6.9**, **3.0.9**, **3.1.3**, and **3.4.4** in CI across protocols 28-32, with **3.5.0** built and cached as an oracle binary ahead of joining the gating matrix. The 3.4.x series shares protocol 32 and is represented in the matrix by 3.4.4; 3.4.1/3.4.2/3.4.3 cells are subsumed because they run identical wire scenarios. 3.5.0 shares that same protocol 32 wire format, so it adds behavioural coverage rather than new protocol coverage. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth. Wire differential fuzzing against upstream rsync validates protocol-level byte equivalence. See the [full interop compatibility matrix](./docs/user/interop-compatibility-matrix.md) for per-version, per-feature, and per-platform detail.
+Tested against upstream rsync **2.6.9**, **3.0.9**, **3.1.3**, **3.4.4** and **3.5.0** in CI across protocols 28-32. The 3.4.x series shares protocol 32 and is represented in the matrix by 3.4.4; 3.4.1/3.4.2/3.4.3 cells are subsumed because they run identical wire scenarios. 3.5.0 shares that same protocol 32 wire format, so it adds behavioural coverage rather than new protocol coverage. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth. Wire differential fuzzing against upstream rsync validates protocol-level byte equivalence. See the [full interop compatibility matrix](./docs/user/interop-compatibility-matrix.md) for per-version, per-feature, and per-platform detail.
 
 ### Supported rsync protocol versions
 
@@ -103,7 +115,7 @@ oc-rsync negotiates `protocol_version` per upstream, defaults to 32, and support
 | 28       | 2.6.0 - 2.6.8          | Wire-level support  | Validated via wire-byte regression tests (RP28.g, RP28.h) |
 | <= 27    | <= 2.5.x               | Not supported       | Pre-dates protocol cleanup; not tested |
 
-Per-version dispatch is implemented as `protocol_version` gates in the wire codecs. See [`crates/protocol/src/wire/compressed_token/zlib_codec.rs`](./crates/protocol/src/wire/compressed_token/zlib_codec.rs) and the sibling [`zstd_codec.rs`](./crates/protocol/src/wire/compressed_token/zstd_codec.rs) / [`lz4_codec.rs`](./crates/protocol/src/wire/compressed_token/lz4_codec.rs) for representative examples of the gates that switch on `protocol_version`.
+Per-version dispatch is implemented as `protocol_version` gates in the wire codecs. See [`crates/protocol/src/wire/compressed_token/zlib_codec.rs`](./crates/protocol/src/wire/compressed_token/zlib_codec.rs) and the sibling [`zstd_codec/`](./crates/protocol/src/wire/compressed_token/zstd_codec) / [`lz4_codec.rs`](./crates/protocol/src/wire/compressed_token/lz4_codec.rs) for representative examples of the gates that switch on `protocol_version`.
 
 ### Supported rsync wire protocol versions
 
@@ -114,7 +126,7 @@ Per-version dispatch is implemented as `protocol_version` gates in the wire code
 | 3.0.9                  | 30       | push, pull, daemon       | gating |
 | 3.1.3                  | 31       | push, pull, daemon       | gating |
 | 3.4.4                  | 32       | push, pull, daemon, SSH  | gating |
-| 3.5.0                  | 32       | push, pull, daemon, SSH  | built + cached (not yet gating) |
+| 3.5.0                  | 32       | push, pull, daemon, SSH  | gating |
 
 Wire format is verified byte-identical to upstream rsync via CI golden-byte tests for the listed versions. Wire differential fuzzing validates protocol-level byte equivalence against upstream. Other versions may work but are not regression-tested.
 
@@ -208,8 +220,8 @@ Three one-shot warnings may appear on stderr (sync path) or via `tracing` target
 oc-rsync is wire-compatible with upstream rsync 3.5.0, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:
 
 - **io_uring kernel requirement.** Provided buffer rings (PBUF_RING) require Linux **5.19+**; older 5.6-5.18 kernels fall back to standard buffered I/O via runtime probing.
-- **io_uring buffer pool.** The registered buffer pool defaults to 1024 × 4 KiB = 4 MiB and does not auto-adapt under sustained I/O pressure, though its slot count, memory cap, and block size are tunable at runtime via the `OC_RSYNC_BUFFER_POOL_SIZE`, `OC_RSYNC_BUFFER_POOL_MEMORY_CAP`, and `OC_BUFFER_POOL_BLOCK_SIZE` environment variables. Workloads with very high concurrent file fan-out may still see throughput plateau before saturating the device.
-- **bgid namespace.** io_uring buffer-group IDs are a 16-bit namespace; the buffer ring helpers cap at this bound. Long-running daemons that recycle thousands of distinct ring groups should monitor for exhaustion.
+- **Two distinct buffer pools.** The **engine** `BufferPool` is the one the `OC_RSYNC_BUFFER_POOL_SIZE`, `OC_RSYNC_BUFFER_POOL_MEMORY_CAP` and `OC_BUFFER_POOL_BLOCK_SIZE` environment variables tune (`crates/engine/src/local_copy/buffer_pool/`). The **io_uring registered buffer pool** is separate, is sized statically, does not auto-adapt under sustained I/O pressure, and is *not* affected by those variables. Workloads with very high concurrent file fan-out may see throughput plateau before saturating the device.
+- **bgid namespace.** io_uring buffer-group IDs are a 16-bit namespace and the buffer-ring helpers cap at that bound, returning a typed error rather than wrapping. In practice IDs are recycled rather than accumulated - a measured run of 100,000 sessions consumed a single bgid - so exhaustion is not an expected operational condition.
 - **Delta computation is single-threaded per file by default.** The delta sender is sequential per file. Large-file delta scanning can be parallelised opt-in with `--parallel-delta-scan`, and basis-signature hashing with `--checksum-threads=N`; without those flags a large-file transfer uses one CPU for delta work.
 - **SSH compression interaction.** When the SSH transport already compresses the stream (e.g., `Compression yes` in `ssh_config`), running `oc-rsync -z` compresses payloads twice. oc-rsync warns when it detects `-C` / `-o Compression=yes` in the SSH argv it builds, and - with the default `ssh-config-parse` feature - when a `Compression yes` directive applies via `~/.ssh/config` / `-F` / `/etc/ssh/ssh_config`; it does not auto-disable either layer, so operators should pick one.
 - **Daemon encryption.** The daemon protocol is plaintext, matching upstream rsync (authentication only, no encryption). oc-rsync has no built-in TLS client - the former `--ssl` / `client-tls` path was removed to match upstream. Encrypt with the SSH transport, or place the daemon behind a TLS-terminating proxy (`stunnel`, HAProxy, nginx) and reach it through an external wrapper such as `rsync-ssl` or `stunnel`, the same model as upstream.
@@ -297,9 +309,9 @@ The concurrent-delta receiver bounds its in-memory `ReorderBuffer` through a
 process-wide `SpillPolicy` knob. The default policy keeps everything in memory
 (byte-equivalent to prior releases). Opt in to disk-backed spill by setting
 `OC_RSYNC_SPILL_THRESHOLD_BYTES` (e.g. `64M`) and, optionally,
-`OC_RSYNC_SPILL_DIR` to point at a fast scratch directory. CLI flags
-`--spill-dir` and `--spill-threshold-bytes` are planned for STN-11 and will
-shadow the env vars when present. Full surface (env vars, reclaim mode,
+`OC_RSYNC_SPILL_DIR` to point at a fast scratch directory. The CLI flags
+`--spill-dir` and `--spill-threshold-bytes` shadow the env vars when present.
+Full surface (env vars, reclaim mode,
 granularity, compression, validation rules, defaults table) is in
 [`docs/design/spill-policy-public-api.md`](./docs/design/spill-policy-public-api.md);
 the underlying buffer is documented in
@@ -442,7 +454,7 @@ All crates enforce `#![deny(unsafe_code)]`. Targeted `#[allow(unsafe_code)]` is 
 - **protocol** - One isolated allow in `multiplex::helpers` for frame parsing
 - **windows-gnu-eh** - Windows GNU exception handling shims
 
-Not vulnerable to (or mitigated against) known upstream rsync CVEs (CVE-2024-12084 through CVE-2024-12088, CVE-2024-12747) - see `SECURITY.md` for the per-CVE status. All CVE mitigations complete (SEC-1, SEC-2, SEC-3, SEC-MK series). TOCTOU path-based syscalls replaced with `*at` variants throughout.
+Not vulnerable to (or mitigated against) the 2024 upstream rsync CVEs (CVE-2024-12084 through CVE-2024-12088, CVE-2024-12747), and the rsync 3.4.3 batch (CVE-2026-29518, 43617, 43618, 43619, 43620, 45232) is closed - SEC-1, SEC-2, SEC-3 and SEC-MK series complete, TOCTOU path-based syscalls replaced with `*at` variants throughout. The rsync **3.5.0** batch of 33 CVEs is **partially closed and openly tracked**: it is a behavioural release, not a protocol one, so each item needs its own evidence rather than a blanket claim. See [`SECURITY.md`](./SECURITY.md) for per-CVE status, including which items are fixed and which remain under audit.
 
 ### Upstream rsync 3.4.3 hardening
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,23 +81,33 @@ rsync 3.5.0 is a major security release closing **33 CVEs**, concentrated in pat
 
 **What is established.** 3.5.0 is wire-identical to 3.4.4 (`PROTOCOL_VERSION` 32, `SUBPROTOCOL_VERSION` 0, unchanged `errcode.h`), so none of these CVEs stem from a protocol change and none require a wire-format response. They are implementation vulnerabilities in areas oc-rsync reimplements independently, which means neither "inherited" nor "not applicable" can be assumed for any of them - each needs its own evidence.
 
-**What is measured.** Running upstream's 3.5.0 test suite against oc-rsync reports 133 divergent tests. That set is the triage input, not a vulnerability count: it mixes real behavioural gaps, harness differences, and probes for C-level memory errors that have no Rust analogue. Classification requires per-test evidence.
+**What is measured.** Upstream's 3.5.0 test suite runs against oc-rsync as a gate on every pull request, in four legs - privilege {non-root, root} x daemon transport {stdio pipe, loopback TCP}. Each leg carries an expected-outcome manifest generated from a real run, so the divergence set is a committed, per-test ledger rather than an estimate:
+
+| leg | pass | fail | skip | corpus |
+|---|---:|---:|---:|---:|
+| non-root, pipe | 217 | 43 | 85 | 345 |
+| root, pipe | 229 | 62 | 54 | 345 |
+| non-root, tcp | 80 | 42 | 33 | 155 |
+| root, tcp | 87 | 55 | 13 | 155 |
+
+The two pipe legs run the whole corpus; the tcp legs add `--daemon-tests-only`, so they re-run the 155 tests that can observe the transport. **64 distinct tests** diverge across the two full-corpus legs, and **89** across all four. That set is the triage input, not a vulnerability count: it mixes real behavioural gaps, harness differences, and probes for C-level memory errors that have no Rust analogue. Classification requires per-test evidence, and a fix flips its manifest rows in the same commit - re-baselining a row without a fix would be a waiver, and the gate fails on an unexpected *pass* for exactly that reason.
 
 **Highest-severity items and their oc-rsync bearing:**
 
 | CVE | Severity | Upstream issue | oc-rsync bearing |
 |-----|----------|----------------|------------------|
-| CVE-2026-53791 | CRITICAL | `proxy protocol = true` let a directly-connecting client forge a PROXY header and spoof its source address, defeating `hosts allow`/`hosts deny`. Fixed by a new `proxy protocol hosts` allow-list that fails **closed** when unset. | Related and independently tracked: oc-rsync's daemon currently derives a placeholder peer address on its stdio paths, which weakens `hosts allow`/`hosts deny` in the same direction. Being fixed as a prerequisite. |
-| CVE-2026-70452 | HIGH | `hosts deny` failed **open** when a configured hostname would not resolve. | Under audit. Same fail-open class as the above. |
-| CVE-2026-70464 | HIGH | An unauthenticated peer could complete the `@RSYNCD` handshake. | Under audit; 3.5.0 also adds an `auth digest` floor directive. |
-| CVE-2026-53784 / 53793 | HIGH | Daemon module-root chdir escape under `use chroot`, and a `/./` inner-module escape via a symlinked path. | Under audit. |
-| CVE-2026-53795 | HIGH | An absolute `--temp-dir` or `--link-dest` **disabled path confinement entirely**. | Directly applicable: oc-rsync's confinement is narrower than 3.5.0's and is being widened to the new model. |
-| CVE-2026-53783 | HIGH | `rrsync` restricted-directory escape - each path was validated, but the validation could be walked out of. | oc-rsync ships no restricted-shell wrapper today; one is being added, enforcing through the same path resolver rather than a separate validator. |
-| CVE-2026-53790 | HIGH | Command / argument injection via unquoted peer- or config-supplied values. | Under audit. |
-| CVE-2026-70453 | HIGH | Quadratic CPU exhaustion in `hash_search()` from a long equal-weak-checksum chain. | Under audit; oc-rsync's block matcher differs from upstream's, so the bound must be reasoned about independently. |
-| CVE-2026-70455 / 70463 / 70461 / 70458 / 70456 | HIGH | Peer-controlled Zstandard thread count; `auth users` separator handling; three out-of-bounds heap writes. | The memory-safety trio has no direct Rust analogue, but each also has an observable half - whether malformed input is **rejected** rather than accepted with wrong state - which is being checked rather than assumed. |
+| CVE-2026-53791 | CRITICAL | `proxy protocol = true` let a directly-connecting client forge a PROXY header and spoof its source address, defeating `hosts allow`/`hosts deny`. Fixed by a new `proxy protocol hosts` allow-list that fails **closed** when unset. | The `proxy protocol hosts` directive itself is still **under audit**. The related prerequisite is **fixed**: the daemon's two stdio entry points fabricated `127.0.0.1` as the peer address, which made every `hosts allow` / `hosts deny` rule evaluate against a synthetic localhost. Both now mirror upstream `client_addr()` - `getpeername` under inetd, the `REMOTE_HOST` / `SSH_CONNECTION` / `SSH_CLIENT` / `SSH2_CLIENT` environment chain under a remote shell - and abort with `RERR_SOCKETIO` rather than inventing a value (PR #7303). |
+| CVE-2026-70452 | HIGH | `hosts deny` failed **open** when a configured hostname would not resolve. | **Fixed.** The root cause was a missing distinction, not a missing check: `forward_resolve` collapsed "lookup failed" and "resolved but did not match" into one empty result, which is what made the deny side fail open. The resolver now returns `Option<Vec<IpAddr>>` so the two are separable, and hostname matching is case-insensitive against a lowercased list per upstream `iwildmatch` (access.c:46) (PR #7314). |
+| CVE-2026-70464 | HIGH | An unauthenticated peer could complete the `@RSYNCD` handshake. | Under audit. The related `auth digest` minimum-digest floor has **shipped** (PR #7350); `Md4Old` must rank as md4 or the floor locks out the very clients it exists to reason about. |
+| CVE-2026-53784 / 53793 | HIGH | Daemon module-root chdir escape under `use chroot`, and a `/./` inner-module escape via a symlinked path. | Under audit. Related and fixed: the daemon fused the operator module root and the peer-supplied tail into one absolute string and applied `RESOLVE_NO_SYMLINKS` to the whole thing. Upstream keeps the two in different mechanisms - plain `chdir`/`openat` for the root, a confined `RESOLVE_BENEATH` walk for the tail - and oc-rsync now does the same (PR #7304). |
+| CVE-2026-53795 | HIGH | An absolute `--temp-dir` or `--link-dest` **disabled path confinement entirely**. | Directly applicable, and **largely closed**. oc-rsync's confinement was narrower than 3.5.0's and has been widened onto one shared per-component resolver: the staging family (`--temp-dir`, `--partial-dir`, `--backup-dir`), `--log-file`, the alt-dest basis leaf, `--relative` implied parents, and absolute rename endpoints all now resolve through the ownership walk (PRs #7398, #7404, #7415, #7419, #7393). The remaining operator-path families are tracked as open work. |
+| CVE-2026-53783 | HIGH | `rrsync` restricted-directory escape - each path was validated, but the validation could be walked out of. | oc-rsync ships no restricted-shell wrapper today; one is being added, enforcing through the same path resolver rather than a separate validator. The upstream rule set is extracted as a spec (PR #7283) - note it forces `--drop-D`, not `--no-D`. |
+| CVE-2026-53790 | HIGH | Command / argument injection via unquoted peer- or config-supplied values. | Under audit. Upstream has four sinks and three remedies; oc-rsync has two of the same shape, one structurally different, and one that does not apply. The live sink in oc-rsync is its own single-character config expansion, which upstream does not have - so an upstream-shaped port alone would be inert here. |
+| CVE-2026-70453 | HIGH | Quadratic CPU exhaustion in `hash_search()` from a long equal-weak-checksum chain. | **Fixed** (PR #7293). oc-rsync's block matcher differs from upstream's, so the bound was derived independently rather than copied. |
+| CVE-2026-70463 | HIGH | `auth users` separator handling. | **Fixed** (PR #7345). Upstream's leading-comma separator form is honoured at both affected sites - `auth users` and `gid`, not just the one named in the advisory. |
+| CVE-2026-70455 / 70461 / 70458 / 70456 | HIGH | Peer-controlled Zstandard thread count; three out-of-bounds heap writes. | The memory-safety trio has no direct Rust analogue, but each also has an observable half - whether malformed input is **rejected** rather than accepted with wrong state - which is being checked rather than assumed. |
 
-**New defensive surfaces in 3.5.0** that oc-rsync is adopting: `--confine-root=DIR`, `--drop-D` / `--no-drop-D`, `--insecure-links` / `--no-insecure-links`, and the `insecure links`, `proxy protocol hosts` and `auth digest` daemon directives.
+**New defensive surfaces in 3.5.0.** `--confine-root=DIR`, `--drop-D` / `--no-drop-D`, `--insecure-links` / `--no-insecure-links` and the `auth digest` daemon directive have **shipped** (PRs #7396, #7299, #7350). Like upstream, `--confine-root` and `--drop-D` are deliberately **not forwarded** to the remote side: both are meant to be applied to one end of a connection by itself. The `insecure links` and `proxy protocol hosts` daemon directives are **not yet implemented**.
 
 `--drop-D` tells a receiver to refuse to create device and special files whatever the transfer requested. It exists because the obvious alternative does not work: `--no-D` also frames the file list's rdev fields, and only one end of a connection receives the option, so a `-D` sender writes rdev that a `--no-D` receiver never reads. That desynchronises the list - a FIFO hangs the transfer at protocol 29 and corrupts it at 30, and a device node breaks every protocol. `--drop-D` refuses the creation while leaving the wire format untouched. Like `--confine-root`, it is deliberately **not forwarded** to the remote side: both are meant to be applied to one end of a connection by itself.
 
@@ -146,7 +156,7 @@ Additionally shipped since the last update:
 
 **Status: Fixed.** All receiver call sites are wired through `DirSandbox`, and the SEC-1.m / SEC-1.n regression suites pass against the fully-wired pipeline. The SEC-1.p Landlock layer provides defense-in-depth.
 
-CI integration: as of 2026-05-21 the interop job (`.github/workflows/_interop.yml`) runs upstream rsync's own testsuite corpus against oc-rsync as `$RSYNC`, pinned to upstream 3.4.4 by default. A separate nightly job runs the rewritten 3.5.0 Python suite so the divergence set above stays measured rather than estimated. The known-failures roster lives at `tools/ci/upstream_testsuite_known_failures.conf`.
+CI integration: upstream rsync's own testsuite runs against oc-rsync as `$RSYNC` on every pull request. As of 2026-08-21 the gating corpus is the rewritten **3.5.0 Python suite**, run as the four legs tabulated above; the required checks are the two stdio-pipe legs, and the two loopback-TCP legs run alongside them. Each leg is gated by its committed expected-outcome manifest (`tools/ci/upstream-3.5.0-expect.{nonroot,root}{,.tcp}.txt`), generated from a real run and never hand-typed. The older 3.4.4 shell corpus still runs in the interop job with the roster at `tools/ci/upstream_testsuite_known_failures.conf`, which is currently empty - against 3.4.4 all tests pass.
 
 ### Upstream rsync 3.4.2 audits
 
@@ -185,7 +195,7 @@ For each new upstream rsync CVE:
 
 ## Fuzzing
 
-The repo ships 24 cargo-fuzz targets covering security-critical parsing, SIMD parity, and differential fuzzing against upstream rsync:
+The repo ships 26 cargo-fuzz targets covering security-critical parsing, SIMD parity, concurrency, and differential fuzzing against upstream rsync:
 
 **Core protocol parsing:**
 - `varint_decode` - variable-length integer codec
@@ -201,20 +211,24 @@ The repo ships 24 cargo-fuzz targets covering security-critical parsing, SIMD pa
 
 **Daemon and configuration:**
 - `daemon_greeting` - daemon greeting generation
-- `rsyncd_conf` (FCV-16) - `rsyncd.conf` line parser
 - `batch_reader` (FCV-12) - rsync batch file header
 - `bwlimit` (FCV-15) - bwlimit CLI string parser
 
 **Metadata and extensions:**
 - `acl_xattr_wire` (FCV-11) - ACL/xattr wire format
 - `filter_list_wire` - filter list wire format
+- `buffered_map` - buffered map decoder
 
 **Compression:**
 - `decompressor_zlib` - zlib decompression
 - `decompressor_zstd` - zstd decompression
+- `zlib_token_decode` - zlib compressed-token decoder
 
 **SIMD parity:**
 - `simd_checksum_parity` - cross-validates AVX2, SSE2, NEON, and scalar rolling/strong checksum paths against random inputs (see #2103)
+
+**Concurrency:**
+- `parallel_receive_delta_adversarial` - adversarial scheduling against the parallel receive-delta pipeline
 
 **Filter rules:**
 - `filter_rules_vs_upstream` - filter rule evaluation vs upstream behavior
@@ -233,11 +247,11 @@ These cover operationally relevant trade-offs in the current code base and how t
 
 ### Buffer pool bounds checks
 
-`recycle_buffer(buf_id)` in the io_uring path validates that `buf_id` falls within the registered buffer pool using `debug_assert!`. In release builds the assertion compiles out, so a corrupted or attacker-influenced `buf_id` reaching this code path would index out of range and either produce undefined behaviour inside the io_uring crate or — more likely — be caught by the kernel as an invalid SQE. A defense-in-depth fix to upgrade the check to a release-mode bound is tracked; until it lands, do not expose the io_uring path to untrusted protocol input.
+`recycle_buffer(buf_id)` in the io_uring path (`crates/fast_io/src/io_uring/buffer_ring/mod.rs`) validates that `buf_id` falls within the registered buffer pool and returns `BufferRingError::BufferIdOutOfRange` when it does not. The check runs in **both debug and release builds**, and the recycle is refused before any state is mutated, so a corrupted or attacker-influenced `buf_id` cannot advance the ring tail or write into kernel-shared memory. Callers may log and ignore the error or surface it through the `From<BufferRingError> for io::Error` conversion.
 
 ### io_uring buffer-group ID namespace
 
-io_uring buffer-group IDs (`bgid`) live in a 16-bit namespace. The provided-buffer ring helpers in `fast_io` cap allocation at this bound, and exhaustion returns an error rather than wrapping. Long-running daemons that churn ring groups should monitor for the bounded error and recycle.
+io_uring buffer-group IDs (`bgid`) live in a 16-bit namespace. The provided-buffer ring helpers in `fast_io` cap allocation at this bound, and exhaustion returns a typed error rather than wrapping - it is never silent. IDs are recycled rather than accumulated: a measured run of 100,000 sessions consumed a single bgid, so exhaustion is not an expected operational condition and no monitoring is required for it.
 
 ### SSH double compression
 


### PR DESCRIPTION
## What

Updates and cleans up `README.md`, `SECURITY.md` and `CHANGELOG.md`.

The changelog had not been touched since 2026-08-13 (#7279) while roughly 140 PRs merged. Several claims in README and SECURITY had drifted far enough to mislead an operator - two of them in a direction that matters.

Every correction below was checked against the tree at this commit, not inferred.

## CHANGELOG

`## [Unreleased]` now covers everything merged since #7279, grouped **Security / Added / Changed / Fixed / Testing and CI / Documentation**, with PR references.

## SECURITY.md - corrections

| Claim | Reality |
|---|---|
| "Running upstream's 3.5.0 test suite reports **133** divergent tests" | The committed expect manifests say **43** (non-root, pipe) and **62** (root, pipe) - **64 distinct**, and **89** across all four legs. Replaced the estimate with the per-leg table plus how the manifest gate works. |
| The 3.5.0 suite runs as "a separate nightly job" | It is the **required gate on every PR**, four legs (privilege x transport). |
| CVE-2026-53791: "oc-rsync's daemon **currently** derives a placeholder peer address ... being fixed as a prerequisite" | **Fixed** in #7303. Both stdio entry points mirror upstream `client_addr()`. The directive itself is still under audit and stays marked so. |
| CVE-2026-70452, -70463, -70453 listed as "Under audit" | All three **fixed** (#7314, #7345, #7293). |
| "New defensive surfaces ... that oc-rsync **is adopting**" (all 8) | Four have **shipped**; `insecure links` and `proxy protocol hosts` have **not**. Stated per item. |
| "The repo ships **24** cargo-fuzz targets", listing `rsyncd_conf` | There are **26**, and `rsyncd_conf` **does not exist** in `fuzz/fuzz_targets`. Removed it, added the three real targets that were missing (`buffered_map`, `zlib_token_decode`, `parallel_receive_delta_adversarial`). |
| Buffer-pool note: `recycle_buffer` guards `buf_id` with `debug_assert!`, which "compiles out in release" - therefore **"do not expose the io_uring path to untrusted protocol input"** | **False, and it was the load-bearing sentence.** `buffer_ring/mod.rs:472` performs a real bound check in both debug and release, returning `BufferRingError::BufferIdOutOfRange` **before any state is mutated**. Rewritten; the warning is gone. |
| bgid: "should monitor for exhaustion" | Exhaustion returns a typed error and does not occur in practice - a measured 100,000-session run consumed a single bgid. |

## README.md - corrections

- **3.5.0 was described as built-and-cached "ahead of joining the gating matrix"**, and the protocol table row read `built + cached (not yet gating)`. `tools/ci/run_interop.sh` has it in `versions=(3.0.9 3.1.3 3.4.4 3.5.0)` - it is gating.
- **The testsuite section described the mechanism but never stated the outcome.** Added the per-leg table and said plainly that **64 of 345 tests currently diverge**, that each was re-run against the real 3.5.0 binary as a negative control, and that the gate fails on an unexpected *pass* precisely so a divergence cannot be quietly re-baselined instead of fixed.
- **CVE line stopped at the 2024 batch.** The 3.4.3 batch is closed; the 3.5.0 batch of 33 is partially closed and openly tracked.
- **`--spill-dir` / `--spill-threshold-bytes` were described as "planned for STN-11".** Both exist in the CLI today.
- **`OC_RSYNC_BUFFER_POOL_SIZE` / `_MEMORY_CAP` / `OC_BUFFER_POOL_BLOCK_SIZE` were attributed to the io_uring registered buffer pool.** All three live in `crates/engine/src/local_copy/buffer_pool/global.rs` and tune the **engine** pool. An operator setting them expecting io_uring behaviour would get nothing. The two pools are now named separately.
- Fixed a broken relative link (`compressed_token/zstd_codec` is a directory, not `.rs`).
- Added the shipped 3.5.0 option surface to the feature table.

## Verification

- All relative links in the three files resolve to real paths (checked mechanically; the `zstd_codec` break was found this way).
- Every factual claim changed above was verified by reading the tree: manifest row counts via `awk`, fuzz targets via `git ls-tree`, env vars and CLI flags via grep against `crates/`, `recycle_buffer` by reading the function.
- No em-dashes; hyphens throughout, per house style.

## Deliberately not changed

`Cargo.toml:461` still pins `upstream_version = "3.4.4"` while the changelog prose tracks 3.5.0. That flip is the **last** step of the 3.5.0 retarget and moves the citation gate across the tree, so it does not belong in a documentation pass. Flagging it rather than smuggling it in.
