### PR TITLE
fix(cli): read --password-file through the ownership walk

### DIFF
--- a/crates/cli/src/frontend/password.rs
+++ b/crates/cli/src/frontend/password.rs
@@ -152,6 +152,38 @@ fn first_line(bytes: &[u8]) -> Vec<u8> {
     }
 }
 
+/// Open an operator-named file, refusing an attacker-owned symlink component.
+///
+/// `--password-file` is named by the operator, never by a peer, and is read
+/// while the process may still hold elevated privilege. A plain [`File::open`]
+/// follows a symlink at every component, so a link planted on the path
+/// redirects a privileged read to a file the operator never named. Upstream
+/// opens it through the same component walk it uses for the daemon's secrets
+/// file: each component is opened without following it, and a symlink is
+/// followed only when owned by uid 0 or our euid.
+///
+/// The platform seam lives here rather than at the call site. On non-Unix
+/// targets the ownership walk has no meaning (there is no `st_uid` to trust)
+/// and this degrades to a plain open, matching how the rest of the tree gates
+/// `fast_io`'s operator-path helpers.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/authenticate.c:245` - `getpassf()` opens `--password-file`
+///   with `open_no_attacker_symlinks(filename, O_RDONLY, 0)`.
+/// - `rsync-3.5.0/syscall.c:538` - `open_no_attacker_symlinks()`; the
+///   trust rule is at `syscall.c:406`.
+fn open_operator_named(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_read(path)
+    }
+    #[cfg(not(unix))]
+    {
+        File::open(path)
+    }
+}
+
 /// Reads a password from `path` while enforcing upstream rsync's permission rules.
 ///
 /// The function accepts either an on-disk file or `-` to read from standard
@@ -174,7 +206,7 @@ pub(crate) fn load_password_file(path: &Path) -> Result<Vec<u8>, Message> {
     // handle. This mirrors upstream rsync's approach and avoids time-of-check
     // to time-of-use races where an attacker swaps the path after the
     // metadata check but before the read.
-    let mut file = File::open(path).map_err(|error| {
+    let mut file = open_operator_named(path).map_err(|error| {
         rsync_error!(
             1,
             format!("failed to access password file '{}': {}", display, error)
@@ -305,6 +337,35 @@ mod tests {
         let loaded = load_optional_password(Some(path.as_ref())).expect("load password");
 
         assert_eq!(loaded, Some(b"from-file".to_vec()));
+    }
+
+    /// The ownership walk must still FOLLOW a symlink the caller owns.
+    ///
+    /// The refusal direction needs a symlink owned by a third uid, which needs
+    /// root to plant; the upstream suite covers it in its root leg
+    /// (`password-file-symlink_test.py`, which skips without root). What is
+    /// checkable here is the other direction, and it is the one a regression
+    /// would break: swapping the walk for a refuse-all resolver would reject
+    /// this legitimate self-owned parent symlink and break every operator who
+    /// keeps a password file behind one.
+    #[cfg(unix)]
+    #[test]
+    fn load_password_file_follows_a_self_owned_parent_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().expect("create temp dir");
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).expect("create real dir");
+        let secret = real.join("pw");
+        std::fs::write(&secret, b"through-the-link\n").expect("write secret");
+        std::fs::set_permissions(&secret, std::fs::Permissions::from_mode(0o600))
+            .expect("tighten secret permissions");
+        symlink(&real, dir.path().join("link")).expect("plant self-owned symlink");
+
+        let loaded =
+            load_password_file(&dir.path().join("link").join("pw")).expect("read through symlink");
+
+        assert_eq!(loaded, b"through-the-link".to_vec());
     }
 
     #[test]

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -119,7 +119,7 @@ operator-path-partial-dir-exclude-daemon fail
 operator-path-traversal-backup-dir-daemon fail
 operator-path-traversal-dest-dir-daemon fail
 operator-path-traversal-partial-dir-daemon pass
-password-file-symlink fail
+password-file-symlink pass
 peer-legacy-implied-delete-scope pass
 proto-cleared-dirflist fail
 proto-cleared-ndx fail

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -236,7 +236,7 @@ partial-dir-abs-delta pass
 partial-protected-regular-retry-linux fail
 partial-protected-regular-retry-policy skip
 partial_nowrite pass
-password-file-symlink fail
+password-file-symlink pass
 peer-legacy-implied-delete-scope skip
 preallocate fail
 protected-regular pass


### PR DESCRIPTION
## Problem

`--password-file` is named by the operator, never by a peer, and is read while
the process may still hold elevated privilege. The open was a plain
`File::open`, which follows a symlink at **every** path component. A link
planted on that path redirects the privileged read to a file the operator never
named, and those bytes are then sent as the daemon auth response - so a
malicious daemon, or a timing channel, observes the leaked content.

## Upstream

Upstream opens it through the same component walk it uses for the daemon
secrets file: each component is opened without following it, and a symlink is
followed only when owned by uid 0 or our euid.

| upstream site | what |
|---|---|
| `authenticate.c:245` | `getpassf()` -> `open_no_attacker_symlinks(filename, O_RDONLY, 0)` |
| `syscall.c:538` | `open_no_attacker_symlinks()` |
| `syscall.c:406` | the trust rule (uid 0 or euid) |

oc already ports that primitive as `fast_io::operator_open_read` - and its own
rustdoc names `--password-file` as an intended caller. It was simply never
routed there. #7422 routed the daemon config, motd and secrets files onto it;
this closes the client-side sibling.

## Shape

The platform seam lives in one helper rather than at the call site, matching
the daemon's existing `operator_file::read_to_string`. On non-Unix targets
there is no `st_uid` to trust, so it degrades to a plain open - the same gating
the rest of the tree uses for `fast_io`'s operator-path helpers.

## Manifests

`password-file-symlink` flips `fail` -> `pass` in **both root** expect
manifests, in this commit. The cell plants a symlink owned by a third uid at
both the leaf and a parent component and asserts the read is refused. It
self-skips without root, which is why the two non-root manifests correctly keep
`skip`. Row counts are unchanged (349 / 158).

## Verification

- `cargo nextest run -p cli --all-features -E 'test(password)' --no-fail-fast` - **30 run, 30 passed** (`passed == run`, so no fail-fast truncation).
- **Reachability proven by mutation.** The new test alone cannot discriminate the fix - `File::open` would pass it too - so the helper body was replaced with an unconditional `Err`; the password tests then fail. That is the check that would have caught an inert fix.
- `cargo fmt --all -- --check` clean; `cargo clippy -p cli --all-targets --all-features --no-deps -- -D warnings` clean.

The added test pins the **follow** direction, not the refusal: at non-root a
test-created symlink is euid-owned and is legitimately followed, so the refusal
direction needs root and is covered by the suite's root leg. The follow test is
the one that matters locally - it fails if anyone swaps the ownership walk for
a refuse-all resolver, which would break every operator keeping a password file
behind a symlinked parent.
