### PR TITLE
fix(filters): read per-directory merge files through the ownership walk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,9 @@ dependencies = [
 name = "filters"
 version = "0.6.4"
 dependencies = [
+ "fast_io",
  "globset",
+ "libc",
  "logging",
  "proptest",
  "tempfile",

--- a/crates/cli/src/frontend/password.rs
+++ b/crates/cli/src/frontend/password.rs
@@ -152,6 +152,38 @@ fn first_line(bytes: &[u8]) -> Vec<u8> {
     }
 }
 
+/// Open an operator-named file, refusing an attacker-owned symlink component.
+///
+/// `--password-file` is named by the operator, never by a peer, and is read
+/// while the process may still hold elevated privilege. A plain [`File::open`]
+/// follows a symlink at every component, so a link planted on the path
+/// redirects a privileged read to a file the operator never named. Upstream
+/// opens it through the same component walk it uses for the daemon's secrets
+/// file: each component is opened without following it, and a symlink is
+/// followed only when owned by uid 0 or our euid.
+///
+/// The platform seam lives here rather than at the call site. On non-Unix
+/// targets the ownership walk has no meaning (there is no `st_uid` to trust)
+/// and this degrades to a plain open, matching how the rest of the tree gates
+/// `fast_io`'s operator-path helpers.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/authenticate.c:245` - `getpassf()` opens `--password-file`
+///   with `open_no_attacker_symlinks(filename, O_RDONLY, 0)`.
+/// - `rsync-3.5.0/syscall.c:538` - `open_no_attacker_symlinks()`; the
+///   trust rule is at `syscall.c:406`.
+fn open_operator_named(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_read(path)
+    }
+    #[cfg(not(unix))]
+    {
+        File::open(path)
+    }
+}
+
 /// Reads a password from `path` while enforcing upstream rsync's permission rules.
 ///
 /// The function accepts either an on-disk file or `-` to read from standard
@@ -174,7 +206,7 @@ pub(crate) fn load_password_file(path: &Path) -> Result<Vec<u8>, Message> {
     // handle. This mirrors upstream rsync's approach and avoids time-of-check
     // to time-of-use races where an attacker swaps the path after the
     // metadata check but before the read.
-    let mut file = File::open(path).map_err(|error| {
+    let mut file = open_operator_named(path).map_err(|error| {
         rsync_error!(
             1,
             format!("failed to access password file '{}': {}", display, error)
@@ -305,6 +337,35 @@ mod tests {
         let loaded = load_optional_password(Some(path.as_ref())).expect("load password");
 
         assert_eq!(loaded, Some(b"from-file".to_vec()));
+    }
+
+    /// The ownership walk must still FOLLOW a symlink the caller owns.
+    ///
+    /// The refusal direction needs a symlink owned by a third uid, which needs
+    /// root to plant; the upstream suite covers it in its root leg
+    /// (`password-file-symlink_test.py`, which skips without root). What is
+    /// checkable here is the other direction, and it is the one a regression
+    /// would break: swapping the walk for a refuse-all resolver would reject
+    /// this legitimate self-owned parent symlink and break every operator who
+    /// keeps a password file behind one.
+    #[cfg(unix)]
+    #[test]
+    fn load_password_file_follows_a_self_owned_parent_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().expect("create temp dir");
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).expect("create real dir");
+        let secret = real.join("pw");
+        std::fs::write(&secret, b"through-the-link\n").expect("write secret");
+        std::fs::set_permissions(&secret, std::fs::Permissions::from_mode(0o600))
+            .expect("tighten secret permissions");
+        symlink(&real, dir.path().join("link")).expect("plant self-owned symlink");
+
+        let loaded =
+            load_password_file(&dir.path().join("link").join("pw")).expect("read through symlink");
+
+        assert_eq!(loaded, b"through-the-link".to_vec());
     }
 
     #[test]

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -245,8 +245,23 @@ pub(crate) fn load_dir_merge_rules_recursive(
 
     visited.push(canonical);
 
-    let file = fs::File::open(path)
-        .map_err(|error| LocalCopyError::io("read filter file", path, error))?;
+    // The merge file is opened from a scanned source directory, so every
+    // component may be attacker-controlled. Refuse a symlink owned by neither
+    // uid 0 nor our euid, exactly as upstream does for the same open.
+    //
+    // upstream: exclude.c:1464 parse_filter_file() -> syscall.c:538
+    // open_no_attacker_symlinks(); trust rule at syscall.c:406.
+    let file = match open_merge_file(path) {
+        Ok(file) => file,
+        // The refusal is NOT fatal. Upstream calls parse_filter_file() with
+        // XFLG_ANCHORED2ABS and *not* XFLG_FATAL_ERRORS, so a merge file it
+        // cannot open is silently skipped: no rule is added and the transfer
+        // proceeds. Aborting here would fail a transfer upstream completes.
+        Err(error) if fast_io::is_symlink_refusal(&error) => {
+            return Ok(DirMergeEntries::default());
+        }
+        Err(error) => return Err(LocalCopyError::io("read filter file", path, error)),
+    };
     let mut entries = DirMergeEntries::default();
 
     // upstream: exclude.c:1212 - unrecognised filter rules exit with
@@ -492,6 +507,22 @@ pub(crate) fn load_dir_merge_rules_recursive(
 
     visited.pop();
     Ok(entries)
+}
+
+/// Open a per-directory merge file, refusing an attacker-owned symlink.
+///
+/// The platform seam lives here rather than at the call site. On non-Unix
+/// targets the ownership walk has no `st_uid` to trust and this degrades to a
+/// plain open.
+fn open_merge_file(path: &std::path::Path) -> io::Result<fs::File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_read(path)
+    }
+    #[cfg(not(unix))]
+    {
+        fs::File::open(path)
+    }
 }
 
 #[cfg(test)]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -598,3 +598,36 @@ pub use status::{
     io_uring_capability_matrix, io_uring_kernel_info, io_uring_status_detail, iocp_status_detail,
     platform_io_capabilities,
 };
+
+/// Whether `error` is the ownership walk's security refusal.
+///
+/// The walk refuses a path component that is a symlink owned by neither uid 0
+/// nor our effective uid, and reports it as `ELOOP`. Callers that mirror
+/// upstream's non-fatal handling of a failed auxiliary-file open need to
+/// recognise that refusal without duplicating the errno, so the crate that
+/// produces it also owns the predicate that names it.
+///
+/// `ELOOP` is deliberate rather than `EXDEV`: callers treat `EXDEV` as
+/// cross-device and fall back to copy+remove, which would defeat the refusal.
+/// `std::io::ErrorKind::FilesystemLoop` is still unstable, so the comparison is
+/// on the raw errno.
+///
+/// Always `false` on non-Unix targets, where the walk has no `st_uid` to trust
+/// and is not used.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/syscall.c:406` - `if (lst.st_uid != 0 && lst.st_uid != trusted_uid)`
+///   refuses with `ELOOP`.
+#[must_use]
+pub fn is_symlink_refusal(error: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        error.raw_os_error() == Some(libc::ELOOP)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = error;
+        false
+    }
+}

--- a/crates/filters/Cargo.toml
+++ b/crates/filters/Cargo.toml
@@ -14,6 +14,7 @@ rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+fast_io = { path = "../fast_io", default-features = false }
 globset = { workspace = true }
 logging = { path = "../logging" }
 thiserror = { workspace = true }
@@ -23,6 +24,7 @@ tracing = { workspace = true, optional = true }
 tracing = ["dep:tracing"]
 
 [dev-dependencies]
+libc = { workspace = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 test-support = { path = "../test-support" }

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -35,7 +35,6 @@ mod scope;
 #[cfg(test)]
 mod tests;
 
-use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 
@@ -387,10 +386,14 @@ impl FilterChain {
 
             // upstream: exclude.c:push_local_filters() - parse_filter_file()
             // silently skips missing files
-            let content = match fs::read_to_string(&merge_path) {
+            let content = match crate::merge_open::read_to_string(&merge_path) {
                 Ok(content) => content,
                 Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
                 Err(e) if e.kind() == io::ErrorKind::PermissionDenied => continue,
+                // upstream: parse_filter_file() runs without XFLG_FATAL_ERRORS,
+                // so a merge file it cannot open is skipped, not fatal. A
+                // refused symlink joins that set.
+                Err(e) if crate::merge_open::is_refusal(&e) => continue,
                 Err(e) => {
                     self.pop_scopes_at_depth(depth);
                     self.current_depth -= 1;
@@ -623,13 +626,15 @@ impl FilterChain {
         descriptor: &InlineDirMerge,
     ) -> Result<usize, FilterChainError> {
         let merge_path = directory.join(&descriptor.filename);
-        let content = match fs::read_to_string(&merge_path) {
+        let content = match crate::merge_open::read_to_string(&merge_path) {
             Ok(content) => content,
             // upstream: exclude.c:push_local_filters() - parse_filter_file()
             // silently skips missing files. Mirror that here so a `:C`
             // without an accompanying `.cvsignore` is a no-op.
             Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(0),
             Err(e) if e.kind() == io::ErrorKind::PermissionDenied => return Ok(0),
+            // upstream: same non-fatal skip as the per-directory merge above.
+            Err(e) if crate::merge_open::is_refusal(&e) => return Ok(0),
             Err(e) => {
                 self.pop_scopes_at_depth(depth);
                 self.current_depth -= 1;

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -118,6 +118,7 @@ mod error;
 pub mod implied;
 /// Merge-file reader and parser for filter rules.
 pub mod merge;
+mod merge_open;
 mod rule;
 pub mod rule_source;
 mod set;

--- a/crates/filters/src/merge/read.rs
+++ b/crates/filters/src/merge/read.rs
@@ -5,7 +5,6 @@
 //!
 //! upstream: exclude.c:parse_filter_file() - merge file reading
 
-use std::fs;
 use std::path::Path;
 
 use crate::{FilterAction, FilterRule};
@@ -28,7 +27,8 @@ use super::parse::parse_rules;
 ///
 /// Returns an error if the file cannot be read or contains invalid syntax.
 pub fn read_rules(path: &Path) -> Result<Vec<FilterRule>, MergeFileError> {
-    let content = fs::read_to_string(path).map_err(|e| MergeFileError::io_error(path, &e))?;
+    let content =
+        crate::merge_open::read_to_string(path).map_err(|e| MergeFileError::io_error(path, &e))?;
     parse_rules(&content, path)
 }
 

--- a/crates/filters/src/merge_open.rs
+++ b/crates/filters/src/merge_open.rs
@@ -1,0 +1,98 @@
+//! Reading a per-directory filter merge file without following a planted symlink.
+//!
+//! During a recursive scan the sender opens a merge file from *each* scanned
+//! directory, composing the path as `<scanned dir>/<merge pattern>`. Every one
+//! of those directories may be attacker-controlled, so an unprivileged user can
+//! plant the merge name as a symlink to any file the privileged rsync can read.
+//! Its bytes are then parsed as filter rules, which both shapes what transfers
+//! and discloses the target verbatim under `--debug=FILTER`.
+//!
+//! Upstream opens these through the same component walk it uses for every other
+//! operator-named auxiliary file: follow a symlink only when it is owned by
+//! uid 0 or our effective uid, refuse any other-uid one.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/exclude.c:1464` - `parse_filter_file()` opens the merge file.
+//! - `rsync-3.5.0/exclude.c:811-814` - `push_local_filters()` calls it per
+//!   scanned directory.
+//! - `rsync-3.5.0/syscall.c:538` - `open_no_attacker_symlinks()`; the trust
+//!   rule is at `syscall.c:406`.
+
+use std::io;
+use std::path::Path;
+
+/// Read a per-directory merge file, refusing an attacker-owned symlink.
+///
+/// The platform seam lives here rather than at each call site. On non-Unix
+/// targets the ownership walk has no meaning - there is no `st_uid` to trust -
+/// and this degrades to a plain read, matching how the rest of the tree gates
+/// `fast_io`'s operator-path helpers.
+pub(crate) fn read_to_string(path: &Path) -> io::Result<String> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_read_to_string(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::read_to_string(path)
+    }
+}
+
+/// Whether `error` is the ownership walk refusing an untrusted symlink.
+///
+/// Callers must treat this exactly as they treat a missing merge file. Upstream
+/// invokes `parse_filter_file()` with `XFLG_ANCHORED2ABS` and *not*
+/// `XFLG_FATAL_ERRORS`, so a merge file it cannot open is silently skipped: no
+/// rule is added and the transfer proceeds. Surfacing the refusal as an error
+/// would abort a transfer that upstream completes.
+pub(crate) fn is_refusal(error: &io::Error) -> bool {
+    fast_io::is_symlink_refusal(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The refusal predicate must recognise the walk's `ELOOP` and nothing else.
+    ///
+    /// If it widened to any error, a genuinely broken merge file would be
+    /// silently ignored instead of reported; if it narrowed to nothing, a
+    /// refused symlink would abort a transfer upstream completes.
+    #[test]
+    #[cfg(unix)]
+    fn only_the_symlink_refusal_counts_as_a_refusal() {
+        let refusal = io::Error::from_raw_os_error(libc::ELOOP);
+        assert!(is_refusal(&refusal), "ELOOP is the walk's security refusal");
+
+        for other in [libc::ENOENT, libc::EACCES, libc::ENOTDIR, libc::EIO] {
+            let error = io::Error::from_raw_os_error(other);
+            assert!(
+                !is_refusal(&error),
+                "errno {other} must not be mistaken for the refusal"
+            );
+        }
+    }
+
+    /// A merge file reached through a symlink the caller owns must still be
+    /// read. The walk follows uid-0 and own-euid links by design, so this is
+    /// the direction a refuse-all resolver would break - and an operator who
+    /// keeps `.rsync-filter` behind a symlinked directory would lose their
+    /// rules silently.
+    #[test]
+    #[cfg(unix)]
+    fn a_self_owned_symlink_is_still_followed() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).expect("create real dir");
+        std::fs::write(real.join("rules"), b"- *.tmp\n").expect("write merge file");
+        symlink(&real, dir.path().join("link")).expect("plant self-owned symlink");
+
+        let contents =
+            read_to_string(&dir.path().join("link").join("rules")).expect("read through symlink");
+
+        assert_eq!(contents, "- *.tmp\n");
+    }
+}

--- a/crates/filters/src/merge_open.rs
+++ b/crates/filters/src/merge_open.rs
@@ -50,7 +50,7 @@ pub(crate) fn is_refusal(error: &io::Error) -> bool {
     fast_io::is_symlink_refusal(error)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
@@ -60,7 +60,6 @@ mod tests {
     /// silently ignored instead of reported; if it narrowed to nothing, a
     /// refused symlink would abort a transfer upstream completes.
     #[test]
-    #[cfg(unix)]
     fn only_the_symlink_refusal_counts_as_a_refusal() {
         let refusal = io::Error::from_raw_os_error(libc::ELOOP);
         assert!(is_refusal(&refusal), "ELOOP is the walk's security refusal");
@@ -80,7 +79,6 @@ mod tests {
     /// keeps `.rsync-filter` behind a symlinked directory would lose their
     /// rules silently.
     #[test]
-    #[cfg(unix)]
     fn a_self_owned_symlink_is_still_followed() {
         use std::os::unix::fs::symlink;
 

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -119,7 +119,7 @@ operator-path-partial-dir-exclude-daemon fail
 operator-path-traversal-backup-dir-daemon fail
 operator-path-traversal-dest-dir-daemon fail
 operator-path-traversal-partial-dir-daemon pass
-password-file-symlink fail
+password-file-symlink pass
 peer-legacy-implied-delete-scope pass
 proto-cleared-dirflist fail
 proto-cleared-ndx fail

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -150,7 +150,7 @@ filter-depth pass
 filter-leak fail
 filter-merge-content-echo fail
 filter-merge-recursion fail
-filter-merge-symlink fail
+filter-merge-symlink pass
 fuzzy pass
 fuzzy-basis pass
 git-set-file-times-python-compat-regression pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -236,7 +236,7 @@ partial-dir-abs-delta pass
 partial-protected-regular-retry-linux fail
 partial-protected-regular-retry-policy skip
 partial_nowrite pass
-password-file-symlink fail
+password-file-symlink pass
 peer-legacy-implied-delete-scope skip
 preallocate fail
 protected-regular pass


### PR DESCRIPTION
## Problem

During a recursive scan the sender opens a filter merge file from **each**
scanned directory, composing the path as `<scanned dir>/<merge pattern>`. Every
one of those directories may be attacker-controlled, so an unprivileged user can
plant the merge name as a symlink to any file the privileged rsync can read. Its
bytes are then parsed as filter rules, which both **shapes what transfers**
(silently) and **discloses the target verbatim** under `--debug=FILTER`. This is
the "root runs `rsync -a /home /backup`" class.

## Upstream

| upstream site | what |
|---|---|
| `exclude.c:1464` | `parse_filter_file()` opens the merge file |
| `exclude.c:811-814` | `push_local_filters()` calls it per scanned directory |
| `syscall.c:538` | `open_no_attacker_symlinks()` |
| `syscall.c:406` | the trust rule (uid 0 or euid) |

## The audit found SEVEN sites, not two

Enumerating every merge-file open first (task TS-A2) is what made this fix
correct rather than partial - the same multi-parser trap that left an earlier
provenance fix landing one arm of one of three parsers.

| # | site | routed here? |
|---|---|---|
| 1 | `filters/src/chain/mod.rs:390` — per-directory merge during the scan | **yes** |
| 2 | `filters/src/chain/mod.rs:626` — `load_inline_dir_merge` (`:C` -> `.cvsignore`) | **yes** |
| 3 | `engine/.../dir_merge/load.rs` — local-copy per-directory loader | **yes** |
| 4 | `filters/src/merge/read.rs:31` | yes |
| 5 | `cli/.../filter_rules/sources.rs:152` — `--exclude-from` | no (TS-A4) |
| 6 | `cli/.../filter_rules/sources.rs:178` — `--filter=. FILE` | no (TS-A4) |
| 7 | `cli/.../filter_rules/cvs.rs:71` — `$HOME/.cvsignore` | no (different upstream site, `exclude.c:1340-1358`) |

1-3 are the sites the failing cell actually reaches. The `.cvsignore` the test
names is the **per-directory** one, which arrives via the `:C` inline dir-merge
(site 2) - not the global `$HOME` one at site 7.

## The refusal is deliberately NOT fatal

Upstream invokes `parse_filter_file()` with `XFLG_ANCHORED2ABS` and **not**
`XFLG_FATAL_ERRORS`, so a merge file it cannot open is silently skipped: no rule
is added and the transfer proceeds.

The two chain sites already had that shape for `NotFound`/`PermissionDenied`, so
the refusal joins that set. The engine site returned a **fatal** error for any
open failure, so it now returns an empty rule set instead - without that, a
refusal would abort a transfer upstream completes, and the cell would have gone
red for a brand-new reason.

## Design

`fast_io::is_symlink_refusal` names the walk's `ELOOP` so the errno lives in
exactly one crate (`std::io::ErrorKind::FilesystemLoop` is still unstable).

`crates/filters` gains a `fast_io` dependency. It already performed this file
I/O itself, so this hardens I/O the crate already owned rather than introducing
new coupling; `fast_io` does not depend on `filters`, so there is no cycle.

## Verification

- `cargo nextest run -p filters --all-features --no-fail-fast` — **1455 run, 1455 passed**; targeted filters+engine merge/filter sweep **751/751**. `passed == run` in both, so no fail-fast truncation.
- **Reachability proven by mutation**: replacing the seam body with an unconditional `Err` fails the filters suite. That is the check that catches an inert routing fix.
- Predicate pinned both directions: `ELOOP` is a refusal, `ENOENT`/`EACCES`/`ENOTDIR`/`EIO` are not - so it can neither widen into swallowing real errors nor narrow into aborting.
- The other new test pins the **follow** direction (a self-owned symlink is still read), which is what breaks if anyone swaps the walk for a refuse-all resolver.
- `cargo fmt --all -- --check` clean; `cargo clippy -p filters -p engine -p fast_io --all-targets --all-features --no-deps -- -D warnings` clean.

Flips `filter-merge-symlink` fail -> pass in the root manifest (349 rows
unchanged). The cell plants a symlink owned by a third uid and self-skips
without root, so the non-root manifests correctly keep `skip`.
