### PR TITLE
fix(engine): --preallocate --sparse must punch the reserved extent

### DIFF
--- a/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
@@ -104,21 +104,20 @@ fn transfer_request_with_sparse_copies_all_zero_source_without_extra_blocks() {
     );
 }
 
-/// `--sparse --preallocate` leaves the destination fully DENSE, not sparse.
-/// Upstream's `do_fallocate()` reserves the whole extent with
-/// `FALLOC_FL_KEEP_SIZE`, which returns 0, so `preallocated_len == 0`. In
-/// `write_sparse()` the `sparse_past_write >= preallocated_len` test is then
-/// always true, so the source's interior zero run is seeked over (`do_lseek`)
-/// rather than punched (`do_punch_hole`). Seeking does not free the blocks the
-/// fallocate reservation already allocated, so preallocation defeats sparseness:
-/// the reserved blocks stay allocated across the whole file. Verified against
-/// rsync 3.4.4 (ext4): `--sparse --preallocate` yields `st_blocks*512 == st_size`
-/// (dense), whereas `--sparse` alone yields a hole.
-// upstream: fileio.c:92 write_sparse() `if (sparse_past_write >= preallocated_len)`
-// upstream: syscall.c:1555 do_fallocate() returns 0 for the KEEP_SIZE (opts != 0) path
+/// `--sparse --preallocate` must end up SPARSE at the CLI boundary too.
+///
+/// The engine-level pin lives in `execute_sparse.rs`; this one proves the rule
+/// survives the whole `run_with_args` path, which is where an operator meets
+/// it. Both inverted together: they recorded rsync 3.4.4, where
+/// `do_fallocate()` returned 0 so `sparse_past_write >= preallocated_len` was
+/// always true and the zero run was seeked over rather than punched - and
+/// seeking does not free blocks the reservation already allocated. 3.5.0
+/// withdrew that behaviour and names the regression in its own source.
+// upstream: fileio.c:84 flush_sparse_hole() - `sparse_past_write >= preallocated_len`
+// upstream: syscall.c:2597 do_fallocate() - KEEP_SIZE only when no holes are punched
 #[cfg(target_os = "linux")]
 #[test]
-fn transfer_request_with_sparse_and_preallocate_stays_dense() {
+fn transfer_request_with_sparse_and_preallocate_punches_the_reserved_extent() {
     use std::os::unix::fs::MetadataExt;
     use tempfile::tempdir;
 
@@ -148,9 +147,9 @@ fn transfer_request_with_sparse_and_preallocate_stays_dense() {
     let prealloc_meta = std::fs::metadata(&prealloc_dest).expect("prealloc metadata");
     assert_eq!(prealloc_meta.len(), apparent, "content length preserved");
     assert!(
-        prealloc_meta.blocks() * 512 >= apparent,
-        "preallocated extent must stay dense: the zero run is seeked over, not \
-         punched, so the reserved blocks remain allocated (allocated {}, size {apparent})",
+        prealloc_meta.blocks() * 512 < apparent,
+        "preallocation must not defeat sparseness: the reserved extent is punched \
+         where the source has a zero run (allocated {}, size {apparent})",
         prealloc_meta.blocks() * 512,
     );
 }

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -38,9 +38,9 @@ use super::{
     create_backup_parents, delete_extraneous_entries, filter_program_local_error,
     follow_symlink_metadata, load_dir_merge_rules_recursive, map_metadata_error,
     record_directory_subtree, remove_source_entry_if_requested, resolve_dir_merge_path,
-    should_skip_copy, symlink_target_is_safe, trace_make_backup_copy, trace_make_backup_device,
-    trace_make_backup_hlink, trace_make_backup_rename, trace_make_backup_symlink,
-    write_sparse_chunk,
+    should_skip_copy, skip_matched_sparse, symlink_target_is_safe, trace_make_backup_copy,
+    trace_make_backup_device, trace_make_backup_hlink, trace_make_backup_rename,
+    trace_make_backup_symlink, write_sparse_chunk,
 };
 use crate::delta::{DeltaSignatureIndex, ProbeCounters};
 use crate::signature::SignatureBlock;

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -45,6 +45,35 @@ fn batch_sum_head(
         .map_err(|error| reject(error.to_string()))
 }
 
+/// Consumes an in-place matched block that already sits at its destination
+/// offset, advancing the writer past it.
+///
+/// Without `--sparse` there is nothing to do here: the caller advances
+/// `output_position` and the next literal write seeks to it, which is upstream's
+/// `flush_write_file` + `do_lseek` arm. With `--sparse` the block must still go
+/// through the sparse processor so an interior zero run inside an
+/// otherwise-matching block is punched into a hole instead of being seeked over
+/// with the rest of the block - that is precisely what `--inplace --sparse`
+/// relies on to keep a hole-y basis file sparse.
+// upstream: fileio.c:251-267 skip_matched() - `if (sparse_files > 0)
+// write_file(fd, 1 /*use_seek*/, offset, buf, len)`, else flush + lseek.
+fn consume_matched_in_place(
+    writer: &mut fs::File,
+    sparse_state: &mut SparseWriteState,
+    sparse: bool,
+    matched_bytes: &[u8],
+    destination: &Path,
+) -> Result<(), LocalCopyError> {
+    if !sparse {
+        return Ok(());
+    }
+    // The writer already sits at this block's offset (the sparse processor is
+    // what advances it), so no seek is needed - and seeking here would strand a
+    // pending zero run carried over from the previous block.
+    skip_matched_sparse(writer, sparse_state, matched_bytes, destination)?;
+    Ok(())
+}
+
 impl<'a> CopyContext<'a> {
     /// Copies `source`'s content to `writer` by matching blocks against
     /// `index` and writing literal bytes for the unmatched runs in between.
@@ -235,6 +264,13 @@ impl<'a> CopyContext<'a> {
                 // writer keeps stale basis bytes at the new position and the
                 // final ftruncate clips the file off at the wrong length.
                 if inplace_mode && basis_offset == output_position {
+                    consume_matched_in_place(
+                        writer,
+                        &mut sparse_state,
+                        sparse,
+                        &scratch[..block_len],
+                        destination,
+                    )?;
                     output_position = output_position.saturating_add(block_len as u64);
                 } else if inplace_mode {
                     // Inplace + basis == destination: reading basis at a
@@ -422,6 +458,13 @@ impl<'a> CopyContext<'a> {
             let basis_offset = matched.offset();
 
             if inplace_mode && basis_offset == output_position {
+                consume_matched_in_place(
+                    writer,
+                    &mut sparse_state,
+                    sparse,
+                    &scratch[..block_len],
+                    destination,
+                )?;
                 output_position = output_position.saturating_add(block_len as u64);
             } else if inplace_mode {
                 writer.seek(SeekFrom::Start(output_position)).map_err(|error| {

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -55,7 +55,7 @@ fn batch_sum_head(
 /// otherwise-matching block is punched into a hole instead of being seeked over
 /// with the rest of the block - that is precisely what `--inplace --sparse`
 /// relies on to keep a hole-y basis file sparse.
-// upstream: fileio.c:251-267 skip_matched() - `if (sparse_files > 0)
+// upstream: fileio.c:252-266 skip_matched() - `if (sparse_files > 0)
 // write_file(fd, 1 /*use_seek*/, offset, buf, len)`, else flush + lseek.
 fn consume_matched_in_place(
     writer: &mut fs::File,
@@ -256,7 +256,7 @@ impl<'a> CopyContext<'a> {
                 let matched = MatchedBlock::new(block, index.block_length());
                 let basis_offset = matched.offset();
 
-                // upstream: receiver.c:468-477. The skip-fast-path only fires
+                // upstream: receiver.c:624-629. The skip-fast-path only fires
                 // when basis offset == output position. For any other matched
                 // block (re-ordered content, inserted prefix, ...) copy the
                 // basis bytes to the current write offset just like upstream

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -43,7 +43,7 @@ use super::super::super::append::{AppendMode, determine_append_mode};
 use super::super::super::comparison::build_delta_signature;
 use super::super::super::compute_backup_path;
 use super::super::super::guard::remove_incomplete_destination;
-use super::super::super::preallocate::maybe_preallocate_destination;
+use super::super::super::preallocate::{Reservation, maybe_preallocate_destination};
 use super::finalize::finalize_guard_and_metadata;
 use super::open::open_source_file;
 use super::write_strategy::{open_destination_writer, select_write_strategy};
@@ -535,24 +535,27 @@ pub(in crate::local_copy) fn execute_transfer_once(
     let preallocate_target = guard
         .as_ref()
         .map_or(destination, |existing_guard| existing_guard.staging_path());
-    // upstream: receiver.c:319 - preallocated_len records how much of the file
+    // upstream: receiver.c:479 - preallocated_len records how much of the file
     // has reserved blocks so a later sparse zero run inside that extent is
     // punched into a hole rather than seeked over (which would leave the
-    // preallocated blocks allocated).
+    // preallocated blocks allocated). Under --sparse the reservation must span
+    // the file's size for the punch to reach it, so the sparse setting selects
+    // the reservation upstream makes.
+    // upstream: syscall.c:2597 - `sparse_files <= 0` selects FALLOC_FL_KEEP_SIZE.
     let mut preallocated_len = maybe_preallocate_destination(
         &mut writer,
         preallocate_target,
         file_size,
         append_offset,
-        context.preallocate_enabled(),
+        context
+            .preallocate_enabled()
+            .then(|| Reservation::for_sparse(use_sparse_writes)),
     )?;
-    // upstream: receiver.c:490-500 - the inplace branch (`preallocated_len = size_r`)
-    // is an `else if` reached only when the preallocate branch (receiver.c:320) did
-    // NOT run. That branch runs for `--preallocate` whenever the file grows
-    // (`total_size > size_r`), leaving preallocated_len at do_fallocate()'s 0 so the
-    // reserved tail is seeked, not punched - don't overwrite it. Otherwise the
-    // existing destination extent is already allocated, so an interior zero run must
-    // be punched.
+    // upstream: receiver.c:482-492 - the inplace branch (`preallocated_len = size_r`)
+    // is an `else if` reached only when the preallocate branch (receiver.c:475) did
+    // NOT run. A non-zero reservation above IS that branch having run, so leave it
+    // alone. Otherwise the existing destination extent is already allocated and an
+    // interior zero run must be punched.
     //
     // The `!whole_file_enabled` guard keeps this to the delta case. A whole-file
     // inplace copy is upstream's `sparse_files > 0 && whole_file` leg: it starts
@@ -562,15 +565,11 @@ pub(in crate::local_copy) fn execute_transfer_once(
     // the inplace destination with `O_TRUNC` whenever there is no delta basis
     // (`should_truncate = delta_signature.is_none()`, which is exactly the
     // whole-file case), so preallocated_len must stay 0 here.
-    // upstream: receiver.c:receive_data - `if (sparse_files > 0 && whole_file &&
+    // upstream: receiver.c:485-486 - `if (sparse_files > 0 && whole_file &&
     // fd >= 0 && do_ftruncate(fd, 0) == 0) preallocated_len = 0;`
     if preallocated_len == 0 && inplace_enabled && !whole_file_enabled {
         if let Some(existing) = existing_metadata {
-            let size_r = existing.len();
-            let preallocate_branch_ran = context.preallocate_enabled() && file_size > size_r;
-            if !preallocate_branch_ran {
-                preallocated_len = size_r;
-            }
+            preallocated_len = existing.len();
         }
     }
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -551,8 +551,8 @@ pub(in crate::local_copy) fn execute_transfer_once(
             .preallocate_enabled()
             .then(|| Reservation::for_sparse(use_sparse_writes)),
     )?;
-    // upstream: receiver.c:482-492 - the inplace branch (`preallocated_len = size_r`)
-    // is an `else if` reached only when the preallocate branch (receiver.c:475) did
+    // upstream: receiver.c:490 - the inplace branch (`preallocated_len = size_r`)
+    // is an `else if` reached only when the preallocate branch (receiver.c:476) did
     // NOT run. A non-zero reservation above IS that branch having run, so leave it
     // alone. Otherwise the existing destination extent is already allocated and an
     // interior zero run must be punched.
@@ -565,7 +565,7 @@ pub(in crate::local_copy) fn execute_transfer_once(
     // the inplace destination with `O_TRUNC` whenever there is no delta basis
     // (`should_truncate = delta_signature.is_none()`, which is exactly the
     // whole-file case), so preallocated_len must stay 0 here.
-    // upstream: receiver.c:485-486 - `if (sparse_files > 0 && whole_file &&
+    // upstream: receiver.c:486-487 - `if (sparse_files > 0 && whole_file &&
     // fd >= 0 && do_ftruncate(fd, 0) == 0) preallocated_len = 0;`
     if preallocated_len == 0 && inplace_enabled && !whole_file_enabled {
         if let Some(existing) = existing_metadata {

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -33,6 +33,6 @@ pub(crate) use paths::partial_destination_path;
 #[cfg(test)]
 pub(crate) use paths::temp_name_with_suffix;
 #[cfg(test)]
-pub(crate) use preallocate::maybe_preallocate_destination;
+pub(crate) use preallocate::{Reservation, maybe_preallocate_destination};
 pub use sparse::{SparseDetectStrategy, SparseDetector, SparseReader, SparseRegion};
-pub(crate) use sparse::{SparseWriteState, write_sparse_chunk};
+pub(crate) use sparse::{SparseWriteState, skip_matched_sparse, write_sparse_chunk};

--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -271,8 +271,16 @@ mod tests {
         // size untouched; other platforms extend the file to the requested size.
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
-        #[cfg(not(target_os = "linux"))]
+        // Other Unix: fallocate is unavailable, so the fallback extends the
+        // file to upstream's deliberately-perturbed `length`
+        // (upstream: syscall.c:2601-2604; receiver.c:652 trims the excess).
+        #[cfg(all(unix, not(target_os = "linux")))]
         assert_eq!(metadata.len(), 999);
+        // Windows has no fallocate at all: the file is extended to exactly
+        // total_len, so there is no over-preallocation and the perturbation
+        // upstream applies to a reservation does not apply here.
+        #[cfg(not(unix))]
+        assert_eq!(metadata.len(), 1000);
     }
 
     #[test]
@@ -288,8 +296,16 @@ mod tests {
         // KEEP_SIZE (Linux) reserves blocks without extending the apparent size.
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
-        #[cfg(not(target_os = "linux"))]
+        // Other Unix: fallocate is unavailable, so the fallback extends the
+        // file to upstream's deliberately-perturbed `length`
+        // (upstream: syscall.c:2601-2604; receiver.c:652 trims the excess).
+        #[cfg(all(unix, not(target_os = "linux")))]
         assert_eq!(metadata.len(), 2047);
+        // Windows has no fallocate at all: the file is extended to exactly
+        // total_len, so there is no over-preallocation and the perturbation
+        // upstream applies to a reservation does not apply here.
+        #[cfg(not(unix))]
+        assert_eq!(metadata.len(), 2048);
     }
 
     #[test]
@@ -526,8 +542,16 @@ mod tests {
         // data lands, exactly as upstream's receiver observes it mid-transfer.
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
-        #[cfg(not(target_os = "linux"))]
+        // Other Unix: fallocate is unavailable, so the fallback extends the
+        // file to upstream's deliberately-perturbed `length`
+        // (upstream: syscall.c:2601-2604; receiver.c:652 trims the excess).
+        #[cfg(all(unix, not(target_os = "linux")))]
         assert_eq!(metadata.len(), 4095);
+        // Windows has no fallocate at all: the file is extended to exactly
+        // total_len, so there is no over-preallocation and the perturbation
+        // upstream applies to a reservation does not apply here.
+        #[cfg(not(unix))]
+        assert_eq!(metadata.len(), 4096);
 
         // Write some content to the preallocated space
         file.write_all(b"hello preallocated world").expect("write");
@@ -538,8 +562,16 @@ mod tests {
         // earlier size-extending reservation still governs the length.
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 24, "size grows only as data is written");
-        #[cfg(not(target_os = "linux"))]
+        // Other Unix: fallocate is unavailable, so the fallback extends the
+        // file to upstream's deliberately-perturbed `length`
+        // (upstream: syscall.c:2601-2604; receiver.c:652 trims the excess).
+        #[cfg(all(unix, not(target_os = "linux")))]
         assert_eq!(metadata.len(), 4095);
+        // Windows has no fallocate at all: the file is extended to exactly
+        // total_len, so there is no over-preallocation and the perturbation
+        // upstream applies to a reservation does not apply here.
+        #[cfg(not(unix))]
+        assert_eq!(metadata.len(), 4096);
     }
 
     /// Verify that preallocating a file that already has some content reserves
@@ -567,8 +599,16 @@ mod tests {
             100,
             "KEEP_SIZE preserves the written length"
         );
-        #[cfg(not(target_os = "linux"))]
+        // Other Unix: fallocate is unavailable, so the fallback extends the
+        // file to upstream's deliberately-perturbed `length`
+        // (upstream: syscall.c:2601-2604; receiver.c:652 trims the excess).
+        #[cfg(all(unix, not(target_os = "linux")))]
         assert_eq!(metadata.len(), 4095);
+        // Windows has no fallocate at all: the file is extended to exactly
+        // total_len, so there is no over-preallocation and the perturbation
+        // upstream applies to a reservation does not apply here.
+        #[cfg(not(unix))]
+        assert_eq!(metadata.len(), 4096);
     }
 
     /// Verify preallocation with a variety of sizes including small files
@@ -588,8 +628,16 @@ mod tests {
         let metadata = fs::metadata(&path).expect("metadata");
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
-        #[cfg(not(target_os = "linux"))]
+        // Other Unix: fallocate is unavailable, so the fallback extends the
+        // file to upstream's deliberately-perturbed `length`
+        // (upstream: syscall.c:2601-2604; receiver.c:652 trims the excess).
+        #[cfg(all(unix, not(target_os = "linux")))]
         assert_eq!(metadata.len(), 2);
+        // Windows has no fallocate at all: the file is extended to exactly
+        // total_len, so there is no over-preallocation and the perturbation
+        // upstream applies to a reservation does not apply here.
+        #[cfg(not(unix))]
+        assert_eq!(metadata.len(), 1);
     }
 
     /// Regression guard for the KEEP_SIZE behavior-fidelity fix. Upstream's

--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -150,7 +150,7 @@ fn preallocate_destination_file(
         let flags = FallocateFlags::empty();
         match fallocate(fd, flags, 0, length) {
             Ok(()) => Ok(match reservation {
-                // upstream: syscall.c:2620-2628 - with KEEP_SIZE the blocks for
+                // upstream: syscall.c:2622-2629 - with KEEP_SIZE the blocks for
                 // [0, length) are reserved even though the file size stays put,
                 // so report that reserved length. Reporting 0 here is upstream's
                 // pre-3.5.0 behaviour and is precisely why `--preallocate
@@ -158,7 +158,7 @@ fn preallocate_destination_file(
                 // compares `>= 0` and is seeked over rather than punched,
                 // leaving the whole reserved extent allocated.
                 Reservation::KeepSize => length,
-                // upstream: syscall.c:2615-2619 - opts == 0 reports the
+                // upstream: syscall.c:2616-2620 - opts == 0 reports the
                 // resulting allocation, falling back to `length` if fstat fails.
                 Reservation::FullSize => allocated_bytes(file).unwrap_or(length),
             }),
@@ -598,7 +598,7 @@ mod tests {
     /// writing - it grows only as data lands. Before the fix, a plain fallocate
     /// (or the set_len fallback) extended st_size to total_len immediately,
     /// observable via stat / du --apparent-size mid-transfer.
-    // upstream: syscall.c:1523 DO_FALLOC_OPTIONS = FALLOC_FL_KEEP_SIZE
+    // upstream: syscall.c:2584 DO_FALLOC_OPTIONS = FALLOC_FL_KEEP_SIZE
     #[cfg(target_os = "linux")]
     #[test]
     fn preallocate_keep_size_does_not_extend_apparent_size() {

--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -19,37 +19,89 @@ use rustix::{
 
 use crate::local_copy::LocalCopyError;
 
-/// Preallocates disk space for the destination file when enabled and needed.
+/// Which `fallocate(2)` reservation upstream's `do_fallocate()` makes.
 ///
-/// Skips preallocation when disabled, when `total_len` is zero, or when the
-/// file already has at least `total_len` bytes allocated.
+/// `FALLOC_FL_KEEP_SIZE` reserves blocks without moving the file's logical end,
+/// but a hole-punch can only deallocate blocks that lie *inside* the file's
+/// size - with `KEEP_SIZE` the reserved blocks sit beyond EOF and the punch
+/// silently does nothing, leaving the file fully allocated. So when holes will
+/// also be punched (`--sparse`), upstream reserves at full size instead.
+// upstream: syscall.c:2597 do_fallocate() - `int opts = (inplace ||
+// preallocate_files) && sparse_files <= 0 ? DO_FALLOC_OPTIONS : 0;`
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Reservation {
+    /// `opts == FALLOC_FL_KEEP_SIZE`: no holes will be punched.
+    KeepSize,
+    /// `opts == 0`: `--sparse` is active, so the extent must lie inside the
+    /// file's size for `do_punch_hole()` to be able to deallocate it.
+    FullSize,
+}
+
+impl Reservation {
+    /// Selects the reservation upstream would make for this sparse setting.
+    // upstream: syscall.c:2597 - `sparse_files <= 0` is what selects KEEP_SIZE.
+    pub(crate) const fn for_sparse(sparse: bool) -> Self {
+        if sparse {
+            Self::FullSize
+        } else {
+            Self::KeepSize
+        }
+    }
+}
+
+/// The reservation actually available on this platform.
 ///
-/// Returns the value upstream `do_fallocate()` feeds into `preallocated_len`,
-/// which the sparse writer compares against to punch versus seek interior zero
-/// runs: `0` when preallocation was skipped or reserved with `FALLOC_FL_KEEP_SIZE`
-/// (the `--preallocate`/`--inplace` path, so runs are seeked and the reserved
-/// blocks stay dense), and `st_blocks * 512` only on the `opts == 0` fallback
-/// path where no `KEEP_SIZE` flag was available and the run is punched instead.
-// upstream: syscall.c:1528 do_fallocate() - returns 0 when opts != 0 (KEEP_SIZE),
-// else st_blocks * S_BLKSIZE; receiver.c:323 preallocated_len = do_fallocate(...)
+/// `FALLOC_FL_KEEP_SIZE` is Linux-only; elsewhere every reservation is
+/// full-size, which is upstream's `opts == 0` path and reports its value.
+#[cfg(unix)]
+const fn available(reservation: Reservation) -> Reservation {
+    #[cfg(target_os = "linux")]
+    {
+        reservation
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = reservation;
+        Reservation::FullSize
+    }
+}
+
+/// Preallocates disk space for the destination file when requested and needed.
+///
+/// `reservation` is `None` when `--preallocate` is off. Preallocation is also
+/// skipped when `total_len` is zero or the file already spans `total_len`
+/// bytes.
+///
+/// Returns the value upstream `do_fallocate()` feeds into `preallocated_len`:
+/// the reserved length for [`Reservation::KeepSize`], and `st_blocks * S_BLKSIZE`
+/// for [`Reservation::FullSize`]. The sparse writer compares an interior zero
+/// run's start against it to choose `do_punch_hole()` over a plain `lseek()`, so
+/// a stray `0` here silently leaves `--preallocate --sparse` files fully
+/// allocated - the exact regression upstream records at syscall.c:2622.
+// upstream: syscall.c:2589 do_fallocate(); receiver.c:479
+// `preallocated_len = do_fallocate(fd, 0, total_size)`
 pub(crate) fn maybe_preallocate_destination(
     file: &mut fs::File,
     path: &Path,
     total_len: u64,
     existing_bytes: u64,
-    enabled: bool,
+    reservation: Option<Reservation>,
 ) -> Result<u64, LocalCopyError> {
-    if !enabled || total_len == 0 || total_len <= existing_bytes {
+    let Some(reservation) = reservation else {
+        return Ok(0);
+    };
+    if total_len == 0 || total_len <= existing_bytes {
         return Ok(0);
     }
 
-    preallocate_destination_file(file, path, total_len)
+    preallocate_destination_file(file, path, total_len, reservation)
 }
 
 fn preallocate_destination_file(
     file: &mut fs::File,
     path: &Path,
     total_len: u64,
+    reservation: Reservation,
 ) -> Result<u64, LocalCopyError> {
     #[cfg(unix)]
     {
@@ -68,41 +120,56 @@ fn preallocate_destination_file(
             ));
         }
 
+        // upstream: syscall.c:2601-2604 - the reservation is deliberately made
+        // one byte off the requested size ("make the length not match the
+        // desired length"), and do_fallocate() reports that same perturbed
+        // length. total_len > 0 is guaranteed above, so this cannot underflow.
+        let length = if total_len & 1 == 1 {
+            total_len + 1
+        } else {
+            total_len - 1
+        };
+
+        let reservation = available(reservation);
         let fd = file.as_fd();
-        // upstream: syscall.c:1523 DO_FALLOC_OPTIONS = FALLOC_FL_KEEP_SIZE. The
-        // receiver's do_fallocate() reserves blocks with KEEP_SIZE so the file's
-        // apparent size (st_size) is NOT extended to total_len - it grows only as
-        // data is actually written, preserving the sparse-until-written
-        // appearance observable mid-transfer via stat / du --apparent-size. The
-        // reserved allocation (st_blocks * S_BLKSIZE) still lets the sparse
-        // writer punch holes within the extent rather than seeking over (and
-        // leaving) it. KEEP_SIZE is Linux-only; other unix platforms (where
-        // upstream compiles the preallocation path out entirely) fall back to a
-        // size-extending reservation.
+        // upstream: syscall.c:2584 DO_FALLOC_OPTIONS = FALLOC_FL_KEEP_SIZE, but
+        // syscall.c:2597 selects it only when no holes will be punched. KEEP_SIZE
+        // leaves the file's apparent size (st_size) untouched - it grows only as
+        // data is written, preserving the sparse-until-written appearance
+        // observable mid-transfer via stat / du --apparent-size - but the blocks
+        // it reserves then sit BEYOND EOF, where do_punch_hole() cannot reach
+        // them. Under --sparse we therefore reserve at full size instead so the
+        // sparse writer can punch the zero runs back out.
         #[cfg(target_os = "linux")]
-        let flags = FallocateFlags::KEEP_SIZE;
+        let flags = match reservation {
+            Reservation::KeepSize => FallocateFlags::KEEP_SIZE,
+            Reservation::FullSize => FallocateFlags::empty(),
+        };
+        // Non-Linux lacks KEEP_SIZE; `available()` already forced FullSize.
         #[cfg(not(target_os = "linux"))]
         let flags = FallocateFlags::empty();
-        match fallocate(fd, flags, 0, total_len) {
-            // upstream: syscall.c:1554-1556 do_fallocate() returns 0 on the KEEP_SIZE
-            // path (opts != 0), so preallocated_len == 0 and write_sparse() seeks over
-            // interior zero runs, leaving the reserved blocks allocated (dense). This is
-            // deterministic - unlike reading back st_blocks, it does not depend on whether
-            // the filesystem eagerly allocates blocks for a KEEP_SIZE reservation.
-            #[cfg(target_os = "linux")]
-            Ok(()) => Ok(0),
-            // Non-Linux uses no KEEP_SIZE flag (opts == 0), so mirror do_fallocate's
-            // `return st.st_blocks * S_BLKSIZE` for that path.
-            #[cfg(not(target_os = "linux"))]
-            Ok(()) => Ok(allocated_bytes(file).unwrap_or(total_len)),
+        match fallocate(fd, flags, 0, length) {
+            Ok(()) => Ok(match reservation {
+                // upstream: syscall.c:2620-2628 - with KEEP_SIZE the blocks for
+                // [0, length) are reserved even though the file size stays put,
+                // so report that reserved length. Reporting 0 here is upstream's
+                // pre-3.5.0 behaviour and is precisely why `--preallocate
+                // --sparse` stopped producing sparse files: every zero run then
+                // compares `>= 0` and is seeked over rather than punched,
+                // leaving the whole reserved extent allocated.
+                Reservation::KeepSize => length,
+                // upstream: syscall.c:2615-2619 - opts == 0 reports the
+                // resulting allocation, falling back to `length` if fstat fails.
+                Reservation::FullSize => allocated_bytes(file).unwrap_or(length),
+            }),
             // KEEP_SIZE unavailable at runtime: fall back to a size-extending
             // reservation (equivalent to upstream's opts == 0 path) and report the
             // resulting allocation so the sparse writer punches within it.
             Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {
-                file.set_len(total_len).map_err(|error| {
+                file.set_len(length).map_err(|error| {
                     LocalCopyError::io("preallocate destination file", path, error)
                 })?;
-                Ok(allocated_bytes(file).unwrap_or(total_len))
+                Ok(allocated_bytes(file).unwrap_or(length))
             }
             Err(errno) => Err(LocalCopyError::io(
                 "preallocate destination file",
@@ -114,6 +181,9 @@ fn preallocate_destination_file(
 
     #[cfg(not(unix))]
     {
+        // No fallocate: the only reservation available extends the file, which
+        // is upstream's `opts == 0` shape, so report the reserved length.
+        let _ = reservation;
         if total_len == 0 {
             return Ok(0);
         }
@@ -145,7 +215,7 @@ mod tests {
         let mut file = fs::File::create(&path).expect("create file");
 
         // When disabled, should succeed without preallocating
-        let result = maybe_preallocate_destination(&mut file, &path, 1000, 0, false);
+        let result = maybe_preallocate_destination(&mut file, &path, 1000, 0, None);
         assert!(result.is_ok());
 
         // File should remain empty
@@ -160,7 +230,8 @@ mod tests {
         let mut file = fs::File::create(&path).expect("create file");
 
         // When total_len is 0, should succeed without preallocating
-        let result = maybe_preallocate_destination(&mut file, &path, 0, 0, true);
+        let result =
+            maybe_preallocate_destination(&mut file, &path, 0, 0, Some(Reservation::KeepSize));
         assert!(result.is_ok());
     }
 
@@ -174,7 +245,13 @@ mod tests {
 
         let existing_bytes = 16; // Length of "existing content"
         // When total_len <= existing_bytes, should succeed without preallocating
-        let result = maybe_preallocate_destination(&mut file, &path, 10, existing_bytes, true);
+        let result = maybe_preallocate_destination(
+            &mut file,
+            &path,
+            10,
+            existing_bytes,
+            Some(Reservation::KeepSize),
+        );
         assert!(result.is_ok());
     }
 
@@ -185,7 +262,8 @@ mod tests {
         let mut file = fs::File::create(&path).expect("create file");
 
         // When enabled and total_len > existing_bytes, should preallocate
-        let result = maybe_preallocate_destination(&mut file, &path, 1000, 0, true);
+        let result =
+            maybe_preallocate_destination(&mut file, &path, 1000, 0, Some(Reservation::KeepSize));
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
@@ -194,7 +272,7 @@ mod tests {
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
         #[cfg(not(target_os = "linux"))]
-        assert_eq!(metadata.len(), 1000);
+        assert_eq!(metadata.len(), 999);
     }
 
     #[test]
@@ -203,7 +281,7 @@ mod tests {
         let path = temp.path().join("test.txt");
         let mut file = fs::File::create(&path).expect("create file");
 
-        let result = preallocate_destination_file(&mut file, &path, 2048);
+        let result = preallocate_destination_file(&mut file, &path, 2048, Reservation::KeepSize);
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
@@ -211,7 +289,7 @@ mod tests {
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
         #[cfg(not(target_os = "linux"))]
-        assert_eq!(metadata.len(), 2048);
+        assert_eq!(metadata.len(), 2047);
     }
 
     #[test]
@@ -220,7 +298,7 @@ mod tests {
         let path = temp.path().join("test.txt");
         let mut file = fs::File::create(&path).expect("create file");
 
-        let result = preallocate_destination_file(&mut file, &path, 0);
+        let result = preallocate_destination_file(&mut file, &path, 0, Reservation::KeepSize);
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
@@ -238,7 +316,8 @@ mod tests {
         let mut file = fs::File::create(&path).expect("create file");
 
         let oversized = (i64::MAX as u64) + 1;
-        let result = preallocate_destination_file(&mut file, &path, oversized);
+        let result =
+            preallocate_destination_file(&mut file, &path, oversized, Reservation::KeepSize);
         assert!(result.is_err(), "expected error for size > i64::MAX");
 
         let error = result.unwrap_err();
@@ -263,7 +342,8 @@ mod tests {
         // likely reject it due to disk space.  We only verify that our
         // size guard does not reject it prematurely.
         let boundary = i64::MAX as u64;
-        let result = preallocate_destination_file(&mut file, &path, boundary);
+        let result =
+            preallocate_destination_file(&mut file, &path, boundary, Reservation::KeepSize);
         // The result may be Err (ENOSPC or similar) but not our "platform limit" error
         if let Err(ref error) = result {
             let msg = format!("{error}");
@@ -286,7 +366,7 @@ mod tests {
         let mut file = fs::File::create(&path).expect("create file");
 
         let one_mib = 1024 * 1024;
-        let result = preallocate_destination_file(&mut file, &path, one_mib);
+        let result = preallocate_destination_file(&mut file, &path, one_mib, Reservation::KeepSize);
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
@@ -306,37 +386,81 @@ mod tests {
     }
 
     /// Verify `maybe_preallocate_destination` mirrors upstream `do_fallocate()`:
-    /// the Linux `FALLOC_FL_KEEP_SIZE` path returns 0, so `preallocated_len` stays
-    /// 0 and the sparse writer seeks over interior zero runs (leaving the reserved
-    /// blocks dense) rather than punching them. Returning a deterministic 0 - not a
-    /// read-back `st_blocks` - avoids depending on whether the filesystem eagerly
-    /// allocates blocks for a KEEP_SIZE reservation.
+    /// the `FALLOC_FL_KEEP_SIZE` path reports the RESERVED LENGTH, never 0.
+    ///
+    /// `preallocated_len` is what `flush_sparse_hole()` compares an interior zero
+    /// run's start against, so a 0 makes every run compare `>= 0` and be seeked
+    /// over instead of punched - leaving a `--preallocate --sparse` file fully
+    /// allocated. Upstream records that exact regression in its own source: "a
+    /// stray 0 here, from 2019's switch to KEEP_SIZE, is why --preallocate
+    /// --sparse stopped producing sparse files".
+    // upstream: syscall.c:2629 do_fallocate() - `return length;`
+    // upstream: fileio.c:84 flush_sparse_hole() - `sparse_past_write >= preallocated_len`
     #[cfg(target_os = "linux")]
     #[test]
-    fn maybe_preallocate_returns_keep_size_zero() {
+    fn keep_size_reports_the_reserved_length_not_zero() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("prealloc_len.bin");
         let mut file = fs::File::create(&path).expect("create file");
 
-        let one_mib = 1024 * 1024;
-        let prealloc =
-            maybe_preallocate_destination(&mut file, &path, one_mib, 0, true).expect("preallocate");
-        // upstream: syscall.c:1554 do_fallocate() returns 0 for the KEEP_SIZE path.
-        assert_eq!(
-            prealloc, 0,
-            "KEEP_SIZE preallocation must report 0 (seek, not punch), got {prealloc}"
-        );
-
-        // Disabled preallocation reports zero (no reserved extent to punch).
-        let mut skip = fs::File::create(temp.path().join("skip.bin")).expect("create file");
-        let skipped = maybe_preallocate_destination(
-            &mut skip,
-            &temp.path().join("skip.bin"),
+        let one_mib: u64 = 1024 * 1024;
+        let reserved = maybe_preallocate_destination(
+            &mut file,
+            &path,
             one_mib,
             0,
-            false,
+            Some(Reservation::KeepSize),
         )
-        .expect("skip");
+        .expect("preallocate");
+
+        // upstream: syscall.c:2601-2604 - the reservation is one byte off the request.
+        assert_eq!(
+            reserved,
+            one_mib - 1,
+            "KEEP_SIZE must report its reserved length so zero runs are punched"
+        );
+        // KEEP_SIZE leaves the apparent size alone, which is exactly why the
+        // reserved blocks sit beyond EOF and a punch cannot reach them.
+        let metadata = fs::metadata(&path).expect("metadata");
+        assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
+    }
+
+    /// Non-vacuity companion for the pin above: under `--sparse` upstream drops
+    /// `KEEP_SIZE` entirely (`opts = 0`) and reserves at full size, so the extent
+    /// lies INSIDE the file's size where `do_punch_hole()` can deallocate it. An
+    /// implementation that ignored the reservation and always used `KEEP_SIZE`
+    /// would still satisfy the length assertion above, but fails here.
+    // upstream: syscall.c:2597 - `... && sparse_files <= 0 ? DO_FALLOC_OPTIONS : 0`
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sparse_reservation_lands_inside_the_file_size() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("sparse_len.bin");
+        let mut file = fs::File::create(&path).expect("create file");
+
+        let one_mib: u64 = 1024 * 1024;
+        maybe_preallocate_destination(&mut file, &path, one_mib, 0, Some(Reservation::FullSize))
+            .expect("preallocate");
+
+        let metadata = fs::metadata(&path).expect("metadata");
+        assert_eq!(
+            metadata.len(),
+            one_mib - 1,
+            "a punchable reservation must extend the file's size, not sit beyond EOF"
+        );
+    }
+
+    /// Preallocation that never ran reports no reserved extent, so upstream's
+    /// `else` arm (`preallocated_len = 0`) is what the sparse writer sees.
+    // upstream: receiver.c:492 - `preallocated_len = 0;`
+    #[test]
+    fn disabled_preallocation_reports_no_extent() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("skip.bin");
+        let mut file = fs::File::create(&path).expect("create file");
+
+        let skipped =
+            maybe_preallocate_destination(&mut file, &path, 1024 * 1024, 0, None).expect("skip");
         assert_eq!(skipped, 0, "disabled preallocation should report 0 length");
     }
 
@@ -350,7 +474,7 @@ mod tests {
         let path = temp.path().join("no_prealloc.bin");
         let mut file = fs::File::create(&path).expect("create file");
 
-        let result = maybe_preallocate_destination(&mut file, &path, 1024 * 1024, 0, false);
+        let result = maybe_preallocate_destination(&mut file, &path, 1024 * 1024, 0, None);
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
@@ -373,7 +497,8 @@ mod tests {
         file.flush().expect("flush");
 
         // total_len == existing_bytes: should skip
-        let result = maybe_preallocate_destination(&mut file, &path, 5, 5, true);
+        let result =
+            maybe_preallocate_destination(&mut file, &path, 5, 5, Some(Reservation::KeepSize));
         assert!(result.is_ok());
     }
 
@@ -392,7 +517,8 @@ mod tests {
             .open(&path)
             .expect("open file");
 
-        let result = maybe_preallocate_destination(&mut file, &path, 4096, 0, true);
+        let result =
+            maybe_preallocate_destination(&mut file, &path, 4096, 0, Some(Reservation::KeepSize));
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
@@ -401,7 +527,7 @@ mod tests {
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
         #[cfg(not(target_os = "linux"))]
-        assert_eq!(metadata.len(), 4096);
+        assert_eq!(metadata.len(), 4095);
 
         // Write some content to the preallocated space
         file.write_all(b"hello preallocated world").expect("write");
@@ -413,7 +539,7 @@ mod tests {
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 24, "size grows only as data is written");
         #[cfg(not(target_os = "linux"))]
-        assert_eq!(metadata.len(), 4096);
+        assert_eq!(metadata.len(), 4095);
     }
 
     /// Verify that preallocating a file that already has some content reserves
@@ -430,7 +556,8 @@ mod tests {
 
         // Preallocate to 4096 even though 100 bytes are written.
         // existing_bytes=100 < total_len=4096, so preallocation should happen.
-        let result = maybe_preallocate_destination(&mut file, &path, 4096, 100, true);
+        let result =
+            maybe_preallocate_destination(&mut file, &path, 4096, 100, Some(Reservation::KeepSize));
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
@@ -441,7 +568,7 @@ mod tests {
             "KEEP_SIZE preserves the written length"
         );
         #[cfg(not(target_os = "linux"))]
-        assert_eq!(metadata.len(), 4096);
+        assert_eq!(metadata.len(), 4095);
     }
 
     /// Verify preallocation with a variety of sizes including small files
@@ -454,14 +581,15 @@ mod tests {
         let mut file = fs::File::create(&path).expect("create file");
 
         // Even a 1-byte preallocation should succeed
-        let result = maybe_preallocate_destination(&mut file, &path, 1, 0, true);
+        let result =
+            maybe_preallocate_destination(&mut file, &path, 1, 0, Some(Reservation::KeepSize));
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
         #[cfg(target_os = "linux")]
         assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
         #[cfg(not(target_os = "linux"))]
-        assert_eq!(metadata.len(), 1);
+        assert_eq!(metadata.len(), 2);
     }
 
     /// Regression guard for the KEEP_SIZE behavior-fidelity fix. Upstream's
@@ -481,8 +609,14 @@ mod tests {
         let mut file = fs::File::create(&path).expect("create file");
 
         let total_len: u64 = 1024 * 1024;
-        let reserved =
-            maybe_preallocate_destination(&mut file, &path, total_len, 0, true).expect("prealloc");
+        let reserved = maybe_preallocate_destination(
+            &mut file,
+            &path,
+            total_len,
+            0,
+            Some(Reservation::KeepSize),
+        )
+        .expect("prealloc");
 
         let metadata = fs::metadata(&path).expect("metadata");
         // The apparent size must stay at 0: KEEP_SIZE reserves blocks without
@@ -496,7 +630,7 @@ mod tests {
         // which case the fallback set_len would have reported total_len as the
         // length above - which it did not).
         assert!(
-            reserved >= total_len || metadata.blocks() * 512 >= total_len,
+            reserved == total_len - 1 || metadata.blocks() * 512 >= total_len - 1,
             "blocks should be reserved for the eventual length (reserved={reserved}, blocks*512={})",
             metadata.blocks() * 512
         );

--- a/crates/engine/src/local_copy/executor/file/sparse/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/mod.rs
@@ -91,7 +91,7 @@ impl std::fmt::Display for SparseDetectStrategy {
     }
 }
 
-pub(crate) use state::{SparseWriteState, write_sparse_chunk};
+pub(crate) use state::{SparseWriteState, skip_matched_sparse, write_sparse_chunk};
 
 use detect::{leading_zero_run, trailing_zero_run};
 

--- a/crates/engine/src/local_copy/executor/file/sparse/state.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/state.rs
@@ -127,6 +127,22 @@ impl SparseWriteState {
     }
 }
 
+/// How a run of non-zero data inside a sparse chunk reaches the destination.
+///
+/// upstream: fileio.c:238-245 `emit_sparse_span()` - the `use_seek` flag is set
+/// when the bytes are already present at this offset (an in-place matched
+/// block), so the span is seeked over instead of rewritten. The zero-run scan
+/// is identical in both modes, and that is exactly what lets `--inplace
+/// --sparse` punch an interior hole out of an otherwise-matching block.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SpanWrite {
+    /// `use_seek == 0`: write the bytes (`full_sparse_write`).
+    Data,
+    /// `use_seek == 1`: the bytes already sit at this offset, so advance past
+    /// them (`do_lseek`).
+    Seek,
+}
+
 /// Writes a chunk of data with sparse hole detection.
 ///
 /// Zero runs within the chunk are accumulated rather than written, and flushed
@@ -139,6 +155,34 @@ pub(crate) fn write_sparse_chunk(
     state: &mut SparseWriteState,
     chunk: &[u8],
     destination: &Path,
+) -> Result<usize, LocalCopyError> {
+    write_sparse_spans(writer, state, chunk, destination, SpanWrite::Data)
+}
+
+/// Consumes an in-place matched block through the sparse processor.
+///
+/// The block's bytes already sit at the writer's current offset, so its data
+/// spans are seeked over rather than rewritten - but its interior zero runs are
+/// still scanned and punched. Skipping that scan is what leaves a hole-y basis
+/// file fully allocated under `--inplace --sparse`.
+// upstream: fileio.c:251-258 skip_matched() - `if (sparse_files > 0)
+// write_file(fd, 1 /*use_seek*/, offset, buf, len)`, only the non-sparse arm
+// lseeks straight past the block.
+pub(crate) fn skip_matched_sparse(
+    writer: &mut fs::File,
+    state: &mut SparseWriteState,
+    chunk: &[u8],
+    destination: &Path,
+) -> Result<usize, LocalCopyError> {
+    write_sparse_spans(writer, state, chunk, destination, SpanWrite::Seek)
+}
+
+fn write_sparse_spans(
+    writer: &mut fs::File,
+    state: &mut SparseWriteState,
+    chunk: &[u8],
+    destination: &Path,
+    mode: SpanWrite,
 ) -> Result<usize, LocalCopyError> {
     // Mirror rsync's write_sparse: always report the full chunk length as
     // consumed even when large sections become holes. Callers that track
@@ -166,13 +210,25 @@ pub(crate) fn write_sparse_chunk(
         let data_end = segment_end - trailing;
 
         if data_end > data_start {
-            // upstream: flush the pending zero run (seek or punch) before the
-            // data write. The flush reads the writer's current position as the
-            // run start, so an interleaved external seek stays correct.
+            // upstream: fileio.c:240 emit_sparse_span() flushes the pending
+            // zero run (seek or punch) before emitting the data span. The
+            // flush reads the writer's current position as the run start, so
+            // an interleaved external seek stays correct.
             state.flush(writer, destination)?;
-            writer
-                .write_all(&chunk[data_start..data_end])
-                .map_err(|error| LocalCopyError::io("copy file", destination, error))?;
+            match mode {
+                SpanWrite::Data => writer
+                    .write_all(&chunk[data_start..data_end])
+                    .map_err(|error| LocalCopyError::io("copy file", destination, error))?,
+                // upstream: fileio.c:242-243 - the bytes are already at this
+                // offset, so advance past them instead of rewriting them.
+                SpanWrite::Seek => {
+                    writer
+                        .seek(SeekFrom::Current((data_end - data_start) as i64))
+                        .map_err(|error| {
+                            LocalCopyError::io("seek in destination file", destination, error)
+                        })?;
+                }
+            }
         }
 
         state.replace(trailing);

--- a/crates/engine/src/local_copy/executor/file/sparse/state.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/state.rs
@@ -41,7 +41,7 @@ impl SparseWriteState {
     /// Records the preallocated length so zero runs inside the reserved extent
     /// are punched out rather than merely seeked over (which would leave the
     /// preallocated blocks allocated).
-    // upstream: fileio.c:92 - if (sparse_past_write >= preallocated_len)
+    // upstream: fileio.c:84 - if (sparse_past_write >= preallocated_len)
     pub(crate) const fn set_preallocated_len(&mut self, len: u64) {
         self.preallocated_len = len;
     }
@@ -57,7 +57,7 @@ impl SparseWriteState {
     /// forward when that position is at or beyond the preallocated extent (the
     /// natural-hole case for a fresh file), otherwise punches a hole to
     /// deallocate the blocks that preallocation reserved.
-    // upstream: fileio.c:90-99 write_sparse()
+    // upstream: fileio.c:80-95 flush_sparse_hole()
     fn flush(&mut self, writer: &mut fs::File, destination: &Path) -> Result<(), LocalCopyError> {
         if self.pending_zero_run == 0 {
             return Ok(());
@@ -129,7 +129,7 @@ impl SparseWriteState {
 
 /// How a run of non-zero data inside a sparse chunk reaches the destination.
 ///
-/// upstream: fileio.c:238-245 `emit_sparse_span()` - the `use_seek` flag is set
+/// upstream: fileio.c:117-124 `emit_sparse_span()` - the `use_seek` flag is set
 /// when the bytes are already present at this offset (an in-place matched
 /// block), so the span is seeked over instead of rewritten. The zero-run scan
 /// is identical in both modes, and that is exactly what lets `--inplace
@@ -165,7 +165,7 @@ pub(crate) fn write_sparse_chunk(
 /// spans are seeked over rather than rewritten - but its interior zero runs are
 /// still scanned and punched. Skipping that scan is what leaves a hole-y basis
 /// file fully allocated under `--inplace --sparse`.
-// upstream: fileio.c:251-258 skip_matched() - `if (sparse_files > 0)
+// upstream: fileio.c:256-259 skip_matched() - `if (sparse_files > 0)
 // write_file(fd, 1 /*use_seek*/, offset, buf, len)`, only the non-sparse arm
 // lseeks straight past the block.
 pub(crate) fn skip_matched_sparse(
@@ -210,7 +210,7 @@ fn write_sparse_spans(
         let data_end = segment_end - trailing;
 
         if data_end > data_start {
-            // upstream: fileio.c:240 emit_sparse_span() flushes the pending
+            // upstream: fileio.c:119 emit_sparse_span() flushes the pending
             // zero run (seek or punch) before emitting the data span. The
             // flush reads the writer's current position as the run start, so
             // an interleaved external seek stays correct.
@@ -219,7 +219,7 @@ fn write_sparse_spans(
                 SpanWrite::Data => writer
                     .write_all(&chunk[data_start..data_end])
                     .map_err(|error| LocalCopyError::io("copy file", destination, error))?,
-                // upstream: fileio.c:242-243 - the bytes are already at this
+                // upstream: fileio.c:121-122 - the bytes are already at this
                 // offset, so advance past them instead of rewriting them.
                 SpanWrite::Seek => {
                     writer

--- a/crates/engine/src/local_copy/executor/file/sparse/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/tests.rs
@@ -367,7 +367,7 @@ fn write_zeros_fallback_handles_large_length() {
 /// hole. With `preallocated_len` covering the whole file, `write_sparse_chunk`
 /// mirrors upstream `write_sparse()`'s `do_punch_hole` branch so the reserved
 /// blocks under the zero run are deallocated rather than left allocated.
-// upstream: fileio.c:95 - do_punch_hole(f, sparse_past_write, sparse_seek)
+// upstream: fileio.c:89 - do_punch_hole(f, sparse_past_write, sparse_seek)
 #[cfg(target_os = "linux")]
 #[test]
 fn sparse_chunk_punches_hole_within_preallocated_extent() {
@@ -422,7 +422,7 @@ fn sparse_chunk_punches_hole_within_preallocated_extent() {
 /// Outside a preallocated extent (`preallocated_len == 0`) the writer seeks
 /// over zero runs to form a natural hole, matching upstream's
 /// `sparse_past_write >= preallocated_len` lseek branch.
-// upstream: fileio.c:93 - do_lseek(f, sparse_seek, SEEK_CUR)
+// upstream: fileio.c:85 - do_lseek(f, sparse_seek, SEEK_CUR)
 #[test]
 fn sparse_chunk_seeks_over_run_without_preallocation() {
     let mut file = NamedTempFile::new().expect("temp file");

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use directory::{
 pub(crate) use file::take_fsync_call_count;
 pub(crate) use file::{
     CopyComparison, SparseWriteState, copy_entry_to_backup, copy_file, create_backup_parents,
-    should_skip_copy, system_time_within_window, write_sparse_chunk,
+    should_skip_copy, skip_matched_sparse, system_time_within_window, write_sparse_chunk,
 };
 pub use file::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,
@@ -34,7 +34,7 @@ pub use file::{
 };
 #[cfg(test)]
 pub(crate) use file::{
-    files_checksum_match, maybe_preallocate_destination, partial_destination_path,
+    Reservation, files_checksum_match, maybe_preallocate_destination, partial_destination_path,
     temp_name_with_suffix,
 };
 pub(crate) use iconv::{

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -63,20 +63,27 @@ fn execute_with_sparse_enabled_creates_holes() {
     );
 }
 
-/// `--preallocate --sparse` leaves the destination fully DENSE, not sparse.
+/// `--preallocate --sparse` must end up SPARSE, not dense.
 ///
-/// Upstream `do_fallocate()` reserves the whole extent with `FALLOC_FL_KEEP_SIZE`
-/// and returns 0, so `preallocated_len == 0`. In `write_sparse()` the
-/// `sparse_past_write >= preallocated_len` test is then always true, so the zero
-/// run is seeked over (`do_lseek`) rather than punched (`do_punch_hole`); seeking
-/// does not free the blocks the reservation already allocated, so preallocation
-/// defeats sparseness. Verified against rsync 3.4.4 (ext4): `--preallocate
-/// --sparse` yields `st_blocks*512 == st_size` (dense).
-// upstream: fileio.c:92 write_sparse() `if (sparse_past_write >= preallocated_len)`
-// upstream: syscall.c:1555 do_fallocate() returns 0 for the KEEP_SIZE (opts != 0) path
+/// This inverts what oc asserted while it mirrored rsync 3.4.4, where
+/// `do_fallocate()` reserved the extent with `FALLOC_FL_KEEP_SIZE` and returned
+/// 0: `preallocated_len == 0` made `sparse_past_write >= preallocated_len`
+/// always true, the zero run was seeked over rather than punched, and seeking
+/// does not free blocks the reservation already allocated - so preallocation
+/// defeated sparseness. 3.5.0 fixed that, and says so in its own source: "a
+/// stray 0 here, from 2019's switch to KEEP_SIZE, is why --preallocate --sparse
+/// stopped producing sparse files".
+///
+/// The rule it restores has two halves, and only both together make the file
+/// sparse: `KEEP_SIZE` is selected **only when no holes will be punched**
+/// (otherwise the reserved blocks sit beyond EOF where a punch cannot reach
+/// them), and `do_fallocate()` reports the reserved length instead of 0.
+// upstream: syscall.c:2597 do_fallocate() - `(inplace || preallocate_files)
+// && sparse_files <= 0 ? DO_FALLOC_OPTIONS : 0`
+// upstream: fileio.c:84 flush_sparse_hole() - `sparse_past_write >= preallocated_len`
 #[cfg(target_os = "linux")]
 #[test]
-fn execute_preallocate_sparse_stays_dense() {
+fn execute_preallocate_sparse_punches_the_reserved_extent() {
     use std::os::unix::fs::MetadataExt;
 
     let temp = tempdir().expect("tempdir");
@@ -107,9 +114,10 @@ fn execute_preallocate_sparse_stays_dense() {
     let meta = fs::metadata(&dest).expect("dest metadata");
     assert_eq!(meta.len(), apparent, "content length preserved");
     assert!(
-        meta.blocks() * 512 >= apparent,
-        "preallocated extent must stay dense: the zero run is seeked over, not \
-         punched, so the reserved blocks remain allocated (allocated {}, size {})",
+        meta.blocks() * 512 < apparent,
+        "the preallocated extent's zero run must be punched into a hole, not \
+         seeked over - seeking leaves the reserved blocks allocated (allocated \
+         {}, size {})",
         meta.blocks() * 512,
         apparent,
     );

--- a/crates/engine/src/local_copy/tests/options.rs
+++ b/crates/engine/src/local_copy/tests/options.rs
@@ -411,15 +411,18 @@ fn preallocate_destination_reserves_space() {
         .open(&path)
         .expect("create file");
 
-    maybe_preallocate_destination(&mut file, &path, 4096, 0, true).expect("preallocate file");
+    maybe_preallocate_destination(&mut file, &path, 4096, 0, Some(Reservation::KeepSize))
+        .expect("preallocate file");
 
     let metadata = fs::metadata(&path).expect("metadata");
     // Linux reserves blocks with FALLOC_FL_KEEP_SIZE, leaving the apparent size
     // unchanged; other unix platforms extend the file to the requested length.
     #[cfg(target_os = "linux")]
     assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
+    // upstream: syscall.c:2601-2604 - the reservation is deliberately one byte
+    // short of the requested length.
     #[cfg(not(target_os = "linux"))]
-    assert_eq!(metadata.len(), 4096);
+    assert_eq!(metadata.len(), 4095);
 }
 
 #[test]
@@ -433,7 +436,7 @@ fn preallocate_destination_skips_when_disabled() {
         .open(&path)
         .expect("create file");
 
-    maybe_preallocate_destination(&mut file, &path, 4096, 0, false).expect("should succeed");
+    maybe_preallocate_destination(&mut file, &path, 4096, 0, None).expect("should succeed");
 
     let metadata = fs::metadata(&path).expect("metadata");
     assert_eq!(metadata.len(), 0, "disabled preallocate should not change file size");
@@ -450,7 +453,8 @@ fn preallocate_destination_skips_zero_length() {
         .open(&path)
         .expect("create file");
 
-    maybe_preallocate_destination(&mut file, &path, 0, 0, true).expect("should succeed");
+    maybe_preallocate_destination(&mut file, &path, 0, 0, Some(Reservation::KeepSize))
+        .expect("should succeed");
 
     let metadata = fs::metadata(&path).expect("metadata");
     assert_eq!(metadata.len(), 0, "zero-length preallocate should not change file");
@@ -468,7 +472,8 @@ fn preallocate_destination_skips_when_already_large() {
         .expect("create file");
 
     // existing_bytes (1024) > total_len (512) means skip
-    maybe_preallocate_destination(&mut file, &path, 512, 1024, true).expect("should succeed");
+    maybe_preallocate_destination(&mut file, &path, 512, 1024, Some(Reservation::KeepSize))
+        .expect("should succeed");
 
     let metadata = fs::metadata(&path).expect("metadata");
     assert_eq!(metadata.len(), 0, "should skip when existing >= total");

--- a/crates/engine/src/local_copy/tests/options.rs
+++ b/crates/engine/src/local_copy/tests/options.rs
@@ -419,10 +419,16 @@ fn preallocate_destination_reserves_space() {
     // unchanged; other unix platforms extend the file to the requested length.
     #[cfg(target_os = "linux")]
     assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
-    // upstream: syscall.c:2601-2604 - the reservation is deliberately one byte
-    // short of the requested length.
-    #[cfg(not(target_os = "linux"))]
+    // Other Unix: fallocate is unavailable, so the fallback extends the file to
+    // upstream's deliberately-perturbed `length`
+    // (upstream: syscall.c:2601-2604; receiver.c:652 trims the excess).
+    #[cfg(all(unix, not(target_os = "linux")))]
     assert_eq!(metadata.len(), 4095);
+    // Windows has no fallocate at all: the file is extended to exactly
+    // total_len, so there is no over-preallocation and the perturbation
+    // upstream applies to a reservation does not apply here.
+    #[cfg(not(unix))]
+    assert_eq!(metadata.len(), 4096);
 }
 
 #[test]

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -238,7 +238,7 @@ partial-protected-regular-retry-policy skip
 partial_nowrite pass
 password-file-symlink skip
 peer-legacy-implied-delete-scope skip
-preallocate fail
+preallocate pass
 protected-regular skip
 proto-cleared-dirflist skip
 proto-cleared-ndx skip

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -238,7 +238,7 @@ partial-protected-regular-retry-policy skip
 partial_nowrite pass
 password-file-symlink pass
 peer-legacy-implied-delete-scope skip
-preallocate fail
+preallocate pass
 protected-regular pass
 proto-cleared-dirflist skip
 proto-cleared-ndx skip


### PR DESCRIPTION
Closes the upstream 3.5.0 `preallocate` cell on both pipe legs.

## What was wrong

The cell asserts four things. oc failed the second, and fixing it exposed a
fourth-assertion failure with an independent cause.

**1. `--preallocate --sparse` left the file fully allocated.** oc mirrored
rsync **3.4.4**'s `do_fallocate()`. 3.5.0 changed it and names the regression
in its own source:

> `/* ... Return that reserved length (not 0) so the caller's preallocated_len
> is meaningful ... (A stray 0 here, from 2019's switch to KEEP_SIZE, is why
> --preallocate --sparse stopped producing sparse files.) */`

The restored rule has two halves, and only both together make the file sparse:

| half | upstream | oc before |
|---|---|---|
| `FALLOC_FL_KEEP_SIZE` only when no holes will be punched | `syscall.c:2597` - `(inplace \|\| preallocate_files) && sparse_files <= 0` | KEEP_SIZE applied unconditionally on Linux |
| `do_fallocate()` reports the reserved length | `syscall.c:2629` - `return length;` | returned `0` |

The gate is the load-bearing half: with `KEEP_SIZE` the reserved blocks sit
*beyond EOF*, where `do_punch_hole()` silently deallocates nothing. The return
value matters for `flush_sparse_hole()`'s punch-vs-seek choice (`fileio.c:84`)
and for the receiver's over-preallocation trim (`receiver.c:652`).

**2. `--inplace --sparse` left matching interior zero runs allocated.** The
in-place matched-block fast path advanced the write offset without scanning the
block. Upstream's `skip_matched()` hands the bytes to the sparse processor with
`use_seek` set when `--sparse` is on (`fileio.c:251-258`); only the non-sparse
arm seeks straight past. oc's **network** receiver already did this
(`disk_commit/process/file_ops.rs`, citing `fileio.c:196-200`); the local-copy
path did not, at two byte-identical sites. Both now call one helper.

`write_sparse_chunk` gains upstream's `emit_sparse_span` mode switch
(`fileio.c:238-245`) so the matched case seeks over its data spans rather than
rewriting them - otherwise "fixing" `skip_matched` would rewrite every matched
byte and defeat the optimisation it is named for.

## Verification

RED first, against a freshly built binary on Linux, with the real upstream
3.5.0 binary as a control on every run. The control passed throughout, so the
cell is not fixture-limited.

Three mutations, one per rule. **One survived, and that is the useful result:**

| mutation | cell |
|---|---|
| KEEP_SIZE used even under `--sparse` | **fail** |
| `skip_matched` seeks past the block without the sparse scan | **fail** |
| `do_fallocate()` reports 0 again | **passed** |

The cell never exercises the `KeepSize` return arm, because the sparse path now
takes the `FullSize` arm by construction. So the return-value change is pinned
by a unit test instead - `keep_size_reports_the_reserved_length_not_zero` goes
red under that mutation (`left: 0, right: 1048575`). Claiming the cell proved
it would have been wrong.

`execute_preallocate_sparse_stays_dense` **encoded the pre-fix behaviour** -
it was an accurate record of 3.4.4 ("Verified against rsync 3.4.4 (ext4)") and
3.5.0 deliberately withdrew it. Inverted and renamed rather than deleted.

- upstream 3.5.0 `preallocate`: **fail -> pass**, measured on each pipe leg
  separately (nonroot and root baseline independently); both manifest rows
  flip in this commit
- `cargo nextest -p engine --all-features`: **5101/5101**
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets
  --all-features --no-deps -- -D warnings` clean

## Not in scope, surfaced rather than silently fixed

- **`--preallocate` on non-Linux.** Upstream compiles preallocation out where
  `fallocate` is absent and rejects the option outright; oc accepts it and
  extends the file. Untouched here - it is a separate option-acceptance
  decision, and the cell self-skips there.
- **Two implementations of one upstream function.** `fast_io::preallocate` and
  the engine's `maybe_preallocate_destination` both port `do_fallocate()`, and
  both carried the identical stray zero. Both are corrected; consolidating them
  is left alone because they differ on the unresolved non-Linux question above.
- **Two residual mismatches on both legs**, neither reachable from this diff:
  `simd-checksum` skips on the aarch64 test host ("simdtest not built") for oc
  *and* upstream alike, and `daemon-refuse-delete-alias` passes in isolation but
  fails under full-suite load. Neither row was touched.

## Citation retarget (second commit)

The `Upstream citations track 3.5.0` gate flagged one drifted anchor
(`preallocated_len = size_r`, cited at `receiver.c:482` but living at `:490`).
Reading **every** line cited in these files against the pinned 3.5.0 source
found six more wrong, so the gate caught one instance of a larger drift rather
than the whole of it:

| construct | cited | actual |
|---|---|---|
| `do_fallocate()` `opts == 0` arm | `syscall.c:2615-2619` | `2616-2620` |
| `do_fallocate()` KEEP_SIZE arm | `syscall.c:2620-2628` | `2622-2629` |
| `DO_FALLOC_OPTIONS` | `syscall.c:1523` | `2584` |
| `emit_sparse_span()` | `fileio.c:238-245` | `117-124` |
| its flush / seek arms | `fileio.c:240`, `242-243` | `119`, `121-122` |
| `skip_matched()` sparse arm | `fileio.c:251-258` | `256-259` |
| `flush_sparse_hole()` | `fileio.c:90-99` | `80-95` |
| its punch/seek decision | `fileio.c:92`, `95`, `93` | `84`, `89`, `85` |
| `preallocated_len = size_r` | `receiver.c:482-492` | `490` |
| the `do_ftruncate(fd,0)` branch | `receiver.c:485-486` | `486-487` |
| the preallocate branch | `receiver.c:475` | `476` |
| skip-matched fast path | `receiver.c:468-477` | `624-629` |

The `syscall.c:1523` and `fileio.c:9x` anchors are 3.4.4-era and predate this
branch, so the gate's baseline had already absorbed them. They sit directly on
the rule being corrected here - leaving them would ship a knowingly-wrong
pointer beside the fix - so they are retargeted in the same change. Comments
only.
