### PR TITLE
fix(core): validate and quote the RSYNC_CONNECT_PROG %H substitution

### DIFF
--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -21,15 +21,26 @@
 //!
 //! # Security Model
 //!
-//! The `%H` (host) and `%P` (port) substitutions are performed without shell
-//! escaping, matching upstream rsync behavior. This is safe because:
+//! The rendered command is run as `sh -c <command>`, so `%H` is substituted
+//! into a word a shell parses. The template is operator-supplied, but the host
+//! is not: it comes from the `rsync://host/module` operand. Upstream therefore
+//! applies two defences before substituting, and so does this module
+//! (upstream: socket.c:488-495):
 //!
-//! - `RSYNC_CONNECT_PROG` is set by the administrator, not end users
-//! - The template controls whether `%H`/`%P` are used at all
-//! - Hostnames with shell metacharacters are extremely rare
+//! - the host is refused outright unless every byte stays data through a shell
+//!   pass, and its first byte is additionally restricted
+//!   ([`shell_unsafe_connect_host`]);
+//! - what remains is single-quoted so the outer shell sees one literal word
+//!   ([`shell_quote_connect_host`]).
 //!
-//! If untrusted input could reach the host parameter, callers should validate
-//! the hostname format before invoking connection programs.
+//! Both are needed. Quoting alone cannot help when a hook of the form
+//! `sh -c '... %H ...'` re-parses the word in a nested shell, where the quotes
+//! have already been consumed by the outer one.
+//!
+//! This bounds what a *shell* can do with the value. It cannot bound what the
+//! named program does with it - `host:-rf` arrives intact, and a program that
+//! splits on `:` may reinterpret the tail. That boundary belongs to whoever
+//! writes `RSYNC_CONNECT_PROG`.
 
 use std::env;
 use std::ffi::{OsStr, OsString};
@@ -253,7 +264,32 @@ impl ConnectProgramConfig {
         self.shell.as_ref()
     }
 
+    /// Whether the template contains a substitution specifier at all.
+    ///
+    /// upstream: socket.c:488 - `strchr(prog, '%')`. A `%` byte is ASCII, so a
+    /// lossy view answers this question identically for a non-UTF-8 template.
+    fn template_has_specifier(&self) -> bool {
+        self.template.to_string_lossy().contains('%')
+    }
+
+    /// Renders the template, substituting `%H` and `%P`.
+    ///
+    /// Returns [`UNSAFE_CONNECT_HOST`] when the host cannot be safely
+    /// substituted; the rendered command is run through `sh -c`, so an
+    /// unchecked host would be shell syntax rather than data.
     pub(crate) fn format_command(&self, host: &str, port: u16) -> Result<OsString, String> {
+        // upstream: socket.c:488-495 - the refusal, the quoting and the
+        // substitution all sit inside `if (prog && strchr(prog, '%'))`, so a
+        // template with no specifier never inspects the host at all.
+        if !self.template_has_specifier() {
+            return Ok(self.template.clone());
+        }
+        if shell_unsafe_connect_host(host) {
+            return Err(UNSAFE_CONNECT_HOST.to_owned());
+        }
+        let quoted = shell_quote_connect_host(host);
+        let host = quoted.as_str();
+
         #[cfg(unix)]
         {
             use std::os::unix::ffi::OsStringExt;
@@ -549,6 +585,67 @@ impl Drop for ConnectProgramStream {
             let _ = child.wait();
         }
     }
+}
+
+/// The refusal text upstream prints when a host cannot be substituted.
+///
+/// upstream: socket.c:492 - `rprintf(FERROR, "unsafe host characters for
+/// RSYNC_CONNECT_PROG\n")`.
+const UNSAFE_CONNECT_HOST: &str = "unsafe host characters for RSYNC_CONNECT_PROG";
+
+/// Whether `byte` stays data when a shell re-parses the word containing it.
+///
+/// upstream: socket.c:209-212. The set is deliberately wider than a DNS name:
+/// `RSYNC_CONNECT_PROG` exists for custom transports, where `%H` may be an
+/// alias the program resolves itself rather than a name the resolver ever sees,
+/// so `+` and `~` are allowed inside the string. `%` is required for an IPv6
+/// zone id (`fe80::1%eth0`) and is not special to a POSIX shell.
+const fn connect_host_byte_is_safe(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+        || matches!(byte, b'.' | b'_' | b':' | b'-' | b'%' | b'+' | b'~')
+}
+
+/// Whether `host` must be refused rather than substituted into the template.
+///
+/// upstream: socket.c:204-215 `shell_unsafe_connect_host()`.
+///
+/// The first byte is checked separately because several of the otherwise
+/// allowed ones change an argument's MEANING rather than its text, which no
+/// amount of quoting prevents. Mid-word each is literal, which is why the set
+/// still allows them:
+/// - `-` and `+` both introduce options to plenty of programs - `sh +x` is as
+///   real as `sh -x`;
+/// - `~` is tilde-expanded by a nested shell, turning `~root` into `/root`;
+/// - `%` is expanded by a nested fish, where `%self` becomes its pid (an IPv6
+///   zone id has its `%` mid-word, so nothing legitimate is lost).
+///
+/// An empty host is refused too: it survives a direct exec as an empty
+/// argument but vanishes entirely when a nested shell re-splits the command,
+/// shifting every argument after it.
+fn shell_unsafe_connect_host(host: &str) -> bool {
+    match host.as_bytes() {
+        [] => true,
+        [first, ..] if matches!(first, b'-' | b'+' | b'~' | b'%') => true,
+        bytes => !bytes.iter().copied().all(connect_host_byte_is_safe),
+    }
+}
+
+/// Wraps `host` in single quotes so the outer shell sees exactly one literal
+/// word, rendering an embedded quote as `'\''`.
+///
+/// upstream: socket.c `shell_quote_connect_host()`.
+fn shell_quote_connect_host(host: &str) -> String {
+    let mut quoted = String::with_capacity(host.len() + 2);
+    quoted.push('\'');
+    for ch in host.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
 }
 
 fn connect_program_configuration_error(text: impl Into<String>) -> ClientError {

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -625,7 +625,7 @@ const fn connect_host_byte_is_safe(byte: u8) -> bool {
 fn shell_unsafe_connect_host(host: &str) -> bool {
     match host.as_bytes() {
         [] => true,
-        [first, ..] if matches!(first, b'-' | b'+' | b'~' | b'%') => true,
+        [b'-' | b'+' | b'~' | b'%', ..] => true,
         bytes => !bytes.iter().copied().all(connect_host_byte_is_safe),
     }
 }

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -601,8 +601,7 @@ const UNSAFE_CONNECT_HOST: &str = "unsafe host characters for RSYNC_CONNECT_PROG
 /// so `+` and `~` are allowed inside the string. `%` is required for an IPv6
 /// zone id (`fe80::1%eth0`) and is not special to a POSIX shell.
 const fn connect_host_byte_is_safe(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric()
-        || matches!(byte, b'.' | b'_' | b':' | b'-' | b'%' | b'+' | b'~')
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-' | b'%' | b'+' | b'~')
 }
 
 /// Whether `host` must be refused rather than substituted into the template.

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -793,14 +793,14 @@ mod tests {
     fn format_command_port_zero() {
         let config = ConnectProgramConfig::new("nc %H %P".into(), None).unwrap();
         let result = config.format_command("host", 0).unwrap();
-        assert_eq!(result, "nc host 0");
+        assert_eq!(result, "nc 'host' 0");
     }
 
     #[test]
     fn format_command_port_max() {
         let config = ConnectProgramConfig::new("nc %H %P".into(), None).unwrap();
         let result = config.format_command("host", 65535).unwrap();
-        assert_eq!(result, "nc host 65535");
+        assert_eq!(result, "nc 'host' 65535");
     }
 
     /// `@` is outside upstream's allowed byte set, so a `user@host` form is

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -701,7 +701,7 @@ mod tests {
     fn format_command_substitutes_host() {
         let config = ConnectProgramConfig::new("connect to %H".into(), None).unwrap();
         let result = config.format_command("example.com", 873).unwrap();
-        assert_eq!(result, "connect to example.com");
+        assert_eq!(result, "connect to 'example.com'");
     }
 
     #[test]
@@ -715,7 +715,7 @@ mod tests {
     fn format_command_substitutes_both() {
         let config = ConnectProgramConfig::new("nc %H %P".into(), None).unwrap();
         let result = config.format_command("server.local", 22).unwrap();
-        assert_eq!(result, "nc server.local 22");
+        assert_eq!(result, "nc 'server.local' 22");
     }
 
     #[test]
@@ -743,7 +743,7 @@ mod tests {
     fn format_command_multiple_substitutions() {
         let config = ConnectProgramConfig::new("%H:%P and %H again".into(), None).unwrap();
         let result = config.format_command("myhost", 9999).unwrap();
-        assert_eq!(result, "myhost:9999 and myhost again");
+        assert_eq!(result, "'myhost':9999 and 'myhost' again");
     }
 
     #[test]
@@ -757,7 +757,7 @@ mod tests {
     fn format_command_adjacent_specifiers() {
         let config = ConnectProgramConfig::new("%H%P".into(), None).unwrap();
         let result = config.format_command("test", 123).unwrap();
-        assert_eq!(result, "test123");
+        assert_eq!(result, "'test'123");
     }
 
     #[test]
@@ -765,21 +765,28 @@ mod tests {
         let config =
             ConnectProgramConfig::new("ssh -p %P %H -o 'Port=%P' %% done".into(), None).unwrap();
         let result = config.format_command("server", 2222).unwrap();
-        assert_eq!(result, "ssh -p 2222 server -o 'Port=2222' % done");
+        assert_eq!(result, "ssh -p 2222 'server' -o 'Port=2222' % done");
     }
 
     #[test]
     fn format_command_ipv6_host() {
         let config = ConnectProgramConfig::new("nc %H %P".into(), None).unwrap();
         let result = config.format_command("::1", 873).unwrap();
-        assert_eq!(result, "nc ::1 873");
+        assert_eq!(result, "nc '::1' 873");
     }
 
+    /// An empty host is refused, not substituted.
+    ///
+    /// upstream: socket.c:208 - `if (!*host || ...) return 1`. It survives a
+    /// direct exec as an empty argument but vanishes when a nested shell
+    /// re-splits the command, shifting every later argument left.
     #[test]
-    fn format_command_empty_host() {
-        let config = ConnectProgramConfig::new("nc '%H' %P".into(), None).unwrap();
-        let result = config.format_command("", 873).unwrap();
-        assert_eq!(result, "nc '' 873");
+    fn format_command_empty_host_is_refused() {
+        let config = ConnectProgramConfig::new("nc %H %P".into(), None).unwrap();
+        assert_eq!(
+            config.format_command("", 873),
+            Err(UNSAFE_CONNECT_HOST.to_owned())
+        );
     }
 
     #[test]
@@ -796,11 +803,91 @@ mod tests {
         assert_eq!(result, "nc host 65535");
     }
 
+    /// `@` is outside upstream's allowed byte set, so a `user@host` form is
+    /// refused rather than quoted.
+    ///
+    /// upstream: socket.c:211 - the set is alphanumerics plus `._:-%+~`.
     #[test]
-    fn format_command_special_chars_in_host() {
+    fn format_command_refuses_a_byte_outside_the_allowed_set() {
         let config = ConnectProgramConfig::new("nc %H %P".into(), None).unwrap();
-        let result = config.format_command("user@host.example.com", 22).unwrap();
-        assert_eq!(result, "nc user@host.example.com 22");
+        assert_eq!(
+            config.format_command("user@host.example.com", 22),
+            Err(UNSAFE_CONNECT_HOST.to_owned())
+        );
+    }
+
+    /// Every host the upstream cell expects to be refused.
+    ///
+    /// upstream: `testsuite/connect-prog-host-quoting_test.py`. The first four
+    /// are refused by the leading-byte rule (they change an argument's meaning,
+    /// which quoting cannot undo); the injection string is refused because `;`,
+    /// space, `$`, `{` and `#` are all outside the allowed set.
+    #[test]
+    fn format_command_refuses_every_unsafe_host_from_the_upstream_cell() {
+        let config = ConnectProgramConfig::new("nc %H %P".into(), None).unwrap();
+        for host in [
+            "localhost;touch${IFS}pwned;#",
+            "-c",
+            "+x",
+            "~root",
+            "%self",
+            "",
+        ] {
+            assert_eq!(
+                config.format_command(host, 873),
+                Err(UNSAFE_CONNECT_HOST.to_owned()),
+                "host {host:?} must be refused"
+            );
+        }
+    }
+
+    /// Every host the upstream cell expects to survive, quoted.
+    ///
+    /// upstream: `testsuite/connect-prog-host-quoting_test.py`. `+`, `~` and
+    /// `%` are legal mid-word - `%` in particular is required for an IPv6 zone
+    /// id, which the cell passes as `[fe80::1%eth0]` and rsync unwraps to
+    /// `fe80::1%eth0` before this point.
+    #[test]
+    fn format_command_accepts_every_safe_host_from_the_upstream_cell() {
+        let config = ConnectProgramConfig::new("nc %H %P".into(), None).unwrap();
+        for host in [
+            "example.com",
+            "example.com.",
+            "host_name",
+            "host+alias",
+            "host~alias",
+            "fe80::1%eth0",
+        ] {
+            assert_eq!(
+                config.format_command(host, 873),
+                Ok(format!("nc '{host}' 873").into()),
+                "host {host:?} must pass through quoted"
+            );
+        }
+    }
+
+    /// A template with no specifier never inspects the host at all.
+    ///
+    /// upstream: socket.c:488 - the refusal, the quoting and the substitution
+    /// all sit inside `if (prog && strchr(prog, '%'))`. Without this gate a
+    /// fixed command such as `nc localhost 873` would start failing for hosts
+    /// it never interpolates.
+    #[test]
+    fn format_command_skips_host_validation_without_a_specifier() {
+        let config = ConnectProgramConfig::new("nc localhost 873".into(), None).unwrap();
+        let result = config.format_command("localhost;touch pwned", 873).unwrap();
+        assert_eq!(result, "nc localhost 873");
+    }
+
+    /// The `'\''` escape is upstream's backstop, unreachable through
+    /// `format_command` because `'` is outside the allowed byte set. Pinned
+    /// directly so the two halves cannot drift apart.
+    ///
+    /// upstream: socket.c:152 `shell_quote_connect_host()`.
+    #[test]
+    fn shell_quote_renders_an_embedded_quote_as_the_escape_sequence() {
+        assert_eq!(shell_quote_connect_host("a'b"), r"'a'\''b'");
+        assert!(shell_unsafe_connect_host("a'b"));
     }
 
     /// Verifies that a child process spawned via `connect_via_program` receives


### PR DESCRIPTION
Ports upstream 3.5.0's two `RSYNC_CONNECT_PROG` host defences, which oc did
not have at all.

## What was wrong

`%H` is substituted into a command string that a shell runs. oc substituted
the host with **zero validation and no quoting**, so a host taken from an
`rsync://HOST/mod` operand became shell syntax rather than data.

Upstream applies two defences, both inside `if (prog && strchr(prog, '%'))`
(`socket.c:488-495`), so a template with no specifier never inspects the host:

| defence | upstream | oc before |
|---|---|---|
| refuse a shell-active host | `socket.c:204-215` `shell_unsafe_connect_host()` | absent |
| single-quote what survives | `socket.c:152` `shell_quote_connect_host()` | absent |

The refusal is not redundant with the quoting. Quoting keeps a host one word
but cannot stop a *leading* `-`/`+` looking like an option to the named
program, `~root` being tilde-expanded by a nested shell, or `%self` being
expanded by a nested fish - those change an argument's meaning, not its text.
An empty host is refused for the same reason: it survives a direct exec as an
empty argument but vanishes when a nested shell re-splits, shifting every
later argument left.

## Measured

Against the real upstream 3.5.0 binary as the control, on Linux:

| cell | oc before | oc after | upstream 3.5.0 |
|---|---|---|---|
| `connect-prog-host-quoting` | pass | **pass** | pass |
| `connect-prog-nested-singlequote-host-injection` | fail | fail | pass |

⚠ **This change flips no manifest row, and the PR does not claim one.**
`connect-prog-host-quoting` was already recorded `pass`; the cell that
actually exercises the guard is the nested one, and it still fails for an
independent reason given below. The change is upstream fidelity plus a real
injection defence, not a row flip - stated plainly rather than implied.

⚠ **METHOD NOTE.** My first control run used `rsync` from `PATH`, which is
**3.4.1** here - it fails the nested cell too, which would have read as
"fixture-limited, not an oc bug" and closed the investigation. Re-run against
the pinned 3.5.0 binary, upstream passes and the residual is oc's. A control
from `PATH` is not a control.

## The residual, surfaced rather than folded in

The nested cell now fails on exactly one row: host `%self` is **not refused**,
because it never reaches the validator. oc percent-decodes the daemon host
(`module_list/parsing.rs`, `invalid percent-encoding in daemon host`) with an
IPv6-zone fallback, so `%self` is rejected as a malformed escape before the
connect-program path runs.

Upstream 3.5.0 has **no percent-decoding of the daemon host anywhere** -
verified by reading, not assumed: `%` is a literal hostname byte, which is why
`%self` reaches `shell_unsafe_connect_host()` and is refused there. So oc's
decode is an invention, and removing it is the upstream-fidelity direction.

It is left out of this PR deliberately: it is a user-visible behaviour change
to every `rsync://` URL, it has its own tests asserting the current error, and
the IPv6-zone fallback exists only to paper over the decode. That belongs in
its own reviewable change, not bolted onto a security fix.

## Tests

Both upstream cells are transcribed directly, row for row - the refuse set
(`localhost;touch${IFS}pwned;#`, `-c`, `+x`, `~root`, `%self`, empty) and the
accept set (`example.com`, `example.com.`, `host_name`, `host+alias`,
`host~alias`, `fe80::1%eth0`), so an allow-list that simply refused everything
cannot pass. Plus the no-specifier gate, and a direct pin on the `'\''` escape
- unreachable through `format_command` by construction, since `'` is outside
the allowed byte set, so it is pinned against its own helper instead of
through a path that cannot reach it.

Nine existing assertions recorded the pre-fix unquoted rendering. They are
**inverted, not deleted**: `format_command("example.com")` now yields
`connect to 'example.com'`, and the empty-host and `user@host` cases become
refusals. The end-to-end `run_module_list_uses_connect_program_command` test
is untouched and still passes - the outer shell strips the quotes, which is
the demonstration that the quoting is transparent to a real connect program.

⚠ The first two rounds fixed only the assertions a failing run named. The
third round swept every `format_command` call in the module and found two more
(`port_zero`, `port_max`) that no run had reached yet.

- `cargo nextest -p core --all-features --lib -E 'test(connect) or
  test(format_command) or test(shell_quote)'`: **181/181** on Linux
- `cargo fmt --all -- --check` clean and `cargo clippy --workspace
  --all-targets --all-features --no-deps -- -D warnings` clean, both verified
  on Linux (macOS `cargo fmt` reported clean while Linux rustfmt did not)
