### PR TITLE
fix(core): take the rsync:// daemon host verbatim

### DIFF
--- a/crates/core/src/client/module_list/client_tests.rs
+++ b/crates/core/src/client/module_list/client_tests.rs
@@ -265,7 +265,7 @@ fn run_module_list_reports_authentication_failure() {
     });
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         Some(String::from("user")),
         ProtocolVersion::NEWEST,
     );
@@ -294,7 +294,7 @@ fn run_module_list_reports_access_denied() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -322,7 +322,7 @@ fn run_module_list_accepts_plaintext_motd_before_acknowledgment() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -353,7 +353,7 @@ fn run_module_list_suppresses_plaintext_motd_when_requested() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -393,7 +393,7 @@ fn establish_proxy_tunnel_formats_ipv6_authority_without_brackets() {
         stream.flush().expect("flush proxy response");
     });
 
-    let daemon_addr = DaemonAddress::new(String::from("fe80::1%eth0"), 873).expect("daemon addr");
+    let daemon_addr = DaemonAddress::new(String::from("fe80::1%eth0"), 873);
     let proxy = ProxyConfig {
         host: String::from("proxy.example"),
         port: addr.port(),
@@ -420,7 +420,7 @@ fn run_module_list_accepts_lowercase_proxy_status_line() {
     );
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(daemon_addr.ip().to_string(), daemon_addr.port()).expect("address"),
+        DaemonAddress::new(daemon_addr.ip().to_string(), daemon_addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -439,7 +439,7 @@ fn run_module_list_reports_invalid_proxy_configuration() {
     let _guard = EnvGuard::set("RSYNC_PROXY", "invalid-proxy");
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(String::from("localhost"), 873).expect("address"),
+        DaemonAddress::new(String::from("localhost"), 873),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -456,7 +456,7 @@ fn run_module_list_reports_invalid_proxy_configuration() {
 
 #[test]
 fn map_daemon_handshake_error_converts_error_payload() {
-    let addr = DaemonAddress::new("127.0.0.1".to_string(), 873).expect("address");
+    let addr = DaemonAddress::new("127.0.0.1".to_string(), 873);
     let error = io::Error::new(
         io::ErrorKind::InvalidData,
         NegotiationError::MalformedLegacyGreeting {
@@ -471,7 +471,7 @@ fn map_daemon_handshake_error_converts_error_payload() {
 
 #[test]
 fn map_daemon_handshake_error_converts_plain_invalid_data_error() {
-    let addr = DaemonAddress::new("127.0.0.1".to_string(), 873).expect("address");
+    let addr = DaemonAddress::new("127.0.0.1".to_string(), 873);
     let error = io::Error::new(io::ErrorKind::InvalidData, "@ERROR daemon unavailable");
 
     let mapped = map_daemon_handshake_error(error, &addr);
@@ -481,7 +481,7 @@ fn map_daemon_handshake_error_converts_plain_invalid_data_error() {
 
 #[test]
 fn map_daemon_handshake_error_converts_other_malformed_greetings() {
-    let addr = DaemonAddress::new("127.0.0.1".to_string(), 873).expect("address");
+    let addr = DaemonAddress::new("127.0.0.1".to_string(), 873);
     let error = io::Error::new(
         io::ErrorKind::InvalidData,
         NegotiationError::MalformedLegacyGreeting {
@@ -496,7 +496,7 @@ fn map_daemon_handshake_error_converts_other_malformed_greetings() {
 
 #[test]
 fn map_daemon_handshake_error_propagates_other_failures() {
-    let addr = DaemonAddress::new("127.0.0.1".to_string(), 873).expect("address");
+    let addr = DaemonAddress::new("127.0.0.1".to_string(), 873);
     let error = io::Error::new(io::ErrorKind::TimedOut, "timed out");
 
     let mapped = map_daemon_handshake_error(error, &addr);
@@ -514,7 +514,7 @@ fn run_module_list_reports_authentication_required() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -534,7 +534,7 @@ fn run_module_list_requires_password_for_authentication() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         Some(String::from("user")),
         ProtocolVersion::NEWEST,
     );
@@ -601,7 +601,7 @@ fn run_module_list_authenticates_with_credentials() {
     });
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         Some(String::from("user")),
         ProtocolVersion::NEWEST,
     );
@@ -670,7 +670,7 @@ fn run_module_list_authenticates_with_password_override() {
     });
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         Some(String::from("user")),
         ProtocolVersion::NEWEST,
     );
@@ -749,7 +749,7 @@ fn run_module_list_authenticates_with_split_challenge() {
     });
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         Some(String::from("user")),
         ProtocolVersion::NEWEST,
     );
@@ -765,13 +765,19 @@ fn run_module_list_authenticates_with_split_challenge() {
     handle.join().expect("server thread");
 }
 
+/// The RFC 6874 `%25` spelling of a zone id is passed through, not decoded.
+///
+/// upstream has no percent-decoder, so this reaches the resolver as typed.
+/// The spelling that actually works on both implementations is the bare one,
+/// covered by `module_list_request_supports_raw_ipv6_zone_identifier` below -
+/// which is also the form the upstream testsuite uses.
 #[test]
-fn module_list_request_supports_ipv6_zone_identifier() {
+fn module_list_request_keeps_an_encoded_ipv6_zone_identifier_verbatim() {
     let operands = vec![OsString::from("rsync://[fe80::1%25eth0]/")];
     let request = ModuleListRequest::from_operands(&operands)
         .expect("parse succeeds")
         .expect("request detected");
-    assert_eq!(request.address().host(), "fe80::1%eth0");
+    assert_eq!(request.address().host(), "fe80::1%25eth0");
     assert_eq!(request.address().port(), 873);
 }
 
@@ -786,22 +792,18 @@ fn module_list_request_supports_raw_ipv6_zone_identifier() {
 }
 
 #[test]
-fn module_list_request_rejects_truncated_percent_encoding_in_username() {
+fn module_list_request_keeps_a_truncated_percent_sequence_in_the_username() {
     let operands = vec![OsString::from("user%2@localhost::")];
-    let error =
-        ModuleListRequest::from_operands(&operands).expect_err("invalid encoding should fail");
-    assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("invalid percent-encoding in daemon username")
-    );
+    let request = ModuleListRequest::from_operands(&operands)
+        .expect("parse succeeds")
+        .expect("request present");
+    assert_eq!(request.username(), Some("user%2"));
+    assert_eq!(request.address().host(), "localhost");
 }
 
 #[test]
 fn resolve_daemon_addresses_filters_ipv4_mode() {
-    let address = DaemonAddress::new(String::from("127.0.0.1"), 873).expect("address");
+    let address = DaemonAddress::new(String::from("127.0.0.1"), 873);
     let addresses =
         resolve_daemon_addresses(&address, AddressMode::Ipv4).expect("ipv4 resolution succeeds");
 
@@ -811,7 +813,7 @@ fn resolve_daemon_addresses_filters_ipv4_mode() {
 
 #[test]
 fn resolve_daemon_addresses_rejects_missing_ipv6_addresses() {
-    let address = DaemonAddress::new(String::from("127.0.0.1"), 873).expect("address");
+    let address = DaemonAddress::new(String::from("127.0.0.1"), 873);
     let error = resolve_daemon_addresses(&address, AddressMode::Ipv6)
         .expect_err("IPv6 filtering should fail for IPv4-only host");
 
@@ -822,7 +824,7 @@ fn resolve_daemon_addresses_rejects_missing_ipv6_addresses() {
 
 #[test]
 fn resolve_daemon_addresses_filters_ipv6_mode() {
-    let address = DaemonAddress::new(String::from("::1"), 873).expect("address");
+    let address = DaemonAddress::new(String::from("::1"), 873);
     let addresses =
         resolve_daemon_addresses(&address, AddressMode::Ipv6).expect("ipv6 resolution succeeds");
 
@@ -832,8 +834,7 @@ fn resolve_daemon_addresses_filters_ipv6_mode() {
 
 #[test]
 fn daemon_address_accepts_ipv6_zone_identifier() {
-    let address =
-        DaemonAddress::new(String::from("fe80::1%eth0"), 873).expect("zone identifier accepted");
+    let address = DaemonAddress::new(String::from("fe80::1%eth0"), 873);
     assert_eq!(address.host(), "fe80::1%eth0");
     assert_eq!(address.port(), 873);
 
@@ -850,26 +851,30 @@ fn module_list_request_parses_ipv6_zone_identifier() {
     assert_eq!(request.address().host(), "fe80::1%eth0");
     assert_eq!(request.address().port(), 873);
 
+    // `%25` is NOT decoded back to `%`. The RFC 6874 spelling of a zone id is
+    // not something rsync implements: upstream has no percent-decoder, so the
+    // bytes reach the resolver as typed. Previously oc decoded this to
+    // `fe80::1%eth0`, which is a URI oc invented support for.
     let bracketed = vec![OsString::from("rsync://[fe80::1%25eth0]/")];
     let request = ModuleListRequest::from_operands(&bracketed)
         .expect("parse succeeds")
         .expect("request present");
-    assert_eq!(request.address().host(), "fe80::1%eth0");
+    assert_eq!(request.address().host(), "fe80::1%25eth0");
     assert_eq!(request.address().port(), 873);
 }
 
+/// A truncated `%XX` is not an error, because it is not an escape.
+///
+/// upstream: no percent-decoder exists, so `example%2` is simply a host whose
+/// name contains `%2`. oc used to reject it with "invalid percent-encoding in
+/// daemon host" - a diagnostic for a syntax upstream does not define.
 #[test]
-fn module_list_request_rejects_truncated_percent_encoding() {
+fn module_list_request_keeps_a_truncated_percent_sequence_verbatim() {
     let operands = vec![OsString::from("rsync://example%2/")];
-    let error = ModuleListRequest::from_operands(&operands)
-        .expect_err("truncated percent encoding should fail");
-    assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("invalid percent-encoding in daemon host")
-    );
+    let request = ModuleListRequest::from_operands(&operands)
+        .expect("parse succeeds")
+        .expect("request present");
+    assert_eq!(request.address().host(), "example%2");
 }
 
 #[test]
@@ -894,7 +899,7 @@ fn run_module_list_collects_entries() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -940,7 +945,7 @@ fn run_module_list_uses_connect_program_command() {
     let _proxy_guard = EnvGuard::remove("RSYNC_PROXY");
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new("example.com".to_string(), 873).expect("address"),
+        DaemonAddress::new("example.com".to_string(), 873),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -966,7 +971,7 @@ fn run_module_list_collects_motd_after_acknowledgement() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -997,7 +1002,7 @@ fn run_module_list_suppresses_motd_when_requested() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -1027,7 +1032,7 @@ fn run_module_list_collects_warnings() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -1061,7 +1066,7 @@ fn run_module_list_collects_capabilities() {
     let (addr, handle) = spawn_stub_daemon(responses);
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        DaemonAddress::new(addr.ip().to_string(), addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -1091,7 +1096,7 @@ fn run_module_list_via_proxy_connects_through_tunnel() {
     );
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(daemon_addr.ip().to_string(), daemon_addr.port()).expect("address"),
+        DaemonAddress::new(daemon_addr.ip().to_string(), daemon_addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );
@@ -1130,7 +1135,7 @@ fn run_module_list_via_proxy_includes_auth_header() {
     );
 
     let request = ModuleListRequest::from_components(
-        DaemonAddress::new(daemon_addr.ip().to_string(), daemon_addr.port()).expect("address"),
+        DaemonAddress::new(daemon_addr.ip().to_string(), daemon_addr.port()),
         None,
         ProtocolVersion::NEWEST,
     );

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -696,9 +696,7 @@ mod quic_connect_tests {
     /// passes, with `Ipv4` mode so it resolves to the `127.0.0.1` the acceptor
     /// bound.
     fn quic_addr(port: u16) -> DaemonAddress {
-        DaemonAddress::new("localhost".to_owned(), port)
-            .expect("addr")
-            .with_transport(Transport::Quic)
+        DaemonAddress::new("localhost".to_owned(), port).with_transport(Transport::Quic)
     }
 
     fn dial(addr: &DaemonAddress, ca: Option<PathBuf>) -> Result<DaemonStream, ClientError> {
@@ -955,8 +953,7 @@ mod connect_timeout_tests {
     fn connect_direct_applies_io_timeout() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
         let addr = listener.local_addr().expect("listener addr");
-        let daemon_addr =
-            DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("daemon addr");
+        let daemon_addr = DaemonAddress::new(addr.ip().to_string(), addr.port());
 
         let handle = thread::spawn(move || {
             if let Ok((mut stream, _)) = listener.accept() {
@@ -994,7 +991,7 @@ mod connect_timeout_tests {
             credentials: None,
         };
 
-        let target = DaemonAddress::new(String::from("daemon.example"), 873).expect("daemon addr");
+        let target = DaemonAddress::new(String::from("daemon.example"), 873);
 
         let handle = thread::spawn(move || {
             if let Ok((stream, _)) = proxy_listener.accept() {

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -915,7 +915,7 @@ mod tests {
             ConnectProgramConfig::new(format!("python3 -c \"{probe_script}\"").into(), None)
                 .unwrap();
 
-        let addr = DaemonAddress::new("localhost".to_owned(), 873).unwrap();
+        let addr = DaemonAddress::new("localhost".to_owned(), 873);
         let result = connect_via_program(&addr, &config);
 
         // If python3 is not available, skip rather than fail.
@@ -950,7 +950,7 @@ mod tests {
     #[test]
     fn connect_program_socketpair_bidirectional() {
         let config = ConnectProgramConfig::new("cat".into(), None).unwrap();
-        let addr = DaemonAddress::new("localhost".to_owned(), 873).unwrap();
+        let addr = DaemonAddress::new("localhost".to_owned(), 873);
         let mut stream = connect_via_program(&addr, &config).unwrap();
 
         let message = b"hello socketpair\n";

--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -700,8 +700,11 @@ mod tests {
 
     /// A control byte in the CONNECT host must be refused before any write.
     ///
-    /// WHY: `DaemonAddress::new` only trims the ends, so an interior CRLF
-    /// survives into `format!("CONNECT {host}:{port} HTTP/1.0\r\n")`. Without
+    /// WHY: `DaemonAddress::new` stores the host verbatim, so a CRLF anywhere
+    /// in it survives into `format!("CONNECT {host}:{port} HTTP/1.0\r\n")`.
+    /// This guard is the only thing that stops it - do not reintroduce
+    /// trimming as a substitute, which would silently accept some hosts
+    /// upstream refuses while still passing an interior CRLF through. Without
     /// the guard the request line terminates at the injected newline and the
     /// remainder of the host is read by the proxy as attacker-chosen headers.
     /// Asserting that the socket saw ZERO bytes is what makes this a real
@@ -723,8 +726,7 @@ mod tests {
         });
 
         let mut stream = TcpStream::connect(listen_addr).expect("connect to listener");
-        let addr = DaemonAddress::new("evil\r\nX-Injected: 1".to_owned(), 873)
-            .expect("interior control bytes survive the constructor's trim");
+        let addr = DaemonAddress::new("evil\r\nX-Injected: 1".to_owned(), 873);
         let proxy = ProxyConfig {
             host: listen_addr.ip().to_string(),
             port: listen_addr.port(),
@@ -756,7 +758,7 @@ mod tests {
     #[test]
     fn connect_host_allows_ipv6_zone_id_and_ordinary_names() {
         for host in ["fe80::1%eth0", "proxy.example.com", "192.0.2.10"] {
-            let addr = DaemonAddress::new(host.to_owned(), 873).expect("valid host");
+            let addr = DaemonAddress::new(host.to_owned(), 873);
             assert!(
                 !addr
                     .host()

--- a/crates/core/src/client/module_list/parsing.rs
+++ b/crates/core/src/client/module_list/parsing.rs
@@ -25,7 +25,7 @@ pub(crate) fn parse_bracketed_host(
         )
     })?;
 
-    let decoded = decode_host_component(addr)?;
+    let decoded = addr.to_owned();
 
     if remainder.is_empty() {
         return Ok((decoded, default_port));
@@ -45,115 +45,20 @@ pub(crate) fn parse_bracketed_host(
     Ok((decoded, port))
 }
 
-pub(crate) fn decode_host_component(input: &str) -> Result<String, ClientError> {
-    decode_percent_component(
-        input,
-        invalid_percent_encoding_error,
-        invalid_host_utf8_error,
-    )
-}
-
-pub(crate) fn decode_daemon_username(input: &str) -> Result<String, ClientError> {
-    decode_percent_component(
-        input,
-        invalid_username_percent_encoding_error,
-        invalid_username_utf8_error,
-    )
-}
-
-pub(crate) fn decode_percent_component(
-    input: &str,
-    invalid_percent: fn() -> ClientError,
-    invalid_utf8: fn() -> ClientError,
-) -> Result<String, ClientError> {
-    if !input.contains('%') {
-        return Ok(input.to_owned());
-    }
-
-    let mut decoded = Vec::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] == b'%' {
-            let zone_fallback = input[..index].contains(':');
-
-            if index + 2 >= bytes.len() {
-                if zone_fallback {
-                    decoded.push(bytes[index]);
-                    index += 1;
-                    continue;
-                }
-                return Err(invalid_percent());
-            }
-
-            let hi = hex_value(bytes[index + 1]);
-            let lo = hex_value(bytes[index + 2]);
-
-            match (hi, lo) {
-                (Some(hi), Some(lo)) => {
-                    decoded.push((hi << 4) | lo);
-                    index += 3;
-                    continue;
-                }
-                _ if zone_fallback => {
-                    decoded.push(bytes[index]);
-                    index += 1;
-                    continue;
-                }
-                _ => {
-                    return Err(invalid_percent());
-                }
-            }
-        }
-
-        decoded.push(bytes[index]);
-        index += 1;
-    }
-
-    String::from_utf8(decoded).map_err(|_| invalid_utf8())
-}
-
-pub(crate) const fn hex_value(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
-    }
-}
-
-#[cold]
-pub(crate) fn invalid_percent_encoding_error() -> ClientError {
-    daemon_error(
-        "invalid percent-encoding in daemon host",
-        FEATURE_UNAVAILABLE_EXIT_CODE,
-    )
-}
-
-#[cold]
-pub(crate) fn invalid_host_utf8_error() -> ClientError {
-    daemon_error(
-        "daemon host contains invalid UTF-8",
-        FEATURE_UNAVAILABLE_EXIT_CODE,
-    )
-}
-
-#[cold]
-pub(crate) fn invalid_username_percent_encoding_error() -> ClientError {
-    daemon_error(
-        "invalid percent-encoding in daemon username",
-        FEATURE_UNAVAILABLE_EXIT_CODE,
-    )
-}
-
-#[cold]
-pub(crate) fn invalid_username_utf8_error() -> ClientError {
-    daemon_error(
-        "daemon username contains invalid UTF-8",
-        FEATURE_UNAVAILABLE_EXIT_CODE,
-    )
-}
+// The daemon host and username are taken from the URL VERBATIM.
+//
+// upstream: options.c:3295 `check_for_hostspec()` parses `rsync://HOST:PORT/PATH`
+// and never decodes anything - rsync 3.5.0 contains no percent-decoder at all,
+// so `%` is an ordinary hostname byte. That is load-bearing rather than an
+// omission: `socket.c:204-215 shell_unsafe_connect_host()` refuses a host
+// beginning with `%` precisely because a nested fish would expand `%self`, and
+// it can only refuse what reaches it. An IPv6 zone id (`fe80::1%eth0`) relies on
+// the same literal treatment.
+//
+// oc previously decoded both components and rejected a lone `%` as a malformed
+// escape unless the text before it contained `:`. That rejected `%self` before
+// `RSYNC_CONNECT_PROG` validation could refuse it, and it silently rewrote any
+// host or username containing a `%XX` sequence.
 
 pub(crate) fn split_host_port(input: &str) -> Option<(&str, &str)> {
     let idx = input.rfind(':')?;
@@ -233,19 +138,23 @@ pub(crate) fn parse_host_port(
     input: &str,
     default_port: u16,
 ) -> Result<ParsedDaemonTarget, ClientError> {
-    const DEFAULT_HOST: &str = "localhost";
-
     let (username, input) = split_daemon_username(input)?;
-    let username = username.map(decode_daemon_username).transpose()?;
+    let username = username.map(str::to_owned);
 
     if input.is_empty() {
-        let address = DaemonAddress::new(DEFAULT_HOST.to_owned(), default_port)?;
+        // An empty authority stays empty. Upstream substitutes no default:
+        // `rsync:///mod/` reaches getaddrinfo with an empty node and fails
+        // there, and under RSYNC_CONNECT_PROG it reaches
+        // shell_unsafe_connect_host (socket.c:204-215), which refuses it -
+        // an empty argument survives a direct exec but vanishes when a
+        // nested shell re-splits, shifting every later argument left.
+        let address = DaemonAddress::new(String::new(), default_port);
         return Ok(ParsedDaemonTarget { address, username });
     }
 
     if let Some(host) = input.strip_prefix('[') {
         let (address, port) = parse_bracketed_host(host, default_port)?;
-        let address = DaemonAddress::new(address, port)?;
+        let address = DaemonAddress::new(address, port);
         return Ok(ParsedDaemonTarget { address, username });
     }
 
@@ -264,8 +173,8 @@ pub(crate) fn parse_host_port(
             let port = port
                 .parse::<u16>()
                 .map_err(|_| daemon_error("invalid daemon port", FEATURE_UNAVAILABLE_EXIT_CODE))?;
-            let host = decode_host_component(host)?;
-            let address = DaemonAddress::new(host, port)?;
+            let host = host.to_owned();
+            let address = DaemonAddress::new(host, port);
             return Ok(ParsedDaemonTarget { address, username });
         }
 
@@ -277,8 +186,8 @@ pub(crate) fn parse_host_port(
         }
     }
 
-    let host = decode_host_component(input)?;
-    let address = DaemonAddress::new(host, default_port)?;
+    let host = input.to_owned();
+    let address = DaemonAddress::new(host, default_port);
     Ok(ParsedDaemonTarget { address, username })
 }
 
@@ -317,36 +226,6 @@ mod tests {
     }
 
     #[test]
-    fn hex_value_parses_digits() {
-        assert_eq!(hex_value(b'0'), Some(0));
-        assert_eq!(hex_value(b'5'), Some(5));
-        assert_eq!(hex_value(b'9'), Some(9));
-    }
-
-    #[test]
-    fn hex_value_parses_lowercase_hex() {
-        assert_eq!(hex_value(b'a'), Some(10));
-        assert_eq!(hex_value(b'c'), Some(12));
-        assert_eq!(hex_value(b'f'), Some(15));
-    }
-
-    #[test]
-    fn hex_value_parses_uppercase_hex() {
-        assert_eq!(hex_value(b'A'), Some(10));
-        assert_eq!(hex_value(b'C'), Some(12));
-        assert_eq!(hex_value(b'F'), Some(15));
-    }
-
-    #[test]
-    fn hex_value_returns_none_for_invalid() {
-        assert!(hex_value(b'g').is_none());
-        assert!(hex_value(b'G').is_none());
-        assert!(hex_value(b'z').is_none());
-        assert!(hex_value(b' ').is_none());
-        assert!(hex_value(b'%').is_none());
-    }
-
-    #[test]
     fn split_host_port_splits_on_last_colon() {
         let result = split_host_port("localhost:8873");
         assert_eq!(result, Some(("localhost", "8873")));
@@ -382,34 +261,73 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// A `%XX` sequence in the host reaches the connector as typed.
+    ///
+    /// upstream: rsync 3.5.0 has no percent-decoder; `%` is an ordinary
+    /// hostname byte. These assertions are the INVERSE of what oc recorded
+    /// while it decoded - `hello%20world` used to become `hello world`.
     #[test]
-    fn decode_host_component_passes_through_plain_text() {
-        let result = decode_host_component("localhost").expect("decode");
-        assert_eq!(result, "localhost");
+    fn parse_host_port_keeps_percent_sequences_in_the_host_verbatim() {
+        for host in ["hello%20world", "%41%42%43", "%self"] {
+            let parsed = parse_host_port(host, 873).expect("parse");
+            assert_eq!(
+                parsed.address.host(),
+                host,
+                "host {host:?} must be verbatim"
+            );
+        }
     }
 
+    /// `rsync:///mod/` names an empty host, and upstream substitutes nothing
+    /// for it - it reaches getaddrinfo (which fails) or, under
+    /// RSYNC_CONNECT_PROG, shell_unsafe_connect_host (which refuses it).
+    /// oc used to swap in `localhost`, which both invented a target the
+    /// operator never named and hid the empty host from the validator.
     #[test]
-    fn decode_host_component_decodes_percent_encoding() {
-        let result = decode_host_component("hello%20world").expect("decode");
-        assert_eq!(result, "hello world");
+    fn parse_host_port_keeps_an_empty_host_empty() {
+        let parsed = parse_host_port("", 873).expect("parse");
+        assert_eq!(parsed.address.host(), "");
+        assert_eq!(parsed.address.port(), 873);
     }
 
+    /// Non-vacuity companion: the empty case above must not be passing
+    /// because every host now comes back empty.
     #[test]
-    fn decode_host_component_decodes_multiple_percent_encodings() {
-        let result = decode_host_component("%41%42%43").expect("decode");
-        assert_eq!(result, "ABC");
+    fn parse_host_port_still_returns_a_named_host() {
+        let parsed = parse_host_port("example.com", 873).expect("parse");
+        assert_eq!(parsed.address.host(), "example.com");
     }
 
+    /// The username is taken verbatim for the same reason, and from the same
+    /// absence of a decoder upstream. `user%40domain` is NOT `user@domain`:
+    /// the split already happened at the last `@`, so decoding one here would
+    /// invent a second, later separator that upstream never sees.
     #[test]
-    fn decode_daemon_username_passes_through_plain_text() {
-        let result = decode_daemon_username("testuser").expect("decode");
-        assert_eq!(result, "testuser");
+    fn parse_host_port_keeps_percent_sequences_in_the_username_verbatim() {
+        let parsed = parse_host_port("user%40domain@localhost", 873).expect("parse");
+        assert_eq!(parsed.username.as_deref(), Some("user%40domain"));
+        assert_eq!(parsed.address.host(), "localhost");
     }
 
+    /// An IPv6 zone id keeps working, and now does so WITHOUT a special case.
+    /// oc previously needed a `zone_fallback` that kept a bare `%` literal only
+    /// when the text before it contained `:` - that branch existed solely to
+    /// stop the decoder mangling this shape, and it is gone with the decoder.
     #[test]
-    fn decode_daemon_username_decodes_percent_encoding() {
-        let result = decode_daemon_username("user%40domain").expect("decode");
-        assert_eq!(result, "user@domain");
+    fn parse_host_port_keeps_an_ipv6_zone_id() {
+        let parsed = parse_host_port("[fe80::1%eth0]", 873).expect("parse");
+        assert_eq!(parsed.address.host(), "fe80::1%eth0");
+    }
+
+    /// The non-vacuity companion: a plain host is unaffected, so the three
+    /// tests above are pinning the percent behaviour rather than a parser that
+    /// stopped working.
+    #[test]
+    fn parse_host_port_still_parses_a_plain_host_and_port() {
+        let parsed = parse_host_port("localhost:8873", 873).expect("parse");
+        assert_eq!(parsed.address.host(), "localhost");
+        assert_eq!(parsed.address.port(), 8873);
+        assert!(parsed.username.is_none());
     }
 
     #[test]

--- a/crates/core/src/client/module_list/types.rs
+++ b/crates/core/src/client/module_list/types.rs
@@ -5,8 +5,6 @@
 
 use std::fmt;
 
-use super::super::{ClientError, FEATURE_UNAVAILABLE_EXIT_CODE, daemon_error};
-
 /// Transport carrying the (unmodified) rsync daemon wire protocol.
 ///
 /// The variant rides on [`DaemonAddress`] alongside the host and port, so the
@@ -43,19 +41,21 @@ impl DaemonAddress {
     ///
     /// The transport defaults to [`Transport::Tcp`]; use
     /// [`DaemonAddress::with_transport`] to select another.
-    pub fn new(host: String, port: u16) -> Result<Self, ClientError> {
-        let trimmed = host.trim();
-        if trimmed.is_empty() {
-            return Err(daemon_error(
-                "daemon host must be non-empty",
-                FEATURE_UNAVAILABLE_EXIT_CODE,
-            ));
-        }
-        Ok(Self {
-            host: trimmed.to_owned(),
+    ///
+    /// The host is stored verbatim, so construction cannot fail. Upstream
+    /// never rewrites it: an empty or whitespace-padded host reaches
+    /// `getaddrinfo` unchanged and fails there (`socket.c:150`
+    /// open_socket_out), and reaches `shell_unsafe_connect_host` unchanged
+    /// under `RSYNC_CONNECT_PROG` (`socket.c:204-215`), which refuses both.
+    /// Trimming or defaulting here would convert a host upstream refuses into
+    /// one it accepts, so neither happens.
+    #[must_use]
+    pub fn new(host: String, port: u16) -> Self {
+        Self {
+            host,
             port,
             transport: Transport::default(),
-        })
+        }
     }
 
     /// Returns this address with the given [`Transport`] selected.
@@ -112,34 +112,37 @@ mod tests {
 
     #[test]
     fn daemon_address_new_creates_address() {
-        let addr = DaemonAddress::new("localhost".to_owned(), 873).expect("address");
+        let addr = DaemonAddress::new("localhost".to_owned(), 873);
         assert_eq!(addr.host(), "localhost");
         assert_eq!(addr.port(), 873);
     }
 
     #[test]
-    fn daemon_address_new_trims_whitespace() {
-        let addr = DaemonAddress::new("  example.com  ".to_owned(), 8873).expect("address");
-        assert_eq!(addr.host(), "example.com");
+    fn daemon_address_new_keeps_surrounding_whitespace() {
+        // Trimming would convert a host upstream refuses as shell-unsafe
+        // (socket.c:204-215 - space is outside the allowed byte set) into one
+        // it accepts, so the padding has to survive to the validator.
+        let addr = DaemonAddress::new("  example.com  ".to_owned(), 8873);
+        assert_eq!(addr.host(), "  example.com  ");
     }
 
     #[test]
-    fn daemon_address_new_rejects_empty_host() {
-        let result = DaemonAddress::new("".to_owned(), 873);
-        assert!(result.is_err());
+    fn daemon_address_new_accepts_an_empty_host() {
+        let addr = DaemonAddress::new(String::new(), 873);
+        assert_eq!(addr.host(), "");
     }
 
     #[test]
-    fn daemon_address_new_rejects_whitespace_only_host() {
-        let result = DaemonAddress::new("   ".to_owned(), 873);
-        assert!(result.is_err());
+    fn daemon_address_new_accepts_a_whitespace_only_host() {
+        let addr = DaemonAddress::new("   ".to_owned(), 873);
+        assert_eq!(addr.host(), "   ");
     }
 
     #[test]
     fn daemon_address_eq_works() {
-        let a = DaemonAddress::new("localhost".to_owned(), 873).expect("a");
-        let b = DaemonAddress::new("localhost".to_owned(), 873).expect("b");
-        let c = DaemonAddress::new("localhost".to_owned(), 8873).expect("c");
+        let a = DaemonAddress::new("localhost".to_owned(), 873);
+        let b = DaemonAddress::new("localhost".to_owned(), 873);
+        let c = DaemonAddress::new("localhost".to_owned(), 8873);
 
         assert_eq!(a, b);
         assert_ne!(a, c);
@@ -151,7 +154,7 @@ mod tests {
         // must stay TCP so a default build behaves exactly like upstream. Every
         // existing construction path (rsync://, host::module) flows through
         // `new`, so this default is what reaches the connect-selection point.
-        let addr = DaemonAddress::new("localhost".to_owned(), 873).expect("address");
+        let addr = DaemonAddress::new("localhost".to_owned(), 873);
         assert_eq!(addr.transport(), Transport::Tcp);
     }
 
@@ -160,9 +163,7 @@ mod tests {
         // WHY: the selection made at parse time must reach `open_daemon_stream`
         // (which reads `transport()`) unchanged - the value rides on the same
         // struct as host and port.
-        let addr = DaemonAddress::new("localhost".to_owned(), 873)
-            .expect("address")
-            .with_transport(Transport::Tcp);
+        let addr = DaemonAddress::new("localhost".to_owned(), 873).with_transport(Transport::Tcp);
         assert_eq!(addr.transport(), Transport::Tcp);
         assert_eq!(addr.host(), "localhost");
         assert_eq!(addr.port(), 873);
@@ -174,15 +175,14 @@ mod tests {
         // WHY: under the opt-in `quic` feature a QUIC selection must be
         // representable and carried unchanged, ready for the follow-up that
         // dials it; it never appears in a default build.
-        let addr = DaemonAddress::new("example.com".to_owned(), 873)
-            .expect("address")
-            .with_transport(Transport::Quic);
+        let addr =
+            DaemonAddress::new("example.com".to_owned(), 873).with_transport(Transport::Quic);
         assert_eq!(addr.transport(), Transport::Quic);
     }
 
     #[test]
     fn daemon_address_clone_works() {
-        let addr = DaemonAddress::new("example.com".to_owned(), 873).expect("address");
+        let addr = DaemonAddress::new("example.com".to_owned(), 873);
         let cloned = addr.clone();
         assert_eq!(addr, cloned);
     }
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn daemon_address_socket_addr_display_formats_correctly() {
-        let addr = DaemonAddress::new("192.168.1.1".to_owned(), 873).expect("address");
+        let addr = DaemonAddress::new("192.168.1.1".to_owned(), 873);
         let display = addr.socket_addr_display();
         assert_eq!(format!("{display}"), "192.168.1.1:873");
     }

--- a/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
@@ -241,7 +241,7 @@ mod early_input_roundtrip_tests {
 
     fn test_request() -> DaemonTransferRequest {
         DaemonTransferRequest {
-            address: DaemonAddress::new("127.0.0.1".to_owned(), 873).unwrap(),
+            address: DaemonAddress::new("127.0.0.1".to_owned(), 873),
             module: "test".to_owned(),
             path: String::new(),
             username: None,
@@ -531,7 +531,7 @@ mod handle_at_error_tests {
         use std::io::{BufReader, Cursor};
 
         let request = DaemonTransferRequest {
-            address: DaemonAddress::new("127.0.0.1".to_owned(), 873).unwrap(),
+            address: DaemonAddress::new("127.0.0.1".to_owned(), 873),
             module: "mod".to_owned(),
             path: String::new(),
             username: None,
@@ -568,7 +568,7 @@ mod handle_at_error_tests {
         use std::io::{BufReader, Cursor};
 
         let request = DaemonTransferRequest {
-            address: DaemonAddress::new("127.0.0.1".to_owned(), 873).unwrap(),
+            address: DaemonAddress::new("127.0.0.1".to_owned(), 873),
             module: "mod".to_owned(),
             path: String::new(),
             username: None,

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -16,7 +16,7 @@ mod protect_args_daemon_tests {
 
     fn test_daemon_request() -> DaemonTransferRequest {
         DaemonTransferRequest {
-            address: DaemonAddress::new("127.0.0.1".to_owned(), 873).unwrap(),
+            address: DaemonAddress::new("127.0.0.1".to_owned(), 873),
             module: "test".to_owned(),
             path: String::new(),
             username: None,
@@ -1762,7 +1762,7 @@ mod files_from_daemon_args_tests {
 
     fn test_daemon_request() -> DaemonTransferRequest {
         DaemonTransferRequest {
-            address: DaemonAddress::new("127.0.0.1".to_owned(), 873).unwrap(),
+            address: DaemonAddress::new("127.0.0.1".to_owned(), 873),
             module: "test".to_owned(),
             path: String::new(),
             username: None,

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -17,7 +17,7 @@ chroot-receiver-write-inner-module skip
 chroot-special-inner-module skip
 compress-zlib-insert fail
 connect-prog-host-quoting pass
-connect-prog-nested-singlequote-host-injection fail
+connect-prog-nested-singlequote-host-injection pass
 copy-dest-source-symlink pass
 daemon pass
 daemon-access pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -52,7 +52,7 @@ compare pass
 compress-options pass
 compress-zlib-insert fail
 connect-prog-host-quoting pass
-connect-prog-nested-singlequote-host-injection fail
+connect-prog-nested-singlequote-host-injection pass
 copy-dest-source-symlink pass
 copy-dest-symlink-readleak skip
 copy-xattrs-symlink-race pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -17,7 +17,7 @@ chroot-receiver-write-inner-module pass
 chroot-special-inner-module pass
 compress-zlib-insert fail
 connect-prog-host-quoting pass
-connect-prog-nested-singlequote-host-injection fail
+connect-prog-nested-singlequote-host-injection pass
 copy-dest-source-symlink pass
 daemon pass
 daemon-access pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -52,7 +52,7 @@ compare pass
 compress-options pass
 compress-zlib-insert fail
 connect-prog-host-quoting pass
-connect-prog-nested-singlequote-host-injection fail
+connect-prog-nested-singlequote-host-injection pass
 copy-dest-source-symlink pass
 copy-dest-symlink-readleak pass
 copy-xattrs-symlink-race pass


### PR DESCRIPTION
oc rewrote the `rsync://` daemon host three ways before anything could judge
it. Upstream rewrites it in none of them: `check_for_hostspec`
(`options.c:3295`) takes the host as written and hands the same bytes to
`getaddrinfo`, or, under `RSYNC_CONNECT_PROG`, to `shell_unsafe_connect_host`
(`socket.c:204-215`).

| rewrite | oc before | upstream 3.5.0 |
|---|---|---|
| percent-decode `%XX` in host and username | decoded; a lone `%` rejected as a malformed escape | no percent-decoder exists anywhere |
| empty authority | substituted `localhost` | stays empty |
| leading/trailing whitespace | trimmed | kept |

Each one fails in the same direction: **the validator can only refuse what
reaches it.**

- `%self` was rejected as a bad escape before the connect-program guard could
  refuse it - and refusing it is the point, since a nested fish expands
  `%self` to its pid.
- `rsync:///mod/` silently dialled a host the operator never named. Measured
  against the pinned 3.5.0 binary: upstream fails in `getaddrinfo` with an
  empty node, and refuses the empty host outright under `RSYNC_CONNECT_PROG` -
  an empty argument survives a direct exec but vanishes when a nested shell
  re-splits, shifting every later argument left.
- Trimming is **not cosmetic**. Measured: `rsync:// localhost /m/` under a
  connect program is refused by upstream as shell-unsafe (space is outside the
  allowed byte set) while oc handed the program a clean `localhost`. Trimming
  converted a host upstream refuses into one it accepts.

An IPv6 zone id (`fe80::1%eth0`) relies on the same literal treatment, which
is why the decoder needed a zone-id fallback to paper over itself.

`DaemonAddress::new` therefore cannot fail and no longer returns `Result`; its
empty-host rejection existed only to be routed around by the `localhost`
default. The CONNECT-header CRLF guard in `proxy.rs` is now the only thing
between a hostile host and the request line, and its comment says so rather
than describing the trim that used to precede it.

## Measured

Against the pinned upstream 3.5.0 binary as the control, on Linux:

| cell | before | after | upstream 3.5.0 |
|---|---|---|---|
| `connect-prog-host-quoting` | pass | pass | pass |
| `connect-prog-nested-singlequote-host-injection` | fail | **pass** | pass |

The nested cell needs **both** this change and #7430 - neither flips it alone,
which is why #7430's body claimed no row and this one carries all four
manifest flips (nonroot, root, and both TCP legs).

RED proven by restoring only the `localhost` default: the cell returns to
`overall result is 1`.

Full nonroot leg at this commit: **219 passed / 40 failed / 86 skipped = 345**,
and the only expected-result mismatch is `simd-checksum: expected pass, got
skip` - which the **real upstream 3.5.0 binary also skips** on this aarch64
host ("simdtest not built (SIMD not available)"). Environmental, not from this
change; CI's x86_64 runner is where that `pass` row was generated.

⚠ The empty-host parse had **no test at all** before this - that absence is
why the substitution survived. It is pinned now, with a named-host companion
so the pin cannot pass by everything coming back empty.

## Gates

- `cargo nextest run -p core --all-features --lib`: **2558/2558** on Linux
- `cargo fmt --all -- --check`: clean on Linux
- `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings`: clean on Linux
