### PR TITLE
fix(filters): bound merge-file nesting by depth, not by cycle

### DIFF
--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -1,6 +1,5 @@
 #![deny(unsafe_code)]
 
-use std::collections::HashSet;
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -45,7 +44,7 @@ where
     Err: std::io::Write,
 {
     let mut filter_rules = Vec::new();
-    let mut merge_stack = HashSet::new();
+    let mut merge_stack = Vec::new();
     let merge_base = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let from0 = inputs.from0;
 
@@ -97,7 +96,7 @@ fn push_filter_directive(
     filter_rules: &mut Vec<FilterRuleSpec>,
     rule: &OsString,
     merge_base: &std::path::Path,
-    merge_stack: &mut HashSet<PathBuf>,
+    merge_stack: &mut Vec<PathBuf>,
 ) -> Result<(), Message> {
     match parse_filter_directive(rule.as_os_str())? {
         FilterDirective::Rule(spec) => filter_rules.push(spec),

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
@@ -47,7 +46,7 @@ pub(crate) fn apply_merge_directive(
     directive: MergeDirective,
     base_dir: &Path,
     destination: &mut Vec<FilterRuleSpec>,
-    visited: &mut HashSet<PathBuf>,
+    visited: &mut Vec<PathBuf>,
     source: RuleSource<'_>,
 ) -> Result<(), Message> {
     let options = directive.options().clone();
@@ -83,10 +82,23 @@ pub(crate) fn apply_merge_directive(
         resolved_path.clone()
     };
 
-    if !visited.insert(guard_key.clone()) {
-        let text = format!("recursive filter merge detected for '{display}'");
-        return Err(rsync_error!(1, text).with_role(Role::Client));
+    // upstream: exclude.c:1619-1627 parse_filter_file() bounds the nesting DEPTH
+    // at MAX_MERGE_DEPTH (exclude.c:168) instead of detecting a cycle, and under
+    // XFLG_FATAL_ERRORS - which every operator-supplied merge carries - reports
+    // the limit and exits RERR_FILEIO.
+    //
+    // `visited` is the enclosing merge chain, so its length is that depth. It is
+    // a stack rather than a set precisely because the depth is what is bounded:
+    // a set cannot count a self-including file, whose second insert would not
+    // grow it.
+    if visited.len() >= filters::MAX_MERGE_DEPTH {
+        // upstream renders the offending directive with rule_text() and prefixes
+        // who_am_i(); filter arguments are parsed before any fork, where
+        // who_am_i() is "client" - the role this error already carries.
+        let text = filters::depth_limit_exceeded("client", &display);
+        return Err(rsync_error!(11, text).with_role(Role::Client));
     }
+    visited.push(guard_key.clone());
 
     let next_base_storage = if is_stdin {
         None
@@ -123,7 +135,7 @@ pub(crate) fn apply_merge_directive(
             &contents, &options, next_base, &display, &mut local, visited,
         )
     })();
-    visited.remove(&guard_key);
+    visited.pop();
     if result.is_ok() {
         destination.extend(local);
         if options.excludes_self() && !is_stdin {
@@ -141,7 +153,7 @@ fn parse_merge_contents(
     base_dir: &Path,
     display: &str,
     destination: &mut Vec<FilterRuleSpec>,
-    visited: &mut HashSet<PathBuf>,
+    visited: &mut Vec<PathBuf>,
 ) -> Result<(), Message> {
     if options.uses_whitespace() {
         let mut tokens = contents.split_whitespace();
@@ -276,7 +288,7 @@ pub(crate) fn process_merge_directive(
     display: &str,
     source: RuleSource<'_>,
     destination: &mut Vec<FilterRuleSpec>,
-    visited: &mut HashSet<PathBuf>,
+    visited: &mut Vec<PathBuf>,
 ) -> Result<(), Message> {
     match parse_filter_directive(OsStr::new(directive)) {
         Ok(FilterDirective::Rule(mut rule)) => {

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -105,8 +105,6 @@ use logging_sink::MessageSink;
 use outbuf::{OutbufAdapter, parse_outbuf_mode};
 use progress::diagnostic::flush_diagnostics;
 #[cfg(test)]
-use std::collections::HashSet;
-#[cfg(test)]
 use std::env;
 #[cfg(test)]
 use std::net::IpAddr;
@@ -189,7 +187,7 @@ pub(crate) fn process_merge_directive(
     display: &str,
     source: filters::RuleSource<'_>,
     destination: &mut Vec<FilterRuleSpec>,
-    visited: &mut HashSet<PathBuf>,
+    visited: &mut Vec<PathBuf>,
 ) -> Result<(), Message> {
     filter_rules::process_merge_directive(
         directive,

--- a/crates/cli/src/frontend/tests/apply.rs
+++ b/crates/cli/src/frontend/tests/apply.rs
@@ -17,7 +17,7 @@ fn apply_merge_directive_resolves_relative_paths() {
     std::fs::write(&grand, b"+ grand\n").expect("write grand");
 
     let mut rules = Vec::new();
-    let mut visited = HashSet::new();
+    let mut visited = Vec::new();
     let directive = MergeDirective::new(OsString::from("outer.rules"), None)
         .with_options(DirMergeOptions::default().allow_list_clearing(true));
     super::apply_merge_directive(
@@ -43,7 +43,7 @@ fn apply_merge_directive_respects_forced_include() {
     std::fs::write(&path, b"alpha\n!\nbeta\n").expect("write filters");
 
     let mut rules = vec![FilterRuleSpec::exclude("existing".to_owned())];
-    let mut visited = HashSet::new();
+    let mut visited = Vec::new();
     let directive = MergeDirective::new(path.into_os_string(), Some(FilterRuleKind::Include))
         .with_options(
             DirMergeOptions::default()

--- a/crates/cli/src/frontend/tests/merge.rs
+++ b/crates/cli/src/frontend/tests/merge.rs
@@ -40,7 +40,7 @@ fn apply_merge_directive_parses_whitespace_risk_and_exclude_if_present() {
     let directive = MergeDirective::new(merge_file.into_os_string(), None).with_options(options);
 
     let mut rules = Vec::new();
-    let mut visited = HashSet::new();
+    let mut visited = Vec::new();
     apply_merge_directive(
         directive,
         temp.path(),
@@ -77,7 +77,7 @@ fn apply_merge_directive_rejects_per_dir_alias() {
     let directive = MergeDirective::new(merge_file.into_os_string(), None).with_options(options);
 
     let mut rules = Vec::new();
-    let mut visited = HashSet::new();
+    let mut visited = Vec::new();
     // "per-dir" is not an upstream directive, so a merge file that uses it must
     // fail to load rather than silently accept the oc-only alias.
     assert!(
@@ -140,7 +140,7 @@ fn apply_merge_directive_collapses_dot_dot_before_opening_the_file() {
 
     let directive = MergeDirective::new(OsString::from("a/b/../rules.txt"), None);
     let mut rules = Vec::new();
-    let mut visited = HashSet::new();
+    let mut visited = Vec::new();
     apply_merge_directive(
         directive,
         temp.path(),
@@ -170,7 +170,7 @@ fn apply_merge_directive_still_fails_when_the_collapsed_name_is_absent() {
 
     let directive = MergeDirective::new(OsString::from("a/b/../missing.txt"), None);
     let mut rules = Vec::new();
-    let mut visited = HashSet::new();
+    let mut visited = Vec::new();
     assert!(
         apply_merge_directive(
             directive,

--- a/crates/cli/src/frontend/tests/process.rs
+++ b/crates/cli/src/frontend/tests/process.rs
@@ -16,7 +16,7 @@ fn process_merge_directive_applies_parent_overrides_to_nested_merges() {
         .allow_list_clearing(false);
 
     let mut rules = Vec::new();
-    let mut visited = HashSet::new();
+    let mut visited = Vec::new();
     super::process_merge_directive(
         "merge nested.rules",
         &options,

--- a/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
@@ -175,8 +175,17 @@ fn transfer_request_with_filter_protect_preserves_destination_entry() {
     assert!(copied_root.join("keep.txt").exists());
 }
 
+/// upstream: exclude.c:1619-1627 `parse_filter_file()` bounds the merge nesting
+/// DEPTH at `MAX_MERGE_DEPTH` (exclude.c:168) rather than detecting a cycle, and
+/// exits `RERR_FILEIO` under `XFLG_FATAL_ERRORS`.
+///
+/// WHY the depth cap and not a cycle test: a self-including file is only the
+/// easiest way to exceed the bound. A chain of 40 distinct files that never
+/// repeats is equally unbounded, and no "have I seen this file?" test refuses
+/// it. Pinning the wording as well as the exit code keeps oc's diagnostic
+/// comparable with rsync's for an operator debugging a filter set.
 #[test]
-fn transfer_request_with_filter_merge_detects_recursion() {
+fn transfer_request_with_filter_merge_bounds_include_depth() {
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
@@ -199,10 +208,94 @@ fn transfer_request_with_filter_merge_detects_recursion() {
         dest_root.into_os_string(),
     ]);
 
-    assert_eq!(code, 1);
+    assert_eq!(
+        code, 11,
+        "upstream: exclude.c:1626 exit_cleanup(RERR_FILEIO)"
+    );
     assert!(stdout.is_empty());
     let rendered = String::from_utf8_lossy(&stderr);
-    assert!(rendered.contains("recursive filter merge"));
+    assert!(
+        rendered.contains("merge-file include depth limit (32) exceeded"),
+        "expected upstream's depth-limit diagnostic, got: {rendered}"
+    );
+}
+
+/// The class-level companion: no file is merged twice, so a cycle test cannot
+/// refuse this chain at any length. Only the depth bound can. This is the case
+/// that distinguishes upstream's rule from the one oc used to implement, and
+/// without it the fix could regress to a cycle set and still look correct.
+#[test]
+fn transfer_request_with_filter_merge_bounds_an_acyclic_chain() {
+    use tempfile::tempdir;
+
+    const CHAIN: usize = filters::MAX_MERGE_DEPTH + 4;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_root = tmp.path().join("source");
+    let dest_root = tmp.path().join("dest");
+    std::fs::create_dir_all(&source_root).expect("create source root");
+    std::fs::create_dir_all(&dest_root).expect("create dest root");
+
+    // link[i] merges link[i + 1]; the last link is an inert comment. Every file
+    // is distinct, so `visited` never sees a repeat.
+    let link = |i: usize| tmp.path().join(format!("link{i}.txt"));
+    for i in 0..CHAIN {
+        std::fs::write(link(i), format!("merge {}\n", link(i + 1).display()))
+            .expect("write chain link");
+    }
+    std::fs::write(link(CHAIN), "# end of chain\n").expect("write chain tail");
+
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--filter"),
+        OsString::from(format!("merge {}", link(0).display())),
+        source_root.into_os_string(),
+        dest_root.into_os_string(),
+    ]);
+
+    assert_eq!(code, 11, "an acyclic chain must still hit the depth cap");
+    let rendered = String::from_utf8_lossy(&stderr);
+    assert!(
+        rendered.contains("merge-file include depth limit (32) exceeded"),
+        "expected upstream's depth-limit diagnostic, got: {rendered}"
+    );
+}
+
+/// Non-vacuity companion: a chain shorter than the cap must parse cleanly, so
+/// the two tests above cannot pass merely because merge chains are broken.
+#[test]
+fn transfer_request_with_filter_merge_allows_a_chain_within_the_cap() {
+    use tempfile::tempdir;
+
+    const CHAIN: usize = filters::MAX_MERGE_DEPTH - 2;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_root = tmp.path().join("source");
+    let dest_root = tmp.path().join("dest");
+    std::fs::create_dir_all(&source_root).expect("create source root");
+    std::fs::create_dir_all(&dest_root).expect("create dest root");
+
+    let link = |i: usize| tmp.path().join(format!("link{i}.txt"));
+    for i in 0..CHAIN {
+        std::fs::write(link(i), format!("merge {}\n", link(i + 1).display()))
+            .expect("write chain link");
+    }
+    std::fs::write(link(CHAIN), "- *.tmp\n").expect("write chain tail");
+
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--filter"),
+        OsString::from(format!("merge {}", link(0).display())),
+        source_root.into_os_string(),
+        dest_root.into_os_string(),
+    ]);
+
+    let rendered = String::from_utf8_lossy(&stderr);
+    assert_eq!(code, 0, "chain within the cap must parse: {rendered}");
+    assert!(
+        !rendered.contains("merge-file include depth limit"),
+        "unexpected depth diagnostic: {rendered}"
+    );
 }
 
 /// upstream: exclude.c:1393-1402 resolves `FILTRULE_CLEAR_LIST` via

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -232,17 +232,34 @@ pub(crate) fn load_dir_merge_rules_recursive(
     delete_excluded: bool,
     visited: &mut Vec<PathBuf>,
 ) -> Result<DirMergeEntries, LocalCopyError> {
-    let canonical = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    if visited.contains(&canonical) {
-        let path_display = path.display();
-        let message = format!("recursive filter merge detected for {path_display}");
-        return Err(LocalCopyError::io(
-            "parse filter file",
-            path.to_path_buf(),
-            io::Error::new(io::ErrorKind::InvalidData, message),
-        ));
+    // upstream: exclude.c:1619-1627 parse_filter_file() bounds the nesting
+    // DEPTH at MAX_MERGE_DEPTH (exclude.c:168) rather than detecting a cycle.
+    // `visited` is the enclosing merge chain, so its length is that depth.
+    //
+    // The depth bound strictly subsumes a cycle test: a self-including file
+    // reaches the cap after 32 cheap re-reads, and a long non-cyclic chain -
+    // which no "have I seen this file?" test refuses - is bounded too.
+    //
+    // Upstream drops the rule rather than aborting here, because the per-dir
+    // merge is parsed without XFLG_FATAL_ERRORS (exclude.c:1623-1626 gates
+    // exit_cleanup on that flag). That is the same choice the failed-open arm
+    // below already makes, so both refusals leave the transfer running.
+    if visited.len() >= filters::MAX_MERGE_DEPTH {
+        // upstream renders the offending directive with rule_text(), i.e. the
+        // rule as written; oc reaches this site with the resolved merge target
+        // only, so it reports that. `sender` is upstream's who_am_i() here:
+        // the merge chain is walked by the file-list scan, which is the
+        // sender's phase (exclude.c is reached from flist.c:send_directory).
+        logging::emit_info_coded(
+            logging::InfoFlag::Misc,
+            0,
+            logging::LogCode::Error,
+            filters::depth_limit_exceeded("sender", &path.display().to_string()),
+        );
+        return Ok(DirMergeEntries::default());
     }
 
+    let canonical = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     visited.push(canonical);
 
     // The merge file is opened from a scanned source directory, so every

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -135,7 +135,10 @@ pub use compiled::XattrSide;
 pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};
-pub use merge::{MergeFileError, parse_rules, read_rules, read_rules_recursive};
+pub use merge::{
+    MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded, parse_rules, read_rules,
+    read_rules_recursive,
+};
 pub use rule::FilterRule;
 pub use rule_source::RuleSource;
 pub use set::{FilterSet, FilterSetError, apple_double_exclusion_rules, cvs_exclusion_rules};

--- a/crates/filters/src/merge/depth.rs
+++ b/crates/filters/src/merge/depth.rs
@@ -1,0 +1,59 @@
+//! The merge-file include depth cap.
+//!
+//! upstream: exclude.c:168 `#define MAX_MERGE_DEPTH 32`, enforced in
+//! `parse_filter_file()` at exclude.c:1619-1627.
+//!
+//! A merge directive inside a filter file re-enters the parser on the named
+//! file, so a file that merges itself - or a long chain that eventually does -
+//! recurses until the stack guard page is hit. Upstream bounds the *nesting
+//! depth* rather than detecting a cycle, which is the stronger of the two
+//! rules: a depth cap also refuses a non-cyclic chain deeper than the cap,
+//! where a "have I seen this file?" test would happily keep descending.
+
+/// Maximum nesting depth for merge-file includes.
+///
+/// upstream: exclude.c:168 `#define MAX_MERGE_DEPTH 32`. Checked with `>=`
+/// *before* the depth is incremented (exclude.c:1619), so 32 nested files are
+/// parsed and the 33rd entry is refused.
+pub const MAX_MERGE_DEPTH: usize = 32;
+
+/// Renders upstream's depth-limit diagnostic.
+///
+/// upstream: exclude.c:1620-1622
+/// ```text
+/// rprintf(FERROR, "[%s] merge-file include depth limit (%d) exceeded at %s\n",
+///         who_am_i(), MAX_MERGE_DEPTH, rule_text(template, fname));
+/// ```
+///
+/// `role` is upstream's `who_am_i()` and `rule` its `rule_text()` rendering of
+/// the offending merge directive - the rule as written, not the resolved path,
+/// so the operator sees what they typed.
+#[must_use]
+pub fn depth_limit_exceeded(role: &str, rule: &str) -> String {
+    format!("[{role}] merge-file include depth limit ({MAX_MERGE_DEPTH}) exceeded at {rule}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// WHY: the cap is a wire-visible constant an operator can hit; it must be
+    /// upstream's value, not a rounded-off one. A different number changes
+    /// which filter sets parse.
+    #[test]
+    fn cap_matches_upstream() {
+        assert_eq!(MAX_MERGE_DEPTH, 32, "upstream: exclude.c:168");
+    }
+
+    /// WHY: the testsuite cell `filter-merge-recursion` greps for the exact
+    /// substring `merge-file include depth limit`, and an operator comparing
+    /// oc against rsync should see the same line. Pin the whole rendering, not
+    /// just the substring, so a reworded prefix cannot drift silently.
+    #[test]
+    fn diagnostic_matches_upstream_wording() {
+        assert_eq!(
+            depth_limit_exceeded("sender", ". .merge"),
+            "[sender] merge-file include depth limit (32) exceeded at . .merge"
+        );
+    }
+}

--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -44,6 +44,7 @@
 //! - upstream: exclude.c:parse_filter_file() - reading rules from merge files
 //! - upstream: exclude.c lines 1220-1288 - modifier character handling
 
+mod depth;
 mod error;
 pub(crate) mod parse;
 pub(crate) mod read;
@@ -51,6 +52,7 @@ pub(crate) mod read;
 #[cfg(test)]
 mod tests;
 
+pub use depth::{MAX_MERGE_DEPTH, depth_limit_exceeded};
 pub use error::MergeFileError;
 pub use parse::parse_rules;
 pub(crate) use read::scope_local_clear;

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -149,7 +149,7 @@ files-from-path-clamp fail
 filter-depth pass
 filter-leak skip
 filter-merge-content-echo fail
-filter-merge-recursion fail
+filter-merge-recursion pass
 filter-merge-symlink skip
 fuzzy pass
 fuzzy-basis pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -149,7 +149,7 @@ files-from-path-clamp fail
 filter-depth pass
 filter-leak fail
 filter-merge-content-echo fail
-filter-merge-recursion fail
+filter-merge-recursion pass
 filter-merge-symlink pass
 fuzzy pass
 fuzzy-basis pass


### PR DESCRIPTION
Closes the `filter-merge-recursion` cell of the upstream 3.5.0 testsuite on both
pipe legs.

## The divergence

Upstream caps merge-file includes at `MAX_MERGE_DEPTH` (exclude.c:168) and
enforces it in `parse_filter_file()` (exclude.c:1619-1627). oc instead kept a
set of already-visited files and refused a repeat, reporting
`recursive filter merge detected for <path>`.

Before:

```
oc-rsync error: failed to parse filter file '.../.merge': recursive filter
merge detected for .../.merge (code 23) ...
```

After (matching rsync):

```
[client] merge-file include depth limit (32) exceeded at .../.merge
```

## Why the rules are not interchangeable

A depth cap also refuses a chain of *distinct* files deeper than the cap. A
visited-set descends it happily, because no file repeats. That is the case the
new `..._bounds_an_acyclic_chain` test pins.

On the self-including fixture the two rules are indistinguishable, so the
testsuite cell alone could not tell them apart: restoring the visited-set leaves
that cell green and only the acyclic chain goes red. Measured -
`3 tests run: 2 passed, 1 failed` under that mutation.

## Shape

`crates/filters/src/merge/depth.rs` is the single owner of the cap and the
message rendering, so the two parser sites cannot drift apart.

- **CLI parser** - operator-supplied merges carry `XFLG_FATAL_ERRORS`, so it
  exits `RERR_FILEIO` (11) per exclude.c:1626. Its guard container becomes a
  stack: a `HashSet` cannot count depth, since a self-include's second insert
  does not grow it.
- **Engine per-directory merge** - parsed without `XFLG_FATAL_ERRORS`
  (exclude.c:912), so it reports and drops the rule. That is the same choice the
  failed-open arm directly beside it already makes.

## Gap surfaced

oc has no `who_am_i()` equivalent, so upstream's `[%s]` prefix has no engine-side
source. The roles here are read off upstream's call structure rather than
invented: the dir-merge chain is walked by the file-list scan (sender), and
`--filter` arguments are parsed before any fork (client, matching the `Role::Client`
already carried at that site). A general role parameter for the wire emitter is
tracked separately.

## Verification

Linux (aarch64), against the real rsync 3.5.0 build:

- Cell RED before, PASS after, on both the nonroot and root legs.
- Upstream 3.5.0 control on the same cell: PASS - so it is an oc defect, not a
  fixture limit.
- Mutation (restore the visited-set): the acyclic-chain test fails, the
  within-cap non-vacuity companion stays green.
- Full nonroot 3.5.0 leg against the updated manifest: 345 cells,
  220 passed / 39 failed / 86 skipped, and the only expected-result mismatch is
  `simd-checksum: expected pass, got skip` - a host-capability skip on this
  aarch64 box, unrelated to this change.
- `cargo fmt --all -- --check` clean on Linux; clippy clean on the three touched
  crates; 361/361 on the merge-scoped nextest selection.

Manifest rows for `filter-merge-recursion` flip `fail` -> `pass` in the same
commit on both legs.
