### PR TITLE
fix(output): print `skipping directory` at default verbosity, in production order

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -10,7 +10,7 @@ use core::{
     },
     message::Message,
 };
-use logging::{DebugFlag, InfoFlag, LogCode, debug_gte, info_gte};
+use logging::{DebugFlag, InfoFlag, LogCode, debug_gte, drain_stamped_events_for_client, info_gte};
 use logging_sink::{MessageSink, logfile::LogFileWriter};
 
 use crate::frontend::escape::EscapeStyle;
@@ -19,7 +19,8 @@ use crate::frontend::{
     out_format::{OutFormat, OutFormatContext},
     progress::{
         DeltaTransmissionState, DeltaTransmissionSummary, LiveProgress, NameOutputLevel,
-        ProgressMode, ProgressOutputConfig, StderrMode, emit_transfer_summary,
+        PendingDiagnostics, ProgressMode, ProgressOutputConfig, StderrMode, emit_transfer_summary,
+        partition_by_summary_stream, render_diagnostic_events,
     },
 };
 
@@ -230,6 +231,26 @@ where
                 .with_escape_style(EscapeStyle::terminal(eight_bit_output))
                 .with_preserve_links(preserve_links)
                 .with_full_checksum(full_checksum_algorithm, always_checksum);
+            // upstream: log.c:272-373 rwrite() writes each diagnostic the moment
+            // it is produced, so it lands among the per-file lines rather than
+            // after them. oc buffers the event stream and renders it here, so
+            // the diagnostics have to be merged back in by production order.
+            // This is the only place that holds both streams, so it is where the
+            // stream split has to happen: `emit_transfer_summary` receives one
+            // writer and can only carry the half bound for it.
+            //
+            // `FLOG` events stay queued - the log-file sink below takes those.
+            let (interleaved, other_stream) =
+                partition_by_summary_stream(drain_stamped_events_for_client(), msgs_to_stderr);
+            let mut pending = PendingDiagnostics::new(interleaved);
+            if !other_stream.is_empty() {
+                let _ = render_diagnostic_events(
+                    &other_stream,
+                    stdout,
+                    stderr.writer_mut(),
+                    msgs_to_stderr,
+                );
+            }
             if let Err(error) = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
                 emit_transfer_summary(
                     &summary,
@@ -253,6 +274,7 @@ where
                     show_crtimes,
                     EscapeStyle::terminal(eight_bit_output),
                     writer,
+                    &mut pending,
                 )
             }) {
                 let _ = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
@@ -436,6 +458,9 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         // and 0xA0-0xFF stay verbatim.
         EscapeStyle::passthrough(),
         &mut log.file,
+        // The log file is fed from the FLOG queue above, not from the
+        // client-stream diagnostics, so there is nothing to interleave here.
+        &mut PendingDiagnostics::empty(),
     )?;
     // upstream: cleanup.c:222-226 gates log_exit() on
     // `logfile_name && (am_server || !INFO_GTE(STATS, 1))`, and log_exit()

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -282,6 +282,13 @@ where
 
     let verbosity_config = VerbosityConfig::from_verbose_level(verbosity);
     logging::init(verbosity_config);
+    // The parser already folded `--quiet` into `verbosity = 0`, which is what
+    // silences every verbosity-gated line. Upstream additionally keeps `quiet`
+    // as its own global and consults it in the `FINFO` arm of `rwrite()`
+    // (log.c:344-345), so a notice it prints at DEFAULT verbosity - `skipping
+    // directory %s` (flist.c:1484) - still disappears under `-q`. Carrying the
+    // flag past the parser is what makes those two states distinguishable.
+    logging::set_quiet(quiet);
 
     let rayon_thread_count = rayon_threads.and_then(|n| NonZeroUsize::new(n as usize));
     let tokio_thread_count = tokio_threads.and_then(|n| NonZeroUsize::new(n as usize));

--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -49,13 +49,16 @@ pub fn msgs_to_stderr() -> bool {
 /// diagnostic emitter share one implementation of the rule; a second copy here
 /// is what made #352 and #357 two separate bugs instead of one. This helper
 /// keeps the *inputs* to that rule equally singular.
-const fn stream_context(msgs2stderr: bool) -> logging::StreamContext {
+fn stream_context(msgs2stderr: bool) -> logging::StreamContext {
     logging::StreamContext {
-        // The client renderers run after the CLI has already folded `--quiet`
-        // into the verbosity level, so the events that reach them are
-        // pre-filtered; passing `quiet: false` keeps that behaviour unchanged.
-        // Wiring the real flag through is task #346.
-        quiet: false,
+        // upstream: log.c:345 `if (quiet)` - the FINFO arm of rwrite() returns
+        // without writing when quiet is set. Folding `--quiet` into
+        // `verbose = 0` at parse time silences only the verbosity-gated
+        // events; a notice upstream prints at DEFAULT verbosity - `skipping
+        // directory %s` (flist.c:1338), `skipping non-regular file "%s"` under
+        // `INFO_GTE(NONREG, 1)` - still reaches this renderer and has to be
+        // suppressed here, where upstream suppresses it.
+        quiet: logging::finfo_suppressed(),
         // `Never` and `Default` select the same stream (log.c:253 keys on
         // `== 1`), so a caller that only knows the boolean loses nothing here.
         // The tri-state is available for callers that have it.
@@ -388,56 +391,62 @@ mod tests {
     fn test_renderer_delegates_every_code_to_the_shared_funnel() {
         for code in LogCode::ALL {
             for msgs2stderr in [false, true] {
-                let ctx = logging::StreamContext {
-                    quiet: false,
-                    msgs2stderr: if msgs2stderr {
-                        logging::Msgs2Stderr::Always
-                    } else {
-                        logging::Msgs2Stderr::Default
-                    },
-                    log_destination: false,
-                };
-                let events = vec![DiagnosticEvent::Info {
-                    flag: InfoFlag::Misc,
-                    level: 1,
-                    code,
-                    message: "probe".to_owned(),
-                }];
-                let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
-                let result =
-                    render_diagnostic_events(&events, &mut stdout, &mut stderr, msgs2stderr);
+                for quiet in [false, true] {
+                    logging::set_quiet(quiet);
+                    let ctx = logging::StreamContext {
+                        quiet,
+                        msgs2stderr: if msgs2stderr {
+                            logging::Msgs2Stderr::Always
+                        } else {
+                            logging::Msgs2Stderr::Default
+                        },
+                        log_destination: false,
+                    };
+                    let events = vec![DiagnosticEvent::Info {
+                        flag: InfoFlag::Misc,
+                        level: 1,
+                        code,
+                        message: "probe".to_owned(),
+                    }];
+                    let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+                    let result =
+                        render_diagnostic_events(&events, &mut stdout, &mut stderr, msgs2stderr);
 
-                match logging::message_stream(code, ctx) {
-                    Ok(logging::MessageStream::Stdout) => {
-                        assert!(result.is_ok(), "{code} must render");
-                        assert!(
-                            String::from_utf8_lossy(&stdout).contains("probe"),
-                            "{code} belongs on stdout with msgs2stderr={msgs2stderr}",
-                        );
-                        assert!(stderr.is_empty(), "{code} must not also hit stderr");
-                    }
-                    Ok(logging::MessageStream::Stderr) => {
-                        assert!(result.is_ok(), "{code} must render");
-                        assert!(
-                            String::from_utf8_lossy(&stderr).contains("probe"),
-                            "{code} belongs on stderr with msgs2stderr={msgs2stderr}",
-                        );
-                        assert!(stdout.is_empty(), "{code} must not also hit stdout");
-                    }
-                    Ok(logging::MessageStream::LogOnly | logging::MessageStream::Suppressed) => {
-                        assert!(result.is_ok(), "{code} must render");
-                        assert!(
-                            stdout.is_empty() && stderr.is_empty(),
-                            "{code} must emit nothing"
-                        );
-                    }
-                    Err(_) => {
-                        assert!(result.is_err(), "{code} must be rejected, not rendered");
-                        assert!(stdout.is_empty(), "a rejected code must not reach stdout");
+                    match logging::message_stream(code, ctx) {
+                        Ok(logging::MessageStream::Stdout) => {
+                            assert!(result.is_ok(), "{code} must render");
+                            assert!(
+                                String::from_utf8_lossy(&stdout).contains("probe"),
+                                "{code} belongs on stdout with msgs2stderr={msgs2stderr}",
+                            );
+                            assert!(stderr.is_empty(), "{code} must not also hit stderr");
+                        }
+                        Ok(logging::MessageStream::Stderr) => {
+                            assert!(result.is_ok(), "{code} must render");
+                            assert!(
+                                String::from_utf8_lossy(&stderr).contains("probe"),
+                                "{code} belongs on stderr with msgs2stderr={msgs2stderr}",
+                            );
+                            assert!(stdout.is_empty(), "{code} must not also hit stdout");
+                        }
+                        Ok(
+                            logging::MessageStream::LogOnly | logging::MessageStream::Suppressed,
+                        ) => {
+                            assert!(result.is_ok(), "{code} must render");
+                            assert!(
+                                stdout.is_empty() && stderr.is_empty(),
+                                "{code} must emit nothing"
+                            );
+                        }
+                        Err(_) => {
+                            assert!(result.is_err(), "{code} must be rejected, not rendered");
+                            assert!(stdout.is_empty(), "a rejected code must not reach stdout");
+                        }
                     }
                 }
             }
         }
+        logging::set_quiet(false);
     }
 
     /// `--msgs-to-stderr` moves the stdout-bound codes only; a warning was

--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -7,6 +7,7 @@ use std::cell::Cell;
 use std::io::{self, Write};
 
 pub use logging::DiagnosticEvent;
+use logging::Stamped;
 
 thread_local! {
     // The workflow records its resolved `--msgs-to-stderr` decision here so
@@ -41,6 +42,80 @@ pub fn msgs_to_stderr() -> bool {
 /// error and warning codes (log.c:309-316), the silent return taken by an
 /// FLOG message with no log destination (log.c:306-307), and the fatal
 /// "Bad logcode" default arm (log.c:325-327).
+/// The context every client-side stream decision is taken in.
+///
+/// upstream: log.c:251 `rwrite()` is the sole chooser of a stream. The decision
+/// lives in `logging::message_stream` so that this renderer and every other
+/// diagnostic emitter share one implementation of the rule; a second copy here
+/// is what made #352 and #357 two separate bugs instead of one. This helper
+/// keeps the *inputs* to that rule equally singular.
+const fn stream_context(msgs2stderr: bool) -> logging::StreamContext {
+    logging::StreamContext {
+        // The client renderers run after the CLI has already folded `--quiet`
+        // into the verbosity level, so the events that reach them are
+        // pre-filtered; passing `quiet: false` keeps that behaviour unchanged.
+        // Wiring the real flag through is task #346.
+        quiet: false,
+        // `Never` and `Default` select the same stream (log.c:253 keys on
+        // `== 1`), so a caller that only knows the boolean loses nothing here.
+        // The tri-state is available for callers that have it.
+        msgs2stderr: if msgs2stderr {
+            logging::Msgs2Stderr::Always
+        } else {
+            logging::Msgs2Stderr::Default
+        },
+        log_destination: false,
+    }
+}
+
+/// The stream the transfer-summary writer represents.
+///
+/// `with_output_writer` hands `emit_transfer_summary` a single writer chosen by
+/// the same `--msgs-to-stderr` decision `message_stream` applies, so a
+/// diagnostic routed to this stream is one the summary renderer can interleave;
+/// anything else has to be written by the caller, which holds both handles.
+const fn summary_stream(msgs2stderr: bool) -> logging::MessageStream {
+    if msgs2stderr {
+        logging::MessageStream::Stderr
+    } else {
+        logging::MessageStream::Stdout
+    }
+}
+
+/// Splits drained diagnostics by whether they belong on the summary's stream.
+///
+/// The first half keeps its production key so [`PendingDiagnostics`] can
+/// interleave it with the buffered event stream at the position upstream would
+/// have written it. The second half is handed back to
+/// [`render_diagnostic_events`], which re-derives the stream per event - so the
+/// routing rule stays in `logging::message_stream` alone, and an event carrying
+/// a code that rule rejects stays in the second half where its diagnosis is
+/// still reported rather than being silently interleaved or dropped.
+///
+/// [`PendingDiagnostics`]: super::PendingDiagnostics
+#[must_use]
+pub fn partition_by_summary_stream(
+    events: Vec<Stamped<DiagnosticEvent>>,
+    msgs2stderr: bool,
+) -> (Vec<Stamped<String>>, Vec<DiagnosticEvent>) {
+    let summary = summary_stream(msgs2stderr);
+    let ctx = stream_context(msgs2stderr);
+    let mut interleaved = Vec::new();
+    let mut deferred = Vec::new();
+    for stamped in events {
+        let key = stamped.sequence();
+        let event = stamped.into_value();
+        if logging::message_stream(event.code(), ctx) == Ok(summary) {
+            let (DiagnosticEvent::Info { message, .. } | DiagnosticEvent::Debug { message, .. }) =
+                event;
+            interleaved.push(Stamped::with_sequence(key, message));
+        } else {
+            deferred.push(event);
+        }
+    }
+    (interleaved, deferred)
+}
+
 /// Render diagnostic events to the stream their log code selects.
 ///
 /// Error and warning codes go to stderr, info codes to stdout, and FLOG
@@ -73,28 +148,7 @@ pub fn render_diagnostic_events<O: Write, E: Write>(
         // upstream: rwrite() prints debug traces through rprintf(FINFO, ...)
         // with no flag-category bracket, so info and debug events differ only
         // in the code they carry, never in their rendering.
-        // upstream: log.c:251 rwrite() is the sole chooser of a stream. The
-        // decision lives in `logging::message_stream` so that this renderer
-        // and every other diagnostic emitter share one implementation of the
-        // rule; a second copy here is what made #352 and #357 two separate
-        // bugs instead of one.
-        let ctx = logging::StreamContext {
-            // This renderer runs after the CLI has already folded `--quiet`
-            // into the verbosity level, so the events that reach it are
-            // pre-filtered; passing `quiet: false` keeps that behaviour
-            // unchanged. Wiring the real flag through is task #346.
-            quiet: false,
-            // `Never` and `Default` select the same stream (log.c:253 keys on
-            // `== 1`), so a caller that only knows the boolean loses nothing
-            // here. The tri-state is available for callers that have it.
-            msgs2stderr: if msgs2stderr {
-                logging::Msgs2Stderr::Always
-            } else {
-                logging::Msgs2Stderr::Default
-            },
-            log_destination: false,
-        };
-        match logging::message_stream(code, ctx) {
+        match logging::message_stream(code, stream_context(msgs2stderr)) {
             Ok(logging::MessageStream::Stderr) => writeln!(err, "{message}")?,
             Ok(logging::MessageStream::Stdout) => writeln!(out, "{message}")?,
             Ok(logging::MessageStream::LogOnly | logging::MessageStream::Suppressed) => {}

--- a/crates/cli/src/frontend/progress/interleave.rs
+++ b/crates/cli/src/frontend/progress/interleave.rs
@@ -1,0 +1,178 @@
+//! Merging deferred diagnostics back into the rendered event stream.
+//!
+//! upstream: log.c:272-373 `rwrite()` writes each message the instant it is
+//! produced, so upstream never needs an ordering key - the output order *is*
+//! the production order. oc buffers the per-file event stream and renders it
+//! post-hoc, which splits one output order into two buffers. This module puts
+//! them back together, keyed on the production order both sides carry
+//! (`logging::Sequence`).
+
+use std::collections::VecDeque;
+use std::io::{self, Write};
+
+use logging::{Sequence, Stamped};
+
+/// Diagnostics held back for rendering at the position they were produced.
+///
+/// The queue holds *already-routed* messages: the caller has run each event
+/// through `logging::message_stream` and kept only those bound for the stream
+/// this renderer writes to. Nothing here decides a stream, which keeps
+/// `message_stream` the single owner of that rule.
+///
+/// This is a collaborator passed alongside the writer rather than a wrapper
+/// around it. A plain `Write` cannot express "a new event is about to be
+/// rendered, with this key", and a `Write` subtrait would need a blanket impl
+/// for plain writers to keep existing callers compiling - which would overlap
+/// the merging type's own impl and be rejected by coherence.
+#[derive(Debug, Default)]
+pub(crate) struct PendingDiagnostics {
+    queue: VecDeque<Stamped<String>>,
+}
+
+impl PendingDiagnostics {
+    /// Nothing to interleave.
+    ///
+    /// Every method is then a no-op, so a caller with no diagnostic buffer
+    /// behind its event stream - the log-file renderer, and every test that
+    /// exercises an emitter directly - pays nothing for the seam.
+    pub(crate) const fn empty() -> Self {
+        Self {
+            queue: VecDeque::new(),
+        }
+    }
+
+    /// Takes the messages to interleave, ordered by production key.
+    ///
+    /// The input is sorted here rather than assumed sorted: the buffer is
+    /// drained from one thread-local queue today, but the key exists precisely
+    /// so that messages from several producers can be merged, and a merge that
+    /// silently depends on input order would break the first time one is added.
+    pub(crate) fn new(mut messages: Vec<Stamped<String>>) -> Self {
+        messages.sort_by_key(Stamped::sequence);
+        Self {
+            queue: messages.into(),
+        }
+    }
+
+    /// Renders every diagnostic produced before the event about to be written.
+    ///
+    /// `key` is `None` for an event that carries no production key - every
+    /// remote-transfer event, which is built from the wire rather than from a
+    /// recorded local action. Such an event has no position to order against,
+    /// so **nothing is flushed**: treating it as position zero would push every
+    /// held diagnostic ahead of output it may well have followed.
+    pub(crate) fn begin_event<W: Write + ?Sized>(
+        &mut self,
+        key: Option<Sequence>,
+        out: &mut W,
+    ) -> io::Result<()> {
+        let Some(key) = key else {
+            return Ok(());
+        };
+        while let Some(held) = self.queue.front()
+            && held.sequence() < key
+        {
+            writeln!(out, "{}", held.value())?;
+            self.queue.pop_front();
+        }
+        Ok(())
+    }
+
+    /// Renders the diagnostics that outlived the event stream.
+    ///
+    /// Everything produced after the last rendered event belongs here, at the
+    /// end of the per-file block - which is where upstream would have written
+    /// it, ahead of the `match_report()` totals and the summary trailer.
+    pub(crate) fn finish<W: Write + ?Sized>(&mut self, out: &mut W) -> io::Result<()> {
+        for held in self.queue.drain(..) {
+            writeln!(out, "{}", held.value())?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_diagnostic_produced_first_renders_before_the_event() {
+        // WHY: this is the whole point of the funnel. Upstream writes the
+        // diagnostic at production time, so it precedes the per-file line that
+        // was produced after it; oc must reproduce that from the key alone.
+        let first = Sequence::stamp();
+        let second = Sequence::stamp();
+        let mut pending =
+            PendingDiagnostics::new(vec![Stamped::with_sequence(first, "skipping".to_owned())]);
+
+        let mut out = Vec::new();
+        pending.begin_event(Some(second), &mut out).unwrap();
+
+        assert_eq!(String::from_utf8(out).unwrap(), "skipping\n");
+    }
+
+    #[test]
+    fn a_diagnostic_produced_later_is_held_back() {
+        // WHY: the merge must be an ordering, not a flush-everything-first. A
+        // diagnostic produced after the event stays behind it.
+        let first = Sequence::stamp();
+        let second = Sequence::stamp();
+        let mut pending =
+            PendingDiagnostics::new(vec![Stamped::with_sequence(second, "later".to_owned())]);
+
+        let mut out = Vec::new();
+        pending.begin_event(Some(first), &mut out).unwrap();
+        assert!(out.is_empty(), "held diagnostic leaked ahead of its event");
+
+        pending.finish(&mut out).unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "later\n");
+    }
+
+    #[test]
+    fn an_unkeyed_event_flushes_nothing() {
+        // WHY: a remote-transfer event has no production key. Treating `None`
+        // as position zero would dump every held diagnostic ahead of the whole
+        // event stream - the exact mis-ordering the funnel exists to remove.
+        let mut pending = PendingDiagnostics::new(vec![Stamped::with_sequence(
+            Sequence::stamp(),
+            "held".to_owned(),
+        )]);
+
+        let mut out = Vec::new();
+        pending.begin_event(None, &mut out).unwrap();
+
+        assert!(out.is_empty(), "unkeyed event flushed a held diagnostic");
+    }
+
+    #[test]
+    fn messages_render_in_production_order_not_input_order() {
+        // WHY: `new` sorts rather than trusting its caller, so a buffer merged
+        // from more than one producer still renders in production order.
+        let first = Sequence::stamp();
+        let second = Sequence::stamp();
+        let third = Sequence::stamp();
+        let mut pending = PendingDiagnostics::new(vec![
+            Stamped::with_sequence(third, "c".to_owned()),
+            Stamped::with_sequence(first, "a".to_owned()),
+            Stamped::with_sequence(second, "b".to_owned()),
+        ]);
+
+        let mut out = Vec::new();
+        pending.finish(&mut out).unwrap();
+
+        assert_eq!(String::from_utf8(out).unwrap(), "a\nb\nc\n");
+    }
+
+    #[test]
+    fn an_empty_collaborator_writes_nothing() {
+        let mut pending = PendingDiagnostics::empty();
+
+        let mut out = Vec::new();
+        pending
+            .begin_event(Some(Sequence::stamp()), &mut out)
+            .unwrap();
+        pending.finish(&mut out).unwrap();
+
+        assert!(out.is_empty());
+    }
+}

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -2,12 +2,15 @@
 
 pub mod diagnostic;
 mod format;
+mod interleave;
 mod live;
 mod mode;
 mod render;
 
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every module
-pub use self::diagnostic::{DiagnosticEvent, flush_diagnostics, render_diagnostic_events};
+pub use self::diagnostic::{
+    DiagnosticEvent, flush_diagnostics, partition_by_summary_stream, render_diagnostic_events,
+};
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every module
 pub(crate) use self::format::{
     event_matches_name_level, format_count, format_decimal_bytes, format_human_bytes,
@@ -16,6 +19,7 @@ pub(crate) use self::format::{
     format_progress_rate_decimal, format_progress_rate_from_value, format_size,
     format_stat_categories, format_summary_rate, is_progress_event, list_only_event,
 };
+pub(crate) use self::interleave::PendingDiagnostics;
 pub(crate) use self::live::{LiveProgress, ProgressOutputConfig};
 pub(crate) use self::mode::ProgressMode;
 pub use self::mode::{NameOutputLevel, ProgressSetting, StderrMode}; // Changed to pub for test_utils

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -1193,17 +1193,17 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
             ClientEventKind::SkippedDirectory => {
-                // upstream: flist.c:1338 and flist.c:2452 -
-                // `rprintf(FINFO, "skipping directory %s\n", ...)`: the bare
-                // relative name with no surrounding quotes and no trailing
-                // "(no recursion)" suffix.
-                writeln_wrapped(
-                    stdout,
-                    "skipping directory ",
-                    event.relative_path(),
-                    escape,
-                    "",
-                )?;
+                // Deliberately silent here, for the same reason as
+                // `SkippedNonRegular` above. Upstream gates the notice on
+                // `!xfer_dirs` and nothing else - no INFO_GTE, no verbosity
+                // test - so it prints at DEFAULT verbosity, where this
+                // renderer never runs: the event log itself is only collected
+                // when `verbosity > 0 || progress || list_only`
+                // (core: client/config/client/output.rs `collect_events`), so
+                // at `-q` and at the default the record never reaches here.
+                // The engine emits it on the info channel instead
+                // (context_impl/reporting.rs), which is where `--quiet` can
+                // still suppress it via `message_stream`.
                 continue;
             }
             ClientEventKind::SkippedUnsafeSymlink => {
@@ -1531,7 +1531,7 @@ mod tests {
     }
 
     #[test]
-    fn skipped_directory_matches_upstream_bare_message() {
+    fn skipped_directory_renders_nothing_because_the_engine_owns_the_notice() {
         let event = ClientEvent::for_test(
             PathBuf::from("subdir"),
             ClientEventKind::SkippedDirectory,
@@ -1539,11 +1539,20 @@ mod tests {
             Some(ClientEntryMetadata::for_test(ClientEntryKind::Directory)),
             LocalCopyChangeSet::new(),
         );
-        // upstream: flist.c:1338 and flist.c:2452 emit
-        // `rprintf(FINFO, "skipping directory %s\n", ...)` - a bare relative
-        // name with no surrounding quotes and no "(no recursion)" suffix. Byte
-        // fidelity with upstream requires exactly this form.
-        assert_eq!(render_verbose(event), "skipping directory subdir\n");
+        // Upstream gates `skipping directory %s` on `!xfer_dirs` alone, so it
+        // prints at DEFAULT verbosity - but this renderer only ever runs over a
+        // collected event log, and collection requires
+        // `verbosity > 0 || progress || list_only`. Rendering the notice here
+        // therefore emitted it at `-v` and above while staying silent in
+        // exactly the case upstream prints. The notice now comes from
+        // `record_skipped_directory` in the engine; a second copy here would
+        // duplicate it at `-v`.
+        //
+        // The upstream byte form - bare relative name, no quotes, no
+        // "(no recursion)" suffix - is pinned end to end against the real
+        // binary's stdout by `skipping_directory_prints_without_name_output`,
+        // which compares whole lines, not by this unit.
+        assert_eq!(render_verbose(event), "");
     }
 
     /// Renders the summary trailer for an empty (default) transfer at the given

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -49,6 +49,7 @@ use super::format::{
     format_progress_rate, format_size, format_stat_categories, format_summary_rate,
     is_progress_event, list_only_event,
 };
+use super::interleave::PendingDiagnostics;
 use super::mode::{NameOutputLevel, ProgressMode};
 use crate::{OutFormat, OutFormatContext, emit_out_format};
 use logging::{InfoFlag, info_gte};
@@ -122,6 +123,12 @@ pub(crate) fn emit_transfer_summary(
     show_crtimes: bool,
     escape: EscapeStyle,
     writer: &mut dyn Write,
+    // Diagnostics produced during the transfer, already routed to this writer's
+    // stream by the caller (which holds both handles). They render at the
+    // position they were produced rather than dead-last, mirroring upstream's
+    // write-on-production ordering. `PendingDiagnostics::empty()` for a caller
+    // with nothing to interleave, such as the log-file renderer.
+    pending: &mut PendingDiagnostics,
 ) -> io::Result<()> {
     let events = summary.events();
     let stats_on = stats_level > 0;
@@ -137,9 +144,11 @@ pub(crate) fn emit_transfer_summary(
                 show_crtimes,
                 escape,
                 out_format_context.preserve_links(),
+                pending,
             )?;
             wrote_listing = true;
         }
+        pending.finish(writer)?;
 
         if stats_on {
             if wrote_listing {
@@ -227,7 +236,7 @@ pub(crate) fn emit_transfer_summary(
     let progress_rendered = if progress_already_rendered {
         true
     } else if matches!(progress_mode, Some(ProgressMode::PerFile)) && !events.is_empty() {
-        emit_progress(events, writer, human_readable_mode, escape)?
+        emit_progress(events, writer, human_readable_mode, escape, pending)?
     } else {
         false
     };
@@ -271,8 +280,14 @@ pub(crate) fn emit_transfer_summary(
             human_readable_mode,
             escape,
             writer,
+            pending,
         )?;
     }
+
+    // Whatever was produced after the last rendered entry belongs at the end of
+    // the per-file block - where upstream wrote it, ahead of the match_report
+    // totals and the summary trailer below.
+    pending.finish(writer)?;
 
     // upstream: match.c:439-446 match_report() - the sender prints the
     // cumulative match totals once at DEBUG_GTE(DELTASUM, 1) (first active at
@@ -375,8 +390,10 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
     show_crtimes: bool,
     escape: EscapeStyle,
     preserve_links: bool,
+    pending: &mut PendingDiagnostics,
 ) -> io::Result<()> {
     for event in events {
+        pending.begin_event(event.sequence(), stdout)?;
         if !list_only_event(event.kind()) {
             continue;
         }
@@ -464,6 +481,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
     stdout: &mut W,
     human_readable: HumanReadableMode,
     escape: EscapeStyle,
+    pending: &mut PendingDiagnostics,
 ) -> io::Result<bool> {
     // upstream: progress.c counts every checked file-list entry toward
     // `to-chk=<remaining>/<total>`, but prints a per-file block and advances
@@ -493,6 +511,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
     let mut xfr_index = 0usize;
     let mut checked = 0usize;
     for event in flist_entries.into_iter() {
+        pending.begin_event(event.sequence(), stdout)?;
         checked += 1;
         if !event.kind().is_transfer() || is_uptodate_event(event) {
             continue;
@@ -951,6 +970,7 @@ fn verbose_listing_name(event: &ClientEvent, escape: EscapeStyle) -> Vec<u8> {
 }
 
 /// Renders verbose listings for the provided transfer events.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_verbose<W: Write + ?Sized>(
     events: &[ClientEvent],
     verbosity: u8,
@@ -959,6 +979,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
     _human_readable: HumanReadableMode,
     escape: EscapeStyle,
     stdout: &mut W,
+    pending: &mut PendingDiagnostics,
 ) -> io::Result<()> {
     // upstream: log.c:920 log_delete() prints "deleting %n" whenever
     // INFO_GTE(DEL, 1), independent of the NAME level that gates the per-file
@@ -1000,6 +1021,11 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
     });
 
     for event in ordered_events {
+        // The list above is re-sorted into upstream's generator-then-receiver
+        // phase order, so keys are not monotonic here. The merge stays correct
+        // because it only ever flushes forward: a diagnostic renders before the
+        // first event it preceded, which is the position upstream wrote it at.
+        pending.begin_event(event.sequence(), stdout)?;
         let kind = event.kind();
         // upstream: log.c:920-924 log_delete() prints "deleting %n" gated on
         // INFO_GTE(DEL, 1), which -v raises to 1 (options.c:251). The deletion
@@ -1339,6 +1365,7 @@ mod tests {
             HumanReadableMode::Grouped,
             EscapeStyle::terminal(false),
             &mut out,
+            &mut PendingDiagnostics::empty(),
         )
         .expect("emit_verbose writes to an in-memory buffer");
         String::from_utf8(out).expect("output is valid UTF-8")
@@ -1358,6 +1385,7 @@ mod tests {
             HumanReadableMode::Grouped,
             EscapeStyle::terminal(false),
             &mut out,
+            &mut PendingDiagnostics::empty(),
         )
         .expect("emit_verbose writes to an in-memory buffer");
         String::from_utf8(out).expect("output is valid UTF-8")
@@ -1545,6 +1573,7 @@ mod tests {
             false,                               // show_crtimes
             EscapeStyle::terminal(false),        // escape style
             &mut out,
+            &mut PendingDiagnostics::empty(),
         )
         .expect("emit_transfer_summary writes to an in-memory buffer");
         String::from_utf8(out).expect("output is valid UTF-8")

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -1479,6 +1479,7 @@ fn list_only_renders_specials_and_symlink_arrow_gate() {
             false,
             EscapeStyle::terminal(false),
             preserve_links,
+            &mut PendingDiagnostics::empty(),
         )
         .expect("render");
         String::from_utf8(out).expect("utf8").trim_end().to_owned()
@@ -1564,6 +1565,7 @@ fn list_only_renders_atime_and_crtime_columns() {
         true,
         EscapeStyle::terminal(false),
         true,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render");
     let rendered = String::from_utf8(out).expect("utf8");

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -248,6 +248,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,                               // show_crtimes
         EscapeStyle::terminal(false),        // escape style
         &mut with_out_format,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render with out-format");
 
@@ -274,6 +275,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,                               // show_crtimes
         EscapeStyle::terminal(false),        // escape style
         &mut without_out_format,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render without out-format");
 

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -79,6 +79,7 @@ fn render_stats_at_level(
         false,                               // show_crtimes
         EscapeStyle::terminal(false),        // escape style
         &mut rendered,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render stats");
     String::from_utf8(rendered).expect("utf8")
@@ -108,6 +109,7 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         false,                               // show_crtimes
         EscapeStyle::terminal(false),        // escape style
         &mut rendered,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render verbose");
     String::from_utf8(rendered).expect("utf8")
@@ -153,6 +155,7 @@ fn info_name_only_suppresses_stats_footer() {
         false,                               // show_crtimes
         EscapeStyle::terminal(false),        // escape style
         &mut rendered,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render");
     let out = String::from_utf8(rendered).expect("utf8");
@@ -551,6 +554,7 @@ fn parity_totals_only_without_stats_flag() {
         false,                               // show_crtimes
         EscapeStyle::terminal(false),        // escape style
         &mut rendered,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render");
     let output = String::from_utf8(rendered).expect("utf8");
@@ -823,6 +827,7 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         false,                               // show_crtimes
         EscapeStyle::terminal(false),        // escape style
         &mut rendered,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render");
     let output = String::from_utf8(rendered).expect("utf8");

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -63,6 +63,7 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         false,                               // show_crtimes
         EscapeStyle::terminal(false),        // escape style
         &mut rendered,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render summary");
 
@@ -100,6 +101,7 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         false,                               // show_crtimes
         EscapeStyle::terminal(false),        // escape style
         &mut rendered,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render summary");
 
@@ -145,6 +147,7 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         false, // show_crtimes
         EscapeStyle::terminal(false), // escape style
         &mut rendered,
+        &mut PendingDiagnostics::empty(),
     )
     .expect("render summary");
 

--- a/crates/cli/src/frontend/tests/transfer_request_skips_directories_without_recursion.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_skips_directories_without_recursion.rs
@@ -81,6 +81,82 @@ fn non_trailing_slash_source_without_recursion_skips_directory() {
     );
 }
 
+/// Runs `oc-rsync <flags> <src-dir> <dst>/` on a fresh tree and returns stdout.
+///
+/// The source is a bare directory operand with no `-r`/`-d`, which is the only
+/// shape that reaches upstream's `!xfer_dirs` guard.
+fn skip_notice_stdout(flags: &[&str]) -> String {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("subdir");
+    std::fs::create_dir(&source_dir).expect("create source");
+    std::fs::write(source_dir.join("child.txt"), b"payload").expect("write child");
+    let dest_dir = tmp.path().join("dst");
+    std::fs::create_dir(&dest_dir).expect("create dest");
+
+    let mut args = vec![OsString::from(RSYNC)];
+    args.extend(flags.iter().map(OsString::from));
+    args.push(source_dir.into_os_string());
+    args.push(dest_dir.into_os_string());
+
+    let (code, stdout, _stderr) = run_with_args(args);
+    assert_eq!(code, 0, "skipping a directory operand is a success");
+    String::from_utf8(stdout).expect("stdout is utf-8")
+}
+
+fn skip_notice_count(stdout: &str) -> usize {
+    stdout
+        .lines()
+        .filter(|line| *line == "skipping directory subdir")
+        .count()
+}
+
+/// The notice is printed at DEFAULT verbosity, and `--info=name0` does not
+/// silence it.
+///
+/// upstream's condition is `!xfer_dirs` and nothing else - there is no
+/// `INFO_GTE` and no verbosity test at either call site (flist.c:1484 in
+/// `send_file_name`, flist.c:2724 in `send_file_list`). The only suppressor is
+/// `quiet` inside `rwrite()` (log.c:344-345). Routing it through the NAME
+/// output level, as the per-file listing is, hides it from every operator who
+/// did not pass `-v` - and from one who explicitly disabled NAME, which is what
+/// makes `--info=name0` the discriminating cell rather than a variation on the
+/// default.
+///
+/// Measured against rsync 3.5.0: it prints the line in all three cells below.
+#[test]
+fn skipping_directory_prints_without_name_output() {
+    for flags in [&[][..], &["--info=name0"][..], &["--info=skip1"][..]] {
+        assert_eq!(
+            skip_notice_count(&skip_notice_stdout(flags)),
+            1,
+            "`skipping directory subdir` must print exactly once with {flags:?}"
+        );
+    }
+}
+
+/// `-q` is the one thing that does suppress it, and the notice must not
+/// duplicate at `-v`.
+///
+/// Without the `-q` half this pin would also pass on a renderer that simply
+/// printed the line unconditionally, so the two cells are a pair: one proves
+/// the notice escapes the NAME gate, the other proves it still answers to
+/// upstream's actual suppressor.
+#[test]
+fn quiet_suppresses_the_notice_and_verbose_does_not_duplicate_it() {
+    assert_eq!(
+        skip_notice_count(&skip_notice_stdout(&["-q"])),
+        0,
+        "upstream's rwrite() returns early for FINFO under --quiet (log.c:344-345)"
+    );
+    assert_eq!(
+        skip_notice_count(&skip_notice_stdout(&["-v"])),
+        1,
+        "-v must not add a second copy of the notice"
+    );
+}
+
 /// Verifies that `-r` re-enables the recursive copy that the default would have
 /// skipped. Guards against an over-broad fix that disables recursion entirely.
 #[test]

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -393,6 +393,16 @@ impl ClientEvent {
         &self.kind
     }
 
+    /// Returns where this event sits in the overall output order.
+    ///
+    /// A renderer merging this event stream with the diagnostic buffer compares
+    /// against this key. `None` means the event carries no position - it is not
+    /// "position zero", and a merge must flush nothing rather than guess.
+    #[must_use]
+    pub const fn sequence(&self) -> Option<Sequence> {
+        self.sequence
+    }
+
     /// Returns the number of bytes transferred as part of this event.
     #[must_use]
     pub const fn bytes_transferred(&self) -> u64 {

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use engine::local_copy::{LocalCopyAction, LocalCopyChangeSet, LocalCopyRecord};
+use logging::Sequence;
 
 use super::metadata::{ClientEntryKind, ClientEntryMetadata, RemoteItemizeFields};
 
@@ -116,6 +117,18 @@ pub struct ClientEvent {
     change_set: LocalCopyChangeSet,
     hardlink_uptodate: bool,
     is_directory: bool,
+    /// When the underlying action was recorded, relative to every other
+    /// message, carried so the renderer can interleave these events with the
+    /// diagnostic channel in production order.
+    ///
+    /// Taken from the source [`LocalCopyRecord`], never minted here: two of
+    /// the three conversion sites convert a whole batch at once, so a key
+    /// minted during conversion would order every event by conversion time and
+    /// place them all after the diagnostics regardless of when they happened.
+    ///
+    /// `None` for an event with no local record behind it - a remote transfer
+    /// builds its events from the wire, not from a recorded local action.
+    sequence: Option<Sequence>,
     /// Pre-rendered `%i` itemize string supplied by a remote transfer.
     ///
     /// Local events derive `%i` from [`Self::change_set`]; a remote transfer has
@@ -141,6 +154,11 @@ impl ClientEvent {
     /// Creates an event by consuming a [`LocalCopyRecord`], moving heap-allocated
     /// fields instead of cloning them.
     pub(crate) fn from_record_owned(record: LocalCopyRecord, destination_root: Arc<Path>) -> Self {
+        // Read the key before `into_parts` consumes the record. Carrying it
+        // across rather than minting one here is what keeps batch conversion
+        // honest: `into_parts` is called in a `.map()` over a whole Vec at two
+        // of the three call sites.
+        let sequence = record.sequence();
         let (
             relative_path,
             action,
@@ -217,6 +235,7 @@ impl ClientEvent {
         };
         let destination_path = Self::resolve_destination_path(&destination_root, &relative_path);
         Self {
+            sequence,
             relative_path,
             kind,
             bytes_transferred,
@@ -244,6 +263,7 @@ impl ClientEvent {
     ) -> Self {
         let destination_path = Self::resolve_destination_path(&destination_root, relative);
         Self {
+            sequence: None,
             relative_path: relative.to_path_buf(),
             kind: ClientEventKind::DataCopied,
             bytes_transferred,
@@ -285,6 +305,7 @@ impl ClientEvent {
         let total_bytes = Some(metadata.length());
         let destination_root: Arc<Path> = Arc::from(Path::new(""));
         Self {
+            sequence: None,
             relative_path,
             kind,
             bytes_transferred: 0,
@@ -324,6 +345,7 @@ impl ClientEvent {
             ClientEventKind::DataCopied
         };
         Self {
+            sequence: None,
             relative_path: fields.relative_path,
             kind,
             bytes_transferred: 0,
@@ -492,6 +514,7 @@ impl ClientEvent {
         let destination_root: Arc<Path> = Arc::from(Path::new("/tmp"));
         let destination_path = destination_root.join(&relative_path);
         Self {
+            sequence: None,
             relative_path,
             kind,
             bytes_transferred: 0,

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -73,8 +73,21 @@ impl<'a> CopyContext<'a> {
     }
 
     /// Records a skip event for a directory (when `-r` is not enabled).
+    ///
+    /// Emits the notice here, not from the verbose renderer. Upstream's guard
+    /// is `S_ISDIR(st.st_mode) && !xfer_dirs` and nothing else - there is no
+    /// `INFO_GTE` and no verbosity test at either call site - so the line
+    /// prints at DEFAULT verbosity. The event log this record joins is only
+    /// collected when `verbosity > 0 || progress || list_only`, so a renderer
+    /// arm alone is unreachable in exactly the case upstream prints. `--quiet`
+    /// still suppresses it, at `rwrite()`'s FINFO arm, which
+    /// `logging::message_stream` owns.
+    // upstream: flist.c:1338 and flist.c:2452 -
+    // `rprintf(FINFO, "skipping directory %s\n", ...)`: the bare relative name
+    // with no surrounding quotes and no trailing "(no recursion)" suffix.
     pub(super) fn record_skipped_directory(&mut self, relative: Option<&Path>) {
         if let Some(path) = relative {
+            info_log!(Misc, 0, "skipping directory {}", path.display());
             self.record(LocalCopyRecord::new(
                 path.to_path_buf(),
                 LocalCopyAction::SkippedDirectory,

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -555,7 +555,14 @@ impl<'a> CopyContext<'a> {
     /// Records a completed copy action: updates the `--stats` created-entry
     /// counters, forwards the record to the observer, and appends it to the
     /// event log when event collection is enabled.
-    pub(super) fn record(&mut self, record: LocalCopyRecord) {
+    pub(super) fn record(&mut self, mut record: LocalCopyRecord) {
+        // Fix the record's place in the output stream here, before either
+        // consumer sees it, so the observer's copy and the logged copy carry
+        // the same key. This is the moment the action becomes observable, and
+        // it is the only ordering the renderer can reconstruct once the two
+        // output channels are drained at different times.
+        record.stamp();
+
         // upstream: receiver.c:733-746 / sender.c:295-308 - every ITEM_IS_NEW
         // entry bumps `stats.created_*` for its type, whether or not file data
         // moved. `was_created()` is the ITEM_IS_NEW mirror; classify by action

--- a/crates/engine/src/local_copy/plan/record.rs
+++ b/crates/engine/src/local_copy/plan/record.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use logging::Sequence;
+
 use super::{LocalCopyAction, LocalCopyChangeSet, LocalCopyMetadata, LocalCopyProgress};
 
 /// Record describing a single filesystem action performed during local copy execution.
@@ -16,6 +18,13 @@ pub struct LocalCopyRecord {
     change_set: LocalCopyChangeSet,
     hardlink_uptodate: bool,
     is_directory: bool,
+    /// When this action was recorded, relative to every other message.
+    ///
+    /// `None` until the record reaches the one site that logs it. The key is
+    /// deliberately not taken in the constructor: a record is *built* over
+    /// several `with_*` steps and only later handed to the context, and it is
+    /// the hand-off that fixes its place in the output, not the allocation.
+    sequence: Option<Sequence>,
 }
 
 impl LocalCopyRecord {
@@ -39,7 +48,35 @@ impl LocalCopyRecord {
             change_set: LocalCopyChangeSet::new(),
             hardlink_uptodate: false,
             is_directory: false,
+            sequence: None,
         }
+    }
+
+    /// Fixes this record's place in the output stream.
+    ///
+    /// Called once, by the context method that logs the record, so the key
+    /// reflects when the action was *recorded* rather than when the struct was
+    /// built - those differ, because a record is assembled across several
+    /// `with_*` steps.
+    ///
+    /// Assign-once: a second call would hand the record a later key than the
+    /// messages it was already ordered against, silently moving it in the
+    /// output. The debug assertion is the guard.
+    pub(in crate::local_copy) fn stamp(&mut self) {
+        debug_assert!(
+            self.sequence.is_none(),
+            "a record's production order must be fixed exactly once"
+        );
+        self.sequence = Some(Sequence::stamp());
+    }
+
+    /// Returns when this action was recorded, if it has been logged.
+    ///
+    /// `None` means the record never reached the logging site, so it has no
+    /// place in the output stream to report.
+    #[must_use]
+    pub const fn sequence(&self) -> Option<Sequence> {
+        self.sequence
     }
 
     /// Marks whether this record describes a directory entry.

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -99,7 +99,7 @@ pub use error_format::{
 pub use levels::{DebugFlag, DebugLevels, InfoFlag, InfoLevels};
 pub use log_code::{LogCode, ParseLogCodeError};
 pub use phase_timer::PhaseTimer;
-pub use sequence::Sequence;
+pub use sequence::{Sequence, Stamped};
 pub use stream::{BadLogCode, MessageStream, Msgs2Stderr, StreamContext, message_stream};
 pub use thread_local::{
     DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events,

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -103,8 +103,8 @@ pub use sequence::{Sequence, Stamped};
 pub use stream::{BadLogCode, MessageStream, Msgs2Stderr, StreamContext, message_stream};
 pub use thread_local::{
     DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events,
-    drain_events_coded, drain_events_for_peer, emit_debug, emit_debug_coded, emit_info,
-    emit_info_coded, emit_warning, info_gte, init,
+    drain_events_coded, drain_events_for_peer, drain_stamped_events_for_client, emit_debug,
+    emit_debug_coded, emit_info, emit_info_coded, emit_warning, info_gte, init,
 };
 pub use verify_failure::{VerifyFailure, verification_failure};
 

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -104,7 +104,8 @@ pub use stream::{BadLogCode, MessageStream, Msgs2Stderr, StreamContext, message_
 pub use thread_local::{
     DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events,
     drain_events_coded, drain_events_for_peer, drain_stamped_events_for_client, emit_debug,
-    emit_debug_coded, emit_info, emit_info_coded, emit_warning, info_gte, init,
+    emit_debug_coded, emit_info, emit_info_coded, emit_warning, finfo_suppressed, info_gte, init,
+    set_quiet,
 };
 pub use verify_failure::{VerifyFailure, verification_failure};
 

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -81,6 +81,7 @@ mod levels;
 mod log_code;
 mod macros;
 mod phase_timer;
+mod sequence;
 mod stream;
 mod thread_local;
 mod verify_failure;
@@ -98,6 +99,7 @@ pub use error_format::{
 pub use levels::{DebugFlag, DebugLevels, InfoFlag, InfoLevels};
 pub use log_code::{LogCode, ParseLogCodeError};
 pub use phase_timer::PhaseTimer;
+pub use sequence::Sequence;
 pub use stream::{BadLogCode, MessageStream, Msgs2Stderr, StreamContext, message_stream};
 pub use thread_local::{
     DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events,

--- a/crates/logging/src/sequence.rs
+++ b/crates/logging/src/sequence.rs
@@ -1,0 +1,101 @@
+//! The production-order key shared by every diagnostic producer.
+//!
+//! Upstream never needs one: `rwrite()` writes immediately, so the order
+//! messages appear in *is* the order they were produced (upstream:
+//! log.c:269 `rwrite()`). oc buffers its messages in two places that are
+//! drained at different times, so it has to carry the ordering explicitly.
+//! This module is the single source of that key.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The process-wide counter behind [`Sequence::stamp`].
+///
+/// Deliberately a `static AtomicU64` and not a `thread_local!`. A message can
+/// be produced on a worker thread, and per-thread counters would hand out the
+/// same small integers on every thread, making keys from different threads
+/// incomparable - which is the one property this type exists to provide.
+static NEXT: AtomicU64 = AtomicU64::new(0);
+
+/// When a message was produced, relative to every other message.
+///
+/// Ordering by this key reproduces the order upstream gets for free by writing
+/// immediately. It carries no timestamp and no thread identity: it answers
+/// only "which came first", which is what the funnel needs.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Sequence(u64);
+
+impl Sequence {
+    /// Issues the next key.
+    ///
+    /// Every call returns a distinct value, and values are handed out in
+    /// increasing order across all threads.
+    ///
+    /// `Relaxed` is sufficient and is the deliberate choice: a single atomic's
+    /// modification order is agreed by all threads, so `fetch_add` alone
+    /// guarantees both uniqueness and a total order over the values. No
+    /// happens-before relation with the message payload is needed, because the
+    /// keys are only compared once the producers have finished and their
+    /// buffers are drained - that drain is already ordered by other means.
+    #[must_use]
+    pub fn stamp() -> Self {
+        Self(NEXT.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Returns the raw key.
+    ///
+    /// Intended for tests and for rendering; comparisons should use the
+    /// derived ordering rather than unwrapping first.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Sequence;
+    use std::collections::BTreeSet;
+    use std::thread;
+
+    #[test]
+    fn stamps_increase_within_a_thread() {
+        let first = Sequence::stamp();
+        let second = Sequence::stamp();
+        assert!(
+            first < second,
+            "a later stamp must sort after an earlier one: {first:?} vs {second:?}"
+        );
+    }
+
+    /// The property that a `thread_local!` counter would silently break: keys
+    /// issued on different threads must still be distinct and comparable.
+    #[test]
+    fn stamps_are_unique_across_threads() {
+        const THREADS: usize = 8;
+        const PER_THREAD: usize = 64;
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                thread::spawn(|| {
+                    (0..PER_THREAD)
+                        .map(|_| Sequence::stamp().get())
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        let issued: Vec<u64> = handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("stamping thread panicked"))
+            .collect();
+
+        let distinct: BTreeSet<u64> = issued.iter().copied().collect();
+        assert_eq!(
+            distinct.len(),
+            THREADS * PER_THREAD,
+            "every stamp must be distinct, got {} for {} calls",
+            distinct.len(),
+            THREADS * PER_THREAD
+        );
+    }
+}

--- a/crates/logging/src/sequence.rs
+++ b/crates/logging/src/sequence.rs
@@ -51,9 +51,59 @@ impl Sequence {
     }
 }
 
+/// A value carrying the point in the output stream where it was produced.
+///
+/// The key is kept *beside* the value rather than inside it: when it was
+/// produced is not part of what a message is, and threading it through every
+/// variant of every event enum would couple the producers to the funnel. This
+/// also keeps the existing drains able to hand out bare values to the many
+/// consumers that only care about the message.
+///
+/// Deliberately not `Ord`. Ordering would have to key on the sequence alone,
+/// which forces an `Eq` that ignores the value - true here, since sequences
+/// are unique, but surprising to read at a call site. Merging sorts explicitly
+/// on [`Stamped::sequence`] instead, where the intent is visible.
+#[derive(Clone, Copy, Debug)]
+pub struct Stamped<T> {
+    sequence: Sequence,
+    value: T,
+}
+
+impl<T> Stamped<T> {
+    /// Stamps `value` with the next key, recording it as produced now.
+    #[must_use]
+    pub fn stamp(value: T) -> Self {
+        Self {
+            sequence: Sequence::stamp(),
+            value,
+        }
+    }
+
+    /// Returns the production-order key.
+    #[must_use]
+    pub const fn sequence(&self) -> Sequence {
+        self.sequence
+    }
+
+    /// Borrows the stamped value.
+    #[must_use]
+    pub const fn value(&self) -> &T {
+        &self.value
+    }
+
+    /// Discards the key and returns the value.
+    ///
+    /// This is what the drains that predate the funnel project through, so
+    /// their consumers keep seeing bare events.
+    #[must_use]
+    pub fn into_value(self) -> T {
+        self.value
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::Sequence;
+    use super::{Sequence, Stamped};
     use std::collections::BTreeSet;
     use std::thread;
 
@@ -97,5 +147,27 @@ mod tests {
             distinct.len(),
             THREADS * PER_THREAD
         );
+    }
+
+    /// Sorting by the key must recover production order even when the values
+    /// were collected out of order - the property the funnel merge relies on.
+    #[test]
+    fn sorting_by_the_key_recovers_production_order() {
+        let first = Stamped::stamp("first");
+        let second = Stamped::stamp("second");
+        let third = Stamped::stamp("third");
+
+        let mut shuffled = vec![third, first, second];
+        shuffled.sort_by_key(Stamped::sequence);
+
+        let order: Vec<&str> = shuffled.into_iter().map(Stamped::into_value).collect();
+        assert_eq!(order, ["first", "second", "third"]);
+    }
+
+    #[test]
+    fn a_stamp_preserves_the_value_it_carries() {
+        let stamped = Stamped::stamp(42_u8);
+        assert_eq!(*stamped.value(), 42);
+        assert_eq!(stamped.into_value(), 42);
     }
 }

--- a/crates/logging/src/sequence.rs
+++ b/crates/logging/src/sequence.rs
@@ -79,6 +79,17 @@ impl<T> Stamped<T> {
         }
     }
 
+    /// Rebinds an existing key onto a value derived from the stamped one.
+    ///
+    /// A funnel consumer routes an event and keeps only its rendered text; the
+    /// key must be *carried* across that transform, never re-minted, or the
+    /// text would sort at the position of the routing rather than of the
+    /// production it describes.
+    #[must_use]
+    pub const fn with_sequence(sequence: Sequence, value: T) -> Self {
+        Self { sequence, value }
+    }
+
     /// Returns the production-order key.
     #[must_use]
     pub const fn sequence(&self) -> Sequence {

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -19,10 +19,15 @@ use super::config::VerbosityConfig;
 use super::levels::{DebugFlag, InfoFlag};
 use super::log_code::LogCode;
 use super::sequence::Stamped;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 thread_local! {
     static VERBOSITY: RefCell<VerbosityConfig> = RefCell::new(VerbosityConfig::default());
+    /// upstream: log.c:345 - `quiet` is its own global, consulted in the FINFO
+    /// arm of `rwrite()`. It is NOT the same state as the verbosity level, so
+    /// folding `--quiet` into `verbose = 0` cannot express it: a notice
+    /// upstream prints at DEFAULT verbosity still has to disappear under `-q`.
+    static QUIET: Cell<bool> = const { Cell::new(false) };
     /// Events are held stamped with their production order so a consumer that
     /// interleaves them with another output channel can recover that order.
     /// The buffer itself stays thread-local; only the ordering key is shared
@@ -81,6 +86,28 @@ pub fn init(config: VerbosityConfig) {
     VERBOSITY.with(|v| {
         *v.borrow_mut() = config;
     });
+}
+
+/// Record whether `-q` / `--quiet` was requested, for the current thread.
+///
+/// Upstream keeps `quiet` as a global of its own, separate from `verbose` and
+/// from `info_levels[]`, and consults it in exactly one place: the `FINFO` arm
+/// of `rwrite()` returns without writing (upstream: log.c:344-345). Anything
+/// that only folds `--quiet` into `verbose = 0` cannot express a notice
+/// upstream prints at default verbosity and suppresses only under `-q` - the
+/// two states become indistinguishable.
+pub fn set_quiet(quiet: bool) {
+    QUIET.with(|q| q.set(quiet));
+}
+
+/// Whether `FINFO` output is suppressed on this thread.
+///
+/// The single question a producer or renderer should ask before emitting an
+/// upstream `rprintf(FINFO, ...)` that carries no `INFO_GTE` gate of its own.
+// upstream: log.c:345 rwrite() `if (quiet)` - the FINFO arm's early return.
+#[must_use]
+pub fn finfo_suppressed() -> bool {
+    QUIET.with(Cell::get)
 }
 
 /// Check if the info flag is at or above the specified level.

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -207,13 +207,13 @@ pub fn drain_events() -> Vec<DiagnosticEvent> {
 /// its own codes without disturbing the others. Keeping one retain loop here
 /// means a new consumer supplies a policy, not another copy of the traversal.
 /// Returns matches in emission order.
-fn drain_events_where(accept: impl Fn(LogCode) -> bool) -> Vec<DiagnosticEvent> {
+fn drain_stamped_events_where(accept: impl Fn(LogCode) -> bool) -> Vec<Stamped<DiagnosticEvent>> {
     EVENTS.with(|e| {
         let mut events = e.borrow_mut();
         let mut matched = Vec::new();
         events.retain(|stamped| {
             if accept(stamped.value().code()) {
-                matched.push(stamped.value().clone());
+                matched.push(stamped.clone());
                 false
             } else {
                 true
@@ -221,6 +221,28 @@ fn drain_events_where(accept: impl Fn(LogCode) -> bool) -> Vec<DiagnosticEvent> 
         });
         matched
     })
+}
+
+/// A projection of [`drain_stamped_events_where`] for the consumers that render
+/// their share of the buffer on its own, where the key would be noise.
+fn drain_events_where(accept: impl Fn(LogCode) -> bool) -> Vec<DiagnosticEvent> {
+    drain_stamped_events_where(accept)
+        .into_iter()
+        .map(Stamped::into_value)
+        .collect()
+}
+
+/// Drain the events bound for the client stream, leaving `FLOG` queued.
+///
+/// This is the client renderer's drain, and it carries the production key
+/// because that renderer has something to interleave against: the buffered
+/// per-file event stream, which it emits post-hoc. `FLOG` is left behind
+/// because upstream's `rwrite()` writes a log message and returns before the
+/// client-stream dispatch (upstream: log.c:290-307) - the log-file sink takes
+/// those through [`drain_events_coded`], and draining them here would consume
+/// them before that sink ever runs.
+pub fn drain_stamped_events_for_client() -> Vec<Stamped<DiagnosticEvent>> {
+    drain_stamped_events_where(|code| code != LogCode::Log)
 }
 
 /// Drain only the events carrying `code`, leaving all other events queued.

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -18,12 +18,17 @@
 use super::config::VerbosityConfig;
 use super::levels::{DebugFlag, InfoFlag};
 use super::log_code::LogCode;
+use super::sequence::Stamped;
 use std::cell::RefCell;
 
 thread_local! {
     static VERBOSITY: RefCell<VerbosityConfig> = RefCell::new(VerbosityConfig::default());
+    /// Events are held stamped with their production order so a consumer that
+    /// interleaves them with another output channel can recover that order.
+    /// The buffer itself stays thread-local; only the ordering key is shared
+    /// process-wide, which is what makes keys from two threads comparable.
     #[allow(clippy::missing_const_for_thread_local)]
-    static EVENTS: RefCell<Vec<DiagnosticEvent>> = RefCell::new(Vec::new());
+    static EVENTS: RefCell<Vec<Stamped<DiagnosticEvent>>> = RefCell::new(Vec::new());
 }
 
 /// A diagnostic event collected during execution.
@@ -113,12 +118,12 @@ pub fn emit_info(flag: InfoFlag, level: u8, message: String) {
 /// code to pick the client stream versus the log file).
 pub fn emit_info_coded(flag: InfoFlag, level: u8, code: LogCode, message: String) {
     EVENTS.with(|e| {
-        e.borrow_mut().push(DiagnosticEvent::Info {
+        e.borrow_mut().push(Stamped::stamp(DiagnosticEvent::Info {
             flag,
             level,
             code,
             message,
-        });
+        }));
     });
 }
 
@@ -161,21 +166,38 @@ pub fn emit_debug(flag: DebugFlag, level: u8, message: String) {
 /// code to pick the client stream versus the log file).
 pub fn emit_debug_coded(flag: DebugFlag, level: u8, code: LogCode, message: String) {
     EVENTS.with(|e| {
-        e.borrow_mut().push(DiagnosticEvent::Debug {
+        e.borrow_mut().push(Stamped::stamp(DiagnosticEvent::Debug {
             flag,
             level,
             code,
             message,
-        });
+        }));
     });
+}
+
+/// Drain all collected events with their production order, clearing the buffer.
+///
+/// This is the drain for a consumer that has to interleave these events with
+/// another output channel: the key says which of two messages was produced
+/// first, which the buffers alone cannot say once they are drained at
+/// different times.
+pub fn drain_stamped_events() -> Vec<Stamped<DiagnosticEvent>> {
+    EVENTS.with(|e| e.borrow_mut().drain(..).collect())
 }
 
 /// Drain all collected events, clearing the internal buffer.
 ///
 /// Returns events in emission order. After draining, the buffer is empty
 /// and ready to accumulate new events.
+///
+/// A projection of [`drain_stamped_events`] for the consumers that render this
+/// buffer on its own: with nothing to interleave against, the vector's own
+/// order already is the production order, and the key would be noise.
 pub fn drain_events() -> Vec<DiagnosticEvent> {
-    EVENTS.with(|e| e.borrow_mut().drain(..).collect())
+    drain_stamped_events()
+        .into_iter()
+        .map(Stamped::into_value)
+        .collect()
 }
 
 /// Drain the events whose code `accept` selects, leaving the rest queued.
@@ -189,9 +211,9 @@ fn drain_events_where(accept: impl Fn(LogCode) -> bool) -> Vec<DiagnosticEvent> 
     EVENTS.with(|e| {
         let mut events = e.borrow_mut();
         let mut matched = Vec::new();
-        events.retain(|event| {
-            if accept(event.code()) {
-                matched.push(event.clone());
+        events.retain(|stamped| {
+            if accept(stamped.value().code()) {
+                matched.push(stamped.value().clone());
                 false
             } else {
                 true

--- a/docs/design/logcode-funnel.md
+++ b/docs/design/logcode-funnel.md
@@ -1,0 +1,112 @@
+# One logcode-to-stream funnel
+
+Status: design, partially implemented (the routing half already ships).
+
+## The defect
+
+oc has **two output channels that are drained at different times**, so the
+relative order of two messages depends on which channel each happened to use,
+not on which was produced first.
+
+| channel | produced by | buffered in | drained at |
+|---|---|---|---|
+| client events | `core`/`engine` transfer records | the client summary collection | `emit_transfer_summary`, inside `execute()` |
+| diagnostic events | `info_log!` / `warn_log!` / `debug_log!` | `logging::thread_local::EVENTS` | `flush_diagnostics`, **after** `execute()` returns |
+
+Because `flush_diagnostics` runs once after `execute()`, every deferred
+diagnostic lands after every client event, by construction - regardless of
+production order.
+
+### It already forced one workaround
+
+`crates/engine/src/local_copy/executor/sources/orchestration.rs` documents a
+notice that had to be moved out of the deferred channel to get it into the
+right place:
+
+> the generator prints the delta-transmission status once at
+> `DEBUG_GTE(FLIST, 1)` ... before the per-file generate loop. A local copy
+> renders its name list post-hoc in the CLI, so that notice is emitted there
+> (in `emit_transfer_summary`) to keep it ahead of the list rather than
+> dead-last through the deferred diagnostic flush.
+
+That is the cost this design removes: without a funnel, **every** notice whose
+position matters needs its own hand-placed emission at the render site, and
+each one is a separate opportunity to get the gate or the wording wrong.
+
+## Upstream's model
+
+Upstream has exactly one chooser. `rwrite()` is called in production order and
+writes immediately, so ordering is not a concern it has to solve.
+
+| step | upstream | anchor |
+|---|---|---|
+| default sink | `f = msgs2stderr == 1 ? stderr : stdout` | `log.c:272` |
+| daemon redirection | `am_daemon > 0 && code != FCLIENT` becomes `FLOG` | `log.c:290-291` |
+| sibling forwarding | `send_msgs_to_gen` forwards and returns | `log.c:292-301` |
+| code normalisation | `FERROR_SOCKET`/`FERROR_UTF8` become `FERROR`; `FCLIENT` becomes `FINFO` | `log.c:303-311` |
+| log destination | `am_daemon \|\| logfile_name` writes the log copy, returns for `FLOG` | `log.c:312-334` |
+| stream switch | `FERROR_XFER`/`FERROR`/`FWARNING` to stderr; `FINFO` to stdout, suppressed under `quiet` | `log.c:336-355` |
+| server forwarding | `am_server` sends the message to the client, with a proto<30 downgrade | `log.c:357-373` |
+
+The normalisation happening **before** the switch is load-bearing: those three
+codes never reach the switch under their own name.
+
+## What oc already has
+
+The routing half is built and live. Do not rebuild it.
+
+- `crates/logging/src/log_code.rs` - `LogCode` mirrors upstream's `enum logcode`
+  one variant per `F*` identifier, each documenting its routing rule.
+- `crates/logging/src/stream.rs` - `message_stream(code, ctx)` implements the
+  switch, in upstream's order, including the pre-switch normalisation. Returns
+  `BadLogCode` rather than silently picking a stream.
+- `StreamContext` carries the non-code inputs (`quiet`, `msgs2stderr`,
+  `log_destination`); `Msgs2Stderr` is a tri-state because upstream's gate
+  distinguishes all three values.
+- Live consumers: `crates/cli/src/frontend/progress/diagnostic.rs` at two sites.
+
+So the missing piece is **ordering**, not routing.
+
+## Design
+
+Both channels are already buffered (verified: `render.rs` takes a collection
+and a writer; it does not stream during the transfer). Uniform deferral plus a
+single ordering key therefore reproduces upstream's order exactly, without
+needing a process-wide write-through sink.
+
+1. **One sequence source.** A monotonic counter in `logging`, stamped at
+   production time. `core` already depends on `logging`, so both producers can
+   reach it. It must be process-wide (an `AtomicU64`), not thread-local - the
+   emitter can run on a worker thread.
+2. **Stamp both event kinds** with that sequence as they are produced.
+3. **Merge at render.** Emit the two buffers as one sequence-ordered stream,
+   routing each entry through the existing `message_stream(code, ctx)`.
+4. **Remove the workaround.** The relocated delta-transmission notice returns to
+   its production site once ordering is intrinsic.
+
+### Why not write-through
+
+Mirroring `rwrite()` literally - resolve and write at the emit site - would
+need a sink reachable from deep inside `engine`/`transfer`, where no writer is
+threaded. It would also collide with the server path, which must frame
+diagnostics to the peer instead of writing them locally
+(`drain_events_for_peer`). Deferring uniformly preserves the observable order
+that upstream gets from writing immediately, which is the property under test.
+
+## Known adjacent defect
+
+`logging::set_quiet` and the `QUIET` cell are thread-local while the emitter may
+run on a worker thread, so the suppression can be consulted on a thread that
+never had it set. The sequence counter must not repeat that mistake. Fixing
+`QUIET` is in scope for the step that introduces the shared counter.
+
+## Gates
+
+- The relative order of a diagnostic and a client event must follow production
+  order, proven by a test that fails when the sequence is dropped.
+- No change to which stream a message lands on: `message_stream` is unchanged,
+  and its existing tests stay green.
+- Server-side framing (`drain_events_for_peer`) must keep working - the funnel
+  changes ordering, not destination.
+- Both 3.5.0 pipe legs stay at their current pass/fail counts, with any row that
+  flips recorded in the same commit.

--- a/docs/design/logcode-funnel.md
+++ b/docs/design/logcode-funnel.md
@@ -84,6 +84,42 @@ needing a process-wide write-through sink.
 4. **Remove the workaround.** The relocated delta-transmission notice returns to
    its production site once ordering is intrinsic.
 
+### The merge seam
+
+Two properties of the render path were measured before choosing where step 3
+attaches; both rule out the obvious placements.
+
+**`emit_transfer_summary` has no stderr.** Its signature ends
+`writer: &mut dyn Write` (`render.rs:124`) - one stream. So it cannot route
+diagnostics itself: `message_stream` returns `Stderr` for the error and warning
+codes, and there is nowhere to put them. The stream split therefore has to
+happen in the caller, which holds both `out` and `err`; only the stdout-bound
+diagnostics travel into the summary renderer.
+
+That is not a compromise, it is upstream's own rule: `rwrite()` picks a stream
+per log code, so relative order is only observable *within* a stream. Ordering
+stdout-bound diagnostics against the stdout listing is the whole requirement.
+
+**The per-event emitters are generic over the writer, not over a sink.**
+`emit_list_only` (:370), `emit_progress` (:462) and `emit_verbose` (:954) are
+each `<W: Write + ?Sized>`. A plain `Write` cannot express "a new event is about
+to be rendered, with this key", which is exactly the hook the merge needs - so
+decorating the writer is not enough.
+
+The seam is therefore a collaborator passed alongside the writer, not a wrapper
+around it. A `Write` subtrait would need a blanket impl for plain writers to
+keep existing callers compiling, and that blanket impl would also cover the
+merging type - the two impls overlap and coherence rejects them. Passing the
+pending diagnostics as their own parameter sidesteps that entirely: the three
+emitters gain one argument and one call at the top of their per-entry loop, and
+callers with nothing to interleave pass the empty value.
+
+Client events carry `Option<Sequence>`: `None` on a remote transfer, which builds
+its events from the wire and never populates the diagnostic buffer from the same
+production run. `begin_event(None)` must therefore flush nothing rather than
+flush everything - an unkeyed event has no position to order against, and
+draining on it would hoist unrelated diagnostics to an arbitrary point.
+
 ### Why not write-through
 
 Mirroring `rwrite()` literally - resolve and write at the emit site - would

--- a/docs/design/logcode-funnel.md
+++ b/docs/design/logcode-funnel.md
@@ -95,10 +95,15 @@ that upstream gets from writing immediately, which is the property under test.
 
 ## Known adjacent defect
 
-`logging::set_quiet` and the `QUIET` cell are thread-local while the emitter may
-run on a worker thread, so the suppression can be consulted on a thread that
-never had it set. The sequence counter must not repeat that mistake. Fixing
-`QUIET` is in scope for the step that introduces the shared counter.
+`logging::set_quiet`, the `QUIET` cell and `finfo_suppressed` are **not on
+master** - they are added by the `skipping directory` branch. There, they are
+thread-local while the emitter may run on a worker thread, so the suppression
+can be consulted on a thread that never had it set.
+
+The sequence counter must not repeat that mistake, which is why it is an
+`AtomicU64` rather than a thread-local. Fixing `QUIET` itself belongs to the
+step that rebases that branch onto the funnel, not to the step that introduces
+the counter - on master there is nothing to fix yet.
 
 ## Gates
 


### PR DESCRIPTION
Supersedes #7386. Same defect, plus the ordering machinery it turned out to
need. Opened as one branch because each half alone regresses master.

## The defect

Upstream gates `skipping directory %s` on `S_ISDIR(st.st_mode) && !xfer_dirs`
and nothing else - no `INFO_GTE`, no verbosity test at either call site
(flist.c:1338 in `make_file`, flist.c:2452 in `send_file_list`). It therefore
prints at DEFAULT verbosity, and only `quiet` suppresses it, inside `rwrite()`
(log.c:345).

oc emitted it from the verbose renderer. That renderer runs over a collected
event log, and collection is gated on `verbosity > 0 || progress || list_only`,
so at the default every disjunct is false and the notice was unreachable - the
exact inverse of upstream.

## Why #7386 alone was not enough

Moving the emission to the decision site fixes the gating and breaks the
ordering. Measured on that branch:

```
sub/
sub/f.txt

sent 3 bytes  received 0 bytes  6.00 bytes/sec
total size is 3  speedup is 1.00
skipping directory .          <- last, not first
```

`info_log!` enqueues into the thread-local diagnostic queue, which
`flush_diagnostics` drains at `cli/src/frontend/mod.rs:368` - after `execute()`
returns, so after the renderer has written its rows and the summary. Upstream
has no queue: `rprintf(FINFO, ...)` inside `make_file()` writes synchronously
during the flist scan, before any name row. That is why
`relative_dot_root_skipped_directory.rs` - which passes on master - went red on
13 platforms.

Draining the queue before the renderer would fix this one line and mis-order
every other queued event (the `--info=backup` notice rides the same channel and
upstream interleaves it per file). The ordering has to come from production
order, not from moving one flush.

## What this branch adds

The deferred-diagnostic funnel: a process-wide monotonic `Sequence` stamped on
each diagnostic at production time and carried on local-copy records, plus
`PendingDiagnostics` in `cli/frontend/progress/interleave.rs`, which merges the
two streams at render time by that key. The notice is produced during the flist
scan, so it sorts ahead of every row without special-casing it.

`--quiet` is carried past the parser as its own state (`logging::set_quiet` /
`finfo_suppressed`), because folding it into `verbose = 0` cannot express a
notice upstream prints at the default. The rule lives in the existing
`stream_context()` helper rather than a second inlined `StreamContext`, so
there is one implementation of the stream decision.

## Verification

Measured against the real rsync 3.5.0 binary, same layout, from inside `src/`:

| cell | upstream 3.5.0 | oc (this branch) |
|---|---|---|
| `-Rv ./sub/f.txt` | `skipping directory .` / `sub/` / `sub/f.txt` | identical |
| `-R ./sub/f.txt` | `skipping directory .` | identical |
| `-Rq ./sub/f.txt` | (silent, exit 0) | identical |

3/3. On master the second cell is silent; on #7386 the first is misordered.

`cargo fmt --all -- --check` clean on Linux; clippy clean across logging, cli,
engine and core; `-p logging -p cli` 4175/4175.
