### PR TITLE
fix(protocol): write the pending token run before flushing zlib literals

### DIFF
--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -237,6 +237,109 @@ fn encode_decode_with_see_token_roundtrip() {
     assert!(combined.starts_with(literal_data));
 }
 
+/// Deterministic incompressible bytes. A run of identical bytes deflates to
+/// almost nothing, so the compressible fixtures the other tests use never grow
+/// the insert's deflate output past a buffer boundary.
+fn incompressible(len: usize) -> Vec<u8> {
+    let mut state = 0x2545_F491_4F6C_DD1Du64;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 33) as u8
+        })
+        .collect()
+}
+
+/// Drives one literal / block-match / literal exchange with a matched block of
+/// `insert_len` bytes, mirroring what the sender and receiver do on the wire,
+/// and returns the decoded literal stream.
+///
+/// The second literal is the discriminator: a desynced dictionary only shows up
+/// once the peer inflates data that follows the insert.
+fn roundtrip_across_insert(
+    insert_len: usize,
+    head_len: usize,
+    tail_len: usize,
+) -> io::Result<Vec<u8>> {
+    let block_data = incompressible(insert_len);
+    let head = incompressible(head_len);
+    let tail = incompressible(tail_len);
+
+    let mut encoded = Vec::new();
+    let mut encoder = CompressedTokenEncoder::new(CompressionLevel::Default, 31);
+    encoder.send_literal(&mut encoded, &head)?;
+    encoder.send_block_match(&mut encoded, 0)?;
+    encoder.see_token(&block_data)?;
+    encoder.send_literal(&mut encoded, &tail)?;
+    encoder.finish(&mut encoded)?;
+
+    let mut cursor = Cursor::new(&encoded);
+    let mut decoder = CompressedTokenDecoder::new();
+    let mut literals = Vec::new();
+    loop {
+        match decoder.recv_token(&mut cursor)? {
+            CompressedToken::Literal(data) => literals.extend_from_slice(&data),
+            CompressedToken::BlockMatch(_) => decoder.see_token(&block_data)?,
+            CompressedToken::End => break,
+        }
+    }
+
+    let mut expected = head;
+    expected.extend_from_slice(&tail);
+    assert_eq!(
+        literals, expected,
+        "insert_len={insert_len} head_len={head_len} tail_len={tail_len}"
+    );
+    Ok(literals)
+}
+
+#[test]
+fn literal_only_roundtrips_at_every_buffer_boundary() {
+    // Control for the matrix below: no block match, no dictionary insert, so
+    // any failure here is the plain literal path rather than see_token.
+    for literal_len in [8 * 1024, CHUNK_SIZE + 1, 40_000, 0x1_0000 + 1000] {
+        let data = incompressible(literal_len);
+        let mut encoded = Vec::new();
+        let mut encoder = CompressedTokenEncoder::new(CompressionLevel::Default, 31);
+        encoder.send_literal(&mut encoded, &data).unwrap();
+        encoder.finish(&mut encoded).unwrap();
+
+        let mut cursor = Cursor::new(&encoded);
+        let mut decoder = CompressedTokenDecoder::new();
+        let mut literals = Vec::new();
+        loop {
+            match decoder.recv_token(&mut cursor).unwrap() {
+                CompressedToken::Literal(d) => literals.extend_from_slice(&d),
+                CompressedToken::BlockMatch(_) => unreachable!("no matches sent"),
+                CompressedToken::End => break,
+            }
+        }
+        assert_eq!(literals, data, "literal_len={literal_len}");
+    }
+}
+
+#[test]
+fn matched_block_roundtrips_at_every_buffer_boundary() {
+    // Both the insert and the literal cross codec buffer boundaries as
+    // --block-size grows: CHUNK_SIZE is the decoder's inflate output buffer
+    // and the encoder's literal chunk unit, 2*CHUNK_SIZE the encoder's deflate
+    // output buffer. The small/small cell is the non-vacuity companion - it
+    // proves the harness transfers at all, so a failure in any other cell is
+    // about the size and not the fixture.
+    const SMALL: usize = 8 * 1024;
+    for insert_len in [SMALL, CHUNK_SIZE + 1, 40_000, 0xFFFF, 0x1_0000 + 1000] {
+        for literal_len in [SMALL, CHUNK_SIZE, CHUNK_SIZE + 1, 40_000, 0x1_0000 + 1000] {
+            // Vary head and tail independently: only a literal *after* the
+            // match reopens a token run, so a symmetric fixture would leave the
+            // discriminating case (large tail) tangled with the inert one.
+            roundtrip_across_insert(insert_len, literal_len, SMALL).unwrap();
+            roundtrip_across_insert(insert_len, SMALL, literal_len).unwrap();
+        }
+    }
+}
+
 #[test]
 fn encoder_protocol_version_31_advances_offset() {
     // Protocol >= 31 advances the offset between 0xFFFF chunks in see_token,

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -78,7 +78,27 @@ impl ZlibTokenEncoder {
     pub(super) fn send_literal<W: Write>(&mut self, writer: &mut W, data: &[u8]) -> io::Result<()> {
         self.literal_buf.extend_from_slice(data);
         while self.literal_buf.len() >= CHUNK_SIZE {
+            // The chunk flush below writes DEFLATED_DATA to the wire, so any
+            // pending token run has to be closed first: the receiver ends an
+            // inflate run at the first non-DEFLATED_DATA flag and injects the
+            // Z_SYNC_FLUSH trailer there, so a token byte arriving after these
+            // blocks would split one deflate stream in two.
+            self.flush_pending_token_run(writer)?;
             self.compress_chunk_no_flush(writer)?;
+        }
+        Ok(())
+    }
+
+    /// Emits the pending token run, if any, and records that the literal data
+    /// which follows opens a fresh run.
+    ///
+    /// upstream: token.c:414 `last_token = token` with the caller's `-2`
+    /// flush sentinel - emitting literal data leaves `last_token` at -2, the
+    /// state `send_block_match` already tests for at token.c:394.
+    fn flush_pending_token_run<W: Write>(&mut self, writer: &mut W) -> io::Result<()> {
+        if self.last_token >= 0 {
+            self.write_token_run(writer)?;
+            self.last_token = -2;
         }
         Ok(())
     }
@@ -105,9 +125,7 @@ impl ZlibTokenEncoder {
     }
 
     pub(super) fn finish<W: Write>(&mut self, writer: &mut W) -> io::Result<()> {
-        if self.last_token >= 0 {
-            self.write_token_run(writer)?;
-        }
+        self.flush_pending_token_run(writer)?;
         self.flush_all_literals(writer)?;
         writer.write_all(&[END_FLAG])?;
         self.reset();

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -15,7 +15,7 @@ chroot-copy-dest-inner-module skip
 chroot-link-dest-inner-module skip
 chroot-receiver-write-inner-module skip
 chroot-special-inner-module skip
-compress-zlib-insert fail
+compress-zlib-insert pass
 connect-prog-host-quoting pass
 connect-prog-nested-singlequote-host-injection pass
 copy-dest-source-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -50,7 +50,7 @@ clean-fname-collapse pass
 clean-fname-underflow pass
 compare pass
 compress-options pass
-compress-zlib-insert fail
+compress-zlib-insert pass
 connect-prog-host-quoting pass
 connect-prog-nested-singlequote-host-injection pass
 copy-dest-source-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -15,7 +15,7 @@ chroot-copy-dest-inner-module pass
 chroot-link-dest-inner-module pass
 chroot-receiver-write-inner-module pass
 chroot-special-inner-module pass
-compress-zlib-insert fail
+compress-zlib-insert pass
 connect-prog-host-quoting pass
 connect-prog-nested-singlequote-host-injection pass
 copy-dest-source-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -50,7 +50,7 @@ clean-fname-collapse pass
 clean-fname-underflow pass
 compare pass
 compress-options pass
-compress-zlib-insert fail
+compress-zlib-insert pass
 connect-prog-host-quoting pass
 connect-prog-nested-singlequote-host-injection pass
 copy-dest-source-symlink pass


### PR DESCRIPTION
Closes the `compress-zlib-insert` divergence in the upstream 3.5.0 testsuite.

## Root cause

`ZlibTokenEncoder::send_literal` flushes `literal_buf` as soon as it reaches
`CHUNK_SIZE`, and that flush writes `DEFLATED_DATA` blocks straight to the
wire. The pending token run, however, was only written from `send_block_match`
or `finish`. So a literal larger than `CHUNK_SIZE` following a block match
produced:

```
[DEFLATED_DATA of the literal] [TOKEN_RUN] [rest of the literal]
```

The receiver ends a consecutive `DEFLATED_DATA` run at the first non-data flag
and restores the `Z_SYNC_FLUSH` trailer there (`step.rs:345`, mirroring
`token.c:recv_deflated_token`). That token byte therefore split one deflate
stream in two and the peer aborted - as `invalid stored block lengths`,
`invalid block type`, or an unconsumed sync trailer, depending on where the
split landed.

Upstream writes the open run *before* the literal data it precedes
(`token.c:762-779`), leaving `last_token` at the `-2` flush sentinel
(`token.c:414`) that `send_block_match` already tests for (`token.c:394`).
The **zstd** encoder in this tree already mirrors that, with the citation.
The zlib one did not, and its `-2` arm was consequently unreachable.

## The trigger is the literal, not the insert

Measured matrix (insert length x literal length, on master):

| insert | literal <= 32768 | literal > 32768 |
|---|---|---|
| 8 KiB .. 66 KiB | pass | **fail** |

Matched-block length is irrelevant; head-side literals are irrelevant. Only a
literal *after* the match reopens a run. That is why default block sizes never
exposed it and `compress-zlib-insert` (block size 65535, so ~65 KB literal
runs) did.

## Verification

- `compress-zlib-insert` PASSES on both transports (pipe and `--use-tcp`)
  against a freshly built binary; upstream 3.5.0 passes it too (control).
- All four expect-manifests flipped `fail` -> `pass` in the same commit.
- Full nonroot pipe leg: **221 passed / 38 failed / 86 skipped = 345**, one
  more pass and one fewer fail than the recorded baseline, with no
  expected-result mismatch on this row. (The single reported mismatch,
  `simd-checksum: expected pass, got skip`, is this aarch64 host lacking the
  SIMD test binary; it is unrelated and does not occur on x86_64 CI.)
- `protocol` crate: 6073/6073.
- RED proven by removing only the new call from `send_literal`: the matrix
  test fails with `invalid stored block lengths` while the literal-only
  companion stays green.

## Note on the sibling codecs

`zstd` already had this fix. **`lz4` has the same shape** (`send_literal`
flushes at `MAX_DATA_COUNT` without closing the run) but its decoder decodes
each block independently, so it cannot corrupt its own stream; whether the
resulting flag order still diverges from upstream on the wire is filed
separately rather than widened into this change.
