### PR TITLE
fix(engine): match upstream's hardlink notices on both alt-dest paths

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -445,23 +445,21 @@ pub(super) fn process_links(
             }
         }
 
-        // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1) when an
-        // already-copied inode is hard-linked into place.
-        info_log!(
-            Name,
-            1,
-            "{} => {}",
-            record_path.display(),
-            existing_target.display()
-        );
-        // upstream: hlink.c:223 - "%s is uptodate" at INFO_GTE(NAME, 2) when
-        // the destination's content is already in sync with the source group
-        // leader's inode. Upstream emits both the `=> realname` arrow (NAME>=1)
-        // and the `is uptodate` notice (NAME>=2) for the same alias when the
-        // generator pipes the row through `maybe_hard_link()` against a matched
-        // basis. Mirror that pairing here so `-vv` reports the leader-uptodate
-        // status alongside the freshly-linked alias.
-        info_log!(Name, 2, "{} is uptodate", record_path.display());
+        // The alias notice is NOT emitted here. upstream hard_link_one()
+        // (hlink.c:229-253) picks exactly one of two notices and the choice is
+        // enforced by an early return: a destination that already shares the
+        // leader's dev+ino prints `"%s is uptodate"` at INFO_GTE(NAME, 2) and
+        // returns (hlink.c:238-241), so it never reaches the
+        // `"%s => %s"` arrow that the freshly-linked branch prints at
+        // INFO_GTE(NAME, 1) (hlink.c:251). The two are mutually exclusive for
+        // one alias, and the arrow names the leader by its RELATIVE `realname`,
+        // not an absolute path.
+        //
+        // The client renderer owns both notices and already mirrors that
+        // structure - `is uptodate` for an up-to-date alias and `=> <leader>`
+        // for a freshly-linked one, keyed on the same distinction. Emitting
+        // from here as well produced a second, absolute-path copy of a line the
+        // renderer had already written correctly.
 
         // upstream: hlink.c:474-521 finish_hard_link() - every alias in a cohort
         // is linked against the group's data-holder (`our_name` stays fixed for

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -188,15 +188,14 @@ pub(super) fn process_links(
             }
         }
 
-        // upstream: hlink.c:236 - rprintf(code, "%s => %s\n", fname, realname)
-        // emitted at INFO_GTE(NAME, 1) when a hard link is created via --link-dest.
-        info_log!(
-            Name,
-            1,
-            "{} => {}",
-            record_path.display(),
-            link_target.display()
-        );
+        // No notice is emitted for a link made from an alt-dest basis.
+        // `hlink.c:236` belongs to maybe_hard_link(), the -H COHORT path, which
+        // names the in-transfer group leader by its relative realname.
+        // --link-dest goes through a DIFFERENT upstream function -
+        // hard_link_one(file, fname, oldname, terse) at hlink.c:475-492 - which
+        // prints nothing on success and only rsyserr()s on failure. Its caller
+        // try_dests_reg() (generator.c) then itemizes with an EMPTY xname, so
+        // the itemize row is the only output upstream produces here.
 
         // upstream: hlink.c:215-224 / generator.c:1020-1025 - a `--link-dest`
         // cluster member is linked from the basis, so it ends up sharing the

--- a/tests/integration_links.rs
+++ b/tests/integration_links.rs
@@ -174,6 +174,73 @@ fn hard_links_preserved_with_hard_links_flag() {
     );
 }
 
+/// A freshly-linked hardlink alias must be announced EXACTLY ONCE, by the
+/// relative leader name.
+///
+/// upstream hard_link_one() (hlink.c:229-253) chooses one of two notices and
+/// enforces the choice with an early return: a destination that already shares
+/// the leader's dev+ino prints `"%s is uptodate"` at INFO_GTE(NAME, 2) and
+/// returns, so it never reaches the `"%s => %s"` arrow the freshly-linked
+/// branch prints at INFO_GTE(NAME, 1). One alias therefore yields one line, and
+/// the arrow names the leader by its RELATIVE `realname`.
+///
+/// This COUNTS rather than asserting containment: the defect this pins was a
+/// second, absolute-path copy of the arrow plus a spurious `is uptodate`, and a
+/// `contains` assertion is satisfied by one occurrence and by three alike.
+#[test]
+#[cfg(unix)]
+fn freshly_linked_alias_is_announced_exactly_once() {
+    let test_dir = TestDir::new().expect("create test dir");
+    let src_dir = test_dir.mkdir("src").unwrap();
+    let prior_dir = test_dir.mkdir("prior").unwrap();
+    let dest_dir = test_dir.mkdir("dest").unwrap();
+
+    fs::write(src_dir.join("a-leader.txt"), b"shared content").unwrap();
+    fs::hard_link(src_dir.join("a-leader.txt"), src_dir.join("z-alias.txt")).unwrap();
+
+    // Populate the --copy-dest basis so the alias is linked rather than sent.
+    let mut seed = RsyncCommand::new();
+    seed.args([
+        "-a",
+        "--hard-links",
+        &format!("{}/", src_dir.display()),
+        &format!("{}/", prior_dir.display()),
+    ]);
+    seed.assert_success();
+
+    let mut cmd = RsyncCommand::new();
+    cmd.args([
+        "-vv",
+        "-plrtH",
+        &format!("--copy-dest={}", prior_dir.display()),
+        &format!("{}/", src_dir.display()),
+        &format!("{}/", dest_dir.display()),
+    ]);
+    let output = cmd.assert_success();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let arrows = stdout
+        .lines()
+        .filter(|line| line.starts_with("z-alias.txt => "))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        arrows.len(),
+        1,
+        "the alias must be announced once, got {arrows:?}\n--- full output ---\n{stdout}"
+    );
+    assert_eq!(
+        arrows[0], "z-alias.txt => a-leader.txt",
+        "upstream names the leader by its relative realname (hlink.c:251)\n\
+         --- full output ---\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("z-alias.txt is uptodate"),
+        "a freshly-linked alias takes the arrow branch, which upstream reaches \
+         only after the `is uptodate` branch has returned (hlink.c:238-241)\n\
+         --- full output ---\n{stdout}"
+    );
+}
+
 #[test]
 #[cfg(unix)]
 fn hard_links_copied_separately_without_flag() {

--- a/tests/integration_links.rs
+++ b/tests/integration_links.rs
@@ -859,3 +859,65 @@ fn hardlinks_modify_through_any_link() {
         b"modified content"
     );
 }
+
+/// A `--link-dest` basis link is announced by its itemize row only - never by an
+/// `"%s => %s"` arrow.
+///
+/// The alt-dest path does NOT go through maybe_hard_link(). try_dests_reg()
+/// calls hard_link_one(file, fname, cmpbuf, 1) (hlink.c:475-492), which prints
+/// nothing on success and only rsyserr()s the `"link %s => %s failed"` message
+/// on failure; the caller then itemizes with an EMPTY xname. Sharing
+/// `hlink.c:236` between the two is what produced a spurious arrow here naming
+/// the basis by ABSOLUTE path - a form upstream never emits at any verbosity.
+///
+/// The `is uptodate` assertion is the non-vacuity anchor: without it, "no
+/// arrows" would also hold for a fixture that linked nothing at all.
+#[test]
+#[cfg(unix)]
+fn link_dest_basis_link_is_not_announced_with_an_arrow() {
+    let test_dir = TestDir::new().expect("create test dir");
+    let src_dir = test_dir.mkdir("src").unwrap();
+    let basis_dir = test_dir.mkdir("basis").unwrap();
+    let dest_dir = test_dir.mkdir("dest").unwrap();
+
+    fs::write(src_dir.join("a-leader.txt"), b"shared content").unwrap();
+    fs::hard_link(src_dir.join("a-leader.txt"), src_dir.join("z-alias.txt")).unwrap();
+
+    let mut seed = RsyncCommand::new();
+    seed.args([
+        "-a",
+        "--hard-links",
+        &format!("{}/", src_dir.display()),
+        &format!("{}/", basis_dir.display()),
+    ]);
+    seed.assert_success();
+
+    let mut cmd = RsyncCommand::new();
+    cmd.args([
+        "-vv",
+        "-plrtH",
+        &format!("--link-dest={}", basis_dir.display()),
+        &format!("{}/", src_dir.display()),
+        &format!("{}/", dest_dir.display()),
+    ]);
+    let output = cmd.assert_success();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let arrows = stdout
+        .lines()
+        .filter(|line| line.contains(" => "))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        arrows.len(),
+        0,
+        "hard_link_one() prints nothing on success (hlink.c:475-492)\n\
+         --- full output ---\n{stdout}"
+    );
+    for name in ["a-leader.txt", "z-alias.txt"] {
+        assert!(
+            stdout.contains(&format!("{name} is uptodate")),
+            "fixture must actually link {name} from the basis, else the \
+             arrow count above is vacuous\n--- full output ---\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
oc emitted hardlink notices upstream does not write, on **two different alt-dest paths**. Upstream splits these across two functions with different contracts, and oc had collapsed both onto one citation (`hlink.c:236`).

### 1. `--copy-dest`: the alias was announced twice

`maybe_hard_link()` (hlink.c:229-253) picks one of two notices and enforces the choice with an early return:

- already shares the leader's dev+ino → `"%s is uptodate"` at `INFO_GTE(NAME, 2)`, then `return 0` (hlink.c:238-241)
- freshly linked via `atomic_create` → `itemize(..., realname)` then `"%s => %s"` at `INFO_GTE(NAME, 1)` (hlink.c:251), naming the leader by its **relative** `realname`

oc printed both, plus a second arrow using an absolute path. The comment justifying the pair asserted the inverse of the upstream rule, which is why it survived review.

### 2. `--link-dest`: an arrow upstream never writes at all

The alt-dest path does **not** go through `maybe_hard_link()`. `try_dests_reg()` calls `hard_link_one(file, fname, cmpbuf, 1)` (hlink.c:475-492), which prints nothing on success and only `rsyserr()`s `"link %s => %s failed"` on failure. The caller then itemizes with an **empty** xname, so the itemize row is the only output.

`hlink.c:236` is the wrong function for this path, and oc emitted an arrow naming the basis by absolute path.

### Measured

Against real rsync 3.5.0, `-vvplrtH --link-dest=DIR src/ dst/`:

| | notice lines |
|---|---|
| upstream 3.5.0 | `foo/ is uptodate`, `foo/a is uptodate`, `foo/b is uptodate` |
| oc before | the same, **plus** `foo/a => /abs/path/to/foo/a` and `foo/b => …` |
| oc after | byte-identical to upstream |

**Scope note:** the upstream 3.5.0 `itemize` cell passes on this base both before and after — it does not exercise this shape, so it is not the instrument here. (It does go red on #7433, which changes verbose ordering and makes the cell sensitive to these arrows; this fix clears that too.)

### Tests

Both pins **count** rather than assert containment — a `contains` assertion is satisfied by one occurrence and by three alike, which is exactly what let the duplicate through.

- `freshly_linked_alias_is_announced_exactly_once` — one arrow, naming the leader relatively, no `is uptodate`
- `link_dest_basis_link_is_not_announced_with_an_arrow` — zero arrows, with the `is uptodate` lines as the non-vacuity anchor (without them a zero count also holds for a fixture that linked nothing)

Restoring either emitter fails only its own test and leaves the sibling green, which shows the two are independent defects rather than one seen twice.
