### PR TITLE
fix(protocol): write the pending token run before flushing lz4 literals

### DIFF
--- a/crates/protocol/src/wire/compressed_token/lz4_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/lz4_codec.rs
@@ -97,7 +97,28 @@ impl Lz4TokenEncoder {
         self.literal_buf.extend_from_slice(data);
         // upstream: token.c lines 923-947 - compress in MAX_DATA_COUNT chunks
         while self.literal_buf.len() >= MAX_DATA_COUNT {
+            // The chunk flush below writes DEFLATED_DATA to the wire, so any
+            // open token run has to be closed first. Upstream never faces this
+            // ordering choice: send_compressed_token() writes the run
+            // (token.c:945-961) and the literal data (token.c:965-993) in ONE
+            // call, so a run is always on the wire before the literal that
+            // follows it.
+            self.flush_pending_token_run(writer)?;
             self.compress_one_chunk(writer)?;
+        }
+        Ok(())
+    }
+
+    /// Emits the pending token run, if any, and records that the literal data
+    /// which follows opens a fresh run.
+    ///
+    /// upstream: token.c:943 - `last_token == -2` is the state meaning "the run
+    /// is closed"; the next token starts a new one at `run_start = token`
+    /// without re-emitting the run just written.
+    fn flush_pending_token_run<W: Write>(&mut self, writer: &mut W) -> io::Result<()> {
+        if self.last_token >= 0 {
+            self.write_token_run(writer)?;
+            self.last_token = -2;
         }
         Ok(())
     }
@@ -140,9 +161,7 @@ impl Lz4TokenEncoder {
     ///
     /// upstream: token.c lines 950-953
     pub(super) fn finish<W: Write>(&mut self, writer: &mut W) -> io::Result<()> {
-        if self.last_token >= 0 {
-            self.write_token_run(writer)?;
-        }
+        self.flush_pending_token_run(writer)?;
         self.compress_and_emit(writer)?;
         writer.write_all(&[END_FLAG])?;
         self.reset();

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -1892,3 +1892,100 @@ fn zlib_streams_large_literal_exceeding_old_64mib_cap() {
     }
     assert_eq!(offset, data.len(), "decoded length must match the source");
 }
+
+/// Pseudo-random bytes that deflate/LZ4 cannot shrink, so a literal of length
+/// `len` really does cross the encoder's chunk boundary. A run of identical
+/// bytes compresses to almost nothing and would never exercise the boundary.
+#[cfg(feature = "lz4")]
+fn lz4_incompressible(len: usize) -> Vec<u8> {
+    let mut state: u64 = 0x2545_f491_4f6c_dd1d;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state & 0xFF) as u8
+        })
+        .collect()
+}
+
+/// Encodes `match(block) -> literal -> match(block + 4) -> finish` and returns
+/// the raw wire bytes.
+#[cfg(feature = "lz4")]
+fn lz4_encode_match_then_literal(literal_len: usize) -> Vec<u8> {
+    let mut encoder = CompressedTokenEncoder::new_lz4();
+    let mut wire = Vec::new();
+    encoder.send_block_match(&mut wire, 0).expect("first match");
+    encoder
+        .send_literal(&mut wire, &lz4_incompressible(literal_len))
+        .expect("literal");
+    encoder
+        .send_block_match(&mut wire, 4)
+        .expect("second match");
+    encoder.finish(&mut wire).expect("finish");
+    wire
+}
+
+/// An open token run must reach the wire before the literal data that follows
+/// it, however long that literal is.
+///
+/// upstream `send_compressed_token()` never faces this ordering choice: one
+/// call writes the previous run (token.c:945-961) and then the literal's
+/// DEFLATED_DATA blocks (token.c:965-993), so the run is always first. oc
+/// splits the two across `send_block_match` and `send_literal`, and
+/// `send_literal` flushes eagerly once `MAX_DATA_COUNT` accumulates - which is
+/// where the run could be overtaken.
+///
+/// This asserts on the FIRST WIRE BYTE rather than on a decode round-trip:
+/// each LZ4 DEFLATED_DATA block decompresses independently, so a stream whose
+/// blocks precede their token run still yields the right literal bytes while
+/// reconstructing the file in the wrong order. Only the framing can tell.
+#[test]
+#[cfg(feature = "lz4")]
+fn lz4_open_token_run_precedes_the_literal_it_encloses() {
+    for literal_len in [
+        MAX_DATA_COUNT - 1,
+        MAX_DATA_COUNT,
+        MAX_DATA_COUNT + 1,
+        MAX_DATA_COUNT * 2 + 7,
+        CHUNK_SIZE * 2,
+    ] {
+        let wire = lz4_encode_match_then_literal(literal_len);
+        let first = *wire.first().expect("non-empty stream");
+        assert_eq!(
+            first & 0xC0,
+            TOKEN_REL & 0xC0,
+            "literal_len {literal_len}: stream must open with the token run for \
+             block 0, got flag {first:#04x}"
+        );
+        let first_data = wire
+            .iter()
+            .position(|b| b & 0xC0 == DEFLATED_DATA)
+            .expect("literal must produce DEFLATED_DATA");
+        assert!(
+            first_data > 0,
+            "literal_len {literal_len}: DEFLATED_DATA must not precede the run"
+        );
+    }
+}
+
+/// Non-vacuity companion: the assertion above CAN fail. A literal with no
+/// preceding block match legitimately opens the stream with DEFLATED_DATA, so
+/// "first byte is a token run" is a real discriminator, not a tautology.
+#[test]
+#[cfg(feature = "lz4")]
+fn lz4_literal_without_a_preceding_match_opens_with_deflated_data() {
+    let mut encoder = CompressedTokenEncoder::new_lz4();
+    let mut wire = Vec::new();
+    encoder
+        .send_literal(&mut wire, &lz4_incompressible(MAX_DATA_COUNT * 2))
+        .expect("literal");
+    encoder.finish(&mut wire).expect("finish");
+
+    let first = *wire.first().expect("non-empty stream");
+    assert_eq!(
+        first & 0xC0,
+        DEFLATED_DATA,
+        "a leading literal must open with DEFLATED_DATA, got {first:#04x}"
+    );
+}


### PR DESCRIPTION
## Upstream rule

`send_compressed_token()` (token.c:929-1000) is called **once per token** and
does both halves in that one call:

- token.c:945-961 - write the previous token run
- token.c:965-993 - compress and write the literal's `DEFLATED_DATA` blocks

So an open token run is always on the wire *before* the literal data that
follows it. Upstream never faces the ordering choice because the two are never
separated.

## The divergence

oc splits the work across `send_block_match` and `send_literal`, and
`send_literal` flushes eagerly once `MAX_DATA_COUNT` (16383) accumulates -
without closing the open run first. For `match(0) -> literal(>= 16 KiB)`:

```
upstream:   [TOKEN_REL 0] [DEFLATED_DATA ...]
oc (before): [DEFLATED_DATA ...] [TOKEN_REL 0] [DEFLATED_DATA ...]
```

The receiver reconstructs the matched block **in the wrong position** within
the file. The module doc at the top of `lz4_codec.rs` already states the
correct rule verbatim - "This ensures the wire ordering is
`[prev_token_run] [DEFLATED_DATA...]`" - so the invariant was documented and
unenforced.

Same shape as the zlib fix in #7434; zstd (`zstd_codec/encoder.rs:158-163`)
already carried it with the upstream citation. All three codecs now agree.

## Why the pin asserts on framing, not a round-trip

Each LZ4 `DEFLATED_DATA` block decompresses independently, so the broken
stream still yields the **correct literal bytes** - it only reconstructs the
file in the wrong order. A decode round-trip that compares literals therefore
passes either way, which is exactly why this codec round-trips against itself
today and no existing test noticed. The new test asserts on the first wire
byte.

`lz4_literal_without_a_preceding_match_opens_with_deflated_data` is its
non-vacuity companion: it proves a stream *can* legitimately open with
`DEFLATED_DATA`, so "first byte is a token run" is a real discriminator rather
than a tautology.

## Verification

RED proven by reverting only the `send_literal` hunk:

```
assertion `left == right` failed: literal_len 16383: stream must open with the
token run for block 0, got flag 0x60
  left: 64      <- DEFLATED_DATA
 right: 128     <- TOKEN_REL
```

The companion stayed green under the same mutation.

- `protocol` 6075/6075 (rebased on #7434)
- `cargo fmt --all -- --check` clean
- `cargo clippy -p protocol --all-targets --all-features --no-deps -D warnings` clean

Fixture note: the literal is xorshift64 pseudo-random. A run of identical
bytes compresses to almost nothing and would never reach the chunk boundary
the bug lives at.
