### PR TITLE
fix(client): exit RERR_SOCKETIO when RSYNC_CONNECT_PROG refuses the host

### DIFF
--- a/crates/core/src/client/module_list/client_tests.rs
+++ b/crates/core/src/client/module_list/client_tests.rs
@@ -957,6 +957,51 @@ fn run_module_list_uses_connect_program_command() {
     assert_eq!(entry.comment(), Some("example.com:873"));
 }
 
+/// A host refused by the `%H` safety check must exit `RERR_SOCKETIO` (10), the
+/// code upstream uses for a connection that could not be opened - not the
+/// syntax code.
+///
+/// upstream: `open_socket_out_wrapped()` prints the refusal and returns -1
+/// (socket.c:490-493); `start_socket_client()` turns that into
+/// `exit_cleanup(RERR_SOCKETIO)` (clientserver.c:163-165). Measured against
+/// real rsync 3.5.0: `rsync rsync://-rf/mod/` with a `%H` template reports
+/// `unsafe host characters for RSYNC_CONNECT_PROG` and exits 10, where oc
+/// exited 1.
+///
+/// The message assertion is the non-vacuity anchor: without it the exit-code
+/// check would also pass for a fixture that failed somewhere else entirely and
+/// happened to carry the same code.
+#[cfg(unix)]
+#[test]
+fn connect_program_host_refusal_exits_socket_io() {
+    let _guard = env_lock().lock().expect("env mutex poisoned");
+
+    // The template must contain a specifier: upstream inspects the host only
+    // inside `if (prog && strchr(prog, '%'))`, so a template without one never
+    // reaches the refusal at all.
+    let _prog_guard = EnvGuard::set_os("RSYNC_CONNECT_PROG", &OsString::from("sh -c 'echo %H'"));
+    let _shell_guard = EnvGuard::remove("RSYNC_SHELL");
+    let _proxy_guard = EnvGuard::remove("RSYNC_PROXY");
+
+    let request = ModuleListRequest::from_components(
+        DaemonAddress::new("-rf".to_string(), 873),
+        None,
+        ProtocolVersion::NEWEST,
+    );
+
+    let error = run_module_list(request).expect_err("an unsafe host must be refused");
+    assert!(
+        error.to_string().contains("unsafe host characters"),
+        "expected the upstream refusal message, got: {error}"
+    );
+    assert_eq!(
+        error.exit_code(),
+        crate::client::SOCKET_IO_EXIT_CODE,
+        "upstream exits RERR_SOCKETIO for a connection it could not open \
+         (clientserver.c:163-165)"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn run_module_list_collects_motd_after_acknowledgement() {

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -51,7 +51,9 @@ use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
 use super::super::DaemonAddress;
-use crate::client::{ClientError, FEATURE_UNAVAILABLE_EXIT_CODE, daemon_error};
+use crate::client::{
+    ClientError, FEATURE_UNAVAILABLE_EXIT_CODE, SOCKET_IO_EXIT_CODE, daemon_error,
+};
 
 /// Spawns a connect program with a loopback TCP socketpair for stdin/stdout.
 ///
@@ -70,7 +72,7 @@ pub(crate) fn connect_via_program(
 ) -> Result<super::DaemonStream, ClientError> {
     let command = program
         .format_command(addr.host(), addr.port())
-        .map_err(|error| daemon_error(error, FEATURE_UNAVAILABLE_EXIT_CODE))?;
+        .map_err(refused_connect_host_error)?;
 
     let shell = program
         .shell()
@@ -165,7 +167,7 @@ pub(crate) fn connect_via_program(
 ) -> Result<super::DaemonStream, ClientError> {
     let command = program
         .format_command(addr.host(), addr.port())
-        .map_err(|error| daemon_error(error, FEATURE_UNAVAILABLE_EXIT_CODE))?;
+        .map_err(refused_connect_host_error)?;
 
     let shell = program
         .shell()
@@ -645,6 +647,21 @@ fn shell_quote_connect_host(host: &str) -> String {
     }
     quoted.push('\'');
     quoted
+}
+
+/// Maps a [`ConnectProgramConfig::format_command`] refusal onto upstream's exit
+/// code for it.
+///
+/// `format_command` fails for exactly one reason - the host did not survive
+/// [`shell_unsafe_connect_host`] - and upstream reports that as a failure to
+/// open the connection, not as a usage error: `open_socket_out_wrapped()`
+/// returns -1 (socket.c:490-493) and `start_socket_client()` answers with
+/// `exit_cleanup(RERR_SOCKETIO)` (clientserver.c:163-165).
+///
+/// Both `connect_via_program` arms route through here so the unix and non-unix
+/// builds cannot drift to different codes.
+fn refused_connect_host_error(error: String) -> ClientError {
+    daemon_error(error, SOCKET_IO_EXIT_CODE)
 }
 
 fn connect_program_configuration_error(text: impl Into<String>) -> ClientError {


### PR DESCRIPTION
`ConnectProgramConfig::format_command` fails for exactly one reason — the host did not survive `shell_unsafe_connect_host` — and upstream treats that as a connection it could not open, not a usage error:

- `open_socket_out_wrapped()` prints `unsafe host characters for RSYNC_CONNECT_PROG` and returns `-1` (socket.c:490-493)
- `start_socket_client()` turns that into `exit_cleanup(RERR_SOCKETIO)` (clientserver.c:163-165), i.e. **10**

Both `connect_via_program` arms mapped it to the syntax code instead, so oc exited **1**. The refusal itself and its message were already correct and byte-identical to upstream — only the code diverged.

### Measured against real rsync 3.5.0

`RSYNC_CONNECT_PROG='sh -c "echo %H"'` with a refused host:

| host | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| `-rf` | 10 | 1 | 10 |
| `x;id` | 10 | 1 | 10 |
| *(empty)* | 10 | 1 | 10 |

### Shape

Both arms now route through one named helper instead of each repeating the constant, so the unix and non-unix builds cannot drift to different codes. That is the same failure mode that let a pair of alt-dest emitters disagree in #7435 — cheaper to prevent structurally than to catch twice.

### Test

`connect_program_host_refusal_exits_socket_io` asserts the exit code **and** the message. The message assertion is the non-vacuity anchor: without it the code check would also pass for a fixture that failed somewhere else entirely and happened to carry the same code. The template deliberately contains `%H`, because upstream inspects the host only inside `if (prog && strchr(prog, '%'))` — a template without a specifier never reaches the refusal at all.

RED proven by reverting the helper to the old constant: the new pin fails `left: 1, right: 10` while the other 13 `connect_program` tests stay green.
