### PR TITLE
fix(daemon): open the lock file through the ownership walk at mode 0600

### DIFF
--- a/crates/daemon/src/daemon/module_state/connection_limiter.rs
+++ b/crates/daemon/src/daemon/module_state/connection_limiter.rs
@@ -73,6 +73,10 @@ fn lock_file_error(path: &Path, error: io::Error) -> DaemonError {
 /// mode is upstream's explicit choice rather than an inherited
 /// `0666 & ~umask`, so a shared `lock file` is not left group- or
 /// world-readable on a daemon running with a permissive umask.
+///
+/// Unix-only: the mode is consumed by the ownership-walk arm of
+/// [`open_lock_file`], and Windows has no POSIX mode bits to pass.
+#[cfg(unix)]
 const LOCK_FILE_MODE: u32 = 0o600;
 
 /// Opens the operator-named lock file, creating it if absent.

--- a/crates/daemon/src/daemon/module_state/connection_limiter.rs
+++ b/crates/daemon/src/daemon/module_state/connection_limiter.rs
@@ -1,4 +1,8 @@
-use std::fs::{File, OpenOptions};
+use std::fs::File;
+// Only the non-Unix arm of `open_lock_file` opens by path; Unix goes through
+// the ownership walk.
+#[cfg(not(unix))]
+use std::fs::OpenOptions;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -62,6 +66,46 @@ fn lock_file_error(path: &Path, error: io::Error) -> DaemonError {
     )
 }
 
+/// Mode applied when the lock file is created.
+///
+/// upstream: connection.c:35 `claim_connection()` passes `0600` to
+/// `open_no_attacker_symlinks()`. The lock file records nothing secret, but the
+/// mode is upstream's explicit choice rather than an inherited
+/// `0666 & ~umask`, so a shared `lock file` is not left group- or
+/// world-readable on a daemon running with a permissive umask.
+const LOCK_FILE_MODE: u32 = 0o600;
+
+/// Opens the operator-named lock file, creating it if absent.
+///
+/// `lock file = PATH` is named by the operator in `oc-rsyncd.conf`, and the
+/// daemon opens it as whatever user it is running as - typically root, and
+/// before the per-module privilege drop. A symlink planted at any component
+/// therefore redirects a privileged `O_CREAT` open to a file the operator never
+/// named, and because the leaf need not exist yet a leaf-only `O_NOFOLLOW`
+/// cannot reject it. The ownership walk refuses any component symlink not owned
+/// by uid 0 or our euid.
+///
+/// upstream: connection.c:35 `claim_connection()` -
+/// `open_no_attacker_symlinks(fname, O_RDWR|O_CREAT, 0600)`.
+///
+/// On Windows there is no `st_uid` to trust, so this degrades to a plain open,
+/// matching how the rest of the tree gates `fast_io`'s operator-path helpers.
+fn open_lock_file(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_rw_create(path, LOCK_FILE_MODE)
+    }
+    #[cfg(not(unix))]
+    {
+        OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(path)
+    }
+}
+
 impl ConnectionLimiter {
     /// Opens or creates the lock file at the given path.
     pub(crate) fn open(path: PathBuf) -> Result<Self, DaemonError> {
@@ -71,13 +115,7 @@ impl ConnectionLimiter {
             std::fs::create_dir_all(parent).map_err(|error| lock_file_error(&path, error))?;
         }
 
-        let file = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&path)
-            .map_err(|error| lock_file_error(&path, error))?;
+        let file = open_lock_file(&path).map_err(|error| lock_file_error(&path, error))?;
 
         drop(file);
 
@@ -85,8 +123,13 @@ impl ConnectionLimiter {
     }
 
     /// Opens the lock file for read/write access.
+    ///
+    /// Creates it when absent, as upstream does on every `claim_connection()`:
+    /// re-opening without `O_CREAT` would fail if the file were removed between
+    /// [`ConnectionLimiter::open`] and the claim, and would resolve the operator
+    /// path a second time outside the ownership walk.
     fn open_file(&self) -> io::Result<File> {
-        OpenOptions::new().read(true).write(true).open(&self.path)
+        open_lock_file(&self.path)
     }
 }
 

--- a/crates/daemon/src/daemon/module_state/tests.rs
+++ b/crates/daemon/src/daemon/module_state/tests.rs
@@ -319,11 +319,20 @@ fn negative_max_connections_still_opens_the_lock_file_first() {
     // connection.c:44-46 afterwards. The two failures are distinguishable on
     // the wire - an unopenable lock file reports "failed to open lock file" -
     // so a disabled module must not short-circuit ahead of the open.
+    //
+    // ⚠ The unopenable condition is a DIRECTORY at the lock path, not a
+    // missing file. Upstream opens `O_RDWR|O_CREAT` on every claim
+    // (connection.c:35), so a merely absent lock file is recreated rather than
+    // reported - deleting it would silently stop detecting the short-circuit
+    // this test exists to catch. A directory fails `EISDIR` even with
+    // `O_CREAT`, so the detector survives the create. Do not "simplify" this
+    // back to `remove_file`.
     let dir = tempfile::tempdir().expect("tempdir");
     let lock_path = dir.path().join("module.lock");
     let limiter =
         std::sync::Arc::new(ConnectionLimiter::open(lock_path.clone()).expect("lock file"));
     std::fs::remove_file(&lock_path).expect("remove lock file");
+    std::fs::create_dir(&lock_path).expect("obstruct the lock path with a directory");
 
     let def = ModuleDefinition {
         name: "disabled".to_owned(),

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -116,6 +116,7 @@ include!("tests/chunks/apply_verbosity_seeds_logging_levels.rs");
 include!("tests/chunks/builder_allows_brand_override.rs");
 include!("tests/chunks/builder_collects_arguments.rs");
 include!("tests/chunks/clap_parse_error_is_reported_via_message.rs");
+include!("tests/chunks/connection_limiter_creates_the_lock_file_with_upstream_mode.rs");
 include!("tests/chunks/connection_limiter_enforces_limits_across_guards.rs");
 include!("tests/chunks/connection_limiter_open_preserves_existing_counts.rs");
 include!("tests/chunks/connection_limiter_propagates_io_errors.rs");

--- a/crates/daemon/src/tests/chunks/connection_limiter_creates_the_lock_file_with_upstream_mode.rs
+++ b/crates/daemon/src/tests/chunks/connection_limiter_creates_the_lock_file_with_upstream_mode.rs
@@ -1,0 +1,33 @@
+/// WHY (upstream fidelity + security): upstream passes `0600` explicitly to
+/// `open_no_attacker_symlinks()` when creating the `lock file`
+/// (connection.c:35), rather than letting the open inherit `0666 & ~umask`. A
+/// daemon running with a permissive umask would otherwise leave a shared lock
+/// file group- or world-readable.
+///
+/// The assertion is umask-independent by construction: a umask can only CLEAR
+/// permission bits, and `0600` has no group or other bits left to clear, so
+/// `0600 & !umask == 0600` for every umask that grants the owner read+write.
+/// The pre-fix `OpenOptions::create(true)` requested `0666`, which lands on
+/// `0644` under the common `022` - so this discriminates rather than restating
+/// whatever the environment happens to produce.
+#[cfg(unix)]
+#[test]
+fn connection_limiter_creates_the_lock_file_with_upstream_mode() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let temp = tempdir().expect("lock dir");
+    let lock_path = temp.path().join("daemon.lock");
+
+    let limiter = ConnectionLimiter::open(lock_path.clone()).expect("open lock file");
+    drop(limiter);
+
+    let mode = fs::metadata(&lock_path)
+        .expect("stat lock file")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "lock file must be created 0600 per connection.c:35, got {mode:o}"
+    );
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -399,8 +399,8 @@ pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
-    operator_link, operator_open_append, operator_open_read, operator_read_to_string,
-    operator_rename, owner_trusted_parent, symlink_owner_is_trusted,
+    operator_link, operator_open_append, operator_open_read, operator_open_rw_create,
+    operator_read_to_string, operator_rename, owner_trusted_parent, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -393,6 +393,35 @@ pub fn operator_open_append(path: &Path, mode: u32) -> io::Result<std::fs::File>
     )
 }
 
+/// Open an operator-supplied path read/write, creating it if absent.
+///
+/// The daemon `lock file` shape: the file is both read and written in place
+/// (upstream locks byte ranges in it, oc's Windows arm rewrites a count map),
+/// and the daemon creates it on first use as root, before the privilege drop.
+/// That makes the `O_CREAT` the dangerous part - a symlink planted at any
+/// component redirects a privileged create-and-write to a file the operator
+/// never named, and the leaf does not exist yet for an `O_NOFOLLOW` to reject.
+///
+/// `mode` applies only when the file is created, as with `open(2)`.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/connection.c:35` `claim_connection()` -
+///   `open_no_attacker_symlinks(fname, O_RDWR|O_CREAT, 0600)`.
+///
+/// # Errors
+///
+/// See [`operator_open_with`].
+pub fn operator_open_rw_create(path: &Path, mode: u32) -> io::Result<std::fs::File> {
+    operator_open_with(
+        path,
+        OFlags::RDWR | OFlags::CREATE,
+        // `RawMode` is u16 on macOS and u32 on Linux, so route the cast through
+        // it rather than naming either width here.
+        Mode::from_bits_truncate(mode as rustix::fs::RawMode),
+    )
+}
+
 /// Read an operator-supplied file to a `String` through the ownership walk.
 ///
 /// The `read_to_string` counterpart to [`operator_open_read`], for the auxiliary


### PR DESCRIPTION
## The gap

`lock file = PATH` is operator-named in `oc-rsyncd.conf`, and the daemon opens it as whatever user it runs as — typically root, and before the per-module privilege drop. Both opens went straight to `OpenOptions`:

```rust
OpenOptions::new().create(true).truncate(false).read(true).write(true).open(&path)   // create
OpenOptions::new().read(true).write(true).open(&self.path)                           // per claim
```

A symlink planted at any component redirects that privileged `O_CREAT` open to a file the operator never named. The leaf need not exist yet, so a leaf-only `O_NOFOLLOW` could not reject it either — the parent-component case is exactly what the ownership walk exists for.

Upstream closes it with the same primitive it uses for every other operator-named aux file:

```c
/* connection.c:35 — claim_connection() */
if ((fd = open_no_attacker_symlinks(fname, O_RDWR|O_CREAT, 0600)) < 0)
```

## Why this was the last one

oc already had the walk and already routed the daemon config, `motd`, `secrets file`, `--password-file`, `--log-file` and both merge-file parsers onto it. The lock file was the **one daemon aux-file open still on a bare path**, because no existing helper opened `O_RDWR|O_CREAT` — `operator_open_read` and `operator_open_append` were the only variants. This adds `operator_open_rw_create` beside them; all three delegate to the same private `operator_open_with`, so there is one walk, not a third copy.

## The mode is upstream's, not incidental

`OpenOptions::create(true)` requests `0666`, which lands on **0644** under the common `022` umask — a shared lock file left world-readable on a daemon with a permissive umask. Upstream passes `0600` explicitly.

## Two deliberate behaviour changes

**1. The per-claim reopen now carries `O_CREAT`**, matching upstream's single `O_RDWR|O_CREAT` per `claim_connection()`. Previously, a lock file removed after startup made every later claim fail; upstream recreates it. It also removes a second unguarded resolution of the operator path.

**2. That invalidated a test's DETECTOR, not its claim — stated explicitly rather than re-baselined.** `negative_max_connections_still_opens_the_lock_file_first` proves *a disabled module must not short-circuit ahead of the open* (upstream `connection.c:31`), and it detected the open by **deleting** the lock file. With `O_CREAT`, a missing file is no longer an error, so that detector would have silently stopped detecting anything. It is now a **directory** at the lock path, which fails `EISDIR` even with `O_CREAT`. The assertion is unchanged; the comment records why, so it is not "simplified" back to `remove_file`.

## Verification

The new pin asserts the created mode is exactly `0600`. That is umask-independent by construction — a umask can only *clear* bits, and `0600` has no group or other bits left to clear — so it discriminates rather than restating whatever the environment produces.

**RED proven** by setting the constant to `0666`:

```
assertion `left == right` failed: lock file must be created 0600 per connection.c:35, got 644
```

`644` is precisely the pre-fix behaviour, so this test is red against master and green only with upstream's constant.

`cargo nextest run -p daemon -p fast_io --all-features --no-fail-fast` → **2570 run, 2570 passed, 6 skipped**. fmt + clippy clean.

## Scope note

`create_dir_all(parent)` in `ConnectionLimiter::open` is **left as-is**. Upstream does not create the lock file's parent at all; removing it would change behaviour for operators relying on the auto-created directory, which is a separate decision from routing the open.
