### PR TITLE
fix(daemon): route the log-file open onto the ownership walk

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -1222,10 +1222,17 @@ fn derive_batch_seed() -> i32 {
 /// upstream: `syscall.c:537` `open_no_attacker_symlinks()` - the entry point for
 /// the opens that are not confined beneath a root, `--log-file` among them
 /// (`syscall.c:232`).
+/// Opens the client `--log-file` for appending, refusing untrusted symlinks.
+///
+/// upstream: log.c:170 passes `0644`, not `0666`. The difference is observable:
+/// upstream additionally forces `umask(022 | orig_umask)` around the open
+/// (log.c:163), so it can never create a group- or world-writable log; passing
+/// `0666` here would do exactly that under a permissive umask. `0644` reaches
+/// upstream's fixed point without needing the umask dance.
 fn open_log_file(path: &Path) -> io::Result<File> {
     #[cfg(unix)]
     {
-        fast_io::operator_open_append(path, 0o666)
+        fast_io::operator_open_append(path, 0o644)
     }
     #[cfg(not(unix))]
     {

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -10,12 +10,15 @@
 ///
 /// The log file is opened in append mode, creating it if it doesn't exist.
 /// Returns a thread-safe [`SharedLogSink`] for concurrent logging.
+///
+/// upstream: log.c:169 opens the logfile through `open_no_attacker_symlinks()`
+/// with `O_WRONLY|O_APPEND|O_CREAT, 0644`, for the reason stated at log.c:165 -
+/// `--log-file` and `log file =` are operator-supplied paths that may transit
+/// attacker-writable directories, and a planted symlink would redirect the root
+/// daemon's log into a file of the attacker's choosing. The ownership walk
+/// refuses symlink components not owned by uid 0 or our euid.
 pub(crate) fn open_log_sink(path: &Path, brand: Brand) -> Result<SharedLogSink, DaemonError> {
-    let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|error| log_file_error(path, error))?;
+    let file = open_log_file(path).map_err(|error| log_file_error(path, error))?;
     // upstream: log.c:122-132 logit() stamps `%Y/%m/%d %H:%M:%S [pid] ` on
     // every log-file line; the wrapper applies the same shared formatter used
     // by the client `--log-file` sink.
@@ -23,6 +26,31 @@ pub(crate) fn open_log_sink(path: &Path, brand: Brand) -> Result<SharedLogSink, 
         logging_sink::logfile::LogFileWriter::new(file),
         brand,
     ))))
+}
+
+/// Mode applied when the log file is created.
+///
+/// upstream: log.c:170 passes `0644`. The surrounding `umask(022 | orig_umask)`
+/// (log.c:163) is what forbids a group- or world-writable log file under a
+/// permissive umask; passing `0644` here reaches the same fixed point without
+/// the dance, because `0644` has no group or other write bit for a umask to
+/// need to clear.
+#[cfg(unix)]
+const LOG_FILE_MODE: u32 = 0o644;
+
+/// Opens the log file for appending, refusing untrusted symlink components.
+///
+/// Windows has no POSIX mode bits and no ownership-walk equivalent, so it keeps
+/// the plain open.
+fn open_log_file(path: &Path) -> io::Result<std::fs::File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_append(path, LOG_FILE_MODE)
+    }
+    #[cfg(not(unix))]
+    {
+        OpenOptions::new().create(true).append(true).open(path)
+    }
 }
 
 /// Reopens the connection's log sink to the selected module's `log file`.

--- a/tests/log_file_created_with_upstream_mode.rs
+++ b/tests/log_file_created_with_upstream_mode.rs
@@ -1,0 +1,201 @@
+//! A newly created log file carries upstream's `0644`, on both log sinks.
+//!
+//! Upstream opens every log file through one call:
+//!
+//! ```c
+//! logfile_fp = fdopen(open_no_attacker_symlinks(logfile_name,
+//!                     O_WRONLY|O_APPEND|O_CREAT, 0644), "a");
+//! ```
+//!
+//! (`log.c:169-170`, reached by `log_init()` for the client `--log-file` and by
+//! the daemon for `log file =`). Two things are being pinned here, and one test
+//! shape settles both:
+//!
+//! - the **mode**: `0644`, not the `0666` an ordinary `open(2)` default carries;
+//! - the **routing**: an open that passes no mode at all - which is what
+//!   `OpenOptions::new().create(true).append(true)` does - cannot produce
+//!   `0644` once the umask is out of the way.
+//!
+//! The umask is what makes that discriminating, and it has to be pinned or the
+//! assertion is worthless: `umask(2)` can only *clear* bits, so under the usual
+//! `022` a `0666` request lands as `0644` too and the two spellings become
+//! indistinguishable. Every child below is therefore spawned with its umask
+//! pinned to `0`, where `0666` stays `0666` and only a genuine `0644` request
+//! reads back as `0644`. [`pinning_the_child_umask_takes_effect`] is the
+//! control for that claim.
+//!
+//! Upstream reaches the same fixed point by a different route - it wraps the
+//! open in `umask(022 | orig_umask)` (`log.c:163`) so a permissive umask can
+//! never yield a group- or world-writable log. Requesting `0644` needs no such
+//! dance, because `0644` holds no group or other write bit for a umask to have
+//! to clear.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::net::TcpListener;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// upstream: log.c:170 - the literal mode argument at the single log-file open.
+const UPSTREAM_LOG_FILE_MODE: u32 = 0o644;
+
+/// How long a spawned daemon is given to reach its log-file open.
+const DAEMON_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Builds a command whose child runs under umask `0`.
+///
+/// Pinned on the child rather than by mutating this process's umask around the
+/// spawn: `umask(2)` is process-global, and the test harness runs cases in
+/// parallel threads, so an in-process pin would leak into whatever else is
+/// creating files at that moment. `pre_exec` runs after `fork(2)` and before
+/// `exec(2)`, where only async-signal-safe calls are permitted - `umask(2)` is
+/// one of them.
+fn command_with_open_umask(program: impl AsRef<std::ffi::OsStr>) -> Command {
+    let mut command = Command::new(program);
+    // SAFETY-equivalent reasoning lives in the doc comment above; `pre_exec` is
+    // safe to use here because `umask(2)` is async-signal-safe.
+    unsafe {
+        command.pre_exec(|| {
+            libc::umask(0);
+            Ok(())
+        });
+    }
+    command
+}
+
+fn mode_of(path: &Path) -> u32 {
+    fs::metadata(path)
+        .unwrap_or_else(|error| panic!("stat {}: {error}", path.display()))
+        .permissions()
+        .mode()
+        & 0o777
+}
+
+/// Waits until `path` exists, so the assertion never races the child's open.
+fn wait_for(path: &Path) -> bool {
+    let deadline = Instant::now() + DAEMON_STARTUP_TIMEOUT;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    false
+}
+
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+/// Validates the instrument the two assertions below depend on.
+///
+/// If the `pre_exec` pin silently did not apply, the children would run under
+/// the ambient umask - typically `022`, which masks a `0666` request down to
+/// `0644` and makes both mode assertions pass no matter which constant the
+/// production code carries. This is exactly that failure mode, checked
+/// directly: the child reports its own umask, and it must be `0`.
+#[test]
+fn pinning_the_child_umask_takes_effect() {
+    let output = command_with_open_umask("/bin/sh")
+        .args(["-c", "umask"])
+        .output()
+        .expect("run /bin/sh");
+    assert!(output.status.success(), "shell failed: {:?}", output.status);
+    let reported = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(
+        u32::from_str_radix(&reported, 8).expect("octal umask"),
+        0,
+        "the child umask was not pinned (reported {reported:?}), so a 0666 \
+         request would be masked to 0644 and the mode assertions would hold \
+         vacuously"
+    );
+}
+
+/// upstream: log.c:170 - the client `--log-file` is created `0644`.
+#[test]
+fn client_log_file_is_created_with_upstream_mode() {
+    let tmp = TempDir::new().expect("tempdir");
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(src.join("payload"), b"contents\n").expect("write source");
+    let log = tmp.path().join("client.log");
+
+    let status = command_with_open_umask(oc_binary())
+        .arg("-a")
+        .arg(format!("--log-file={}", log.display()))
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", tmp.path().join("dst").display()))
+        .status()
+        .expect("run oc-rsync");
+    assert!(status.success(), "transfer failed: {status:?}");
+
+    assert_eq!(
+        mode_of(&log),
+        UPSTREAM_LOG_FILE_MODE,
+        "the client --log-file must be created with upstream's 0644"
+    );
+}
+
+/// upstream: log.c:170 - the daemon's log sink takes the same open, so it takes
+/// the same mode. The two sinks are separate call sites in oc, and a correction
+/// applied to only one of them leaves the other on `0666`.
+///
+/// The path is given as `--log-file` rather than a `log file =` config line
+/// because only the option is consumed at daemon startup: the config directive
+/// is applied per connection, when the selected module reopens the sink, so a
+/// config-driven fixture would have to drive a whole client session to observe
+/// the same open. Both spellings land on the same `open_log_sink`.
+#[test]
+fn daemon_log_file_is_created_with_upstream_mode() {
+    let Some(port) = free_port() else {
+        eprintln!("skipping: loopback TCP unavailable");
+        return;
+    };
+    let tmp = TempDir::new().expect("tempdir");
+    let module = tmp.path().join("module");
+    fs::create_dir_all(&module).expect("create module root");
+    let log = tmp.path().join("daemon.log");
+    let conf = tmp.path().join("oc-rsyncd.conf");
+    fs::write(
+        &conf,
+        format!(
+            "port = {port}\nuse chroot = no\n\n[data]\n\tpath = {}\n\tread only = yes\n",
+            module.display()
+        ),
+    )
+    .expect("write config");
+
+    let mut child = command_with_open_umask(oc_binary())
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--log-file={}", log.display()))
+        .arg(format!("--config={}", conf.display()))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let appeared = wait_for(&log);
+    let mode = appeared.then(|| mode_of(&log));
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(appeared, "the daemon never created its log file");
+    assert_eq!(
+        mode,
+        Some(UPSTREAM_LOG_FILE_MODE),
+        "the daemon `log file` must be created with upstream's 0644"
+    );
+}


### PR DESCRIPTION
## What

The daemon opened its log file with a plain path-based
`OpenOptions::new().create(true).append(true)`. Upstream opens every log file
through the ownership walk:

```c
logfile_fp = fdopen(open_no_attacker_symlinks(logfile_name,
                    O_WRONLY|O_APPEND|O_CREAT, 0644), "a");
```

`log.c:169-170`, reached by `log_init()` for both the client `--log-file` and the
daemon's log sink. The reason is stated at `log.c:165`: these are
operator-supplied paths that may transit attacker-writable directories, and a
symlink planted at any component redirects a root daemon's log into a file of the
attacker's choosing. The walk refuses symlink components not owned by uid 0 or
our euid.

The client `--log-file` was already routed through the walk, but requested mode
`0666` where upstream passes `0644`. Both sinks now pass `0644`.

## Why 0644 and not 0666

Upstream wraps its open in `umask(022 | orig_umask)` (`log.c:163`) so a permissive
umask can never produce a group- or world-writable log. Requesting `0644` reaches
the same fixed point without the dance - `0644` holds no group or other write bit
for a umask to have to clear.

## Tests

`tests/log_file_created_with_upstream_mode.rs` pins both sinks, each with the
spawned child's umask pinned to `0` via `pre_exec`.

The umask pin is what makes the assertion mean anything: `umask(2)` can only
*clear* bits, so under the usual `022` a `0666` request also lands as `0644` and
the two spellings become indistinguishable. Under umask `0`, `0666` stays `0666`
and only a genuine `0644` request reads back as `0644` - so the same assertion
also discriminates routing, since an open that passes no mode at all cannot
produce `0644`.

A third test (`pinning_the_child_umask_takes_effect`) validates that instrument
directly, so the pair cannot pass vacuously if the pin ever stops applying.

Proven RED three ways, each with the others staying green:

| mutation | result |
|---|---|
| both mode constants -> `0o666` | both mode tests fail, control green |
| daemon open -> plain `OpenOptions` | daemon test fails, client + control green |
| (unmutated) | 3/3 green |

## Verification

- `cargo fmt --all -- --check`, workspace clippy `-D warnings`: clean
- Windows GNU cross-check (`-D warnings`, `--all-targets`) on `daemon` + `cli`: clean
- `cargo nextest run -p daemon --all-features`: 1814 passed, 0 failed
- log-file sweep across `cli` + root integration tests: 27 passed, 0 failed
