### PR TITLE
fix(cli): route --files-from and --early-input onto the ownership walk

### DIFF
--- a/crates/cli/src/frontend/execution/file_list/loader.rs
+++ b/crates/cli/src/frontend/execution/file_list/loader.rs
@@ -4,7 +4,6 @@
 //! buffered reader. Supports both newline-delimited and null-terminated formats.
 
 use std::ffi::{OsStr, OsString};
-use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 
@@ -48,9 +47,13 @@ pub(crate) fn load_file_list_operands(
             continue;
         }
 
+        // upstream: options.c:2654 opens `--files-from` through
+        // `open_no_attacker_symlinks()`. The list is an operator-supplied path
+        // that may transit attacker-writable parents, so a planted symlink
+        // would redirect the read to a file the operator never named.
         let path_buf = PathBuf::from(path);
         let display = path_buf.display().to_string();
-        let file = File::open(&path_buf).map_err(|error| {
+        let file = crate::frontend::operator_file::open_read(&path_buf).map_err(|error| {
             rsync_error!(
                 1,
                 format!("failed to read file list '{}': {}", display, error)

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -142,10 +142,9 @@ fn filter_file_open_error(
 /// and both `--*clude-from` and a `merge` rule run with `XFLG_FATAL_ERRORS`,
 /// so the failure is fatal either way.
 ///
-/// The walk is Unix-only. The `cfg` is deliberately spelled at the call site
-/// rather than hidden behind a cross-platform `fast_io` export: this is a
-/// security control, and a silent fallback would make its absence on non-Unix
-/// invisible to a reader of this function.
+/// The walk itself lives in [`crate::frontend::operator_file`], the crate's
+/// single platform seam for operator-named opens, so the Unix-only `cfg` is
+/// written once rather than once per option.
 ///
 /// # Upstream Reference
 ///
@@ -156,14 +155,7 @@ fn filter_file_open_error(
 /// - `rsync-3.5.0/syscall.c:538` - `open_no_attacker_symlinks()`; the trust
 ///   rule is at `syscall.c:406`.
 fn open_operator_named(path: &Path) -> io::Result<File> {
-    #[cfg(unix)]
-    {
-        fast_io::operator_open_read(path)
-    }
-    #[cfg(not(unix))]
-    {
-        File::open(path)
-    }
+    crate::frontend::operator_file::open_read(path)
 }
 
 /// Reads the raw pattern lines from a filter file, or from standard input when

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -121,6 +121,7 @@ pub mod info_output;
 pub mod itemize;
 mod local_time;
 mod lsm_status;
+mod operator_file;
 mod out_format;
 pub(crate) mod password;
 /// Progress and verbose output helpers extracted from the CLI front-end.

--- a/crates/cli/src/frontend/operator_file.rs
+++ b/crates/cli/src/frontend/operator_file.rs
@@ -1,0 +1,44 @@
+//! Opening the client's operator-supplied auxiliary files.
+//!
+//! Several options name a file the *operator* chose rather than one a peer
+//! requested - `--files-from`, `--exclude-from`/`--include-from`, a `merge`
+//! rule, `--password-file`. Those paths may transit directories an attacker can
+//! write, and a symlink planted at any component redirects the read to a file
+//! the operator never named. Upstream closes this with one primitive applied at
+//! every such open.
+//!
+//! This module is the crate's single platform seam for that primitive, so the
+//! `cfg` is written once instead of once per option. It is deliberately *not*
+//! hidden behind a cross-platform `fast_io` export: the walk is a security
+//! control, and a silent fallback exported as if it were portable would make
+//! its absence on non-Unix invisible to a reader of the call site.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/syscall.c:538` `open_no_attacker_symlinks()` - walk each
+//!   component without following it; follow a symlink only when it is owned by
+//!   uid 0 or our euid, refuse any other-uid one (`syscall.c:406`).
+//! - `rsync-3.5.0/options.c:2654` - `--files-from`.
+//! - `rsync-3.5.0/exclude.c:1683` - `--*clude-from` and `merge`.
+//! - `rsync-3.5.0/authenticate.c:245` - `--password-file`.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Opens an operator-named file, refusing a component symlink owned by a uid
+/// that is neither root nor our own.
+///
+/// On non-Unix targets the ownership walk has no meaning - there is no `st_uid`
+/// to trust - so this degrades to a plain open, matching how the rest of the
+/// tree gates `fast_io`'s operator-path helpers.
+pub(crate) fn open_read(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_read(path)
+    }
+    #[cfg(not(unix))]
+    {
+        File::open(path)
+    }
+}

--- a/crates/cli/src/frontend/tests/files_from.rs
+++ b/crates/cli/src/frontend/tests/files_from.rs
@@ -1928,3 +1928,38 @@ fn files_from_integration_keeps_every_top_level_entry() {
         assert_eq!(actual, format!("body of {name}").as_bytes());
     }
 }
+
+/// The ownership walk must still FOLLOW a symlink the operator owns.
+///
+/// upstream: syscall.c:270-272 states the contract in its own words - "a
+/// trusted-owned symlink (e.g. root's `/var/log -> /data/log`) is still
+/// followed; an untrusted one fails `ELOOP`". Routing `--files-from` through
+/// `open_no_attacker_symlinks()` (options.c:2654) closes the attacker case, and
+/// this pins the other direction: the ordinary administrative layout, where the
+/// list is reached through a symlink the invoking user owns, must keep working.
+///
+/// The refusal half needs a symlink owned by a *third* uid, which only root can
+/// plant - it is covered by the upstream 3.5.0 testsuite's root leg, not here.
+/// This test is the half that runs unprivileged, and it is the half that would
+/// break if the walk ever over-refused.
+#[cfg(unix)]
+#[test]
+fn files_from_follows_a_symlink_the_operator_owns() {
+    let tmp = test_support::create_tempdir();
+    let real_dir = tmp.path().join("real");
+    std::fs::create_dir(&real_dir).expect("create real dir");
+    std::fs::write(real_dir.join("file.list"), "file1.txt\nfile2.txt\n").expect("write list");
+
+    let link_dir = tmp.path().join("link");
+    std::os::unix::fs::symlink(&real_dir, &link_dir).expect("symlink the list's parent");
+
+    let through_link = link_dir.join("file.list");
+    let entries =
+        load_file_list_operands(&[through_link.into_os_string()], false).expect("load entries");
+
+    assert_eq!(
+        entries,
+        vec![OsString::from("file1.txt"), OsString::from("file2.txt")],
+        "the walk refused a symlink owned by the invoking user; upstream follows it"
+    );
+}

--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -483,12 +483,14 @@ pub(crate) fn perform_daemon_handshake<R: std::io::Read, W: Write>(
 /// Returns an empty `Vec` for empty files.
 ///
 /// upstream: clientserver.c:266-294 - `start_inband_exchange()` reads the file
-/// specified by `--early-input` before sending it to the daemon.
+/// specified by `--early-input` before sending it to the daemon, and opens it
+/// at clientserver.c:303 through `open_no_attacker_symlinks()`: the path is
+/// operator-supplied and may transit attacker-writable parents, so a planted
+/// symlink would redirect the read to a file the operator never named.
 pub(crate) fn read_early_input_file(path: &Path) -> Result<Vec<u8>, ClientError> {
-    use std::fs::File;
     use std::io::Read;
 
-    let mut file = File::open(path).map_err(|e| {
+    let mut file = crate::client::remote::operator_file::open_read(path).map_err(|e| {
         daemon_error(
             format!("failed to open {}: {e}", path.display()),
             CLIENT_SERVER_PROTOCOL_EXIT_CODE,

--- a/crates/core/src/client/remote/files_from_forwarding.rs
+++ b/crates/core/src/client/remote/files_from_forwarding.rs
@@ -78,7 +78,10 @@ fn read_path_into(
     eol_nulls: bool,
     iconv_converter: Option<&protocol::FilenameConverter>,
 ) -> Result<(), ClientError> {
-    let mut file = std::fs::File::open(path).map_err(|e| {
+    // upstream: options.c:2654 - the same `open_no_attacker_symlinks()` guard
+    // as the local read. Forwarding the list to a remote sender does not make
+    // the local path any less operator-supplied.
+    let mut file = super::operator_file::open_read(path).map_err(|e| {
         invalid_argument_error(
             &format!("failed to open --files-from {}: {e}", path.display()),
             23,

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -37,6 +37,7 @@ pub mod invocation;
 /// Shared client-visible itemize sink for the remote transports.
 pub(crate) mod itemize_sink;
 /// `--info=`/`--debug=` server-argument construction (make_output_option).
+pub(crate) mod operator_file;
 pub(crate) mod output_option;
 /// Remote-to-remote transfer via local proxy relay.
 pub mod remote_to_remote;

--- a/crates/core/src/client/remote/operator_file.rs
+++ b/crates/core/src/client/remote/operator_file.rs
@@ -1,0 +1,43 @@
+//! Opening the operator-supplied auxiliary files a remote session reads.
+//!
+//! Two client options name a file the *operator* chose rather than one a peer
+//! requested, and both are read on the way to a remote server: the
+//! `--files-from` list that gets forwarded to the sender, and the
+//! `--early-input` payload sent ahead of the daemon handshake. Either path may
+//! transit a directory an attacker can write, and a symlink planted at any
+//! component redirects the read to a file the operator never named. Upstream
+//! closes this with one primitive applied at every such open.
+//!
+//! This module is the crate's single platform seam for that primitive. It is
+//! deliberately *not* hidden behind a cross-platform `fast_io` export: the walk
+//! is a security control, and a silent fallback exported as if it were portable
+//! would make its absence on non-Unix invisible to a reader of the call site.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/syscall.c:538` `open_no_attacker_symlinks()` - walk each
+//!   component without following it; follow a symlink only when it is owned by
+//!   uid 0 or our euid, refuse any other-uid one (`syscall.c:406`).
+//! - `rsync-3.5.0/options.c:2654` - `--files-from`.
+//! - `rsync-3.5.0/clientserver.c:303` - `--early-input`.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Opens an operator-named file, refusing a component symlink owned by a uid
+/// that is neither root nor our own.
+///
+/// On non-Unix targets the ownership walk has no meaning - there is no `st_uid`
+/// to trust - so this degrades to a plain open, matching how the rest of the
+/// tree gates `fast_io`'s operator-path helpers.
+pub(crate) fn open_read(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_read(path)
+    }
+    #[cfg(not(unix))]
+    {
+        File::open(path)
+    }
+}


### PR DESCRIPTION
## What

Three operator-supplied auxiliary opens still used a plain path-based
`File::open` where upstream applies `open_no_attacker_symlinks()`:

| site | upstream |
|---|---|
| `--files-from`, read locally | `options.c:2654` |
| `--files-from`, read again when forwarded to a remote sender | same guard, second site |
| `--early-input`, read before the daemon handshake | `clientserver.c:303` |

All three are paths the *operator* chose that may transit directories an attacker
can write. A symlink planted at any component redirects the read to a file the
operator never named. The walk follows a symlink only when it is owned by uid 0
or our euid, and refuses any other-uid one (`syscall.c:406`).

The second `--files-from` site is the one worth calling out: forwarding the list
to a remote sender does not make the *local* path any less operator-supplied, and
it had its own untouched `File::open`.

## Deliberately not in scope

Upstream also sets `operator_path_resolve` around the `--files-from` open so a
daemon re-anchors the list beneath the module root (`options.c:2646-2654`). That
half only fires under a daemon and is a separate concern from the ownership walk.

## Structure

The `cfg(unix)` split moves into one seam module per crate instead of being
repeated per option, and the existing `--*clude-from` / `merge` opener now
delegates to the cli seam rather than carrying its own copy.

The seam stays crate-local rather than becoming a cross-platform `fast_io`
export: the walk is a security control, and exporting a silent non-Unix fallback
as if it were portable would hide its absence from a reader of the call site.
That reasoning was already written at the `--*clude-from` site; this keeps it and
updates it to point at the seam.

## Tests

The refusal direction needs a symlink owned by a *third* uid, which only root can
plant — it is covered by the upstream 3.5.0 testsuite's root leg, the same
instrument that verified the `--*clude-from` routing.

The new test pins the other direction, which is what runs unprivileged and what
would break if the walk ever over-refused: a `--files-from` list reached through a
symlink the invoking user owns must still load. `syscall.c:270-272` states that
contract in upstream's own words.

Non-vacuity proven by mutating the seam to refuse every open: the new test and its
plain-path neighbour both fail, confirming both run through the routed path.

## Verification

- `cargo fmt --all -- --check`, workspace clippy `-D warnings`: clean
- Windows GNU cross-check (`-D warnings`, `--all-targets`) on `cli` + `core`: clean
- `cargo nextest run -p cli -p core --all-features`: 6621/6622; the one failure is
  `run_client_sparse_copy_creates_holes`, the known APFS parallel-run flake that
  reproduces on an untouched base
- Rebased onto master and re-verified there; footprint unchanged across the
  rebase, so master did not already carry any of it
