### PR TITLE
fix(batch): route batch file opens onto the ownership walk at upstream modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 name = "batch"
 version = "0.6.4"
 dependencies = [
+ "fast_io",
  "filetime",
  "metadata",
  "protocol",

--- a/crates/batch/Cargo.toml
+++ b/crates/batch/Cargo.toml
@@ -19,6 +19,7 @@ zstd = ["protocol/zstd"]
 thiserror = { workspace = true }
 protocol = { path = "../protocol" }
 metadata = { path = "../metadata" }
+fast_io = { path = "../fast_io" }
 filetime = { workspace = true }
 
 [dev-dependencies]

--- a/crates/batch/src/lib.rs
+++ b/crates/batch/src/lib.rs
@@ -158,6 +158,8 @@
 
 mod error;
 
+mod operator_file;
+
 /// Binary format definitions for batch files.
 ///
 /// This module contains the low-level structures for reading and writing

--- a/crates/batch/src/operator_file.rs
+++ b/crates/batch/src/operator_file.rs
@@ -1,0 +1,77 @@
+//! Opening the operator-supplied batch files.
+//!
+//! `--read-batch`, `--write-batch` and the generated `.sh` companion all name a
+//! file the *operator* chose. Those paths may transit directories an attacker
+//! can write, and a symlink planted at any component redirects the open to a
+//! file the operator never named - which for the two write sides means a
+//! privileged create-and-truncate lands somewhere else entirely. Upstream
+//! closes this with one primitive applied at every such open.
+//!
+//! This module is the crate's single platform seam for that primitive, so the
+//! `cfg` is written once instead of once per call site. It is deliberately
+//! *not* hidden behind a cross-platform `fast_io` export: the walk is a
+//! security control, and a silent fallback exported as if it were portable
+//! would make its absence on non-Unix invisible to a reader of the call site.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/syscall.c:538` `open_no_attacker_symlinks()` - walk each
+//!   component without following it; follow a symlink only when it is owned by
+//!   uid 0 or our euid, refuse any other-uid one (`syscall.c:406`).
+//! - `rsync-3.5.0/batch.c:254` - the `.sh` companion, created `0700`.
+//! - `rsync-3.5.0/batch.c:263` - `--write-batch`, created `0600`.
+//! - `rsync-3.5.0/batch.c:267` - `--read-batch`, opened read-only.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Mode upstream creates the batch file with (`batch.c:263`).
+///
+/// Owner-only: the batch stream carries the transferred file *contents*, so a
+/// world-readable batch would publish everything the transfer moved.
+pub(crate) const BATCH_FILE_MODE: u32 = 0o600;
+
+/// Mode upstream creates the `.sh` companion with (`batch.c:254`).
+///
+/// Owner-only plus execute, because the generated script is meant to be run.
+pub(crate) const BATCH_SCRIPT_MODE: u32 = 0o700;
+
+/// Opens an operator-named file for reading, refusing a component symlink owned
+/// by a uid that is neither root nor our own.
+///
+/// On non-Unix targets the ownership walk has no meaning - there is no `st_uid`
+/// to trust - so this degrades to a plain open, matching how the rest of the
+/// tree gates `fast_io`'s operator-path helpers.
+pub(crate) fn open_read(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_read(path)
+    }
+    #[cfg(not(unix))]
+    {
+        File::open(path)
+    }
+}
+
+/// Creates or truncates an operator-named file for writing, refusing a
+/// component symlink owned by a uid that is neither root nor our own.
+///
+/// `mode` applies only when the file is created, exactly as upstream's
+/// `O_CREAT|O_TRUNC` open does - re-running `--write-batch` over an existing
+/// file truncates it and leaves its mode alone.
+///
+/// On non-Unix targets this degrades to a plain create, as above; `mode` has no
+/// counterpart there and is ignored, which is also why the caller must not rely
+/// on it for anything but Unix parity.
+pub(crate) fn create_write(path: &Path, mode: u32) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_write_create(path, mode)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = mode;
+        File::create(path)
+    }
+}

--- a/crates/batch/src/reader/mod.rs
+++ b/crates/batch/src/reader/mod.rs
@@ -131,7 +131,11 @@ impl BatchReader {
             })?;
             Ok(BatchSource::Stdin(Cursor::new(buf)))
         } else {
-            let file = File::open(path).map_err(|e| {
+            // upstream: batch.c:267 opens the read-batch file through
+            // `open_no_attacker_symlinks()`. The path is operator-supplied and
+            // may transit attacker-writable parents, so a planted symlink would
+            // feed the replay a batch stream the operator never named.
+            let file = crate::operator_file::open_read(path).map_err(|e| {
                 BatchError::Io(io::Error::new(
                     e.kind(),
                     format!("Failed to open batch file '{}': {}", path.display(), e),

--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -8,9 +8,6 @@ use crate::error::{BatchError, BatchResult};
 use std::fs::File;
 use std::io::{self, Write};
 
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
 /// Generate a minimal shell script for replaying a batch file.
 ///
 /// Creates a script matching upstream rsync's format: a single command line
@@ -53,7 +50,15 @@ pub fn generate_script_with_filters(
 ) -> BatchResult<()> {
     let script_path = config.script_file_path();
     let batch_name = config.batch_file_path().to_string_lossy();
-    let mut file = File::create(&script_path).map_err(|e| {
+    // upstream: batch.c:254 creates the `.sh` companion through
+    // `open_no_attacker_symlinks()` at `S_IRUSR|S_IWUSR|S_IXUSR`. Passing the
+    // mode to the create is what makes the script executable; upstream never
+    // chmods afterwards, so an existing file keeps whatever mode it had.
+    let mut file = crate::operator_file::create_write(
+        std::path::Path::new(&script_path),
+        crate::operator_file::BATCH_SCRIPT_MODE,
+    )
+    .map_err(|e| {
         BatchError::Io(io::Error::new(
             e.kind(),
             format!("Failed to create script file '{script_path}': {e}"),
@@ -108,9 +113,6 @@ pub fn generate_script_with_filters(
     writeln!(file)?;
 
     file.flush()?;
-
-    // upstream: batch_sh_fd opened with S_IRUSR | S_IWUSR | S_IXUSR (0o700)
-    set_script_permissions(&script_path)?;
 
     Ok(())
 }
@@ -169,7 +171,15 @@ pub fn generate_script_with_args(
     filter_rules: Option<&str>,
 ) -> BatchResult<()> {
     let script_path = config.script_file_path();
-    let mut file = File::create(&script_path).map_err(|e| {
+    // upstream: batch.c:254 creates the `.sh` companion through
+    // `open_no_attacker_symlinks()` at `S_IRUSR|S_IWUSR|S_IXUSR`. Passing the
+    // mode to the create is what makes the script executable; upstream never
+    // chmods afterwards, so an existing file keeps whatever mode it had.
+    let mut file = crate::operator_file::create_write(
+        std::path::Path::new(&script_path),
+        crate::operator_file::BATCH_SCRIPT_MODE,
+    )
+    .map_err(|e| {
         BatchError::Io(io::Error::new(
             e.kind(),
             format!("Failed to create script file '{script_path}': {e}"),
@@ -247,9 +257,6 @@ pub fn generate_script_with_args(
     writeln!(file)?;
 
     file.flush()?;
-
-    // upstream: batch.c:232 batch_sh_fd opened with S_IRUSR | S_IWUSR | S_IXUSR (0o700)
-    set_script_permissions(&script_path)?;
 
     Ok(())
 }
@@ -484,23 +491,6 @@ fn parse_hostspec_path(s: &str, is_url: bool) -> Option<usize> {
         }
         i += 1;
     }
-}
-
-/// Set script file permissions to match upstream rsync.
-///
-/// Upstream rsync opens the `.sh` file with `S_IRUSR | S_IWUSR | S_IXUSR`
-/// (0o700), granting read/write/execute only to the owner.
-#[cfg(unix)]
-fn set_script_permissions(path: &str) -> BatchResult<()> {
-    use std::fs;
-    let permissions = fs::Permissions::from_mode(0o700);
-    fs::set_permissions(path, permissions)?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn set_script_permissions(_path: &str) -> BatchResult<()> {
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1220,7 +1210,9 @@ mod tests {
         let script_path = config.script_file_path();
         let metadata = fs::metadata(&script_path).unwrap();
         let permissions = metadata.permissions();
-        // upstream: batch_sh_fd opened with S_IRUSR | S_IWUSR | S_IXUSR (0o700)
+        use std::os::unix::fs::PermissionsExt as _;
+        // upstream: batch.c:254 batch_sh_fd opened with
+        // S_IRUSR | S_IWUSR | S_IXUSR (0o700)
         assert_eq!(
             permissions.mode() & 0o777,
             0o700,

--- a/crates/batch/src/writer.rs
+++ b/crates/batch/src/writer.rs
@@ -30,16 +30,22 @@ impl BatchWriter {
     /// Create a new batch writer.
     pub fn new(config: BatchConfig) -> BatchResult<Self> {
         let batch_path = config.batch_file_path();
-        let file = File::create(batch_path).map_err(|e| {
-            BatchError::Io(io::Error::new(
-                e.kind(),
-                format!(
-                    "Failed to create batch file '{}': {}",
-                    batch_path.display(),
-                    e
-                ),
-            ))
-        })?;
+        // upstream: batch.c:263 creates the batch file through
+        // `open_no_attacker_symlinks()` at `S_IRUSR|S_IWUSR`. Owner-only is
+        // load-bearing: the batch stream carries the transferred file contents,
+        // so a `File::create` default (0666 & ~umask) publishes them.
+        let file =
+            crate::operator_file::create_write(batch_path, crate::operator_file::BATCH_FILE_MODE)
+                .map_err(|e| {
+                BatchError::Io(io::Error::new(
+                    e.kind(),
+                    format!(
+                        "Failed to create batch file '{}': {}",
+                        batch_path.display(),
+                        e
+                    ),
+                ))
+            })?;
 
         Ok(Self {
             config,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -400,7 +400,8 @@ pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
     operator_link, operator_open_append, operator_open_read, operator_open_rw_create,
-    operator_read_to_string, operator_rename, owner_trusted_parent, symlink_owner_is_trusted,
+    operator_open_write_create, operator_read_to_string, operator_rename, owner_trusted_parent,
+    symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -422,6 +422,40 @@ pub fn operator_open_rw_create(path: &Path, mode: u32) -> io::Result<std::fs::Fi
     )
 }
 
+/// Open an operator-supplied path for writing, creating or truncating it.
+///
+/// The batch-file shape: `--write-batch` and its `.sh` companion are named by
+/// the operator and created fresh on every run, so the `O_CREAT` is again the
+/// dangerous part - the leaf need not exist for a planted symlink at any
+/// component to redirect the write.
+///
+/// `mode` applies only when the file is created, as with `open(2)`. Upstream
+/// relies on exactly that: re-running `--write-batch` over an existing batch
+/// file truncates it and leaves its mode alone. Forcing the mode afterwards
+/// with a `chmod` would both diverge from that and reopen the window this walk
+/// closes, so the mode is passed to the create and never re-applied.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/batch.c:263` - the batch file itself:
+///   `open_no_attacker_symlinks(batch_name, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY,
+///   S_IRUSR|S_IWUSR)` - owner-only, because the batch holds the file data.
+/// - `rsync-3.5.0/batch.c:254` - the `.sh` companion, the same call with
+///   `S_IRUSR|S_IWUSR|S_IXUSR` so the generated script is executable.
+///
+/// # Errors
+///
+/// See [`operator_open_with`].
+pub fn operator_open_write_create(path: &Path, mode: u32) -> io::Result<std::fs::File> {
+    operator_open_with(
+        path,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::TRUNC,
+        // `RawMode` is u16 on macOS and u32 on Linux, so route the cast through
+        // it rather than naming either width here.
+        Mode::from_bits_truncate(mode as rustix::fs::RawMode),
+    )
+}
+
 /// Read an operator-supplied file to a `String` through the ownership walk.
 ///
 /// The `read_to_string` counterpart to [`operator_open_read`], for the auxiliary

--- a/tests/batch_files_created_with_upstream_modes.rs
+++ b/tests/batch_files_created_with_upstream_modes.rs
@@ -1,0 +1,185 @@
+//! `--write-batch` creates its two files with upstream's modes.
+//!
+//! Upstream opens all three batch files through one primitive, each with its
+//! own literal mode:
+//!
+//! ```c
+//! batch_sh_fd = open_no_attacker_symlinks(filename, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY,
+//!                                         S_IRUSR | S_IWUSR | S_IXUSR);   /* batch.c:254 */
+//! batch_fd    = open_no_attacker_symlinks(batch_name, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY,
+//!                                         S_IRUSR | S_IWUSR);             /* batch.c:263 */
+//! ```
+//!
+//! Owner-only on the batch file is load-bearing rather than incidental: the
+//! batch stream carries the transferred file *contents*, so a world-readable
+//! batch publishes everything the transfer moved, and a world-*writable* one
+//! lets an attacker choose what a later `--read-batch` writes.
+//!
+//! Two independent things are pinned here, and they fail in opposite
+//! directions:
+//!
+//! - **the create mode** - `0600` / `0700`, not the `0666 & ~umask` an ordinary
+//!   `File::create` carries. The umask has to be pinned or this assertion is
+//!   worthless: `umask(2)` can only *clear* bits, so under the usual `022` a
+//!   `0666` request lands as `0644` and a `0600` request also lands as `0600` -
+//!   close enough to look right while the request was wrong. Under umask `0`,
+//!   `0666` stays `0666` and only a genuine `0600` request reads back as
+//!   `0600`. [`pinning_the_child_umask_takes_effect`] is the control for that.
+//!
+//! - **that the mode is applied by the create and never re-applied** - upstream
+//!   passes the mode to `O_CREAT` and issues no `chmod`, so re-running over an
+//!   existing batch file truncates it and leaves its mode alone. Measured
+//!   directly against rsync 3.5.0: pre-existing `0666` files stay `0666` on
+//!   both. A post-hoc `chmod` would satisfy the first assertion and break this
+//!   one, which is why both cells are here.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// upstream: batch.c:263 - `S_IRUSR | S_IWUSR` on the batch file itself.
+const UPSTREAM_BATCH_FILE_MODE: u32 = 0o600;
+
+/// upstream: batch.c:254 - `S_IRUSR | S_IWUSR | S_IXUSR` on the `.sh` companion.
+const UPSTREAM_BATCH_SCRIPT_MODE: u32 = 0o700;
+
+/// A mode with group and other bits set, used to seed the pre-existing-file
+/// cell. Chosen so that a umask of `0` leaves it untouched and any re-applied
+/// create mode is visible as a change.
+const PERMISSIVE_SEED_MODE: u32 = 0o666;
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Builds a command whose child runs under umask `0`.
+///
+/// Pinned on the child rather than by mutating this process's umask around the
+/// spawn: `umask(2)` is process-global, and the harness runs cases in parallel
+/// threads, so an in-process pin would leak into whatever else is creating
+/// files at that moment. `pre_exec` runs after `fork(2)` and before `exec(2)`,
+/// where only async-signal-safe calls are permitted - `umask(2)` is one.
+fn command_with_open_umask(program: impl AsRef<std::ffi::OsStr>) -> Command {
+    let mut command = Command::new(program);
+    unsafe {
+        command.pre_exec(|| {
+            libc::umask(0);
+            Ok(())
+        });
+    }
+    command
+}
+
+fn mode_of(path: &Path) -> u32 {
+    fs::metadata(path)
+        .unwrap_or_else(|e| panic!("stat {}: {e}", path.display()))
+        .permissions()
+        .mode()
+        & 0o7777
+}
+
+/// Lays out `src/` with one file plus an empty `dst/`, and returns both.
+fn setup_tree(root: &Path) -> (PathBuf, PathBuf) {
+    let src = root.join("src");
+    let dst = root.join("dst");
+    fs::create_dir_all(&src).expect("create src");
+    fs::create_dir_all(&dst).expect("create dst");
+    fs::write(src.join("payload.txt"), b"batch payload\n").expect("write payload");
+    (src, dst)
+}
+
+/// Runs `oc-rsync -a --write-batch=<batch> src/ dst/` under umask 0.
+fn run_write_batch(root: &Path, batch: &Path) {
+    let (src, dst) = setup_tree(root);
+    let status = command_with_open_umask(oc_binary())
+        .current_dir(root)
+        .arg("-a")
+        .arg(format!("--write-batch={}", batch.display()))
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dst.display()))
+        .status()
+        .expect("spawn oc-rsync");
+    assert!(status.success(), "--write-batch failed: {status:?}");
+}
+
+/// The control: without this, every mode assertion below could pass for the
+/// wrong reason. A child under umask `0` that requests `0666` must read back
+/// `0666`; if the pin did not take, the ambient `022` would clear the write
+/// bits and `0644` would be indistinguishable from a correct `0644` request.
+#[test]
+fn pinning_the_child_umask_takes_effect() {
+    let temp = TempDir::new().expect("temp dir");
+    let probe = temp.path().join("probe");
+
+    let status = command_with_open_umask("/bin/sh")
+        .arg("-c")
+        .arg(format!("> {}", probe.display()))
+        .status()
+        .expect("spawn sh");
+    assert!(status.success(), "probe shell failed: {status:?}");
+
+    assert_eq!(
+        mode_of(&probe),
+        PERMISSIVE_SEED_MODE,
+        "child umask was not pinned to 0, so no mode assertion in this file \
+         can discriminate a 0600 request from a 0666 one",
+    );
+}
+
+#[test]
+fn write_batch_creates_its_files_with_upstream_modes() {
+    let temp = TempDir::new().expect("temp dir");
+    let batch = temp.path().join("BATCH");
+
+    run_write_batch(temp.path(), &batch);
+
+    let script = temp.path().join("BATCH.sh");
+    assert_eq!(
+        mode_of(&batch),
+        UPSTREAM_BATCH_FILE_MODE,
+        "batch file must be owner-only (upstream batch.c:263); it carries the \
+         transferred file contents",
+    );
+    assert_eq!(
+        mode_of(&script),
+        UPSTREAM_BATCH_SCRIPT_MODE,
+        "batch .sh must be owner-only plus execute (upstream batch.c:254)",
+    );
+}
+
+#[test]
+fn rerunning_write_batch_leaves_an_existing_files_mode_alone() {
+    let temp = TempDir::new().expect("temp dir");
+    let batch = temp.path().join("BATCH");
+    let script = temp.path().join("BATCH.sh");
+
+    for path in [&batch, &script] {
+        fs::write(path, b"").expect("seed file");
+        fs::set_permissions(path, fs::Permissions::from_mode(PERMISSIVE_SEED_MODE))
+            .expect("seed mode");
+    }
+
+    run_write_batch(temp.path(), &batch);
+
+    // upstream passes the mode to `O_CREAT` and never chmods, so an existing
+    // file is truncated with its mode untouched. Measured against rsync 3.5.0:
+    // both files stay 0666.
+    assert_eq!(
+        mode_of(&batch),
+        PERMISSIVE_SEED_MODE,
+        "an existing batch file's mode must survive the rewrite - upstream \
+         applies the mode only on create",
+    );
+    assert_eq!(
+        mode_of(&script),
+        PERMISSIVE_SEED_MODE,
+        "an existing .sh's mode must survive the rewrite - a post-hoc chmod \
+         here would diverge from upstream",
+    );
+}


### PR DESCRIPTION
Routes the three `--read-batch` / `--write-batch` / `.sh` opens onto the
ownership walk, and corrects the create modes to upstream's.

## Upstream

All three go through one primitive, each with its own literal mode:

```c
batch_sh_fd = open_no_attacker_symlinks(filename, O_WRONLY|O_CREAT|O_TRUNC,
                                        S_IRUSR|S_IWUSR|S_IXUSR);   /* batch.c:254 */
batch_fd    = open_no_attacker_symlinks(batch_name, O_WRONLY|O_CREAT|O_TRUNC,
                                        S_IRUSR|S_IWUSR);           /* batch.c:263 */
batch_fd    = open_no_attacker_symlinks(batch_name, O_RDONLY, ...); /* batch.c:267 */
```

oc used plain `File::open` / `File::create` at all four call sites, so a
symlink planted at any component redirected the open. For the two write sides
that means a privileged create-and-truncate landing where the operator never
named.

## The modes diverged too, in two opposite directions

Measured against real rsync 3.5.0:

| file | upstream | oc @umask 022 | oc @umask 000 |
|---|---|---|---|
| `BATCH` | `0600` | **`0644`** | **`0666`** |
| `BATCH.sh` | `0700` | `0700` | `0700` |

Owner-only on the batch file is load-bearing rather than incidental: the
batch stream carries the transferred file **contents**, so a world-readable
batch publishes everything the transfer moved, and a world-*writable* one
lets an attacker choose what a later `--read-batch` writes.

The `.sh` reached `0700` only via a post-hoc `chmod`, which is the second
divergence. Upstream passes the mode to `O_CREAT` and never chmods, so
re-running over an existing file truncates it and leaves its mode alone:

| pre-existing `0666` | upstream 3.5.0 | oc (before) |
|---|---|---|
| `BATCH` | `0666` | `0666` |
| `BATCH.sh` | `0666` | **`0700`** |

Passing the mode to the create fixes both cells at once and lets
`set_script_permissions` go, removing a duplicated owner of the mode along
with the TOCTOU window the walk exists to close.

## Shape

Adds `fast_io::operator_open_write_create` - the `O_WRONLY|O_CREAT|O_TRUNC`
arm the primitive lacked - and a `crates/batch/src/operator_file.rs` platform
seam matching the per-crate shape already used by `cli` and `core`: the `cfg`
is written once instead of once per call site, and the walk is deliberately
not re-exported as if it were portable, so its absence on non-Unix stays
visible to a reader of the call site.

## Tests

`tests/batch_files_created_with_upstream_modes.rs`, with the child umask
pinned to `0` via `pre_exec`. That pin is what makes the assertions
discriminating: under the usual `022` a `0666` request lands as `0644` and a
`0600` request lands as `0600`, so the two spellings become
indistinguishable. `pinning_the_child_umask_takes_effect` is the control for
that claim.

Non-vacuity proven with two orthogonal mutations, each killing exactly one
test while the other two stayed green (`--no-fail-fast`, so the kill list is
complete rather than truncated):

- `create_write` reverted to `File::create` → `write_batch_creates_its_files_with_upstream_modes`
  fails, `left: 438` (0o666) vs `right: 384` (0o600).
- post-hoc `chmod 0700` restored → `rerunning_write_batch_leaves_an_existing_files_mode_alone`
  fails, `left: 448` (0o700) vs `right: 438` (0o666).

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets
  --all-features --no-deps -- -D warnings` exit 0.
- `cargo nextest run -p batch -p fast_io`: 979/979.
- New test file 3/3.
- `crates/batch` keeps `#![deny(unsafe_code)]` - the walk is reached through
  `fast_io`'s safe public API, no unsafe added to a denying crate.
