### PR TITLE
fix(batch): close two replay-script injections in the generated .sh

### DIFF
--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -343,49 +343,60 @@ fn write_replay_options(
 }
 
 /// Quote an argument for the generated `.sh` batch wrapper, byte-matching
-/// upstream rsync's `write_arg` (batch.c:164-190).
+/// upstream rsync's `write_arg` (batch.c:164-198).
 ///
-/// A leading `-opt=value` token has its `-opt=` prefix written bare and only
-/// the value quote-processed (batch.c:169-172). Quoting engages only when the
-/// remaining argument contains one of upstream's special characters
-/// (`strpbrk(arg, " \"'&;|[]()$#!*?^\\")`, batch.c:174); otherwise the argument
-/// is emitted verbatim, so `,` `+` `@` `~` `%` `{` `}` `<` `>` stay bare.
-/// Embedded single quotes are closed rather than escaped (`''`,
-/// batch.c:176-179), reproducing upstream's byte output for `.sh` fidelity.
+/// Quoting is UNCONDITIONAL. Upstream's own comment gives the reason: single
+/// quotes keep "every shell metacharacter (backtick, newline, redirection,
+/// ...) literal in the replay script". Its 3.4.x predecessor quoted only when
+/// `strpbrk` matched a special-character set that omitted the backtick, `<`,
+/// `>` and the braces - so a destination path such as ``d`cmd`x`` was emitted
+/// bare and the backtick *executed* when the operator ran `BATCH.sh`.
+///
+/// An embedded `'` closes the quote, is backslash-escaped, then the quote
+/// reopens (`'\''`, batch.c:189-192).
+///
+/// A leading `-opt=` prefix is written bare so the replay script stays
+/// readable, but only when every byte from the leading `-` up to the first `=`
+/// is `[-_0-9A-Za-z]` (batch.c:169-183). A metacharacter before the `=` marks
+/// what upstream calls "an attacker-shaped arg", which is quoted whole.
+///
+/// upstream: batch.c:164 write_arg()
 fn shell_quote(s: &str) -> String {
-    // upstream: batch.c:174 special-character set for strpbrk().
-    const SPECIAL: &[char] = &[
-        ' ', '"', '\'', '&', ';', '|', '[', ']', '(', ')', '$', '#', '!', '*', '?', '^', '\\',
-    ];
-
     let mut result = String::new();
     let mut arg = s;
 
-    // upstream: batch.c:169-172 — a leading "-opt=" prefix is written unquoted,
-    // then only the value that follows the first '=' is quote-processed.
-    if let Some(eq) = arg.strip_prefix('-').and(arg.find('=')) {
-        result.push_str(&arg[..=eq]);
-        arg = &arg[eq + 1..];
+    // upstream: batch.c:169-183 - the bare "-opt=" prefix is conditional on the
+    // option name being a plain token; upstream walks `p` from `arg` to the '='
+    // accepting only `-`, `_` and alphanumerics, and emits the prefix only when
+    // the walk reaches the '=' (`p == x`).
+    if arg.starts_with('-') {
+        if let Some(eq) = arg.find('=') {
+            if arg[..eq].bytes().all(is_plain_option_byte) {
+                result.push_str(&arg[..=eq]);
+                arg = &arg[eq + 1..];
+            }
+        }
     }
 
-    // upstream: batch.c:174 — quote only when a special character is present.
-    if !arg.contains(SPECIAL) {
-        result.push_str(arg);
-        return result;
-    }
-
-    // upstream: batch.c:175-182 — single-quote wrap; an embedded single quote
-    // closes the quote (`''`) instead of being backslash-escaped.
+    // upstream: batch.c:187-195 - unconditional single-quote wrap.
     result.push('\'');
     for ch in arg.chars() {
         if ch == '\'' {
-            result.push_str("''");
+            // upstream: batch.c:191 - write "'\\''", i.e. the four bytes '\''
+            result.push_str("'\\''");
         } else {
             result.push(ch);
         }
     }
     result.push('\'');
     result
+}
+
+/// Bytes upstream accepts in the option name of a bare `-opt=` prefix.
+///
+/// upstream: batch.c:174-178 - `'-' || '_' || 0-9 || A-Z || a-z`.
+fn is_plain_option_byte(b: u8) -> bool {
+    b == b'-' || b == b'_' || b.is_ascii_alphanumeric()
 }
 
 /// Find the destination path from the argument list (last non-option argument).
@@ -503,36 +514,53 @@ mod tests {
 
     #[test]
     fn test_shell_quote() {
-        assert_eq!(shell_quote("simple"), "simple");
-        assert_eq!(shell_quote("with-dash"), "with-dash");
-        assert_eq!(shell_quote("/path/to/file"), "/path/to/file");
+        // Quoting is unconditional (batch.c:187-195): even an argument with no
+        // metacharacter at all comes back wrapped.
+        assert_eq!(shell_quote("simple"), "'simple'");
+        assert_eq!(shell_quote("with-dash"), "'with-dash'");
+        assert_eq!(shell_quote("/path/to/file"), "'/path/to/file'");
         assert_eq!(shell_quote("needs quoting"), "'needs quoting'");
-        // upstream closes the quote (`''`) instead of `'\''` (batch.c:176-179).
-        assert_eq!(shell_quote("has'quote"), "'has''quote'");
+        // upstream closes, escapes, then reopens: `'\''` (batch.c:189-192).
+        assert_eq!(shell_quote("has'quote"), "'has'\\''quote'");
         assert_eq!(shell_quote("$special"), "'$special'");
     }
 
-    /// Golden byte parity with upstream `write_arg` (batch.c:164-190).
+    /// The metacharacters upstream's 3.4.x `strpbrk` set did NOT cover.
+    ///
+    /// Each of these was emitted bare by the old conditional quoting, so a
+    /// destination path or option value containing one was interpreted by the
+    /// shell when the operator ran `BATCH.sh`. The backtick is the live
+    /// exploit: the rsync 3.5.0 `write-batch-quoting` cell plants a
+    /// destination named ``d`>PWNED`x/`` and fails if the command substitution
+    /// runs.
     #[test]
-    fn test_shell_quote_matches_upstream_write_arg() {
-        // Characters upstream never quotes (outside its strpbrk set) stay bare,
-        // even though oc's old whitelist would have single-quoted them.
-        for bare in [
+    fn shell_quote_neutralises_the_metacharacters_the_old_set_missed() {
+        for arg in [
+            "d`>PWNED`x/",
+            "a`cmd`b",
+            "a>b",
+            "a<b",
+            "a{b}c",
             "a,b",
             "a+b",
             "user@host",
             "~/dir",
             "50%",
-            "a{b}c",
-            "a<b>c",
-            "=val",
-            "x:y=z",
+            "a\nb",
         ] {
-            assert_eq!(shell_quote(bare), bare, "{bare:?} must stay bare");
+            assert_eq!(
+                shell_quote(arg),
+                format!("'{arg}'"),
+                "{arg:?} must be quoted whole"
+            );
         }
+    }
 
-        // Each character in upstream's special set (batch.c:174) triggers
-        // single-quote wrapping.
+    /// Golden byte parity with upstream `write_arg` (batch.c:164-198).
+    #[test]
+    fn test_shell_quote_matches_upstream_write_arg() {
+        // Every character in the old special set still quotes - the set simply
+        // stopped being the deciding factor.
         for c in [
             ' ', '"', '&', ';', '|', '[', ']', '(', ')', '$', '#', '!', '*', '?', '^', '\\',
         ] {
@@ -540,20 +568,30 @@ mod tests {
             assert_eq!(shell_quote(&arg), format!("'{arg}'"), "{c:?} must quote");
         }
 
-        // Embedded single quote: upstream emits `''` (drops the quote on eval),
-        // not the POSIX `'\''` idiom.
-        assert_eq!(shell_quote("'"), "''''");
-        assert_eq!(shell_quote("a'b"), "'a''b'");
-        assert_eq!(shell_quote("a'b'c"), "'a''b''c'");
+        // Embedded single quote: close, backslash-escape, reopen
+        // (batch.c:189-192).
+        assert_eq!(shell_quote("'"), "''\\'''");
+        assert_eq!(shell_quote("a'b"), "'a'\\''b'");
+        assert_eq!(shell_quote("a'b'c"), "'a'\\''b'\\''c'");
 
-        // Leading "-opt=" prefix is written bare; only the value is quoted
-        // (batch.c:169-172).
+        // A leading "-opt=" prefix is written bare so the replay script stays
+        // readable; only the value is quote-processed (batch.c:169-183).
         assert_eq!(shell_quote("--filter=- *.tmp"), "--filter='- *.tmp'");
         assert_eq!(shell_quote("--rsh=ssh -p 22"), "--rsh='ssh -p 22'");
-        // Value with no special char stays bare after the split.
-        assert_eq!(shell_quote("--opt=a,b+c"), "--opt=a,b+c");
-        // Non-option token with '=' is not split.
+        // The value is quoted even when it holds no metacharacter.
+        assert_eq!(shell_quote("--opt=a,b+c"), "--opt='a,b+c'");
+        // A non-option token with '=' is not split.
         assert_eq!(shell_quote("a=b c"), "'a=b c'");
+        assert_eq!(shell_quote("x:y=z"), "'x:y=z'");
+        // The bare prefix is conditional: a metacharacter before the '=' marks
+        // an attacker-shaped argument, which upstream quotes whole
+        // (batch.c:169-183).
+        assert_eq!(shell_quote("-a`b=c"), "'-a`b=c'");
+        assert_eq!(shell_quote("-a b=c"), "'-a b=c'");
+        assert_eq!(shell_quote("-$x=c"), "'-$x=c'");
+        // ... while `-`, `_` and alphanumerics keep the readable prefix.
+        assert_eq!(shell_quote("--no_iconv=x"), "--no_iconv='x'");
+        assert_eq!(shell_quote("-4=x"), "-4='x'");
     }
 
     #[test]
@@ -627,7 +665,7 @@ mod tests {
 
         let content = fs::read_to_string(config.script_file_path()).unwrap();
         assert!(
-            content.contains("${1:-/remote/dest}"),
+            content.contains("${1:-'/remote/dest'}"),
             "remote host: prefix must be stripped from the default: {content}"
         );
         assert!(
@@ -688,7 +726,7 @@ mod tests {
         let content = fs::read_to_string(config.script_file_path()).unwrap();
         let first_line = content.lines().next().expect("script must have content");
         assert!(
-            first_line.starts_with(absolute_invoker),
+            first_line.starts_with(&format!("'{absolute_invoker}'")),
             "wrapper script must start with the configured invoker path \
              (matches upstream batch.c:259 raw_argv[0]); got: {first_line}"
         );
@@ -734,7 +772,7 @@ mod tests {
         generate_script(&config).unwrap();
 
         let content = fs::read_to_string(config.script_file_path()).unwrap();
-        assert!(content.starts_with("oc-rsync "));
+        assert!(content.starts_with("'oc-rsync' "));
     }
 
     #[test]
@@ -838,7 +876,7 @@ mod tests {
         let script_path = config.script_file_path();
         let content = fs::read_to_string(&script_path).unwrap();
         assert!(
-            content.contains("--read-batch=mybatch"),
+            content.contains("--read-batch='mybatch'"),
             "Bare --write-batch should be converted to --read-batch=<name>: {content}"
         );
         let occurrences = content.matches("mybatch").count();
@@ -1062,7 +1100,7 @@ mod tests {
         let content = fs::read_to_string(&script_path).unwrap();
 
         assert!(
-            content.contains("${1:-/path/to/dest}"),
+            content.contains("${1:-'/path/to/dest'}"),
             "Script must embed destination in placeholder: {content}"
         );
         assert!(
@@ -1157,16 +1195,16 @@ mod tests {
 
         // Transfer-affecting flags must be preserved for replay.
         assert!(
-            content.contains(" -az"),
+            content.contains(" '-az'"),
             "replay script must re-apply -az: {content}"
         );
         assert!(
-            content.contains(" --numeric-ids"),
+            content.contains(" '--numeric-ids'"),
             "replay script must re-apply --numeric-ids: {content}"
         );
         // --write-batch is converted to --read-batch.
         assert!(
-            content.contains(&format!("--read-batch={batch_name}")),
+            content.contains(&format!("--read-batch='{batch_name}'")),
             "replay script must convert --write-batch to --read-batch: {content}"
         );
         assert!(
@@ -1184,7 +1222,7 @@ mod tests {
         );
         // Filename operands are elided; the destination returns via ${1:-<dest>}.
         assert!(
-            content.contains("${1:-dst/}"),
+            content.contains("${1:-'dst/'}"),
             "destination must be re-supplied via placeholder: {content}"
         );
         assert!(

--- a/crates/batch/tests/batch_arg_roundtrip.rs
+++ b/crates/batch/tests/batch_arg_roundtrip.rs
@@ -139,16 +139,20 @@ fn batch_sh_options_round_trip_through_the_shell_to_the_replay_set() {
     );
 }
 
-/// KNOWN LIMITATION (shared with upstream, pinned not papered over): an arg
-/// value containing a literal single quote does NOT round-trip through the
-/// `.sh`. Upstream `write_arg()` (batch.c:174-185) wraps in single quotes and
-/// emits an embedded `'` as `''`, which POSIX sh collapses to nothing
-/// (`'a''b'` tokenizes to `ab`). oc mirrors that byte-for-byte for `.sh`
-/// fidelity (#116), so it inherits the same lossy behavior - this is NOT an
-/// oc-vs-upstream divergence. Pinned so any change to the quoting is a
-/// deliberate, reviewed decision.
+/// An arg value containing a literal single quote round-trips through the
+/// `.sh` intact.
+///
+/// This was a KNOWN LIMITATION until upstream 3.5.0: `write_arg()` used to wrap
+/// in single quotes and emit an embedded `'` as `''`, which POSIX sh collapses
+/// to nothing (`'a''b'` tokenizes to `ab`), silently corrupting the option
+/// value in the generated replay script. 3.5.0 switched to the POSIX
+/// close/escape/reopen idiom `'\''` (batch.c:189-192) and the loss is gone.
+///
+/// Pinned in the round-trip direction - through the real `/bin/sh` - because
+/// the byte-golden tests in `script.rs` cannot tell a quoting form that *looks*
+/// right from one that *tokenizes* right.
 #[test]
-fn embedded_single_quote_is_lossy_matching_upstream_write_arg() {
+fn embedded_single_quote_survives_the_sh_round_trip() {
     let dir = tempdir().expect("tempdir");
     let shim = write_echo_shim(dir.path());
     let batch = dir.path().join("b");
@@ -168,14 +172,16 @@ fn embedded_single_quote_is_lossy_matching_upstream_write_arg() {
 
     let argv = replay_argv(&config.script_file_path());
 
-    // The single quote is dropped by the shell (`'a''b'` -> `ab`), exactly as an
-    // upstream-generated batch `.sh` would behave.
+    // upstream 3.5.0 emits the POSIX close/escape/reopen idiom (`'a'\''b'`,
+    // batch.c:189-192), so the quote survives evaluation. Its 3.4.x predecessor
+    // wrote `'a''b'`, which the shell collapses to `ab` - the option value was
+    // silently corrupted by the generated replay script.
     assert!(
-        argv.iter().any(|a| a == "--suffix=ab"),
-        "embedded single quote is collapsed (upstream-identical): {argv:?}"
+        argv.iter().any(|a| a == "--suffix=a'b"),
+        "the literal single quote must survive the .sh round-trip: {argv:?}"
     );
     assert!(
-        !argv.iter().any(|a| a == "--suffix=a'b"),
-        "the literal single quote does not survive the .sh round-trip: {argv:?}"
+        !argv.iter().any(|a| a == "--suffix=ab"),
+        "the quote must not be collapsed away (the pre-3.5.0 behaviour): {argv:?}"
     );
 }

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -232,7 +232,7 @@ pub(crate) fn finalize_batch(
     }
 
     // upstream: batch.c:305-306 - embed filter rules in the replay script
-    let filter_text = serialize_filter_rules(config.filter_rules());
+    let filter_text = serialize_filter_rules(config.filter_rules())?;
     let filter_opt = if filter_text.is_empty() {
         None
     } else {
@@ -279,17 +279,39 @@ pub(crate) fn finalize_batch(
 /// flags (`s`/`r`/`p`/`x`/`!`). A trailing `/` is appended for
 /// directory-only patterns. Returns an empty string when no rules are present.
 ///
+/// A pattern containing a newline is refused rather than written. Each rule is
+/// one here-doc line, so an embedded newline lets a crafted pattern - from a
+/// dir-merge or `--exclude-from` file in an untrusted tree - forge the `#E#`
+/// terminator on a line of its own and inject shell commands into the
+/// generated replay script. Such a pattern also cannot round-trip a
+/// line-delimited here-doc, so upstream fails closed and so does this.
+///
+/// This is the last layer that still sees rules individually; the script
+/// emitter receives one flattened string, where a rule-internal newline is
+/// indistinguishable from the separator between rules.
+///
 /// # Upstream Reference
 ///
-/// - `batch.c:205-222`: `write_filter_rules()` iterates filter_list
+/// - `batch.c:213-240`: `write_filter_rules()` iterates filter_list and, per
+///   rule, `if (ent->pattern && strchr(ent->pattern, '\n'))` reports the error
+///   below and calls `exit_cleanup(RERR_SYNTAX)`.
 /// - `exclude.c:1525-1587`: `get_rule_prefix()` builds the prefix string
-fn serialize_filter_rules(rules: &[FilterRuleSpec]) -> String {
+fn serialize_filter_rules(rules: &[FilterRuleSpec]) -> Result<String, ClientError> {
     if rules.is_empty() {
-        return String::new();
+        return Ok(String::new());
     }
 
     let mut output = String::new();
     for rule in rules {
+        // upstream: batch.c:222-231 - refuse a newline-bearing pattern before
+        // any of it reaches the script.
+        if rule.pattern().contains('\n') {
+            let msg = "cannot write a filter rule containing a newline to the batch replay script";
+            return Err(ClientError::new(
+                1,
+                rsync_error!(1, "{}", msg).with_role(Role::Client),
+            ));
+        }
         // upstream: exclude.c:1532-1541 - action prefix
         let action_char = match rule.kind() {
             FilterRuleKind::Include => '+',
@@ -339,7 +361,7 @@ fn serialize_filter_rules(rules: &[FilterRuleSpec]) -> String {
         output.push('\n');
     }
 
-    output
+    Ok(output)
 }
 
 /// Replay a batch file to reconstruct the transfer at the destination.
@@ -666,27 +688,27 @@ mod tests {
 
     #[test]
     fn serialize_empty_rules_returns_empty_string() {
-        assert_eq!(serialize_filter_rules(&[]), "");
+        assert_eq!(serialize_filter_rules(&[]).expect("no rules to reject"), "");
     }
 
     #[test]
     fn serialize_exclude_rule() {
         let rules = [FilterRuleSpec::exclude("*.tmp")];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         assert_eq!(output, "- *.tmp\n");
     }
 
     #[test]
     fn serialize_include_rule() {
         let rules = [FilterRuleSpec::include("*.rs")];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         assert_eq!(output, "+ *.rs\n");
     }
 
     #[test]
     fn serialize_protect_rule() {
         let rules = [FilterRuleSpec::protect("/data")];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         // upstream: protect is 'P', receiver-only gets 'r' modifier
         assert_eq!(output, "Pr /data\n");
     }
@@ -694,7 +716,7 @@ mod tests {
     #[test]
     fn serialize_risk_rule() {
         let rules = [FilterRuleSpec::risk("/temp")];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         // upstream: risk is 'R', receiver-only gets 'r' modifier
         assert_eq!(output, "Rr /temp\n");
     }
@@ -702,7 +724,7 @@ mod tests {
     #[test]
     fn serialize_clear_rule() {
         let rules = [FilterRuleSpec::clear()];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         assert_eq!(output, "! \n");
     }
 
@@ -714,14 +736,14 @@ mod tests {
             FilterRuleSpec::include("*.txt"),
             FilterRuleSpec::exclude("*"),
         ];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         assert_eq!(output, "- *.tmp\n+ */\n+ *.txt\n- *\n");
     }
 
     #[test]
     fn serialize_sender_only_rule() {
         let rules = [FilterRuleSpec::hide("*.bak")];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         // upstream: sender-only gets 's' modifier
         assert_eq!(output, "-s *.bak\n");
     }
@@ -729,21 +751,21 @@ mod tests {
     #[test]
     fn serialize_perishable_rule() {
         let rules = [FilterRuleSpec::exclude("*.tmp").with_perishable(true)];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         assert_eq!(output, "-p *.tmp\n");
     }
 
     #[test]
     fn serialize_xattr_only_rule() {
         let rules = [FilterRuleSpec::exclude("user.*").with_xattr_only(true)];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         assert_eq!(output, "-x user.*\n");
     }
 
     #[test]
     fn serialize_negated_rule() {
         let rules = [FilterRuleSpec::exclude("*.txt").with_negate(true)];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         assert_eq!(output, "-! *.txt\n");
     }
 
@@ -751,7 +773,7 @@ mod tests {
     fn serialize_directory_only_pattern() {
         // FilterRuleSpec stores the trailing '/' as part of the pattern
         let rules = [FilterRuleSpec::exclude("build/")];
-        let output = serialize_filter_rules(&rules);
+        let output = serialize_filter_rules(&rules).expect("rules must serialize");
         assert_eq!(output, "- build/\n");
     }
 
@@ -769,7 +791,7 @@ mod tests {
             FilterRuleSpec::include("*.txt"),
             FilterRuleSpec::exclude("*"),
         ];
-        let filter_text = serialize_filter_rules(&rules);
+        let filter_text = serialize_filter_rules(&rules).expect("rules must serialize");
 
         let result = engine::batch::script::generate_script_with_filters(
             &batch_cfg,

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -340,8 +340,8 @@ update pass
 variety pass
 variety-symlink-traversal skip
 wildmatch pass
-write-batch-filter-injection fail
-write-batch-quoting fail
+write-batch-filter-injection pass
+write-batch-quoting pass
 xattr-wire-cap skip
 xattrs pass
 xattrs-depth pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -340,8 +340,8 @@ update pass
 variety pass
 variety-symlink-traversal skip
 wildmatch pass
-write-batch-filter-injection fail
-write-batch-quoting fail
+write-batch-filter-injection pass
+write-batch-quoting pass
 xattr-wire-cap skip
 xattrs pass
 xattrs-depth pass


### PR DESCRIPTION
## What

Two independent ways a crafted name reached the shell when an operator ran the
`BATCH.sh` a `--write-batch` run generates. Both reproduce against the rsync
3.5.0 testsuite, with the real 3.5.0 binary passing as the control.

### 1. `write-batch-quoting` - the option quoter was upstream 3.4.x

`shell_quote` implemented upstream's *conditional* quoting: wrap an argument
only when `strpbrk` matches a special-character set. Its doc even cited the set,
` "'&;|[]()$#!*?^\` - which omits the **backtick**, `<`, `>` and the braces. A
destination named ``d`>PWNED`x/`` was therefore written **bare**, and the command
substitution **executed** on replay.

Upstream 3.5.0 rewrote `write_arg` (`batch.c:164-198`) to single-quote
unconditionally, and its own comment gives the reason: every metacharacter -
backtick, newline, redirection - must stay literal. Two further rules changed
with it, and all three are ported:

| rule | 3.4.x | 3.5.0 (now) |
|---|---|---|
| wrap | only if `strpbrk` hits | always |
| embedded `'` | `''` (close/reopen) | `'\''` (close/escape/reopen) |
| bare `-opt=` prefix | whenever an `=` exists | only if every byte from the leading `-` to the `=` is `[-_0-9A-Za-z]` |

The third rule matters on its own: without it an attacker-shaped ``-a`cmd`=v``
gets its `-a`cmd`=` half emitted outside the quotes.

**Bonus defect closed.** Switching to `'\''` also fixes silent data loss the old
form had: `'a''b'` collapses to `ab`, so an option value containing a quote was
**corrupted** by the generated replay script. The round-trip test that pinned
that loss as a known limitation now pins the opposite - the quote survives.

### 2. `write-batch-filter-injection` - the filter here-doc had no newline guard

Filter rules are replayed through a here-doc terminated by `#E#`. Nothing
rejected a rule whose pattern contained a newline, so a pattern could forge that
terminator on a line of its own and append arbitrary shell to the script.

Upstream refuses **fail-closed, per rule** (`batch.c:213-240`): `strchr(pattern,
'\n')` -> `rprintf(FERROR, ...)` + `exit_cleanup(RERR_SYNTAX)`. Ported verbatim,
message included.

**Placement is the substance here.** The refusal goes in
`serialize_filter_rules`, the last layer that still sees rules *individually*.
By the time the script emitter runs they are one flattened string, where a
rule-internal newline is indistinguishable from the separator between rules - a
check there could only guess.

## Tests

The existing `shell_quote` goldens encoded the 3.4.x rules, so they had to be
re-based - **against the 3.5.0 C source, not against current oc output**, which
would have made them tautological. Added:

- a case per metacharacter the old set missed, with the live backtick exploit
  first;
- the conditional-prefix rule in **both** directions (`--no_iconv='x'` takes the
  prefix, ``'-a`b=c'`` does not);
- `''\'''` and `'a'\''b'` for the new escape idiom.

## Verification

- `write-batch-quoting` and `write-batch-filter-injection`: **PASS**. Real rsync
  3.5.0 passes both as the control.
- **RED proven by mutation, one fix at a time.** Reverting `shell_quote` to the
  conditional form reds `write-batch-quoting` and leaves
  `write-batch-filter-injection` green; disabling the newline guard reds
  `write-batch-filter-injection` and leaves `write-batch-quoting` green. Each
  cell is the other's non-vacuity control, so neither row can be passing for the
  other fix's reason.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets
  --all-features --no-deps -- -D warnings` clean.
- `cargo nextest run -p core -p batch --all-features`: 3035 passed. The one
  failure, `run_client_sparse_copy_creates_holes`, passes in isolation and is a
  recorded APFS parallel-run flake unrelated to this change.

## Manifest

Both rows flip `fail` -> `pass` in `upstream-3.5.0-expect.{nonroot,root}.txt`
in the same PR. Row counts unchanged at 349 per leg. The TCP manifests do not
carry these cells.
