### PR TITLE
fix(receiver): don't let the sender widen --delete scope via an implied parent

### DIFF
--- a/crates/filters/src/implied.rs
+++ b/crates/filters/src/implied.rs
@@ -61,6 +61,11 @@ pub struct ImpliedIncludes {
     opts: ImpliedIncludeOptions,
     rules: Vec<CompiledRule>,
     seen: HashSet<String>,
+    /// Whether an arg contributed a rule accepting the transfer root's own
+    /// contents (upstream: the `/**` / `/*` patterns `is_implied_parent_dir()`
+    /// scans for at `exclude.c:1153-1163`). Only the empty-arg branch of
+    /// [`add_arg`](Self::add_arg) can produce them.
+    root_content: bool,
 }
 
 impl ImpliedIncludes {
@@ -71,6 +76,7 @@ impl ImpliedIncludes {
             opts,
             rules: Vec::new(),
             seen: HashSet::new(),
+            root_content: false,
         }
     }
 
@@ -156,6 +162,10 @@ impl ImpliedIncludes {
             let suffix = if self.opts.recurse { "**" } else { "*" };
             let pattern = format!("{base}/{suffix}");
             self.push_rule(&pattern, false)?;
+            // upstream: exclude.c:1153-1163 - `/**` / `/*` are the only implied
+            // patterns that accept the transfer root's own contents, and only an
+            // empty (root) arg produces them.
+            self.root_content |= segments.is_empty();
         }
 
         Ok(())
@@ -179,6 +189,53 @@ impl ImpliedIncludes {
         self.rules
             .iter()
             .any(|rule| rule.matches(path, is_dir, false))
+    }
+
+    /// Returns `true` when `path` is only reachable as a *parent* of something
+    /// the client requested - i.e. every implied rule it matches is
+    /// directory-only, and none names it as a requested leaf.
+    ///
+    /// The receiver uses this to refuse a malicious sender that marks such a
+    /// directory as a content dir: the honest encoding of an implied parent is
+    /// `XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR`, so trusting the sender's byte would
+    /// let `--delete` sweep pre-existing siblings under the parent.
+    ///
+    /// An empty set returns `false` (the mechanism is inactive, as upstream's
+    /// `!implied_filter_list.head` early return does). The transfer root is
+    /// parent-only unless an empty source arg contributed a root-content rule.
+    ///
+    /// Upstream skips per-dir-merge and CVS-ignore rules, and considers only
+    /// include rules; the implied list holds neither by construction (every rule
+    /// is an anchored `FilterRule::include`), so no filtering is needed here.
+    ///
+    /// upstream: `exclude.c:1144` `is_implied_parent_dir()`.
+    #[must_use]
+    pub fn is_parent_only_dir(&self, path: &Path) -> bool {
+        if self.rules.is_empty() {
+            return false;
+        }
+
+        // upstream: exclude.c:1151-1165 - the receiver's synthetic transfer-root
+        // entry is exempt from the requested-name filter, so it is treated as
+        // parent-only unless a root-content rule exists.
+        if path == Path::new(".") || path == Path::new("/.") {
+            return !self.root_content;
+        }
+
+        let mut parent_match = false;
+        for rule in &self.rules {
+            if !rule.matches(path, true, false) {
+                continue;
+            }
+            if rule.is_directory_only() {
+                parent_match = true;
+                continue;
+            }
+            // upstream: exclude.c:1178-1180 - a non-directory include rule names
+            // a leaf the client asked for, so the dir is legitimately content.
+            return false;
+        }
+        parent_match
     }
 
     /// Compiles and stores one anchored include rule, de-duplicating repeats.

--- a/crates/transfer/src/receiver/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/file_list/filter_recheck.rs
@@ -181,36 +181,9 @@ impl ReceiverContext {
         &self,
         entries: &[FileEntry],
     ) -> io::Result<()> {
-        // upstream: options.c:2510 / exclude.c:385 - trust_sender_args makes
-        // add_implied_include() a no-op, leaving implied_filter_list empty.
-        if self.config.trust_sender {
+        let Some(implied) = self.build_implied_includes()? else {
             return Ok(());
-        }
-
-        let sources = &self.config.connection.implied_source_args;
-        if sources.is_empty() {
-            return Ok(());
-        }
-
-        // upstream: exclude.c:403-567 - relative_paths, recurse, xfer_dirs and
-        // the daemon-module flag shape the implied rules. The module-name strip
-        // applies only to a daemon source arg (main.c:1549 passes
-        // skip_daemon_module=daemon_connection); local --files-from entries are
-        // already module-relative, so upstream records them with
-        // skip_daemon_module=0 (io.c:427,464). The strip decision is read from
-        // the stable flag recorded when the args were built: files_from_data is
-        // consumed while forwarding the list and would misreport here.
-        let opts = ImpliedIncludeOptions {
-            relative: self.config.flags.relative,
-            recurse: self.config.flags.recursive,
-            dirs: self.config.flags.dirs,
-            skip_daemon_module: self.config.connection.implied_skip_daemon_module,
         };
-        let implied = ImpliedIncludes::from_args(opts, sources)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
-        if implied.is_empty() {
-            return Ok(());
-        }
 
         for entry in entries {
             let path = entry.path().as_path();
@@ -233,6 +206,98 @@ impl ReceiverContext {
                         path.display()
                     ),
                 ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Builds the implied-include set from the client's requested source args,
+    /// or `None` when the mechanism is inactive.
+    ///
+    /// Shared by the unrequested-name refusal and the implied-parent downgrade,
+    /// which upstream drives from the one `implied_filter_list` global.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2510` / `exclude.c:385` - `trust_sender_args` makes
+    ///   `add_implied_include()` a no-op, leaving `implied_filter_list` empty.
+    /// - `exclude.c:403-567` - `relative_paths`, `recurse`, `xfer_dirs` and the
+    ///   daemon-module flag shape the implied rules. The module-name strip
+    ///   applies only to a daemon source arg (`main.c:1549` passes
+    ///   `skip_daemon_module=daemon_connection`); local `--files-from` entries
+    ///   are already module-relative, so upstream records them with
+    ///   `skip_daemon_module=0` (`io.c:427,464`). The strip decision is read
+    ///   from the stable flag recorded when the args were built:
+    ///   `files_from_data` is consumed while forwarding the list and would
+    ///   misreport here.
+    fn build_implied_includes(&self) -> io::Result<Option<ImpliedIncludes>> {
+        if self.config.trust_sender {
+            return Ok(None);
+        }
+
+        let sources = &self.config.connection.implied_source_args;
+        if sources.is_empty() {
+            return Ok(None);
+        }
+
+        let opts = ImpliedIncludeOptions {
+            relative: self.config.flags.relative,
+            recurse: self.config.flags.recursive,
+            dirs: self.config.flags.dirs,
+            skip_daemon_module: self.config.connection.implied_skip_daemon_module,
+        };
+        let implied = ImpliedIncludes::from_args(opts, sources)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+        Ok((!implied.is_empty()).then_some(implied))
+    }
+
+    /// Forces every implied-parent directory entry back to the honest
+    /// non-content encoding, whatever xflags byte the sender sent.
+    ///
+    /// A malicious sender can omit `XMIT_NO_CONTENT_DIR` from an implied parent
+    /// (whose honest encoding is `XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR`) to make
+    /// the receiver treat it as a content dir. The deletion pass would then run
+    /// on that directory and sweep pre-existing siblings the client never asked
+    /// to touch - a `--delete` scope expansion chosen by the peer.
+    ///
+    /// `implied_source_args` is receiver-owned state, so this is deliberately
+    /// **not** gated on the sender-trusting escape hatches that suppress the
+    /// per-directory filter re-check: a per-dir merge rule must not be able to
+    /// downgrade the defense.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1230-1252` `recv_file_entry()` - re-asserts
+    ///   `XMIT_NO_CONTENT_DIR | XMIT_TOP_DIR` before flag mapping, so the entry
+    ///   lands in `FLAG_IMPLIED_DIR` rather than `FLAG_CONTENT_DIR`.
+    /// - `exclude.c:1144` `is_implied_parent_dir()` - the parent-only test.
+    pub(in crate::receiver) fn downgrade_implied_parent_dirs(&mut self) -> io::Result<()> {
+        self.downgrade_implied_parent_dirs_from(0)
+    }
+
+    /// Range-scoped variant of
+    /// [`downgrade_implied_parent_dirs`](Self::downgrade_implied_parent_dirs)
+    /// covering only `self.file_list[flat_start..]`, so INC_RECURSE sub-list
+    /// entries get the same defense. upstream: `flist.c:1230` runs per received
+    /// entry, sub-lists included.
+    pub(in crate::receiver) fn downgrade_implied_parent_dirs_from(
+        &mut self,
+        flat_start: usize,
+    ) -> io::Result<()> {
+        let Some(implied) = self.build_implied_includes()? else {
+            return Ok(());
+        };
+
+        for entry in &mut self.file_list[flat_start..] {
+            if !entry.is_dir() || !entry.content_dir() {
+                continue;
+            }
+            if implied.is_parent_only_dir(entry.path().as_path()) {
+                // upstream: flist.c:1249 - both flags, so the entry maps to
+                // FLAG_IMPLIED_DIR (oc: top_dir without content_dir).
+                entry.set_content_dir(false);
+                entry.set_top_dir(true);
             }
         }
 

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -377,6 +377,9 @@ impl ReceiverContext {
         self.sanitize_segment_paths(flat_start)?;
         self.recheck_received_filter_entries(&self.file_list[flat_start..])?;
         self.recheck_received_implied_includes_entries(&self.file_list[flat_start..])?;
+        // upstream: flist.c:1230-1252 - the implied-parent downgrade is part of
+        // the same per-entry defense set, so sub-list dirs get it too.
+        self.downgrade_implied_parent_dirs_from(flat_start)?;
 
         match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);
 

--- a/crates/transfer/src/receiver/tests/file_list/implied_recheck.rs
+++ b/crates/transfer/src/receiver/tests/file_list/implied_recheck.rs
@@ -241,3 +241,72 @@ fn no_source_args_is_a_no_op() {
     ctx.recheck_received_implied_includes()
         .expect("no recorded source args means nothing to validate");
 }
+
+/// A malicious daemon-sender that omits `XMIT_NO_CONTENT_DIR` from an implied
+/// parent must not widen the receiver's `--delete` scope.
+///
+/// Shape of the PoC the rsync 3.5.0 testsuite drives (`malicious-sender-delete-
+/// scope`): `-rR --delete rsync://host/m/dir/file` asks for one leaf, so `dir`
+/// is reachable only as its parent. An honest sender encodes that pair as
+/// `XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR` (oc: `top_dir` without `content_dir`);
+/// a sender that drops the second flag would otherwise get `delete_in_dir()`
+/// run on `dest/dir`, sweeping siblings the client never named.
+///
+/// upstream: `flist.c:1230-1252` `recv_file_entry()`.
+#[test]
+fn implied_parent_dir_is_downgraded_whatever_the_sender_sent() {
+    let mut config = test_config();
+    config.flags.relative = true;
+    config.flags.recursive = true;
+    config.connection.implied_source_args = vec!["m/dir/file".to_owned()];
+    config.connection.implied_skip_daemon_module = true;
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+
+    // The malicious encoding: a content dir where the honest sender would have
+    // cleared the flag.
+    let mut parent = FileEntry::new_directory("dir".into(), 0o755);
+    parent.set_content_dir(true);
+    ctx.file_list.push(parent);
+    ctx.file_list
+        .push(FileEntry::new_file("dir/file".into(), 12, 0o644));
+
+    ctx.downgrade_implied_parent_dirs()
+        .expect("downgrade never fails on a well-formed list");
+
+    assert!(
+        !ctx.file_list[0].content_dir(),
+        "an implied parent must not stay a content dir: the deletion pass \
+         would sweep its pre-existing siblings"
+    );
+    assert!(
+        ctx.file_list[0].top_dir(),
+        "upstream re-asserts XMIT_TOP_DIR alongside XMIT_NO_CONTENT_DIR, \
+         which is oc's FLAG_IMPLIED_DIR encoding"
+    );
+}
+
+/// Non-vacuity companion: a directory the client *requested* keeps its content
+/// flag, so the downgrade cannot be passing the test above by clearing the flag
+/// on everything.
+///
+/// upstream: `exclude.c:1178-1180` - a non-directory-only include rule names a
+/// requested leaf, so the entry is legitimately a content dir.
+#[test]
+fn a_requested_directory_keeps_its_content_flag() {
+    let mut config = test_config();
+    config.flags.recursive = true;
+    config.connection.implied_source_args = vec!["dir".to_owned()];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+
+    let mut requested = FileEntry::new_directory("dir".into(), 0o755);
+    requested.set_content_dir(true);
+    ctx.file_list.push(requested);
+
+    ctx.downgrade_implied_parent_dirs()
+        .expect("downgrade never fails on a well-formed list");
+
+    assert!(
+        ctx.file_list[0].content_dir(),
+        "the client asked for `dir` itself, so --delete legitimately scopes to it"
+    );
+}

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -412,6 +412,13 @@ impl ReceiverContext {
         // sender injected a name that was never requested (CVE-2022-29154).
         self.recheck_received_implied_includes()?;
 
+        // upstream: flist.c:1230-1252 recv_file_entry() re-asserts
+        // XMIT_NO_CONTENT_DIR|XMIT_TOP_DIR on any directory the implied-include
+        // list only allows as a parent, so a sender that omits
+        // XMIT_NO_CONTENT_DIR cannot make delete_in_dir() sweep the siblings of
+        // a path the client merely traversed.
+        self.downgrade_implied_parent_dirs()?;
+
         let checksum_factory = ChecksumFactory::from_negotiation(
             self.negotiated_algorithms.as_ref(),
             self.protocol,

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -97,9 +97,9 @@ ki62-io-error-mask pass
 link-dest-module-escape pass
 link-dest-pathroot pass
 link-dest-relative-basis pass
-malicious-dot-dir-delete-scope fail
+malicious-dot-dir-delete-scope pass
 malicious-dot-file-delete-scope pass
-malicious-sender-delete-scope fail
+malicious-sender-delete-scope pass
 malicious-server-partial-basis-symlink-overwrite fail
 match-append-empty-nullmap skip
 match-want-i-nolen skip

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -186,7 +186,7 @@ longdir pass
 macos-setgid-ordinary-mode-regression skip
 malicious-dot-dir-delete-scope skip
 malicious-dot-file-delete-scope skip
-malicious-sender-delete-scope fail
+malicious-sender-delete-scope pass
 malicious-server-partial-basis-symlink-overwrite skip
 match-append-empty-nullmap skip
 match-want-i-nolen skip

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -97,9 +97,9 @@ ki62-io-error-mask pass
 link-dest-module-escape pass
 link-dest-pathroot pass
 link-dest-relative-basis pass
-malicious-dot-dir-delete-scope fail
+malicious-dot-dir-delete-scope pass
 malicious-dot-file-delete-scope pass
-malicious-sender-delete-scope fail
+malicious-sender-delete-scope pass
 malicious-server-partial-basis-symlink-overwrite fail
 match-append-empty-nullmap skip
 match-want-i-nolen skip

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -186,7 +186,7 @@ longdir pass
 macos-setgid-ordinary-mode-regression skip
 malicious-dot-dir-delete-scope skip
 malicious-dot-file-delete-scope skip
-malicious-sender-delete-scope fail
+malicious-sender-delete-scope pass
 malicious-server-partial-basis-symlink-overwrite skip
 match-append-empty-nullmap skip
 match-want-i-nolen skip


### PR DESCRIPTION
## The defect

A daemon-sender chose the scope of the receiver's `--delete` pass.

With `-rR --delete rsync://host/m/dir/file` the client requests one leaf, so
`dir` exists in the file list only as its parent. The honest wire encoding for
that is `XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR`. A sender that simply **omits the
second flag** made the receiver mark `dir` a content dir, and the generator then
ran `delete_in_dir()` on `dest/dir` - deleting pre-existing siblings the client
never named.

Reproduced with the rsync 3.5.0 testsuite cell `malicious-sender-delete-scope`,
which patches one line of `flist.c` in a copy of the upstream tree, builds it,
and runs *that* binary as the daemon-sender against the binary under test. On
current master the sentinel is destroyed:

```
delete_in_dir(.../mal-test/dest/dir)
delete_item(.../mal-test/dest/dir/keep.txt) mode=100000
FAIL    malicious-sender-delete-scope
```

Real rsync 3.5.0 passes the same cell, so this is an oc divergence, not a
fixture limit.

## The fix

Upstream does not trust the byte - it **re-asserts the honest encoding on the
receiving side** (`flist.c:1230-1252 recv_file_entry`). If the entry is a
directory that the implied-include list only allows as a *parent*, it forces
`XMIT_NO_CONTENT_DIR | XMIT_TOP_DIR` back on **before** flag mapping, so the
entry lands in `FLAG_IMPLIED_DIR` and `delete_in_dir()` can never reach it.

Ported as two pieces:

- `ImpliedIncludes::is_parent_only_dir` - upstream `exclude.c:1144
  is_implied_parent_dir`. Every implied rule the name matches must be
  directory-only; a non-directory-only match means the client asked for the
  directory itself, so it stays a content dir. The transfer root is parent-only
  unless an empty source arg contributed the `/**` / `/*` root-content rule,
  which is tracked at construction rather than by re-scanning pattern text.
- a receiver pass over the decoded list, run on the level-1 list **and on every
  INC_RECURSE sub-list** - upstream runs the guard per received entry, sub-lists
  included, so covering only the first list would leave the deeper ones open.

**Deliberately not gated** on the sender-trusting escape hatches that suppress
the per-directory filter re-check. `implied_source_args` is receiver-owned
state; a per-dir merge rule must not be able to downgrade this defense. That is
upstream's own stated reason on the guard, and it is the difference between a
defense and a suggestion.

The implied-include set is now built once by a shared helper and consumed by
both the unrequested-name refusal (CVE-2022-29154) and this downgrade - upstream
drives both from the single `implied_filter_list` global, so one builder is the
faithful shape as well as the DRY one.

## Verification

- The four `*-delete-scope` cells go **4/4 over TCP**, and the pipe cell passes.
- **RED proven by neutralising only `is_parent_only_dir`**: exactly the two cells
  whose manifest rows said `fail` go red -
  ```
  FAIL    malicious-sender-delete-scope
  FAIL    malicious-dot-dir-delete-scope
  PASS    malicious-dot-file-delete-scope
  PASS    peer-legacy-implied-delete-scope
  ```
  The two `pass` rows stay green as controls, so neither flipped row can be
  passing for an unrelated reason. That the red set matches the manifest exactly
  is the evidence that the rows are earned, not guessed.
- The two new Rust pins are RED-proven the same way, and ship with a
  requested-directory companion - without it the pin would also pass if the
  downgrade simply cleared the flag on every directory.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets
  --all-features --no-deps -- -D warnings` clean.
- `cargo nextest run -p filters -p transfer --all-features`: 4223 passed.
- Root-level `tests/integration_*.rs` delete/relative/implied cells: 30 passed -
  run explicitly, because a per-crate run does not cover them.

## Manifest

Six rows flip in the same commit: `malicious-sender-delete-scope` on all four
legs, `malicious-dot-dir-delete-scope` on the two TCP legs. Row counts unchanged
(349 pipe, 158 TCP). Leaving them would report an unexpected PASS.

`malicious-dot-dir-delete-scope` was measured to fail before the change and pass
after, so it is closed by the same root cause rather than assumed to be.
