### PR TITLE
fix(daemon): refuse options = delete must also refuse a pull's --remove-source-files

### DIFF
--- a/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
@@ -234,10 +234,31 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
     // pass catches the timing variants the client actually sends on the wire
     // (oc emits `--delete-during` for a plain `-a --delete`). The reported
     // option is always `--delete`, matching `create_refuse_error(refused_delete)`.
-    if is_option_refused(module, "delete", None)
-        && client_args.iter().any(|arg| enables_delete_mode(arg))
-    {
-        return Some("--delete".to_owned());
+    if is_option_refused(module, "delete", None) {
+        if client_args.iter().any(|arg| enables_delete_mode(arg)) {
+            return Some("--delete".to_owned());
+        }
+
+        // upstream: options.c:2359-2367 - `--remove-source-files` inherits the
+        // refusal of `delete`, but ONLY when this process is the sender:
+        // `if (refused_delete && am_sender)`. On a pull the daemon is the
+        // sender and would be deleting its OWN module contents, which is what
+        // the rule exists to stop; on a push the deletions happen on the
+        // client's side and upstream does not refuse them. The reported option
+        // is `--delete`, from the same `create_refuse_error(refused_delete)`.
+        //
+        // Upstream's own comment pins the narrower half: the inference runs off
+        // the refusal of "delete" only, never a `delete-FOO` option - and
+        // `refused_delete` is set solely by the bare `delete` row
+        // (options.c:1128), which is exactly what `is_option_refused(.., "delete")`
+        // asks here.
+        if daemon_is_sender(client_args)
+            && client_args
+                .iter()
+                .any(|arg| is_long_option(arg, "remove-source-files"))
+        {
+            return Some("--delete".to_owned());
+        }
     }
 
     for arg in client_args {
@@ -313,6 +334,28 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
 /// refuses the transfer whenever `refused_delete` is set and any of those is
 /// active. `--delete-missing-args` also needs the `missing_args == 2` guard
 /// there, which matches this option once it has been requested.
+/// Reports whether `arg` is the long option `--<long_name>`.
+///
+/// The `--` prefix is required: [`canonical_option`] strips leading dashes, so
+/// matching on it alone would also fire on a bare transfer operand that happens
+/// to be named like the option. Upstream's popt only ever treats the dashed
+/// form as an option, and the operands sit after it in the same argv.
+fn is_long_option(arg: &str, long_name: &str) -> bool {
+    let trimmed = arg.trim();
+    trimmed.starts_with("--") && canonical_option(trimmed) == long_name
+}
+
+/// Reports whether the daemon is the sender for this transfer, i.e. the client
+/// is pulling from the module.
+///
+/// upstream: options.c:863 + :1524 - the client puts `--sender` in the server
+/// argv and `OPT_SENDER` sets `am_sender = 1`. `sender` is one of the options a
+/// module may never refuse (options.c:1048, mirrored in [`VITAL_OPTIONS`]), so
+/// it is always present and never filtered out when the daemon is sending.
+fn daemon_is_sender(client_args: &[String]) -> bool {
+    client_args.iter().any(|arg| is_long_option(arg, "sender"))
+}
+
 fn enables_delete_mode(arg: &str) -> bool {
     let canonical = canonical_option(arg);
     matches!(

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -912,6 +912,62 @@ fn refused_client_arg_delete_rule_allows_non_delete_transfer() {
 }
 
 #[test]
+fn refused_client_arg_delete_rule_refuses_remove_source_files_on_a_pull() {
+    // upstream: options.c:2359-2367 - `--remove-source-files` inherits the
+    // refusal of `delete` when `am_sender`, because on a pull the daemon would
+    // be deleting its own module contents. Reported as `--delete`, from the
+    // same `create_refuse_error(refused_delete)`.
+    let module = ModuleDefinition {
+        refuse_options: vec!["delete".to_owned()],
+        ..Default::default()
+    };
+    let args = vec![
+        "--server".to_owned(),
+        "--sender".to_owned(),
+        "-vlogDtpr".to_owned(),
+        "--remove-source-files".to_owned(),
+    ];
+    assert_eq!(
+        refused_client_arg(&module, &args),
+        Some("--delete".to_owned()),
+    );
+}
+
+#[test]
+fn refused_client_arg_delete_rule_allows_remove_source_files_on_a_push() {
+    // Non-vacuity companion for the pull case above, and the pin on upstream's
+    // `am_sender` half of `if (refused_delete && am_sender)`. Without
+    // `--sender` the daemon is the RECEIVER: the client is pushing and deletes
+    // its own local sources, which upstream does not refuse. Without this test a
+    // blanket "refuse remove-source-files whenever delete is refused" would
+    // still satisfy the pull case while over-refusing every push.
+    let module = ModuleDefinition {
+        refuse_options: vec!["delete".to_owned()],
+        ..Default::default()
+    };
+    let args = vec![
+        "--server".to_owned(),
+        "-vlogDtpr".to_owned(),
+        "--remove-source-files".to_owned(),
+    ];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
+fn refused_client_arg_remove_source_files_allowed_without_a_delete_rule() {
+    // The inference is gated on the `delete` rule, not on the option itself: a
+    // module with no refuse list must still accept a pull that removes source
+    // files. Guards against the inference firing unconditionally.
+    let module = ModuleDefinition::default();
+    let args = vec![
+        "--server".to_owned(),
+        "--sender".to_owned(),
+        "--remove-source-files".to_owned(),
+    ];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
 fn refused_client_arg_delete_negation_clears_semantic_refusal() {
     // `refuse options = !delete` un-refuses the `delete` entry, so the
     // semantic delete-mode pass must not fire. With no other refuse rule a


### PR DESCRIPTION
## The gap

A module with `refuse options = delete` still accepted a pull that carried
`--remove-source-files`, so a client could get the daemon to delete its own
module contents through the one option the rule exists to block.

oc already implemented the `delete_mode` half of upstream's rule
(`refuse_options.rs:228`, citing `if (refused_delete && (delete_mode ||
missing_args == 2))`). The second consequence of `refused_delete` was missing.

## Upstream

`options.c:2359-2367`:

```c
if (remove_source_files) {
        /* We only want to infer this refusal of --remove-source-files
         * via the refusal of "delete", not any of the "delete-FOO"
         * options. */
        if (refused_delete && am_sender) {
                create_refuse_error(refused_delete);
                goto cleanup;
        }
```

Three details this ports deliberately:

- **`am_sender` gates it.** On a pull the daemon is the sender and would be
  deleting its own files - that is the case upstream refuses. On a push the
  deletions happen on the client's side and upstream does **not** refuse them,
  so mirroring this without the gate would over-refuse every push.
- **The role is already in the argv.** `--sender` is what sets `am_sender` in
  server mode (`options.c:863` -> `OPT_SENDER` at `:1524`), and it is one of the
  options a module may never refuse (`options.c:1048`, mirrored in oc's
  `VITAL_OPTIONS`), so it is always present and unfiltered when the daemon is
  sending. No new plumbing is needed.
- **"delete" only, never `delete-FOO`.** `refused_delete` is set solely by the
  bare `delete` row (`options.c:1128`), which is exactly what oc's existing
  `is_option_refused(module, "delete", None)` asks - so both consequences now sit
  under one shared guard, matching upstream's own structure.

The reported option is `--delete`, from the same
`create_refuse_error(refused_delete)`.

## Note on the `--` prefix

`canonical_option` strips leading dashes, so matching an option name through it
alone would also fire on a transfer operand that happens to be named
`sender` or `remove-source-files` - and operands sit in the same argv. The new
`is_long_option` helper requires the `--`, which is the only form upstream's
popt treats as an option.

## Verification

- **RED proven twice, each mutation killing a different test:**
  - forcing `daemon_is_sender` to `true` -> `24 tests run: 23 passed, 1 failed`,
    the failure being the **push** case. That test exists only to pin the
    `am_sender` gate, and without it a blanket refusal would satisfy the pull
    case while silently over-refusing every push.
  - removing the inference entirely -> `24 run: 23 passed, 1 failed`, this time
    the **pull** case.
- A third test covers the other gate: with no `refuse options` line at all, a
  pull with `--remove-source-files` is still allowed, so the inference cannot
  fire unconditionally.
- `cargo fmt --all -- --check` clean; `cargo clippy -p daemon --all-targets
  --all-features --no-deps -- -D warnings` clean.
- `cargo nextest run -p daemon --all-features`: 1815 passed.
