### PR TITLE
fix(daemon): honour a forwarded --max-size/--min-size on a push

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -7,12 +7,11 @@
 /// as long-form arguments that are not encoded in the compact flag string.
 /// The daemon must parse these to correctly configure the transfer.
 ///
-/// Returns `Some(offender)` when a client-only flag (write/read-batch family)
-/// reaches the daemon. The caller surfaces that as an `@ERROR` and exits
-/// instead of letting the unrecognised option drive a silent connection
-/// close mid file-list framing. Upstream mirrors this at
-/// `options.c:1460-1465` with `rsync: <BAD>: <err> (in daemon mode)` then
-/// `daemon_error:` (`options.c:1480-1482`) exiting `RERR_SYNTAX`.
+/// Returns `Some(rejection)` when an argument must abort the session rather
+/// than be applied. The caller surfaces that as an `@ERROR` and exits instead
+/// of letting the argument drive a silent connection close mid file-list
+/// framing, or - worse for a bad value - be silently ignored. See
+/// [`ClientArgRejection`] for the two upstream rules involved.
 ///
 /// # Upstream Reference
 ///
@@ -23,13 +22,16 @@
 /// - `options.c:2906` - `--numeric-ids`
 /// - `options.c:2909` - `--use-qsort`
 /// - `options.c:2755-2758` - `--compress-level=N`
-fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Option<String> {
+fn apply_long_form_args(
+    client_args: &[String],
+    config: &mut ServerConfig,
+) -> Option<ClientArgRejection> {
     // Positional path args follow the standalone `.` separator. Upstream
     // `glob_expand_module()` consumes them through a different code path, so
     // the daemon's option parser only validates the option region.
     let dot_position = client_args.iter().position(|a| a == ".");
 
-    let mut unknown: Option<String> = None;
+    let mut rejection: Option<ClientArgRejection> = None;
     let mut i = 0;
     while i < client_args.len() {
         let arg = &client_args[i];
@@ -262,6 +264,29 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                             config.deletion.max_delete = Some(n as u64);
                         }
                     }
+                // upstream: options.c:2998-3001 - `server_options()` forwards
+                // `--min-size`/`--max-size` (as one `--opt=VALUE` token, see
+                // safe_arg at options.c:2716-2720) only when the local end is
+                // the sender, i.e. only to a daemon that is RECEIVING a push.
+                // That is the one direction where the filter runs on the
+                // daemon: enforcement lives in the generator
+                // (generator.c:2118-2133), which is the receiving side. A
+                // dropped value therefore lets a push deposit exactly the
+                // files the client asked to exclude.
+                } else if let Some(val) = arg.strip_prefix("--max-size=") {
+                    match parse_transfer_size_limit("max-size", val) {
+                        Ok(limit) => config.file_selection.max_file_size = Some(limit),
+                        Err(message) => {
+                            rejection.get_or_insert(ClientArgRejection::InvalidValue(message));
+                        }
+                    }
+                } else if let Some(val) = arg.strip_prefix("--min-size=") {
+                    match parse_transfer_size_limit("min-size", val) {
+                        Ok(limit) => config.file_selection.min_file_size = Some(limit),
+                        Err(message) => {
+                            rejection.get_or_insert(ClientArgRejection::InvalidValue(message));
+                        }
+                    }
                 // upstream: options.c - server_options() forwards `--modify-window=NUM`.
                 // The daemon receiver's quick-check honours it via same_time() so
                 // files within the window are not needlessly re-transferred.
@@ -359,7 +384,7 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     if fmt.contains("%I") {
                         config.flags.info_flags.itemize_unchanged = true;
                     }
-                } else if unknown.is_none() && is_client_only_flag_reaching_daemon(arg) {
+                } else if rejection.is_none() && is_client_only_flag_reaching_daemon(arg) {
                     // upstream: options.c:1460-1465 - the daemon's popt loop
                     // emits `rsync: <BAD>: <err> (in daemon mode)` on the
                     // first unrecognised option and jumps to `daemon_error:`
@@ -369,14 +394,87 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     // them here converts the previously silent connection
                     // close at protocol byte ~2241725 into an explicit
                     // `@ERROR` frame plus non-zero exit.
-                    unknown = Some(arg.clone());
+                    rejection = Some(ClientArgRejection::Unrecognized(arg.clone()));
                 }
             }
         }
         i += 1;
     }
 
-    unknown
+    rejection
+}
+
+/// Why a client argument aborts the session instead of being applied.
+///
+/// Upstream reaches these two outcomes through the same `parse_arguments()`
+/// failure return, but by different routes and with different text, so the
+/// daemon needs to tell them apart to report either one faithfully.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ClientArgRejection {
+    /// A client-only flag (the write/read-batch family) reached the daemon.
+    ///
+    /// upstream: `options.c:1460-1465` - the daemon-mode popt loop emits
+    /// `rsync: <BAD>: <err> (in daemon mode)` and jumps to `daemon_error:`
+    /// (`options.c:1480-1482`), exiting `RERR_SYNTAX`.
+    Unrecognized(String),
+    /// A recognised option carried a value upstream's own parser rejects.
+    ///
+    /// The payload is the message verbatim, already in upstream's
+    /// `--%s=%s is %s` shape (`options.c:1253`).
+    InvalidValue(String),
+}
+
+/// Parses a `--max-size`/`--min-size` value the way upstream's popt case does.
+///
+/// upstream: `options.c:1808-1817` - both options call
+/// `parse_size_arg(arg, 'b', "<name>", 0, -1, False)`, and a failure aborts
+/// option parsing rather than falling back to a default. Ignoring a bad value
+/// here would re-open the very hole this arm closes: the option would be
+/// dropped, silently, on a peer-supplied argument.
+fn parse_transfer_size_limit(opt_name: &str, value: &str) -> Result<u64, String> {
+    // upstream: options.c:1172-1175 - the digit scan leaves the cursor on the
+    // terminator, so the suffix switch takes `def_suf` and `strtod("")` gives
+    // 0. An empty value is exactly `=0`, not "no limit"; the shared parser
+    // rejects the empty string, so the rule is applied per option (the same
+    // placement the CLI uses, since `--max-alloc` must keep rejecting it).
+    let text = if value.is_empty() { "0" } else { value };
+
+    // upstream: options.c:1169 + :1216-1221 - with max_value = -1 (what :1809
+    // and :1815 pass) the ceiling is `(ssize_t)(SIZE_MAX / 2)`, and the range
+    // check runs against the `double` returned by strtod with a STRICT
+    // `dsize >= size_max` clause. `(double)(SIZE_MAX / 2)` rounds to 2^63, so
+    // the boundary is 2^63 in DOUBLE space, not in integer space.
+    //
+    // Measured against real rsync 3.5.0: the largest accepted value is
+    // 9223372036854774784 (2^63 - 1024, the greatest double below 2^63), while
+    // 9223372036854775807 (`i64::MAX`) is already reported "too large".
+    // Comparing as integers would accept a band of values upstream refuses,
+    // so the comparison is kept in `f64` deliberately.
+    const SIZE_MAX_AS_DOUBLE: f64 = (i64::MAX as u64 + 1) as f64;
+
+    match ::core::bandwidth::parse_size_arg(text, b'b') {
+        Ok(parsed) if parsed.bytes as f64 >= SIZE_MAX_AS_DOUBLE => {
+            Err(size_arg_error(opt_name, value, "too large"))
+        }
+        Ok(parsed) => u64::try_from(parsed.bytes)
+            .map_err(|_| size_arg_error(opt_name, value, "too large")),
+        Err(::core::bandwidth::SizeArgError::Invalid) => {
+            Err(size_arg_error(opt_name, value, "invalid"))
+        }
+        Err(::core::bandwidth::SizeArgError::TooLarge) => {
+            Err(size_arg_error(opt_name, value, "too large"))
+        }
+    }
+}
+
+/// Renders upstream's size-argument failure text.
+///
+/// upstream: `options.c:1253` - `snprintf(err_buf, .., "--%s=%s is %s",
+/// opt_name, size_arg, err)`. The `(max: N)` suffix upstream appends at
+/// `:1254-1258` applies only when the option declares a bound; `--max-size`
+/// and `--min-size` pass `max_value = -1`, so no suffix is emitted.
+fn size_arg_error(opt_name: &str, value: &str, reason: &str) -> String {
+    format!("--{opt_name}={value} is {reason}")
 }
 
 /// Reports whether `arg` is a client-only flag that should never reach the

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -206,17 +206,28 @@ fn build_server_config(
             // upstream: options.c:1460-1465 - daemon-mode unknown option
             // emits `rsync: <BAD>: <err> (in daemon mode)` and exits
             // `RERR_SYNTAX` via `daemon_error:` (options.c:1480-1482).
-            if let Some(offender) = apply_long_form_args(client_args, &mut cfg) {
+            if let Some(rejection) = apply_long_form_args(client_args, &mut cfg) {
+                let (log_text, error_text) = match rejection {
+                    ClientArgRejection::Unrecognized(offender) => (
+                        format!(
+                            "module '{}': refusing client-only flag '{offender}' in daemon mode",
+                            ctx.request,
+                        ),
+                        format!("{offender}: unrecognized option (in daemon mode)"),
+                    ),
+                    // upstream: options.c:907-918 `option_error()` reports the
+                    // parser's own `err_buf` text, so the value's own message
+                    // is what reaches the client - not the unknown-option one.
+                    ClientArgRejection::InvalidValue(message) => (
+                        format!("module '{}': {message}", ctx.request),
+                        message.clone(),
+                    ),
+                };
                 if let Some(log) = ctx.log_sink {
-                    let text = format!(
-                        "module '{}': refusing client-only flag '{offender}' in daemon mode",
-                        ctx.request,
-                    );
-                    let message = rsync_warning!(text).with_role(Role::Daemon);
+                    let message = rsync_warning!(log_text).with_role(Role::Daemon);
                     log_message(log, &message);
                 }
-                let error =
-                    AtError::message(format!("{offender}: unrecognized option (in daemon mode)"));
+                let error = AtError::message(error_text);
                 send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
                 return Ok(None);
             }

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1157,7 +1157,10 @@ mod module_access_tests {
         ];
         let mut config = ServerConfig::default();
         let offender = apply_long_form_args(&args, &mut config);
-        assert_eq!(offender.as_deref(), Some("--write-batch=/tmp/bad.batch"));
+        assert_eq!(
+            offender,
+            Some(ClientArgRejection::Unrecognized("--write-batch=/tmp/bad.batch".to_owned()))
+        );
     }
 
     #[test]
@@ -1169,7 +1172,10 @@ mod module_access_tests {
         ];
         let mut config = ServerConfig::default();
         let offender = apply_long_form_args(&args, &mut config);
-        assert_eq!(offender.as_deref(), Some("--read-batch=/tmp/in.batch"));
+        assert_eq!(
+            offender,
+            Some(ClientArgRejection::Unrecognized("--read-batch=/tmp/in.batch".to_owned()))
+        );
     }
 
     #[test]
@@ -1181,7 +1187,130 @@ mod module_access_tests {
         ];
         let mut config = ServerConfig::default();
         let offender = apply_long_form_args(&args, &mut config);
-        assert_eq!(offender.as_deref(), Some("--only-write-batch=/tmp/dry.batch"));
+        assert_eq!(
+            offender,
+            Some(ClientArgRejection::Unrecognized("--only-write-batch=/tmp/dry.batch".to_owned()))
+        );
+    }
+
+    // upstream: options.c:2998-3001 - `server_options()` forwards
+    // `--min-size`/`--max-size` only under `if (am_sender)`, i.e. only to a
+    // daemon that is RECEIVING a push, because enforcement lives in the
+    // generator (generator.c:2118-2133) on the receiving side. Dropping the
+    // value made a push deposit exactly the files the client asked to
+    // exclude - measured against real rsync 3.5.0, which lands only the small
+    // file where oc landed both.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_max_size() {
+        let args = vec![
+            "--server".to_owned(),
+            "-logDtpr".to_owned(),
+            "--max-size=100".to_owned(),
+            ".".to_owned(),
+            "module/".to_owned(),
+        ];
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert_eq!(config.file_selection.max_file_size, Some(100));
+    }
+
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_min_size_with_a_suffix() {
+        let args = vec![
+            "--server".to_owned(),
+            "-logDtpr".to_owned(),
+            "--min-size=1K".to_owned(),
+            ".".to_owned(),
+            "module/".to_owned(),
+        ];
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert_eq!(config.file_selection.min_file_size, Some(1024));
+    }
+
+    // upstream: options.c:1172-1175 - the digit scan leaves the cursor on the
+    // terminator, so an empty value parses as 0. For `--max-size` that means
+    // "exclude every non-empty file", NOT "no limit"; treating it as absent
+    // would ship the files upstream withholds.
+    #[test]
+    fn apply_long_form_args_treats_an_empty_max_size_as_zero() {
+        let args = vec!["--server".to_owned(), "--max-size=".to_owned()];
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert_eq!(config.file_selection.max_file_size, Some(0));
+    }
+
+    // upstream: options.c:1808-1817 - a `parse_size_arg` failure aborts option
+    // parsing, and options.c:1253 renders `--%s=%s is %s`. Silently ignoring
+    // the value would re-open the drop this arm exists to close, so the
+    // rejection carries the value's own message rather than the
+    // unknown-option one.
+    #[test]
+    fn apply_long_form_args_rejects_an_unparseable_max_size() {
+        let args = vec!["--server".to_owned(), "--max-size=12Q".to_owned()];
+        let mut config = ServerConfig::default();
+        assert_eq!(
+            apply_long_form_args(&args, &mut config),
+            Some(ClientArgRejection::InvalidValue(
+                "--max-size=12Q is invalid".to_owned()
+            ))
+        );
+        assert_eq!(config.file_selection.max_file_size, None);
+    }
+
+    // Boundary MEASURED against real rsync 3.5.0, not derived from the C by
+    // reading: upstream's range check compares the strtod `double` with a
+    // strict `dsize >= size_max` (options.c:1216-1221), and
+    // `(double)(SIZE_MAX / 2)` rounds to 2^63 - so `i64::MAX` itself is
+    // already "too large" and the largest accepted value is 2^63 - 1024.
+    // An integer comparison would accept that whole band.
+    #[test]
+    fn apply_long_form_args_rejects_a_min_size_above_upstreams_ceiling() {
+        for value in ["9223372036854775807", "9223372036854775806", "8192P"] {
+            let args = vec!["--server".to_owned(), format!("--min-size={value}")];
+            let mut config = ServerConfig::default();
+            assert_eq!(
+                apply_long_form_args(&args, &mut config),
+                Some(ClientArgRejection::InvalidValue(format!(
+                    "--min-size={value} is too large"
+                ))),
+                "{value} must be refused exactly as upstream refuses it"
+            );
+            assert_eq!(config.file_selection.min_file_size, None, "{value}");
+        }
+    }
+
+    // Non-vacuity companion: the greatest value upstream ACCEPTS must still be
+    // accepted, so the ceiling cannot pass by rejecting everything large.
+    #[test]
+    fn apply_long_form_args_accepts_the_largest_value_upstream_allows() {
+        for (value, bytes) in [
+            ("9223372036854774784", 9_223_372_036_854_774_784u64),
+            ("8191P", 8191 * 1024 * 1024 * 1024 * 1024 * 1024),
+        ] {
+            let args = vec!["--server".to_owned(), format!("--min-size={value}")];
+            let mut config = ServerConfig::default();
+            assert!(
+                apply_long_form_args(&args, &mut config).is_none(),
+                "{value} must be accepted exactly as upstream accepts it"
+            );
+            assert_eq!(config.file_selection.min_file_size, Some(bytes), "{value}");
+        }
+    }
+
+    // A positional operand that happens to look like the option must not be
+    // decoded: everything after the standalone `.` is a path, and upstream
+    // consumes it through `glob_expand_module()` instead.
+    #[test]
+    fn apply_long_form_args_ignores_a_max_size_shaped_operand() {
+        let args = vec![
+            "--server".to_owned(),
+            ".".to_owned(),
+            "--max-size=12Q".to_owned(),
+        ];
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert_eq!(config.file_selection.max_file_size, None);
     }
 
     // Recognised client args do NOT produce the unknown-arg signal. This


### PR DESCRIPTION
## The gap

The daemon's long-option decoder (`apply_long_form_args`) had no arm for
`--max-size` or `--min-size`. A forwarded value was silently dropped, so a
**push** deposited exactly the files the client asked to exclude.

Measured with a module holding `small.txt` (5 B) and `big.txt` (5000 B),
pushing with `-M--max-size=100`:

| | landed on the daemon |
|---|---|
| rsync 3.5.0 | `small.txt` |
| oc before | `small.txt` **and** `big.txt` |
| oc after | `small.txt` |

## Why only a push

`options.c:2998-3001` forwards both options **only under `if (am_sender)`** -
that is, only to a daemon that is *receiving*. Enforcement lives in the
generator (`generator.c:2118-2133`), which runs on the receiving side. On a
pull the client filters locally and nothing is forwarded at all, which is why
the drop is invisible from that direction and why a pull-only probe reports no
divergence.

`safe_arg` (`options.c:2716-2720`) always joins the option and value into one
`--opt=VALUE` token, so the `=` form is the only shape upstream emits - the
same arity the neighbouring `--max-delete=` arm assumes.

## Rejecting a bad value

Ignoring an unparseable value would re-open the very hole this closes, on a
peer-supplied argument. Upstream aborts option parsing (`options.c:1808-1817`)
and reports the parser's own text via `option_error()` (`:907-918`), so the
message is the value's, not the unknown-option one. The decoder's rejection
channel therefore became a two-variant type rather than a bare option name -
each variant carries exactly what its framing needs.

Message format confirmed against the real 3.5.0 binary, not inferred:

```
--max-size=12Q                -> rsync: --max-size=12Q is invalid
--max-size=9223372036854775808 -> rsync: --max-size=... is too large
```

## Both bounds are mirrored from the C, not from the Rust field type

`parse_size_arg` runs its range check against the `double` from `strtod` with a
**strict** `dsize >= size_max` clause (`options.c:1216-1221`), and
`(double)(SIZE_MAX / 2)` rounds to 2^63 - so the ceiling is 2^63 *in double
space*. Measured boundary against real 3.5.0:

| value | upstream |
|---|---|
| `9223372036854774784` (2^63 - 1024) | accepted |
| `9223372036854775807` (`i64::MAX`) | **too large** |
| `8191P` | accepted |
| `8192P` | **too large** |

A `u64` bound would have accepted everything up to `u64::MAX`, and even an
`i64::MAX` integer bound would have accepted a 1023-value band upstream
refuses. The comparison is kept in `f64` deliberately, with the measurement
recorded at the site so it is not "cleaned up" into an integer compare.

An empty value is `=0` **exactly** (`options.c:1172-1175`), which for
`--max-size` excludes every non-empty file rather than meaning "no limit" - the
rule is applied per option, matching the placement the CLI already uses because
`--max-alloc` must keep rejecting an empty value.

## Verification

- **RED proven by two mutations, each killing a different set:**
  - dropping the parsed value (arms decode, then discard) -> `9 tests run: 6
    passed, 3 failed` - the three honour tests; both rejection tests stay green.
  - dropping the rejection (bad values silently accepted) -> `9 run: 7 passed,
    2 failed` - the two rejection tests; all three honour tests stay green.
- The ceiling test carries a non-vacuity companion asserting the largest value
  upstream *accepts* is still accepted, so it cannot pass by refusing
  everything large.
- A test pins that a `--max-size`-shaped **operand** after the standalone `.`
  is not decoded, since everything past that separator is a path.
- End-to-end: the push table above, re-run against a freshly built binary. An
  invalid value refuses the transfer - nothing lands, non-zero exit.
- `cargo fmt --all -- --check` clean; `cargo clippy -p daemon --all-targets
  --all-features --no-deps -- -D warnings` clean.
- `cargo nextest run -p daemon --all-features`: 1819 passed.

## Residual, not addressed here

The rejection reaches the client through the daemon's existing `send_error`
path, which frames a plain `@ERROR` line into a stream the client is already
reading as multiplexed - so the client renders `unknown multiplexed message
code 38` instead of upstream's `RERR_UNSUPPORTED` plus the message. That is the
same channel every rejected server option already uses, unchanged by this PR;
it belongs to the daemon-error framing work, not here. The refusal itself is
effective: the transfer does not proceed.

No expect-manifest rows are changed.
