### PR TITLE
fix(daemon): apply the module exclude to the client's destination argument

### DIFF
--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -83,6 +83,19 @@ impl CompiledRule {
         }
     }
 
+    /// Like [`Self::matches`] but for a bare NAME that no traversal will
+    /// revisit, gating descendants on this rule's own directory form.
+    ///
+    /// The synthetic `pattern/**` matchers stand in for upstream's
+    /// `XFLG_DIR2WILD3` rewrite, which appends `/***` to a *directory-form*
+    /// rule only (exclude.c:307-313). A rule written without the trailing
+    /// slash keeps upstream's exact `strcmp` semantics (exclude.c:1002), so its
+    /// descendants must stay dormant here. `directory_only` is exactly the
+    /// record of which form the rule was written in.
+    pub(crate) fn matches_name(&self, path: &Path, is_dir: bool) -> bool {
+        self.matches(path, is_dir, self.directory_only)
+    }
+
     /// Like [`Self::matches`] but for the receiver's deletion scan.
     ///
     /// Adds the `deletion_descendant_matchers` set on top of the regular

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -71,6 +71,36 @@ impl FilterSetInner {
         self.decision_with_traversal(path, is_dir, context, false)
     }
 
+    /// First rule matching `path` treated as a bare NAME, or `None`.
+    ///
+    /// This is upstream's `check_filter()` loop applied to a single name that
+    /// no traversal will ever revisit - the shape the daemon uses to vet the
+    /// client's destination argument (main.c:700-737 `get_local_name()`).
+    /// Upstream's loop consults neither side modifiers nor perishability, so
+    /// neither is consulted here.
+    ///
+    /// Descendants are gated per-rule on `directory_only`, which is the whole
+    /// point of this predicate. Upstream's daemon parser rewrites a
+    /// directory-form rule to the `pattern/***` wildcard via `XFLG_DIR2WILD3`
+    /// (exclude.c:307-313), so `- /excluded/` matches both the directory and
+    /// everything beneath it, while a bare `- /excluded` stays an exact
+    /// `strcmp` (exclude.c:1002 `rule_matches()`) that matches the directory
+    /// alone. oc collapses `pattern/***` back to a `directory_only` stem plus
+    /// synthetic `pattern/**` descendant matchers, so `directory_only` is
+    /// precisely the record of "this rule was written in directory form" - and
+    /// therefore precisely the gate that reproduces upstream's two behaviours.
+    /// A blanket `true` over-matches the bare form; a blanket `false`
+    /// under-matches the directory form.
+    pub(crate) fn first_rule_matching_name(
+        &self,
+        path: &Path,
+        is_dir: bool,
+    ) -> Option<&CompiledRule> {
+        self.include_exclude
+            .iter()
+            .find(|rule| rule.matches_name(path, is_dir))
+    }
+
     /// Like [`Self::decision`] but lets callers signal that the query comes
     /// from a tree traversal that already prunes excluded subtrees.
     ///

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -200,6 +200,28 @@ impl FilterSet {
             .allows_transfer()
     }
 
+    /// Returns `true` if `path`, treated as a bare NAME, is not excluded.
+    ///
+    /// This is the predicate for a one-shot check against a name no traversal
+    /// will revisit - upstream's `check_filter()` over the daemon filter list,
+    /// as `get_local_name()` applies it to the client's destination argument
+    /// (main.c:700-737). A name matching no rule is allowed, matching
+    /// upstream's `return 0`.
+    ///
+    /// Unlike [`Self::allows`] (which assumes a single-path API caller with no
+    /// traversal and so keeps every synthetic descendant matcher live) and
+    /// [`Self::allows_during_traversal`] (which drops them all because the walk
+    /// prunes subtrees itself), this honours the descendant matchers only for
+    /// rules written in directory form. That is what upstream's `XFLG_DIR2WILD3`
+    /// rewrite encodes: `- /excluded/` becomes the wildcard `/excluded/***` and
+    /// covers the subtree, while `- /excluded` stays an exact compare.
+    #[must_use]
+    pub fn allows_name(&self, path: &Path, is_dir: bool) -> bool {
+        self.inner
+            .first_rule_matching_name(path, is_dir)
+            .is_none_or(|rule| matches!(rule.action, FilterAction::Include))
+    }
+
     /// Like [`Self::allows`] but tailored for a tree traversal that already
     /// prunes excluded subtrees.
     ///
@@ -616,6 +638,77 @@ pub fn apple_double_exclusion_rules(perishable: bool) -> impl Iterator<Item = Fi
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The three spellings a daemon operator can write for the same directory,
+    /// and what upstream's `check_filter()` does with each, measured against
+    /// real rsync 3.5.0 (`exclude = ...` on a module, pushing to
+    /// `excluded/x2.tx`):
+    ///
+    /// | rule           | `excluded` | `excluded/x2.tx` |
+    /// |----------------|------------|------------------|
+    /// | `/excluded`    | excluded   | **allowed**      |
+    /// | `/excluded/`   | excluded   | excluded         |
+    /// | `/excluded/***`| excluded   | excluded         |
+    ///
+    /// The bare form is an exact `strcmp` (exclude.c:1002); the other two are
+    /// the same `pattern/***` wildcard after `XFLG_DIR2WILD3`
+    /// (exclude.c:307-313). A predicate that answers the same for all three
+    /// rows is wrong in one direction or the other, which is why neither
+    /// `allows` nor `allows_during_traversal` can serve here.
+    fn name_set(pattern: &str) -> FilterSet {
+        FilterSet::from_rules(vec![FilterRule::exclude(pattern.to_owned())]).unwrap()
+    }
+
+    #[test]
+    fn allows_name_bare_rule_does_not_reach_into_the_directory() {
+        let set = name_set("/excluded");
+        assert!(
+            !set.allows_name(Path::new("excluded"), true),
+            "the exact name must still be excluded"
+        );
+        assert!(
+            set.allows_name(Path::new("excluded/x2.tx"), false),
+            "a bare rule is an exact strcmp upstream - it must NOT cover descendants"
+        );
+    }
+
+    #[test]
+    fn allows_name_directory_forms_cover_the_subtree() {
+        for pattern in ["/excluded/", "/excluded/***"] {
+            let set = name_set(pattern);
+            assert!(
+                !set.allows_name(Path::new("excluded"), true),
+                "{pattern}: the directory itself must be excluded"
+            );
+            assert!(
+                !set.allows_name(Path::new("excluded/x2.tx"), false),
+                "{pattern}: DIR2WILD3 makes this the subtree wildcard"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_name_permits_a_name_no_rule_matches() {
+        let set = name_set("/excluded/***");
+        assert!(
+            set.allows_name(Path::new("allowed.txt"), false),
+            "upstream check_filter() returns 0 for an unmatched name"
+        );
+    }
+
+    #[test]
+    fn allows_name_honours_an_earlier_include() {
+        let set = FilterSet::from_rules(vec![
+            FilterRule::include("excluded/keep.txt".to_owned()),
+            FilterRule::exclude("/excluded/***".to_owned()),
+        ])
+        .unwrap();
+        assert!(
+            set.allows_name(Path::new("excluded/keep.txt"), false),
+            "first match wins - the include precedes the exclude"
+        );
+        assert!(!set.allows_name(Path::new("excluded/other.txt"), false));
+    }
 
     #[test]
     fn filter_set_default_is_empty() {

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -370,6 +370,27 @@ impl ReceiverContext {
             return Ok(());
         };
         let cleaned = filters::collapse_dot_dot_dirs(dest);
+        // The daemon filter is NAME-based and anchored at the module root, so it
+        // must see the module-relative name. Upstream gets that for free:
+        // `rsync_module()` chdir's into the module (clientserver.c:864
+        // `module_chdir = normalize_path(module_dir, ..)`) long before
+        // `get_local_name()` runs, so its `dest_path` is already relative - which
+        // is why upstream's own diagnostic quotes `"excluded/x2.tx"`, not an
+        // absolute path. oc instead carries the dest as
+        // `<module root>/<peer tail>` joined absolute, so an anchored rule like
+        // `/excluded/***` could never match and every rule silently passed.
+        // Stripping the module root is upstream's `p1 = curr_dir + module_dirlen`
+        // (util1.c:1285) expressed against an owned path.
+        //
+        // A dest that does not lie under the module root is left as-is rather
+        // than guessed at: the confinement resolver refuses that shape before any
+        // data lands, so there is no path here that needs a fabricated name.
+        let cleaned = match self.config.connection.daemon_module_root.as_deref() {
+            Some(root) => cleaned
+                .strip_prefix(root)
+                .map_or(cleaned.clone(), Path::to_path_buf),
+            None => cleaned,
+        };
         // upstream: main.c:729-730 - a trailing `/` or `/.` component is
         // lopped off before matching, and a bare `.` is not checked at all.
         let cleaned = match cleaned.file_name() {
@@ -381,7 +402,20 @@ impl ReceiverContext {
         if cleaned.as_os_str().is_empty() || cleaned == Path::new(".") {
             return Ok(());
         }
-        if filters.allows(&cleaned, false) && filters.allows(&cleaned, true) {
+        // upstream: main.c:723-731 calls check_filter() TWICE, once per
+        // name_flags value, and refuses if either says excluded - the daemon
+        // does not yet know whether the dest names a directory.
+        //
+        // `allows_name` is the predicate that mirrors check_filter() on a name
+        // no traversal will revisit: `exclude = /excluded` does NOT protect
+        // `excluded/x2.tx` (an anchored non-wild rule is a bare
+        // `strcmp(name, pattern)`, exclude.c:1002), while `/excluded/` and
+        // `/excluded/***` do, because XFLG_DIR2WILD3 (exclude.c:307-313) makes
+        // both of those the subtree wildcard. Neither `allows` (all synthetic
+        // descendants live, over-matching the bare form) nor
+        // `allows_during_traversal` (none live, under-matching the directory
+        // form) can express that split.
+        if filters.allows_name(&cleaned, false) && filters.allows_name(&cleaned, true) {
             return Ok(());
         }
         // upstream: main.c:734-735 quotes the ORIGINAL argument, not the

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -117,7 +117,7 @@ operator-path-insecure-links-refused pass
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
 operator-path-traversal-backup-dir-daemon fail
-operator-path-traversal-dest-dir-daemon fail
+operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass
 password-file-symlink skip
 peer-legacy-implied-delete-scope pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -41,7 +41,7 @@ daemon-deny-dns-failopen pass
 daemon-dot-file-force-wipe pass
 daemon-early-exec-nameconv fail
 daemon-exclude-from-outside-module pass
-daemon-exclude-namebased fail
+daemon-exclude-namebased pass
 daemon-exec pass
 daemon-exec-metachar-documented-limit fail
 daemon-exec-metachar-refused fail

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -80,7 +80,7 @@ daemon-deny-dns-failopen skip
 daemon-dot-file-force-wipe skip
 daemon-early-exec-nameconv fail
 daemon-exclude-from-outside-module pass
-daemon-exclude-namebased fail
+daemon-exclude-namebased pass
 daemon-exec pass
 daemon-exec-metachar-documented-limit fail
 daemon-exec-metachar-refused fail

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -226,7 +226,7 @@ operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
 operator-path-temp-dir pass
 operator-path-traversal-backup-dir-daemon fail
-operator-path-traversal-dest-dir-daemon fail
+operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass
 operator-path-write-batch pass
 output-options pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -117,7 +117,7 @@ operator-path-insecure-links-refused pass
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
 operator-path-traversal-backup-dir-daemon fail
-operator-path-traversal-dest-dir-daemon fail
+operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass
 password-file-symlink pass
 peer-legacy-implied-delete-scope pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -41,7 +41,7 @@ daemon-deny-dns-failopen pass
 daemon-dot-file-force-wipe pass
 daemon-early-exec-nameconv fail
 daemon-exclude-from-outside-module pass
-daemon-exclude-namebased fail
+daemon-exclude-namebased pass
 daemon-exec pass
 daemon-exec-metachar-documented-limit fail
 daemon-exec-metachar-refused fail

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -226,7 +226,7 @@ operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
 operator-path-temp-dir fail
 operator-path-traversal-backup-dir-daemon fail
-operator-path-traversal-dest-dir-daemon fail
+operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass
 operator-path-write-batch fail
 output-options pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -80,7 +80,7 @@ daemon-deny-dns-failopen skip
 daemon-dot-file-force-wipe skip
 daemon-early-exec-nameconv fail
 daemon-exclude-from-outside-module pass
-daemon-exclude-namebased fail
+daemon-exclude-namebased pass
 daemon-exec pass
 daemon-exec-metachar-documented-limit fail
 daemon-exec-metachar-refused fail


### PR DESCRIPTION
## The gap

The daemon vets the client's destination argument against the module filter
list - upstream `get_local_name()`, `main.c:700-737`. oc ran that check, but
against the absolute `<module root>/<peer tail>` path. The daemon filter is
name-based and anchored at the module root, so an anchored rule could never
match: the check ran and silently passed for every destination.

Two independent defects had to be fixed together; either alone leaves the
cell red.

## 1. The name was never module-relative

Upstream gets this for free. `rsync_module()` chdir's into the module
(`clientserver.c:864`) long before `get_local_name()` runs, so its `dest_path`
is already relative - which is why upstream's own diagnostic quotes
`"excluded/x2.tx"` and not an absolute path. oc carries the destination as an
owned absolute path, so the module root has to be stripped explicitly; that is
upstream's `p1 = curr_dir + module_dirlen` (`util1.c:1285`).

A destination that does not lie under the module root is left as-is rather
than guessed at - the confinement resolver refuses that shape before any data
lands, so no path here needs a fabricated name.

## 2. Neither existing predicate can express upstream's rule

Upstream's daemon parser rewrites a **directory-form** rule to the
`pattern/***` wildcard via `XFLG_DIR2WILD3` (`exclude.c:307-313`); a bare
`/pattern` stays an exact `strcmp` (`exclude.c:1002` `rule_matches()` - no
descendant matching at all). Measured against the real 3.5.0 binary, pushing
to `excluded/x2.tx` with `exclude = ...` on the module:

| rule | `excluded` | `excluded/x2.tx` |
|---|---|---|
| `/excluded` | excluded | **allowed** |
| `/excluded/` | excluded | excluded |
| `/excluded/***` | excluded | excluded |

oc normalises `pattern/***` back to a `directory_only` stem plus synthetic
`pattern/**` descendant matchers, so all three spellings compile to the same
core matcher and are separated **only** by `directory_only`. That makes the
existing predicates wrong in opposite directions:

- `allows` keeps every descendant matcher live → over-matches the bare form
  (refuses a push upstream lands).
- `allows_during_traversal` drops them all → under-matches the directory forms
  (lands a push upstream refuses).

`allows_name` gates the descendant matchers **per rule** on `directory_only`,
which is precisely oc's record of which form the operator wrote. It is a third
predicate rather than a change to either existing one because the other two
have correct, different contracts: `allows` answers a single-path API query
with no traversal, `allows_during_traversal` answers from inside a walk that
prunes subtrees itself.

## Verification

- **Cell green with a passing upstream control** on both transports:
  `daemon-exclude-namebased` PASS for oc and for real 3.5.0, pipe and
  `--use-tcp`. All four expect-manifest rows flip in the same commit.
- **RED proven by three mutations**, each lethal on its own:
  - drop the module-root relativisation → FAIL
  - force descendants off for every rule → FAIL
  - force descendants on for every rule → FAIL

  The third is the one that matters: the cell pins the bare form against
  over-refusal too, so a blanket "always match descendants" fix would not have
  passed.
- **Four in-crate tests** pin the table above, plus first-match-wins against an
  earlier include and the unmatched-name allow. Mutation-proven in both
  directions: `descendants = false` kills the include-precedence test,
  `descendants = true` kills the bare-rule test.
- `cargo fmt --all -- --check` clean; `clippy -p filters -p transfer
  --all-targets --all-features` clean.
- `filters` 1461/1461, `transfer` 2766/2766, `daemon`+`engine` 6836/6836, root
  integration package 498/498.

## Security note

Before this change a module `exclude` was unenforced on the destination
argument of a push to any subdirectory - the operator-facing rule existed and
did nothing. This is the same class as the fused-composite destination path
already tracked separately; the fix here is confined to the filter check.
