### PR TITLE
fix(engine): a non-directory alt-dest arg must not fail the transfer

### DIFF
--- a/crates/engine/src/local_copy/context_impl/link_dest.rs
+++ b/crates/engine/src/local_copy/context_impl/link_dest.rs
@@ -46,16 +46,15 @@ impl<'a> CopyContext<'a> {
             // LSTAT, so a basis entry that is itself a symlink reports S_IFLNK and is skipped
             // rather than followed. Using a following stat here would accept a symlink-to-regular
             // candidate and then hard-link or read THROUGH it - the read oracle upstream closed.
-            let candidate_metadata = match fs::symlink_metadata(&candidate) {
-                Ok(metadata) => metadata,
-                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-                Err(error) => {
-                    return Err(LocalCopyError::io(
-                        "inspect link-dest candidate",
-                        candidate,
-                        error,
-                    ));
-                }
+            // upstream: generator.c:1084 `if (basis_link_stat(cmpbuf, &sxp->st) < 0
+            // || !S_ISREG(sxp->st.st_mode)) continue;` - and likewise at :1110,
+            // :1227 and :1254. EVERY caller treats ANY stat failure as "no
+            // candidate in this basis dir", not just ENOENT. A basis dir that is
+            // missing or is not a directory has already been reported once by
+            // check_alt_basis_dirs(); aborting the transfer on the resulting
+            // ENOTDIR would fail a run upstream completes normally.
+            let Ok(candidate_metadata) = fs::symlink_metadata(&candidate) else {
+                continue;
             };
 
             if !candidate_metadata.file_type().is_file() {
@@ -123,16 +122,10 @@ impl<'a> CopyContext<'a> {
 
         for entry in self.options.link_dest_entries() {
             let candidate = entry.resolve(self.destination_root(), relative);
-            let candidate_metadata = match fs::symlink_metadata(&candidate) {
-                Ok(metadata) => metadata,
-                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-                Err(error) => {
-                    return Err(LocalCopyError::io(
-                        "inspect link-dest symlink",
-                        candidate,
-                        error,
-                    ));
-                }
+            // upstream: generator.c:1227 - any basis_link_stat() failure skips
+            // this basis dir. See the note at the head of `link_dest_target`.
+            let Ok(candidate_metadata) = fs::symlink_metadata(&candidate) else {
+                continue;
             };
 
             if !candidate_metadata.file_type().is_symlink() {
@@ -190,16 +183,10 @@ impl<'a> CopyContext<'a> {
 
         for entry in self.options.link_dest_entries() {
             let candidate = entry.resolve(self.destination_root(), relative);
-            let candidate_metadata = match fs::symlink_metadata(&candidate) {
-                Ok(metadata) => metadata,
-                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-                Err(error) => {
-                    return Err(LocalCopyError::io(
-                        "inspect link-dest special",
-                        candidate,
-                        error,
-                    ));
-                }
+            // upstream: generator.c:1254 - any basis_link_stat() failure skips
+            // this basis dir. See the note at the head of `link_dest_target`.
+            let Ok(candidate_metadata) = fs::symlink_metadata(&candidate) else {
+                continue;
             };
 
             let cand_type = candidate_metadata.file_type();

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -195,16 +195,15 @@ pub(crate) fn find_reference_action(
     let mut best: Option<(ReferenceDirectoryKind, PathBuf, u8)> = None;
     for reference in context.reference_directories() {
         let candidate = resolve_reference_candidate(reference.path(), relative, destination);
-        let candidate_metadata = match fs::symlink_metadata(&candidate) {
-            Ok(meta) => meta,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-            Err(error) => {
-                return Err(LocalCopyError::io(
-                    "inspect reference file",
-                    candidate,
-                    error,
-                ));
-            }
+        // upstream: generator.c:1084 `if (basis_link_stat(cmpbuf, &sxp->st) < 0
+        // || !S_ISREG(sxp->st.st_mode)) continue;` - and likewise at :1110,
+        // :1227 and :1254. EVERY caller treats ANY stat failure as "no candidate
+        // in this basis dir", not just ENOENT. An alt-dest arg that is missing
+        // or is not a directory has already been reported once by
+        // check_alt_basis_dirs() (main.c:867); aborting the transfer on the
+        // resulting ENOTDIR would fail a run upstream completes normally.
+        let Ok(candidate_metadata) = fs::symlink_metadata(&candidate) else {
+            continue;
         };
 
         if !candidate_metadata.file_type().is_file() {

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -384,16 +384,14 @@ pub(crate) fn find_copy_dest_basis(
     // row itemizes against the basis root.
     for reference in context.reference_directories() {
         let candidate = resolve_reference_candidate(reference.path(), relative, destination);
-        let candidate_metadata = match fs::symlink_metadata(&candidate) {
-            Ok(meta) => meta,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-            Err(error) => {
-                return Err(LocalCopyError::io(
-                    "inspect reference directory",
-                    candidate,
-                    error,
-                ));
-            }
+        // upstream: generator.c:1227 - `if (basis_link_stat(cmpbuf, &sxp->st) < 0
+        // || ...) continue;`. ANY stat failure means "no candidate in this basis
+        // dir", not just ENOENT. This is the transfer-root (`./`) lookup, so an
+        // alt-dest arg naming a plain file yields ENOTDIR here on the very first
+        // entry; aborting would fail a run upstream completes normally, having
+        // merely warned once from check_alt_basis_dirs().
+        let Ok(candidate_metadata) = fs::symlink_metadata(&candidate) else {
+            continue;
         };
         if candidate_metadata.file_type().is_dir() {
             return Ok(Some(candidate_metadata));

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -1794,3 +1794,51 @@ fn link_dest_arg_that_is_a_plain_file_does_not_fail_a_recursive_transfer() {
     );
     assert_eq!(summary.hard_links_created(), 0);
 }
+
+/// upstream: generator.c:1227 try_dests_non() - a directory entry consults the
+/// basis through the same `basis_link_stat(..) < 0 || .. continue` arm, so a
+/// non-directory basis must be skipped rather than abort the run.
+///
+/// This is a FIFTH candidate-stat site, distinct from the four the regular /
+/// symlink / special / recursive-file pins cover: `find_copy_dest_basis` serves
+/// the DIRECTORY lookup. A source tree carrying a subdirectory is what reaches
+/// it - a flat source never emits a directory entry, which is why the
+/// recursive-file pin above stayed green while `oc-rsync -a src/ dst/` against
+/// a plain-file basis still exited 23 with `NotADirectory (20)`.
+#[test]
+fn link_dest_arg_that_is_a_plain_file_does_not_fail_a_directory_entry() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let nested = source_dir.join("nested");
+    fs::create_dir_all(&nested).expect("create source");
+    fs::write(nested.join("file.txt"), b"content").expect("write source");
+
+    let basis = temp.path().join("basis");
+    fs::write(&basis, b"not a directory").expect("write basis file");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+    let mut source_operand = source_dir.into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest_dir.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .times(true)
+        .extend_reference_directories([ReferenceDirectory::new(
+            ReferenceDirectoryKind::Link,
+            basis,
+        )]);
+
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("a non-directory link-dest must not fail a directory entry");
+
+    assert_eq!(
+        fs::read(dest_dir.join("nested").join("file.txt")).expect("read dest"),
+        b"content",
+        "the nested file must still be transferred"
+    );
+    assert_eq!(summary.hard_links_created(), 0);
+}

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -1633,3 +1633,164 @@ fn link_dest_links_special_when_the_destination_accepts_it() {
         "an accepted link must share the basis inode"
     );
 }
+
+// An alt-dest arg naming something that is NOT a directory must degrade to a
+// normal transfer, not fail the run.
+//
+// upstream: main.c:867 check_alt_basis_dirs() warns `%s arg is not a dir: %s`
+// (main.c:903) and keeps going, and every basis_link_stat() caller in
+// generator.c (:1084, :1110, :1227, :1254) treats ANY stat failure as "no
+// candidate here". Joining a non-directory basis with the relative name yields
+// ENOTDIR, which is not NotFound - oc used to surface that as a fatal
+// LocalCopyError and abort the whole transfer, so a stale --link-dest pointing
+// at a file destroyed the run instead of merely losing the hard-link
+// optimisation.
+//
+// `link_dest_hardlinks_identical_file` above is the non-vacuity companion:
+// it proves this same fixture shape DOES hard-link when the basis really is a
+// directory, so a green result here cannot come from a basis that could never
+// have matched anyway.
+
+#[test]
+fn link_dest_arg_that_is_a_plain_file_does_not_fail_the_transfer() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source");
+    let source_file = source_dir.join("file.txt");
+    fs::write(&source_file, b"content").expect("write source");
+
+    // The alt-dest arg is a regular FILE, not a directory.
+    let basis = temp.path().join("basis");
+    fs::write(&basis, b"not a directory").expect("write basis file");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+    let dest_file = dest_dir.join("file.txt");
+    let operands = vec![
+        source_file.into_os_string(),
+        dest_file.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .times(true)
+        .extend_link_dests([basis]);
+
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("a non-directory link-dest must not fail the transfer");
+
+    assert_eq!(fs::read(&dest_file).expect("read dest"), b"content");
+    assert_eq!(summary.files_copied(), 1);
+    assert_eq!(summary.hard_links_created(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn link_dest_arg_that_is_a_plain_file_does_not_fail_a_symlink_transfer() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source");
+    std::os::unix::fs::symlink("target", source_dir.join("link")).expect("symlink");
+
+    let basis = temp.path().join("basis");
+    fs::write(&basis, b"not a directory").expect("write basis file");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+    let mut source_operand = source_dir.into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest_dir.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .extend_link_dests([basis]);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("a non-directory link-dest must not fail a symlink transfer");
+
+    let copied = fs::read_link(dest_dir.join("link")).expect("destination symlink");
+    assert_eq!(copied, std::path::Path::new("target"));
+}
+
+#[cfg(unix)]
+#[test]
+fn link_dest_arg_that_is_a_plain_file_does_not_fail_a_special_transfer() {
+    use std::os::unix::fs::FileTypeExt;
+
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source");
+    mkfifo_for_tests(&source_dir.join("node"), 0o600).expect("mkfifo");
+
+    let basis = temp.path().join("basis");
+    fs::write(&basis, b"not a directory").expect("write basis file");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+    let mut source_operand = source_dir.into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest_dir.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .specials(true)
+        .extend_link_dests([basis]);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("a non-directory link-dest must not fail a special-file transfer");
+
+    let created = fs::symlink_metadata(dest_dir.join("node")).expect("destination entry");
+    assert!(created.file_type().is_fifo(), "the fifo must be recreated");
+}
+
+// The RECURSIVE regular-file path resolves alt-dest candidates through
+// `executor::reference::…`, a different scan from the single-file
+// `link_dest_target` above. It carried its own copy of the same fatal-on-
+// ENOTDIR arm, so the pin above passed while a real `-r` transfer still
+// aborted. Both callers need their own cell.
+#[test]
+fn link_dest_arg_that_is_a_plain_file_does_not_fail_a_recursive_transfer() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source");
+    fs::write(source_dir.join("file.txt"), b"content").expect("write source");
+
+    let basis = temp.path().join("basis");
+    fs::write(&basis, b"not a directory").expect("write basis file");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+    let mut source_operand = source_dir.into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest_dir.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // `extend_reference_directories`, NOT `extend_link_dests`: they populate two
+    // different lists consulted by two different scans. `link_dest_entries()`
+    // drives `link_dest_target` (step 1); `reference_directories()` drives
+    // `executor::reference::find_reference_action` (step 3), which carries its
+    // OWN copy of the same stat arm. A real `--link-dest` invocation populates
+    // the reference list, so only this shape reaches the second site.
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .times(true)
+        .extend_reference_directories([ReferenceDirectory::new(
+            ReferenceDirectoryKind::Link,
+            basis,
+        )]);
+
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("a non-directory link-dest must not fail a recursive transfer");
+
+    assert_eq!(
+        fs::read(dest_dir.join("file.txt")).expect("read dest"),
+        b"content",
+        "the file must still be transferred"
+    );
+    assert_eq!(summary.hard_links_created(), 0);
+}


### PR DESCRIPTION
## The defect

A `--link-dest` / `--copy-dest` / `--compare-dest` arg that names something which
is **not a directory** aborted the whole transfer. Measured against the real
3.5.0 binary:

| basis arg | upstream 3.5.0 | oc (before) |
|---|---|---|
| missing path | exit 0, file copied | exit 0, file copied |
| **a plain file** | exit 0, file copied | **exit 23, destination MISSING** |

Joining a non-directory basis with the relative name yields `ENOTDIR`, which is
not `NotFound`, so oc surfaced it as a fatal `LocalCopyError`. A stale
`--link-dest` pointing at a file therefore failed a backup run outright instead
of merely losing the hard-link optimisation.

## Upstream's rule

Every caller of `basis_link_stat()` treats **any** stat failure as "no candidate
in this basis dir", not just `ENOENT`:

```c
if (basis_link_stat(cmpbuf, &sxp->st) < 0 || !S_ISREG(sxp->st.st_mode))
        continue;
```

`generator.c:1084`, and likewise at `:1110`, `:1227`, `:1254`. Upstream can do
that safely because a bad basis dir has already been reported once by
`check_alt_basis_dirs()` (`main.c:867`, warning at `:901`).

## Scope: FIVE sites, not one

`fs::symlink_metadata` on an alt-dest candidate appears at five places, each
reached by a different caller. They had to be fixed together:

| site | reached by |
|---|---|
| `context_impl/link_dest.rs:56` | regular file, `link_dest_entries()` |
| `context_impl/link_dest.rs:127` | symlink basis |
| `context_impl/link_dest.rs:188` | device / special basis |
| `executor/reference.rs:205` | the recursive regular-file scan, `reference_directories()` |
| `executor/reference.rs:386` | the **directory** scan (`find_copy_dest_basis`) |

Two traps made the scope larger than it first looked:

1. **Two lists, two scans.** Step 1 (`link_dest_target`) reads
   `link_dest_entries()`; step 3 (`find_reference_action`) reads
   `reference_directories()`. A real `--link-dest` invocation populates the
   *second*, so fixing only the `link_dest.rs` trio left the end-to-end run
   still failing - and, worse, turned the hard error into a silent skip with
   exit 0.
2. **Files and directories take different lookups.** `find_copy_dest_basis`
   serves directory entries and carries its own copy of the arm. The fourth-site
   pin used a flat source, which emits no directory entry, so it stayed green
   while `oc-rsync -a src/ dst/` still exited 23. A source tree containing a
   subdirectory is what discriminates.

**Deliberately unchanged:** `executor/file/copy/links.rs:643` re-stats a basis
that has *already* matched. Upstream does not re-stat there at all - it reuses
the populated `sxp->st` (`generator.c:1140`) - so a failure at that point is a
genuine race, not "no candidate here", and it keeps its error.

## Verification

- **Oracle**: re-measured against real 3.5.0 over `--link-dest` / `--copy-dest` /
  `--compare-dest` crossed with absolute / relative / missing basis args. Exit
  code and destination contents now match upstream on every cell.
- **Five pins**, one per site (regular / symlink / special / recursive-file /
  directory-entry).
- **RED proven per site**, not in aggregate: restoring the pre-fix arm at
  `link_dest.rs:56` fails only the regular-file pin; restoring it at
  `reference.rs:205` fails only the recursive pin; restoring it at
  `reference.rs:386` reports `5 tests run: 4 passed, 1 failed` with only the
  directory-entry pin red. Each mutation leaves the others green, which is what
  attributes each pin to its own site.
- **Non-vacuity companion**: the pre-existing `link_dest_hardlinks_identical_file`
  proves this fixture shape *does* hard-link when the basis really is a
  directory, so a green result cannot come from a basis that could never have
  matched.
- `cargo fmt --all -- --check` clean; `clippy -p engine --all-targets
  --all-features` clean.
- `engine` 5019/5019.

## Residual (filed, not fixed here)

oc has **no `check_alt_basis_dirs()` equivalent at all** - neither the
`%s arg does not exist: %s` nor the `%s arg is not a dir: %s` warning exists
anywhere in the tree, on any path. Upstream emits them from two call sites
(`main.c:1241` server receiver, `main.c:1424` client receiver), so this is a
receiver-wide gap rather than a daemon one. Two behaviours come with it and are
also absent here: the basis dir is made absolute against the *destination*
directory (`main.c:885-898` - a relative `--link-dest=x` resolves to
`<dest>/x`, not `<cwd>/x`), and one trailing slash is stripped. This PR fixes
the behaviour, not the diagnostic.
