### PR TITLE
docs(daemon): retarget the check_alt_basis_dirs citations at 3.5.0

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -528,12 +528,12 @@ fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf {
 /// Relative paths join under `resolve_base`; absolute paths are normalised
 /// in place. Both branches then run the same canonicalise-with-lexical-
 /// fallback containment check. The fallback is essential because a basis
-/// directory is allowed to be missing on disk - upstream `main.c:841
+/// directory is allowed to be missing on disk - upstream `main.c:867
 /// check_alt_basis_dirs` only warns, never aborts - and we must still apply
 /// the containment policy in that case.
 ///
 /// upstream: util1.c:1138 `sanitize_path` collapses `..` against the
-/// module root depth; main.c:1199-1206 `check_alt_basis_dirs` warns on
+/// module root depth; main.c:867 `check_alt_basis_dirs` warns (main.c:901) on
 /// out-of-tree basis. We mirror the silent-drop side of that contract
 /// instead of upstream's path-rewrite because our daemon does not chdir
 /// per connection.

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -240,7 +240,7 @@ fn build_server_config(
                 cfg.connection.compression_level = Some(compress::zlib::CompressionLevel::Default);
             }
 
-            // upstream: main.c:1217-1224 calls `check_alt_basis_dirs()` after
+            // upstream: main.c:1230-1241 calls `check_alt_basis_dirs()` after
             // `get_local_name(flist, argv[0])` chdir's into the dest directory,
             // so relative basis paths like `--link-dest=../01` resolve against
             // the receiver's destination (a sibling of `dest/00/`), not against

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2474,7 +2474,7 @@ mod module_access_tests {
         // root (a sibling path `<module>/../linkdest-ref-daemon`). The
         // daemon must silently drop the basis so the receiver re-transfers
         // instead of aborting with `@ERROR` - aborting broke the standalone
-        // suite on master. upstream `main.c:841 check_alt_basis_dirs` warns
+        // suite on master. upstream `main.c:867 check_alt_basis_dirs` warns
         // on a missing/out-of-tree basis but never aborts.
         let module = tempfile::TempDir::new().expect("module tempdir");
         let outside = tempfile::TempDir::new().expect("outside tempdir");
@@ -2527,7 +2527,7 @@ mod module_access_tests {
     #[test]
     fn confine_basis_joins_relative_under_resolve_base() {
         // Relative basis paths still resolve under the receiver's dest dir
-        // (the `resolve_base`), matching upstream `main.c:1199-1206`
+        // (the `resolve_base`), matching upstream `main.c:1230-1241`
         // post-`get_local_name` chdir behaviour. This pins the legacy
         // relative branch so the absolute-path extension doesn't regress it.
         let module = tempfile::TempDir::new().expect("module tempdir");
@@ -2584,7 +2584,7 @@ mod module_access_tests {
     // Behavioural divergence from the upstream test: upstream's daemon never
     // emits a literal "outside the module" `@ERROR` for these scenarios. Its
     // `util1.c:1138 sanitize_path` collapses `..` against the module root
-    // depth (rewriting the path under the module) and `main.c:841
+    // depth (rewriting the path under the module) and `main.c:867
     // check_alt_basis_dirs` only warns when the resulting basis is missing.
     // PR #5778 aligned the oc-rsync daemon with that contract by switching
     // from a hard `@ERROR` reject to a silent drop. These tests pin the
@@ -2621,8 +2621,8 @@ mod module_access_tests {
         // Positive control paired with the `../etc/passwd` negative case
         // above. A relative basis that resolves to an in-module sibling
         // must survive so operator-permitted snapshot layouts (e.g. the
-        // upstream `dest/00 + --link-dest=../01` pattern from main.c:1199
-        // -1206) still hard-link instead of re-transferring.
+        // upstream `dest/00 + --link-dest=../01` pattern from
+        // main.c:885-898) still hard-link instead of re-transferring.
         let module = tempfile::TempDir::new().expect("module tempdir");
         let module_root = module.path().canonicalize().expect("canonicalise module");
         let dest = module_root.join("00");

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -388,7 +388,7 @@ fn process_approved_module(
     // operator's configuration permits, so the Landlock allowlist below can
     // be widened to cover them (URV-5.b.REOPEN). Out-of-module paths are
     // silently dropped here and again in `build_server_config`'s ref_dir
-    // retain block - upstream `main.c:841 check_alt_basis_dirs` warns on
+    // retain block - upstream `main.c:867 check_alt_basis_dirs` warns on
     // a missing/out-of-tree basis but never aborts, and the standalone
     // link-dest / copy-dest interop fixtures rely on that contract.
     //

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -264,7 +264,7 @@ fn classify_client_path_against_module(
 /// would EACCES legitimate writes (URV-5.b.REOPEN).
 ///
 /// upstream: util1.c:1138 `sanitize_path` collapses `..` against the
-/// module root depth; main.c:841 `check_alt_basis_dirs` warns but does not
+/// module root depth; main.c:867 `check_alt_basis_dirs` warns but does not
 /// abort when the sanitised basis is missing or out-of-tree.
 ///
 /// Returns `Ok(Some(ValidatedClientPaths))` carrying only the in-module


### PR DESCRIPTION
Eight `check_alt_basis_dirs` citations across five daemon files pointed at three
different wrong ranges. Two of the three resolve to **blank lines** in the
pinned 3.5.0 source, so a reader following them lands on whitespace.

| was | occurrences | now | what is actually there |
|---|---|---|---|
| `main.c:841` | 5 | `main.c:867` | `static void check_alt_basis_dirs(void)` |
| `main.c:1199-1206` | 2 | `main.c:1230-1241` / `main.c:885-898` | see below |
| `main.c:1217-1224` | 1 | `main.c:1230-1241` | `get_local_name(...)` → `check_alt_basis_dirs()` |

The eight split across three distinct upstream constructs, so this is a
retarget per claim rather than one search-and-replace:

- **the function / warns-but-never-aborts** → `main.c:867`, with the two
  warnings at `main.c:901` (`%s arg does not exist: %s`) and `:903`
  (`%s arg is not a dir: %s`).
- **called after `get_local_name`** → `main.c:1230-1241`.
- **the `dest/00 + --link-dest=../01` relative→absolute join** →
  `main.c:885-898`, the `if (*bdir != '/' && ...) pathjoin(...)` block.

Every new anchor was read out of `rsync-3.5.0/main.c` and confirmed to land on
the construct the comment claims, not inferred from the old value.

⚠ One citation was **split across two source lines** (`main.c:1199` / `-1206`),
so it is invisible to a single-line grep — the same shape as the multi-line
macro noted in the hardlink-notice work. A `git grep main.c:1199-1206` finds
seven of the eight.

⚠ The citation-drift CI gate does **not** catch these: it filters on lines
containing `"upstream"` and these are plain `//` prose, so the gate has been
green against all eight the whole time. That filter gap is tracked separately
and is not addressed here.

Comments only - no behaviour change. `cargo fmt --all -- --check` clean,
`cargo check -p daemon --all-features` clean.
