### PR TITLE
feat(core): warn about a bad alt-dest argument on the network paths too

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -482,6 +482,19 @@ where
     // returned an unexpected status; the latter is treated as a hard refusal
     // because the intended sandbox did not engage.
     if role == ServerRole::Receiver {
+        // upstream: main.c:1241 - the SERVER receiver runs `check_alt_basis_dirs()`
+        // once the destination is known. This is the push direction: the client
+        // is the sender and forwards the basis-dir args to us
+        // (`options.c:2911-2934` emits them only when the server receives), so
+        // the values are already in our own decoded argv and no per-connection
+        // plumbing is involved. Warn-only, exit code untouched.
+        if let Some(dest) = config.args.last() {
+            ::core::client::check_alt_basis_dirs(
+                &config.reference_directories,
+                std::path::Path::new(dest),
+            );
+        }
+
         if let Some(dest) = config.args.last() {
             let dest_path = std::path::PathBuf::from(dest);
             if let Some(root) = landlock_root_for_dest(&dest_path) {

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -122,6 +122,7 @@ pub use self::module_list::{
 };
 pub use self::outcome::ClientOutcome;
 pub use self::progress::{ClientProgressObserver, ClientProgressUpdate};
+pub use self::run::alt_basis::check_alt_basis_dirs;
 pub use self::run::{run_client, run_client_with_observer};
 pub use self::summary::{
     ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind, ClientSummary,

--- a/crates/core/src/client/run/alt_basis.rs
+++ b/crates/core/src/client/run/alt_basis.rs
@@ -122,6 +122,21 @@ fn resolve_against_destination(basis: &Path, destination: &Path) -> PathBuf {
     anchor.join(basis)
 }
 
+/// Whether the CLIENT should run the basis-dir check for a remote transfer.
+///
+/// upstream: `main.c:1424` runs `check_alt_basis_dirs()` on the client only
+/// when the client is the receiver, i.e. on a pull. On a push the remote server
+/// is the receiver and checks its own forwarded argv (`main.c:1241`), because
+/// `options.c:2911-2934` emits the basis-dir args only in that direction - so
+/// warning here too would double-report.
+///
+/// The remote-operand conjunct keeps a purely local copy out: that path has its
+/// own call once `LocalCopyPlan` resolves the destination, and without this the
+/// same run would warn twice.
+pub(crate) fn client_checks_basis_dirs(is_pull: bool, has_remote_operand: bool) -> bool {
+    is_pull && has_remote_operand
+}
+
 /// Warns about each `--compare-dest` / `--copy-dest` / `--link-dest` argument
 /// that is missing or is not a directory.
 ///
@@ -131,7 +146,7 @@ fn resolve_against_destination(basis: &Path, destination: &Path) -> PathBuf {
 ///
 /// The stat follows symlinks (upstream uses `do_stat`, not `do_lstat`), so a
 /// basis directory reached through a symlink is accepted silently.
-pub(crate) fn check_alt_basis_dirs(references: &[ReferenceDirectory], destination: &Path) {
+pub fn check_alt_basis_dirs(references: &[ReferenceDirectory], destination: &Path) {
     for reference in references {
         let basis = strip_one_trailing_separator(&reference.path);
         let resolved = resolve_against_destination(&basis, destination);
@@ -283,6 +298,30 @@ mod tests {
                 destination.join("absent").display()
             )],
             "the reported path must be anchored at the destination"
+        );
+    }
+
+    /// The client checks basis dirs only when it is the RECEIVER of a REMOTE
+    /// transfer. Exhaustive over both inputs: a push must stay silent (the
+    /// server reports it) and a local copy must stay silent here (the
+    /// local-copy path reports it), or the same run warns twice.
+    #[test]
+    fn client_only_checks_basis_dirs_on_a_remote_pull() {
+        assert!(
+            client_checks_basis_dirs(true, true),
+            "remote pull must check"
+        );
+        assert!(
+            !client_checks_basis_dirs(false, true),
+            "remote push: the server receiver checks its own forwarded argv"
+        );
+        assert!(
+            !client_checks_basis_dirs(true, false),
+            "local copy: checked once the LocalCopyPlan destination resolves"
+        );
+        assert!(
+            !client_checks_basis_dirs(false, false),
+            "local push is local"
         );
     }
 

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -51,7 +51,7 @@
 //! run_client_with_observer(config, Some(&mut observer))?;
 //! ```
 
-mod alt_basis;
+pub(crate) mod alt_basis;
 mod batch;
 mod filters;
 
@@ -304,6 +304,27 @@ fn run_client_internal(
         }
         false
     });
+
+    let has_remote = config
+        .transfer_args()
+        .iter()
+        .any(|arg| remote::operand_is_remote(arg));
+
+    // upstream: main.c:1424 - the CLIENT receiver runs `check_alt_basis_dirs()`
+    // once its destination is known. On a PULL the client is the receiver, so
+    // the check belongs here, ahead of both remote transports. On a PUSH the
+    // remote server is the receiver and runs its own check from the forwarded
+    // argv - `options.c:2911-2934` emits the basis-dir args only in that
+    // direction, which is why neither side needs the other's copy.
+    //
+    // Gated on a remote operand so a purely local copy is not warned about
+    // twice: that path has its own call once `LocalCopyPlan` resolves the
+    // destination.
+    if alt_basis::client_checks_basis_dirs(config.is_pull(), has_daemon_url || has_remote)
+        && let Some(destination) = config.transfer_args().last()
+    {
+        alt_basis::check_alt_basis_dirs(config.reference_directories(), Path::new(destination));
+    }
 
     if has_daemon_url {
         // upstream: main.c:1593-1608 - when `-e`/`--rsh` is active with `::`,


### PR DESCRIPTION
Completes task 852 gap 2. PR #7453 wired upstream's `check_alt_basis_dirs()` at the
local-copy entry only and said so; this closes the two network directions.

## The gap, measured

Head-to-head against real 3.5.0 over an `-e` wrapper with **both ends pinned** (each
cell's fake shell execs the matching binary):

| cell | upstream 3.5.0 | oc (before) |
|---|---|---|
| **push** | `--link-dest arg is not a dir: <path>` | *(silent)* |
| **pull** | `--link-dest arg is not a dir: <path>` | *(silent)* |

All four cells exit 0 and transfer the file, so it is advisory-only here exactly as
on the local path.

## ⚠ No config plumbing is involved - I expected the opposite

My working assumption was that `reference_directories` had to be threaded to the
network receivers through the `ServerConfig` builders. **That is wrong**, and worth
recording because the builders are a known drop-silently hazard.

`check_alt_basis_dirs()` runs on the **receiver**, and basis dirs are *role-scoped*:
`options.c:2911-2934` forwards `--link-dest`/`--copy-dest`/`--compare-dest` to the
server **only on a push**, because only then is the server the receiver. So:

- **push** - the server is the receiver and already parses the option from its own
  argv (`crates/cli/src/frontend/server/flags.rs:809`).
- **pull** - the client is the receiver and already holds it in `ClientConfig`; oc
  deliberately does *not* forward it, pinned by the existing
  `reference_directories_not_forwarded_on_pull`.

Each side already has the data. Two call sites, **zero** builder changes.

## Shape

One implementation, re-exported through the existing convention
(`pub use self::run::…` in `client/mod.rs`, alongside `run_client`). Both receivers
call it; nothing is duplicated.

The client gate is extracted as a named predicate rather than left inline:

```rust
pub(crate) fn client_checks_basis_dirs(is_pull: bool, has_remote_operand: bool) -> bool
```

so it is testable and self-documenting. The `has_remote_operand` conjunct is
load-bearing: without it a purely local copy would warn twice, once here and once
from the local-copy call.

## Verification

- **Oracle 4/4 byte-identical** to real 3.5.0 (push + pull, warning text and exit
  code), re-confirmed after the predicate refactor. Real-directory control stays
  silent on both. Relative-basis cells match too, reported uncollapsed.
- **Local copy warns exactly once** on both binaries - the property the gate exists
  for.
- **Per-site RED proof.** Each call is independently load-bearing, and this also
  confirms the push warning genuinely originates server-side:

  | mutation | push | pull |
  |---|---|---|
  | remove **server** call | **silent** | WARNS |
  | remove **client** call | WARNS | **silent** |

- Truth-table pin over both gate inputs, including the two silent rows.
- `fmt` clean; `clippy -p core -p cli --all-targets --all-features` clean;
  **core + cli 6633/6633**.

⚠ **Residual, filed not fixed:** the four network cells are proven by the
head-to-head oracle above, not by an in-repo test - there is no existing harness for
an `-e` wrapper transfer under nextest. The gate predicate and the helper itself are
pinned in-crate; the end-to-end network behaviour is not.
