### PR TITLE
fix(daemon): refuse an alternate-basis directory the module excludes

### DIFF
--- a/crates/core/src/exit_code/codes.rs
+++ b/crates/core/src/exit_code/codes.rs
@@ -350,6 +350,16 @@ impl ExitCode {
             return Self::Protocol;
         }
 
+        // upstream: errcode.h RERR_SYNTAX=1 - an option-usage refusal is tagged
+        // at its call site, exactly as the protocol-violation class above;
+        // without the tag it would fall through to the `_ => FileIo` arm.
+        if error
+            .get_ref()
+            .is_some_and(|inner| inner.is::<protocol::SyntaxViolation>())
+        {
+            return Self::Syntax;
+        }
+
         match error.kind() {
             ErrorKind::NotFound | ErrorKind::PermissionDenied | ErrorKind::AlreadyExists => {
                 Self::FileSelect

--- a/crates/core/src/exit_code/tests.rs
+++ b/crates/core/src/exit_code/tests.rs
@@ -448,3 +448,21 @@ fn from_i32_covers_all_exit_codes() {
         );
     }
 }
+
+#[test]
+fn from_io_error_maps_tagged_syntax_violation_to_syntax() {
+    // WHY: an option-usage refusal raised from a transfer role carries no
+    // ErrorKind that means "syntax", so without the marker it lands on the
+    // mapper's `_ => FileIo` arm and reports 11 where upstream exits 1
+    // (errcode.h RERR_SYNTAX). This pins the marker as the selector.
+    let err = protocol::syntax_violation("Your options have been rejected by the server.");
+    assert_eq!(ExitCode::from_io_error(&err), ExitCode::Syntax);
+
+    // Non-vacuity: the SAME ErrorKind without the tag must NOT map to Syntax,
+    // otherwise the assertion above would hold for the wrong reason.
+    let untagged = std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        "Your options have been rejected by the server.",
+    );
+    assert_ne!(ExitCode::from_io_error(&untagged), ExitCode::Syntax);
+}

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -172,28 +172,19 @@ fn apply_long_form_args(
             // upstream: options.c:2933-2941 - reference directories
             "--compare-dest" => {
                 if let Some(dir) = client_args.get(i + 1) {
-                    config.reference_directories.push(ReferenceDirectory {
-                        path: std::path::PathBuf::from(dir),
-                        kind: ReferenceDirectoryKind::Compare,
-                    });
+                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Compare, std::path::PathBuf::from(dir)));
                     i += 1;
                 }
             }
             "--copy-dest" => {
                 if let Some(dir) = client_args.get(i + 1) {
-                    config.reference_directories.push(ReferenceDirectory {
-                        path: std::path::PathBuf::from(dir),
-                        kind: ReferenceDirectoryKind::Copy,
-                    });
+                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Copy, std::path::PathBuf::from(dir)));
                     i += 1;
                 }
             }
             "--link-dest" => {
                 if let Some(dir) = client_args.get(i + 1) {
-                    config.reference_directories.push(ReferenceDirectory {
-                        path: std::path::PathBuf::from(dir),
-                        kind: ReferenceDirectoryKind::Link,
-                    });
+                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Link, std::path::PathBuf::from(dir)));
                     i += 1;
                 }
             }
@@ -324,20 +315,11 @@ fn apply_long_form_args(
                 } else if let Some(suffix) = arg.strip_prefix("--backup-suffix=") {
                     config.backup_suffix = Some(suffix.to_owned());
                 } else if let Some(dir) = arg.strip_prefix("--link-dest=") {
-                    config.reference_directories.push(ReferenceDirectory {
-                        path: std::path::PathBuf::from(dir),
-                        kind: ReferenceDirectoryKind::Link,
-                    });
+                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Link, std::path::PathBuf::from(dir)));
                 } else if let Some(dir) = arg.strip_prefix("--compare-dest=") {
-                    config.reference_directories.push(ReferenceDirectory {
-                        path: std::path::PathBuf::from(dir),
-                        kind: ReferenceDirectoryKind::Compare,
-                    });
+                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Compare, std::path::PathBuf::from(dir)));
                 } else if let Some(dir) = arg.strip_prefix("--copy-dest=") {
-                    config.reference_directories.push(ReferenceDirectory {
-                        path: std::path::PathBuf::from(dir),
-                        kind: ReferenceDirectoryKind::Copy,
-                    });
+                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Copy, std::path::PathBuf::from(dir)));
                 } else if let Some(dir) = arg.strip_prefix("--temp-dir=") {
                     config.temp_dir = Some(std::path::PathBuf::from(dir));
                 } else if let Some(path) = arg.strip_prefix("--files-from=") {

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -63,18 +63,48 @@ pub enum ReferenceDirectoryKind {
 pub struct ReferenceDirectory {
     /// The kind of reference directory operation.
     pub kind: ReferenceDirectoryKind,
-    /// The path to the reference directory.
+    /// The path to the reference directory, as resolved for use.
+    ///
+    /// The daemon rewrites this in place when it confines a client-supplied
+    /// basis under the module root, so it is the path to *open*, not the name
+    /// the peer asked for. Anything matching against operator-written rules
+    /// wants [`Self::requested`] instead.
     pub path: PathBuf,
+    /// The basis path exactly as the peer or operator wrote it.
+    ///
+    /// Upstream never rewrites `basis_dir[]` before matching it against the
+    /// daemon filter list: `main.c:1246-1252` runs `sanitize_path(clean,
+    /// *dir_p, "/", 0, SP_DEFAULT)` over the *given* argument, which leaves a
+    /// relative `--link-dest=secret` as `secret`. That is why upstream's own
+    /// diagnostics quote `secret` and not a resolved path, and why an anchored
+    /// module rule like `exclude = secret/` matches it.
+    ///
+    /// oc resolves the basis against the destination and confines it under the
+    /// module root before the receiver sees it, so `path` by then reads
+    /// `<module>/<dest>/secret` and no anchored rule can ever match. Keeping
+    /// the original here preserves the only value the filter check can use.
+    pub requested: PathBuf,
 }
 
 impl ReferenceDirectory {
     /// Creates a new reference directory entry.
+    ///
+    /// `requested` starts equal to `path`; only a later resolution step (the
+    /// daemon's module-root confinement) moves them apart.
     #[must_use]
     pub fn new(kind: ReferenceDirectoryKind, path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
         Self {
             kind,
-            path: path.into(),
+            requested: path.clone(),
+            path,
         }
+    }
+
+    /// Returns the basis path as the peer or operator wrote it.
+    #[must_use]
+    pub fn requested(&self) -> &std::path::Path {
+        &self.requested
     }
 
     /// Returns the reference directory kind.

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -153,6 +153,8 @@ pub mod secluded_args;
 pub mod state;
 /// Transfer statistics wire format encoding and decoding.
 pub mod stats;
+/// Marker error type for option-usage refusals (RERR_SYNTAX).
+pub mod syntax_violation;
 mod varint;
 mod version;
 /// Wire protocol serialization for signatures, deltas, and file entries.
@@ -220,6 +222,7 @@ pub use negotiation::{
 };
 pub use protocol_violation::{ProtocolViolation, protocol_violation};
 pub use stats::{CreatedStats, DeleteStats, TransferStats};
+pub use syntax_violation::{SyntaxViolation, syntax_violation};
 pub use varint::{
     decode_varint, encode_varint_to_vec, read_int, read_longint, read_varint, read_varint_bounded,
     read_varint_size, read_varint30_int, read_varlong, read_varlong30, write_int, write_longint,

--- a/crates/protocol/src/syntax_violation.rs
+++ b/crates/protocol/src/syntax_violation.rs
@@ -1,0 +1,90 @@
+//! Marker error for option-usage refusals (RERR_SYNTAX).
+//!
+//! Rust's [`std::io::ErrorKind`] has no syntax/usage variant, so an option
+//! refusal raised from a transfer role would otherwise fall through the
+//! exit-code mapper's catch-all and report `RERR_FILEIO` (11). A subset of
+//! those sites correspond to upstream call sites that invoke
+//! `exit_cleanup(RERR_SYNTAX)` (exit code 1) - for example a daemon receiver
+//! refusing the options the client asked for.
+//!
+//! [`SyntaxViolation`] tags exactly those sites. It is attached as the inner
+//! error of an [`InvalidInput`](std::io::ErrorKind::InvalidInput)
+//! [`std::io::Error`] via [`fn@syntax_violation`], so the error's
+//! [`kind`](std::io::Error::kind) and [`Display`](std::fmt::Display) text stay
+//! ordinary, while the exit-code mapper can downcast the inner error and return
+//! `RERR_SYNTAX` (1).
+//!
+//! This is the sibling of [`ProtocolViolation`](crate::ProtocolViolation),
+//! which selects `RERR_PROTOCOL` the same way.
+//!
+//! # Upstream Reference
+//!
+//! `errcode.h` - `RERR_SYNTAX = 1` (syntax or usage error). Upstream selects it
+//! at the call site via `exit_cleanup(RERR_SYNTAX)`; oc selects it via this
+//! marker.
+
+use std::error::Error;
+use std::fmt;
+use std::io;
+
+/// Inner marker error identifying an [`io::Error`] as an option-usage refusal
+/// that upstream rsync would exit with `RERR_SYNTAX` (1).
+///
+/// Constructed via [`syntax_violation`] and detected by the core exit-code
+/// mapper. Its [`Display`](fmt::Display) renders exactly the wrapped message,
+/// so wrapping a diagnostic changes neither the error text nor its
+/// [`io::ErrorKind`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyntaxViolation(pub String);
+
+impl fmt::Display for SyntaxViolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Error for SyntaxViolation {}
+
+/// Builds an [`io::Error`] of kind [`InvalidInput`](io::ErrorKind::InvalidInput)
+/// tagged as a [`SyntaxViolation`].
+///
+/// Use this at sites that mirror an upstream `exit_cleanup(RERR_SYNTAX)` call.
+/// Without the tag the error would map to `RERR_FILEIO` (11) via the mapper's
+/// catch-all arm.
+///
+/// # Upstream Reference
+///
+/// `errcode.h` - `RERR_SYNTAX = 1`.
+pub fn syntax_violation(msg: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, SyntaxViolation(msg.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_kind_and_display() {
+        // WHY: the wrapper must stay observationally identical to a plain
+        // InvalidInput error so callers that read `.kind()` or format the
+        // message are unaffected; only the exit-code mapping may change.
+        let err = syntax_violation("Your options have been rejected by the server.");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(
+            err.to_string(),
+            "Your options have been rejected by the server."
+        );
+    }
+
+    #[test]
+    fn inner_downcasts_to_marker() {
+        // WHY: the core exit-code mapper identifies the RERR_SYNTAX class by
+        // downcasting the inner error. If this stops working the refusal
+        // silently reverts to RERR_FILEIO (11) - upstream exits 1.
+        let err = syntax_violation("rejected");
+        let inner = err
+            .get_ref()
+            .and_then(|e| e.downcast_ref::<SyntaxViolation>());
+        assert_eq!(inner, Some(&SyntaxViolation("rejected".into())));
+    }
+}

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -852,10 +852,10 @@ mod tests {
         std::fs::create_dir(&sub).expect("mkdir sub");
         symlink(&secret, sub.join("basis")).expect("symlink basis -> secret");
 
-        let ref_dirs = vec![ReferenceDirectory {
-            kind: crate::config::ReferenceDirectoryKind::Compare,
-            path: ref_root.clone(),
-        }];
+        let ref_dirs = vec![ReferenceDirectory::new(
+            crate::config::ReferenceDirectoryKind::Compare,
+            ref_root.clone(),
+        )];
         let rel = std::path::Path::new("sub").join("basis");
 
         assert!(
@@ -1255,14 +1255,14 @@ mod tests {
 
         let dest_file = dest_dir.join("file.bin");
         let reference_directories = vec![
-            crate::config::ReferenceDirectory {
-                kind: crate::config::ReferenceDirectoryKind::Compare,
-                path: ref0.clone(),
-            },
-            crate::config::ReferenceDirectory {
-                kind: crate::config::ReferenceDirectoryKind::Compare,
-                path: ref1.clone(),
-            },
+            crate::config::ReferenceDirectory::new(
+                crate::config::ReferenceDirectoryKind::Compare,
+                ref0.clone(),
+            ),
+            crate::config::ReferenceDirectory::new(
+                crate::config::ReferenceDirectoryKind::Compare,
+                ref1.clone(),
+            ),
         ];
         let config = BasisFileConfig {
             file_path: &dest_file,
@@ -1332,10 +1332,10 @@ mod tests {
         }
 
         let dest_file = dest_dir.join("data.txt");
-        let reference_directories = vec![crate::config::ReferenceDirectory {
-            kind: crate::config::ReferenceDirectoryKind::Compare,
-            path: ref_dir.clone(),
-        }];
+        let reference_directories = vec![crate::config::ReferenceDirectory::new(
+            crate::config::ReferenceDirectoryKind::Compare,
+            ref_dir.clone(),
+        )];
         let config = BasisFileConfig {
             file_path: &dest_file,
             dest_dir: &dest_dir,

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -1064,10 +1064,7 @@ mod info_copy_emission_tests {
         fs::set_permissions(&dest_dir, perms).expect("chmod dest");
 
         let entry = FileEntry::new_file(relative.clone(), payload.len() as u64, 0o644);
-        let reference = ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Copy,
-            path: ref_dir.clone(),
-        };
+        let reference = ReferenceDirectory::new(ReferenceDirectoryKind::Copy, ref_dir.clone());
         let metadata_opts = MetadataOptions::default();
         let mut metadata_errors = Vec::new();
 
@@ -1125,10 +1122,7 @@ mod info_copy_emission_tests {
         fs::set_permissions(&dest_dir, perms).expect("chmod dest");
 
         let entry = FileEntry::new_file(relative.clone(), payload.len() as u64, 0o644);
-        let reference = ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Copy,
-            path: ref_dir,
-        };
+        let reference = ReferenceDirectory::new(ReferenceDirectoryKind::Copy, ref_dir);
         let metadata_opts = MetadataOptions::default();
         let mut metadata_errors = Vec::new();
 
@@ -1232,10 +1226,7 @@ mod symlink_basis_tests {
         entry_size: u64,
     ) -> bool {
         let entry = FileEntry::new_file(PathBuf::from(entry_name), entry_size, 0o644);
-        let reference = ReferenceDirectory {
-            kind,
-            path: ref_dir.to_path_buf(),
-        };
+        let reference = ReferenceDirectory::new(kind, ref_dir.to_path_buf());
         let metadata_opts = MetadataOptions::default();
         let mut metadata_errors = Vec::new();
 
@@ -1825,10 +1816,10 @@ mod alt_dest_match_level_tests {
         let ref_path = write_basis(&ref_dir, "payload.bin", b"hello", 0o644, MTIME);
         let entry = source_entry("payload.bin", 5, 0o644, MTIME + 10_000);
 
-        let refs = [ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Link,
-            path: ref_dir.clone(),
-        }];
+        let refs = [ReferenceDirectory::new(
+            ReferenceDirectoryKind::Link,
+            ref_dir.clone(),
+        )];
 
         let handled = run(&entry, &dest_dir, &refs, false, true);
         let dest_path = dest_dir.join("payload.bin");
@@ -1863,10 +1854,10 @@ mod alt_dest_match_level_tests {
         let ref_path = write_basis(&ref_dir, "payload.bin", b"world", 0o644, MTIME);
         let entry = source_entry("payload.bin", 5, 0o644, MTIME);
 
-        let refs = [ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Link,
-            path: ref_dir.clone(),
-        }];
+        let refs = [ReferenceDirectory::new(
+            ReferenceDirectoryKind::Link,
+            ref_dir.clone(),
+        )];
 
         let handled = run(&entry, &dest_dir, &refs, false, false);
         let dest_path = dest_dir.join("payload.bin");
@@ -1901,10 +1892,10 @@ mod alt_dest_match_level_tests {
         write_basis(&ref_dir, "payload.bin", b"abc", 0o600, MTIME);
         let entry = source_entry("payload.bin", 3, 0o644, MTIME);
 
-        let refs = [ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Compare,
-            path: ref_dir.clone(),
-        }];
+        let refs = [ReferenceDirectory::new(
+            ReferenceDirectoryKind::Compare,
+            ref_dir.clone(),
+        )];
 
         let handled = run(&entry, &dest_dir, &refs, false, false);
         let dest_path = dest_dir.join("payload.bin");
@@ -1931,10 +1922,10 @@ mod alt_dest_match_level_tests {
         write_basis(&ref_dir, "payload.bin", b"abc", 0o644, MTIME);
         let entry = source_entry("payload.bin", 3, 0o644, MTIME);
 
-        let refs = [ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Compare,
-            path: ref_dir.clone(),
-        }];
+        let refs = [ReferenceDirectory::new(
+            ReferenceDirectoryKind::Compare,
+            ref_dir.clone(),
+        )];
 
         let handled = run(&entry, &dest_dir, &refs, false, false);
         let dest_path = dest_dir.join("payload.bin");
@@ -1972,14 +1963,8 @@ mod alt_dest_match_level_tests {
         let entry = source_entry("payload.bin", 4, 0o644, MTIME);
 
         let refs = [
-            ReferenceDirectory {
-                kind: ReferenceDirectoryKind::Link,
-                path: early.clone(),
-            },
-            ReferenceDirectory {
-                kind: ReferenceDirectoryKind::Link,
-                path: late.clone(),
-            },
+            ReferenceDirectory::new(ReferenceDirectoryKind::Link, early.clone()),
+            ReferenceDirectory::new(ReferenceDirectoryKind::Link, late.clone()),
         ];
 
         let handled = run(&entry, &dest_dir, &refs, false, false);
@@ -2040,10 +2025,7 @@ mod non_regular_alt_dest_tests {
     use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
 
     fn refs(kind: ReferenceDirectoryKind, dir: &Path) -> Vec<ReferenceDirectory> {
-        vec![ReferenceDirectory {
-            kind,
-            path: dir.to_path_buf(),
-        }]
+        vec![ReferenceDirectory::new(kind, dir.to_path_buf())]
     }
 
     /// Options that preserve no attributes, so `metadata_unchanged` is always

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
@@ -264,3 +264,103 @@ fn daemon_excluded_destination_honours_dir_only_rules() {
         "a dir-only rule must still refuse the directory itself"
     );
 }
+
+/// Builds a receiver whose module excludes `secret` and whose client asked for
+/// `basis` as an alternate-basis directory.
+///
+/// `requested` is what the peer wrote; `path` is set to the resolved shape the
+/// daemon's module-root confinement produces, so the fixture reproduces the
+/// real divergence between the two fields rather than assuming they agree.
+fn ctx_with_basis(requested: &str) -> ReceiverContext {
+    use engine::local_copy::{ReferenceDirectory, ReferenceDirectoryKind};
+    use protocol::filters::{FilterRuleWireFormat, RuleType};
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    // ANCHORED, as a module `exclude = /secret` is. An UNANCHORED rule would
+    // match the basename at any depth and so match the resolved path too -
+    // making the fixture unable to tell `requested` from `path`, which is
+    // exactly the bug under test.
+    config.daemon_filter_rules = vec![FilterRuleWireFormat {
+        rule_type: RuleType::Exclude,
+        pattern: "secret".into(),
+        anchored: true,
+        ..FilterRuleWireFormat::default()
+    }];
+    config.connection.daemon_module_root = Some("/srv/mod".into());
+    let mut entry = ReferenceDirectory::new(ReferenceDirectoryKind::Link, requested);
+    // What the daemon's confinement pass leaves behind: the basis resolved
+    // against the destination and confined under the module root. Relative to
+    // the module that reads `dest/secret`, which an anchored rule cannot match.
+    entry.path = std::path::PathBuf::from(format!("/srv/mod/dest/{requested}"));
+    config.reference_directories = vec![entry];
+    ReceiverContext::new_for_test(&handshake, config)
+}
+
+/// upstream: `main.c:1243-1270` - a daemon receiver runs every `basis_dir[]`
+/// entry through the module filter list and refuses the whole session when one
+/// matches, with `"Your options have been rejected by the server."` and
+/// `RERR_SYNTAX`.
+///
+/// This is a READ barrier distinct from the destination check: `--copy-dest`
+/// at an excluded directory copies excluded content into a destination the
+/// client can then pull back.
+///
+/// ⚠ The match must use the name the peer WROTE. oc resolves and confines the
+/// basis before the receiver sees it, so `path` reads `<module>/<dest>/secret`
+/// and an anchored `secret` rule can never match it - which is exactly how this
+/// check shipped inert the first time.
+#[test]
+fn daemon_excluded_basis_dir_is_refused_by_requested_name() {
+    let ctx = ctx_with_basis("secret");
+    let err = ctx
+        .reject_daemon_excluded_basis_dirs()
+        .expect_err("an excluded alternate-basis directory must refuse the session");
+
+    assert_eq!(
+        err.to_string(),
+        "Your options have been rejected by the server.",
+        "upstream's exact refusal text (main.c:1267)"
+    );
+    // `crates/transfer` sits below `crates/core`, so the ExitCode mapping
+    // itself is pinned in `core::exit_code`. What is observable here is the
+    // marker that selects it - without the tag the refusal would fall through
+    // the mapper's catch-all to RERR_FILEIO (11) instead of upstream's 1.
+    assert!(
+        err.get_ref()
+            .is_some_and(|inner| inner.is::<protocol::SyntaxViolation>()),
+        "the refusal must carry the RERR_SYNTAX marker"
+    );
+}
+
+/// Non-vacuity companion: with the SAME module filter, a basis the rules do not
+/// exclude must pass. Without this a refusal that fired unconditionally - or a
+/// fixture that could not produce a pass - would look identical.
+#[test]
+fn daemon_allows_a_basis_dir_the_module_does_not_exclude() {
+    let ctx = ctx_with_basis("nosuch");
+    assert!(
+        ctx.reject_daemon_excluded_basis_dirs().is_ok(),
+        "an allowed basis must not refuse the session"
+    );
+}
+
+/// A receiver with no daemon filter list at all must never refuse: upstream
+/// gates the whole block on `daemon_filter_list.head` (`main.c:1243`), so the
+/// client and SSH-server receivers keep passing basis dirs through untouched.
+#[test]
+fn no_daemon_filter_list_never_refuses_a_basis_dir() {
+    use engine::local_copy::{ReferenceDirectory, ReferenceDirectoryKind};
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.reference_directories = vec![ReferenceDirectory::new(
+        ReferenceDirectoryKind::Link,
+        "secret",
+    )];
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+    assert!(
+        ctx.reject_daemon_excluded_basis_dirs().is_ok(),
+        "without a module filter list there is no rule to enforce"
+    );
+}

--- a/crates/transfer/src/receiver/tests/partial_resume.rs
+++ b/crates/transfer/src/receiver/tests/partial_resume.rs
@@ -98,14 +98,11 @@ fn try_reference_directories_finds_file_in_first_directory() {
     std::fs::write(&test_file, b"test content from ref1").unwrap();
 
     let ref_dirs = vec![
-        ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Compare,
-            path: ref_dir1.path().to_path_buf(),
-        },
-        ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Link,
-            path: ref_dir2.path().to_path_buf(),
-        },
+        ReferenceDirectory::new(
+            ReferenceDirectoryKind::Compare,
+            ref_dir1.path().to_path_buf(),
+        ),
+        ReferenceDirectory::new(ReferenceDirectoryKind::Link, ref_dir2.path().to_path_buf()),
     ];
 
     let relative_path = std::path::Path::new("subdir/test.txt");
@@ -130,14 +127,11 @@ fn try_reference_directories_finds_file_in_second_directory() {
     std::fs::write(&test_file, b"test content from ref2").unwrap();
 
     let ref_dirs = vec![
-        ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Compare,
-            path: ref_dir1.path().to_path_buf(),
-        },
-        ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Copy,
-            path: ref_dir2.path().to_path_buf(),
-        },
+        ReferenceDirectory::new(
+            ReferenceDirectoryKind::Compare,
+            ref_dir1.path().to_path_buf(),
+        ),
+        ReferenceDirectory::new(ReferenceDirectoryKind::Copy, ref_dir2.path().to_path_buf()),
     ];
 
     let relative_path = std::path::Path::new("test.txt");
@@ -157,10 +151,10 @@ fn try_reference_directories_returns_none_when_not_found() {
 
     let ref_dir = test_support::create_tempdir();
 
-    let ref_dirs = vec![ReferenceDirectory {
-        kind: ReferenceDirectoryKind::Link,
-        path: ref_dir.path().to_path_buf(),
-    }];
+    let ref_dirs = vec![ReferenceDirectory::new(
+        ReferenceDirectoryKind::Link,
+        ref_dir.path().to_path_buf(),
+    )];
 
     let relative_path = std::path::Path::new("nonexistent.txt");
     let result = try_reference_directories(relative_path, &ref_dirs);

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -335,6 +335,76 @@ impl ReceiverContext {
             .with_group_mapping(self.config.group_mapping.clone())
     }
 
+    /// Collapses `..` and strips the daemon module root, yielding the name the
+    /// module's filter list is written against.
+    ///
+    /// The daemon filter is NAME-based and anchored at the module root, so it
+    /// must see the module-relative name. Upstream gets that for free:
+    /// `rsync_module()` chdir's into the module (clientserver.c:864
+    /// `module_chdir = normalize_path(module_dir, ..)`) long before either
+    /// consumer runs, which is why upstream's own diagnostics quote
+    /// `"excluded/x2.tx"` and `secret`, never an absolute path. oc instead
+    /// carries these paths as `<module root>/<peer tail>` joined absolute, so an
+    /// anchored rule like `/excluded/***` could never match and every rule
+    /// silently passed. Stripping the module root is upstream's
+    /// `p1 = curr_dir + module_dirlen` (util1.c:1285), and the basis-dir loop's
+    /// own `dir = clean + module_dirlen` (main.c:1252), expressed against an
+    /// owned path.
+    ///
+    /// A path that does not lie under the module root is left as-is rather than
+    /// guessed at: the confinement resolver refuses that shape before any data
+    /// lands, so there is no path here that needs a fabricated name.
+    fn daemon_filter_name(&self, path: &Path) -> PathBuf {
+        let cleaned = filters::collapse_dot_dot_dirs(path);
+        match self.config.connection.daemon_module_root.as_deref() {
+            Some(root) => cleaned
+                .strip_prefix(root)
+                .map_or(cleaned.clone(), Path::to_path_buf),
+            None => cleaned,
+        }
+    }
+
+    /// Refuses the session when the daemon module's filter list excludes one of
+    /// the alternate-basis directories the client asked for.
+    ///
+    /// upstream: `main.c:1243-1270` - after `check_alt_basis_dirs()`, a receiver
+    /// with a non-empty `daemon_filter_list` runs every `basis_dir[]` entry
+    /// through `check_filter(elp, FLOG, dir, 1)` and, on a match, prints
+    /// `"Your options have been rejected by the server."` and calls
+    /// `exit_cleanup(RERR_SYNTAX)`.
+    ///
+    /// This is a *read* barrier, distinct from the destination check above:
+    /// `--copy-dest`/`--link-dest` name a tree the receiver reads from, so
+    /// without it a client can name an excluded directory as its basis and have
+    /// the daemon copy or hard-link excluded content into a destination the
+    /// client can then pull back.
+    ///
+    /// `is_dir` is `true` only, mirroring upstream's single
+    /// `check_filter(..., 1)`, because a basis argument always names a
+    /// directory. That is the one place this differs from the destination
+    /// check, which cannot yet know what the dest names and so ORs both values.
+    pub(in crate::receiver) fn reject_daemon_excluded_basis_dirs(&self) -> io::Result<()> {
+        let Some(filters) = self.daemon_filter_set() else {
+            return Ok(());
+        };
+        for reference in &self.config.reference_directories {
+            // The basis is matched by the name the peer WROTE, not the path oc
+            // resolved it to: the daemon rewrites `path` to
+            // `<module>/<dest>/secret` while confining it, and no module-anchored
+            // rule could ever match that. See `ReferenceDirectory::requested`.
+            let cleaned = self.daemon_filter_name(&reference.requested);
+            if cleaned.as_os_str().is_empty() || filters.allows_name(&cleaned, true) {
+                continue;
+            }
+            // upstream: main.c:1267 - the refusal text carries no path; the
+            // rejected option is reported to the daemon's own log, not the peer.
+            return Err(protocol::syntax_violation(
+                "Your options have been rejected by the server.",
+            ));
+        }
+        Ok(())
+    }
+
     /// Refuses a destination argument that the daemon module's own filter list
     /// excludes.
     ///
@@ -369,28 +439,7 @@ impl ReceiverContext {
         let Some(filters) = self.daemon_filter_set() else {
             return Ok(());
         };
-        let cleaned = filters::collapse_dot_dot_dirs(dest);
-        // The daemon filter is NAME-based and anchored at the module root, so it
-        // must see the module-relative name. Upstream gets that for free:
-        // `rsync_module()` chdir's into the module (clientserver.c:864
-        // `module_chdir = normalize_path(module_dir, ..)`) long before
-        // `get_local_name()` runs, so its `dest_path` is already relative - which
-        // is why upstream's own diagnostic quotes `"excluded/x2.tx"`, not an
-        // absolute path. oc instead carries the dest as
-        // `<module root>/<peer tail>` joined absolute, so an anchored rule like
-        // `/excluded/***` could never match and every rule silently passed.
-        // Stripping the module root is upstream's `p1 = curr_dir + module_dirlen`
-        // (util1.c:1285) expressed against an owned path.
-        //
-        // A dest that does not lie under the module root is left as-is rather
-        // than guessed at: the confinement resolver refuses that shape before any
-        // data lands, so there is no path here that needs a fabricated name.
-        let cleaned = match self.config.connection.daemon_module_root.as_deref() {
-            Some(root) => cleaned
-                .strip_prefix(root)
-                .map_or(cleaned.clone(), Path::to_path_buf),
-            None => cleaned,
-        };
+        let cleaned = self.daemon_filter_name(dest);
         // upstream: main.c:729-730 - a trailing `/` or `/.` component is
         // lopped off before matching, and a bare `.` is not checked at all.
         let cleaned = match cleaned.file_name() {
@@ -469,6 +518,13 @@ impl ReceiverContext {
         let dest_dir = dest_arg.map_or_else(|| PathBuf::from("."), PathBuf::from);
 
         self.reject_daemon_excluded_destination(&dest_dir)?;
+
+        // upstream: main.c:1243-1270 - the daemon receiver vets the client's
+        // alternate-basis directories against the module filter list right after
+        // the destination is known, refusing the whole session if any is
+        // excluded. Ordered after the destination check because upstream reaches
+        // it later in the same function (get_local_name at :1229, this at :1243).
+        self.reject_daemon_excluded_basis_dirs()?;
 
         // upstream: main.c:805-832 get_local_name() - single-file rename
         // semantics. When the transfer is exactly one non-directory entry,

--- a/crates/transfer/tests/fuzzy_level2_basis_search.rs
+++ b/crates/transfer/tests/fuzzy_level2_basis_search.rs
@@ -57,10 +57,10 @@ fn fuzzy_level2_finds_basis_in_reference_directory() {
     let file_path = dest_dir_a.join("data_v2.bin");
     let relative_path = Path::new("dir_a/data_v2.bin");
 
-    let ref_dirs = vec![ReferenceDirectory {
-        kind: ReferenceDirectoryKind::Compare,
-        path: ref_base.clone(),
-    }];
+    let ref_dirs = vec![ReferenceDirectory::new(
+        ReferenceDirectoryKind::Compare,
+        ref_base.clone(),
+    )];
 
     let config = BasisFileConfig {
         file_path: &file_path,
@@ -118,10 +118,10 @@ fn fuzzy_level1_does_not_search_reference_directories() {
     let file_path = dest_dir_a.join("data_v2.bin");
     let relative_path = Path::new("dir_a/data_v2.bin");
 
-    let ref_dirs = vec![ReferenceDirectory {
-        kind: ReferenceDirectoryKind::Compare,
-        path: ref_base.clone(),
-    }];
+    let ref_dirs = vec![ReferenceDirectory::new(
+        ReferenceDirectoryKind::Compare,
+        ref_base.clone(),
+    )];
 
     let config = BasisFileConfig {
         file_path: &file_path,
@@ -177,14 +177,8 @@ fn fuzzy_level2_selects_best_match_across_reference_dirs() {
     let relative_path = Path::new("subdir/report_2024.csv");
 
     let ref_dirs = vec![
-        ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Compare,
-            path: ref1_base.clone(),
-        },
-        ReferenceDirectory {
-            kind: ReferenceDirectoryKind::Link,
-            path: ref2_base.clone(),
-        },
+        ReferenceDirectory::new(ReferenceDirectoryKind::Compare, ref1_base.clone()),
+        ReferenceDirectory::new(ReferenceDirectoryKind::Link, ref2_base.clone()),
     ];
 
     let config = BasisFileConfig {
@@ -239,10 +233,10 @@ fn fuzzy_level2_generates_valid_signature_from_basis() {
     let file_path = dest_dir.join("archive_v2.tar");
     let relative_path = Path::new("project/archive_v2.tar");
 
-    let ref_dirs = vec![ReferenceDirectory {
-        kind: ReferenceDirectoryKind::Copy,
-        path: ref_base.clone(),
-    }];
+    let ref_dirs = vec![ReferenceDirectory::new(
+        ReferenceDirectoryKind::Copy,
+        ref_base.clone(),
+    )];
 
     let config = BasisFileConfig {
         file_path: &file_path,
@@ -299,10 +293,10 @@ fn fuzzy_level0_skips_search() {
     let file_path = dest_dir.join("file_new.txt");
     let relative_path = Path::new("dir/file_new.txt");
 
-    let ref_dirs = vec![ReferenceDirectory {
-        kind: ReferenceDirectoryKind::Compare,
-        path: ref_base.clone(),
-    }];
+    let ref_dirs = vec![ReferenceDirectory::new(
+        ReferenceDirectoryKind::Compare,
+        ref_base.clone(),
+    )];
 
     let config = BasisFileConfig {
         file_path: &file_path,
@@ -349,10 +343,10 @@ fn whole_file_bypasses_fuzzy_search() {
     let file_path = dest_dir.join("data_v2.bin");
     let relative_path = Path::new("dir/data_v2.bin");
 
-    let ref_dirs = vec![ReferenceDirectory {
-        kind: ReferenceDirectoryKind::Compare,
-        path: ref_base.clone(),
-    }];
+    let ref_dirs = vec![ReferenceDirectory::new(
+        ReferenceDirectoryKind::Compare,
+        ref_base.clone(),
+    )];
 
     let config = BasisFileConfig {
         file_path: &file_path,


### PR DESCRIPTION
## What

A daemon receiver never vetted the client's `--link-dest` / `--copy-dest` /
`--compare-dest` arguments against the module's own filter list, so a peer could
name an excluded directory as its transfer basis.

With `--copy-dest` that copies excluded content into a destination the peer can
then pull back, so this is a read barrier, not just a missing diagnostic.

## Upstream

`main.c:1243-1270` runs every `basis_dir[]` entry through
`check_filter(elp, FLOG, dir, 1)` once the destination is known, and on a match
prints `Your options have been rejected by the server.` and calls
`exit_cleanup(RERR_SYNTAX)`. The whole block is gated on
`daemon_filter_list.head`, so it stays inert for the client and SSH-server
receivers - as it does here.

`is_dir` is `true` only, mirroring upstream's single `check_filter(..., 1)`,
because a basis argument always names a directory. That is the one place this
differs from the sibling destination check (#7450), which cannot yet know what
the dest names and so ORs both values.

## The substance: match the name the peer WROTE

Upstream never rewrites `basis_dir[]` before matching. `sanitize_path(clean,
*dir_p, "/", 0, SP_DEFAULT)` leaves a relative `--link-dest=secret` as `secret`,
which is why upstream's own diagnostics quote `secret` and why an anchored
module rule matches it.

oc resolves the basis against the destination and confines it under the module
root *before* the receiver sees it, so by then the path reads
`<module>/<dest>/secret` and no anchored rule can ever match.
`ReferenceDirectory` therefore keeps the requested name alongside the resolved
one, and the six daemon parse sites move onto the constructor that owns the
`requested == path` invariant.

`RERR_SYNTAX` needed a selector: no `ErrorKind` means "syntax", so the refusal
would have landed on the exit-code mapper's `_ => FileIo` arm and reported 11
where upstream exits 1. `protocol::syntax_violation` tags it, mirroring the
existing `ProtocolViolation` marker for `RERR_PROTOCOL`.

## Measured

Two daemons, same module (`exclude = secret/`), real rsync 3.5.0 as the oracle:

| cell | upstream | oc before | oc after |
|---|---|---|---|
| `--link-dest=secret` (excluded) | rc=1, refused | rc=0, transferred | refused, nothing transferred |
| `--copy-dest=secret` (excluded) | rc=1, refused | rc=0, transferred | refused, nothing transferred |
| `--link-dest=nosuch` (allowed) | rc=0 | rc=0 | rc=0 |
| no basis (control) | rc=0 | rc=0 | rc=0 |

## ⚠ Two things that shipped inert first

**The fix.** The first version matched `reference.path` and changed nothing on
the wire - it compiled, the suite was green, and a live daemon still transferred
the excluded basis. Instrumenting the running daemon is what showed `refs` held
the resolved path.

**The test.** The first fixture used an unanchored `secret` rule, which matches
the basename at any depth - so it matched the resolved path too and could not
tell `requested` from `path`. Mutating the fix back to `reference.path` left it
green. The fixture now uses the anchored form a module `exclude` compiles to,
and that mutation fails the pin alone while both companions stay green.

## Residual (inherited, separately owned)

The client sees exit 23 + `multiplexed frame truncated` instead of upstream's
message and exit 1. The already-merged sibling refusal from #7450 behaves
identically against the same daemon, so this is the known peer-error delivery
gap, not a regression introduced here.

No testsuite manifest row moves: no cell asserts this message.

## Verification

- fmt + workspace clippy `-D warnings`: clean
- `nextest -p transfer -p engine -p protocol -p core --all-features`: 16682 run,
  16682 passed
- mutation M1 (match the resolved path) kills the pin only; M2 (drop the
  `daemon_filter_list` gate) kills the no-filter-list guard only
