### PR TITLE
fix(client): honour --port on a daemon transfer, not only a listing

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -28,6 +28,8 @@ pub(crate) struct ConfigInputs {
     pub(crate) bind_address: Option<core::client::BindAddress>,
     pub(crate) sockopts: Option<OsString>,
     pub(crate) tcp_fastopen: TcpFastOpenMode,
+    /// `--port=PORT` - daemon port used when the target names none.
+    pub(crate) daemon_port: Option<u16>,
     /// `--quic` - select the QUIC daemon transport (873/udp).
     #[cfg(feature = "quic")]
     pub(crate) quic: bool,
@@ -338,7 +340,8 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         .human_readable(inputs.human_readable)
         .mkpath(inputs.mkpath)
         .prune_empty_dirs(inputs.prune_empty_dirs)
-        .qsort(inputs.qsort);
+        .qsort(inputs.qsort)
+        .daemon_port(inputs.daemon_port);
     // `--quic` selects the QUIC daemon transport; without it the default TCP
     // transport is preserved byte-for-byte (QUIC-8c/8d).
     #[cfg(feature = "quic")]

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -913,6 +913,7 @@ where
         bind_address,
         sockopts: sockopts.clone(),
         tcp_fastopen,
+        daemon_port,
         #[cfg(feature = "quic")]
         quic,
         #[cfg(feature = "quic")]

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -289,6 +289,7 @@ pub struct ClientConfigBuilder {
     bind_address: Option<BindAddress>,
     sockopts: Option<OsString>,
     tcp_fastopen: TcpFastOpenMode,
+    daemon_port: Option<u16>,
     #[cfg(feature = "quic")]
     daemon_transport: crate::client::Transport,
     #[cfg(feature = "quic")]
@@ -594,6 +595,7 @@ impl ClientConfigBuilder {
             bind_address: self.bind_address,
             sockopts: self.sockopts,
             tcp_fastopen: self.tcp_fastopen,
+            daemon_port: self.daemon_port,
             #[cfg(feature = "quic")]
             daemon_transport: self.daemon_transport,
             #[cfg(feature = "quic")]

--- a/crates/core/src/client/config/builder/network.rs
+++ b/crates/core/src/client/config/builder/network.rs
@@ -17,6 +17,17 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Sets the `--port=PORT` default used when a daemon target names no port.
+    ///
+    /// upstream: `options.c:852` stores `--port` in `rsync_port`, which
+    /// `main.c:1591-1594` keeps unless the operand carried its own `:port`.
+    #[must_use]
+    #[doc(alias = "--port")]
+    pub const fn daemon_port(mut self, port: Option<u16>) -> Self {
+        self.daemon_port = port;
+        self
+    }
+
     /// Selects the transport that carries the daemon protocol.
     ///
     /// [`Transport::Quic`](crate::client::Transport::Quic) is chosen by `--quic`

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -255,6 +255,14 @@ pub struct ClientConfig {
     pub(super) bind_address: Option<BindAddress>,
     pub(super) sockopts: Option<OsString>,
     pub(super) tcp_fastopen: TcpFastOpenMode,
+    /// `--port=PORT` - the daemon port to use when the target names none.
+    ///
+    /// upstream: `options.c` stores `--port` in `rsync_port`, and
+    /// `main.c:1590` `start_socket_client()` passes it to `open_socket_out*`
+    /// for every daemon connection. An explicit `:port` in an `rsync://` URL
+    /// still wins, matching upstream, which overwrites `rsync_port` while
+    /// parsing the URL.
+    pub(super) daemon_port: Option<u16>,
     /// Transport carrying the daemon protocol (`--quic` / `quic://`). QUIC is an
     /// opt-in oc extension compiled only under the `quic` feature; a default
     /// build always uses TCP, so the field is absent there.
@@ -485,6 +493,7 @@ impl Default for ClientConfig {
             bind_address: None,
             sockopts: None,
             tcp_fastopen: TcpFastOpenMode::Auto,
+            daemon_port: None,
             #[cfg(feature = "quic")]
             daemon_transport: crate::client::Transport::Tcp,
             #[cfg(feature = "quic")]

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -9,6 +9,16 @@ impl ClientConfig {
         self.address_mode
     }
 
+    /// Returns the `--port=PORT` default for daemon targets that name no port.
+    ///
+    /// `None` means the operator supplied no `--port`, so the connection falls
+    /// back to 873 (upstream `RSYNC_PORT`, `main.c:1591`).
+    #[must_use]
+    #[doc(alias = "--port")]
+    pub const fn daemon_port(&self) -> Option<u16> {
+        self.daemon_port
+    }
+
     /// Returns the transport that carries the daemon protocol.
     ///
     /// [`Transport::Quic`](crate::client::Transport::Quic) is selected by

--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -39,16 +39,31 @@ impl DaemonTransferRequest {
     /// (design: `docs/design/quic-transport-policy.md`, Decision D).
     const DEFAULT_PORT: u16 = 873;
 
+    /// Resolves the port an operand that names none connects to.
+    ///
+    /// upstream: `main.c:1591-1594` - `--port` seeds `rsync_port`, and only the
+    /// `-1` sentinel (no `--port` and no `:port` in the operand) falls back to
+    /// `RSYNC_PORT`. An explicit `:port` in the operand still wins, because
+    /// `check_for_hostspec()` (`options.c:3301-3327`) overwrites `rsync_port`
+    /// while parsing it.
+    pub(crate) const fn resolve_default_port(configured: Option<u16>) -> u16 {
+        match configured {
+            Some(port) => port,
+            None => Self::DEFAULT_PORT,
+        }
+    }
+
     /// Parses an rsync:// URL into a transfer request.
     ///
-    /// Format: `rsync://[user@]host[:port]/module/path`
-    pub(crate) fn parse_rsync_url(url: &str) -> Result<Self, ClientError> {
+    /// Format: `rsync://[user@]host[:port]/module/path`. `default_port` applies
+    /// when the authority names no port; see [`Self::resolve_default_port`].
+    pub(crate) fn parse_rsync_url(url: &str, default_port: u16) -> Result<Self, ClientError> {
         let rest = url
             .strip_prefix("rsync://")
             .or_else(|| url.strip_prefix("RSYNC://"))
             .ok_or_else(|| invalid_argument_error(&format!("not an rsync:// URL: {url}"), 1))?;
 
-        Self::from_url_authority(rest, url, "rsync")
+        Self::from_url_authority(rest, url, "rsync", default_port)
     }
 
     /// Parses a quic:// URL into a transfer request, tagging the address with
@@ -57,26 +72,32 @@ impl DaemonTransferRequest {
     /// Format: `quic://[user@]host[:port]/module/path`. The grammar is
     /// identical to `rsync://`; only the selected transport differs (QUIC-8b).
     #[cfg(feature = "quic")]
-    pub(crate) fn parse_quic_url(url: &str) -> Result<Self, ClientError> {
+    pub(crate) fn parse_quic_url(url: &str, default_port: u16) -> Result<Self, ClientError> {
         let rest = url
             .strip_prefix("quic://")
             .or_else(|| url.strip_prefix("QUIC://"))
             .ok_or_else(|| invalid_argument_error(&format!("not a quic:// URL: {url}"), 1))?;
 
-        Ok(Self::from_url_authority(rest, url, "quic")?.with_transport(Transport::Quic))
+        Ok(Self::from_url_authority(rest, url, "quic", default_port)?
+            .with_transport(Transport::Quic))
     }
 
     /// Parses the shared daemon-URL body (`[user@]host[:port]/module/path`)
     /// after the scheme prefix has been stripped. `scheme` names the origin
     /// scheme for the "must specify a module" diagnostic.
-    fn from_url_authority(rest: &str, url: &str, scheme: &str) -> Result<Self, ClientError> {
+    fn from_url_authority(
+        rest: &str,
+        url: &str,
+        scheme: &str,
+        default_port: u16,
+    ) -> Result<Self, ClientError> {
         use super::super::super::module_list::parse_host_port;
 
         let mut parts = rest.splitn(2, '/');
         let host_port = parts.next().unwrap_or("");
         let path_part = parts.next().unwrap_or("");
 
-        let target = parse_host_port(host_port, Self::DEFAULT_PORT)?;
+        let target = parse_host_port(host_port, default_port)?;
 
         let mut path_parts = path_part.splitn(2, '/');
         let module = path_parts.next().unwrap_or("").to_owned();
@@ -109,17 +130,21 @@ impl DaemonTransferRequest {
 
     /// Parses a double-colon daemon operand into a transfer request.
     ///
-    /// Format: `[user@]host::module[/path]`
+    /// Format: `[user@]host::module[/path]`. `default_port` applies when the
+    /// host names no port; see [`Self::resolve_default_port`].
     ///
     /// upstream: `main.c` - `host::module` is equivalent to `rsync://host/module`.
-    pub(crate) fn parse_double_colon(operand: &str) -> Result<Self, ClientError> {
+    pub(crate) fn parse_double_colon(
+        operand: &str,
+        default_port: u16,
+    ) -> Result<Self, ClientError> {
         use super::super::super::module_list::parse_host_port;
 
         let (host_part, module_path) = operand.split_once("::").ok_or_else(|| {
             invalid_argument_error(&format!("not a daemon operand: {operand}"), 1)
         })?;
 
-        let target = parse_host_port(host_part, Self::DEFAULT_PORT)?;
+        let target = parse_host_port(host_part, default_port)?;
 
         let mut path_parts = module_path.splitn(2, '/');
         let module = path_parts.next().unwrap_or("").to_owned();

--- a/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
@@ -664,7 +664,7 @@ mod quic_url_tests {
     fn parse_rsync_url_selects_tcp() {
         // WHY: `rsync://` transfers keep the TCP transport (default behaviour).
         let request =
-            DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path").expect("parse");
+            DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path", 873).expect("parse");
         assert_eq!(request.address.transport(), Transport::Tcp);
         assert_eq!(request.address.port(), 873);
         assert_eq!(request.module, "mod");
@@ -674,7 +674,8 @@ mod quic_url_tests {
     fn parse_quic_url_selects_quic_default_port() {
         // WHY (QUIC-8b): `quic://` is parsed beside `rsync://` and yields the
         // QUIC transport on the shared default port 873 (873/udp).
-        let request = DaemonTransferRequest::parse_quic_url("quic://host/mod/path").expect("parse");
+        let request =
+            DaemonTransferRequest::parse_quic_url("quic://host/mod/path", 873).expect("parse");
         assert_eq!(request.address.transport(), Transport::Quic);
         assert_eq!(request.address.port(), 873);
         assert_eq!(request.module, "mod");
@@ -684,7 +685,8 @@ mod quic_url_tests {
     #[test]
     fn parse_quic_url_honours_explicit_port() {
         // WHY: an explicit `:port` overrides the 873 default, as for `rsync://`.
-        let request = DaemonTransferRequest::parse_quic_url("quic://host:4321/mod").expect("parse");
+        let request =
+            DaemonTransferRequest::parse_quic_url("quic://host:4321/mod", 873).expect("parse");
         assert_eq!(request.address.port(), 4321);
         assert_eq!(request.address.transport(), Transport::Quic);
     }
@@ -692,7 +694,8 @@ mod quic_url_tests {
     #[test]
     fn parse_quic_url_requires_module() {
         // WHY: a module is mandatory, and the diagnostic names the quic scheme.
-        let err = DaemonTransferRequest::parse_quic_url("quic://host/").expect_err("no module");
+        let err =
+            DaemonTransferRequest::parse_quic_url("quic://host/", 873).expect_err("no module");
         assert!(
             err.message()
                 .to_string()
@@ -703,7 +706,7 @@ mod quic_url_tests {
     #[test]
     fn with_transport_upgrades_double_colon_to_quic() {
         // WHY (QUIC-8c): `--quic` upgrades an ordinary `host::` target to QUIC.
-        let request = DaemonTransferRequest::parse_double_colon("host::mod/path")
+        let request = DaemonTransferRequest::parse_double_colon("host::mod/path", 873)
             .expect("parse")
             .with_transport(Transport::Quic);
         assert_eq!(request.address.transport(), Transport::Quic);

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -132,23 +132,24 @@ pub fn run_daemon_transfer(
         .ok_or_else(|| invalid_argument_error("no daemon URL or host::module operand found", 1))?;
 
     let daemon_operand_str = daemon_operand.to_string_lossy();
+    let default_port = DaemonTransferRequest::resolve_default_port(config.daemon_port());
     #[cfg_attr(not(feature = "quic"), allow(unused_mut))]
     let mut request = if daemon_operand_str.starts_with("rsync://")
         || daemon_operand_str.starts_with("RSYNC://")
     {
-        DaemonTransferRequest::parse_rsync_url(&daemon_operand_str)?
+        DaemonTransferRequest::parse_rsync_url(&daemon_operand_str, default_port)?
     } else {
         // A `quic://` operand is dispatched to the QUIC parser under the
         // feature; without it `is_daemon_url` never matches `quic://`, so this
         // branch only sees `host::module` targets.
         #[cfg(feature = "quic")]
         if daemon_operand_str.starts_with("quic://") || daemon_operand_str.starts_with("QUIC://") {
-            DaemonTransferRequest::parse_quic_url(&daemon_operand_str)?
+            DaemonTransferRequest::parse_quic_url(&daemon_operand_str, default_port)?
         } else {
-            DaemonTransferRequest::parse_double_colon(&daemon_operand_str)?
+            DaemonTransferRequest::parse_double_colon(&daemon_operand_str, default_port)?
         }
         #[cfg(not(feature = "quic"))]
-        DaemonTransferRequest::parse_double_colon(&daemon_operand_str)?
+        DaemonTransferRequest::parse_double_colon(&daemon_operand_str, default_port)?
     };
 
     // The `--quic` modifier upgrades an ordinary `rsync://` / `host::` target to
@@ -357,7 +358,13 @@ pub fn run_daemon_over_remote_shell(
         .find(|arg| arg.to_string_lossy().contains("::"))
         .ok_or_else(|| invalid_argument_error("no host::module operand found", 1))?;
     let daemon_operand_str = daemon_operand.to_string_lossy();
-    let request = DaemonTransferRequest::parse_double_colon(&daemon_operand_str)?;
+    // upstream: main.c:1632 - a daemon-over-remote-shell connection carries the
+    // port to the child as RSYNC_PORT rather than dialling it, but the value is
+    // the same `rsync_port` the socket path uses.
+    let request = DaemonTransferRequest::parse_double_colon(
+        &daemon_operand_str,
+        DaemonTransferRequest::resolve_default_port(config.daemon_port()),
+    )?;
 
     // upstream: main.c:603-613 - when daemon_connection > 0, the remote
     // command is `rsync_path --server --daemon .` with no server_options().

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -1246,7 +1246,8 @@ mod server_option_fidelity_tests {
     use protocol::ProtocolVersion;
 
     fn request() -> DaemonTransferRequest {
-        DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path").expect("valid rsync url")
+        DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path", 873)
+            .expect("valid rsync url")
     }
 
     fn args(config: &ClientConfig, is_sender: bool) -> Vec<String> {
@@ -1917,7 +1918,8 @@ mod oc_flag_forwarding_tests {
     ];
 
     fn request() -> DaemonTransferRequest {
-        DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path").expect("valid rsync url")
+        DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path", 873)
+            .expect("valid rsync url")
     }
 
     /// Sets every oc-invented tuning knob to a non-default value. These are

--- a/crates/core/tests/daemon_port_option.rs
+++ b/crates/core/tests/daemon_port_option.rs
@@ -1,0 +1,150 @@
+//! `--port=PORT` must reach the daemon *transfer* path, not just the listing.
+//!
+//! Upstream stores `--port` in `rsync_port` (`options.c:852`) and keeps it
+//! through operand parsing: `check_for_hostspec()` (`options.c:3301-3327`)
+//! substitutes the `-1` "use the default" sentinel only when `rsync_port` is
+//! still 0, so an operator-supplied port survives, and only a `:port` written
+//! into the operand itself overwrites it. `main.c:1591` then falls back to
+//! `RSYNC_PORT` (873) for the sentinel alone.
+//!
+//! oc honoured that on the module-listing path only: the three daemon-transfer
+//! parsers hardcoded 873, so `--port=N rsync://host/mod/file` dialled 873 and
+//! failed with "connection refused" while upstream transferred the file. These
+//! tests pin all three legs of the rule against a live oc-rsync daemon on an
+//! OS-assigned port - the only port a hardcoded 873 can never be.
+//!
+//! Unix-only: daemon mode is unsupported on Windows (`daemon.rs`), so the
+//! harness cannot start a peer there.
+
+#![cfg(unix)]
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+use common::{DaemonBinary, TestDaemon, create_test_file};
+use core::client::ClientConfig;
+use core::client::run_client;
+use tempfile::{TempDir, tempdir};
+
+/// Payload the daemon publishes; the byte comparison is what proves the
+/// transfer reached the daemon rather than merely exiting 0.
+const PAYLOAD: &[u8] = b"port option reached the transfer path";
+
+/// Starts an oc-rsync daemon serving `file.txt`, or `None` when the binary has
+/// not been built - the harness's degrade-not-fail convention, so a local run
+/// without a build reports a skip instead of a spurious failure.
+fn daemon_serving_a_file() -> Option<TestDaemon> {
+    let bin = test_support::oc_rsync_bin();
+    if !Path::new(&bin).exists() {
+        eprintln!("skipping: oc-rsync binary not built at {}", bin.display());
+        return None;
+    }
+    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
+    create_test_file(&daemon.module_path().join("file.txt"), PAYLOAD);
+    Some(daemon)
+}
+
+/// Pulls `file.txt` from `operand` with `--port` set to `daemon_port`, and
+/// returns the destination directory so the caller can assert on the bytes.
+fn pull(operand: String, daemon_port: Option<u16>) -> TempDir {
+    let dest = tempdir().expect("create dest dir");
+    let config = ClientConfig::builder()
+        .transfer_args([operand, dest.path().to_string_lossy().to_string()])
+        .daemon_port(daemon_port)
+        .build();
+    run_client(config).expect("daemon pull succeeds");
+    dest
+}
+
+fn assert_payload_landed(dest: &TempDir) {
+    let landed = dest.path().join("file.txt");
+    assert_eq!(
+        fs::read(&landed).expect("read transferred file"),
+        PAYLOAD,
+        "the pull must deliver the daemon's bytes"
+    );
+}
+
+/// An `rsync://` operand that names no port takes the operator's `--port`.
+#[test]
+fn rsync_url_without_a_port_uses_the_port_option() {
+    let Some(daemon) = daemon_serving_a_file() else {
+        return;
+    };
+    let dest = pull(
+        "rsync://127.0.0.1/testmodule/file.txt".to_owned(),
+        Some(daemon.port()),
+    );
+    assert_payload_landed(&dest);
+}
+
+/// `host::module` carries no port syntax at all, so it always takes `--port`.
+/// upstream: `options.c:3318-3321` - the `path[0] == ':'` arm sets the same
+/// sentinel the URL arm does.
+#[test]
+fn double_colon_operand_uses_the_port_option() {
+    let Some(daemon) = daemon_serving_a_file() else {
+        return;
+    };
+    let dest = pull(
+        "127.0.0.1::testmodule/file.txt".to_owned(),
+        Some(daemon.port()),
+    );
+    assert_payload_landed(&dest);
+}
+
+/// Non-vacuity companion for the two pins above: a port written into the
+/// operand must WIN over `--port`, so a deliberately unusable `--port=1` still
+/// transfers. Without this row, "`--port` is honoured" could be satisfied by an
+/// implementation that lets the option override an explicit `:port` - which
+/// upstream does not do (`parse_hostspec` overwrites `rsync_port` from the
+/// operand before the sentinel is ever applied).
+#[test]
+fn an_explicit_operand_port_outranks_the_port_option() {
+    let Some(daemon) = daemon_serving_a_file() else {
+        return;
+    };
+    let dest = pull(
+        format!("rsync://127.0.0.1:{}/testmodule/file.txt", daemon.port()),
+        Some(1),
+    );
+    assert_payload_landed(&dest);
+}
+
+/// The library pins above enter at `ClientConfig`, so they cannot see the CLI
+/// leg: `--port` is parsed into `ParsedArgs` and has to be copied into the
+/// config the transfer path reads. A field that never makes that hop is inert
+/// no matter how correct the parser is, so this cell drives the real binary.
+#[test]
+fn the_port_flag_reaches_the_transfer_path_through_the_cli() {
+    let Some(daemon) = daemon_serving_a_file() else {
+        return;
+    };
+    let dest = tempdir().expect("create dest dir");
+    let output = std::process::Command::new(test_support::oc_rsync_bin())
+        .arg(format!("--port={}", daemon.port()))
+        .arg("rsync://127.0.0.1/testmodule/file.txt")
+        .arg(dest.path())
+        .output()
+        .expect("run oc-rsync");
+    assert!(
+        output.status.success(),
+        "pull failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_payload_landed(&dest);
+}
+
+/// With no `--port`, the fallback is upstream's `RSYNC_PORT`. Asserted on the
+/// resolver rather than over a socket, because 873 needs privileges to bind.
+#[test]
+fn no_port_option_falls_back_to_the_upstream_default() {
+    let config = ClientConfig::builder().build();
+    assert_eq!(
+        config.daemon_port(),
+        None,
+        "an unset --port must stay unset, so the parser can apply upstream's default"
+    );
+}


### PR DESCRIPTION
## Problem

`--port=PORT` was honoured only on the module-listing path. Every daemon
*transfer* operand parser hardcoded 873, so the option was silently dropped:

```
--- rsync:// URL, port only from --port ---
  upstream: rc=0 landed=[a.txt]
  oc      : rc=10 failed to read daemon greeting from 127.0.0.1:873: Connection refused (61)
--- host::module, port only from --port ---
  upstream: rc=0 landed=[a.txt]
  oc      : rc=10 failed to read daemon greeting from 127.0.0.1:873: Connection refused (61)
```

(measured with a real rsync 3.5.0 daemon on 8898 and an oc daemon on 8899,
each client given the matching `--port`)

## Upstream rule

`--port` is stored in `rsync_port` (`options.c:852`). `check_for_hostspec()`
(`options.c:3301-3327`) substitutes the `-1` "use the default" sentinel only
when `rsync_port` is still 0, so an operator-supplied port survives operand
parsing; a `:port` written into the operand overwrites it via
`parse_hostspec()`. `main.c:1591-1594` applies `RSYNC_PORT` (873) to the
sentinel alone, and `main.c:1632` exports the same value as `RSYNC_PORT` to
the child of a daemon-over-remote-shell connection.

Precedence, therefore: **operand `:port` > `--port` > 873**.

## Change

- `ClientConfig` / `ClientConfigBuilder` gain `daemon_port: Option<u16>`, with a
  setter and accessor placed beside the existing `daemon_transport` pair.
- The CLI copies `ParsedArgs::daemon_port` into the config (it previously
  reached only `ModuleListingInputs`).
- The three parsers (`parse_rsync_url`, `parse_quic_url`, `parse_double_colon`)
  take the resolved default as a parameter. The precedence rule itself lives at
  one site, `DaemonTransferRequest::resolve_default_port`, called from both the
  socket path and the daemon-over-remote-shell path.

`None` still means "no `--port`", so the fallback stays exactly 873.

## Tests

`crates/core/tests/daemon_port_option.rs`, against a live oc-rsync daemon on an
OS-assigned port - the one port a hardcoded 873 can never be:

| cell | asserts |
|---|---|
| `rsync_url_without_a_port_uses_the_port_option` | URL leg |
| `double_colon_operand_uses_the_port_option` | `host::mod` leg |
| `the_port_flag_reaches_the_transfer_path_through_the_cli` | drives the real binary, so a dropped CLI→config hop is caught |
| `an_explicit_operand_port_outranks_the_port_option` | non-vacuity: `--port=1` must NOT override an explicit `:port` |
| `no_port_option_falls_back_to_the_upstream_default` | unset stays unset |

RED proven by mutation, and the kills are targeted rather than blanket:

- resolving the default from `None` instead of the config: `5 tests run:
  3 passed, 2 failed` - exactly the two operand legs, with the precedence
  companion still green.
- dropping `.daemon_port(inputs.daemon_port)` in the CLI: `5 tests run:
  4 passed, 1 failed` - only the CLI cell.

Post-fix the oracle is 4/4 against real rsync 3.5.0, including the row where
`--port=1` must lose to an explicit `:port`.

`cargo fmt` / `cargo clippy --workspace --all-targets --all-features -D warnings`
clean; `-p core --all-features` 2821/2821.
