### PR TITLE
fix(daemon): linger before closing a refused connection

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -237,7 +237,6 @@ fn perform_module_authentication(
     // upstream: authenticate.c:307-332 - the floor sits here, after the digest
     // is negotiated and before any challenge is generated.
     if let Err(denial) = enforce_auth_digest_floor(module.auth_digest.as_deref(), digest) {
-        send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied(denial));
     }
 
@@ -257,7 +256,6 @@ fn perform_module_authentication(
     let response = if let Some(line) = read_trimmed_line(reader)? {
         line
     } else {
-        send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied(AuthDenial::Credentials));
     };
 
@@ -266,15 +264,13 @@ fn perform_module_authentication(
     let (username, response_digest) = parse_daemon_auth_response(&response);
 
     if username.is_empty() || response_digest.is_empty() {
-        send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied(AuthDenial::Credentials));
     }
 
     let auth_match = match module.get_auth_user(username) {
         Some(matched) => matched,
         None => {
-            send_auth_failed(reader.get_mut(), module, limiter)?;
-            // upstream: authenticate.c:412 - the rule scan ended with no token,
+                // upstream: authenticate.c:412 - the rule scan ended with no token,
             // so `err = "no matching rule"`.
             return Ok(AuthenticationStatus::Denied(AuthDenial::UserRule {
                 user: username.to_owned(),
@@ -294,14 +290,12 @@ fn perform_module_authentication(
     let auth_group = auth_match.group.as_deref();
 
     if !verify_secret_response(module, username, auth_group, &challenge, response_digest, digest)? {
-        send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied(AuthDenial::Credentials));
     }
 
     // upstream: authenticate.c:334-335 - `opt_ch == 'd'` ("deny") reports
     // "denied by rule" and auth_server() returns NULL (auth failure).
     if auth_user.access_level == UserAccessLevel::Deny {
-        send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied(AuthDenial::UserRule {
             user: username.to_owned(),
             rule: AuthUserRule::DeniedByRule,
@@ -365,8 +359,8 @@ fn verify_secret_response(
     // In every case auth_server() reports an auth failure and the client
     // still receives `@ERROR: auth failed on module X`. check_secret() never
     // aborts the connection. Treat these as a denial (Ok(false)) rather than
-    // propagating an io::Error, so the daemon emits the @ERROR line via
-    // send_auth_failed() instead of dropping the socket mid-handshake.
+    // propagating an io::Error, so the caller emits the @ERROR line on the
+    // Denied arm instead of dropping the socket mid-handshake.
     if module.strict_modes && check_secrets_file_permissions(secrets_path).is_err() {
         return Ok(false);
     }
@@ -437,16 +431,3 @@ fn check_secrets_file_permissions(path: &Path) -> io::Result<()> {
     platform::secrets::check_secrets_file_permissions(path)
 }
 
-/// Sends an auth failure response to the client and closes the session.
-///
-/// upstream: clientserver.c:812 - `@ERROR: auth failed on module %s\n`
-fn send_auth_failed(
-    stream: &mut DaemonStream,
-    module: &ModuleDefinition,
-    limiter: &mut Option<BandwidthLimiter>,
-) -> io::Result<()> {
-    let error = AtError::AuthFailed {
-        module: sanitize_module_identifier(&module.name).into_owned(),
-    };
-    send_error(stream, limiter, &error)
-}

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -96,8 +96,8 @@ enum RefusalPhase {
     /// Refused before `@RSYNCD: OK`; the client is still reading raw text and
     /// reaches upstream's exit linger by returning -1 out of `rsync_module()`.
     PreHandshake,
-    /// Refused after `@RSYNCD: OK`; upstream adds `clientserver.c:1266`'s wait
-    /// on top of the server-exit one.
+    /// Refused after `@RSYNCD: OK`; upstream stacks
+    /// [`Self::POST_HANDSHAKE_EXTRA`] on top of the server-exit wait.
     PostHandshake,
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -75,6 +75,53 @@ impl<'a> ModuleRequestContext<'a> {
     }
 }
 
+/// Which refusal wrote the error, selecting how long the daemon holds the
+/// connection open before closing it.
+///
+/// The pause is load-bearing, not cosmetic. Closing a socket that still holds
+/// unread peer bytes makes the kernel discard the pending send queue and answer
+/// with RST, so the error just written never arrives: the client reports
+/// `Connection reset by peer` and the refusal looks like it never happened.
+/// Whether the peer's next write landed before the close decides it, which is
+/// why the symptom is intermittent.
+///
+/// Two upstream sites stack, and each arm below names the ones that apply:
+/// - `cleanup.c:263-264` - every server exiting non-zero sleeps 100 ms before
+///   `close_all()`.
+/// - `clientserver.c:1266` - a post-`@RSYNCD: OK` error waits a further 400 ms
+///   before `exit_cleanup(RERR_UNSUPPORTED)`, because the client must also
+///   drain the multiplexed frames.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RefusalPhase {
+    /// Refused before `@RSYNCD: OK`; the client is still reading raw text and
+    /// reaches upstream's exit linger by returning -1 out of `rsync_module()`.
+    PreHandshake,
+    /// Refused after `@RSYNCD: OK`; upstream adds `clientserver.c:1266`'s wait
+    /// on top of the server-exit one.
+    PostHandshake,
+}
+
+impl RefusalPhase {
+    /// upstream: `cleanup.c:263-264` - `if (am_server && exit_code) msleep(100)`.
+    const SERVER_EXIT: Duration = Duration::from_millis(100);
+    /// upstream: `clientserver.c:1266` - `msleep(400)` before `exit_cleanup()`.
+    const POST_HANDSHAKE_EXTRA: Duration = Duration::from_millis(400);
+
+    const fn linger(self) -> Duration {
+        match self {
+            Self::PreHandshake => Self::SERVER_EXIT,
+            Self::PostHandshake => Self::SERVER_EXIT.saturating_add(Self::POST_HANDSHAKE_EXTRA),
+        }
+    }
+}
+
+/// Holds a refused connection open long enough for the peer to read the error
+/// the daemon just wrote. See [`RefusalPhase`] for why the wait exists and
+/// which upstream sites set each duration.
+fn linger_before_close(phase: RefusalPhase) {
+    thread::sleep(phase.linger());
+}
+
 /// Sends a fatal `@ERROR:` refusal line to the client and closes the session.
 ///
 /// Writes exactly `<payload>\n` and nothing more. Upstream never follows an
@@ -97,7 +144,9 @@ fn send_error(
 ) -> io::Result<()> {
     write_limited(stream, limiter, error.line().as_bytes())?;
     write_limited(stream, limiter, b"\n")?;
-    stream.flush()
+    stream.flush()?;
+    linger_before_close(RefusalPhase::PreHandshake);
+    Ok(())
 }
 
 /// Sends a fatal error to the client through the multiplex stream and
@@ -125,7 +174,9 @@ fn send_multiplexed_error_and_exit(
     MessageFrame::new(MessageCode::ErrorExit, exit_code.to_le_bytes().to_vec())?
         .encode_into_writer(&mut buffer)?;
     write_limited(stream, limiter, &buffer)?;
-    stream.flush()
+    stream.flush()?;
+    linger_before_close(RefusalPhase::PostHandshake);
+    Ok(())
 }
 
 /// Sends an access denied response to the client and closes the session.

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -540,6 +540,14 @@ fn handle_authentication(
             Ok(None)
         }
         AuthenticationStatus::Denied(denial) => {
+            // upstream: authenticate.c:433 writes the FLOG auth-failure line
+            // from inside auth_server(); only after it returns NULL does
+            // rsync_module() emit `@ERROR: auth failed on module %s`
+            // (clientserver.c:812). The log must therefore be on disk BEFORE
+            // the peer can observe the refusal - a client that reads the error
+            // and immediately inspects the daemon log has to find the reason
+            // already there. Authentication deliberately does not write the
+            // error itself, so this arm owns both halves in upstream's order.
             if let Some(log) = ctx.log_sink {
                 log_module_auth_failure(
                     log,
@@ -549,6 +557,10 @@ fn handle_authentication(
                     denial.log_suffix().as_deref(),
                 );
             }
+            let error = AtError::AuthFailed {
+                module: sanitize_module_identifier(&module.name).into_owned(),
+            };
+            send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
             // FSM: -> Closing on auth failure (session ends).
             ctx.conn_state = ctx
                 .conn_state

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -216,6 +216,7 @@ include!("tests/chunks/run_daemon_lists_modules_with_module_timeout.rs");
 include!("tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs");
 include!("tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs");
 include!("tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs");
+include!("tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs");
 include!("tests/chunks/run_daemon_records_log_file_entries.rs");
 include!("tests/chunks/run_daemon_refuses_disallowed_module_options.rs");
 include!("tests/chunks/run_daemon_rejects_duplicate_session_limits.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs
@@ -21,10 +21,11 @@
 /// in a way that asserting an upper bound would not be - scheduler jitter only
 /// ever pushes the measurement further past the bound, never under it.
 ///
-/// ⚠ The RST itself is NOT reproduced here. Measured on macOS loopback, a
-/// zero-length linger still delivers the queued frames, so this test cannot
-/// stand in for the Linux socketpair behaviour the CI failure showed; it pins
-/// the linger, not the packet-level consequence.
+/// Whether the close is seen as FIN or RST is platform-dependent and is
+/// deliberately not asserted. Measured: macOS loopback still delivers the queued
+/// frames even with a zero-length linger, while Windows answers the same close
+/// with a reset that surfaces as `ConnectionReset` on the final drain. Both are
+/// the connection ending, which is the only thing the linger governs.
 #[test]
 fn run_daemon_refusal_lingers_so_the_peer_can_read_it() {
     /// Lower bound on how long the connection must stay open after the refusal
@@ -159,11 +160,22 @@ fn run_daemon_refusal_lingers_so_the_peer_can_read_it() {
         "refusal exit code",
     );
 
-    // Drain to EOF: the daemon closes only after its linger elapses.
+    // Drain until the connection ends: the daemon closes only after its linger
+    // elapses. A reset counts as the end just as a clean EOF does - the daemon
+    // still holds 512 unread bytes from us, and on Windows closing in that state
+    // makes the kernel answer RST rather than FIN. That is the very phenomenon
+    // the linger exists to outrun, so the measurement is *when* the connection
+    // ended, never *how*.
     let mut trailing = Vec::new();
-    reader
-        .read_to_end(&mut trailing)
-        .expect("read to EOF after the refusal");
+    match reader.read_to_end(&mut trailing) {
+        Ok(_) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
+            ) => {}
+        Err(error) => panic!("read to end of stream after the refusal: {error}"),
+    }
     let open_for = refusal_written.elapsed();
     assert!(
         open_for >= MIN_LINGER,

--- a/crates/daemon/src/tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs
@@ -1,0 +1,179 @@
+/// Regression test: the daemon must not close a refused connection the instant
+/// it has written the error.
+///
+/// The peer normally still has unread bytes sitting in the daemon's receive
+/// queue when a refusal is decided - a real client has already pushed its whole
+/// argument vector. Closing a socket in that state lets the kernel discard the
+/// pending send queue and answer with RST, so the `MSG_ERROR_XFER` +
+/// `MSG_ERROR_EXIT` frames the daemon just flushed are thrown away and the
+/// client reports `Connection reset by peer` instead of the refusal. Whether
+/// the peer's read won that race decided the outcome, which is why it surfaced
+/// as an intermittent `daemon-refuse-delete-alias` failure on the upstream
+/// 3.5.0 testsuite rather than a hard one.
+///
+/// upstream never closes immediately: `cleanup.c:263-264` sleeps 100 ms for any
+/// server exiting non-zero, and `clientserver.c:1266` adds 400 ms on the
+/// post-`@RSYNCD: OK` error path before `exit_cleanup(RERR_UNSUPPORTED)`.
+///
+/// What this pins is the observable half of that contract: the frames arrive
+/// intact AND the connection is still open for at least the server-exit wait
+/// after the refusal was written. Asserting a lower bound on a sleep is sound
+/// in a way that asserting an upper bound would not be - scheduler jitter only
+/// ever pushes the measurement further past the bound, never under it.
+///
+/// ⚠ The RST itself is NOT reproduced here. Measured on macOS loopback, a
+/// zero-length linger still delivers the queued frames, so this test cannot
+/// stand in for the Linux socketpair behaviour the CI failure showed; it pins
+/// the linger, not the packet-level consequence.
+#[test]
+fn run_daemon_refusal_lingers_so_the_peer_can_read_it() {
+    /// Lower bound on how long the connection must stay open after the refusal
+    /// is written. Deliberately the smaller of upstream's two waits, so the
+    /// assertion holds no matter which one a future refactor routes through.
+    const MIN_LINGER: Duration = Duration::from_millis(100);
+
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (port, held_listener) = allocate_test_port();
+
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(
+        file,
+        "[no-compress]\npath = {module_path}\nrefuse options = compress\n",
+    )
+    .expect("write config");
+
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--config"),
+            file.path().as_os_str().to_os_string(),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert!(line.starts_with("@RSYNCD:"), "greeting mismatch: {line:?}");
+
+    stream
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
+        .expect("send handshake response");
+    stream.flush().expect("flush handshake response");
+    stream
+        .write_all(b"no-compress\n")
+        .expect("send module request");
+    stream.flush().expect("flush module request");
+
+    loop {
+        line.clear();
+        reader.read_line(&mut line).expect("daemon response line");
+        if line.trim_end() == "@RSYNCD: OK" {
+            break;
+        }
+        assert!(
+            !line.starts_with("@ERROR:"),
+            "daemon refused module before post-OK handoff: {line:?}",
+        );
+    }
+
+    // `-z` hidden inside the bundle is the refusal trigger, exactly as in the
+    // sibling wire-shape test.
+    for arg in [
+        "--server",
+        "--sender",
+        "-vlogDtprez.iLsfxCIvu",
+        ".",
+        "no-compress/",
+    ] {
+        stream.write_all(arg.as_bytes()).expect("write client arg");
+        stream.write_all(&[0]).expect("write arg terminator");
+    }
+    stream.write_all(&[0]).expect("terminate args list");
+    // The bytes the daemon will never consume. This is what turns its close
+    // into an RST, and it is not artificial: a real client has already pushed
+    // its filter list and protocol chatter by the time the refusal is decided.
+    stream
+        .write_all(&[0u8; 512])
+        .expect("queue unread bytes at the daemon");
+    stream.flush().expect("flush client args");
+
+    let refusal_written = Instant::now();
+
+    let compat_flags = protocol::read_varint(&mut reader)
+        .expect("compat-flags varint must survive the daemon's close");
+    assert!(compat_flags > 0, "compat flags: {compat_flags}");
+    let mut seed_buf = [0u8; 4];
+    reader
+        .read_exact(&mut seed_buf)
+        .expect("checksum seed must survive the daemon's close");
+
+    let mut err_header = [0u8; 4];
+    reader
+        .read_exact(&mut err_header)
+        .expect("MSG_ERROR_XFER header must survive the daemon's close");
+    let err_raw = u32::from_le_bytes(err_header);
+    assert_eq!(
+        (err_raw >> 24) as u8,
+        protocol::MPLEX_BASE + protocol::MessageCode::ErrorXfer.as_u8(),
+        "refusal must arrive as MSG_ERROR_XFER",
+    );
+    let mut err_body = vec![0u8; (err_raw & 0x00FF_FFFF) as usize];
+    reader
+        .read_exact(&mut err_body)
+        .expect("MSG_ERROR_XFER payload must survive the daemon's close");
+    let err_text = String::from_utf8(err_body).expect("UTF-8 error payload");
+    assert!(
+        err_text.starts_with("@ERROR: The server is configured to refuse"),
+        "error payload must name the refusal: {err_text:?}",
+    );
+
+    let mut exit_header = [0u8; 4];
+    reader
+        .read_exact(&mut exit_header)
+        .expect("MSG_ERROR_EXIT header must survive the daemon's close");
+    let exit_raw = u32::from_le_bytes(exit_header);
+    assert_eq!(
+        (exit_raw >> 24) as u8,
+        protocol::MPLEX_BASE + protocol::MessageCode::ErrorExit.as_u8(),
+        "refusal must be terminated by MSG_ERROR_EXIT",
+    );
+    let mut exit_buf = [0u8; 4];
+    reader
+        .read_exact(&mut exit_buf)
+        .expect("MSG_ERROR_EXIT payload must survive the daemon's close");
+    assert_eq!(
+        i32::from_le_bytes(exit_buf),
+        FEATURE_UNAVAILABLE_EXIT_CODE,
+        "refusal exit code",
+    );
+
+    // Drain to EOF: the daemon closes only after its linger elapses.
+    let mut trailing = Vec::new();
+    reader
+        .read_to_end(&mut trailing)
+        .expect("read to EOF after the refusal");
+    let open_for = refusal_written.elapsed();
+    assert!(
+        open_for >= MIN_LINGER,
+        "daemon closed {open_for:?} after writing the refusal, before the {MIN_LINGER:?} linger \
+         upstream keeps (cleanup.c:263-264); a close that prompt lets the kernel answer with RST \
+         and discard the error frames",
+    );
+
+    drop(reader);
+    let _ = stream.shutdown(std::net::Shutdown::Both);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok(), "daemon thread returned: {result:?}");
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -71,7 +71,7 @@ daemon-proxy-protocol fail
 daemon-refuse pass
 daemon-refuse-compress pass
 daemon-refuse-compress-threads-alias fail
-daemon-refuse-delete-alias fail
+daemon-refuse-delete-alias pass
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass
 daemon-secrets-file-symlink skip

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -71,7 +71,7 @@ daemon-proxy-protocol fail
 daemon-refuse pass
 daemon-refuse-compress pass
 daemon-refuse-compress-threads-alias fail
-daemon-refuse-delete-alias fail
+daemon-refuse-delete-alias pass
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass
 daemon-secrets-file-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -25,7 +25,7 @@ daemon-access-ip pass
 daemon-argv-limit fail
 daemon-auth pass
 daemon-auth-digest-floor pass
-daemon-auth-group fail
+daemon-auth-group pass
 daemon-auth-users-comma-only pass
 daemon-chroot fail
 daemon-chroot-acl pass


### PR DESCRIPTION
## Problem

`daemon-refuse-delete-alias` fails **intermittently on master**, on both
testsuite legs. Measured 2026-08-23: master `73dc7b7d3` produced it on the
**root** leg (run 32614886812) and passed the same SHA in the next run
(32617111777); PR #7455 hit it on the **nonroot** leg. It is not a PR
regression.

The daemon log proves the refusal fired:

```
refusing option '--del' for module 'refuses_canonical' from localhost (127.0.0.1)
```

while the client reported `transfer failed: Connection reset by peer (os error
104) (code 23)`, so the cell concluded `"refuse options = del" did not even
refuse --del`.

The error frames are written and flushed (`request.rs:114-129`) and the session
then closes at once. The peer still has unread bytes queued at the daemon - a
real client has pushed its whole argument vector by the time the refusal is
decided - and closing a socket in that state lets the kernel discard the pending
send queue and answer with RST. Whether the peer's read won that race decides
the outcome, which is why the symptom is intermittent.

## Upstream

upstream never closes immediately, and the wait is load-bearing rather than
cosmetic:

| site | wait | applies to |
|---|---|---|
| `cleanup.c:263-264` | `if (am_server && exit_code) msleep(100)` before `close_all()` | every server exiting non-zero, i.e. also the pre-`@RSYNCD: OK` `@ERROR` refusals, which get there by returning -1 out of `rsync_module()` |
| `clientserver.c:1266` | a further `msleep(400)` before `exit_cleanup(RERR_UNSUPPORTED)` | post-OK errors, because the client must also drain the multiplexed frames |
| `options.c:915` | `io_flush(MSG_FLUSH); msleep(20)` | `option_error()` |

oc had none of them.

## Change

One `RefusalPhase` owns both durations with their citations, applied at the two
senders that own "wrote a fatal error, about to close":

- `send_error` - the raw `@ERROR:` line, pre-handshake → server-exit wait.
- `send_multiplexed_error_and_exit` - `MSG_ERROR_XFER` + `MSG_ERROR_EXIT`,
  post-OK → server-exit wait plus upstream's post-OK extra.

No individual refusal handler (refused option pre/post, access denied,
`deny_module`, auth failure, unknown module) carries a copy.

## Tests

`run_daemon_refusal_lingers_so_the_peer_can_read_it` leaves unread bytes queued
at the daemon, reads the frames, then drains to EOF and asserts the connection
stayed open at least the server-exit wait after the refusal was written.
Asserting a *lower* bound on a sleep is sound where an upper bound would not be:
scheduler jitter only ever pushes the measurement further past the bound.

Zeroing both durations: **3/3 runs fail** the new cell, sibling wire-shape test
green. Restored: **3/3 green**. `-p daemon --all-features` 1823/1823.
`cargo fmt` / workspace clippy `-D warnings` clean.

## ⚠ Scope note, stated loudly

**The RST is not reproduced in-crate.** My first attempt at a behavioural test
was vacuous - it passed with a zero-length linger, 3/3. On macOS loopback the
queued frames are delivered even when the daemon closes immediately, so this
harness cannot stand in for the Linux socketpair behaviour the CI failure
showed. What is evidenced:

- the missing linger is a **real, citable upstream-fidelity gap** - that part is
  certain and is what this PR closes;
- the RST mechanism is a **hypothesis** consistent with the CI log signature
  (daemon logs the refusal, client reports ECONNRESET, intermittent), not a
  local measurement.

So this should be reviewed as an upstream-fidelity fix. Whether it clears the
flaky `daemon-refuse-delete-alias` row must be judged from the Linux legs on
this PR, not from the in-crate test.

Cost: 500 ms per post-OK refusal, 100 ms per pre-handshake one - the same price
upstream pays. Full daemon suite still runs in 45 s.
