### PR TITLE
fix(engine): a non-directory alt-dest arg must not fail a symlink transfer

### DIFF
--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -1,7 +1,6 @@
 //! Handling of reference directories and link-dest decisions.
 
 use std::fs;
-use std::io;
 use std::path::{Path, PathBuf};
 
 use ::metadata::MetadataOptions;
@@ -329,32 +328,25 @@ fn find_reference_symlink(
             continue;
         }
         let candidate = resolve_reference_candidate(reference.path(), relative, destination);
-        let candidate_metadata = match fs::symlink_metadata(&candidate) {
-            Ok(meta) => meta,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-            Err(error) => {
-                return Err(LocalCopyError::io(
-                    "inspect reference symlink",
-                    candidate,
-                    error,
-                ));
-            }
+        // upstream: generator.c:1227 `if (basis_link_stat(cmpbuf, &sxp->st) < 0)
+        // continue;` in try_dests_non() - ANY stat failure means "no candidate in
+        // this basis dir", not just ENOENT, exactly as the regular-file lookup
+        // above already treats it. An alt-dest arg that is not a directory yields
+        // ENOTDIR here, and aborting on it would fail a run upstream completes.
+        let Ok(candidate_metadata) = fs::symlink_metadata(&candidate) else {
+            continue;
         };
         if !candidate_metadata.file_type().is_symlink() {
             continue;
         }
+        // upstream: generator.c:642-646 quick_check_ok() FT_SYMLINK - a readlink
+        // that fails (`len <= 0`) returns 0, which try_dests_non() turns into a
+        // `continue`. The unreadable basis link is skipped, never fatal.
         match fs::read_link(&candidate) {
             Ok(basis_target) if basis_target == target => {
                 return Ok(Some(candidate_metadata));
             }
-            Ok(_) => continue,
-            Err(error) => {
-                return Err(LocalCopyError::io(
-                    "read reference symlink",
-                    candidate,
-                    error,
-                ));
-            }
+            Ok(_) | Err(_) => continue,
         }
     }
     Ok(None)

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -1842,3 +1842,54 @@ fn link_dest_arg_that_is_a_plain_file_does_not_fail_a_directory_entry() {
     );
     assert_eq!(summary.hard_links_created(), 0);
 }
+
+/// An alt-dest arg that names a plain file, not a directory, must not abort a
+/// transfer that carries a symlink.
+///
+/// Joining a relative name onto a non-directory yields ENOTDIR, not ENOENT, so
+/// the symlink lookup used to classify it as a hard I/O error and fail the whole
+/// run with exit 23. Upstream never does: `try_dests_non()` skips any basis whose
+/// `basis_link_stat()` fails, and `check_alt_basis_dirs()` has already warned
+/// about the bad arg once. The regular-file lookup was corrected earlier; this
+/// pins the symlink lookup to the same rule.
+///
+/// upstream: generator.c:1227 `if (basis_link_stat(cmpbuf, &sxp->st) < 0)
+/// continue;`
+#[cfg(unix)]
+#[test]
+fn alt_dest_arg_that_is_not_a_directory_does_not_fail_a_symlink_transfer() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source");
+    std::os::unix::fs::symlink("target.txt", source_dir.join("link")).expect("plant source link");
+
+    // The alt-dest arg is a regular file: every candidate under it is ENOTDIR.
+    let not_a_directory = temp.path().join("previous");
+    fs::write(&not_a_directory, b"not a directory").expect("write alt-dest arg");
+
+    let dest_dir = temp.path().join("dest");
+    let operands = vec![
+        source_dir.clone().into_os_string(),
+        dest_dir.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .times(true)
+        .push_reference_directory(crate::local_copy::ReferenceDirectory::new(
+            crate::local_copy::ReferenceDirectoryKind::Copy,
+            not_a_directory,
+        ));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("a non-directory alt-dest arg must be skipped, not fail the transfer");
+
+    let planted = dest_dir.join("source").join("link");
+    assert_eq!(
+        fs::read_link(&planted).expect("dest symlink"),
+        std::path::Path::new("target.txt"),
+        "the symlink must still be recreated at the destination"
+    );
+}


### PR DESCRIPTION
## Problem

An alt-dest arg that names a plain file, not a directory, aborts a transfer that carries a symlink.

The regular-file basis lookup in `reference.rs` already treats every stat failure as "no candidate in this basis dir", mirroring upstream. The symlink lookup did not: it special-cased `ENOENT` and turned anything else into a hard I/O error, failing the whole run with exit 23.

Joining a relative name onto a non-directory gives `ENOTDIR`, so one mistyped `--link-dest` / `--copy-dest` / `--compare-dest` was enough. Upstream completes the same run normally, having only warned about the bad arg once in `check_alt_basis_dirs()`.

## Upstream

Both arms are skips, never fatal:

- `generator.c:1227` — `try_dests_non()`: `if (basis_link_stat(cmpbuf, &sxp->st) < 0) continue;`. ANY stat failure means "no candidate here", not just `ENOENT`.
- `generator.c:642-646` — `quick_check_ok()` `FT_SYMLINK`: `int len = do_readlink(...); if (len <= 0) return 0;`. A failed readlink is "not a match", which `try_dests_non()` turns into a `continue`.

## Verification

RED proven by restoring only the pre-fix stat arm — the new test fails with `Os { code: 20, kind: NotADirectory }` raised from `inspect reference symlink`.

⚠ The first version of that test used `--link-dest` and was **inert**: the symlink lookup accepts only `Copy` and `Compare` references, so the mutation killed nothing. The fixture is re-keyed to `--copy-dest`, which is what makes the pin discriminate.

engine alt-dest sweep 87/87; `cargo fmt --all -- --check` and `cargo clippy -p engine --all-targets --all-features` clean.

## Scope

The regular-file and directory lookups were corrected earlier and are unchanged here. The network receiver path was already correct — `try_reference_directories` (`crates/transfer/src/receiver/basis.rs:184`) skips on any open failure. This closes the one remaining site.
