### PR TITLE
fix(fast_io): honour --insecure-links in the operator-path walk

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -290,6 +290,20 @@ where
     // flag past the parser is what makes those two states distinguishable.
     logging::set_quiet(quiet);
 
+    // Publish `--insecure-links` for the operator-path ownership walk. Upstream
+    // reads its `insecure_links` global from inside `ona_open()`
+    // (syscall.c:301), so the answer reaches every operator-path open without
+    // any of them naming the flag; this is where oc gives that global a value.
+    //
+    // Client side only. The daemon arm of `optout_allowed` reads the served
+    // module's `insecure links` directive, which is not known until a module is
+    // selected, and upstream is explicit that a peer-supplied
+    // `--insecure-links` must never reach it (syscall.c:117-121). Leaving the
+    // daemon on the default keeps the confinement fully engaged there.
+    fast_io::confinement::install_local_session(
+        fast_io::confinement::LocalInsecureLinks::from_local_flag(insecure_links),
+    );
+
     let rayon_thread_count = rayon_threads.and_then(|n| NonZeroUsize::new(n as usize));
     let tokio_thread_count = tokio_threads.and_then(|n| NonZeroUsize::new(n as usize));
 

--- a/crates/fast_io/src/confinement.rs
+++ b/crates/fast_io/src/confinement.rs
@@ -39,6 +39,81 @@
 //! - `syscall.c:552` - `int operator_path_resolve = 0;`
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// The session's answer to [`Activation::optout_allowed`], published for the
+/// ownership walk to read.
+///
+/// Upstream asks the question *inside* the walk - `ona_open()` opens with
+/// `symlink_optout_allowed()` and returns a plain symlink-following `open()`
+/// when it holds (`syscall.c:300-302`) - so the answer reaches both
+/// `open_no_attacker_symlinks()` and `owner_walk_parent()` from one place. It
+/// can do that because `insecure_links` and `am_daemon` are process globals.
+///
+/// Mirroring that shape is deliberate. The alternative - threading the flag
+/// through every operator-path open - would touch ten call sites across seven
+/// crates and every helper between them, and would let one un-threaded site
+/// silently keep confining under an opt-out the operator asked for. The value
+/// is a property of the session, not of the call, so it is stored once.
+///
+/// Only the derived bit is stored, never the flag itself: [`Activation`] stays
+/// the single place the daemon-vs-local rule is written down, and this is the
+/// answer it produced.
+static SESSION_OPTOUT: AtomicBool = AtomicBool::new(false);
+
+/// Publish `activation`'s opt-out answer for the ownership walk.
+///
+/// Call once, as early as the flag and the daemon/module state are both known.
+/// Not calling it leaves the confinement fully engaged, which is the safe
+/// default and upstream's own (`options.c:134` `int insecure_links = 0;`).
+///
+/// Most callers want [`install_local_session`] or [`install_daemon_session`]:
+/// upstream's two arms read disjoint state, and those spell out which arm the
+/// caller is without making it invent values for fields its arm ignores.
+pub fn install_session(activation: &Activation) {
+    SESSION_OPTOUT.store(activation.optout_allowed(), Ordering::Relaxed);
+}
+
+/// Publish the opt-out for a non-daemon session: the local `--insecure-links`.
+///
+/// upstream: `syscall.c:126` - the `am_daemon`-false arm of
+/// `symlink_optout_allowed()` is `return insecure_links;`, reading nothing
+/// else. So this takes nothing else.
+pub fn install_local_session(insecure_links: LocalInsecureLinks) {
+    install_session(&Activation {
+        // Neither field is read by `optout_allowed`; they are the arm's
+        // don't-cares, spelled out here once rather than at every call site.
+        role: Role::Receiver,
+        confine_root: None,
+        daemon: DaemonState::NotDaemon,
+        insecure_links,
+    });
+}
+
+/// Publish the opt-out for a daemon serving `module`.
+///
+/// upstream: `syscall.c:125` - the `am_daemon`-true arm is
+/// `module_id >= 0 && lp_insecure_links(module_id)`. A peer-supplied
+/// `--insecure-links` is deliberately unreachable from here: a client cannot
+/// switch off a daemon's confinement (`syscall.c:117-121`), which is why this
+/// takes a [`ModuleState`] and not a [`LocalInsecureLinks`].
+pub fn install_daemon_session(module: ModuleState) {
+    install_session(&Activation {
+        role: Role::Receiver,
+        confine_root: None,
+        daemon: DaemonState::Daemon(module),
+        insecure_links: LocalInsecureLinks::default(),
+    });
+}
+
+/// Whether this session opted out of the operator-path symlink confinement.
+///
+/// upstream: `syscall.c:301` - the `symlink_optout_allowed()` test at the top
+/// of `ona_open()`.
+#[must_use]
+pub fn session_optout_allowed() -> bool {
+    SESSION_OPTOUT.load(Ordering::Relaxed)
+}
 
 /// Which end of the transfer this process is.
 ///

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -182,6 +182,27 @@ fn open_final(
 /// - `ENOTDIR` when an interior component is not a directory.
 /// - Otherwise the `openat`/`statat`/`readlinkat` errno verbatim.
 fn owner_walk_open(path: &Path, flags: OFlags, mode: Mode) -> io::Result<OwnedFd> {
+    // upstream: syscall.c:300-302 - "Opted out (local --insecure-links, or a
+    // daemon module with `insecure links = yes`): restore the legacy
+    // symlink-following open." The test sits at the top of ona_open(), so it
+    // covers open_no_attacker_symlinks() and owner_walk_parent() alike; the
+    // single short-circuit here covers this walk's two entry points for the
+    // same reason. Opting out is not "confine less" - it is the pre-3.4.3
+    // resolver verbatim, which is what the option promises.
+    if crate::confinement::session_optout_allowed() {
+        // `owner_trusted_parent` hands the walk an EMPTY parent for a bare
+        // relative leaf ("rsync.log"), which the walk below resolves by
+        // starting at ".". A plain open() has no such convention and would
+        // report ENOENT, so the same meaning has to be spelled out here.
+        let target = if path.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            path
+        };
+        return rustix::fs::open(target, flags, mode)
+            .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()));
+    }
+
     let mut pending = walk_components(path);
     let mut dirfd = open_start_dir(path.is_absolute())?;
     let mut hops = MAX_SYMLINK_HOPS;

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -204,7 +204,7 @@ nondaemon-symlink-race pass
 nonroot-restrictive-perms pass
 omit-times pass
 open-noatime pass
-operator-path-backup-dir fail
+operator-path-backup-dir pass
 operator-path-backup-dir-daemon pass
 operator-path-backup-dir-exclude-daemon fail
 operator-path-backup-rmdir pass
@@ -215,12 +215,12 @@ operator-path-dir-daemon-inmodule pass
 operator-path-dir-daemon-leaf fail
 operator-path-dir-daemon-mkdir fail
 operator-path-dir-daemon-outside pass
-operator-path-files-from fail
+operator-path-files-from pass
 operator-path-inplace-backup-dir fail
 operator-path-insecure-links-daemon pass
 operator-path-insecure-links-refused pass
 operator-path-link-dest fail
-operator-path-log-file fail
+operator-path-log-file pass
 operator-path-partial-dir fail
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
@@ -228,7 +228,7 @@ operator-path-temp-dir fail
 operator-path-traversal-backup-dir-daemon fail
 operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass
-operator-path-write-batch fail
+operator-path-write-batch pass
 output-options pass
 ownership-depth pass
 partial pass


### PR DESCRIPTION
`--insecure-links` promises the pre-3.4.3 follow-any-symlink behaviour, but oc's
operator-path ownership walk refused an untrusted symlink unconditionally, so the
option could not restore anything. Four upstream 3.5.0 cells fail on that alone,
all with the same text:

```
--<opt>: CROSS-UID abs leaf insecure: --insecure-links did not restore symlink following.
```

`operator-path-backup-dir`, `-files-from`, `-log-file`, `-write-batch`.

## Where the fix goes

Upstream asks the question *inside* the walk, not at its callers - `ona_open()`
opens with

```c
if (symlink_optout_allowed())
        return open(path, flags, mode);
```

(`syscall.c:300-302`), which is why the answer reaches both
`open_no_attacker_symlinks()` and `owner_walk_parent()`. The short-circuit added
here sits at the same place and covers this walk's two entry points for the same
reason.

Threading the flag instead would have touched ten call sites across seven crates
and every helper between them, and one un-threaded site would have gone on
confining under an opt-out the operator asked for. The value is a property of the
session, not of the call.

`Activation::optout_allowed` already spelled the rule out with a twenty-row truth
table and had no production caller; it is now what computes the value the walk
reads. Two arm-specific constructors say which of upstream's two disjoint arms
the caller is, so no site invents values for fields its arm ignores. A daemon's
arm needs a selected module, so the daemon stays on the fully-confined default
until that lands.

## Verification

Measured on Linux aarch64, root, against the 3.5.0 suite.

| | before | after |
|---|---|---|
| the four cells | FAIL | **PASS** |
| `operator-path-insecure-links-refused` (confinement still enforced) | pass | pass |
| `operator-path-insecure-links-daemon` (daemon arm untouched) | pass | pass |
| `operator-path-backup-rmdir`, `-backup-symlink` | pass | pass |

**Mutation**: forcing `session_optout_allowed()` to `false` turns all four back to
FAIL while `insecure-links-refused` stays green - so they are not passing for an
unrelated reason, and the control does not depend on the opt-out.

The other operator-path failures are untouched and report identical text -
`-link-dest`/`-compare-dest`/`-copy-dest`/`-temp-dir`/`-inplace-backup-dir` still
say the symlink was *followed* (a separate defect: the walk is not reached at
all), and `-partial-dir` still over-refuses the operator's own euid-owned link.
Neither class is in scope here.

Manifest rows were generated from a full root-leg run, not hand typed; the only
other difference was `simd-checksum`, which is `skip` on aarch64 and `pass` on the
x86_64 runner, so it is deliberately left alone.
