### PR TITLE
fix(cli): clamp --files-from lines through upstream's sanitize_path

### DIFF
--- a/crates/cli/src/frontend/execution/file_list/resolver.rs
+++ b/crates/cli/src/frontend/execution/file_list/resolver.rs
@@ -133,8 +133,13 @@ pub(crate) fn resolve_file_list_entries(
             continue;
         }
 
-        let entry_path = Path::new(entry);
-        if entry_path.is_absolute() {
+        // An absolute entry is only left alone on the legacy (non-files-from)
+        // path. `sanitize_path` strips a leading `/` itself, so bailing out
+        // here would make the clamp unreachable for exactly the entries that
+        // most need it - upstream takes `/file` as relative to the transfer
+        // root, not as a filesystem-absolute path (flist.c:2571 via
+        // `util1.c`, which skips one leading slash before walking components).
+        if !files_from_active && Path::new(entry).is_absolute() {
             continue;
         }
 
@@ -184,7 +189,7 @@ pub(crate) fn resolve_file_list_entries(
             }
         } else {
             let mut combined = base_path.to_path_buf();
-            combined.push(entry_path);
+            combined.push(Path::new(entry));
             *entry = combined.into_os_string();
         }
     }

--- a/crates/cli/src/frontend/execution/file_list/resolver.rs
+++ b/crates/cli/src/frontend/execution/file_list/resolver.rs
@@ -34,6 +34,46 @@ fn entry_contains_dot_marker(operand: &OsStr) -> bool {
     }
 }
 
+/// Clamps one `--files-from` entry to the transfer root.
+///
+/// Delegates to the shared [`filters::sanitize_path`] rule rather than
+/// re-deriving it: the daemon applies the same clamp to peer-requested module
+/// paths and the transfer generator applies it to names arriving over the wire,
+/// and a second implementation here would be free to drift from those.
+///
+/// Note this is the `sanitize_path` dialect, not the `clean_fname` one that
+/// `filters::clean_fname::collapse_dot_dot_dirs` provides. They disagree on
+/// exactly the input that matters here: `clean_fname` KEEPS a leading `..` it
+/// cannot consume, `sanitize_path` DROPS it once the depth budget (0) is spent.
+/// Using the collapse helper would leave the `..` in place and be inert.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:2571` - `sanitize_path(fbuf, fbuf, "", 0, SP_KEEP_DOT_DIRS)` on
+///   every line read from `filesfrom_fd`.
+fn clamp_files_from_entry(entry: &OsStr) -> OsString {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+        // The byte entry point keeps a non-UTF-8 filename intact; upstream
+        // carries the name as a raw `char *` and never transcodes it here.
+        OsString::from_vec(filters::sanitize_path::sanitize_path_keep_dot_dirs_bytes(
+            entry.as_bytes(),
+        ))
+    }
+
+    #[cfg(not(unix))]
+    {
+        // Windows paths are UTF-16 and have no byte-oriented `OsStr` view, so
+        // this arm necessarily goes through `str`. That matches how the rest of
+        // this module already handles non-Unix operands (see
+        // `entry_contains_dot_marker`).
+        OsString::from(filters::sanitize_path::sanitize_path_keep_dot_dirs(
+            &entry.to_string_lossy(),
+        ))
+    }
+}
+
 /// Resolves file list entries against the source base directory.
 ///
 /// When `files_from_active` is true, entries are joined with a `./` marker
@@ -99,6 +139,28 @@ pub(crate) fn resolve_file_list_entries(
         }
 
         if files_from_active {
+            // upstream: flist.c:2571 - `sanitize_path(fbuf, fbuf, "", 0,
+            // SP_KEEP_DOT_DIRS)` is applied UNCONDITIONALLY to every line read
+            // from the files-from fd, before the name is joined onto argv[0].
+            // The neighbouring argv arm at :2576 makes the same call but gates
+            // it on `sanitize_paths`, and that asymmetry is the point: a line
+            // out of a files-from file is supplied by the file, an argv operand
+            // is supplied by the operator. Every entry reaching here came from
+            // `load_file_list_operands`, i.e. upstream's `use_ff_fd` arm, so it
+            // takes the unconditional clamp.
+            //
+            // Without it a `../x` entry survives into the join and the
+            // resulting `base/./../x` addresses a file outside the transfer
+            // root: the confinement layer then refuses the write, but only
+            // after upstream would already have retargeted the name, so a
+            // legitimate clamped entry fails to transfer and the refusal
+            // reports ELOOP instead of naming the real cause.
+            //
+            // `SP_KEEP_DOT_DIRS` preserves an entry's own `./` marker so the
+            // split below still sees it (see `entry_contains_dot_marker`).
+            let clamped = clamp_files_from_entry(entry);
+            let entry_path = Path::new(&clamped);
+
             // upstream: flist.c:2316-2318 - when relative_paths is set and a
             // file list entry contains "/./", upstream splits the entry at that
             // marker: the portion before becomes a chdir prefix (relative to
@@ -110,7 +172,7 @@ pub(crate) fn resolve_file_list_entries(
             // second "./" would create base/./from/./dir/file which makes the
             // engine split at the first marker, incorrectly keeping "from/" in
             // the destination path.
-            if entry_contains_dot_marker(entry.as_os_str()) {
+            if entry_contains_dot_marker(clamped.as_os_str()) {
                 let mut combined = base_path.to_path_buf();
                 combined.push(entry_path);
                 *entry = combined.into_os_string();

--- a/crates/cli/src/frontend/execution/file_list/tests.rs
+++ b/crates/cli/src/frontend/execution/file_list/tests.rs
@@ -317,6 +317,73 @@ fn resolve_file_list_entries_files_from_with_relative_still_inserts_marker() {
     assert_eq!(entries[0], expected.as_os_str());
 }
 
+/// A `--files-from` entry that climbs above the transfer root is CLAMPED to
+/// the root, not carried through verbatim.
+///
+/// Measured against real upstream 3.5.0: given `src/secret/leak.txt` and a
+/// files-from line `../secret/leak.txt`, upstream clamps to `secret/leak.txt`,
+/// finds it under argv[0], and TRANSFERS it (exit 0). Before this clamp oc
+/// carried the `..` into the join, producing `src/./../secret/leak.txt`, which
+/// addresses a different file entirely - so the entry upstream delivers failed
+/// with `link_stat ... No such file or directory` and exit 23.
+///
+/// This is the shape that proves the clamp RUNS. Asserting only that an escape
+/// is refused would pass without it: the confinement layer already blocks the
+/// write, which is why the pre-fix behaviour was a failed transfer rather than
+/// a leak.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:2571` - `sanitize_path(fbuf, fbuf, "", 0, SP_KEEP_DOT_DIRS)`,
+///   applied unconditionally to every line read from `filesfrom_fd`.
+#[test]
+fn resolve_file_list_entries_files_from_clamps_parent_dir_escape() {
+    let mut entries = vec![OsString::from("../secret/leak.txt")];
+    let operands = vec![OsString::from("/base/src"), OsString::from("/dest")];
+
+    resolve_file_list_entries(&mut entries, &operands, false, true);
+
+    let expected = Path::new("/base/src").join(".").join("secret/leak.txt");
+    assert_eq!(
+        entries[0],
+        expected.as_os_str(),
+        "a `..` entry must be clamped to the transfer root, not joined verbatim"
+    );
+}
+
+/// Non-vacuity companion to the clamp test: an entry with no `..` is passed
+/// through byte-for-byte.
+///
+/// Without this, a clamp that mangled ordinary names would still satisfy the
+/// test above, since that one only pins what happens to the escaping shape.
+#[test]
+fn resolve_file_list_entries_files_from_ordinary_entry_survives_the_clamp() {
+    let mut entries = vec![OsString::from("secret/leak.txt")];
+    let operands = vec![OsString::from("/base/src"), OsString::from("/dest")];
+
+    resolve_file_list_entries(&mut entries, &operands, false, true);
+
+    let expected = Path::new("/base/src").join(".").join("secret/leak.txt");
+    assert_eq!(entries[0], expected.as_os_str());
+}
+
+/// The clamp must not eat an entry's own `/./` marker.
+///
+/// `SP_KEEP_DOT_DIRS` exists precisely so the split at `flist.c:2316` can still
+/// find the marker; the plain `SP_DEFAULT` dialect would strip it and silently
+/// move the entry's chdir pivot, changing where the file lands at the
+/// destination.
+#[test]
+fn resolve_file_list_entries_files_from_clamp_keeps_the_entry_dot_marker() {
+    let mut entries = vec![OsString::from("from/./dir/file.txt")];
+    let operands = vec![OsString::from("/base"), OsString::from("/dest")];
+
+    resolve_file_list_entries(&mut entries, &operands, false, true);
+
+    let expected = Path::new("/base").join("from/./dir/file.txt");
+    assert_eq!(entries[0], expected.as_os_str());
+}
+
 #[test]
 fn resolve_file_list_entries_files_from_absolute_entry_unchanged() {
     let mut entries = vec![OsString::from("/absolute/path.txt")];

--- a/crates/cli/src/frontend/execution/file_list/tests.rs
+++ b/crates/cli/src/frontend/execution/file_list/tests.rs
@@ -385,11 +385,30 @@ fn resolve_file_list_entries_files_from_clamp_keeps_the_entry_dot_marker() {
 }
 
 #[test]
-fn resolve_file_list_entries_files_from_absolute_entry_unchanged() {
+fn resolve_file_list_entries_files_from_absolute_entry_is_taken_relative_to_the_root() {
+    // upstream: `sanitize_path` skips one leading slash before walking the
+    // components (flist.c:2571 -> util1.c), so a `/absolute/path.txt`
+    // files-from line names an entry INSIDE the transfer root, not a
+    // filesystem-absolute path. Measured against rsync 3.5.0: a `/file` entry
+    // transfers `<source>/file`; oc used to bail out on `is_absolute()` before
+    // the clamp could run and failed with exit 23.
     let mut entries = vec![OsString::from("/absolute/path.txt")];
     let operands = vec![OsString::from("/base"), OsString::from("/dest")];
 
     resolve_file_list_entries(&mut entries, &operands, false, true);
+
+    let expected = Path::new("/base").join(".").join("absolute/path.txt");
+    assert_eq!(entries[0], expected.as_os_str());
+}
+
+/// The legacy (non-files-from) path still leaves an absolute operand alone -
+/// that clamp is specific to lines read from a files-from source.
+#[test]
+fn resolve_file_list_entries_absolute_entry_unchanged_without_files_from() {
+    let mut entries = vec![OsString::from("/absolute/path.txt")];
+    let operands = vec![OsString::from("/base"), OsString::from("/dest")];
+
+    resolve_file_list_entries(&mut entries, &operands, false, false);
 
     assert_eq!(entries[0], "/absolute/path.txt");
 }

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -121,6 +121,18 @@ pub mod merge;
 mod merge_open;
 mod rule;
 pub mod rule_source;
+/// Traversal clamp for peer- and file-supplied names, mirroring
+/// `sanitize_path()`.
+///
+/// Lives in the same crate as [`clean_fname`] because both port the same
+/// upstream file (`util1.c`) and answer the same question about a path, and
+/// because this is the one crate every consumer of the rule can reach: the CLI
+/// clamps `--files-from` lines, the daemon clamps peer-requested module paths,
+/// and the transfer generator clamps names arriving over the wire. Keeping one
+/// owner is what stops the two dialects drifting - they decide different things
+/// and are not interchangeable: `clean_fname` KEEPS a `..` it cannot consume,
+/// while `sanitize_path` DROPS it once the depth budget is spent.
+pub mod sanitize_path;
 mod set;
 mod wildmatch;
 

--- a/crates/filters/src/sanitize_path.rs
+++ b/crates/filters/src/sanitize_path.rs
@@ -190,10 +190,10 @@ fn sanitize_path_bytes(bytes: &[u8], mut depth: i32, keep_dot_dirs: bool) -> Vec
         }
     }
 
-    if result.len() > 1 && result.last() == Some(&b'/') {
-        result.pop();
-    }
-
+    // upstream: util1.c copies each component "through next slash", so a
+    // trailing slash survives into the result and is only NUL-terminated. The
+    // slash is meaningful - on a `--files-from` line it selects a directory's
+    // contents rather than the directory itself - so it must not be stripped.
     if result.is_empty() {
         // upstream: util1.c:1103 - an empty result becomes ".".
         b".".to_vec()
@@ -221,9 +221,12 @@ mod tests {
         assert_eq!(sanitize_path("foo/bar"), "foo/bar");
     }
 
+    // upstream: util1.c - each component is copied "through next slash", so a
+    // trailing slash survives. It is not decoration: on a `--files-from` line
+    // `dir/` selects the directory's contents where `dir` selects the directory.
     #[test]
-    fn trailing_slash_removed() {
-        assert_eq!(sanitize_path("foo/bar/"), "foo/bar");
+    fn trailing_slash_preserved() {
+        assert_eq!(sanitize_path("foo/bar/"), "foo/bar/");
     }
 
     #[test]
@@ -277,17 +280,30 @@ mod tests {
     /// nothing means the retained name still carries `..` segments into the
     /// open, so this is a confinement invariant, not formatting.
     ///
-    /// `sanitize_path` additionally strips the leading `/` (that is the
-    /// `sanitize_path`-vs-`clean_fname` difference, not a collapse difference),
-    /// so the absolute row's expectation is de-anchored before comparison.
+    /// This test pins WHICH component a `..` consumes. The two functions differ
+    /// in two ways that are not collapse differences, so both are normalised
+    /// out before comparison:
+    ///
+    /// 1. `sanitize_path` strips the leading `/`, so the absolute row's
+    ///    expectation is de-anchored.
+    /// 2. After backing up, upstream's `clean_fname` resets `t` to the prior
+    ///    component's first character while `sanitize_path` rewinds `sanp` to
+    ///    just past the preceding separator - so `d/e/..` is `d` through the
+    ///    first and `d/` through the second. The trailing separator is pinned
+    ///    on its own by `trailing_slash_preserved` and
+    ///    `dotdot_with_trailing_slash`; keeping it out of this comparison is
+    ///    what lets the table stay shared.
+    ///
     /// The table is shared (`test_support::COLLAPSE_CASES`) so a new edge case
     /// is one row and reaches every oc-rsync copy of this rule at once.
     // upstream: util1.c clean_fname() CFN_COLLAPSE_DOT_DOT_DIRS; t_clean_fname.c
     #[test]
     fn upstream_collapse_cases_consume_the_preceding_component() {
         for (input, expected) in test_support::COLLAPSE_CASES {
+            let collapsed = sanitize_path(input);
+            let consumed = collapsed.strip_suffix('/').unwrap_or(&collapsed);
             assert_eq!(
-                sanitize_path(input),
+                consumed,
                 expected.trim_start_matches('/'),
                 "clean_fname collapse case {input:?}"
             );
@@ -296,7 +312,7 @@ mod tests {
 
     #[test]
     fn dotdot_at_end_collapses() {
-        assert_eq!(sanitize_path("a/b/.."), "a");
+        assert_eq!(sanitize_path("a/b/.."), "a/");
     }
 
     #[test]
@@ -384,7 +400,9 @@ mod tests {
 
     #[test]
     fn dotdot_with_trailing_slash() {
-        assert_eq!(sanitize_path("a/b/../"), "a");
+        // Backing out `b/` leaves the slash that terminated `a`, matching
+        // upstream, which rewinds `sanp` to just past the previous separator.
+        assert_eq!(sanitize_path("a/b/../"), "a/");
     }
 
     #[test]

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -1026,13 +1026,23 @@ mod tests {
 
     #[test]
     fn split_files_from_entry_with_trailing_dot_after_sanitize_keeps_base_as_path() {
-        // UTS-21.REOPEN: `sanitize_path_keep_dot_dirs("from/./")` returns
-        // `"from/."` because our sanitizer strips the trailing slash that
-        // upstream preserves. Without trailing-dot handling, the split would
-        // miss the anchor and emit a `from/` directory entry instead of
-        // promoting `from` to the walk base.
-        let sanitized = crate::sanitize_path::sanitize_path_keep_dot_dirs_bytes(b"from/./");
+        // A `from/.` line - written without the trailing slash - sanitizes to
+        // `from/.`, so the split must still promote `from` to the walk base
+        // rather than emitting a `from/` directory entry.
+        //
+        // This case used to be reached from `from/./` as well, because the
+        // sanitizer stripped the trailing slash that upstream preserves. That
+        // strip is gone (see `filters::sanitize_path`), so `from/./` now keeps
+        // its slash and is covered by
+        // `split_files_from_entry_with_trailing_anchor_keeps_base_as_path`;
+        // the trailing-dot branch stays reachable through this spelling.
+        let sanitized = crate::sanitize_path::sanitize_path_keep_dot_dirs_bytes(b"from/.");
         assert_eq!(sanitized, b"from/.");
+        assert_eq!(
+            crate::sanitize_path::sanitize_path_keep_dot_dirs_bytes(b"from/./"),
+            b"from/./",
+            "the trailing slash must survive sanitising, as it does upstream"
+        );
         let base = PathBuf::from("/src");
         let split = split_files_from_entry(&base, &sanitized, true, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -135,7 +135,11 @@ mod reader;
 pub mod receiver;
 pub mod role;
 pub(crate) mod role_trailer;
-pub mod sanitize_path;
+/// Re-export of the shared traversal clamp, which now lives in `filters`
+/// alongside `clean_fname` so the CLI and the daemon can reach the same rule.
+/// Kept as a path here because this crate's own call sites (and the daemon's)
+/// name it as `transfer::sanitize_path`.
+pub use filters::sanitize_path;
 pub mod setup;
 pub mod shared;
 pub mod symlink_safety;

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -145,7 +145,7 @@ file-to-file-mkpath-dry-run pass
 files-from pass
 files-from-depth pass
 files-from-leak skip
-files-from-path-clamp fail
+files-from-path-clamp pass
 filter-depth pass
 filter-leak skip
 filter-merge-content-echo fail

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -145,7 +145,7 @@ file-to-file-mkpath-dry-run pass
 files-from pass
 files-from-depth pass
 files-from-leak fail
-files-from-path-clamp fail
+files-from-path-clamp pass
 filter-depth pass
 filter-leak fail
 filter-merge-content-echo fail


### PR DESCRIPTION
## What

`--files-from` lines are now clamped to the transfer root through upstream's
`sanitize_path`, and that clamp no longer eats a trailing slash.

## Why

Upstream applies `sanitize_path(fbuf, fbuf, "", 0, SP_KEEP_DOT_DIRS)` to every
line read from the files-from fd (`flist.c:2571`). The argv arm two lines later
makes the same call but gates it on `sanitize_paths` — the asymmetry is
deliberate, since a files-from line is supplied by the file and an argv operand
by the operator. oc applied neither clamp on the local path.

Fixing that exposed a second, pre-existing divergence in `sanitize_path` itself.

### 1. The clamp was missing

A `../secret/leak.txt` entry survived into the join as
`base/./../secret/leak.txt`. Confinement refused the write, **so there was no
escape** — but only after upstream would already have retargeted the name. The
result was a legitimate clamped entry failing to transfer, with the refusal
blaming `ELOOP` rather than naming the cause.

### 2. `sanitize_path` stripped a trailing slash upstream preserves

Upstream copies each component "through next slash" and only NUL-terminates, so
`from/./` stays `from/./` and `foo/bar/` stays `foo/bar/`. That slash is
load-bearing: on a files-from line `dir/` selects the directory's *contents*
where `dir` selects the directory. Stripping it also silently dropped
`subsubdir2/`'s contents from the transfer.

A comment in `generator/filters.rs` already recorded this divergence and worked
around it downstream. The workaround branch is still reachable through a
`from/.` line so it stays — now covered by an input that actually produces it.

## Measured against rsync 3.5.0

| fixture | before | after |
|---|---|---|
| `../secret/leak.txt`, target inside src | oc fails, upstream transfers | identical |
| upstream dot-dir walk (`from/./`, `subsubdir2/`) | oc: 13 entries under `./from/`, no `bin-lt-list` | byte-identical to upstream |
| missing entry (control) | exit 23 both | unchanged |
| escape attempt, differing depths | exit 23, outside file untouched | unchanged |

## Structure

`sanitize_path` moves from `transfer` to `filters` so all three consumers reach
one owner: the CLI clamps files-from lines, the daemon clamps peer-requested
module paths, the generator clamps names off the wire.
`transfer::sanitize_path` remains as a re-export, so existing call sites are
untouched.

It sits beside `clean_fname` because both port `util1.c` — but they are **not**
interchangeable: `clean_fname` KEEPS a `..` it cannot consume, `sanitize_path`
DROPS it once the depth budget is spent, and after backing up they leave the
separator differently. Both differences are now written down at the shared
test table rather than hidden by a normalising assertion.

## Tests

- `resolve_file_list_entries_files_from_clamps_parent_dir_escape` — the
  discriminating case. RED proven: reverting the clamp fails it with
  `/base/src/./../secret/leak.txt`, byte-identical to the pre-fix path measured
  against the real binary, while both companions stay green.
- `..._files_from_ordinary_entry_survives_the_clamp` — non-vacuity companion.
- `..._files_from_clamp_keeps_the_entry_dot_marker` — `SP_KEEP_DOT_DIRS`.
- `trailing_slash_preserved` / `dotdot_with_trailing_slash` — pin the separator
  rule directly, so the shared collapse table can stay focused on *which*
  component a `..` consumes.
