### PR TITLE
fix(engine): follow an existing dest symlink under --no-implied-dirs

### DIFF
--- a/crates/engine/src/local_copy/context_impl/options/dirs.rs
+++ b/crates/engine/src/local_copy/context_impl/options/dirs.rs
@@ -98,7 +98,8 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
     ///   left in place and the transfer writes through it. That redirection is
     ///   the documented effect of `--no-implied-dirs` - rsync(1) says the
     ///   receiver "updates path/foo/file using the existing path elements,
-    ///   which means that the file ends up being created in path/bar".
+    ///   which means that the file ends up being created in path/bar". The
+    ///   follow is confined: see `symlink_stays_within_destination`.
     ///
     /// The default `--relative` case is deliberately absent: with implied dirs
     /// the parent arrives as its own file-list entry and takes the
@@ -109,7 +110,33 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
     fn follows_existing_parent_symlink(&self, parent: &Path, existing: &fs::Metadata) -> bool {
         self.keep_dirlinks_enabled()
             || (parent == self.destination_root() && Self::operator_owns_symlink(existing))
-            || (self.relative_paths_enabled() && !self.implied_dirs_enabled())
+            || (self.relative_paths_enabled()
+                && !self.implied_dirs_enabled()
+                && self.symlink_stays_within_destination(parent))
+    }
+
+    /// Whether an existing symlink standing at `parent` resolves to a location
+    /// beneath the destination root.
+    ///
+    /// The `--no-implied-dirs` follow above is granted by a `do_stat_at()` that
+    /// follows, but the directory creation it guards runs through upstream's
+    /// confined walk, which follows a relative in-tree symlink
+    /// (`syscall.c:2961` `ds_descend`) and refuses an absolute target
+    /// (`syscall.c:2953`) or a `..` that climbs above the anchor
+    /// (`syscall.c:2896`). Without that second half the follow becomes an
+    /// escape: an attacker-planted `dest/A -> /elsewhere` would redirect the
+    /// whole implied-parent chain outside the tree.
+    ///
+    /// A link that does not resolve is not followed - there is nothing to write
+    /// through, and refusing is the conservative half of the rule.
+    fn symlink_stays_within_destination(&self, parent: &Path) -> bool {
+        let (Ok(root), Ok(target)) = (
+            fs::canonicalize(self.destination_root()),
+            fs::canonicalize(parent),
+        ) else {
+            return false;
+        };
+        target.starts_with(&root)
     }
 
     /// Removes a non-directory occupying a level where a directory must exist.

--- a/crates/engine/src/local_copy/context_impl/options/dirs.rs
+++ b/crates/engine/src/local_copy/context_impl/options/dirs.rs
@@ -75,6 +75,43 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
     false
 }
 
+    /// Whether a symlink occupying one destination path level is followed
+    /// rather than deleted and recreated as a real directory.
+    ///
+    /// Upstream reaches this decision from three separate places, and each
+    /// grants the follow on its own:
+    ///
+    /// - `--keep-dirlinks`: `generator.c:1745` stats the entry with
+    ///   `gen_entry_stat(.., keep_dirlinks && is_dir)`, which FOLLOWS, so a
+    ///   symlink to a directory reports `FT_DIR` and never reaches the
+    ///   `delete_item(.., DEL_FOR_DIR)` at `generator.c:1840`. The same call
+    ///   passes `keep_dirlinks && is_dir`, so a sender *file* of that name
+    ///   still lstats and still replaces the symlink.
+    /// - The destination root: `util1.c:1216` `change_dir()` resolves the
+    ///   operator's own destination argument and `fchdir`s to it, independent
+    ///   of `--keep-dirlinks`. Trust here is ownership, not location - uid 0 or
+    ///   our euid is the admin's own `/backup -> /mnt/disk` layout; any other
+    ///   uid raced the component and stays refused.
+    /// - `--relative --no-implied-dirs`: `generator.c:1718-1719` tests the
+    ///   parent with `do_stat_at()`, which FOLLOWS. A parent that already
+    ///   resolves makes the whole `make_path()` arm dead, so the symlink is
+    ///   left in place and the transfer writes through it. That redirection is
+    ///   the documented effect of `--no-implied-dirs` - rsync(1) says the
+    ///   receiver "updates path/foo/file using the existing path elements,
+    ///   which means that the file ends up being created in path/bar".
+    ///
+    /// The default `--relative` case is deliberately absent: with implied dirs
+    /// the parent arrives as its own file-list entry and takes the
+    /// unconditional `DEL_FOR_DIR` rule, replacing the symlink with a real
+    /// directory. That is the same code path as a plain non-relative copy, so
+    /// widening this predicate to all of `--relative` would silently convert
+    /// both into follows.
+    fn follows_existing_parent_symlink(&self, parent: &Path, existing: &fs::Metadata) -> bool {
+        self.keep_dirlinks_enabled()
+            || (parent == self.destination_root() && Self::operator_owns_symlink(existing))
+            || (self.relative_paths_enabled() && !self.implied_dirs_enabled())
+    }
+
     /// Removes a non-directory occupying a level where a directory must exist.
     ///
     /// upstream: `generator.c:1839-1842` `recv_generator()` - a directory entry
@@ -214,19 +251,6 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
         let parent_within_root = parent.starts_with(self.destination_root());
         let allow_creation =
             self.mkpath_enabled() || (self.implied_dirs_enabled() && parent_within_root);
-        let keep_dirlinks = self.keep_dirlinks_enabled();
-        // The destination ROOT is an operator-supplied path, so a symlink there
-        // is followed on the operator's own authority - `--keep-dirlinks`
-        // governs peer-supplied directories *inside* the tree, not the operand
-        // the operator typed. Trust is ownership, not location: uid 0 or our
-        // euid is the admin's own `/backup -> /mnt/disk` layout; any other uid
-        // is an attacker who raced the component, and stays refused.
-        //
-        // upstream: `rsync-3.5.0/util1.c:1216` `change_dir()` resolves an
-        // absolute destination with `open_no_attacker_symlinks()` and `fchdir`s
-        // to it, independent of `--keep-dirlinks`.
-        let follow_operator_dest_symlink = parent == self.destination_root();
-
         let result = if self.mode.is_dry_run() {
             match fs::symlink_metadata(parent) {
                 Ok(existing) => {
@@ -234,9 +258,7 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
                     if ty.is_dir() {
                         Ok(())
                     } else if ty.is_symlink()
-                        && (keep_dirlinks
-                            || (follow_operator_dest_symlink
-                                && Self::operator_owns_symlink(&existing)))
+                        && self.follows_existing_parent_symlink(parent, &existing)
                     {
                         follow_symlink_metadata(parent).and_then(|metadata| {
                             if metadata.file_type().is_dir() {
@@ -286,9 +308,7 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
                     if ty.is_dir() {
                         Ok(())
                     } else if ty.is_symlink()
-                        && (keep_dirlinks
-                            || (follow_operator_dest_symlink
-                                && Self::operator_owns_symlink(&existing)))
+                        && self.follows_existing_parent_symlink(parent, &existing)
                     {
                         let metadata = follow_symlink_metadata(parent)?;
                         if metadata.file_type().is_dir() {
@@ -320,9 +340,7 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
                     if ty.is_dir() {
                         Ok(())
                     } else if ty.is_symlink()
-                        && (keep_dirlinks
-                            || (follow_operator_dest_symlink
-                                && Self::operator_owns_symlink(&existing)))
+                        && self.follows_existing_parent_symlink(parent, &existing)
                     {
                         let metadata = follow_symlink_metadata(parent)?;
                         if metadata.file_type().is_dir() {

--- a/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
@@ -646,3 +646,96 @@ fn mkpath_creates_missing_dest_arg_parent() {
     assert_eq!(fs::read(&destination).expect("read"), b"content");
     assert_eq!(summary.files_copied(), 1);
 }
+
+/// Builds `dest/` holding `path` as a symlink to a real sibling directory, and
+/// the `src/./path/file` operand that targets it.
+#[cfg(unix)]
+fn dest_with_symlinked_path_element(temp: &Path, name: &str) -> (OsString, PathBuf) {
+    let source_root = temp.join(format!("{name}-src"));
+    let listed = source_root.join("path");
+    fs::create_dir_all(&listed).expect("create source path dir");
+    fs::write(listed.join("file"), b"NEW\n").expect("write source file");
+
+    let dest_root = temp.join(format!("{name}-dest"));
+    fs::create_dir_all(dest_root.join("real")).expect("create real dest dir");
+    std::os::unix::fs::symlink("real", dest_root.join("path")).expect("plant dest symlink");
+
+    let mut source_operand = source_root.into_os_string();
+    source_operand.push("/./");
+    source_operand.push("path/file");
+    (source_operand, dest_root)
+}
+
+/// `--relative --no-implied-dirs` FOLLOWS an existing destination symlink used
+/// as a path element, so the write is redirected through it.
+///
+/// upstream: `generator.c:1718-1719` gates the on-demand `make_path()` on
+/// `do_stat_at(dn, &sx.st) < 0` - a FOLLOW-stat. A parent that already resolves
+/// to a directory makes that arm dead, leaving the symlink in place, and the
+/// later open of `path/file` traverses it. rsync(1) documents the consequence
+/// under `--no-implied-dirs`: the receiver "updates path/foo/file using the
+/// existing path elements, which means that the file ends up being created in
+/// path/bar".
+#[cfg(unix)]
+#[test]
+fn no_implied_dirs_follows_an_existing_dest_symlink_path_element() {
+    let temp = tempdir().expect("tempdir");
+    let (source_operand, dest_root) = dest_with_symlinked_path_element(temp.path(), "follow");
+
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .relative_paths(true)
+        .implied_dirs(false);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("--no-implied-dirs follows the existing dest symlink");
+
+    assert!(
+        dest_root.join("path").symlink_metadata().expect("stat path").file_type().is_symlink(),
+        "--no-implied-dirs must KEEP the dest symlink, not replace it"
+    );
+    let through = dest_root.join("real").join("file");
+    assert_eq!(
+        fs::read(&through).expect("read through the symlink"),
+        b"NEW\n",
+        "the write must be redirected through the kept symlink into real/"
+    );
+}
+
+/// Non-vacuity companion, and the guard on the trap: with implied dirs (the
+/// default) the SAME fixture must still delete the symlink and recreate it as a
+/// real directory. Without this, a fix that simply followed every symlinked
+/// path element would also pass the test above.
+///
+/// upstream: `generator.c:1840-1842` - the implied parent arrives as its own
+/// file-list entry, finds a non-directory in its place, and takes the
+/// unconditional `delete_item(.., DEL_FOR_DIR)`.
+#[cfg(unix)]
+#[test]
+fn implied_dirs_replaces_the_same_dest_symlink_with_a_real_directory() {
+    let temp = tempdir().expect("tempdir");
+    let (source_operand, dest_root) = dest_with_symlinked_path_element(temp.path(), "replace");
+
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default().relative_paths(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("default implied dirs recreates the path element");
+
+    let planted = dest_root.join("path");
+    assert!(
+        !planted.symlink_metadata().expect("stat path").file_type().is_symlink(),
+        "the default must REPLACE the dest symlink with a real directory"
+    );
+    assert_eq!(
+        fs::read(planted.join("file")).expect("read the recreated dir"),
+        b"NEW\n",
+        "the file must land in the recreated real directory"
+    );
+    assert!(
+        !dest_root.join("real").join("file").exists(),
+        "nothing may be written through the replaced symlink"
+    );
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -199,7 +199,7 @@ mkpath pass
 msg-io-timeout-overflow pass
 msg-io-timeout-zero pass
 nested-socket-specials pass
-no-implied-dirs-symlink fail
+no-implied-dirs-symlink pass
 nondaemon-symlink-race skip
 nonroot-restrictive-perms skip
 omit-times pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -199,7 +199,7 @@ mkpath pass
 msg-io-timeout-overflow pass
 msg-io-timeout-zero pass
 nested-socket-specials pass
-no-implied-dirs-symlink fail
+no-implied-dirs-symlink pass
 nondaemon-symlink-race pass
 nonroot-restrictive-perms pass
 omit-times pass


### PR DESCRIPTION
## What

`-R --no-implied-dirs` now follows an existing destination symlink used as a
path element **when that symlink stays inside the destination tree**, instead of
failing the transfer. A symlink pointing outside the tree stays refused.

## Why

Upstream reaches this decision in two halves, and both are load-bearing:

- **The follow.** The on-demand parent creation is gated on
  `do_stat_at(dn, &sx.st) < 0` (`generator.c:1718-1719`) - and `do_stat_at`
  *follows*. A parent that already resolves to a directory makes the whole
  `make_path()` arm dead, so the symlink is left in place and the later open
  traverses it. rsync(1) documents the consequence under `--no-implied-dirs`:
  the receiver "updates `path/foo/file` using the existing path elements, which
  means that the file ends up being created in `path/bar`".
- **The confinement.** The `make_path()` that the stat guards builds its parent
  chain through the held-dirfd `do_mkdir_at()`, i.e. the confined walk: it
  follows a relative in-tree symlink (`syscall.c:2961` `ds_descend`) but refuses
  an absolute target (`syscall.c:2953`) and any `..` climbing above the anchor
  (`syscall.c:2896`).

oc had neither half. Porting only the first would turn a failed transfer into
an arbitrary-write primitive for anyone able to plant one symlink.

## The two halves are exactly what separate the testsuite cells

| cell | plant | required |
|---|---|---|
| `no-implied-dirs-symlink` | `symlink('real', dst/'path')` - relative, in-tree | **follow**, write redirected through it |
| `relative-mkpath-symlink` | `(dest/'A').symlink_to(outside)` - absolute, outside | **refuse**, nothing may land in `outside` |
| `relative-mkpath-dir-symlink` | same, via the dir-entry `ENOENT` fallback | **refuse** |

## Measured against rsync 3.5.0 (Linux)

| cell | before | after |
|---|---|---|
| `no-implied-dirs-symlink` | oc exit 23, nothing transferred | **pass** |
| `relative-mkpath-symlink` | pass | pass |
| `relative-mkpath-dir-symlink` | pass | pass |
| `keep-dirlinks-rule` | pass | pass |
| `keep-dirlinks-symlinked-dest` | pass | pass |

Upstream 3.5.0 control on `no-implied-dirs-symlink`: pass.

**RED proven** by making the confinement check vacuous (`true`): both
`relative-mkpath` cells go red while `no-implied-dirs-symlink` stays green - the
mutation kills the escape guard and nothing else. That green cell is the
non-vacuity companion: it rules out a "refuse everything" fix.

## Structure

The follow-vs-replace classification was **duplicated across all three arms** of
`prepare_directory_component` (dry-run / creation-allowed / creation-forbidden),
so the rule was missing three times over. The three copies collapse into one
predicate, `follows_existing_parent_symlink`, a disjunction of exactly the three
places upstream grants the follow:

- `--keep-dirlinks` - `generator.c:1745`, `gen_entry_stat(.., keep_dirlinks && is_dir)`, which follows
- the operator-named destination root - `util1.c:1216` `change_dir()`, gated on symlink ownership
- `--relative --no-implied-dirs` - added here, gated on `symlink_stays_within_destination`

**The default `--relative` case is deliberately absent.** With implied dirs the
parent arrives as its own file-list entry and takes the unconditional
`delete_item(.., DEL_FOR_DIR)` (`generator.c:1840-1842`), replacing the symlink
with a real directory. Widening the predicate to all of `--relative` would
silently convert that case - and the plain non-relative copy, which shares this
code path - into follows.

## Divergence worth naming

Upstream gets the confinement structurally: creation goes through the held-dirfd
walk, so no separate predicate exists. oc expresses it here as a predicate on the
follow decision instead. Same observable behaviour on every cell measured, but it
is a second place the rule lives rather than one. Routing the local-copy
directory creation through the shared confined walk would remove the duplication;
that is a larger change than this fix and is tracked separately.

## Tests

- `no_implied_dirs_follows_an_existing_dest_symlink_path_element` - the pin.
- `implied_dirs_replaces_the_same_dest_symlink_with_a_real_directory` -
  non-vacuity companion on the **same fixture**: the default must still delete
  the symlink, recreate it as a real directory, and write nothing through it.

No unit test is added for the escape refusal. One was written and then removed:
it passed with the confinement check disabled on **both** macOS and Linux, so it
could never fail and would have been false comfort. The escape is guarded by the
two `relative-mkpath` rows, which are `pass` in both required pipe manifests and
are RED/GREEN-proven above.

## Manifests

`no-implied-dirs-symlink` flips `fail` -> `pass` in both pipe manifests in this
commit; both keep their 349 rows. The TCP manifests do not carry the row (the
test is local-only).

`dest-symlinked-dir` is **deliberately left `fail`**: measured separately, it is
a different root cause - the metadata apply re-derives the operator-named dest
path and walks it with a symlink-refusing walk, so the data lands correctly but
the subsequent chmod fails. Not addressed here.
