### PR TITLE
fix(metadata): follow the operator's own symlinked destination root

### DIFF
--- a/crates/engine/src/local_copy/context_impl/options/metadata.rs
+++ b/crates/engine/src/local_copy/context_impl/options/metadata.rs
@@ -17,6 +17,11 @@ impl<'a> CopyContext<'a> {
             .with_user_mapping(self.options.user_mapping().cloned())
             .with_group_mapping(self.options.group_mapping().cloned())
             .with_keep_dirlinks(self.options.keep_dirlinks_enabled())
+            // Upstream resolves the destination once via `change_dir`
+            // (`main.c:765`) and works relative to it, so a symlinked root is
+            // never a path component the per-entry syscalls have to walk. oc
+            // keeps absolute paths, so it hands the root over instead.
+            .with_destination_root(Some(self.destination_root().to_path_buf()))
     }
 
     /// Reports whether ACL preservation is enabled.

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -92,7 +92,7 @@ pub fn apply_file_metadata_with_options(
             metadata,
             destination,
             None,
-            options.keep_dirlinks(),
+            options.resolves_symlinked_parent(destination),
         )?;
     }
     if options.crtimes() {
@@ -210,7 +210,7 @@ pub fn apply_file_metadata_if_changed(
             metadata,
             destination,
             Some(existing),
-            options.keep_dirlinks(),
+            options.resolves_symlinked_parent(destination),
         )?;
     }
     if options.crtimes() {
@@ -722,7 +722,7 @@ pub fn apply_metadata_with_attrs_flags_and_pre_transfer(
             destination,
             entry,
             cached_meta.as_ref(),
-            options.keep_dirlinks(),
+            options.resolves_symlinked_parent(destination),
         )?;
     }
 

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -60,9 +60,9 @@ fn chown_path(
     owner: Option<unix_fs::Uid>,
     group: Option<unix_fs::Gid>,
     follow_symlinks: bool,
-    keep_dirlinks: bool,
+    resolve_symlinked_parent: bool,
 ) -> Result<(), MetadataError> {
-    if keep_dirlinks {
+    if resolve_symlinked_parent {
         let flag = if follow_symlinks {
             nix::fcntl::AtFlags::empty()
         } else {
@@ -530,7 +530,7 @@ pub(super) fn set_owner_like(
             owner,
             group,
             follow_symlinks,
-            options.keep_dirlinks(),
+            options.resolves_symlinked_parent(destination),
         )?;
 
         // upstream: rsync.c:558-568 - impossible-id warning + suid/sgid re-stat.
@@ -679,7 +679,13 @@ pub(super) fn apply_ownership_from_entry(
             // upstream: rsync.c:535-546 - DEBUG_GTE(OWN, 1) fires before do_lchown.
             trace_chown_change(destination, owner, group, cached_meta);
 
-            chown_path(destination, owner, group, true, options.keep_dirlinks())?;
+            chown_path(
+                destination,
+                owner,
+                group,
+                true,
+                options.resolves_symlinked_parent(destination),
+            )?;
 
             // upstream: rsync.c:558-568 - impossible-id warning + suid/sgid re-stat.
             return Ok(post_chown_bookkeeping(
@@ -758,7 +764,13 @@ pub(super) fn apply_symlink_ownership_from_entry(
     if needs_chown {
         trace_chown_change(destination, owner, group, cached_meta);
 
-        chown_path(destination, owner, group, false, options.keep_dirlinks())?;
+        chown_path(
+            destination,
+            owner,
+            group,
+            false,
+            options.resolves_symlinked_parent(destination),
+        )?;
 
         // upstream: rsync.c:558-561 - impossible-id warning also fires for
         // symlink chowns. The suid/sgid re-stat is irrelevant here because

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -698,7 +698,7 @@ fn chmod_path_honoring_keep_dirlinks(
     options: &MetadataOptions,
     action: &'static str,
 ) -> Result<(), MetadataError> {
-    if options.keep_dirlinks() {
+    if options.resolves_symlinked_parent(destination) {
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(destination, fs::Permissions::from_mode(mode))
             .map_err(|error| MetadataError::new(action, destination, error))?;

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -2343,6 +2343,64 @@ fn keep_dirlinks_bypasses_secure_chmod_sandbox() {
     );
 }
 
+/// The operator-named destination ROOT is followed even without
+/// `--keep-dirlinks`.
+///
+/// upstream: `main.c:765` resolves the destination exactly once via
+/// `change_dir(dest_path, CD_NORMAL)` - a plain `chdir` for a non-daemon
+/// receiver - and then works relative to it, so the root never reappears as a
+/// path component and the per-entry syscalls always meet a real directory
+/// (`do_lchown` is a bare `lchown(2)` with no sandbox at all). oc keeps
+/// absolute paths, so without this the root re-enters the dirfd walk on every
+/// entry and is refused.
+///
+/// This is the exact companion of
+/// `keep_dirlinks_bypasses_secure_chmod_sandbox` above, which pins the other
+/// half of the rule: a symlink that is a CHILD of the destination root stays
+/// refused. Only the root itself is operator-named, so only the root is
+/// trusted.
+#[cfg(unix)]
+#[test]
+fn operator_destination_root_symlink_is_followed_without_keep_dirlinks() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let real = temp.path().join("real");
+    fs::create_dir(&real).expect("create real");
+
+    // The operator's destination argument IS the symlink.
+    let dest_root = temp.path().join("backup");
+    std::os::unix::fs::symlink(&real, &dest_root).expect("symlink dest root");
+
+    let source = temp.path().join("a.txt");
+    fs::write(&source, b"alpha").expect("write source");
+    fs::set_permissions(&source, PermissionsExt::from_mode(0o644)).expect("source mode");
+
+    // Directly under the root - the only depth the two-level walk inspects.
+    let dest_file = dest_root.join("a.txt");
+    fs::write(&dest_file, b"alpha").expect("write dest through the root symlink");
+    fs::set_permissions(&dest_file, PermissionsExt::from_mode(0o600)).expect("dest mode");
+
+    let source_meta = fs::metadata(&source).expect("stat source");
+    let options = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(false)
+        .with_destination_root(Some(dest_root.clone()));
+
+    apply_file_metadata_with_options(&dest_file, &source_meta, &options)
+        .expect("the operator's own destination root must be followed");
+
+    let landed_mode = fs::metadata(real.join("a.txt"))
+        .expect("stat real/a.txt")
+        .permissions()
+        .mode()
+        & 0o7777;
+    assert_eq!(
+        landed_mode, 0o644,
+        "the chmod must land through the root symlink on real/a.txt (got {landed_mode:o})",
+    );
+}
+
 // KDL.7.1 cross-platform regression: `--keep-dirlinks` must succeed through a
 // symlinked destination directory on every supported platform. Pins the
 // guarantee from PR #5793 (macOS chmod bypass), PRs #5798/#5799 (extended to

--- a/crates/metadata/src/apply/timestamps.rs
+++ b/crates/metadata/src/apply/timestamps.rs
@@ -42,9 +42,9 @@ fn set_times_via(
     atime: Option<FileTime>,
     mtime: Option<FileTime>,
     follow_symlinks: bool,
-    keep_dirlinks: bool,
+    resolve_symlinked_parent: bool,
 ) -> std::io::Result<()> {
-    if !keep_dirlinks {
+    if !resolve_symlinked_parent {
         return fast_io::secure_utimes_at(destination, atime, mtime, follow_symlinks);
     }
     let to_timespec = |time: Option<FileTime>| match time {
@@ -79,7 +79,7 @@ fn set_times_via(
     atime: Option<FileTime>,
     mtime: Option<FileTime>,
     follow_symlinks: bool,
-    _keep_dirlinks: bool,
+    _resolve_symlinked_parent: bool,
 ) -> std::io::Result<()> {
     match (atime, mtime) {
         (Some(atime), Some(mtime)) => {
@@ -154,13 +154,14 @@ pub(super) fn set_timestamp_like(
     #[cfg(not(unix))]
     let open_free_path = !follow_symlinks;
 
-    let keep_dirlinks = options.is_some_and(|o| o.keep_dirlinks());
+    let resolve_symlinked_parent =
+        options.is_some_and(|o| o.resolves_symlinked_parent(destination));
     let result = set_times_via(
         destination,
         accessed,
         Some(modified),
         !open_free_path,
-        keep_dirlinks,
+        resolve_symlinked_parent,
     );
 
     if let Err(error) = result {
@@ -279,7 +280,7 @@ pub(super) fn apply_atime_only_from_metadata(
     metadata: &fs::Metadata,
     destination: &Path,
     existing: Option<&fs::Metadata>,
-    keep_dirlinks: bool,
+    resolve_symlinked_parent: bool,
 ) -> Result<(), MetadataError> {
     // upstream: rsync.c:609 - the applied access time's nanosecond field is 0.
     let source_atime =
@@ -307,7 +308,7 @@ pub(super) fn apply_atime_only_from_metadata(
         Some(source_atime),
         Some(dest_mtime),
         true,
-        keep_dirlinks,
+        resolve_symlinked_parent,
     )
     .map_err(|error| MetadataError::new("preserve access time", destination, error))?;
 
@@ -410,7 +411,7 @@ pub(super) fn apply_timestamps_from_entry(
             entry,
             atime,
             mtime,
-            options.keep_dirlinks(),
+            options.resolves_symlinked_parent(destination),
             "preserve timestamps",
         )?;
     }
@@ -434,14 +435,20 @@ fn set_entry_times(
     entry: &protocol::flist::FileEntry,
     atime: Option<FileTime>,
     mtime: FileTime,
-    keep_dirlinks: bool,
+    resolve_symlinked_parent: bool,
     context: &'static str,
 ) -> Result<(), MetadataError> {
     let is_special = entry.is_device() || entry.is_special();
     // upstream: rsync.c:588-589 - `atime = None` reproduces ATTRS_SKIP_ATIME,
     // leaving the destination's access time untouched (UTIME_OMIT). Special
     // files take the `AT_SYMLINK_NOFOLLOW` leaf (open-free node timestamping).
-    let result = set_times_via(destination, atime, Some(mtime), !is_special, keep_dirlinks);
+    let result = set_times_via(
+        destination,
+        atime,
+        Some(mtime),
+        !is_special,
+        resolve_symlinked_parent,
+    );
 
     if let Err(error) = result {
         #[cfg(unix)]
@@ -502,7 +509,7 @@ pub(super) fn apply_symlink_timestamps_from_entry(
             atime,
             Some(mtime),
             false,
-            options.keep_dirlinks(),
+            options.resolves_symlinked_parent(destination),
         )
         .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?;
     }
@@ -523,7 +530,7 @@ pub(super) fn apply_atime_only_from_entry(
     destination: &Path,
     entry: &protocol::flist::FileEntry,
     cached_meta: Option<&fs::Metadata>,
-    keep_dirlinks: bool,
+    resolve_symlinked_parent: bool,
 ) -> Result<(), MetadataError> {
     let atime = if entry.atime() != 0 {
         FileTime::from_unix_time(entry.atime(), 0)
@@ -554,7 +561,7 @@ pub(super) fn apply_atime_only_from_entry(
             entry,
             Some(atime),
             mtime,
-            keep_dirlinks,
+            resolve_symlinked_parent,
             "preserve access time",
         )?;
     }

--- a/crates/metadata/src/options/accessors.rs
+++ b/crates/metadata/src/options/accessors.rs
@@ -4,6 +4,8 @@
 //! modification, enabling callers to query which metadata attributes
 //! will be preserved during a transfer.
 
+use std::path::Path;
+
 use crate::chmod::ChmodModifiers;
 use crate::{GroupMapping, UserMapping};
 
@@ -163,5 +165,70 @@ impl MetadataOptions {
             || self.owner_override.is_some()
             || self.group_override.is_some()
             || self.chmod.is_some()
+    }
+
+    /// Whether a path-based metadata apply may resolve a symlinked parent
+    /// instead of being refused by the dirfd-anchored walk in
+    /// `fast_io::secure_*_at`.
+    ///
+    /// Two upstream reasons, either sufficient on its own:
+    ///
+    /// - `--keep-dirlinks`: the operator opted into following dest-side
+    ///   symlinked directories (`generator.c:1356`,
+    ///   `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`).
+    /// - The entry sits directly under the operator-named destination root and
+    ///   that root is a symlink the operator owns. Upstream never meets this
+    ///   case at all: it resolves the destination once up front (`main.c:765`
+    ///   `change_dir`), so every later syscall sees a real directory -
+    ///   `do_lchown` is a bare `lchown(2)` with no sandbox of any kind.
+    ///
+    /// Only the immediate parent is consulted, because that is the entire
+    /// horizon of the walk: it inspects the entry and its parent, never the
+    /// grandparent, so an entry deeper than one level never sees the root as a
+    /// path component.
+    ///
+    /// oc is deliberately STRICTER than upstream here. For a non-daemon
+    /// receiver upstream's `change_dir` is a plain `chdir` with no ownership
+    /// test at all; it walks with `open_no_attacker_symlinks` only when
+    /// `am_daemon && !am_chrooted`. oc applies that walk's uid rule - trust
+    /// only uid 0 or our euid - on every path, so a destination root raced in
+    /// by another uid stays refused where upstream would follow it.
+    pub(crate) fn resolves_symlinked_parent(&self, destination: &Path) -> bool {
+        self.keep_dirlinks() || self.parent_is_owned_destination_root(destination)
+    }
+
+    /// Whether `destination`'s immediate parent is the operator-named
+    /// destination root and that root is a symlink the operator owns.
+    ///
+    /// upstream: `syscall.c:406` - the `ona_open` component walk follows a
+    /// symlink only when its `st_uid` is 0 or our euid.
+    #[cfg(unix)]
+    fn parent_is_owned_destination_root(&self, destination: &Path) -> bool {
+        use std::os::unix::fs::MetadataExt;
+
+        let Some(root) = self.destination_root.as_deref() else {
+            return false;
+        };
+        // The operator's destination argument usually keeps its trailing slash
+        // (`dst/`), and that slash is load-bearing twice over: `Path::parent`
+        // never produces one, and `lstat("sym/")` resolves THROUGH the symlink
+        // because a trailing slash demands a directory - so the raw form would
+        // both miss the comparison and report the target instead of the link.
+        // `components().as_path()` drops it once for both uses.
+        let root = root.components().as_path();
+        if destination.parent() != Some(root) {
+            return false;
+        }
+        let Ok(metadata) = std::fs::symlink_metadata(root) else {
+            return false;
+        };
+        metadata.file_type().is_symlink() && fast_io::symlink_owner_is_trusted(metadata.uid())
+    }
+
+    /// Non-Unix has no uid to consult, so the root is never treated as
+    /// operator-owned and every path stays confined.
+    #[cfg(not(unix))]
+    fn parent_is_owned_destination_root(&self, _destination: &Path) -> bool {
+        false
     }
 }

--- a/crates/metadata/src/options/mod.rs
+++ b/crates/metadata/src/options/mod.rs
@@ -14,6 +14,8 @@ mod tests;
 
 pub use attrs_flags::AttrsFlags;
 
+use std::path::PathBuf;
+
 use crate::chmod::ChmodModifiers;
 use crate::{GroupMapping, UserMapping};
 
@@ -49,6 +51,21 @@ pub struct MetadataOptions {
     /// is incompatible with `secure_open_dir`'s ELOOP/ENOTDIR rejection of
     /// symlinked parents.
     pub(crate) keep_dirlinks: bool,
+    /// The operator-named destination root, when the caller knows it.
+    ///
+    /// Upstream resolves the destination exactly once, before any entry is
+    /// touched: `main.c:765` calls `change_dir(dest_path, CD_NORMAL)`. For a
+    /// non-daemon receiver that is a plain `chdir`; for a daemon it walks the
+    /// path with `open_no_attacker_symlinks` and `fchdir`s the result
+    /// (`util1.c` `change_dir`). Either way the root never reappears as a path
+    /// component, so the per-entry syscalls - `do_lchown` is a bare
+    /// `lchown(2)` - always see a real directory.
+    ///
+    /// oc keeps absolute paths instead, so a symlinked root re-enters the
+    /// dirfd-anchored walk on every entry. Recording it here lets
+    /// `resolves_symlinked_parent` restore upstream's outcome without widening
+    /// the walk for anything below the root.
+    pub(crate) destination_root: Option<PathBuf>,
 }
 
 impl MetadataOptions {
@@ -75,6 +92,7 @@ impl MetadataOptions {
             group_mapping: None,
             destination_is_new: false,
             keep_dirlinks: false,
+            destination_root: None,
         }
     }
 }

--- a/crates/metadata/src/options/setters.rs
+++ b/crates/metadata/src/options/setters.rs
@@ -173,4 +173,16 @@ impl MetadataOptions {
         self.keep_dirlinks = keep;
         self
     }
+
+    /// Records the operator-named destination root.
+    ///
+    /// Only callers that genuinely know the operator's destination argument
+    /// should set this; leaving it unset keeps every path fully confined. See
+    /// `MetadataOptions::destination_root` for why upstream never needs the
+    /// equivalent.
+    #[must_use]
+    pub fn with_destination_root(mut self, root: Option<std::path::PathBuf>) -> Self {
+        self.destination_root = root;
+        self
+    }
 }

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -127,7 +127,7 @@ delay-updates-deep pass
 delete pass
 delete-deep pass
 delete-missing-args-files-from pass
-dest-symlinked-dir fail
+dest-symlinked-dir pass
 devices pass
 devices-fake pass
 dir-sgid pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -127,7 +127,7 @@ delay-updates-deep pass
 delete pass
 delete-deep pass
 delete-missing-args-files-from pass
-dest-symlinked-dir fail
+dest-symlinked-dir pass
 devices pass
 devices-fake pass
 dir-sgid pass


### PR DESCRIPTION
## What

A local copy into a symlinked destination (`oc-rsync -a src/ dst/` where
`dst -> /real`) failed with `Not a directory (20)`. The data landed correctly;
only the metadata apply failed - and on **all three** families:

| flags | oc before | upstream 3.5.0 |
|---|---|---|
| `-rp` permissions | exit 23 | 0 |
| `-rt` timestamps | exit 23 | 0 |
| `-rog` ownership | exit 23 | 0 |
| `-a` | exit 23 | 0 |

`-a` reported only the ownership failure because oc stops at the first error,
which is why this initially looked like a single site.

## Why

**Upstream never meets this case.** It resolves the destination exactly once,
before any entry is touched - `main.c:765` calls `change_dir(dest_path,
CD_NORMAL)`:

- non-daemon receiver: a plain `chdir`, no ownership test at all;
- daemon (`am_daemon && !am_chrooted`): walks the path with
  `open_no_attacker_symlinks` and `fchdir`s the result.

Either way the root never reappears as a path component afterwards, so the
per-entry syscalls always see a real directory. `do_lchown` is a bare
`lchown(2)` with **no sandbox of any kind**; all the confinement lives in that
one-time resolve.

oc keeps absolute paths instead, so the symlinked root re-enters the
dirfd-anchored walk in `fast_io::secure_*_at` on *every* entry and is refused.

## Structure

`MetadataOptions` now carries the operator-named destination root, and a single
predicate answers the follow question for all three walkers:

```rust
fn resolves_symlinked_parent(&self, destination: &Path) -> bool {
    self.keep_dirlinks() || self.parent_is_owned_destination_root(destination)
}
```

This replaces the `keep_dirlinks` bool that `chown_path`, `set_times_via` and
`chmod_path_honoring_keep_dirlinks` each threaded separately - one rule, one
place, three consumers. The threaded parameter is renamed
`resolve_symlinked_parent` because its meaning is now broader than the flag.

Threading cost is one line: the engine has exactly one `MetadataOptions`
construction site and it already owns `destination_root()`.

**Only the immediate parent is tested.** That is the entire horizon of the
walk - it inspects the entry and its parent, never the grandparent - so an
entry deeper than one level never sees the root as a component. Everything
below the root stays fully confined.

## Divergences worth naming

**oc is deliberately STRICTER than upstream.** For a non-daemon receiver
upstream's `change_dir` is a plain `chdir` with no ownership test whatsoever.
oc applies the confined walk's uid rule - trust only uid 0 or our euid,
`syscall.c:406` - on every path, so a destination root raced in by another uid
stays refused where upstream would follow it. That is a deliberate hardening,
not an accident.

**oc expresses structurally-derived behaviour as a predicate.** Upstream gets
this for free from the one-time resolve; oc reconstructs it per entry. Same
observable behaviour on every cell measured, but the rule lives in a second
place. Routing the metadata apply through a resolved destination handle would
collapse it back to upstream's single mechanism - that is the larger change
tracked separately, not this fix.

## Tests

`operator_destination_root_symlink_is_followed_without_keep_dirlinks` - the
pin, placed directly beside its natural companion.

`keep_dirlinks_bypasses_secure_chmod_sandbox` (**unchanged**) is that
companion: it asserts that without `--keep-dirlinks` a symlink which is a
**child** of the destination root is still refused. The two together state the
whole rule - only the operator-named root is trusted, nothing beneath it. That
existing assertion is why the fix is scoped to the parent and not to the walk.

**RED proven** by removing the destination-root arm of the predicate:

- `dest-symlinked-dir` goes red while `keep-dirlinks-rule` and
  `keep-dirlinks-symlinked-dest` stay green;
- the new unit test fails with the original `Not a directory (20)`.

⚠ The first version of this fix was **inert** - it compiled, read correctly,
and changed nothing. The destination root arrives with a trailing slash
(`dst/`), and that slash is load-bearing twice: `Path::parent` never produces
one, and `lstat("sym/")` resolves *through* the symlink because a trailing
slash demands a directory. `components().as_path()` drops it once for both
uses. Caught by instrumenting the predicate, not by re-reading it.

## Manifests

`dest-symlinked-dir` flips `fail` -> `pass` in both pipe manifests, which keep
their 349 rows. The TCP manifests do not carry the row - the cell is
local-only.
