### PR TITLE
fix(engine): confine the local-copy alt-dest basis stat to the ownership walk

### DIFF
--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -1,6 +1,7 @@
 //! Handling of reference directories and link-dest decisions.
 
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use ::metadata::MetadataOptions;
@@ -44,6 +45,48 @@ pub(crate) fn resolve_reference_candidate(
     }
 }
 
+/// `lstat`s an alt-dest basis candidate with its parent resolved by the
+/// ownership walk, mirroring upstream's `basis_link_stat()`.
+///
+/// A `--link-dest` / `--copy-dest` / `--compare-dest` argument is an
+/// operator-supplied path, so it may legitimately point outside the transfer
+/// tree and location cannot be the trust signal. Authority is: a symlink
+/// component owned by uid 0 or our euid is the operator's own layout and is
+/// followed; any other owner is refused. Without that, an unprivileged user who
+/// controls a directory anywhere along the basis path can swap a component for a
+/// symlink and redirect the stat - and then the hard link, the copy, or the
+/// `--compare-dest` skip - at a file of their choosing.
+///
+/// A refusal is reported as "no basis here", which is upstream's outcome too:
+/// `basis_link_stat()` returns `-1` and every call site turns that into a
+/// `continue`, so the file transfers normally instead of being linked, copied or
+/// skipped through an attacker's symlink.
+///
+/// Local copy has no daemon arm. Upstream selects the plain `link_stat()`
+/// fall-through on `am_daemon` (generator.c:1010), whose confinement comes from
+/// the module resolver instead; a local copy is never a daemon worker, so the
+/// ownership walk is the only reachable arm here.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/generator.c:962` `basis_link_stat()` - the non-daemon arm:
+///   `owner_walk_parent()` then `link_stat_at()` on the leaf.
+/// - `rsync-3.5.0/generator.c:1084` / `:1110` / `:1227` / `:1254` - its call
+///   sites in `try_dests_reg()` and `try_dests_non()`.
+#[cfg(unix)]
+fn basis_stat(path: &Path) -> io::Result<fs::Metadata> {
+    fast_io::operator_symlink_metadata(path)
+}
+
+/// Non-Unix fallback: the ownership walk is a dirfd construction with no Windows
+/// analogue, so the basis is stat'd by path. `symlink_metadata` still refuses to
+/// follow a symlink at the leaf, which keeps a symlinked basis entry from being
+/// consumed; only the parent components are unguarded.
+#[cfg(not(unix))]
+fn basis_stat(path: &Path) -> io::Result<fs::Metadata> {
+    fs::symlink_metadata(path)
+}
+
 /// Parameters for finding a matching file in reference directories.
 pub(crate) struct ReferenceQuery<'a> {
     pub(crate) destination: &'a Path,
@@ -84,7 +127,7 @@ pub(crate) fn reference_attrs_unchanged(
     options: &MetadataOptions,
     preserve_xattrs: bool,
 ) -> bool {
-    let Ok(basis_meta) = fs::symlink_metadata(basis) else {
+    let Ok(basis_meta) = basis_stat(basis) else {
         return false;
     };
 
@@ -201,7 +244,7 @@ pub(crate) fn find_reference_action(
         // or is not a directory has already been reported once by
         // check_alt_basis_dirs() (main.c:867); aborting the transfer on the
         // resulting ENOTDIR would fail a run upstream completes normally.
-        let Ok(candidate_metadata) = fs::symlink_metadata(&candidate) else {
+        let Ok(candidate_metadata) = basis_stat(&candidate) else {
             continue;
         };
 
@@ -333,7 +376,7 @@ fn find_reference_symlink(
         // this basis dir", not just ENOENT, exactly as the regular-file lookup
         // above already treats it. An alt-dest arg that is not a directory yields
         // ENOTDIR here, and aborting on it would fail a run upstream completes.
-        let Ok(candidate_metadata) = fs::symlink_metadata(&candidate) else {
+        let Ok(candidate_metadata) = basis_stat(&candidate) else {
             continue;
         };
         if !candidate_metadata.file_type().is_symlink() {
@@ -382,7 +425,7 @@ pub(crate) fn find_copy_dest_basis(
         // alt-dest arg naming a plain file yields ENOTDIR here on the very first
         // entry; aborting would fail a run upstream completes normally, having
         // merely warned once from check_alt_basis_dirs().
-        let Ok(candidate_metadata) = fs::symlink_metadata(&candidate) else {
+        let Ok(candidate_metadata) = basis_stat(&candidate) else {
             continue;
         };
         if candidate_metadata.file_type().is_dir() {

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -400,8 +400,8 @@ pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
     operator_link, operator_open_append, operator_open_read, operator_open_rw_create,
-    operator_open_write_create, operator_read_to_string, operator_rename, owner_trusted_parent,
-    symlink_owner_is_trusted,
+    operator_open_write_create, operator_read_to_string, operator_rename,
+    operator_symlink_metadata, owner_trusted_parent, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -513,6 +513,58 @@ pub fn operator_read_to_string(path: &Path) -> io::Result<String> {
     Ok(contents)
 }
 
+/// `lstat`s an operator-supplied path with its parent resolved by the ownership
+/// walk, so a foreign-owned symlink among the parent components cannot redirect
+/// the stat.
+///
+/// Only the parent is walked. The leaf is `fstatat`'d with
+/// `AT_SYMLINK_NOFOLLOW`, never opened and never resolved: a symlink sitting at
+/// the leaf must report *as a symlink* so a caller's file-type filter can drop
+/// it, even when the link is trusted-owned. Opening the leaf instead would both
+/// follow that symlink and demand read permission the caller may not need.
+///
+/// The returned [`std::fs::Metadata`] comes from a second, path-based stat, so
+/// callers keep the `std` type their comparisons are written against. It is
+/// accepted only when it names the same `(dev, ino)` the confined stat saw: a
+/// parent flipped between the two calls lands on a different inode and is
+/// refused, which is what makes the path stat safe to use as the carrier.
+///
+/// Callers are expected to treat any error as "nothing here" - upstream's
+/// `basis_link_stat()` returns `-1` on a refused walk, and every one of its call
+/// sites turns that into a `continue`, so a redirected basis simply looks absent
+/// and the file transfers normally.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/generator.c:962` `basis_link_stat()` - `owner_walk_parent()`
+///   for the parent components, then `link_stat_at()` on the leaf through the
+///   returned descriptor.
+/// - `rsync-3.5.0/generator.c:1084` / `:1110` / `:1227` / `:1254` - the call
+///   sites, each treating a failure as "no candidate in this basis dir".
+///
+/// # Errors
+///
+/// Surfaces the walk's `ELOOP` when a parent component is a symlink owned by
+/// neither uid 0 nor our euid, any other error the walk reports (see
+/// [`owner_trusted_parent`]), the `fstatat` error for a missing or unreadable
+/// leaf, and `io::ErrorKind::NotFound` when the path-based stat disagrees with
+/// the confined one about which inode the leaf names.
+pub fn operator_symlink_metadata(path: &Path) -> io::Result<std::fs::Metadata> {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let (parent, leaf) = owner_trusted_parent(path)?;
+    let confined = crate::fstatat_nofollow(parent.as_fd(), &leaf)?;
+    let meta = std::fs::symlink_metadata(path)?;
+    if meta.dev() == confined.dev() && meta.ino() == confined.ino() {
+        Ok(meta)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "operator path changed inode between the confined and path stat",
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -557,9 +609,66 @@ mod tests {
             "motd line\n"
         );
     }
+    use super::operator_symlink_metadata;
     use std::io::{Read, Write};
     use std::os::unix::fs::symlink;
     use tempfile::TempDir;
+
+    /// The basis lookup must see a LEAF symlink *as a symlink*, so a caller's
+    /// `is_file()` filter drops it - even though the same link would be followed
+    /// were it a parent component. That asymmetry is deliberate: upstream reaches
+    /// the leaf through `link_stat_at(.., 0)` after walking only the parent
+    /// (`generator.c:979-990`), which is what stops a symlinked `--link-dest`
+    /// entry from being hard-linked or read.
+    #[test]
+    fn operator_symlink_metadata_does_not_follow_a_leaf_symlink() {
+        let temp = TempDir::new().expect("tempdir");
+        let target = temp.path().join("real");
+        std::fs::write(&target, b"basis payload").expect("write");
+
+        let link = temp.path().join("basis");
+        symlink(&target, &link).expect("symlink");
+
+        let meta = operator_symlink_metadata(&link).expect("stat the leaf symlink");
+        assert!(
+            meta.file_type().is_symlink(),
+            "a leaf symlink must report as a symlink so the is_file() filter drops it"
+        );
+    }
+
+    /// A PARENT component the operator owns is their own layout
+    /// (`--link-dest=/var/backups` where `/var/backups -> /data/backups`) and
+    /// must still be followed. Refusing it would make every such basis look
+    /// absent and silently re-transfer files upstream hard-links.
+    ///
+    /// The refusing half needs a symlink owned by neither uid 0 nor our euid and
+    /// therefore root, so it is pinned at the predicate by
+    /// `refuses_an_owner_that_is_neither_root_nor_the_euid`. This cell pins the
+    /// half that a careless "refuse every symlink" change would break.
+    #[test]
+    fn operator_symlink_metadata_follows_a_self_owned_parent_symlink() {
+        let temp = TempDir::new().expect("tempdir");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir(&outside).expect("mkdir");
+        std::fs::write(outside.join("basis"), b"basis payload").expect("write");
+
+        let link = temp.path().join("via");
+        symlink(&outside, &link).expect("symlink");
+
+        let meta = operator_symlink_metadata(&link.join("basis"))
+            .expect("follow a euid-owned parent symlink");
+        assert!(meta.file_type().is_file());
+        assert_eq!(meta.len(), b"basis payload".len() as u64);
+    }
+
+    /// A missing leaf is an error, not a zero-sized success - callers read any
+    /// error as "no basis in this directory", and a silent empty result there
+    /// would make an absent basis look like a matching one.
+    #[test]
+    fn operator_symlink_metadata_reports_a_missing_leaf_as_an_error() {
+        let temp = TempDir::new().expect("tempdir");
+        assert!(operator_symlink_metadata(&temp.path().join("absent")).is_err());
+    }
 
     /// A plain path with no symlink anywhere resolves and opens normally - the
     /// walk must not break the ordinary case it guards.

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -369,17 +369,11 @@ mod basis_trust_tests {
 /// - `rsync-3.5.0/syscall.c:558` `owner_walk_parent()` - the walk itself.
 #[cfg(unix)]
 fn basis_stat(path: &Path, trust: BasisTrust) -> Option<fs::Metadata> {
-    use std::os::fd::AsFd;
-    use std::os::unix::fs::MetadataExt;
-
     if trust == BasisTrust::PlainStat {
         return fs::symlink_metadata(path).ok();
     }
 
-    let (parent, leaf) = fast_io::owner_walk::owner_trusted_parent(path).ok()?;
-    let confined = fast_io::fstatat_nofollow(parent.as_fd(), &leaf).ok()?;
-    let meta = fs::symlink_metadata(path).ok()?;
-    (meta.dev() == confined.dev() && meta.ino() == confined.ino()).then_some(meta)
+    fast_io::operator_symlink_metadata(path).ok()
 }
 
 /// Non-Unix fallback: the ownership walk is a dirfd construction with no

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -209,8 +209,8 @@ operator-path-backup-dir-daemon pass
 operator-path-backup-dir-exclude-daemon fail
 operator-path-backup-rmdir pass
 operator-path-backup-symlink pass
-operator-path-compare-dest fail
-operator-path-copy-dest fail
+operator-path-compare-dest pass
+operator-path-copy-dest pass
 operator-path-dir-daemon-inmodule pass
 operator-path-dir-daemon-leaf fail
 operator-path-dir-daemon-mkdir fail
@@ -219,7 +219,7 @@ operator-path-files-from pass
 operator-path-inplace-backup-dir fail
 operator-path-insecure-links-daemon pass
 operator-path-insecure-links-refused pass
-operator-path-link-dest fail
+operator-path-link-dest pass
 operator-path-log-file pass
 operator-path-partial-dir fail
 operator-path-partial-dir-daemon fail


### PR DESCRIPTION
## What

Routes the local-copy alt-dest basis lookup onto the ownership walk, mirroring upstream's `basis_link_stat()`.

A `--link-dest` / `--copy-dest` / `--compare-dest` argument is an operator-supplied path, so it may legitimately point outside the transfer tree and location cannot be the trust signal. Upstream makes **authority** the signal instead — `generator.c:962 basis_link_stat()`:

```c
if (!am_daemon && am_root >= 0 && !symlink_optout_allowed()) {
    int dfd = owner_walk_parent(path, &leaf);
    if (dfd < 0) return -1;          /* basis looks ABSENT -> transfer normally */
    r = link_stat_at(dfd, leaf, stp, 0);
```

A symlink component owned by neither uid 0 nor our euid is refused, and every one of its four call sites (`generator.c:1084`, `:1110`, `:1227`, `:1254`) turns the `-1` into a `continue` — so a redirected basis simply looks absent and the file transfers normally.

The local-copy engine resolved its basis candidates with a plain `fs::symlink_metadata` at all four of its matching sites. An unprivileged user who controls a directory anywhere along the basis path could swap a component for a symlink and redirect the stat — and then the hard link, the copy, or the `--compare-dest` skip — at a file of their choosing.

## Measured

Real upstream 3.5.0 vs `oc-rsync`, run as root on Linux, parent symlink owned by uid 65534, basis byte-identical to the source. `--link-dest`:

| basis matches src | fixture | upstream 3.5.0 | oc (before) |
|---|---|---|---|
| yes | euid-owned link | nlink=**2** (follows, links) | nlink=**2** |
| yes | foreign-owned link | nlink=**1** (refuses, transfers fresh) | nlink=**2** (followed and hard-linked) |
| no | euid-owned link | nlink=1 | nlink=1 |
| no | foreign-owned link | nlink=1 | nlink=1 |

The `euid-owned` row is the control that validates the instrument in both directions. `--compare-dest` showed the same class: oc skipped the file (destination left stale) where upstream transferred it. The non-matching-basis rows transfer on both impls, which is what rules out "wrong fallback on an unreadable basis" and leaves "followed the link".

## Shape

The receiver already carried a complete port of this rule (`crates/transfer/src/receiver/quick_check.rs::basis_stat`, from #7421). The local-copy path is its unhardened twin. Rather than copy it:

- the mechanism moves into `fast_io::operator_symlink_metadata` (parent via `owner_trusted_parent`, leaf via `fstatat_nofollow`, plus the `(dev, ino)` cross-check that makes the returned `std::fs::Metadata` safe to carry),
- the receiver's `BasisTrust::OwnerWalk` arm delegates to it,
- the engine's four sites call it through one private `basis_stat`.

Local copy is never a daemon worker, so it has no analogue of upstream's `am_daemon` plain-stat fall-through (`generator.c:1010`) — stated in the doc comment rather than left implicit.

## Tests, and what they do *not* prove

Three new `fast_io` cells pin the contract: a **leaf** symlink reports as a symlink (so the `is_file()` filter drops it, which is what stops a symlinked basis entry being hard-linked), a euid-owned **parent** component is still followed, and a missing leaf is an error rather than a silent empty result.

⚠ Stated plainly: these three do **not** discriminate the ownership walk from a plain path stat. Mutating `operator_symlink_metadata` back to `fs::symlink_metadata` leaves all three green — the mutation kills nothing. The discriminating fixture needs a symlink owned by a foreign uid, which needs root; that is the same reason upstream marks its own matching cells root-only. The discriminating coverage is therefore the root testsuite leg's `operator-path-*-dest` cells, not a unit test, and the measured table above is the cross-implementation evidence.

The follow-direction cells are still load-bearing: they are what a careless "confine it, refuse every symlink" change would break, and that over-refusal is the most likely regression a future edit introduces here.

## Residuals (filed, not claimed as covered)

- Upstream additionally wraps `hard_link_one` in `operator_path_resolve = 1` (`generator.c:1120-1133`) to close the stat→link race. This change fixes the stat gate, which is the substance; the race is a separate step.
- `BasisTrust::for_receiver` branches only on `is_daemon_connection`, while upstream's predicate also carries `am_root >= 0` (`--fake-super`) and `!symlink_optout_allowed()` (`--insecure-links`). oc is therefore *stricter* than upstream in those two cells — the opposite direction, and deliberately not folded into a security fix.
