### PR TITLE
fix(engine): --compare-dest must clear a destination its basis makes redundant

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -639,66 +639,87 @@ pub(super) fn process_links(
                 // destination. Compare source against the basis with
                 // `destination_previously_existed = true` so identical files
                 // stay blank.
-                context.summary_mut().record_regular_file_matched();
-                let basis_metadata = fs::symlink_metadata(&basis).map_err(|error| {
-                    LocalCopyError::io("inspect compare-dest basis", basis.clone(), error)
-                })?;
-                let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
-                    .virtualize_fake_super(source, metadata_options.fake_super_enabled());
-                let total_bytes = Some(metadata_snapshot.len());
-                let change_set = LocalCopyChangeSet::for_file(
-                    metadata,
-                    Some(&basis_metadata),
-                    &metadata_options,
-                    true,
-                    false,
-                    {
-                        #[cfg(all(unix, feature = "xattr"))]
+                //
+                // upstream: generator.c:1115-1119 - the `find_exact_for_existing`
+                // unlink sits ABOVE the `alt_dest_type == LINK_DEST` branch, so an
+                // exact (match_level 3) basis clears a pre-existing destination for
+                // `--compare-dest` too, not only for `--link-dest`. That is the
+                // point of `--compare-dest`: the file lives in the reference tree,
+                // so the destination keeps only what differs, and leaving a
+                // redundant copy behind would defeat it. `find_exact_for_existing`
+                // is `statret == 0` at the call site (generator.c:2156) - i.e.
+                // exactly "the destination already exists".
+                //
+                // upstream: generator.c:1119 `goto got_nothing_for_ya` - a failed
+                // unlink (other than ENOENT, which `remove_existing_destination`
+                // already tolerates) abandons the basis match entirely, so the file
+                // transfers normally instead of being reported up to date over a
+                // destination that is still sitting there. Falling out of this arm
+                // without a `copy_source_override` is exactly that outcome.
+                let destination_cleared =
+                    existing_metadata.is_none() || remove_existing_destination(destination).is_ok();
+                if destination_cleared {
+                    context.summary_mut().record_regular_file_matched();
+                    let basis_metadata = fs::symlink_metadata(&basis).map_err(|error| {
+                        LocalCopyError::io("inspect compare-dest basis", basis.clone(), error)
+                    })?;
+                    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+                        .virtualize_fake_super(source, metadata_options.fake_super_enabled());
+                    let total_bytes = Some(metadata_snapshot.len());
+                    let change_set = LocalCopyChangeSet::for_file(
+                        metadata,
+                        Some(&basis_metadata),
+                        &metadata_options,
+                        true,
+                        false,
                         {
-                            preserve_xattrs
-                        }
-                        #[cfg(not(all(unix, feature = "xattr")))]
+                            #[cfg(all(unix, feature = "xattr"))]
+                            {
+                                preserve_xattrs
+                            }
+                            #[cfg(not(all(unix, feature = "xattr")))]
+                            {
+                                false
+                            }
+                        },
                         {
-                            false
-                        }
-                    },
-                    {
-                        #[cfg(all(any(unix, windows), feature = "acl"))]
-                        {
-                            preserve_acls
-                        }
-                        #[cfg(not(all(any(unix, windows), feature = "acl")))]
-                        {
-                            false
-                        }
-                    },
-                    context.options().modify_window(),
-                );
-                context.record(
-                    LocalCopyRecord::new(
-                        record_path.to_path_buf(),
-                        LocalCopyAction::MetadataReused,
-                        0,
-                        total_bytes,
-                        Duration::default(),
-                        Some(metadata_snapshot),
-                    )
-                    .with_change_set(change_set),
-                );
-                context.register_progress();
-                remove_source_entry_if_requested(
-                    context,
-                    source,
-                    destination,
-                    metadata,
-                    Some(record_path),
-                    file_type,
-                )?;
-                return Ok(LinkOutcome {
-                    copy_source_override: None,
-                    reference_basis: None,
-                    completed: true,
-                });
+                            #[cfg(all(any(unix, windows), feature = "acl"))]
+                            {
+                                preserve_acls
+                            }
+                            #[cfg(not(all(any(unix, windows), feature = "acl")))]
+                            {
+                                false
+                            }
+                        },
+                        context.options().modify_window(),
+                    );
+                    context.record(
+                        LocalCopyRecord::new(
+                            record_path.to_path_buf(),
+                            LocalCopyAction::MetadataReused,
+                            0,
+                            total_bytes,
+                            Duration::default(),
+                            Some(metadata_snapshot),
+                        )
+                        .with_change_set(change_set),
+                    );
+                    context.register_progress();
+                    remove_source_entry_if_requested(
+                        context,
+                        source,
+                        destination,
+                        metadata,
+                        Some(record_path),
+                        file_type,
+                    )?;
+                    return Ok(LinkOutcome {
+                        copy_source_override: None,
+                        reference_basis: None,
+                        completed: true,
+                    });
+                }
             }
             ReferenceDecision::Copy(path) => {
                 // upstream: generator.c:1033-1039 - copy_altdest_file() copies

--- a/crates/engine/src/local_copy/tests/execute_compare_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_compare_dest.rs
@@ -43,6 +43,119 @@ fn compare_dest_skips_identical_file() {
     assert_eq!(summary.regular_files_matched(), 1);
 }
 
+/// A destination that an exact `--compare-dest` basis makes redundant is
+/// REMOVED, not left sitting there stale.
+///
+/// upstream: generator.c:1115-1119 - the `find_exact_for_existing` unlink sits
+/// ABOVE the `alt_dest_type == LINK_DEST` branch, so a match_level-3 basis clears
+/// a pre-existing destination for `--compare-dest` as well. That is the option's
+/// whole point: the file lives in the reference tree, so the destination keeps
+/// only what differs. `find_exact_for_existing` is `statret == 0` at the call
+/// site (generator.c:2156) - exactly "the destination already exists".
+///
+/// The companion below is what makes this non-vacuous: it pins that the removal
+/// follows from an EXACT basis match rather than from the destination merely
+/// existing.
+#[test]
+fn compare_dest_removes_a_redundant_existing_destination() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let compare_dir = temp.path().join("compare");
+    let dest_dir = temp.path().join("dest");
+
+    fs::create_dir_all(&source_dir).expect("create source");
+    fs::create_dir_all(&compare_dir).expect("create compare");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+
+    let source_file = source_dir.join("file.txt");
+    let compare_file = compare_dir.join("file.txt");
+    let dest_file = dest_dir.join("file.txt");
+
+    fs::write(&source_file, b"identical content").expect("write source");
+    fs::write(&compare_file, b"identical content").expect("write compare");
+    // Differs in length from the source, so a stale leftover is unmistakable.
+    fs::write(&dest_file, b"stale destination payload").expect("write dest");
+
+    let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
+    set_file_mtime(&source_file, timestamp).expect("set source mtime");
+    set_file_mtime(&compare_file, timestamp).expect("set compare mtime");
+
+    let operands = vec![
+        source_file.into_os_string(),
+        dest_file.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .times(true)
+        .push_reference_directory(ReferenceDirectory::new(
+            ReferenceDirectoryKind::Compare,
+            &compare_dir,
+        ));
+
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("execution succeeds");
+
+    assert!(
+        !dest_file.exists(),
+        "an exact compare-dest basis must clear the redundant destination, \
+         but it was left behind"
+    );
+    assert_eq!(summary.files_copied(), 0);
+    assert_eq!(summary.regular_files_matched(), 1);
+}
+
+/// Non-vacuity companion for the pin above: the destination is cleared because
+/// the basis is an EXACT match, not merely because it exists. With a basis whose
+/// contents differ from the source, the same fixture must transfer the file and
+/// leave a destination in place.
+#[test]
+fn compare_dest_keeps_a_destination_whose_basis_differs() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let compare_dir = temp.path().join("compare");
+    let dest_dir = temp.path().join("dest");
+
+    fs::create_dir_all(&source_dir).expect("create source");
+    fs::create_dir_all(&compare_dir).expect("create compare");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+
+    let source_file = source_dir.join("file.txt");
+    let compare_file = compare_dir.join("file.txt");
+    let dest_file = dest_dir.join("file.txt");
+
+    fs::write(&source_file, b"identical content").expect("write source");
+    fs::write(&compare_file, b"a wholly different basis").expect("write compare");
+    fs::write(&dest_file, b"stale destination payload").expect("write dest");
+
+    let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
+    set_file_mtime(&source_file, timestamp).expect("set source mtime");
+    set_file_mtime(&compare_file, timestamp).expect("set compare mtime");
+
+    let operands = vec![
+        source_file.into_os_string(),
+        dest_file.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .times(true)
+        .push_reference_directory(ReferenceDirectory::new(
+            ReferenceDirectoryKind::Compare,
+            &compare_dir,
+        ));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("execution succeeds");
+
+    assert_eq!(
+        fs::read(&dest_file).expect("destination still present"),
+        b"identical content",
+        "a non-matching basis must transfer the source, not clear the destination"
+    );
+}
+
 #[test]
 fn compare_dest_transfers_different_file() {
     let temp = tempdir().expect("tempdir");


### PR DESCRIPTION
> ## ⚠ MERGE ORDER CONSTRAINT — do not merge this before #7463
>
> **Measured on Linux as root against real upstream 3.5.0.** With a matching basis reached through a **foreign-uid parent symlink**:
>
> | | upstream 3.5.0 | this PR **alone** | #7463 + this PR |
> |---|---|---|---|
> | destination after run | SOURCE (transferred) | **absent (removed)** | SOURCE ✅ |
>
> On master the foreign-uid symlink is still *followed* (the confinement gap #7463 closes), so the basis matches, this PR's unlink fires, and the destination is **destroyed** — strictly worse than the stale file it replaces. Upstream refuses the symlink, sees no basis, and transfers.
>
> With #7463 merged the basis correctly looks absent, no match occurs, and the row returns to upstream's answer. Merged together the full alt-dest matrix is **12/12 identical to upstream 3.5.0** (`--compare-dest` / `--copy-dest` / `--link-dest` x matching/non-matching basis x euid-owned/foreign-uid symlink).
>
> Held as a draft until #7463 lands, then rebased onto master.

## What

`--compare-dest` did not clear a destination that its basis makes redundant, leaving a stale file where upstream removes it.

Upstream places the `find_exact_for_existing` unlink **above** the `alt_dest_type == LINK_DEST` branch, so it is shared by `--compare-dest` (`generator.c:1114-1119`):

```c
if (match_level == 3 && alt_dest_type != COPY_DEST) {
    if (find_exact_for_existing) {
        if (alt_dest_type == LINK_DEST && real_st.st_dev == sxp->st.st_dev
                                       && real_st.st_ino == sxp->st.st_ino)
            return -1;
        if (do_unlink_at(fname) < 0 && errno != ENOENT)
            goto got_nothing_for_ya;
    }
```

`find_exact_for_existing` is `statret == 0` at the call site (`generator.c:2156`) — exactly "the destination already exists". That is the point of `--compare-dest`: the file lives in the reference tree, so the destination keeps only what differs from it; a redundant copy left behind defeats the option.

oc had the removal in the `ReferenceDecision::Link` arm only.

## Measured

Real upstream 3.5.0 vs `oc-rsync`, matching basis + pre-existing destination, no symlinks involved:

| | upstream 3.5.0 | oc (before) |
|---|---|---|
| destination after run | **absent** | **stale** (old contents) |

Every other cell of the alt-dest matrix (`--copy-dest`, `--link-dest`, and all non-matching-basis rows) already agreed.

## Failure handling

A failed unlink is not fatal. Upstream's `goto got_nothing_for_ya` restores the real destination stat and returns `-1`, abandoning the basis match so the file transfers normally. Falling out of the arm without a `copy_source_override` is exactly that outcome. `remove_existing_destination` already tolerates `NotFound`, matching upstream's `errno != ENOENT`.

## Tests

- `compare_dest_removes_a_redundant_existing_destination` — the pin.
- `compare_dest_keeps_a_destination_whose_basis_differs` — the non-vacuity companion, pinning that the removal follows from an **exact basis match** rather than from the destination merely existing. Without it, a mutation that unconditionally unlinks would pass.

**RED proven** by reverting the predicate to the pre-fix behaviour: only the pin fails (`an exact compare-dest basis must clear the redundant destination, but it was left behind`); the companion and the other 19 compare-dest cells stay green.

Unlike the sibling confinement work, this fixture needs no root, so the discriminating coverage rides the ordinary `nextest` contexts.

fmt + clippy clean; `-p engine` 5024/5024; workspace-wide alt-dest sweep (`compare_dest|copy_dest|link_dest|reference|uptodate`) 375/375 including the root-level `tests/` cells that a per-crate run would miss.

## Deliberately not ported

Upstream's `LINK_DEST` same-inode short-circuit (`generator.c:1116-1117`, "the destination is already this inode, leave it alone") is a separate decision on a different arm and is unmeasured here.
