### PR TITLE
fix(daemon): frame a post-OK client-argument rejection as a multiplex error

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -144,6 +144,7 @@ fn build_server_config(
     ctx: &mut ModuleRequestContext<'_>,
     client_args: &[String],
     module: &ModuleRuntime,
+    protocol_version: Option<ProtocolVersion>,
 ) -> io::Result<Option<ServerConfig>> {
     let role = determine_server_role(client_args);
 
@@ -227,8 +228,16 @@ fn build_server_config(
                     let message = rsync_warning!(log_text).with_role(Role::Daemon);
                     log_message(log, &message);
                 }
+                // `@RSYNCD: OK` is already on the wire, so the client is
+                // reading multiplexed frames; the rejection has to travel as
+                // one. upstream: clientserver.c:1229-1266.
                 let error = AtError::message(error_text);
-                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
+                handle_client_arg_rejection_post_handshake(
+                    ctx,
+                    &error.line(),
+                    protocol_version,
+                    client_args,
+                )?;
                 return Ok(None);
             }
 

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -352,6 +352,40 @@ fn handle_access_denied_post_handshake(
     )
 }
 
+/// Rejects a post-`@RSYNCD: OK` client-argument parse failure through the
+/// multiplexed error path.
+///
+/// upstream: clientserver.c:1258-1266 - when `parse_arguments()` returns 0 (or
+/// leaves a deferred `err_msg`), `rsync_module()` runs `option_error()`, which
+/// emits the parser's own `err_buf` text over `FERROR`
+/// (options.c:915 `rprintf(FERROR, RSYNC_NAME ": %s", err_buf)`), and then
+/// `exit_cleanup(RERR_UNSUPPORTED)`. Both writes happen *after* the
+/// `setup_protocol()` + `io_start_multiplex_out()` pair at
+/// clientserver.c:1229-1251, which upstream performs precisely so "we can get
+/// the error back to the client".
+///
+/// Delivering this rejection with [`send_error`] instead put raw `@ERROR:`
+/// text on a stream the client had already switched to multiplex input,
+/// leaving it to decode the plaintext as a frame header: the daemon's
+/// diagnostic was replaced on the client by
+/// `unknown multiplexed message code 38` (the `-` of `--max-size` at the tag
+/// position, minus `MPLEX_BASE = 7`), so the operator never learned which
+/// option was rejected.
+fn handle_client_arg_rejection_post_handshake(
+    ctx: &mut ModuleRequestContext<'_>,
+    payload: &str,
+    protocol_version: Option<ProtocolVersion>,
+    client_args: &[String],
+) -> io::Result<()> {
+    finalize_post_ok_protocol_for_error(ctx, protocol_version, client_args)?;
+    send_multiplexed_error_and_exit(
+        ctx.reader.get_mut(),
+        ctx.limiter,
+        payload,
+        RERR_UNSUPPORTED_EXIT_CODE,
+    )
+}
+
 /// Mirrors the prefix of upstream's `setup_protocol(f_out, f_in)` that the
 /// daemon writes before turning on `io_start_multiplex_out()` for an error
 /// it needs to deliver after `@RSYNCD: OK`.

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -461,7 +461,12 @@ fn process_approved_module(
         module
     };
 
-    let mut config = match build_server_config(ctx, &client_args, config_module)? {
+    let mut config = match build_server_config(
+        ctx,
+        &client_args,
+        config_module,
+        negotiated_protocol,
+    )? {
         Some(cfg) => cfg,
         None => {
             // upstream: clientserver.c - config assembly runs after the

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -216,6 +216,7 @@ include!("tests/chunks/run_daemon_lists_modules_with_module_timeout.rs");
 include!("tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs");
 include!("tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs");
 include!("tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs");
+include!("tests/chunks/run_daemon_post_ok_bad_option_value_uses_multiplexed_error.rs");
 include!("tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs");
 include!("tests/chunks/run_daemon_records_log_file_entries.rs");
 include!("tests/chunks/run_daemon_refuses_disallowed_module_options.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_post_ok_bad_option_value_uses_multiplexed_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_post_ok_bad_option_value_uses_multiplexed_error.rs
@@ -1,0 +1,161 @@
+/// Regression test for the post-`@RSYNCD: OK` client-argument parse failure.
+///
+/// upstream: clientserver.c:1258-1266 - `parse_arguments()` returning 0 sends
+/// the parser's own `err_buf` text through `option_error()`
+/// (options.c:915 `rprintf(FERROR, ...)`) and then
+/// `exit_cleanup(RERR_UNSUPPORTED)`. Both run *after* the
+/// `setup_protocol()` + `io_start_multiplex_out()` pair at
+/// clientserver.c:1229-1251, which upstream performs precisely so it "can get
+/// the error back to the client".
+///
+/// oc delivered this one rejection with the pre-handshake raw `@ERROR:` writer
+/// while its two sibling post-OK refusals (refused options, read-only access)
+/// already used the multiplexed path. The client had switched to multiplex
+/// input at `@RSYNCD: OK`, so it decoded the plaintext as a frame header and
+/// aborted with `unknown multiplexed message code 38` - the `-` of
+/// `--max-size` landing at the tag position, minus `MPLEX_BASE = 7`. The
+/// operator never learned which option was rejected. Pinning the byte stream
+/// here keeps the three post-OK refusals on one framing.
+#[test]
+fn run_daemon_post_ok_bad_option_value_uses_multiplexed_error() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (port, held_listener) = allocate_test_port();
+
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(file, "[sizemod]\npath = {module_path}\nread only = yes\n").expect("write config");
+
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--config"),
+            file.path().as_os_str().to_os_string(),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert!(line.starts_with("@RSYNCD:"), "greeting mismatch: {line:?}");
+
+    stream
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
+        .expect("send handshake response");
+    stream.flush().expect("flush handshake response");
+
+    stream
+        .write_all(b"sizemod\n")
+        .expect("send module request");
+    stream.flush().expect("flush module request");
+
+    loop {
+        line.clear();
+        reader.read_line(&mut line).expect("daemon response line");
+        if line.trim_end() == "@RSYNCD: OK" {
+            break;
+        }
+        if line.starts_with("@ERROR:") {
+            panic!("daemon refused module before post-OK handoff: {line:?}");
+        }
+    }
+
+    // A value far wider than any size the parser can represent. The client
+    // never sends this itself - it parses --max-size locally and would reject
+    // it first - so upstream's testsuite forwards it with `-M` and so does
+    // this pin, exercising the daemon's own option parser.
+    let oversized = "9".repeat(5000);
+    let max_size_arg = format!("--max-size={oversized}");
+    let post_ok_args: &[&str] = &["--server", "--sender", "-logDtpre.LsfxCIvu", &max_size_arg];
+    for arg in post_ok_args {
+        stream.write_all(arg.as_bytes()).expect("write client arg");
+        stream.write_all(&[0]).expect("write arg terminator");
+    }
+    for arg in [".", "sizemod/"] {
+        stream.write_all(arg.as_bytes()).expect("write operand");
+        stream.write_all(&[0]).expect("write operand terminator");
+    }
+    stream.write_all(&[0]).expect("terminate args list");
+    stream.flush().expect("flush client args");
+
+    // The post-OK `setup_protocol()` prefix: compat-flags varint then the
+    // 4-byte checksum seed. Without these the client would consume the first
+    // error-frame bytes in their place.
+    let compat_flags =
+        protocol::read_varint(&mut reader).expect("read compat-flags varint after @RSYNCD: OK");
+    assert!(
+        compat_flags > 0,
+        "daemon must advertise at least one compat flag, got {compat_flags}",
+    );
+    let mut seed_buf = [0u8; 4];
+    reader
+        .read_exact(&mut seed_buf)
+        .expect("read checksum seed");
+
+    let mut err_header = [0u8; 4];
+    reader
+        .read_exact(&mut err_header)
+        .expect("read MSG_ERROR_XFER header");
+    let err_raw = u32::from_le_bytes(err_header);
+    let err_tag = (err_raw >> 24) as u8;
+    let err_len = (err_raw & 0x00FF_FFFF) as usize;
+    assert_eq!(
+        err_tag,
+        protocol::MPLEX_BASE + protocol::MessageCode::ErrorXfer.as_u8(),
+        "post-OK option-value rejection must use MSG_ERROR_XFER (tag = MPLEX_BASE + 1 = 8); \
+         got raw tag {err_tag}, which is what surfaces on the client as \
+         `unknown multiplexed message code {}`",
+        err_tag.wrapping_sub(protocol::MPLEX_BASE),
+    );
+
+    let mut err_body = vec![0u8; err_len];
+    reader
+        .read_exact(&mut err_body)
+        .expect("read MSG_ERROR_XFER payload");
+    let err_text = String::from_utf8(err_body).expect("UTF-8 error payload");
+    // Upstream echoes the rejected value back verbatim (options.c:1254
+    // `"--%s=%s is %s"`), which is what lets an operator see which option was
+    // refused. Assert on the value, not just the option name.
+    assert!(
+        err_text.contains(&oversized),
+        "error payload must echo the rejected value back to the client: {err_text:?}",
+    );
+
+    let mut exit_header = [0u8; 4];
+    reader
+        .read_exact(&mut exit_header)
+        .expect("read MSG_ERROR_EXIT header");
+    let exit_raw = u32::from_le_bytes(exit_header);
+    let exit_tag = (exit_raw >> 24) as u8;
+    let exit_len = (exit_raw & 0x00FF_FFFF) as usize;
+    assert_eq!(
+        exit_tag,
+        protocol::MPLEX_BASE + protocol::MessageCode::ErrorExit.as_u8(),
+        "post-OK option-value rejection must use MSG_ERROR_EXIT (tag = MPLEX_BASE + 86 = 93)",
+    );
+    assert_eq!(exit_len, 4, "MSG_ERROR_EXIT payload must carry an i32");
+    let mut exit_buf = [0u8; 4];
+    reader
+        .read_exact(&mut exit_buf)
+        .expect("read MSG_ERROR_EXIT payload");
+    assert_eq!(
+        i32::from_le_bytes(exit_buf),
+        crate::daemon::RERR_UNSUPPORTED_EXIT_CODE,
+        "upstream exits RERR_UNSUPPORTED after option_error() (clientserver.c:1266)",
+    );
+
+    drop(reader);
+    let _ = stream.shutdown(std::net::Shutdown::Both);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok(), "daemon thread returned: {result:?}");
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -75,7 +75,7 @@ daemon-refuse-delete-alias pass
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass
 daemon-secrets-file-symlink skip
-daemon-size-arg-overflow fail
+daemon-size-arg-overflow pass
 daemon-standalone-detach fail
 daemon-strict-modes-matrix pass
 daemon-subdir-climb-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -114,7 +114,7 @@ daemon-refuse-delete-alias pass
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass
 daemon-secrets-file-symlink skip
-daemon-size-arg-overflow fail
+daemon-size-arg-overflow pass
 daemon-standalone-detach skip
 daemon-strict-modes-matrix fail
 daemon-subdir-climb-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -75,7 +75,7 @@ daemon-refuse-delete-alias pass
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass
 daemon-secrets-file-symlink pass
-daemon-size-arg-overflow fail
+daemon-size-arg-overflow pass
 daemon-standalone-detach fail
 daemon-strict-modes-matrix pass
 daemon-subdir-climb-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -114,7 +114,7 @@ daemon-refuse-delete-alias pass
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass
 daemon-secrets-file-symlink pass
-daemon-size-arg-overflow fail
+daemon-size-arg-overflow pass
 daemon-standalone-detach skip
 daemon-strict-modes-matrix fail
 daemon-subdir-climb-symlink pass


### PR DESCRIPTION
## Problem

`daemon-size-arg-overflow` fails on all four upstream 3.5.0 testsuite legs. Measured on macOS, upstream control first:

| cell | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| pipe | PASS | FAIL | PASS |
| TCP (`--use-tcp`) | PASS | FAIL | PASS |

The client saw:

```
oc-rsync error: transfer failed: unknown multiplexed message code 38 (code 23)
```

## Root cause — framing, not parsing

The daemon **did** reject the oversized value and **did** log it:

```
oc-rsync warning: module 'mod': --max-size=999… is too large [daemon=0.6.4]
```

but delivered it to the client with `send_error`, the **pre-handshake** raw `@ERROR:` writer. `@RSYNCD: OK` had already gone out, so the client was decoding multiplexed frames and read the plaintext as a frame header — the `-` of `--max-size` landing at the tag position, minus `MPLEX_BASE = 7`, giving 38. The operator never learned which option was rejected.

`request.rs` already documents this exact trap, and oc's two *other* post-OK refusals (refused options, read-only access) already go through the multiplexed path. This rejection was simply never routed onto it.

upstream `clientserver.c:1258-1266` runs `option_error()` (which writes `err_buf` over `FERROR`, `options.c:915`) and then `exit_cleanup(RERR_UNSUPPORTED)` — both **after** the `setup_protocol()` + `io_start_multiplex_out()` pair at `clientserver.c:1229-1251`, which upstream performs precisely so it "can get the error back to the client".

## Fix

Route the rejection onto the existing `finalize_post_ok_protocol_for_error` + `send_multiplexed_error_and_exit` pair, alongside its two siblings. `build_server_config` takes the negotiated protocol so it can complete the post-OK prefix; the delivery helper sits next to the two it mirrors.

## Loudly: the filed CVE shape does not exist in oc

Upstream's `daemon-size-arg-overflow` guards an out-of-bounds `.bss` write in `parse_size_arg()`: C99 `snprintf` returns what it *would* have written, so `err_buf[len] = '\n'` could land thousands of bytes past a 200-byte buffer. 3.5.0's fix is the clamp at `options.c:1260-1261`.

**oc has no analogue to port** — its error text is an owned `String`. oc's wording already matches upstream's `--%s=%s is %s` shape (`options.c:1254`). The cell failed for a completely unrelated reason, and a shape-faithful port of the clamp would have been inert.

## Verification

- **Upstream control first** on both transports: PASS/PASS.
- **RED proven by mutation**: restoring `send_error` at the one call site reproduces the original failure verbatim, including `unknown multiplexed message code 38`.
- **Rust pin added** (the testsuite cell does not ride nextest): `run_daemon_post_ok_bad_option_value_uses_multiplexed_error` asserts the wire bytes — compat-flags varint, checksum seed, `MSG_ERROR_XFER` tag, the rejected value echoed back in the payload, `MSG_ERROR_EXIT` carrying `RERR_UNSUPPORTED`. It asserts on the **value**, not just the option name, because echoing the value back is what makes the diagnostic useful. 2/2 with its sibling.
- Manifest rows flipped in the same commit, all four legs; row counts unchanged at 345 / 345 / 155 / 155.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` both exit 0.

⚠ The two **root** manifest rows are flipped on mechanism, not direct measurement — this cell has no root-specific behaviour and both nonroot transports were measured. The root legs in CI are the judge.
