### PR TITLE
fix(daemon): clamp a client's alt-dest basis instead of dropping it silently

### DIFF
--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -122,7 +122,7 @@ pub use self::module_list::{
 };
 pub use self::outcome::ClientOutcome;
 pub use self::progress::{ClientProgressObserver, ClientProgressUpdate};
-pub use self::run::alt_basis::check_alt_basis_dirs;
+pub use self::run::alt_basis::{check_alt_basis_dir_at, check_alt_basis_dirs};
 pub use self::run::{run_client, run_client_with_observer};
 pub use self::summary::{
     ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind, ClientSummary,

--- a/crates/core/src/client/run/alt_basis.rs
+++ b/crates/core/src/client/run/alt_basis.rs
@@ -150,20 +150,41 @@ pub fn check_alt_basis_dirs(references: &[ReferenceDirectory], destination: &Pat
     for reference in references {
         let basis = strip_one_trailing_separator(&reference.path);
         let resolved = resolve_against_destination(&basis, destination);
-        let option = alt_dest_opt(reference.kind);
+        check_alt_basis_dir_at(reference.kind, &resolved, &resolved);
+    }
+}
 
-        // `warn_log!` expands to a statement (it ends in `;`), so each arm keeps
-        // it in statement position. Calling it directly as an arm value puts a
-        // trailing-semicolon macro in expression position, which newer compilers
-        // reject outright - and every other caller in the tree does it this way.
-        match fs::metadata(&resolved) {
-            Ok(metadata) if metadata.is_dir() => {}
-            Ok(_) => {
-                warn_log!("{option} arg is not a dir: {}", resolved.display());
-            }
-            Err(_) => {
-                warn_log!("{option} arg does not exist: {}", resolved.display());
-            }
+/// Warns about ONE basis directory, given the path to stat and the spelling to
+/// print.
+///
+/// Split out because the two are not always the same string. A daemon receiver
+/// has `sanitize_paths` set (`clientserver.c:1068`), so `main.c:885`'s
+/// `if (*bdir != '/' && (dry_run > 1 || !sanitize_paths))` skips the join onto
+/// `curr_dir` and upstream stats and prints the *sanitized* value: relative for
+/// a relative arg (`--link-dest arg does not exist: sibling`), absolute for an
+/// absolute one, because `util1.c:1145-1152` re-roots an absolute arg at
+/// `module_dir` inside the sanitize itself. Upstream can stat that relative
+/// name because it chdir'd into the destination; oc does not, so the caller
+/// supplies the absolute equivalent to stat and keeps upstream's spelling to
+/// print.
+///
+/// Path resolution therefore belongs to the caller, which knows its own
+/// anchoring rules; what is shared - and what must not be duplicated - is the
+/// choice between the two diagnostics and their exact wording.
+pub fn check_alt_basis_dir_at(kind: ReferenceDirectoryKind, stat_path: &Path, reported: &Path) {
+    let option = alt_dest_opt(kind);
+
+    // `warn_log!` expands to a statement (it ends in `;`), so each arm keeps
+    // it in statement position. Calling it directly as an arm value puts a
+    // trailing-semicolon macro in expression position, which newer compilers
+    // reject outright - and every other caller in the tree does it this way.
+    match fs::metadata(stat_path) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => {
+            warn_log!("{option} arg is not a dir: {}", reported.display());
+        }
+        Err(_) => {
+            warn_log!("{option} arg does not exist: {}", reported.display());
         }
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -479,80 +479,133 @@ fn glob_match_segment(pattern: &str, name: &str) -> bool {
     go(pat, s)
 }
 
-/// Collapses `.` and `..` segments lexically without touching the filesystem.
+/// Collapses `.` and `..` in a module-relative tail, the `Path`-typed
+/// counterpart of [`collapse_module_relative`].
 ///
-/// Used to fold a relative basis path like `mod/00/../01` into `mod/01` before
-/// the module-root containment check runs. Pure path arithmetic: no syscalls,
-/// no canonicalisation, so the result is well-defined even when the resolved
-/// directory does not exist yet (a `--link-dest` basis is allowed to be
-/// missing without aborting the transfer).
+/// Same rule, same anchor: upstream's `sanitize_path()` runs at **depth 0** for
+/// a daemon connection, so `util1.c:1183`'s `if (depth <= 0 || sanp != start)`
+/// arm always wins - a `..` either backs up over one already-emitted component
+/// or, with nothing to back up over, is discarded. There is no arm that
+/// refuses. The output is therefore closed under the module root by
+/// construction, which is what lets the caller join it onto the root without a
+/// separate containment check.
 ///
-/// `..` at the head of an otherwise relative path is preserved verbatim so a
-/// climb that escapes the join base survives into the caller's `starts_with`
-/// check, which then rejects the basis as out-of-module.
-fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf {
+/// Two functions rather than one because the inputs differ in type and
+/// separator policy: [`collapse_module_relative`] walks a `/`-separated wire
+/// string, this one walks OS `Path` components so a non-UTF-8 basis keeps its
+/// bytes. Both implement the identical upstream rule.
+///
+/// Pure path arithmetic: no syscalls, no canonicalisation, so the result is
+/// well-defined even when the resolved directory does not exist yet (a
+/// `--link-dest` basis is allowed to be missing without aborting the transfer).
+fn collapse_under_root(path: &std::path::Path) -> std::path::PathBuf {
     use std::path::{Component, PathBuf};
 
     let mut out = PathBuf::new();
     for component in path.components() {
         match component {
-            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
-                out.push(component.as_os_str());
-            }
-            Component::CurDir => {}
+            Component::Normal(name) => out.push(name),
+            // A tail is module-relative by construction; a root or drive
+            // prefix carries no meaning under the module and is dropped the
+            // way upstream drops the leading `/` at `util1.c:1151` (`p++`).
+            Component::Prefix(_) | Component::RootDir | Component::CurDir => {}
             Component::ParentDir => {
-                let popped = out.pop();
-                if !popped {
-                    // Nothing to pop; preserve the `..` so the caller's
-                    // `starts_with(module_root)` check rejects the escape.
-                    out.push("..");
-                }
+                out.pop();
             }
         }
-    }
-    if out.as_os_str().is_empty() {
-        out.push(".");
     }
     out
 }
 
-/// Resolves a client-supplied alt-basis path (`--link-dest` / `--copy-dest` /
-/// `--compare-dest`) against the receiver's resolve base and confines the
-/// result inside the module root.
+/// Clamps a client-supplied alt-basis path (`--link-dest` / `--copy-dest` /
+/// `--compare-dest`) to the served module, mirroring upstream's
+/// `sanitize_path()` rewrite.
 ///
-/// Returns `Some(resolved)` when the lexically-normalised path stays inside
-/// `module_root_canonical`, and `None` when the path escapes (in which case
-/// the caller silently drops the basis so the receiver re-transfers instead
-/// of hard-linking outside the module tree).
+/// upstream: `main.c:1233-1236` - a daemon receiver passes every `basis_dir[]`
+/// through `sanitize_path(NULL, dir, NULL, curr_dir_depth, SP_DEFAULT)` before
+/// `check_alt_basis_dirs()` runs. That call **rewrites**; it never rejects. A
+/// `--link-dest=../sibling` sent against the module root becomes `sibling`,
+/// which then fails to exist and draws the `arg does not exist` warning at
+/// `main.c:901` - so the operator learns their basis was out of tree instead of
+/// silently getting a full copy. `curr_dir_depth` is the destination's depth
+/// below the module root, so a client pushing into `mod/sub/` may legitimately
+/// climb one level to `mod/sibling`; the budget is exactly "up to the module
+/// root, no further".
 ///
-/// Relative paths join under `resolve_base`; absolute paths are normalised
-/// in place. Both branches then run the same canonicalise-with-lexical-
-/// fallback containment check. The fallback is essential because a basis
-/// directory is allowed to be missing on disk - upstream `main.c:867
-/// check_alt_basis_dirs` only warns, never aborts - and we must still apply
-/// the containment policy in that case.
+/// Two arms, both upstream's:
+/// - absolute: `util1.c:1145-1152` re-roots at `module_dir` and forces
+///   `depth = 0`, so `/etc` addresses `<module>/etc`.
+/// - relative: folded onto `curr_dir` (the receiver's destination), which oc
+///   supplies explicitly as `resolve_base` because the daemon does not chdir
+///   per connection.
 ///
-/// upstream: util1.c:1138 `sanitize_path` collapses `..` against the
-/// module root depth; main.c:867 `check_alt_basis_dirs` warns (main.c:901) on
-/// out-of-tree basis. We mirror the silent-drop side of that contract
-/// instead of upstream's path-rewrite because our daemon does not chdir
-/// per connection.
-fn confine_basis_under_module(
+/// The `..` collapse in [`collapse_under_root`] is what makes the result closed
+/// under the module root, so no separate containment check is needed - and no
+/// syscall either, which matters because a basis directory is allowed to be
+/// missing on disk.
+fn clamp_basis_to_module(
     ref_path: &std::path::Path,
     resolve_base: &std::path::Path,
     module_root_canonical: &std::path::Path,
-) -> Option<std::path::PathBuf> {
-    let joined = if ref_path.is_relative() {
-        resolve_base.join(ref_path)
-    } else {
+) -> std::path::PathBuf {
+    let tail = if ref_path.is_absolute() {
         ref_path.to_path_buf()
+    } else {
+        destination_below_root(resolve_base, module_root_canonical).join(ref_path)
     };
-    let resolved = lexically_normalize(&joined);
-    let resolved_canonical = resolved
+    module_root_canonical.join(collapse_under_root(&tail))
+}
+
+/// Whether an already-clamped basis directory resolves out of the module tree
+/// through a symlink.
+///
+/// The clamp in [`clamp_basis_to_module`] is lexical, so a name that is
+/// module-relative on paper - `cd` - can still land outside once `mod/cd` turns
+/// out to be a symlink to `/outside`. That is the `alt-dest-symlink-race`
+/// attack shape: the basis becomes a read-disclosure primitive through the
+/// delta-rolling checksums.
+///
+/// upstream: `receiver.c` `secure_relative_open()` refuses this at
+/// basis-lookup time rather than at argument-parse time. oc drops the basis
+/// here so the request never reaches the receiver; the receiver then
+/// re-transfers, which is the same observable outcome as upstream refusing the
+/// open.
+///
+/// A basis is allowed to be MISSING - that is upstream's `arg does not exist`
+/// warning, not an escape - so an unresolvable path is kept, not dropped.
+fn basis_resolves_outside_module(
+    clamped: &std::path::Path,
+    module_root_canonical: &std::path::Path,
+) -> bool {
+    clamped
         .canonicalize()
-        .unwrap_or_else(|_| resolved.clone());
-    if !resolved_canonical.starts_with(module_root_canonical) {
-        return None;
+        .is_ok_and(|resolved| !resolved.starts_with(module_root_canonical))
+}
+
+/// The receiver's destination expressed relative to the module root - upstream's
+/// `curr_dir_depth`, as a path rather than a count.
+///
+/// A destination that does not sit under the root (which `resolve_receiver_dest`
+/// does not produce) degrades to the root itself, which clamps harder rather
+/// than escaping.
+fn destination_below_root(
+    resolve_base: &std::path::Path,
+    module_root_canonical: &std::path::Path,
+) -> std::path::PathBuf {
+    if let Ok(relative) = resolve_base.strip_prefix(module_root_canonical) {
+        return relative.to_path_buf();
     }
-    Some(resolved)
+    // `resolve_base` can carry an uncanonicalised spelling of the same tree
+    // when the module path is reached through a symlink, so compare canonical
+    // forms before giving up.
+    resolve_base
+        .canonicalize()
+        .ok()
+        .and_then(|canonical| {
+            canonical
+                .strip_prefix(module_root_canonical)
+                .map(std::path::Path::to_path_buf)
+                .ok()
+        })
+        .unwrap_or_default()
 }

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -250,11 +250,13 @@ fn build_server_config(
             // keep the module-root fallback so the legacy compare-dest lookup
             // path stays unchanged.
             //
-            // The resolved path is then confined inside the module root: if
-            // the lexical climb (`..`) escapes the module tree the ref_dir is
-            // silently dropped so the basis lookup falls through to a normal
-            // transfer instead of leaking files from outside the module
-            // (link-dest-module-escape security pin).
+            // The resolved path is then CLAMPED to the module root rather than
+            // dropped: upstream's `sanitize_path()` rewrites a climbing basis
+            // (`../sibling` -> `sibling`) and leaves `check_alt_basis_dirs()` to
+            // warn that the rewritten path does not exist, so the operator
+            // learns their basis was out of tree. Dropping it silently kept the
+            // same confinement but withheld the diagnostic
+            // (link-dest-module-escape security pin, daemon-link-dest-escape).
             let module_root_canonical = std::path::Path::new(&module.path)
                 .canonicalize()
                 .unwrap_or_else(|_| std::path::PathBuf::from(&module.path));
@@ -267,17 +269,52 @@ fn build_server_config(
                 std::path::PathBuf::from(&module.path)
             };
             cfg.reference_directories.retain_mut(|ref_dir| {
-                match confine_basis_under_module(
-                    &ref_dir.path,
-                    &resolve_base,
-                    &module_root_canonical,
-                ) {
-                    Some(resolved) => {
-                        ref_dir.path = resolved;
-                        true
-                    }
-                    None => false,
+                // upstream prints the SANITIZED value verbatim (main.c:885
+                // skips the `curr_dir` join under `sanitize_paths`), which is
+                // relative for a relative arg and absolute for an absolute one
+                // - `util1.c:1145-1152` re-roots the latter at `module_dir`
+                // during the sanitize itself. oc has no chdir, so it keeps the
+                // absolute form for the basis lookup and reproduces upstream's
+                // spelling only for the diagnostic.
+                let arg_was_absolute = ref_dir.path.is_absolute();
+                let clamped =
+                    clamp_basis_to_module(&ref_dir.path, &resolve_base, &module_root_canonical);
+
+                // SECOND, independent rule: the clamp is lexical, so a name
+                // that stays module-relative on paper can still resolve out of
+                // the tree through an in-module symlink - the
+                // `alt-dest-symlink-race` attack shape, where `mod/cd ->
+                // /outside` turns `--link-dest=cd` into a read-disclosure
+                // primitive. Upstream refuses that at basis-lookup time in
+                // `secure_relative_open()` (receiver.c); oc drops the basis
+                // here instead, before the request reaches the receiver.
+                //
+                // Deliberately NOT folded into the clamp: `..` is a rewrite
+                // upstream never refuses, while a symlink escape is a refusal
+                // upstream never rewrites. Collapsing them either re-opens the
+                // escape or resurrects the silent-drop the testsuite cell
+                // daemon-link-dest-escape exists to detect.
+                if basis_resolves_outside_module(&clamped, &module_root_canonical) {
+                    return false;
                 }
+
+                // upstream: main.c:1241 - the server receiver runs
+                // `check_alt_basis_dirs()` immediately after that sanitize
+                // loop. Warn-only; the exit code is untouched.
+                if role == ServerRole::Receiver {
+                    let reported = if arg_was_absolute {
+                        clamped.clone()
+                    } else {
+                        clamped
+                            .strip_prefix(&module_root_canonical)
+                            .unwrap_or(&clamped)
+                            .to_path_buf()
+                    };
+                    ::core::client::check_alt_basis_dir_at(ref_dir.kind, &clamped, &reported);
+                }
+
+                ref_dir.path = clamped;
+                true
             });
 
             // upstream: loadparm.c - `temp dir` module parameter provides a

--- a/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
@@ -309,21 +309,19 @@ mod daemon_module_suffix_tests {
 
 #[cfg(test)]
 mod daemon_clean_fname_collapse_tests {
-    use super::lexically_normalize;
+    use super::collapse_under_root;
     use std::path::{Path, PathBuf};
     use test_support::COLLAPSE_CASES;
 
     /// Every upstream `clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS)` case must
     /// collapse identically here.
     ///
-    /// `lexically_normalize` folds a client-supplied `--link-dest` /
-    /// `--copy-dest` / `--compare-dest` basis before
-    /// `confine_basis_under_module` tests it against the module root. The
-    /// containment check is a `starts_with` on the folded path, so a `..` that
-    /// fails to consume the component before it leaves a path that still
-    /// *looks* like it sits under the module while resolving elsewhere. That is
-    /// exactly the shape of upstream's off-by-one, which left the collapse dead
-    /// for every multi-component and absolute path.
+    /// `collapse_under_root` folds a client-supplied `--link-dest` /
+    /// `--copy-dest` / `--compare-dest` basis into a module-relative tail. A
+    /// `..` that fails to consume the component before it would leave a path
+    /// that still *looks* module-relative while resolving elsewhere - exactly
+    /// the shape of upstream's off-by-one, which left the collapse dead for
+    /// every multi-component and absolute path.
     ///
     /// The table is shared (`test_support::COLLAPSE_CASES`) so a new edge case
     /// is one row and reaches every oc-rsync copy of this rule at once.
@@ -331,28 +329,47 @@ mod daemon_clean_fname_collapse_tests {
     #[test]
     fn upstream_collapse_cases_consume_the_preceding_component() {
         for (input, expected) in COLLAPSE_CASES {
+            // The shared table spells its expectations for a resolver that
+            // keeps a root or a bare `.`; this one emits a module-relative
+            // tail, so strip the leading `/` and read an empty tail as `.`.
+            let want = expected.strip_prefix('/').unwrap_or(expected);
+            let want = if want == "." { "" } else { want };
             assert_eq!(
-                lexically_normalize(Path::new(input)),
-                PathBuf::from(expected),
+                collapse_under_root(Path::new(input)),
+                PathBuf::from(want),
                 "clean_fname collapse case {input:?}"
             );
         }
     }
 
-    /// A `..` with nothing left to pop survives into the result so the
-    /// caller's `starts_with(module_root)` check sees the escape and rejects
-    /// the basis. Silently swallowing it would hand the caller a path that
-    /// passes containment while naming a directory outside the module.
-    // upstream: util1.c clean_fname() - "collapse '..' elements (except at the start)"
+    /// A `..` with nothing left to pop is DISCARDED, not preserved.
+    ///
+    /// That is upstream's rule, not a shortcut: a daemon runs
+    /// `sanitize_path()` at depth 0 (`options.c:2405`, gated on
+    /// `sanitize_paths` which `clientserver.c:1068` sets for every daemon
+    /// connection), so `util1.c:1183`'s `if (depth <= 0 || sanp != start)` arm
+    /// always wins and there is no arm that refuses. Discarding is what makes
+    /// the output closed under the module root by construction, which is what
+    /// lets `clamp_basis_to_module` join it onto the root with no separate
+    /// containment check - and it is why a client's `--link-dest=../sibling`
+    /// becomes an in-module `sibling` that then draws upstream's
+    /// `arg does not exist` warning instead of being dropped in silence.
+    // upstream: util1.c:1183-1191 sanitize_path(), depth 0
     #[test]
-    fn unpoppable_leading_dot_dot_is_preserved_for_the_containment_check() {
+    fn unpoppable_leading_dot_dot_is_discarded_at_the_root() {
         assert_eq!(
-            lexically_normalize(Path::new("../outside")),
-            PathBuf::from("../outside")
+            collapse_under_root(Path::new("../outside")),
+            PathBuf::from("outside")
         );
         assert_eq!(
-            lexically_normalize(Path::new("mod/../../outside")),
-            PathBuf::from("../outside")
+            collapse_under_root(Path::new("mod/../../outside")),
+            PathBuf::from("outside")
+        );
+        // Every level of an all-`..` climb is consumed, leaving the root
+        // itself rather than any ancestor of it.
+        assert_eq!(
+            collapse_under_root(Path::new("../../..")),
+            PathBuf::from("")
         );
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2515,12 +2515,32 @@ mod module_access_tests {
         std::fs::create_dir(&in_module).expect("create in-module snap dir");
 
         let resolved = clamp_basis_to_module(&in_module, &module_root, &module_root);
-        let re_rooted = module_root.join(
-            in_module
-                .strip_prefix("/")
-                .expect("an absolute tempdir path starts at the root"),
+
+        // Asserted as OBSERVABLE PROPERTIES, not by recomputing the component
+        // walk: re-deriving the expected value with the same rule the function
+        // uses would pass for any rule at all. Spelling the root prefix by hand
+        // (`strip_prefix("/")`) is not portable either - an absolute path is
+        // `C:\...` on Windows, so that form panicked there while passing on
+        // Unix.
+        assert!(
+            resolved.starts_with(&module_root),
+            "the clamp must stay under the module root, got {resolved:?}",
         );
-        assert_eq!(resolved, re_rooted);
+        assert_ne!(
+            resolved, in_module,
+            "an absolute basis is RE-ROOTED, not passed through - that is the \
+             whole divergence this test pins",
+        );
+        assert_eq!(
+            resolved.file_name(),
+            in_module.file_name(),
+            "re-rooting preserves the components, it only moves them",
+        );
+        assert!(
+            !resolved.exists(),
+            "the re-rooted path names nothing, which is why upstream warns \
+             `arg does not exist` even though `{in_module:?}` really exists",
+        );
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2481,26 +2481,46 @@ mod module_access_tests {
         let module_root = module.path().canonicalize().expect("canonicalise module");
         let outside_root = outside.path().canonicalize().expect("canonicalise outside");
 
+        // upstream rewrites rather than refuses: util1.c:1145-1152 re-roots an
+        // absolute arg at `module_dir` with depth forced to 0, so the basis
+        // lands under the module and check_alt_basis_dirs then warns that it
+        // does not exist. The out-of-module directory is never reached.
+        let clamped = clamp_basis_to_module(&outside_root, &module_root, &module_root);
         assert!(
-            confine_basis_under_module(&outside_root, &module_root, &module_root).is_none(),
-            "absolute out-of-module basis must be dropped",
+            clamped.starts_with(&module_root),
+            "absolute out-of-module basis must be clamped under the module, got {clamped:?}",
         );
+        assert!(!clamped.exists(), "the clamped basis must not resolve to a real out-of-tree dir");
     }
 
     #[test]
-    fn confine_basis_accepts_absolute_in_module() {
-        // Companion to the drop-out-of-module pin: an absolute path that
-        // canonicalises *inside* the module root must survive so legitimate
-        // operator-permitted snapshots (e.g. `<module>/snap/01`) still
-        // hard-link instead of re-transferring.
+    fn confine_basis_re_roots_absolute_in_module_the_way_upstream_does() {
+        // An ABSOLUTE basis is re-rooted at the module unconditionally -
+        // upstream `util1.c:1145-1152` takes the `*p == '/'` branch, sets
+        // `rootdir = module_dir` and `depth = 0`, with no
+        // already-under-the-root special case. So even a path that already
+        // names an in-module directory gets the module prefix a second time
+        // and then fails to exist.
+        //
+        // MEASURED against real 3.5.0 over a daemon push, not inferred: with
+        // module `<B>/mod` and `--link-dest=<B>/mod/snap` (a directory that
+        // really exists), upstream prints
+        //   `--link-dest arg does not exist: <B>/mod<B>/mod/snap`
+        // and oc now prints the same bytes. Addressing an in-module basis
+        // from a daemon client therefore requires the RELATIVE spelling -
+        // which is what the sibling `../01` tests cover.
         let module = tempfile::TempDir::new().expect("module tempdir");
         let module_root = module.path().canonicalize().expect("canonicalise module");
         let in_module = module_root.join("snap");
         std::fs::create_dir(&in_module).expect("create in-module snap dir");
 
-        let resolved = confine_basis_under_module(&in_module, &module_root, &module_root)
-            .expect("in-module basis must be accepted");
-        assert_eq!(resolved, in_module);
+        let resolved = clamp_basis_to_module(&in_module, &module_root, &module_root);
+        let re_rooted = module_root.join(
+            in_module
+                .strip_prefix("/")
+                .expect("an absolute tempdir path starts at the root"),
+        );
+        assert_eq!(resolved, re_rooted);
     }
 
     #[test]
@@ -2518,10 +2538,12 @@ mod module_access_tests {
 
         // Lexical escape via `..` that resolves to a real sibling on disk.
         let escape = module_root.join("..").join("linkdest-ref-daemon");
+        let clamped = clamp_basis_to_module(&escape, &module_root, &module_root);
         assert!(
-            confine_basis_under_module(&escape, &module_root, &module_root).is_none(),
-            "absolute `..` escape to sibling must be dropped (was @ERROR pre-fix)",
+            clamped.starts_with(&module_root),
+            "absolute `..` escape must be clamped under the module, got {clamped:?}",
         );
+        assert_ne!(clamped, sibling, "the real sibling must never be reached");
     }
 
     #[test]
@@ -2537,12 +2559,7 @@ mod module_access_tests {
         let sibling = module_root.join("01");
         std::fs::create_dir(&sibling).expect("create sibling 01");
 
-        let resolved = confine_basis_under_module(
-            std::path::Path::new("../01"),
-            &dest,
-            &module_root,
-        )
-        .expect("relative climb to in-module sibling must be accepted");
+        let resolved = clamp_basis_to_module(std::path::Path::new("../01"), &dest, &module_root);
         // Lexically normalised: dest/../01 -> module_root/01.
         assert_eq!(resolved, module_root.join("01"));
     }
@@ -2610,9 +2627,15 @@ mod module_access_tests {
         let resolve_base = module_root.clone();
         let escape = std::path::Path::new("../etc/passwd");
 
+        // Upstream's depth-0 sanitize DISCARDS the unpoppable `..` rather than
+        // refusing, so the basis becomes the in-module `etc/passwd` - which
+        // does not exist, drawing the `arg does not exist` warning. The point
+        // is that `<module_parent>/etc/passwd` is never addressed.
+        let clamped = clamp_basis_to_module(escape, &resolve_base, &module_root);
+        assert_eq!(clamped, module_root.join("etc/passwd"));
         assert!(
-            confine_basis_under_module(escape, &resolve_base, &module_root).is_none(),
-            "--link-dest=../etc/passwd must be dropped (relative climb past module root)",
+            clamped.starts_with(&module_root),
+            "relative climb past the module root must be clamped, got {clamped:?}",
         );
     }
 
@@ -2630,12 +2653,7 @@ mod module_access_tests {
         let sibling = module_root.join("01");
         std::fs::create_dir(&sibling).expect("create sibling 01");
 
-        let resolved = confine_basis_under_module(
-            std::path::Path::new("../01"),
-            &dest,
-            &module_root,
-        )
-        .expect("relative in-module sibling basis must survive");
+        let resolved = clamp_basis_to_module(std::path::Path::new("../01"), &dest, &module_root);
         assert_eq!(resolved, module_root.join("01"));
     }
 
@@ -2667,13 +2685,15 @@ mod module_access_tests {
         // (the receiver dest for the bare-module push the upstream test
         // uses). The symlink resolution must be detected and the basis
         // dropped.
+        // The clamp is LEXICAL, so `cd` stays module-relative on paper; the
+        // separate symlink-resolution rule is what refuses it. Asserting both
+        // halves keeps a future simplification from collapsing them: a clamp
+        // alone would admit the escape.
+        let clamped =
+            clamp_basis_to_module(std::path::Path::new("cd"), &module_root, &module_root);
+        assert_eq!(clamped, trap, "the lexical clamp alone does NOT refuse this");
         assert!(
-            confine_basis_under_module(
-                std::path::Path::new("cd"),
-                &module_root,
-                &module_root,
-            )
-            .is_none(),
+            basis_resolves_outside_module(&clamped, &module_root),
             "in-module symlink whose target escapes the module must be dropped \
              (upstream alt-dest-symlink-race attack shape)",
         );
@@ -2700,10 +2720,12 @@ mod module_access_tests {
             .join("passwd");
         std::fs::write(&outside, b"root:x:0:0:root:/root:/bin/sh\n").expect("write outside file");
 
+        let clamped = clamp_basis_to_module(&outside, &module_root, &module_root);
         assert!(
-            confine_basis_under_module(&outside, &module_root, &module_root).is_none(),
-            "absolute --link-dest pointing outside the module root must be dropped",
+            clamped.starts_with(&module_root),
+            "absolute --link-dest pointing outside the module root must be clamped, got {clamped:?}",
         );
+        assert!(!clamped.exists(), "the clamped basis must not name the real outside file");
     }
 
     #[test]

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -57,7 +57,7 @@ daemon-handshake-timeout fail
 daemon-http-proxy pass
 daemon-include-maxconn pass
 daemon-leaf-type-race-fchmod skip
-daemon-link-dest-escape fail
+daemon-link-dest-escape pass
 daemon-max-alloc-zero skip
 daemon-module-chdir-symlink skip
 daemon-module-options pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -96,7 +96,7 @@ daemon-handshake-timeout skip
 daemon-http-proxy skip
 daemon-include-maxconn pass
 daemon-leaf-type-race-fchmod skip
-daemon-link-dest-escape fail
+daemon-link-dest-escape pass
 daemon-max-alloc-zero skip
 daemon-module-chdir-symlink skip
 daemon-module-options skip

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -57,7 +57,7 @@ daemon-handshake-timeout fail
 daemon-http-proxy pass
 daemon-include-maxconn fail
 daemon-leaf-type-race-fchmod skip
-daemon-link-dest-escape fail
+daemon-link-dest-escape pass
 daemon-max-alloc-zero skip
 daemon-module-chdir-symlink pass
 daemon-module-options pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -96,7 +96,7 @@ daemon-handshake-timeout skip
 daemon-http-proxy skip
 daemon-include-maxconn fail
 daemon-leaf-type-race-fchmod skip
-daemon-link-dest-escape fail
+daemon-link-dest-escape pass
 daemon-max-alloc-zero skip
 daemon-module-chdir-symlink pass
 daemon-module-options skip


### PR DESCRIPTION
Closes the `daemon-link-dest-escape` cell of the upstream 3.5.0 testsuite on all four legs.

## What was wrong

⚠ **The filed premise does not hold, and the correction matters:** oc was **not** leaking. Measured with an identical-content fixture, oc confines `--link-dest=../sibling` exactly as upstream does - the out-of-tree directory is never used as a basis, and the destination is a fresh copy, not a hard link to it.

The divergence is the **diagnostic**. Upstream's daemon receiver passes every basis dir through `sanitize_path()` and then `check_alt_basis_dirs()` (`main.c:1233-1241`). That call **rewrites**; it never rejects. `../sibling` becomes the in-module `sibling`, which does not exist, so upstream prints

```
--link-dest arg does not exist: sibling
```

oc reached the same confinement by **dropping** the entry, and never ran `check_alt_basis_dirs()` on the daemon path at all. Same security outcome, no diagnostic - the operator silently gets a full copy and never learns their basis was out of tree.

That silence is precisely what the cell detects: it treats the absence of the warning as evidence the daemon reached the real out-of-tree directory.

## The fix

**Clamp, don't drop** - both of upstream's arms:

* absolute argument: re-rooted at the module with `depth = 0` (`util1.c:1145-1152`)
* relative argument: folded onto the receiver's destination

`..` beyond the module root is **discarded, not refused**. Upstream's depth-0 `sanitize_path` has no arm that refuses (`util1.c:1183`), and discarding is what makes the result closed under the module root by construction - which is why no separate containment check is needed.

**The symlink escape is kept as a second, independent rule.** The clamp is lexical, so `--link-dest=cd` where `mod/cd -> /outside` still resolves out of tree - the `alt-dest-symlink-race` shape. Upstream refuses that in `secure_relative_open()` at basis-lookup time; oc keeps dropping it at argument-parse time. The two are deliberately **not** folded together: `..` is a rewrite upstream never refuses, a symlink escape is a refusal upstream never rewrites. Collapsing them either re-opens the escape or resurrects the silent drop.

**Reporting split from resolution.** `check_alt_basis_dir_at` now owns the stat and the choice between the two messages; callers own their own anchoring. A daemon has `sanitize_paths` set, so `main.c:885`'s join onto `curr_dir` is skipped and the sanitized value is printed verbatim - relative for a relative argument, absolute for an absolute one. That is one `if` with two arms upstream, not two different messages.

## Measured against real 3.5.0

Daemon push, five basis shapes, **5/5 byte-identical** after the fix:

| `--link-dest=` | upstream 3.5.0 | oc (after) |
|---|---|---|
| `../sibling` | `arg does not exist: sibling` | same |
| `inner` (exists) | silent | same |
| `nope` | `arg does not exist: nope` | same |
| `/etc` | `arg does not exist: <module>/etc` | same |
| `plainfile` | `arg is not a dir: plainfile` | same |

⚠ **One test changed meaning, not just its assertion.** Upstream also double-roots an *absolute in-module* basis: with module `<B>/mod` and `--link-dest=<B>/mod/snap` (a directory that really exists), upstream prints `arg does not exist: <B>/mod<B>/mod/snap`, because the `*p == '/'` branch re-roots unconditionally with no already-under-the-root special case. oc now prints the same bytes. The test that asserted such a path survives unchanged was encoding oc's old non-upstream behaviour; it now pins upstream's measured one. **Addressing an in-module basis from a daemon client requires the relative spelling** - which the sibling `../01` tests cover.

## Verification

* **RED first** with a passing upstream control: upstream `PASS`, oc `FAIL`.
* **GREEN** after the fix, re-run after the reporting refactor.
* **Mutation lethal**: suppressing only the warning call puts the cell back to `FAIL` with the leak message, while the clamp stays in place - so the cell is testing the diagnostic, not the confinement.
* 41/41 on the daemon + core basis tests; `cargo fmt --all -- --check` and workspace `clippy -D warnings` both exit 0.
* All four expect manifests flip `daemon-link-dest-escape` `fail` -> `pass` in the same commit; totals hold at 345 / 345 / 155 / 155.

## Loud flag

The manifest rows for the two **root** legs are flipped on mechanism, not on a direct root-leg measurement: the cell has no root-specific behaviour (no uid-dependent plant, no privileged syscall) and both non-root legs were measured. Calling that out rather than implying four measured legs.
