### PR TITLE
fix(daemon): gate the secrets-file mode rule on `strict modes`

### DIFF
--- a/crates/daemon/src/daemon/sections/config_helpers/secrets_validation.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/secrets_validation.rs
@@ -1,7 +1,8 @@
 /// Validates a secrets file path from a config directive.
 ///
-/// Checks that the file exists, is a regular file, and has secure permissions
-/// (0600 on Unix). Returns a [`DaemonError`] with config context on failure.
+/// Checks that the file exists and is a regular file. Returns a [`DaemonError`]
+/// with config context on failure. Permission enforcement is deliberately NOT
+/// done here - see [`ensure_secrets_file`].
 fn validate_secrets_file(
     path: &Path,
     config_path: &Path,
@@ -56,29 +57,22 @@ fn validate_secrets_file_from_env(
     Ok(Some(path.to_path_buf()))
 }
 
-/// Ensures a file has proper secrets file permissions.
+/// Ensures a configured secrets file is usable as one.
 ///
-/// Verifies the file is a regular file and (on Unix) is not other-accessible.
-/// Group access (e.g. mode 0640) is allowed, matching upstream.
+/// Only the file *type* is checked here. Mode and ownership are NOT: upstream
+/// stores the `secrets file` value verbatim at parse time and applies the
+/// permission rules in `check_secret()` (authenticate.c:168-181), gated on
+/// `lp_strict_modes(module)`. Enforcing them here would make `strict modes = no`
+/// unhonourable - the daemon would refuse the whole config instead of serving
+/// the other-accessible file the operator deliberately opted into. The single
+/// owner of that rule is `platform::secrets::check_secrets_file_permissions`,
+/// called from `verify_secret_response` behind the module's `strict_modes` flag.
 fn ensure_secrets_file(path: &Path, metadata: &fs::Metadata) -> Result<(), String> {
     if !metadata.is_file() {
         return Err(format!(
             "secrets file '{}' must be a regular file",
             path.display()
         ));
-    }
-
-    #[cfg(unix)]
-    {
-        let mode = metadata.permissions().mode();
-        // upstream: authenticate.c:120 check_secret() rejects only when OTHER
-        // has access ((st.st_mode & 06) != 0); group-readable (0640) is allowed.
-        if mode & 0o6 != 0 {
-            return Err(format!(
-                "secrets file '{}' must not be other-accessible",
-                path.display()
-            ));
-        }
     }
 
     Ok(())

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -392,7 +392,7 @@ include!("tests/chunks/runtime_options_rejects_invalid_uid.rs");
 include!("tests/chunks/runtime_options_rejects_ipv4_ipv6_combo.rs");
 include!("tests/chunks/runtime_options_rejects_missing_secrets_from_environment.rs");
 include!("tests/chunks/runtime_options_rejects_relative_path_with_chroot_enabled.rs");
-include!("tests/chunks/runtime_options_rejects_world_readable_secrets_file.rs");
+include!("tests/chunks/runtime_options_secrets_file_parse_time_modes.rs");
 include!("tests/chunks/runtime_options_require_secrets_file_with_auth_users.rs");
 include!("tests/chunks/sanitize_module_identifier_preserves_clean_input.rs");
 include!("tests/chunks/sanitize_module_identifier_replaces_control_characters.rs");

--- a/crates/daemon/src/tests/chunks/runtime_options_secrets_file_parse_time_modes.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_secrets_file_parse_time_modes.rs
@@ -1,6 +1,12 @@
+/// Config parsing stores `secrets file` without judging its mode, exactly as
+/// upstream's params.c does. The permission rules belong to `check_secret()`
+/// (authenticate.c:168-181), which applies them per-authentication behind
+/// `lp_strict_modes(module)` - see the `verify_secret_*` tests. Rejecting here
+/// would make `strict modes = no` unhonourable, because the daemon would refuse
+/// to load the config instead of serving the file the operator opted into.
 #[cfg(unix)]
 #[test]
-fn runtime_options_rejects_world_readable_secrets_file() {
+fn runtime_options_accepts_world_readable_secrets_file_at_parse_time() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempdir().expect("config dir");
@@ -19,23 +25,16 @@ fn runtime_options_rejects_world_readable_secrets_file() {
     )
     .expect("write config");
 
-    let error = RuntimeOptions::parse(&[
+    RuntimeOptions::parse(&[
         OsString::from("--config"),
         file.path().as_os_str().to_os_string(),
     ])
-    .expect_err("world-readable secrets file should error");
-
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("must not be other-accessible")
-    );
+    .expect("a world-readable secrets file must not fail config parsing");
 }
 
-/// A group-readable (0640) secrets file is accepted, matching upstream
-/// authenticate.c:120 check_secret() which rejects only OTHER access
-/// ((st.st_mode & 06) != 0). Group access is permitted.
+/// A group-readable (0640) secrets file is accepted at parse time, and stays
+/// accepted at auth time too: `check_secret()` rejects only OTHER access
+/// (`(st.st_mode & 06) != 0`).
 #[cfg(unix)]
 #[test]
 fn runtime_options_accepts_group_readable_secrets_file() {
@@ -64,11 +63,12 @@ fn runtime_options_accepts_group_readable_secrets_file() {
     .expect("group-readable secrets file should be accepted");
 }
 
-/// An other-writable (0602) secrets file is rejected: 0o6 catches OTHER
-/// write even without OTHER read, matching upstream's `& 06` mask.
+/// Other-writable (0602) is likewise a parse-time non-event. It IS rejected at
+/// auth time under `strict modes = yes`; that half is pinned by
+/// `verify_secret_rejects_other_accessible_when_strict_modes_enabled`.
 #[cfg(unix)]
 #[test]
-fn runtime_options_rejects_other_writable_secrets_file() {
+fn runtime_options_accepts_other_writable_secrets_file_at_parse_time() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempdir().expect("config dir");
@@ -87,17 +87,43 @@ fn runtime_options_rejects_other_writable_secrets_file() {
     )
     .expect("write config");
 
+    RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        file.path().as_os_str().to_os_string(),
+    ])
+    .expect("other-writable secrets file should not fail config parsing");
+}
+
+/// Non-vacuity companion for the three acceptances above: the parse-time
+/// validator is still wired and still rejects. Without this, dropping the whole
+/// validator would leave every acceptance test green.
+#[test]
+fn runtime_options_rejects_a_secrets_file_that_is_not_a_regular_file() {
+    let dir = tempdir().expect("config dir");
+    let module_dir = dir.path().join("module");
+    fs::create_dir_all(&module_dir).expect("module dir");
+    let secrets_path = dir.path().join("secrets-dir");
+    fs::create_dir(&secrets_path).expect("secrets dir");
+
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(
+        file,
+        "[secure]\npath = {}\nauth users = alice\nsecrets file = {}\n",
+        module_dir.display(),
+        secrets_path.display()
+    )
+    .expect("write config");
+
     let error = RuntimeOptions::parse(&[
         OsString::from("--config"),
         file.path().as_os_str().to_os_string(),
     ])
-    .expect_err("other-writable secrets file should error");
+    .expect_err("a directory is not a usable secrets file");
 
     assert!(
         error
             .message()
             .to_string()
-            .contains("must not be other-accessible")
+            .contains("must be a regular file")
     );
 }
-

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -116,7 +116,7 @@ daemon-scan-dir-escape pass
 daemon-secrets-file-symlink skip
 daemon-size-arg-overflow pass
 daemon-standalone-detach skip
-daemon-strict-modes-matrix fail
+daemon-strict-modes-matrix pass
 daemon-subdir-climb-symlink pass
 daemon-symlink-escape-matrix skip
 daemon-unix-socket-atfd pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -116,7 +116,7 @@ daemon-scan-dir-escape pass
 daemon-secrets-file-symlink pass
 daemon-size-arg-overflow pass
 daemon-standalone-detach skip
-daemon-strict-modes-matrix fail
+daemon-strict-modes-matrix pass
 daemon-subdir-climb-symlink pass
 daemon-symlink-escape-matrix skip
 daemon-unix-socket-atfd pass


### PR DESCRIPTION
## Root cause

oc rejected an other-accessible `secrets file` while **parsing the config**, unconditionally.

Upstream stores the directive verbatim at parse time (`params.c`) and applies the
permission rules per-authentication in `check_secret()` (`authenticate.c:168-181`),
gated on `lp_strict_modes(module)`:

```c
} else if (lp_strict_modes(module)) {
        if ((st.st_mode & 06) != 0) { ... ok = 0; }
        else if (MY_UID() == ROOT_UID && st.st_uid != ROOT_UID) { ... ok = 0; }
}
```

Because oc's copy of that rule ran at parse time it could not consult the module's
`strict modes` setting at all. `strict modes = no` was therefore unhonourable: rather
than serving the other-accessible file the operator deliberately opted into, the daemon
refused to load the whole config.

## Fix

oc's **auth-time** rule was already faithful — both halves, other-access and root
ownership under a root daemon (`platform::secrets::check_secrets_file_permissions`,
called from `verify_secret_response` behind `module.strict_modes`). So the fix is to
delete the parse-time copy and leave that function as the rule's single owner. The
parse-time validator keeps only the file-type check.

## Measurement

`daemon-strict-modes-matrix` from the rsync 3.5.0 testsuite, upstream control first
(real 3.5.0 binary: PASS). Its 12 rows, oc before → after:

| row | expected | before | after |
|---|---|---|---|
| strict 0600 / 0400 / 0640 / 0660 / 0610 / 0601 | accept | accept | accept |
| strict 0604 / 0602 / 0606 / 0644 / 0666 | reject | reject | reject |
| **loose 0666 (`strict modes = no`)** | **accept** | **reject** | **accept** |
| strict 0600 owned by uid != 0, root daemon | reject | — | reject |

11 of 12 already matched; exactly one row moved. Both legs now PASS
(`overall result is 0`), and the root leg exercises the owner-mismatch row rather than
skipping it (`owner=65534 accepted=0`), which shows the auth-time rule's second half is
still live — the fix narrows *where* the rule runs, not *whether* it runs.

## Manifests

Both **pipe** expect-manifests flip in this commit (345 rows each, unchanged count).

The two **TCP** manifests already recorded `pass` and are untouched: under `--use-tcp`
the config is parsed once at daemon start while the file is still 0600, so the
parse-time check never re-fired. That asymmetry is itself corroboration that the
per-connection re-parse is where the divergence lived.

## Tests

The three parse-time rejection tests encoded the pre-fix behaviour and are rewritten to
assert the post-fix contract (parse accepts 0644 / 0640 / 0602), with a non-vacuity
companion — a directory as `secrets file` is still rejected, so deleting the validator
outright would not leave them green. The auth-time halves stay pinned by the existing
`verify_secret_rejects_other_accessible_when_strict_modes_enabled` /
`..._accepts_..._when_strict_modes_disabled` pair.

`cargo fmt` + `clippy -p daemon --all-targets --all-features -D warnings` clean;
23/23 targeted daemon tests pass.
