### PR TITLE
fix(client): let a connect program finish instead of killing it

### DIFF
--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -558,7 +558,7 @@ impl DaemonStream {
                 Ok((
                     DaemonStreamReader::Program(parts.reader),
                     DaemonStreamWriter::Program(parts.writer),
-                    DaemonStreamGuard::Child(parts.child),
+                    DaemonStreamGuard::Child(Some(parts.child)),
                 ))
             }
             // The QUIC read and write handles are cheap clones over one
@@ -600,26 +600,52 @@ impl DaemonStream {
 
 /// Ownership guard for resources backing a split [`DaemonStream`].
 ///
-/// For connect programs, this holds the `Child` process handle and
-/// kills/reaps it on drop. For TCP streams, no guard is needed.
+/// For connect programs, this owns the `Child` process handle. For TCP
+/// streams, no guard is needed.
 pub(crate) enum DaemonStreamGuard {
     /// No resource to guard (TCP).
     None,
-    /// Owns a connect program child process.
-    Child(std::process::Child),
+    /// Owns a connect program child process; `None` once [`Self::finish`] reaped it.
+    Child(Option<std::process::Child>),
     /// Owns the QUIC connection teardown (flush + FIN + graceful close on drop).
     #[cfg(feature = "quic")]
     Quic(rsync_io::quic::QuicShutdown),
+}
+
+impl DaemonStreamGuard {
+    /// Waits for a connect program child to exit on its own.
+    ///
+    /// The caller must drop both stream halves first: closing them is what
+    /// gives the child EOF, and the child does the rest of its work - a daemon
+    /// reached through `RSYNC_CONNECT_PROG` runs its `post-xfer exec` hook
+    /// after the last transfer byte - before exiting.
+    ///
+    /// upstream: socket.c:1046 `sock_exec()` forks the connect program and
+    /// never signals it; the child ends when the socket closes.
+    pub(crate) fn finish(mut self) {
+        if let Self::Child(child) = &mut self {
+            if let Some(mut child) = child.take() {
+                let _ = child.wait();
+            }
+        }
+    }
 }
 
 impl Drop for DaemonStreamGuard {
     fn drop(&mut self) {
         match self {
             Self::None => {}
-            Self::Child(child) => {
-                let _ = child.kill();
+            // Safety net for abnormal control flow (early return, panic) that
+            // never reached `finish`. The halves may still be open here, so the
+            // child cannot be waited for; kill it rather than block. Mirrors
+            // `SshChildHandle::drop`.
+            Self::Child(Some(child)) => {
+                if let Ok(None) = child.try_wait() {
+                    let _ = child.kill();
+                }
                 let _ = child.wait();
             }
+            Self::Child(None) => {}
             // The QUIC teardown (flush + FIN + graceful close) runs when the
             // held `QuicShutdown` drops right after this body; nothing to do
             // here beyond keeping ownership until now.

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -582,8 +582,15 @@ impl Write for ConnectProgramStream {
 
 impl Drop for ConnectProgramStream {
     fn drop(&mut self) {
+        // Close our end first so the child sees EOF and exits on its own, then
+        // reap it. The child is never signalled: whatever it still has to do
+        // after the last byte - a daemon spawned through `RSYNC_CONNECT_PROG`
+        // runs its `post-xfer exec` hook there - must be allowed to finish.
+        //
+        // upstream: socket.c:1046 `sock_exec()` forks the connect program and
+        // never signals it; the child ends when the socket closes.
+        drop(self.transport.take());
         if let Some(child) = &mut self.child {
-            let _ = child.kill();
             let _ = child.wait();
         }
     }
@@ -1012,5 +1019,82 @@ mod tests {
 
         let _ = parts.child.kill();
         let _ = parts.child.wait();
+    }
+
+    /// A connect program that keeps working after the last transfer byte must
+    /// be allowed to finish. A daemon reached through `RSYNC_CONNECT_PROG` runs
+    /// its `post-xfer exec` hook there, so signalling the child - as oc did -
+    /// destroys it.
+    ///
+    /// The fixture writes its marker only *after* stdin reaches EOF and a short
+    /// delay, so a child that is killed on drop deterministically leaves no
+    /// marker.
+    ///
+    /// upstream: socket.c:1046 `sock_exec()` never signals the child.
+    #[cfg(unix)]
+    #[test]
+    fn dropping_the_stream_lets_the_connect_program_finish_after_eof() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("post.out");
+
+        let config = ConnectProgramConfig::new(
+            format!(
+                "cat >/dev/null; sleep 0.2; printf done > {}",
+                marker.display()
+            )
+            .into(),
+            None,
+        )
+        .unwrap();
+        let addr = DaemonAddress::new("localhost".to_owned(), 873);
+        let stream = connect_via_program(&addr, &config).unwrap();
+
+        drop(stream);
+
+        assert_eq!(
+            std::fs::read_to_string(&marker).ok().as_deref(),
+            Some("done"),
+            "the connect program must reach its post-transfer work and be waited for"
+        );
+    }
+
+    /// Same contract on the split path taken by every daemon transfer: the
+    /// halves close first, then `DaemonStreamGuard::finish` waits. Without the
+    /// wait the marker is not yet there; with a kill it never arrives at all.
+    #[cfg(unix)]
+    #[test]
+    fn finishing_the_split_guard_waits_for_the_connect_program() {
+        use std::process::Command;
+
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("post.out");
+
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "cat >/dev/null; sleep 0.2; printf done > {}",
+                marker.display()
+            ))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+
+        let (reader, writer, guard) =
+            crate::client::module_list::DaemonStream::from_child_process(child, stdin, stdout)
+                .split()
+                .unwrap();
+        drop(writer);
+        drop(reader);
+        guard.finish();
+
+        assert_eq!(
+            std::fs::read_to_string(&marker).ok().as_deref(),
+            Some("done"),
+            "finish() must wait for the child that the closed halves released"
+        );
     }
 }

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -35,8 +35,9 @@ use super::super::error::{ClientError, invalid_argument_error, socket_error};
 #[cfg(feature = "quic")]
 use super::super::module_list::Transport;
 use super::super::module_list::{
-    DaemonConnectTimeouts, QuicDialParams, RshDaemonSpawn, open_daemon_stream,
-    resolve_connect_timeout, spawn_rsh_daemon_stream,
+    DaemonConnectTimeouts, DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter,
+    QuicDialParams, RshDaemonSpawn, open_daemon_stream, resolve_connect_timeout,
+    spawn_rsh_daemon_stream,
 };
 use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
@@ -265,12 +266,11 @@ pub fn run_daemon_transfer(
     // as an implied include for the receiver-side flist validation
     // (CVE-2022-29154); is_daemon_connection strips the module on the receiver.
     let implied_source_args = [format!("{}/{}", request.module, request.path)];
-    match role {
+    let outcome = match role {
         RemoteRole::Receiver => run_pull_transfer(
             config,
             &mut reader_half,
             &mut writer_half,
-            guard,
             &local_paths,
             &implied_source_args,
             protocol,
@@ -282,7 +282,6 @@ pub fn run_daemon_transfer(
             config,
             &mut reader_half,
             &mut writer_half,
-            guard,
             &local_paths,
             protocol,
             batch_ctx,
@@ -292,7 +291,29 @@ pub fn run_daemon_transfer(
         RemoteRole::Proxy => {
             unreachable!("Proxy transfers via daemon are rejected earlier")
         }
-    }
+    };
+    close_then_reap(reader_half, writer_half, guard);
+    outcome
+}
+
+/// Tears the transport down in the order the peer needs after a transfer.
+///
+/// Both stream halves are closed BEFORE the guard is finished, so a connect
+/// program child sees EOF and exits on its own; only then is it reaped. The
+/// child is never signalled - it may still have work to do after the last
+/// transfer byte, and a daemon reached through `RSYNC_CONNECT_PROG` runs its
+/// `post-xfer exec` hook exactly there.
+///
+/// upstream: socket.c:1046 `sock_exec()` forks the connect program and never
+/// signals it; the child ends when the socket closes.
+fn close_then_reap(
+    reader: DaemonStreamReader,
+    writer: DaemonStreamWriter,
+    guard: DaemonStreamGuard,
+) {
+    drop(writer);
+    drop(reader);
+    guard.finish();
 }
 
 /// Executes a daemon transfer tunneled over a remote shell (SSH with `::` syntax).
@@ -429,12 +450,11 @@ pub fn run_daemon_over_remote_shell(
     // as an implied include for the receiver-side flist validation
     // (CVE-2022-29154); is_daemon_connection strips the module on the receiver.
     let implied_source_args = [format!("{}/{}", request.module, request.path)];
-    match role {
+    let outcome = match role {
         RemoteRole::Receiver => run_pull_transfer(
             config,
             &mut reader_half,
             &mut writer_half,
-            guard,
             &local_paths,
             &implied_source_args,
             protocol,
@@ -446,7 +466,6 @@ pub fn run_daemon_over_remote_shell(
             config,
             &mut reader_half,
             &mut writer_half,
-            guard,
             &local_paths,
             protocol,
             batch_ctx,
@@ -456,5 +475,7 @@ pub fn run_daemon_over_remote_shell(
         RemoteRole::Proxy => {
             unreachable!("Proxy transfers via daemon-over-remote-shell are rejected earlier")
         }
-    }
+    };
+    close_then_reap(reader_half, writer_half, guard);
+    outcome
 }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -15,8 +15,7 @@ use super::stats::convert_server_stats_to_summary;
 use crate::client::config::ClientConfig;
 use crate::client::error::{ClientError, invalid_argument_error, remote_exit_error};
 use crate::client::module_list::{
-    DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter, build_io_timeout_reapply,
-    register_shutdown_wake,
+    DaemonStreamReader, DaemonStreamWriter, build_io_timeout_reapply, register_shutdown_wake,
 };
 use crate::client::progress::ClientProgressObserver;
 use crate::client::remote::batch_support::{BatchContext, build_batch_recording};
@@ -45,7 +44,6 @@ pub(crate) fn run_pull_transfer(
     config: &ClientConfig,
     reader: &mut DaemonStreamReader,
     writer: &mut DaemonStreamWriter,
-    _guard: DaemonStreamGuard,
     local_paths: &[OsString],
     implied_source_args: &[String],
     protocol: ProtocolVersion,
@@ -167,7 +165,6 @@ pub(crate) fn run_push_transfer(
     config: &ClientConfig,
     reader: &mut DaemonStreamReader,
     writer: &mut DaemonStreamWriter,
-    _guard: DaemonStreamGuard,
     local_paths: &[OsString],
     protocol: ProtocolVersion,
     batch_ctx: Option<BatchContext>,


### PR DESCRIPTION
## The defect

A `RSYNC_CONNECT_PROG` child was SIGKILLed the moment the transfer returned.
Both teardown paths did `kill()` then `wait()`:

- `ConnectProgramStream::drop` (module listing, un-split streams)
- `DaemonStreamGuard::drop` (every daemon transfer, after `split()`)

Upstream never signals the child. `sock_exec()` (socket.c:1046) forks it,
keeps no handle at all, and lets it end when the socket closes.

Anything the child still had to do after the last transfer byte was
destroyed. That is not hypothetical: a daemon reached through
`RSYNC_CONNECT_PROG` runs its `post-xfer exec` hook exactly there.

## Measurement

The rsync 3.5.0 testsuite's default transport *is* `RSYNC_CONNECT_PROG` (it
forks an in-tree daemon over a private stdio pipe rather than opening a TCP
socket), so `daemon-exec` exercises this directly.

On an 8-core Linux host, before the fix:

```
----- daemon-exec log follows
post-xfer exec did not run with RSYNC_EXIT_STATUS=0
----- daemon-exec rsyncd.log follows
... pre-xfer exec succeeded for module 'hook'
... module 'hook' from localhost (127.0.0.1): protocol 32, role: Receiver
... receiving file list
FAIL    daemon-exec
```

The daemon log simply stops - the process was killed mid-shutdown. The real
rsync 3.5.0 binary passes the same cell on the same host (upstream control).
After the fix: `PASS daemon-exec`.

The cell is recorded `pass` in all four expect manifests and does pass on the
GitHub runner, so no manifest row moves. The kill turned it into a race the
runner happened to win and this host deterministically lost - which is the
reason to fix it rather than accept it.

Full nonroot pipe leg on that host: 345 tests, 234 pass / 27 fail / 84 skip,
one expect mismatch (`protected-regular: expected skip, got pass`) which is
environment-derived - the host has `fs.protected_regular = 1` so the cell
runs instead of self-skipping. Unrelated to this diff.

## The fix

Teardown now mirrors upstream's order: close both stream halves, which gives
the child EOF, then wait for it. No signal.

- `close_then_reap` in `daemon_transfer/mod.rs` owns that ordering, used at
  both dispatch sites (`rsync://` and daemon-over-remote-shell). The transfer
  functions no longer take the guard, since they never used it for anything
  but keeping it alive.
- `DaemonStreamGuard::finish` owns the wait.
- `Drop` keeps a kill-if-still-running safety net for abnormal control flow
  (early return, panic) where the halves may still be open and a blocking
  wait could hang - the same shape as `SshChildHandle::drop`.

## Tests

Two behavioural tests, each with a fixture that writes its marker only after
stdin reaches EOF plus a short delay, so a killed child deterministically
leaves no marker:

- `dropping_the_stream_lets_the_connect_program_finish_after_eof` - the
  un-split path.
- `finishing_the_split_guard_waits_for_the_connect_program` - the split path
  every transfer takes.

Both are mutation-proven: restoring the kill in either drop turns them red
(`2 tests run: 0 passed, 2 failed`), and they pass with the fix in place.
