### PR TITLE
fix(engine): diagnose a local-copy source that ended before its length

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -189,6 +189,14 @@ pub(crate) struct CopyContext<'a> {
     /// general I/O error occurred without `--ignore-errors`.
     // upstream: generator.c:299 static int already_warned
     io_error_delete_warning_emitted: bool,
+    /// Set when a source file ended before the length this transfer was sized
+    /// from - it shrank after the file list recorded it. Drives the final
+    /// `RERR_PARTIAL` (exit 23) exit code without aborting the remaining
+    /// file-list entries.
+    // upstream: sender.c:787-795 - `unmap_file()` returns the status
+    // `map_ptr()` recorded, and the sender sets `io_error |= IOERR_GENERAL`
+    // plus one `read errors mapping %s` line before continuing.
+    source_read_error: bool,
     /// Set when an `--iconv` filename could not be strictly transcoded to the
     /// remote charset and its entry was skipped. Drives the final
     /// `RERR_PARTIAL` (exit 23) exit code, mirroring upstream's

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -67,6 +67,7 @@ impl<'a> CopyContext<'a> {
             destination_metadata_cache: HashMap::new(),
             io_errors_occurred: false,
             io_error_delete_warning_emitted: false,
+            source_read_error: false,
             iconv_conversion_error: false,
             unsupported_operation_skipped: false,
             sender_remove_error: false,
@@ -535,6 +536,30 @@ impl<'a> CopyContext<'a> {
     /// even though every other entry was copied.
     pub(super) const fn sender_remove_error_occurred(&self) -> bool {
         self.sender_remove_error
+    }
+
+    /// Records that a source file ended before the length this transfer was
+    /// sized from, and suppresses deletions like any other general I/O error.
+    ///
+    /// Upstream reaches the same state through `map_ptr()`: a `read()` that
+    /// returns 0 with the window unfilled stores `ENODATA` in `map->status`
+    /// (fileio.c:359-365), `unmap_file()` hands that status back
+    /// (fileio.c:385), and the sender turns it into `io_error |=
+    /// IOERR_GENERAL` plus one `read errors mapping %s` line at `FERROR_XFER`
+    /// before moving on to the next entry (sender.c:787-795).
+    pub(super) fn record_source_read_error(&mut self) {
+        self.source_read_error = true;
+        self.io_errors_occurred = true;
+    }
+
+    /// Reports whether a short source read must force `RERR_PARTIAL` (23).
+    ///
+    /// Deliberately not gated on `--ignore-errors`: that flag decides whether
+    /// the sender *transmits* its `io_error` to the peer and whether the
+    /// delete pass proceeds, not whether the process that saw the read error
+    /// exits non-zero.
+    pub(super) const fn source_read_error_occurred(&self) -> bool {
+        self.source_read_error
     }
 
     /// Records that the delete emitter stepped over a genuine unlink/rmdir

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -614,6 +614,59 @@ impl<'a> CopyContext<'a> {
         }
     }
 
+    /// The error upstream reports for a premature EOF while mapping a source.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `fileio.c:362`: `map->status = nread ? errno : ENODATA` - a `read()`
+    ///   that returns 0 with the window unfilled is reported as `ENODATA`,
+    ///   which `strerror` renders as "No data available".
+    /// - `fileio.c:25-26`: `#ifndef ENODATA / #define ENODATA EAGAIN` - the
+    ///   same fallback shape for platforms that lack the code.
+    #[cfg(unix)]
+    fn premature_eof_error() -> io::Error {
+        io::Error::from_raw_os_error(libc::ENODATA)
+    }
+
+    /// Non-Unix counterpart of [`Self::premature_eof_error`]. `ENODATA` has no
+    /// portable numeric value here, so the text is carried directly;
+    /// `upstream_io_error` passes a non-OS message through verbatim.
+    #[cfg(not(unix))]
+    fn premature_eof_error() -> io::Error {
+        io::Error::other("No data available")
+    }
+
+    /// Diagnoses a source that ended before the length this transfer was sized
+    /// from - it shrank after the file list recorded it - and lets the run
+    /// continue with the remaining entries.
+    ///
+    /// Every content path funnels its byte count through here so the three of
+    /// them cannot drift: a `copy_file_range` that returns short, a dense read
+    /// loop that hits EOF early, and the sparse loop all describe the same
+    /// upstream condition.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `fileio.c:359-365`: `map_ptr()` records `ENODATA` when a `read()`
+    ///   returns 0 with the window unfilled ("the file has changed mid
+    ///   transfer"), or `errno` when the read fails outright; the first status
+    ///   wins.
+    /// - `sender.c:787-795`: `j = unmap_file(mbuf); if (j) { io_error |=
+    ///   IOERR_GENERAL; rsyserr(FERROR_XFER, j, "read errors mapping %s",
+    ///   full_fname(fname)); }` - one line, then the loop moves to the next
+    ///   file-list entry, and the run finishes `RERR_PARTIAL` (23).
+    fn note_short_source_read(&mut self, source: &Path, copied: u64, expected: u64) {
+        if copied >= expected {
+            return;
+        }
+        self.record_source_read_error();
+        eprintln!(
+            "rsync: [sender] read errors mapping \"{}\": {}",
+            source.display(),
+            crate::local_copy::upstream_io_error(&Self::premature_eof_error()),
+        );
+    }
+
     /// Copies file contents from `reader` to `writer`, dispatching to a delta,
     /// sparse, or plain streaming path depending on the arguments. Reports
     /// progress to the observer and enforces the bandwidth limiter and
@@ -671,6 +724,9 @@ impl<'a> CopyContext<'a> {
                 buffer,
             )
             .map_err(|error| LocalCopyError::io("copy file", source, error))?;
+            // A short return here is the kernel telling us the source ran out
+            // early - the same condition upstream's read loop reports.
+            self.note_short_source_read(source, copied, expected_remaining);
             if self.observer.is_some() {
                 let progressed = initial_bytes.saturating_add(copied);
                 self.notify_progress(relative, Some(total_size), progressed, start.elapsed());
@@ -761,6 +817,10 @@ impl<'a> CopyContext<'a> {
                 self.notify_progress(relative, Some(total_size), progressed, start.elapsed());
             }
         }
+
+        // `read == 0` breaks out of the loop above; arriving here with fewer
+        // bytes than the transfer was sized for means the source shrank.
+        self.note_short_source_read(source, total_bytes, expected_remaining);
 
         let outcome = if let Some(encoder) = compressor {
             let compressed_total = encoder.finish().map_err(|error| {
@@ -885,6 +945,10 @@ impl<'a> CopyContext<'a> {
             )
         })?;
         self.register_progress();
+
+        // `read == 0` breaks out of the loop above; arriving here with fewer
+        // bytes than the transfer was sized for means the source shrank.
+        self.note_short_source_read(source, total_bytes, expected_remaining);
 
         let outcome = if let Some(encoder) = compressor {
             let compressed_total = encoder.finish().map_err(|error| {

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
@@ -208,3 +208,139 @@ fn copy_is_bounded_by_the_opened_file_not_the_recorded_length() {
         "destination was bounded by the recorded length instead of the opened file's size"
     );
 }
+
+/// Length the file list recorded for a source that then shrank.
+const SHRUNK_LEN: usize = 1024;
+
+/// A source that ends before the length the transfer was sized from must be
+/// diagnosed, not silently reported as a complete copy.
+///
+/// upstream: `map_ptr()` (fileio.c:359-371) records `ENODATA` when a read
+/// returns 0 before the mapped window is filled, `unmap_file()` (fileio.c:385)
+/// returns that status, and the sender turns it into
+/// `io_error |= IOERR_GENERAL` plus one `read errors mapping %s` line
+/// (sender.c:787-795) - which main.c reports as `RERR_PARTIAL` (23). Without
+/// this the destination is silently short and the run exits 0, so data loss is
+/// indistinguishable from success.
+///
+/// Driving the loop with a `total_size` larger than the file reproduces
+/// "the source shrank after it was sized" without racing a real truncation.
+/// Each copy path owns its own loop, so each gets its own `#[test]`: a single
+/// test looping over them would stop at the first panic and report nothing
+/// about the rest, silently halving the mutation kill set.
+fn assert_short_source_is_recorded(sparse: bool, paced: bool) {
+    let temp = TempDir::new().expect("tempdir");
+    let source = temp.path().join("src.bin");
+    let destination = temp.path().join("dst.bin");
+
+    write_bytes(&source, SHRUNK_LEN);
+
+    let mut reader = File::open(&source).expect("open source");
+    let mut writer = File::create(&destination).expect("create destination");
+    let mut buffer = vec![0u8; 128 * 1024];
+
+    // A limiter keeps the dense case off the `copy_file_range` fast path, so
+    // the two are exercised separately rather than one masking the other.
+    const NO_PACING: u64 = 1 << 30;
+    let options = if paced {
+        LocalCopyOptions::default().bandwidth_limit(Some(NonZeroU64::new(NO_PACING).unwrap()))
+    } else {
+        LocalCopyOptions::default()
+    };
+    let mut context = CopyContext::new(
+        LocalCopyExecution::Apply,
+        options,
+        None,
+        temp.path().to_path_buf(),
+    );
+
+    context
+        .copy_file_contents(
+            &mut reader,
+            &mut writer,
+            &mut buffer,
+            sparse,
+            false,
+            &source,
+            &destination,
+            Path::new("src.bin"),
+            None,
+            // Declared longer than the file: the source shrank after sizing.
+            (SHRUNK_LEN + APPENDED_LEN) as u64,
+            0,
+            0,
+            Instant::now(),
+            false,
+        )
+        .expect("a short source must not abort the copy");
+    drop(writer);
+
+    assert!(
+        context.source_read_error_occurred(),
+        "sparse={sparse} paced={paced}: a source that ended early was not recorded, \
+         so the run would exit 0 on a short destination"
+    );
+}
+
+#[test]
+fn dense_copy_records_a_source_that_ended_early() {
+    assert_short_source_is_recorded(false, true);
+}
+
+#[test]
+fn sparse_copy_records_a_source_that_ended_early() {
+    assert_short_source_is_recorded(true, false);
+}
+
+#[test]
+fn copy_file_range_records_a_source_that_ended_early() {
+    assert_short_source_is_recorded(false, false);
+}
+
+/// Non-vacuity companion: the same fixture with an honest length must leave
+/// the flag clear. Without this, a predicate that fired unconditionally would
+/// satisfy every assertion above.
+#[test]
+fn a_complete_source_records_no_read_error() {
+    let temp = TempDir::new().expect("tempdir");
+    let source = temp.path().join("src.bin");
+    let destination = temp.path().join("dst.bin");
+
+    write_bytes(&source, SHRUNK_LEN);
+
+    let mut reader = File::open(&source).expect("open source");
+    let mut writer = File::create(&destination).expect("create destination");
+    let mut buffer = vec![0u8; 128 * 1024];
+
+    let mut context = CopyContext::new(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default(),
+        None,
+        temp.path().to_path_buf(),
+    );
+
+    context
+        .copy_file_contents(
+            &mut reader,
+            &mut writer,
+            &mut buffer,
+            false,
+            false,
+            &source,
+            &destination,
+            Path::new("src.bin"),
+            None,
+            SHRUNK_LEN as u64,
+            0,
+            0,
+            Instant::now(),
+            false,
+        )
+        .expect("copy");
+    drop(writer);
+
+    assert!(
+        !context.source_read_error_occurred(),
+        "a source that matched its recorded length was reported as short"
+    );
+}

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -601,6 +601,14 @@ pub(crate) fn copy_sources(
             if context.sender_remove_error_occurred() {
                 return Err(LocalCopyError::partial_transfer());
             }
+            // upstream: sender.c:787-795 - a source that shrank mid-transfer
+            // sets `io_error |= IOERR_GENERAL` and logs one `read errors
+            // mapping %s` at FERROR_XFER without aborting; main.c then exits
+            // RERR_PARTIAL (23). The per-entry diagnostic was already printed
+            // at the copy site, so surface only the summary error here.
+            if context.source_read_error_occurred() {
+                return Err(LocalCopyError::partial_transfer());
+            }
             // upstream: delete.c:86-210 - the delete pass logs each
             // un-removable entry via `rsyserr(FERROR_XFER, ...)` and sets
             // `io_error |= IOERR_GENERAL` without aborting; main.c then exits


### PR DESCRIPTION
## Problem

A local copy is sized from the length the file list recorded. If the source
shrinks between that scan and the read, oc moved fewer bytes than it was sized
for, wrote a short destination, printed nothing, and exited 0 - data loss
reported as success.

Measured on Linux against a source truncated mid-transfer:

| binary | exit | diagnostic |
|---|---|---|
| upstream 3.5.0 | 23 | `read errors mapping "...": No data available (61)` |
| oc, before | **0** | **none** |
| oc, after | 23 | `read errors mapping "...": No data available (61)` |

Destination contents matched in all three cases; the divergence was purely the
missing error report and exit code.

## Upstream contract

`map_ptr()` records `ENODATA` when a read returns 0 before the mapped window is
filled (fileio.c:359-371); `unmap_file()` returns that status (fileio.c:385);
the sender logs one `read errors mapping %s` at `FERROR_XFER` and sets
`io_error |= IOERR_GENERAL` before continuing to the next entry
(sender.c:787-795), which main.c reports as `RERR_PARTIAL` (23).

This mirrors that: record the short read, emit the same per-entry diagnostic,
keep transferring the remaining file-list entries, exit 23.

The flag is deliberately **not** gated on `--ignore-errors`. That option decides
whether the sender transmits `io_error` to its peer and whether the delete pass
proceeds - not whether the process that saw the read error exits non-zero.

## Scope

All three local-copy paths own a separate loop and all three needed the call:
the `copy_file_range` fast path, the dense loop and the sparse loop. Each is
pinned by its own test - one test looping over the three would stop at the first
panic and silently halve the mutation kill set.

## Verification

- Per-call-site mutation gives a clean one-to-one kill map: disabling each site
  fails exactly its own test and no other.
- `a_complete_source_records_no_read_error` is the non-vacuity companion; without
  it a predicate that always fired would satisfy every other assertion.
- `cargo nextest run -p engine` targeted: 6/6 (4 new + the 2 existing
  copy-bound pins).
- fmt + clippy clean.
- End-to-end on Linux: exit 23, byte-identical diagnostic to upstream 3.5.0, and
  the later file-list entry still transfers.
