### PR TITLE
fix(receiver): --delay-updates stages through the implicit .~tmp~ partial dir

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -115,19 +115,21 @@ pub(super) fn commit_file(
     };
 
     if needs_rename && config.delay_updates {
-        // upstream: receiver.c:1039-1052 - stage to partial dir (.~tmp~)
-        let staging_path = partial_dir_path(&begin.file_path);
-        if let Some(parent) = staging_path.parent() {
-            fs::create_dir_all(parent)?;
+        if let Some(staging_path) = delay_updates_staging_path(config, &begin.file_path) {
+            // upstream: util1.c handle_partial_dir(..., PDIR_CREATE) creates the
+            // partial directory before moving the temp into it.
+            if let Some(parent) = staging_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let result = rename_config_sandboxed(config, cleanup_guard.path(), &staging_path)?;
+            CleanupManager::global().unregister_temp_file(cleanup_guard.path());
+            cleanup_guard.keep();
+            return Ok(CommitOutcome {
+                was_copy: result,
+                delayed_path: Some(staging_path),
+                backup_notice,
+            });
         }
-        let result = rename_config_sandboxed(config, cleanup_guard.path(), &staging_path)?;
-        CleanupManager::global().unregister_temp_file(cleanup_guard.path());
-        cleanup_guard.keep();
-        return Ok(CommitOutcome {
-            was_copy: result,
-            delayed_path: Some(staging_path),
-            backup_notice,
-        });
     }
 
     let was_copy = if needs_rename {
@@ -196,21 +198,27 @@ fn remove_partial_dir_basis(config: &DiskCommitConfig, dest_path: &Path) {
     }
 }
 
-/// Upstream partial dir name for `--delay-updates` staging.
+/// Resolves the `--delay-updates` staging path for a destination file.
 ///
-/// upstream: options.c - `static char tmp_partialdir[] = ".~tmp~";`
-const DELAY_UPDATES_PARTIAL_DIR: &str = ".~tmp~";
-
-/// Computes the `.~tmp~/<filename>` staging path for a destination file.
+/// upstream: receiver.c - under `--delay-updates` the received temp is
+/// committed through `handle_partial_dir(partialptr, PDIR_CREATE)` instead of
+/// being renamed onto the destination, where `partialptr` comes from
+/// `partial_dir_fname(fname)`. The directory itself is whatever
+/// `--partial-dir` names; `--delay-updates` alone is promoted to the implicit
+/// `.~tmp~` by `TransferConfigBuilder::effective_partial_dir`
+/// (upstream options.c:2563-2564), so the staging directory is read from the
+/// configured partial mode rather than hardcoded here.
 ///
-/// upstream: receiver.c:537 - `partial_dir_fname(fname)` returns
-/// `<parent>/.~tmp~/<basename>`.
-pub(super) fn partial_dir_path(file_path: &Path) -> PathBuf {
-    let parent = file_path.parent().unwrap_or(Path::new("."));
-    let basename = file_path
-        .file_name()
-        .unwrap_or_else(|| std::ffi::OsStr::new("unknown"));
-    parent.join(DELAY_UPDATES_PARTIAL_DIR).join(basename)
+/// Returns `None` when the config carries no partial directory, which leaves
+/// the caller on the ordinary rename-to-destination path.
+pub(super) fn delay_updates_staging_path(
+    config: &DiskCommitConfig,
+    dest_path: &Path,
+) -> Option<PathBuf> {
+    let PartialMode::PartialDir(ref dir) = config.partial_mode else {
+        return None;
+    };
+    crate::temp_guard::partial_dir_fname(dest_path, dir)
 }
 
 /// Retains a partial temp file instead of deleting it on interrupt.

--- a/crates/transfer/src/disk_commit/process/mod.rs
+++ b/crates/transfer/src/disk_commit/process/mod.rs
@@ -31,7 +31,8 @@ use self::commit::ForceExdev;
 use self::commit::rename_config_sandboxed;
 #[cfg(test)]
 use self::commit::{
-    is_cross_device, make_backup, make_backup_copy, partial_dir_path, rename_with_io_uring_fallback,
+    delay_updates_staging_path, is_cross_device, make_backup, make_backup_copy,
+    rename_with_io_uring_fallback,
 };
 #[cfg(all(test, target_os = "macos"))]
 use self::file_ops::make_writer;

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -304,21 +304,72 @@ fn rename_io_uring_availability_consistent() {
     );
 }
 
-/// Verifies `partial_dir_path` constructs `.~tmp~/<basename>` under the
-/// file's parent directory, matching upstream `options.c:tmp_partialdir`.
-#[test]
-fn partial_dir_path_constructs_staging_path() {
-    let path = Path::new("/dest/subdir/file.txt");
-    let staging = partial_dir_path(path);
-    assert_eq!(staging, PathBuf::from("/dest/subdir/.~tmp~/file.txt"));
+fn delay_updates_config(partial_mode: crate::disk_commit::PartialMode) -> DiskCommitConfig {
+    DiskCommitConfig {
+        delay_updates: true,
+        partial_mode,
+        ..DiskCommitConfig::default()
+    }
 }
 
-/// Verifies `partial_dir_path` handles files directly in the root dest dir.
+/// Verifies a bare `--delay-updates` stages into `.~tmp~/<basename>` beside
+/// the destination file, matching upstream `options.c:2563-2564`, which the
+/// receiver applies when deriving its `PartialMode`.
 #[test]
-fn partial_dir_path_root_level_file() {
-    let path = Path::new("/dest/file.txt");
-    let staging = partial_dir_path(path);
-    assert_eq!(staging, PathBuf::from("/dest/.~tmp~/file.txt"));
+fn delay_updates_stages_into_implicit_tmp_dir() {
+    let config = delay_updates_config(crate::disk_commit::PartialMode::PartialDir(PathBuf::from(
+        crate::disk_commit::DELAY_UPDATES_PARTIAL_DIR,
+    )));
+    let staging = delay_updates_staging_path(&config, Path::new("/dest/subdir/file.txt"));
+    assert_eq!(
+        staging,
+        Some(PathBuf::from("/dest/subdir/.~tmp~/file.txt")),
+        "bare --delay-updates stages into the implicit .~tmp~"
+    );
+}
+
+/// Verifies an operator-named relative `--partial-dir` is honoured instead of
+/// the implicit `.~tmp~`. This is the case a hardcoded staging name silently
+/// got wrong: upstream stages `--delay-updates` into whatever `--partial-dir`
+/// names (options.c:2563-2564 only substitutes when none was given).
+#[test]
+fn delay_updates_honours_an_explicit_relative_partial_dir() {
+    let config = delay_updates_config(crate::disk_commit::PartialMode::PartialDir(PathBuf::from(
+        ".staging",
+    )));
+    let staging = delay_updates_staging_path(&config, Path::new("/dest/subdir/file.txt"));
+    assert_eq!(
+        staging,
+        Some(PathBuf::from("/dest/subdir/.staging/file.txt")),
+        "an explicit --partial-dir must override the implicit .~tmp~"
+    );
+}
+
+/// Verifies an absolute `--partial-dir` is used as-is rather than being
+/// re-anchored under the destination's parent, matching upstream
+/// `util1.c partial_dir_fname`'s `*partial_dir != '/'` guard.
+#[test]
+fn delay_updates_uses_an_absolute_partial_dir_verbatim() {
+    let config = delay_updates_config(crate::disk_commit::PartialMode::PartialDir(PathBuf::from(
+        "/var/tmp/staging",
+    )));
+    let staging = delay_updates_staging_path(&config, Path::new("/dest/subdir/file.txt"));
+    assert_eq!(
+        staging,
+        Some(PathBuf::from("/var/tmp/staging/file.txt")),
+        "an absolute --partial-dir is not re-anchored under the destination"
+    );
+}
+
+/// Verifies a config carrying no partial directory stages nothing, leaving the
+/// caller on the ordinary rename-to-destination path.
+#[test]
+fn delay_updates_without_a_partial_dir_stages_nothing() {
+    let config = delay_updates_config(crate::disk_commit::PartialMode::None);
+    assert_eq!(
+        delay_updates_staging_path(&config, Path::new("/dest/file.txt")),
+        None
+    );
 }
 
 /// Verifies `make_backup` returns the upstream-format backup notice with

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -9,6 +9,22 @@ use crate::pipeline::spsc::TryRecvError;
 use super::config::{BackupConfig, DELAY_UPDATES_PARTIAL_DIR, DiskCommitConfig, PartialMode};
 use super::thread::spawn_disk_thread;
 
+/// Builds the config a `--delay-updates` receiver actually runs with.
+///
+/// `--delay-updates` always stages through a partial directory: upstream
+/// substitutes the implicit `.~tmp~` when the operator named none
+/// (options.c:2563-2564) and oc mirrors that in
+/// `TransferConfigBuilder::effective_partial_dir`. Constructing
+/// `delay_updates` without a partial mode would exercise a state the
+/// production config cannot produce.
+fn delay_updates_config() -> DiskCommitConfig {
+    DiskCommitConfig {
+        delay_updates: true,
+        partial_mode: PartialMode::PartialDir(std::path::PathBuf::from(DELAY_UPDATES_PARTIAL_DIR)),
+        ..DiskCommitConfig::default()
+    }
+}
+
 #[test]
 fn default_config() {
     let _lock = channel_cap_env::ENV_LOCK.lock().unwrap();
@@ -927,10 +943,7 @@ fn delay_updates_stages_to_partial_dir() {
     let dir = test_support::create_tempdir();
     let file_path = dir.path().join("delayed.dat");
 
-    let config = DiskCommitConfig {
-        delay_updates: true,
-        ..DiskCommitConfig::default()
-    };
+    let config = delay_updates_config();
     let h = spawn_disk_thread(config).unwrap();
 
     h.file_tx
@@ -997,10 +1010,7 @@ fn delay_updates_whole_file_stages_to_partial_dir() {
     let dir = test_support::create_tempdir();
     let file_path = dir.path().join("whole_delayed.dat");
 
-    let config = DiskCommitConfig {
-        delay_updates: true,
-        ..DiskCommitConfig::default()
-    };
+    let config = delay_updates_config();
     let h = spawn_disk_thread(config).unwrap();
 
     h.file_tx
@@ -2577,10 +2587,7 @@ fn delay_updates_interrupt_leaves_committed_files_in_staging() {
     let _registry_lock = test_support::cleanup_registry_test_guard();
     let dir = test_support::create_tempdir();
 
-    let config = DiskCommitConfig {
-        delay_updates: true,
-        ..DiskCommitConfig::default()
-    };
+    let config = delay_updates_config();
     let h = spawn_disk_thread(config).unwrap();
 
     // Commit file 1 successfully - it should be staged in .~tmp~/.
@@ -2675,10 +2682,7 @@ fn delay_updates_interrupt_mid_file_retains_prior_staged_files() {
     let _registry_lock = test_support::cleanup_registry_test_guard();
     let dir = test_support::create_tempdir();
 
-    let config = DiskCommitConfig {
-        delay_updates: true,
-        ..DiskCommitConfig::default()
-    };
+    let config = delay_updates_config();
     let h = spawn_disk_thread(config).unwrap();
 
     // Commit file 1 successfully.
@@ -2760,10 +2764,7 @@ fn delay_updates_manual_sweep_after_commit_moves_to_final() {
     let _registry_lock = test_support::cleanup_registry_test_guard();
     let dir = test_support::create_tempdir();
 
-    let config = DiskCommitConfig {
-        delay_updates: true,
-        ..DiskCommitConfig::default()
-    };
+    let config = delay_updates_config();
     let h = spawn_disk_thread(config).unwrap();
 
     // Commit two files.
@@ -2845,10 +2846,7 @@ fn delay_updates_channel_disconnect_preserves_staged_files() {
     let _registry_lock = test_support::cleanup_registry_test_guard();
     let dir = test_support::create_tempdir();
 
-    let config = DiskCommitConfig {
-        delay_updates: true,
-        ..DiskCommitConfig::default()
-    };
+    let config = delay_updates_config();
     let h = spawn_disk_thread(config).unwrap();
 
     // Commit a file successfully.

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -681,6 +681,23 @@ impl Drop for PipelinedReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Builds the config a `--delay-updates` receiver actually runs with.
+    ///
+    /// `--delay-updates` always stages through a partial directory: upstream
+    /// substitutes the implicit `.~tmp~` when the operator named none
+    /// (options.c:2563-2564), and oc mirrors that where the receiver derives
+    /// its `PartialMode`. A `delay_updates` config carrying no partial mode is
+    /// a state the production path cannot produce.
+    fn delay_updates_config() -> DiskCommitConfig {
+        DiskCommitConfig {
+            delay_updates: true,
+            partial_mode: PartialMode::PartialDir(std::path::PathBuf::from(
+                crate::disk_commit::DELAY_UPDATES_PARTIAL_DIR,
+            )),
+            ..DiskCommitConfig::default()
+        }
+    }
     use crate::pipeline::messages::BeginMessage;
 
     #[test]
@@ -1729,11 +1746,7 @@ mod tests {
         let dir = test_support::create_tempdir();
         let file_path = dir.path().join("drop_staged.dat");
 
-        let mut pr = PipelinedReceiver::new(DiskCommitConfig {
-            delay_updates: true,
-            ..DiskCommitConfig::default()
-        })
-        .unwrap();
+        let mut pr = PipelinedReceiver::new(delay_updates_config()).unwrap();
 
         pr.file_sender()
             .send(FileMessage::WholeFile {
@@ -1796,11 +1809,7 @@ mod tests {
         let dir = test_support::create_tempdir();
         let file_path = dir.path().join("shutdown_staged.dat");
 
-        let mut pr = PipelinedReceiver::new(DiskCommitConfig {
-            delay_updates: true,
-            ..DiskCommitConfig::default()
-        })
-        .unwrap();
+        let mut pr = PipelinedReceiver::new(delay_updates_config()).unwrap();
 
         pr.file_sender()
             .send(FileMessage::WholeFile {
@@ -1853,11 +1862,7 @@ mod tests {
         let dir = test_support::create_tempdir();
         let file_path = dir.path().join("e2e.dat");
 
-        let mut pr = PipelinedReceiver::new(DiskCommitConfig {
-            delay_updates: true,
-            ..DiskCommitConfig::default()
-        })
-        .unwrap();
+        let mut pr = PipelinedReceiver::new(delay_updates_config()).unwrap();
 
         pr.file_sender()
             .send(FileMessage::WholeFile {

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -299,7 +299,9 @@ impl ReceiverContext {
         ndx_write_codec: &mut MonotonicNdxWriter,
         ndx_read_codec: &mut NdxCodecEnum,
     ) -> io::Result<PipelineResult> {
-        use crate::disk_commit::{BackupConfig, DiskCommitConfig, PartialMode};
+        use crate::disk_commit::{
+            BackupConfig, DELAY_UPDATES_PARTIAL_DIR, DiskCommitConfig, PartialMode,
+        };
         use crate::pipeline::receiver::{PipelinedReceiver, VerifyReport};
         use crate::shared::TransferDeadline;
 
@@ -421,13 +423,25 @@ impl ReceiverContext {
         } else {
             None
         };
-        // upstream: cleanup.c - compute partial mode from --partial / --partial-dir flags
-        let partial_mode = if let Some(ref dir) = self.config.partial_dir {
-            PartialMode::PartialDir(dir.clone())
-        } else if self.config.flags.partial {
-            PartialMode::Partial
-        } else {
-            PartialMode::None
+        // upstream: cleanup.c - compute partial mode from --partial / --partial-dir flags.
+        //
+        // `--delay-updates` with no explicit `--partial-dir` stages through the
+        // implicit `.~tmp~` beside each destination file:
+        // upstream options.c:2563-2564 `if (delay_updates && !partial_dir)
+        // partial_dir = tmp_partialdir;` (`static char tmp_partialdir[] = ".~tmp~"`).
+        //
+        // The substitution belongs here, on the receiver, rather than on the
+        // option value itself: upstream keeps the implicit directory off the wire
+        // by comparing the pointer against `tmp_partialdir` before forwarding
+        // `--partial-dir` (options.c:3052-3055), sending only `--delay-updates`
+        // so the peer re-derives `.~tmp~` for itself. oc builds its argv from
+        // `ClientConfig`, which this never touches, so the same split holds
+        // without threading provenance through the option value.
+        let partial_mode = match (&self.config.partial_dir, self.config.write.delay_updates) {
+            (Some(dir), _) => PartialMode::PartialDir(dir.clone()),
+            (None, true) => PartialMode::PartialDir(PathBuf::from(DELAY_UPDATES_PARTIAL_DIR)),
+            (None, false) if self.config.flags.partial => PartialMode::Partial,
+            (None, false) => PartialMode::None,
         };
         let disk_config = DiskCommitConfig {
             do_fsync: self.config.write.fsync,


### PR DESCRIPTION
## What

`--delay-updates` given without an explicit `--partial-dir` did not stage
through the implicit `.~tmp~` directory the way upstream does, and an
operator-named `--partial-dir` was silently ignored under `--delay-updates`.

## Upstream

`options.c:2563-2564` substitutes the implicit staging directory:

```c
if (delay_updates && !partial_dir)
        partial_dir = tmp_partialdir;      /* static char tmp_partialdir[] = ".~tmp~" */
```

oc never applied that substitution. The receiver derived its `PartialMode`
from `--partial-dir`/`--partial` alone, so a bare `--delay-updates` yielded
`PartialMode::None`, and the disk-commit path compensated with a hardcoded
`".~tmp~"` of its own. The compensation is what hid the defect: files staged
into `.~tmp~` regardless of what `--partial-dir` named.

## Change

- Apply the substitution where the receiver derives `PartialMode`.
- Route the staging path through the existing `partial_dir_fname` helper, so
  the configured directory is honoured - including the absolute-vs-relative
  distinction upstream draws in `util1.c` (an absolute `--partial-dir` is used
  as-is; a relative one is anchored beside each destination file).
- Delete the hardcoded constant and its shadowed copy of the path helper.

### Why the receiver, not the option value

Upstream keeps the implicit directory off the wire by comparing the pointer
against `tmp_partialdir` before forwarding the option
(`options.c:3052-3055`), sending only `--delay-updates` so the peer
re-derives `.~tmp~` for itself. oc builds its argv from `ClientConfig`, which
this change does not touch, so the same split holds without threading
provenance through the option value. Promoting the option value instead would
have started emitting `--partial-dir=.~tmp~` on the wire.

## False citations removed

Two comments in the disk-commit path attributed behaviour to upstream that
upstream does not have: one credited the hardcoded staging name to
`partial_dir_fname` (which reads the *configured* directory), the other cited
a `receiver.c` line range for the staging branch that does not describe it.

## Verification

- `daemon_pull_delay_updates_stages_through_tmp_dir` is the behavioural
  oracle; it is green here and was green on the base commit, so this change
  does not regress it.
- Mutating the substitution to `PartialMode::None` turns that cell red, so the
  new behaviour is load-bearing rather than incidentally satisfied.
- New unit pins cover the implicit `.~tmp~`, an explicit relative
  `--partial-dir`, an absolute one used verbatim, and the no-partial-dir case.
- `transfer` 2720/2720. `engine` 5027/5028 - the one failure,
  `execute_sparse_with_multiple_hole_patterns`, reproduces identically on the
  unmodified base commit and is unrelated (APFS sparse allocation).
- fmt + clippy clean.

Test fixtures that constructed `delay_updates` with no partial mode were
encoding a state the production config cannot produce; each crate now has one
helper owning that shape.
