### PR TITLE
fix(local-copy): --delay-updates stages through the --partial-dir

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -249,7 +249,7 @@ pub use util::cleanup::CleanupManager;
 /// Moves an interrupted `--partial` temp file onto its partial destination (or
 /// unlinks it when no partial is kept). Shared by the transfer guard and the
 /// signal-driven abort path so both finalise identically.
-pub use util::cleanup::finalize_partial;
+pub use util::cleanup::{create_partial_dir, finalize_partial};
 
 /// Async I/O operations (available with `async` feature).
 #[cfg(feature = "async")]

--- a/crates/engine/src/local_copy/context_impl/deferred_updates.rs
+++ b/crates/engine/src/local_copy/context_impl/deferred_updates.rs
@@ -29,17 +29,14 @@ impl<'a> CopyContext<'a> {
     /// Queues a deferred update for `--delay-updates` and records the hard-link
     /// source. The staging directory is tracked for cleanup after commit.
     pub(super) fn register_deferred_update(&mut self, update: DeferredUpdate) {
-        // Track the `.~tmp~` staging directory for cleanup after all updates
-        // are committed.
-        if let Some(parent) = update.guard.staging_path().parent() {
-            if parent
-                .file_name()
-                .is_some_and(|name| name == super::options::staging::DELAY_UPDATES_PARTIAL_DIR)
-            {
-                self.deferred_ops
-                    .delay_staging_dirs
-                    .insert(parent.to_path_buf());
-            }
+        // Track the staging directory for rmdir once every update has been moved
+        // out of it. The guard reports it only for a RELATIVE `--partial-dir`;
+        // an absolute one is a reserved location upstream never removes.
+        //
+        // upstream: receiver.c:718 handle_partial_dir(partialptr, PDIR_DELETE)
+        // after the delayed rename succeeds.
+        if let Some(dir) = update.guard.partial_dir_to_remove() {
+            self.deferred_ops.delay_staging_dirs.insert(dir.to_path_buf());
         }
         let metadata = update.metadata.clone();
         let destination = update.destination.clone();

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/finalize.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/finalize.rs
@@ -51,9 +51,16 @@ pub(in crate::local_copy) fn finalize_guard_and_metadata(
     #[cfg(all(any(unix, windows), feature = "acl"))] preserve_acls: bool,
 ) -> Result<(), LocalCopyError> {
     let relative_for_removal = Some(record_path.to_path_buf());
-    if let Some(guard) = guard {
+    if let Some(mut guard) = guard {
         if delay_updates_enabled {
             drop(writer_for_metadata.take());
+            // upstream: receiver.c:1301-1314 - a delayed update is published into
+            // the --partial-dir first and only renamed onto its real name by
+            // handle_delayed_updates() after the walk. Staging here (rather than
+            // simply holding the temp back) is what creates the partial dir, and
+            // `--partial-dir` with `--delay-updates` is always set: options.c
+            // substitutes `.~tmp~` when the operator named none.
+            guard.stage_into_partial_dir()?;
             let destination_path = guard.final_path().to_path_buf();
             let update = DeferredUpdate::new(
                 guard,

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -468,6 +468,67 @@ impl DestinationWriteGuard {
         }
     }
 
+    /// Publishes the staged temp into the `--partial-dir` entry, leaving the
+    /// pending [`commit`](Self::commit) to rename that entry onto the
+    /// destination.
+    ///
+    /// Returns the staged path, or `None` when no `--partial-dir` applies - the
+    /// guard is then untouched and its ordinary commit still renames the temp
+    /// straight onto the destination.
+    ///
+    /// upstream: `receiver.c:1301-1314` - under `--delay-updates` the receiver
+    /// calls `handle_partial_dir(partialptr, PDIR_CREATE)` and then
+    /// `finish_transfer(partialptr, fnametmp, ...)`, so the completed file lands
+    /// in the partial dir under its real name and only
+    /// `handle_delayed_updates()` (`receiver.c:685-720`) renames it onto the
+    /// destination after the walk. Deferring this guard's own
+    /// temp-to-destination rename instead reaches the same end state but never
+    /// creates the operator-named `--partial-dir` at all.
+    ///
+    /// The abort path is deliberately unchanged: the temp now already sits at
+    /// its partial-dir resting place, so an interrupted run leaves it there to
+    /// be resumed exactly as before.
+    pub fn stage_into_partial_dir(&mut self) -> Result<Option<PathBuf>, LocalCopyError> {
+        #[allow(irrefutable_let_patterns)]
+        let GuardStrategy::NamedTempFile { temp_path, partial } = &mut self.strategy else {
+            return Ok(None);
+        };
+        let PartialKind::Dir { file, .. } = partial else {
+            return Ok(None);
+        };
+        let staged = file.clone();
+        if let Some(parent) = staged.parent() {
+            crate::create_partial_dir(parent)
+                .map_err(|error| LocalCopyError::io("create partial dir", parent, error))?;
+        }
+        hardened_rename(temp_path, &staged, self.dest_root.as_deref())
+            .map_err(|error| LocalCopyError::io("stage delayed update", &staged, error))?;
+        CleanupManager::global().unregister_partial(temp_path);
+        // The pending commit now renames the staged entry onto the destination,
+        // and `partial_dest()` still points at that same entry, so a drop before
+        // the commit is a self-rename that leaves the staged file in place.
+        *temp_path = staged.clone();
+        Ok(Some(staged))
+    }
+
+    /// The `--partial-dir` entry a relative partial dir should be rmdir'd from
+    /// once the entry has been moved out of it.
+    ///
+    /// `None` for an absolute `--partial-dir`, which upstream treats as a
+    /// reserved location and never removes.
+    ///
+    /// upstream: `util1.c:handle_partial_dir()` - `if (!create && *partial_dir
+    /// == '/') return 1;` guards the `do_rmdir_at()`.
+    pub fn partial_dir_to_remove(&self) -> Option<&Path> {
+        match &self.strategy {
+            GuardStrategy::NamedTempFile {
+                partial: PartialKind::Dir { remove_dir, .. },
+                ..
+            } => remove_dir.as_deref(),
+            _ => None,
+        }
+    }
+
     /// Commits the temporary file to the final destination.
     ///
     /// For named temp files, this atomically renames the temp file. For anonymous

--- a/crates/engine/src/local_copy/tests/execute_delay_updates.rs
+++ b/crates/engine/src/local_copy/tests/execute_delay_updates.rs
@@ -2340,3 +2340,169 @@ fn delay_updates_restores_nested_directory_mtime_after_rename() {
          not just the transfer root"
     );
 }
+
+// --- staging THROUGH the --partial-dir -------------------------------------
+//
+// upstream: receiver.c:1301-1314 - under --delay-updates a completed file is
+// published INTO the --partial-dir under its real name
+// (`handle_partial_dir(partialptr, PDIR_CREATE)` then
+// `finish_transfer(partialptr, fnametmp, ...)`), and only
+// `handle_delayed_updates()` (receiver.c:685-720) renames it onto the
+// destination after the walk. Merely holding the temp back until the end
+// reaches the same destination content but never creates the partial dir,
+// which an operator who named `--partial-dir=DIR` can observe.
+
+/// 2001-09-09. Any later mtime means the directory was written through.
+/// A pinned epoch rather than a sub-second delta: on a 1-second-granularity
+/// filesystem a same-second change is invisible, and the test would then read
+/// a staged file as "never staged".
+const PINNED_EPOCH: i64 = 1_000_000_000;
+
+#[test]
+fn delay_updates_creates_an_absolute_partial_dir_and_leaves_it() {
+    let temp = create_tempdir();
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    let partial_dir = temp.path().join("staging").join("pd");
+    fs::write(&source, b"PAYLOAD-DATA").expect("write source");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    LocalCopyPlan::from_operands(&operands)
+        .expect("plan")
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default()
+                .delay_updates(true)
+                .with_partial_directory(Some(partial_dir.clone())),
+        )
+        .expect("copy succeeds");
+
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"PAYLOAD-DATA",
+        "the delayed update must still land on the destination"
+    );
+    assert!(
+        partial_dir.is_dir(),
+        "an absolute --partial-dir must be created and left in place: upstream \
+         handle_partial_dir() returns early on PDIR_DELETE when *partial_dir == '/'"
+    );
+    assert_eq!(
+        fs::read_dir(&partial_dir)
+            .expect("read partial dir")
+            .count(),
+        0,
+        "the staged entry must have been renamed out of the partial dir"
+    );
+}
+
+#[test]
+fn delay_updates_writes_through_a_pre_existing_partial_dir() {
+    // Non-vacuity companion for the test above: that one is satisfied by a
+    // bare mkdir, this one is not. Staging is what advances the directory's
+    // mtime, so an implementation that created the dir and then renamed the
+    // temp straight onto the destination leaves the pinned mtime untouched.
+    let temp = create_tempdir();
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    let partial_dir = temp.path().join("pd");
+    fs::write(&source, b"PAYLOAD-DATA").expect("write source");
+    fs::create_dir_all(&partial_dir).expect("pre-create partial dir");
+
+    let pinned = FileTime::from_unix_time(PINNED_EPOCH, 0);
+    set_file_mtime(&partial_dir, pinned).expect("pin partial dir mtime");
+    let stored = FileTime::from_last_modification_time(
+        &fs::metadata(&partial_dir).expect("partial dir metadata"),
+    );
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    LocalCopyPlan::from_operands(&operands)
+        .expect("plan")
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default()
+                .delay_updates(true)
+                .with_partial_directory(Some(partial_dir.clone())),
+        )
+        .expect("copy succeeds");
+
+    let after = FileTime::from_last_modification_time(
+        &fs::metadata(&partial_dir).expect("partial dir metadata"),
+    );
+    assert_ne!(
+        after, stored,
+        "the delayed update must be staged INTO the --partial-dir, which \
+         advances its mtime; an unchanged mtime means nothing was written there"
+    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"PAYLOAD-DATA");
+}
+
+#[test]
+fn delay_updates_removes_a_relative_partial_dir_after_the_rename() {
+    // upstream: receiver.c:718 handle_partial_dir(partialptr, PDIR_DELETE)
+    // rmdir's a now-empty RELATIVE partial dir once the delayed rename lands.
+    let temp = create_tempdir();
+    let source_root = temp.path().join("source");
+    let dest_root = temp.path().join("dest");
+    fs::create_dir_all(&source_root).expect("create source");
+    fs::create_dir_all(&dest_root).expect("create dest");
+    fs::write(source_root.join("f0"), b"PAYLOAD-DATA").expect("write source");
+
+    let mut source_operand = source_root.into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    LocalCopyPlan::from_operands(&operands)
+        .expect("plan")
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default()
+                .delay_updates(true)
+                .with_partial_directory(Some(std::path::PathBuf::from(".pd"))),
+        )
+        .expect("copy succeeds");
+
+    assert_eq!(fs::read(dest_root.join("f0")).expect("read dest"), b"PAYLOAD-DATA");
+    assert!(
+        !dest_root.join(".pd").exists(),
+        "a relative --partial-dir must be rmdir'd once emptied"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn delay_updates_creates_the_partial_dir_private() {
+    // upstream: util1.c:handle_partial_dir() - `do_mkdir_at(dir, 0700)`. The
+    // partial dir holds a complete copy of the file mid-transfer, so a
+    // umask-derived 0755 would expose it to every local user meanwhile.
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = create_tempdir();
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    let partial_dir = temp.path().join("pd");
+    fs::write(&source, b"PAYLOAD-DATA").expect("write source");
+
+    let operands = vec![source.into_os_string(), destination.into_os_string()];
+    LocalCopyPlan::from_operands(&operands)
+        .expect("plan")
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default()
+                .delay_updates(true)
+                .with_partial_directory(Some(partial_dir.clone())),
+        )
+        .expect("copy succeeds");
+
+    let mode = fs::metadata(&partial_dir)
+        .expect("partial dir metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o700, "the partial dir must be created private (0700)");
+}

--- a/crates/engine/src/util/cleanup.rs
+++ b/crates/engine/src/util/cleanup.rs
@@ -25,6 +25,45 @@ struct PartialEntry {
     tweak_mtime: bool,
 }
 
+/// Creates a `--partial-dir` with upstream's private 0700 mode.
+///
+/// upstream: `util1.c:handle_partial_dir()` - `do_mkdir_at(dir, 0700)`. The mode
+/// is load-bearing rather than incidental: the partial dir holds a complete copy
+/// of the file for the length of the transfer (and across runs, for a reserved
+/// absolute dir), so a umask-derived 0755 exposes that content to every local
+/// user. This is the single owner of the rule for both the abort path
+/// ([`finalize_partial`]) and the `--delay-updates` staging path.
+///
+/// On unix the create goes through `fast_io::operator_mkdir`, so a symlink
+/// planted at any component by a foreign uid is refused rather than followed -
+/// an absolute `--partial-dir` names a location outside the transfer tree, and
+/// without the walk a planted parent redirects the staged file (which is a
+/// complete copy of the source) out of the tree entirely. Upstream wraps the
+/// same `do_mkdir_at()` in `operator_path_resolve = 1` for that reason.
+///
+/// Any missing ancestor is created first, matching what the abort path has
+/// always done; upstream mkdirs only the final component and fails when the
+/// parent is absent. Each level goes through its own walk.
+pub fn create_partial_dir(dir: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        if dir.as_os_str().is_empty() || dir.is_dir() {
+            return Ok(());
+        }
+        if let Some(parent) = dir.parent()
+            && !parent.as_os_str().is_empty()
+            && !parent.is_dir()
+        {
+            create_partial_dir(parent)?;
+        }
+        fast_io::operator_mkdir(dir, 0o700)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::DirBuilder::new().recursive(true).create(dir)
+    }
+}
+
 /// Moves an interrupted temp file to its partial destination, or removes it.
 ///
 /// upstream: `cleanup.c:exit_cleanup()` calls `finish_transfer()` to rename the
@@ -36,7 +75,7 @@ pub fn finalize_partial(temp: &Path, partial_dest: Option<&Path>, tweak_mtime: b
     match partial_dest {
         Some(dest) => {
             if let Some(parent) = dest.parent() {
-                let _ = std::fs::create_dir_all(parent);
+                let _ = create_partial_dir(parent);
             }
             // Best-effort: an already-committed transfer leaves no temp, so a
             // failed rename here is expected and harmless.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -399,8 +399,8 @@ pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
-    operator_link, operator_open_append, operator_open_read, operator_open_rw_create,
-    operator_open_write_create, operator_read_to_string, operator_rename,
+    operator_link, operator_mkdir, operator_open_append, operator_open_read,
+    operator_open_rw_create, operator_open_write_create, operator_read_to_string, operator_rename,
     operator_symlink_metadata, owner_trusted_parent, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -291,6 +291,41 @@ pub fn owner_trusted_parent(path: &Path) -> io::Result<(OwnedFd, OsString)> {
     Ok((dirfd, leaf))
 }
 
+/// Create a directory at an operator-supplied path through the ownership walk.
+///
+/// The `mkdir` counterpart to the `operator_open_*` family: the parent chain is
+/// resolved by the ownership walk and the leaf created with `mkdirat` on the
+/// resulting descriptor, so a symlink planted at any component by a foreign uid
+/// cannot redirect the new directory out of the tree. An existing directory at
+/// the leaf is success, which makes the call idempotent across runs that reuse a
+/// reserved `--partial-dir`.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/util1.c:1501` `handle_partial_dir()` - sets
+///   `operator_path_resolve = 1` around its `do_lstat_at()`/`do_mkdir_at(dir,
+///   0700)` pair precisely so the partial dir is created through the ownership
+///   walk rather than by a plain path-based `mkdir`.
+///
+/// # Errors
+///
+/// Surfaces any walk error (including the refusal of a foreign-owned symlink)
+/// and any `mkdirat` error other than `EEXIST`.
+pub fn operator_mkdir(path: &Path, mode: u32) -> io::Result<()> {
+    let (parent, leaf) = owner_trusted_parent(path)?;
+    match rustix::fs::mkdirat(
+        &parent,
+        leaf.as_os_str(),
+        // `RawMode` is u16 on macOS and u32 on Linux, so route the cast through
+        // it rather than naming either width here.
+        Mode::from_bits_truncate(mode as rustix::fs::RawMode),
+    ) {
+        Ok(()) => Ok(()),
+        Err(Errno::EXIST) => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
 /// Rename `old_path` to `new_path` with both endpoints resolved by the
 /// ownership walk.
 ///

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -221,7 +221,7 @@ operator-path-insecure-links-daemon skip
 operator-path-insecure-links-refused pass
 operator-path-link-dest pass
 operator-path-log-file pass
-operator-path-partial-dir fail
+operator-path-partial-dir pass
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
 operator-path-temp-dir pass


### PR DESCRIPTION
## Problem

Under `--delay-updates` the local-copy executor held the temp file beside the
destination and deferred its commit to the end of the walk. That reaches the same
destination content, but the `--partial-dir` the operator named is never created.

Measured against real rsync 3.5.0 (`-a --delay-updates --partial-dir=<abs>`):

| | upstream | oc (before) |
|---|---|---|
| partial dir created | YES | **NO** |
| destination content | correct | correct |

Two further rules were wrong or missing on the same path:

- **Mode.** The dir was created with `create_dir_all`, i.e. `0777 & ~umask` -
  0755 under a default umask. It holds a complete copy of the file for the length
  of the transfer, and across runs for a reserved absolute dir. Upstream creates
  it `0700`. Measured: upstream 700 on both success and abort paths, oc **755**
  on the abort path.
- **Confinement.** `create_dir_all` follows symlinks. An absolute `--partial-dir`
  names a location outside the transfer tree, so a foreign-owned symlink planted
  at a parent component redirected the staged file out of the tree.

## Upstream

`receiver.c:1301-1314` stages in two steps - `handle_partial_dir(partialptr,
PDIR_CREATE)` then `finish_transfer(partialptr, fnametmp, ...)`, so the completed
file lands in the partial dir under its real name; `handle_delayed_updates()`
(`receiver.c:685-720`) renames it onto the destination after the walk.
`util1.c:handle_partial_dir()` supplies both other rules: `do_mkdir_at(dir,
0700)`, wrapped in `operator_path_resolve = 1`, and an early return on
`PDIR_DELETE` when `*partial_dir == '/'` so an absolute dir is never rmdir'd.

## Change

- `DestinationWriteGuard::stage_into_partial_dir()` publishes the temp to its
  partial-dir entry; the pending commit becomes the final rename.
- `create_partial_dir()` becomes the single owner of the create rule (0700, via
  the ownership walk) for both the staging and abort paths.
- `fast_io::operator_mkdir` joins the existing `operator_open_*` family - the
  walk had no mkdir member, which is why the site used a plain `create_dir_all`.
- The `.~tmp~`-by-name check in `register_deferred_update` is replaced by the
  guard's own `remove_dir`. The name check could never match: the temp never
  lived in the partial dir, so that branch was dead.

The abort path is **deliberately unchanged** and was already correct - measured
under SIGINT, oc and upstream both leave the staged file in the partial dir under
its real name.

## Verification

- **A/B vs rsync 3.5.0**, absolute / relative / implicit `.~tmp~`: 3/3 match on
  exit code, dir creation, mode, rmdir and destination content.
- **Testsuite**: `operator-path-partial-dir` flips fail -> PASS, with the upstream
  binary passing the same cell as a control. Sibling staging cells
  (`operator-path-temp-dir`, `operator-path-backup-dir`, `partial`,
  `partial-dir-abs-delta`, `partial_nowrite`,
  `rrsync-no-overwrite-partial-dir`) all pass. Manifest row flipped in the same
  commit.
- **Mutation**: reverting the staging call to a no-op turns the testsuite cell
  red and kills 3 of the 4 new unit pins. The fourth (relative-rmdir) passes
  under that mutation by construction - "dir absent" also satisfies "must not
  exist" - so it pins the opposite error (leaving the dir behind), not the
  staging rule.
- fmt + workspace clippy clean; engine + fast_io 5793/5793; workspace
  partial/delay/staging sweep 609/609 (root-level `tests/integration_*.rs`
  included - a per-crate run does not cover those).

## Known gap, not claimed here

The **root** leg's cross-uid cells additionally require `--insecure-links` to
re-enable following. `create_partial_dir` has no access to that opt-out, so the
root manifest row deliberately stays `fail`. Threading it belongs to the
per-option-family confinement work, and it could not be measured on this host
(cross-uid cells self-skip without root).
