### PR TITLE
fix(local-copy): degrade the anonymous commit to a named temp

### DIFF
--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -189,6 +189,30 @@ fn hardened_rename(
     }
 }
 
+/// Whether a `linkat(2)` failure means the platform cannot publish an anonymous
+/// inode *at all*, as opposed to refusing this particular commit.
+///
+/// `O_TMPFILE` is an optimisation, and the write strategy already degrades to a
+/// named temp when the *open* fails. The same rule has to hold at commit time:
+/// a filesystem can accept `O_TMPFILE` and still refuse the `linkat` that gives
+/// the inode a name (a filesystem without hard links reports `EPERM`, an
+/// interposed or restricted `linkat` reports `EOPNOTSUPP`, an old kernel
+/// `ENOSYS`). Upstream never reaches this state - `receiver.c` only ever stages
+/// into a named temp - so aborting here would lose a file no upstream run can
+/// lose.
+///
+/// The set is deliberately narrow. A confinement refusal reports `ELOOP`
+/// (`fast_io::confined_link_anonymous`) and stays fatal: degrading it would
+/// write the payload through the very path the confined walk just refused.
+/// `ENOSPC`, `EDQUOT` and `EMLINK` are genuine failures and stay fatal too.
+#[cfg(target_os = "linux")]
+fn anonymous_publish_unsupported(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(libc::EOPNOTSUPP | libc::EPERM | libc::ENOSYS)
+    )
+}
+
 // Test-only fault injection for the commit rename boundary. A thread-local flag
 // (nextest runs each test in its own process, and the guard is thread-scoped
 // regardless) makes `hardened_rename` report a cross-device error, driving the
@@ -241,6 +265,44 @@ impl ForceExdev {
 impl Drop for ForceExdev {
     fn drop(&mut self) {
         FORCE_EXDEV.with(|c| c.set(false));
+    }
+}
+
+// Test-only fault injection for the anonymous commit boundary, mirroring
+// `ForceExdev` above: it makes the `linkat` report a chosen errno, so both
+// sides of the degrade decision - the unsupported errnos that fall back and the
+// refusals that must stay fatal - are exercised on a filesystem that does
+// support publishing an `O_TMPFILE` inode. Zero means "no injection".
+#[cfg(all(test, target_os = "linux"))]
+thread_local! {
+    static FORCED_LINK_ERRNO: std::cell::Cell<i32> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(all(test, target_os = "linux"))]
+fn forced_link_errno() -> Option<i32> {
+    match FORCED_LINK_ERRNO.with(std::cell::Cell::get) {
+        0 => None,
+        errno => Some(errno),
+    }
+}
+
+/// Test-only RAII guard that forces the anonymous commit's `linkat` to fail
+/// with `errno` for its lifetime.
+#[cfg(all(test, target_os = "linux"))]
+struct ForceLinkErrno;
+
+#[cfg(all(test, target_os = "linux"))]
+impl ForceLinkErrno {
+    fn new(errno: i32) -> Self {
+        FORCED_LINK_ERRNO.with(|c| c.set(errno));
+        Self
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+impl Drop for ForceLinkErrno {
+    fn drop(&mut self) {
+        FORCED_LINK_ERRNO.with(|c| c.set(0));
     }
 }
 
@@ -672,6 +734,11 @@ impl DestinationWriteGuard {
     /// Commits an anonymous `O_TMPFILE` via `linkat(2)`.
     ///
     /// If the destination already exists, it is removed first so `linkat` succeeds.
+    ///
+    /// When `linkat` reports that the platform cannot publish an anonymous inode
+    /// at all, the commit degrades to a named temp file
+    /// ([`commit_anonymous_via_named_temp`](Self::commit_anonymous_via_named_temp))
+    /// instead of failing the transfer.
     #[cfg(target_os = "linux")]
     fn commit_anonymous(&self, file: Option<fs::File>) -> Result<(), LocalCopyError> {
         let file = file.ok_or_else(|| {
@@ -686,21 +753,32 @@ impl DestinationWriteGuard {
         // *refused* commit destructive: the confined walk rejects an escaping
         // destination after the unlink, leaving nothing behind. Upstream
         // refuses without touching the file, and so must this.
-        let attempt = |guard: &Self| match guard.dest_root.as_deref() {
-            Some(root) => {
-                use std::os::fd::AsFd;
-                fast_io::confined_link_anonymous(file.as_fd(), root, &guard.final_path)
+        let attempt = |guard: &Self| {
+            #[cfg(test)]
+            if let Some(errno) = forced_link_errno() {
+                return Err(io::Error::from_raw_os_error(errno));
             }
-            None => fast_io::link_anonymous_tmpfile(&file, &guard.final_path),
+            match guard.dest_root.as_deref() {
+                Some(root) => {
+                    use std::os::fd::AsFd;
+                    fast_io::confined_link_anonymous(file.as_fd(), root, &guard.final_path)
+                }
+                None => fast_io::link_anonymous_tmpfile(&file, &guard.final_path),
+            }
         };
 
-        match attempt(self) {
-            Ok(()) => Ok(()),
+        let published = match attempt(self) {
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
                 remove_existing_destination(&self.final_path)?;
-                attempt(self).map_err(|error| {
-                    LocalCopyError::io("finalise anonymous temp file", &self.final_path, error)
-                })
+                attempt(self)
+            }
+            result => result,
+        };
+
+        match published {
+            Ok(()) => Ok(()),
+            Err(error) if anonymous_publish_unsupported(&error) => {
+                self.commit_anonymous_via_named_temp(&file)
             }
             Err(error) => Err(LocalCopyError::io(
                 "finalise anonymous temp file",
@@ -708,6 +786,36 @@ impl DestinationWriteGuard {
                 error,
             )),
         }
+    }
+
+    /// Materialises the staged anonymous inode through a named temp file.
+    ///
+    /// The payload only exists in the unnamed inode, so it is copied into a
+    /// `.name.XXXXXX` temp beside the destination and committed by the same
+    /// confined rename every non-Linux run uses. That reuses
+    /// [`new_confined`](Self::new_confined) and [`commit`](Self::commit)
+    /// wholesale, so the degraded path cannot drift from the primary one.
+    #[cfg(target_os = "linux")]
+    fn commit_anonymous_via_named_temp(&self, file: &fs::File) -> Result<(), LocalCopyError> {
+        use std::io::{Seek, SeekFrom, Write};
+
+        let (guard, mut temp) = Self::new_confined(
+            &self.final_path,
+            false,
+            None,
+            None,
+            self.dest_root.as_deref(),
+        )?;
+        let staging = guard.staging_path().to_path_buf();
+        let mut staged = file;
+        let mut copy = || -> io::Result<()> {
+            staged.seek(SeekFrom::Start(0))?;
+            io::copy(&mut staged, &mut temp)?;
+            temp.flush()
+        };
+        copy().map_err(|error| LocalCopyError::io("copy file", staging, error))?;
+        drop(temp);
+        guard.commit().map(|_| ())
     }
 
     /// Returns the final destination path.
@@ -1207,6 +1315,69 @@ mod tests {
 
             guard.commit().expect("commit");
             assert_eq!(fs::read_to_string(&dest).expect("read"), "new");
+        }
+
+        /// A filesystem can accept `O_TMPFILE` and still refuse to publish the
+        /// inode. The commit must degrade to a named temp, exactly as the open
+        /// degrades when `O_TMPFILE` itself is unavailable, rather than abort
+        /// the transfer and lose the payload.
+        #[test]
+        fn anonymous_commit_degrades_to_named_temp_when_publish_unsupported() {
+            let temp = tempdir().expect("tempdir");
+            let dest = temp.path().join("anon_degrade.txt");
+            if !o_tmpfile_supported(temp.path()) {
+                return;
+            }
+
+            fs::write(&dest, b"stale").expect("create existing");
+
+            let (guard, mut file) =
+                DestinationWriteGuard::new_anonymous(&dest, None).expect("guard");
+            file.write_all(b"degraded payload").expect("write");
+            drop(file);
+
+            let _forced = ForceLinkErrno::new(libc::EOPNOTSUPP);
+            guard.commit().expect("commit degrades instead of failing");
+
+            assert_eq!(
+                fs::read_to_string(&dest).expect("read"),
+                "degraded payload",
+                "the staged payload must reach the destination"
+            );
+            let leftovers: Vec<_> = fs::read_dir(temp.path())
+                .expect("read dir")
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name())
+                .filter(|name| name != "anon_degrade.txt")
+                .collect();
+            assert!(
+                leftovers.is_empty(),
+                "the degraded commit must leave no temp behind: {leftovers:?}"
+            );
+        }
+
+        /// The degrade is keyed on "the platform cannot publish an anonymous
+        /// inode", not on "the commit failed". A confinement refusal reports
+        /// `ELOOP` and must stay fatal - falling back there would write the
+        /// payload through the path the confined walk just refused.
+        #[test]
+        fn anonymous_commit_refusal_stays_fatal() {
+            let temp = tempdir().expect("tempdir");
+            let dest = temp.path().join("anon_refused.txt");
+            if !o_tmpfile_supported(temp.path()) {
+                return;
+            }
+
+            let (guard, mut file) =
+                DestinationWriteGuard::new_anonymous(&dest, None).expect("guard");
+            file.write_all(b"refused payload").expect("write");
+            drop(file);
+
+            let _forced = ForceLinkErrno::new(libc::ELOOP);
+            guard
+                .commit()
+                .expect_err("a refused commit must not degrade");
+            assert!(!dest.exists(), "a refused commit must not create the file");
         }
 
         #[test]

--- a/crates/fast_io/src/o_tmpfile/low_level.rs
+++ b/crates/fast_io/src/o_tmpfile/low_level.rs
@@ -88,12 +88,14 @@ mod linux {
         };
 
         // Safety: `dir_cstr` is a valid null-terminated C string pointing to an
-        // existing directory. `O_TMPFILE | O_WRONLY` creates an unnamed inode
+        // existing directory. `O_TMPFILE | O_RDWR` creates an unnamed inode
         // with no directory entry. Mode 0o600 is used for the probe file.
+        // The access mode matches `open_anonymous_tmpfile` so the probe answers
+        // the question the caller actually asks.
         let fd = unsafe {
             libc::open(
                 dir_cstr.as_ptr(),
-                libc::O_TMPFILE | libc::O_WRONLY,
+                libc::O_TMPFILE | libc::O_RDWR,
                 libc::mode_t::from(0o600u32),
             )
         };
@@ -114,6 +116,12 @@ mod linux {
     /// The returned file has no directory entry - it exists only as an open
     /// file descriptor. Write data to it, then call [`link_anonymous_tmpfile`]
     /// to atomically materialize it at the final path.
+    ///
+    /// The descriptor is opened `O_RDWR`, not `O_WRONLY`: the staged inode has
+    /// no name, so the descriptor is the only handle on the payload. A caller
+    /// whose `linkat` is refused by the filesystem can then still read the
+    /// bytes back out and fall back to a named temp file instead of losing
+    /// them.
     ///
     /// # Arguments
     ///
@@ -136,13 +144,13 @@ mod linux {
         })?;
 
         // Safety: `dir_cstr` is a valid null-terminated C string. `O_TMPFILE |
-        // O_WRONLY` creates an unnamed inode with no directory entry. `mode` is
+        // O_RDWR` creates an unnamed inode with no directory entry. `mode` is
         // the permission bits for the new file. The returned fd is valid on
         // success (>= 0) and is immediately wrapped in a `File` which owns it.
         let fd = unsafe {
             libc::open(
                 dir_cstr.as_ptr(),
-                libc::O_TMPFILE | libc::O_WRONLY | libc::O_CLOEXEC,
+                libc::O_TMPFILE | libc::O_RDWR | libc::O_CLOEXEC,
                 libc::mode_t::from(mode),
             )
         };
@@ -249,6 +257,27 @@ mod linux {
             if let Ok(file) = result {
                 drop(file);
             }
+        }
+
+        /// The staged inode has no name, so the descriptor is the only handle
+        /// on the payload: a caller whose `linkat` is refused must be able to
+        /// read the bytes back and fall back to a named temp. `O_WRONLY` would
+        /// make that fallback impossible and lose the file.
+        #[test]
+        fn anonymous_tmpfile_is_readable() {
+            use std::io::{Read, Seek, SeekFrom};
+
+            let dir = tempfile::tempdir().unwrap();
+            let mut file = match open_anonymous_tmpfile(dir.path(), 0o644) {
+                Ok(f) => f,
+                Err(_) => return, // O_TMPFILE not supported on this filesystem
+            };
+            file.write_all(b"readable payload").unwrap();
+            file.seek(SeekFrom::Start(0)).unwrap();
+
+            let mut back = String::new();
+            file.read_to_string(&mut back).unwrap();
+            assert_eq!(back, "readable payload");
         }
 
         #[test]


### PR DESCRIPTION
## Problem

The `O_TMPFILE` write strategy has two points where the platform can refuse to
publish the staged inode: the `open`, and the `linkat` that gives it a name.
Only the open-time refusal degraded to a named temp
(`write_strategy.rs`: *"O_TMPFILE open failed, falling back to named temp file"*).
At commit time every errno was fatal, so a filesystem that accepts `O_TMPFILE`
and then refuses `linkat` aborted the whole transfer and lost the payload:

```
oc-rsync error: failed to finalise anonymous temp file '.../reg':
Operation not supported (95) (code 23)
```

Upstream cannot fail this way - `receiver.c` only ever stages into a named temp
file - so this is an oc-only failure mode, found by the upstream 3.5.0
`link-dest-symlink-enotsup` cell, whose `LD_PRELOAD` hook refuses a `linkat`
whose source is a symlink. oc's materialisation names the staged inode with
`/proc/self/fd/N`, which *is* a symlink, so the hook refuses it.

## Change

`commit_anonymous` now copies the staged inode into a `.name.XXXXXX` temp beside
the destination and commits it through the existing confined rename, reusing
`new_confined` + `commit` wholesale so the degraded path cannot drift from the
primary one.

The errno set is deliberately narrow - `EOPNOTSUPP`, `EPERM`, `ENOSYS`, the
three ways a platform says "no anonymous inode can be published here":

- a **confinement refusal** reports `ELOOP` (`fast_io::confined_link_anonymous`)
  and stays fatal. Degrading there would write the payload through the very
  path the confined walk just refused.
- `ENOSPC`, `EDQUOT` and `EMLINK` are genuine failures and stay fatal.

The second commit opens the anonymous temp `O_RDWR` instead of `O_WRONLY`: the
staged inode has no directory entry, so the descriptor is the only handle on the
payload, and a write-only descriptor makes the fallback impossible by
construction. The support probe moves with it so it answers the question the
caller actually asks.

## Verification (Linux, ext4)

- `engine` + `fast_io`: 45/45 green for `test(anonymous) or test(o_tmpfile)`.
- **Mutation matrix**, both directions of the predicate:
  - `false` (never degrade) -> `anonymous_commit_degrades_to_named_temp_when_publish_unsupported` FAILS, refusal test stays green.
  - `true` (always degrade) -> `anonymous_commit_refusal_stays_fatal` FAILS, degrade test stays green.
  - restored -> 2/2 green. Neither over- nor under-matching.
- The `link-dest-symlink-enotsup` cell no longer aborts (`rc=23` -> `rc=0`). It
  still fails on a later assertion from an unrelated root cause (the alt-dest
  basis match compares mtime with nanosecond precision where upstream
  `same_time()` compares seconds unless `--modify-window` is negative), so its
  manifest row is deliberately left `fail` and is not flipped here.
