### PR TITLE
fix(local-copy): compare an alt-dest basis mtime the way same_time does

### DIFF
--- a/crates/engine/src/local_copy/context_impl/link_dest.rs
+++ b/crates/engine/src/local_copy/context_impl/link_dest.rs
@@ -83,6 +83,7 @@ impl<'a> CopyContext<'a> {
                 source,
                 metadata,
                 &metadata_options,
+                self.options.modify_window(),
                 preserve_xattrs,
             ) {
                 3
@@ -249,10 +250,13 @@ impl<'a> CopyContext<'a> {
 /// Returns `true` when two nodes' modification times are equal within
 /// `--modify-window`.
 ///
-/// upstream: util1.c:1478 same_time() - a whole-second delta within
-/// `modify_window` counts as unchanged. For a zero window (the default) or a
-/// negative window (`--modify-window < 0`, nsec-exact) a hardlink candidate
-/// must match on both the whole-second and nanosecond components.
+/// Delegates to the shared predicate so the special-file basis and the regular
+/// -file basis cannot disagree about what "same time" means.
+///
+/// upstream: `rsync-3.5.0/util1.c:1649` `same_time()` - a zero window (the
+/// default) compares WHOLE SECONDS; only a negative window
+/// (`--modify-window < 0`) also compares nanoseconds; a positive window is a
+/// whole-second tolerance in which "the nanoseconds do not figure".
 #[cfg(unix)]
 fn mtimes_within_window(
     source: &fs::Metadata,
@@ -261,11 +265,10 @@ fn mtimes_within_window(
 ) -> bool {
     use std::os::unix::fs::MetadataExt;
 
-    let delta = source.mtime().abs_diff(candidate.mtime());
-    let window = modify_window.as_secs();
-    if window <= 0 {
-        delta == 0 && source.mtime_nsec() == candidate.mtime_nsec()
-    } else {
-        delta <= window as u64
-    }
+    modify_window.same_time(
+        source.mtime(),
+        source.mtime_nsec() as u32,
+        candidate.mtime(),
+        candidate.mtime_nsec() as u32,
+    )
 }

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -137,6 +137,7 @@ pub(super) fn process_links(
             source,
             metadata,
             &metadata_options,
+            context.options().modify_window(),
             preserve_xattrs_flag,
         );
         // On Unix a match_level-2 basis is routed through the same reference-copy

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -3,8 +3,9 @@
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use ::metadata::MetadataOptions;
+use ::metadata::{MetadataOptions, ModifyWindow};
 
 use crate::local_copy::{CopyContext, LocalCopyError, ReferenceDirectoryKind};
 
@@ -104,6 +105,49 @@ pub(crate) struct ReferenceQuery<'a> {
     pub(crate) preserve_xattrs: bool,
 }
 
+/// Splits a `SystemTime` into the `(seconds, nanoseconds)` pair `same_time`
+/// compares, mirroring the `st_mtime` / `ST_MTIME_NSEC` split upstream reads
+/// from `struct stat`. `fs::Metadata::modified` is the only portable source, so
+/// the split happens here rather than through the Unix-only `MetadataExt`.
+///
+/// A pre-epoch time carries a negative second count with a positive nanosecond
+/// remainder, exactly as `struct timespec` stores it.
+fn unix_time_parts(time: SystemTime) -> (i64, u32) {
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(since) => (
+            i64::try_from(since.as_secs()).unwrap_or(i64::MAX),
+            since.subsec_nanos(),
+        ),
+        Err(before) => {
+            let delta = before.duration();
+            let secs = i64::try_from(delta.as_secs()).unwrap_or(i64::MAX);
+            match delta.subsec_nanos() {
+                0 => (-secs, 0),
+                nanos => (-secs - 1, 1_000_000_000 - nanos),
+            }
+        }
+    }
+}
+
+/// Whether a reference basis carries the source's modification time under
+/// `--modify-window`.
+///
+/// upstream: `rsync-3.5.0/util1.c:1649` `same_time()` - a zero window (the
+/// default) compares whole seconds, a negative window compares seconds and
+/// nanoseconds, and a positive window is a whole-second tolerance.
+fn reference_mtime_matches(
+    source_meta: &fs::Metadata,
+    basis_meta: &fs::Metadata,
+    modify_window: ModifyWindow,
+) -> bool {
+    let (Ok(source_time), Ok(basis_time)) = (source_meta.modified(), basis_meta.modified()) else {
+        return false;
+    };
+    let (source_secs, source_nanos) = unix_time_parts(source_time);
+    let (basis_secs, basis_nanos) = unix_time_parts(basis_time);
+    modify_window.same_time(source_secs, source_nanos, basis_secs, basis_nanos)
+}
+
 /// Reports whether a reference basis already carries the source's preserved
 /// attributes, mirroring upstream `generator.c:475 unchanged_attrs()`.
 ///
@@ -125,6 +169,7 @@ pub(crate) fn reference_attrs_unchanged(
     source: &Path,
     source_meta: &fs::Metadata,
     options: &MetadataOptions,
+    modify_window: ModifyWindow,
     preserve_xattrs: bool,
 ) -> bool {
     let Ok(basis_meta) = basis_stat(basis) else {
@@ -138,15 +183,17 @@ pub(crate) fn reference_attrs_unchanged(
         return false;
     }
 
-    // upstream: generator.c:492 any_time_differs - the mtime must match for a
-    // level-3 basis. Compared through `SystemTime` (like the quick-check
-    // `unchanged_file` path) so the check holds on every platform, not just Unix
-    // where `st_mtime` is available.
-    if options.times() {
-        match (source_meta.modified(), basis_meta.modified()) {
-            (Ok(source_time), Ok(basis_time)) if source_time == basis_time => {}
-            _ => return false,
-        }
+    // upstream: generator.c:400 mtime_differs -> util1.c:1649 same_time - the
+    // mtime must match for a level-3 basis, and `same_time` compares WHOLE
+    // SECONDS for the default `modify_window` of 0. Nanoseconds only enter the
+    // comparison for a negative window (`--modify-window` < 0, nsec-exact), and
+    // a positive window is a whole-second tolerance. Comparing `SystemTime`
+    // directly would be nsec-exact always, so a basis whose mtime was not
+    // preserved to nanosecond precision - the common case for anything not
+    // written by rsync itself - is demoted from match_level 3 to 2 and copied
+    // instead of hard-linked.
+    if options.times() && !reference_mtime_matches(source_meta, &basis_meta, modify_window) {
+        return false;
     }
 
     // upstream: generator.c:494 perms_differ - Unix compares the full permission
@@ -274,6 +321,7 @@ pub(crate) fn find_reference_action(
             source,
             metadata,
             metadata_options,
+            context.options().modify_window(),
             preserve_xattrs,
         ) {
             3

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -1925,10 +1925,16 @@ fn link_dest_hardlinks_a_basis_differing_only_in_mtime_nanoseconds() {
     );
 }
 
-/// The non-vacuity companion: under `--modify-window=-1` upstream DOES compare
+/// End-to-end companion: under `--modify-window=-1` upstream DOES compare
 /// nanoseconds (`same_time` returns `f1_sec == f2_sec && f1_nsec == f2_nsec`),
-/// so the very same fixture must NOT link. Without this row a fix that ignored
-/// nanoseconds unconditionally would look correct.
+/// so the very same fixture must NOT link.
+///
+/// ⚠ Measured: mutating the attrs comparison to drop nanoseconds entirely does
+/// NOT kill this row - the negative window is already discriminating in the
+/// data-level quick check, which rejects the candidate before the attrs
+/// comparison is reached. It is kept as an end-to-end pin of the option, not as
+/// the non-vacuity proof for the line below; that role belongs to
+/// `whole_second_difference_refuses_the_basis`.
 #[cfg(unix)]
 #[test]
 fn nsec_exact_modify_window_still_refuses_a_nanosecond_differing_basis() {
@@ -1952,6 +1958,36 @@ fn nsec_exact_modify_window_still_refuses_a_nanosecond_differing_basis() {
     );
 }
 
+/// End-to-end pin of the seconds arm: a basis one WHOLE SECOND away is not
+/// `same_time` under the default window, so it must not be hard-linked.
+///
+/// ⚠ Measured: mutating the attrs comparison to report "same" unconditionally
+/// does NOT kill this row either. The data-level quick check applies the same
+/// `same_time` predicate first and rejects the candidate before the attrs
+/// comparison runs, so no reachable input can distinguish an over-permissive
+/// attrs comparison - which mirrors upstream, where `quick_check_ok()` and
+/// `unchanged_attrs()` both route through `same_time()`. The one lethal
+/// mutation is restoring the nanosecond-exact comparison, which kills
+/// `link_dest_hardlinks_a_basis_differing_only_in_mtime_nanoseconds`.
+#[cfg(unix)]
+#[test]
+fn whole_second_difference_refuses_the_basis() {
+    let fixture = NanosecondBasis::build_with_basis_offset_secs(1);
+
+    let summary = fixture.run(LocalCopyOptions::default().times(true));
+
+    assert_eq!(
+        summary.hard_links_created(),
+        0,
+        "a basis a whole second away is not an exact match"
+    );
+    assert_ne!(
+        fixture.dest_ino(),
+        fixture.basis_ino(),
+        "a basis a whole second away must not be hard-linked"
+    );
+}
+
 /// Source and `--link-dest` basis with identical content, size and mtime
 /// SECONDS, differing only in the nanosecond component.
 #[cfg(unix)]
@@ -1966,6 +2002,10 @@ struct NanosecondBasis {
 #[cfg(unix)]
 impl NanosecondBasis {
     fn build() -> Self {
+        Self::build_with_basis_offset_secs(0)
+    }
+
+    fn build_with_basis_offset_secs(offset: i64) -> Self {
         let temp = tempdir().expect("tempdir");
         let source_dir = temp.path().join("source");
         let basis_dir = temp.path().join("previous");
@@ -1990,8 +2030,8 @@ impl NanosecondBasis {
         .expect("set source times");
         set_file_times(
             &basis_file,
-            FileTime::from_unix_time(SECS, 222_000_000),
-            FileTime::from_unix_time(SECS, 222_000_000),
+            FileTime::from_unix_time(SECS + offset, 222_000_000),
+            FileTime::from_unix_time(SECS + offset, 222_000_000),
         )
         .expect("set basis times");
 

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -1893,3 +1893,135 @@ fn alt_dest_arg_that_is_not_a_directory_does_not_fail_a_symlink_transfer() {
         "the symlink must still be recreated at the destination"
     );
 }
+
+/// A basis whose mtime differs from the source only in the NANOSECOND
+/// component is still an exact match for upstream, so it is hard-linked.
+///
+/// Every other cell in this file synchronises the two timestamps exactly, which
+/// is why none of them can see this: `same_time()` with the default
+/// `modify_window` of 0 compares WHOLE SECONDS, and a basis produced by anything
+/// other than rsync itself routinely lands on a different nanosecond. Comparing
+/// the full `SystemTime` demoted such a basis from match_level 3 to 2, copying
+/// the file into a fresh inode instead of linking it - silently, with exit 0.
+///
+/// upstream: `rsync-3.5.0/util1.c:1649` `same_time()`;
+/// `generator.c:400` `mtime_differs()` -> `generator.c:1090` `try_dests_reg()`.
+#[cfg(unix)]
+#[test]
+fn link_dest_hardlinks_a_basis_differing_only_in_mtime_nanoseconds() {
+    let fixture = NanosecondBasis::build();
+
+    let summary = fixture.run(LocalCopyOptions::default().times(true));
+
+    assert_eq!(
+        summary.hard_links_created(),
+        1,
+        "the basis matched exactly, so it is linked not copied"
+    );
+    assert_eq!(
+        fixture.dest_ino(),
+        fixture.basis_ino(),
+        "a basis differing only in mtime nanoseconds must still be hard-linked"
+    );
+}
+
+/// The non-vacuity companion: under `--modify-window=-1` upstream DOES compare
+/// nanoseconds (`same_time` returns `f1_sec == f2_sec && f1_nsec == f2_nsec`),
+/// so the very same fixture must NOT link. Without this row a fix that ignored
+/// nanoseconds unconditionally would look correct.
+#[cfg(unix)]
+#[test]
+fn nsec_exact_modify_window_still_refuses_a_nanosecond_differing_basis() {
+    let fixture = NanosecondBasis::build();
+
+    let summary = fixture.run(
+        LocalCopyOptions::default()
+            .times(true)
+            .with_modify_window(::metadata::ModifyWindow::from_secs(-1)),
+    );
+
+    assert_eq!(
+        summary.hard_links_created(),
+        0,
+        "the basis did not match, so nothing is linked"
+    );
+    assert_ne!(
+        fixture.dest_ino(),
+        fixture.basis_ino(),
+        "an nsec-exact window must not link a nanosecond-differing basis"
+    );
+}
+
+/// Source and `--link-dest` basis with identical content, size and mtime
+/// SECONDS, differing only in the nanosecond component.
+#[cfg(unix)]
+struct NanosecondBasis {
+    _temp: tempfile::TempDir,
+    source_file: std::path::PathBuf,
+    basis_dir: std::path::PathBuf,
+    basis_file: std::path::PathBuf,
+    dest_file: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl NanosecondBasis {
+    fn build() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let source_dir = temp.path().join("source");
+        let basis_dir = temp.path().join("previous");
+        let dest_dir = temp.path().join("dest");
+        for dir in [&source_dir, &basis_dir, &dest_dir] {
+            fs::create_dir_all(dir).expect("create dir");
+        }
+
+        let source_file = source_dir.join("file.txt");
+        let basis_file = basis_dir.join("file.txt");
+        fs::write(&source_file, b"identical content").expect("write source");
+        fs::write(&basis_file, b"identical content").expect("write basis");
+
+        // Same second, different nanoseconds - the shape a basis acquires
+        // whenever its mtime was not copied at nanosecond resolution.
+        const SECS: i64 = 1_700_000_000;
+        set_file_times(
+            &source_file,
+            FileTime::from_unix_time(SECS, 111_000_000),
+            FileTime::from_unix_time(SECS, 111_000_000),
+        )
+        .expect("set source times");
+        set_file_times(
+            &basis_file,
+            FileTime::from_unix_time(SECS, 222_000_000),
+            FileTime::from_unix_time(SECS, 222_000_000),
+        )
+        .expect("set basis times");
+
+        Self {
+            _temp: temp,
+            source_file,
+            basis_dir,
+            basis_file,
+            dest_file: dest_dir.join("file.txt"),
+        }
+    }
+
+    fn run(&self, options: LocalCopyOptions) -> crate::local_copy::LocalCopySummary {
+        let operands = vec![
+            self.source_file.clone().into_os_string(),
+            self.dest_file.clone().into_os_string(),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+        plan.execute_with_options(
+            LocalCopyExecution::Apply,
+            options.extend_link_dests([self.basis_dir.clone()]),
+        )
+        .expect("copy succeeds")
+    }
+
+    fn dest_ino(&self) -> u64 {
+        fs::metadata(&self.dest_file).expect("dest metadata").ino()
+    }
+
+    fn basis_ino(&self) -> u64 {
+        fs::metadata(&self.basis_file).expect("basis metadata").ino()
+    }
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -178,7 +178,7 @@ ki73-cvs-clear-list pass
 link-dest-module-escape pass
 link-dest-pathroot pass
 link-dest-relative-basis pass
-link-dest-symlink-enotsup fail
+link-dest-symlink-enotsup pass
 links pass
 log-control-chars pass
 log-file-symlink skip

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -178,7 +178,7 @@ ki73-cvs-clear-list pass
 link-dest-module-escape pass
 link-dest-pathroot pass
 link-dest-relative-basis pass
-link-dest-symlink-enotsup fail
+link-dest-symlink-enotsup pass
 links pass
 log-control-chars pass
 log-file-symlink pass


### PR DESCRIPTION
## Problem

`--link-dest` silently stops hard-linking when the basis mtime differs from the
source only in the **nanosecond** component.

Measured on Linux against the real `rsync 3.5.0` binary, same fixture, same argv
(`-a --link-dest=ldest src/ dest/`), the two files written back to back so they
share a second but not a nanosecond:

| | `dest/reg` inode |
|---|---|
| upstream 3.5.0 | **== basis** (hard-linked) |
| oc-rsync | different (copied into a fresh inode) |

Exit 0, no message. That defeats the point of `--link-dest`, and it fires for any
basis whose mtime was not preserved at nanosecond resolution - i.e. anything not
written by rsync itself.

## Upstream rule (read, not assumed)

`rsync-3.5.0/util1.c:1649`:

```c
int same_time(time_t f1_sec, unsigned long f1_nsec, time_t f2_sec, unsigned long f2_nsec)
{
    if (modify_window == 0)  return f1_sec == f2_sec;                       /* the DEFAULT */
    if (modify_window < 0)   return f1_sec == f2_sec && f1_nsec == f2_nsec;
    /* The nanoseconds do not figure into these checks -- time windows don't care about that. */
    ...
}
```

Reached from `generator.c:400 mtime_differs()` -> `quick_check_ok()` and
`unchanged_attrs()` -> `try_dests_reg()` (`generator.c:1090`). Nanoseconds are
compared **only** under `--modify-window=-1`.

`reference_attrs_unchanged` compared the two `SystemTime` values directly, which
is nanosecond-exact always, so the basis was demoted from match_level 3 to 2 and
`copy_altdest_file`'d instead of hard-linked.

## Change

Both alt-dest mtime comparisons now delegate to the shared, already-tested
`metadata::ModifyWindow::same_time`:

- `reference_attrs_unchanged` (regular files) - via a portable
  `SystemTime -> (secs, nsec)` split, since `fs::Metadata::modified` is the only
  cross-platform source. `ModifyWindow` is threaded from the caller's options at
  all three call sites.
- `mtimes_within_window` (device/special basis) carried a **second copy** of the
  rule whose `window <= 0` arm folded the zero and negative cases together,
  requiring nsec equality for both. Its doc comment stated that wrong rule
  explicitly. It now delegates too, so the two basis kinds cannot disagree about
  what "same time" means.

## Scope (measured, do not widen)

The **plain** quick check was already correct: the same ns-differing fixture with
no `--link-dest` transfers nothing on both implementations. The divergence was
confined to the alt-dest comparison.

## Verification

- 122/122 green across the whole `link_dest` / `copy_dest` / `compare_dest` /
  `reference` family; fmt + clippy clean.
- **Lethal mutation:** restoring the nanosecond-exact comparison fails
  `link_dest_hardlinks_a_basis_differing_only_in_mtime_nanoseconds` and leaves
  the companions green.
- ⚠ **Two other mutations are NOT lethal, and the tests say so in their doc
  comments.** Dropping nanoseconds entirely, or reporting "same" unconditionally,
  kills nothing: the data-level quick check applies the same `same_time`
  predicate first and rejects a mismatched candidate before the attrs comparison
  runs. That mirrors upstream, where `quick_check_ok()` and `unchanged_attrs()`
  both route through `same_time()`. The two extra rows are kept as end-to-end
  pins of `--modify-window=-1` and of the whole-second case, not as non-vacuity
  proofs for the changed line.

## Relationship to the upstream 3.5.0 testsuite

This is the second of two root causes behind the `link-dest-symlink-enotsup`
cell. The first (an `O_TMPFILE` commit-time abort) is #7478. The manifest row is
not flipped here because it needs both; whichever lands second should flip it.
