### PR TITLE
fix(ci): let the caller name the upstream rsync the benchmark compares against

### DIFF
--- a/.github/scripts/benchmark.py
+++ b/.github/scripts/benchmark.py
@@ -15,9 +15,14 @@ import sys
 import tempfile
 import time
 
-UPSTREAM = os.environ.get(
-    "UPSTREAM_RSYNC", "target/interop/upstream-src/rsync-3.4.4/rsync"
-)
+UPSTREAM = os.environ.get("UPSTREAM_RSYNC", "")
+if not UPSTREAM:
+    sys.exit(
+        "UPSTREAM_RSYNC is not set: point it at the upstream rsync binary to "
+        "compare against, e.g. target/interop/upstream-src/rsync-3.5.0/rsync. "
+        "The caller that builds that binary owns the version, so this script "
+        "does not name one."
+    )
 OC_RSYNC = "target/release/oc-rsync"
 OC_RSYNC_OPENSSL = os.environ.get("OC_RSYNC_OPENSSL", "")
 OC_RSYNC_RUSSH = os.environ.get("OC_RSYNC_RUSSH", "")

--- a/.github/workflows/_benchmark-macos.yml
+++ b/.github/workflows/_benchmark-macos.yml
@@ -112,6 +112,10 @@ jobs:
           ssh -o StrictHostKeyChecking=no localhost true
 
       - name: Run benchmark
+        env:
+          # The build step above owns the upstream version; naming it again
+          # inside benchmark.py is what let the two drift apart.
+          UPSTREAM_RSYNC: target/interop/upstream-src/rsync-3.5.0/rsync
         run: |
           set -euo pipefail
           python3 .github/scripts/benchmark.py > benchmark_results_macos.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Run benchmark
         id: benchmark
         env:
+          # The build step above owns the upstream version; naming it again
+          # inside benchmark.py is what let the two drift apart.
+          UPSTREAM_RSYNC: target/interop/upstream-src/rsync-3.5.0/rsync
           OC_RSYNC_OPENSSL: target/release/oc-rsync-openssl
           OC_RSYNC_RUSSH: target/release/oc-rsync-russh
         run: |


### PR DESCRIPTION
The weekly `Benchmark` workflow has failed on every run since 2026-08-16
(2026-08-09 was the last green one). Both cells die the same way:

```
FileNotFoundError: [Errno 2] No such file or directory:
    'target/interop/upstream-src/rsync-3.4.4/rsync'
```

`benchmark.yml` and `_benchmark-macos.yml` download, build, cache and verify
upstream rsync **3.5.0** — the cache key is `upstream-rsync-3.5.0-<os>-full`
and the Linux cell copies `rsync-3.5.0/rsync` to `/usr/local/bin/rsync`.
Neither sets `UPSTREAM_RSYNC`, so `.github/scripts/benchmark.py` fell back to
its own default, which still named **3.4.4**. The version was written down
twice and only one copy moved.

Each workflow now passes `UPSTREAM_RSYNC` to the benchmark step, taken from
the path its own build step produces, so the version is stated once per
workflow. The script no longer names a version: with the variable unset it
exits with a message saying what to set, rather than a traceback pointing at
a path the caller never intended.

## Verification

- The env var is read back **out of the committed YAML** with `yaml.safe_load`
  (not from a hand copy), asserting the benchmark step in each workflow sets
  it: both resolve to `target/interop/upstream-src/rsync-3.5.0/rsync`.
- Script unset: exits 1 with the guidance message.
- Script set: guard passes and the value reaches `UPSTREAM`.

The end-to-end benchmark itself is a weekly scheduled job and is not run here;
what is verified is the complete causal chain — the path the workflows build
and verify is now the path the script uses.
