### PR TITLE
fix(local-copy): make --no-zero-copy reach the content path it documents

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -764,19 +764,30 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
         options
     }
 
-    /// Swaps in [`fast_io::NoZeroCopyPlatformCopy`] when the user passed
-    /// `--no-zero-copy`, forcing whole-file copies through the portable
-    /// `std::fs::copy` fallback.
+    /// Applies `--zero-copy` / `--no-zero-copy` to both halves of the local
+    /// copy path.
     ///
-    /// `Auto` and `Enabled` leave the engine's default platform copy
-    /// strategy in place so the platform fallback chain
-    /// (`FICLONE`/`copy_file_range` on Linux, `clonefile`/`fcopyfile` on
-    /// macOS, `CopyFileExW`/ReFS on Windows) remains active.
+    /// The policy governs two independent mechanisms, and disabling only one
+    /// leaves the flag half-inert:
+    ///
+    /// 1. The **clone/reflink tier** - swapped to
+    ///    [`fast_io::NoZeroCopyPlatformCopy`] so whole-file copies take the
+    ///    portable `std::fs::copy` fallback.
+    /// 2. The **content path** - carried on the options so the engine skips
+    ///    the kernel-side movers (`io_uring`, then `copy_file_range`) that run
+    ///    when no clone tier applied, and reads the source in userspace
+    ///    instead.
+    ///
+    /// `Auto` and `Enabled` leave both in place, so the platform fallback
+    /// chain (`FICLONE`/`copy_file_range` on Linux, `clonefile`/`fcopyfile` on
+    /// macOS, `CopyFileExW`/ReFS on Windows) remains active by default.
     fn apply_zero_copy_policy(
         options: LocalCopyOptions,
         config: &ClientConfig,
     ) -> LocalCopyOptions {
-        if matches!(config.zero_copy_policy(), fast_io::ZeroCopyPolicy::Disabled) {
+        let policy = config.zero_copy_policy();
+        let options = options.with_zero_copy_policy(policy);
+        if matches!(policy, fast_io::ZeroCopyPolicy::Disabled) {
             options.with_platform_copy(std::sync::Arc::new(fast_io::NoZeroCopyPlatformCopy::new()))
         } else {
             options

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -710,13 +710,24 @@ impl<'a> CopyContext<'a> {
 
         let expected_remaining = total_size.saturating_sub(initial_bytes);
 
-        // Fast path: use copy_file_range for simple whole-file copies.
+        // Fast path: hand the whole file to the kernel. `fast_io` tries
+        // io_uring first and falls back to copy_file_range; neither performs a
+        // userspace read, so both are gated together by the one policy the
+        // operator sets with `--no-zero-copy`. Without that conjunct the flag
+        // is inert here: `apply_zero_copy_policy` only swaps the
+        // clone/reflink tier, which never reaches these movers.
+        //
         // Requires no sparse detection, no compression, no bandwidth limiter.
         // Disabled for append mode (initial_bytes > 0) because copy_file_range
         // and io_uring on Linux do not reliably respect the seeked file position
         // when both source and destination have been seeked to non-zero offsets.
         // upstream: receiver.c - append path uses standard read/write loop.
-        if !sparse && !compress && self.limiter.is_none() && initial_bytes == 0 {
+        if self.options.kernel_content_copy_allowed()
+            && !sparse
+            && !compress
+            && self.limiter.is_none()
+            && initial_bytes == 0
+        {
             let copied = fast_io::copy_file_range::copy_file_contents_buffered(
                 reader,
                 writer,

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -209,6 +209,11 @@ impl LocalCopyOptionsBuilder {
             log_file: self.log_file,
             log_file_format: self.log_file_format,
             platform_copy: self.platform_copy,
+            // Defaults to the same `Auto` as `LocalCopyOptions::new()`. The
+            // policy is an operator flag, applied after construction by
+            // `core::client::run::apply_zero_copy_policy`, so the builder has
+            // no setter for it rather than a setter nobody calls.
+            zero_copy: fast_io::ZeroCopyPolicy::Auto,
         };
         options.apply_delay_updates_partial_dir_default();
         options

--- a/crates/engine/src/local_copy/options/platform_copy.rs
+++ b/crates/engine/src/local_copy/options/platform_copy.rs
@@ -27,12 +27,41 @@ impl LocalCopyOptions {
     pub fn platform_copy(&self) -> &Arc<dyn PlatformCopy> {
         &self.platform_copy
     }
+
+    /// Sets the I/O-level zero-copy policy for the file content path,
+    /// mirroring `--zero-copy` / `--no-zero-copy`.
+    #[must_use]
+    pub const fn with_zero_copy_policy(mut self, policy: fast_io::ZeroCopyPolicy) -> Self {
+        self.zero_copy = policy;
+        self
+    }
+
+    /// Returns the configured I/O-level zero-copy policy.
+    #[must_use]
+    pub const fn zero_copy_policy(&self) -> fast_io::ZeroCopyPolicy {
+        self.zero_copy
+    }
+
+    /// Reports whether the content path may hand a copy to the kernel
+    /// (io_uring, then `copy_file_range`) instead of reading it in userspace.
+    ///
+    /// `Auto` and `Enabled` both allow it; only
+    /// [`fast_io::ZeroCopyPolicy::Disabled`] forces the portable read/write
+    /// loop. That is the contract `ZeroCopyPolicy` already documents - "the
+    /// chain is bypassed" - and the content path is the second half of it: the
+    /// first half swaps the clone/reflink tier via [`Self::with_platform_copy`],
+    /// which does not reach the kernel-side movers that run when no clone
+    /// applied.
+    #[must_use]
+    pub const fn kernel_content_copy_allowed(&self) -> bool {
+        !matches!(self.zero_copy, fast_io::ZeroCopyPolicy::Disabled)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fast_io::{CopyMethod, CopyResult, DefaultPlatformCopy};
+    use fast_io::{CopyMethod, CopyResult, DefaultPlatformCopy, ZeroCopyPolicy};
     use std::io;
     use std::path::Path;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -76,6 +105,56 @@ mod tests {
             .copy_file(Path::new("/dev/null"), Path::new("/dev/null"), 0)
             .expect("counting strategy returns Ok");
         assert_eq!(result.method, CopyMethod::StandardCopy);
+        assert_eq!(counting.calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// The content path may hand a copy to the kernel unless the operator
+    /// disabled it, so the default must not change today's behaviour.
+    #[test]
+    fn zero_copy_policy_defaults_to_auto_and_allows_the_kernel_content_copy() {
+        let opts = LocalCopyOptions::new();
+        assert_eq!(opts.zero_copy_policy(), ZeroCopyPolicy::Auto);
+        assert!(opts.kernel_content_copy_allowed());
+    }
+
+    /// Exhaustive over the three arms: only `Disabled` forces the portable
+    /// read/write loop. Asserting the whole enum rather than the one arm the
+    /// fix targets is what stops a later variant from silently defaulting to
+    /// "kernel copy allowed" - the direction that would make `--no-zero-copy`
+    /// half-inert again.
+    #[test]
+    fn only_disabled_forbids_the_kernel_content_copy() {
+        for (policy, allowed) in [
+            (ZeroCopyPolicy::Auto, true),
+            (ZeroCopyPolicy::Enabled, true),
+            (ZeroCopyPolicy::Disabled, false),
+        ] {
+            let opts = LocalCopyOptions::new().with_zero_copy_policy(policy);
+            assert_eq!(opts.zero_copy_policy(), policy);
+            assert_eq!(
+                opts.kernel_content_copy_allowed(),
+                allowed,
+                "{policy:?} must {} the kernel content copy",
+                if allowed { "allow" } else { "forbid" }
+            );
+        }
+    }
+
+    /// `--no-zero-copy` governs two independent mechanisms. This pins that
+    /// setting the content policy leaves the clone/reflink tier alone, so a
+    /// future edit cannot collapse them into one field and quietly drop half
+    /// the flag's contract.
+    #[test]
+    fn the_content_policy_is_independent_of_the_platform_copy_tier() {
+        let counting = Arc::new(CountingPlatformCopy::default());
+        let opts = LocalCopyOptions::new()
+            .with_platform_copy(counting.clone())
+            .with_zero_copy_policy(ZeroCopyPolicy::Disabled);
+
+        assert!(!opts.kernel_content_copy_allowed());
+        opts.platform_copy()
+            .copy_file(Path::new("/dev/null"), Path::new("/dev/null"), 0)
+            .expect("the injected tier is still the configured one");
         assert_eq!(counting.calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -285,6 +285,15 @@ pub struct LocalCopyOptions {
     /// macOS, ReFS reflink/CopyFileExW on Windows) with portable fallback.
     /// Tests can inject a fake implementation to verify dispatch.
     pub(super) platform_copy: Arc<dyn PlatformCopy>,
+    /// I/O-level zero-copy policy for the file *content* path, mirroring
+    /// `--zero-copy` / `--no-zero-copy`.
+    ///
+    /// Distinct from [`Self::platform_copy`], which selects the filesystem
+    /// clone/reflink tier. This one governs the kernel-side content movers
+    /// (io_uring, `copy_file_range`) that run when no clone tier applied, and
+    /// [`fast_io::ZeroCopyPolicy::Disabled`] routes the copy through the
+    /// portable read/write loop instead.
+    pub(super) zero_copy: fast_io::ZeroCopyPolicy,
 }
 
 impl LocalCopyOptions {
@@ -396,6 +405,7 @@ impl LocalCopyOptions {
             log_file: None,
             log_file_format: None,
             platform_copy: Arc::new(DefaultPlatformCopy::new()),
+            zero_copy: fast_io::ZeroCopyPolicy::Auto,
         }
     }
 }


### PR DESCRIPTION
## What

`--no-zero-copy` advertises that it disables "I/O-level zero-copy syscalls
(sendfile, splice, copy_file_range)", and `ZeroCopyPolicy`'s own rustdoc says
that under `Disabled` "the chain is bypassed". On a local copy neither held —
the flag changed nothing at all.

`apply_zero_copy_policy` swapped only `LocalCopyOptions::platform_copy`, the
clone/reflink tier. The file *content* path is a separate mechanism that runs
when no clone applied, and its gate consulted no policy: `LocalCopyOptions` had
no field to consult, because the policy never crossed from `core` into `engine`.

## Measured

x86_64 Linux, `-a --no-whole-file`, fresh destination, tmpfs **and** ext4 —
identical on both. Before, with an upstream 3.4.4 control:

| config | copy_file_range | io_uring | src reads |
|---|---|---|---|
| default | 0 | 32 | 0 |
| `--no-zero-copy` | 0 | 32 | 0 |
| upstream 3.4.4 (control) | 0 | 0 | 4 |

After — the default row is the negative control and is unchanged:

| config | copy_file_range | io_uring | src reads |
|---|---|---|---|
| default | 0 | 32 | 0 |
| `--no-zero-copy` | 0 | **0** | **8** |

Destination is 1048576 bytes in every cell, so the data still moves correctly.

## Two movers, not one

`fast_io::copy_file_range::copy_file_contents_buffered` tries io_uring first and
falls back to `copy_file_range`. Gating only the latter would have left the
default configuration untouched — the pre-fix table shows io_uring is what
actually carries the bytes, and `copy_file_range` appears only once io_uring is
disabled. Both are now gated by the one policy the operator sets.

When it is `Disabled`, control falls through to the existing dense read/write
loop, which already carries the short-source diagnostic — so no second copy of
that rule appears.

## Default is unchanged

`Auto` and `Enabled` both keep the kernel-side movers. This costs nothing unless
the operator asks for it.

## Scope

The policy is carried on the options rather than folded into `platform_copy`
because the two tiers are genuinely independent — one selects a filesystem
clone, the other decides whether the copy is read in userspace. A test pins that
setting one leaves the other alone, so a later edit cannot collapse them and
quietly drop half the flag's contract again.

⚠ The in-crate tests cover the predicate and the plumbing. They cannot observe
*which* syscall ran, because both paths return the same `FileCopyOutcome` — the
policy switches mechanism, not result. The mechanism change is proven by the
strace matrix above, not by the unit tests.

⚠ This does **not** by itself flip the `source-change-size-continues` testsuite
cell: that cell does not pass `--no-zero-copy`, so oc still takes the kernel
path there and the cell's `LD_PRELOAD` read hook still cannot fire. Closing that
cell is a separate decision about the default, tracked separately.
