### PR TITLE
fix(partial-dir): confine the reuse probe and discard on a refused create

### DIFF
--- a/crates/engine/src/util/cleanup.rs
+++ b/crates/engine/src/util/cleanup.rs
@@ -34,12 +34,15 @@ struct PartialEntry {
 /// user. This is the single owner of the rule for both the abort path
 /// ([`finalize_partial`]) and the `--delay-updates` staging path.
 ///
-/// On unix the create goes through `fast_io::operator_mkdir`, so a symlink
-/// planted at any component by a foreign uid is refused rather than followed -
-/// an absolute `--partial-dir` names a location outside the transfer tree, and
-/// without the walk a planted parent redirects the staged file (which is a
-/// complete copy of the source) out of the tree entirely. Upstream wraps the
-/// same `do_mkdir_at()` in `operator_path_resolve = 1` for that reason.
+/// On unix *both* path decisions go through the ownership walk, because
+/// upstream wraps both in `operator_path_resolve = 1`: the reuse probe
+/// (`do_lstat_at`, `util1.c:1521`) and the create (`do_mkdir_at`,
+/// `util1.c:1529`). An absolute `--partial-dir` names a location outside the
+/// transfer tree, so a foreign-owned symlink planted at any component would
+/// otherwise redirect the staged file - a complete copy of the source - out of
+/// the tree. Probing with `Path::is_dir()` would defeat the walk on exactly the
+/// case an operator hits most: a reserved absolute partial dir that already
+/// exists, where the create is never reached at all.
 ///
 /// Any missing ancestor is created first, matching what the abort path has
 /// always done; upstream mkdirs only the final component and fails when the
@@ -47,14 +50,34 @@ struct PartialEntry {
 pub fn create_partial_dir(dir: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {
-        if dir.as_os_str().is_empty() || dir.is_dir() {
+        // `""`, `/`, `.` and `..` name a directory that already exists and have
+        // no leaf for the walk to resolve.
+        if dir.file_name().is_none() {
             return Ok(());
         }
-        if let Some(parent) = dir.parent()
-            && !parent.as_os_str().is_empty()
-            && !parent.is_dir()
-        {
-            create_partial_dir(parent)?;
+        // upstream: util1.c:1521 - `do_lstat_at(dir, &st)` under
+        // `operator_path_resolve`, so the reuse probe is confined by the same
+        // rule as the create. A refusal propagates rather than degrading to an
+        // unconfined create.
+        match fast_io::operator_symlink_metadata(dir) {
+            // upstream: util1.c:1522 - `statret == 0 && S_ISDIR` skips the
+            // mkdir and the dir is reused as it stands.
+            Ok(metadata) if metadata.is_dir() => return Ok(()),
+            // Something that is not a directory occupies the name. Upstream
+            // unlinks it (util1.c:1523); oc has never done that, and the
+            // `operator_mkdir` below keeps today's behaviour of reporting the
+            // resulting `EEXIST` as success. Left unchanged here on purpose:
+            // this function also creates ancestors upstream never touches, so
+            // an unlink placed here would delete beyond the leaf.
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                if let Some(parent) = dir.parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    create_partial_dir(parent)?;
+                }
+            }
+            Err(error) => return Err(error),
         }
         fast_io::operator_mkdir(dir, 0o700)
     }
@@ -71,11 +94,25 @@ pub fn create_partial_dir(dir: &Path) -> std::io::Result<()> {
 /// `handle_partial_dir(PDIR_CREATE)`), tweaking the modtime to epoch 0 when the
 /// partial lands on the real destination file so `--update` will not skip it.
 /// With no partial destination it unlinks the temp (`do_unlink_at`).
+///
+/// Creating the partial dir is a PRECONDITION of the rename, not a best-effort
+/// prelude: upstream guards `finish_transfer()` on it in both places
+/// (`cleanup.c:168` has the call inside a `&&`; `receiver.c:1302-1306` reports
+/// "Unable to create partial-dir for %s -- discarding %s" and `do_unlink_at`s
+/// the temp). Renaming anyway would undo the ownership walk's refusal - the
+/// rename resolves the same path with plain libc and lands the file exactly
+/// where the walk declined to create the directory.
 pub fn finalize_partial(temp: &Path, partial_dest: Option<&Path>, tweak_mtime: bool) {
     match partial_dest {
         Some(dest) => {
-            if let Some(parent) = dest.parent() {
-                let _ = create_partial_dir(parent);
+            if let Some(parent) = dest.parent()
+                && create_partial_dir(parent).is_err()
+            {
+                // upstream: receiver.c:1306 `do_unlink_at(fnametmp)` - the
+                // completed file is discarded rather than retained somewhere
+                // the operator did not name.
+                let _ = std::fs::remove_file(temp);
+                return;
             }
             // Best-effort: an already-committed transfer leaves no temp, so a
             // failed rename here is expected and harmless.
@@ -472,6 +509,83 @@ mod tests {
         manager.register_temp_file(path);
 
         assert_eq!(manager.temp_file_count(), 1, "HashSet deduplicates");
+    }
+
+    /// Builds the shape the `--partial-dir` reuse probe has to decide on: an
+    /// absolute partial dir `<plant>/opd/sub` whose parent component `opd` is a
+    /// symlink to an out-of-tree directory, with `sub` ALREADY PRESENT inside
+    /// it. Returns `(partial_dir, planted_link, out_of_tree_leaf)`.
+    ///
+    /// The leaf existing is the whole point: it is the arm a probe that stats
+    /// through the symlink answers "already a directory, nothing to do" - never
+    /// reaching the create, and therefore never reaching the ownership walk.
+    #[cfg(unix)]
+    fn plant_reused_partial_dir(base: &Path) -> (PathBuf, PathBuf, PathBuf) {
+        let outside = base.join("outside");
+        let leaf = outside.join("sub");
+        fs::create_dir_all(&leaf).expect("create the out-of-tree leaf");
+        let plant = base.join("plant");
+        fs::create_dir(&plant).expect("create the plant dir");
+        let link = plant.join("opd");
+        std::os::unix::fs::symlink(&outside, &link).expect("plant the parent symlink");
+        (link.join("sub"), link, leaf)
+    }
+
+    /// The operator's own symlink is followed, so an existing partial dir
+    /// reached through it is reused. This is the half that must keep working:
+    /// `/backup -> /mnt/disk` is the ordinary administrative layout, and
+    /// refusing every parent symlink would break it.
+    ///
+    /// upstream: `syscall.c:406` - uid 0 or our euid is trusted and followed.
+    #[cfg(unix)]
+    #[test]
+    fn an_existing_partial_dir_behind_the_operators_own_parent_symlink_is_reused() {
+        let base = tempdir().expect("tempdir");
+        let (partial_dir, _link, leaf) = plant_reused_partial_dir(base.path());
+
+        create_partial_dir(&partial_dir).expect("the operator's own symlink must be followed");
+        assert!(leaf.is_dir(), "the existing leaf is reused, not replaced");
+    }
+
+    /// The same shape with the symlink owned by someone else must be refused,
+    /// even though the leaf already exists.
+    ///
+    /// upstream: `util1.c:1521` `handle_partial_dir()` runs its `do_lstat_at()`
+    /// reuse probe under `operator_path_resolve = 1`, i.e. through the same
+    /// ownership walk as the `do_mkdir_at()` beneath it. Probing with a
+    /// following stat would answer this case before the walk ever ran, and the
+    /// staged file - a complete copy of the source - would land in
+    /// `outside/sub`.
+    ///
+    /// Planting a symlink owned by a foreign uid needs root, which is why
+    /// upstream's own `operator-path-partial-dir [reuse]` cell only exercises
+    /// this on its root leg. The companion above carries the other direction at
+    /// any uid.
+    #[cfg(unix)]
+    #[test]
+    fn an_existing_partial_dir_behind_a_foreign_owned_parent_symlink_is_refused() {
+        if rustix::process::geteuid().as_raw() != 0 {
+            eprintln!(
+                "SKIPPED an_existing_partial_dir_behind_a_foreign_owned_parent_symlink_is_refused: \
+                 planting a symlink owned by a foreign uid requires root"
+            );
+            return;
+        }
+        // An arbitrary uid that is neither 0 nor our euid; `lchown` accepts it
+        // whether or not an account exists, and the walk compares numbers.
+        const ATTACKER_UID: u32 = 12345;
+
+        let base = tempdir().expect("tempdir");
+        let (partial_dir, link, leaf) = plant_reused_partial_dir(base.path());
+        std::os::unix::fs::lchown(&link, Some(ATTACKER_UID), Some(ATTACKER_UID))
+            .expect("give the planted symlink to the attacker");
+
+        create_partial_dir(&partial_dir)
+            .expect_err("a foreign-owned parent symlink must be refused, leaf present or not");
+        assert!(
+            leaf.is_dir(),
+            "the refusal must not have disturbed the out-of-tree leaf"
+        );
     }
 
     #[test]

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -221,7 +221,7 @@ operator-path-insecure-links-daemon pass
 operator-path-insecure-links-refused pass
 operator-path-link-dest pass
 operator-path-log-file pass
-operator-path-partial-dir fail
+operator-path-partial-dir pass
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
 operator-path-temp-dir fail


### PR DESCRIPTION
`--partial-dir` is an operator-supplied path, and an absolute one names a location
outside the transfer tree, so upstream resolves it through the ownership walk:
`handle_partial_dir()` sets `operator_path_resolve = 1` around **both** of its
syscalls - the `do_lstat_at()` that reuses an existing directory and the
`do_mkdir_at(dir, 0700)` that creates a missing one (`util1.c:1518-1530`).

oc had only the second half. `create_partial_dir()` opened with

```rust
if dir.as_os_str().is_empty() || dir.is_dir() { return Ok(()); }
```

and `Path::is_dir()` is a *following* stat. The `fast_io::operator_mkdir` beneath it
was therefore reached only when the directory was absent. For a reserved absolute
`--partial-dir` reused across runs - the case the option exists for - a foreign-owned
symlink planted at a parent component answered the probe before the walk ever ran,
and the staged file, a complete copy of the source, was written out of the tree. The
recursion guard `!parent.is_dir()` followed for the same reason.

The reuse probe is now `fast_io::operator_symlink_metadata`, which walks the parent
chain and `lstat`s the leaf, so one rule covers reuse and create alike.

## That alone was not enough

With the create refused, the guard's error propagated but the abort path then planted
the file anyway: `finalize_partial()` ran `let _ = create_partial_dir(parent)` and
renamed regardless. Upstream treats the create as a **precondition** of the rename in
both of its call sites - `cleanup.c:168` has `handle_partial_dir(...)` inside a `&&`,
and `receiver.c:1302-1306` reports `Unable to create partial-dir for %s -- discarding
%s` and `do_unlink_at`s the temp. Renaming anyway undoes the refusal exactly, because
the rename resolves the same path with plain libc and lands the file where the walk
declined to create the directory. `finalize_partial` now discards the temp instead,
mirroring `receiver.c:1306`.

## Measured

x86_64 Linux as root, `-a --delay-updates --partial-dir=<plant>/opd/sub` with `opd` a
symlink owned by a foreign uid and `outside/sub` already present:

| binary | exit | out-of-tree leaf | dest |
|---|---|---|---|
| upstream 3.5.0 | 0 | untouched, empty | empty |
| oc before | 23 | `f0` **planted** | empty |
| oc after | 23\* | untouched, empty | empty |

\* oc reports exit 23 with the refusal on stderr rather than upstream's exit 0 +
`FERROR` line; both leave the tree unchanged, and the cell scores only whether the
symlink was followed.

Both halves are independently load-bearing: restoring the following `is_dir()` probe
reds `operator-path-partial-dir` again, and so does restoring the best-effort create
in `finalize_partial`.

## Manifest

The root manifest row flips in this commit (`fail` -> `pass`). The nonroot row was
already `pass` - only root can plant a symlink owned by a foreign uid, which is why
the in-crate pin for that direction is root-gated; its companion, that the operator's
**own** symlink is still followed and the existing directory reused, runs at any uid
and is what stops the fix becoming a blanket refusal.

Full root leg re-run against the built binary: 264 passed / 27 failed / 54 skipped,
`overall result is 0`, no expected-result mismatches.

## Residual, deliberately not claimed

Upstream also **unlinks** a non-directory occupying the partial-dir name before the
mkdir (`util1.c:1522-1527`). oc has never done that and still reports the resulting
`EEXIST` as success. Left alone here because this function also creates ancestors
upstream never touches, so an unlink placed at the leaf would need scoping that no
cell currently exercises.
