### PR TITLE
fix(receiver): recover a read-only in-place destination

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -155,6 +155,20 @@ pub(in crate::local_copy) fn open_destination_writer(
                     .open(destination),
                 other => other,
             };
+            // upstream: receiver.c:1219-1224 - the third arm, recovering a
+            // read-only destination. Not platform-gated: a read-only file is an
+            // EACCES everywhere. The caller's truncate choice is preserved, so
+            // this changes only *whether* the open succeeds.
+            #[cfg(unix)]
+            let opened = match opened {
+                Err(error) if error.raw_os_error() == Some(libc::EACCES) => {
+                    fast_io::readonly_inplace::open_readonly_inplace(
+                        destination,
+                        fs::OpenOptions::new().write(true).truncate(should_truncate),
+                    )
+                }
+                other => other,
+            };
             opened.map_err(|error| LocalCopyError::io("copy file", destination, error))
         }
         WriteStrategy::Direct => {

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -134,6 +134,10 @@ pub mod page_aligned;
 pub mod parallel;
 /// Total physical memory detection (for the buffer pool's RAM-derived cap).
 pub mod physical_memory;
+/// Unix-only: read-only in-place recovery, mirroring upstream
+/// `open_readonly_inplace` (`receiver.c:200`).
+#[cfg(unix)]
+pub mod readonly_inplace;
 /// Same-filesystem (device) detection for reflink / copy-on-write gating.
 pub mod same_fs;
 /// Strict-resolution directory open for the SEC-1 dirfd sandbox.

--- a/crates/fast_io/src/readonly_inplace.rs
+++ b/crates/fast_io/src/readonly_inplace.rs
@@ -1,0 +1,81 @@
+//! Read-only in-place recovery: open a mode-0444 regular file for writing by
+//! granting owner-write only for as long as the open takes.
+//!
+//! upstream: `open_readonly_inplace()` (receiver.c:200-287), the third arm of
+//! the in-place open chain at receiver.c:1219-1224 - after the primary
+//! `O_WRONLY|O_CREAT` and after Linux's `protected_regular` retry.
+
+use std::fs;
+use std::io;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::Path;
+
+/// `CHMOD_BITS` (rsync.h) - the mode bits a chmod may carry.
+const CHMOD_BITS: u32 = 0o7777;
+/// `S_IWUSR`.
+const OWNER_WRITE: u32 = 0o200;
+
+/// Opens a read-only regular file for an in-place update, restoring its mode
+/// before returning.
+///
+/// `options` supplies the caller's own open semantics (the receiver never
+/// truncates; the local-copy path truncates when there is no delta basis), so
+/// this owns the upstream mode dance and nothing else. It must be write-enabled.
+///
+/// The prior mode is restored *before* the descriptor is handed back: once a
+/// writable descriptor exists the writes no longer consult the pathname's
+/// permission bits, so an abort - peer EOF, checksum failure, a signal - cannot
+/// strand the file at 0600. That is what makes a cleanup path unnecessary, and
+/// why the restore must never be deferred to commit time.
+///
+/// Upstream has two branches, fd-based (receiver.c:214) and path-based (:253).
+/// This mirrors the fd-based one unconditionally: upstream keeps the path arm
+/// only to retain existing pathname semantics for local and chrooted transfers,
+/// and notes the fd branch is the one that pins an inode. Observable behaviour
+/// is identical, and `File::set_permissions` is `fchmod` on the open descriptor,
+/// so pinning costs nothing here.
+///
+/// # Errors
+///
+/// `EACCES` when the leaf is not a regular file, or is already owner-writable
+/// (in which case the caller's `EACCES` came from an ACL or the parent
+/// directory and a chmod could not help). Otherwise the underlying open or
+/// chmod error - and a failed *restore* wins over a successful open, because
+/// leaving the file owner-writable is the worse outcome.
+pub fn open_readonly_inplace(path: &Path, options: &fs::OpenOptions) -> io::Result<fs::File> {
+    let eacces = || io::Error::from_raw_os_error(libc::EACCES);
+
+    // upstream: receiver.c:216 - O_NOFOLLOW refuses a symlink at the leaf, so
+    // every syscall below acts on this one pinned inode.
+    let probe = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+
+    let metadata = probe.metadata()?;
+    // upstream: receiver.c:219-222 - not the read-only regular file we recover.
+    if !metadata.is_file() {
+        return Err(eacces());
+    }
+
+    let prior_mode = metadata.permissions().mode() & CHMOD_BITS;
+    // upstream: receiver.c:224-230 - each chmod risks losing a special bit, so
+    // do not spend one when it cannot help.
+    if prior_mode & OWNER_WRITE != 0 {
+        return Err(eacces());
+    }
+
+    probe.set_permissions(fs::Permissions::from_mode(prior_mode | OWNER_WRITE))?;
+
+    let opened = options.open(path);
+
+    // upstream: receiver.c:235-241 - restore unconditionally, and a failed
+    // restore WINS: drop the descriptor and report the restore error.
+    match probe.set_permissions(fs::Permissions::from_mode(prior_mode)) {
+        Ok(()) => opened,
+        Err(restore) => Err(restore),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fast_io/src/readonly_inplace/tests.rs
+++ b/crates/fast_io/src/readonly_inplace/tests.rs
@@ -1,0 +1,117 @@
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use super::open_readonly_inplace;
+
+const READ_ONLY: u32 = 0o444;
+
+fn write_options() -> fs::OpenOptions {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).truncate(false);
+    options
+}
+
+fn mode_of(path: &Path) -> u32 {
+    fs::symlink_metadata(path).unwrap().permissions().mode() & 0o7777
+}
+
+fn plant_readonly(dir: &Path, name: &str, contents: &[u8]) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, contents).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(READ_ONLY)).unwrap();
+    path
+}
+
+/// The recovery itself: a 0444 regular file becomes writable, and the mode is
+/// already restored by the time the descriptor is returned - which is why no
+/// abort path can strand it at 0600. upstream: receiver.c:200-241.
+#[test]
+fn a_read_only_file_is_writable_and_its_mode_is_restored_on_return() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = plant_readonly(dir.path(), "basis.bin", b"old");
+
+    let mut file = open_readonly_inplace(&path, &write_options()).expect("recoverable");
+
+    assert_eq!(
+        mode_of(&path),
+        READ_ONLY,
+        "restored while the fd is still open"
+    );
+    file.write_all(b"new").unwrap();
+    drop(file);
+
+    assert_eq!(fs::read(&path).unwrap(), b"new");
+    assert_eq!(mode_of(&path), READ_ONLY);
+}
+
+/// Upstream refuses rather than chmods when the file is already owner-writable:
+/// the EACCES came from an ACL or the parent directory, so a chmod cannot help
+/// and would risk dropping a special bit. upstream: receiver.c:224-230.
+#[test]
+fn an_owner_writable_file_is_refused_instead_of_chmodded() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("writable.bin");
+    fs::write(&path, b"old").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+    let error = open_readonly_inplace(&path, &write_options()).expect_err("must be refused");
+
+    assert_eq!(error.raw_os_error(), Some(libc::EACCES));
+    assert_eq!(mode_of(&path), 0o644, "a refusal must not spend a chmod");
+}
+
+/// The recovery pins an inode: `O_NOFOLLOW` refuses a symlink at the leaf, so a
+/// planted link cannot redirect the owner-write grant onto another file.
+/// upstream: receiver.c:216.
+#[test]
+fn a_symlink_at_the_leaf_is_refused_without_touching_its_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = plant_readonly(dir.path(), "target.bin", b"old");
+    let link = dir.path().join("link.bin");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    open_readonly_inplace(&link, &write_options()).expect_err("a symlink leaf must be refused");
+
+    assert_eq!(mode_of(&target), READ_ONLY, "the target keeps its mode");
+    assert_eq!(fs::read(&target).unwrap(), b"old");
+}
+
+/// Only a regular file is recoverable. The directory is planted 0555 so that it
+/// is *not* owner-writable: EACCES can then only come from the type check, which
+/// pins that the type check runs before the owner-write rule.
+/// upstream: receiver.c:219-222.
+#[test]
+fn a_non_regular_target_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let subdir = dir.path().join("subdir");
+    fs::create_dir(&subdir).unwrap();
+    fs::set_permissions(&subdir, fs::Permissions::from_mode(0o555)).unwrap();
+
+    let error = open_readonly_inplace(&subdir, &write_options()).expect_err("must be refused");
+
+    assert_eq!(error.raw_os_error(), Some(libc::EACCES));
+}
+
+/// The caller owns its open semantics: the local-copy path truncates when there
+/// is no delta basis, the receiver never does. Passing `truncate(true)` must
+/// therefore still truncate through the recovery.
+#[test]
+fn the_callers_open_options_are_honoured() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = plant_readonly(dir.path(), "basis.bin", b"a longer old payload");
+
+    let mut options = fs::OpenOptions::new();
+    options.write(true).truncate(true);
+    let mut file = open_readonly_inplace(&path, &options).expect("recoverable");
+    file.write_all(b"new").unwrap();
+    drop(file);
+
+    assert_eq!(
+        fs::read(&path).unwrap(),
+        b"new",
+        "truncate(true) was honoured"
+    );
+    assert_eq!(mode_of(&path), READ_ONLY);
+}

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -874,6 +874,8 @@ fn inplace_pre_transfer_stat(begin: &BeginMessage) -> Option<fs::Metadata> {
 ///
 /// - `receiver.c`: `write_devices && IS_DEVICE(st.st_mode)` - inplace write to device
 /// - `receiver.c:968-984`: opens destination directly when inplace
+/// - `receiver.c:1219-1224`: recovers a read-only destination via
+///   `open_readonly_inplace`
 fn open_output_file(
     begin: &BeginMessage,
     config: &DiskCommitConfig,
@@ -906,6 +908,19 @@ fn open_output_file(
                 .write(true)
                 .truncate(false)
                 .open(&begin.file_path),
+            other => other,
+        };
+        // upstream: receiver.c:1219-1224 - the third arm, recovering a read-only
+        // destination. Unlike the protected_regular retry above it is NOT
+        // platform-gated: a read-only file is an EACCES everywhere.
+        #[cfg(unix)]
+        let opened = match opened {
+            Err(error) if error.raw_os_error() == Some(libc::EACCES) => {
+                fast_io::readonly_inplace::open_readonly_inplace(
+                    &begin.file_path,
+                    fs::OpenOptions::new().write(true).truncate(false),
+                )
+            }
             other => other,
         };
         let mut file = opened?;
@@ -1127,3 +1142,6 @@ pub(super) fn make_writer<'a>(
     }
     Ok(Writer::Buffered(ReusableBufWriter::new(file, write_buf)))
 }
+
+#[cfg(all(test, unix))]
+mod tests;

--- a/crates/transfer/src/disk_commit/process/file_ops/tests.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops/tests.rs
@@ -1,0 +1,88 @@
+//! Tests for the in-place output open chain, in particular upstream's read-only
+//! recovery arm (`receiver.c:1219-1224`).
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use super::{BeginMessage, DiskCommitConfig, open_output_file};
+
+const READ_ONLY: u32 = 0o444;
+
+fn mode_of(path: &Path) -> u32 {
+    fs::symlink_metadata(path).unwrap().permissions().mode() & 0o7777
+}
+
+fn inplace_begin(path: &Path) -> BeginMessage {
+    BeginMessage {
+        file_path: path.to_path_buf(),
+        target_size: 0,
+        file_entry_index: 0,
+        checksum_verifier: None,
+        is_device_target: false,
+        is_inplace: true,
+        append_offset: 0,
+        xattr_list: None,
+        xattr_basis: None,
+        file_entry: None,
+    }
+}
+
+fn plant_readonly(dir: &Path, name: &str, contents: &[u8]) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, contents).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(READ_ONLY)).unwrap();
+    path
+}
+
+/// A read-only in-place destination must still be updated, as upstream 3.5.0
+/// does through the third arm of its open chain. Without that arm oc failed the
+/// whole transfer with `Permission denied (13)` and left the file untouched.
+/// upstream: receiver.c:1219-1224.
+#[test]
+fn a_read_only_inplace_destination_is_opened_for_writing() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = plant_readonly(dir.path(), "basis.bin", b"old");
+
+    let (mut file, _guard, is_temp) =
+        open_output_file(&inplace_begin(&path), &DiskCommitConfig::default())
+            .expect("a read-only in-place destination is recoverable");
+
+    assert!(!is_temp, "in-place writes the destination itself");
+    file.write_all(b"new").unwrap();
+    drop(file);
+
+    assert_eq!(fs::read(&path).unwrap(), b"new");
+    assert_eq!(
+        mode_of(&path),
+        READ_ONLY,
+        "the update must not alter the mode"
+    );
+}
+
+/// The prior mode is restored *before* the descriptor is handed back, so an abort
+/// part-way through the transfer - peer EOF, checksum failure, a signal - cannot
+/// strand the file owner-writable. That is what makes a cleanup path unnecessary,
+/// and why the restore must never be deferred to commit time.
+/// upstream: receiver.c:200-206.
+#[test]
+fn the_prior_mode_is_restored_before_the_descriptor_is_returned() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = plant_readonly(dir.path(), "basis.bin", b"old");
+
+    let (file, _guard, _) =
+        open_output_file(&inplace_begin(&path), &DiskCommitConfig::default()).unwrap();
+
+    assert_eq!(
+        mode_of(&path),
+        READ_ONLY,
+        "restored while the writable fd is still open"
+    );
+
+    // The abort: the transfer loop never writes a byte.
+    drop(file);
+
+    assert_eq!(mode_of(&path), READ_ONLY);
+    assert_eq!(fs::read(&path).unwrap(), b"old");
+}

--- a/tests/readonly_inplace_recovery.rs
+++ b/tests/readonly_inplace_recovery.rs
@@ -1,0 +1,97 @@
+//! A read-only destination must still be updated under `--inplace`.
+//!
+//! upstream 3.5.0 opens the in-place output through a three-arm chain
+//! (`receiver.c:1210-1224`): the primary `O_WRONLY|O_CREAT`, Linux's
+//! `protected_regular` retry, and finally `open_readonly_inplace()`
+//! (`receiver.c:200-287`), which grants owner-write only for the duration of
+//! the open and restores the prior mode before returning.
+//!
+//! oc had the first two arms at both of its in-place open sites and neither had
+//! the third, so `--inplace` onto a 0444 file failed the whole transfer with
+//! `Permission denied (13)` and left the file untouched.
+//!
+//! These tests drive the LOCAL-COPY site
+//! (`engine/.../copy/transfer/write_strategy.rs`). The receiver site has its own
+//! unit tests in `crates/transfer/src/disk_commit/process/file_ops/tests.rs`;
+//! the two are separate `OpenOptions` chains and a fix to one does not reach the
+//! other.
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    if built.is_file() {
+        return built;
+    }
+    PathBuf::from("oc-rsync")
+}
+
+fn mode_of(path: &Path) -> u32 {
+    fs::symlink_metadata(path).unwrap().permissions().mode() & 0o7777
+}
+
+/// Seeds a source and a destination whose contents differ, then sets the
+/// destination's mode. Both files are given distinct lengths so the quick check
+/// cannot legitimately skip the transfer.
+fn seed(root: &Path, dest_mode: u32) -> (PathBuf, PathBuf) {
+    let source = root.join("source");
+    let dest = root.join("dest");
+    fs::create_dir_all(&source).unwrap();
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(source.join("f"), b"replacement data\n").unwrap();
+    fs::write(dest.join("f"), b"old data\n").unwrap();
+    fs::set_permissions(dest.join("f"), fs::Permissions::from_mode(dest_mode)).unwrap();
+    (source, dest)
+}
+
+fn run_inplace(source: &Path, dest: &Path) -> std::process::Output {
+    Command::new(oc_rsync_binary())
+        .arg("--inplace")
+        .arg("-r")
+        .arg(format!("{}/", source.display()))
+        .arg(format!("{}/", dest.display()))
+        .output()
+        .expect("run oc-rsync")
+}
+
+/// The fix. Before the third arm existed this exited 23 with
+/// `failed to copy file ...: Permission denied (13)` and left `old data`.
+#[test]
+fn a_read_only_destination_is_updated_in_place_and_keeps_its_mode() {
+    let root = tempfile::tempdir().unwrap();
+    let (source, dest) = seed(root.path(), 0o444);
+
+    let output = run_inplace(&source, &dest);
+
+    assert!(
+        output.status.success(),
+        "read-only --inplace update failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read(dest.join("f")).unwrap(), b"replacement data\n");
+    assert_eq!(
+        mode_of(&dest.join("f")),
+        0o444,
+        "the recovery must restore the prior mode"
+    );
+}
+
+/// Non-vacuity companion: the same fixture with an already-writable destination
+/// never reaches the recovery arm at all. Without it, a harness that could not
+/// perform *any* in-place update would still make the test above look like a
+/// mode-restore assertion rather than the recovery it is.
+#[test]
+fn a_writable_destination_takes_the_same_path_without_the_recovery() {
+    let root = tempfile::tempdir().unwrap();
+    let (source, dest) = seed(root.path(), 0o644);
+
+    let output = run_inplace(&source, &dest);
+
+    assert!(output.status.success());
+    assert_eq!(fs::read(dest.join("f")).unwrap(), b"replacement data\n");
+    assert_eq!(mode_of(&dest.join("f")), 0o644);
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -134,7 +134,7 @@ proxy-host-crlf pass
 proxy-protocol-trusted-peer fail
 proxy-response-header-too-long fail
 proxy-response-line-too-long pass
-readonly-partial-abort-mode-regression fail
+readonly-partial-abort-mode-regression pass
 recv-discard-nullderef pass
 rename-mixed-parent-transfer skip
 reverse-daemon-delta pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -254,7 +254,7 @@ proxy-protocol-trusted-peer skip
 proxy-response-header-too-long skip
 proxy-response-line-too-long skip
 prune-empty-dirs pass
-readonly-partial-abort-mode-regression fail
+readonly-partial-abort-mode-regression pass
 recv-discard-nullderef pass
 recv-generator-acl-leak skip
 relative pass


### PR DESCRIPTION
Upstream 3.5.0 opens an in-place output through a **three-arm** chain. oc had the first two at both of its in-place open sites, and the third at neither.

```c
if (secure_relpath_active())
    fd2 = secure_recv_open(fnametmp, O_WRONLY|O_CREAT, 0600, one_inplace);
else
    fd2 = do_open(fnametmp, O_WRONLY|O_CREAT, 0600);      /* 1: oc had this */
#ifdef linux
if (fd2 == -1 && errno == EACCES) {
    /* Maybe the error was due to protected_regular setting? */
    ...                                                    /* 2: oc had this */
}
#endif
if (fd2 == -1 && errno == EACCES)
    fd2 = open_readonly_inplace(fnametmp, one_inplace);    /* 3: MISSING */
                                            /* receiver.c:1210-1224 */
```

Note the third arm is **not** `#ifdef linux`: a read-only destination is an `EACCES` everywhere, and both of oc's sites gated their whole recovery behind the Linux-only sysctl retry.

## Measured, with the upstream control run first

Read-only (0444) destination, `--inplace`, backdated so the quick check cannot legitimately skip:

| | exit | mode | content |
|---|---|---|---|
| upstream 3.5.0 | 0 | 0444 preserved | **updated** |
| oc (before) | 23 `failed to copy file '…': Permission denied (13)` | 0444 | **unchanged** |
| oc (after) | 0 | 0444 preserved | updated |

## One owner, two consumers

`transfer` depends on `engine`, so the two open sites cannot share code through either crate. The recovery is hoisted into **`fast_io::readonly_inplace`**, next to the `operator_open_*` family it belongs with — a platform I/O primitive with a safe public API, and no `unsafe`: `File::set_permissions` *is* `fchmod` on the open descriptor.

It takes the **caller's `OpenOptions`** rather than fixing them. The receiver never truncates; the local-copy path truncates when there is no delta basis. So the helper owns the upstream mode dance and nothing else, and neither site's open semantics change — only *whether* the open succeeds.

## The restore ordering is the substance

Upstream restores the prior mode *before returning to the transfer loop*, and says why (`receiver.c:200-206`): an abort — peer EOF, checksum failure, a signal — must not strand the file at 0600. Once a writable descriptor exists, later writes no longer consult the pathname's permission bits, so **no cleanup or Drop path is needed** — and deferring the restore to commit time would be strictly worse. That is exactly what the testsuite cell's two abort cases exist to catch.

Four upstream rules ported 1:1, each with its own test:

- `O_NOFOLLOW` on the probe pins an inode, so a planted symlink cannot redirect the owner-write grant (`:216`).
- Non-regular target → `EACCES` (`:219-222`).
- Already owner-writable → **refuse rather than chmod**: the `EACCES` came from an ACL or the parent directory, and "each chmod risks losing a special bit" (`:224-230`).
- Restore unconditionally, and a **failed restore wins** over a successful open — drop the descriptor, report the restore error (`:235-241`).

### Deliberate, stated deviation

Upstream has two branches: fd-based (`:214`) and path-based (`:253`). This mirrors the fd-based one **unconditionally**. Upstream keeps the path arm only to retain existing pathname semantics for local and chrooted transfers, and notes the fd branch "is the one that pins an inode". Observable behaviour is identical and pinning costs nothing here, so there is no reason to carry the weaker arm.

## Non-vacuity

Both arms are independently mutation-lethal — severing either makes its own test fail with the exact pre-fix error:

```
transfer: a_read_only_inplace_destination_is_opened_for_writing
  panicked: Os { code: 13, kind: PermissionDenied }

engine:   a_read_only_destination_is_updated_in_place_and_keeps_its_mode
  panicked: failed to copy file '…/dest/f': Permission denied (13) (code 23)
```

The end-to-end test carries a companion on an already-writable (0644) destination, which never reaches the recovery arm at all — without it the first test would read as a mode-restore assertion rather than the recovery it is.

## Manifest

`readonly-partial-abort-mode-regression` flips `fail` → `pass` on **both** nonroot manifests in this commit. The cell has three cases — two abort cases over the network receiver and one local-copy success case — so a fix to either site alone leaves it red; that is what identified the second site.

## Verification (Linux x86_64, kernel 7.1.5)

- Testsuite cell: upstream 3.5.0 control PASS first, then oc PASS.
- Full nonroot pipe leg against the committed manifest: **345 cells, 242 passed / 19 failed / 84 skipped**, one mismatch — `protected-regular: expected skip, got pass`.
  That row is **environmental, not from this change**, proven by severing both new arms and re-running it: it still passes. This host has `fs.protected_regular=1`; the manifest was generated where it is `0` and the cell self-skips. Deliberately **not** re-baselined.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- 13 targeted tests green across `fast_io` + `transfer`; the end-to-end pair green under a full-workspace nextest.
