### PR TITLE
ci: default the upstream testsuite runner to 3.5.0

### DIFF
--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -14,9 +14,9 @@
 #   - known failures are tracked in tools/ci/upstream_testsuite_known_failures.conf
 #
 # Usage:
-#   tools/ci/run_upstream_testsuite.sh                # run all *.test
+#   tools/ci/run_upstream_testsuite.sh                # run the whole suite
 #   WHICHTESTS=00-hello.test tools/ci/...sh           # run a single test
-#   UPSTREAM_VERSION=3.4.4 tools/ci/...sh             # pin upstream version
+#   UPSTREAM_VERSION=3.4.4 tools/ci/...sh             # pin an older release
 #   PRESERVE_SCRATCH=yes tools/ci/...sh               # keep per-test scratch dirs
 #
 # Python-suite options (see run_python_suite_mode):
@@ -66,7 +66,12 @@
 set -euo pipefail
 
 workspace_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-upstream_version="${UPSTREAM_VERSION:-3.4.4}"
+# Default to the current upstream stable release. Every CI caller passes
+# UPSTREAM_VERSION explicitly, so this default is what a bare local invocation
+# gets - and 3.4.4 silently routed those runs into the 57-cell `*.test` shell
+# suite instead of the 345-cell Python suite the committed expect-manifests are
+# written against, which reads as a passing run over a fifth of the coverage.
+upstream_version="${UPSTREAM_VERSION:-3.5.0}"
 # Git-ref mode is selected by an explicit UPSTREAM_REF, or by the sentinel
 # UPSTREAM_VERSION=master. Default (empty UPSTREAM_REF, numeric version) keeps
 # the release-tarball path untouched.


### PR DESCRIPTION
`tools/ci/run_upstream_testsuite.sh` defaulted to `UPSTREAM_VERSION=3.4.4`. That is no longer the current stable release, and the staleness is not cosmetic — it silently changes **which suite runs**.

The runner is shape-dispatched on what the extracted tree ships (`python_suite_available`, `:723-726`):

| tree | ships | suite | cells |
|---|---|---|---|
| 3.4.4 | `runtests.py` + 57 `*.test` | shell | **60** |
| 3.5.0 | `runtests.py` + 345 `*_test.py` | Python | **345** |

So a bare local invocation ran the 57-cell shell suite and reported a clean `overall result is 0` over roughly a fifth of the coverage, while the committed `tools/ci/upstream-3.5.0-expect.*.txt` manifests are written against the 345-cell Python suite. The two are not comparable, and nothing said so.

Measured on the same tree, differing only in that one variable:

```
$ bash tools/ci/run_upstream_testsuite.sh                        # before
  passed: 58  failed: 1  skipped: 1          <- 60 cells, shell suite

$ UPSTREAM_VERSION=3.5.0 bash tools/ci/run_upstream_testsuite.sh # after (now the default)
  242 passed / 19 failed / 84 skipped        <- 345 cells, Python suite
```

## Blast radius: local only

Every CI caller already passes `UPSTREAM_VERSION` explicitly, so no workflow behaviour changes:

- `_upstream-testsuite.yml:135`, `:305` — `UPSTREAM_VERSION: ${{ env.UPSTREAM_RSYNC_VERSION }}`
- `validate-daemon-environmental.yml:60`, `:72` — same
- `track-3.5.0dev-testsuite.yml` — git-ref mode via `UPSTREAM_REF`

The default was reachable *only* from a bare local run — which is precisely the invocation with no manifest and no second opinion to catch it.

## Verified

A bare invocation now announces `==> Building upstream (release 3.5.0)` and enters `run_python_suite_mode`. `bash -n` clean.

Pinning an older release still works and is still documented: `UPSTREAM_VERSION=3.4.4 tools/ci/run_upstream_testsuite.sh`.

This is the runner default only. The broader source-of-truth pin (`Cargo.toml`, citations, the surface extractors) is tracked separately and deliberately untouched here.
