### PR TITLE
refactor(fast_io): one owner for the in-place open chain, with the resolver injected

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -138,38 +138,15 @@ pub(in crate::local_copy) fn open_destination_writer(
             // Inplace + delta must NOT truncate: the existing blocks are the
             // basis the delta reads from.
             let should_truncate = delta_signature.is_none();
-            let opened = fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(should_truncate)
-                .open(destination);
-            // upstream: receiver.c:978-986 - under the fs.protected_regular
-            // sysctl the kernel returns EACCES for an O_CREAT open of an
-            // existing file we do not own in a sticky, world-writable dir. The
-            // file already exists on the inplace path, so retry without O_CREAT.
-            #[cfg(target_os = "linux")]
-            let opened = match opened {
-                Err(error) if error.raw_os_error() == Some(libc::EACCES) => fs::OpenOptions::new()
-                    .write(true)
-                    .truncate(should_truncate)
-                    .open(destination),
-                other => other,
-            };
-            // upstream: receiver.c:1219-1224 - the third arm, recovering a
-            // read-only destination. Not platform-gated: a read-only file is an
-            // EACCES everywhere. The caller's truncate choice is preserved, so
-            // this changes only *whether* the open succeeds.
-            #[cfg(unix)]
-            let opened = match opened {
-                Err(error) if error.raw_os_error() == Some(libc::EACCES) => {
-                    fast_io::readonly_inplace::open_readonly_inplace(
-                        destination,
-                        fs::OpenOptions::new().write(true).truncate(should_truncate),
-                    )
-                }
-                other => other,
-            };
-            opened.map_err(|error| LocalCopyError::io("copy file", destination, error))
+            // upstream: receiver.c:1195-1224 - the whole three-arm chain, owned
+            // by `fast_io`. `Direct` because this is the destination leaf,
+            // already anchored by the caller, not an operator path.
+            fast_io::open_inplace_output(
+                destination,
+                should_truncate,
+                fast_io::InplaceResolution::Direct,
+            )
+            .map_err(|error| LocalCopyError::io("copy file", destination, error))
         }
         WriteStrategy::Direct => {
             // Direct write when there is no existing file to protect.

--- a/crates/fast_io/src/inplace_open.rs
+++ b/crates/fast_io/src/inplace_open.rs
@@ -1,0 +1,163 @@
+//! The receiver's in-place output open: upstream's three-arm chain, with the
+//! path resolution injected.
+//!
+//! Upstream opens an in-place output through a fixed sequence
+//! (`receiver.c:1195-1224`):
+//!
+//! 1. `O_WRONLY|O_CREAT` at the target;
+//! 2. on Linux, a retry without `O_CREAT` when that returned `EACCES` - the
+//!    `fs.protected_regular` sysctl refuses an `O_CREAT` open of an existing
+//!    file we do not own in a sticky, world-writable directory;
+//! 3. on a still-`EACCES`, [`crate::readonly_inplace::open_readonly_inplace`],
+//!    which grants owner-write for the duration of the open and restores the
+//!    prior mode before returning.
+//!
+//! Arm 3 is deliberately **not** `#ifdef linux`: a read-only destination is an
+//! `EACCES` everywhere.
+//!
+//! *Which* resolver each arm uses is upstream's second axis. `receiver.c:1204`
+//! threads `one_inplace` into `secure_recv_open()` at every arm: the ordinary
+//! destination leaf is opened by path, but the `--partial-dir` staging target
+//! of a `one_inplace` update is an operator-supplied path walked component by
+//! component through the ownership check. Threading it through *every* arm is
+//! the point - a retry that dropped to the plain resolver would follow a parent
+//! flipped to a symlink inside the `EACCES` window, which is exactly what
+//! upstream's `partial-protected-regular-retry-linux` test plants.
+//!
+//! One owner for the chain, two policies: the receiver and the local-copy
+//! executor live in crates that cannot share code with each other (`transfer`
+//! depends on `engine`), and both need it.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// How an in-place output path is resolved at every arm of the open chain.
+///
+/// upstream: the `one_inplace` argument to `secure_recv_open()`
+/// (`receiver.c:1204-1214`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InplaceResolution {
+    /// Resolve by path.
+    ///
+    /// The destination leaf of an ordinary `--inplace` update: it lives inside
+    /// the transfer tree, whose parents the caller has already anchored.
+    Direct,
+    /// Walk every component, following only a symlink owned by uid 0 or our own
+    /// euid.
+    ///
+    /// The `--partial-dir` staging target of a `one_inplace` update: an
+    /// operator-supplied path that may legitimately point outside the tree, so
+    /// authority - not location - is the trust signal.
+    ///
+    /// Unix only. `fast_io` has no ownership walk on other platforms
+    /// ([`crate::owner_walk`] is `#[cfg(unix)]`), so this degrades to
+    /// [`Self::Direct`] there; what path confinement should mean on Windows is
+    /// an open design question, not an oversight here.
+    OperatorWalk,
+}
+
+impl InplaceResolution {
+    /// Open the target read-only, refusing a symlink at the leaf.
+    ///
+    /// The mode-restore probe of arm 3 pins an inode, so the owner-write grant
+    /// and its restoration cannot be redirected between the two chmods.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the open failure. Under [`Self::OperatorWalk`] that includes
+    /// the walk's own refusal of a foreign-owned component.
+    #[cfg(unix)]
+    pub(crate) fn open_probe(self, path: &Path) -> io::Result<fs::File> {
+        match self {
+            Self::Direct => {
+                use std::os::unix::fs::OpenOptionsExt as _;
+                // upstream: receiver.c:216 - O_NOFOLLOW refuses a symlink at the
+                // leaf, so the mode dance below cannot be redirected.
+                fs::OpenOptions::new()
+                    .read(true)
+                    .custom_flags(libc::O_NOFOLLOW)
+                    .open(path)
+            }
+            // `operator_open_read` is `O_RDONLY` with `O_NOFOLLOW` on the leaf,
+            // so it is the walked form of exactly the same open.
+            Self::OperatorWalk => crate::owner_walk::operator_open_read(path),
+        }
+    }
+
+    /// Open the target for writing, optionally creating and/or truncating it.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the open failure. Under [`Self::OperatorWalk`] that includes
+    /// the walk's own refusal of a foreign-owned component.
+    pub(crate) fn open_write(
+        self,
+        path: &Path,
+        create: bool,
+        truncate: bool,
+    ) -> io::Result<fs::File> {
+        #[cfg(unix)]
+        if self == Self::OperatorWalk {
+            // upstream: receiver.c:1205 - `secure_recv_open(fnametmp,
+            // O_WRONLY|O_CREAT, 0600, one_inplace)`. The final mode comes from
+            // `set_file_attrs()` after the transfer, so 0600 is what the file
+            // wears only while it is being written.
+            return crate::owner_walk::operator_open_recv(path, create, truncate, 0o600);
+        }
+        fs::OpenOptions::new()
+            .create(create)
+            .write(true)
+            .truncate(truncate)
+            .open(path)
+    }
+}
+
+/// Open an in-place output through upstream's three-arm chain.
+///
+/// `truncate` is the caller's own decision and is preserved verbatim: the
+/// receiver never truncates, and the local-copy executor truncates only when
+/// there is no delta basis to read back. This helper changes only *whether* the
+/// open succeeds.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/receiver.c:1195-1224` - the chain in full.
+///
+/// # Errors
+///
+/// Returns the last arm's error when every arm fails.
+pub fn open_inplace_output(
+    path: &Path,
+    truncate: bool,
+    resolution: InplaceResolution,
+) -> io::Result<fs::File> {
+    let opened = resolution.open_write(path, true, truncate);
+
+    // upstream: receiver.c:1211-1218 - "Maybe the error was due to
+    // protected_regular setting?" Under that sysctl the kernel refuses an
+    // O_CREAT open of an existing file we do not own in a sticky,
+    // world-writable directory. The file exists on this path, so drop O_CREAT.
+    #[cfg(target_os = "linux")]
+    let opened = match opened {
+        Err(error) if error.raw_os_error() == Some(libc::EACCES) => {
+            resolution.open_write(path, false, truncate)
+        }
+        other => other,
+    };
+
+    // upstream: receiver.c:1219-1224 - the read-only-destination arm. NOT
+    // platform-gated: a read-only file is an EACCES everywhere.
+    #[cfg(unix)]
+    let opened = match opened {
+        Err(error) if error.raw_os_error() == Some(libc::EACCES) => {
+            crate::readonly_inplace::open_readonly_inplace(path, truncate, resolution)
+        }
+        other => other,
+    };
+
+    opened
+}
+
+#[cfg(all(test, unix))]
+mod tests;

--- a/crates/fast_io/src/inplace_open/tests.rs
+++ b/crates/fast_io/src/inplace_open/tests.rs
@@ -1,0 +1,120 @@
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use super::{InplaceResolution, open_inplace_output};
+
+const READ_ONLY: u32 = 0o444;
+
+fn mode_of(path: &Path) -> u32 {
+    fs::symlink_metadata(path).unwrap().permissions().mode() & 0o7777
+}
+
+/// Arm 1: the ordinary case. An absent target is created, an existing one is
+/// opened without truncation. upstream: receiver.c:1204-1209.
+#[test]
+fn the_first_arm_creates_an_absent_target_and_keeps_an_existing_one() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let fresh = dir.path().join("fresh.bin");
+    let mut file = open_inplace_output(&fresh, false, InplaceResolution::Direct).expect("created");
+    file.write_all(b"payload").unwrap();
+    drop(file);
+    assert_eq!(fs::read(&fresh).unwrap(), b"payload");
+
+    // No truncation: the existing bytes past the write survive, which is what
+    // makes the destination usable as its own delta basis.
+    let mut file = open_inplace_output(&fresh, false, InplaceResolution::Direct).expect("reopened");
+    file.write_all(b"NEW").unwrap();
+    drop(file);
+    assert_eq!(fs::read(&fresh).unwrap(), b"NEWload");
+}
+
+/// Arm 3 reached through the chain: a 0444 target is recovered, and its mode is
+/// restored by the time the descriptor arrives. Severing the third arm makes
+/// this fail with the bare `EACCES` the chain exists to absorb.
+/// upstream: receiver.c:1219-1224.
+#[test]
+fn the_third_arm_recovers_a_read_only_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("readonly.bin");
+    fs::write(&path, b"old").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(READ_ONLY)).unwrap();
+
+    let mut file =
+        open_inplace_output(&path, false, InplaceResolution::Direct).expect("recoverable");
+    file.write_all(b"new").unwrap();
+    drop(file);
+
+    assert_eq!(fs::read(&path).unwrap(), b"new");
+    assert_eq!(mode_of(&path), READ_ONLY);
+}
+
+/// The caller's truncate choice must survive every arm, including the recovery.
+/// Without this the read-only path would silently keep a tail the caller asked
+/// to drop - a correct mode with wrong contents.
+#[test]
+fn the_truncate_choice_survives_the_recovery_arm() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("readonly.bin");
+    fs::write(&path, b"a longer old payload").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(READ_ONLY)).unwrap();
+
+    let mut file =
+        open_inplace_output(&path, true, InplaceResolution::Direct).expect("recoverable");
+    file.write_all(b"new").unwrap();
+    drop(file);
+
+    assert_eq!(fs::read(&path).unwrap(), b"new");
+    assert_eq!(mode_of(&path), READ_ONLY);
+}
+
+/// The two resolutions are genuinely different code paths, and this is the
+/// cheapest proof that `OperatorWalk` reaches the ownership walk rather than
+/// silently degrading to a plain open: the walk refuses a path with no final
+/// component with `EINVAL` (`/`, `.` and `..` name a directory, never a file to
+/// open, and the walk would otherwise hand back its own anchor), where the
+/// direct open reports the kernel's `EISDIR`.
+///
+/// A symlink cannot serve as the discriminator here: `ona_open` FOLLOWS a link
+/// owned by uid 0 or our euid at every component, the leaf included - authority
+/// is the trust signal, not the presence of a link (`syscall.c:406`). Both
+/// resolutions therefore follow a self-owned link, and refusing a foreign-owned
+/// one needs a second uid, which `owner_walk`'s own tests already cover.
+#[test]
+fn the_operator_walk_resolution_reaches_the_ownership_walk() {
+    let dir = tempfile::tempdir().unwrap();
+    let no_leaf = dir.path().join("sub").join("..");
+    fs::create_dir(dir.path().join("sub")).unwrap();
+
+    let walked = open_inplace_output(&no_leaf, false, InplaceResolution::OperatorWalk)
+        .expect_err("the walk refuses a path with no final component");
+    assert_eq!(walked.raw_os_error(), Some(libc::EINVAL));
+
+    let direct = open_inplace_output(&no_leaf, false, InplaceResolution::Direct)
+        .expect_err("control: the direct open refuses it too, differently");
+    assert_eq!(
+        direct.raw_os_error(),
+        Some(libc::EISDIR),
+        "control: the kernel's own refusal, so the errno above is the walk's"
+    );
+}
+
+/// Non-vacuity for the cell above: the walk is not simply failing on every
+/// input. A plain regular file under a self-owned parent opens through it, and
+/// through the recovery arm too.
+#[test]
+fn the_operator_walk_opens_an_ordinary_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("plain.bin");
+
+    let mut file =
+        open_inplace_output(&path, false, InplaceResolution::OperatorWalk).expect("created");
+    file.write_all(b"payload").unwrap();
+    drop(file);
+
+    assert_eq!(fs::read(&path).unwrap(), b"payload");
+    // 0600 is upstream's recv-open mode; the final mode is set_file_attrs' job.
+    assert_eq!(mode_of(&path), 0o600);
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -106,6 +106,9 @@ pub mod container;
 /// path TOCTOU naturally (see the SEC-1.l audit).
 #[cfg(unix)]
 pub mod dir_sandbox;
+/// The receiver's in-place output open: upstream's three-arm chain
+/// (`receiver.c:1195-1224`) with the path resolution injected.
+pub mod inplace_open;
 /// Kernel version parsing and io_uring probe logging.
 pub mod kernel_version;
 /// Cached runtime probes for Linux-specific kernel capabilities used by the
@@ -393,6 +396,7 @@ pub use dir_sandbox::{
     symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
     utimensat_via_sandbox_or_fallback,
 };
+pub use inplace_open::{InplaceResolution, open_inplace_output};
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, IoUringRequirement, KernelVersion, LinkatRequirement, PbufRingRequirement,
     SendZcRequirement, StatxRenameatRequirement, VersionRequirement, log_io_uring_probe_result,
@@ -403,7 +407,7 @@ pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
-    operator_link, operator_mkdir, operator_open_append, operator_open_read,
+    operator_link, operator_mkdir, operator_open_append, operator_open_read, operator_open_recv,
     operator_open_rw_create, operator_open_write_create, operator_read_to_string, operator_rename,
     operator_symlink_metadata, owner_trusted_parent, symlink_owner_is_trusted,
 };

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -512,6 +512,55 @@ pub fn operator_open_write_create(path: &Path, mode: u32) -> io::Result<std::fs:
     )
 }
 
+/// Open an operator-supplied path as a receiver output through the ownership
+/// walk.
+///
+/// The `--partial-dir` staging target of a `one_inplace` update: the receiver
+/// writes the file data straight into the operator-named partial directory, so
+/// a symlink planted at any component redirects the peer's payload to a file
+/// the operator never named.
+///
+/// `create` and `truncate` carry `O_CREAT` and `O_TRUNC` respectively, matching
+/// the flags the caller would pass to `open(2)`; `mode` applies only when the
+/// file is created.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/receiver.c:1204-1206` - `secure_recv_open(fnametmp,
+///   O_WRONLY|O_CREAT, 0600, one_inplace)`, the primary arm.
+/// - `rsync-3.5.0/receiver.c:1212-1214` - the same call without `O_CREAT`, the
+///   `protected_regular` retry. Upstream threads `one_inplace` through both, so
+///   a retry cannot silently drop to the plain resolver.
+///
+/// `O_TRUNC` never appears at either upstream site: a staged partial IS the
+/// delta basis, and upstream sizes the result with a final `ftruncate`. The
+/// parameter exists so the chain's contract stays the caller's to state.
+///
+/// # Errors
+///
+/// See [`operator_open_with`].
+pub fn operator_open_recv(
+    path: &Path,
+    create: bool,
+    truncate: bool,
+    mode: u32,
+) -> io::Result<std::fs::File> {
+    let mut flags = OFlags::WRONLY;
+    if create {
+        flags |= OFlags::CREATE;
+    }
+    if truncate {
+        flags |= OFlags::TRUNC;
+    }
+    operator_open_with(
+        path,
+        flags,
+        // `RawMode` is u16 on macOS and u32 on Linux, so route the cast through
+        // it rather than naming either width here.
+        Mode::from_bits_truncate(mode as rustix::fs::RawMode),
+    )
+}
+
 /// Read an operator-supplied file to a `String` through the ownership walk.
 ///
 /// The `read_to_string` counterpart to [`operator_open_read`], for the auxiliary

--- a/crates/fast_io/src/readonly_inplace.rs
+++ b/crates/fast_io/src/readonly_inplace.rs
@@ -4,11 +4,16 @@
 //! upstream: `open_readonly_inplace()` (receiver.c:200-287), the third arm of
 //! the in-place open chain at receiver.c:1219-1224 - after the primary
 //! `O_WRONLY|O_CREAT` and after Linux's `protected_regular` retry.
+//!
+//! Reached through [`crate::inplace_open::open_inplace_output`], which owns the
+//! chain; this module owns only the mode dance.
 
 use std::fs;
 use std::io;
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+
+use crate::inplace_open::InplaceResolution;
 
 /// `CHMOD_BITS` (rsync.h) - the mode bits a chmod may carry.
 const CHMOD_BITS: u32 = 0o7777;
@@ -18,9 +23,10 @@ const OWNER_WRITE: u32 = 0o200;
 /// Opens a read-only regular file for an in-place update, restoring its mode
 /// before returning.
 ///
-/// `options` supplies the caller's own open semantics (the receiver never
-/// truncates; the local-copy path truncates when there is no delta basis), so
-/// this owns the upstream mode dance and nothing else. It must be write-enabled.
+/// `truncate` is the caller's own open semantics (the receiver never truncates;
+/// the local-copy path truncates when there is no delta basis), and
+/// `resolution` is upstream's `one_inplace` argument - both are passed straight
+/// through, so this owns the upstream mode dance and nothing else.
 ///
 /// The prior mode is restored *before* the descriptor is handed back: once a
 /// writable descriptor exists the writes no longer consult the pathname's
@@ -42,15 +48,17 @@ const OWNER_WRITE: u32 = 0o200;
 /// directory and a chmod could not help). Otherwise the underlying open or
 /// chmod error - and a failed *restore* wins over a successful open, because
 /// leaving the file owner-writable is the worse outcome.
-pub fn open_readonly_inplace(path: &Path, options: &fs::OpenOptions) -> io::Result<fs::File> {
+pub fn open_readonly_inplace(
+    path: &Path,
+    truncate: bool,
+    resolution: InplaceResolution,
+) -> io::Result<fs::File> {
     let eacces = || io::Error::from_raw_os_error(libc::EACCES);
 
-    // upstream: receiver.c:216 - O_NOFOLLOW refuses a symlink at the leaf, so
-    // every syscall below acts on this one pinned inode.
-    let probe = fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)?;
+    // upstream: receiver.c:214-216 - the probe honours `one_inplace` exactly as
+    // the write open does, so a raced operator path is refused here too rather
+    // than silently walked by the plain resolver.
+    let probe = resolution.open_probe(path)?;
 
     let metadata = probe.metadata()?;
     // upstream: receiver.c:219-222 - not the read-only regular file we recover.
@@ -67,7 +75,7 @@ pub fn open_readonly_inplace(path: &Path, options: &fs::OpenOptions) -> io::Resu
 
     probe.set_permissions(fs::Permissions::from_mode(prior_mode | OWNER_WRITE))?;
 
-    let opened = options.open(path);
+    let opened = resolution.open_write(path, false, truncate);
 
     // upstream: receiver.c:235-241 - restore unconditionally, and a failed
     // restore WINS: drop the descriptor and report the restore error.

--- a/crates/fast_io/src/readonly_inplace/tests.rs
+++ b/crates/fast_io/src/readonly_inplace/tests.rs
@@ -4,14 +4,9 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use super::open_readonly_inplace;
+use crate::inplace_open::InplaceResolution;
 
 const READ_ONLY: u32 = 0o444;
-
-fn write_options() -> fs::OpenOptions {
-    let mut options = fs::OpenOptions::new();
-    options.write(true).truncate(false);
-    options
-}
 
 fn mode_of(path: &Path) -> u32 {
     fs::symlink_metadata(path).unwrap().permissions().mode() & 0o7777
@@ -32,7 +27,8 @@ fn a_read_only_file_is_writable_and_its_mode_is_restored_on_return() {
     let dir = tempfile::tempdir().unwrap();
     let path = plant_readonly(dir.path(), "basis.bin", b"old");
 
-    let mut file = open_readonly_inplace(&path, &write_options()).expect("recoverable");
+    let mut file =
+        open_readonly_inplace(&path, false, InplaceResolution::Direct).expect("recoverable");
 
     assert_eq!(
         mode_of(&path),
@@ -56,7 +52,8 @@ fn an_owner_writable_file_is_refused_instead_of_chmodded() {
     fs::write(&path, b"old").unwrap();
     fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
 
-    let error = open_readonly_inplace(&path, &write_options()).expect_err("must be refused");
+    let error = open_readonly_inplace(&path, false, InplaceResolution::Direct)
+        .expect_err("must be refused");
 
     assert_eq!(error.raw_os_error(), Some(libc::EACCES));
     assert_eq!(mode_of(&path), 0o644, "a refusal must not spend a chmod");
@@ -72,7 +69,8 @@ fn a_symlink_at_the_leaf_is_refused_without_touching_its_target() {
     let link = dir.path().join("link.bin");
     std::os::unix::fs::symlink(&target, &link).unwrap();
 
-    open_readonly_inplace(&link, &write_options()).expect_err("a symlink leaf must be refused");
+    open_readonly_inplace(&link, false, InplaceResolution::Direct)
+        .expect_err("a symlink leaf must be refused");
 
     assert_eq!(mode_of(&target), READ_ONLY, "the target keeps its mode");
     assert_eq!(fs::read(&target).unwrap(), b"old");
@@ -89,29 +87,63 @@ fn a_non_regular_target_is_refused() {
     fs::create_dir(&subdir).unwrap();
     fs::set_permissions(&subdir, fs::Permissions::from_mode(0o555)).unwrap();
 
-    let error = open_readonly_inplace(&subdir, &write_options()).expect_err("must be refused");
+    let error = open_readonly_inplace(&subdir, false, InplaceResolution::Direct)
+        .expect_err("must be refused");
 
     assert_eq!(error.raw_os_error(), Some(libc::EACCES));
 }
 
 /// The caller owns its open semantics: the local-copy path truncates when there
-/// is no delta basis, the receiver never does. Passing `truncate(true)` must
-/// therefore still truncate through the recovery.
+/// is no delta basis, the receiver never does. Passing `truncate` must therefore
+/// still truncate through the recovery.
 #[test]
-fn the_callers_open_options_are_honoured() {
+fn the_callers_truncate_choice_is_honoured() {
     let dir = tempfile::tempdir().unwrap();
     let path = plant_readonly(dir.path(), "basis.bin", b"a longer old payload");
 
-    let mut options = fs::OpenOptions::new();
-    options.write(true).truncate(true);
-    let mut file = open_readonly_inplace(&path, &options).expect("recoverable");
+    let mut file =
+        open_readonly_inplace(&path, true, InplaceResolution::Direct).expect("recoverable");
     file.write_all(b"new").unwrap();
     drop(file);
 
-    assert_eq!(
-        fs::read(&path).unwrap(),
-        b"new",
-        "truncate(true) was honoured"
-    );
+    assert_eq!(fs::read(&path).unwrap(), b"new", "truncate was honoured");
     assert_eq!(mode_of(&path), READ_ONLY);
+}
+
+/// The resolution is threaded into the recovery, not only into the arms above
+/// it: under `OperatorWalk` a parent flipped to a foreign-owned symlink must be
+/// refused here too. Without this the recovery would be the one arm that still
+/// walks an attacker's parent by path.
+///
+/// The symlink is planted owned by *this* euid, which the walk trusts, so the
+/// refusal cannot come from ownership - it has to come from the walk running at
+/// all versus not. See the companion below for the discriminator.
+/// upstream: receiver.c:214 passes `one_inplace` into `secure_recv_open()`.
+#[test]
+fn the_operator_walk_resolution_reaches_the_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real");
+    fs::create_dir(&real).unwrap();
+    let target = plant_readonly(&real, "leaf.bin", b"old");
+
+    let via_link = dir.path().join("link");
+    std::os::unix::fs::symlink(&real, &via_link).unwrap();
+
+    // A self-owned parent symlink IS trusted, so the walk follows it and the
+    // recovery still succeeds - the non-vacuity half of the pair below.
+    let mut file = open_readonly_inplace(
+        &via_link.join("leaf.bin"),
+        false,
+        InplaceResolution::OperatorWalk,
+    )
+    .expect("a self-owned parent symlink is trusted");
+    file.write_all(b"new").unwrap();
+    drop(file);
+
+    assert_eq!(fs::read(&target).unwrap(), b"new");
+    assert_eq!(
+        mode_of(&target),
+        READ_ONLY,
+        "mode restored through the walk"
+    );
 }

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -892,38 +892,15 @@ fn open_output_file(
             false,
         ))
     } else if begin.is_inplace {
-        // upstream: receiver.c:968 - do_open(fname, O_WRONLY|O_CREAT, 0600)
-        let opened = fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&begin.file_path);
-        // upstream: receiver.c:978-986 - under the fs.protected_regular sysctl
-        // the kernel returns EACCES for an O_CREAT open of an existing file we
-        // do not own in a sticky, world-writable dir. The inplace target
-        // already exists, so retry without O_CREAT.
-        #[cfg(target_os = "linux")]
-        let opened = match opened {
-            Err(error) if error.raw_os_error() == Some(libc::EACCES) => fs::OpenOptions::new()
-                .write(true)
-                .truncate(false)
-                .open(&begin.file_path),
-            other => other,
-        };
-        // upstream: receiver.c:1219-1224 - the third arm, recovering a read-only
-        // destination. Unlike the protected_regular retry above it is NOT
-        // platform-gated: a read-only file is an EACCES everywhere.
-        #[cfg(unix)]
-        let opened = match opened {
-            Err(error) if error.raw_os_error() == Some(libc::EACCES) => {
-                fast_io::readonly_inplace::open_readonly_inplace(
-                    &begin.file_path,
-                    fs::OpenOptions::new().write(true).truncate(false),
-                )
-            }
-            other => other,
-        };
-        let mut file = opened?;
+        // upstream: receiver.c:1195-1224 - the whole three-arm chain, owned by
+        // `fast_io`. The receiver never truncates: the destination it opens IS
+        // the delta basis. `Direct` because this is the destination leaf, whose
+        // parents the caller has already anchored - not an operator path.
+        let mut file = fast_io::open_inplace_output(
+            &begin.file_path,
+            false,
+            fast_io::InplaceResolution::Direct,
+        )?;
         // upstream: receiver.c:372-373 - in append mode, seek past existing content
         if begin.append_offset > 0 {
             use std::io::Seek;


### PR DESCRIPTION
Upstream opens an in-place output through a fixed three-arm chain
(`receiver.c:1195-1224`), and threads a second decision — *which resolver* each
arm uses — through all three:

```c
if (secure_relpath_active())
    fd2 = secure_recv_open(fnametmp, O_WRONLY|O_CREAT, 0600, one_inplace);
else
    fd2 = do_open(fnametmp, O_WRONLY|O_CREAT, 0600);
#ifdef linux
if (fd2 == -1 && errno == EACCES) {           /* protected_regular retry */
    fd2 = secure_recv_open(fnametmp, O_WRONLY, 0600, one_inplace);
}
#endif
if (fd2 == -1 && errno == EACCES)
    fd2 = open_readonly_inplace(fnametmp, one_inplace);
```

oc had the chain **written twice** — `transfer`'s receiver and `engine`'s
local-copy executor each carried their own copy (#7485 added the third arm to
both) — and had no way to express the resolver axis at all.

## One owner, two consumers

`transfer` depends on `engine`, so the two sites cannot share code through
either. The chain moves into **`fast_io::inplace_open`**, next to the
`operator_open_*` family and the `readonly_inplace` helper it already calls.
Both sites collapse to one call:

```rust
fast_io::open_inplace_output(path, truncate, fast_io::InplaceResolution::Direct)
```

`truncate` stays the caller's own decision and is passed through verbatim — the
receiver never truncates, the local-copy path truncates only when there is no
delta basis — so this is a pure consolidation: **-56 lines of duplicated arm
logic, no behaviour change at either site.**

## The resolver axis

`InplaceResolution` is upstream's `one_inplace` argument as a type:

| | resolves by | why |
|---|---|---|
| `Direct` | path | the destination leaf, whose parents the caller already anchored |
| `OperatorWalk` | per-component ownership walk | an operator-supplied path that may legitimately point outside the tree |

Threading it through *every* arm is the substance, not decoration. A retry that
dropped to the plain resolver would follow a parent flipped to a symlink inside
the `EACCES` window — precisely what upstream's
`partial-protected-regular-retry-linux` test plants. `readonly_inplace`
therefore takes it too, and uses it for its mode-restore probe as well as its
write open, matching `receiver.c:214`.

`OperatorWalk` has no consumer on this branch. It is the seam the local-copy
`--partial-dir` `one_inplace` staging needs (measured separately: oc's local
path uses the partial-dir leaf neither as a delta basis nor as a staging
target), and it is built here so that change is a routing decision rather than a
second chain.

On non-Unix `fast_io` has no ownership walk at all (`owner_walk` is
`#[cfg(unix)]`), so `OperatorWalk` degrades to `Direct` there. That is stated in
the docs rather than left implicit; what path confinement should mean on Windows
is a separate open question.

## `operator_open_recv`

`owner_walk` gained one function, named for the upstream call it mirrors:
`secure_recv_open(fnametmp, O_WRONLY[|O_CREAT], 0600, one_inplace)`. The
existing `operator_open_write_create` could not serve — it carries `O_TRUNC`,
which never appears at either upstream site, because a staged partial *is* the
delta basis.

## Non-vacuity

Severing arm 3 kills its own cell with the exact pre-fix error:

```
inplace_open::tests::the_truncate_choice_survives_the_recovery_arm
  panicked: recoverable: Os { code: 13, kind: PermissionDenied }
```

The routing cell for `OperatorWalk` uses the walk's own `EINVAL`-on-no-final-
component contract against the kernel's `EISDIR`, so it proves *which* code path
ran without needing a second uid.

A leaf symlink cannot discriminate the two resolutions, which is worth stating
because it is the obvious thing to reach for: `ona_open` **follows** a symlink
owned by uid 0 or our euid at *every* component, the leaf included
(`syscall.c:406`). Authority is the trust signal, not the presence of a link, so
both resolutions follow a self-owned link and such a test passes either way. The
reasoning is repeated in the routing cell's doc comment so it does not have to
be re-derived.

## Verification (Linux x86_64)

- `cargo fmt --all -- --check` clean.
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- `fast_io` inplace/readonly cells: 12/12.
- `transfer` + `engine`, every `inplace` / `partial` / `readonly` cell: **361/361**.

