### PR TITLE
fix(daemon): resolve an absolute --backup-dir against the module root

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -326,6 +326,32 @@ fn build_server_config(
                 true
             });
 
+            // upstream: options.c:2402-2409 - the same `if (sanitize_paths)`
+            // block that sanitises the alt-dest dirs also runs `backup_dir`
+            // through `sanitize_path(NULL, backup_dir, NULL, 0, SP_DEFAULT)`.
+            // An ABSOLUTE --backup-dir therefore re-roots at `module_dir`
+            // (util1.c:1145-1152, the `if (!rootdir) rootdir = module_dir`
+            // arm), while a relative one stays relative to the destination -
+            // the same two arms `clamp_basis_to_module` already implements for
+            // a basis directory, so it is reused rather than reimplemented.
+            //
+            // Without this the daemon resolved `/backup/` against the
+            // filesystem root and the backup silently failed. That is not a
+            // cosmetic loss: `atomic_create()` makes the backup a PRECONDITION
+            // (generator.c:2477-2479 `if (!make_backup(...)) return 0`), so the
+            // failure SKIPPED the entry entirely, leaving the destination stale
+            // while still exiting 0.
+            if let Some(dir) = cfg.backup_dir.as_deref() {
+                let clamped = clamp_basis_to_module(
+                    std::path::Path::new(dir),
+                    &resolve_base,
+                    &module_root_canonical,
+                );
+                // Lossless: `dir` is a String, and the clamp only joins and
+                // drops whole components, so every retained byte stays UTF-8.
+                cfg.backup_dir = Some(clamped.to_string_lossy().into_owned());
+            }
+
             // upstream: loadparm.c - `temp dir` module parameter provides a
             // default temp directory. The client's --temp-dir takes precedence
             // if already set from apply_long_form_args.

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -107,7 +107,7 @@ misc-coverage fail
 msg-io-timeout-zero pass
 nonroot-restrictive-perms skip
 operator-path-backup-dir-daemon pass
-operator-path-backup-dir-exclude-daemon fail
+operator-path-backup-dir-exclude-daemon pass
 operator-path-dir-daemon-inmodule pass
 operator-path-dir-daemon-leaf fail
 operator-path-dir-daemon-mkdir fail

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -206,7 +206,7 @@ omit-times pass
 open-noatime pass
 operator-path-backup-dir pass
 operator-path-backup-dir-daemon pass
-operator-path-backup-dir-exclude-daemon fail
+operator-path-backup-dir-exclude-daemon pass
 operator-path-backup-rmdir skip
 operator-path-backup-symlink skip
 operator-path-compare-dest pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -86,8 +86,8 @@ deep-path pass
 delete-missing-args-files-from pass
 early-input-symlink pass
 exclude-implied-trailing-backslash skip
-files-from-leak fail
-filter-leak fail
+files-from-leak skip
+filter-leak skip
 inband-modname-leak skip
 insecure-links-admin-optout fail
 io-noop-flood-recursion skip
@@ -107,7 +107,7 @@ misc-coverage fail
 msg-io-timeout-zero pass
 nonroot-restrictive-perms fail
 operator-path-backup-dir-daemon pass
-operator-path-backup-dir-exclude-daemon fail
+operator-path-backup-dir-exclude-daemon pass
 operator-path-dir-daemon-inmodule pass
 operator-path-dir-daemon-leaf fail
 operator-path-dir-daemon-mkdir fail

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -144,10 +144,10 @@ fake-super-backup-fifo-regression pass
 file-to-file-mkpath-dry-run pass
 files-from pass
 files-from-depth pass
-files-from-leak fail
+files-from-leak skip
 files-from-path-clamp pass
 filter-depth pass
-filter-leak fail
+filter-leak skip
 filter-merge-content-echo fail
 filter-merge-recursion pass
 filter-merge-symlink pass
@@ -206,7 +206,7 @@ omit-times pass
 open-noatime pass
 operator-path-backup-dir pass
 operator-path-backup-dir-daemon pass
-operator-path-backup-dir-exclude-daemon fail
+operator-path-backup-dir-exclude-daemon pass
 operator-path-backup-rmdir pass
 operator-path-backup-symlink pass
 operator-path-compare-dest pass


### PR DESCRIPTION
Pushing to a non-chrooted daemon module with `-b --backup-dir=/backup/`,
oc resolved the absolute path against the filesystem root instead of the
module root. The backup then failed, and because `atomic_create()` makes
the backup a PRECONDITION (generator.c:2477-2479, `if (!make_backup(...))
return 0`), the entry was skipped entirely - leaving the destination
STALE while still exiting 0.

Measured against the real rsync 3.5.0 binary, daemon push replacing an
existing destination symlink:

  | --backup-dir | upstream 3.5.0          | oc (before)         |
  |--------------|-------------------------|---------------------|
  | /backup/     | base/backup/sub/f0      | MISSING, dest stale |
  | backup/      | base/dest/backup/sub/f0 | identical (correct) |

Both arms now match upstream 4/4, and the destination is updated.

upstream: options.c:2402-2409 runs `backup_dir` through
`sanitize_path(NULL, backup_dir, NULL, 0, SP_DEFAULT)` in the same
`if (sanitize_paths)` block that handles the alt-dest dirs.
util1.c:1145-1152 (`if (!rootdir) rootdir = module_dir`) is what re-roots
an absolute path at the module dir and resets depth to 0; a relative path
is left relative and resolves against the destination.

Those are exactly the two arms `clamp_basis_to_module` already implements
for a basis directory, so `backup_dir` is routed through the existing
helper rather than growing a second copy of the rule. Upstream applies it
as a single post-parse block, which is why the call sits beside the
alt-dest clamp instead of in the four option arms that assign the field.

Scope is wider than the symlink case that exposed it: `atomic_create()`
is shared, so any destination kind reached through it inherited the skip.

Expect-manifest rows updated from a real run on both transports:

  - operator-path-backup-dir-exclude-daemon: fail -> pass (all four legs,
    measured individually; a cell this change closes that was not part of
    the original investigation)
  - filter-leak / files-from-leak (root legs): fail -> skip

The two leak cells previously aborted at their own positive control ("the
old destination symlink was not backed up"). They now clear it and reach
a later precondition, where the harness skips them because the race did
not produce a root-owned backup symlink. That is progress, not a pass -
their leak assertion has still never executed against oc, and upstream
reaches a genuine PASS on the same host. Tracked separately; the rows
record what actually happens rather than asserting a fix that is not
there.

Root leg: 265 passed / 24 failed / 56 skipped (was 264 / 27 / 54).
