### PR TITLE
fix(backup): resolve the --inplace backup copy through the ownership walk

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -224,9 +224,9 @@ pub use local_copy::{
     LocalCopyError, LocalCopyErrorKind, LocalCopyOptions, LocalCopyOptionsBuilder, LocalCopyPlan,
     LocalCopySummary, ReferenceDirectory, ReferenceDirectoryKind, SkipCompressList,
     SkipCompressParseError, SparseDetectStrategy, SparseDetector, SparseReader, SparseRegion,
-    compute_backup_path, create_backup_dir_parents, trace_make_backup_copy,
-    trace_make_backup_device, trace_make_backup_hlink, trace_make_backup_rename,
-    trace_make_backup_symlink,
+    compute_backup_path, copy_pre_image_to_backup, create_backup_dir_parents,
+    trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
+    trace_make_backup_rename, trace_make_backup_symlink,
 };
 
 /// File signature generation for delta transfers.

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -35,12 +35,12 @@ use super::{
     LocalCopyMetadata, LocalCopyOptions, LocalCopyProgress, LocalCopyRecord,
     LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, MergeFileRegistry, NestedDirMerge,
     ReferenceDirectory, SparseWriteState, compute_backup_path, copy_entry_to_backup,
-    create_backup_parents, delete_extraneous_entries, filter_program_local_error,
-    follow_symlink_metadata, load_dir_merge_rules_recursive, map_metadata_error,
-    record_directory_subtree, remove_source_entry_if_requested, resolve_dir_merge_path,
-    should_skip_copy, skip_matched_sparse, symlink_target_is_safe, trace_make_backup_copy,
-    trace_make_backup_device, trace_make_backup_hlink, trace_make_backup_rename,
-    trace_make_backup_symlink, write_sparse_chunk,
+    copy_pre_image_to_backup, create_backup_parents, delete_extraneous_entries,
+    filter_program_local_error, follow_symlink_metadata, load_dir_merge_rules_recursive,
+    map_metadata_error, record_directory_subtree, remove_source_entry_if_requested,
+    resolve_dir_merge_path, should_skip_copy, skip_matched_sparse, symlink_target_is_safe,
+    trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
+    trace_make_backup_rename, trace_make_backup_symlink, write_sparse_chunk,
 };
 use crate::delta::{DeltaSignatureIndex, ProbeCounters};
 use crate::signature::SignatureBlock;

--- a/crates/engine/src/local_copy/context_impl/backup.rs
+++ b/crates/engine/src/local_copy/context_impl/backup.rs
@@ -321,8 +321,11 @@ impl<'a> CopyContext<'a> {
         // upstream: generator.c:1866 copy_file() - duplicate the pre-image; the
         // destination inode is left in place to be rewritten by the inplace
         // writer. A pre-existing backup is overwritten (upstream robust_unlinks
-        // it at generator.c:1901); fs::copy truncates to the same end state.
-        match fs::copy(destination, &backup_path) {
+        // it at generator.c:1901); the O_TRUNC create reaches the same end
+        // state. The backup path is operator-named, so it resolves through the
+        // ownership walk - generator.c:2283 raises `operator_path_resolve` for
+        // exactly this copy because it bypasses `make_backup()`.
+        match copy_pre_image_to_backup(destination, &backup_path) {
             Ok(_) => {}
             // A vanished destination has nothing to back up, mirroring the
             // NotFound arm of the rename path (backup.c:make_backup returns 3).

--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -16,6 +16,51 @@ use crate::local_copy::create_symlink;
 #[cfg(unix)]
 use crate::local_copy::map_metadata_error;
 
+/// Duplicates a destination's pre-transfer bytes into the operator-named
+/// backup path, resolving that path with the ownership walk.
+///
+/// Used by the `--inplace --backup` paths, where the destination inode is
+/// rewritten in place rather than replaced, so the pre-image must be COPIED
+/// aside instead of renamed.
+///
+/// upstream: generator.c:2279-2300 and generator.c:2327-2350 - the in-place
+/// backup BYPASSES `make_backup()`, so the generator raises
+/// `operator_path_resolve` around `get_backup_name()` and the `copy_file()` /
+/// `do_open_at()` that follow, clearing it again on every exit path. Without
+/// it the open of `backupptr` resolves with libc and FOLLOWS a symlink planted
+/// at the `--backup-dir` leaf. `std::fs::copy` has exactly that behaviour,
+/// which is what upstream's `operator-path-inplace-backup-dir` cell observes as
+/// an escape out of the transfer tree.
+///
+/// Permissions are taken from the source and applied through the open
+/// descriptor, matching `fs::copy` (and upstream's
+/// `copy_file(..., back_file->mode)`) without ever re-resolving the path the
+/// walk has already vetted.
+///
+/// A vanished source surfaces as [`io::ErrorKind::NotFound`], exactly as
+/// `fs::copy` did, so callers keep their existing "nothing to back up" arm.
+pub fn copy_pre_image_to_backup(source: &Path, backup_path: &Path) -> io::Result<()> {
+    let mut reader = fs::File::open(source)?;
+    let permissions = reader.metadata()?.permissions();
+
+    #[cfg(unix)]
+    let mut writer = {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // Mask to the permission bits: `mode()` carries the file-type bits too,
+        // and only the low 12 are meaningful as an `O_CREAT` mode.
+        fast_io::operator_open_write_create(backup_path, permissions.mode() & 0o7777)?
+    };
+    // Non-Unix has no ownership walk to run; degrade to a plain create, as the
+    // other operator-path helpers do.
+    #[cfg(not(unix))]
+    let mut writer = fs::File::create(backup_path)?;
+
+    io::copy(&mut reader, &mut writer)?;
+    writer.set_permissions(permissions)?;
+    Ok(())
+}
+
 /// Computes the backup file path for a destination file.
 ///
 /// When `backup_dir` is `Some`, the backup is placed under that directory
@@ -347,6 +392,77 @@ mod tests {
     use super::*;
     use std::ffi::OsStr;
     use std::path::Path;
+
+    /// `copy_pre_image_to_backup` replaced a `std::fs::copy`, which carries the
+    /// permission bits as well as the bytes. Dropping that second half would
+    /// silently re-mode every `--inplace` backup.
+    ///
+    /// The backup is pre-created with a DIFFERENT mode on purpose: that is the
+    /// only shape that discriminates. `O_CREAT` applies its mode argument to a
+    /// NEW file only, so against a fresh path the open alone already produces
+    /// the right bits and the test would pass whether or not the permissions
+    /// are carried. The receiver path (`disk_commit`) has no metadata apply
+    /// after the copy, so on a re-run over an existing backup this is the only
+    /// thing setting its mode.
+    #[test]
+    fn copy_pre_image_to_backup_carries_content_and_permissions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = dir.path().join("dest");
+        let backup = dir.path().join("dest~");
+        fs::write(&source, b"PRE-IMAGE").expect("write source");
+        fs::write(&backup, b"stale").expect("write pre-existing backup");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            fs::set_permissions(&source, fs::Permissions::from_mode(0o640)).expect("chmod source");
+            fs::set_permissions(&backup, fs::Permissions::from_mode(0o600)).expect("chmod backup");
+        }
+
+        copy_pre_image_to_backup(&source, &backup).expect("copy the pre-image aside");
+
+        assert_eq!(fs::read(&backup).expect("read backup"), b"PRE-IMAGE");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            let mode = fs::metadata(&backup)
+                .expect("stat backup")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o640, "backup must inherit the source mode");
+        }
+    }
+
+    /// upstream `robust_unlink`s an existing backup before writing the new one
+    /// (`generator.c:1901`); the `O_TRUNC` create has to reach the same end
+    /// state, or a shorter pre-image would leave the previous backup's tail
+    /// appended to it.
+    #[test]
+    fn copy_pre_image_to_backup_truncates_a_longer_pre_existing_backup() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = dir.path().join("dest");
+        let backup = dir.path().join("dest~");
+        fs::write(&source, b"short").expect("write source");
+        fs::write(&backup, b"a much longer previous backup").expect("write stale backup");
+
+        copy_pre_image_to_backup(&source, &backup).expect("copy the pre-image aside");
+
+        assert_eq!(fs::read(&backup).expect("read backup"), b"short");
+    }
+
+    /// Both call sites branch on this errno for their "nothing to back up" arm,
+    /// mirroring `backup.c:make_backup` returning 3 for a vanished entry. It is
+    /// the one part of `fs::copy`'s contract they actually depend on.
+    #[test]
+    fn copy_pre_image_to_backup_reports_notfound_for_a_vanished_source() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let error = copy_pre_image_to_backup(&dir.path().join("gone"), &dir.path().join("gone~"))
+            .expect_err("a missing source cannot be backed up");
+
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    }
 
     #[test]
     fn compute_backup_path_with_suffix_only() {

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -12,7 +12,7 @@ mod paths;
 mod preallocate;
 mod sparse;
 
-pub use backup::{compute_backup_path, create_backup_dir_parents};
+pub use backup::{compute_backup_path, copy_pre_image_to_backup, create_backup_dir_parents};
 pub(crate) use backup::{copy_entry_to_backup, create_backup_parents};
 pub use backup_trace::{
     trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -27,10 +27,10 @@ pub(crate) use file::{
 };
 pub use file::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,
-    SparseReader, SparseRegion, compute_backup_path, create_backup_dir_parents,
-    remove_existing_destination, remove_incomplete_destination, trace_make_backup_copy,
-    trace_make_backup_device, trace_make_backup_hlink, trace_make_backup_rename,
-    trace_make_backup_symlink,
+    SparseReader, SparseRegion, compute_backup_path, copy_pre_image_to_backup,
+    create_backup_dir_parents, remove_existing_destination, remove_incomplete_destination,
+    trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
+    trace_make_backup_rename, trace_make_backup_symlink,
 };
 #[cfg(test)]
 pub(crate) use file::{

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -122,10 +122,10 @@ pub(crate) use dir_merge::{
 pub(crate) use executor::*;
 pub use executor::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,
-    SparseReader, SparseRegion, compute_backup_path, create_backup_dir_parents,
-    remove_existing_destination, remove_incomplete_destination, trace_make_backup_copy,
-    trace_make_backup_device, trace_make_backup_hlink, trace_make_backup_rename,
-    trace_make_backup_symlink,
+    SparseReader, SparseRegion, compute_backup_path, copy_pre_image_to_backup,
+    create_backup_dir_parents, remove_existing_destination, remove_incomplete_destination,
+    trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
+    trace_make_backup_rename, trace_make_backup_symlink,
 };
 
 pub(crate) use hard_links::HardLinkTracker;

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -11,8 +11,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use engine::{
-    CleanupManager, compute_backup_path, create_backup_dir_parents, trace_make_backup_copy,
-    trace_make_backup_hlink, trace_make_backup_rename,
+    CleanupManager, compute_backup_path, copy_pre_image_to_backup, create_backup_dir_parents,
+    trace_make_backup_copy, trace_make_backup_hlink, trace_make_backup_rename,
 };
 
 use crate::pipeline::messages::{BackupNotice, BeginMessage};
@@ -877,9 +877,11 @@ pub(super) fn make_backup_copy(
     // upstream: generator.c:1866 copy_file() - duplicate the pre-transfer bytes
     // into the backup, leaving the original inode in place to be updated. A
     // pre-existing backup at this path is overwritten (upstream robust_unlinks
-    // it at generator.c:1901); `fs::copy` truncates, reaching the same end
-    // state. `fs::copy` is portable across Linux/macOS/Windows.
-    fs::copy(file_path, &backup_path)?;
+    // it at generator.c:1901); the O_TRUNC create reaches the same end state.
+    // The backup path is operator-named and resolves through the ownership
+    // walk: generator.c:2283 raises `operator_path_resolve` around this copy
+    // precisely because the in-place backup bypasses `make_backup()`.
+    copy_pre_image_to_backup(file_path, &backup_path)?;
 
     // upstream: generator.c:1990-1992 - INFO_GTE(BACKUP, 1) "backed up X to Y".
     // Paths are relative to the destination root to match test assertions; the

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -216,7 +216,7 @@ operator-path-dir-daemon-leaf fail
 operator-path-dir-daemon-mkdir fail
 operator-path-dir-daemon-outside pass
 operator-path-files-from pass
-operator-path-inplace-backup-dir fail
+operator-path-inplace-backup-dir pass
 operator-path-insecure-links-daemon pass
 operator-path-insecure-links-refused pass
 operator-path-link-dest pass


### PR DESCRIPTION
With `--inplace --backup --backup-dir=<abs>`, a symlink planted at the
backup-dir leaf by another uid was **followed**, writing the destination's
pre-image outside the transfer tree. Upstream's
`operator-path-inplace-backup-dir` cell observes exactly that:

```
--inplace --backup-dir: CROSS-UID abs leaf safe: the planted symlink was
FOLLOWED (op escaped to outside/). An operator path must refuse a symlink
not owned by uid 0 or the euid.
```

## Upstream

The in-place backup **bypasses `make_backup()`** - the generator builds it
itself - so `generator.c:2279-2300` and `generator.c:2327-2350` raise
`operator_path_resolve` around `get_backup_name()` and the `copy_file()` /
`do_open_at()` that follow, clearing it again on every exit path. Both of
oc's in-place backup sites used a plain `std::fs::copy`, which resolves the
destination with libc and therefore follows any planted symlink.

## Two sinks, and the failing cell only exercises one

| sink | path | covered by the cell |
|---|---|---|
| `crates/engine/.../context_impl/backup.rs` | local copy | yes |
| `crates/transfer/.../disk_commit/commit.rs` | network receiver | no |

Both already share `compute_backup_path` from `engine`, so the rule gets one
owner - `copy_pre_image_to_backup` - rather than a second copy. The parents
were already confined at both sites; only the leaf write was not.

Permissions are carried explicitly and applied through the open descriptor,
matching what `fs::copy` did without re-resolving a path the walk has already
vetted. On non-Unix this degrades to a plain create, as the other
operator-path helpers do.

## Measured (Linux, root leg)

| binary | `operator-path-inplace-backup-dir` |
|---|---|
| rsync 3.5.0 | PASS (control) |
| oc-rsync before | FAIL |
| oc-rsync after | PASS |

Non-vacuity: restoring the plain `fs::copy` at the local sink returns the
cell to FAIL.

## Test scope, stated plainly

The three unit tests pin the helper's **contract**, not the confinement -
content and permissions carried, a pre-existing longer backup truncated, and
a vanished source surfacing as `NotFound` (the arm both call sites branch
on). The confinement needs a symlink owned by a third uid, which an
unprivileged test cannot create; the testsuite root leg is what covers it.

The permissions test deliberately pre-creates the backup with a different
mode: `O_CREAT` applies its mode to a **new** file only, so against a fresh
path the open alone yields the right bits and the assertion would hold either
way. That fixture was vacuous until retargeted - the mutation that dropped
the permission carry killed nothing.

Root manifest row flipped in the same commit.
