### PR TITLE
fix(daemon): refuse a staging directory the module filter excludes

### DIFF
--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
@@ -266,6 +266,114 @@ fn daemon_excluded_destination_honours_dir_only_rules() {
 }
 
 /// Builds a receiver whose module excludes `secret` and whose client asked for
+/// the given `--temp-dir` / `--backup-dir` values.
+///
+/// Both are given as the module-rooted paths oc stores, because that is what
+/// upstream matches: `options.c:2400-2407` sanitises both options IN PLACE
+/// (rootdir `NULL` = `module_dir`) BEFORE the filter block at `:2409-2436`
+/// re-cleans them for the check. Unlike a basis directory there is no
+/// "requested" form to preserve.
+fn ctx_with_staging(temp_dir: Option<&str>, backup_dir: Option<&str>) -> ReceiverContext {
+    use protocol::filters::{FilterRuleWireFormat, RuleType};
+    let handshake = test_handshake();
+    let mut config = test_config();
+    // ANCHORED, as a module `exclude = /secret` is.
+    config.daemon_filter_rules = vec![FilterRuleWireFormat {
+        rule_type: RuleType::Exclude,
+        pattern: "secret".into(),
+        anchored: true,
+        ..FilterRuleWireFormat::default()
+    }];
+    config.connection.daemon_module_root = Some("/srv/mod".into());
+    config.temp_dir = temp_dir.map(std::path::PathBuf::from);
+    config.backup_dir = backup_dir.map(str::to_owned);
+    ReceiverContext::new_for_test(&handshake, config)
+}
+
+fn assert_options_rejected(err: std::io::Error) {
+    assert_eq!(
+        err.to_string(),
+        "Your options have been rejected by the server.",
+        "upstream's exact refusal text (clientserver.c:1267)"
+    );
+    assert!(
+        err.get_ref()
+            .is_some_and(|inner| inner.is::<protocol::SyntaxViolation>()),
+        "the refusal must carry the RERR_SYNTAX marker, or the exit-code mapper's \
+         catch-all reports RERR_FILEIO (11) instead of upstream's 1"
+    );
+}
+
+/// upstream: `options.c:2427-2435` - a peer-supplied `--backup-dir` naming a
+/// directory the module excludes refuses the whole session.
+///
+/// Measured against a real 3.5.0 daemon before the fix: oc wrote the
+/// destination's pre-image INTO the excluded subtree and exited 0, where
+/// upstream exits 4 with this text.
+#[test]
+fn daemon_excluded_backup_dir_is_refused() {
+    let ctx = ctx_with_staging(None, Some("/srv/mod/secret"));
+    assert_options_rejected(
+        ctx.reject_daemon_excluded_staging_dirs()
+            .expect_err("an excluded --backup-dir must refuse the session"),
+    );
+}
+
+/// upstream: `options.c:2419-2425` - the SAME block applies the identical rule
+/// to `tmpdir`. Pinned separately because a fix that covered only `backup_dir`
+/// would leave this operand live, and both tests share one implementation.
+#[test]
+fn daemon_excluded_temp_dir_is_refused() {
+    let ctx = ctx_with_staging(Some("/srv/mod/secret"), None);
+    assert_options_rejected(
+        ctx.reject_daemon_excluded_staging_dirs()
+            .expect_err("an excluded --temp-dir must refuse the session"),
+    );
+}
+
+/// upstream: `options.c:2421` / `:2429` - `if (!*tmpdir)` / `if (!*backup_dir)`
+/// jumps straight to `options_rejected`. An empty value is refused OUTRIGHT,
+/// before any filter match, so it cannot slip through on a module whose rules
+/// happen not to match the empty name.
+#[test]
+fn daemon_empty_staging_dir_is_refused_without_matching() {
+    let ctx = ctx_with_staging(None, Some(""));
+    assert_options_rejected(
+        ctx.reject_daemon_excluded_staging_dirs()
+            .expect_err("an empty --backup-dir must refuse the session"),
+    );
+}
+
+/// Non-vacuity companion: with the SAME module filter, staging directories the
+/// rules do not exclude must pass. Without this, a refusal that fired
+/// unconditionally would look identical to a correct one.
+#[test]
+fn daemon_allows_staging_dirs_the_module_does_not_exclude() {
+    let ctx = ctx_with_staging(Some("/srv/mod/tmp"), Some("/srv/mod/backups"));
+    assert!(
+        ctx.reject_daemon_excluded_staging_dirs().is_ok(),
+        "allowed staging directories must not refuse the session"
+    );
+}
+
+/// upstream gates the whole block on `daemon_filter_list.head`
+/// (`options.c:2409`), so a receiver with no module filter list - every client
+/// and SSH-server receiver - must never refuse, even on a name that would
+/// otherwise match.
+#[test]
+fn receiver_without_a_daemon_filter_list_never_refuses_staging_dirs() {
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.connection.daemon_module_root = Some("/srv/mod".into());
+    config.backup_dir = Some("/srv/mod/secret".to_owned());
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+    assert!(
+        ctx.reject_daemon_excluded_staging_dirs().is_ok(),
+        "with no daemon filter list the check must be inert"
+    );
+}
+
+/// Builds a receiver whose module excludes `secret` and whose client asked for
 /// `basis` as an alternate-basis directory.
 ///
 /// `requested` is what the peer wrote; `path` is set to the resolved shape the

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -405,6 +405,51 @@ impl ReceiverContext {
         Ok(())
     }
 
+    /// Refuses a peer-supplied staging directory that the daemon module's own
+    /// filter list excludes.
+    ///
+    /// upstream: `options.c:2409-2436` - with a non-empty `daemon_filter_list`
+    /// and `!am_sender`, both `tmpdir` and `backup_dir` are re-sanitised against
+    /// rootdir `"/"` and run through `check_filter(elp, FLOG, dir, 1)`. An empty
+    /// value, or a match, jumps to `options_rejected`, which prints
+    /// `"Your options have been rejected by the server."` and exits
+    /// `RERR_SYNTAX`.
+    ///
+    /// Unlike the basis-directory check above, this matches the value oc has
+    /// already stored rather than the name the peer wrote. That is upstream's
+    /// own ordering, not a shortcut: `options.c:2400-2407` sanitises both
+    /// options IN PLACE first (rootdir `NULL`, i.e. `module_dir`), so by the
+    /// time the filter block runs, `backup_dir` is already the operational,
+    /// module-rooted path. A basis directory has no such prior pass, which is
+    /// why `ReferenceDirectory` must retain `requested` and this must not.
+    ///
+    /// `is_dir` is `true`, mirroring upstream's single `check_filter(..., 1)`:
+    /// both options always name a directory.
+    ///
+    /// The empty-value arm is upstream's `if (!*backup_dir) goto
+    /// options_rejected;` and deliberately tests the value as given, before any
+    /// cleaning - an empty option is refused outright rather than matched.
+    pub(in crate::receiver) fn reject_daemon_excluded_staging_dirs(&self) -> io::Result<()> {
+        let Some(filters) = self.daemon_filter_set() else {
+            return Ok(());
+        };
+        let staging = [
+            self.config.temp_dir.as_deref(),
+            self.config.backup_dir.as_deref().map(Path::new),
+        ];
+        for dir in staging.into_iter().flatten() {
+            if dir.as_os_str().is_empty()
+                || !filters.allows_name(&self.daemon_filter_name(dir), true)
+            {
+                // upstream: options.c:1267 - the refusal text carries no path;
+                // the rejected option goes to the daemon's log, not the peer.
+                return Err(protocol::syntax_violation(
+                    "Your options have been rejected by the server.",
+                ));
+            }
+        }
+        Ok(())
+    }
     /// Refuses a destination argument that the daemon module's own filter list
     /// excludes.
     ///
@@ -525,6 +570,12 @@ impl ReceiverContext {
         // excluded. Ordered after the destination check because upstream reaches
         // it later in the same function (get_local_name at :1229, this at :1243).
         self.reject_daemon_excluded_basis_dirs()?;
+        // upstream: options.c:2409-2436 - the same daemon-filter gate also vets
+        // the client's staging directories (--temp-dir, --backup-dir), refusing
+        // the session when either names an excluded directory. Ordered with the
+        // other two module-filter refusals so a rejected session never reaches
+        // the transfer.
+        self.reject_daemon_excluded_staging_dirs()?;
 
         // upstream: main.c:805-832 get_local_name() - single-file rename
         // semantics. When the transfer is exactly one non-directory entry,

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -116,7 +116,7 @@ operator-path-insecure-links-daemon skip
 operator-path-insecure-links-refused pass
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
-operator-path-traversal-backup-dir-daemon fail
+operator-path-traversal-backup-dir-daemon pass
 operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass
 password-file-symlink skip

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -225,7 +225,7 @@ operator-path-partial-dir pass
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
 operator-path-temp-dir pass
-operator-path-traversal-backup-dir-daemon fail
+operator-path-traversal-backup-dir-daemon pass
 operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass
 operator-path-write-batch pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -116,7 +116,7 @@ operator-path-insecure-links-daemon pass
 operator-path-insecure-links-refused pass
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
-operator-path-traversal-backup-dir-daemon fail
+operator-path-traversal-backup-dir-daemon pass
 operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass
 password-file-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -225,7 +225,7 @@ operator-path-partial-dir pass
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
 operator-path-temp-dir fail
-operator-path-traversal-backup-dir-daemon fail
+operator-path-traversal-backup-dir-daemon pass
 operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass
 operator-path-write-batch pass


### PR DESCRIPTION
A daemon receiver never checked the client's `--backup-dir` or `--temp-dir`
against the module's own filter list, so a peer could name an excluded
directory as its staging target. With `--backup` that writes the destination's
pre-image **into** the excluded subtree, which makes it a write barrier and not
just a missing diagnostic.

## Upstream

`options.c:2409-2436` runs both options through `check_filter(elp, FLOG, dir, 1)`
once the daemon filter list is known and `!am_sender`, and on a match - or an
empty value - jumps to `options_rejected`, which prints `"Your options have been
rejected by the server."` and exits `RERR_SYNTAX`. The gate is inert for the
client and SSH-server receivers, exactly as here.

This is a third sibling of the two module-filter refusals already in
`ReceiverContext` (`main.c:718-737` for the destination, `main.c:1243-1270` for
the alternate-basis dirs) and reuses all three of their helpers, so it inherits
the existing refusal channel rather than adding one.

## Why this matches the STORED value, unlike #7455

`options.c:2400-2407` sanitises both options **in place** first (rootdir `NULL`
= `module_dir`), so by the time the filter block runs, `backup_dir` is already
the operational, module-rooted path. A basis directory has no such prior pass,
which is why `ReferenceDirectory` must retain `requested` and this must not.

I built the requested-name threading first, on the strength of that analogy.
Reading the ordering refuted it, and measuring confirmed the reading: both the
absolute and the relative form are refused with the simpler fix.

## Measured

Against a real 3.5.0 daemon on a module with `exclude = /secret/`:

| `--backup-dir` form                  | upstream | oc before | oc after |
|--------------------------------------|----------|-----------|----------|
| absolute, `..` into excluded subtree | exit 4   | ESCAPED   | refused  |
| relative `../secret/`, anchored rule | exit 4   | wrote in  | refused  |

Both forms are covered because the relative one was **measured**, not assumed -
a check on the stored value alone would otherwise have been a half fix.

The testsuite cell `operator-path-traversal-backup-dir-daemon` moves
fail -> pass on **all four legs** (root/nonroot x pipe/tcp), each measured
rather than inferred from the root-pipe result, with the real 3.5.0 binary
passing as the control. All four manifest rows flip in this commit.

Non-vacuity: neutering the check (iterating zero operands) returns the cell to
FAIL and fails 3 of the 5 new unit tests, with the allowed-dirs companion
staying green.

## Deliberately not claimed

`operator-path-temp-dir` still fails. Upstream applies the identical rule to
`tmpdir` in the same block and this change implements it - but that cell has a
different root cause and is untouched here. `partial_dir` is absent from
upstream's block entirely, so the `operator-path-partial-dir-*` cells are a
separate class and are not folded in.

## Residual, inherited and separately owned

The client sees exit 23 and `multiplexed frame truncated` rather than
upstream's message and exit 4. The already-merged sibling refusal from #7455
behaves identically against the same daemon, so this is the known peer-error
delivery gap, not a regression here.
