### PR TITLE
fix(engine): resolve the staging temp through the ownership walk under --temp-dir

### DIFF
--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -118,13 +118,40 @@ pub fn remove_incomplete_destination(destination: &Path) {
 /// closing the CVE-2024-12747 residual on the temp-create side. This mirrors the
 /// transfer receiver's `temp_guard::try_create_new`. On every other platform it
 /// is the plain `create_new` open the local-copy guard has always used.
-fn create_new_temp(path: &Path) -> io::Result<fs::File> {
+/// Exclusively creates the staging temp, resolving through the ownership walk
+/// when the operator named a `--temp-dir`.
+///
+/// upstream: `receiver.c:426-434` `open_tmpfile()` - for any non-chrooted
+/// receiver upstream calls `secure_mkstemp(fnametmp, mode, tmpdir != NULL)`,
+/// whose third argument selects the ownership-walk resolver for an
+/// operator-supplied `--temp-dir` and the strict transfer-path one otherwise.
+/// `operator_path` carries upstream's own parameter name and meaning, and it is
+/// `temp_dir.is_some()` for the same reason upstream writes `tmpdir != NULL`.
+///
+/// Without the walk, `O_EXCL` guards only the final component: it refuses a
+/// planted `.name.XXXXXX`, but a symlink planted at the `--temp-dir` itself is
+/// resolved through before the leaf is reached, so the scratch file - and the
+/// transferred data with it - is written outside the tree.
+///
+/// The `--insecure-links` opt-out needs no threading here: the walk consults
+/// the installed session policy itself (`fast_io::confinement`), so an
+/// opted-out session keeps following exactly as before.
+///
+/// The mode stays `0o666` so the umask still decides the created bits, matching
+/// what `OpenOptions::create_new` did; this change is about WHICH path is
+/// resolved, not what permissions land on the temp.
+fn create_new_temp(path: &Path, operator_path: bool) -> io::Result<fs::File> {
     #[cfg(windows)]
     {
+        // Windows was already hardened here; the walk is the Unix counterpart.
+        let _ = operator_path;
         fast_io::create_new_no_follow(path)
     }
     #[cfg(not(windows))]
     {
+        if operator_path {
+            return fast_io::operator_open_create_new(path, 0o666);
+        }
         fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -436,7 +463,7 @@ impl DestinationWriteGuard {
         // partial only appears at its final resting place on interrupt/success.
         loop {
             let temp_path = temp_name_with_suffix(destination, temp_dir, &temp_suffix());
-            match create_new_temp(&temp_path) {
+            match create_new_temp(&temp_path, temp_dir.is_some()) {
                 Ok(file) => {
                     let final_path = destination.to_path_buf();
                     // Only --partial/--partial-dir temps need the abort-path

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -407,9 +407,10 @@ pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
-    operator_link, operator_mkdir, operator_open_append, operator_open_read, operator_open_recv,
-    operator_open_rw_create, operator_open_write_create, operator_read_to_string, operator_rename,
-    operator_symlink_metadata, owner_trusted_parent, symlink_owner_is_trusted,
+    operator_link, operator_mkdir, operator_open_append, operator_open_create_new,
+    operator_open_read, operator_open_recv, operator_open_rw_create, operator_open_write_create,
+    operator_read_to_string, operator_rename, operator_symlink_metadata, owner_trusted_parent,
+    symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -512,6 +512,43 @@ pub fn operator_open_write_create(path: &Path, mode: u32) -> io::Result<std::fs:
     )
 }
 
+/// Exclusively create an operator-supplied path through the ownership walk.
+///
+/// The `O_EXCL` twin of [`operator_open_write_create`], for the receiver's
+/// staging temp under an operator-supplied `--temp-dir`.
+///
+/// `O_EXCL` alone is NOT sufficient here. It refuses a symlink at the *final*
+/// component only, so it defeats a planted `.name.XXXXXX` but not a planted
+/// `--temp-dir` itself: the path resolves *through* the directory symlink
+/// before the leaf is ever considered, and the receiver's scratch file - and
+/// with it the transferred data - lands outside the tree.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/receiver.c:426-434` `open_tmpfile()` - for any non-chrooted
+///   receiver, `secure_mkstemp(fnametmp, mode, tmpdir != NULL)`. The third
+///   argument is the resolver selector, and upstream's own comment states the
+///   rule: "An operator-supplied --temp-dir (tmpdir) gets the ownership-walk
+///   resolver (it may legitimately point outside the tree); the deep-entry-dir
+///   fallback ... gets the strict transfer-path one."
+///
+/// Name generation stays the caller's: upstream's `mkstemp` is
+/// generate-then-`O_EXCL`-retry, which is what the caller's retry loop already
+/// implements. This supplies only the walked, exclusive open.
+///
+/// # Errors
+///
+/// See [`operator_open_with`]. `AlreadyExists` is the expected, retryable
+/// outcome when the generated name collides.
+pub fn operator_open_create_new(path: &Path, mode: u32) -> io::Result<std::fs::File> {
+    operator_open_with(
+        path,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL,
+        // `RawMode` is u16 on macOS and u32 on Linux, so route the cast through
+        // it rather than naming either width here.
+        Mode::from_bits_truncate(mode as rustix::fs::RawMode),
+    )
+}
 /// Open an operator-supplied path as a receiver output through the ownership
 /// walk.
 ///

--- a/crates/fast_io/tests/operator_open_create_new.rs
+++ b/crates/fast_io/tests/operator_open_create_new.rs
@@ -1,0 +1,109 @@
+//! `operator_open_create_new` is the `O_EXCL` arm of the ownership walk.
+//!
+//! It backs the receiver's staging temp under an operator-supplied `--temp-dir`.
+//! `O_EXCL` alone guards only the FINAL component, so a symlink planted at the
+//! `--temp-dir` itself is resolved through before the leaf is considered - the
+//! walk is what closes that, and these pin the contract the caller relies on.
+//!
+//! The cross-uid refusal itself needs a symlink owned by a third uid, which only
+//! root can plant, so it is covered by the `operator-path-temp-dir` cell of the
+//! upstream 3.5.0 testsuite (run as root in CI). What is pinned here is
+//! everything that is reachable unprivileged: the create, the exclusivity the
+//! caller's retry loop depends on, and the FOLLOW direction - without that last
+//! one a future "refuse every symlink" simplification would look correct.
+//!
+//! upstream: `rsync-3.5.0/syscall.c:3379` `secure_mkstemp()`.
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Write;
+
+use tempfile::TempDir;
+
+/// Non-vacuity companion: with no symlink in play the walked create makes an
+/// ordinary nested file. Without this, the refusal test below would also pass if
+/// `operator_open_create_new` simply failed for every input.
+#[test]
+fn operator_open_create_new_creates_a_nested_file() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir(root.path().join("tmp")).expect("mkdir tmp");
+    let dest = root.path().join("tmp").join(".f0.XXXXXX");
+
+    let mut file = fast_io::operator_open_create_new(&dest, 0o666).expect("create");
+    file.write_all(b"payload").expect("write");
+    drop(file);
+
+    assert_eq!(fs::read_to_string(&dest).unwrap(), "payload");
+}
+
+/// The caller (`create_new_temp`) generates a random name and RETRIES on
+/// `AlreadyExists`, which is upstream's generate-then-`O_EXCL`-retry `mkstemp`
+/// loop. That contract only holds if a collision reports exactly that kind - any
+/// other error would escape the retry arm and abort the transfer.
+#[test]
+fn operator_open_create_new_reports_already_exists_on_a_collision() {
+    let root = TempDir::new().expect("tempdir");
+    let dest = root.path().join("occupied");
+    fs::write(&dest, b"first").expect("seed");
+
+    let error = fast_io::operator_open_create_new(&dest, 0o666)
+        .expect_err("an existing name must not be opened or truncated");
+
+    assert_eq!(
+        error.kind(),
+        std::io::ErrorKind::AlreadyExists,
+        "the caller's retry loop keys on AlreadyExists"
+    );
+    assert_eq!(
+        fs::read_to_string(&dest).unwrap(),
+        "first",
+        "O_EXCL must leave the existing file untouched"
+    );
+}
+
+/// A symlink planted at the LEAF name is refused rather than followed: `O_EXCL`
+/// makes the open fail instead of writing through it. Pinned because this is the
+/// half `O_EXCL` does cover, so a regression here would otherwise be invisible
+/// behind the walk.
+#[test]
+fn operator_open_create_new_refuses_a_symlinked_leaf() {
+    let root = TempDir::new().expect("tempdir");
+    let outside = TempDir::new().expect("outside tempdir");
+    let target = outside.path().join("victim");
+    fs::write(&target, b"original").expect("seed victim");
+    let dest = root.path().join(".f0.XXXXXX");
+    std::os::unix::fs::symlink(&target, &dest).expect("plant leaf symlink");
+
+    fast_io::operator_open_create_new(&dest, 0o666)
+        .expect_err("a symlink at the leaf must not be followed");
+
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        "original",
+        "nothing may be written through the planted link"
+    );
+}
+
+/// FOLLOW direction: a parent symlink owned by our own euid is trusted and
+/// descended (`syscall.c:406` trusts uid 0 or the euid). Without this pin, a
+/// "refuse every parent symlink" change would pass the refusal tests while
+/// breaking a legitimate operator `--temp-dir` that happens to be a symlink -
+/// which is precisely the case upstream's comment says must keep working.
+#[test]
+fn operator_open_create_new_follows_a_self_owned_parent_symlink() {
+    let root = TempDir::new().expect("tempdir");
+    fs::create_dir(root.path().join("real")).expect("mkdir real");
+    std::os::unix::fs::symlink("real", root.path().join("tmp")).expect("plant symlink");
+    let dest = root.path().join("tmp").join(".f0.XXXXXX");
+
+    let mut file =
+        fast_io::operator_open_create_new(&dest, 0o666).expect("create through our own link");
+    file.write_all(b"payload").expect("write");
+    drop(file);
+
+    assert_eq!(
+        fs::read_to_string(root.path().join("real").join(".f0.XXXXXX")).unwrap(),
+        "payload",
+        "the temp must land in the symlink's target"
+    );
+}

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -224,7 +224,7 @@ operator-path-log-file pass
 operator-path-partial-dir pass
 operator-path-partial-dir-daemon fail
 operator-path-partial-dir-exclude-daemon fail
-operator-path-temp-dir fail
+operator-path-temp-dir pass
 operator-path-traversal-backup-dir-daemon pass
 operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass


### PR DESCRIPTION
The local-copy guard created its `.name.XXXXXX` staging temp with a plain
`O_CREAT|O_EXCL` open. `O_EXCL` guards only the **final** component, so it
defeats a symlink planted at the temp *name* but not one planted at the
`--temp-dir` **itself**: the path resolves *through* the directory symlink
before the leaf is considered, and the receiver's scratch file - and with it
the transferred data - lands outside the tree.

## Upstream

`receiver.c:426-434` `open_tmpfile()` calls
`secure_mkstemp(fnametmp, mode, tmpdir != NULL)` for any non-chrooted receiver.
The third argument is the resolver selector, and upstream itself names it
`operator_path` (`syscall.c:3379`). Upstream's own comment states the rule:

> An operator-supplied --temp-dir (tmpdir) gets the ownership-walk resolver
> (it may legitimately point outside the tree); the deep-entry-dir fallback,
> when the held-dirfd cache declines, gets the strict transfer-path one.

`create_new_temp` now takes exactly that selector, passed as
`temp_dir.is_some()` for the same reason upstream writes `tmpdir != NULL`.

**The walk is not new.** This adds `operator_open_create_new`, the `O_EXCL`
twin of the existing `operator_open_write_create`, so the change routes an
already-tested primitive at the site upstream routes it rather than inventing
policy. Name generation stays with the caller: upstream's `mkstemp` is
generate-then-`O_EXCL`-retry, which the caller's retry loop already implements.

The `--insecure-links` opt-out needs no threading - the walk consults the
installed session policy itself, exactly as upstream's `secure_mkstemp` checks
`operator_path && symlink_optout_allowed()` internally.

## Measured (Linux, upstream control first)

| binary | `operator-path-temp-dir` |
|---|---|
| upstream 3.5.0 | PASS |
| oc before | FAIL - *"the planted symlink was FOLLOWED (op escaped to outside/)"* |
| oc after | PASS |

A genuine divergence, not a fixture limit. The three sibling cells `temp-dir`,
`temp-dir-symlink-injection` and `chmod-temp-dir` stay green. The root manifest
row flips in this commit.

**Root leg: 268 passed / 21 failed / 56 skipped, `overall result is 0`** - zero
mismatches, exactly +1 pass / -1 fail against the 267/22/56 baseline.

## Non-vacuity, at both levels

- Forcing the selector to `false` returns the cell to FAIL while the `temp-dir`
  companion stays PASS.
- Dropping `O_EXCL` from the new primitive fails exactly the two refusal pins
  (2 of 4, with `passed + failed == run`, so no fail-fast truncation) while the
  follow and create companions stay green.

The cross-uid refusal needs a symlink owned by a third uid, which only root can
plant, so it is owned by the testsuite cell. The unit pins cover everything
reachable unprivileged: the create, the exclusivity the retry loop depends on,
and the **follow** direction - without that last one a future "refuse every
parent symlink" change would look correct while breaking a legitimate symlinked
`--temp-dir`, which is exactly the case upstream's comment says must keep working.

## Deliberately unchanged

The mode stays `0o666` so the umask still decides the created bits, matching
what `OpenOptions::create_new` did. This change is about *which path* is
resolved, not what permissions land on the temp. Windows is untouched - that arm
already used `create_new_no_follow`.

## Not claimed

oc gates the receiver on `is_daemon_connection` where upstream hardens **every**
non-chrooted receiver (`secure_relpath_active()`). This cell is one instance of
that broader gap; closing this sink does not close the class.

## Environmental note on the nonroot leg

The nonroot leg reports one mismatch, `protected-regular: expected skip, got
pass`. That is a sysctl, not this change: the row was generated where
`fs.protected_regular=0` and the verifying host has it set to `1`. The cell's
only invocation is `run_rsync('--inplace', src, dst)` with no `--temp-dir`, so
it takes the unchanged arm of `create_new_temp` and is structurally unable to
reach either changed function. The row is deliberately **not** re-baselined.
