### PR TITLE
fix(cli): apply -M/--remote-option to a local transfer instead of refusing it

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -20,6 +20,7 @@ use crate::frontend::progress::{NameOutputLevel, ProgressSetting, StderrMode};
 use core::client::{
     AddressMode, DeleteMode, HumanReadableMode, StrongChecksumChoice, TcpFastOpenMode,
 };
+use engine::operand::operand_is_remote;
 
 use super::coerce::{parse_checksum_threads, parse_spill_threshold_bytes, parse_thread_count};
 use super::cow::{last_occurrence, parse_reflink_mode, resolve_cow_policy};
@@ -143,6 +144,63 @@ fn check_remote_option_dashes(remote_options: &[OsString]) -> Result<(), clap::E
     Ok(())
 }
 
+/// Splices `-M` / `--remote-option` values into the option stream of a local
+/// transfer, returning the argv to re-parse, or `None` when the fold does not
+/// apply.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/options.c:1763-1771` - each `-M` value is accumulated into
+///   `remote_options[]`.
+/// - `rsync-3.5.0/options.c:3175-3182` - `server_options()` appends that whole
+///   array to the argv of the server the client starts.
+///
+/// A local copy is NOT an exception there: `do_cmd()` still forks a server
+/// child (`local_child` -> `child_main` -> `start_server`), so the child parses
+/// the `-M` values with the same option table as every other argument.
+/// Upstream has no local-transfer refusal for `-M` - the only "remote
+/// connections" string in the whole C tree is an unrelated comment in
+/// `socket.c`.
+///
+/// oc has no server child on a local copy: one process performs the whole
+/// transfer, and the options `-M` carries (`--fake-super` and friends) already
+/// act on the receiving side there. Re-parsing argv with each value spliced in
+/// therefore reproduces upstream's semantics through the SAME option table,
+/// which is exactly what upstream's child re-parse gets for free - and it
+/// avoids a hand-maintained per-option mapping that would silently omit
+/// whatever it failed to list.
+///
+/// The values are spliced immediately after the program name so they are
+/// parsed as ordinary options; [`check_remote_option_dashes`] has already
+/// guaranteed each begins with `-`, so none can be mistaken for an operand.
+///
+/// The transfer is judged local from clap's own operand split rather than a
+/// hand-rolled scan of the raw argv, so this cannot disagree with the option
+/// vs operand boundary the rest of the parse used.
+fn local_remote_option_argv(
+    matches: &clap::ArgMatches,
+    args: &[OsString],
+) -> Option<Vec<OsString>> {
+    let remote_options: Vec<OsString> = matches
+        .get_many::<OsString>("remote-option")?
+        .cloned()
+        .collect();
+    if remote_options.is_empty() {
+        return None;
+    }
+    let mut operands = matches.get_many::<OsString>("args")?.peekable();
+    operands.peek()?;
+    if operands.any(|operand| operand_is_remote(operand)) {
+        return None;
+    }
+    let (program, rest) = args.split_first()?;
+    let mut folded = Vec::with_capacity(args.len() + remote_options.len());
+    folded.push(program.clone());
+    folded.extend(remote_options);
+    folded.extend_from_slice(rest);
+    Some(folded)
+}
+
 /// Parses command-line arguments into a structured [`ParsedArgs`] representation.
 ///
 /// This function accepts an iterator of arguments (typically from `std::env::args_os()`)
@@ -168,6 +226,15 @@ where
     let args = expand_short_options(&command, args);
     let mut matches = command.try_get_matches_from(args.clone())?;
 
+    // A local transfer applies its `-M` values to itself, exactly as upstream's
+    // forked server child does. Re-parsed here, before any check below, so every
+    // later validation sees the final option set.
+    if let Some(folded) = local_remote_option_argv(&matches, &args) {
+        let command = clap_command(program_name.as_str());
+        let folded = hoist_options_before_operands(&command, folded);
+        let folded = expand_short_options(&command, folded);
+        matches = command.try_get_matches_from(folded)?;
+    }
     check_basis_dir_limit(&matches)?;
     #[cfg(not(feature = "quic"))]
     check_quic_feature(&matches)?;

--- a/crates/cli/src/frontend/execution/drive/validation.rs
+++ b/crates/cli/src/frontend/execution/drive/validation.rs
@@ -6,9 +6,6 @@ use logging_sink::MessageSink;
 
 use super::messages::fail_with_message;
 
-/// Error message when `--remote-option` is used without a remote connection.
-pub(crate) const REMOTE_OPTION_REMOTE_ONLY_MESSAGE: &str =
-    "the --remote-option option may only be used with remote connections";
 /// Error message when a password option is used without a daemon connection.
 pub(crate) const PASSWORD_DAEMON_ONLY_MESSAGE: &str = "the --password-file and --password-command options may only be used when accessing an rsync daemon";
 /// Error message when `--connect-program` is used without a daemon connection.
@@ -23,24 +20,24 @@ pub(crate) const CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE: &str =
 /// silently ignores it on local copies (options.c stores the value but only
 /// uses it when spawning a remote shell). The upstream testsuite relies on
 /// this behavior (e.g., the exclude test passes `--rsync-path` on local runs).
+///
+/// Note: `--remote-option` is likewise NOT rejected. Upstream appends its
+/// values to the argv of the server it starts (options.c:3175-3182), and a
+/// local copy still forks one, so `-M` reaches the receiving side there
+/// instead of being an error. oc reproduces that by folding the values into
+/// its own option stream when the transfer is local - see
+/// `local_remote_option_argv` in the argument parser - so by the time this runs
+/// they have already been applied.
 pub(super) fn validate_local_only_options<Err>(
     has_password_override: bool,
     has_password_option: bool,
     connect_program: Option<&OsString>,
     _rsync_path: Option<&OsString>,
-    remote_options: &[OsString],
     stderr: &mut MessageSink<Err>,
 ) -> Option<i32>
 where
     Err: Write,
 {
-    if !remote_options.is_empty() {
-        return Some(reject_local_only_option(
-            stderr,
-            REMOTE_OPTION_REMOTE_ONLY_MESSAGE,
-        ));
-    }
-
     // upstream imposes no daemon-only restriction on `--protocol`: setup_protocol
     // (compat.c) runs for local copies too, so `--protocol=N` (20..=32) is
     // accepted locally and simply ignored (this build never negotiates a

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -756,7 +756,6 @@ where
             password_file.is_some() || password_command.is_some(),
             connect_program.as_ref(),
             parsed.rsync_path.as_ref(),
-            &remote_options,
             stderr,
         ) {
             return exit_code;

--- a/crates/cli/src/frontend/tests/remote.rs
+++ b/crates/cli/src/frontend/tests/remote.rs
@@ -1,27 +1,67 @@
 use super::common::*;
 use super::*;
 
+/// A local transfer APPLIES its `-M` values instead of refusing them.
+///
+/// upstream: options.c:3175-3182 appends `remote_options[]` to the argv of the
+/// server the client starts, and a local copy still forks one (do_cmd ->
+/// local_child -> child_main), so the child parses them normally. Upstream has
+/// no local-transfer refusal for `-M` anywhere; oc used to invent one because
+/// the values had no local consumer and would otherwise have been dropped
+/// silently.
+///
+/// The log file is the load-bearing assertion: a test that only checked the
+/// exit code and the destination would pass just as well if `-M` were silently
+/// IGNORED, which is the failure mode the old refusal existed to prevent.
 #[test]
-fn remote_option_requires_remote_operands() {
+fn remote_option_applies_to_a_local_transfer() {
     use tempfile::tempdir;
 
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     let dest = temp.path().join("dest.txt");
+    let log = temp.path().join("applied.log");
     std::fs::write(&source, b"content").expect("write source");
 
-    let (code, stdout, stderr) = run_with_args([
+    let (code, _stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        OsString::from("--remote-option=--log-file=/tmp/rsync.log"),
+        OsString::from(format!("--remote-option=--log-file={}", log.display())),
         source.into_os_string(),
         dest.clone().into_os_string(),
     ]);
 
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
     let message = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(
-        message.contains("the --remote-option option may only be used with remote connections")
+    assert_eq!(code, 0, "-M must not be refused on a local copy: {message}");
+    assert_eq!(
+        std::fs::read(&dest).expect("dest"),
+        b"content",
+        "the transfer itself must still run"
     );
-    assert!(!dest.exists());
+    assert!(
+        log.exists(),
+        "the -M value must be APPLIED, not merely tolerated"
+    );
+}
+
+/// Non-vacuity companion for [`remote_option_applies_to_a_local_transfer`]:
+/// without `-M` the same copy leaves no log file, so that test's log-file
+/// assertion is attributable to the folded option and nothing else.
+#[test]
+fn a_local_transfer_writes_no_log_file_without_the_remote_option() {
+    use tempfile::tempdir;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let dest = temp.path().join("dest.txt");
+    let log = temp.path().join("applied.log");
+    std::fs::write(&source, b"content").expect("write source");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        source.into_os_string(),
+        dest.into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(!log.exists());
 }


### PR DESCRIPTION
oc rejected `-M` outright whenever the transfer was local:

```
oc-rsync error: the --remote-option option may only be used with remote connections (code 1)
```

## Upstream

There is no such refusal anywhere in the C tree. `-M` values are accumulated
into `remote_options[]` (`options.c:1763-1771`) and appended to the argv of the
server the client starts (`options.c:3175-3182`). A **local** copy is not an
exception: `do_cmd()` still forks a server child (`local_child` -> `child_main`
-> `start_server`) which parses them with the same option table as every other
argument. The only `remote connections` string in the whole tree is an unrelated
comment in `socket.c`.

The refusal was not arbitrary, though. `remote_options()` has exactly two
consumers - the SSH argv builder and the daemon argv builder - and neither runs
on a local copy, so without a local consumer the values would have been dropped
**silently**. Erroring was the safer of two wrong answers.

## The fix

This adds the missing consumer. When the transfer is local each value is spliced
into the option stream and argv is parsed once more, so `-M--fake-super` becomes
`--fake-super` for the process that does the receiving - exactly what upstream's
forked child receives.

Routing it through the **same option table** is the point: a hand-maintained
per-option mapping would silently omit whatever it failed to list, and upstream's
child re-parse gets that generality for free. The measured `-M--log-file` row
below is the evidence that it is general rather than fake-super-specific.

The transfer is judged local from clap's own operand split rather than a scan of
the raw argv, so the fold cannot disagree with the option-vs-operand boundary the
rest of the parse already used. `-M` values are guaranteed to begin with `-` by
the existing `check_remote_option_dashes`, so none can be mistaken for an operand.

## Measured (release binary)

| invocation | before | after |
|---|---|---|
| `-rA -M--fake-super src/ dst/` | exit 1, refused | exit 0, applied on the receiving side |
| `-r -M--log-file=P src/ dst/` | exit 1, refused | log file created - the fold is general |
| `-r -M--fake-super src/ host:/x` | dials the peer | unchanged, still not folded |

## Tests

The test that pinned the old refusal is **replaced, not deleted**. Its successor
asserts the log file EXISTS, which is the load-bearing part: a test checking only
the exit code and the destination would pass just as well if `-M` were silently
IGNORED - and silent-ignore is precisely the failure the old refusal existed to
prevent. A companion pins that the same copy without `-M` leaves no log file, so
that assertion is attributable to the folded option and nothing else.

RED proven by making the fold never fire: `9 tests run: 8 passed, 1 failed`
(8+1 == 9, so no fail-fast truncation), and the one death is the fold pin on its
own message - *"the -M value must be APPLIED, not merely tolerated"*. The
companion stays green.

## Not claimed

This does **not** by itself green the upstream 3.5.0 `fake-super-acl-xattr` cell,
so no manifest row is flipped here. That cell needs a second, independent fix:
the local `%stat` xattr is gated on ownership preservation
(`options.owner() || options.group()`), a precondition upstream's
`set_stat_xattr` does not have. Measured on that cell's own flag set (`-rA`),
upstream writes `%stat` and oc writes none. Separate root cause, separate change.

A third finding from the same investigation is filed but deliberately out of
scope: oc's `%aacl` encoding does not apply upstream's `NO_ENTRY` strip for the
mode-derivable ACL slots (`acls.c:146-158`), so the stored blob differs from
upstream's for the same ACL. It does not affect this cell, which makes
structural assertions only.
