### PR TITLE
fix(daemon): honour a peer-supplied --partial-dir on the receiving side

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -213,6 +213,21 @@ fn apply_long_form_args(
                     i += 1;
                 }
             }
+            // upstream: options.c:3052-3056 - `if (partial_dir && am_sender)`
+            // emits `--partial-dir` and its value as two argv entries via
+            // `safe_arg("", partial_dir)`, then `--delay-updates` when that is
+            // also active. The receiving side stages each incoming temp file
+            // through this directory and looks there for a resume basis
+            // (`cleanup.c:handle_partial_dir`), so a daemon that consumes the
+            // adjacent `--delay-updates` but drops this value honours the
+            // staging request with nowhere to stage.
+            "--partial-dir" => {
+                if let Some(dir) = client_args.get(i + 1) {
+                    config.partial_dir = Some(std::path::PathBuf::from(dir));
+                    config.has_partial_dir = true;
+                    i += 1;
+                }
+            }
             // upstream: options.c:2818-2823 - --compress-choice, --new-compress, --old-compress
             "--new-compress" => {
                 config.flags.compress = true;
@@ -322,6 +337,9 @@ fn apply_long_form_args(
                     config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Copy, std::path::PathBuf::from(dir)));
                 } else if let Some(dir) = arg.strip_prefix("--temp-dir=") {
                     config.temp_dir = Some(std::path::PathBuf::from(dir));
+                } else if let Some(dir) = arg.strip_prefix("--partial-dir=") {
+                    config.partial_dir = Some(std::path::PathBuf::from(dir));
+                    config.has_partial_dir = true;
                 } else if let Some(path) = arg.strip_prefix("--files-from=") {
                     config.file_selection.files_from_path = Some(path.to_owned());
                 // upstream: options.c:2912 / 2915 - --usermap=SPEC / --groupmap=SPEC.

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -351,6 +351,26 @@ fn build_server_config(
                 // drops whole components, so every retained byte stays UTF-8.
                 cfg.backup_dir = Some(clamped.to_string_lossy().into_owned());
             }
+            // upstream: main.c:1233-1240 - the server receiver runs the very
+            // same `if (sanitize_paths)` block over `partial_dir`
+            // (`sanitize_path(NULL, partial_dir, NULL, curr_dir_depth,
+            // SP_DEFAULT)`), and `clientserver.c` sets `sanitize_paths` for
+            // every daemon connection. An ABSOLUTE `--partial-dir` therefore
+            // re-roots at `module_dir` (util1.c:1145-1152) instead of naming a
+            // filesystem-absolute path, exactly as `--backup-dir` above -
+            // so the same clamp is reused rather than reimplemented.
+            //
+            // Without it an absolute `--partial-dir=/pdir` resolved against the
+            // filesystem root, where the daemon has no business writing: the
+            // staging `mkstemp` failed EACCES and the entry was reported as an
+            // I/O error rather than transferred.
+            if let Some(dir) = cfg.partial_dir.as_deref() {
+                cfg.partial_dir = Some(clamp_basis_to_module(
+                    dir,
+                    &resolve_base,
+                    &module_root_canonical,
+                ));
+            }
 
             // upstream: loadparm.c - `temp dir` module parameter provides a
             // default temp directory. The client's --temp-dir takes precedence

--- a/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
@@ -373,3 +373,64 @@ mod daemon_clean_fname_collapse_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod daemon_partial_dir_arg_tests {
+    use super::{ServerConfig, ServerRole, apply_long_form_args};
+    use std::ffi::OsString;
+    use std::path::Path;
+
+    fn parse(client_args: &[&str]) -> ServerConfig {
+        let mut config = ServerConfig::from_flag_string_and_args(
+            ServerRole::Receiver,
+            "-logDtpre.iLsfxCIvu".to_owned(),
+            vec![OsString::from(".")],
+        )
+        .expect("server flag string parses");
+        let owned: Vec<String> = client_args.iter().map(|a| (*a).to_owned()).collect();
+        let unknown = apply_long_form_args(&owned, &mut config);
+        assert_eq!(unknown, None, "no arg in {client_args:?} is client-only");
+        config
+    }
+
+    /// The spelling upstream actually puts on the wire.
+    ///
+    /// upstream: `options.c:3052-3056` - `server_options()` emits
+    /// `--partial-dir` and its value as TWO argv entries via
+    /// `safe_arg("", partial_dir)`, exactly as it does for `--temp-dir` and
+    /// `--backup-dir`. Without this arm the value fell through to the
+    /// positional region and the daemon receiver staged nowhere.
+    #[test]
+    fn split_partial_dir_reaches_the_daemon_receiver() {
+        let config = parse(&["--partial-dir", "pdir", "--delay-updates"]);
+        assert_eq!(
+            config.partial_dir.as_deref(),
+            Some(Path::new("pdir")),
+            "the split spelling upstream emits must reach the receiver",
+        );
+        assert!(config.has_partial_dir);
+        assert!(config.write.delay_updates);
+    }
+
+    /// oc's own daemon client emits the joined spelling
+    /// (`daemon_transfer/orchestration/arguments.rs`), and upstream's popt
+    /// accepts it too, so both must resolve to the same configuration.
+    #[test]
+    fn joined_partial_dir_reaches_the_daemon_receiver() {
+        let config = parse(&["--partial-dir=pdir", "--delay-updates"]);
+        assert_eq!(config.partial_dir.as_deref(), Some(Path::new("pdir")));
+        assert!(config.has_partial_dir);
+    }
+
+    /// Non-vacuity companion: the two assertions above are attributable to the
+    /// option and not to a default. Without `--partial-dir` the receiver has no
+    /// staging directory even when `--delay-updates` is present - which is
+    /// precisely the state the missing arm used to produce for both spellings.
+    #[test]
+    fn delay_updates_alone_leaves_no_partial_dir() {
+        let config = parse(&["--delay-updates"]);
+        assert_eq!(config.partial_dir, None);
+        assert!(!config.has_partial_dir);
+        assert!(config.write.delay_updates);
+    }
+}

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -448,7 +448,54 @@ impl ReceiverContext {
                 ));
             }
         }
-        Ok(())
+        self.reject_daemon_excluded_partial_dir()
+    }
+    /// Refuses a peer-supplied `--partial-dir` that the daemon module's own
+    /// filter list excludes.
+    ///
+    /// upstream: `main.c:1258-1266` - the server receiver, inside the same
+    /// `if (daemon_filter_list.head)` block that screens `basis_dir[]`, screens
+    /// `partial_dir` too: re-sanitise against rootdir `"/"`, drop the
+    /// module-dir prefix, then `check_filter(elp, FLOG, dir, 1)`; a match jumps
+    /// to `options_rejected`.
+    ///
+    /// Two things about that block are load-bearing and are the reason this is
+    /// a separate function rather than another entry in the staging array:
+    ///
+    /// - It is gated on `*partial_dir == '/'`. By the time it runs, an absolute
+    ///   value has already been re-rooted at `module_dir` by the `sanitize_path`
+    ///   at `main.c:1239`, so "absolute" means "module-anchored", while a
+    ///   relative value still names a directory beside each destination file and
+    ///   is covered by the destination check instead. oc reaches the same state
+    ///   through `clamp_basis_to_module` on the daemon's client-arg path, so the
+    ///   same predicate selects the same values.
+    /// - It matches the NAME, never the resolved path. A `--partial-dir` whose
+    ///   name is not excluded stays allowed even when an in-module symlink
+    ///   redirects it into an excluded directory - upstream defends a writable
+    ///   module with `munge symlinks`, not with this filter. Resolving first
+    ///   would refuse what upstream permits.
+    ///
+    /// There is deliberately no empty-value arm here. `options.c:2597-2598`
+    /// normalises an empty or `"."` partial-dir to `NULL` before it can ever be
+    /// forwarded, so unlike `--backup-dir` upstream has nothing to reject.
+    fn reject_daemon_excluded_partial_dir(&self) -> io::Result<()> {
+        let Some(filters) = self.daemon_filter_set() else {
+            return Ok(());
+        };
+        let Some(dir) = self.config.partial_dir.as_deref() else {
+            return Ok(());
+        };
+        if !dir.is_absolute() {
+            return Ok(());
+        }
+        if filters.allows_name(&self.daemon_filter_name(dir), true) {
+            return Ok(());
+        }
+        // upstream: main.c:1267 - the refusal text carries no path; the rejected
+        // option goes to the daemon's log, not the peer.
+        Err(protocol::syntax_violation(
+            "Your options have been rejected by the server.",
+        ))
     }
     /// Refuses a destination argument that the daemon module's own filter list
     /// excludes.

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -109,13 +109,13 @@ nonroot-restrictive-perms skip
 operator-path-backup-dir-daemon pass
 operator-path-backup-dir-exclude-daemon pass
 operator-path-dir-daemon-inmodule pass
-operator-path-dir-daemon-leaf fail
+operator-path-dir-daemon-leaf pass
 operator-path-dir-daemon-mkdir fail
 operator-path-dir-daemon-outside pass
 operator-path-insecure-links-daemon skip
 operator-path-insecure-links-refused pass
-operator-path-partial-dir-daemon fail
-operator-path-partial-dir-exclude-daemon fail
+operator-path-partial-dir-daemon pass
+operator-path-partial-dir-exclude-daemon pass
 operator-path-traversal-backup-dir-daemon pass
 operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -212,7 +212,7 @@ operator-path-backup-symlink skip
 operator-path-compare-dest pass
 operator-path-copy-dest pass
 operator-path-dir-daemon-inmodule pass
-operator-path-dir-daemon-leaf fail
+operator-path-dir-daemon-leaf pass
 operator-path-dir-daemon-mkdir fail
 operator-path-dir-daemon-outside pass
 operator-path-files-from pass
@@ -222,8 +222,8 @@ operator-path-insecure-links-refused pass
 operator-path-link-dest pass
 operator-path-log-file pass
 operator-path-partial-dir pass
-operator-path-partial-dir-daemon fail
-operator-path-partial-dir-exclude-daemon fail
+operator-path-partial-dir-daemon pass
+operator-path-partial-dir-exclude-daemon pass
 operator-path-temp-dir pass
 operator-path-traversal-backup-dir-daemon pass
 operator-path-traversal-dest-dir-daemon pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -109,13 +109,13 @@ nonroot-restrictive-perms fail
 operator-path-backup-dir-daemon pass
 operator-path-backup-dir-exclude-daemon pass
 operator-path-dir-daemon-inmodule pass
-operator-path-dir-daemon-leaf fail
+operator-path-dir-daemon-leaf pass
 operator-path-dir-daemon-mkdir fail
 operator-path-dir-daemon-outside pass
 operator-path-insecure-links-daemon pass
 operator-path-insecure-links-refused pass
-operator-path-partial-dir-daemon fail
-operator-path-partial-dir-exclude-daemon fail
+operator-path-partial-dir-daemon pass
+operator-path-partial-dir-exclude-daemon pass
 operator-path-traversal-backup-dir-daemon pass
 operator-path-traversal-dest-dir-daemon pass
 operator-path-traversal-partial-dir-daemon pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -212,7 +212,7 @@ operator-path-backup-symlink pass
 operator-path-compare-dest pass
 operator-path-copy-dest pass
 operator-path-dir-daemon-inmodule pass
-operator-path-dir-daemon-leaf fail
+operator-path-dir-daemon-leaf pass
 operator-path-dir-daemon-mkdir fail
 operator-path-dir-daemon-outside pass
 operator-path-files-from pass
@@ -222,8 +222,8 @@ operator-path-insecure-links-refused pass
 operator-path-link-dest pass
 operator-path-log-file pass
 operator-path-partial-dir pass
-operator-path-partial-dir-daemon fail
-operator-path-partial-dir-exclude-daemon fail
+operator-path-partial-dir-daemon pass
+operator-path-partial-dir-exclude-daemon pass
 operator-path-temp-dir pass
 operator-path-traversal-backup-dir-daemon pass
 operator-path-traversal-dest-dir-daemon pass


### PR DESCRIPTION
An oc daemon receiving a push silently ignored `--partial-dir`: it never created
the directory and never staged through it.

## Measured

Two-leg probe against real upstream 3.5.0, daemon push, `-a --delay-updates`,
one leg with a plain absolute `--partial-dir=/pdir` and one reached through an
in-module symlink:

| | plain | via symlink |
|---|---|---|
| upstream 3.5.0 | `[blink, f0, pdir]` | `[blink, f0, pdir]` |
| oc (before) | `[blink, f0]` | `[blink, f0]` |

The symlink is a red herring - a plain absolute partial-dir was equally ignored.

## Root cause

There are two server-side long-option tables and only one of them knew the
option. `crates/cli/src/frontend/server/flags.rs` handles both the split and
joined spellings and wires the value into the config, but the daemon parses the
client's argv with its **own** table, which has no `--partial-dir` arm at all -
while it does consume the adjacent `--delay-updates` and the split forms of
`--backup-dir`, `--temp-dir`, `--link-dest`, `--compare-dest`, `--copy-dest`
and `--suffix`. Half a rule: the daemon honoured the staging request and
dropped the place to stage.

## Three pieces, each visible only after the previous one landed

1. **The missing arm.** `options.c:3052-3056` emits `--partial-dir` and its
   value as two argv entries via `safe_arg("", partial_dir)`, followed by
   `--delay-updates`. Both spellings accepted, as already done for
   `--backup-dir`.

2. **The value needs the module-root clamp its siblings get.**
   `main.c:1233-1240` runs the same `if (sanitize_paths)` block over
   `partial_dir`; `util1.c:1145-1152` re-roots an absolute one at `module_dir`.
   Without it an absolute `--partial-dir=/pdir` resolved against the filesystem
   root - staging failed EACCES and the entry was reported as an I/O error
   rather than transferred. `clamp_basis_to_module` is reused, not
   reimplemented.

3. **Pieces 1+2 alone open a module escape.** `main.c:1258-1266` screens
   `partial_dir` through the module filter inside the same
   `if (daemon_filter_list.head)` block that screens `basis_dir[]`. Two
   properties of that block are load-bearing: it is gated on
   `*partial_dir == '/'` (module-anchored after the sanitize above), and it
   matches the **name**, never the symlink-resolved path. Matching the resolved
   path would refuse what upstream permits; not matching at all lets a `..`
   traversal stage into an excluded subtree.

## Verification

All four upstream-3.5.0 testsuite legs. Each leg's manifest was **regenerated
from a real run** and diffed against the committed one; every leg reports
exactly the same three rows moving and nothing else.

| leg | totals | manifest diff |
|---|---|---|
| nonroot, pipe | 247 / 14 / 84 | the 3 rows |
| root, pipe | 271 / 18 / 56 | the 3 rows |
| nonroot, TCP | 100 / 23 / 32 | the 3 rows |
| root, TCP | 109 / 31 / 15 | the 3 rows |

```
operator-path-dir-daemon-leaf              fail -> pass
operator-path-partial-dir-daemon           fail -> pass
operator-path-partial-dir-exclude-daemon   fail -> pass
```

Flipped in the same commit. Neighbouring cells stay green:
`operator-path-traversal-{partial-dir,backup-dir,dest-dir}-daemon`,
`operator-path-backup-dir-daemon`, `operator-path-temp-dir`.

Two rows moved on this host for reasons unrelated to the change and were
deliberately **not** re-baselined: `protected-regular` and `daemon-chroot-acl`
differ by host configuration, not by code.

## Not closed

`operator-path-dir-daemon-mkdir` stays `fail`. It needs the confined create to
follow a euid-owned **relative** in-module symlink, which is the ownership-walk
resolver rather than this option path. Separate root cause, separate change.

## Tests

Both spellings are pinned, plus a non-vacuity companion showing that
`--delay-updates` alone leaves no partial-dir - which is exactly the state the
missing arm used to produce, so without it the two pins would also hold if the
option were simply defaulted.

RED proven by deleting the split arm: `3 tests run: 2 passed, 1 failed`
(2+1 == 3, so no fail-fast truncation), and the one death is the split-spelling
pin on its own message.
