### PR TITLE
fix(receiver): keep an absolute --partial-dir through the delayed-updates sweep

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -249,7 +249,7 @@ pub use util::cleanup::CleanupManager;
 /// Moves an interrupted `--partial` temp file onto its partial destination (or
 /// unlinks it when no partial is kept). Shared by the transfer guard and the
 /// signal-driven abort path so both finalise identically.
-pub use util::cleanup::{create_partial_dir, finalize_partial};
+pub use util::cleanup::{create_partial_dir, finalize_partial, remove_partial_dir};
 
 /// Async I/O operations (available with `async` feature).
 #[cfg(feature = "async")]

--- a/crates/engine/src/util/cleanup.rs
+++ b/crates/engine/src/util/cleanup.rs
@@ -87,6 +87,39 @@ pub fn create_partial_dir(dir: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Removes an emptied `--partial-dir` once its staged file has been committed.
+///
+/// upstream: `util1.c:1501-1535 handle_partial_dir(fname, PDIR_DELETE)`, whose
+/// delete half opens with `if (!create && *partial_dir == '/') return 1;`. An
+/// ABSOLUTE `--partial-dir` is therefore never rmdir'd: it is operator-named,
+/// it is reserved across runs, and it generally exists before the transfer
+/// starts. Only a relative one - created beside each destination file and
+/// belonging to that file's transfer - is swept away once emptied. Upstream
+/// keeps both halves of the rule in one function, which is why this sits beside
+/// [`create_partial_dir`] instead of being open-coded at each call site: the
+/// rule had been written at one of oc's two removal sites and forgotten at the
+/// other, and the forgotten one destroyed a pre-existing absolute partial-dir.
+///
+/// `partial_dir` is the configured option value - the string upstream tests
+/// with `*partial_dir == '/'`. `None` means no `--partial-dir` was given, in
+/// which case `--delay-updates` stages through upstream's implicit
+/// `.~tmp~` (`options.c:347,2564` assign the literal `tmp_partialdir`), which is
+/// relative and so always removable.
+///
+/// `staged_file` is the entry inside the directory; its parent is what gets
+/// removed, exactly as upstream derives the directory by truncating
+/// `partial_fname` at its last `'/'`.
+///
+/// Best-effort, like upstream's unchecked `do_rmdir_at`: a partial-dir that
+/// still holds another file stays put.
+pub fn remove_partial_dir(partial_dir: Option<&Path>, staged_file: &Path) {
+    if partial_dir.is_some_and(Path::is_absolute) {
+        return;
+    }
+    if let Some(dir) = staged_file.parent() {
+        let _ = std::fs::remove_dir(dir);
+    }
+}
 /// Moves an interrupted temp file to its partial destination, or removes it.
 ///
 /// upstream: `cleanup.c:exit_cleanup()` calls `finish_transfer()` to rename the

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -180,8 +180,9 @@ pub(super) fn commit_file(
 /// `--partial-dir`, mirroring upstream `handle_partial_dir(PDIR_DELETE)`.
 ///
 /// Best-effort: a missing partial file or a non-empty partial-dir leaves the
-/// filesystem untouched. Absolute `--partial-dir` values are never rmdir'd,
-/// matching upstream `util1.c:1507` (`if (!create && *partial_dir == '/')`).
+/// filesystem untouched. The absolute-`--partial-dir` exemption belongs to
+/// [`engine::remove_partial_dir`], which owns upstream `util1.c:1506-1507` for
+/// both of oc's removal sites.
 fn remove_partial_dir_basis(config: &DiskCommitConfig, dest_path: &Path) {
     let PartialMode::PartialDir(ref dir) = config.partial_mode else {
         return;
@@ -190,12 +191,7 @@ fn remove_partial_dir_basis(config: &DiskCommitConfig, dest_path: &Path) {
         return;
     };
     let _ = fs::remove_file(&partial);
-    // upstream: handle_partial_dir() only rmdir's a relative partial-dir.
-    if !dir.is_absolute() {
-        if let Some(parent) = partial.parent() {
-            let _ = fs::remove_dir(parent);
-        }
-    }
+    engine::remove_partial_dir(Some(dir), &partial);
 }
 
 /// Resolves the `--delay-updates` staging path for a destination file.

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -236,7 +236,11 @@ impl ReceiverContext {
             // sandbox without ACCESS_FS_REFER on kernels 5.13-5.18) sets
             // IOERR_GENERAL so the transfer exits 23 (RERR_PARTIAL) instead
             // of reporting success while the file was never updated.
-            self.flist_io_error |= handle_delayed_updates(all_delayed_updates, backup_cfg);
+            self.flist_io_error |= handle_delayed_updates(
+                all_delayed_updates,
+                backup_cfg,
+                self.config.partial_dir.as_deref(),
+            );
         }
 
         #[cfg(unix)]
@@ -439,12 +443,16 @@ pub(in crate::receiver) enum DeletePassPhase {
     Late,
 }
 
-/// Renames all delayed-update files from their `.~tmp~` staging paths to
-/// their final destinations, then removes the empty `.~tmp~` directories.
+/// Renames all delayed-update files from their staging paths to their final
+/// destinations, removing each emptied staging directory as it goes.
 ///
-/// Mirrors upstream `receiver.c:529-557 handle_delayed_updates()` which
+/// Mirrors upstream `receiver.c:688-717 handle_delayed_updates()` which
 /// iterates `delayed_bits`, renames each file from its `partial_dir_fname()`
 /// path to the final destination, and calls `handle_partial_dir(PDIR_DELETE)`.
+///
+/// `partial_dir` is the configured `--partial-dir` and decides whether that
+/// last step does anything at all: upstream skips the rmdir entirely for an
+/// absolute value. [`engine::remove_partial_dir`] owns the rule.
 ///
 /// When `backup_config` is `Some`, backs up the existing destination file
 /// before the rename (upstream: `receiver.c:538 make_backup(fname, False)`).
@@ -467,13 +475,12 @@ pub(in crate::receiver) enum DeletePassPhase {
 pub(in crate::receiver) fn handle_delayed_updates(
     delayed: &[(PathBuf, PathBuf)],
     backup_config: Option<crate::disk_commit::BackupConfig>,
+    partial_dir: Option<&Path>,
 ) -> i32 {
-    use std::collections::HashSet;
     use std::fs;
 
     use crate::generator::io_error_flags::IOERR_GENERAL;
 
-    let mut staging_dirs: HashSet<PathBuf> = HashSet::new();
     // Mirrors upstream's got_xfer_error: any rename/backup failure here is a
     // transfer error that must yield exit 23 (RERR_PARTIAL), not a silent 0.
     let mut io_error = 0;
@@ -555,16 +562,13 @@ pub(in crate::receiver) fn handle_delayed_updates(
             continue;
         }
 
-        // Track parent staging directories for cleanup.
-        if let Some(parent) = staging_path.parent() {
-            staging_dirs.insert(parent.to_path_buf());
-        }
-    }
-
-    // upstream: receiver.c:553 - handle_partial_dir(partialptr, PDIR_DELETE)
-    // Remove empty .~tmp~ staging directories.
-    for dir in &staging_dirs {
-        let _ = fs::remove_dir(dir);
+        // upstream: receiver.c:716 - handle_partial_dir(partialptr, PDIR_DELETE)
+        // fires per file on the rename's success branch rather than as a
+        // deferred sweep over the distinct parents. That ordering is what makes
+        // the unchecked rmdir correct when two entries stage in one directory:
+        // the first call fails harmlessly on the still-occupied directory and
+        // the second succeeds.
+        engine::remove_partial_dir(partial_dir, staging_path);
     }
 
     io_error
@@ -846,7 +850,7 @@ mod tests {
             (staged_b.clone(), final_b.clone()),
         ];
 
-        handle_delayed_updates(&delayed, None);
+        handle_delayed_updates(&delayed, None, None);
 
         // Files should be at final paths.
         assert_eq!(fs::read_to_string(&final_a).unwrap(), "content-a");
@@ -889,7 +893,7 @@ mod tests {
             (staged2.clone(), final2.clone()),
         ];
 
-        handle_delayed_updates(&delayed, None);
+        handle_delayed_updates(&delayed, None, None);
 
         assert_eq!(fs::read_to_string(&final1).unwrap(), "one");
         assert_eq!(fs::read_to_string(&final2).unwrap(), "two");
@@ -897,6 +901,66 @@ mod tests {
         assert!(!tmp2.exists());
     }
 
+    /// An ABSOLUTE `--partial-dir` must survive the sweep.
+    ///
+    /// upstream: `util1.c:1506-1507` - `handle_partial_dir(fname, PDIR_DELETE)`
+    /// returns immediately when `*partial_dir == '/'`, so `receiver.c:716` never
+    /// rmdir's an operator-named absolute staging directory. Measured against
+    /// real rsync 3.5.0 over a daemon push with `-a --delay-updates
+    /// --partial-dir=/pdir`: upstream leaves a pre-existing `/pdir` in place,
+    /// while oc removed it. The directory is reserved across runs and generally
+    /// exists before the transfer starts, so removing it destroys operator
+    /// state that is not ours to touch.
+    #[test]
+    fn absolute_partial_dir_survives_the_delayed_update_sweep() {
+        let dir = test_support::create_tempdir();
+        // An absolute --partial-dir is one path for the whole transfer, not one
+        // per destination directory - so the configured value and the staging
+        // directory are the same thing.
+        let partial_dir = dir.path().join("pdir");
+        fs::create_dir(&partial_dir).unwrap();
+        let staged = partial_dir.join("f.txt");
+        fs::write(&staged, b"payload").unwrap();
+        let final_path = dir.path().join("f.txt");
+        handle_delayed_updates(
+            &[(staged, final_path.clone())],
+            None,
+            Some(partial_dir.as_path()),
+        );
+        assert_eq!(fs::read_to_string(&final_path).unwrap(), "payload");
+        assert!(
+            partial_dir.is_dir(),
+            "an absolute --partial-dir must outlive the transfer (util1.c:1507)"
+        );
+    }
+    /// Non-vacuity companion for
+    /// [`absolute_partial_dir_survives_the_delayed_update_sweep`]: the same
+    /// fixture with a RELATIVE `--partial-dir` must still be swept away.
+    ///
+    /// Without this the pin would also hold if the sweep had simply stopped
+    /// removing anything at all, which is a different bug in the other
+    /// direction - upstream does rmdir a relative partial-dir, because it is
+    /// created beside each destination file and belongs to that file's
+    /// transfer.
+    #[test]
+    fn relative_partial_dir_is_removed_by_the_delayed_update_sweep() {
+        let dir = test_support::create_tempdir();
+        let partial_dir = dir.path().join("pdir");
+        fs::create_dir(&partial_dir).unwrap();
+        let staged = partial_dir.join("f.txt");
+        fs::write(&staged, b"payload").unwrap();
+        let final_path = dir.path().join("f.txt");
+        handle_delayed_updates(
+            &[(staged, final_path.clone())],
+            None,
+            Some(Path::new("pdir")),
+        );
+        assert_eq!(fs::read_to_string(&final_path).unwrap(), "payload");
+        assert!(
+            !partial_dir.exists(),
+            "an emptied relative --partial-dir is rmdir'd (util1.c:1531)"
+        );
+    }
     /// Verifies the sweep continues past a rename failure (matching upstream
     /// which logs the error but does not abort) AND flags the failure so the
     /// transfer exits 23 rather than silently reporting success.
@@ -928,7 +992,7 @@ mod tests {
         ];
 
         // Should not panic or abort, but must report the failed rename.
-        let io_error = handle_delayed_updates(&delayed, None);
+        let io_error = handle_delayed_updates(&delayed, None, None);
 
         assert_eq!(
             io_error & IOERR_GENERAL,
@@ -954,7 +1018,7 @@ mod tests {
         fs::write(&staged, b"content").unwrap();
         let final_path = dir.path().join("a.txt");
 
-        let io_error = handle_delayed_updates(&[(staged, final_path)], None);
+        let io_error = handle_delayed_updates(&[(staged, final_path)], None, None);
 
         assert_eq!(
             io_error, 0,
@@ -966,7 +1030,7 @@ mod tests {
     /// reports no error.
     #[test]
     fn handle_delayed_updates_empty_is_noop() {
-        assert_eq!(handle_delayed_updates(&[], None), 0);
+        assert_eq!(handle_delayed_updates(&[], None, None), 0);
     }
 
     /// Verifies that `handle_delayed_updates` backs up a pre-existing
@@ -1004,7 +1068,11 @@ mod tests {
             suffix: OsString::from("~"),
         };
 
-        handle_delayed_updates(&[(staged.clone(), final_path.clone())], Some(backup_config));
+        handle_delayed_updates(
+            &[(staged.clone(), final_path.clone())],
+            Some(backup_config),
+            None,
+        );
 
         assert_eq!(
             fs::read_to_string(&final_path).unwrap(),
@@ -1055,7 +1123,11 @@ mod tests {
             suffix: OsString::from("~"),
         };
 
-        handle_delayed_updates(&[(staged.clone(), final_path.clone())], Some(backup_config));
+        handle_delayed_updates(
+            &[(staged.clone(), final_path.clone())],
+            Some(backup_config),
+            None,
+        );
 
         assert_eq!(fs::read_to_string(&final_path).unwrap(), "only-content");
         assert!(
@@ -1091,7 +1163,11 @@ mod tests {
             suffix: OsString::from("~"),
         };
 
-        handle_delayed_updates(&[(staged.clone(), final_path.clone())], Some(backup_config));
+        handle_delayed_updates(
+            &[(staged.clone(), final_path.clone())],
+            Some(backup_config),
+            None,
+        );
 
         assert_eq!(
             fs::read_to_string(&final_path).unwrap(),
@@ -1139,7 +1215,11 @@ mod tests {
             suffix: OsString::from("~"),
         };
 
-        handle_delayed_updates(&[(staged.clone(), final_path.clone())], Some(backup_config));
+        handle_delayed_updates(
+            &[(staged.clone(), final_path.clone())],
+            Some(backup_config),
+            None,
+        );
 
         let backup_path = backup_root.join("deep").join("name1~");
         assert!(
@@ -1189,7 +1269,11 @@ mod tests {
             suffix: OsString::from(""),
         };
 
-        handle_delayed_updates(&[(staged.clone(), final_path.clone())], Some(backup_config));
+        handle_delayed_updates(
+            &[(staged.clone(), final_path.clone())],
+            Some(backup_config),
+            None,
+        );
 
         let suffixed = backup_root.join("name1~");
         assert!(
@@ -1245,6 +1329,7 @@ mod tests {
                 (staged_b.clone(), final_b.clone()),
             ],
             Some(backup_config),
+            None,
         );
 
         assert_eq!(fs::read_to_string(&final_a).unwrap(), "new-a");
@@ -1302,7 +1387,7 @@ mod tests {
             (staged_a.clone(), final_a.clone()),
             (staged_b.clone(), final_b.clone()),
         ];
-        handle_delayed_updates(&delayed, None);
+        handle_delayed_updates(&delayed, None, None);
 
         assert!(final_a.exists());
         assert!(final_b.exists());

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -110,7 +110,7 @@ operator-path-backup-dir-daemon pass
 operator-path-backup-dir-exclude-daemon pass
 operator-path-dir-daemon-inmodule pass
 operator-path-dir-daemon-leaf pass
-operator-path-dir-daemon-mkdir fail
+operator-path-dir-daemon-mkdir pass
 operator-path-dir-daemon-outside pass
 operator-path-insecure-links-daemon skip
 operator-path-insecure-links-refused pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -213,7 +213,7 @@ operator-path-compare-dest pass
 operator-path-copy-dest pass
 operator-path-dir-daemon-inmodule pass
 operator-path-dir-daemon-leaf pass
-operator-path-dir-daemon-mkdir fail
+operator-path-dir-daemon-mkdir pass
 operator-path-dir-daemon-outside pass
 operator-path-files-from pass
 operator-path-inplace-backup-dir pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -110,7 +110,7 @@ operator-path-backup-dir-daemon pass
 operator-path-backup-dir-exclude-daemon pass
 operator-path-dir-daemon-inmodule pass
 operator-path-dir-daemon-leaf pass
-operator-path-dir-daemon-mkdir fail
+operator-path-dir-daemon-mkdir pass
 operator-path-dir-daemon-outside pass
 operator-path-insecure-links-daemon pass
 operator-path-insecure-links-refused pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -213,7 +213,7 @@ operator-path-compare-dest pass
 operator-path-copy-dest pass
 operator-path-dir-daemon-inmodule pass
 operator-path-dir-daemon-leaf pass
-operator-path-dir-daemon-mkdir fail
+operator-path-dir-daemon-mkdir pass
 operator-path-dir-daemon-outside pass
 operator-path-files-from pass
 operator-path-inplace-backup-dir pass


### PR DESCRIPTION
The delayed-updates sweep removed its staging directory unconditionally,
destroying an operator-named absolute `--partial-dir` that upstream leaves in
place.

## Measured

Daemon push, `-a --delay-updates --partial-dir=/pdir`, with the directory
created **before** the transfer:

| | with `--delay-updates` | without |
|---|---|---|
| upstream 3.5.0 | `/pdir` KEPT | KEPT |
| oc (before) | `/pdir` **GONE** | KEPT |
| oc (after) | KEPT | KEPT |

The directory is present before the run and absent after it. The `without` cell
matching upstream is what localises the defect to the `--delay-updates` path.

## Root cause

`util1.c:1501-1535 handle_partial_dir()` opens its delete half with

```c
if (!create && *partial_dir == '/')
    return 1;
```

An absolute `--partial-dir` is never rmdir'd: it is operator-named, reserved
across runs, and generally exists before the transfer starts. Only a relative
one - created beside each destination file and belonging to that file's
transfer - is swept away once emptied. `receiver.c:716`, the delayed-updates
sweep, calls `handle_partial_dir(partialptr, PDIR_DELETE)` and inherits the
rule.

oc had two removal sites and the rule at one:

- `disk_commit/process/commit.rs` `remove_partial_dir_basis` **had** it, citing
  `util1.c:1507`.
- `receiver/transfer.rs` `handle_delayed_updates` collected every staging parent
  into a `HashSet` and ran `fs::remove_dir` over all of them with **no guard**,
  under a comment citing `receiver.c`.

Upstream keeps both halves in one function, so the rule moves into one owner -
`engine::util::cleanup::remove_partial_dir`, beside the existing PDIR_CREATE
port - and both sites route onto it. `None` means no `--partial-dir` was given,
so `--delay-updates` stages through upstream's implicit `.~tmp~`
(`options.c:347,2564`), which is relative and always removable.

The deferred sweep becomes a per-file call on the rename's success branch, where
upstream puts it. That ordering is what makes the unchecked rmdir correct when
two entries stage in one directory: the first call fails harmlessly on the
still-occupied directory and the second succeeds.

## Scope, measured - not a guess

The **SSH path does not exhibit this**. An SSH push with an absolute
`--partial-dir` creates the directory and keeps it on upstream and on oc, before
and after this change. The observed divergence is daemon-only, which is why the
end-to-end repro needed #7498 (without it the daemon never had a `partial_dir`
at all).

## Manifest

`operator-path-dir-daemon-mkdir` flips `fail` -> `pass` in all four legs, in this
commit. Verified by regenerating the nonroot pipe manifest from a real run and
diffing it against the committed file: the only difference is
`protected-regular`, which differs by host `fs.protected_regular` configuration
and is deliberately **not** re-baselined (same environmental row recorded when
#7483 landed). The flipped row does not appear in the diff, i.e. the fresh run
agrees with it, and no other row moved.

The single cell run directly:

```
PASS    operator-path-dir-daemon-mkdir
```

## Tests

The absolute case is pinned, plus a relative non-vacuity companion - without it
the pin would also hold if the sweep had simply stopped removing anything, which
is the same bug in the other direction.

RED proven by dropping the guard: `2 tests run: 1 passed, 1 failed` (1+1 == 2,
so no fail-fast truncation); the one death is the absolute pin on its own
message and the companion stays green.

Gates: fmt clean, workspace clippy `-D warnings` exit 0, `-p transfer -p engine`
7863/7863.
