### PR TITLE
fix(receiver): clear a non-directory occupying the --partial-dir name

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -249,7 +249,9 @@ pub use util::cleanup::CleanupManager;
 /// Moves an interrupted `--partial` temp file onto its partial destination (or
 /// unlinks it when no partial is kept). Shared by the transfer guard and the
 /// signal-driven abort path so both finalise identically.
-pub use util::cleanup::{create_partial_dir, finalize_partial, remove_partial_dir};
+pub use util::cleanup::{
+    clear_partial_dir_obstruction, create_partial_dir, finalize_partial, remove_partial_dir,
+};
 
 /// Async I/O operations (available with `async` feature).
 #[cfg(feature = "async")]

--- a/crates/engine/src/util/cleanup.rs
+++ b/crates/engine/src/util/cleanup.rs
@@ -86,6 +86,52 @@ pub fn create_partial_dir(dir: &Path) -> std::io::Result<()> {
         std::fs::DirBuilder::new().recursive(true).create(dir)
     }
 }
+/// Removes a non-directory occupying the `--partial-dir` name so the staging
+/// directory can be created in its place.
+///
+/// A no-op when the name is absent or already a directory; the caller creates
+/// it in the first case and reuses it in the second.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/util1.c:1521-1528` `handle_partial_dir()` - `do_lstat_at`
+///   then, when the entry exists and is not a directory,
+///   `do_unlink_at(dir) < 0` aborts, otherwise `do_mkdir_at` runs against the
+///   cleared name. Without the unlink an obstruction is fatal, where upstream
+///   clears it and proceeds.
+///
+/// Only the FINAL component is cleared. Upstream's `handle_partial_dir` names
+/// exactly one directory, so an obstruction standing where an *ancestor*
+/// belongs is not something upstream removes and is not removed here either -
+/// it surfaces as the caller's create error.
+///
+/// The probe is `symlink_metadata`, so a symlink at the name is removed as the
+/// non-directory it is rather than being followed to whatever it points at
+/// (upstream's `do_lstat_at` makes the same choice).
+///
+/// # Errors
+///
+/// Surfaces the `lstat` error for anything other than "not found", and any
+/// `unlink` error.
+pub fn clear_partial_dir_obstruction(dir: &Path) -> std::io::Result<()> {
+    match std::fs::symlink_metadata(dir) {
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        // A SYMLINK is deliberately left in place, which upstream would unlink.
+        // Upstream can afford to because its unlink runs inside
+        // `operator_path_resolve`, so a link leading out of the served tree is
+        // refused rather than followed; oc cannot use that walk here (it
+        // resolves from `/` and the daemon's Landlock ruleset admits only the
+        // module root, measured). Removing the link unconfined would be worse
+        // than not removing it: it destroys an operator-visible symlink AND
+        // pre-empts the confined rename that currently refuses the escape.
+        // Leaving it means the staging open follows the link and the confined
+        // rename makes the refusal, which is upstream's outcome for that shape.
+        Ok(metadata) if metadata.is_symlink() => Ok(()),
+        Ok(_) => std::fs::remove_file(dir),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
 
 /// Removes an emptied `--partial-dir` once its staged file has been committed.
 ///

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -11,8 +11,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use engine::{
-    CleanupManager, compute_backup_path, copy_pre_image_to_backup, create_backup_dir_parents,
-    trace_make_backup_copy, trace_make_backup_hlink, trace_make_backup_rename,
+    CleanupManager, clear_partial_dir_obstruction, compute_backup_path, copy_pre_image_to_backup,
+    create_backup_dir_parents, trace_make_backup_copy, trace_make_backup_hlink,
+    trace_make_backup_rename,
 };
 
 use crate::pipeline::messages::{BackupNotice, BeginMessage};
@@ -116,9 +117,15 @@ pub(super) fn commit_file(
 
     if needs_rename && config.delay_updates {
         if let Some(staging_path) = delay_updates_staging_path(config, &begin.file_path) {
-            // upstream: util1.c handle_partial_dir(..., PDIR_CREATE) creates the
-            // partial directory before moving the temp into it.
+            // upstream: util1.c:1518-1530 handle_partial_dir(..., PDIR_CREATE)
+            // creates the partial directory before moving the temp into it,
+            // and clears a non-directory standing at that name first
+            // (:1523-1528). Without the clear, `create_dir_all` reports
+            // `AlreadyExists` for that shape and the `?` fails the whole
+            // transfer where upstream unlinks the obstruction and proceeds -
+            // measured against real 3.5.0 over a daemon push, which exits 0.
             if let Some(parent) = staging_path.parent() {
+                clear_partial_dir_obstruction(parent)?;
                 fs::create_dir_all(parent)?;
             }
             let result = rename_config_sandboxed(config, cleanup_guard.path(), &staging_path)?;

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -1002,6 +1002,126 @@ fn delay_updates_stages_to_partial_dir() {
     let _ = fs::remove_dir(dir.path().join(".~tmp~"));
 }
 
+/// A non-directory standing where the `--delay-updates` staging directory
+/// belongs must be cleared, not reported as a failure.
+///
+/// upstream: util1.c:1521-1528 `handle_partial_dir()` lstats the name and,
+/// when it exists and is not a directory, unlinks it before `do_mkdir_at`.
+/// oc's `create_dir_all` returns `AlreadyExists` for that shape, and the `?`
+/// turned an obstruction upstream clears into a failed transfer. Measured
+/// against real rsync 3.5.0 over a daemon push with a regular file planted at
+/// the staging name: upstream exits 0 and consumes the plant, oc exited 23.
+#[test]
+fn delay_updates_clears_a_non_directory_at_the_partial_dir() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("obstructed.dat");
+    let staging_dir = dir.path().join(DELAY_UPDATES_PARTIAL_DIR);
+    fs::write(&staging_dir, b"plant").unwrap();
+
+    let h = spawn_disk_thread(delay_updates_config()).unwrap();
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 13,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+            xattr_basis: None,
+            file_entry: None,
+        })))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Chunk(b"delayed write".to_vec()))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
+
+    let result =
+        h.result_rx.recv().unwrap().expect(
+            "an obstructing non-directory must be cleared, not reported as a failed commit",
+        );
+    let staging_path = staging_dir.join("obstructed.dat");
+    assert_eq!(
+        result.delayed_path,
+        Some(staging_path.clone()),
+        "the entry must stage through the cleared partial dir"
+    );
+    assert!(
+        staging_dir.is_dir(),
+        "the planted file must be replaced by the staging directory"
+    );
+    assert_eq!(fs::read(&staging_path).unwrap(), b"delayed write");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+    let _ = fs::remove_file(&staging_path);
+    let _ = fs::remove_dir(&staging_dir);
+}
+/// Non-vacuity companion: clearing the obstruction must not clear a partial
+/// directory that is already a directory.
+///
+/// Without this the pin above would also hold for an over-broad fix that
+/// removed the name unconditionally (a `remove_dir_all`), which would destroy
+/// partials retained from an earlier interrupted run - upstream reuses an
+/// existing directory untouched (util1.c:1522, `S_ISDIR` skips the mkdir).
+#[test]
+fn delay_updates_reuses_an_existing_partial_dir_untouched() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("reuse.dat");
+    let staging_dir = dir.path().join(DELAY_UPDATES_PARTIAL_DIR);
+    fs::create_dir(&staging_dir).unwrap();
+    let retained = staging_dir.join("retained-from-an-earlier-run.dat");
+    fs::write(&retained, b"keep me").unwrap();
+
+    let h = spawn_disk_thread(delay_updates_config()).unwrap();
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 13,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+            xattr_basis: None,
+            file_entry: None,
+        })))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Chunk(b"delayed write".to_vec()))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
+
+    h.result_rx
+        .recv()
+        .unwrap()
+        .expect("an existing partial dir is reused");
+    assert_eq!(
+        fs::read(&retained).unwrap(),
+        b"keep me",
+        "an existing partial dir must be reused, never cleared"
+    );
+
+    let staging_path = staging_dir.join("reuse.dat");
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+    let _ = fs::remove_file(&staging_path);
+    let _ = fs::remove_file(&retained);
+    let _ = fs::remove_dir(&staging_dir);
+}
 /// Verifies that the coalesced WholeFile path also stages to `.~tmp~`
 /// when `delay_updates` is enabled.
 #[test]


### PR DESCRIPTION
Under `--delay-updates` every entry stages through the partial directory. When
a **regular file** already occupies that name, upstream unlinks it and
proceeds; oc reported the whole transfer as failed.

## Measured

Real rsync 3.5.0 over a daemon push, upstream control run first, with a regular
file planted where the staging directory belongs:

| | rc | transfer | plant |
|---|---|---|---|
| upstream 3.5.0 | 0 | OK | consumed |
| oc (before) | 23 | MISSING | untouched |
| oc (after) | 0 | OK | replaced by the staging dir |

The daemon-side log named the cause directly - `File exists (os error 17)` -
while upstream's log was clean.

## Root cause

`util1.c:1521-1528` `handle_partial_dir()`:

```c
if (statret == 0 && !S_ISDIR(st.st_mode)) {
        if (do_unlink_at(dir) < 0) ...
        statret = -1;
}
if (statret < 0 && do_mkdir_at(dir, 0700) < 0) ...
```

`fs::create_dir_all` returns `AlreadyExists` for a non-directory at the path,
and the `?` turned an obstruction upstream clears into a failed transfer.

The rule gets one owner, `engine::util::cleanup::clear_partial_dir_obstruction`,
mirroring the idiom already used for the backup-directory chain (`backup.rs`,
citing `backup.c:48-53`).

## A symlink is deliberately left in place

Upstream would unlink it. Upstream can afford to because its unlink runs inside
`operator_path_resolve`, so a link leading out of the served tree is refused
rather than followed. oc cannot use that walk here: it resolves from `/` and a
daemon's Landlock ruleset admits only the module root - measured, by routing
this site onto the ownership-walk creator and watching four probe cells regress
with `mkstemp ... Permission denied`.

**Removing the link unconfined would be strictly worse than not removing it,
and the upstream testsuite proved it.** An earlier revision of this PR did
exactly that and regressed `operator-path-partial-dir-daemon` from `pass` to
`fail`. That cell plants a euid-owned symlink pointing **outside** the module
and requires the daemon to refuse. Today the refusal comes from the confined
rename; unlinking the symlink first both destroys an operator-visible link and
pre-empts the refusal, turning it into a successful transfer.

⚠ That also **retracts a claim in this PR's first description**: "this changes
behaviour, not confinement" was wrong. The site previously removed *nothing*,
so an unconditional removal is a new unconfined destructive operation, not a
neutral one.

So the change narrows to what oc can express safely - only the **final**
component, only when it is **not** a symlink. `handle_partial_dir` names
exactly one directory, so an obstruction standing where an *ancestor* belongs
is not upstream's to remove either.

## Tests

The obstruction case is pinned, plus a non-vacuity companion asserting an
**existing** partial directory is reused untouched - without it the pin would
also hold for an over-broad fix that removed the name unconditionally,
destroying partials retained from an earlier interrupted run.

RED proven by neutering the clear to a no-op: nextest reports
`2 tests run: 1 passed, 1 failed` (1+1 == 2, so no fail-fast truncation).

## Gates

fmt clean; workspace clippy `-D warnings` exit 0; `-p transfer -p engine`
7865/7865; the three `operator-path-partial-dir*` cells PASS individually; and
the full nonroot pipe upstream-testsuite leg at **248 passed / 13 failed / 84
skipped** - identical to the pre-change baseline, the only expect-manifest
mismatch being the known environmental `protected-regular` XPASS on that host.
