### PR TITLE
fix(daemon): keep a relative --partial-dir relative per upstream

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -796,20 +796,28 @@ where
     let partial_dir_cli = matches
         .remove_one::<OsString>("partial-dir")
         .map(PathBuf::from);
-    let partial_dir = if no_partial {
+    let partial_dir_given = if no_partial {
         None
     } else if let Some(dir) = partial_dir_cli {
         Some(dir)
     } else if partial_flag {
-        // upstream: options.c:2448-2454 - RSYNC_PARTIAL_DIR is consulted only
+        // upstream: options.c:2590-2593 - RSYNC_PARTIAL_DIR is consulted only
         // when keep_partial is set (--partial/-P) and no explicit --partial-dir
-        // was given. An empty value or a literal "." is treated as unset.
+        // was given. Upstream's own guard here is only `*arg` (non-empty); a
+        // literal "." is rejected by the shared normalisation below, which runs
+        // over the CLI value and the environment value alike.
         env::var_os("RSYNC_PARTIAL_DIR")
-            .filter(|value| !value.is_empty() && value.as_os_str() != std::ffi::OsStr::new("."))
+            .filter(|value| !value.is_empty())
             .map(PathBuf::from)
     } else {
         None
     };
+    // upstream: options.c:2594-2598 - the end-of-parse normalisation runs over
+    // whichever value survived above, collapsing `..` and mapping the
+    // "no partial directory" spellings to NULL.
+    let partial_dir = partial_dir_given
+        .as_deref()
+        .and_then(crate::frontend::partial_dir::normalize_partial_dir);
     let partial = if no_partial {
         false
     } else {

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -123,6 +123,7 @@ mod local_time;
 mod lsm_status;
 mod operator_file;
 mod out_format;
+mod partial_dir;
 pub(crate) mod password;
 /// Progress and verbose output helpers extracted from the CLI front-end.
 pub mod progress;

--- a/crates/cli/src/frontend/partial_dir.rs
+++ b/crates/cli/src/frontend/partial_dir.rs
@@ -1,0 +1,87 @@
+//! Normalisation of the `--partial-dir` value, shared by the client argument
+//! parser and the `--server` argument decoder.
+//!
+//! Upstream applies one rule to `partial_dir` at the end of option parsing,
+//! inside `parse_arguments()`, which both the client and the server run. The
+//! two roles therefore cannot legitimately disagree about what a given spelling
+//! means. Keeping the rule in one place is what makes that guarantee explicit
+//! rather than a coincidence of two copies staying in step.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/options.c:2594-2598` - the `if (partial_dir)` block, which
+//!   sits OUTSIDE the `!am_server` guard at `:2590` that wraps the
+//!   `RSYNC_PARTIAL_DIR` environment fallback.
+
+use std::path::{Path, PathBuf};
+
+/// Applies upstream's end-of-parse `--partial-dir` normalisation, returning
+/// `None` for the spellings that mean "no partial directory".
+///
+/// Two rules, in upstream's order:
+///
+/// 1. a non-empty value is collapsed with `clean_fname(..,
+///    CFN_COLLAPSE_DOT_DOT_DIRS)`, so `a/b/../c` names `a/c`;
+/// 2. a value that is empty or exactly `.` becomes no partial directory at all.
+///
+/// Rule 2 has to run *after* rule 1, because the collapse is what turns `./`
+/// into `.`. Both are delegated to [`filters::collapse_dot_dot_dirs`], oc's
+/// port of `clean_fname`, which already yields `.` for an empty input - so the
+/// two upstream arms fold into one comparison here without changing either.
+///
+/// Dropping the value matters beyond tidiness: `partial_dir_fname()` re-anchors
+/// a relative partial directory at the destination file's own directory, so a
+/// surviving `.` would make the staging target `<dirname>/./<basename>` - the
+/// destination file itself, defeating the staging that `--delay-updates` and
+/// `--partial-dir` exist to provide.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/options.c:2594-2598` `parse_arguments()`.
+/// - `rsync-3.5.0/util1.c` `clean_fname()` with `CFN_COLLAPSE_DOT_DOT_DIRS`.
+pub(crate) fn normalize_partial_dir(dir: &Path) -> Option<PathBuf> {
+    let cleaned = filters::collapse_dot_dot_dirs(dir);
+    (cleaned != Path::new(".")).then_some(cleaned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_partial_dir;
+    use std::path::{Path, PathBuf};
+
+    /// Every spelling upstream maps to "no partial directory" must yield
+    /// `None`, and every other spelling must survive collapsed.
+    ///
+    /// The expectations are upstream's two arms read directly:
+    /// `if (*partial_dir) clean_fname(...)` then
+    /// `if (!*partial_dir || strcmp(partial_dir, ".") == 0) partial_dir = NULL`
+    /// (options.c:2594-2598).
+    #[test]
+    fn matches_upstream_end_of_parse_normalisation() {
+        for unset in ["", ".", "./", "./.", "a/.."] {
+            assert_eq!(
+                normalize_partial_dir(Path::new(unset)),
+                None,
+                "{unset:?} means no partial directory upstream"
+            );
+        }
+
+        for (given, want) in [
+            ("pdir", "pdir"),
+            ("pdir/", "pdir"),
+            ("./pdir", "pdir"),
+            ("a/b/../c", "a/c"),
+            ("a//b", "a/b"),
+            // A `..` with nothing to consume is KEPT, so a value that climbs
+            // above its anchor still says so rather than silently flattening.
+            ("../pdir", "../pdir"),
+            ("/abs/pdir", "/abs/pdir"),
+        ] {
+            assert_eq!(
+                normalize_partial_dir(Path::new(given)),
+                Some(PathBuf::from(want)),
+                "{given:?} must collapse to {want:?}"
+            );
+        }
+    }
+}

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -383,10 +383,17 @@ where
     // with no partial-dir at all - in that case the receiver's normal commit
     // path runs, which is what the regression test
     // `symlink-dirlink-basis_test.py` exercises through `lsh.sh`.
+    //
+    // upstream: options.c:2594-2598 - the end-of-parse normalisation sits
+    // OUTSIDE the `!am_server` guard at :2590, so the server applies it to the
+    // value the peer sent exactly as the client applies it to its own. Taking
+    // the peer's spelling verbatim let `--partial-dir=.` through, and a
+    // relative partial dir is re-anchored per file at `dirname(dest)`, so `.`
+    // would make the staging target the destination file itself.
     if let Some(dir) = &long_flags.partial_dir {
-        let path = std::path::PathBuf::from(dir);
-        config.partial_dir = Some(path);
-        config.has_partial_dir = true;
+        config.partial_dir =
+            crate::frontend::partial_dir::normalize_partial_dir(std::path::Path::new(dir));
+        config.has_partial_dir = config.partial_dir.is_some();
     }
     // upstream: options.c:2891-2892 - `--delay-updates` rides alongside
     // `--partial-dir` whenever both are active.

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -548,7 +548,13 @@ fn clamp_basis_to_module(
     resolve_base: &std::path::Path,
     module_root_canonical: &std::path::Path,
 ) -> std::path::PathBuf {
-    let tail = if ref_path.is_absolute() {
+    // upstream: `util1.c:1145` tests `*p == '/'` on the peer-supplied byte
+    // string, not a platform notion of absoluteness. `Path::is_absolute()` is
+    // FALSE on Windows for `/etc/foo` (no drive prefix), which would route a
+    // peer-sent absolute value down the relative arm and skip the re-root
+    // entirely. `has_root()` is true for a leading separator on both platforms
+    // and additionally true for a drive-absolute Windows path.
+    let tail = if ref_path.has_root() {
         ref_path.to_path_buf()
     } else {
         destination_below_root(resolve_base, module_root_canonical).join(ref_path)
@@ -643,8 +649,11 @@ fn sanitize_partial_dir(
     resolve_base: &std::path::Path,
     module_root_canonical: &std::path::Path,
 ) -> std::path::PathBuf {
-    if ref_path.is_absolute() {
-        // upstream: util1.c:1145-1151 - the rootdir replaces the leading slash
+    if ref_path.has_root() {
+        // upstream: util1.c:1145-1151 - the test is `*p == '/'` on the
+        // peer-supplied bytes, so `has_root()` not `is_absolute()`: the latter
+        // is FALSE on Windows for a leading-slash path and would skip the
+        // re-root. See `clamp_basis_to_module` for the same rule. - the rootdir replaces the leading slash
         // and `depth` is forced to 0, which is exactly the absolute arm of
         // `clamp_basis_to_module`.
         return clamp_basis_to_module(ref_path, resolve_base, module_root_canonical);

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -556,6 +556,109 @@ fn clamp_basis_to_module(
     module_root_canonical.join(collapse_under_root(&tail))
 }
 
+/// Collapses a RELATIVE operator path the way `sanitize_path()` does when the
+/// value carries no leading `/`, keeping the result relative.
+///
+/// upstream: `util1.c:1145-1151` prefixes the rootdir **only** inside
+/// `if (*p == '/')`. A relative value therefore keeps no prefix at all: it is
+/// merely `..`-collapsed and handed back relative, for the consumer to anchor
+/// wherever it anchors.
+///
+/// The `depth` budget is upstream's, and it is a budget for *leading* `..`
+/// only (`util1.c:1184-1197`): a `..` is kept when nothing has been emitted
+/// yet and budget remains, in which case upstream advances its virtual start
+/// past the `../` so the following component is again "at the start" - which
+/// is why consecutive leading `..` each consume one unit, and why a `..` that
+/// pops the output back to empty re-enters the leading state. Any other `..`
+/// backs up over one emitted component, or is discarded when there is nothing
+/// to back up over. There is no arm that refuses.
+///
+/// Pure path arithmetic: no syscalls, so it is well defined for a directory
+/// that does not exist yet.
+fn collapse_relative_within_depth(path: &std::path::Path, depth: usize) -> std::path::PathBuf {
+    use std::path::{Component, PathBuf};
+
+    let mut budget = depth;
+    let mut leading_parents = 0usize;
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::Normal(name) => tail.push(name.to_os_string()),
+            // upstream: util1.c:1173-1182 drops extra slashes and `.` elements.
+            // A root or prefix cannot reach here - the caller routes absolute
+            // values to `clamp_basis_to_module` instead.
+            Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
+            Component::ParentDir => {
+                if tail.is_empty() && budget > 0 {
+                    budget -= 1;
+                    leading_parents += 1;
+                } else {
+                    tail.pop();
+                }
+            }
+        }
+    }
+
+    let mut out = PathBuf::new();
+    for _ in 0..leading_parents {
+        out.push("..");
+    }
+    out.extend(tail);
+    if out.as_os_str().is_empty() {
+        // upstream: util1.c:1203-1206 - "If the resulting name would be empty,
+        // change it into a `.`".
+        return PathBuf::from(".");
+    }
+    out
+}
+
+/// Sanitises a client-supplied `--partial-dir` for a daemon receiver.
+///
+/// upstream: `main.c:1238-1239` runs `partial_dir` through the very same
+/// `sanitize_path(NULL, partial_dir, NULL, curr_dir_depth, SP_DEFAULT)` call it
+/// runs over `basis_dir[]`, so the *rewrite* is identical for both. What
+/// differs is the CONSUMER, and that is why this cannot simply reuse
+/// [`clamp_basis_to_module`]:
+///
+/// - an alt-basis dir and `--backup-dir` are anchored ONCE, at the destination,
+///   so pre-joining the destination onto a relative value (what
+///   `clamp_basis_to_module` does) reaches the same place upstream reaches when
+///   its consumer resolves the still-relative value against `curr_dir`;
+/// - `--partial-dir` is anchored PER FILE at `dirname(fname)`
+///   (`util1.c` `partial_dir_fname()`, mirrored by `temp_guard.rs`
+///   `partial_dir_fname`). Pre-joining the destination would pin every entry's
+///   staging directory at the transfer root, so a nested entry would stage at
+///   `<module_root>/pdir` where upstream stages at `<dest>/sub/pdir`.
+///
+/// So the two arms are kept apart: an ABSOLUTE value re-roots at the module
+/// root exactly as a basis dir does, and a RELATIVE value stays relative with
+/// only its `..` collapsed, for `partial_dir_fname` to anchor per file.
+///
+/// Keeping a relative value relative also preserves the meaning of
+/// `engine::remove_partial_dir`'s absolute-path guard, which reads the value's
+/// own shape to decide whether the directory is operator-named.
+fn sanitize_partial_dir(
+    ref_path: &std::path::Path,
+    resolve_base: &std::path::Path,
+    module_root_canonical: &std::path::Path,
+) -> std::path::PathBuf {
+    if ref_path.is_absolute() {
+        // upstream: util1.c:1145-1151 - the rootdir replaces the leading slash
+        // and `depth` is forced to 0, which is exactly the absolute arm of
+        // `clamp_basis_to_module`.
+        return clamp_basis_to_module(ref_path, resolve_base, module_root_canonical);
+    }
+    // upstream: util1.c:47 + :1391 - `curr_dir_depth` is the destination's
+    // depth below the module root, "only set for a sanitizing daemon", counted
+    // by `count_dir_elements()`. oc has no chdir, so the destination is passed
+    // explicitly and its component count is the same number.
+    let depth = destination_below_root(resolve_base, module_root_canonical)
+        .components()
+        .count();
+    collapse_relative_within_depth(ref_path, depth)
+}
+
 /// Whether an already-clamped basis directory resolves out of the module tree
 /// through a symlink.
 ///

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -357,15 +357,20 @@ fn build_server_config(
             // SP_DEFAULT)`), and `clientserver.c` sets `sanitize_paths` for
             // every daemon connection. An ABSOLUTE `--partial-dir` therefore
             // re-roots at `module_dir` (util1.c:1145-1152) instead of naming a
-            // filesystem-absolute path, exactly as `--backup-dir` above -
-            // so the same clamp is reused rather than reimplemented.
+            // filesystem-absolute path, exactly as `--backup-dir` above.
             //
             // Without it an absolute `--partial-dir=/pdir` resolved against the
             // filesystem root, where the daemon has no business writing: the
             // staging `mkstemp` failed EACCES and the entry was reported as an
             // I/O error rather than transferred.
+            //
+            // A RELATIVE value must NOT go through the basis clamp, though:
+            // that clamp folds the destination in and returns an absolute path,
+            // which is right only for a consumer that anchors once. This one
+            // anchors per file, so the value stays relative - see
+            // `sanitize_partial_dir`.
             if let Some(dir) = cfg.partial_dir.as_deref() {
-                cfg.partial_dir = Some(clamp_basis_to_module(
+                cfg.partial_dir = Some(sanitize_partial_dir(
                     dir,
                     &resolve_base,
                     &module_root_canonical,

--- a/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
@@ -434,3 +434,154 @@ mod daemon_partial_dir_arg_tests {
         assert!(config.write.delay_updates);
     }
 }
+
+#[cfg(test)]
+mod daemon_partial_dir_sanitize_tests {
+    use super::{clamp_basis_to_module, collapse_relative_within_depth, sanitize_partial_dir};
+    use std::path::{Path, PathBuf};
+
+    /// upstream: `util1.c:1184-1197` `sanitize_path()` - the `..` arms.
+    ///
+    /// `depth` budgets LEADING `..` only. Upstream keeps a virtual start that
+    /// advances past each allowed `../`, so consecutive leading `..` each
+    /// consume one unit while budget lasts, and a `..` that pops the output
+    /// back to empty re-enters the leading state.
+    #[test]
+    fn relative_collapse_matches_upstream_depth_budget() {
+        // depth 0 - upstream's `if (depth <= 0 || sanp != start)` always wins,
+        // so every `..` either pops or is discarded, and nothing escapes.
+        for (given, want) in [
+            ("pdir", "pdir"),
+            ("a/b", "a/b"),
+            ("a/../b", "b"),
+            ("../pdir", "pdir"),
+            ("../../pdir", "pdir"),
+            ("a/../../pdir", "pdir"),
+        ] {
+            assert_eq!(
+                collapse_relative_within_depth(Path::new(given), 0),
+                PathBuf::from(want),
+                "depth 0: {given:?}"
+            );
+        }
+
+        // depth 1 - exactly one LEADING `..` survives.
+        assert_eq!(
+            collapse_relative_within_depth(Path::new("../pdir"), 1),
+            PathBuf::from("../pdir")
+        );
+        // The second one exhausts the budget and is discarded.
+        assert_eq!(
+            collapse_relative_within_depth(Path::new("../../pdir"), 1),
+            PathBuf::from("../pdir")
+        );
+        // A `..` AFTER a real component pops instead of being kept, even with
+        // budget remaining - upstream's `sanp != start` half of the guard.
+        assert_eq!(
+            collapse_relative_within_depth(Path::new("a/../pdir"), 1),
+            PathBuf::from("pdir")
+        );
+        // ...but once that pop empties the output, the leading state returns
+        // and the budget applies again.
+        assert_eq!(
+            collapse_relative_within_depth(Path::new("a/../../pdir"), 1),
+            PathBuf::from("../pdir")
+        );
+
+        // depth 2 - consecutive leading `..` each consume one unit.
+        assert_eq!(
+            collapse_relative_within_depth(Path::new("../../pdir"), 2),
+            PathBuf::from("../../pdir")
+        );
+
+        // upstream: util1.c:1203-1206 - an empty result becomes ".".
+        assert_eq!(
+            collapse_relative_within_depth(Path::new("a/.."), 0),
+            PathBuf::from(".")
+        );
+    }
+
+    /// THE DEFECT THIS FIXES: a relative `--partial-dir` must stay RELATIVE.
+    ///
+    /// `partial_dir_fname()` re-anchors the value at `dirname(fname)` for every
+    /// entry, so an absolute result pins every entry's staging directory at the
+    /// transfer root. Upstream leaves a relative value relative
+    /// (`util1.c:1145-1151` applies the rootdir only inside `if (*p == '/')`),
+    /// and a nested entry then stages at `<dest>/sub/pdir`.
+    ///
+    /// Measured against real rsync 3.5.0 over a daemon push with
+    /// `--delay-updates --partial-dir=pdir` into `mod/sub/`: upstream consumes
+    /// `<module>/sub/pdir`, oc staged at `<module>/pdir` and left `sub/pdir`
+    /// untouched.
+    #[test]
+    fn a_relative_partial_dir_stays_relative() {
+        let module_root = Path::new("/srv/mod");
+        let dest = Path::new("/srv/mod/sub");
+
+        assert_eq!(
+            sanitize_partial_dir(Path::new("pdir"), dest, module_root),
+            PathBuf::from("pdir"),
+            "a relative --partial-dir must not be anchored at the destination"
+        );
+        // The destination's depth below the module root IS upstream's
+        // `curr_dir_depth`, so one `..` is affordable from `mod/sub`.
+        assert_eq!(
+            sanitize_partial_dir(Path::new("../pdir"), dest, module_root),
+            PathBuf::from("../pdir")
+        );
+        // At the module root the budget is 0, so the same value collapses
+        // rather than climbing out.
+        assert_eq!(
+            sanitize_partial_dir(Path::new("../pdir"), module_root, module_root),
+            PathBuf::from("pdir")
+        );
+    }
+
+    /// Non-vacuity companion: the ABSOLUTE arm must still re-root at the module,
+    /// exactly as `--backup-dir` and the alt-basis dirs do.
+    ///
+    /// Without this the pin above would also hold for a fix that simply stopped
+    /// clamping altogether, which would let `--partial-dir=/pdir` address the
+    /// filesystem root - the defect PR #7498 closed.
+    #[test]
+    fn an_absolute_partial_dir_still_re_roots_at_the_module() {
+        let module_root = Path::new("/srv/mod");
+        let dest = Path::new("/srv/mod/sub");
+
+        assert_eq!(
+            sanitize_partial_dir(Path::new("/pdir"), dest, module_root),
+            PathBuf::from("/srv/mod/pdir")
+        );
+        assert_eq!(
+            sanitize_partial_dir(Path::new("/etc/pdir"), dest, module_root),
+            PathBuf::from("/srv/mod/etc/pdir")
+        );
+        // And it agrees with the basis clamp on that arm, which is why the
+        // absolute case delegates rather than reimplementing.
+        assert_eq!(
+            sanitize_partial_dir(Path::new("/pdir"), dest, module_root),
+            clamp_basis_to_module(Path::new("/pdir"), dest, module_root)
+        );
+    }
+
+    /// The two consumers genuinely need different answers for a RELATIVE value:
+    /// the basis clamp anchors once and returns an absolute path, the partial
+    /// dir must not. Pinning the disagreement is what stops the two being
+    /// "simplified" back into one call.
+    #[test]
+    fn the_basis_clamp_and_the_partial_dir_disagree_on_a_relative_value() {
+        let module_root = Path::new("/srv/mod");
+        let dest = Path::new("/srv/mod/sub");
+
+        assert_eq!(
+            clamp_basis_to_module(Path::new("pdir"), dest, module_root),
+            PathBuf::from("/srv/mod/sub/pdir"),
+            "the basis clamp folds the destination in, as its consumer expects"
+        );
+        assert_eq!(
+            sanitize_partial_dir(Path::new("pdir"), dest, module_root),
+            PathBuf::from("pdir"),
+            "the partial dir must not, because its consumer re-anchors per file"
+        );
+    }
+}

--- a/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
@@ -564,6 +564,33 @@ mod daemon_partial_dir_sanitize_tests {
         );
     }
 
+    /// `has_root()`, NOT `is_absolute()`: upstream's test is the literal byte
+    /// `*p == '/'` (`util1.c:1145`) applied to a PEER-SUPPLIED path.
+    ///
+    /// On Windows `Path::is_absolute()` is FALSE for `/pdir` because there is
+    /// no drive prefix, so an `is_absolute()` gate routes a peer-sent absolute
+    /// value down the RELATIVE arm and never re-roots it at the module root.
+    /// The sibling test above cannot see that: on Unix the two spellings
+    /// agree, so it passes either way. This one pins the predicate so the
+    /// divergence cannot be reintroduced by "simplifying" back.
+    #[test]
+    fn a_leading_slash_partial_dir_re_roots_on_every_platform() {
+        let module_root = Path::new("/srv/mod");
+        let dest = Path::new("/srv/mod/sub");
+
+        for given in ["/pdir", "/etc/pdir"] {
+            assert!(
+                Path::new(given).has_root(),
+                "{given:?} must be recognised as rooted on this platform"
+            );
+            let got = sanitize_partial_dir(Path::new(given), dest, module_root);
+            assert!(
+                got.starts_with(module_root),
+                "{given:?} must re-root under {module_root:?}, got {got:?}"
+            );
+        }
+    }
+
     /// The two consumers genuinely need different answers for a RELATIVE value:
     /// the basis clamp anchors once and returns an absolute path, the partial
     /// dir must not. Pinning the disagreement is what stops the two being


### PR DESCRIPTION
## What

Upstream normalises `--partial-dir` at **two** sites. oc was missing both.

### Stage 1 - `options.c:2594-2598` (end of `parse_arguments()`)

The block sits **outside** the `!am_server` guard at `:2590` that wraps the
`RSYNC_PARTIAL_DIR` fallback, so client and server both run it: a non-empty
value is collapsed with `clean_fname(.., CFN_COLLAPSE_DOT_DOT_DIRS)`, then an
empty or `.` value becomes no partial directory at all.

oc applied the empty/`.` half to the **environment branch only**, never
collapsed `..` on either branch, and the server took the peer's spelling
verbatim. So `--partial-dir=.` survived - and since a relative partial dir is
re-anchored per file at `dirname(fname)`, `.` made the staging target the
destination file itself, defeating the staging `--delay-updates` exists to
provide.

Both roles now share one owner for the rule (`frontend/partial_dir.rs`), which
makes their agreement structural rather than a coincidence of two copies
staying in step.

### Stage 2 - `main.c:1238-1239` (daemon receiver)

`partial_dir` goes through the *same* `sanitize_path(NULL, .., curr_dir_depth,
SP_DEFAULT)` call as `basis_dir[]`, so the **rewrite** is identical for both.
What differs is the **consumer**, and that is what oc got wrong by reusing
`clamp_basis_to_module`:

| option | anchored | pre-joining the destination is |
|---|---|---|
| alt-basis, `--backup-dir` | **once**, at the destination | correct - lands where upstream lands |
| `--partial-dir` | **per file**, at `dirname(fname)` | wrong - pins every entry at the transfer root |

So the arms are now kept apart. An **absolute** value still re-roots at the
module root via the basis clamp (unchanged, and pinned by a test asserting the
two agree on that arm). A **relative** value stays relative with only its `..`
collapsed, honouring upstream's leading-`..` depth budget (`util1.c:1184-1197`),
where `curr_dir_depth` is the destination's component depth below the module
root (`util1.c:47` + `:1391`).

The backup-dir and alt-basis arms are deliberately untouched - they are correct
for their once-anchored consumers.

## Measured against real rsync 3.5.0

Daemon push, `--delay-updates --partial-dir=pdir` into `mod/sub/`, both impls
exit 0. A regular file is planted where the staging directory belongs:

| binary | `sub/pdir` | verdict |
|---|---|---|
| upstream 3.5.0 | `ABSENT` | oracle |
| oc @ base `40b42b2cf` | `dir` | **divergent** |
| oc @ this branch | `ABSENT` | matches |

Turning the value absolute also flipped `engine::remove_partial_dir`'s
`is_absolute()` guard from remove to keep, which is why the staging directory
was left behind.

## Verification (Linux, x86_64)

- **A/B end-to-end**: table above, base vs branch vs the real 3.5.0 binary.
- **Unit**: 4 new daemon cases (upstream's depth budget, relative stays
  relative, absolute still re-roots, and the two clamps *disagree* on a relative
  value) + 1 new CLI case covering every spelling upstream maps to "no partial
  directory".
- **Testsuite, nonroot pipe leg, branch**: `248 passed / 13 failed / 84 skipped`.
- **Same leg on the base binary as a control**: `248 / 13 / 84`, identical, with
  the same single `protected-regular: expected skip, got pass` mismatch. That
  mismatch is therefore **pre-existing and environmental** (this host has
  `fs.protected_regular=1`), not introduced here - proven by the control rather
  than asserted, and the manifest row is deliberately **not** re-baselined.
- All 5 `*partial-dir*` cells pass individually.
- `cargo fmt --all -- --check` and `cargo clippy -p cli -p daemon --all-targets
  --all-features --no-deps -- -D warnings` both exit 0.

## Scope notes

⚠ **This flips no manifest row.** Every `*partial-dir*` row is already `pass` in
all four manifests, so no testsuite cell covered this divergence - it was only
visible against the real upstream binary. The gate here is therefore
*no regression*, which the base-vs-branch control establishes.

⚠ **Coverage split, stated plainly.** The new unit tests pin the two
*functions* against upstream's algorithm. The **routing** decision in
`build_server_config` has no unit-test seam in that crate (nothing constructs it
under test), so it is covered end-to-end by the testsuite cells, not by a unit
test. A mutation that routes `partial_dir` back onto `clamp_basis_to_module`
does **not** turn the unit tests red - I checked, and say so rather than claim
mutation coverage the tests do not have.

⚠ **Stage 1's `--partial-dir=.` consequence is reasoned from source, not
measured.** The interesting state is transient and I found no clean end-to-end
observable for it. The upstream rule itself is read directly from
`options.c:2594-2598`; only the downstream effect is inferred.
