### PR TITLE
fix(metadata): condense the fake-super access ACL to upstream's stored form

### DIFF
--- a/crates/metadata/src/acl_exacl/apply.rs
+++ b/crates/metadata/src/acl_exacl/apply.rs
@@ -139,6 +139,8 @@ pub fn apply_acls_from_cache(
 /// * `default_ndx` - Optional index into the default ACL cache (directories only).
 /// * `follow_symlinks` - Whether to process this entry at all. If `false`,
 ///   returns immediately.
+/// * `mode` - The entry's permission word, which decides which access-ACL
+///   slots the stored blob may leave as `NO_ENTRY`.
 ///
 /// # Errors
 ///
@@ -147,7 +149,7 @@ pub fn apply_acls_from_cache(
 /// # Upstream Reference
 ///
 /// Mirrors the `am_root < 0` branch of `set_rsync_acl()` in `acls.c` lines
-/// 933-971.
+/// 1229-1245.
 #[allow(clippy::module_name_repetitions)]
 pub fn store_acls_via_fake_super(
     destination: &Path,
@@ -155,6 +157,7 @@ pub fn store_acls_via_fake_super(
     access_ndx: u32,
     default_ndx: Option<u32>,
     follow_symlinks: bool,
+    mode: u32,
 ) -> Result<(), MetadataError> {
     use crate::fake_super::{remove_fake_super_default_acl, store_fake_super_acl};
 
@@ -163,7 +166,7 @@ pub fn store_acls_via_fake_super(
     }
 
     if let Some(acl) = cache.get_access(access_ndx) {
-        store_fake_super_acl(destination, true, acl)
+        store_fake_super_acl(destination, true, acl, mode)
             .map_err(|e| MetadataError::new("store fake-super access ACL", destination, e))?;
     }
 
@@ -177,7 +180,7 @@ pub fn store_acls_via_fake_super(
                 })?;
             }
             Some(def_acl) => {
-                store_fake_super_acl(destination, false, def_acl).map_err(|e| {
+                store_fake_super_acl(destination, false, def_acl, mode).map_err(|e| {
                     MetadataError::new("store fake-super default ACL", destination, e)
                 })?;
             }

--- a/crates/metadata/src/acl_exacl/sync.rs
+++ b/crates/metadata/src/acl_exacl/sync.rs
@@ -199,7 +199,7 @@ pub fn sync_acls_via_fake_super(
         .flatten()
         .unwrap_or_else(|| super::read::get_rsync_acl(source, source_mode, false));
 
-    crate::fake_super::store_fake_super_acl(destination, true, &access_acl)
+    crate::fake_super::store_fake_super_acl(destination, true, &access_acl, source_mode)
         .map_err(|e| MetadataError::new("store fake-super access ACL", destination, e))?;
 
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -217,9 +217,13 @@ pub fn sync_acls_via_fake_super(
             // upstream: acls.c:934-935 - user_obj == NO_ENTRY means "no default
             // ACL", so the xattr is removed rather than storing an empty ACL.
             if default_acl.has_user_obj() {
-                crate::fake_super::store_fake_super_acl(destination, false, &default_acl).map_err(
-                    |e| MetadataError::new("store fake-super default ACL", destination, e),
-                )?;
+                crate::fake_super::store_fake_super_acl(
+                    destination,
+                    false,
+                    &default_acl,
+                    source_mode,
+                )
+                .map_err(|e| MetadataError::new("store fake-super default ACL", destination, e))?;
             } else {
                 crate::fake_super::remove_fake_super_default_acl(destination).map_err(|e| {
                     MetadataError::new("remove fake-super default ACL", destination, e)

--- a/crates/metadata/src/acl_noop.rs
+++ b/crates/metadata/src/acl_noop.rs
@@ -89,6 +89,7 @@ pub fn store_acls_via_fake_super(
     _access_ndx: u32,
     _default_ndx: Option<u32>,
     _follow_symlinks: bool,
+    _mode: u32,
 ) -> Result<(), MetadataError> {
     warn_acl_unsupported();
     Ok(())
@@ -171,7 +172,7 @@ mod tests {
     fn store_acls_via_fake_super_returns_ok() {
         let dst = Path::new("/nonexistent/dst");
         let cache = AclCache::new();
-        let result = store_acls_via_fake_super(dst, &cache, 0, Some(1), true);
+        let result = store_acls_via_fake_super(dst, &cache, 0, Some(1), true, 0o644);
         assert!(result.is_ok());
     }
 }

--- a/crates/metadata/src/acl_stub.rs
+++ b/crates/metadata/src/acl_stub.rs
@@ -107,8 +107,16 @@ pub fn store_acls_via_fake_super(
     access_ndx: u32,
     default_ndx: Option<u32>,
     follow_symlinks: bool,
+    mode: u32,
 ) -> Result<(), MetadataError> {
-    let _ = (destination, cache, access_ndx, default_ndx, follow_symlinks);
+    let _ = (
+        destination,
+        cache,
+        access_ndx,
+        default_ndx,
+        follow_symlinks,
+        mode,
+    );
     warn_acl_unsupported();
     Ok(())
 }
@@ -174,7 +182,7 @@ mod tests {
     fn store_acls_via_fake_super_returns_ok() {
         let dst = Path::new("/nonexistent/dst");
         let cache = AclCache::new();
-        let result = store_acls_via_fake_super(dst, &cache, 0, None, false);
+        let result = store_acls_via_fake_super(dst, &cache, 0, None, false, 0o644);
         assert!(result.is_ok());
     }
 }

--- a/crates/metadata/src/acl_windows/dacl.rs
+++ b/crates/metadata/src/acl_windows/dacl.rs
@@ -354,7 +354,10 @@ pub fn apply_acls_from_cache(
 /// (upstream: `acls.c`'s `am_root < 0` branch operates on `SMB_ACL_T`, which
 /// has no Windows equivalent). Windows ACLs are already persisted via their
 /// own SDDL xattr (`WINDOWS_SDDL_XATTR_NAME`), so this falls straight through
-/// to the normal apply path unchanged.
+/// to the normal apply path unchanged - `mode` included, since the sender
+/// strips mode-derivable entries before transmitting (`acls.c:142`
+/// `rsync_acl_strip_perms()`, called from `send_acl()` at `acls.c:888`) and
+/// `reconstruct_acl` needs it to put them back.
 ///
 /// # Errors
 ///
@@ -366,6 +369,7 @@ pub fn store_acls_via_fake_super(
     access_ndx: u32,
     default_ndx: Option<u32>,
     follow_symlinks: bool,
+    mode: u32,
 ) -> Result<(), MetadataError> {
     apply_acls_from_cache(
         destination,
@@ -373,7 +377,7 @@ pub fn store_acls_via_fake_super(
         access_ndx,
         default_ndx,
         follow_symlinks,
-        None,
+        Some(mode),
         None,
     )
 }

--- a/crates/metadata/src/fake_super.rs
+++ b/crates/metadata/src/fake_super.rs
@@ -306,20 +306,34 @@ const fn fake_super_acl_xattr(is_access_acl: bool) -> &'static str {
 /// ACL is stashed in `%aacl`/`%dacl` instead, mirroring how ownership is
 /// stashed in `%stat`.
 ///
+/// `mode` is the source entry's permission word. An access ACL is condensed
+/// into the wire-round-tripped form upstream ends up storing (see
+/// [`protocol::acl::RsyncAcl::condense_for_fake_super_store`]) before it is
+/// encoded; a default ACL is stored as-is, because upstream's sender strips
+/// only the access ACL. Doing this here rather than at the call sites makes
+/// this function the single owner of the on-disk `%aacl`/`%dacl` form: the
+/// condensing is idempotent, so a caller holding an ACL that already came off
+/// the wire gets the same bytes.
+///
 /// # Upstream Reference
 ///
 /// Mirrors the `am_root < 0` branch of `set_rsync_acl()` in `acls.c` lines
-/// 950-971, which calls `set_xattr_acl()` (`xattrs.c` lines 1118-1126).
+/// 1229-1245, which calls `set_xattr_acl()` (`xattrs.c` lines 1196-1207).
 #[cfg(all(unix, feature = "xattr"))]
 pub fn store_fake_super_acl(
     path: &Path,
     is_access_acl: bool,
     acl: &protocol::acl::RsyncAcl,
+    mode: u32,
 ) -> io::Result<()> {
+    let mut stored = acl.clone();
+    if is_access_acl {
+        stored.condense_for_fake_super_store(mode);
+    }
     xattr::set(
         path,
         fake_super_acl_xattr(is_access_acl),
-        &acl.to_fake_super_bytes(),
+        &stored.to_fake_super_bytes(),
     )
 }
 
@@ -753,9 +767,12 @@ mod tests {
         }
     }
 
-    // A stored access ACL must read back byte-for-byte identical, including
-    // named user/group entries - the exact round trip a `--fake-super --acls`
-    // receive-then-resend cycle depends on.
+    // A stored access ACL loses exactly the slots upstream's wire round trip
+    // loses (user_obj/other_obj, and group_obj when it equals the mode's group
+    // bits) and keeps everything else, including named user/group entries -
+    // the round trip a `--fake-super --acls` receive-then-resend depends on.
+    // The identity a reader needs is not byte equality with the source ACL: it
+    // is that every slot left as NO_ENTRY is recoverable from the mode.
     #[cfg(all(unix, feature = "xattr"))]
     #[test]
     fn store_and_load_fake_super_acl_roundtrips() {
@@ -773,20 +790,80 @@ mod tests {
         acl.names.push(IdAccess::user(1000, 0x07));
 
         // Skip when the FS can't hold user xattrs (e.g. tmpfs without support).
-        if store_fake_super_acl(&path, true, &acl).is_err() {
+        // 0o774: group bits equal the mask, the shape a real `setfacl` leaves.
+        if store_fake_super_acl(&path, true, &acl, 0o774).is_err() {
             return;
         }
 
         let loaded = load_fake_super_acl(&path, true)
             .expect("load must succeed")
             .expect("xattr must be present");
-        assert_eq!(loaded, acl);
+        let mut expected = acl.clone();
+        expected.condense_for_fake_super_store(0o774);
+        assert_eq!(loaded, expected);
+        assert_eq!(loaded.user_obj, protocol::acl::NO_ENTRY);
+        assert_eq!(loaded.other_obj, protocol::acl::NO_ENTRY);
+        // group_obj (5) differs from the mode's group bits (7), so it survives;
+        // the mask survives because the receiver restores it from those bits.
+        assert_eq!(loaded.group_obj, 0x05);
+        assert_eq!(loaded.mask_obj, 0x07);
+        assert_eq!(loaded.names.len(), 1);
 
         // The default-ACL xattr is a separate attribute; it must not exist yet.
         assert!(
             load_fake_super_acl(&path, false)
                 .expect("load must succeed")
                 .is_none()
+        );
+    }
+
+    // Wiring pin for the byte-level oracle in `protocol::acl::tests`: the bytes
+    // that actually reach the xattr must be the condensed form for `%aacl` and
+    // the verbatim form for `%dacl`. The oracle test proves the transform is the
+    // one upstream 3.5.0 produces; this proves the storage site applies it (and
+    // applies it to the access ACL only).
+    #[cfg(all(unix, feature = "xattr"))]
+    #[test]
+    fn stored_blobs_condense_the_access_acl_and_not_the_default() {
+        use protocol::acl::{IdAccess, RsyncAcl};
+
+        const NOBODY: u32 = 65534;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("acl-target");
+        std::fs::write(&path, b"body").expect("write");
+
+        // `chmod 0644 f; setfacl -m u:nobody:rwx f` leaves mode 0o674.
+        let mut acl = RsyncAcl::new();
+        acl.user_obj = 0o6;
+        acl.group_obj = 0o4;
+        acl.mask_obj = 0o7;
+        acl.other_obj = 0o4;
+        acl.names.push(IdAccess::user(NOBODY, 0o7));
+
+        // Skip when the FS can't hold user xattrs.
+        if store_fake_super_acl(&path, true, &acl, 0o674).is_err() {
+            return;
+        }
+        store_fake_super_acl(&path, false, &acl, 0o674).expect("store default ACL");
+
+        let read_u32s = |name: &str| -> Vec<u32> {
+            xattr::get(&path, name)
+                .expect("getxattr")
+                .expect("xattr present")
+                .chunks_exact(4)
+                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect()
+        };
+
+        // Measured from `rsync-3.5.0/rsync -rA -M--fake-super src/ dst/`.
+        assert_eq!(
+            read_u32s(FAKE_SUPER_ACCESS_ACL_XATTR),
+            vec![128, 4, 7, 128, NOBODY, 0x8000_0007]
+        );
+        assert_eq!(
+            read_u32s(FAKE_SUPER_DEFAULT_ACL_XATTR),
+            vec![6, 4, 7, 4, NOBODY, 0x8000_0007]
         );
     }
 
@@ -802,7 +879,7 @@ mod tests {
         // Confirm the FS supports user xattrs at all; skip otherwise.
         let probe = temp.path().join("probe");
         std::fs::write(&probe, b"probe").expect("write");
-        if store_fake_super_acl(&probe, true, &RsyncAcl::new()).is_err() {
+        if store_fake_super_acl(&probe, true, &RsyncAcl::new(), 0o644).is_err() {
             return;
         }
 
@@ -868,7 +945,7 @@ mod tests {
         fn store_fake_super_acl_stub_returns_unsupported() {
             let path = Path::new("/nonexistent/file");
             let acl = protocol::acl::RsyncAcl::new();
-            let err = store_fake_super_acl(path, true, &acl).unwrap_err();
+            let err = store_fake_super_acl(path, true, &acl, 0o644).unwrap_err();
             assert_eq!(err.kind(), io::ErrorKind::Unsupported);
         }
 

--- a/crates/metadata/src/fake_super.rs
+++ b/crates/metadata/src/fake_super.rs
@@ -505,11 +505,17 @@ pub fn remove_fake_super(_path: &Path) -> io::Result<()> {
 }
 
 /// Returns `Unsupported` on platforms without xattr support.
+///
+/// Takes `_mode` so the signature matches the xattr arm above: the two are one
+/// API with two implementations, and a caller must not have to know which arm
+/// it compiled against. The mode is unused here only because this arm stores
+/// nothing.
 #[cfg(not(all(unix, feature = "xattr")))]
 pub fn store_fake_super_acl(
     _path: &Path,
     _is_access_acl: bool,
     _acl: &protocol::acl::RsyncAcl,
+    _mode: u32,
 ) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,

--- a/crates/protocol/src/acl/entry.rs
+++ b/crates/protocol/src/acl/entry.rs
@@ -487,6 +487,42 @@ impl RsyncAcl {
         self.other_obj = NO_ENTRY;
     }
 
+    /// Condenses an access ACL into the form upstream stores in the
+    /// `--fake-super` `%aacl` xattr.
+    ///
+    /// Upstream never condenses at the storage site: `set_rsync_acl()` writes
+    /// `duo_item->racl` verbatim (`acls.c:1235-1238`). The `NO_ENTRY` slots in a
+    /// stored `%aacl` are the residue of the *wire* round trip the ACL took to
+    /// reach the receiver, so an implementation that stores an ACL it never sent
+    /// over the wire has to reproduce that round trip explicitly. It is exactly
+    /// two steps:
+    ///
+    /// 1. the sender's strip (`acls.c:888` `send_acl()` calling
+    ///    `rsync_acl_strip_perms()`), which blanks the slots recoverable from
+    ///    the file mode, and
+    /// 2. the receiver's mask restoration (`acls.c:1000-1006`
+    ///    `recv_rsync_acl()`), which puts back a mask that named entries
+    ///    require - for an access ACL from the mode's group bits.
+    ///
+    /// Composing the two leaves `mask_obj` unchanged whenever step 1 stripped it
+    /// (it strips only when the mask already equals those group bits), which is
+    /// why a stored `%aacl` keeps a real mask while `user_obj` and `other_obj`
+    /// read `NO_ENTRY`. The composition is idempotent, so applying it to an ACL
+    /// that already arrived over the wire is a no-op beyond that restoration.
+    ///
+    /// Default ACLs take no condensing: `send_acl()` strips only `acc_acl`, so
+    /// a `%dacl` blob holds the fully populated ACL.
+    pub fn condense_for_fake_super_store(&mut self, mode: u32) {
+        self.strip_perms_for_send(mode);
+
+        // upstream: acls.c:1000-1006 recv_rsync_acl() - "Mask must be non-empty
+        // with lists", and for SMB_ACL_TYPE_ACCESS the replacement value is
+        // `(mode >> 3) & 7` rather than the OR of the named entries' bits.
+        if !self.names.is_empty() && self.mask_obj == NO_ENTRY {
+            self.mask_obj = ((mode >> 3) & 7) as u8;
+        }
+    }
+
     /// Reports whether two ACLs are exactly equal in every object and named
     /// entry. Used for the default ACL of a directory, which upstream compares
     /// with strict equality (default ACLs are transmitted un-stripped, so both

--- a/crates/protocol/src/acl/tests.rs
+++ b/crates/protocol/src/acl/tests.rs
@@ -2090,3 +2090,145 @@ mod strip_perms_for_send_tests {
         }
     }
 }
+
+/// Byte-level oracle for the `--fake-super` ACL blobs, measured against the
+/// real upstream rsync 3.5.0 binary rather than derived from oc's own encoder.
+///
+/// A store/load round trip through [`RsyncAcl::to_fake_super_bytes`] and
+/// [`RsyncAcl::from_fake_super_bytes`] cannot see the defect these tests exist
+/// for: oc's encoder and decoder are symmetric, so a blob that omits upstream's
+/// `NO_ENTRY` slots round-trips perfectly while being byte-incompatible with a
+/// tree upstream wrote or reads.
+///
+/// Each `UPSTREAM_*` constant below is the `user.rsync.%aacl` / `%dacl` value
+/// decoded as little-endian `u32`s from a real run of
+/// `rsync-3.5.0/rsync -rA -M--fake-super src/ dst/` on Linux (`-M--fake-super`
+/// puts the receiving side, and only the receiving side, into fake-super mode -
+/// the invocation `testsuite/fake-super-acl-xattr_test.py` leg 1 uses).
+mod fake_super_store_oracle_tests {
+    use super::*;
+
+    /// Named-entry access value as it appears in a stored blob: the in-memory
+    /// `NAME_IS_USER` bit is written verbatim, so a named *user* with `rwx`
+    /// encodes as `0x8000_0007`.
+    const NAMED_USER_RWX: u32 = NAME_IS_USER | 0x07;
+    const NAMED_USER_RX: u32 = NAME_IS_USER | 0x05;
+    const NOBODY: u32 = 65534;
+
+    /// `chmod 0644 f; setfacl -m u:nobody:rwx f` - setfacl raises the mode's
+    /// group bits to the new mask, leaving mode 0o674.
+    const UPSTREAM_FILE_AACL: [u32; 6] = [128, 4, 7, 128, NOBODY, NAMED_USER_RWX];
+
+    /// `chmod 0755 d; setfacl -m u:nobody:rx d` on a directory (mode 0o755).
+    const UPSTREAM_DIR_AACL: [u32; 6] = [128, 128, 5, 128, NOBODY, NAMED_USER_RX];
+
+    /// `setfacl -d -m u:nobody:rwx d` on the same directory.
+    const UPSTREAM_DIR_DACL: [u32; 6] = [7, 5, 7, 5, NOBODY, NAMED_USER_RWX];
+
+    fn le_u32s(bytes: &[u8]) -> Vec<u32> {
+        bytes
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    /// The access ACL of `f` as `getfacl` reports it: `user::rw-`,
+    /// `user:nobody:rwx`, `group::r--`, `mask::rwx`, `other::r--`.
+    fn file_access_acl() -> RsyncAcl {
+        let mut acl = RsyncAcl::new();
+        acl.user_obj = 0o6;
+        acl.group_obj = 0o4;
+        acl.mask_obj = 0o7;
+        acl.other_obj = 0o4;
+        acl.names.push(IdAccess::user(NOBODY, 0o7));
+        acl
+    }
+
+    /// The access ACL of `d`: `user::rwx`, `user:nobody:r-x`, `group::r-x`,
+    /// `mask::r-x`, `other::r-x`.
+    fn dir_access_acl() -> RsyncAcl {
+        let mut acl = RsyncAcl::new();
+        acl.user_obj = 0o7;
+        acl.group_obj = 0o5;
+        acl.mask_obj = 0o5;
+        acl.other_obj = 0o5;
+        acl.names.push(IdAccess::user(NOBODY, 0o5));
+        acl
+    }
+
+    /// The default ACL of `d`: `user::rwx`, `user:nobody:rwx`, `group::r-x`,
+    /// `mask::rwx`, `other::r-x`.
+    fn dir_default_acl() -> RsyncAcl {
+        let mut acl = RsyncAcl::new();
+        acl.user_obj = 0o7;
+        acl.group_obj = 0o5;
+        acl.mask_obj = 0o7;
+        acl.other_obj = 0o5;
+        acl.names.push(IdAccess::user(NOBODY, 0o7));
+        acl
+    }
+
+    #[test]
+    fn file_access_blob_matches_upstream_3_5_0() {
+        let mut acl = file_access_acl();
+        acl.condense_for_fake_super_store(0o674);
+        assert_eq!(le_u32s(&acl.to_fake_super_bytes()), UPSTREAM_FILE_AACL);
+    }
+
+    #[test]
+    fn dir_access_blob_matches_upstream_3_5_0() {
+        let mut acl = dir_access_acl();
+        acl.condense_for_fake_super_store(0o755);
+        assert_eq!(le_u32s(&acl.to_fake_super_bytes()), UPSTREAM_DIR_AACL);
+    }
+
+    // Upstream's sender strips only the access ACL (`send_acl()`, acls.c:888
+    // passes `sxp->acc_acl`), so the default ACL reaches the receiver fully
+    // populated and is stored verbatim. Condensing it would be a divergence in
+    // the opposite direction, so this pins that it is NOT condensed.
+    #[test]
+    fn dir_default_blob_is_stored_verbatim() {
+        let acl = dir_default_acl();
+        assert_eq!(le_u32s(&acl.to_fake_super_bytes()), UPSTREAM_DIR_DACL);
+    }
+
+    // Non-vacuity: without the condensing step the same two ACLs encode to
+    // something upstream never writes. If this ever stops holding, the two
+    // assertions above have become tautologies.
+    #[test]
+    fn uncondensed_access_blobs_differ_from_upstream() {
+        assert_ne!(
+            le_u32s(&file_access_acl().to_fake_super_bytes()),
+            UPSTREAM_FILE_AACL
+        );
+        assert_ne!(
+            le_u32s(&dir_access_acl().to_fake_super_bytes()),
+            UPSTREAM_DIR_AACL
+        );
+    }
+
+    // The composition is idempotent, which is what lets one storage site serve
+    // both the local-copy path (a freshly read filesystem ACL) and the network
+    // path (an ACL that already took upstream's strip on the wire).
+    #[test]
+    fn condensing_is_idempotent() {
+        for (mut acl, mode) in [(file_access_acl(), 0o674), (dir_access_acl(), 0o755)] {
+            acl.condense_for_fake_super_store(mode);
+            let once = acl.clone();
+            acl.condense_for_fake_super_store(mode);
+            assert_eq!(acl, once);
+        }
+    }
+
+    // An access ACL with no named entries has no mask to restore, so the whole
+    // group slot is derivable and only the mask stays NO_ENTRY.
+    #[test]
+    fn base_only_access_acl_keeps_nothing_but_the_absent_mask() {
+        let mut acl = RsyncAcl::from_mode(0o644);
+        acl.condense_for_fake_super_store(0o644);
+        assert_eq!(
+            le_u32s(&acl.to_fake_super_bytes()),
+            vec![128, 128, 128, 128]
+        );
+    }
+}

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -165,6 +165,7 @@ fn apply_metadata_acls_and_xattrs(
                     access_ndx,
                     entry.def_acl_ndx(),
                     follow,
+                    entry.mode(),
                 )
             } else {
                 metadata::apply_acls_from_cache(


### PR DESCRIPTION
## What

A fake-super `%aacl` written by oc was not byte-compatible with the blob upstream
writes for the same ACL, so a tree written by one and read by the other disagreed.

Measured against a real `rsync-3.5.0` binary, all three blob kinds now match:

| blob | upstream 3.5.0 | before | after |
|---|---|---|---|
| file `%aacl` | `[128,4,7,128,65534,0x80000007]` | `[6,4,7,4,…]` | identical |
| dir `%aacl` | `[128,128,5,128,65534,0x80000005]` | unstripped | identical |
| dir `%dacl` | `[7,5,7,5,65534,0x80000007]` | verbatim | identical |

## The mechanism, which is not the obvious one

`rsync_acl_strip_perms` has exactly **one** call site — `send_acl()` at `acls.c:888`,
the wire send path. The xattr-store path does **not** strip: `set_rsync_acl()`'s
`am_root < 0` branch (`acls.c:1229-1245`) writes the struct verbatim.

So the `NO_ENTRY` slots in a stored blob are the *residue of a wire round trip*, and
that trip is two steps:

1. `send_acl()` → `rsync_acl_strip_perms()` blanks `user_obj`, `other_obj`, and
   `group_obj`/`mask_obj` where mode-derivable.
2. `recv_rsync_acl()` (`acls.c:1000-1006`) restores a mask that named entries
   require — `(mode >> 3) & 7` for ACCESS.

Composing them leaves `mask_obj` populated while `user_obj`/`other_obj` read
`NO_ENTRY`. **Porting only the strip would have written `mask = NO_ENTRY` where
upstream writes `7`** — a new divergence in place of the old one.

## Deliberately unchanged

`send_acl()` passes `def_acl` to `send_rsync_acl` unstripped, so a `%dacl` blob holds
the fully populated ACL. oc was already correct there; condensing it would be a
regression. `dir_default_blob_is_stored_verbatim` pins that so a later "consistency"
cleanup cannot break it.

## Verification

Oracle tests pin golden `u32` vectors captured from a real
`rsync-3.5.0 -rA -M--fake-super` run on Linux with real ACLs and real `user.rsync.*`
xattrs. The reproducing command is in the module rustdoc. This is deliberately **not**
a round-trip: a round-trip through oc's own encoder is symmetric and cannot see this
defect. An existing test, `store_and_load_fake_super_acl_roundtrips`, asserted the
stored blob reads back byte-identical — false, and false for exactly that reason. It
has been corrected.

Two mutations, both lethal, covering transform and wiring separately:

- transform no-op → 3 passed / 3 failed (`dir_access` reports
  `left [7,5,5,5,…]` vs `right [128,128,5,128,…]`); the `%dacl` pin, the non-vacuity
  companion and the idempotence test correctly stay green.
- condensing dropped at the storage site only → 33 passed / 2 failed.

`fmt` and workspace `clippy` exit 0; `-p protocol -p metadata --all-features --lib`
4399 passed / 0 failed.

## Not verified

- The oc↔oc **network** fake-super path end-to-end. The ssh route fails on the test
  host with a phase-transition error that reproduces **without** `-A` and **without**
  `--fake-super`, so it is unrelated to ACLs — but it means the network mask
  restoration is proven by unit test and source reading only, never by a live
  transfer.
- Full-workspace nextest was not run locally; per-crate runs do not cover root-level
  `tests/`. CI covers it.
- This flips **no** manifest row. The `fake-super-acl-xattr` cell needs
  `-M--fake-super`, which oc still refuses on a local transfer — a separate residual.
