### PR TITLE
fix(receiver): stop confining a client's destination on a daemon pull

### DIFF
--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -8,7 +8,7 @@ pub use error::BuilderError;
 
 use std::ffi::OsString;
 use std::num::NonZeroU32;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use bandwidth::BandwidthLimitComponents;
@@ -327,6 +327,35 @@ pub struct ConnectionConfig {
     /// - `options.c:2394-2397` - `bwlimit_writemax = bwlimit * 128`, min 512.
     /// - `main.c:1068` - the receiver disables its own bwlimit.
     pub bwlimit: Option<BandwidthLimitComponents>,
+}
+
+impl ConnectionConfig {
+    /// The module root this process serves **as the daemon**, or `None` when it
+    /// is not one.
+    ///
+    /// This is oc-rsync's `am_daemon`, and it is deliberately not
+    /// [`is_daemon_connection`](Self::is_daemon_connection). That flag is set on
+    /// BOTH ends of an `rsync://` transfer - the connecting client sets it too -
+    /// while upstream's `am_daemon` is true only in the serving process. Every
+    /// confinement decision upstream gates on `am_daemon` must read this
+    /// instead, or a client pulling from a daemon has a daemon's confinement
+    /// applied to its own local destination, which upstream leaves unconfined.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:1093` - `use_secure_symlinks = am_daemon &&
+    ///   (!am_chrooted || module_dirlen)`
+    /// - `syscall.c:136` - `confinement_root()` yields `module_dir` only when
+    ///   `am_daemon`
+    /// - `receiver.c:152` - `if (!am_daemon || ...)` takes the plain-open arm
+    #[must_use]
+    pub fn served_module_root(&self) -> Option<&Path> {
+        if self.is_daemon_connection {
+            self.daemon_module_root.as_deref()
+        } else {
+            None
+        }
+    }
 }
 
 /// File selection and filtering options for transfer candidates.

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -24,7 +24,7 @@ use crate::shared::ChecksumFactory;
 use crate::transfer_state::TransferPhase;
 
 #[cfg(unix)]
-use super::sandbox::{open_sandbox_for_dest_anchored, open_sandbox_for_dest_strict};
+use super::sandbox::{open_sandbox_for_dest, open_sandbox_for_dest_anchored};
 use super::wire_filters::parse_wire_filters_for_receiver;
 
 /// Merges the daemon module `incoming chmod` modifiers with the client
@@ -712,20 +712,32 @@ impl ReceiverContext {
         // relative to the resolved cwd. We mirror that by canonicalizing
         // here instead of relying on chdir.
         //
-        // Skipped under daemon connections: the daemon strict path in
-        // `open_sandbox_for_dest_strict` refuses a symlinked dest outright
-        // (chdir-symlink-race defense), and the module loader has already
-        // restricted `module.path`. Canonicalizing here would mask the
-        // symlink and let strict mode silently succeed against the resolved
-        // target. Local-mode and non-daemon SSH transfers are the
-        // upstream-parity case (issue #715 `symlink-dirlink-basis`).
+        // Skipped only in the daemon SERVER process: there `dest_dir` is
+        // `<module root>/<peer tail>` and `open_sandbox_for_dest_anchored`
+        // gives each half its own resolve policy. Canonicalizing first would
+        // mask a symlinked tail and let the anchored walk succeed against the
+        // already-resolved target. Every other receiver - local, SSH, and the
+        // CLIENT half of an `rsync://` pull - is `am_daemon == 0` upstream and
+        // gets `change_dir()`'s ordinary resolution (issue #715
+        // `symlink-dirlink-basis`).
+        //
+        // The probe runs on the operand with its trailing separators trimmed.
+        // `lstat("dest/")` resolves the link - the kernel reads a trailing
+        // separator as a directory reference - so probing the operand verbatim
+        // reports a directory for exactly the shape that needs resolving, and
+        // `oc-rsync -a rsync://h/m/ DEST/` then carried the link path into the
+        // metadata apply and failed it. Upstream never meets the distinction:
+        // `change_dir()` chdir's through both spellings alike.
+        // `Components::as_path` trims separators without collapsing `.` or
+        // `..`, so nothing else about the operand moves.
+        let probe = dest_dir.components().as_path().to_path_buf();
         let dest_dir = if !self.config.flags.skip_dest_writes()
-            && !self.config.connection.is_daemon_connection
-            && dest_dir
+            && self.config.connection.served_module_root().is_none()
+            && probe
                 .symlink_metadata()
                 .is_ok_and(|m| m.file_type().is_symlink())
         {
-            match std::fs::canonicalize(&dest_dir) {
+            match std::fs::canonicalize(&probe) {
                 Ok(resolved) => {
                     debug_log!(
                         Recv,
@@ -777,37 +789,28 @@ impl ReceiverContext {
         // destination root may not exist yet, and the existing
         // path-based fall-backs cover that case today).
         //
-        // Daemon receivers without chroot tighten this: a leaf-symlink at
-        // the destination is the chdir-symlink-race attack window, so we
-        // refuse the transfer outright when DirSandbox open fails with
-        // ELOOP/ENOTDIR instead of falling through to path-based syscalls
-        // that would follow the symlink. ENOENT (first-run push that has
-        // not created the directory yet) and EACCES (real permission
-        // problems) keep the existing soft-fail behaviour.
-        // upstream: clientserver.c:1018 - `use_secure_symlinks = am_daemon
-        // && !am_chrooted` gates the do_*_at wrappers in syscall.c that
-        // implement the same refusal.
-        //
-        // A daemon receiver takes the anchored path instead. `dest_dir` is
-        // `module_root.join(peer_tail)` (see
+        // Only the daemon SERVER confines its destination. `dest_dir` is
+        // `module_root.join(peer_tail)` there (see
         // `open_sandbox_for_dest_anchored`), and the two halves are not
         // equally trusted: the operator authored the root, the client sent
         // the tail. Opening the fused string under one resolve policy made
         // an operator's own symlinked module root - `path = /srv/...` where
         // `/srv` is a link - refuse every transfer, because the policy that
         // belongs to the tail was being applied to the root as well.
+        //
+        // upstream: clientserver.c:1093 - `use_secure_symlinks = am_daemon &&
+        // (!am_chrooted || module_dirlen)` gates the do_*_at wrappers in
+        // syscall.c. `am_daemon` is the serving process only, so the client
+        // half of an `rsync://` pull, an SSH server receiver and a local
+        // receiver are all unconfined here and take the plain-open arm of
+        // `secure_basis_open()` (receiver.c:152). Reading
+        // `is_daemon_connection` instead - it is set on BOTH ends of an
+        // `rsync://` transfer - made oc refuse an ordinary symlinked
+        // destination on a daemon pull that upstream accepts.
         #[cfg(unix)]
-        let sandbox = {
-            let strict = self.config.connection.is_daemon_connection;
-            match self.config.connection.daemon_module_root.as_deref() {
-                Some(module_root) if strict => {
-                    open_sandbox_for_dest_anchored(module_root, &dest_dir)?
-                }
-                // No module root recorded (every non-daemon receiver, plus a
-                // daemon connection that never resolved one): there is no
-                // operator/peer split to make, so keep the existing open.
-                _ => open_sandbox_for_dest_strict(&dest_dir, strict)?,
-            }
+        let sandbox = match self.config.connection.served_module_root() {
+            Some(module_root) => open_sandbox_for_dest_anchored(module_root, &dest_dir)?,
+            None => open_sandbox_for_dest(&dest_dir),
         };
 
         // FSM: file list received and sanitized. Advance to DeltaTransfer.

--- a/crates/transfer/src/receiver/transfer/setup/sandbox.rs
+++ b/crates/transfer/src/receiver/transfer/setup/sandbox.rs
@@ -1,29 +1,52 @@
 //! Destination-root sandbox carriers for the receiver transfer setup.
 //!
 //! Opens the destination root as a [`fast_io::DirSandbox`] so the per-entry
-//! `*at` syscall cutover sites can ride a sandboxed dirfd. The strict variant
-//! propagates symlink-class refusals as a transfer error for daemon receivers
-//! without chroot (the chdir-symlink-race defence).
+//! `*at` syscall cutover sites can ride a sandboxed dirfd. The split mirrors
+//! upstream's `am_daemon` gate: a daemon server takes the anchored variant,
+//! which confines the peer-supplied tail beneath the operator's module root
+//! (the chdir-symlink-race defence), and every other receiver takes the plain
+//! variant, which upstream leaves unconfined.
 
 #[cfg(unix)]
 use std::io;
 #[cfg(unix)]
 use std::sync::Arc;
 
-/// Open the destination root as a [`fast_io::DirSandbox`] carrier.
+/// Open the destination root as a [`fast_io::DirSandbox`] carrier for a
+/// receiver that applies no confinement.
 ///
 /// Returns `Some(Arc<DirSandbox>)` when the path exists and resolves to
 /// a non-symlink directory the receiver can open. Returns `None` for any
 /// other outcome (path does not exist yet, path is a symlink, EACCES,
-/// etc.) so the receiver can keep running on the existing path-based
+/// etc.) so the receiver keeps running on the existing path-based
 /// fall-backs while the SEC-1.f-j cutover lands site by site.
+///
+/// This is the arm for every receiver upstream leaves unconfined -
+/// local, SSH server, and the client half of an `rsync://` pull. There a
+/// failed sandbox open is not a degraded security posture but the normal
+/// state: `secure_basis_open()` takes its `if (!am_daemon || ...)` branch
+/// and does a plain `do_open`, so following a symlinked destination is the
+/// behaviour, not a fall-back from it. The daemon server takes
+/// [`open_sandbox_for_dest_anchored`] instead, which is where a failure
+/// does mean lost confinement and says so out loud.
 ///
 /// Failures are logged at `Debug` level only; they are expected on
 /// first-run transfers where the destination is created later in
-/// `ensure_relative_parents` / `create_directories`.
+/// `ensure_relative_parents` / `create_directories`. `--debug=recv2`
+/// reaches them, matching upstream, whose `-v` ladder likewise never
+/// raises RECV past 1 (`options.c:248` `debug_verbosity[3]`).
+///
+/// # Upstream Reference
+///
+/// - `clientserver.c:1093` - `use_secure_symlinks = am_daemon &&
+///   (!am_chrooted || module_dirlen)`
+/// - `receiver.c:152` - the `if (!am_daemon || ...)` plain-open arm of
+///   `secure_basis_open()`
+/// - `syscall.c:136` - `confinement_root()` is `module_dir` only for a daemon
 #[cfg(unix)]
-#[allow(dead_code)] // kept for tests; the strict variant is the active call site.
-fn open_sandbox_for_dest(dest_dir: &std::path::Path) -> Option<Arc<fast_io::DirSandbox>> {
+pub(super) fn open_sandbox_for_dest(
+    dest_dir: &std::path::Path,
+) -> Option<Arc<fast_io::DirSandbox>> {
     match fast_io::DirSandbox::open_root(dest_dir) {
         Ok(sandbox) => Some(Arc::new(sandbox)),
         Err(err) => {
@@ -34,66 +57,6 @@ fn open_sandbox_for_dest(dest_dir: &std::path::Path) -> Option<Arc<fast_io::DirS
                 dest_dir.display()
             );
             None
-        }
-    }
-}
-
-/// Open the destination root as a [`fast_io::DirSandbox`] carrier and, when
-/// `strict` is set, propagate symlink-class refusals as a transfer error.
-///
-/// When `strict` is `false` this is identical to [`open_sandbox_for_dest`]:
-/// every failure falls back to path-based syscalls.
-///
-/// When `strict` is `true` the failure mode splits by errno:
-/// - `ELOOP` / `ENOTDIR`: the destination resolves through a symlink, which
-///   is the chdir-symlink-race attack window. Convert to `io::Error` so the
-///   transfer fails before any data lands on disk and no path-relative
-///   syscall ever resolves through the attacker-planted symlink.
-/// - `ENOENT`: the destination does not exist yet (first-run push). Return
-///   `Ok(None)` so the receiver creates it through the existing
-///   `ensure_relative_parents` / `create_directories` path.
-/// - Any other error: keep the soft-fall-back so legitimate permission or
-///   I/O problems surface at a more specific call site downstream.
-///
-/// # Upstream Reference
-///
-/// - `clientserver.c:1018` - `use_secure_symlinks = am_daemon &&
-///   !am_chrooted` gates the do_*_at wrappers in `syscall.c`.
-/// - `util1.c:1175-1216` - `change_dir()`'s
-///   `secure_relative_open()` + `fchdir()` branch refuses the symlink at the
-///   same level the chdir-symlink-race POC plants it.
-#[cfg(unix)]
-pub(super) fn open_sandbox_for_dest_strict(
-    dest_dir: &std::path::Path,
-    strict: bool,
-) -> io::Result<Option<Arc<fast_io::DirSandbox>>> {
-    match fast_io::DirSandbox::open_root(dest_dir) {
-        Ok(sandbox) => Ok(Some(Arc::new(sandbox))),
-        Err(err) => {
-            let code = err.raw_os_error();
-            let is_symlink_refusal = matches!(
-                code,
-                Some(libc::ELOOP) | Some(libc::ENOTDIR) | Some(libc::EXDEV)
-            );
-            if strict && is_symlink_refusal {
-                return Err(io::Error::new(
-                    err.kind(),
-                    format!(
-                        "refusing to open destination '{}' via a symlink: \
-                         {err} (errno={}) (would expose the \
-                         chdir-symlink-race attack window)",
-                        dest_dir.display(),
-                        code.unwrap_or(0),
-                    ),
-                ));
-            }
-            logging::debug_log!(
-                Recv,
-                2,
-                "DirSandbox::open_root({}) failed: {err}; falling back to path-based syscalls",
-                dest_dir.display()
-            );
-            Ok(None)
         }
     }
 }
@@ -185,12 +148,18 @@ pub(super) fn open_sandbox_for_dest_anchored(
             // dirfd and will fall back to path-based syscalls - it keeps
             // running, but without the per-component confinement its role
             // is supposed to have. Upstream confines exactly this role
-            // (`use_secure_symlinks = am_daemon && !am_chrooted`,
-            // clientserver.c:1018), so degrading is worth saying out loud.
+            // (`use_secure_symlinks = am_daemon && (!am_chrooted ||
+            // module_dirlen)`, clientserver.c:1093), so degrading is worth
+            // saying out loud.
             //
-            // Warning, not debug: `debug_log!` here is unreachable at every
-            // verbosity an operator can actually set, which made this
-            // condition unobservable in the field. upstream: FWARNING is
+            // Warning, not debug, because a daemon silently losing its
+            // confinement is an operator-facing condition, not a trace. Not
+            // because `debug_log!` would be unreachable: `--debug=recv2`
+            // reaches level 2 (measured). What the `-v` ladder alone cannot
+            // reach is upstream's own arrangement - `debug_verbosity[3]`
+            // (options.c:248) sets RECV to 1 and no later level raises it -
+            // so a debug channel here would be invisible to `-vvvvv`, which
+            // is what an operator actually reaches for. upstream: FWARNING is
             // dispatched by rwrite() (log.c:341) and is not verbosity-gated.
             logging::warn_log!(
                 "receiver: could not anchor destination '{}' under module \
@@ -203,10 +172,11 @@ pub(super) fn open_sandbox_for_dest_anchored(
     }
 }
 
-// upstream: clientserver.c:1018 - use_secure_symlinks gating that the
-// chdir-symlink-race fix mirrors. Tests below verify the strict daemon
-// branch refuses a leaf-symlink at the destination while the legacy
-// non-daemon branch preserves the existing soft-fail behaviour.
+// upstream: clientserver.c:1093 - `use_secure_symlinks = am_daemon &&
+// (!am_chrooted || module_dirlen)`, the gating the chdir-symlink-race fix
+// mirrors. Tests below verify the anchored daemon branch confines the
+// peer-supplied tail beneath the operator's module root, while the plain
+// branch - every receiver upstream leaves unconfined - keeps its soft-fail.
 #[cfg(all(test, unix))]
 mod symlink_race_tests {
     use super::*;
@@ -219,64 +189,40 @@ mod symlink_race_tests {
         (dir, canon)
     }
 
+    /// A symlinked destination root must never become a hard refusal on the
+    /// unconfined path. `DirSandbox::open_root` declines to open through the
+    /// link, so the receiver takes `None` and keeps running on the path-based
+    /// syscalls - which follow the link, exactly as upstream's
+    /// `secure_basis_open()` plain-open arm does for `am_daemon == 0`
+    /// (receiver.c:152).
+    ///
+    /// Returning `Err` here instead is what made `oc-rsync -a rsync://h/m/ DEST`
+    /// exit 23 on a symlinked `DEST` that real rsync 3.5.0 transfers into.
     #[test]
-    fn strict_mode_refuses_symlink_destination() {
+    fn unconfined_open_soft_fails_for_a_symlinked_destination() {
         let (_keep, root) = canonical_tempdir();
         let outside = root.join("outside");
         std::fs::create_dir(&outside).expect("create outside dir");
         let subdir = root.join("subdir");
         symlink(&outside, &subdir).expect("symlink subdir -> outside");
 
-        let err = open_sandbox_for_dest_strict(&subdir, true)
-            .expect_err("daemon receiver must refuse a symlink destination");
-        // The wrapped error embeds the underlying errno from
-        // `DirSandbox::open_root` (ELOOP on Linux + openat2; ENOTDIR on
-        // macOS/BSD where O_DIRECTORY is evaluated before O_NOFOLLOW).
-        // Both prove the symlink was refused at the syscall layer. The
-        // wrapped Display also carries the security-context message so
-        // operators see why the transfer aborted. Asserting on the embedded
-        // errno avoids the unstable `io::ErrorKind::FilesystemLoop` /
-        // `NotADirectory` variants (rust-lang/rust#86442).
-        let msg = err.to_string();
-        let expected_errno_a = format!("errno={}", libc::ELOOP);
-        let expected_errno_b = format!("errno={}", libc::ENOTDIR);
         assert!(
-            msg.contains(&expected_errno_a) || msg.contains(&expected_errno_b),
-            "expected ELOOP or ENOTDIR errno embedded in message, got: {err}"
-        );
-        assert!(
-            msg.contains("chdir-symlink-race"),
-            "expected chdir-symlink-race security context in message, got: {err}"
+            open_sandbox_for_dest(&subdir).is_none(),
+            "an unconfined receiver must soft-fail to the path-based syscalls, \
+             not refuse the transfer"
         );
     }
 
     #[test]
-    fn non_strict_mode_falls_back_for_symlink_destination() {
-        let (_keep, root) = canonical_tempdir();
-        let outside = root.join("outside");
-        std::fs::create_dir(&outside).expect("create outside dir");
-        let subdir = root.join("subdir");
-        symlink(&outside, &subdir).expect("symlink subdir -> outside");
-
-        let result = open_sandbox_for_dest_strict(&subdir, false)
-            .expect("non-daemon receiver keeps soft-fail behaviour");
-        // The sandbox open failed, but the receiver still gets None and
-        // falls through to the path-based syscall path (existing
-        // behaviour before the chdir-symlink-race fix).
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn strict_mode_accepts_real_directory_destination() {
+    fn unconfined_open_accepts_a_real_directory_destination() {
         let (_keep, root) = canonical_tempdir();
         let real = root.join("realdir");
         std::fs::create_dir(&real).expect("create real dir");
 
-        let result = open_sandbox_for_dest_strict(&real, true)
-            .expect("real directory must open under strict mode");
         assert!(
-            result.is_some(),
-            "strict mode must hand back a sandbox when the dest is a real dir"
+            open_sandbox_for_dest(&real).is_some(),
+            "the unconfined open must hand back a sandbox when the dest is a \
+             real dir; otherwise the *at cutover never engages"
         );
     }
 
@@ -323,11 +269,10 @@ mod symlink_race_tests {
         // for a reason unrelated to the fix.
         #[cfg(target_os = "linux")]
         {
-            let old = open_sandbox_for_dest_strict(&module_root, true);
             assert!(
-                old.is_err(),
-                "control failed: the pre-fix path accepted this layout, so \
-                 the assertion above cannot be evidence of the fix"
+                open_sandbox_for_dest(&module_root).is_none(),
+                "control failed: the fused single-policy open accepted this \
+                 layout, so the assertion above cannot be evidence of the fix"
             );
         }
     }
@@ -459,12 +404,13 @@ mod symlink_race_tests {
     }
 
     #[test]
-    fn strict_mode_soft_fails_when_destination_is_missing() {
+    fn unconfined_open_soft_fails_when_destination_is_missing() {
         let (_keep, root) = canonical_tempdir();
         let missing = root.join("not-yet-created");
 
-        let result = open_sandbox_for_dest_strict(&missing, true)
-            .expect("ENOENT must be a soft failure - first-run push will mkdir later");
-        assert!(result.is_none());
+        assert!(
+            open_sandbox_for_dest(&missing).is_none(),
+            "ENOENT must be a soft failure - first-run push will mkdir later"
+        );
     }
 }

--- a/crates/transfer/tests/daemon_pull_symlinked_dest_root.rs
+++ b/crates/transfer/tests/daemon_pull_symlinked_dest_root.rs
@@ -1,0 +1,376 @@
+//! A client pulling from a daemon must not apply the daemon's own destination
+//! confinement to its local destination root.
+//!
+//! # Background
+//!
+//! Upstream gates the receiver's confined `*at` resolver on `am_daemon`:
+//! `use_secure_symlinks = am_daemon && (!am_chrooted || module_dirlen)`
+//! (`clientserver.c:1093`), and `confinement_root()` hands back `module_dir`
+//! only when `am_daemon` (`syscall.c:136`). `am_daemon` is true in the *serving*
+//! process, never in the client that dials `rsync://`. So on a pull the client
+//! is an ordinary, unconfined receiver: `secure_basis_open()` takes its
+//! `if (!am_daemon || ...)` arm (`receiver.c:152`) and does a plain `do_open`,
+//! and a symlinked destination root is followed exactly as it is for a local
+//! copy or an SSH pull.
+//!
+//! oc-rsync carries `ConnectionConfig::is_daemon_connection`, which is set on
+//! BOTH ends of an `rsync://` transfer - the connecting client sets it in
+//! `apply_common_daemon_config`, the daemon server in `build_server_config`. It
+//! is therefore not `am_daemon`. `daemon_module_root` is: it is populated only
+//! by the daemon's own `apply_module_transfer_directives`. The receiver's
+//! sandbox decision must read the latter, which is what
+//! `ConnectionConfig::served_module_root` exists to express.
+//!
+//! # Why this matters (Rule 9)
+//!
+//! A symlinked destination directory is an ordinary deployment shape
+//! (`/srv/backup -> /mnt/big/backup`). Measured against real rsync 3.5.0 on a
+//! loopback daemon, `rsync -a rsync://host/mod/ DEST` where `DEST` is such a
+//! symlink exits 0 and installs the file at the link target, with and without a
+//! trailing slash. Before this fix oc-rsync exited 23 on both spellings: the
+//! no-slash form was refused outright with a "chdir-symlink-race" message, and
+//! the trailing-slash form completed the data transfer but failed metadata
+//! application, leaving the file at mode 0600.
+//!
+//! Asserting only on the exit status would let a build that quietly created a
+//! real `DEST/` directory next to the symlink pass, so both cells assert the
+//! payload landed at the *link target* - the fixture's proof that the symlink
+//! was followed rather than replaced.
+//!
+//! # Platform gate
+//!
+//! `#![cfg(unix)]` - matches the sibling daemon-spawning tests; the
+//! `use chroot = false` toggle needs Unix process semantics, and the assertion
+//! reads a Unix mode.
+//!
+//! # Skip semantics
+//!
+//! Self-skips (prints `skipping:` and returns) when a tempdir cannot be made or
+//! the daemon fails to start. A non-zero exit, a payload that did not reach the
+//! link target, or a wrong mode are real regressions.
+//!
+//! # Upstream References
+//!
+//! - `clientserver.c:1093` - `use_secure_symlinks = am_daemon && ...`
+//! - `syscall.c:136` - `confinement_root()` returns `module_dir` only for a daemon
+//! - `receiver.c:152` - `if (!am_daemon || ...)` plain-open arm of `secure_basis_open()`
+//! - `main.c:757` - `change_dir(dest_path, CD_NORMAL)` resolves a symlinked
+//!   destination root once, for every non-daemon receiver
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use tempfile::{TempDir, tempdir};
+
+/// Payload the pull must install at the destination.
+const PAYLOAD: &[u8] = b"symlinked-dest-root payload\n";
+
+/// Source mode the transfer must reproduce under `--perms`. Deliberately not
+/// the umask default, so a receiver that never applied the mode is visible.
+const PAYLOAD_MODE: u32 = 0o640;
+
+/// Write an `rsyncd.conf` exposing one read-only module rooted at
+/// `module_root`. `use chroot = false` keeps the unprivileged test process from
+/// needing `CAP_SYS_CHROOT`.
+fn write_daemon_config(
+    config_path: &Path,
+    pid_path: &Path,
+    log_path: &Path,
+    module_name: &str,
+    module_root: &Path,
+) -> io::Result<()> {
+    let body = format!(
+        "pid file = {pid}\n\
+         log file = {log}\n\
+         use chroot = false\n\
+         max connections = 4\n\
+         \n\
+         [{module}]\n\
+         path = {root}\n\
+         comment = symlinked-dest-root regression\n\
+         read only = true\n\
+         list = true\n",
+        pid = pid_path.display(),
+        log = log_path.display(),
+        module = module_name,
+        root = module_root.display(),
+    );
+    fs::write(config_path, body)
+}
+
+/// Guard that kills the daemon child on drop so a panicking test never leaks
+/// the listener.
+struct DaemonGuard {
+    child: Child,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn `oc-rsync --daemon` on a free loopback port against `config_path` and
+/// wait until it accepts connections.
+fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
+}
+
+/// Drive one `oc-rsync` invocation and return `(status, stdout, stderr)`.
+fn run_oc_rsync_capture(
+    bin: &Path,
+    args: &[&OsStr],
+) -> io::Result<(std::process::ExitStatus, String, String)> {
+    let output = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+    Ok((
+        output.status,
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    ))
+}
+
+/// Per-test scratch state: tempdir plus daemon log/pid/config paths.
+struct Scratch {
+    _tmp: TempDir,
+    root: PathBuf,
+    config: PathBuf,
+    log: PathBuf,
+    pid: PathBuf,
+}
+
+impl Scratch {
+    fn new() -> Option<Self> {
+        let tmp = tempdir().ok()?;
+        // `DirSandbox::open_root` refuses a symlink anywhere in the path under
+        // `RESOLVE_NO_SYMLINKS`, and macOS resolves `/tmp -> /private/tmp`, so
+        // canonicalise before the fixture plants its own symlink. Otherwise the
+        // ambient prefix, not the planted link, is what the test measures.
+        let root = fs::canonicalize(tmp.path()).ok()?;
+        Some(Self {
+            config: root.join("rsyncd.conf"),
+            log: root.join("rsyncd.log"),
+            pid: root.join("rsyncd.pid"),
+            root,
+            _tmp: tmp,
+        })
+    }
+}
+
+/// Where the fixture plants its symlink relative to the destination operand.
+#[derive(Clone, Copy)]
+enum LinkAt {
+    /// `DEST` itself is the symlink. Reachable by the leaf `O_NOFOLLOW` check
+    /// on every platform.
+    Leaf,
+    /// `DEST` is a real directory under a symlinked ancestor - the ordinary
+    /// `/srv -> /mnt/srv` layout with `DEST = /srv/backup/dest`.
+    ///
+    /// This is the cell that discriminates the confinement gate from the
+    /// destination-root resolution: a leaf `symlink_metadata` reports a
+    /// directory here, so no amount of canonicalising the operand helps; only
+    /// the `openat2(RESOLVE_NO_SYMLINKS)` root open sees the interior
+    /// component, and only on Linux. Elsewhere the walk is leaf-only
+    /// `O_NOFOLLOW`, so the cell is unable to fail and is skipped rather than
+    /// passing vacuously.
+    Ancestor,
+}
+
+/// Run one daemon pull into `dest_arg` and assert the payload landed at the
+/// real directory with its source mode.
+///
+/// `dest_suffix` selects the operand spelling: `""` for the bare name, `"/"`
+/// for the trailing-slash form. The two take different paths through the
+/// receiver setup - `lstat("x/")` resolves the link where `lstat("x")` does not
+/// - and failed differently, so both are exercised.
+fn assert_pull_follows_symlinked_dest(link_at: LinkAt, dest_suffix: &str) {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(scratch) = Scratch::new() else {
+        eprintln!("skipping: tempdir allocation failed");
+        return;
+    };
+
+    let module_root = scratch.root.join("source");
+    fs::create_dir_all(&module_root).expect("create module root");
+    let source_file = module_root.join("payload.bin");
+    fs::write(&source_file, PAYLOAD).expect("seed source payload");
+    fs::set_permissions(&source_file, fs::Permissions::from_mode(PAYLOAD_MODE))
+        .expect("chmod source payload");
+
+    // The operator's destination reaches its real storage through a link, the
+    // ordinary `/srv/backup -> /mnt/big/backup` shape.
+    let (real_dest, linked_dest) = match link_at {
+        LinkAt::Leaf => {
+            let real_dest = scratch.root.join("real-dest");
+            fs::create_dir_all(&real_dest).expect("create real destination");
+            let linked_dest = scratch.root.join("linked-dest");
+            symlink(&real_dest, &linked_dest).expect("plant destination symlink");
+            (real_dest, linked_dest)
+        }
+        LinkAt::Ancestor => {
+            if !interior_components_are_inspected() {
+                eprintln!(
+                    "skipping: this platform's destination-root open is leaf-only \
+                     O_NOFOLLOW, so a symlinked ancestor cannot fail here"
+                );
+                return;
+            }
+            // `mnt/big/backup` is real; `srv -> mnt/big` is the link, so the
+            // operand `srv/backup` has a symlinked ANCESTOR and a real leaf.
+            let store = scratch.root.join("mnt").join("big");
+            let real_dest = store.join("backup");
+            fs::create_dir_all(&real_dest).expect("create real destination");
+            symlink(&store, scratch.root.join("srv")).expect("plant ancestor symlink");
+            let linked_dest = scratch.root.join("srv").join("backup");
+            (real_dest, linked_dest)
+        }
+    };
+
+    write_daemon_config(
+        &scratch.config,
+        &scratch.pid,
+        &scratch.log,
+        "pullmod",
+        &module_root,
+    )
+    .expect("write daemon config");
+
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return;
+        }
+    };
+
+    let src_url = OsString::from(format!("rsync://127.0.0.1:{port}/pullmod/"));
+    let mut dest_arg = linked_dest.clone().into_os_string();
+    dest_arg.push(dest_suffix);
+
+    let args: &[&OsStr] = &[
+        OsStr::new("--recursive"),
+        OsStr::new("--perms"),
+        OsStr::new("--times"),
+        &src_url,
+        &dest_arg,
+    ];
+
+    let (status, stdout, stderr) =
+        run_oc_rsync_capture(&oc_bin, args).expect("spawn oc-rsync client (daemon pull)");
+
+    // Common to every cell: the confinement gate must not fire. It is worded
+    // for an operator, so match the wording and say what it means rather than
+    // reading only a status.
+    assert!(
+        !stderr.contains("chdir-symlink-race") && !stderr.contains("refusing to open destination"),
+        "a client pulling from a daemon is not `am_daemon`, so upstream applies no \
+         confinement to its destination root; pull into '{}' was refused\nstderr:\n{stderr}",
+        dest_arg.to_string_lossy(),
+    );
+
+    // The fixture's own proof: the payload must be at the real directory. A
+    // build that replaced or side-stepped the symlink would satisfy a
+    // status-only assertion.
+    let landed = real_dest.join("payload.bin");
+    assert_eq!(
+        fs::read(&landed).unwrap_or_default(),
+        PAYLOAD,
+        "the pulled payload must land at {}",
+        real_dest.display(),
+    );
+
+    match link_at {
+        LinkAt::Leaf => {
+            assert!(
+                status.success(),
+                "pull into '{}' exited {status:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+                dest_arg.to_string_lossy(),
+            );
+            // Metadata must be applied through the followed link too. The
+            // trailing-slash spelling used to transfer the data and then fail
+            // metadata application, leaving the file at 0600 with exit 23.
+            let mode = fs::metadata(&landed)
+                .expect("stat landed payload")
+                .permissions()
+                .mode()
+                & 0o7777;
+            assert_eq!(
+                mode, PAYLOAD_MODE,
+                "--perms must reproduce the source mode through the followed \
+                 destination symlink",
+            );
+        }
+        // The ancestor cell deliberately stops at the confinement contract.
+        //
+        // Its destination resolves through a link the sandbox open still
+        // declines, so the receiver keeps running on the path-based syscalls -
+        // and on that fall-back the metadata apply fails silently and forces
+        // exit 23. Measured on Linux against real rsync 3.5.0 on the same
+        // fixture: upstream exits 0 with mode 0640, oc exits 23 with 0644 and
+        // prints nothing at any verbosity. That residual is a separate,
+        // pre-existing defect of the no-sandbox metadata path - reachable from
+        // any destination whose sandbox open fails, symlink or not - so
+        // asserting it here would fail this cell for a reason this change does
+        // not own.
+        LinkAt::Ancestor => {}
+    }
+}
+
+/// True when the receiver's destination-root open inspects interior path
+/// components, i.e. when [`LinkAt::Ancestor`] is able to fail at all.
+///
+/// Only `openat2(RESOLVE_NO_SYMLINKS)` walks the whole path; the portable
+/// fallback is `openat(O_NOFOLLOW | O_DIRECTORY)` on the leaf alone. Declaring
+/// this instead of hard-coding `cfg(target_os = "linux")` keeps the cell honest
+/// on a Linux kernel too old for `openat2`, where the fallback is what runs.
+fn interior_components_are_inspected() -> bool {
+    fast_io::openat2_supported()
+}
+
+/// The bare symlink name (`DEST`, no trailing slash).
+#[test]
+fn daemon_pull_follows_symlinked_dest_root_bare() {
+    assert_pull_follows_symlinked_dest(LinkAt::Leaf, "");
+}
+
+/// The trailing-slash spelling (`DEST/`), which the kernel resolves as a
+/// directory before `O_NOFOLLOW` is consulted and so reached a different
+/// failure than the bare form.
+#[test]
+fn daemon_pull_follows_symlinked_dest_root_trailing_slash() {
+    assert_pull_follows_symlinked_dest(LinkAt::Leaf, "/");
+}
+
+/// `DEST` is a real directory under a symlinked ancestor.
+///
+/// This is the cell that discriminates the two halves of the fix: no operand
+/// resolution helps, because the leaf is not a link. Only dropping the daemon
+/// confinement from the client receiver lets the transfer through.
+#[test]
+fn daemon_pull_follows_symlinked_dest_ancestor() {
+    assert_pull_follows_symlinked_dest(LinkAt::Ancestor, "");
+}

--- a/crates/transfer/tests/uts_nextest_chdir_symlink_race.rs
+++ b/crates/transfer/tests/uts_nextest_chdir_symlink_race.rs
@@ -29,9 +29,9 @@
 //! target.
 //!
 //! Existing coverage:
-//! - `crates/transfer/src/receiver/transfer/setup.rs::symlink_race_tests`
-//!   unit-tests the private `open_sandbox_for_dest_strict` helper for
-//!   the daemon strict path.
+//! - `crates/transfer/src/receiver/transfer/setup/sandbox.rs::symlink_race_tests`
+//!   unit-tests the private `open_sandbox_for_dest_anchored` helper for
+//!   the daemon path.
 //! - `crates/transfer/tests/dir_sandbox_carrier.rs` exercises descent
 //!   shape on quiescent trees.
 //! - `crates/transfer/tests/sec_1_m_symlink_swap_attack.rs` covers the


### PR DESCRIPTION
## What

`ConnectionConfig::is_daemon_connection` is set on **both ends** of an `rsync://`
transfer — the connecting client sets it in `apply_common_daemon_config`, the daemon
server in `build_server_config` — so it is not upstream's `am_daemon`. The receiver's
destination-root sandbox read it anyway and applied the daemon's per-component
confinement to the **client** half of a pull.

Measured against a real `rsync-3.5.0` on a loopback daemon, `-a rsync://h/m/ DEST`:

| destination shape | upstream | oc before |
|---|---|---|
| bare symlinked `DEST` | exit 0 | exit 23, "refusing to open destination … chdir-symlink-race" |
| `DEST/` (trailing slash) | exit 0, mode 0640 | exit 23, mode 0644, **stderr empty** |
| symlinked ancestor | exit 0, mode 0640 | exit 23, ELOOP refusal (Linux) |

## Upstream

`use_secure_symlinks = am_daemon && (!am_chrooted || module_dirlen)`
(`clientserver.c:1093`); `confinement_root()` yields `module_dir` only under
`am_daemon` (`syscall.c:136`); a non-daemon receiver takes the plain `do_open` arm of
`secure_basis_open()` (`receiver.c:152`).

`daemon_module_root` **is** oc's `am_daemon` — only the daemon's own
`apply_module_transfer_directives` populates it — so both receiver decisions now read
one accessor, `served_module_root()`, that says so. With the predicate corrected the
`strict` parameter had no production caller left, so `open_sandbox_for_dest_strict`
collapses back into the plain opener it wrapped.

## Two further corrections in the same area

- The destination-root symlink probe ran on the operand verbatim, and `lstat("dest/")`
  **resolves** the link — so the trailing-slash spelling, the one shape that needs
  resolving, reported a directory and carried the link path into the metadata apply.
  It now probes with trailing separators trimmed, which is what `change_dir()` gives
  upstream for both spellings. Same trailing-slash trap as task 844.
- A comment justified its warning by claiming `debug_log!` is unreachable at every
  operator-settable verbosity. That is **wrong**: `--debug=recv2` reaches level 2.
  What the `-v` ladder alone cannot reach is upstream's own arrangement
  (`debug_verbosity[3]` sets RECV to 1 and no later level raises it), so an operator
  running `-vvvvv` seeing nothing is upstream's design, not an oc defect.

## Verification

New integration test drives a real loopback daemon in three cells, **all red before
this change** (Linux 0/3; macOS 0/2, the ancestor cell self-skipping where the
dest-root open is leaf-only `O_NOFOLLOW`).

Per-change mutation, not a single aggregate: reverting the canonicalize gate kills
exactly the two leaf cells and leaves the ancestor untouched — correct, canonicalize
can never see it. Reverting the probe trim kills exactly the trailing-slash cell. The
ancestor cell is the one that discriminates the confinement half; no operand
resolution can fix it, because its leaf is a real directory.

`fmt --check` 0, `clippy -p transfer -D warnings` 0, transfer 2733/2733 macOS and
2735/2735 Linux.

## Residual, deliberately not fixed here

Whenever the receiver ends up with **no** dest sandbox, the metadata apply fails
silently and forces exit 23 (0644 against upstream's 0640, nothing printed even at
`-vvv --debug=all`). The discriminator is `sandbox == None`, not the symlink, so it is
reachable from any destination whose sandbox open fails. Filed separately; the
ancestor cell here asserts only the confinement contract for that reason, with the
residual named in a comment.
