### PR TITLE
refactor(test-support): one owner for bounded drain-and-wait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4881,6 +4881,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
+ "test-support",
  "toml",
  "toml_edit",
  "walkdir",

--- a/crates/metadata/tests/acl_root_root_interop.rs
+++ b/crates/metadata/tests/acl_root_root_interop.rs
@@ -67,10 +67,11 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use exacl::{AclEntry, AclOption, Perm, getfacl, setfacl};
 use tempfile::TempDir;
+use test_support::Deadlined;
 
 /// Wall-clock cap for any single rsync invocation. Generous because some
 /// CI machines run under cgroup throttling, but still short enough to
@@ -136,33 +137,44 @@ fn locate_upstream_rsync() -> Option<PathBuf> {
 /// detailed assertion message; the caller decides whether non-zero is
 /// fatal.
 fn run_with_timeout(bin: &Path, args: &[&OsStr]) -> io::Result<Output> {
-    let mut child = Command::new(bin)
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    let start = Instant::now();
-    loop {
-        match child.try_wait()? {
-            Some(_) => return child.wait_with_output(),
-            None => {
-                if start.elapsed() >= RUN_TIMEOUT {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        format!(
-                            "{} exceeded {:?} and was killed",
-                            bin.display(),
-                            RUN_TIMEOUT
-                        ),
-                    ));
-                }
-                std::thread::sleep(Duration::from_millis(50));
-            }
-        }
+    let mut command = Command::new(bin);
+    command.args(args);
+    match test_support::run_deadlined(&mut command, RUN_TIMEOUT)? {
+        Deadlined::Finished {
+            status,
+            stdout,
+            stderr,
+        } => Ok(Output {
+            status,
+            stdout,
+            stderr,
+        }),
+        Deadlined::Expired { budget, .. } => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("{} exceeded {budget:?} and was killed", bin.display()),
+        )),
     }
+}
+
+/// The harness must collect a child that outwrites the pipe buffer.
+///
+/// An `rsync -v` over a large ACL tree passes 64 KiB easily; undrained, the
+/// child blocks in `write` and [`run_with_timeout`] reports the harness's own
+/// back-pressure as a transfer that overran [`RUN_TIMEOUT`].
+#[test]
+fn run_with_timeout_collects_a_child_that_outwrites_the_pipe_buffer() {
+    const FLOOD: usize = 256 * 1024;
+    let script = format!(
+        "yes 0123456789abcdef | head -c {FLOOD}\n\
+         yes 0123456789abcdef | head -c {FLOOD} >&2\n"
+    );
+    let output = run_with_timeout(
+        Path::new("/bin/sh"),
+        &[OsStr::new("-c"), OsStr::new(script.as_str())],
+    )
+    .expect("flooding child must not be reported as a timeout");
+    assert_eq!(output.stdout.len(), FLOOD, "stdout was truncated");
+    assert_eq!(output.stderr.len(), FLOOD, "stderr was truncated");
 }
 
 /// Run a binary in transfer mode and require success. Includes stdout and

--- a/crates/test-support/src/cli.rs
+++ b/crates/test-support/src/cli.rs
@@ -13,12 +13,11 @@
 
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
-use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
-use std::thread;
+use std::process::Command;
 use std::time::{Duration, Instant};
 
+use crate::deadline::Deadlined;
 use crate::skip::locate_workspace_binary;
 
 /// Default wall-time cap for a single invocation.
@@ -27,9 +26,6 @@ use crate::skip::locate_workspace_binary;
 /// regression that would otherwise hang (e.g. a goodbye-flush stall) fails
 /// loud inside nextest's per-test budget instead of stalling the cell.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Poll interval used while waiting for the child to exit.
-const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Error raised when a runner cannot locate, spawn, or drive the binary.
 ///
@@ -230,14 +226,6 @@ impl OcRsyncCliRunner {
         if let Some(dir) = &self.cwd {
             cmd.current_dir(dir);
         }
-        cmd.stdin(if self.stdin.is_some() {
-            Stdio::piped()
-        } else {
-            Stdio::null()
-        });
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
-
         #[cfg(unix)]
         if let Some(mask) = self.umask {
             use std::os::unix::process::CommandExt;
@@ -255,59 +243,47 @@ impl OcRsyncCliRunner {
         }
 
         let start = Instant::now();
-        let mut child = cmd.spawn().map_err(RunnerError::Spawn)?;
-
-        if let Some(data) = &self.stdin {
-            // Write on a scratch thread so a child that never drains stdin
-            // cannot deadlock us; the timeout below still reaps such a child.
-            let mut sink = child.stdin.take().expect("stdin was piped");
-            let data = data.clone();
-            // Detached: the thread finishes when the child consumes the input
-            // or when the pipe closes on child exit. Dropping the JoinHandle
-            // does not detach the OS thread, which is intended here.
-            let _ = thread::spawn(move || {
-                let _ = sink.write_all(&data);
-                // Dropping `sink` closes the pipe, signalling EOF.
-            });
-        }
-
-        // Poll for completion under the timeout. Draining the pipes happens
-        // after exit via `wait_with_output`; the payloads in operational tests
-        // are small (design section 8), so pipe buffers do not fill before the
-        // child exits.
-        loop {
-            match child.try_wait().map_err(RunnerError::Wait)? {
-                Some(_) => break,
-                None => {
-                    if start.elapsed() >= self.timeout {
-                        let _ = child.kill();
-                        let output = child.wait_with_output().map_err(RunnerError::Wait)?;
-                        return Err(RunnerError::Timeout {
-                            after: self.timeout,
-                            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-                        });
-                    }
-                    thread::sleep(POLL_INTERVAL);
-                }
-            }
-        }
-
-        let output = child.wait_with_output().map_err(RunnerError::Wait)?;
+        // Both pipes are drained throughout and the timeout bounds the whole
+        // run, output included. The earlier form polled `try_wait()` over
+        // undrained pipes on the reasoning that operational payloads are small
+        // enough never to fill a pipe buffer; that assumption is false in the
+        // general case - a child writing past ~64 KiB blocks in `write` and the
+        // runner reports its own back-pressure as a timeout.
+        let outcome = crate::deadline::run_deadlined_with_stdin(
+            &mut cmd,
+            self.timeout,
+            self.stdin.as_deref(),
+        )
+        .map_err(RunnerError::Spawn)?;
         let duration = start.elapsed();
+
+        let (status, stdout, stderr) = match outcome {
+            Deadlined::Finished {
+                status,
+                stdout,
+                stderr,
+            } => (status, stdout, stderr),
+            Deadlined::Expired { budget, stderr, .. } => {
+                return Err(RunnerError::Timeout {
+                    after: budget,
+                    stderr: String::from_utf8_lossy(&stderr).into_owned(),
+                });
+            }
+        };
 
         #[cfg(unix)]
         let signal = {
             use std::os::unix::process::ExitStatusExt;
-            output.status.signal()
+            status.signal()
         };
         #[cfg(not(unix))]
         let signal = None;
 
         Ok(CliOutput {
-            status: output.status.code(),
+            status: status.code(),
             signal,
-            stdout: output.stdout,
-            stderr: output.stderr,
+            stdout,
+            stderr,
             duration,
         })
     }

--- a/crates/test-support/src/deadline.rs
+++ b/crates/test-support/src/deadline.rs
@@ -1,0 +1,200 @@
+//! Bounded drain-and-wait for a spawned child process.
+//!
+//! Every harness in this workspace that runs a child under a wall-clock cap
+//! needs the same two properties, and a poll loop over `try_wait()` gives
+//! neither for free:
+//!
+//! 1. **Both pipes are drained from the moment the child is spawned.** A child
+//!    that writes past the pipe buffer - 64 KiB is typical on Linux and macOS -
+//!    blocks in `write` until someone reads. A parent that only polls
+//!    `try_wait()` never reads, so the child never exits, and the harness
+//!    reports its own back-pressure as the hang it exists to detect. Measured:
+//!    a child writing 256 KiB per stream burns the entire budget on both
+//!    platforms before being killed.
+//!
+//! 2. **The budget bounds every wait, not just the process wait.** A descendant
+//!    that outlives the child keeps the pipe write end open, so a final
+//!    read-to-EOF never returns - `Child::wait_with_output()` blocks there
+//!    forever, past a deadline that has already been checked for the last time.
+//!    Measured: a 5 s budget against `sh -c 'sleep N & exit 0'` returns after
+//!    exactly N seconds, so the wait is bounded by the descendant's lifetime
+//!    and not at all by the deadline.
+//!
+//! [`run_deadlined`] is the single owner of both. Callers pass a configured
+//! [`Command`] and a budget and get back a [`Deadlined`]; a run that overruns
+//! its budget still returns whatever the child managed to write, which is
+//! strictly better diagnostics than a lost buffer.
+
+use std::io::{self, Read, Write};
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Interval between `try_wait()` probes while the child runs.
+///
+/// The probe is non-blocking and the pipes are drained on their own threads, so
+/// this only bounds how promptly an exit is noticed.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Outcome of one deadlined run.
+///
+/// Both variants carry the output collected so far: on [`Deadlined::Expired`]
+/// that is everything the child wrote before it was killed, not an empty
+/// buffer.
+#[derive(Debug)]
+pub enum Deadlined {
+    /// The child exited and both streams reached EOF within the budget.
+    Finished {
+        /// The child's exit status.
+        status: ExitStatus,
+        /// Everything the child wrote to stdout.
+        stdout: Vec<u8>,
+        /// Everything the child wrote to stderr.
+        stderr: Vec<u8>,
+    },
+    /// The budget expired. The child has been killed and reaped.
+    ///
+    /// Reached either because the child was still running, or because it had
+    /// exited but a surviving descendant still held a pipe open so the output
+    /// never reached EOF.
+    Expired {
+        /// The budget that was exceeded, for the caller's diagnostic.
+        budget: Duration,
+        /// Whatever reached stdout before the budget ran out.
+        stdout: Vec<u8>,
+        /// Whatever reached stderr before the budget ran out.
+        stderr: Vec<u8>,
+    },
+}
+
+/// Run `command` under `budget`, draining both pipes throughout.
+///
+/// The child's stdio is configured by this function - stdin null, stdout and
+/// stderr piped - so a caller's own `stdin`/`stdout`/`stderr` settings are
+/// overridden. Everything else (argv, env, cwd, `pre_exec`) is the caller's.
+///
+/// # Errors
+///
+/// Returns the spawn error if the child cannot be started, or a `try_wait`
+/// error. Overrunning the budget is *not* an error: it comes back as
+/// [`Deadlined::Expired`] so the caller can attach its own diagnostic.
+pub fn run_deadlined(command: &mut Command, budget: Duration) -> io::Result<Deadlined> {
+    run_deadlined_with_stdin(command, budget, None)
+}
+
+/// [`run_deadlined`], additionally feeding `stdin` to the child.
+///
+/// The bytes are written on a scratch thread so a child that never reads its
+/// stdin cannot block the caller; the budget still reaps such a child.
+///
+/// # Errors
+///
+/// As [`run_deadlined`].
+pub fn run_deadlined_with_stdin(
+    command: &mut Command,
+    budget: Duration,
+    stdin: Option<&[u8]>,
+) -> io::Result<Deadlined> {
+    command.stdin(if stdin.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    });
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let mut child = command.spawn()?;
+    let deadline = Instant::now() + budget;
+
+    if let Some(data) = stdin {
+        let mut sink = child.stdin.take().expect("stdin was piped");
+        let data = data.to_vec();
+        // Detached on purpose: the thread ends when the child consumes the
+        // input or when the pipe closes on child exit. Dropping `sink` there
+        // signals EOF.
+        thread::spawn(move || {
+            let _ = sink.write_all(&data);
+        });
+    }
+
+    let stdout = Drain::spawn(child.stdout.take().expect("stdout was piped"));
+    let stderr = Drain::spawn(child.stderr.take().expect("stderr was piped"));
+
+    let status = loop {
+        match child.try_wait()? {
+            Some(status) => break Some(status),
+            None if Instant::now() >= deadline => break None,
+            None => thread::sleep(POLL_INTERVAL),
+        }
+    };
+
+    // Both streams must reach EOF before the collected output is complete. A
+    // descendant holding a pipe open makes that never happen, so it is bounded
+    // against the same instant as the poll above.
+    let drained =
+        status.is_some() && stdout.wait_for_eof(deadline) && stderr.wait_for_eof(deadline);
+
+    match status {
+        Some(status) if drained => Ok(Deadlined::Finished {
+            status,
+            stdout: stdout.snapshot(),
+            stderr: stderr.snapshot(),
+        }),
+        _ => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Ok(Deadlined::Expired {
+                budget,
+                stdout: stdout.snapshot(),
+                stderr: stderr.snapshot(),
+            })
+        }
+    }
+}
+
+/// One child pipe being read to EOF on its own thread.
+///
+/// The bytes land in a shared buffer rather than a channel payload so the
+/// parent can snapshot partial output at any moment - including after giving up
+/// on a stream that will never reach EOF.
+struct Drain {
+    buf: Arc<Mutex<Vec<u8>>>,
+    eof: mpsc::Receiver<()>,
+}
+
+impl Drain {
+    fn spawn<R: Read + Send + 'static>(mut pipe: R) -> Self {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&buf);
+        let (tx, eof) = mpsc::channel();
+        thread::spawn(move || {
+            let mut chunk = [0u8; 8192];
+            loop {
+                match pipe.read(&mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => sink
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .extend_from_slice(&chunk[..n]),
+                }
+            }
+            let _ = tx.send(());
+        });
+        Self { buf, eof }
+    }
+
+    /// Wait until the pipe reaches EOF, giving up at `deadline`.
+    fn wait_for_eof(&self, deadline: Instant) -> bool {
+        self.eof
+            .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+            .is_ok()
+    }
+
+    fn snapshot(&self) -> Vec<u8> {
+        self.buf
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -10,6 +10,7 @@ pub mod capabilities;
 pub mod clean_fname;
 pub mod cli;
 pub mod daemon_port;
+pub mod deadline;
 pub mod dir_diff;
 pub mod lsh;
 pub mod skip;
@@ -22,6 +23,7 @@ pub use capabilities::Capabilities;
 pub use clean_fname::COLLAPSE_CASES;
 pub use cli::{CliOutput, OcRsyncCliRunner, RunnerError};
 pub use daemon_port::{daemon_listen_port, spawn_daemon_on_free_port};
+pub use deadline::{Deadlined, run_deadlined, run_deadlined_with_stdin};
 pub use dir_diff::{DirDiff, DirDiffEntry, DirDiffError, DirDiffMismatch, DirDiffOptions};
 pub use lsh::{LSH_STUB_BIN, LshError, LshRunnerStub};
 pub use skip::{

--- a/crates/test-support/tests/deadline_drain.rs
+++ b/crates/test-support/tests/deadline_drain.rs
@@ -1,0 +1,154 @@
+//! The bounded drain-and-wait contract, pinned on the two shapes that break a
+//! naive `try_wait` poll over undrained pipes.
+//!
+//! Both were measured against the pre-fix code on macOS and on Linux before
+//! this owner existed: a child writing 256 KiB per stream burned the entire
+//! budget and was reported as a timeout, and a run whose output never reached
+//! EOF did not return at all until its descendant died.
+//!
+//! `#![cfg(unix)]` - the fixtures drive `/bin/sh`. The primitive itself is
+//! platform-neutral.
+#![cfg(unix)]
+
+use std::process::Command;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use test_support::{Deadlined, OcRsyncCliRunner, RunnerError, run_deadlined};
+
+/// Output per stream, comfortably past the 64 KiB pipe buffer on both Linux and
+/// macOS, so the child MUST block unless the parent is reading.
+const FLOOD: usize = 256 * 1024;
+/// Budget for the flooding cells. Long enough that `/bin/sh` writing a few
+/// hundred KiB cannot race it.
+const FLOOD_BUDGET: Duration = Duration::from_secs(10);
+/// Budget for the descendant cells. Short, because the point is that it fires.
+const SHORT_BUDGET: Duration = Duration::from_secs(2);
+
+/// Run `body` on a worker thread, failing if it does not return within `bound`.
+///
+/// The bound has to live outside the code under test: a regression in the
+/// primitive blocks its caller forever, so an assertion placed after the call
+/// would never be reached and the test would hang CI instead of failing it.
+fn within<T: Send + 'static>(bound: Duration, body: impl FnOnce() -> T + Send + 'static) -> T {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(body());
+    });
+    rx.recv_timeout(bound)
+        .unwrap_or_else(|_| panic!("call did not return within {bound:?}"))
+}
+
+/// A child writing far past the pipe buffer on both streams.
+fn flood_script() -> String {
+    format!(
+        "yes 0123456789abcdef | head -c {FLOOD}\n\
+         yes 0123456789abcdef | head -c {FLOOD} >&2\n"
+    )
+}
+
+/// `sh` exits immediately while a backgrounded child keeps both pipes open well
+/// past any budget here, so the output never reaches EOF.
+const ORPHAN_SCRIPT: &str = "sleep 30 & exit 0";
+
+#[test]
+fn run_deadlined_collects_a_child_that_outwrites_the_pipe_buffer() {
+    let script = flood_script();
+    let outcome = within(FLOOD_BUDGET * 3, move || {
+        let mut command = Command::new("/bin/sh");
+        command.arg("-c").arg(&script);
+        run_deadlined(&mut command, FLOOD_BUDGET)
+    })
+    .expect("spawn");
+
+    match outcome {
+        Deadlined::Finished {
+            status,
+            stdout,
+            stderr,
+        } => {
+            assert!(status.success(), "flooding child exited non-zero");
+            assert_eq!(stdout.len(), FLOOD, "stdout was truncated");
+            assert_eq!(stderr.len(), FLOOD, "stderr was truncated");
+        }
+        Deadlined::Expired { budget, .. } => {
+            panic!("flooding child was starved and reported as a timeout after {budget:?}")
+        }
+    }
+}
+
+/// The budget must bound the whole run, not just the process wait.
+///
+/// `try_wait` reports the exit on the first poll, so the deadline is never
+/// consulted again - but the output still cannot reach EOF. This is the
+/// remote-shell shape (client -> `lsh-stub` -> `--server`), and it does not
+/// return at all unless the collection is deadlined too.
+#[test]
+fn run_deadlined_expires_when_a_descendant_holds_the_pipe_open() {
+    let started = Instant::now();
+    let outcome = within(FLOOD_BUDGET * 3, move || {
+        let mut command = Command::new("/bin/sh");
+        command.arg("-c").arg(ORPHAN_SCRIPT);
+        run_deadlined(&mut command, SHORT_BUDGET)
+    })
+    .expect("spawn");
+
+    match outcome {
+        Deadlined::Expired { budget, .. } => assert_eq!(budget, SHORT_BUDGET),
+        Deadlined::Finished { .. } => {
+            panic!("a run whose output never reaches EOF must expire")
+        }
+    }
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= SHORT_BUDGET,
+        "returned before the budget expired: {elapsed:?}",
+    );
+    assert!(
+        elapsed < FLOOD_BUDGET,
+        "the budget did not bound the collection: {elapsed:?}",
+    );
+}
+
+/// [`OcRsyncCliRunner`] inherits the drain: a verbose run is collected in full
+/// rather than starved into its own timeout.
+#[test]
+fn cli_runner_collects_a_child_that_outwrites_the_pipe_buffer() {
+    let script = flood_script();
+    let out = within(FLOOD_BUDGET * 3, move || {
+        OcRsyncCliRunner::new()
+            .binary("/bin/sh")
+            .args(["-c", script.as_str()])
+            .timeout(FLOOD_BUDGET)
+            .run()
+    })
+    .expect("flooding child must not be reported as a timeout");
+
+    assert_eq!(out.stdout.len(), FLOOD, "stdout was truncated");
+    assert_eq!(out.stderr.len(), FLOOD, "stderr was truncated");
+}
+
+/// ...and inherits the bound, mapping an overrun onto its own typed error
+/// instead of blocking in the collection.
+#[test]
+fn cli_runner_reports_a_timeout_when_a_descendant_holds_the_pipe_open() {
+    let started = Instant::now();
+    let err = within(FLOOD_BUDGET * 3, move || {
+        OcRsyncCliRunner::new()
+            .binary("/bin/sh")
+            .args(["-c", ORPHAN_SCRIPT])
+            .timeout(SHORT_BUDGET)
+            .run()
+            .err()
+    })
+    .expect("a run whose output never reaches EOF must time out");
+
+    match err {
+        RunnerError::Timeout { after, .. } => assert_eq!(after, SHORT_BUDGET),
+        other => panic!("expected a timeout, got: {other}"),
+    }
+    assert!(
+        started.elapsed() < FLOOD_BUDGET,
+        "the timeout did not bound the collection",
+    );
+}

--- a/crates/transfer/tests/verify_redo_recovers_network_paths.rs
+++ b/crates/transfer/tests/verify_redo_recovers_network_paths.rs
@@ -106,11 +106,10 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use tempfile::{TempDir, tempdir};
-use test_support::{LSH_STUB_BIN, LshRunnerStub, require_binaries};
+use test_support::{Deadlined, LSH_STUB_BIN, LshRunnerStub, require_binaries};
 
 /// Authoritative source length. Spans many signature blocks so the redo resend
 /// is a real multi-block delta round-trip, not a single-token special case.
@@ -281,85 +280,30 @@ struct RunOutcome {
 }
 
 /// Drive one `oc-rsync` invocation under [`CLIENT_DEADLINE`].
+///
+/// Delegates to the workspace's bounded drain-and-wait primitive: both pipes
+/// are read throughout, and the deadline bounds the output collection as well
+/// as the process wait. The remote-shell cells spawn a descendant chain
+/// (client -> `lsh-stub` -> `--server`) that can hold a pipe open after the
+/// client exits, which is exactly what an unbounded final read cannot survive.
 fn run_oc_rsync_deadlined(bin: &Path, args: &[&OsStr]) -> io::Result<RunOutcome> {
-    run_deadlined(bin, args, CLIENT_DEADLINE)
-}
-
-/// Drive one child under `budget`, returning `Err(TimedOut)` if the whole run -
-/// process *and* output - is not finished by then.
-///
-/// Two properties this has to hold, both of which a naive poll loop loses:
-///
-/// 1. Both pipes are drained by dedicated threads from the moment the child is
-///    spawned. A child that writes past the pipe buffer (64 KiB is typical)
-///    blocks in `write` until someone reads; polling `try_wait` while the buffer
-///    fills starves the child for the whole budget and reports the harness's own
-///    back-pressure as a transport hang.
-/// 2. The budget bounds *every* wait, not just the process wait. A descendant
-///    that outlives the client keeps the pipe write end open, so the final
-///    read-to-EOF never returns - `wait_with_output()` there hangs forever, past
-///    a deadline that has already been checked for the last time. The remote-shell
-///    cells spawn exactly that shape (client -> `lsh-stub` -> `--server`), so the
-///    collection is bounded against the same instant as the process poll.
-fn run_deadlined(bin: &Path, args: &[&OsStr], budget: Duration) -> io::Result<RunOutcome> {
-    let mut child = Command::new(bin)
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    let deadline = Instant::now() + budget;
-    let stdout = drain(child.stdout.take().expect("stdout piped"));
-    let stderr = drain(child.stderr.take().expect("stderr piped"));
-
-    let status = loop {
-        match child.try_wait()? {
-            Some(status) => break status,
-            None if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    format!("client did not finish within {budget:?}"),
-                ));
-            }
-            None => std::thread::sleep(Duration::from_millis(20)),
-        }
-    };
-
-    Ok(RunOutcome {
-        status,
-        stdout: collect(stdout, deadline, budget, "stdout")?,
-        stderr: collect(stderr, deadline, budget, "stderr")?,
-    })
-}
-
-/// Read one child pipe to EOF on its own thread, handing the text back over a
-/// channel so the caller can wait for it under a deadline.
-fn drain<R: io::Read + Send + 'static>(mut pipe: R) -> mpsc::Receiver<String> {
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        let _ = pipe.read_to_end(&mut buf);
-        let _ = tx.send(String::from_utf8_lossy(&buf).into_owned());
-    });
-    rx
-}
-
-/// Wait for one drained stream, giving up at `deadline`.
-fn collect(
-    rx: mpsc::Receiver<String>,
-    deadline: Instant,
-    budget: Duration,
-    stream: &str,
-) -> io::Result<String> {
-    rx.recv_timeout(deadline.saturating_duration_since(Instant::now()))
-        .map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::TimedOut,
-                format!("client {stream} was still open {budget:?} after spawn"),
-            )
-        })
+    let mut command = Command::new(bin);
+    command.args(args);
+    match test_support::run_deadlined(&mut command, CLIENT_DEADLINE)? {
+        Deadlined::Finished {
+            status,
+            stdout,
+            stderr,
+        } => Ok(RunOutcome {
+            status,
+            stdout: String::from_utf8_lossy(&stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        }),
+        Deadlined::Expired { budget, .. } => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("client did not finish within {budget:?}"),
+        )),
+    }
 }
 
 /// Seeds the authoritative source and the wrong-prefix destination basis,
@@ -999,109 +943,5 @@ fn daemon_pull_redo_redeltas_against_the_retained_basis() {
         "matched {matched} exceeds the retained tail plus its short trailing \
          block - the redo counted unmatchable bytes\nstdout:\n{}",
         outcome.stdout,
-    );
-}
-
-// The harness itself. Every cell above trusts [`run_deadlined`] to turn a stuck
-// transport into a failing test; these two pin that it can, on the two shapes
-// that break a naive `try_wait` poll over undrained pipes.
-
-/// Budget for the harness self-tests. Long enough that `/bin/sh` finishing a
-/// few hundred KiB of output cannot race it, short enough that the pre-fix
-/// starvation shows up as a bounded failure rather than a slow one.
-const HARNESS_BUDGET: Duration = Duration::from_secs(10);
-/// Output per stream, comfortably past the 64 KiB pipe buffer on both Linux and
-/// macOS so the child MUST block unless the parent is reading.
-const PIPE_FLOOD_BYTES: usize = 256 * 1024;
-
-/// Run `body` on a worker thread, failing if it does not return within `bound`.
-///
-/// The bound has to live outside the code under test: a regression in
-/// [`run_deadlined`] blocks its caller forever, so an assertion placed after the
-/// call would never be reached and the test would hang CI instead of failing it.
-fn within<T: Send + 'static>(bound: Duration, body: impl FnOnce() -> T + Send + 'static) -> T {
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(body());
-    });
-    rx.recv_timeout(bound)
-        .unwrap_or_else(|_| panic!("harness call did not return within {bound:?}"))
-}
-
-/// A child that outwrites the pipe buffer must still be collected in full.
-///
-/// Undrained, the child blocks in `write` at ~64 KiB and the poll loop reports
-/// the harness's own back-pressure as a client that missed its deadline - a
-/// verbose cell or a larger tree would fail every run for a reason that has
-/// nothing to do with the redo under test.
-#[test]
-fn deadlined_runner_collects_a_child_that_outwrites_the_pipe_buffer() {
-    let script = format!(
-        "yes 0123456789abcdef | head -c {PIPE_FLOOD_BYTES}\n\
-         yes 0123456789abcdef | head -c {PIPE_FLOOD_BYTES} >&2\n"
-    );
-    let outcome = within(HARNESS_BUDGET * 3, move || {
-        run_deadlined(
-            Path::new("/bin/sh"),
-            &[OsStr::new("-c"), OsStr::new(script.as_str())],
-            HARNESS_BUDGET,
-        )
-    })
-    .expect("flooding child must not be reported as a timeout");
-
-    assert!(outcome.status.success(), "flooding child exited non-zero");
-    assert_eq!(
-        outcome.stdout.len(),
-        PIPE_FLOOD_BYTES,
-        "stdout was truncated - the drain did not read to EOF",
-    );
-    assert_eq!(
-        outcome.stderr.len(),
-        PIPE_FLOOD_BYTES,
-        "stderr was truncated - the drain did not read to EOF",
-    );
-}
-
-/// The deadline must bound the whole run, not just the process wait.
-///
-/// The child exits immediately, so `try_wait` reports done on the first poll and
-/// the deadline is never consulted again - but a descendant still holds the pipe
-/// write end, so reading to EOF never returns. That is the remote-shell shape
-/// (client -> `lsh-stub` -> `--server`), and it hangs with no bound at all
-/// unless the collection is deadlined too.
-#[test]
-fn deadlined_runner_times_out_when_a_descendant_holds_the_pipe_open() {
-    let budget = Duration::from_secs(2);
-    let started = Instant::now();
-    let outcome = within(HARNESS_BUDGET * 3, move || {
-        run_deadlined(
-            Path::new("/bin/sh"),
-            // Backgrounded, so `sh` exits at once while the child keeps stdout
-            // and stderr open well past the budget.
-            &[OsStr::new("-c"), OsStr::new("sleep 30 & exit 0")],
-            budget,
-        )
-    });
-    let err = match outcome {
-        Ok(outcome) => panic!(
-            "a run whose output never reaches EOF must time out, got {:?}",
-            outcome.status,
-        ),
-        Err(err) => err,
-    };
-
-    assert_eq!(
-        err.kind(),
-        io::ErrorKind::TimedOut,
-        "expected a timeout, got: {err}",
-    );
-    let elapsed = started.elapsed();
-    assert!(
-        elapsed >= budget,
-        "returned before the budget expired: {elapsed:?}",
-    );
-    assert!(
-        elapsed < HARNESS_BUDGET,
-        "the deadline did not bound the collection: {elapsed:?}",
     );
 }

--- a/crates/transfer/tests/verify_redo_recovers_network_paths.rs
+++ b/crates/transfer/tests/verify_redo_recovers_network_paths.rs
@@ -106,6 +106,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use tempfile::{TempDir, tempdir};
@@ -279,38 +280,86 @@ struct RunOutcome {
     stderr: String,
 }
 
-/// Drive one `oc-rsync` invocation under a deadline.
-///
-/// The child is polled rather than waited on so a transport that deadlocks (the
-/// pre-fix remote-shell pull) is reported as a failure instead of hanging the
-/// test binary. Returns `Err` describing the timeout after killing the child.
+/// Drive one `oc-rsync` invocation under [`CLIENT_DEADLINE`].
 fn run_oc_rsync_deadlined(bin: &Path, args: &[&OsStr]) -> io::Result<RunOutcome> {
+    run_deadlined(bin, args, CLIENT_DEADLINE)
+}
+
+/// Drive one child under `budget`, returning `Err(TimedOut)` if the whole run -
+/// process *and* output - is not finished by then.
+///
+/// Two properties this has to hold, both of which a naive poll loop loses:
+///
+/// 1. Both pipes are drained by dedicated threads from the moment the child is
+///    spawned. A child that writes past the pipe buffer (64 KiB is typical)
+///    blocks in `write` until someone reads; polling `try_wait` while the buffer
+///    fills starves the child for the whole budget and reports the harness's own
+///    back-pressure as a transport hang.
+/// 2. The budget bounds *every* wait, not just the process wait. A descendant
+///    that outlives the client keeps the pipe write end open, so the final
+///    read-to-EOF never returns - `wait_with_output()` there hangs forever, past
+///    a deadline that has already been checked for the last time. The remote-shell
+///    cells spawn exactly that shape (client -> `lsh-stub` -> `--server`), so the
+///    collection is bounded against the same instant as the process poll.
+fn run_deadlined(bin: &Path, args: &[&OsStr], budget: Duration) -> io::Result<RunOutcome> {
     let mut child = Command::new(bin)
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
+    let deadline = Instant::now() + budget;
+    let stdout = drain(child.stdout.take().expect("stdout piped"));
+    let stderr = drain(child.stderr.take().expect("stderr piped"));
 
-    let deadline = Instant::now() + CLIENT_DEADLINE;
-    while child.try_wait()?.is_none() {
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                format!("client did not finish within {CLIENT_DEADLINE:?}"),
-            ));
+    let status = loop {
+        match child.try_wait()? {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("client did not finish within {budget:?}"),
+                ));
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
         }
-        std::thread::sleep(Duration::from_millis(20));
-    }
+    };
 
-    let output = child.wait_with_output()?;
     Ok(RunOutcome {
-        status: output.status,
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        status,
+        stdout: collect(stdout, deadline, budget, "stdout")?,
+        stderr: collect(stderr, deadline, budget, "stderr")?,
     })
+}
+
+/// Read one child pipe to EOF on its own thread, handing the text back over a
+/// channel so the caller can wait for it under a deadline.
+fn drain<R: io::Read + Send + 'static>(mut pipe: R) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = pipe.read_to_end(&mut buf);
+        let _ = tx.send(String::from_utf8_lossy(&buf).into_owned());
+    });
+    rx
+}
+
+/// Wait for one drained stream, giving up at `deadline`.
+fn collect(
+    rx: mpsc::Receiver<String>,
+    deadline: Instant,
+    budget: Duration,
+    stream: &str,
+) -> io::Result<String> {
+    rx.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("client {stream} was still open {budget:?} after spawn"),
+            )
+        })
 }
 
 /// Seeds the authoritative source and the wrong-prefix destination basis,
@@ -950,5 +999,109 @@ fn daemon_pull_redo_redeltas_against_the_retained_basis() {
         "matched {matched} exceeds the retained tail plus its short trailing \
          block - the redo counted unmatchable bytes\nstdout:\n{}",
         outcome.stdout,
+    );
+}
+
+// The harness itself. Every cell above trusts [`run_deadlined`] to turn a stuck
+// transport into a failing test; these two pin that it can, on the two shapes
+// that break a naive `try_wait` poll over undrained pipes.
+
+/// Budget for the harness self-tests. Long enough that `/bin/sh` finishing a
+/// few hundred KiB of output cannot race it, short enough that the pre-fix
+/// starvation shows up as a bounded failure rather than a slow one.
+const HARNESS_BUDGET: Duration = Duration::from_secs(10);
+/// Output per stream, comfortably past the 64 KiB pipe buffer on both Linux and
+/// macOS so the child MUST block unless the parent is reading.
+const PIPE_FLOOD_BYTES: usize = 256 * 1024;
+
+/// Run `body` on a worker thread, failing if it does not return within `bound`.
+///
+/// The bound has to live outside the code under test: a regression in
+/// [`run_deadlined`] blocks its caller forever, so an assertion placed after the
+/// call would never be reached and the test would hang CI instead of failing it.
+fn within<T: Send + 'static>(bound: Duration, body: impl FnOnce() -> T + Send + 'static) -> T {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(body());
+    });
+    rx.recv_timeout(bound)
+        .unwrap_or_else(|_| panic!("harness call did not return within {bound:?}"))
+}
+
+/// A child that outwrites the pipe buffer must still be collected in full.
+///
+/// Undrained, the child blocks in `write` at ~64 KiB and the poll loop reports
+/// the harness's own back-pressure as a client that missed its deadline - a
+/// verbose cell or a larger tree would fail every run for a reason that has
+/// nothing to do with the redo under test.
+#[test]
+fn deadlined_runner_collects_a_child_that_outwrites_the_pipe_buffer() {
+    let script = format!(
+        "yes 0123456789abcdef | head -c {PIPE_FLOOD_BYTES}\n\
+         yes 0123456789abcdef | head -c {PIPE_FLOOD_BYTES} >&2\n"
+    );
+    let outcome = within(HARNESS_BUDGET * 3, move || {
+        run_deadlined(
+            Path::new("/bin/sh"),
+            &[OsStr::new("-c"), OsStr::new(script.as_str())],
+            HARNESS_BUDGET,
+        )
+    })
+    .expect("flooding child must not be reported as a timeout");
+
+    assert!(outcome.status.success(), "flooding child exited non-zero");
+    assert_eq!(
+        outcome.stdout.len(),
+        PIPE_FLOOD_BYTES,
+        "stdout was truncated - the drain did not read to EOF",
+    );
+    assert_eq!(
+        outcome.stderr.len(),
+        PIPE_FLOOD_BYTES,
+        "stderr was truncated - the drain did not read to EOF",
+    );
+}
+
+/// The deadline must bound the whole run, not just the process wait.
+///
+/// The child exits immediately, so `try_wait` reports done on the first poll and
+/// the deadline is never consulted again - but a descendant still holds the pipe
+/// write end, so reading to EOF never returns. That is the remote-shell shape
+/// (client -> `lsh-stub` -> `--server`), and it hangs with no bound at all
+/// unless the collection is deadlined too.
+#[test]
+fn deadlined_runner_times_out_when_a_descendant_holds_the_pipe_open() {
+    let budget = Duration::from_secs(2);
+    let started = Instant::now();
+    let outcome = within(HARNESS_BUDGET * 3, move || {
+        run_deadlined(
+            Path::new("/bin/sh"),
+            // Backgrounded, so `sh` exits at once while the child keeps stdout
+            // and stderr open well past the budget.
+            &[OsStr::new("-c"), OsStr::new("sleep 30 & exit 0")],
+            budget,
+        )
+    });
+    let err = match outcome {
+        Ok(outcome) => panic!(
+            "a run whose output never reaches EOF must time out, got {:?}",
+            outcome.status,
+        ),
+        Err(err) => err,
+    };
+
+    assert_eq!(
+        err.kind(),
+        io::ErrorKind::TimedOut,
+        "expected a timeout, got: {err}",
+    );
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= budget,
+        "returned before the budget expired: {elapsed:?}",
+    );
+    assert!(
+        elapsed < HARNESS_BUDGET,
+        "the deadline did not bound the collection: {elapsed:?}",
     );
 }

--- a/tools/ci/tests/test_check_bin_build_coverage.sh
+++ b/tools/ci/tests/test_check_bin_build_coverage.sh
@@ -166,10 +166,18 @@ else
 fi
 
 # The crate list must be derived from the tree, not pinned in the script.
+#
+# The negatives are pure libraries that never spawn a subprocess, so they can
+# only appear if the derivation has broken. `test-support` is deliberately NOT
+# among them: it is the provider, and `derive_resolver_packages` exempts only a
+# provider's `src/`, counting any `tests/` reference as a real call site. Its own
+# integration tests name `OcRsyncCliRunner`, so it joins the set by that rule -
+# a conservative classification, since being in the set only ever *demands* a
+# build step, never omits one.
 cases=$((cases + 1))
 crates=$(python3 "${target}" --list-crates)
 if grep -qE '^(cli|core|engine|metadata|transfer)$' <<<"${crates}" &&
-    ! grep -qE '^(checksums|protocol|test-support)$' <<<"${crates}"; then
+    ! grep -qE '^(checksums|protocol)$' <<<"${crates}"; then
     echo "ok(derived_crates)"
 else
     echo "FAIL(derived_crates): unexpected crate list:" >&2

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -24,3 +24,8 @@ which = "8"
 toml_edit = "0.25"
 tempfile = { workspace = true }
 regex = "1"
+
+# `spawn_with_timeout` delegates to the workspace's single bounded
+# drain-and-wait primitive rather than carrying its own poll loop.
+[dev-dependencies]
+test-support = { path = "../crates/test-support" }

--- a/xtask/tests/main_cli.rs
+++ b/xtask/tests/main_cli.rs
@@ -1,30 +1,32 @@
 use std::io;
 use std::process::{Command, Output, Stdio};
 use std::str;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use test_support::Deadlined;
 
 /// Spawn a process and wait for completion with a timeout.
 ///
-/// Kills the process if it exceeds the timeout, preventing CI hangs.
+/// Delegates to the workspace's bounded drain-and-wait primitive, which reads
+/// both pipes throughout and bounds the output collection against the same
+/// deadline as the process wait. An `xtask` subcommand is among the most
+/// verbose children in the repo, so an undrained poll loop would report the
+/// harness's own back-pressure as a timeout.
 fn spawn_with_timeout(mut command: Command, timeout: Duration) -> io::Result<Output> {
-    let mut child = command.spawn()?;
-    let start = Instant::now();
-
-    loop {
-        match child.try_wait()? {
-            Some(_status) => return child.wait_with_output(),
-            None => {
-                if start.elapsed() >= timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        format!("process exceeded timeout of {timeout:?} and was killed"),
-                    ));
-                }
-                std::thread::sleep(Duration::from_millis(50));
-            }
-        }
+    match test_support::run_deadlined(&mut command, timeout)? {
+        Deadlined::Finished {
+            status,
+            stdout,
+            stderr,
+        } => Ok(Output {
+            status,
+            stdout,
+            stderr,
+        }),
+        Deadlined::Expired { budget, .. } => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("process exceeded timeout of {budget:?} and was killed"),
+        )),
     }
 }
 
@@ -73,4 +75,25 @@ fn xtask_unknown_command_reports_error() {
 
     let stderr = str::from_utf8(&output.stderr).expect("stderr is UTF-8");
     assert!(stderr.contains("unrecognized subcommand"));
+}
+
+/// RED-FIRST probe: `spawn_with_timeout` must collect a child that outwrites
+/// the pipe buffer. Undrained, the child blocks in `write` at ~64 KiB and the
+/// poll loop reports the harness's own back-pressure as a timeout.
+#[cfg(unix)]
+#[test]
+fn spawn_with_timeout_collects_a_child_that_outwrites_the_pipe_buffer() {
+    const FLOOD: usize = 256 * 1024;
+    let script = format!(
+        "yes 0123456789abcdef | head -c {FLOOD}\n\
+         yes 0123456789abcdef | head -c {FLOOD} >&2\n"
+    );
+    let mut command = Command::new("/bin/sh");
+    command.arg("-c").arg(&script);
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    let output = spawn_with_timeout(command, Duration::from_secs(10))
+        .expect("flooding child must not be reported as a timeout");
+    assert_eq!(output.stdout.len(), FLOOD, "stdout truncated");
+    assert_eq!(output.stderr.len(), FLOOD, "stderr truncated");
 }


### PR DESCRIPTION
## What

Several test harnesses polled `try_wait()` over a piped child and only called
`wait_with_output()` after exit. Two distinct defects followed, and the second is the
one that actually hangs.

**Half A — misattributed timeout, not a hang.** `try_wait()` is non-blocking, so the
deadline *does* fire. A child writing past the pipe buffer blocks in `write()`, is
never read, and burns the entire budget — the harness's own back-pressure reported as
the transport hang it exists to detect. Measured: a 256 KiB flood consumed a 5s budget
on both macOS and Linux and returned `TimedOut "client did not finish"`.

**Half B — the genuine unbounded wait, and it is not in the poll loop.** It is
`wait_with_output()` *after* it, past the last deadline check. A descendant holding the
pipe write end means read-to-EOF never returns. Measured on macOS: a `sleep 300 &`
orphan against a 5s budget was still running at 120s. Bounded only by the descendant's
lifetime — and the rsh cells spawn exactly that shape (client → lsh-stub → `--server`),
which is what makes it reachable rather than theoretical.

## One owner, not four repairs

`crates/test-support/src/deadline.rs` — `run_deadlined(&mut Command, budget)` returning
`Deadlined::{Finished, Expired}`. Both pipes drained on dedicated threads from spawn;
collection bounded against the *same* `Instant` as the process poll. `std` only, no new
dependencies, no retry or backoff.

Output accumulates into a shared buffer rather than a final `read_to_end`, so an
`Expired` run still returns what the child managed to write — strictly better than any
of the four call sites had, since the old timeout path returned only what survived the
kill.

Four sites converted, each **made to fail first**:

| site | before | after |
|---|---|---|
| `test-support/src/cli.rs` | 10.013s timeout | 0.037s |
| `xtask/tests/main_cli.rs` | 10.064s, killed | 4/4 in 0.73s |
| `metadata/tests/acl_root_root_interop.rs` | 10.04s, killed | 0.016s |
| `transfer/tests/verify_redo_…` | private copy | 7/7 real redo cells, zero `skipping:` |

The comment at `cli.rs:275` justified the tradeoff — "payloads in operational tests are
small, so pipe buffers do not fill" — which is measured false in the general case. It
went with the code it justified, rather than leaving a justification standing over a
tradeoff that had been removed.

## Deliberately not routed

Six further `try_wait()` sites were examined and left, with the reason recorded per site:
two need a lifetime-owning guard rather than a call swap (`core/tests/common/mod.rs:252`
drains nothing for the daemon's whole lifetime; `:854` does not own the pipes at all);
one would change what its cell asserts; one is a readiness poll that feeds another
hazard rather than having its own; one already drains before waiting; one is
structurally immune via `Stdio::null()` on both streams.

## One behaviour change, disclosed

On the `Expired` arm, `RunnerError::Timeout.stderr` now carries everything the child
wrote **before** the kill, where previously it carried only what survived
`wait_with_output()` *after* the kill. Strictly more data, never less.

Checked rather than assumed: `RunnerError::Timeout` has 5 match sites and every arm is
`{ .. }` or `{ after, .. }` — no test reads the field; it is only rendered through
`Display`. The pre-existing pin `timeout_kills_a_hanging_child` (`sleep 30` under a
200ms budget, asserting `Err(RunnerError::Timeout)` and `elapsed < 5s`) is untouched
and passes post-conversion, which is the direct evidence the timeout contract is
unchanged. Zero existing tests changed outcome.

The primitive also owns the child's stdio now (stdin null-or-piped, stdout/stderr
piped), so a caller's own stdio settings would be overridden. Nothing is affected today
— the runner already configured stdio internally and no caller sets it — but it is
stated in the rustdoc rather than left implicit.

## Verification

**Caller scope is complete, not sampled.** `OcRsyncCliRunner` / `RunnerError` /
`CliOutput` appear in 19 files, all of them in `test-support` (5) and `transfer` (14,
the `uts_*` suite) — zero consumers elsewhere. The four-crate run below therefore
covers 100% of the runner's callers.

Linux `-p test-support -p xtask -p metadata -p transfer --all-features --no-fail-fast`:
3916 run, 3916 passed, 3 skipped. Workspace `clippy -D warnings` 0, `fmt` 0.

`--no-fail-fast` throughout: an earlier run reported 490/532 because fail-fast had
truncated it, and the count was the tell.

macOS carries one inherited failure —
`xtask::validate::support::tests::backdated_tree_populates_and_backdates_the_root`, GNU
`touch -d @…` against BSD touch, in a file this branch does not modify.

## Not verified

The new `xtask → test-support` dev-dependency edge is unexercised on Windows. The pins
themselves are `#![cfg(unix)]` by construction, but the edge is new on every platform
and only CI proves the Windows cell. (It is declared `path`, not `workspace = true` —
`test-support` lives in the root `[dependencies]`, not `[workspace.dependencies]`, and
`workspace = true` fails the manifest load.)

The full workspace suite was not run on either host — four crates. For the runner that
is provably complete per the caller scope above; for the primitive it is complete by
construction, since it is new. It is still not a full-workspace green.
