### PR TITLE
fix(engine): itemize the -R implied dot-dir root against the basis

### DIFF
--- a/crates/cli/tests/relative_dot_root_row.rs
+++ b/crates/cli/tests/relative_dot_root_row.rs
@@ -1,0 +1,178 @@
+//! The synthetic `.` transfer root of a leading-`./` `-R` operand is a real
+//! file-list member, so it must appear in the listing and the itemize stream -
+//! not only in the `--stats` tally.
+//!
+//! Upstream arms `implied_dot_dir` for an operand whose transmitted name begins
+//! with a bare `./` (`flist.c:2640-2641`) and then emits exactly one synthetic
+//! entry with `send_file_name(f, flist, ".", NULL, (flags | FLAG_IMPLIED_DIR) &
+//! ~FLAG_CONTENT_DIR, ALL_FILTERS)` (`flist.c:2689-2692`). That is the same
+//! call the implied *ancestors* go through, so the `.` is rendered by the same
+//! rules as `sub/`: listed under `--list-only`, itemized against the basis, and
+//! shown as an all-dot `.d ./` row at `-ii` while `-i` suppresses an unchanged
+//! entry. A freshly created transfer root instead carries ITEM_IS_NEW and reads
+//! `cd+++++++++ ./`.
+//!
+//! The expectations below were captured from rsync 3.5.0 (protocol 32) in this
+//! exact layout, run from inside `src/`:
+//!
+//! | invocation                          | `.` row              |
+//! |-------------------------------------|----------------------|
+//! | `-R --list-only ./sub/f.txt`        | `drwxr-xr-x ... .`   |
+//! | `-R --list-only sub/f.txt`          | absent               |
+//! | `-Rrtii ./sub/f.txt dst/` (synced)  | `.d          ./`     |
+//! | `-Rri ./sub/f.txt dst/` (fresh dst) | `cd+++++++++ ./`     |
+//! | `-Rri ./sub/f.txt dst/` (dst exists)| absent               |
+//!
+//! The last two rows are what separates "emit the row" from "emit it
+//! unconditionally": both have a pre-existing operand tree, and they differ
+//! only in whether the destination *root* was created this run.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+use test_support::oc_rsync_bin;
+
+/// Creates `src/sub/f.txt` and returns the temp root. `dst/` is deliberately
+/// not created: the cells that need it say so, because its presence is the
+/// discriminator between two of them.
+fn dot_root_tree() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join("src/sub")).expect("source tree");
+    fs::write(tmp.path().join("src/sub/f.txt"), b"hi\n").expect("leaf file");
+    tmp
+}
+
+/// Runs `oc-rsync` from inside `src/`, so the operand really is a relative
+/// `./...` path - the only form that arms upstream's `implied_dot_dir`.
+fn run_from_source(root: &Path, args: &[&str]) -> String {
+    let mut cmd = Command::new(oc_rsync_bin());
+    cmd.current_dir(root.join("src"));
+    cmd.args(args);
+    let output = cmd.output().expect("spawn oc-rsync");
+    assert!(
+        output.status.success(),
+        "oc-rsync {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("stdout is utf-8")
+}
+
+/// Appends `<root>/dst/` as the destination operand.
+fn run_to_dst(root: &Path, args: &[&str]) -> String {
+    let mut owned: Vec<String> = args.iter().map(|a| (*a).to_owned()).collect();
+    owned.push(format!("{}/", root.join("dst").display()));
+    let borrowed: Vec<&str> = owned.iter().map(String::as_str).collect();
+    run_from_source(root, &borrowed)
+}
+
+/// The `--list-only` renderer prints the name last, so the `.` entry is the
+/// line whose final field is exactly `.` and whose mode says directory.
+fn lists_dot_entry(stdout: &str) -> bool {
+    stdout
+        .lines()
+        .any(|line| line.starts_with('d') && line.split_whitespace().next_back() == Some("."))
+}
+
+/// `--list-only` must show the synthetic `.` alongside the implied ancestor.
+#[test]
+fn list_only_shows_the_implied_dot_root() {
+    let tmp = dot_root_tree();
+    let stdout = run_from_source(tmp.path(), &["-R", "--list-only", "./sub/f.txt"]);
+
+    assert!(
+        lists_dot_entry(&stdout),
+        "rsync 3.5.0 lists the synthetic `.` transfer root: {stdout}"
+    );
+    assert!(
+        stdout.lines().any(|line| line.ends_with(" sub")),
+        "the implied ancestor must still be listed: {stdout}"
+    );
+}
+
+/// NON-VACUITY: an operand without the bare leading `./` never arms
+/// `implied_dot_dir`, so there is no `.` entry to list. Without this cell the
+/// test above would also pass if the row were emitted unconditionally.
+#[test]
+fn list_only_without_leading_dot_shows_no_dot_root() {
+    let tmp = dot_root_tree();
+    let stdout = run_from_source(tmp.path(), &["-R", "--list-only", "sub/f.txt"]);
+
+    assert!(
+        !lists_dot_entry(&stdout),
+        "no leading `./` means no implied `.` root: {stdout}"
+    );
+}
+
+/// The accounting was already correct and must not move: the `.` counts toward
+/// `Number of files` whether or not its row is rendered. A change here means
+/// the fix reached the counters, which it must not.
+#[test]
+fn stats_still_count_the_dot_root_once() {
+    let tmp = dot_root_tree();
+    let stdout = run_from_source(tmp.path(), &["-R", "--list-only", "--stats", "./sub/f.txt"]);
+
+    assert!(
+        stdout.contains("Number of files: 3 (reg: 1, dir: 2)"),
+        "the `.` and `sub` are both directories in the list: {stdout}"
+    );
+}
+
+/// On a fully synced tree `-ii` shows every entry, including the unchanged
+/// transfer root as an all-dot `.d ./`.
+#[test]
+fn itemize_twice_shows_the_unchanged_dot_root() {
+    let tmp = dot_root_tree();
+    fs::create_dir(tmp.path().join("dst")).expect("destination root");
+    run_to_dst(tmp.path(), &["-Rrt", "./sub/f.txt"]);
+
+    let stdout = run_to_dst(tmp.path(), &["-Rrtii", "./sub/f.txt"]);
+    let rows: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        rows,
+        [
+            ".d          ./",
+            ".d          sub/",
+            ".f          sub/f.txt"
+        ],
+        "rsync 3.5.0 itemizes the unchanged root ahead of the ancestor: {stdout}"
+    );
+}
+
+/// A destination root created by this run keeps ITEM_IS_NEW, so the row is
+/// `cd+++++++++ ./` and not the all-dot form. Guards against replacing the
+/// created-root arm rather than adding beside it.
+#[test]
+fn fresh_destination_root_still_itemizes_as_created() {
+    let tmp = dot_root_tree();
+    let stdout = run_to_dst(tmp.path(), &["-Rri", "./sub/f.txt"]);
+
+    assert!(
+        stdout.lines().any(|line| line == "cd+++++++++ ./"),
+        "a freshly created transfer root is new, not unchanged: {stdout}"
+    );
+}
+
+/// THE DISCRIMINATOR: same first run, but the destination root already exists.
+/// The root is then unchanged, and `-i` (one `i`, not two) suppresses an
+/// all-dot row - upstream prints no `./` line at all here. A fix that emits the
+/// row unconditionally, or that builds the change set from something other than
+/// the source/destination comparison, fails exactly this cell.
+#[test]
+fn preexisting_destination_root_itemizes_no_dot_row() {
+    let tmp = dot_root_tree();
+    fs::create_dir(tmp.path().join("dst")).expect("destination root");
+
+    let stdout = run_to_dst(tmp.path(), &["-Rri", "./sub/f.txt"]);
+    let rows: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        rows,
+        ["cd+++++++++ sub/", ">f+++++++++ sub/f.txt"],
+        "an unchanged transfer root produces no row at -i: {stdout}"
+    );
+}

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -916,17 +916,20 @@ fn emit_relative_implied_parents(
     // the itemize row and the created-dir tally - not the flist entry itself.
     let itemize = context.implied_dirs_enabled();
 
+    let metadata_options = context.metadata_options();
+    let omit_dir_times = context.omit_dir_times_enabled();
+    let modify_window = context.options().modify_window();
+
     // Dot-dir transfer root ".": upstream flist.c:2368+2417-2419 injects a
     // synthetic "." entry into the flist only for an operand that *begins* with
     // `./` (`implied_dot_dir`), so it counts toward "Number of files" whenever
     // directories are being transferred (the `xfer_dirs` gate below). A dot in
     // the middle of the path (e.g. `src/./sub`) reroots the relative path but
     // adds no "." entry. `dot_dir_anchor()` returns "." exactly for the leading
-    // form (its prefix-skip is zero). The receiver never itemizes the
-    // pre-existing destination root and end-of-run touch-up leaves it unchanged,
-    // so the entry stays count-only (no verbose/itemize row, no created-dir bump
-    // - the latter is owned by `mark_destination_root_created` when the root is
-    // freshly made).
+    // form (its prefix-skip is zero). The entry is a real flist member, so it is
+    // both counted and itemized like any other implied parent; the created-dir
+    // bump stays owned by `mark_destination_root_created`, which is what
+    // distinguishes the freshly made root from a pre-existing one.
     if source.dot_dir_anchor().as_deref() == Some(Path::new(".")) {
         let dot = PathBuf::from(".");
         if context.mark_implied_dir_emitted(&dot) {
@@ -961,26 +964,65 @@ fn emit_relative_implied_parents(
                 // which exists in both modes (the destination may not yet).
                 let root_created = destination_root_created
                     || (context.mode().is_dry_run() && !destination_path.exists());
-                if root_created
-                    && itemize
+                if itemize
                     && let Some(anchor) = source.dot_dir_anchor()
                     && let Ok(meta) = fs::symlink_metadata(&anchor)
                     && meta.file_type().is_dir()
                 {
-                    context.summary_mut().record_directory();
                     let snapshot = LocalCopyMetadata::from_metadata(&meta, None);
                     let snapshot_len = snapshot.len();
-                    context.record(
-                        LocalCopyRecord::new(
-                            dot.clone(),
-                            LocalCopyAction::DirectoryCreated,
-                            0,
-                            Some(snapshot_len),
-                            Duration::default(),
-                            Some(snapshot),
+                    let record = if root_created {
+                        context.summary_mut().record_directory();
+                        Some(
+                            LocalCopyRecord::new(
+                                dot.clone(),
+                                LocalCopyAction::DirectoryCreated,
+                                0,
+                                Some(snapshot_len),
+                                Duration::default(),
+                                Some(snapshot),
+                            )
+                            .with_creation(true),
                         )
-                        .with_creation(true),
-                    );
+                    } else if let Ok(existing) = fs::symlink_metadata(destination_path)
+                        && existing.file_type().is_dir()
+                    {
+                        // Pre-existing transfer root: upstream still placed the
+                        // synthetic "." in the flist, so the receiver reaches it
+                        // like any other implied parent and itemizes it against
+                        // the basis - an unchanged root is an all-dot `.d ./`
+                        // row, surfaced under -ii and under --list-only and
+                        // suppressed at -i. Same treatment the ancestor loop
+                        // below gives `sub/`; only the leading "." was missing
+                        // it, so the row vanished from both those cells while
+                        // `--stats` (fed by record_file_list_entry above) still
+                        // counted it.
+                        let change_set = LocalCopyChangeSet::for_existing_directory(
+                            &meta,
+                            &existing,
+                            &metadata_options,
+                            omit_dir_times,
+                            false,
+                            false,
+                            modify_window,
+                        );
+                        Some(
+                            LocalCopyRecord::new(
+                                dot.clone(),
+                                LocalCopyAction::MetadataReused,
+                                0,
+                                Some(snapshot_len),
+                                Duration::default(),
+                                Some(snapshot),
+                            )
+                            .with_change_set(change_set),
+                        )
+                    } else {
+                        None
+                    };
+                    if let Some(record) = record {
+                        context.record(record);
+                    }
                 }
             } else {
                 context.record_skipped_directory(non_empty_path(dot.as_path()));
@@ -999,10 +1041,6 @@ fn emit_relative_implied_parents(
     };
     let destination_root = strip_path_suffix(destination_path, relative)
         .unwrap_or_else(|| destination_path.to_path_buf());
-
-    let metadata_options = context.metadata_options();
-    let omit_dir_times = context.omit_dir_times_enabled();
-    let modify_window = context.options().modify_window();
 
     let mut accumulated = PathBuf::new();
     for component in &components[..parent_count] {


### PR DESCRIPTION
A leading-`./` `-R` operand makes upstream inject a synthetic `.` transfer root
into the file list. `implied_dot_dir` has exactly one emitter (`flist.c:2640-2641`
arms it inside the `relative_paths` branch; `flist.c:2689-2692` fires it), and it
fires through the *same* `send_file_name()` the implied ancestors use - so the
`.` must be rendered by the ancestors' rules, not by a special case.

oc built that entry and counted it, but only produced a row when the destination
root was created during the run. A pre-existing root fell off the end of the
branch with no record at all, so the `.` was missing from `--list-only` and from
the `-ii` itemize stream while `--stats` still reported it.

The entry now takes the same treatment the ancestor loop 60 lines below already
gives `sub/`: a `MetadataReused` record carrying a
`LocalCopyChangeSet::for_existing_directory` comparison against the destination
root. That reproduces upstream's rendering in every cell without inventing a rule.

## Measured against real rsync 3.5.0

| cell | upstream | before | after |
|---|---|---|---|
| `-R --list-only ./sub/f.txt` | `.`, `sub`, `f` | `sub`, `f` | match |
| `-R --list-only sub/f.txt` (control) | `sub`, `f` | same | match |
| `-R --list-only --stats` | `dir: 2` | `dir: 2` | match (unmoved) |
| `-Rrtii ./sub/f.txt`, synced dest | `.d ./` present | absent | match |
| `-Rri ./sub/f.txt`, fresh dest | `cd+++++++++ ./` | same | match |
| `-Rri ./sub/f.txt`, pre-existing dest | no `./` row | no `./` row | match |

Two cells diverged, both the same dropped row. The `--stats` cell shows the
accounting was already correct - this is a rendering fix and no counter changed.
The last two cells are the pair a wrong fix breaks: both have a pre-existing
operand tree and differ only in whether the destination root was created.

## Non-vacuity

The two halves were mutated separately and each has a uniquely lethal cell, so
neither mutation can be repaired by the other:

- wiring reverted -> `list_only_shows_the_implied_dot_root` and
  `itemize_twice_shows_the_unchanged_dot_root` fail
- record shape reverted to `DirectoryCreated` -> `preexisting_destination_root_itemizes_no_dot_row`
  and `itemize_twice_...` fail

## Scope

Local copy only, and that was checked rather than assumed: the generator has its
own independent `implied_dot_dir` emitter, and SSH push `-Rrtii` measured
byte-identical to upstream both before and after.

A now-false comment claiming the receiver never itemizes a pre-existing
destination root was corrected in the same hunk.

## Verification

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets
--all-features --no-deps -D warnings` both clean. Full workspace on Linux:
33147 run, 33147 passed, 149 skipped. The new test file is `#![cfg(unix)]`.
