### PR TITLE
fix(cli): accept --log-file as a server long flag instead of leaking it into the destination

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -1063,6 +1063,27 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--timeout=")
         || arg.starts_with("--io-uring-depth=")
         || arg.starts_with("--log-format=")
+        // upstream: options.c:796 - `--log-file` is POPT_ARG_STRING in the
+        // client/server table, so a server accepts it and binds the value.
+        // `server_options()` never emits it; it reaches a server only as a
+        // client's remote option (`-M--log-file=FILE`), which a restricted
+        // wrapper forwards verbatim after rewriting the path
+        // (`support/rrsync:84` types it 3, the confined-path class). Without
+        // this entry the whole token falls through to the positional list and
+        // becomes the destination. MEASURED on the 3.5.0 suite
+        // (`rrsync-no-overwrite-logfile`): Linux rewrites the value to
+        // `/proc/self/fd/N`, so the receiver statx'd the literal
+        // `--log-file=/proc/self/fd/3` and reported `server error: No such
+        // file or directory`, rc=12; macOS has no such rewrite, so the same
+        // leak instead CREATED a file named `--log-file=protected` in the
+        // module root and exited 0 - a silent wrong-destination write, not a
+        // pass. Same allow-list-drift class as `--confine-root=` above.
+        //
+        // The value is deliberately not captured: oc's server has no log-file
+        // sink (upstream calls `log_init(0)` from options.c:2530), so storing
+        // it would create a field with no reader. Recognising the token is
+        // what stops the leak; server-side `--log-file` writing is separate.
+        || arg.starts_with("--log-file=")
         || arg.starts_with("--info=")
         // upstream: options.c:1777 - `--debug=FLAGS` parsed via
         // parse_output_words(debug_words, ...). The client forwards it like

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -322,6 +322,50 @@ fn parse_server_args_does_not_leak_confine_root_into_the_destination() {
     );
 }
 
+/// A peer's `-M--log-file=FILE` must not become the destination path.
+///
+/// `server_options()` never emits `--log-file`, so it reaches a server only as
+/// a client's remote option, forwarded verbatim by a restricted wrapper
+/// (`support/rrsync:84` allows it as a confined-path argument). It was in
+/// neither server option table, so the whole token fell through to the
+/// positional list and was taken for the destination.
+///
+/// Both spellings below are the two MEASURED failure shapes of the same leak,
+/// and they fail DIFFERENTLY - which is why the divergence looked
+/// platform-specific rather than universal:
+///
+/// - the multi-component `/proc/self/fd/3` value (what a Linux restricted
+///   wrapper rewrites the path to) cannot be created as a relative directory,
+///   so the receiver reported `server error: No such file or directory`, rc=12;
+/// - the single-component `protected` value (no such rewrite on macOS) CAN be
+///   created, so the transfer silently wrote into a file literally named
+///   `--log-file=protected` in the module root and exited 0. That vacuous
+///   success is why `rrsync-no-overwrite-logfile` passed on one platform.
+///
+/// upstream: options.c:796 - the `POPT_ARG_STRING` entry that binds the value
+/// on the server side, so it is never an operand there either.
+#[test]
+fn parse_server_args_does_not_leak_log_file_into_the_destination() {
+    for value in ["/proc/self/fd/3", "protected"] {
+        let args = vec![
+            OsString::from("--server"),
+            OsString::from("-rIe.iLsfxCIvu"),
+            OsString::from(format!("--log-file={value}")),
+            OsString::from("--log-format=X"),
+            OsString::from("."),
+            OsString::from("dest"),
+        ];
+        let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+        assert_eq!(flags, "-rIe.iLsfxCIvu");
+        assert_eq!(
+            pos_args,
+            vec![OsString::from("dest")],
+            "--log-file={value} must be consumed as a flag, never left in the \
+             positional list where it is taken for the destination"
+        );
+    }
+}
+
 /// The value must also survive to the config, not merely be swallowed.
 ///
 /// Paired with the operand test above on purpose: they exercise DIFFERENT

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -281,7 +281,7 @@ rrsync-logfile-symlink pass
 rrsync-merge-file-confine fail
 rrsync-no-overwrite-backup-collision pass
 rrsync-no-overwrite-delay-updates pass
-rrsync-no-overwrite-logfile fail
+rrsync-no-overwrite-logfile pass
 rrsync-no-overwrite-partial-dir pass
 rrsync-pull-arg-shapes fail
 rrsync-pull-delivers-content pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -281,7 +281,7 @@ rrsync-logfile-symlink pass
 rrsync-merge-file-confine fail
 rrsync-no-overwrite-backup-collision pass
 rrsync-no-overwrite-delay-updates pass
-rrsync-no-overwrite-logfile fail
+rrsync-no-overwrite-logfile pass
 rrsync-no-overwrite-partial-dir pass
 rrsync-pull-arg-shapes fail
 rrsync-pull-delivers-content pass


### PR DESCRIPTION
`--log-file` is `POPT_ARG_STRING` in upstream's client/server option table
(`options.c:796`), so a server accepts it and binds the value. `server_options()`
never emits it; it reaches a server only as a client's remote option
(`-M--log-file=FILE`), which a restricted wrapper forwards verbatim after
rewriting the path (`support/rrsync:84` types it 3, the confined-path class).

oc's `is_known_server_long_flag` had no entry for it, so the whole token fell
through to the positional list and **became the destination operand**.

## What it actually does

Not "oc cannot find the file" and not "oc refuses the file" - oc was looking for
the *wrong file*, one whose name is the option token. The intended path was never
opened at all. The strace shows the resolver being handed a path that has never
existed on any filesystem:

```
statx(AT_FDCWD, "--log-file=/proc/self/fd/3", ...)                  = -1 ENOENT
openat2(AT_FDCWD, ".",  {... resolve=0})                            = 4
openat2(AT_FDCWD, "--log-file=/proc/self/fd", {... RESOLVE_NO_SYMLINKS}) = -1 ENOENT
```

The anchor open succeeds; only the input is garbage. The first failing syscall is
the `statx`, *before* the confined `openat2`, so the resolver is downstream of the
leak rather than its cause.

## Both platforms, different symptoms

This was never a platform divergence - Linux only made it visible.

| platform | behaviour |
|---|---|
| Linux | rrsync rewrites the value to `/proc/self/fd/N`, so the multi-component path cannot be created: `server error: No such file or directory`, rc=12 |
| macOS | no such rewrite, so the single-component value **can** be created - oc wrote a file literally named `--log-file=protected` into the module root and exited 0 |

The macOS "pass" was therefore vacuous. Measured with an argv-logging shim plus a
post-run walk. A Linux-only resolver arm cannot explain a macOS misbehaviour,
which is what rules the confined-open path out as the cause.

## Scope

One entry in the allow-list - the same drift class as `--confine-root=`
(PR #7388), which leaked into the destination operand the same way.

The value is deliberately **not** captured: oc's server has no log-file sink
anywhere, so storing it would add a field with no reader.

RED proven by deleting the entry, with the `--confine-root` cell as the
non-vacuity companion. Both expect-manifest rows flipped in the same commit.
