### PR TITLE
fix(client): list a remote source under --list-only

### DIFF
--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -62,6 +62,7 @@ use super::batch_support::{BatchContext, build_batch_context, build_batch_record
 use super::flags;
 use super::implied_source::implied_source_args_for_pull;
 use super::invocation::{RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role};
+use super::operand_split::split_transfer_operands;
 use super::ssh_transfer::{
     build_server_config_for_generator, build_server_config_for_receiver,
     convert_server_stats_to_summary, parse_remote_operands, parse_single_remote,
@@ -139,15 +140,11 @@ pub fn run_async_ssh_transfer(
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let args = config.transfer_args();
-    if args.len() < 2 {
-        return Err(invalid_argument_error(
-            "need at least one source and one destination",
-            1,
-        ));
-    }
-
-    let (sources, destination) = args.split_at(args.len() - 1);
-    let destination = &destination[0];
+    // upstream: main.c:1465-1466 - a remote source with a single operand sets
+    // `argc = 0` ("no dest arg") rather than erroring, and options.c:2311-2312
+    // has already inferred list-only from the operand count.
+    let fallback_dest = std::ffi::OsString::from(".");
+    let (sources, destination) = split_transfer_operands(args, config, &fallback_dest)?;
 
     let transfer_spec = determine_transfer_role(sources, destination)?;
 

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -43,6 +43,7 @@ use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
 use super::batch_support::build_batch_context;
 use super::invocation::{RemoteRole, TransferSpec, determine_transfer_role};
+use super::operand_split::split_transfer_operands;
 
 use connection::{DaemonTransferRequest, perform_daemon_handshake};
 use orchestration::{run_pull_transfer, run_push_transfer, send_daemon_arguments};
@@ -86,26 +87,12 @@ pub fn run_daemon_transfer(
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let args = config.transfer_args();
-    // upstream: options.c:2194 - a single source with list_only set lists the
-    // module contents (`host::module` with no destination); only a genuinely
-    // empty operand list is an error.
-    if args.is_empty() || (args.len() < 2 && !config.list_only()) {
-        return Err(invalid_argument_error(
-            "need at least one source and one destination",
-            1,
-        ));
-    }
 
-    // For an implicit list-only transfer (single source, no dest) synthesize a
-    // dummy `.` destination; config.list_only() forces read-only/no-write so it
-    // is never materialized.
-    let dummy_dest = std::ffi::OsString::from(".");
-    let (sources, destination) = if args.len() < 2 {
-        (args, &dummy_dest)
-    } else {
-        let (sources, destination) = args.split_at(args.len() - 1);
-        (sources, &destination[0])
-    };
+    // upstream: main.c:1465-1466 - a remote source with a single operand sets
+    // `argc = 0` ("no dest arg") rather than erroring, and options.c:2311-2312
+    // has already inferred list-only from the operand count.
+    let fallback_dest = std::ffi::OsString::from(".");
+    let (sources, destination) = split_transfer_operands(args, config, &fallback_dest)?;
 
     let transfer_spec = determine_transfer_role(sources, destination)?;
     let role = transfer_spec.role();
@@ -336,26 +323,12 @@ pub fn run_daemon_over_remote_shell(
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let args = config.transfer_args();
-    // upstream: options.c:2194 - a single source with list_only set lists the
-    // module contents (`host::module` with no destination); only a genuinely
-    // empty operand list is an error.
-    if args.is_empty() || (args.len() < 2 && !config.list_only()) {
-        return Err(invalid_argument_error(
-            "need at least one source and one destination",
-            1,
-        ));
-    }
 
-    // For an implicit list-only transfer (single source, no dest) synthesize a
-    // dummy `.` destination; config.list_only() forces read-only/no-write so it
-    // is never materialized.
-    let dummy_dest = std::ffi::OsString::from(".");
-    let (sources, destination) = if args.len() < 2 {
-        (args, &dummy_dest)
-    } else {
-        let (sources, destination) = args.split_at(args.len() - 1);
-        (sources, &destination[0])
-    };
+    // upstream: main.c:1465-1466 - a remote source with a single operand sets
+    // `argc = 0` ("no dest arg") rather than erroring, and options.c:2311-2312
+    // has already inferred list-only from the operand count.
+    let fallback_dest = std::ffi::OsString::from(".");
+    let (sources, destination) = split_transfer_operands(args, config, &fallback_dest)?;
 
     let transfer_spec = determine_transfer_role(sources, destination)?;
     let role = transfer_spec.role();

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -42,6 +42,7 @@ use super::implied_source::implied_source_args_for_pull;
 use super::invocation::{
     RemoteInvocationBuilder, RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role,
 };
+use super::operand_split::split_transfer_operands;
 use super::ssh_transfer::convert_server_stats_to_summary;
 use crate::exit_code::ExitCode;
 use crate::server::{ServerConfig, ServerRole, TransferProgressCallback, TransferProgressEvent};
@@ -77,15 +78,11 @@ pub fn run_embedded_ssh_transfer(
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let args = config.transfer_args();
-    if args.len() < 2 {
-        return Err(invalid_argument_error(
-            "need at least one source and one destination",
-            1,
-        ));
-    }
-
-    let (sources, destination) = args.split_at(args.len() - 1);
-    let destination = &destination[0];
+    // upstream: main.c:1465-1466 - a remote source with a single operand sets
+    // `argc = 0` ("no dest arg") rather than erroring, and options.c:2311-2312
+    // has already inferred list-only from the operand count.
+    let fallback_dest = std::ffi::OsString::from(".");
+    let (sources, destination) = split_transfer_operands(args, config, &fallback_dest)?;
 
     let transfer_spec = determine_transfer_role(sources, destination)?;
 

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -37,6 +37,8 @@ pub mod invocation;
 /// Shared client-visible itemize sink for the remote transports.
 pub(crate) mod itemize_sink;
 /// `--info=`/`--debug=` server-argument construction (make_output_option).
+/// Shared source/destination operand split for the remote transports.
+pub(crate) mod operand_split;
 pub(crate) mod operator_file;
 pub(crate) mod output_option;
 /// Remote-to-remote transfer via local proxy relay.

--- a/crates/core/src/client/remote/operand_split.rs
+++ b/crates/core/src/client/remote/operand_split.rs
@@ -1,0 +1,134 @@
+//! Splitting a remote transfer's operand vector into sources and a destination.
+//!
+//! Upstream has no "you must supply a destination" check at all. It reaches the
+//! same place from the other direction: when fewer than two operands are given
+//! it *infers* list-only mode, and when the source is remote it explicitly
+//! records that there is no destination argument.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/options.c:2311-2312` - `if (argc < 2 && !read_batch &&
+//!   !am_server) list_only |= 1;`. The inference is transport-agnostic: a local
+//!   path, an SSH `host:path` source and a daemon `host::module` all take it.
+//! - `rsync-3.5.0/main.c:1465-1466` - inside `start_client()`'s remote-source
+//!   branch, `if (argc == 1 || **argv == ':') argc = 0; /* no dest arg */`.
+//! - `rsync-3.5.0/main.c:712` - `get_local_name()` returns NULL immediately for
+//!   `list_only`, which is why a destination that is never consumed is safe.
+
+use std::ffi::OsString;
+
+use crate::client::config::ClientConfig;
+use crate::client::error::{ClientError, invalid_argument_error};
+
+/// Splits `args` into `(sources, destination)` for a remote transfer.
+///
+/// With two or more operands the last is the destination, as usual. With
+/// exactly one the operand is a source and `fallback_dest` stands in for the
+/// destination upstream simply does not have (`main.c:1465-1466`); the caller
+/// owns that value so the borrow outlives the call. `list_only` makes the
+/// stand-in inert - upstream's `get_local_name()` returns NULL before ever
+/// looking at it (`main.c:712`), and oc's receiver is read-only for the same
+/// reason - so a one-operand transfer without `list_only` is rejected rather
+/// than silently writing to it.
+///
+/// The one-operand case normally cannot reach here without `list_only`: the CLI
+/// applies upstream's `argc < 2` inference while parsing
+/// (`crates/cli/src/frontend/execution/drive/workflow/run.rs`). The conjunct
+/// guards the library entry points, which can be called with a hand-built
+/// [`ClientConfig`].
+///
+/// # Errors
+///
+/// Returns an invalid-argument error (exit code 1) when `args` is empty, or
+/// when a single operand is given without `list_only`.
+pub(crate) fn split_transfer_operands<'a>(
+    args: &'a [OsString],
+    config: &ClientConfig,
+    fallback_dest: &'a OsString,
+) -> Result<(&'a [OsString], &'a OsString), ClientError> {
+    if args.is_empty() || (args.len() < 2 && !config.list_only()) {
+        return Err(invalid_argument_error(
+            "need at least one source and one destination",
+            1,
+        ));
+    }
+
+    if args.len() < 2 {
+        return Ok((args, fallback_dest));
+    }
+
+    let (sources, destination) = args.split_at(args.len() - 1);
+    Ok((sources, &destination[0]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_transfer_operands;
+    use crate::client::config::ClientConfig;
+    use std::ffi::OsString;
+
+    fn config(list_only: bool) -> ClientConfig {
+        ClientConfig::builder().list_only(list_only).build()
+    }
+
+    fn operands(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    /// Two or more operands keep the ordinary split: everything but the last is
+    /// a source. `list_only` does not change that - upstream still lists the
+    /// source when a destination is present (`list_only > 1` suppresses the
+    /// transfer, not the operand parse).
+    #[test]
+    fn trailing_operand_is_the_destination() {
+        let dot = OsString::from(".");
+        for list_only in [false, true] {
+            let args = operands(&["a", "b", "dest"]);
+            let (sources, destination) =
+                split_transfer_operands(&args, &config(list_only), &dot).expect("split");
+            assert_eq!(sources, &args[..2]);
+            assert_eq!(destination, &args[2]);
+        }
+    }
+
+    /// THE FIX: a lone operand is a SOURCE, and the caller's stand-in becomes
+    /// the destination. Upstream records `argc = 0` here (main.c:1465-1466);
+    /// the stand-in is inert because `list_only` keeps the receiver read-only.
+    #[test]
+    fn lone_operand_under_list_only_is_a_source() {
+        let dot = OsString::from(".");
+        let args = operands(&["host:path"]);
+        let (sources, destination) =
+            split_transfer_operands(&args, &config(true), &dot).expect("split");
+        assert_eq!(sources, &args[..]);
+        assert_eq!(destination, &dot);
+    }
+
+    /// NON-VACUITY: without `list_only` the same operand vector is still
+    /// rejected, so the fix cannot be mistaken for "always synthesize a
+    /// destination". The CLI never produces this shape (it applies upstream's
+    /// `argc < 2` inference first); a hand-built config can.
+    #[test]
+    fn lone_operand_without_list_only_is_rejected() {
+        let dot = OsString::from(".");
+        let args = operands(&["host:path"]);
+        let error = split_transfer_operands(&args, &config(false), &dot)
+            .expect_err("one operand without list_only must be rejected");
+        assert!(
+            error.to_string().contains("one source and one destination"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// An empty operand vector is an error under every setting - upstream's
+    /// inference turns a short list into list-only, never into a no-op.
+    #[test]
+    fn empty_operands_are_rejected_even_under_list_only() {
+        let dot = OsString::from(".");
+        let args: Vec<OsString> = Vec::new();
+        for list_only in [false, true] {
+            split_transfer_operands(&args, &config(list_only), &dot)
+                .expect_err("an empty operand vector is always an error");
+        }
+    }
+}

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -28,6 +28,7 @@ use super::super::flags;
 use super::super::implied_source::implied_source_args_for_pull;
 use super::super::invocation::{RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role};
 use super::super::itemize_sink::ItemizeEventSink;
+use super::super::operand_split::split_transfer_operands;
 use super::connection::build_ssh_connection;
 use super::exit_status::{convert_server_stats_to_summary, map_child_exit_status};
 use super::parse::{parse_remote_operands, parse_single_remote, remote_operand_source_paths};
@@ -88,15 +89,11 @@ pub fn run_ssh_transfer(
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let args = config.transfer_args();
-    if args.len() < 2 {
-        return Err(invalid_argument_error(
-            "need at least one source and one destination",
-            1,
-        ));
-    }
-
-    let (sources, destination) = args.split_at(args.len() - 1);
-    let destination = &destination[0];
+    // upstream: main.c:1465-1466 - a remote source with a single operand sets
+    // `argc = 0` ("no dest arg") rather than erroring, and options.c:2311-2312
+    // has already inferred list-only from the operand count.
+    let fallback_dest = std::ffi::OsString::from(".");
+    let (sources, destination) = split_transfer_operands(args, config, &fallback_dest)?;
 
     let transfer_spec = determine_transfer_role(sources, destination)?;
 

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -9,7 +9,9 @@
 
 use std::time::Duration;
 
-use super::super::super::summary::ClientSummary;
+use super::super::super::summary::{
+    ClientEntryMetadata, ClientEvent, ClientSummary, ListOnlyEntryFields,
+};
 use crate::exit_code::ExitCode;
 
 /// Converts server-side statistics to a client summary.
@@ -26,6 +28,34 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
     use crate::server::ServerStats;
     use engine::local_copy::LocalCopySummary;
     use transfer::io_error_flags;
+
+    // upstream: generator.c:1249 - in list-only mode the receiver captures every
+    // flist entry's metadata instead of requesting file data; convert those into
+    // metadata-bearing events so the client can render the listing. The daemon
+    // transport does the same in `daemon_transfer/orchestration/stats.rs`;
+    // without this drain an SSH `--list-only` pull completes silently.
+    let list_only_events: Vec<ClientEvent> = match stats {
+        ServerStats::Receiver(ref transfer_stats) => transfer_stats
+            .list_only_entries
+            .iter()
+            .map(|entry| {
+                let metadata = ClientEntryMetadata::from_list_only_entry(&ListOnlyEntryFields {
+                    mode: entry.mode,
+                    size: entry.size,
+                    mtime: entry.mtime,
+                    mtime_nsec: entry.mtime_nsec,
+                    atime: entry.atime,
+                    atime_nsec: entry.atime_nsec,
+                    crtime: entry.crtime,
+                    crtime_nsec: entry.crtime_nsec,
+                    symlink_target: entry.symlink_target.clone(),
+                    is_symlink: entry.is_symlink,
+                });
+                ClientEvent::from_list_only_entry(entry.path.clone(), metadata)
+            })
+            .collect(),
+        ServerStats::Generator(_) => Vec::new(),
+    };
 
     let (local_summary, io_error, got_xfer_error) = match stats {
         ServerStats::Receiver(ref transfer_stats) => {
@@ -79,6 +109,9 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
     };
 
     let mut summary = ClientSummary::from_summary(local_summary);
+    if !list_only_events.is_empty() {
+        summary = summary.with_events(list_only_events);
+    }
 
     // upstream: cleanup.c:210-218 - convert io_error bitfield to RERR_* codes.
     // `log_exit()` only renders the chosen code; the selection rule lives in
@@ -192,6 +225,72 @@ mod windows_exit_status_tests {
         assert!(
             !matches!(mapped, ExitCode::Other(_)),
             "a known RERR_* code must keep its named variant, not fall to Other"
+        );
+    }
+}
+
+#[cfg(test)]
+mod list_only_conversion_tests {
+    use super::convert_server_stats_to_summary;
+    use crate::server::ServerStats;
+    use std::path::PathBuf;
+    use std::time::Duration;
+    use transfer::{ListOnlyEntry, TransferStats};
+
+    fn entry(path: &str) -> ListOnlyEntry {
+        ListOnlyEntry {
+            path: PathBuf::from(path),
+            mode: 0o100_644,
+            size: 6,
+            mtime: 1_700_000_000,
+            mtime_nsec: 0,
+            atime: 0,
+            atime_nsec: 0,
+            crtime: 0,
+            crtime_nsec: 0,
+            symlink_target: None,
+            is_symlink: false,
+        }
+    }
+
+    fn receiver_stats(entries: Vec<ListOnlyEntry>) -> ServerStats {
+        ServerStats::Receiver(TransferStats {
+            files_listed: entries.len(),
+            list_only_entries: entries,
+            ..TransferStats::default()
+        })
+    }
+
+    /// An SSH `--list-only` pull carries its listing in the receiver's
+    /// `list_only_entries`, never as transferred data. The converter is the only
+    /// place those entries can become client-visible events, so a summary built
+    /// without the drain completes silently with exit 0 - the failure mode this
+    /// pins. The daemon transport reaches the same result through
+    /// `daemon_transfer/orchestration/stats.rs`.
+    ///
+    /// upstream: generator.c:1249 `list_file_entry()`.
+    #[test]
+    fn receiver_list_only_entries_become_client_events() {
+        let summary =
+            convert_server_stats_to_summary(receiver_stats(vec![entry("f.txt")]), Duration::ZERO);
+
+        let paths: Vec<_> = summary
+            .events()
+            .iter()
+            .map(|event| event.relative_path().to_path_buf())
+            .collect();
+        assert_eq!(paths, vec![PathBuf::from("f.txt")]);
+    }
+
+    /// NON-VACUITY: an ordinary transfer captures no list-only entries, so the
+    /// drain must add nothing. Without this the first test would also pass if
+    /// the converter fabricated an event from any receiver stats.
+    #[test]
+    fn a_transfer_without_list_only_entries_produces_no_events() {
+        let summary = convert_server_stats_to_summary(receiver_stats(Vec::new()), Duration::ZERO);
+        assert!(
+            summary.events().is_empty(),
+            "a non-list-only receive must not synthesize events"
         );
     }
 }


### PR DESCRIPTION
## Problem

`oc-rsync host:path/` and `oc-rsync --list-only host:path/` both exited 1 with `need at least one source and one destination`, where upstream lists the remote tree.

Upstream has no "you must supply a destination" check at all. It infers list-only from the operand count (`options.c:2311-2312`) and, for a remote source, records `argc = 0` rather than erroring (`main.c:1465-1466`); `get_local_name()` then returns NULL for list-only (`main.c:712`), so the absent destination is never consumed.

## Fix

The rejection lived at **five sites across two transports**, each with its own copy of the operand split. They now share `split_transfer_operands`, which takes the last operand as the destination exactly as before and, under `list_only`, treats a lone operand as a source with a caller-owned `.` standing in. Without `list_only` the rejection is unchanged, so the guard still catches a genuinely missing destination.

## The second half

Relaxing the split alone made an SSH `--list-only` pull exit **0 in silence** — worse than the error it replaced. The receiver captures the listing in `TransferStats::list_only_entries`, and the SSH result converter dropped them on the floor. It now drains them into metadata-bearing client events, as the daemon transport already does in `daemon_transfer/orchestration/stats.rs`.

## Verification

Measured against rsync 3.5.0 across ten cells (local, `host:path`, `rsync://`, `host::module`, module listing, and a push): the two SSH cells moved from exit 1 to upstream's listing; the other eight were already matching and are unchanged.

Spot-checked again before opening, through a remote-shell shim — oc and upstream 3.5.0 produce **byte-identical** output for `-r --list-only localhost:src/`, both exit 0.

`cargo fmt --all -- --check` clean; `cargo clippy -p core --all-targets --all-features` clean; targeted `-p core` suite 32/32.
