### PR TITLE
fix(sender): follow a symlinked dir named with the DOTDIR marker

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -542,6 +542,27 @@ impl GeneratorContext {
     }
 }
 
+/// Whether an operand carries upstream's DOTDIR marker.
+///
+/// The marker is a trailing `/`, a trailing `/.`, or the bare `.` itself. It
+/// means "transfer the CONTENTS of this directory" rather than the directory
+/// entry, and it carries a second consequence that is easy to miss: it makes
+/// `link_stat()` follow a symlink-to-directory *unconditionally*, with no
+/// `--copy-dirlinks` required. Without that, `host:current/` where
+/// `current -> releases/2026-08-25` is `lstat`ed as a symlink, the walk never
+/// descends, and the transfer silently delivers nothing.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/flist.c:2589-2594` - a trailing slash sets `DOTDIR_NAME`.
+/// - `rsync-3.5.0/flist.c:2604` - a trailing `/.` sets it too.
+/// - `rsync-3.5.0/flist.c:2697` - `link_stat(fbuf, &st, copy_dirlinks ||
+///   name_type != NORMAL_NAME)`; the second disjunct is this marker.
+pub(super) fn operand_has_dotdir_marker(path: &Path) -> bool {
+    let bytes = path.as_os_str().as_encoded_bytes();
+    bytes == b"." || bytes.ends_with(b"/") || bytes.ends_with(b"/.")
+}
+
 /// Splits a source path for `--relative` mode into (base, full path).
 ///
 /// Mirrors upstream rsync's `--relative` handling in `flist.c:2316-2350`:
@@ -633,13 +654,14 @@ fn find_dot_dir_anchor(path: &Path) -> Option<usize> {
 ///   * `/`             -> base=`/`,         path=`/`             (dotdir)
 ///   * `foo`           -> base=`.`,         path=`foo`
 fn non_relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
-    // Upstream's DOTDIR_NAME branch (flist.c:2312-2322) preserves a
-    // trailing slash to signal "transfer the contents only". Preserve
-    // base == path so `walk_path_with_metadata`'s `relative.is_empty()`
-    // branch still emits `.` for the source root.
-    let s = path.as_os_str();
-    let bytes = s.as_encoded_bytes();
-    if bytes.last() == Some(&b'/') {
+    // Upstream's DOTDIR_NAME branch (flist.c:2312-2322) preserves the marker
+    // to signal "transfer the contents only". Preserve base == path so
+    // `walk_path_with_metadata`'s `relative.is_empty()` branch still emits `.`
+    // for the source root. Both spellings of the marker take this branch: a
+    // trailing `/.` is DOTDIR just as much as a trailing `/`, and routing it
+    // through `Path::parent()` instead would name the entries under the
+    // operand's own basename rather than transferring its contents.
+    if operand_has_dotdir_marker(path) {
         return (path.to_path_buf(), path.to_path_buf());
     }
     // `Path::parent()` returns the parent directory or `None` for a path

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -602,11 +602,29 @@ impl GeneratorContext {
         //
         // follow_dirlinks has TWO disjuncts upstream, not one
         // (flist.c:2697 `copy_dirlinks || name_type != NORMAL_NAME`). A DOTDIR
-        // operand follows unconditionally, because asking for the CONTENTS of
-        // `current/` is only meaningful once `current` has been resolved to the
-        // directory it points at. Gating on `--copy-dirlinks` alone made
+        // operand follows, because asking for the CONTENTS of `current/` is
+        // only meaningful once `current` has been resolved to the directory it
+        // points at. Gating on `--copy-dirlinks` alone made
         // `oc-rsync -a host:current/ dest/` deliver nothing and exit 0.
-        if (self.config.flags.copy_dirlinks || is_dotdir) && meta.file_type().is_symlink() {
+        //
+        // ⚠ The DOTDIR disjunct is gated on OWNERSHIP, `--copy-dirlinks` is
+        // not, and the asymmetry is deliberate. Upstream reaches this stat with
+        // the operand ALREADY resolved: the daemon runs
+        // `change_dir(module_chdir)` through `open_no_attacker_symlinks()`
+        // (util1.c:1216) before the file list is walked, so by the time
+        // `link_stat()` sees `.` there is no symlink left to follow. oc walks
+        // the unresolved path, and every daemon transfer sends `.` as its
+        // operand - so an ungated DOTDIR follow lets a foreign-uid symlink
+        // planted at the module root redirect the listing outside the module.
+        // `--copy-dirlinks` is an explicit client request over a client-named
+        // tree and keeps its existing meaning untouched.
+        //
+        // upstream: `rsync-3.5.0/syscall.c:406` - a symlink owned by uid 0 or
+        // our euid is the operator's own layout and is followed; any other uid
+        // is an attacker's plant and is refused.
+        let follow_dirlinks = self.config.flags.copy_dirlinks
+            || (is_dotdir && symlink_target_is_operator_owned(&meta));
+        if follow_dirlinks && meta.file_type().is_symlink() {
             if let Ok(followed) = std::fs::metadata(path) {
                 if followed.file_type().is_dir() {
                     return Ok(followed);
@@ -634,6 +652,73 @@ impl GeneratorContext {
         }
 
         Ok(meta)
+    }
+}
+
+/// Is a symlink the operator's own, and therefore safe to follow for a DOTDIR
+/// operand?
+///
+/// Ownership - not location - is upstream's trust signal here. A link owned by
+/// uid 0 or our own euid is the operator's layout (the `current -> releases/X`
+/// deploy pattern this follow exists to serve); any other uid is a plant.
+///
+/// This is the DOTDIR half of `follow_dirlinks` only. `--copy-dirlinks` is an
+/// explicit request over a client-named tree and is deliberately not gated.
+///
+/// On a non-Unix target there is no `st_uid` to test and no unprivileged way to
+/// plant a foreign-owned link in a module root, so the follow proceeds.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/syscall.c:406` - `st_uid != 0 && st_uid != trusted_uid`
+///   refuses the symlink; otherwise the walk follows it.
+/// - `rsync-3.5.0/util1.c:1216` `change_dir()` - the daemon resolves the module
+///   root through this same rule BEFORE the file list is walked, which is why
+///   upstream never reaches this stat with an unresolved operand.
+fn symlink_target_is_operator_owned(meta: &std::fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        fast_io::symlink_owner_is_trusted(meta.uid())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = meta;
+        true
+    }
+}
+
+#[cfg(all(test, unix))]
+mod dotdir_follow_trust_tests {
+    /// The DOTDIR follow is gated on upstream's ownership rule, not on
+    /// location: uid 0 and our own euid are the operator's own layout, any
+    /// other uid is a plant.
+    ///
+    /// This pins the RULE. The behavioural proof that a foreign-owned symlink
+    /// at a daemon module root is not followed lives in the upstream testsuite
+    /// cell `daemon-module-chdir-symlink`, which needs root to create a
+    /// non-self-owned link and therefore cannot run here.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:406`.
+    #[test]
+    fn only_root_and_our_own_euid_are_trusted_symlink_owners() {
+        let euid = rustix::process::geteuid().as_raw();
+        assert!(
+            fast_io::symlink_owner_is_trusted(0),
+            "uid 0 is the operator"
+        );
+        assert!(
+            fast_io::symlink_owner_is_trusted(euid),
+            "our own euid is the operator"
+        );
+
+        // Pick a uid that is neither 0 nor ours. 65534 (nobody) is the uid the
+        // testsuite plants with; fall back if we happen to be running as it.
+        let foreign = if euid == 65534 { 65533 } else { 65534 };
+        assert!(
+            !fast_io::symlink_owner_is_trusted(foreign),
+            "uid {foreign} is neither root nor our euid, so it is a plant"
+        );
     }
 }
 

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -567,15 +567,18 @@ impl GeneratorContext {
         path: &Path,
         base: &Path,
     ) -> io::Result<std::fs::Metadata> {
-        // upstream: flist.c:readlink_stat() operates on paths without trailing
-        // separators. On Linux, lstat("path/") follows symlinks because the
+        // upstream: flist.c:readlink_stat() operates on paths without the
+        // DOTDIR marker. On Linux, lstat("path/") follows symlinks because the
         // kernel resolves the trailing slash, making a symlink appear as its
-        // target directory. Strip trailing separators via Path::components()
-        // so symlink_metadata correctly returns symlink metadata.
+        // target directory - so the marker must be stripped before the stat to
+        // get a decision that is the same on every platform. Capture whether it
+        // was there FIRST: the marker is not noise to discard, it is upstream's
+        // `name_type`, and the follow decision below depends on it.
+        let is_dotdir = super::operand_has_dotdir_marker(path);
         let normalized: PathBuf;
         let path = {
             let bytes = path.as_os_str().as_encoded_bytes();
-            if bytes.len() > 1 && bytes.ends_with(b"/") {
+            if bytes.len() > 1 && (bytes.ends_with(b"/") || bytes.ends_with(b"/.")) {
                 normalized = path.components().collect();
                 normalized.as_path()
             } else {
@@ -589,14 +592,21 @@ impl GeneratorContext {
 
         let meta = std::fs::symlink_metadata(path)?;
 
-        // upstream: flist.c:1362-1370 link_stat() - with --copy-dirlinks
-        // (follow_dirlinks), a symlink whose target is a directory is
-        // transmitted as a real directory. Applied before the
-        // copy-unsafe-links check, mirroring upstream's link_stat()
-        // (dirlink follow) running before readlink_stat()'s S_ISLNK
-        // re-examination. Only symlinks to directories are followed;
-        // symlinks to files stay symlinks (distinct from --copy-links).
-        if self.config.flags.copy_dirlinks && meta.file_type().is_symlink() {
+        // upstream: flist.c:1362-1370 link_stat() - with follow_dirlinks a
+        // symlink whose target is a directory is transmitted as a real
+        // directory. Applied before the copy-unsafe-links check, mirroring
+        // upstream's link_stat() (dirlink follow) running before
+        // readlink_stat()'s S_ISLNK re-examination. Only symlinks to
+        // directories are followed; symlinks to files stay symlinks (distinct
+        // from --copy-links).
+        //
+        // follow_dirlinks has TWO disjuncts upstream, not one
+        // (flist.c:2697 `copy_dirlinks || name_type != NORMAL_NAME`). A DOTDIR
+        // operand follows unconditionally, because asking for the CONTENTS of
+        // `current/` is only meaningful once `current` has been resolved to the
+        // directory it points at. Gating on `--copy-dirlinks` alone made
+        // `oc-rsync -a host:current/ dest/` deliver nothing and exit 0.
+        if (self.config.flags.copy_dirlinks || is_dotdir) && meta.file_type().is_symlink() {
             if let Ok(followed) = std::fs::metadata(path) {
                 if followed.file_type().is_dir() {
                     return Ok(followed);

--- a/tests/dotdir_symlink_operand.rs
+++ b/tests/dotdir_symlink_operand.rs
@@ -1,0 +1,143 @@
+//! A source operand carrying upstream's DOTDIR marker must follow a
+//! symlink-to-directory, with no `--copy-dirlinks` required.
+//!
+//! Upstream sets `name_type = DOTDIR_NAME` for an operand ending in `/`
+//! (`flist.c:2589-2594`) or `/.` (`:2604`), and `flist.c:2697` passes
+//! `copy_dirlinks || name_type != NORMAL_NAME` as `link_stat()`'s
+//! follow_dirlinks argument. The marker therefore does two things: it selects
+//! "contents of", and it resolves the operand before the walk decides what it
+//! is.
+//!
+//! oc gated that follow on `--copy-dirlinks` alone, so
+//! `oc-rsync -a host:current/ dest/` - where `current -> releases/2026-08-25`,
+//! an entirely ordinary layout - DELIVERED NOTHING and exited 0. The `/.`
+//! spelling failed differently: it transmitted the symlink itself, which under
+//! a restricted shell publishes the link's absolute target to the client.
+//!
+//! These cells run over a real two-process remote-shell transfer because the
+//! defect is in the NETWORK sender's file-list walk. The local-copy executor
+//! was measured correct on the same operands throughout, so a local fixture
+//! would pass without exercising the fix at all.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+fn oc_rsync_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// SSH-shaped shim: drop the options and the host placeholder, exec the rest.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+/// Builds `tree/sub/deep/f2` plus `tree/alias -> sub`, pulls `tree/<operand>`
+/// through the shim, and returns the delivered entries, sorted.
+fn pull(operand: &str, extra: &[&str]) -> Vec<String> {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let tree = temp.path().join("tree");
+    fs::create_dir_all(tree.join("sub/deep")).expect("create tree");
+    fs::write(tree.join("sub/deep/f2"), b"payload").expect("write f2");
+    std::os::unix::fs::symlink("sub", tree.join("alias")).expect("symlink alias -> sub");
+
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&dest).expect("create dest");
+    let binary = oc_rsync_binary();
+    let shim = write_rsh_shim(temp.path());
+
+    let output = test_support::OcRsyncCliRunner::new()
+        .binary(&binary)
+        .arg("-a")
+        .args(extra)
+        .arg("--rsh")
+        .arg(&shim)
+        .arg("--rsync-path")
+        .arg(&binary)
+        .arg(format!("dotdirhost:{}/{operand}", tree.display()))
+        .arg(format!("{}/", dest.display()))
+        .run()
+        .expect("pull did not finish");
+    output.assert_success();
+
+    let mut found = Vec::new();
+    let mut stack = vec![dest.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).expect("read dest") {
+            let path = entry.expect("dir entry").path();
+            let rel = path.strip_prefix(&dest).expect("under dest");
+            found.push(rel.to_string_lossy().into_owned());
+            if path.symlink_metadata().expect("stat entry").is_dir() {
+                stack.push(path);
+            }
+        }
+    }
+    found.sort();
+    found
+}
+
+/// The headline defect: a trailing `/` on a symlink-to-directory delivered
+/// NOTHING and still exited 0.
+#[test]
+fn trailing_slash_on_a_symlinked_dir_transfers_its_contents() {
+    assert_eq!(
+        pull("alias/", &[]),
+        vec!["deep".to_string(), "deep/f2".to_string()],
+        "a DOTDIR operand must resolve the symlink and transfer the contents; \
+         delivering nothing here is silent data loss, not an empty directory"
+    );
+}
+
+/// The `/.` spelling is DOTDIR too, and its old failure was different in kind:
+/// it transmitted the symlink itself rather than the contents.
+#[test]
+fn trailing_dot_on_a_symlinked_dir_transfers_its_contents() {
+    assert_eq!(
+        pull("alias/.", &[]),
+        vec!["deep".to_string(), "deep/f2".to_string()],
+        "`/.` is upstream's other DOTDIR spelling (flist.c:2604); transmitting \
+         `alias` itself publishes the link instead of the tree it names"
+    );
+}
+
+/// Non-vacuity for the fixture: the same tree through a REAL directory already
+/// worked, so it cannot be what makes the two cells above pass.
+#[test]
+fn trailing_slash_on_a_real_dir_is_unchanged() {
+    assert_eq!(
+        pull("sub/", &[]),
+        vec!["deep".to_string(), "deep/f2".to_string()],
+        "the real-directory control must keep behaving exactly as before"
+    );
+}
+
+/// The other side of the gate: WITHOUT the marker the symlink stays a symlink.
+/// Without this, a fix that simply always followed dirlinks would pass every
+/// cell above while breaking `-a` on an ordinary symlink.
+#[test]
+fn no_marker_leaves_the_symlink_a_symlink() {
+    assert_eq!(
+        pull("alias", &[]),
+        vec!["alias".to_string()],
+        "a bare operand is NORMAL_NAME: upstream transmits the link itself"
+    );
+}


### PR DESCRIPTION
## Silent data loss on an ordinary invocation

`oc-rsync -a host:current/ dest/`, where `current` is a symlink to a directory, **delivered nothing and exited 0**. Upstream delivers the contents. `current -> releases/2026-08-25` is how most people lay out a deploy tree.

No rrsync, no procfs, no restricted shell — plain SSH.

## Upstream rule

`--list-only`-style option tables aren't involved; this is the file-list walk. Upstream sets `name_type = DOTDIR_NAME` for an operand ending in `/` (`flist.c:2589-2594`) or `/.` (`:2604`), and `flist.c:2697` passes:

```c
link_stat(fbuf, &st, copy_dirlinks || name_type != NORMAL_NAME)
```

So the marker does **two** things: selects "contents of", and resolves the operand *before* the walk decides what it is. `--copy-dirlinks` is not required.

oc had only the first disjunct.

## Two spellings, two different failures

- `alias/` — `resolve_symlink_metadata` stripped the trailing separator (correctly, so the stat is platform-independent) then **discarded that it had been there**, leaving the follow gated on `--copy-dirlinks` alone. lstat'd as a symlink, walk never descended → **empty**.
- `alias/.` — `non_relative_walk_base` recognised only a trailing `/`, so `/.` fell through to `Path::parent()`, which normalises `.` away. That **transmitted the symlink itself** plus everything under it. Through a restricted shell the link target is the wrapper's pinned `/proc/self/fd/N`, so the absolute host path is published to the client.

Both sites now consult one `operand_has_dotdir_marker` predicate instead of re-deriving the rule independently — which is exactly what let the two spellings drift apart.

## Measured against real rsync 3.5.0

| operand | oc before | oc after | upstream 3.5.0 |
|---|---|---|---|
| `sub/` (real dir, control) | `deep deep/f2` | `deep deep/f2` | `deep deep/f2` |
| `alias/` | **empty** | `deep deep/f2` | `deep deep/f2` |
| `alias/.` | `alias alias/deep alias/deep/f2` | `deep deep/f2` | `deep deep/f2` |
| `alias` (no marker) | `alias` | `alias` | `alias` |
| `alias/ --copy-dirlinks` | `deep deep/f2` | `deep deep/f2` | `deep deep/f2` |

5/5 match after; 2 were divergent before.

## Scope

The **local-copy executor was measured correct** on all four operands, before and after. The defect is confined to the network sender's file-list walk, so the regression cells run over a real two-process remote-shell transfer — a local fixture would pass without exercising the fix at all.

## Non-vacuity

Both halves are independently mutation-lethal:

- reverting the follow gate to `copy_dirlinks` alone → the two DOTDIR cells fail, both controls stay green;
- reverting the base split to trailing-`/`-only → only the `/.` cell fails, three stay green.

The `alias` (no-marker) cell is the guard against the tempting over-fix: a change that simply always followed dirlinks would pass every other cell while breaking `-a` on an ordinary symlink.

`cargo fmt --all -- --check` clean; `clippy -p transfer --all-targets --all-features` clean; `-p transfer` 2733/2733.

## Related

Task 861 (`rrsync-pull-arg-shapes`) is one symptom of this and should be re-measured after this lands rather than fixed separately. The daemon transport is not measured here — the operand's file type is the variable and the transport is not, so transport-independence is expected but unproven.
