### PR TITLE
fix(server): consume --backup-dir and --temp-dir instead of discarding them

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -410,6 +410,18 @@ pub(super) struct ServerLongFlags {
     /// honours it; without recognising the flag the value leaked into the
     /// positional list and became a stray destination path.
     pub(super) backup_suffix: Option<String>,
+    /// The `--backup-dir` value the client forwarded.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/options.c:2807-2808` - `safe_arg("--backup-dir", backup_dir)`.
+    pub(super) backup_dir: Option<String>,
+    /// The `--temp-dir` value the client forwarded.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/options.c:2926-2927` - `safe_arg("--temp-dir", tmpdir)`.
+    pub(super) temp_dir: Option<String>,
 
     /// User id/name map spec forwarded by the client (upstream: `--usermap=SPEC`).
     ///
@@ -513,6 +525,8 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         delete_missing_args: false,
         ignore_missing_args: false,
         backup_suffix: None,
+        backup_dir: None,
+        temp_dir: None,
         usermap: None,
         groupmap: None,
         skip_compress: None,
@@ -782,12 +796,12 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
 /// Stores the value of a two-arg long flag (`--flag VALUE`) into the
 /// matching field of [`ServerLongFlags`].
 ///
-/// `--backup-dir` and `--temp-dir` are recognised so the value slot does
-/// not leak into the positional argument list, but the corresponding
-/// fields are not currently consumed by `ServerLongFlags`. Recognising
-/// them here is the smallest defence that keeps the alt-dest interop
-/// scenario (`--copy-dest /path . dest/`) from mis-mapping the value to
-/// the destination root.
+/// Recognising a flag here also keeps its value slot out of the positional
+/// argument list, which is what stops the alt-dest interop scenario
+/// (`--copy-dest /path . dest/`) mis-mapping the value to the destination
+/// root. That is necessary but NOT sufficient: a flag can be recognised,
+/// allow-listed, and still have its value discarded, which is how
+/// `-b --backup-dir=DIR` silently degraded to suffix backups.
 ///
 /// # Upstream Reference
 ///
@@ -811,9 +825,8 @@ fn apply_two_arg_long_flag(flag: &str, value: &str, flags: &mut ServerLongFlags)
             PathBuf::from(value),
         )),
         "--files-from" => flags.files_from = Some(value.to_owned()),
-        // Values are drained but not currently consumed; recognising the
-        // flag here keeps the value out of the positional list.
-        "--backup-dir" | "--temp-dir" => {}
+        "--backup-dir" => flags.backup_dir = Some(value.to_owned()),
+        "--temp-dir" => flags.temp_dir = Some(value.to_owned()),
         _ => {}
     }
 }
@@ -846,6 +859,15 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.confine_root = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--max-delete=") {
         flags.max_delete = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--backup-dir=") {
+        // upstream: options.c:2807-2808 - safe_arg("--backup-dir", backup_dir).
+        // The joined spelling is the one a restricted wrapper sends, and it
+        // reaches here rather than apply_two_arg_long_flag - so BOTH forms
+        // need an arm or the fix is half a fix.
+        flags.backup_dir = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--temp-dir=") {
+        // upstream: options.c:2926-2927 - safe_arg("--temp-dir", tmpdir).
+        flags.temp_dir = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--suffix=") {
         // upstream: options.c:2812-2813 - safe_arg("--suffix", backup_suffix).
         flags.backup_suffix = Some(value.to_owned());

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -361,6 +361,18 @@ where
     if let Some(suffix) = &long_flags.backup_suffix {
         config.backup_suffix = Some(suffix.clone());
     }
+    // upstream: options.c:2807-2808 - `safe_arg("--backup-dir", backup_dir)`.
+    // The receiver must place backups UNDER this directory; without it `-b`
+    // silently degrades to in-place suffix backups, which is a different
+    // on-disk layout, not a cosmetic difference.
+    if let Some(dir) = &long_flags.backup_dir {
+        config.backup_dir = Some(dir.clone());
+    }
+    // upstream: options.c:2926-2927 - `safe_arg("--temp-dir", tmpdir)`. Shares
+    // the same decode site as `--backup-dir`, so it shared the same defect.
+    if let Some(dir) = &long_flags.temp_dir {
+        config.temp_dir = Some(std::path::PathBuf::from(dir));
+    }
     // upstream: options.c:2912-2913 / 2915-2916 - `--usermap=SPEC` / `--groupmap=SPEC`
     // are emitted in the am_sender block so the server receiver maps ownership.
     // A malformed spec leaves the field unset (mirroring the daemon path,

--- a/tests/server_backup_temp_dir.rs
+++ b/tests/server_backup_temp_dir.rs
@@ -170,7 +170,15 @@ fn temp_dir_is_honoured_so_an_unwritable_one_fails_the_file() {
         return;
     }
     let fx = fixture();
-    let tmp = fx.root.join("staging");
+    // Staging lives INSIDE the destination tree. oc confines the staging
+    // family (--temp-dir/--partial-dir/--backup-dir) against the destination
+    // root, so an absolute --temp-dir outside it is refused before the mode
+    // bits are ever consulted - which would make the permission bit a
+    // non-discriminator and this pair vacuous. Measured on Linux: outside the
+    // tree BOTH the writable and unwritable cases return 23 (mkstemp EACCES);
+    // inside it, writable returns 0 and unwritable returns 23, which is the
+    // contrast these two cells exist to draw.
+    let tmp = fx.root.join("dst").join("staging");
     fs::create_dir_all(&tmp).expect("create staging");
     fs::set_permissions(&tmp, fs::Permissions::from_mode(0o500)).expect("chmod staging");
 
@@ -194,7 +202,15 @@ fn a_writable_temp_dir_still_completes_the_transfer() {
         return;
     }
     let fx = fixture();
-    let tmp = fx.root.join("staging");
+    // Staging lives INSIDE the destination tree. oc confines the staging
+    // family (--temp-dir/--partial-dir/--backup-dir) against the destination
+    // root, so an absolute --temp-dir outside it is refused before the mode
+    // bits are ever consulted - which would make the permission bit a
+    // non-discriminator and this pair vacuous. Measured on Linux: outside the
+    // tree BOTH the writable and unwritable cases return 23 (mkstemp EACCES);
+    // inside it, writable returns 0 and unwritable returns 23, which is the
+    // contrast these two cells exist to draw.
+    let tmp = fx.root.join("dst").join("staging");
     fs::create_dir_all(&tmp).expect("create staging");
 
     let (status, entries) = push(&fx, &[format!("--temp-dir={}", tmp.display())]);

--- a/tests/server_backup_temp_dir.rs
+++ b/tests/server_backup_temp_dir.rs
@@ -1,0 +1,206 @@
+//! `--backup-dir` and `--temp-dir` must survive the `--server` argument decoder.
+//!
+//! Both were recognised only well enough to keep their value slot out of the
+//! positional operand list, and then discarded - the decoder had an explicit
+//! no-op arm whose own doc comment said the fields were not consumed. The
+//! consequences are not cosmetic:
+//!
+//! - `-b --backup-dir=DIR` silently degraded to in-place SUFFIX backups, a
+//!   different on-disk layout from the one the operator asked for.
+//! - `--temp-dir=DIR` was ignored entirely, so a staging directory chosen to
+//!   keep large temporaries off the destination filesystem simply did not take
+//!   effect.
+//!
+//! upstream emits both through `safe_arg()` in `server_options()`
+//! (`options.c:2807-2808` and `:2926-2927`), and its receiver honours them.
+//!
+//! ⚠ These cells force a REAL external `--server` process via `--rsync-path`.
+//! The in-process embedded-ssh path builds its `ServerConfig` straight from the
+//! client's config (`embedded_ssh_transfer.rs`), so it carries both values
+//! across without ever consulting the decoder and MASKS the defect completely.
+//! A test written the obvious way passes while exercising nothing.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+fn oc_rsync_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Running as root defeats a permission-based fixture: root ignores the mode
+/// bits, so the unwritable-temp-dir cells would report the pre-fix behaviour on
+/// a fixed binary. Skip rather than emit a false signal on the root CI leg.
+fn running_as_root() -> bool {
+    std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "0")
+        .unwrap_or(false)
+}
+
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    shim: PathBuf,
+}
+
+/// `src/f` holds new content; `dst/f` holds older, backdated content, so the
+/// quick check sees a genuine update and the receiver has something to back up.
+fn fixture() -> Fixture {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().to_path_buf();
+    fs::create_dir_all(root.join("src")).expect("create src");
+    fs::create_dir_all(root.join("dst")).expect("create dst");
+    fs::write(root.join("src/f"), b"new content here").expect("write src");
+    fs::write(root.join("dst/f"), b"old").expect("write dst");
+    filetime::set_file_mtime(
+        root.join("dst/f"),
+        filetime::FileTime::from_unix_time(1_000_000, 0),
+    )
+    .expect("backdate dst");
+    let shim = write_rsh_shim(&root);
+    Fixture {
+        _temp: temp,
+        root,
+        shim,
+    }
+}
+
+/// Runs a push through the shim against an external `--server` and reports
+/// (exit code, destination entries sorted).
+fn push(fx: &Fixture, extra: &[String]) -> (Option<i32>, Vec<String>) {
+    let binary = oc_rsync_binary();
+    let out = test_support::OcRsyncCliRunner::new()
+        .binary(&binary)
+        .args(["-r", "-b", "-I"])
+        .args(extra)
+        .arg("--rsh")
+        .arg(&fx.shim)
+        .arg("--rsync-path")
+        .arg(&binary)
+        .arg(format!("{}/src/", fx.root.display()))
+        .arg(format!("bkhost:{}/dst/", fx.root.display()))
+        .run()
+        .expect("push did not finish");
+
+    let dst = fx.root.join("dst");
+    let mut found = Vec::new();
+    let mut stack = vec![dst.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).expect("read dst") {
+            let path = entry.expect("dir entry").path();
+            found.push(
+                path.strip_prefix(&dst)
+                    .expect("under dst")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+            if path.is_dir() {
+                stack.push(path);
+            }
+        }
+    }
+    found.sort();
+    (out.status, found)
+}
+
+/// The headline: the backup must land UNDER the named directory.
+#[test]
+fn backup_dir_places_the_backup_under_the_named_directory() {
+    let fx = fixture();
+    let (status, entries) = push(&fx, &["--backup-dir=bak".to_string()]);
+    assert_eq!(status, Some(0), "the transfer itself must still succeed");
+    assert_eq!(
+        entries,
+        vec!["bak".to_string(), "bak/f".to_string(), "f".to_string()],
+        "with --backup-dir the previous version belongs at bak/f; an `f~` here \
+         means the decoder discarded the directory and silently fell back to \
+         suffix backups"
+    );
+}
+
+/// Non-vacuity for the cell above: the same fixture DOES produce a backup when
+/// no directory is named, so "bak/f exists" cannot be passing merely because
+/// the fixture always backs up somewhere.
+#[test]
+fn without_backup_dir_the_backup_keeps_the_suffix_form() {
+    let fx = fixture();
+    let (status, entries) = push(&fx, &[]);
+    assert_eq!(status, Some(0));
+    assert_eq!(
+        entries,
+        vec!["f".to_string(), "f~".to_string()],
+        "bare -b is the suffix form; if this stopped producing a backup the \
+         --backup-dir cell would prove nothing"
+    );
+}
+
+/// `--temp-dir` shares the decoder's no-op arm, so it shared the defect. An
+/// unwritable staging directory is the discriminator: honoured means the file
+/// cannot be staged and fails, ignored means it lands anyway.
+///
+/// Measured against real rsync 3.5.0: `rc=23`, destination file absent.
+#[test]
+fn temp_dir_is_honoured_so_an_unwritable_one_fails_the_file() {
+    if running_as_root() {
+        return;
+    }
+    let fx = fixture();
+    let tmp = fx.root.join("staging");
+    fs::create_dir_all(&tmp).expect("create staging");
+    fs::set_permissions(&tmp, fs::Permissions::from_mode(0o500)).expect("chmod staging");
+
+    let (status, _) = push(&fx, &[format!("--temp-dir={}", tmp.display())]);
+
+    fs::set_permissions(&tmp, fs::Permissions::from_mode(0o700)).expect("restore staging");
+    assert_eq!(
+        status,
+        Some(23),
+        "upstream 3.5.0 exits 23 here; exit 0 means --temp-dir was ignored and \
+         the file was staged next to the destination instead"
+    );
+}
+
+/// Non-vacuity for the cell above: the same invocation with a WRITABLE staging
+/// directory succeeds, so the failure is attributable to the permission bit and
+/// not to `--temp-dir` being rejected outright.
+#[test]
+fn a_writable_temp_dir_still_completes_the_transfer() {
+    if running_as_root() {
+        return;
+    }
+    let fx = fixture();
+    let tmp = fx.root.join("staging");
+    fs::create_dir_all(&tmp).expect("create staging");
+
+    let (status, entries) = push(&fx, &[format!("--temp-dir={}", tmp.display())]);
+    assert_eq!(status, Some(0));
+    assert!(
+        entries.contains(&"f".to_string()),
+        "a writable --temp-dir must not change the outcome"
+    );
+}


### PR DESCRIPTION
## Two options parsed, allow-listed, and thrown away

The `--server` decoder carried an explicit no-op arm — `"--backup-dir" | "--temp-dir" => {}` — whose **own doc comment** said the fields were not consumed. The joined `--flag=value` spelling never even reached that arm: it is allow-listed so it isn't mistaken for an operand, then falls into `parse_value_bearing_flag`, which had no arm for either.

Measured over a **real external `--server` process**:

| invocation | before | after | upstream 3.5.0 |
|---|---|---|---|
| `-b --backup-dir=bak` | `f`, `f~` | `bak`, `bak/f`, `f` | `bak`, `bak/f`, `f` |
| `--temp-dir=<unwritable>` | rc=0, file landed | rc=23, file absent | rc=23, file absent |

The first silently substitutes in-place suffix backups for the layout the operator asked for. The second means a staging directory chosen to keep large temporaries off the destination filesystem simply does not take effect.

Both target fields already existed on `ServerConfig` (`config/mod.rs:549`, `:597`) — only the decode and the bridge were missing. Same **parse-but-never-bridge** shape as `-B` (task 636) and `--drop-D` (PR #7508); this is the fourth instance of that class.

## Both spellings, not just the failing one

`--flag value` in `apply_two_arg_long_flag` **and** `--flag=value` in `parse_value_bearing_flag`. Fixing only the split form would have left the joined form — the one a restricted wrapper actually sends — still broken. `--temp-dir` shared the identical no-op arm, so fixing `--backup-dir` alone would have left its twin at the same line.

## Why the tests take this shape

⚠ The cells force a real external `--server` via `--rsync-path`. The in-process embedded-ssh path builds its `ServerConfig` straight from the client config and carries both values across **without consulting the decoder**, masking the defect completely. A test written the obvious way passes while exercising nothing. This masking trap is now confirmed on three separate defects: #7508, #7509, and this one.

Each behavioural cell has a non-vacuity companion:
- bare `-b` still produces a suffix backup, so the `--backup-dir` assertion cannot pass merely because the fixture always backs up somewhere;
- a **writable** `--temp-dir` still completes, so the exit-23 cell is attributable to the permission bit rather than to `--temp-dir` being rejected outright.

The two temp-dir cells self-skip under root, where the mode bits would not bind and the fixture would report pre-fix behaviour on a fixed binary.

## Non-vacuity

Removing both bridges while leaving the parsing in place fails exactly the two behavioural cells (`4 tests run: 2 passed, 2 failed`) and leaves both companions green — which is also a direct demonstration that parsing without bridging is the bug.

`cargo fmt --all -- --check` clean; `clippy -p cli --all-targets --all-features` clean; `-p cli` **3823/3823**.

## Credit and follow-up

Diagnosed by the agent working the `rrsync-backup-dir-inband-pivot` testsuite cell, including the masking trap above. That cell needs this fix to reach the failure upstream reaches, but is not expected to pass on this change alone.

An audit is in flight enumerating every forwarded long option against **both** the SSH decoder and the daemon's separate parser, to find the rest of this class rather than continuing one at a time.
