### PR TITLE
fix(fast_io): confine the filter-file open to the module root

### DIFF
--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -155,7 +155,7 @@ fn filter_file_open_error(
 /// - `rsync-3.5.0/syscall.c:538` - `open_no_attacker_symlinks()`; the trust
 ///   rule is at `syscall.c:406`.
 fn open_operator_named(path: &Path) -> io::Result<File> {
-    crate::frontend::operator_file::open_read(path)
+    crate::frontend::operator_file::open_read_confined(path)
 }
 
 /// Reads the raw pattern lines from a filter file, or from standard input when

--- a/crates/cli/src/frontend/operator_file.rs
+++ b/crates/cli/src/frontend/operator_file.rs
@@ -42,3 +42,25 @@ pub(crate) fn open_read(path: &Path) -> io::Result<File> {
         File::open(path)
     }
 }
+
+/// Opens a filter file through the same walk, additionally confined to the
+/// session's root.
+///
+/// A filter file is the one operator path whose CONTENTS come back to a peer,
+/// in "Unknown filter rule" errors, so an out-of-tree read is a disclosure and
+/// not merely a wrong file. Ownership alone cannot stop it: a root-owned
+/// symlink is trusted by the walk by design.
+///
+/// upstream: `rsync-3.5.0/exclude.c:1680-1684` - `parse_filter_file()` sets
+/// `operator_path_resolve = 1` around its open, exempting only the daemon's own
+/// `filter` / `include from` / `exclude from` parameters.
+pub(crate) fn open_read_confined(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_open_read_confined(path)
+    }
+    #[cfg(not(unix))]
+    {
+        File::open(path)
+    }
+}

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -534,7 +534,15 @@ pub(crate) fn load_dir_merge_rules_recursive(
 fn open_merge_file(path: &std::path::Path) -> io::Result<fs::File> {
     #[cfg(unix)]
     {
-        fast_io::operator_open_read(path)
+        // Confined as well as ownership-walked: a per-directory merge file is
+        // named by the PEER, and its contents come back to that peer in
+        // "Unknown filter rule" errors, so a trusted-owned symlink redirecting
+        // the read out of the module is a disclosure. Ownership cannot catch
+        // it - a non-chrooted daemon writes as root, so a planted backup
+        // symlink is root-owned, which the walk trusts by design.
+        //
+        // upstream: `rsync-3.5.0/exclude.c:1668-1684` `parse_filter_file()`.
+        fast_io::operator_open_read_confined(path)
     }
     #[cfg(not(unix))]
     {

--- a/crates/fast_io/src/confinement.rs
+++ b/crates/fast_io/src/confinement.rs
@@ -39,6 +39,7 @@
 //! - `syscall.c:552` - `int operator_path_resolve = 0;`
 
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// The session's answer to [`Activation::optout_allowed`], published for the
@@ -72,6 +73,92 @@ static SESSION_OPTOUT: AtomicBool = AtomicBool::new(false);
 /// caller is without making it invent values for fields its arm ignores.
 pub fn install_session(activation: &Activation) {
     SESSION_OPTOUT.store(activation.optout_allowed(), Ordering::Relaxed);
+    *SESSION_ROOT
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = activation.root().map(physical_root);
+}
+
+/// Resolve the confinement root to a PHYSICAL path.
+///
+/// This is load-bearing, not tidiness. The walk tracks where an open would
+/// really land, after following every trusted symlink, so the path it offers
+/// for judging is always physical. A root kept as the operator SPELLED it is
+/// lexical, and comparing the two compares different namespaces: the first
+/// version of this check over-refused two in-module controls on macOS, where
+/// `/var` is a symlink to `/private/var`, so a root under `/var/folders/...`
+/// never prefix-matched a walk that had already resolved to `/private/var/...`.
+/// The same shape exists wherever an ancestor is a symlink - `/home ->
+/// /usr/home` on FreeBSD, a bind-mounted or symlinked module root anywhere -
+/// and it fails CLOSED, refusing paths that are plainly inside the module, so
+/// it presents as a broken daemon rather than as a hole.
+///
+/// Resolving once, here, is also what keeps [`Activation`] free of I/O, which
+/// is what lets its truth table compile and run on every target.
+///
+/// A root that cannot be resolved (it does not exist yet) keeps the name it was
+/// given: that is the value the caller supplied, and substituting anything else
+/// would be inventing a boundary.
+fn physical_root(root: &Path) -> PathBuf {
+    root.canonicalize().unwrap_or_else(|_| root.to_path_buf())
+}
+
+/// The session's answer to [`Activation::root`], published for the ownership
+/// walk to read.
+///
+/// Stored for the same reason as [`SESSION_OPTOUT`]: upstream reads
+/// `confinement_root()` from *inside* `ona_open()` because `module_dir` and
+/// `confine_root` are process globals, so both entry points into the walk get
+/// the same answer from one place. Threading the root through every operator
+/// open instead would let one un-threaded site silently confine nothing, which
+/// is the failure mode this exists to prevent. The value is a property of the
+/// session, not of the call - unlike [`PathKind`], which is.
+static SESSION_ROOT: RwLock<Option<PathBuf>> = RwLock::new(None);
+
+/// Whether an already-resolved absolute path must be refused for landing
+/// outside the session's confinement root.
+///
+/// The session-scoped counterpart of [`Activation::outside_root`], for the
+/// ownership walk, which has no [`Activation`] in hand.
+///
+/// upstream: `syscall.c:186-240` `abspath_outside_confinement()`.
+#[must_use]
+pub fn outside_session_root(abspath: &Path, kind: PathKind) -> bool {
+    SESSION_ROOT
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_deref()
+        .is_some_and(|root| path_outside_root(root, abspath, kind))
+}
+
+/// The session's confinement root, or `None` when nothing is confined.
+///
+/// The walk needs the value itself, not just the verdict: a *relative*
+/// operator path has to be anchored somewhere before it can be judged.
+///
+/// upstream: `syscall.c:128-144` `confinement_root()`.
+#[must_use]
+pub fn session_confinement_root() -> Option<PathBuf> {
+    SESSION_ROOT
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+}
+
+/// The shared rule behind [`Activation::outside_root`] and
+/// [`outside_session_root`]: one implementation, two ways of naming the root.
+fn path_outside_root(root: &Path, abspath: &Path, kind: PathKind) -> bool {
+    // upstream: `rootlen <= 1` - a root of "/" (or none) confines nothing.
+    if root.parent().is_none() || root.as_os_str().is_empty() {
+        return false;
+    }
+    if abspath.starts_with(root) {
+        return false;
+    }
+    // An empty path, or an ancestor of the root: still descending.
+    if abspath.as_os_str().is_empty() || root.starts_with(abspath) {
+        return false;
+    }
+    kind == PathKind::Confined
 }
 
 /// Publish the opt-out for a non-daemon session: the local `--insecure-links`.
@@ -329,21 +416,8 @@ impl Activation {
     ///
     /// - `syscall.c:197-240` - `abspath_outside_confinement()`
     pub fn outside_root(&self, abspath: &Path, kind: PathKind) -> bool {
-        let Some(root) = self.root() else {
-            return false;
-        };
-        // upstream: `rootlen <= 1` - a root of "/" (or none) confines nothing.
-        if root.parent().is_none() || root.as_os_str().is_empty() {
-            return false;
-        }
-        if abspath.starts_with(root) {
-            return false;
-        }
-        // An empty path, or an ancestor of the root: still descending.
-        if abspath.as_os_str().is_empty() || root.starts_with(abspath) {
-            return false;
-        }
-        kind == PathKind::Confined
+        self.root()
+            .is_some_and(|root| path_outside_root(root, abspath, kind))
     }
 
     fn is_daemon(&self) -> bool {

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -408,9 +408,9 @@ pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
     operator_link, operator_mkdir, operator_open_append, operator_open_create_new,
-    operator_open_read, operator_open_recv, operator_open_rw_create, operator_open_write_create,
-    operator_read_to_string, operator_rename, operator_symlink_metadata, owner_trusted_parent,
-    symlink_owner_is_trusted,
+    operator_open_read, operator_open_read_confined, operator_open_recv, operator_open_rw_create,
+    operator_open_write_create, operator_read_to_string, operator_rename,
+    operator_symlink_metadata, owner_trusted_parent, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -110,6 +110,100 @@ fn prepend_components(pending: &mut Vec<OsString>, path: &Path) {
     *pending = head;
 }
 
+/// The absolute path the walk has actually resolved so far, for the
+/// confinement refusal.
+///
+/// Ownership alone cannot bound a peer-driven path: a trusted-owned symlink is
+/// FOLLOWED by design (`syscall.c:406`), so it can redirect the resolved target
+/// out of the tree. Tracking where the walk has really arrived is what lets the
+/// leaf be judged against the confinement root.
+///
+/// [`Disabled`](AbsPathTracker::Disabled) is not an optimisation but the
+/// contract: an [`Ancillary`](crate::confinement::PathKind::Ancillary) open, or
+/// a session with no root, has nothing to be outside of, and upstream's own
+/// check returns 0 for both (`syscall.c:216`, `syscall.c:239`).
+///
+/// upstream: `rsync-3.5.0/syscall.c:245` `abspath_step()` and the `abspath`
+/// state it advances (`syscall.c:304-329`).
+enum AbsPathTracker {
+    Disabled,
+    Tracking { abspath: PathBuf },
+}
+
+impl AbsPathTracker {
+    /// Seed the tracker for a walk of `path`.
+    ///
+    /// An absolute path starts at `/`. A relative one starts where the walk
+    /// itself does, which is the process's physical working directory - read,
+    /// not assumed. Upstream shortcuts the daemon arm to `module_dir` because
+    /// it knows a daemon's cwd IS the module root (`syscall.c:308-310`);
+    /// reading the real cwd agrees with that whenever the assumption holds and
+    /// is right when it does not, which is why it is used for both arms. It is
+    /// the PHYSICAL cwd, as upstream's own comment requires: a lexical name
+    /// would sit at a different depth after descending a trusted symlink, and a
+    /// `..` that really escapes would look like it landed inside.
+    fn start(path: &Path, kind: crate::confinement::PathKind) -> io::Result<Self> {
+        if kind != crate::confinement::PathKind::Confined
+            || crate::confinement::session_confinement_root().is_none()
+        {
+            return Ok(Self::Disabled);
+        }
+        let abspath = if path.is_absolute() {
+            PathBuf::from("/")
+        } else {
+            std::env::current_dir()?
+        };
+        Ok(Self::Tracking { abspath })
+    }
+
+    /// Advance by one resolved component, normalising `.` and `..` exactly as
+    /// `openat` does so the check sees the REAL resolved target.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:245` `abspath_step()`.
+    fn step(&mut self, name: &OsStr) {
+        let Self::Tracking { abspath } = self else {
+            return;
+        };
+        if name == OsStr::new(".") {
+            return;
+        }
+        if name == OsStr::new("..") {
+            // `pop` at the root is a no-op, which is what `/..` resolves to.
+            abspath.pop();
+            return;
+        }
+        abspath.push(name);
+    }
+
+    /// A followed absolute symlink target restarts resolution at `/`.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:445`.
+    fn restart_at_root(&mut self) {
+        if let Self::Tracking { abspath } = self {
+            *abspath = PathBuf::from("/");
+        }
+    }
+
+    /// Refuse with `ELOOP` when the resolved path has left the confinement
+    /// root.
+    ///
+    /// `ELOOP` and deliberately not `EXDEV`: callers treat `EXDEV` as
+    /// cross-device and fall back to copy+remove, which would launder the
+    /// refusal.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:464-466`.
+    fn refuse_if_outside(&self) -> io::Result<()> {
+        let Self::Tracking { abspath } = self else {
+            return Ok(());
+        };
+        if crate::confinement::outside_session_root(abspath, crate::confinement::PathKind::Confined)
+        {
+            return Err(io::Error::from_raw_os_error(libc::ELOOP));
+        }
+        Ok(())
+    }
+}
+
 /// Open the walk's starting directory: `/` for an absolute path, `.` otherwise.
 fn open_start_dir(absolute: bool) -> io::Result<OwnedFd> {
     rustix::fs::open(
@@ -181,7 +275,12 @@ fn open_final(
 ///   back to copy+remove, which would defeat the refusal.
 /// - `ENOTDIR` when an interior component is not a directory.
 /// - Otherwise the `openat`/`statat`/`readlinkat` errno verbatim.
-fn owner_walk_open(path: &Path, flags: OFlags, mode: Mode) -> io::Result<OwnedFd> {
+fn owner_walk_open(
+    path: &Path,
+    flags: OFlags,
+    mode: Mode,
+    kind: crate::confinement::PathKind,
+) -> io::Result<OwnedFd> {
     // upstream: syscall.c:300-302 - "Opted out (local --insecure-links, or a
     // daemon module with `insecure links = yes`): restore the legacy
     // symlink-following open." The test sits at the top of ona_open(), so it
@@ -206,6 +305,7 @@ fn owner_walk_open(path: &Path, flags: OFlags, mode: Mode) -> io::Result<OwnedFd
     let mut pending = walk_components(path);
     let mut dirfd = open_start_dir(path.is_absolute())?;
     let mut hops = MAX_SYMLINK_HOPS;
+    let mut tracker = AbsPathTracker::start(path, kind)?;
 
     while !pending.is_empty() {
         let name = pending.remove(0);
@@ -221,6 +321,12 @@ fn owner_walk_open(path: &Path, flags: OFlags, mode: Mode) -> io::Result<OwnedFd
                 Err(errno)
                     if is_last && errno == Errno::NOENT && flags.contains(OFlags::CREATE) =>
                 {
+                    // upstream: syscall.c:387-391 - the confinement is checked on
+                    // this arm too. A create is exactly where a redirected leaf
+                    // does its damage, so skipping it here would leave the
+                    // `--partial-dir`/`--temp-dir` shapes unconfined.
+                    tracker.step(&name);
+                    tracker.refuse_if_outside()?;
                     return open_final(dirfd.as_fd(), name.as_os_str(), flags, mode);
                 }
                 Err(errno) => return Err(io::Error::from_raw_os_error(errno.raw_os_error())),
@@ -244,14 +350,23 @@ fn owner_walk_open(path: &Path, flags: OFlags, mode: Mode) -> io::Result<OwnedFd
             if target.is_absolute() {
                 // upstream: syscall.c:445 "followed an absolute target: restart from /".
                 dirfd = open_start_dir(true)?;
+                tracker.restart_at_root();
             }
             prepend_components(&mut pending, &target);
             continue;
         }
 
         if is_last {
+            // upstream: syscall.c:460-468 - `abspath_step()` then
+            // `abspath_outside_confinement()`. The check belongs HERE and not on
+            // interior components: an absolute walk passes through the root's
+            // own ancestors on the way down, which are not-yet-arrived rather
+            // than diverged.
+            tracker.step(&name);
+            tracker.refuse_if_outside()?;
             return open_final(dirfd.as_fd(), name.as_os_str(), flags, mode);
         }
+        tracker.step(&name);
 
         // upstream: syscall.c:479 - an interior component that is not a
         // directory is ENOTDIR, not a silent stop.
@@ -287,7 +402,12 @@ pub fn owner_trusted_parent(path: &Path) -> io::Result<(OwnedFd, OsString)> {
         return Err(io::Error::from_raw_os_error(libc::EINVAL));
     };
     let parent = path.parent().unwrap_or_else(|| Path::new(""));
-    let dirfd = owner_walk_open(parent, OFlags::RDONLY | OFlags::DIRECTORY, Mode::empty())?;
+    let dirfd = owner_walk_open(
+        parent,
+        OFlags::RDONLY | OFlags::DIRECTORY,
+        Mode::empty(),
+        crate::confinement::PathKind::Ancillary,
+    )?;
     Ok((dirfd, leaf))
 }
 
@@ -409,12 +529,26 @@ pub fn operator_link(old_path: &Path, new_path: &Path) -> io::Result<()> {
 /// - `EINVAL` when `path` has no final component.
 /// - Otherwise see `owner_walk_open`.
 fn operator_open_with(path: &Path, flags: OFlags, mode: Mode) -> io::Result<std::fs::File> {
+    operator_open_kind(path, flags, mode, crate::confinement::PathKind::Ancillary)
+}
+
+/// `operator_open_with` with the caller's [`PathKind`](crate::confinement::PathKind).
+///
+/// Upstream expresses the same distinction as a global toggled around each call
+/// site; passing it makes an unstated answer a compile error instead of a
+/// control-flow accident.
+fn operator_open_kind(
+    path: &Path,
+    flags: OFlags,
+    mode: Mode,
+    kind: crate::confinement::PathKind,
+) -> io::Result<std::fs::File> {
     // `/`, `.` and `..` name a directory, never a file to open; the walk would
     // otherwise hand back its own anchor.
     if path.file_name().is_none() {
         return Err(io::Error::from_raw_os_error(libc::EINVAL));
     }
-    owner_walk_open(path, flags, mode).map(std::fs::File::from)
+    owner_walk_open(path, flags, mode, kind).map(std::fs::File::from)
 }
 
 /// Open an operator-supplied path read-only through the ownership walk.
@@ -428,6 +562,41 @@ fn operator_open_with(path: &Path, flags: OFlags, mode: Mode) -> io::Result<std:
 /// See `operator_open_with`.
 pub fn operator_open_read(path: &Path) -> io::Result<std::fs::File> {
     operator_open_with(path, OFlags::RDONLY, Mode::empty())
+}
+
+/// Open a filter/merge file read-only through the ownership walk, additionally
+/// bound to the session's confinement root.
+///
+/// The ownership walk on its own is not enough for a peer-driven merge file: a
+/// non-chrooted daemon writes `--backup-dir` entries as root, so a raced backup
+/// symlink is ROOT-owned - exactly what the walk treats as trusted - and naming
+/// it in a dir-merge rule would read an out-of-module file in as filter rules,
+/// whose text comes back to the peer in "Unknown filter rule" errors. The root
+/// check after the follow is what closes that.
+///
+/// The daemon's OWN `filter` / `include from` / `exclude from` parameters are
+/// deliberately NOT opened through this: they are operator-configured and
+/// legitimately live outside the module (`/etc/rsync/excludes` and the like).
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/exclude.c:1668-1684` `parse_filter_file()` - the comment this
+///   paraphrases, and the `if (!daemon_config_filter_file)
+///   operator_path_resolve = 1;` that scopes it.
+/// - `rsync-3.5.0/syscall.c:186-240` `abspath_outside_confinement()`.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component is an untrusted-owner symlink, or when the
+///   resolved path lands outside the confinement root.
+/// - Otherwise see `operator_open_with`.
+pub fn operator_open_read_confined(path: &Path) -> io::Result<std::fs::File> {
+    operator_open_kind(
+        path,
+        OFlags::RDONLY,
+        Mode::empty(),
+        crate::confinement::PathKind::Confined,
+    )
 }
 
 /// Open an operator-supplied path for appending, creating it if absent.

--- a/crates/fast_io/tests/operator_open_module_confinement.rs
+++ b/crates/fast_io/tests/operator_open_module_confinement.rs
@@ -1,0 +1,228 @@
+//! Module-root confinement of an operator/peer path that resolves out of the
+//! tree through a *trusted* symlink.
+//!
+//! # Why this matters
+//!
+//! The ownership walk deliberately FOLLOWS a symlink owned by uid 0 or our own
+//! euid: that is the operator's own layout (`/var/log -> /data/log`) and
+//! refusing it would break the ordinary case the resolver exists to keep
+//! working. Ownership therefore cannot be the whole defence for a *peer-driven*
+//! path. Upstream states the residual exactly, at the merge-file open:
+//!
+//! > Confine the open to the module root. The ownership walk on its own is not
+//! > enough for a peer-driven merge file: a non-chrooted daemon writes
+//! > `--backup-dir` entries as root, so a raced backup symlink is ROOT-owned -
+//! > exactly what `open_no_attacker_symlinks()` treats as trusted - and naming
+//! > it in a dir-merge rule would read an out-of-module file in as filter rules
+//! > (their text comes back to the peer in "Unknown filter rule" errors).
+//!
+//! So the refusal must come from the CONFINEMENT ROOT, after the follow, not
+//! from ownership. That is the property pinned here.
+//!
+//! # Root ownership is not a separate branch
+//!
+//! Upstream refuses only `st_uid != 0 && st_uid != trusted_uid`
+//! (`syscall.c:406`), so uid 0 and the euid take one identical follow path and
+//! reach one identical confinement check. A plant owned by our own euid
+//! exercises the same code as a root-owned one and needs no privilege, which is
+//! why these run unprivileged. The distinct third-uid REFUSAL - the arm that
+//! does need a second uid - stays with the root leg of the upstream 3.5.0
+//! testsuite, matching the convention already written down in
+//! `tests/owner_walk.rs`.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/syscall.c:286` `ona_open()` - the walk; `abspath` is seeded
+//!   from `module_dir` for a daemon at `:308-310`.
+//! - `rsync-3.5.0/syscall.c:406` - the ownership test that follows a trusted
+//!   symlink.
+//! - `rsync-3.5.0/syscall.c:460-468` - the leaf arm: `abspath_step()` then
+//!   `abspath_outside_confinement()` -> `ELOOP`.
+//! - `rsync-3.5.0/syscall.c:186-240` `abspath_outside_confinement()` - refuses
+//!   only when `operator_path_resolve` is set.
+//! - `rsync-3.5.0/exclude.c:1668-1684` `parse_filter_file()` - the merge-file
+//!   open that sets `operator_path_resolve = 1`, exempting only the daemon's
+//!   own `filter`/`include from`/`exclude from` parameters.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+use fast_io::confinement::{ModuleInsecureLinks, ModuleState};
+use tempfile::TempDir;
+
+/// The session's confinement root is process-global, mirroring upstream's
+/// `module_dir`. Each cell installs the session it needs, so they must not
+/// interleave when the harness runs them as threads.
+static SESSION: Mutex<()> = Mutex::new(());
+
+/// A module root, a directory beneath it, and a secret outside it.
+struct Fixture {
+    _root: TempDir,
+    module: PathBuf,
+    secret: PathBuf,
+}
+
+fn fixture() -> Fixture {
+    let root = TempDir::new().expect("tempdir");
+    let module = root.path().join("module");
+    fs::create_dir_all(module.join("backup/sub")).expect("mkdir module");
+    let outside = root.path().join("outside");
+    fs::create_dir(&outside).expect("mkdir outside");
+    let secret = outside.join("secret");
+    fs::write(&secret, "SECRET-MARKER").expect("write secret");
+    Fixture {
+        _root: root,
+        module,
+        secret,
+    }
+}
+
+/// Serve `module` as a non-chrooted daemon module with the confinement engaged.
+fn serve_module(module: &Path) -> MutexGuard<'static, ()> {
+    let guard = SESSION
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    fast_io::confinement::install_daemon_session(ModuleState {
+        root: Some(module.to_path_buf()),
+        chrooted: false,
+        selected: true,
+        insecure_links: ModuleInsecureLinks::from_module_config(false),
+    });
+    guard
+}
+
+fn read_all(mut file: fs::File) -> String {
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).expect("read");
+    contents
+}
+
+/// THE PIN. A trusted-owned symlink planted inside the module points at a file
+/// outside it. The walk follows the link - that is correct and deliberate - and
+/// then the module root must refuse the resolved target, so the secret never
+/// becomes filter-rule text the peer can read back.
+#[test]
+fn a_trusted_symlink_leaving_the_module_is_refused() {
+    let fixture = fixture();
+    let planted = fixture.module.join("backup/sub/evil");
+    symlink(&fixture.secret, &planted).expect("plant the symlink");
+
+    let _session = serve_module(&fixture.module);
+    let error = fast_io::operator_open_read_confined(&planted)
+        .expect_err("a confined open must not resolve out of the module");
+
+    assert_eq!(
+        error.raw_os_error(),
+        Some(libc::ELOOP),
+        "the refusal must be ELOOP: callers treat EXDEV as cross-device and \
+         fall back to copy+remove, which would launder it"
+    );
+}
+
+/// The plant is real at the moment of the run, and it is trusted. Without this
+/// the pin above would also pass if the symlink had simply failed to appear, or
+/// if it were refused on OWNERSHIP - the arm that is not under test here.
+#[test]
+fn the_plant_is_present_and_trusted_owned() {
+    let fixture = fixture();
+    let planted = fixture.module.join("backup/sub/evil");
+    symlink(&fixture.secret, &planted).expect("plant the symlink");
+
+    let meta = fs::symlink_metadata(&planted).expect("the plant must exist");
+    assert!(meta.file_type().is_symlink(), "the plant must be a symlink");
+    assert!(
+        fast_io::symlink_owner_is_trusted(std::os::unix::fs::MetadataExt::uid(&meta)),
+        "the plant must be TRUSTED-owned, or the refusal proves nothing about \
+         confinement - it would only be the ownership arm firing"
+    );
+
+    // The target really does hold the secret, so a leak would be observable.
+    assert_eq!(
+        read_all(fs::File::open(&planted).expect("plain open follows the link")),
+        "SECRET-MARKER"
+    );
+}
+
+/// NEGATIVE CONTROL for over-refusal. A trusted symlink whose target stays
+/// INSIDE the module is still followed. Without this the pin would be satisfied
+/// by refusing every symlink, which is a different - and wrong - resolver.
+#[test]
+fn a_trusted_symlink_staying_inside_the_module_is_followed() {
+    let fixture = fixture();
+    let inside = fixture.module.join("data");
+    fs::write(&inside, "IN-MODULE").expect("write in-module target");
+    let link = fixture.module.join("backup/sub/benign");
+    symlink(&inside, &link).expect("plant the in-module symlink");
+
+    let _session = serve_module(&fixture.module);
+    let file = fast_io::operator_open_read_confined(&link)
+        .expect("an in-module target must still be followed");
+
+    assert_eq!(read_all(file), "IN-MODULE");
+}
+
+/// NON-VACUITY companion. With no symlink in play a confined open is an
+/// ordinary resolution. Without this, every refusal above would also hold if
+/// the confined walk simply failed for all inputs.
+#[test]
+fn a_plain_path_inside_the_module_opens() {
+    let fixture = fixture();
+    let plain = fixture.module.join("backup/sub/plain");
+    fs::write(&plain, "PLAIN").expect("write");
+
+    let _session = serve_module(&fixture.module);
+    let file = fast_io::operator_open_read_confined(&plain).expect("plain resolution");
+
+    assert_eq!(read_all(file), "PLAIN");
+}
+
+/// The other half of upstream's rule: the confinement applies to CONFINED opens
+/// only. `--log-file`, the `--*-from` family and the daemon's lock and motd
+/// files may legitimately live outside the tree, so the ANCILLARY entry point
+/// must still reach the same target the confined one refused.
+///
+/// Pinned because a blanket confinement would satisfy every assertion above
+/// while creating a new divergence in the opposite direction.
+///
+/// upstream: `rsync-3.5.0/syscall.c:232-239` - "other opens (--log-file,
+/// --*-from, lock/motd) may legitimately live elsewhere".
+#[test]
+fn an_ancillary_open_may_still_leave_the_module() {
+    let fixture = fixture();
+    let planted = fixture.module.join("backup/sub/evil");
+    symlink(&fixture.secret, &planted).expect("plant the symlink");
+
+    let _session = serve_module(&fixture.module);
+    let file = fast_io::operator_open_read(&planted)
+        .expect("an ancillary path is not bound to the module root");
+
+    assert_eq!(read_all(file), "SECRET-MARKER");
+}
+
+/// With no confinement root there is nothing to be outside of, so a confined
+/// open behaves exactly like an unconfined one. This is the plain local client:
+/// upstream's `confinement_root()` returns `confine_root`, which is unset.
+///
+/// upstream: `rsync-3.5.0/syscall.c:128-144` `confinement_root()`.
+#[test]
+fn without_a_confinement_root_a_confined_open_still_follows() {
+    let fixture = fixture();
+    let planted = fixture.module.join("backup/sub/evil");
+    symlink(&fixture.secret, &planted).expect("plant the symlink");
+
+    let _guard = SESSION
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    fast_io::confinement::install_local_session(
+        fast_io::confinement::LocalInsecureLinks::from_local_flag(false),
+    );
+    let file = fast_io::operator_open_read_confined(&planted)
+        .expect("no root means nothing is outside it");
+
+    assert_eq!(read_all(file), "SECRET-MARKER");
+}


### PR DESCRIPTION
The ownership walk implements only the first half of upstream's rule. It follows a
symlink owned by uid 0 or the euid, because such a link is operator-authored by
construction (`syscall.c:406`), but it never asks *where the followed link landed*.
Upstream pairs that follow with `abspath_outside_confinement()`
(`syscall.c:186-240`), refusing a resolved path that has left the confinement root
whenever `operator_path_resolve` is set.

Measured end-to-end against a real daemon: a trusted-owned symlink named in a
dir-merge rule reads an out-of-module file in as filter rules, and its text returns
to the peer through "failed to parse filter rule" errors. That is the attack
upstream describes in its own comment at `exclude.c:1668-1684`, which is why
`parse_filter_file()` sets `operator_path_resolve` around its open.

## Design

The session's confinement root is published alongside the existing opt-out bit and
resolved once to a physical path. The walk tracks the absolute path it has really
resolved, so the leaf can be judged against that root rather than against the
caller's spelling of it.

Refusal is `ELOOP`, matching `syscall.c:464-466`. `EXDEV` would be laundered by
callers that treat it as cross-device and fall back to copy+remove.

## Scope

Scope follows upstream's, not a blanket sweep. The two opens routed through the
confined entry point are the filter/merge-file parsers, which is what
`parse_filter_file()` covers. Every other operator-named open keeps the ownership
walk alone - `--log-file`, `--files-from`, the daemon lock file and motd are left
out deliberately, as they are upstream (`syscall.c:232-239`).

## Verification

Six cells in `crates/fast_io/tests/operator_open_module_confinement.rs`, covering
both directions: the escape is refused, an in-module trusted symlink is still
followed, a plain in-module path still opens, an ancillary open may still leave the
module, and a session with no confinement root still follows.

Mutation-proven: neutering `refuse_if_outside` to `Ok(())` fails exactly
`a_trusted_symlink_leaving_the_module_is_refused` while all 13 companion cells stay
green - so the check is load-bearing and demonstrably not over-refusing.

`fast_io` 782/782; fmt and clippy clean.
