### PR TITLE
fix(receiver): device nodes need upstream's am_root gate

### DIFF
--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -90,10 +90,6 @@ impl<'a> CopyContext<'a> {
         self.options.fsync_enabled()
     }
 
-    pub(super) const fn devices_enabled(&self) -> bool {
-        self.options.devices_enabled()
-    }
-
     pub(super) const fn copy_devices_as_files_enabled(&self) -> bool {
         self.options.copy_devices_as_files_enabled()
     }

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -132,7 +132,7 @@ impl<'a> CopyContext<'a> {
         self.options.specials_enabled()
     }
 
-    pub(super) const fn may_create_devices(&self) -> bool {
+    pub(super) fn may_create_devices(&self) -> bool {
         self.options.may_create_devices()
     }
 

--- a/crates/engine/src/local_copy/executor/sources/handlers.rs
+++ b/crates/engine/src/local_copy/executor/sources/handlers.rs
@@ -327,10 +327,16 @@ pub(super) fn handle_device_copy(
 
     if context.copy_devices_as_files_enabled() {
         let _ = copy_file(context, source_path, &target, metadata, record_path)?;
-    } else if !context.devices_enabled() && !context.list_only_enabled() {
+    } else if !context.may_create_devices() && !context.list_only_enabled() {
         // upstream: generator.c:1155 list_file_entry() lists devices in
         // `--list-only` output regardless of `--devices`; a real transfer
         // without `--devices` still skips them.
+        //
+        // The creation predicate - not the bare `--devices` flag - because
+        // upstream also requires `!drop_devices` and a non-zero `am_root`
+        // before it will attempt the mknod (generator.c:2031-2033). Skipping
+        // here leaves the destination untouched; entering the branch would
+        // remove any obstruction first and only then fail.
         context.record_skipped_non_regular(record_path);
         return Ok(true);
     } else {

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -267,7 +267,10 @@ pub(crate) fn copy_symlink(
             }
 
             if is_device(target_type) {
-                if !context.devices_enabled() {
+                // upstream: generator.c:2031-2033 - the same creation
+                // predicate as every other device site; `--copy-links`
+                // resolving to a device does not relax it.
+                if !context.may_create_devices() {
                     context.record_skipped_non_regular(record_path.as_deref());
                     context.register_progress();
                     return Ok(());

--- a/crates/engine/src/local_copy/options/path_behavior.rs
+++ b/crates/engine/src/local_copy/options/path_behavior.rs
@@ -424,10 +424,31 @@ impl LocalCopyOptions {
 
     /// Reports whether a device node may actually be created.
     ///
-    /// upstream: generator.c:2031 `!drop_devices && ... preserve_devices`.
+    /// Upstream additionally requires `am_root` to be non-zero, so an
+    /// unprivileged receiver skips the entry outright instead of removing any
+    /// obstruction and then failing the `mknod` it was never able to perform.
+    ///
+    /// The privilege term is `am_root != 0` - root, `--super` *or*
+    /// `--fake-super` - which is deliberately NOT
+    /// [`Self::am_root`](super::super::types::LocalCopyOptions::am_root): that
+    /// accessor answers `am_root > 0` for the ownership rules and reports
+    /// false under `--fake-super`, where upstream still writes the `0600`
+    /// placeholder (`syscall.c:do_mknod()`, the `am_root < 0` branch).
+    ///
+    /// upstream: generator.c:2031-2033 `!drop_devices && ((am_root &&
+    /// preserve_devices && ftype == FT_DEVICE) || ...)`.
     #[must_use]
-    pub const fn may_create_devices(&self) -> bool {
-        self.devices && !self.drop_devices
+    pub fn may_create_devices(&self) -> bool {
+        self.devices && !self.drop_devices && self.may_attempt_node_creation()
+    }
+
+    /// Upstream's `am_root != 0` test, as used to gate device-node creation.
+    ///
+    /// upstream: options.c:95 `am_root` tri-state - 0 normal, 1 root,
+    /// 2 `--super`, -1 `--fake-super`; every non-zero value permits the
+    /// `mknod` attempt.
+    fn may_attempt_node_creation(&self) -> bool {
+        self.fake_super || self.super_mode.unwrap_or_else(::metadata::am_root)
     }
 
     /// Reports whether a FIFO or socket may actually be created.

--- a/crates/metadata/src/identity.rs
+++ b/crates/metadata/src/identity.rs
@@ -106,3 +106,27 @@ pub fn set_process_identity(uid: u32, gid: u32) {
     OVERRIDE_UID.store(i64::from(uid), Ordering::Release);
     OVERRIDE_GID.store(i64::from(gid), Ordering::Release);
 }
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::is_root;
+
+    /// `am_root` must agree with the **libc** `geteuid`, never a raw syscall.
+    ///
+    /// The two disagree under `fakeroot`, which intercepts the libc symbol and
+    /// reports uid 0 while the raw syscall still reports the real unprivileged
+    /// uid. Upstream reads libc (`main.c:1764 our_uid = MY_UID()`), so a
+    /// raw-syscall `am_root` refuses device creation and ownership changes in
+    /// exactly the runs where upstream performs them - which is how the 3.5.0
+    /// `devices` testsuite cell, whose non-root leg re-execs under fakeroot,
+    /// observes the difference.
+    #[test]
+    #[allow(unsafe_code)]
+    fn am_root_tracks_the_libc_effective_uid() {
+        // SAFETY: `geteuid` is a POSIX accessor taking no arguments, with no
+        // side effects and no failure mode.
+        let libc_euid = unsafe { libc::geteuid() };
+        assert_eq!(crate::am_root(), libc_euid == 0);
+        assert_eq!(is_root(), libc_euid == 0);
+    }
+}

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -198,11 +198,22 @@ pub mod windows;
 /// which gates ownership-change attempts and the `ITEM_REPORT_OWNER` itemize
 /// flag (`generator.c:546`). Always `false` on Windows, matching upstream's
 /// `am_root = 0` on platforms without POSIX uid semantics.
+///
+/// Delegates to [`identity::is_root`] rather than issuing a fresh `geteuid`, so
+/// this answers the same question upstream's `am_root` does. Upstream computes
+/// it once from `our_uid = MY_UID()` (`main.c:1764-1766`), the libc `geteuid`,
+/// which gives two properties a raw syscall cannot:
+///
+/// - under `fakeroot` the *faked* root identity is observed, because fakeroot
+///   intercepts the libc symbol and not the syscall;
+/// - after the permanent `--copy-as` privilege drop
+///   ([`copy_as::become_copy_as_user`]) the dropped identity is observed,
+///   because that installs an override the accessor consults first.
 #[must_use]
 pub fn am_root() -> bool {
     #[cfg(unix)]
     {
-        rustix::process::geteuid().is_root()
+        identity::is_root()
     }
     #[cfg(not(unix))]
     {

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -82,6 +82,30 @@ impl ReceiverContext {
                 if !self.config.flags.devices {
                     continue;
                 }
+                // upstream: generator.c:2032 - the device arm is
+                // `am_root && preserve_devices && ftype == FT_DEVICE`. Without
+                // the privilege term an unprivileged receiver enters the
+                // creation branch, unlinks whatever occupies the destination,
+                // and only then fails the `mknod` it was never able to
+                // perform - destroying an existing file. Upstream instead
+                // falls through to the non-regular skip at generator.c:2109,
+                // leaving the destination untouched.
+                //
+                // The term is `am_root != 0`, so `--fake-super` qualifies: it
+                // is the -1 arm of the tri-state and still writes the 0600
+                // placeholder (`syscall.c:do_mknod()`).
+                if !metadata::am_root() && !self.config.fake_super {
+                    // upstream: generator.c:2109-2114 - INFO_GTE(NONREG, 1),
+                    // which is info_verbosity[0] and so prints at default
+                    // verbosity.
+                    info_log!(
+                        Nonreg,
+                        1,
+                        "skipping non-regular file \"{}\"",
+                        entry.path().display()
+                    );
+                    continue;
+                }
             } else if is_special {
                 if !self.config.flags.specials {
                     continue;

--- a/tests/drop_devices.rs
+++ b/tests/drop_devices.rs
@@ -453,3 +453,115 @@ fn the_same_remote_push_creates_specials_without_drop_d() {
     );
     assert!(regular_arrived, "the ordinary transfer must still happen");
 }
+
+/// Probes whether this process can actually create a device node.
+///
+/// Upstream's gate is `am_root != 0`, and the honest way to ask that here is to
+/// attempt the syscall rather than read a uid: the root CI leg and the nonroot
+/// CI leg then each assert the arm that actually applies to them, so neither
+/// leg is vacuous.
+fn can_create_device_nodes(scratch: &Path) -> bool {
+    let probe = scratch.join("probe-dev");
+    let created = Command::new("mknod")
+        .arg(&probe)
+        .arg("c")
+        .arg("1")
+        .arg("3")
+        .status()
+        .is_ok_and(|status| status.success());
+    created && is_special(&probe)
+}
+
+fn rendered_output(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// A device entry must never cost an occupied destination its contents.
+///
+/// upstream: generator.c:2031-2033 - the `FT_DEVICE` arm is
+/// `am_root && preserve_devices && ftype == FT_DEVICE`, so an unprivileged
+/// receiver never enters the creation branch and falls through to the
+/// non-regular skip at generator.c:2109. oc ported the `!drop_devices` and
+/// `preserve_devices` conjuncts but not the privilege term, so it entered the
+/// branch, unlinked whatever occupied the destination, and only then failed the
+/// `mknod` it was never able to perform - destroying an existing file.
+///
+/// Measured against real upstream 3.5.0, non-root, `/dev/null` onto an existing
+/// file: `skipping non-regular file "null"`, exit 0, contents intact.
+#[test]
+fn a_device_entry_never_destroys_an_occupied_destination() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let privileged = can_create_device_nodes(temp.path());
+
+    let dest = temp.path().join("null");
+    fs::write(&dest, b"PRECIOUS").expect("seed destination");
+    let dest_arg = dest.display().to_string();
+
+    let output = run(&[
+        OsStr::new("-a"),
+        OsStr::new("-D"),
+        OsStr::new("/dev/null"),
+        OsStr::new(&dest_arg),
+    ]);
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "upstream skips the entry and continues; it is not an error. output:\n{rendered}"
+    );
+
+    if privileged {
+        assert!(
+            is_special(&dest),
+            "a privileged receiver materialises the node. output:\n{rendered}"
+        );
+    } else {
+        assert_eq!(
+            fs::read(&dest).expect("destination must still exist"),
+            b"PRECIOUS",
+            "an unprivileged receiver must leave the destination untouched. output:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("skipping non-regular file \"null\""),
+            "expected upstream's non-regular skip line. output:\n{rendered}"
+        );
+    }
+}
+
+/// `--fake-super` is upstream's `am_root = -1`, which is NON-ZERO and so still
+/// enters the creation branch - `syscall.c:do_mknod()` writes a `0600`
+/// placeholder instead of calling `mknod(2)`.
+///
+/// This is the arm that separates upstream's `am_root != 0` from the ownership
+/// rules' `am_root > 0`. A gate written with the latter predicate - which oc
+/// already has, as `LocalCopyOptions::am_root` - would skip here and silently
+/// drop the placeholder, so this is the companion that makes the test above
+/// non-vacuous rather than merely "oc creates nothing".
+#[test]
+fn fake_super_still_materialises_a_device_placeholder() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let dest = temp.path().join("null");
+    let dest_arg = dest.display().to_string();
+
+    let output = run(&[
+        OsStr::new("-a"),
+        OsStr::new("-D"),
+        OsStr::new("--fake-super"),
+        OsStr::new("/dev/null"),
+        OsStr::new(&dest_arg),
+    ]);
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "--fake-super records the node rather than failing. output:\n{rendered}"
+    );
+    assert!(
+        dest.exists(),
+        "--fake-super must leave a placeholder behind. output:\n{rendered}"
+    );
+}


### PR DESCRIPTION
Upstream enters the device-creation branch only when `am_root` is non-zero:

```c
generator.c:2031-2033
if (!drop_devices
 && ((am_root && preserve_devices && ftype == FT_DEVICE)
  || (preserve_specials && ftype == FT_SPECIAL))) {
```

oc ported the `!drop_devices` and `preserve_devices` conjuncts but not the
privilege term. An unprivileged receiver therefore entered the branch, removed
whatever occupied the destination, and only then failed the `mknod` it could
never perform — **destroying an existing file**. Upstream falls through to the
non-regular skip at `generator.c:2109` and leaves the destination untouched.

Measured against real upstream 3.5.0, non-root, a device source landing on an
existing file:

| | notice | exit | destination |
|---|---|---|---|
| upstream 3.5.0 | `skipping non-regular file "null"` | 0 | intact |
| oc before, local copy | `failed to create device …` | 23 | **gone** |
| oc before, network receiver | *(silent)* | 0 | **gone** |
| oc after, both | matches upstream | 0 | intact |

## The privilege term is `am_root != 0`, not `am_root > 0`

That admits root, `--super` *and* `--fake-super`, and is deliberately **not**
`LocalCopyOptions::am_root`, which answers `am_root > 0` for the ownership
rules and reports false under `--fake-super` — where upstream still writes the
`0600` placeholder (`syscall.c:do_mknod()`, the `am_root < 0` branch). Measured
on 3.5.0 rather than read:

| mode | exit | destination |
|---|---|---|
| none | 0 | absent, notice printed |
| `--super` | 23 | absent, `mknod … Operation not permitted` |
| `--fake-super` | 0 | placeholder created, silent |

## Three sites, not one

`copy_device` has three engine call sites. The recursion planner consulted
`may_create_devices()`; the named-operand handler and the
`--copy-links`-resolves-to-a-device path consulted the bare
`devices_enabled()`. All three now consult `may_create_devices()`, which is
upstream's full entry condition. Each already had a skip arm routing through
`record_skipped_non_regular`, so the notice comes with it.

Verified unchanged by the predicate swap: `--drop-D` and `--list-only` both
still match upstream exactly.

Specials stay ungated — upstream's `FT_SPECIAL` arm carries no `am_root` term,
and `mkfifo` needs no privilege.

## Verification

- 4/4 exact match with upstream 3.5.0 on the local path (none / `--drop-D` /
  `--fake-super` / `--list-only`), plus the network receiver.
- RED proven by mutating the predicate to `true`: the pin fails with the exact
  pre-fix symptom, the `--fake-super` companion stays green.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean;
  `cargo fmt --all --check` clean; 181/181 targeted device/special tests.

## Known gaps, deliberately not in scope

- **`--super` on a network receiver.** `crates/transfer` has no `super_mode`
  field and the server argument decoder has no `--super` arm, so a forwarded
  `--super` never reaches a network receiver — threading it would be inert
  until the decoder gap is closed. The local-copy path expresses all three arms.
- **The receiver's skip notice is lost on a push.** Measured: it prints when
  the receiver is the local client and is dropped when the receiver is the
  remote server. That localises it to server→client *info* framing — warnings
  are framed today, info notices are not — which is pre-existing, not
  device-specific, and belongs to the message-funnel work rather than here.
