### PR TITLE
fix(batch): refuse a non-regular --read-batch path

### DIFF
--- a/crates/batch/src/reader/mod.rs
+++ b/crates/batch/src/reader/mod.rs
@@ -141,7 +141,33 @@ impl BatchReader {
                     format!("Failed to open batch file '{}': {}", path.display(), e),
                 ))
             })?;
+            Self::reject_non_regular(&file, path)?;
             Ok(BatchSource::File(file))
+        }
+    }
+
+    /// Refuse a read-batch path that resolved to a non-regular file.
+    ///
+    /// The batch bytes drive the protocol parser, so a FIFO, device or socket
+    /// planted at the batch path lets whoever planted it stream arbitrary
+    /// protocol data into the replay. The ownership walk in
+    /// [`crate::operator_file::open_read`] refuses a foreign-owned *symlink*
+    /// but has nothing to say about a node the attacker created directly, so
+    /// upstream pairs the safe open with this check.
+    ///
+    /// The stat is taken from the opened descriptor, not the path, so it
+    /// describes the file the reader actually holds and cannot be raced. A
+    /// failing `fstat` is not itself a refusal - upstream only rejects when the
+    /// stat succeeds and reports a non-regular mode.
+    ///
+    /// upstream: batch.c:275-281
+    fn reject_non_regular(file: &File, path: &Path) -> BatchResult<()> {
+        match file.metadata() {
+            Ok(meta) if !meta.file_type().is_file() => Err(BatchError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Batch file \"{}\" is not a regular file", path.display()),
+            ))),
+            _ => Ok(()),
         }
     }
 

--- a/crates/batch/src/reader/tests.rs
+++ b/crates/batch/src/reader/tests.rs
@@ -36,6 +36,35 @@ mod reader_creation_tests {
         assert!(reader.is_ok());
     }
 
+    /// A character device at the read-batch path must be refused.
+    ///
+    /// `/dev/null` is the fixture upstream's own testsuite clones with
+    /// `mknod` (`batch-file-symlink_test.py`): it is openable by anyone, so
+    /// the safe open succeeds and the refusal has to come from the mode check
+    /// on the opened descriptor. Without that check the reader consumes zero
+    /// bytes from the device and reports a generic header failure, treating
+    /// attacker-streamable protocol data as a batch file.
+    ///
+    /// `create_with_valid_file` above is the non-vacuity companion: it proves
+    /// this same open path accepts a regular file, so a refusal here cannot be
+    /// the open failing for an unrelated reason.
+    ///
+    /// upstream: batch.c:275-281
+    #[test]
+    #[cfg(unix)]
+    fn read_batch_refuses_a_character_device() {
+        let config = BatchConfig::new(BatchMode::Read, "/dev/null".to_owned(), 30);
+
+        let Err(err) = BatchReader::new(config) else {
+            panic!("a character device was accepted as a batch file");
+        };
+
+        assert!(
+            err.to_string().contains("is not a regular file"),
+            "expected the non-regular refusal, got: {err}"
+        );
+    }
+
     #[test]
     fn create_with_nonexistent_file() {
         let config = BatchConfig::new(

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -25,7 +25,7 @@ backup-dir-symlink-race pass
 backup-incremental pass
 bare-do-open-symlink-race pass
 basis-xname-traversal fail
-batch-file-symlink fail
+batch-file-symlink pass
 batch-mode pass
 batch-only-remove-source-regression fail
 change-shrink pass


### PR DESCRIPTION
## What

`--read-batch` accepted a non-regular file at the batch path. A FIFO, device
or socket planted there let whoever planted it stream arbitrary protocol data
into the replay.

The ownership walk added earlier already refuses a foreign-owned *symlink* at
any path component, but it has nothing to say about a node the attacker
created directly: the open succeeds, the reader consumes zero bytes and
reports a generic header failure, having treated the node as a batch file.

Upstream pairs the safe open with a mode check on the resulting descriptor and
refuses anything that is not a regular file (`batch.c:275-281`). This mirrors
that rule exactly:

- read-batch only, never `--read-batch=-` (upstream skips `STDIN_FILENO`);
- the stat comes from the opened descriptor, not the path, so it describes the
  file the reader actually holds and cannot be raced;
- a *failing* `fstat` is not a refusal - upstream only rejects when the stat
  succeeds and reports a non-regular mode (`do_fstat(...) == 0 && !S_ISREG`).

## Verification

Closes the `batch-file-symlink` cell of the upstream 3.5.0 testsuite, whose
fourth sub-check plants a `/dev/null` clone via `mknod` and asserts the
refusal. The root expect-manifest row flips `fail` -> `pass` in this commit.

Measured on an x86_64 Linux host, as root, upstream control first:

| run | result |
|---|---|
| upstream 3.5.0 (control) | PASS |
| oc with the fix | PASS |
| oc with the guard call removed (mutation) | **FAIL** |

The mutation run is the attribution: the cell is green because of this change
and nothing else. The unit test uses `/dev/null` as its fixture - openable by
anyone, so the safe open succeeds and only the mode check can refuse it - with
the existing `create_with_valid_file` as its non-vacuity companion.

`cargo fmt` clean, `clippy -D warnings` clean, `batch` 232/232.
