### PR TITLE
fix(transfer): honour the symlink opt-out at the sender confinement root

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -356,7 +356,10 @@ mod module_access_tests {
         let path = std::path::Path::new("/tmp/test.log");
         let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "test error");
         let err = log_file_error(path, io_err);
-        assert_eq!(err.exit_code(), core::exit_code::ExitCode::MessageIo.as_i32());
+        assert_eq!(
+            err.exit_code(),
+            core::exit_code::ExitCode::MessageIo.as_i32()
+        );
     }
 
     #[test]
@@ -425,7 +428,10 @@ mod module_access_tests {
     #[test]
     fn peer_host_display_reports_undetermined_when_no_lookup_ran() {
         assert_eq!(peer_host_display(None, false), "UNDETERMINED");
-        assert_ne!(peer_host_display(None, false), peer_host_display(None, true));
+        assert_ne!(
+            peer_host_display(None, false),
+            peer_host_display(None, true)
+        );
     }
 
     /// The sentinels must never be an address: the daemon log renders
@@ -529,7 +535,6 @@ mod module_access_tests {
         assert!(!line.ends_with("\n\n"), "line must not have double newline");
     }
 
-
     #[cfg(unix)]
     #[test]
     fn check_permissions_accepts_owner_only_file() {
@@ -582,7 +587,6 @@ mod module_access_tests {
         assert!(check_secrets_file_permissions(&secrets).is_ok());
     }
 
-
     #[cfg(unix)]
     #[test]
     fn verify_secret_rejects_other_accessible_when_strict_modes_enabled() {
@@ -602,8 +606,15 @@ mod module_access_tests {
         // violation is an auth denial, not a fatal error: verify returns
         // Ok(false) so the daemon emits `@ERROR: auth failed on module X`
         // rather than dropping the socket mid-handshake.
-        let result = verify_secret_response(&module, "alice", None, "challenge", "response", DaemonAuthDigest::Md5)
-            .expect("strict-modes violation must be a denial, not an io error");
+        let result = verify_secret_response(
+            &module,
+            "alice",
+            None,
+            "challenge",
+            "response",
+            DaemonAuthDigest::Md5,
+        )
+        .expect("strict-modes violation must be a denial, not an io error");
         assert!(
             !result,
             "other-accessible secrets under strict modes must deny auth"
@@ -627,8 +638,15 @@ mod module_access_tests {
 
         // With strict_modes disabled, the file is read even though it's world-readable.
         // Authentication will fail (wrong response), but no permission error is returned.
-        let result = verify_secret_response(&module, "alice", None, "challenge", "response", DaemonAuthDigest::Md5)
-            .expect("should not error on permissions");
+        let result = verify_secret_response(
+            &module,
+            "alice",
+            None,
+            "challenge",
+            "response",
+            DaemonAuthDigest::Md5,
+        )
+        .expect("should not error on permissions");
         assert!(
             !result,
             "auth should fail due to wrong response, not permissions"
@@ -652,8 +670,15 @@ mod module_access_tests {
 
         // Permissions are fine, so the file is read. Auth will fail (wrong response)
         // but no permission error is returned.
-        let result = verify_secret_response(&module, "alice", None, "challenge", "response", DaemonAuthDigest::Md5)
-            .expect("should not error on permissions");
+        let result = verify_secret_response(
+            &module,
+            "alice",
+            None,
+            "challenge",
+            "response",
+            DaemonAuthDigest::Md5,
+        )
+        .expect("should not error on permissions");
         assert!(!result, "auth should fail due to wrong response");
     }
 
@@ -692,15 +717,31 @@ mod module_access_tests {
         let response = client_digest("groupsecret", challenge);
 
         // Authorized via the `@devs` token: the group line is the credential.
-        let granted =
-            verify_secret_response(&module, "alice", Some("devs"), challenge, &response, DaemonAuthDigest::Md5)
-                .expect("no io error");
-        assert!(granted, "group member must authenticate via @devs shared secret");
+        let granted = verify_secret_response(
+            &module,
+            "alice",
+            Some("devs"),
+            challenge,
+            &response,
+            DaemonAuthDigest::Md5,
+        )
+        .expect("no io error");
+        assert!(
+            granted,
+            "group member must authenticate via @devs shared secret"
+        );
 
         // upstream: authenticate.c:318 - a plain-username authorization passes a
         // NULL group, so `@group:` lines are never consulted. Denied here.
-        let denied = verify_secret_response(&module, "alice", None, challenge, &response, DaemonAuthDigest::Md5)
-            .expect("no io error");
+        let denied = verify_secret_response(
+            &module,
+            "alice",
+            None,
+            challenge,
+            &response,
+            DaemonAuthDigest::Md5,
+        )
+        .expect("no io error");
         assert!(
             !denied,
             "a @group secret must not match when the user was not authorized via that group"
@@ -731,8 +772,15 @@ mod module_access_tests {
 
         // The first `alice:` line mismatches, retiring the username; the later
         // `alice:rightpass` duplicate must NOT authenticate.
-        let denied = verify_secret_response(&module, "alice", None, challenge, &response, DaemonAuthDigest::Md5)
-            .expect("no io error");
+        let denied = verify_secret_response(
+            &module,
+            "alice",
+            None,
+            challenge,
+            &response,
+            DaemonAuthDigest::Md5,
+        )
+        .expect("no io error");
         assert!(
             !denied,
             "an earlier wrong-password line must retire the username and deny"
@@ -746,9 +794,15 @@ mod module_access_tests {
             strict_modes: false,
             ..Default::default()
         };
-        let granted =
-            verify_secret_response(&module_ok, "alice", None, challenge, &response, DaemonAuthDigest::Md5)
-                .expect("no io error");
+        let granted = verify_secret_response(
+            &module_ok,
+            "alice",
+            None,
+            challenge,
+            &response,
+            DaemonAuthDigest::Md5,
+        )
+        .expect("no io error");
         assert!(granted, "a correct first line must authenticate");
     }
 
@@ -810,7 +864,6 @@ mod module_access_tests {
         );
     }
 
-
     #[test]
     fn apply_long_form_args_parses_temp_dir_separate_args() {
         let args = vec![
@@ -849,7 +902,6 @@ mod module_access_tests {
         let _ = apply_long_form_args(&args, &mut config);
         assert!(config.temp_dir.is_none());
     }
-
 
     #[test]
     fn apply_long_form_args_parses_compare_dest_equals_format() {
@@ -988,7 +1040,11 @@ mod module_access_tests {
 
     #[test]
     fn apply_long_form_args_parses_log_format_with_itemize() {
-        let args = vec!["--server".to_owned(), "--log-format=%i".to_owned(), ".".to_owned()];
+        let args = vec![
+            "--server".to_owned(),
+            "--log-format=%i".to_owned(),
+            ".".to_owned(),
+        ];
         let mut config = ServerConfig::default();
         let _ = apply_long_form_args(&args, &mut config);
         assert!(config.flags.info_flags.itemize);
@@ -996,7 +1052,11 @@ mod module_access_tests {
 
     #[test]
     fn apply_long_form_args_parses_log_format_with_itemize_and_upper_i() {
-        let args = vec!["--server".to_owned(), "--log-format=%i%I".to_owned(), ".".to_owned()];
+        let args = vec![
+            "--server".to_owned(),
+            "--log-format=%i%I".to_owned(),
+            ".".to_owned(),
+        ];
         let mut config = ServerConfig::default();
         let _ = apply_long_form_args(&args, &mut config);
         assert!(config.flags.info_flags.itemize);
@@ -1004,7 +1064,11 @@ mod module_access_tests {
 
     #[test]
     fn apply_long_form_args_parses_out_format_with_itemize() {
-        let args = vec!["--server".to_owned(), "--out-format=%i".to_owned(), ".".to_owned()];
+        let args = vec![
+            "--server".to_owned(),
+            "--out-format=%i".to_owned(),
+            ".".to_owned(),
+        ];
         let mut config = ServerConfig::default();
         let _ = apply_long_form_args(&args, &mut config);
         assert!(config.flags.info_flags.itemize);
@@ -1012,7 +1076,11 @@ mod module_access_tests {
 
     #[test]
     fn apply_long_form_args_log_format_without_itemize() {
-        let args = vec!["--server".to_owned(), "--log-format=%o".to_owned(), ".".to_owned()];
+        let args = vec![
+            "--server".to_owned(),
+            "--log-format=%o".to_owned(),
+            ".".to_owned(),
+        ];
         let mut config = ServerConfig::default();
         let _ = apply_long_form_args(&args, &mut config);
         assert!(!config.flags.info_flags.itemize);
@@ -1020,7 +1088,11 @@ mod module_access_tests {
 
     #[test]
     fn apply_long_form_args_log_format_x_no_itemize() {
-        let args = vec!["--server".to_owned(), "--log-format=X".to_owned(), ".".to_owned()];
+        let args = vec![
+            "--server".to_owned(),
+            "--log-format=X".to_owned(),
+            ".".to_owned(),
+        ];
         let mut config = ServerConfig::default();
         let _ = apply_long_form_args(&args, &mut config);
         assert!(!config.flags.info_flags.itemize);
@@ -1159,7 +1231,9 @@ mod module_access_tests {
         let offender = apply_long_form_args(&args, &mut config);
         assert_eq!(
             offender,
-            Some(ClientArgRejection::Unrecognized("--write-batch=/tmp/bad.batch".to_owned()))
+            Some(ClientArgRejection::Unrecognized(
+                "--write-batch=/tmp/bad.batch".to_owned()
+            ))
         );
     }
 
@@ -1174,7 +1248,9 @@ mod module_access_tests {
         let offender = apply_long_form_args(&args, &mut config);
         assert_eq!(
             offender,
-            Some(ClientArgRejection::Unrecognized("--read-batch=/tmp/in.batch".to_owned()))
+            Some(ClientArgRejection::Unrecognized(
+                "--read-batch=/tmp/in.batch".to_owned()
+            ))
         );
     }
 
@@ -1189,7 +1265,9 @@ mod module_access_tests {
         let offender = apply_long_form_args(&args, &mut config);
         assert_eq!(
             offender,
-            Some(ClientArgRejection::Unrecognized("--only-write-batch=/tmp/dry.batch".to_owned()))
+            Some(ClientArgRejection::Unrecognized(
+                "--only-write-batch=/tmp/dry.batch".to_owned()
+            ))
         );
     }
 
@@ -1332,7 +1410,10 @@ mod module_access_tests {
         ];
         let mut config = ServerConfig::default();
         let offender = apply_long_form_args(&args, &mut config);
-        assert!(offender.is_none(), "no unknown should be reported: {offender:?}");
+        assert!(
+            offender.is_none(),
+            "no unknown should be reported: {offender:?}"
+        );
     }
 
     // Positional path arguments past the `.` separator must not be
@@ -1348,7 +1429,10 @@ mod module_access_tests {
         ];
         let mut config = ServerConfig::default();
         let offender = apply_long_form_args(&args, &mut config);
-        assert!(offender.is_none(), "positional paths must not flag: {offender:?}");
+        assert!(
+            offender.is_none(),
+            "positional paths must not flag: {offender:?}"
+        );
     }
 
     // WHY: upstream token.c:206-211 treats a bare `*` in the dont-compress match
@@ -1418,7 +1502,6 @@ mod module_access_tests {
         assert!(!dont_compress_is_match_all(DEFAULT_DONT_COMPRESS));
     }
 
-
     fn test_module_with_defaults() -> ModuleRuntime {
         ModuleRuntime::from(ModuleDefinition::default())
     }
@@ -1448,6 +1531,51 @@ mod module_access_tests {
     /// Non-vacuity companion for the pin above: with the directive absent the
     /// confinement stays engaged, so that test measures the directive and not a
     /// predicate that is unconditionally true.
+    /// The SAME directive must also release the Landlock sandbox. Without this
+    /// the ownership walk opts out while the kernel allowlist - pinned to
+    /// `module.path` - still refuses the read, so `insecure links = yes` is
+    /// accepted, logged, and silently inoperative. Measured on CI before the
+    /// fix: both modules sent identical byte counts and the daemon logged
+    /// "landlock fully enforced over 1 root(s)" for the opted-out module.
+    #[test]
+    fn insecure_links_also_releases_the_landlock_sandbox() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            insecure_links: true,
+            ..Default::default()
+        });
+        assert!(
+            landlock_skip_reason(&module).is_some(),
+            "`insecure links = yes` must skip Landlock; leaving it engaged makes the directive inoperative"
+        );
+    }
+
+    /// Non-vacuity companion: a default module must still be sandboxed. Without
+    /// this the test above also passes if the skip were made unconditional.
+    #[test]
+    fn a_default_module_is_still_landlock_sandboxed() {
+        let module = test_module_with_defaults();
+        assert_eq!(
+            landlock_skip_reason(&module),
+            None,
+            "a module with no opt-out and no exec hook must keep Landlock engaged"
+        );
+    }
+
+    /// The pre-existing arm must survive the extraction - it is a separate
+    /// operator decision with a different reason, not a duplicate of the above.
+    #[test]
+    fn a_configured_exec_hook_still_skips_landlock() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            pre_xfer_exec: Some("/usr/local/bin/notify.sh".into()),
+            ..Default::default()
+        });
+        let reason = landlock_skip_reason(&module).expect("exec hook must skip landlock");
+        assert!(
+            reason.contains("xfer-exec"),
+            "the hook arm must report its own reason, got: {reason}"
+        );
+    }
+
     #[test]
     fn absent_insecure_links_leaves_the_confinement_engaged() {
         let module = test_module_with_defaults();
@@ -1692,7 +1820,6 @@ mod module_access_tests {
         assert_eq!(rules[1].pattern, "*.bak");
     }
 
-
     #[test]
     fn build_pattern_rule_exclude() {
         let rule = build_pattern_rule("*.tmp", false);
@@ -1826,7 +1953,6 @@ mod module_access_tests {
         assert!(parse_daemon_filter_token("+").is_none());
     }
 
-
     #[test]
     fn parse_daemon_filter_token_exclude_keyword() {
         let rule = parse_daemon_filter_token("exclude *.bak").unwrap();
@@ -1910,15 +2036,20 @@ mod module_access_tests {
         assert!(parse_daemon_filter_token("include ").is_none());
     }
 
-
     #[test]
     fn strip_keyword_prefix_space_separator() {
-        assert_eq!(strip_keyword_prefix("exclude *.tmp", "exclude"), Some("*.tmp"));
+        assert_eq!(
+            strip_keyword_prefix("exclude *.tmp", "exclude"),
+            Some("*.tmp")
+        );
     }
 
     #[test]
     fn strip_keyword_prefix_comma_separator() {
-        assert_eq!(strip_keyword_prefix("exclude,*.tmp", "exclude"), Some("*.tmp"));
+        assert_eq!(
+            strip_keyword_prefix("exclude,*.tmp", "exclude"),
+            Some("*.tmp")
+        );
     }
 
     #[test]
@@ -1936,7 +2067,6 @@ mod module_access_tests {
     fn strip_keyword_prefix_no_match() {
         assert_eq!(strip_keyword_prefix("include *.tmp", "exclude"), None);
     }
-
 
     #[test]
     fn read_patterns_from_file_basic() {
@@ -2058,7 +2188,6 @@ mod module_access_tests {
             .collect();
         assert!(has_secluded_args_flag(&args));
     }
-
 
     #[test]
     fn apply_long_form_args_parses_backup_dir_two_arg() {
@@ -2308,7 +2437,10 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
         let dest = resolve_receiver_dest(module_path, &args, "upload");
-        assert_eq!(dest.as_os_str(), std::ffi::OsStr::new("/srv/upload/realdir/"));
+        assert_eq!(
+            dest.as_os_str(),
+            std::ffi::OsStr::new("/srv/upload/realdir/")
+        );
     }
 
     // Non-vacuity companion: the SAME tail without the slash must NOT gain one,
@@ -2525,7 +2657,10 @@ mod module_access_tests {
             clamped.starts_with(&module_root),
             "absolute out-of-module basis must be clamped under the module, got {clamped:?}",
         );
-        assert!(!clamped.exists(), "the clamped basis must not resolve to a real out-of-tree dir");
+        assert!(
+            !clamped.exists(),
+            "the clamped basis must not resolve to a real out-of-tree dir"
+        );
     }
 
     #[test]
@@ -2744,9 +2879,11 @@ mod module_access_tests {
         // separate symlink-resolution rule is what refuses it. Asserting both
         // halves keeps a future simplification from collapsing them: a clamp
         // alone would admit the escape.
-        let clamped =
-            clamp_basis_to_module(std::path::Path::new("cd"), &module_root, &module_root);
-        assert_eq!(clamped, trap, "the lexical clamp alone does NOT refuse this");
+        let clamped = clamp_basis_to_module(std::path::Path::new("cd"), &module_root, &module_root);
+        assert_eq!(
+            clamped, trap,
+            "the lexical clamp alone does NOT refuse this"
+        );
         assert!(
             basis_resolves_outside_module(&clamped, &module_root),
             "in-module symlink whose target escapes the module must be dropped \
@@ -2780,7 +2917,10 @@ mod module_access_tests {
             clamped.starts_with(&module_root),
             "absolute --link-dest pointing outside the module root must be clamped, got {clamped:?}",
         );
-        assert!(!clamped.exists(), "the clamped basis must not name the real outside file");
+        assert!(
+            !clamped.exists(),
+            "the clamped basis must not name the real outside file"
+        );
     }
 
     #[test]
@@ -2795,8 +2935,7 @@ mod module_access_tests {
         // instead of `./...`.
         let module_path = std::path::Path::new("/srv/upload");
         let args: Vec<String> = vec![];
-        let sources = resolve_sender_sources(module_path, &args, "upload")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "upload");
         assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
     }
 
@@ -2808,8 +2947,7 @@ mod module_access_tests {
         // engine-side `DOTDIR_NAME` signal (see the bare-module test).
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "upload");
         assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
     }
 
@@ -2820,8 +2958,7 @@ mod module_access_tests {
         // and the per-positional dir/fn split emits the basename.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "upload");
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
@@ -2835,8 +2972,7 @@ mod module_access_tests {
         // emits "." with FLAG_TOP_DIR for the sub-directory's contents.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/d2/".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "upload");
         let lossy: Vec<String> = sources
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
@@ -2852,7 +2988,10 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/../etc/passwd".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload");
-        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/etc/passwd")]);
+        assert_eq!(
+            sources,
+            vec![std::path::PathBuf::from("/srv/upload/etc/passwd")]
+        );
     }
 
     #[test]
@@ -2862,7 +3001,10 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/../../secret".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload");
-        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/secret")]);
+        assert_eq!(
+            sources,
+            vec![std::path::PathBuf::from("/srv/upload/secret")]
+        );
     }
 
     #[test]
@@ -2892,8 +3034,7 @@ mod module_access_tests {
     fn resolve_sender_sources_strips_leading_slash_before_join() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload//d1/d2/f2".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "upload");
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
@@ -2919,8 +3060,7 @@ mod module_access_tests {
         std::fs::write(module_path.join("foo").join("one"), b"one\n").expect("foo/one");
 
         let args = vec![".".to_owned(), "mod/f*".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "mod");
         assert_eq!(sources, vec![module_path.join("foo")]);
     }
 
@@ -2934,8 +3074,7 @@ mod module_access_tests {
         std::fs::create_dir(module_path.join("bar")).expect("bar dir");
 
         let args = vec![".".to_owned(), "mod/z*".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "mod");
         assert_eq!(sources, vec![module_path.join("z*")]);
     }
 
@@ -2949,8 +3088,7 @@ mod module_access_tests {
 
         // `?` matches exactly one character; `?b` must match only `ab`.
         let args = vec![".".to_owned(), "mod/?b".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "mod");
         assert_eq!(sources, vec![module_path.join("ab")]);
     }
 
@@ -2964,8 +3102,7 @@ mod module_access_tests {
 
         // `[ab]` matches `a` or `b` but not `c`.
         let args = vec![".".to_owned(), "mod/[ab]".to_owned()];
-        let mut sources = resolve_sender_sources(module_path, &args, "mod")
-            ;
+        let mut sources = resolve_sender_sources(module_path, &args, "mod");
         sources.sort();
         assert_eq!(sources, vec![module_path.join("a"), module_path.join("b")]);
     }
@@ -2980,8 +3117,7 @@ mod module_access_tests {
         std::fs::write(module_path.join("visible"), b"visible").expect("visible");
 
         let args = vec![".".to_owned(), "mod/*".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "mod");
         assert_eq!(sources, vec![module_path.join("visible")]);
     }
 
@@ -2994,8 +3130,7 @@ mod module_access_tests {
         let module_path = tmp.path();
 
         let args = vec![".".to_owned(), "mod/missing/file".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "mod");
         assert_eq!(sources, vec![module_path.join("missing/file")]);
     }
 
@@ -3031,8 +3166,7 @@ mod module_access_tests {
         // correctly without per-host separator translation.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "upload");
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from(r"C:\srv\upload/d1/d2/f2")]
@@ -3049,8 +3183,7 @@ mod module_access_tests {
         // `rsync://h/mod/d1/d2/` round-trips with the slash intact.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/d1/d2/".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "upload");
         let lossy: Vec<String> = sources
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
@@ -3069,8 +3202,7 @@ mod module_access_tests {
         // to the no-trailing-slash form rather than producing `C:\srv\upload\\d1`.
         let module_path = std::path::Path::new(r"C:\srv\upload\");
         let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload")
-            ;
+        let sources = resolve_sender_sources(module_path, &args, "upload");
         // The exact emitted bytes are `C:\srv\upload\` + `d1/d2/f2` because
         // the resolver detects the trailing `\` as an existing separator and
         // suppresses its own `/` insertion. The result is still a valid
@@ -3252,10 +3384,7 @@ mod module_access_tests {
     #[test]
     fn auth_ro_suffix_forces_read_only_for_session() {
         // `read only = no` module, but the user is pinned to `:ro`.
-        assert!(access_effective_read_only(
-            false,
-            UserAccessLevel::ReadOnly
-        ));
+        assert!(access_effective_read_only(false, UserAccessLevel::ReadOnly));
     }
 
     #[test]
@@ -3271,10 +3400,7 @@ mod module_access_tests {
     fn auth_default_access_preserves_module_read_only() {
         // No suffix: the module's own `read only` setting stands unchanged.
         assert!(access_effective_read_only(true, UserAccessLevel::Default));
-        assert!(!access_effective_read_only(
-            false,
-            UserAccessLevel::Default
-        ));
+        assert!(!access_effective_read_only(false, UserAccessLevel::Default));
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -382,6 +382,38 @@ fn validate_client_paths_in_module(
     }))
 }
 
+/// Why this module's Landlock sandbox is skipped, or `None` to engage it.
+///
+/// Both arms are per-module operator configuration, and both are skips rather
+/// than downgrades because a Landlock ruleset cannot be relaxed once applied -
+/// it is inherited by children and only ever narrows.
+///
+/// - **exec hooks**: rulesets are inherited across `exec()`, so an allowlist
+///   pinned to the module path would block hook scripts that live outside it
+///   (the common case, e.g. `/usr/local/bin/notify.sh`).
+/// - **`insecure links = yes`**: the directive exists to restore the legacy
+///   follow-any-symlink behaviour for a module, which necessarily means reading
+///   through an in-module symlink that leaves the module tree. A kernel
+///   allowlist pinned to `module.path` refuses exactly that, so leaving
+///   Landlock engaged does not harden the module - it makes the directive
+///   silently inoperative while the daemon still logs that it accepted it.
+///   The ownership walk consults the same opt-out
+///   (`fast_io::confinement::session_optout_allowed`), so this keeps the two
+///   confinement layers agreeing on one operator decision.
+///
+/// upstream: rsync has no Landlock layer; `syscall.c:123-127`
+/// `symlink_optout_allowed()` is the whole of its daemon-side rule, and it is
+/// read as `module_id >= 0 && lp_insecure_links(module_id)`.
+fn landlock_skip_reason(module: &ModuleRuntime) -> Option<&'static str> {
+    if module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some() {
+        return Some("pre-xfer-exec or post-xfer-exec configured (would block hook exec)");
+    }
+    if module.insecure_links {
+        return Some("insecure links = yes (operator opted this module out of path confinement)");
+    }
+    None
+}
+
 /// Engages the SEC-1.p Landlock LSM allowlist for the receiver path.
 ///
 /// Called immediately after `apply_module_privilege_restrictions` has
@@ -422,12 +454,9 @@ fn engage_landlock_sandbox(
         restrict_to_module_paths,
     };
 
-    if module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some() {
+    if let Some(reason) = landlock_skip_reason(module) {
         if let Some(log) = ctx.log_sink {
-            let text = format!(
-                "module '{}': landlock=skipped reason=pre-xfer-exec or post-xfer-exec configured (would block hook exec)",
-                ctx.request,
-            );
+            let text = format!("module '{}': landlock=skipped reason={reason}", ctx.request);
             let message = rsync_info!(text).with_role(Role::Daemon);
             log_message(log, &message);
         }

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -689,11 +689,7 @@ impl GeneratorContext {
     ///   peer-supplied argv where honouring it could only WIDEN the module
     ///   (`options.c:2382-2386` nulls it out for a daemon before it is read).
     pub(crate) fn confine_root(&self) -> Option<PathBuf> {
-        if self.config.connection.is_daemon_connection {
-            self.config.connection.daemon_module_root.clone()
-        } else {
-            self.config.connection.confine_root.clone()
-        }
+        confinement_root(&self.config.connection)
     }
 
     /// Reads a source symlink's target with the parent components resolved
@@ -1578,5 +1574,138 @@ mod device_guard_tests {
             let ft = self.file_type();
             ft.is_block_device() || ft.is_char_device()
         }
+    }
+}
+
+/// The root an operator- or peer-supplied source path must stay under, or
+/// `None` when this session confines nothing.
+///
+/// Upstream's opt-out is not a relaxation of the *ownership* rule inside the
+/// walk - it replaces the confined walk with a legacy `open()` outright, before
+/// any root is consulted. Answering it here rather than at each gate is what
+/// keeps [`GeneratorContext::source_open`] and
+/// [`GeneratorContext::read_source_link`] agreeing on the boundary.
+///
+/// For a daemon the opt-out is the served module's `insecure links = yes`; a
+/// peer-supplied `--insecure-links` is structurally unable to reach it.
+///
+/// # Upstream Reference
+///
+/// - `syscall.c:301-303` - `ona_open()` returns `open(path, flags, mode)` when
+///   `symlink_optout_allowed()`, above every use of `confinement_root()`.
+/// - `syscall.c:136-146` - `confinement_root()` - `am_daemon ? module_dir :
+///   confine_root`. The daemon arm wins unconditionally: its module directory
+///   is already the boundary, and `--confine-root` arrives in a peer-supplied
+///   argv where honouring it could only WIDEN the module
+///   (`options.c:2382-2386` nulls it out for a daemon before it is read).
+/// - `syscall.c:123-127` - `symlink_optout_allowed()`.
+fn confinement_root(connection: &crate::config::ConnectionConfig) -> Option<PathBuf> {
+    if fast_io::confinement::session_optout_allowed() {
+        return None;
+    }
+    if connection.is_daemon_connection {
+        connection.daemon_module_root.clone()
+    } else {
+        connection.confine_root.clone()
+    }
+}
+
+#[cfg(test)]
+mod confinement_root_tests {
+    use super::confinement_root;
+    use crate::config::ConnectionConfig;
+    use fast_io::confinement::{
+        LocalInsecureLinks, ModuleInsecureLinks, ModuleState, install_daemon_session,
+        install_local_session,
+    };
+    use std::path::PathBuf;
+
+    /// Safe against the process-global session opt-out because this workspace
+    /// runs under cargo-nextest, which executes each test in its own process.
+    fn daemon_serving(root: &str) -> ConnectionConfig {
+        ConnectionConfig {
+            is_daemon_connection: true,
+            daemon_module_root: Some(PathBuf::from(root)),
+            ..Default::default()
+        }
+    }
+
+    fn serve_module(insecure_links: bool) {
+        install_daemon_session(ModuleState {
+            root: Some(PathBuf::from("/srv/mod")),
+            chrooted: false,
+            // Upstream's `module_id >= 0`: the opt-out is unreachable before a
+            // module has been selected.
+            selected: true,
+            insecure_links: ModuleInsecureLinks::from_module_config(insecure_links),
+        });
+    }
+
+    /// `insecure links = yes` must reach the SENDER's confinement root, not
+    /// only the ownership walk inside it. Upstream short-circuits `ona_open()`
+    /// before `confinement_root()` is ever consulted, so an admin opting a
+    /// module out gets the legacy follow-any-symlink open back.
+    #[test]
+    fn module_optout_releases_the_daemon_confinement_root() {
+        serve_module(true);
+        assert_eq!(
+            confinement_root(&daemon_serving("/srv/mod")),
+            None,
+            "`insecure links = yes` must release the sender's confinement root"
+        );
+    }
+
+    /// Non-vacuity companion: without the directive the same fixture keeps the
+    /// module root. Without this the test above would also pass if
+    /// `confinement_root` had simply been made to always return `None`.
+    #[test]
+    fn a_module_without_the_optout_keeps_its_confinement_root() {
+        serve_module(false);
+        assert_eq!(
+            confinement_root(&daemon_serving("/srv/mod")),
+            Some(PathBuf::from("/srv/mod")),
+            "a default module must stay confined to its own root"
+        );
+    }
+
+    /// The non-daemon arm takes the same short-circuit, driven by the local
+    /// `--insecure-links` instead of a module directive.
+    #[test]
+    fn local_optout_releases_the_confine_root() {
+        install_local_session(LocalInsecureLinks::from_local_flag(true));
+        let connection = ConnectionConfig {
+            confine_root: Some(PathBuf::from("/restricted")),
+            ..Default::default()
+        };
+        assert_eq!(confinement_root(&connection), None);
+    }
+
+    /// Non-vacuity companion for the non-daemon arm.
+    #[test]
+    fn a_local_session_without_the_optout_keeps_its_confine_root() {
+        install_local_session(LocalInsecureLinks::from_local_flag(false));
+        let connection = ConnectionConfig {
+            confine_root: Some(PathBuf::from("/restricted")),
+            ..Default::default()
+        };
+        assert_eq!(
+            confinement_root(&connection),
+            Some(PathBuf::from("/restricted"))
+        );
+    }
+
+    /// The daemon arm ignores a peer-supplied `--confine-root`: obeying it
+    /// could only widen the module. Pins that the opt-out gate did not turn the
+    /// two arms into a fallback chain.
+    #[test]
+    fn a_daemon_never_falls_back_to_a_peer_supplied_confine_root() {
+        serve_module(false);
+        let connection = ConnectionConfig {
+            is_daemon_connection: true,
+            daemon_module_root: None,
+            confine_root: Some(PathBuf::from("/attacker-chosen")),
+            ..Default::default()
+        };
+        assert_eq!(confinement_root(&connection), None);
     }
 }

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -89,7 +89,7 @@ exclude-implied-trailing-backslash skip
 files-from-leak skip
 filter-leak skip
 inband-modname-leak skip
-insecure-links-admin-optout fail
+insecure-links-admin-optout pass
 io-noop-flood-recursion skip
 io-nosend-flood-recursion skip
 io-readargs-argv-nullwrite skip

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -163,7 +163,7 @@ hashtable-overflow pass
 highfd-hang pass
 inband-modname-leak skip
 inplace pass
-insecure-links-admin-optout fail
+insecure-links-admin-optout pass
 io-noop-flood-recursion skip
 io-nosend-flood-recursion skip
 io-readargs-argv-nullwrite skip


### PR DESCRIPTION
## What

Upstream's `ona_open()` short-circuits to a plain `open()` the moment
`symlink_optout_allowed()` holds (`syscall.c:301-303`) - *above* every use of
`confinement_root()`. The opt-out therefore replaces the confined walk outright;
it is not a relaxation of the ownership rule inside it.

oc consulted the opt-out only inside the ownership walk
(`fast_io/src/owner_walk.rs:291`). The sender's confinement root was chosen
without reference to it, so a daemon module carrying `insecure links = yes` was
still confined to its module root: the admin opt-out parsed, stored, published
to the session - and was then ignored by the one gate it exists to release.

`GeneratorContext::confine_root` now delegates to a free `confinement_root()`
mirroring upstream's function of the same name. That keeps the two consumers -
the source open and the file-list symlink read - agreeing on one boundary by
construction, and makes the rule testable from a bare `ConnectionConfig`.

## Verification

Five-row truth table over both arms. RED proven by removing only the opt-out
gate:

```
Starting 5 tests
    FAIL  confinement_root_tests::local_optout_releases_the_confine_root
    FAIL  confinement_root_tests::module_optout_releases_the_daemon_confinement_root
 Summary: 5 tests run: 3 passed, 2 failed
```

Both non-vacuity companions (`a_module_without_the_optout_keeps_its_confinement_root`,
`a_local_session_without_the_optout_keeps_its_confine_root`) stay green under the
mutation, so the pins measure the opt-out and not a predicate made
unconditionally `None`. A fifth row pins that a daemon still never falls back to
a peer-supplied `--confine-root`, which is what would break if the gate had
turned the two arms into a fallback chain.

`insecure-links-admin-optout` flips `fail` -> `pass` on both root manifests
(pipe and TCP) in the same commit; row counts unchanged at 349 and 158. The
nonroot rows stay `skip` - the cell requires root to plant a foreign-owned
symlink.

## Known gap, deliberately not widened here

The receiver's destination sandbox (`ConnectionConfig::served_module_root`) is a
second, independent confinement decision and is **not** gated on the opt-out.
Upstream's short-circuit does cover the receiver's use of `ona_open`, so this is
a real divergence - but it is strictly *more* confinement than upstream, no test
covers it, and relaxing a destination-side guard deserves its own change with
its own escape tests. Flagging rather than folding it in.

fmt, clippy and `-p transfer` are clean.
