### PR TITLE
fix(daemon): resolve munge symlinks before the chroot path rewrite

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -516,12 +516,10 @@ fn process_approved_module(
     // upstream: clientserver.c:847-864 - `module_dir` after the `/./` split.
     let effective_module;
     let config_module = if privilege_outcome.chroot_applied {
-        let mut adjusted = module.definition.clone();
-        adjusted.path = privilege_outcome
-            .inner_module_path
-            .clone()
-            .unwrap_or_else(|| PathBuf::from("/"));
-        effective_module = ModuleRuntime::from(adjusted);
+        effective_module = ModuleRuntime::from(chroot_adjusted_definition(
+            &module.definition,
+            privilege_outcome.inner_module_path.as_deref(),
+        ));
         &effective_module
     } else {
         module
@@ -979,4 +977,94 @@ fn process_approved_module(
         .map_err(transition_error)?;
 
     Ok(())
+}
+
+/// Rebuild a module definition as the chrooted process sees it.
+///
+/// The path becomes the post-chroot inner directory: `/` unless the configured
+/// path carried a `/./` marker, in which case it is the normalized remainder
+/// after it. upstream: clientserver.c:847-864 - `module_dir` after the split.
+///
+/// Any decision that reads the *pre-chroot* path must be resolved here, before
+/// the rewrite consumes its input. `munge symlinks` is such a decision: upstream
+/// captures `module_dirlen` while normalising the configured path
+/// (clientserver.c:897-923), rewrites `module_chdir` only afterwards (:1056),
+/// and defaults munging from the captured length (:1070-1071,
+/// `munge_symlinks = !use_chroot || module_dirlen`). oc re-derives that quantity
+/// textually from the `/./` marker, so evaluating it after the rewrite reports
+/// "no inside-chroot split" for every partial-chroot module - turning munging
+/// off exactly where upstream turns it on.
+fn chroot_adjusted_definition(
+    definition: &ModuleDefinition,
+    inner_module_path: Option<&Path>,
+) -> ModuleDefinition {
+    let mut adjusted = definition.clone();
+    adjusted.munge_symlinks = Some(definition.effective_munge_symlinks());
+    adjusted.path = inner_module_path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("/"));
+    adjusted
+}
+
+#[cfg(test)]
+mod chroot_adjusted_definition_tests {
+    use super::{ModuleDefinition, chroot_adjusted_definition};
+    use std::path::{Path, PathBuf};
+
+    /// Build a chrooted module at `path`, leaving `munge symlinks` unset so the
+    /// auto default is what the assertions observe.
+    fn chrooted_module(path: &str) -> ModuleDefinition {
+        ModuleDefinition {
+            name: "m".to_owned(),
+            path: PathBuf::from(path),
+            use_chroot: true,
+            munge_symlinks: None,
+            ..ModuleDefinition::default()
+        }
+    }
+
+    /// A module served at its own root chroots to `/`, so `module_dirlen`
+    /// collapses to 0 and munging defaults OFF.
+    ///
+    /// upstream: clientserver.c:911-923 then :1070-1071.
+    #[test]
+    fn whole_module_chroot_keeps_munging_off() {
+        let adjusted = chroot_adjusted_definition(&chrooted_module("/srv/mod"), None);
+
+        assert_eq!(adjusted.path, Path::new("/"));
+        assert!(!adjusted.effective_munge_symlinks());
+    }
+
+    /// A `/./` module still exposes a sanitized inner path, so `module_dirlen`
+    /// is non-zero and munging defaults ON - and it must stay ON after the
+    /// rewrite has consumed the marker that says so.
+    ///
+    /// This is the pin: reading the default off the rewritten `/sub` path finds
+    /// no marker and answers OFF, which is the defect.
+    ///
+    /// upstream: clientserver.c:903-907 then :1070-1071.
+    #[test]
+    fn inside_chroot_split_keeps_munging_on_after_the_rewrite() {
+        let adjusted = chroot_adjusted_definition(
+            &chrooted_module("/srv/base/./sub"),
+            Some(Path::new("/sub")),
+        );
+
+        assert_eq!(adjusted.path, Path::new("/sub"));
+        assert!(adjusted.effective_munge_symlinks());
+    }
+
+    /// An explicit directive is not a default, so the rewrite must not disturb
+    /// it in either direction.
+    #[test]
+    fn an_explicit_directive_survives_the_rewrite() {
+        for explicit in [false, true] {
+            let mut definition = chrooted_module("/srv/base/./sub");
+            definition.munge_symlinks = Some(explicit);
+
+            let adjusted = chroot_adjusted_definition(&definition, Some(Path::new("/sub")));
+
+            assert_eq!(adjusted.effective_munge_symlinks(), explicit);
+        }
+    }
 }

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -29,7 +29,7 @@ daemon-auth-group pass
 daemon-auth-users-comma-only pass
 daemon-chroot fail
 daemon-chroot-acl pass
-daemon-chroot-munge-default pass
+daemon-chroot-munge-default fail
 daemon-config pass
 daemon-config-symlink fail
 daemon-copy-links-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -29,7 +29,7 @@ daemon-auth-group pass
 daemon-auth-users-comma-only pass
 daemon-chroot fail
 daemon-chroot-acl pass
-daemon-chroot-munge-default fail
+daemon-chroot-munge-default pass
 daemon-config pass
 daemon-config-symlink fail
 daemon-copy-links-symlink pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -68,7 +68,7 @@ daemon-auth-group pass
 daemon-auth-users-comma-only pass
 daemon-chroot skip
 daemon-chroot-acl skip
-daemon-chroot-munge-default fail
+daemon-chroot-munge-default pass
 daemon-config pass
 daemon-config-symlink pass
 daemon-copy-links-symlink pass


### PR DESCRIPTION
## What

`munge symlinks` was resolved from the module definition *after* the definition's
`path` had already been rewritten to `/` for the chroot, so the effective value
was read from a definition that no longer described the served module.

The decision is now made once, before the rewrite, in a small
`chroot_adjusted_definition()` helper that owns both adjustments together -
the munge resolution and the path substitution - so they cannot drift apart
again. The call site collapses to a single expression.

## Verification, stated honestly

Three unit tests cover the helper directly (munge resolved from the pre-rewrite
definition; path substituted; the two applied together).

⚠ **The end-to-end cell is not verified locally, and the reason is worth
recording.** `daemon-chroot-munge-default` is a root-only cell. On the Linux
host available to me it **XPASSes on unmodified master** - it reports
`expected fail, got pass` against a manifest row that CI proves correct: PR
#7515, whose head is current master, passed the required root leg with that row
recorded as `fail`. So the cell fails in CI and passes on that host; the host
cannot reproduce the failure this change targets, and any green it produced
would be vacuous.

Rather than assert an unverified result, the manifest rows flip in this branch
so the **required root leg adjudicates it**. If the cell does not actually reach
`pass`, CI reports `expected pass, got fail` and this PR goes red - which is the
outcome I want if the fix is incomplete.

That host has one other known environmental divergence in the same shape
(`fs.protected_regular=1` vs `0` where the manifests were generated, which
manufactures EACCES for `batch-file-symlink` and `preallocate`). Those two, plus
this cell, are the only mismatches it reports on unmodified master.

Row counts unchanged: 349 (root pipe) and 158 (root TCP). The nonroot rows stay
`skip` - the cell needs root.


---

## Correction: the TCP root row is restored to `fail` (commit 0898d2c35)

The paragraph above proposed flipping **both** root rows and letting CI adjudicate. It has adjudicated, and it split the two:

- **root pipe: green** with the row at `pass`. The fix is confirmed.
- **root TCP: `expected pass, got fail`**, exactly one mismatch, everything else green.

So the TCP row is back to `fail` — recording what the leg actually does rather than what I predicted.

### The residual TCP failure is a different, pre-existing defect

This branch fixes regime **B** (`use chroot = yes`, module path serving `/`, munge OFF). The TCP failure is regime **C**:

```
c_chroot_sub: uploaded symlink did not land at .../c_base/sub/sl
```

Regime C configures `path = {c_base}/./sub` — upstream's inside-chroot split, the marker `clientserver.c` derives `module_dirlen` from. The cell's `rsyncd.log` in that run contains **no `c_chroot_sub` session at all**: only `a_nochroot` and `b_chroot_root`. Setup fails before the session starts.

The sibling `daemon-chroot` cell fails in the same run with the same shape, and names the cause outright:

```
@ERROR: module 'chrinner' path does not exist: /tmp/.../daemon-chroot/chroot-outer/./inner
```

The module-path validator (`transfer/sandbox.rs:214`) stats the raw `BASE/./SUB` string instead of splitting at the marker first. oc already models the split — `ModuleState::has_inside_chroot_split()` exists and `symlink_munge.rs:183` consumes it for the munge default, citing `clientserver.c:1071-1072` — the path check simply does not consult it.

**Inherited, not introduced:** both `/./` cells are recorded `fail` in master's TCP root manifest. `daemon-chroot` is `skip` on the pipe root leg, which is why that leg never exposed the class.

Filed separately as task 1025. Regimes A and B pass on both legs.

### Final manifest state

- `upstream-3.5.0-expect.root.txt`: one row, `daemon-chroot-munge-default fail` → `pass` (measured).
- `upstream-3.5.0-expect.root.tcp.txt`: **byte-identical to master** (`git diff origin/master` on that file is empty).


---

### Correction to the section above (same day): the regime-C attribution was too broad

I wrote that the TCP failure is the `BASE/./sub` validator refusing the module path. That is **proven for the sibling `daemon-chroot` cell** — it emits its own `@ERROR: module 'chrinner' path does not exist: .../chroot-outer/./inner`. It is **not** proven for this cell, and I generalised without checking the fixture:

- `daemon-chroot-munge-default` `mkdir`s **both** `c_base` and `c_base/sub`. POSIX resolves `/./` natively, so `Path::exists()` on `c_base/./sub` returns **true** — the validator would not refuse it.
- The cell's `rsyncd.log` contains **no** `c_chroot_sub` session and **no** `@ERROR` line at all. That is a different failure shape from `daemon-chroot`'s loud refusal; the only symptom is the test's own `did not land` assertion.
- A shared-pid theory was also considered and refuted: pid reuse across connections is normal in this log (13981 serves 6 connections, 13569 serves 3), so `[13021]` serving `a`+`b` is not anomalous.

**Regime C's cause is currently unknown** and needs its own repro on a root Linux host. Task 1025 has been rescoped to the evidenced `daemon-chroot` half only.

None of this changes what this PR does or the manifest state: regime B is fixed and green on the required pipe leg, and the TCP row stays `fail` because the leg measured it failing.
