### PR TITLE
fix(daemon): resolve string module defaults at end of parse

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/module_defaults.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/module_defaults.rs
@@ -65,3 +65,67 @@ struct GlobalModuleDefaults {
     // route as `auth users` above.
     auth_digest: Option<String>,
 }
+
+impl GlobalModuleDefaults {
+    /// Builds the P_LOCAL defaults a module section finalizes against, given
+    /// the globals in force when its `[name]` header was read (`snapshot`) and
+    /// the globals in force once the whole config has been parsed (`latest`).
+    ///
+    /// upstream: loadparm.c:347-348 - `FN_LOCAL_STRING(fn, val)` expands to
+    /// `if (LP_SNUM_OK(i) && iSECTION(i).val) RETURN_EXPANDED(iSECTION(i).val)
+    /// else RETURN_EXPANDED(Vars.l.val)`, and clientserver.c:781-783 calls
+    /// `lp_uid(i)` only when a client selects the module - long after
+    /// `lp_load()` finished. A string-typed P_LOCAL parameter therefore
+    /// resolves its default at ACCESS time, so a global set *after* a section
+    /// (or after the `&include`/`&merge` that declared it) still applies to
+    /// that section. `FN_LOCAL_BOOL`/`FN_LOCAL_INTEGER` (loadparm.c:351-356)
+    /// carry no such fallback: they read `iSECTION(i).val`, which
+    /// `init_section()` filled from `Vars.l` when the section was created, so
+    /// those keep creation-time semantics.
+    fn resolve(snapshot: &Self, latest: &Self) -> Self {
+        Self {
+            // Access-time (FN_LOCAL_STRING / FN_LOCAL_STRING_SHELL).
+            exclude: latest.exclude.clone(),
+            include: latest.include.clone(),
+            filter: latest.filter.clone(),
+            log_format: latest.log_format.clone(),
+            log_file: latest.log_file.clone(),
+            hosts_allow: latest.hosts_allow.clone(),
+            hosts_deny: latest.hosts_deny.clone(),
+            dont_compress: latest.dont_compress.clone(),
+            syslog_tag: latest.syslog_tag.clone(),
+            exclude_from: latest.exclude_from.clone(),
+            include_from: latest.include_from.clone(),
+            comment: latest.comment.clone(),
+            early_exec: latest.early_exec.clone(),
+            pre_xfer_exec: latest.pre_xfer_exec.clone(),
+            post_xfer_exec: latest.post_xfer_exec.clone(),
+            name_converter: latest.name_converter.clone(),
+            temp_dir: latest.temp_dir.clone(),
+            charset: latest.charset.clone(),
+            uid: latest.uid,
+            gid: latest.gid.clone(),
+            auth_users: latest.auth_users.clone(),
+            auth_digest: latest.auth_digest.clone(),
+            // Creation-time (FN_LOCAL_BOOL / FN_LOCAL_INTEGER).
+            max_verbosity: snapshot.max_verbosity,
+            transfer_logging: snapshot.transfer_logging,
+            timeout: snapshot.timeout,
+            read_only: snapshot.read_only,
+            write_only: snapshot.write_only,
+            listable: snapshot.listable,
+            munge_symlinks: snapshot.munge_symlinks,
+            numeric_ids: snapshot.numeric_ids,
+            fake_super: snapshot.fake_super,
+            insecure_links: snapshot.insecure_links,
+            max_connections: snapshot.max_connections,
+            ignore_errors: snapshot.ignore_errors,
+            ignore_nonreadable: snapshot.ignore_nonreadable,
+            strict_modes: snapshot.strict_modes,
+            forward_lookup: snapshot.forward_lookup,
+            reverse_lookup: snapshot.reverse_lookup,
+            syslog_facility: snapshot.syslog_facility.clone(),
+            open_noatime: snapshot.open_noatime,
+        }
+    }
+}

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
@@ -41,7 +41,9 @@ struct GlobalParseState {
     proxy_protocol: Option<(bool, ConfigDirectiveOrigin)>,
     rsync_port: Option<(u16, ConfigDirectiveOrigin)>,
     daemon_chroot: Option<(PathBuf, ConfigDirectiveOrigin)>,
-    modules: Vec<ModuleDefinition>,
+    /// Module sections read so far, still unfinalized: a string-typed P_LOCAL
+    /// default is not resolved until the whole config tree has been parsed.
+    modules: Vec<PendingModule>,
     /// P_LOCAL parameter defaults from the global section.
     ///
     /// upstream: loadparm.c - P_LOCAL parameters in the global section set
@@ -138,10 +140,33 @@ impl GlobalParseState {
         state
     }
 
-    /// Converts the accumulated global state into the final parsed result.
-    fn into_result(self) -> ParsedConfigModules {
-        ParsedConfigModules {
-            modules: self.modules,
+    /// Converts the accumulated global state into the final parsed result,
+    /// finalizing every module section against the globals left standing at the
+    /// end of the parse.
+    ///
+    /// upstream: loadparm.c:347-348 - `FN_LOCAL_STRING` falls back to
+    /// `Vars.l.<param>` when the section itself never set the parameter, and
+    /// clientserver.c:781-783 performs that lookup when a client picks the
+    /// module, i.e. after `lp_load()` has read the whole file. A global
+    /// declared below a `[section]` - or below the `&include`/`&merge` that
+    /// declared it - therefore still supplies that section's default.
+    fn into_result(self) -> Result<ParsedConfigModules, DaemonError> {
+        let latest = self.module_defaults;
+        let mut modules = Vec::with_capacity(self.modules.len());
+        for module in self.modules {
+            let defaults = module.defaults;
+            modules.push(module.builder.finish(
+                &module.config_path,
+                defaults.secrets_file.as_deref(),
+                defaults.incoming_chmod.as_deref(),
+                defaults.outgoing_chmod.as_deref(),
+                defaults.use_chroot,
+                &GlobalModuleDefaults::resolve(&defaults.module_defaults, &latest),
+            )?);
+        }
+
+        Ok(ParsedConfigModules {
+            modules,
             global_refuse_options: self.global_refuse_directives,
             motd_lines: self.motd_lines,
             pid_file: self.pid_file,
@@ -168,6 +193,6 @@ impl GlobalParseState {
             proxy_protocol: self.proxy_protocol,
             rsync_port: self.rsync_port,
             daemon_chroot: self.daemon_chroot,
-        }
+        })
     }
 }

--- a/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
@@ -130,7 +130,7 @@ fn include_config_file(
 ///
 /// Used for `&merge` (and directory entries pulled in via `&merge`), where the
 /// included file shares the current scope.
-fn merge_included_globals(state: &mut GlobalParseState, included: ParsedConfigModules) {
+fn merge_included_globals(state: &mut GlobalParseState, included: GlobalParseState) {
     if !included.modules.is_empty() {
         state.modules.extend(included.modules);
     }
@@ -141,11 +141,11 @@ fn merge_included_globals(state: &mut GlobalParseState, included: ParsedConfigMo
         state.motd_lines = included.motd_lines;
     }
 
-    if !included.global_refuse_options.is_empty() {
-        state.global_refuse_directives = included.global_refuse_options;
+    if !included.global_refuse_directives.is_empty() {
+        state.global_refuse_directives = included.global_refuse_directives;
     }
 
-    merge_optional_directive(&mut state.global_bwlimit, included.global_bandwidth_limit);
+    merge_optional_directive(&mut state.global_bwlimit, included.global_bwlimit);
     merge_optional_directive(&mut state.global_secrets_file, included.global_secrets_file);
     merge_optional_directive(
         &mut state.global_incoming_chmod,

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -55,14 +55,20 @@ fn collapse_section_name(name: &str) -> String {
 /// Parses the `rsyncd.conf` at `path` into module definitions and global settings.
 pub(crate) fn parse_config_modules(path: &Path) -> Result<ParsedConfigModules, DaemonError> {
     let mut stack = Vec::new();
-    parse_config_modules_inner(path, &mut stack, None)
+    parse_config_modules_inner(path, &mut stack, None)?.into_result()
 }
 
+/// Parses one config file, returning the raw parse state with its module
+/// sections still unfinalized.
+///
+/// Only the top-level [`parse_config_modules`] finalizes them, because a
+/// string-typed P_LOCAL parameter resolves its default against the global state
+/// left standing at the end of the whole parse (upstream: loadparm.c:347-348).
 fn parse_config_modules_inner(
     path: &Path,
     stack: &mut Vec<PathBuf>,
     inherited: Option<&GlobalParseState>,
-) -> Result<ParsedConfigModules, DaemonError> {
+) -> Result<GlobalParseState, DaemonError> {
     let canonical = path
         .canonicalize()
         .map_err(|error| config_io_error("read", path, error))?;
@@ -96,7 +102,7 @@ fn parse_config_modules_inner(
     let mut pending: Vec<PendingModule> = Vec::new();
     let mut current: Option<usize> = None;
 
-    let result = (|| -> Result<ParsedConfigModules, DaemonError> {
+    let result = (|| -> Result<(), DaemonError> {
         for (line_number, logical_line) in logical_config_lines(&contents) {
             let line = logical_line.trim();
 
@@ -153,6 +159,7 @@ fn parse_config_modules_inner(
                     &mut pending,
                     name,
                     line_number,
+                    path,
                     &state,
                 ));
                 continue;
@@ -213,19 +220,19 @@ fn parse_config_modules_inner(
             // `&include`/`&merge`, matching upstream's declaration order.
             if is_amp_directive {
                 current = None;
-                flush_pending_modules(&mut pending, &mut state, path)?;
+                flush_pending_modules(&mut pending, &mut state);
             }
 
             apply_global_directive(&mut state, &key, value, path, line_number, &canonical, stack)?;
         }
 
-        flush_pending_modules(&mut pending, &mut state, path)?;
+        flush_pending_modules(&mut pending, &mut state);
 
-        Ok(state.into_result())
+        Ok(())
     })();
 
     stack.pop();
-    result
+    result.map(|()| state)
 }
 
 /// A module section that has been opened but not yet finalized, together with
@@ -233,11 +240,17 @@ fn parse_config_modules_inner(
 ///
 /// upstream: loadparm.c:add_a_section:329 - a new section is initialized from
 /// `sDefault`, the running snapshot of the P_LOCAL defaults set in the global
-/// section. Later global directives (after a `[global]` header, say) update
-/// `sDefault` for sections created afterwards but never rewrite a section that
-/// already exists, so the defaults must be captured at creation time.
+/// section. Later global directives never rewrite a section that already
+/// exists, so bool- and integer-typed P_LOCAL defaults are pinned here at
+/// creation time. String-typed ones are not: they fall back to the live
+/// `Vars.l` at access time, so they are resolved from the final global state
+/// instead - see `GlobalModuleDefaults::resolve`.
 struct PendingModule {
     builder: ModuleDefinitionBuilder,
+    /// The config file the `[name]` header was read from, so a validation
+    /// failure still names the file that declared the module even though the
+    /// section is finalized once the whole config tree has been parsed.
+    config_path: PathBuf,
     defaults: CapturedModuleDefaults,
 }
 
@@ -248,6 +261,12 @@ struct PendingModule {
 /// parent file (set when the parse state is the body of an `&include`/`&merge`
 /// target), matching upstream's shared-`Vars` semantics where the includer's
 /// defaults serve as fallbacks until the included file overrides them.
+///
+/// `module_defaults` supplies only the bool- and integer-typed P_LOCAL
+/// defaults; the string-typed ones in that bag are read from the final global
+/// state instead, via `GlobalModuleDefaults::resolve`. The four slots below are
+/// the directives the parser tracks separately from that bag (each carries a
+/// `ConfigDirectiveOrigin` for diagnostics) and stay creation-time here.
 struct CapturedModuleDefaults {
     secrets_file: Option<PathBuf>,
     incoming_chmod: Option<String>,
@@ -295,6 +314,7 @@ fn open_module_section(
     pending: &mut Vec<PendingModule>,
     name: &str,
     line_number: usize,
+    config_path: &Path,
     state: &GlobalParseState,
 ) -> usize {
     if let Some(index) = pending
@@ -306,32 +326,20 @@ fn open_module_section(
 
     pending.push(PendingModule {
         builder: ModuleDefinitionBuilder::new(name.to_owned(), line_number),
+        config_path: config_path.to_path_buf(),
         defaults: CapturedModuleDefaults::capture(state),
     });
     pending.len() - 1
 }
 
-/// Finalizes every open module section in declaration order and appends the
-/// resulting definitions to the parse state.
-fn flush_pending_modules(
-    pending: &mut Vec<PendingModule>,
-    state: &mut GlobalParseState,
-    path: &Path,
-) -> Result<(), DaemonError> {
-    for module in pending.drain(..) {
-        let defaults = module.defaults;
-        let definition = module.builder.finish(
-            path,
-            defaults.secrets_file.as_deref(),
-            defaults.incoming_chmod.as_deref(),
-            defaults.outgoing_chmod.as_deref(),
-            defaults.use_chroot,
-            &defaults.module_defaults,
-        )?;
-        state.modules.push(definition);
-    }
-
-    Ok(())
+/// Closes every open module section in declaration order and records it on the
+/// parse state.
+///
+/// The sections are not finalized here: a string-typed P_LOCAL default is only
+/// looked up once the whole config tree has been read, so finalization happens
+/// in [`GlobalParseState::into_result`] at the top level of the parse.
+fn flush_pending_modules(pending: &mut Vec<PendingModule>, state: &mut GlobalParseState) {
+    state.modules.append(pending);
 }
 
 /// Splits `contents` into logical config lines, joining backslash-continued

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -579,6 +579,108 @@ mod config_parsing_tests {
     }
 
     #[test]
+    fn global_uid_declared_after_a_module_section_still_applies_to_it() {
+        // upstream: loadparm.c:347-348 - `uid` is P_LOCAL and reached through
+        // FN_LOCAL_STRING, whose else-branch reads the live `Vars.l.uid`.
+        // clientserver.c:781-783 performs that read when a client selects the
+        // module, long after lp_load() returned, so a global declared *below*
+        // the section still supplies its default. Resolving the default at the
+        // `[name]` header instead left the module at `uid = None`, which
+        // drops a root daemon to `nobody`.
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let file = write_config(&format!(
+            "use chroot = no\n[late]\npath = {}\n[global]\nuid = 0\ngid = 0\n",
+            path.display()
+        ));
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(
+            result.modules[0].uid,
+            Some(0),
+            "a global uid below the section must still be its default"
+        );
+    }
+
+    #[test]
+    fn global_uid_declared_after_a_merge_still_applies_to_the_merged_module() {
+        // upstream: params.c:include_config(val, 0) - `&merge` shares the
+        // caller's `Vars`, and the section it adds is looked up through the
+        // same FN_LOCAL_STRING fallback (loadparm.c:347-348) once the whole
+        // file has been read. The upstream testsuite's write_daemon_conf()
+        // emits `&merge` among the leading globals and appends the root-only
+        // `uid = 0` last, so the merged module has nothing but this fallback.
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("merged");
+        fs::create_dir(&path).expect("create dir");
+
+        let merged = write_config(&format!("[merged]\npath = {}\n", path.display()));
+        let file = write_config(&format!(
+            "use chroot = no\n&merge = {}\nuid = 0\ngid = 0\n",
+            merged.path().display()
+        ));
+
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(result.modules[0].name, "merged");
+        assert_eq!(
+            result.modules[0].uid,
+            Some(0),
+            "a global uid below the `&merge` must still reach the merged module"
+        );
+    }
+
+    #[test]
+    fn module_uid_wins_over_a_global_uid_declared_after_it() {
+        // upstream: loadparm.c:347 - the then-branch `if (LP_SNUM_OK(i) &&
+        // iSECTION(i).uid)` short-circuits before the `Vars.l` fallback is ever
+        // consulted, so a value the section set itself is never reconsidered.
+        // Guards the fallback above from inverting into an override.
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let file = write_config(&format!(
+            "use chroot = no\n[explicit]\npath = {}\nuid = 1\n[global]\nuid = 0\n",
+            path.display()
+        ));
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(
+            result.modules[0].uid,
+            Some(1),
+            "an explicit module uid must outrank a later global"
+        );
+    }
+
+    #[test]
+    fn global_read_only_declared_after_a_module_section_does_not_apply_to_it() {
+        // upstream: loadparm.c:351 - `read only` is reached through
+        // FN_LOCAL_BOOL, which returns `iSECTION(i).read_only` with no
+        // `Vars.l` fallback. That field was filled by init_section() from
+        // `Vars.l` when the `[name]` header created the section, so a bool- or
+        // integer-typed P_LOCAL global below the section is invisible to it -
+        // the opposite of the string-typed `uid` above. Pins the half of
+        // `GlobalModuleDefaults::resolve` that must stay creation-time.
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let file = write_config(&format!(
+            "use chroot = no\n[late_bool]\npath = {}\n[global]\nread only = no\n",
+            path.display()
+        ));
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules.len(), 1);
+        assert!(
+            result.modules[0].read_only,
+            "a global `read only` below the section must not reach it"
+        );
+    }
+
+    #[test]
     fn backslash_continuation_joins_directive_value() {
         // upstream: params.c:Continuation() - a line ending in a backslash is
         // joined with the next physical line into one logical directive. Split

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -55,7 +55,7 @@ daemon-gzip-download pass
 daemon-gzip-upload pass
 daemon-handshake-timeout fail
 daemon-http-proxy pass
-daemon-include-maxconn fail
+daemon-include-maxconn pass
 daemon-leaf-type-race-fchmod skip
 daemon-link-dest-escape pass
 daemon-max-alloc-zero skip

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -94,7 +94,7 @@ daemon-gzip-download pass
 daemon-gzip-upload pass
 daemon-handshake-timeout skip
 daemon-http-proxy skip
-daemon-include-maxconn fail
+daemon-include-maxconn pass
 daemon-leaf-type-race-fchmod skip
 daemon-link-dest-escape pass
 daemon-max-alloc-zero skip


### PR DESCRIPTION
## What

Module string defaults were snapshotted at the `[name]` header, so a global
`uid = 0` declared *below* a section never reached it. The testsuite conf emits
`&include`/`&merge` first and `uid`/`gid` last, so `[merged]` fell back to
`nobody` and the push into a root-owned destination failed.

Upstream reads these at **access time**, not section-open:
`daemon-parm.h:370 FN_LOCAL_STRING(lp_uid, uid)` expands via `loadparm.c:347` to
`if (LP_SNUM_OK(i) && iSECTION(i).uid) ... else RETURN_EXPANDED(Vars.l.uid)`,
and `clientserver.c:781-783` calls `lp_uid(i)` at module-selection time, long
after `lp_load()`.

## Two things that changed the shape of the fix

**1. The obvious one-line fix would have been inert on the failing cell.**
`flush_pending_modules` runs per file and again before every `&`-directive, but
the failing conf declares **no modules in the main file** - `incA`/`incB`/`merged`
are all finalized inside their own recursive `parse_config_modules_inner`, which
the parent's flush can never reach. The fix had to defer finalization: the inner
parse now returns the raw state with sections still pending, and only the
top-level parse finalizes.

**2. The rule is type-scoped, and a blanket fallback would have created a new
divergence.** `FN_LOCAL_BOOL` / `FN_LOCAL_INTEGER` (`loadparm.c:351-356`) are
`LP_SNUM_OK(i) ? iSECTION(i).val : Vars.l.val` - **no** `Vars.l` fallback for a
real section, because `init_section()` already copied `Vars.l` at creation. Only
the string accessors take the access-time path. The 40 P_LOCAL fields are split
accordingly: 22 access-time, 18 creation-time.

`&include` scoping is unaffected: `]pop` restores all of `Vars`
(`loadparm.c:598-607`), so a fragment's own globals are discarded before the
final lookup and fragment modules read the top-level final state - which is
exactly what resolving from the top-level state does.

## Verification

Two **opposite** mutations, because one direction alone cannot distinguish
"applies the default" from "applies every global unconditionally".

Restoring the section-open snapshot:
```
Summary [0.090s] 4 tests run: 2 passed, 2 failed
  FAIL global_uid_declared_after_a_merge_still_applies_to_the_merged_module
    left: None, right: Some(0)
  FAIL global_uid_declared_after_a_module_section_still_applies_to_it
    left: None, right: Some(0)
```
The precedence test (module-explicit wins) and the bool test stayed green.

Blanket-late (`read_only: latest.read_only`):
```
  FAIL global_read_only_declared_after_a_module_section_does_not_apply_to_it
```
Fixed tree: 4/4.

`daemon-include-maxconn` flips `fail` -> `pass` on **both** root manifests. The
TCP root manifest is consumed by `ci.yml:952` and the runner fails on an
unexpected PASS, so flipping only the pipe leg would have reddened the TCP leg
on XPASS. Row counts unchanged (349/349/158/158); the nonroot rows already read
`pass` and were left alone - non-root emits no `uid`/`gid`, so the defect is
invisible there.

`cargo check --workspace --all-features --all-targets`, clippy and fmt clean.

## Residuals reported, not fixed

- `secrets file`, `incoming chmod`, `outgoing chmod` are also `FN_LOCAL_STRING`
  upstream but still snapshot at the header. They live in separate origin-tracked
  slots with an `inherited_*` fallback chain; making them access-time would
  strand that chain and touches existing `&include` scoping tests.
- `merge_included_globals` does not propagate a `&merge`d file's module-defaults
  bag into the parent, so a global P_LOCAL set *inside* a `.inc` still won't
  reach later parent modules. One line would close it; no test demands it.
