### PR TITLE
fix(cli): parse --fake-super in a server argv

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -158,6 +158,27 @@ pub(super) struct ServerLongFlags {
     /// is forwarded to a server receiver, which `fallocate()`s each destination
     /// file to its eventual length before writing to reduce fragmentation.
     pub(super) preallocate: bool,
+    /// `--fake-super` / `--no-fake-super` - record privileged metadata in the
+    /// `user.rsync.%stat` xattr instead of applying it to the inode.
+    ///
+    /// upstream: options.c:672 `{"fake-super", 0, POPT_ARG_VAL, &am_root, -1,
+    /// 0, 0}` - an ordinary popt entry in the one table both the client and
+    /// the server parse, so it binds wherever it appears in argv. It is
+    /// deliberately NOT emitted by `server_options()` ("only affects the side
+    /// where the option is used", rsync.1), which is exactly why an operator
+    /// injects it into the server command line - via `--rsync-path='rsync
+    /// --fake-super'` or a wrapper's rsync-path shim (upstream's own
+    /// `testsuite/rrsync-specials-denied_test.py` uses `#!/bin/sh\nexec
+    /// <RSYNC> --fake-super "$@"`). It therefore arrives BEFORE `--server`,
+    /// ahead of the compact flag string. `None` leaves the value the
+    /// transport/daemon already decided (`fake super = yes`) untouched.
+    ///
+    /// upstream has no `--no-fake-super` popt entry (options.c:670-672 defines
+    /// `super` / `no-super` / `fake-super` only); oc's own client table does
+    /// (command_builder/.../privileges.rs), so it can reach a server through
+    /// `-M--no-fake-super` and must be recognised rather than leak into the
+    /// positional path list.
+    pub(super) fake_super: Option<bool>,
     /// Re-verify the existing prefix under append (upstream: `--append-verify`,
     /// wire-encoded as a doubled `--append`, `append_mode == 2`).
     ///
@@ -490,6 +511,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         inplace: false,
         append: false,
         preallocate: false,
+        fake_super: None,
         append_verify: false,
         size_only: false,
         modify_window: None,
@@ -608,6 +630,19 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // results; the flag is carried onto the receiver config to reserve
             // extents up front.
             "--preallocate" => flags.preallocate = true,
+            // upstream: options.c:672 - `{"fake-super", 0, POPT_ARG_VAL,
+            // &am_root, -1, 0, 0}`. server_options() never emits it, so it can
+            // only reach a server the way an operator injects it:
+            // `--rsync-path='rsync --fake-super'` or an rsync-path shim. That
+            // places it ahead of `--server`, where the operand scan would
+            // otherwise mistake the first `-`-leading token for the compact
+            // flag string and strand the real `-rlptgoDe.<caps>` in the
+            // positional list. MEASURED before this arm existed: a push through
+            // such a shim delivered nothing at all and exited 0.
+            "--fake-super" => flags.fake_super = Some(true),
+            // oc-only negation (see the field doc); upstream's table has
+            // `no-super` but no `no-fake-super`.
+            "--no-fake-super" => flags.fake_super = Some(false),
             // upstream: options.c:696 / 2976-2977 - `--no-implied-dirs` is
             // forwarded to the sender on a pull. The server-side sender must omit
             // implied parent dirs from the flist at protocol < 30.
@@ -978,6 +1013,15 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--force"
             // upstream: options.c:2852-2853 - `--super` (am_root > 1).
             | "--super"
+            // upstream: options.c:672 - `--fake-super` (am_root == -1). An
+            // ordinary popt entry, so the server table binds it wherever it
+            // appears; server_options() never emits it, so it arrives only
+            // because an operator injected it (`--rsync-path='rsync
+            // --fake-super'` / an rsync-path shim) - i.e. BEFORE `--server`,
+            // where an unrecognised `-`-leading token is taken for the compact
+            // flag string. `--no-fake-super` is oc's own negation.
+            | "--fake-super"
+            | "--no-fake-super"
             // upstream: options.c:2990-2991 - `--preallocate` (preallocate_files).
             | "--preallocate"
             // upstream: options.c:2868-2871 - missing-args cooperation flags.

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -244,6 +244,7 @@ where
     // upstream: receiver.c:320 - a server receiver that was passed --preallocate
     // fallocate()s each destination file to its eventual length before writing.
     config.flags.preallocate = long_flags.preallocate;
+    apply_fake_super(&mut config, long_flags.fake_super);
     config.file_selection.size_only = long_flags.size_only;
     // upstream: options.c:2993-2994 - `--open-noatime` forwarded to the sender so
     // it opens source files with O_NOATIME (do_open), leaving atime untouched.
@@ -696,6 +697,29 @@ fn collect_keep_dirlink_targets(root: &std::path::Path, out: &mut Vec<std::path:
                 stack.push((path, depth + 1));
             }
         }
+    }
+}
+
+/// Applies `--fake-super` / `--no-fake-super` to the server config.
+///
+/// upstream: options.c:672 `{"fake-super", 0, POPT_ARG_VAL, &am_root, -1, 0,
+/// 0}` - the option sets `am_root = -1` on whichever side was given it and is
+/// never sent over the wire ("only affects the side where the option is used",
+/// rsync.1). `server_options()` therefore never emits it, and a server sees it
+/// only because the operator put it on the server command line:
+/// `--rsync-path='rsync --fake-super'`, or a wrapper's rsync-path shim.
+///
+/// It matters for both roles: a receiver records ownership and rdev into the
+/// `user.rsync.%stat` xattr instead of the inode (rsync.c `set_file_attrs()`),
+/// and a sender reads that xattr back so an unprivileged tree still presents
+/// devices and specials in the file list.
+///
+/// `None` (the flag absent) leaves the value alone, so a daemon module's
+/// `fake super = yes` (clientserver.c:1120-1121) is never cleared by a server
+/// argv that simply did not mention it.
+pub(super) fn apply_fake_super(config: &mut core::server::ServerConfig, fake_super: Option<bool>) {
+    if let Some(fake_super) = fake_super {
+        config.fake_super = fake_super;
     }
 }
 

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -2834,3 +2834,126 @@ mod end_of_options {
         assert_eq!(paths, vec![OsString::from("src/"), OsString::from("dest/")]);
     }
 }
+
+/// An operator-injected `--fake-super` must not be mistaken for the compact
+/// flag string.
+///
+/// upstream: options.c:672 `{"fake-super", 0, POPT_ARG_VAL, &am_root, -1, 0,
+/// 0}` is an ordinary entry in the one popt table both ends parse, so it binds
+/// wherever it sits in argv. `server_options()` deliberately never emits it -
+/// which is precisely why an operator injects it, via
+/// `--rsync-path='rsync --fake-super'` or a wrapper's rsync-path shim
+/// (upstream's own `testsuite/rrsync-specials-denied_test.py` writes a
+/// `#!/bin/sh` shim that execs `<RSYNC> --fake-super "$@"`). That places it
+/// BEFORE `--server`, ahead of the compact flag string.
+///
+/// Unrecognised, it was taken for the compact flag string itself, so the real
+/// `-rlptgoDe.iLsfxC` fell through to the positional list and both `.` operands
+/// were then filtered out. MEASURED: no `-r`, nothing delivered, rc=0 - a
+/// silent no-op push.
+#[test]
+fn parse_server_args_does_not_mistake_fake_super_for_the_flag_string() {
+    let args = vec![
+        OsString::from("--fake-super"),
+        OsString::from("--server"),
+        OsString::from("-rlptgoDe.iLsfxC"),
+        OsString::from("--specials"),
+        OsString::from("--drop-D"),
+        OsString::from("--"),
+        OsString::from("."),
+        OsString::from("."),
+    ];
+    let (flag_string, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(
+        flag_string, "-rlptgoDe.iLsfxC",
+        "--fake-super must be recognised as a long flag, not consumed as the \
+         compact flag string"
+    );
+    assert!(
+        flag_string.contains('r'),
+        "the compact flag string must still carry recursion"
+    );
+    assert!(
+        pos_args.is_empty(),
+        "both `.` operands are the cwd placeholder"
+    );
+}
+
+/// Non-vacuity companion for the test above: the SAME argv without
+/// `--fake-super` already parsed to that flag string before the fix.
+///
+/// Without this pairing, the test above would also pass if the operand scan
+/// were changed to skip every unrecognised `--` token - which would reinstate
+/// the positional-path leak that `--confine-root=` and `--log-file=` were
+/// MEASURED to cause. The fix must be an allow-list entry, not a blanket skip.
+#[test]
+fn parse_server_args_flag_string_is_unchanged_without_fake_super() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-rlptgoDe.iLsfxC"),
+        OsString::from("--specials"),
+        OsString::from("--drop-D"),
+        OsString::from("--"),
+        OsString::from("."),
+        OsString::from("."),
+    ];
+    let (flag_string, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flag_string, "-rlptgoDe.iLsfxC");
+    assert!(pos_args.is_empty());
+}
+
+/// Recognising the flag is only half of it: it must also reach the config the
+/// receiver and sender actually consult.
+///
+/// `ServerConfig::fake_super` gates the `user.rsync.%stat` xattr path on both
+/// roles (`receiver/directory/special.rs`, `receiver/directory/links.rs`,
+/// `generator/file_list/entry/create.rs`). Recognise-without-apply would stop
+/// the flag-string theft while silently ignoring
+/// `--rsync-path='rsync --fake-super'`, so the two halves are tested together.
+#[test]
+fn fake_super_reaches_the_server_config() {
+    let mut config = core::server::ServerConfig::default();
+    assert!(!config.fake_super, "default must be off");
+
+    let flags = parse_server_long_flags(&[
+        OsString::from("--fake-super"),
+        OsString::from("--server"),
+        OsString::from("-rlptgoDe.iLsfxC"),
+    ]);
+    assert_eq!(flags.fake_super, Some(true));
+    super::run::apply_fake_super(&mut config, flags.fake_super);
+    assert!(config.fake_super);
+
+    // Absent: left alone, so a daemon module's `fake super = yes` survives an
+    // argv that never mentions it (upstream clientserver.c:1120-1121).
+    let mut untouched = core::server::ServerConfig {
+        fake_super: true,
+        ..core::server::ServerConfig::default()
+    };
+    let flags = parse_server_long_flags(&[
+        OsString::from("--server"),
+        OsString::from("-rlptgoDe.iLsfxC"),
+    ]);
+    assert_eq!(flags.fake_super, None);
+    super::run::apply_fake_super(&mut untouched, flags.fake_super);
+    assert!(untouched.fake_super);
+
+    // Explicit negation clears it (oc's own `--no-fake-super`, reachable as
+    // `-M--no-fake-super`; upstream's table has `no-super` but no
+    // `no-fake-super`).
+    let flags = parse_server_long_flags(&[
+        OsString::from("--no-fake-super"),
+        OsString::from("--server"),
+    ]);
+    assert_eq!(flags.fake_super, Some(false));
+    super::run::apply_fake_super(&mut untouched, flags.fake_super);
+    assert!(!untouched.fake_super);
+}
+
+/// The allow-list and the value capture are two different functions; a flag
+/// recognised by only one of them still leaks or is still dropped.
+#[test]
+fn fake_super_is_a_known_server_long_flag() {
+    assert!(is_known_server_long_flag("--fake-super"));
+    assert!(is_known_server_long_flag("--no-fake-super"));
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -287,7 +287,7 @@ rrsync-pull-arg-shapes fail
 rrsync-pull-delivers-content pass
 rrsync-sender-leaf-flip pass
 rrsync-sender-parent-pin pass
-rrsync-specials-denied fail
+rrsync-specials-denied pass
 rrsync-symlink pass
 rrsync-write-only-files-from pass
 rsync-ssl-hostname-validation pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -287,7 +287,7 @@ rrsync-pull-arg-shapes fail
 rrsync-pull-delivers-content pass
 rrsync-sender-leaf-flip pass
 rrsync-sender-parent-pin pass
-rrsync-specials-denied fail
+rrsync-specials-denied pass
 rrsync-symlink pass
 rrsync-write-only-files-from pass
 rsync-ssl-hostname-validation pass


### PR DESCRIPTION
## What

`--fake-super` was not in `is_known_server_long_flag`, and
`parse_server_flag_string_and_args` takes the first unrecognised `-`-leading
token as the **compact flag string** (`parse.rs:74-77`). So for the rrsync shim's
argv:

```
oc-rsync --fake-super --server -rlptgoDe.<caps> --specials --drop-D --confine-root=<dir> -- . .
```

`--fake-super` was swallowed as the flag string and the real
`-rlptgoDe.<caps>` fell through to the positional list, where both `.` operands
were then filtered (`parse.rs:110-120`). No `-r`, nothing delivered, exit 0.

Upstream parses it as an ordinary popt entry in the one table both ends share -
`options.c:672 {"fake-super", 0, POPT_ARG_VAL, &am_root, -1, 0, 0}` - and
deliberately does **not** emit it from `server_options()`, which is why the shim
injects it.

The flag is now recognised **and applied**: recognise-without-apply would green
the cell while leaving `--rsync-path='rsync --fake-super'` broken.

## Refutations worth recording

**Upstream has no `--no-fake-super`.** `grep -n fake options.c` yields only
`:95`, `:672`, `:2245`, `:2251`. It is added here anyway because oc's *own*
client table defines it
(`command_builder/sections/build_base_command/privileges.rs:32`), so it can
reach a server as `-M--no-fake-super` and would otherwise leak into the
positional path list. Marked in the code as an oc-only negation.

**There is no option table here.** `is_known_server_long_flag` is a hand-written
`matches!` chain, and the value capture is a *second, independent* hand-written
`match` in `parse_server_long_flags`. Both were extended, and each site is
pinned by its own test - that two-function split is the shape this class of gap
keeps reappearing in.

## Verification

**Per-site mutation matrix**, because reverting the allow-list arm alone does
*not* fail the bridge test - the two live in different functions:

- **M1** allow-list arm removed -> `7 run: 5 passed, 2 failed`; the flag-string
  test reports `left: "--fake-super", right: "-rlptgoDe.iLsfxC"`. Non-vacuity
  companion and bridge test both stayed green.
- **M2** capture arms neutered -> only `fake_super_reaches_the_server_config` fails.
- **M3** `apply_fake_super` body neutered -> same test fails, at the later assertion.

Restored: 7/7. Full `-p cli --lib`: 3352 passed, 1 skipped.

**Cell measured end-to-end** (non-root leg, absolute `--tooldir`):

1. upstream 3.5.0 control: `PASS` - the cell is a valid oracle here.
2. oc pre-fix: `FAIL`, byte-for-byte the reported symptom
   (`pushing a tree containing a device did not deliver the ordinary file
   beside it`, rc=0, empty output).
3. oc post-fix: `PASS`.

**The device-not-landing half was measured, not assumed.** With
`--preserve-scratch`: `devsrc/achar` carries `rsync.%stat: 20644 1,3 0:0`, so
part 3b really ran; `devserved/ordinary` is 6 B `PLAIN\n`; and
`lexists(devserved/achar) == False`. The discriminator matters - had the fix
merely let the entry through as an ordinary empty regular file, a 0-byte `achar`
would have landed. It did not, so the entry is still classified as a device and
still dropped by `--drop-D`. One failure was not traded for another.

`cargo fmt --all -- --check` was run **with a positive control** (a deliberately
misformatted probe fn made it exit 1) rather than trusting a bare clean result.
Clippy clean.

## ⚠ One row is inferred, not measured

The row appears in only two of the four manifests (`nonroot.txt:290`,
`root.txt:290`; neither TCP manifest has it). Both flipped; counts unchanged at
349/349/158/158.

Only the **non-root** leg was measured - `sudo` needs a password on the machine
used. The root row was flipped on the reasoning that this is a uid-independent
argv-parse bug: the pre-fix failure is `rc=0, nothing delivered` on both legs,
and every path involved (`special.rs:70-76` returns early on `drop_devices`
before any privilege check; `create.rs:504` gates only on `config.fake_super`)
is privilege-independent. That reasoning is sound but it is still an inference,
and the required root leg on this PR is what will confirm or refute it.
