### PR TITLE
fix(engine): keep a directory's metadata on readdir failure

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -201,7 +201,54 @@ fn copy_directory_recursive_inner(
 
     let list_start = Instant::now();
     let (readdir_buf, source_anchor) = context.readdir_buf_with_confined_anchor();
-    let mut entries = read_directory_entries_sorted_reuse(source, readdir_buf, source_anchor)?;
+    // Seeded here rather than at the entry loop so a failed enumeration can
+    // carry its error to the same end-of-frame re-raise the per-entry failures
+    // use.
+    let mut first_entry_io_error: Option<LocalCopyError> = None;
+    // upstream: flist.c:2129-2140 - `send_directory()` emits this directory's
+    // own entry and ACL (flist.c:1847-1858) BEFORE it opens the directory, so a
+    // failed `opendir()` is an enumeration-only failure: upstream `return`s
+    // without descending and the entry it already sent still reaches the
+    // receiver, which mkdir's the destination directory and applies its
+    // metadata and ACLs. The three arms are:
+    //   ENOENT -> `interpret_stat_error()` (flist.c:2003-2013) warns
+    //             `directory <name> has vanished` and sets IOERR_VANISHED (24);
+    //   ENOTDIR with FLAG_PERHAPS_DIR -> silent return. No counterpart here:
+    //             this frame is only entered for a source already stat'd as a
+    //             directory, so the "perhaps" flag is never set and ENOTDIR
+    //             falls through to the general arm exactly as upstream does
+    //             when the flag is clear;
+    //   otherwise -> IOERR_GENERAL (23) plus rsyserr `opendir %s failed`.
+    // Abandoning the frame here instead would skip `ensure_directory` and
+    // `apply_final_directory_metadata`, leaving an unreadable source
+    // directory's own permissions/ACLs unapplied and a stale destination ACL
+    // entry unrevoked. Continue with no children; the tail re-raises.
+    let mut enumeration_failed = false;
+    let mut entries = match read_directory_entries_sorted_reuse(source, readdir_buf, source_anchor)
+    {
+        Ok(entries) => entries,
+        Err(error) => {
+            if error.is_vanished_error() {
+                // full_fname() wraps the path in double quotes (util1.c:1228).
+                eprintln!("directory has vanished: \"{}\"", source.display());
+            } else {
+                let detail = match error.kind() {
+                    crate::local_copy::LocalCopyErrorKind::Io { source, .. } => {
+                        crate::local_copy::upstream_io_error(source)
+                    }
+                    _ => error.to_string(),
+                };
+                eprintln!(
+                    "rsync: [sender] opendir \"{}\" failed: {detail}",
+                    source.display()
+                );
+            }
+            context.record_io_error();
+            first_entry_io_error = Some(error);
+            enumeration_failed = true;
+            Vec::new()
+        }
+    };
     // upstream: the file list is built once before the receiver mkdir's the
     // destination root, so a destination created inside the source tree (e.g.
     // `rsync -a src src/child`) never appears in the list. oc reads each source
@@ -466,10 +513,19 @@ fn copy_directory_recursive_inner(
                 preserve_acls,
             )?;
         }
+        // A failed enumeration still has to reach the caller as an I/O error
+        // even on this early return, or the run would report success.
+        if let Some(error) = first_entry_io_error {
+            return Err(error);
+        }
         return Ok(true);
     }
 
-    if !directory_ready.get() && !prune_enabled {
+    // A directory whose contents could not be enumerated is not known to be
+    // empty, so `--prune-empty-dirs` must not withhold its creation: create it
+    // now, exactly as it would be created without `-m`, so the metadata/ACL
+    // apply at the end of this frame has a destination to write to.
+    if !directory_ready.get() && (!prune_enabled || enumeration_failed) {
         ensure_directory(context)?;
     }
 
@@ -546,7 +602,6 @@ fn copy_directory_recursive_inner(
     // a per-entry PathBuf allocation from Path::join.
     let mut target_buf = destination.to_path_buf();
 
-    let mut first_entry_io_error: Option<LocalCopyError> = None;
     for planned in &plan.planned_entries {
         let result = process_planned_entry(
             context,
@@ -604,7 +659,12 @@ fn copy_directory_recursive_inner(
         &plan.keep_names,
     )?;
 
-    if prune_enabled && !kept_any {
+    // `kept_any` is false after a failed enumeration only because there was no
+    // list to keep anything from - not because the directory is empty. Pruning
+    // it would both destroy a directory whose contents were merely unreadable
+    // and skip the metadata/ACL apply below, which is the whole point of
+    // continuing the frame.
+    if prune_enabled && !kept_any && !enumeration_failed {
         handle_empty_directory_pruning(context, destination, created_directory_on_disk)?;
         // upstream: the --max-delete limit (exit 25) outranks a partial/IO error
         // (exit 23/24); raise it first, mirroring the old post-loop ordering.

--- a/crates/engine/src/local_copy/tests/mod.rs
+++ b/crates/engine/src/local_copy/tests/mod.rs
@@ -1050,6 +1050,7 @@ include!("execute_block_size.rs");
 include!("execute_super.rs");
 include!("execute_archive.rs");
 include!("execute_ignore_errors.rs");
+include!("unreadable_source_directory.rs");
 include!("execute_checksum_seed.rs");
 include!("timeout_handling.rs");
 include!("execute_contimeout.rs");

--- a/crates/engine/src/local_copy/tests/unreadable_source_directory.rs
+++ b/crates/engine/src/local_copy/tests/unreadable_source_directory.rs
@@ -1,0 +1,279 @@
+// A source directory whose contents cannot be enumerated (mode 0300: write and
+// search, no read) is still a directory upstream sends: `send_file_entry()` and
+// `send_acl()` run before `opendir()` (flist.c:1847-1858), and a failed
+// `opendir()` only aborts the descent (flist.c:2129-2140). The receiver
+// therefore still creates the directory and applies its permissions and ACLs.
+// These tests pin that the enumeration failure stays enumeration-only.
+//
+// They must run as a non-root user: root holds CAP_DAC_READ_SEARCH, the mode
+// check never fires, and the fixture becomes structurally unable to fail.
+
+#[cfg(unix)]
+fn running_as_root() -> bool {
+    // `rustix`'s raw getuid is not intercepted by fakeroot, so a fakeroot run
+    // reports the real uid and correctly takes the non-root path.
+    rustix::process::getuid().is_root()
+}
+
+/// Builds `<root>/src/dropbox/inner.txt` plus `<root>/src/top.txt` and a
+/// pre-existing `<root>/dest/dropbox`, returning `(source, dest)`.
+#[cfg(unix)]
+fn build_unreadable_dir_fixture(root: &Path) -> (PathBuf, PathBuf) {
+    let source = root.join("src");
+    let dest = root.join("dest");
+    fs::create_dir_all(source.join("dropbox")).expect("create source dropbox");
+    fs::write(source.join("dropbox/inner.txt"), b"inner").expect("write inner");
+    fs::write(source.join("top.txt"), b"top\n").expect("write top");
+    fs::create_dir_all(dest.join("dropbox")).expect("create dest dropbox");
+    (source, dest)
+}
+
+#[cfg(unix)]
+fn copy_tree_with(
+    source: &Path,
+    dest: &Path,
+    options: LocalCopyOptions,
+) -> Result<LocalCopySummary, LocalCopyError> {
+    let mut source_operand = source.to_path_buf().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest.to_path_buf().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+}
+
+/// Re-opens every 0300 directory in the fixture so `TempDir` can remove it.
+#[cfg(unix)]
+fn restore_fixture_modes(paths: &[PathBuf]) {
+    use std::os::unix::fs::PermissionsExt;
+    for path in paths {
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o755));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn unreadable_source_directory_still_applies_its_own_metadata() {
+    // The defect: the recursive frame propagated the readdir error immediately,
+    // so `ensure_directory` and `apply_final_directory_metadata` never ran and
+    // the directory's own mode (and, with --acls, its ACL) was never applied.
+    // Upstream's entry was already sent before the opendir, so the receiver
+    // does apply it. Exit stays 23 because the enumeration itself failed.
+    use std::os::unix::fs::PermissionsExt;
+
+    if running_as_root() {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let (source, dest) = build_unreadable_dir_fixture(temp.path());
+    fs::set_permissions(source.join("dropbox"), fs::Permissions::from_mode(0o300))
+        .expect("make source dropbox unreadable");
+    // A mode the transfer must overwrite, so a passing assertion cannot be the
+    // pre-existing state.
+    fs::set_permissions(dest.join("dropbox"), fs::Permissions::from_mode(0o755))
+        .expect("seed dest dropbox mode");
+
+    let result = copy_tree_with(
+        &source,
+        &dest,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .permissions(true),
+    );
+
+    let dest_mode = fs::metadata(dest.join("dropbox"))
+        .expect("dest dropbox exists")
+        .permissions()
+        .mode()
+        & 0o777;
+    restore_fixture_modes(&[source.join("dropbox"), dest.join("dropbox")]);
+
+    assert_eq!(
+        dest_mode, 0o300,
+        "the unreadable source directory's own mode must reach the destination"
+    );
+    // Its readable sibling still transfers: the failure is scoped to the frame
+    // that could not be enumerated.
+    assert_eq!(
+        fs::read(dest.join("top.txt")).expect("top.txt copied"),
+        b"top\n"
+    );
+
+    let error = result.expect_err("unreadable source directory must report an I/O error");
+    assert_eq!(
+        error.exit_code(),
+        23,
+        "an unreadable directory is RERR_PARTIAL (upstream IOERR_GENERAL), got {error}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn readable_source_directory_still_transfers_its_contents() {
+    // Non-vacuity companion for the tests above: with the identical fixture and
+    // a *readable* source directory the walk is unchanged - contents transfer
+    // and the run succeeds. Without this, a fix that simply stopped descending
+    // into every directory would satisfy the assertions above.
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let (source, dest) = build_unreadable_dir_fixture(temp.path());
+    fs::set_permissions(source.join("dropbox"), fs::Permissions::from_mode(0o700))
+        .expect("keep source dropbox readable");
+
+    let summary = copy_tree_with(
+        &source,
+        &dest,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .permissions(true),
+    )
+    .expect("readable source directory transfers cleanly");
+
+    assert_eq!(
+        fs::read(dest.join("dropbox/inner.txt")).expect("inner.txt copied"),
+        b"inner"
+    );
+    assert!(summary.files_copied() >= 2, "both files must transfer");
+    assert_eq!(
+        fs::metadata(dest.join("dropbox"))
+            .expect("dest dropbox exists")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn prune_empty_dirs_keeps_a_directory_whose_contents_were_unreadable() {
+    // `--prune-empty-dirs` decides on the entries it saw. A directory that
+    // could not be enumerated produced no entries because it could not be read,
+    // not because it is empty, so pruning it would delete a directory on the
+    // strength of a failed read - and would also return before the metadata
+    // apply, silently defeating the fix. The same failure must suppress the
+    // delete pass (upstream: generator.c:304-311 delete_in_dir()).
+    use std::os::unix::fs::PermissionsExt;
+
+    if running_as_root() {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let (source, dest) = build_unreadable_dir_fixture(temp.path());
+    fs::set_permissions(source.join("dropbox"), fs::Permissions::from_mode(0o300))
+        .expect("make source dropbox unreadable");
+    // The destination directory must be *created* by this run, otherwise
+    // `handle_empty_directory_pruning` would decline to remove it anyway and
+    // the assertion below could not fail.
+    fs::remove_dir_all(dest.join("dropbox")).expect("drop pre-existing dest dropbox");
+    // The extraneous entry has to live in a directory swept *after* the
+    // unreadable one: `--delete-during` sweeps a directory before descending
+    // into its children, so the transfer root's own sweep runs before any
+    // child records an error. "zsub" sorts after "dropbox".
+    fs::create_dir_all(source.join("zsub")).expect("create source zsub");
+    fs::write(source.join("zsub/keep.txt"), b"keep").expect("write keep");
+    fs::create_dir_all(dest.join("zsub")).expect("create dest zsub");
+    fs::write(dest.join("zsub/keep.txt"), b"keep").expect("write dest keep");
+    fs::write(dest.join("zsub/extra.txt"), b"should survive").expect("write extra");
+
+    let result = copy_tree_with(
+        &source,
+        &dest,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .permissions(true)
+            .prune_empty_dirs(true)
+            .delete(true),
+    );
+
+    let dropbox_present = dest.join("dropbox").is_dir();
+    restore_fixture_modes(&[source.join("dropbox"), dest.join("dropbox")]);
+
+    assert!(
+        dropbox_present,
+        "--prune-empty-dirs must not remove a directory that could not be read"
+    );
+    assert!(
+        dest.join("zsub/extra.txt").exists(),
+        "the enumeration failure must suppress the later delete pass (generator.c:304)"
+    );
+    assert_eq!(
+        result
+            .expect_err("unreadable source directory must report an I/O error")
+            .exit_code(),
+        23
+    );
+}
+
+#[cfg(all(target_os = "linux", feature = "acl"))]
+#[test]
+fn acls_reach_an_unreadable_source_directory_and_revoke_the_stale_entry() {
+    // testsuite/acls-unpinnable_test.py: a 0300 source directory's ACL must
+    // still be applied to the destination, and a different (stale) grant
+    // already on the destination must be revoked. Both were lost because the
+    // frame died at the readdir, never reaching sync_acls().
+    use std::os::unix::fs::PermissionsExt;
+
+    if running_as_root() {
+        return;
+    }
+
+    const NEW_UID: u32 = 60002;
+    const STALE_UID: u32 = 60009;
+
+    let temp = tempdir().expect("tempdir");
+    let (source, dest) = build_unreadable_dir_fixture(temp.path());
+
+    let source_dropbox = source.join("dropbox");
+    let dest_dropbox = dest.join("dropbox");
+    set_acl_from_text(
+        &source_dropbox,
+        &format!("user::rwx\ngroup::---\nother::---\nuser:{NEW_UID}:rwx\nmask::rwx\n"),
+        acl_sys::ACL_TYPE_ACCESS,
+    );
+    set_acl_from_text(
+        &dest_dropbox,
+        &format!("user::rwx\ngroup::---\nother::---\nuser:{STALE_UID}:rwx\nmask::rwx\n"),
+        acl_sys::ACL_TYPE_ACCESS,
+    );
+    // The filesystem may have ACLs disabled; skip rather than assert nonsense.
+    let seeded = acl_to_text(&dest_dropbox, acl_sys::ACL_TYPE_ACCESS).unwrap_or_default();
+    if !seeded.contains(&format!("user:{STALE_UID}:")) {
+        return;
+    }
+    fs::set_permissions(&source_dropbox, fs::Permissions::from_mode(0o300))
+        .expect("make source dropbox unreadable");
+    fs::set_permissions(&dest_dropbox, fs::Permissions::from_mode(0o300))
+        .expect("make dest dropbox unreadable");
+
+    let result = copy_tree_with(
+        &source,
+        &dest,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .permissions(true)
+            .acls(true),
+    );
+
+    let applied = acl_to_text(&dest_dropbox, acl_sys::ACL_TYPE_ACCESS).unwrap_or_default();
+    restore_fixture_modes(&[source_dropbox, dest_dropbox]);
+
+    assert!(
+        applied.contains(&format!("user:{NEW_UID}:")),
+        "--acls did not apply the source ACL to the unreadable (0300) destination \
+         directory; getfacl:\n{applied}"
+    );
+    assert!(
+        !applied.contains(&format!("user:{STALE_UID}:")),
+        "--acls left the stale destination ACL entry in place on the unreadable \
+         (0300) directory - a revocation did not propagate; getfacl:\n{applied}"
+    );
+    assert_eq!(
+        result
+            .expect_err("unreadable source directory must report an I/O error")
+            .exit_code(),
+        23
+    );
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -7,7 +7,7 @@ acl-symlink-race pass
 acls pass
 acls-default pass
 acls-depth pass
-acls-unpinnable fail
+acls-unpinnable pass
 alt-dest pass
 alt-dest-deep pass
 alt-dest-symlink-race pass


### PR DESCRIPTION
## What

`read_directory_entries_sorted_reuse(...)?` abandoned the whole directory frame
on a readdir failure, so `apply_final_directory_metadata` never ran. A source
directory with mode 0300 (write+exec, no read) therefore never had its own mode,
ACL or xattrs applied to the destination, and a stale destination ACL entry was
never revoked.

Upstream inverts the order: `flist.c:1847-1858` emits the directory's own entry
and `send_acl()` **before** any descent, so an enumeration failure is
enumeration-only. The `?` is replaced by a match mirroring upstream's arms, and
the frame continues with an empty entry list so `ensure_directory` and the
metadata apply still run. The existing tail re-raises, giving exit 23 (or 24 for
the vanished arm).

## Correction to the brief this PR was written from

**The ENOENT arm does set `io_error`.** The brief said "return, NO io_error
(vanished)". `interpret_stat_error()` (`flist.c:2003-2013`) sets
`io_error |= IOERR_VANISHED` and prints `directory %s has vanished`, and for a
local copy `am_sender` is true, so that arm is reached. Implemented as upstream
actually behaves, not as briefed.

Upstream's second arm (`ENOTDIR && FLAG_PERHAPS_DIR`) has no oc counterpart and
was deliberately **not** synthesised: the recursive entry point is only reached
for a source already stat'd as a directory, so the flag is never set and ENOTDIR
correctly falls to the general arm - which is what upstream does with the flag
clear. Noted in code.

## The delete interlock needed no code

`handle_post_transfer_deletions` already gates on
`delete_pass_blocked_by_io_error()`. Because the enumeration failure records the
error at the *top* of the frame, deletion is suppressed for every later
directory. Verified live: the `IO error encountered -- skipping file deletion`
notice fires and the extraneous file survives.

⚠ Fixture detail: `--delete-during` sweeps a directory before descending, so the
transfer root's own sweep runs before any child records the error - an
extraneous file in the *root* is still deleted (pre-existing, matches the note at
`execute_ignore_errors.rs:250`). The test places it in `zsub/`, which sorts after
the unreadable directory.

## ⚠ One guard is an oc-only divergence - please weigh it

The `--prune-empty-dirs` guard (don't prune a directory whose contents were
merely unreadable) is **not** upstream behaviour. Upstream's `-m` prune
(`flist.c:3423 clean_flist`) is receiver-side and list-shape-based with no
`io_error` interlock, so a directory whose `opendir` failed contributes no
children and upstream *would* prune it.

It is implemented here because pruning on the strength of a failed read is the
same destructive-on-read-failure hazard upstream guards against at
`generator.c:304`, and because without it the fix is inert under `-m`. But it is
a deliberate divergence and should be an explicit decision: if strict fidelity is
preferred, drop the guard and the first assertion of the prune test.

## Verification

RED proven by restoring the bare `?`:
```
FAIL unreadable_source_directory_still_applies_its_own_metadata
  left: 493 (0o755, dest untouched)   right: 192 (0o300, source mode)
FAIL prune_empty_dirs_keeps_a_directory_whose_contents_were_unreadable
PASS readable_source_directory_still_transfers_its_contents   <- non-vacuity companion
Summary: 4 tests run: 2 passed, 2 failed
```

The Linux-gated ACL cell, RED on a real host (uid 1000, non-root):
```
FAIL acls_reach_an_unreadable_source_directory_and_revoke_the_stale_entry
  getfacl: user:60009:rwx  #effective:---   <- stale grant still present
```
The source grant never arrived and the stale one was never revoked - exactly the
`acls-unpinnable` defect. With the fix: 4/4.

Tests were run **non-root by design**: as root, `CAP_DAC_READ_SEARCH` bypasses
the mode check and the cell is structurally unable to fail.

- macOS non-root, `-p engine --all-features`: 5046 passed, 24 skipped.
- Linux non-root: all 4 new tests pass including the ACL cell.
- **The manifest flip is generated, not typed**: a real testsuite run with
  `EMIT_EXPECT_RESULT` on that host produced `acls-unpinnable pass`, and the
  emitted manifest differs from the committed one only in the header comment and
  the environment-dependent `protected-regular` row.
- Only the nonroot manifest is touched; the root row already read `pass`.
  Counts unchanged (349/349/158/158).

## Also found

`cargo fmt --all -- --check` is **false-clean for this file** - it exits 0 while
`rustfmt --check` on the file directly finds real diffs, because the test file is
`include!`d rather than a `mod`, so cargo fmt never visits it. This applies to
every sibling `tests/*.rs` in that directory *and to CI's fmt job*. Formatted
here with `rustfmt --edition 2024` directly; the gate gap is filed separately.

Minor behaviour change worth knowing: an *excluded* directory now drops the
enumeration error silently instead of propagating it. That is more
upstream-faithful (upstream never calls `send_directory` on an excluded dir) and
no test regressed.
