### PR TITLE
docs(engine): fix the broken am_root intra-doc link

### DIFF
--- a/crates/engine/src/local_copy/options/path_behavior.rs
+++ b/crates/engine/src/local_copy/options/path_behavior.rs
@@ -429,8 +429,7 @@ impl LocalCopyOptions {
     /// obstruction and then failing the `mknod` it was never able to perform.
     ///
     /// The privilege term is `am_root != 0` - root, `--super` *or*
-    /// `--fake-super` - which is deliberately NOT
-    /// [`Self::am_root`](super::super::types::LocalCopyOptions::am_root): that
+    /// `--fake-super` - which is deliberately NOT [`Self::am_root`]: that
     /// accessor answers `am_root > 0` for the ownership rules and reports
     /// false under `--fake-super`, where upstream still writes the `0600`
     /// placeholder (`syscall.c:do_mknod()`, the `am_root < 0` branch).


### PR DESCRIPTION
## Problem

The `Pages` workflow has been failing on master. Its "Build rustdoc" step runs

```
cargo doc --workspace --all-features --no-deps --locked
```

with `RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links"` (`.github/workflows/pages.yml:26,47`), and that promotion turns one bad link into a hard `exit 101` for the whole workspace:

```
error: unresolved link to `super::super::types::LocalCopyOptions::am_root`
   --> crates/engine/src/local_copy/options/path_behavior.rs:433:27
    |
433 |     /// [`Self::am_root`](super::super::types::LocalCopyOptions::am_root): that
    |                           ^^^ no item named `types` in module `local_copy`
error: could not document `engine`
```

## Root cause

The path has one `super` too many. `path_behavior.rs` lives in `crates/engine/src/local_copy/options/`, so `super` is `options` and `types` is reached as `super::types` - the file's own import on line 4 already reads `use super::types::LocalCopyOptions;`. Two levels up lands in `local_copy`, which has no `types` child.

## Fix

`am_root` is an accessor on `LocalCopyOptions` (`options/metadata/accessors.rs:148`) and the doc comment is inside `impl LocalCopyOptions`, so the shortcut form resolves without any explicit path - the same shape the sibling links in this file already use (`[`Self::devices_enabled`]`, `[`Self::specials_enabled`]`).

The link is deliberately kept on the *previous* line rather than starting its own. A line beginning `[`Self::am_root`]: that` would be parsed by CommonMark as a **link reference definition**, not a link, which would break rendering and silently drop the reference.

## Verification

- `cargo doc --workspace --all-features --no-deps --locked` with the workflow's exact `RUSTDOCFLAGS`: **exit 0**, zero errors (previously exit 101).
- The link genuinely resolves rather than being dropped - the generated HTML contains:
  `deliberately NOT <a href="struct.LocalCopyOptions.html#method.am_root" title="method engine::local_copy::LocalCopyOptions::am_root"><code>Self::am_root</code></a>: that`
- `cargo fmt --all -- --check`: exit 0.
- `cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings`: exit 0.

Doc-comment text only; no code, no behaviour change.

## Noted, not fixed here

`cargo doc` also emits two warnings in `fast_io` (`operator_open_create_new` / `operator_open_recv` documenting links to the private `operator_open_with`). Those are the `private_intra_doc_links` lint, which the workflow does **not** promote to an error, so they are not the cause of the failure and are left out of this change.
