### PR TITLE
fix(cli): accept --fake-super repeated via -M on a local transfer

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/privileges.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/privileges.rs
@@ -26,7 +26,13 @@ pub(super) fn add_privilege_args(command: ClapCommand) -> ClapCommand {
                 .long("fake-super")
                 .help("Store/restore privileged attrs using xattrs instead of real permissions.")
                 .action(ArgAction::SetTrue)
-                .overrides_with("no-fake-super"),
+                // Self-override makes a repeated flag idempotent instead of an
+                // error. A local transfer splices its -M values back into argv
+                // (local_remote_option_argv), so passing --fake-super together
+                // with -M--fake-super legitimately presents it twice; upstream parses
+                // the same pair with POPT_ARG_VAL, which just re-sets the value.
+                // upstream: options.c:672 {"fake-super", 0, POPT_ARG_VAL, ...}
+                .overrides_with_all(["no-fake-super", "fake-super"]),
         )
         .arg(
             Arg::new("no-fake-super")

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -139,7 +139,7 @@ exclude-implied-trailing-backslash skip
 exclude-lsh pass
 excludefrom-symlink skip
 executability pass
-fake-super-acl-xattr fail
+fake-super-acl-xattr pass
 fake-super-backup-fifo-regression pass
 file-to-file-mkpath-dry-run pass
 files-from pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -139,7 +139,7 @@ exclude-implied-trailing-backslash skip
 exclude-lsh pass
 excludefrom-symlink pass
 executability pass
-fake-super-acl-xattr fail
+fake-super-acl-xattr pass
 fake-super-backup-fifo-regression pass
 file-to-file-mkpath-dry-run pass
 files-from pass


### PR DESCRIPTION
## What

A local transfer splices its `-M`/`--remote-option` values back into argv and
re-parses through the same option table (`local_remote_option_argv`), mirroring
what upstream's forked server child does. That makes
`--fake-super -M--fake-super` present the flag twice in one parse, and clap
rejected the repeat:

```
oc-rsync error: syntax or usage error:
the argument '--fake-super' cannot be used multiple times
```

Upstream parses the identical argv with `POPT_ARG_VAL` (`options.c:672`), which
just re-sets the value, so it succeeds. Self-override makes the repeat
idempotent, matching popt.

## Measured

Same fixture, both binaries, on Linux x86_64 (kernel 7.1.5):

| binary | `-rA --fake-super -M--fake-super src/ dst/` |
|---|---|
| upstream rsync 3.5.0 | succeeds silently |
| oc-rsync (before) | `cannot be used multiple times` |
| oc-rsync (after) | succeeds silently |

## Testsuite cell

Closes `fake-super-acl-xattr`, which died at argument parsing before reaching
any ACL or xattr logic.

- **Upstream control first:** real 3.5.0 PASSes the cell, so it is a genuine
  oc divergence, not a fixture limit.
- **oc before:** FAIL. **oc after:** PASS. Same binary path, one line changed.
- Verified on **both legs** independently — nonroot and root each PASS — so
  both manifest rows are flipped in this commit. Row counts stay at 349.

## Known residual, filed separately

This flag is not unique. Sweeping all 201 long options with `--X -M--X` on the
fixed binary, **130 still reject the repeat** where upstream's popt accepts it.
`--fake-super` is simply the one a testsuite cell happens to exercise. The
systematic fix is a single pass over the built `Command` rather than 130
per-flag edits, and it changes parse behaviour broadly, so it is deliberately
not bundled here.

upstream: options.c:672 `{"fake-super", 0, POPT_ARG_VAL, &am_root, -1, 0, 0}`
