### PR TITLE
docs: re-measure the 3.5.0 outcome figures and record 46 merged PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ families, and putting the 3.5.0 test suite in front of every pull request.
   regressed the `--link-dest` / `--compare-dest` cells on the first attempt
 - Honour `--insecure-links` inside the operator-path walk, so the opt-out
   reaches the resolver instead of being consulted only by its callers (#7459)
+- Confine the `--partial-dir` reuse probe and discard the temp when the
+  directory create is refused; the probe alone was inert because the abort
+  path renamed regardless (#7483)
+- Resolve an absolute `--backup-dir` against the module root, and route the
+  `--inplace` backup copy and the `--temp-dir` staging temp through the
+  ownership walk (#7493, #7494, #7496)
+- Refuse a staging directory the module filter excludes, and confine the
+  filter-file open to the module root (#7495, #7512)
+- Honour the admin symlink opt-out at the sender confinement root, so an
+  operator who opted out is not refused anyway (#7517)
+- Stop confining a *client's* own destination on a daemon pull - the
+  confinement applies to the peer-supplied side, not the operator's (#7503)
 
 **Daemon**
 - Refuse shell metacharacters when expanding a hook variable, closing command
@@ -86,6 +98,7 @@ families, and putting the 3.5.0 test suite in front of every pull request.
 - Name the user and the rule in auth-failure log lines (#7395)
 - Treat a backslash in a requested path as a filename byte, not a path separator
   (#7409)
+- Honour the per-module `insecure links` directive (#7484)
 
 **Peer-supplied input bounds**
 - Bound peer-supplied xattr bytes and the CONNECT host (#7297)
@@ -120,6 +133,8 @@ families, and putting the 3.5.0 test suite in front of every pull request.
 - A missing or non-directory `--compare-dest` / `--copy-dest` / `--link-dest`
   argument now warns instead of passing silently, on the local path (#7453) and
   on the network paths (#7454)
+- `--fake-super` is accepted in a server argv, and repeated via `-M` on a
+  local transfer without being rejected (#7520, #7497)
 
 ### Changed
 
@@ -192,6 +207,15 @@ families, and putting the 3.5.0 test suite in front of every pull request.
   path, created at upstream's private 0700 (#7476)
 - TCP Fast Open must not defeat the multi-address connect fallback; deferring
   the SYN left a dead first address looking alive (#7447)
+- Recover a read-only in-place destination instead of failing the file
+  (#7485)
+- Keep an absolute `--partial-dir` through the delayed-updates sweep, and
+  clear a non-directory occupying the `--partial-dir` name (#7499, #7500)
+- Report a failed metadata apply instead of only counting it (#7506)
+- Gate device-node creation on upstream's `am_root` predicate (#7513)
+- Follow a symlinked directory named with the DOTDIR marker, and keep that
+  marker when the `/./` remainder is empty (#7510, #7516)
+- Refuse a non-regular `--read-batch` path (#7515)
 
 **Local copy and engine**
 - Size a local copy from the opened file, not the flist record, and clamp the
@@ -212,6 +236,13 @@ families, and putting the 3.5.0 test suite in front of every pull request.
 - Follow an existing destination symlink under `--no-implied-dirs` (#7461)
 - Diagnose a local-copy source that ended before its declared length instead of
   committing the short result (#7472)
+- Itemize the `-R` implied dot-dir root against the basis (#7505)
+- Keep a directory's own metadata when `readdir` fails part-way (#7521)
+- Make `--no-zero-copy` reach the content path it documents (#7482)
+- Compare an alt-dest basis mtime the way `same_time` does, so a basis is
+  not wrongly demoted (#7479)
+- Degrade the anonymous commit to a named temp where anonymous is
+  unavailable (#7478)
 
 **Daemon**
 - Collapse `..` in client paths instead of refusing the request (#7343)
@@ -225,6 +256,10 @@ families, and putting the 3.5.0 test suite in front of every pull request.
   bare close (#7466)
 - Route `--early-input` to the early-exec hook, not the pre-transfer one (#7471)
 - Mirror upstream's `daemon_usage` text in `--daemon --help` (#7444)
+- Honour a peer-supplied `--partial-dir` on the receiving side, and keep a
+  relative one relative as upstream does (#7498, #7501)
+- Resolve string module defaults at end of parse, so a global set *after* a
+  module section still applies to it (#7519)
 
 **CLI and output**
 - Honour the `--` end-of-options marker in server-mode argv (#7402)
@@ -246,11 +281,17 @@ families, and putting the 3.5.0 test suite in front of every pull request.
 - Take the `rsync://` daemon host verbatim; three separate rewrites were being
   applied to it (#7431)
 - Honour `--port` on a daemon transfer, not only on a listing (#7456)
+- Accept `--log-file` as a server long flag instead of letting it leak into
+  the destination operand (#7507)
+- Honour `--drop-D` in the server argument decoder, and consume
+  `--backup-dir` / `--temp-dir` instead of discarding them (#7508, #7511)
+- List a remote source under `--list-only` (#7509)
 
 **Metadata**
 - An installed name converter must replace the host database (#7360)
 - Follow the operator's own symlinked destination root when applying metadata
   (#7462)
+- Condense the fake-super access ACL to upstream's stored form (#7502)
 
 ### Testing and CI
 
@@ -280,6 +321,12 @@ families, and putting the 3.5.0 test suite in front of every pull request.
   gate (#7438)
 - The batched-writer threshold tests disarm the flush clock instead of racing
   it, which is what made the musl beta cell flake (#7469)
+- Default the upstream testsuite runner to 3.5.0 (#7486)
+- Publish the testsuite binary to a per-run path rather than a shared one,
+  so two concurrent runs cannot test each other's build (#7514)
+- Key the parallel receive-delta fuzz oracle on every registered file, and
+  let the caller name the upstream rsync the benchmark compares against
+  (#7480, #7481)
 
 ### Documentation
 
@@ -301,10 +348,16 @@ families, and putting the 3.5.0 test suite in front of every pull request.
 - Upstream's `iobuf` / `perform_io` contract extracted into a design note, with
   every anchor verified by reading rather than assumed (#7428)
 - Retargeted the `check_alt_basis_dirs` citations at 3.5.0 (#7452)
+- Close rustdoc gaps, repair references that no longer resolve, and add a
+  comment-policy audit (#7488, #7489, #7522)
+- Refresh the changelog and re-measure the 3.5.0 outcome figures (#7477)
 
 ### Maintenance
 
 - Dependency and action updates (#7473, #7474)
+- Give the in-place open chain a single owner with the resolver injected,
+  and the bounded drain-and-wait helper a single owner (#7487, #7504)
+- Update the Homebrew formulas for v0.6.4 (#7492)
 
 ## [0.6.4] - 2026-07-18
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict
 
 **Release:** 0.6.4 - Wire-compatible drop-in replacement for rsync 3.5.0 and the 3.4.x series (protocols 28-32).
 
-All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop scenarios run in CI against upstream rsync 3.0.9, 3.1.3, 3.4.4 and 3.5.0, with 2.6.9 built and cached; 3.4.4 represents the whole 3.4.x series (3.4.1/3.4.2/3.4.3 share protocol 32 and are superseded by it). Upstream rsync's own testsuite runs in CI against `oc-rsync` as `$RSYNC`: against the 3.4.4 corpus all tests pass and the known-failures roster is empty, and against the newer 3.5.0 corpus **31 of 349 tests currently diverge** (see below).
+All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop scenarios run in CI against upstream rsync 3.0.9, 3.1.3, 3.4.4 and 3.5.0, with 2.6.9 built and cached; 3.4.4 represents the whole 3.4.x series (3.4.1/3.4.2/3.4.3 share protocol 32 and are superseded by it). Upstream rsync's own testsuite runs in CI against `oc-rsync` as `$RSYNC`: against the 3.4.4 corpus all tests pass and the known-failures roster is empty, and against the newer 3.5.0 corpus **11 of 349 tests currently diverge** (see below).
 
 **Tracking rsync 3.5.0.** Upstream released 3.5.0 on 13 Aug 2026. It is wire-identical to 3.4.4 - `PROTOCOL_VERSION` 32, `SUBPROTOCOL_VERSION` 0, unchanged `errcode.h` - so protocol compatibility carries over unchanged and is what the "wire-compatible" claim above rests on. What 3.5.0 changes is *behaviour*: 33 CVEs concentrated in path handling and the daemon, a rewritten path resolver, five new options (`--confine-root`, `--drop-D`, `--no-drop-D`, `--insecure-links`, `--no-insecure-links`), three new daemon directives (`proxy protocol hosts`, `auth digest`, `insecure links`), and a test suite rebuilt from shell scripts into Python. Aligning oc-rsync to those behaviours is in progress and tracked openly.
 
@@ -36,12 +36,12 @@ Current outcomes, as recorded in each leg's committed manifest:
 
 | leg | pass | fail | skip | corpus |
 |---|---:|---:|---:|---:|
-| non-root, pipe | 239 | 21 | 85 | 349 |
-| root, pipe | 262 | 29 | 54 | 349 |
-| non-root, tcp | 93 | 29 | 33 | 158 |
-| root, tcp | 104 | 38 | 13 | 158 |
+| non-root, pipe | 251 | 9 | 89 | 349 |
+| root, pipe | 278 | 11 | 60 | 349 |
+| non-root, tcp | 100 | 22 | 36 | 158 |
+| root, tcp | 112 | 28 | 18 | 158 |
 
-**31 distinct tests** diverge across the two full-corpus legs, and 55 across all four. Every leg carries its own expected-outcome manifest, generated from a real run rather than hand-written, so only a *change* in outcome turns a badge red - and that includes an unexpected **pass**, which is what stops a divergence being quietly re-baselined instead of fixed. A fix flips its manifest rows in the same commit. The divergences are genuine and tracked openly: each was re-run against the real upstream 3.5.0 binary as a negative control, so they are oc-rsync behaviour gaps, not harness artefacts.
+**11 distinct tests** diverge across the two full-corpus legs, and 35 across all four. Every leg carries its own expected-outcome manifest, generated from a real run rather than hand-written, so only a *change* in outcome turns a badge red - and that includes an unexpected **pass**, which is what stops a divergence being quietly re-baselined instead of fixed. A fix flips its manifest rows in the same commit. The divergences are genuine and tracked openly: each was re-run against the real upstream 3.5.0 binary as a negative control, so they are oc-rsync behaviour gaps, not harness artefacts.
 
 Separately, [Upstream Testsuite 3.5.0dev](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml) is a **development** tracker, not a gate and not the 3.5.0 release: it builds RsyncProject git master (`version.h` == `3.5.0dev`), a moving target, and is deliberately non-blocking so an upstream-side break can never fail a PR here.
 
@@ -220,7 +220,7 @@ Three one-shot warnings may appear on stderr (sync path) or via `tracing` target
 oc-rsync is wire-compatible with upstream rsync 3.5.0, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:
 
 - **io_uring kernel requirement.** Provided buffer rings (PBUF_RING) require Linux **5.19+**; older 5.6-5.18 kernels fall back to standard buffered I/O via runtime probing.
-- **Two distinct buffer pools.** The **engine** `BufferPool` is the one the `OC_RSYNC_BUFFER_POOL_SIZE`, `OC_RSYNC_BUFFER_POOL_MEMORY_CAP` and `OC_BUFFER_POOL_BLOCK_SIZE` environment variables tune (`crates/engine/src/local_copy/buffer_pool/`). The **io_uring registered buffer pool** is separate, is sized statically, does not auto-adapt under sustained I/O pressure, and is *not* affected by those variables. Workloads with very high concurrent file fan-out may see throughput plateau before saturating the device.
+- **Two distinct buffer pools.** The **engine** `BufferPool` is the one the `OC_RSYNC_BUFFER_POOL_SIZE`, `OC_RSYNC_BUFFER_POOL_MEMORY_CAP` and `OC_BUFFER_POOL_BLOCK_SIZE` environment variables tune (`crates/engine/src/local_copy/buffer_pool/`). The **io_uring registered buffer pool** is separate, is sized statically, does not auto-adapt under sustained I/O pressure, and is *not* affected by those variables. Whether that static sizing costs anything in practice is **not yet measured**: a same-host comparison of the io_uring and standard-I/O backends came out within noise (+1.2% bulk, -1.2% fan-out on Linux 7.1.5/x86_64), which bounds the whole backend rather than this pool. Treat the fixed sizing as a documented limitation awaiting a fan-out-specific measurement, not as a known bottleneck.
 - **bgid namespace.** io_uring buffer-group IDs are a 16-bit namespace and the buffer-ring helpers cap at that bound, returning a typed error rather than wrapping. In practice IDs are recycled rather than accumulated - a measured run of 100,000 sessions consumed a single bgid - so exhaustion is not an expected operational condition.
 - **Delta computation is single-threaded per file by default.** The delta sender is sequential per file. Large-file delta scanning can be parallelised opt-in with `--parallel-delta-scan`, and basis-signature hashing with `--checksum-threads=N`; without those flags a large-file transfer uses one CPU for delta work.
 - **SSH compression interaction.** When the SSH transport already compresses the stream (e.g., `Compression yes` in `ssh_config`), running `oc-rsync -z` compresses payloads twice. oc-rsync warns when it detects `-C` / `-o Compression=yes` in the SSH argv it builds, and - with the default `ssh-config-parse` feature - when a `Compression yes` directive applies via `~/.ssh/config` / `-F` / `/etc/ssh/ssh_config`; it does not auto-disable either layer, so operators should pick one.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,12 +85,12 @@ rsync 3.5.0 is a major security release closing **33 CVEs**, concentrated in pat
 
 | leg | pass | fail | skip | corpus |
 |---|---:|---:|---:|---:|
-| non-root, pipe | 239 | 21 | 85 | 349 |
-| root, pipe | 262 | 29 | 54 | 349 |
-| non-root, tcp | 93 | 29 | 33 | 158 |
-| root, tcp | 104 | 38 | 13 | 158 |
+| non-root, pipe | 251 | 9 | 89 | 349 |
+| root, pipe | 278 | 11 | 60 | 349 |
+| non-root, tcp | 100 | 22 | 36 | 158 |
+| root, tcp | 112 | 28 | 18 | 158 |
 
-The two pipe legs run the whole corpus; the tcp legs add `--daemon-tests-only`, so they re-run the 158 tests that can observe the transport. **31 distinct tests** diverge across the two full-corpus legs, and **55** across all four. That set is the triage input, not a vulnerability count: it mixes real behavioural gaps, harness differences, and probes for C-level memory errors that have no Rust analogue. Classification requires per-test evidence, and a fix flips its manifest rows in the same commit - re-baselining a row without a fix would be a waiver, and the gate fails on an unexpected *pass* for exactly that reason.
+The two pipe legs run the whole corpus; the tcp legs add `--daemon-tests-only`, so they re-run the 158 tests that can observe the transport. **11 distinct tests** diverge across the two full-corpus legs, and **35** across all four. That set is the triage input, not a vulnerability count: it mixes real behavioural gaps, harness differences, and probes for C-level memory errors that have no Rust analogue. Classification requires per-test evidence, and a fix flips its manifest rows in the same commit - re-baselining a row without a fix would be a waiver, and the gate fails on an unexpected *pass* for exactly that reason.
 
 **Highest-severity items and their oc-rsync bearing:**
 


### PR DESCRIPTION
## What

Three status documents had drifted from what the repository actually records.

### 1. The 3.5.0 testsuite figures were stale in two places

`README.md` and `SECURITY.md` each carry their own copy of the same four-row
outcome table and the same two divergence counts. Both copies were out of date.
Re-read from the committed manifests
(`tools/ci/upstream-3.5.0-expect.{nonroot,root,nonroot.tcp,root.tcp}.txt`):

| leg | was | now |
|---|---|---|
| non-root, pipe | 239 / 21 / 85 | **251 / 9 / 89** |
| root, pipe | 262 / 29 / 54 | **278 / 11 / 60** |
| non-root, tcp | 93 / 29 / 33 | **100 / 22 / 36** |
| root, tcp | 104 / 38 / 13 | **112 / 28 / 18** |

Union counts move with them: **31 -> 11** distinct divergences across the two
full-corpus legs, **55 -> 35** across all four.

Row counts are unchanged (349 pipe, 158 tcp). No manifest is edited here - the
manifests were already correct; the prose copies of them had drifted.

### 2. An unmeasured performance claim stated as fact

The io_uring buffer-pool note ended: *"Workloads with very high concurrent file
fan-out may see throughput plateau before saturating the device."* That plateau
was never measured. A same-host comparison of the io_uring and standard-I/O
backends came out within noise (+1.2% bulk, -1.2% fan-out, Linux 7.1.5/x86_64),
which bounds the whole backend rather than this pool specifically.

The sentence now reports that measurement, says plainly that the pool shape
itself is still unmeasured, and frames the fixed sizing as a documented
limitation awaiting a fan-out-specific measurement - not as a known bottleneck.

### 3. The changelog stopped at #7476

Added the 46 PRs merged since, each written from its merge-commit title rather
than reconstructed, and filed under the subsection it belongs to.

## Note on placement

Three daemon entries are deliberately **outside** the Security section. Only the
per-module `insecure links` directive (#7484) is a security change; the
`--partial-dir` handling (#7498, #7501) and end-of-parse module defaults (#7519)
are ordinary correctness fixes. Listing them beside the CVE entries would
misreport them in a changelog that tracks CVEs.

## Verification

- Every table value and both union counts are computed by reading the manifests
  at this commit, so no number here is hand-typed.
- Every merged PR in `7477..7522` is cited: checked by diffing the `gh pr list`
  set against the numbers appearing in `CHANGELOG.md` - the difference is empty.
- Stale values (`239 | 21 | 85`, `31 distinct`, `and 55 across`, `104 | 38 | 13`)
  are confirmed absent from the committed blobs, not just the working tree.
