### PR TITLE
test(core): name the local-recursion tests for what they actually run

### DIFF
--- a/crates/core/tests/local_recursion_shapes.rs
+++ b/crates/core/tests/local_recursion_shapes.rs
@@ -1,21 +1,18 @@
-//! Stress tests for incremental recursion (INC_RECURSE) with large file counts
-//! and deep directory nesting.
+//! Local recursive transfers over trees of varying shape - deep nesting, wide
+//! fan-out, a mix of both, and a re-run that adds, removes and modifies files.
 //!
-//! These tests exercise the file list batching, sorting, and progressive
-//! discovery logic under load. They are gated with `#[ignore]` to avoid
-//! slowing CI - run manually with:
-//!
-//! ```sh
-//! cargo nextest run -p core --all-features -E 'test(inc_recurse_stress)' -- --ignored
-//! ```
-//!
-//! Reference: upstream rsync 3.4.1 flist.c, io.c (INC_RECURSE)
+//! These cover the local-copy executor's directory walk, entry ordering and
+//! quick-check behaviour as tree shape varies. They deliberately do NOT cover
+//! incremental recursion (INC_RECURSE): `transfer()` runs a local copy, which
+//! has no wire, no file-list segments and no sub-list dispatch, so nothing
+//! here can reach that machinery. Multi-segment coverage needs a wire test
+//! whose tree exceeds `MIN_FILECNT_LOOKAHEAD`.
 
 #[cfg(unix)]
 mod test_timeout;
 
 #[cfg(unix)]
-mod stress {
+mod local_recursion {
     use std::fs;
     use std::path::Path;
     use std::time::Duration;
@@ -25,8 +22,9 @@ mod stress {
 
     use super::test_timeout::run_with_timeout;
 
-    /// Generous timeout for stress tests that create thousands of files.
-    const STRESS_TIMEOUT: Duration = Duration::from_secs(120);
+    /// Deadlock guard, not a runtime budget - the whole file runs in well
+    /// under a second, so any expiry means the walk has wedged.
+    const HANG_GUARD: Duration = Duration::from_secs(120);
 
     /// Creates a file with the given content, building parent directories as needed.
     fn touch(path: &Path, contents: &[u8]) {
@@ -86,15 +84,14 @@ mod stress {
         run_client(config).expect("transfer with delete succeeds")
     }
 
-    /// Deep nesting (depth=50): 50 levels of nested directories, each with 2 files.
-    /// Total: 100 files across 50 directory levels.
+    /// Deep nesting (depth=50): 50 levels of nested directories, each with 2
+    /// files. Total: 100 files across 50 directory levels.
     ///
-    /// Exercises incremental recursion's progressive directory discovery at extreme
-    /// depth. Each level must be discovered and its entries sorted independently.
+    /// Pins that the local walk descends to a depth well past any single-level
+    /// assumption, creating every intermediate directory in the destination.
     #[test]
-    #[ignore = "stress test - run manually"]
     fn deep_nesting_50_levels() {
-        run_with_timeout(STRESS_TIMEOUT, || {
+        run_with_timeout(HANG_GUARD, || {
             let temp = tempdir().expect("tempdir");
             let source = temp.path().join("src");
             let dest = temp.path().join("dst");
@@ -145,12 +142,11 @@ mod stress {
     /// Wide directory (1000 files): single directory containing 1000 files of
     /// varying sizes (1B to ~256B).
     ///
-    /// Exercises the file list sorting and batching when a single directory yields
-    /// a large number of entries under incremental recursion.
+    /// Pins that a single directory yielding a large entry count transfers
+    /// completely - the fan-out counterpart to the depth case above.
     #[test]
-    #[ignore = "stress test - run manually"]
     fn wide_directory_1000_files() {
-        run_with_timeout(STRESS_TIMEOUT, || {
+        run_with_timeout(HANG_GUARD, || {
             let temp = tempdir().expect("tempdir");
             let source = temp.path().join("src");
             let dest = temp.path().join("dst");
@@ -189,12 +185,11 @@ mod stress {
     /// directory containing 20 files. Total: 10 * 20 = 200 leaf files, plus
     /// intermediate levels.
     ///
-    /// Exercises incremental recursion's handling of multiple concurrent subtree
-    /// discoveries with non-trivial fan-out at the leaf level.
+    /// Pins depth and fan-out together, so a fix that handles either shape
+    /// alone cannot pass.
     #[test]
-    #[ignore = "stress test - run manually"]
     fn mixed_deep_and_wide() {
-        run_with_timeout(STRESS_TIMEOUT, || {
+        run_with_timeout(HANG_GUARD, || {
             let temp = tempdir().expect("tempdir");
             let source = temp.path().join("src");
             let dest = temp.path().join("dst");
@@ -265,16 +260,14 @@ mod stress {
         });
     }
 
-    /// Incremental update: transfers a tree, then adds, removes, and modifies
-    /// files before transferring again with `--delete`. Verifies that only the
-    /// changes are applied and deletions are propagated.
+    /// Re-run after edits: transfers a tree, then adds, removes and modifies
+    /// files before transferring again with `--delete`.
     ///
-    /// This tests incremental recursion's interaction with quick-check and
-    /// deletion logic across multiple transfer passes.
+    /// Pins that a second pass applies only the changes and propagates the
+    /// deletions - the quick-check and delete paths across two passes.
     #[test]
-    #[ignore = "stress test - run manually"]
     fn incremental_update_add_remove_modify() {
-        run_with_timeout(STRESS_TIMEOUT, || {
+        run_with_timeout(HANG_GUARD, || {
             let temp = tempdir().expect("tempdir");
             let source = temp.path().join("src");
             let dest = temp.path().join("dst");

--- a/docs/audits/ignored-tests.md
+++ b/docs/audits/ignored-tests.md
@@ -25,9 +25,16 @@ leave it as-is.
   - **DEBUG-HELPER** - not a real test; a scratch printer kept around for
     diagnosis. Candidate for deletion.
 
-Total `#[ignore]` annotations: **154** (across 27 files; the additional 7
-matches in the raw grep are file-level `//!` / `///` doc comments referencing
-the attribute, not attributes themselves).
+Total `#[ignore]` annotations: **145** (across 35 files). Counted with
+
+```sh
+git ls-files -z '*.rs' | xargs -0 grep -h '^\s*#\[ignore' | wc -l
+```
+
+which excludes the `//!` / `///` doc comments that merely mention the
+attribute - a raw `grep '#\[ignore'` reports 177 because of those. The
+earlier figure of 154 across 27 files predates several test additions; use
+the command above rather than trusting a transcribed number.
 
 ## Stale Ignores
 
@@ -62,10 +69,6 @@ CLI surface area for no implementation cost.
 | `crates/daemon/tests/connection_scaling_stress.rs::thread_per_connection_scaling_100` | STRESS | Multi-second runtime; benchmark. | Leave (opt-in). |
 | `crates/daemon/tests/connection_scaling_stress.rs::thread_per_connection_scaling_1000` | STRESS | Multi-second runtime; benchmark. | Leave (opt-in). |
 | `crates/daemon/tests/connection_scaling_stress.rs::thread_per_connection_scaling_10000` | STRESS | Requires high `RLIMIT_NOFILE`; benchmark. | Leave (opt-in). |
-| `crates/core/tests/inc_recurse_stress.rs::deep_nesting_50_levels` | STRESS | Manual stress test. | Leave (opt-in). |
-| `crates/core/tests/inc_recurse_stress.rs::wide_directory_1000_files` | STRESS | Manual stress test. | Leave (opt-in). |
-| `crates/core/tests/inc_recurse_stress.rs::mixed_deep_and_wide` | STRESS | Manual stress test. | Leave (opt-in). |
-| `crates/core/tests/inc_recurse_stress.rs::incremental_update_add_remove_modify` | STRESS | Manual stress test. | Leave (opt-in). |
 | `crates/matching/src/index/sparse_match_tests.rs::sparse_match_100mib_single_overlap` | SLOW | 100 MiB allocations and full-buffer scans. | Leave (opt-in). |
 | `crates/matching/tests/sparse_match_fixture.rs::sparse_match_16mb_block1024` | SLOW | Sparse fixture, skipped by default. | Leave (opt-in). |
 | `crates/matching/tests/sparse_match_fixture.rs::sparse_match_16mb_block4096` | SLOW | Sparse fixture, skipped by default. | Leave (opt-in). |
@@ -247,7 +250,7 @@ fails first, so the test cannot reach the metadata-preservation assertion.
 
 ## Summary
 
-- 154 `#[ignore]` annotations in total.
+- 145 `#[ignore]` annotations in total (see the counting command above).
 - 14 of those are stale (the asserted blocker has shipped) and should be
   re-enabled in a follow-up patch series.
 - 3 are obsolete or debug-only and should be rewritten or deleted.


### PR DESCRIPTION
`crates/core/tests/inc_recurse_stress.rs` asserted, in its module header and in all four test doc comments, that it exercised incremental recursion - "file list batching, sorting, and progressive discovery logic under load", "progressive directory discovery at extreme depth". It cannot reach any of that.

All four tests call a helper documented `Runs a local recursive transfer`, and the local-copy path has no wire, no file-list segments and no sub-list dispatch:

```
$ git grep -c inc_recurse crates/engine/src/local_copy/
3   # all in batch/reporting files, none in the segment machinery
```

## What changed

**Renamed to what it runs.** The file is now `local_recursion_shapes.rs` and the module `local_recursion`. The coverage is real and worth keeping - local recursion at depth 50, at 1000-file fan-out, at both together, and across a second pass with `--delete` - it just isn't INC_RECURSE coverage. Each doc comment now states the property it pins, and the header says explicitly what the file does not cover, so the next reader does not re-derive this.

**Removed the four `#[ignore]` gates.** The stated reason was `"stress test - run manually"`. Measured:

```
$ cargo nextest run -p core --all-features \
    -E 'binary(inc_recurse_stress)' --run-ignored all
Summary [0.746s] 4 tests run: 4 passed, 0 skipped
```

0.746s for all four. They were excluded from CI for a cost that does not exist. Four never-run tests become four covered ones. `STRESS_TIMEOUT` becomes `HANG_GUARD`, documented as a deadlock guard rather than a runtime budget - which is what a 120s bound on a sub-second test actually is.

**Dropped `Reference: upstream rsync 3.4.1`.** This file mirrors no upstream construct, and 3.4.1 is not the pinned version.

## Audit doc

`docs/audits/ignored-tests.md` carried four rows for these tests whose verdict - `STRESS | Manual stress test. | Leave (opt-in).` - rested on the same false premise. Removed along with the gates.

Its two total-count statements were **already stale before this change**: it claimed 154 across 27 files; the tree had 149 across 35. Both now carry the measured value and the command that produces it, so the next reader recomputes instead of trusting a transcribed number. Note the raw-grep figure (177) differs because it counts `//!` mentions of the attribute, which is what the original 154-vs-161 parenthetical was trying to explain.

Re-auditing the remaining 145 ignores is out of scope here.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p core --all-targets --all-features --no-deps -- -D warnings` clean
- The four tests run and pass **without** `--run-ignored`: `Summary [0.708s] 4 tests run: 4 passed, 0 skipped`

The un-ignoring means these four execute in CI for the first time. They are `#[cfg(unix)]` local transfers with no platform-specific behaviour, but the Linux and macOS cells on this PR are the first real evidence of that.
