### PR TITLE
docs(design): map upstream struct file_list field-by-field onto oc

### DIFF
--- a/docs/design/rss-flist-segmentation.md
+++ b/docs/design/rss-flist-segmentation.md
@@ -148,8 +148,11 @@ Upstream stores the flist as a **circular doubly-linked list of separately
 allocated `file_list` objects**, each owning its own `file_struct` array.
 
 - `rsync.h:964-975` - `struct file_list { next, prev; files, sorted;
-  file_pool; used, malloced; low, high; ndx_start; flist_num; parent_ndx;
-  in_progress, to_redo; }`.
+  file_pool; pool_boundary; used, malloced; low, high; ndx_start; flist_num;
+  parent_ndx; in_progress, to_redo; }`. The declaration is unchanged between
+  3.4.4 and 3.5.0 - same twelve members in the same order, only the line
+  number moves (`:964-975` -> `:983-994`), so this anchor survives the
+  source-of-truth flip as a line retarget with no semantic re-reading.
 - Globals `flist.c:101-103` - `cur_flist, first_flist, dir_flist`,
   `flist_cnt`.
 - `flist.c:2960-2977` - `flist_new` appends to the list and assigns
@@ -174,6 +177,41 @@ Only the window between `first_flist` and `cur_flist` is ever live, so peak
 memory is bounded by the lookahead window (`MIN_FILECNT_LOOKAHEAD`), not by
 the total file count. Generation is lazy: `send_extra_file_list` produces the
 next sub-list on demand (`sender.c:230-232`).
+
+### 3.1 Field-by-field: upstream `struct file_list` vs oc today
+
+What oc stores, derives, or simply lacks. Read with §2.1 (storage) - the point
+is that oc has no type corresponding to `struct file_list` at all, so the
+members are scattered, recomputed, or absent rather than owned in one place.
+
+| upstream member | oc equivalent today | status |
+|---|---|---|
+| `next`, `prev` | none - `ndx_segments` is a `Vec`, an array not a chain | absent |
+| `files` | `file_list: Vec<FileEntry>` (`receiver/context.rs:48`) | **shared by every segment**, not per-segment |
+| `sorted` | none - no sorted-vs-files split | absent |
+| `file_pool` | none - entries come from the global allocator | absent |
+| `pool_boundary` | none | absent |
+| `used` | `ndx_segments[i+1].0 - ndx_segments[i].0` | derived, never stored |
+| `malloced` | n/a - `Vec` capacity | n/a |
+| `low`, `high` | none | absent |
+| `ndx_start` | the `i32` of `ndx_segments[i]` (`context.rs:67`) | stored, as a tuple element |
+| `flist_num` | the index into `ndx_segments` | derived |
+| `parent_ndx` | none | absent |
+| `in_progress`, `to_redo` | held on `ReceiverContext`, not per segment | not segment-scoped |
+| `first_flist` (global) | `first_segment_idx: usize` (`context.rs:78`) | stored |
+
+One member is stored as itself, two are derived, and eight are absent. The
+absent set is not arbitrary: `file_pool` + `pool_boundary` + `malloced` are
+the allocation machinery that makes upstream's `flist_free` release a
+segment's memory in one step, and `low`/`high`/`parent_ndx` are the
+per-segment bookkeeping that a shared flat buffer cannot express.
+
+That is the same gap §2.4 reaches from the other direction - oc's
+`reclaim_oldest_segment` cites `flist.c:2980 flist_free()` but walks
+`file_list[start..end]` calling `reclaim_heap_data()` on each entry, so the
+per-entry payloads drop while the `FileEntry` structs and the `Vec`'s backing
+allocation stay resident for the whole transfer. Restoring the upstream
+behaviour needs the pool, not a better loop.
 
 ## 4. Target Design
 


### PR DESCRIPTION
`rss-flist-segmentation.md` section 3 lists the members of upstream's `struct file_list` but never says which of them oc actually has. That is the question every task in the segmentation series ends up re-deriving, so the answer now sits beside the reference model.

## The table

Per member: stored, derived, or absent. **One** is stored as itself (`ndx_start`, as the `i32` of a `(usize, i32)` tuple), **two** are derived (`used`, `flist_num`), **eight** are absent.

The absent set is not arbitrary:

- `file_pool` + `pool_boundary` + `malloced` are the allocation machinery that lets upstream's `flist_free` release a whole segment in one step.
- `low` / `high` / `parent_ndx` are per-segment bookkeeping that a single shared flat buffer cannot express.

That converges with what §2.4 already describes from the other direction. `reclaim_oldest_segment` cites `flist.c:2980 flist_free()` but does this:

```rust
for entry in &mut self.file_list[start..end] {
    entry.reclaim_heap_data();     // scrubs name/dirname/extras IN PLACE
}
self.first_segment_idx += 1;       // Vec never shrinks
```

Per-entry payloads drop; the `FileEntry` structs and the `Vec`'s backing allocation stay resident for the whole transfer. Upstream drops the node. Same citation, opposite semantics — and the reason is the missing pool, so restoring upstream behaviour needs the allocation machinery, not a better loop.

## Two corrections to existing text

**`pool_boundary` was missing from the inline declaration.** `rsync.h:968` does declare it. Restored so the list matches the struct.

**The declaration is unchanged between 3.4.4 and 3.5.0.** Measured — same twelve members, same order, same comments; only the line number moves (`:964-975` → `:983-994`). So this anchor survives the source-of-truth flip as a pure line retarget with no semantic re-reading. Worth recording before that flip is scoped, since it is one construct that will *not* contribute to the retarget cost.

## Scope

Docs only, additive. No new file: an adjacent doc already owns the segment-representation story, and a third overlapping document is what this series has been closing, not creating.

The citation-drift gate scans `crates/*/src/**/*.rs`, so `docs/` is outside its input set — the `:983-994` reference above is prose, not a gated citation, and cannot be validated against the 3.4.4 pin.
