### PR TITLE
test(receiver): pin INC_RECURSE segment count, log segment arrival

### DIFF
--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -429,6 +429,18 @@ mod tests {
             "4 level-1 dirs + 6 files across 3 per-directory sub-lists"
         );
 
+        // The SEGMENT COUNT is the point, and nothing above checks it: every
+        // other assertion in this test holds identically if all six files
+        // arrived in ONE segment, so "across 3 per-directory sub-lists" was a
+        // claim in a message rather than a checked fact. This is also what makes
+        // the "received segment" debug line non-vacuous - that line reports
+        // `ndx_segments.len()`, so pinning the count here pins what it prints.
+        assert_eq!(
+            ctx.ndx_segments.len(),
+            4,
+            "initial level-1 list plus one segment per sub-list (a, b, c)"
+        );
+
         let names: std::collections::BTreeSet<String> = ctx
             .file_list()
             .iter()

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -399,6 +399,20 @@ impl ReceiverContext {
         // upstream: flist.c:2966 - ndx_start = prev->ndx_start + prev->used + 1
         self.ndx_segments.push((flat_start, seg_ndx_start));
 
+        // Counterpart to `reclaim_oldest_segment`'s "reclaiming segment" line:
+        // the receiver logged segment RELEASE but never segment ARRIVAL, so
+        // `ndx_segments.len()` - which is `pub(in crate::receiver)` - had no
+        // observable surface outside this crate. Without it a harness driving the
+        // real binary cannot tell one segment from many, which is what makes an
+        // end-to-end multi-segment assertion vacuous.
+        debug_log!(
+            Flist,
+            2,
+            "received segment {} entries [{flat_start}..{}) ndx_start {seg_ndx_start}",
+            self.ndx_segments.len() - 1,
+            self.file_list.len()
+        );
+
         // Restore the cached reader so the next segment continues the same
         // compression state (upstream's static recv_file_entry() variables).
         self.flist_reader_cache = Some(flist_reader);


### PR DESCRIPTION
## What

Makes the receiver's INC_RECURSE **segment count observable**, and pins it.

## Why

`reclaim_oldest_segment` logs when a file-list segment is *released*
("reclaiming segment", `Flist`/2). Nothing logged when one *arrived*, and
`ndx_segments` is `pub(in crate::receiver)` - invisible to `crates/transfer/tests`
and root `tests/`, which are separate crates.

So there was no way for a harness driving the real binary to tell one segment from
many. Any end-to-end multi-segment assertion built on top of that would be vacuous.

## The vacuity this found

`real_upstream_multisegment_sublist_decodes_as_segments` decodes a captured
real-upstream frame carrying three sub-lists and asserts:

- `file_list().len() == 10`
- the six expected `a/`, `b/`, `c/` entry names are present

Every one of those holds **identically if all six files had arrived in a single
segment**. The string `"4 level-1 dirs + 6 files across 3 per-directory sub-lists"`
asserted the segmenting in a *message*, never in a check.

## Changes

- `receive_one_extra_segment`: emit `"received segment N entries [a..b) ndx_start X"`
  at `--debug=flist2`, the counterpart to the existing reclaim line. `ndx_start` is
  included so the +1 inter-segment gap is observable too.
- the test now asserts `ndx_segments.len() == 4` (initial list + 3 sub-lists). This
  also pins what the new line reports, since it prints `ndx_segments.len()`.

## Non-vacuity

Mutating the expected count to `1`:

```
assertion `left == right` failed: initial level-1 list plus one segment per sub-list (a, b, c)
  left: 4
 right: 1
```

The assertion reads a live value, and would catch a collapse to a single segment.

## Scope

No production behaviour change - the added line is diagnostic only, gated behind
`--debug=flist2`, and mirrors a line that already existed for the opposite event.
`+26` lines across 2 files.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p transfer --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p transfer --all-features` segment/on-demand selection: 35/35
