### PR TITLE
ci: format-check the source files cargo fmt cannot see

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,13 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
+      # rustfmt reaches a file only through the `mod` tree, so every file pulled
+      # in with `include!("...")` is invisible to the step above - it exits 0 no
+      # matter how those files are formatted. Nearly 500 source files in this
+      # workspace are reached that way. This step runs rustfmt on them directly.
+      - name: Format check (include!()d files)
+        run: python3 tools/ci/check_include_fmt.py
+
       - name: Clippy
         run: cargo clippy --locked --workspace --all-targets --all-features --no-deps
 

--- a/crates/core/src/message/tests/part1.rs
+++ b/crates/core/src/message/tests/part1.rs
@@ -356,4 +356,3 @@ fn workspace_prefix_match_requires_separator_boundary() {
     assert_eq!(source.path(), expected);
     assert!(Path::new(source.path()).is_absolute());
 }
-

--- a/crates/core/src/message/tests/part2.rs
+++ b/crates/core/src/message/tests/part2.rs
@@ -244,4 +244,3 @@ fn render_to_writer_matches_render_to() {
 
     assert_eq!(buffer, message.to_string().into_bytes());
 }
-

--- a/crates/core/src/message/tests/part3.rs
+++ b/crates/core/src/message/tests/part3.rs
@@ -383,4 +383,3 @@ fn render_line_to_appends_newline() {
 
     assert_eq!(rendered, format!("{message}\n"));
 }
-

--- a/crates/core/src/message/tests/part4.rs
+++ b/crates/core/src/message/tests/part4.rs
@@ -457,4 +457,3 @@ fn segments_into_iter_collects_bytes() {
 
     assert_eq!(flattened, message.to_line_bytes().unwrap());
 }
-

--- a/crates/core/src/message/tests/part5.rs
+++ b/crates/core/src/message/tests/part5.rs
@@ -310,4 +310,3 @@ fn rsync_info_macro_honors_track_caller() {
         TESTS_DIR
     );
 }
-

--- a/crates/core/src/message/tests/part8.rs
+++ b/crates/core/src/message/tests/part8.rs
@@ -281,10 +281,7 @@ fn exit_code_table_text_matches_upstream_rerr_names() {
             23,
             "some files/attrs were not transferred (see previous errors)",
         ),
-        (
-            24,
-            "some files vanished before they could be transferred",
-        ),
+        (24, "some files vanished before they could be transferred"),
         (25, "the --max-delete limit stopped deletions"),
         (30, "timeout in data send/receive"),
         (35, "timeout waiting for daemon connection"),
@@ -295,8 +292,8 @@ fn exit_code_table_text_matches_upstream_rerr_names() {
     ];
 
     for (code, expected_text) in expected {
-        let template =
-            strings::exit_code_message(code).unwrap_or_else(|| panic!("exit code {code} must be in the table"));
+        let template = strings::exit_code_message(code)
+            .unwrap_or_else(|| panic!("exit code {code} must be in the table"));
         assert_eq!(
             template.text(),
             expected_text,
@@ -332,9 +329,12 @@ fn only_exit_code_24_produces_warning_matching_upstream() {
 fn permission_denied_error_includes_context_like_upstream() {
     // Upstream: rsync: [receiver] <filename>: Permission denied (13)
     // Our format: rsync error: <action description> (code N) [role=version]
-    let msg = Message::error(23, "send_files failed to open \"/test/file\": Permission denied (13)")
-        .with_role(Role::Sender)
-        .with_source(message_source!());
+    let msg = Message::error(
+        23,
+        "send_files failed to open \"/test/file\": Permission denied (13)",
+    )
+    .with_role(Role::Sender)
+    .with_source(message_source!());
     let rendered = msg.to_string();
 
     assert!(rendered.starts_with("rsync error: "));
@@ -373,14 +373,8 @@ fn message_segment_order_matches_upstream() {
     let at_pos = rendered.find(" at ").expect("source separator must exist");
     let trailer_pos = rendered.find("[sender=").expect("trailer must exist");
 
-    assert!(
-        prefix_pos < text_pos,
-        "Prefix must come before text"
-    );
-    assert!(
-        text_pos < code_pos,
-        "Text must come before code suffix"
-    );
+    assert!(prefix_pos < text_pos, "Prefix must come before text");
+    assert!(text_pos < code_pos, "Text must come before code suffix");
     assert!(
         code_pos < at_pos,
         "Code suffix must come before source location"
@@ -440,7 +434,9 @@ fn error_code_names_match_upstream_errcode_h() {
 #[test]
 fn from_exit_code_covers_all_documented_upstream_codes() {
     // All exit codes documented in the upstream rsync man page
-    let upstream_documented = [1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 14, 20, 21, 22, 23, 24, 25, 30, 35];
+    let upstream_documented = [
+        1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 14, 20, 21, 22, 23, 24, 25, 30, 35,
+    ];
 
     for code in upstream_documented {
         let msg = Message::from_exit_code(code);
@@ -473,9 +469,12 @@ fn exit_code_message_with_detail_preserves_upstream_text_prefix() {
 #[test]
 fn error_message_is_parseable_by_regex() {
     // Tools often parse rsync output with regexes. Verify our format is parseable.
-    let msg = Message::error(23, "some files/attrs were not transferred (see previous errors)")
-        .with_role(Role::Sender)
-        .with_source(message_source!());
+    let msg = Message::error(
+        23,
+        "some files/attrs were not transferred (see previous errors)",
+    )
+    .with_role(Role::Sender)
+    .with_source(message_source!());
     let rendered = msg.to_string();
 
     // Pattern: rsync error: <text> (code <N>) at <basename>(<line>) [<role>=<version>]

--- a/crates/daemon/src/daemon/runtime_options/parsing.rs
+++ b/crates/daemon/src/daemon/runtime_options/parsing.rs
@@ -87,13 +87,10 @@ impl RuntimeOptions {
                 options.detach = false;
             } else if argument == "--detach" {
                 options.detach = true;
-            } else if let Some(value) =
-                take_option_value(argument, &mut iter, "--max-sessions")?
-            {
+            } else if let Some(value) = take_option_value(argument, &mut iter, "--max-sessions")? {
                 let max = parse_max_sessions(&value)?;
                 options.set_max_sessions(max)?;
-            } else if let Some(value) =
-                take_option_value(argument, &mut iter, "--max-connections")?
+            } else if let Some(value) = take_option_value(argument, &mut iter, "--max-connections")?
             {
                 let max = parse_max_connections(&value)?;
                 options.set_max_connections(max)?;
@@ -103,17 +100,13 @@ impl RuntimeOptions {
                 options.force_address_family(AddressFamily::Ipv4)?;
             } else if argument == "--ipv6" || argument == "-6" {
                 options.force_address_family(AddressFamily::Ipv6)?;
-            } else if let Some(value) =
-                take_option_value(argument, &mut iter, "--tcp-fastopen")?
-            {
+            } else if let Some(value) = take_option_value(argument, &mut iter, "--tcp-fastopen")? {
                 options.set_tcp_fastopen(parse_tcp_fastopen_mode(&value, brand)?);
             } else if let Some(value) = take_option_value(argument, &mut iter, "--log-file")? {
                 options.set_log_file(PathBuf::from(value))?;
             } else if let Some(value) = take_option_value(argument, &mut iter, "--lock-file")? {
                 options.set_lock_file(PathBuf::from(value))?;
-            } else if let Some(value) =
-                take_option_value(argument, &mut iter, "--secrets-file")?
-            {
+            } else if let Some(value) = take_option_value(argument, &mut iter, "--secrets-file")? {
                 let validated = validate_cli_secrets_file(PathBuf::from(value))?;
                 options.set_cli_secrets_file(validated)?;
             } else if let Some(value) = take_option_value(argument, &mut iter, "--pid-file")? {

--- a/crates/daemon/src/daemon/runtime_options/resolve.rs
+++ b/crates/daemon/src/daemon/runtime_options/resolve.rs
@@ -21,9 +21,9 @@ fn resolve_uid(value: &str) -> Result<u32, String> {
 /// On non-Unix platforms, only numeric IDs are accepted.
 #[cfg(not(unix))]
 fn resolve_uid(value: &str) -> Result<u32, String> {
-    value.parse::<u32>().map_err(|_| {
-        format!("invalid uid '{value}' (only numeric IDs supported on this platform)")
-    })
+    value
+        .parse::<u32>()
+        .map_err(|_| format!("invalid uid '{value}' (only numeric IDs supported on this platform)"))
 }
 
 /// Resolves a gid string to a numeric gid.
@@ -49,9 +49,9 @@ fn resolve_gid(value: &str) -> Result<u32, String> {
 /// On non-Unix platforms, only numeric IDs are accepted.
 #[cfg(not(unix))]
 fn resolve_gid(value: &str) -> Result<u32, String> {
-    value.parse::<u32>().map_err(|_| {
-        format!("invalid gid '{value}' (only numeric IDs supported on this platform)")
-    })
+    value
+        .parse::<u32>()
+        .map_err(|_| format!("invalid gid '{value}' (only numeric IDs supported on this platform)"))
 }
 
 fn validate_cli_secrets_file(path: PathBuf) -> Result<PathBuf, DaemonError> {

--- a/crates/daemon/src/daemon/runtime_options/tests.rs
+++ b/crates/daemon/src/daemon/runtime_options/tests.rs
@@ -334,10 +334,7 @@ mod runtime_options_tests {
             OsString::from("/var/run/rsyncd.lock"),
         ];
         let options = RuntimeOptions::parse(&args).expect("parse");
-        assert_eq!(
-            options.lock_file(),
-            Some(Path::new("/var/run/rsyncd.lock"))
-        );
+        assert_eq!(options.lock_file(), Some(Path::new("/var/run/rsyncd.lock")));
     }
 
     #[test]
@@ -359,10 +356,7 @@ mod runtime_options_tests {
             OsString::from("/var/run/rsyncd.pid"),
         ];
         let options = RuntimeOptions::parse(&args).expect("parse");
-        assert_eq!(
-            options.pid_file(),
-            Some(Path::new("/var/run/rsyncd.pid"))
-        );
+        assert_eq!(options.pid_file(), Some(Path::new("/var/run/rsyncd.pid")));
     }
 
     #[test]
@@ -403,10 +397,7 @@ mod runtime_options_tests {
 
     #[test]
     fn last_detach_flag_wins() {
-        let args = vec![
-            OsString::from("--no-detach"),
-            OsString::from("--detach"),
-        ];
+        let args = vec![OsString::from("--no-detach"), OsString::from("--detach")];
         let options = RuntimeOptions::parse(&args).expect("parse");
         assert!(options.detach());
     }
@@ -505,8 +496,7 @@ mod runtime_options_tests {
         // a configured `listen backlog` must reach RuntimeOptions intact or
         // the directive is cosmetic and the accept queue silently stays at 5.
         let mut file = NamedTempFile::new().expect("config file");
-        writeln!(file, "listen backlog = 128\n[share]\npath = /srv/share\n")
-            .expect("write config");
+        writeln!(file, "listen backlog = 128\n[share]\npath = /srv/share\n").expect("write config");
 
         let args = vec![
             OsString::from("--config"),
@@ -525,8 +515,7 @@ mod runtime_options_tests {
 
     #[test]
     fn parses_short_verbose_stack() {
-        let options =
-            RuntimeOptions::parse(&[OsString::from("-vvv")]).expect("parse -vvv");
+        let options = RuntimeOptions::parse(&[OsString::from("-vvv")]).expect("parse -vvv");
         assert_eq!(options.verbosity(), 3);
     }
 
@@ -540,11 +529,8 @@ mod runtime_options_tests {
         .expect("parse stacked verbose");
         assert_eq!(options.verbosity(), 3);
 
-        let reset = RuntimeOptions::parse(&[
-            OsString::from("-vv"),
-            OsString::from("--no-verbose"),
-        ])
-        .expect("parse with reset");
+        let reset = RuntimeOptions::parse(&[OsString::from("-vv"), OsString::from("--no-verbose")])
+            .expect("parse with reset");
         assert_eq!(reset.verbosity(), 0);
     }
 
@@ -599,10 +585,7 @@ mod runtime_options_tests {
             OsString::from("--secrets-file"),
             secrets.path().as_os_str().to_os_string(),
             OsString::from("--module"),
-            OsString::from(format!(
-                "docs={};auth users=alice",
-                module_path.display()
-            )),
+            OsString::from(format!("docs={};auth users=alice", module_path.display())),
         ];
 
         let options = RuntimeOptions::parse(&args).expect("parse");

--- a/crates/daemon/src/daemon/sections/auth_helpers.rs
+++ b/crates/daemon/src/daemon/sections/auth_helpers.rs
@@ -13,12 +13,7 @@ pub(crate) fn log_list_request(log: &SharedLogSink, host: &str, peer_addr: Socke
     log_message(log, &message);
 }
 
-pub(crate) fn log_module_request(
-    log: &SharedLogSink,
-    host: &str,
-    peer_ip: IpAddr,
-    module: &str,
-) {
+pub(crate) fn log_module_request(log: &SharedLogSink, host: &str, peer_ip: IpAddr, module: &str) {
     let module_display = sanitize_module_identifier(module);
     // upstream: clientserver.c:787 - `rsync allowed access on module %s from %s (%s)`
     let text = format!("rsync allowed access on module {module_display} from {host} ({peer_ip})");
@@ -106,12 +101,7 @@ pub(crate) fn log_module_auth_failure(
     log_message(log, &message);
 }
 
-pub(crate) fn log_module_denied(
-    log: &SharedLogSink,
-    host: &str,
-    peer_ip: IpAddr,
-    module: &str,
-) {
+pub(crate) fn log_module_denied(log: &SharedLogSink, host: &str, peer_ip: IpAddr, module: &str) {
     let module_display = sanitize_module_identifier(module);
     // upstream: clientserver.c:774 - `rsync denied on module %s from %s (%s)`
     let text = format!("rsync denied on module {module_display} from {host} ({peer_ip})");
@@ -119,16 +109,10 @@ pub(crate) fn log_module_denied(
     log_message(log, &message);
 }
 
-pub(crate) fn log_unknown_module(
-    log: &SharedLogSink,
-    host: &str,
-    peer_ip: IpAddr,
-    module: &str,
-) {
+pub(crate) fn log_unknown_module(log: &SharedLogSink, host: &str, peer_ip: IpAddr, module: &str) {
     let module_display = sanitize_module_identifier(module);
     // upstream: clientserver.c:1568 - `unknown module '%s' tried from %s (%s)`
     let text = format!("unknown module '{module_display}' tried from {host} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
-

--- a/crates/daemon/src/daemon/sections/capabilities.rs
+++ b/crates/daemon/src/daemon/sections/capabilities.rs
@@ -68,8 +68,7 @@ fn preflight_required_capabilities(modules: &[ModuleRuntime]) -> Result<(), Stri
         return Ok(());
     }
 
-    let has_cap = caps::has_cap(None, CapSet::Effective, Capability::CAP_CHOWN)
-        .unwrap_or(false);
+    let has_cap = caps::has_cap(None, CapSet::Effective, Capability::CAP_CHOWN).unwrap_or(false);
     if has_cap {
         return Ok(());
     }
@@ -150,8 +149,7 @@ fn drop_cap_net_bind_service(log_sink: Option<&SharedLogSink>) {
     use caps::{CapSet, Capability};
 
     let target = Capability::CAP_NET_BIND_SERVICE;
-    let already_absent =
-        !caps::has_cap(None, CapSet::Permitted, target).unwrap_or(false);
+    let already_absent = !caps::has_cap(None, CapSet::Permitted, target).unwrap_or(false);
     if already_absent {
         if let Some(log) = log_sink {
             let message = rsync_info!("CAP_NET_BIND_SERVICE already absent; nothing to drop")
@@ -172,8 +170,7 @@ fn drop_cap_net_bind_service(log_sink: Option<&SharedLogSink>) {
     }
 
     if let Some(log) = log_sink {
-        let message =
-            rsync_info!("dropped CAP_NET_BIND_SERVICE post-bind").with_role(Role::Daemon);
+        let message = rsync_info!("dropped CAP_NET_BIND_SERVICE post-bind").with_role(Role::Daemon);
         log_message(log, &message);
     }
 }
@@ -201,10 +198,7 @@ fn drop_cap_net_bind_service(_log_sink: Option<&SharedLogSink>) {}
 ///
 /// On non-Linux targets this is a no-op.
 #[cfg(target_os = "linux")]
-fn drop_worker_capabilities(
-    module: &ModuleRuntime,
-    log_sink: Option<&SharedLogSink>,
-) {
+fn drop_worker_capabilities(module: &ModuleRuntime, log_sink: Option<&SharedLogSink>) {
     use caps::{CapSet, Capability};
 
     // Skip the per-worker drop whenever the worker is still running as
@@ -287,11 +281,7 @@ fn drop_worker_capabilities(
 
 /// Stub for non-Linux platforms.
 #[cfg(not(target_os = "linux"))]
-fn drop_worker_capabilities(
-    _module: &ModuleRuntime,
-    _log_sink: Option<&SharedLogSink>,
-) {
-}
+fn drop_worker_capabilities(_module: &ModuleRuntime, _log_sink: Option<&SharedLogSink>) {}
 
 /// Returns the set of capabilities the worker process needs to retain after
 /// the per-worker drop.
@@ -438,9 +428,8 @@ mod capabilities_tests {
             // Granted in the test environment (rare): skip the assertion.
             return;
         }
-        let err = preflight_required_capabilities(&modules).expect_err(
-            "expect missing CAP_CHOWN to surface a remediation message",
-        );
+        let err = preflight_required_capabilities(&modules)
+            .expect_err("expect missing CAP_CHOWN to surface a remediation message");
         assert!(err.contains("CAP_CHOWN"), "error must name the capability");
         assert!(err.contains("systemd: AmbientCapabilities=CAP_CHOWN"));
         assert!(err.contains("setcap:"));

--- a/crates/daemon/src/daemon/sections/cli_args.rs
+++ b/crates/daemon/src/daemon/sections/cli_args.rs
@@ -169,4 +169,3 @@ where
 pub(crate) fn render_help(program_name: ProgramName) -> String {
     help_text(program_name.brand())
 }
-

--- a/crates/daemon/src/daemon/sections/config_helpers/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/tests.rs
@@ -367,7 +367,9 @@ mod config_helpers_tests {
         // value is a slot count.
         assert_eq!(
             parse_max_connections_directive("10"),
-            Some(MaxConnections::Limited(NonZeroU32::new(10).expect("non-zero")))
+            Some(MaxConnections::Limited(
+                NonZeroU32::new(10).expect("non-zero")
+            ))
         );
     }
 
@@ -402,7 +404,9 @@ mod config_helpers_tests {
         );
         assert_eq!(
             parse_max_connections_directive("10x"),
-            Some(MaxConnections::Limited(NonZeroU32::new(10).expect("non-zero")))
+            Some(MaxConnections::Limited(
+                NonZeroU32::new(10).expect("non-zero")
+            ))
         );
         assert_eq!(
             parse_max_connections_directive("-7 trailing"),
@@ -536,9 +540,8 @@ mod config_helpers_tests {
     /// production uses.
     #[test]
     fn hostname_glob_star_and_question_mark() {
-        let matches = |pattern: &str, host: &str| {
-            HostnamePattern::parse(pattern).unwrap().matches(host)
-        };
+        let matches =
+            |pattern: &str, host: &str| HostnamePattern::parse(pattern).unwrap().matches(host);
 
         assert!(matches("h?llo", "hello"));
         assert!(matches("h?llo", "hallo"));
@@ -589,7 +592,10 @@ mod config_helpers_tests {
             } else {
                 "www.example.com"
             };
-            assert!(pattern.matches(host), "token {token} failed to match {host}");
+            assert!(
+                pattern.matches(host),
+                "token {token} failed to match {host}"
+            );
         }
     }
 

--- a/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
@@ -130,10 +130,7 @@ pub(crate) fn parse_auth_user_list(value: &str) -> Result<Vec<AuthUser>, String>
     // upstream: authenticate.c:356 iterates this value with conf_strtok(), so a
     // leading comma opts the whole list into comma-only splitting and an entry
     // may then contain spaces (e.g. a group name like `@domain admins`).
-    let raw_entries: Vec<String> = conf_split(value)
-        .into_iter()
-        .map(str::to_owned)
-        .collect();
+    let raw_entries: Vec<String> = conf_split(value).into_iter().map(str::to_owned).collect();
 
     if raw_entries.is_empty() {
         return Err("must specify at least one username".to_owned());
@@ -504,8 +501,7 @@ mod conf_strtok_tests {
 
     #[test]
     fn auth_users_honours_the_leading_comma_form() {
-        let users = parse_auth_user_list(",domain admins,alice")
-            .expect("comma-only list parses");
+        let users = parse_auth_user_list(",domain admins,alice").expect("comma-only list parses");
         let names: Vec<&str> = users.iter().map(|u| u.username.as_str()).collect();
         assert_eq!(names, ["domain admins", "alice"]);
     }

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -94,14 +94,15 @@ fn apply_global_directive(
             // `open_no_attacker_symlinks()`. The daemon is typically root here,
             // so a symlink planted at any component of an operator-named motd
             // path would otherwise splice an arbitrary file into the greeting.
-            let contents = crate::daemon::operator_file::read_to_string(&motd_path).map_err(|error| {
-                let motd_display = motd_path.display();
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("failed to read motd file '{motd_display}': {error}"),
-                )
-            })?;
+            let contents =
+                crate::daemon::operator_file::read_to_string(&motd_path).map_err(|error| {
+                    let motd_display = motd_path.display();
+                    config_parse_error(
+                        path,
+                        line_number,
+                        format!("failed to read motd file '{motd_display}': {error}"),
+                    )
+                })?;
 
             // upstream: loadparm.c `motd_file` is a P_STRING slot written with
             // string_set(), so a second `motd file` directive replaces the
@@ -160,7 +161,12 @@ fn apply_global_directive(
             }
 
             let components = parse_config_bwlimit(value, path, line_number)?;
-            store_global_directive(&mut state.global_bwlimit, components, canonical, line_number);
+            store_global_directive(
+                &mut state.global_bwlimit,
+                components,
+                canonical,
+                line_number,
+            );
         }
         "secretsfile" => {
             let trimmed = value.trim();
@@ -325,7 +331,12 @@ fn apply_global_directive(
             // upstream: loadparm.c - `syslog tag` is P_LOCAL; the
             // global-section value seeds every module's inherited default.
             state.module_defaults.syslog_tag = Some(value.to_owned());
-            store_global_directive(&mut state.syslog_tag, value.to_owned(), canonical, line_number);
+            store_global_directive(
+                &mut state.syslog_tag,
+                value.to_owned(),
+                canonical,
+                line_number,
+            );
         }
         // upstream: loadparm.c - `address` sets the bind address for
         // the daemon listener.
@@ -338,14 +349,9 @@ fn apply_global_directive(
                 ));
             }
 
-            let parsed_addr = parse_bind_address(&OsString::from(value))
-                .map_err(|_| {
-                    config_parse_error(
-                        path,
-                        line_number,
-                        format!("invalid bind address '{value}'"),
-                    )
-                })?;
+            let parsed_addr = parse_bind_address(&OsString::from(value)).map_err(|_| {
+                config_parse_error(path, line_number, format!("invalid bind address '{value}'"))
+            })?;
 
             store_global_directive(&mut state.bind_address, parsed_addr, canonical, line_number);
         }
@@ -380,7 +386,11 @@ fn apply_global_directive(
                 ));
             }
             let gid = parse_gid_setting(value).map_err(|reason| {
-                config_parse_error(path, line_number, format!("invalid gid '{value}': {reason}"))
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid gid '{value}': {reason}"),
+                )
             })?;
             state.module_defaults.gid = Some(gid);
         }
@@ -396,7 +406,12 @@ fn apply_global_directive(
                 ));
             }
 
-            store_global_directive(&mut state.daemon_uid, value.to_owned(), canonical, line_number);
+            store_global_directive(
+                &mut state.daemon_uid,
+                value.to_owned(),
+                canonical,
+                line_number,
+            );
         }
         // upstream: clientserver.c:1500 `lp_daemon_gid` - `daemon gid` sets the
         // process-wide gid the listener drops to before the accept loop.
@@ -409,7 +424,12 @@ fn apply_global_directive(
                 ));
             }
 
-            store_global_directive(&mut state.daemon_gid, value.to_owned(), canonical, line_number);
+            store_global_directive(
+                &mut state.daemon_gid,
+                value.to_owned(),
+                canonical,
+                line_number,
+            );
         }
         // upstream: daemon-parm.txt - listen_backlog INTEGER, default 5.
         // Controls the backlog argument passed to listen(2).
@@ -547,11 +567,7 @@ fn apply_global_directive(
         }
         "timeout" => {
             let timeout = parse_timeout_seconds(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid timeout '{value}'"),
-                )
+                config_parse_error(path, line_number, format!("invalid timeout '{value}'"))
             })?;
             state.module_defaults.timeout = Some(timeout);
         }

--- a/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
@@ -98,18 +98,19 @@ fn include_config_file(
     // the parent's globals so modules declared in the included file inherit the
     // parent's P_LOCAL defaults (use chroot, hosts allow, secrets file, ...),
     // matching the shared `Vars` that `]push` copies (not resets).
-    let included = parse_config_modules_inner(include_path, stack, Some(state)).map_err(|error| {
-        // Wrap inner failures so the user sees both the directive site that
-        // triggered the include and the underlying parse error from the
-        // included file. Missing-file and recursive-include errors already
-        // name the offending path; this wrap adds the parent line context.
-        let display = include_path.display();
-        config_parse_error(
-            path,
-            line_number,
-            format!("failed to process '{directive} {display}': {error}"),
-        )
-    })?;
+    let included =
+        parse_config_modules_inner(include_path, stack, Some(state)).map_err(|error| {
+            // Wrap inner failures so the user sees both the directive site that
+            // triggered the include and the underlying parse error from the
+            // included file. Missing-file and recursive-include errors already
+            // name the offending path; this wrap adds the parent line context.
+            let display = include_path.display();
+            config_parse_error(
+                path,
+                line_number,
+                format!("failed to process '{directive} {display}': {error}"),
+            )
+        })?;
 
     if manage_globals {
         // `&include`: `]pop` restores the parent's globals afterwards, so the

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -174,17 +174,17 @@ fn apply_module_directive(
         }
         "gid" => {
             let gid = parse_gid_setting(value).map_err(|reason| {
-                config_parse_error(path, line_number, format!("invalid gid '{value}': {reason}"))
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid gid '{value}': {reason}"),
+                )
             })?;
             builder.set_gid(gid);
         }
         "timeout" => {
             let timeout = parse_timeout_seconds(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid timeout '{value}'"),
-                )
+                config_parse_error(path, line_number, format!("invalid timeout '{value}'"))
             })?;
             builder.set_timeout(timeout);
         }

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -201,9 +201,7 @@ fn parse_config_modules_inner(
             // them to the global-directive handler rather than the per-module
             // setter so the recursive include works after a `[name]` line.
             let is_amp_directive = key.starts_with('&');
-            if !is_amp_directive
-                && let Some(index) = current
-            {
+            if !is_amp_directive && let Some(index) = current {
                 apply_module_directive(
                     &mut pending[index].builder,
                     &key,
@@ -223,7 +221,15 @@ fn parse_config_modules_inner(
                 flush_pending_modules(&mut pending, &mut state);
             }
 
-            apply_global_directive(&mut state, &key, value, path, line_number, &canonical, stack)?;
+            apply_global_directive(
+                &mut state,
+                &key,
+                value,
+                path,
+                line_number,
+                &canonical,
+                stack,
+            )?;
         }
 
         flush_pending_modules(&mut pending, &mut state);

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -28,10 +28,10 @@ mod config_parsing_tests {
         }
     }
 
-
     #[test]
     fn resolve_config_relative_path_absolute() {
-        let result = resolve_config_relative_path(Path::new("/etc/rsyncd.conf"), "/var/run/rsync.pid");
+        let result =
+            resolve_config_relative_path(Path::new("/etc/rsyncd.conf"), "/var/run/rsync.pid");
         assert_eq!(result, PathBuf::from("/var/run/rsync.pid"));
     }
 
@@ -43,7 +43,8 @@ mod config_parsing_tests {
 
     #[test]
     fn resolve_config_relative_path_nested() {
-        let result = resolve_config_relative_path(Path::new("/etc/rsync/main.conf"), "sub/file.txt");
+        let result =
+            resolve_config_relative_path(Path::new("/etc/rsync/main.conf"), "sub/file.txt");
         assert_eq!(result, PathBuf::from("/etc/rsync/sub/file.txt"));
     }
 
@@ -52,7 +53,6 @@ mod config_parsing_tests {
         let result = resolve_config_relative_path(Path::new("config.conf"), "relative.txt");
         assert_eq!(result, PathBuf::from("relative.txt"));
     }
-
 
     #[test]
     fn parse_empty_config() {
@@ -118,7 +118,10 @@ mod config_parsing_tests {
         let dir = TempDir::new().expect("create temp dir");
         let mpath = dir.path().join("data");
         fs::create_dir(&mpath).expect("create module dir");
-        let config = format!("[Global]\ntimeout = 30\n[mod]\npath = {}\n", mpath.display());
+        let config = format!(
+            "[Global]\ntimeout = 30\n[mod]\npath = {}\n",
+            mpath.display()
+        );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert_eq!(result.modules.len(), 1, "[global] must not create a module");
@@ -147,7 +150,10 @@ mod config_parsing_tests {
         let config = format!("[mod]\npath = {}/\n", mpath.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
-        assert_eq!(result.modules[0].path, mpath, "trailing slash must be stripped");
+        assert_eq!(
+            result.modules[0].path, mpath,
+            "trailing slash must be stripped"
+        );
     }
 
     #[test]
@@ -157,10 +163,7 @@ mod config_parsing_tests {
         let dir = TempDir::new().expect("create temp dir");
         let mpath = dir.path().join("data");
         fs::create_dir(&mpath).expect("create module dir");
-        let config = format!(
-            "[mod]\npath = {}\nsyslog facility = 17\n",
-            mpath.display()
-        );
+        let config = format!("[mod]\npath = {}\nsyslog facility = 17\n", mpath.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert_eq!(result.modules[0].syslog_facility.as_deref(), Some("17"));
@@ -222,7 +225,6 @@ mod config_parsing_tests {
         assert_eq!(result.modules.len(), 1);
     }
 
-
     #[test]
     fn parse_missing_equals() {
         let file = write_config("[module]\npath /tmp\n");
@@ -237,7 +239,6 @@ mod config_parsing_tests {
         assert!(result.modules.is_empty());
     }
 
-
     #[test]
     fn parse_global_pid_file() {
         let file = write_config("pid file = /var/run/rsync.pid\n");
@@ -251,7 +252,16 @@ mod config_parsing_tests {
     fn parse_global_reverse_lookup_true() {
         let file = write_config("reverse lookup = yes\n");
         let result = parse_config_modules(file.path()).expect("parse succeeds");
-        assert_eq!(result.reverse_lookup, Some((true, ConfigDirectiveOrigin { path: file.path().canonicalize().unwrap(), line: 1 })));
+        assert_eq!(
+            result.reverse_lookup,
+            Some((
+                true,
+                ConfigDirectiveOrigin {
+                    path: file.path().canonicalize().unwrap(),
+                    line: 1
+                }
+            ))
+        );
     }
 
     #[test]
@@ -292,7 +302,6 @@ mod config_parsing_tests {
         assert_eq!(value, "a+r");
     }
 
-
     #[test]
     fn parse_inline_motd() {
         let file = write_config("motd = Welcome to rsync\n");
@@ -309,7 +318,6 @@ mod config_parsing_tests {
         assert_eq!(result.motd_lines.len(), 3);
         assert_eq!(result.motd_lines[0], "Line 1");
     }
-
 
     #[test]
     fn parse_module_read_only() {
@@ -435,7 +443,6 @@ mod config_parsing_tests {
         );
     }
 
-
     /// A bare global `include` is the P_LOCAL include-filter parameter
     /// (daemon-parm.txt Locals; loadparm.c via daemon-parm.h), NOT file
     /// inclusion - upstream reserves `&include` for pulling in another file
@@ -521,7 +528,10 @@ mod config_parsing_tests {
             2,
             "global hosts allow must propagate into included module",
         );
-        assert!(included_mod.read_only, "module's own read only must be honoured");
+        assert!(
+            included_mod.read_only,
+            "module's own read only must be honoured"
+        );
     }
 
     #[test]
@@ -819,7 +829,6 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("recursive include"));
     }
 
-
     #[test]
     fn parse_empty_path_errors() {
         let file = write_config("[mod]\npath = \n");
@@ -852,7 +861,6 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("must not be empty"));
     }
 
-
     /// upstream: loadparm.c:379-470 do_parameter() assigns the parameter slot
     /// unconditionally, so a repeated global directive keeps its last value
     /// instead of aborting the load.
@@ -876,7 +884,6 @@ mod config_parsing_tests {
         assert!(!reverse_lookup);
     }
 
-
     #[test]
     fn parse_invalid_boolean_keeps_default() {
         // upstream: loadparm.c:418-423 - a badly formed boolean warns and
@@ -886,7 +893,6 @@ mod config_parsing_tests {
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(result.modules[0].read_only);
     }
-
 
     #[test]
     fn parse_keys_case_insensitive() {
@@ -900,7 +906,6 @@ mod config_parsing_tests {
         assert_eq!(result.modules.len(), 1);
         assert!(!result.modules[0].read_only);
     }
-
 
     #[test]
     fn parse_module_munge_symlinks_yes() {
@@ -958,13 +963,10 @@ mod config_parsing_tests {
 
     #[test]
     fn parse_module_munge_symlinks_duplicate_last_wins() {
-        let file = write_config(
-            "[mod]\npath = /tmp\nmunge symlinks = yes\nmunge symlinks = no\n",
-        );
+        let file = write_config("[mod]\npath = /tmp\nmunge symlinks = yes\nmunge symlinks = no\n");
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert_eq!(result.modules[0].munge_symlinks, Some(false));
     }
-
 
     #[test]
     fn parse_module_max_verbosity() {
@@ -1036,10 +1038,7 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!(
-            "[mod]\npath = {}\ntransfer logging = yes\n",
-            path.display()
-        );
+        let config = format!("[mod]\npath = {}\ntransfer logging = yes\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(result.modules[0].transfer_logging);
@@ -1057,10 +1056,7 @@ mod config_parsing_tests {
         );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
-        assert_eq!(
-            result.modules[0].log_format.as_deref(),
-            Some("%o %h %f %l")
-        );
+        assert_eq!(result.modules[0].log_format.as_deref(), Some("%o %h %f %l"));
     }
 
     #[test]
@@ -1162,10 +1158,7 @@ mod config_parsing_tests {
         let config = format!("[mod]\npath = {}\ntemp dir = /tmp/rsync\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
-        assert_eq!(
-            result.modules[0].temp_dir.as_deref(),
-            Some("/tmp/rsync")
-        );
+        assert_eq!(result.modules[0].temp_dir.as_deref(), Some("/tmp/rsync"));
     }
 
     #[test]
@@ -1186,10 +1179,7 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!(
-            "[mod]\npath = {}\nforward lookup = no\n",
-            path.display()
-        );
+        let config = format!("[mod]\npath = {}\nforward lookup = no\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(!result.modules[0].forward_lookup);
@@ -1206,7 +1196,6 @@ mod config_parsing_tests {
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(result.modules[0].forward_lookup);
     }
-
 
     #[test]
     fn parse_module_insecure_links_yes() {
@@ -1263,10 +1252,7 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!(
-            "[mod]\npath = {}\nstrict modes = yes\n",
-            path.display()
-        );
+        let config = format!("[mod]\npath = {}\nstrict modes = yes\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(result.modules[0].strict_modes);
@@ -1278,10 +1264,7 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!(
-            "[mod]\npath = {}\nstrict modes = no\n",
-            path.display()
-        );
+        let config = format!("[mod]\npath = {}\nstrict modes = no\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(!result.modules[0].strict_modes);
@@ -1305,10 +1288,7 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!(
-            "[mod]\npath = {}\nstrict modes = false\n",
-            path.display()
-        );
+        let config = format!("[mod]\npath = {}\nstrict modes = false\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(!result.modules[0].strict_modes);
@@ -1326,13 +1306,10 @@ mod config_parsing_tests {
 
     #[test]
     fn parse_module_strict_modes_duplicate_last_wins() {
-        let file = write_config(
-            "[mod]\npath = /tmp\nstrict modes = yes\nstrict modes = no\n",
-        );
+        let file = write_config("[mod]\npath = /tmp\nstrict modes = yes\nstrict modes = no\n");
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(!result.modules[0].strict_modes);
     }
-
 
     #[test]
     fn parse_module_open_noatime_yes() {
@@ -1340,10 +1317,7 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!(
-            "[mod]\npath = {}\nopen noatime = yes\n",
-            path.display()
-        );
+        let config = format!("[mod]\npath = {}\nopen noatime = yes\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(result.modules[0].open_noatime);
@@ -1355,10 +1329,7 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!(
-            "[mod]\npath = {}\nopen noatime = no\n",
-            path.display()
-        );
+        let config = format!("[mod]\npath = {}\nopen noatime = no\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(!result.modules[0].open_noatime);
@@ -1387,9 +1358,7 @@ mod config_parsing_tests {
 
     #[test]
     fn parse_module_open_noatime_duplicate_last_wins() {
-        let file = write_config(
-            "[mod]\npath = /tmp\nopen noatime = yes\nopen noatime = no\n",
-        );
+        let file = write_config("[mod]\npath = /tmp\nopen noatime = yes\nopen noatime = no\n");
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         assert!(!result.modules[0].open_noatime);
     }
@@ -1452,14 +1421,12 @@ mod config_parsing_tests {
         assert!(!module.forward_lookup);
     }
 
-
     #[test]
     fn parse_nonexistent_config() {
-        let err = parse_config_modules(Path::new("/nonexistent/config.conf"))
-            .expect_err("should fail");
+        let err =
+            parse_config_modules(Path::new("/nonexistent/config.conf")).expect_err("should fail");
         assert!(err.to_string().contains("failed to"));
     }
-
 
     #[test]
     fn global_directives_before_modules_apply_as_defaults() {
@@ -1491,18 +1458,12 @@ mod config_parsing_tests {
             result.modules[0].incoming_chmod.as_deref(),
             Some("Dg+s,ug+w")
         );
-        assert_eq!(
-            result.modules[0].outgoing_chmod.as_deref(),
-            Some("Fo-w,+X")
-        );
+        assert_eq!(result.modules[0].outgoing_chmod.as_deref(), Some("Fo-w,+X"));
         assert_eq!(
             result.modules[1].incoming_chmod.as_deref(),
             Some("Dg+s,ug+w")
         );
-        assert_eq!(
-            result.modules[1].outgoing_chmod.as_deref(),
-            Some("Fo-w,+X")
-        );
+        assert_eq!(result.modules[1].outgoing_chmod.as_deref(), Some("Fo-w,+X"));
     }
 
     #[test]
@@ -1960,7 +1921,7 @@ mod config_parsing_tests {
 
         assert_eq!(result.modules.len(), 2);
         assert!(!result.modules[0].use_chroot); // inherits global false
-        assert!(result.modules[1].use_chroot);  // overridden to true per-module
+        assert!(result.modules[1].use_chroot); // overridden to true per-module
     }
 
     #[test]
@@ -1976,7 +1937,6 @@ mod config_parsing_tests {
         // No global 'use chroot' directive - default is true
         assert!(result.modules[0].use_chroot);
     }
-
 
     #[test]
     fn exclude_from_and_include_from_default_to_none() {
@@ -2051,7 +2011,10 @@ mod config_parsing_tests {
         let result = parse_config_modules(file.path()).expect("parse succeeds");
 
         assert_eq!(result.modules.len(), 1);
-        let exclude_from = result.modules[0].exclude_from.as_ref().expect("exclude_from set");
+        let exclude_from = result.modules[0]
+            .exclude_from
+            .as_ref()
+            .expect("exclude_from set");
         let config_dir = file.path().canonicalize().unwrap();
         let expected = config_dir.parent().unwrap().join("excludes.txt");
         assert_eq!(*exclude_from, expected);
@@ -2071,7 +2034,10 @@ mod config_parsing_tests {
         let result = parse_config_modules(file.path()).expect("parse succeeds");
 
         assert_eq!(result.modules.len(), 1);
-        let include_from = result.modules[0].include_from.as_ref().expect("include_from set");
+        let include_from = result.modules[0]
+            .include_from
+            .as_ref()
+            .expect("include_from set");
         let config_dir = file.path().canonicalize().unwrap();
         let expected = config_dir.parent().unwrap().join("includes.txt");
         assert_eq!(*include_from, expected);
@@ -2111,10 +2077,7 @@ mod config_parsing_tests {
         let module_path = dir.path().join("data");
         fs::create_dir(&module_path).expect("create dir");
 
-        let config = format!(
-            "[mod]\npath = {}\nexclude from =\n",
-            module_path.display()
-        );
+        let config = format!("[mod]\npath = {}\nexclude from =\n", module_path.display());
         let file = write_config(&config);
         let err = parse_config_modules(file.path()).expect_err("should fail on empty");
         assert!(err.to_string().contains("exclude from"));
@@ -2126,10 +2089,7 @@ mod config_parsing_tests {
         let module_path = dir.path().join("data");
         fs::create_dir(&module_path).expect("create dir");
 
-        let config = format!(
-            "[mod]\npath = {}\ninclude from =\n",
-            module_path.display()
-        );
+        let config = format!("[mod]\npath = {}\ninclude from =\n", module_path.display());
         let file = write_config(&config);
         let err = parse_config_modules(file.path()).expect_err("should fail on empty");
         assert!(err.to_string().contains("include from"));
@@ -2201,7 +2161,6 @@ mod config_parsing_tests {
         );
         assert!(result.modules[1].exclude_from.is_none());
     }
-
 
     #[test]
     fn parse_syslog_facility_global_directive() {
@@ -2289,7 +2248,10 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!("[mod]\npath = {}\nsyslog facility = bogus\n", path.display());
+        let config = format!(
+            "[mod]\npath = {}\nsyslog facility = bogus\n",
+            path.display()
+        );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         let module = result
@@ -2388,7 +2350,6 @@ mod config_parsing_tests {
         assert_eq!(result.modules[0].syslog_facility.as_deref(), Some("local3"));
     }
 
-
     #[test]
     fn parse_syslog_tag_global_directive() {
         let file = write_config(&format!(
@@ -2474,7 +2435,6 @@ mod config_parsing_tests {
         assert_eq!(tag, "backup-daemon");
     }
 
-
     #[test]
     fn parse_address_ipv4() {
         let file = write_config("address = 192.168.1.100\n");
@@ -2503,7 +2463,10 @@ mod config_parsing_tests {
         let file = write_config("address =\n");
         let err = parse_config_modules(file.path()).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("'address' directive must not be empty"), "{msg}");
+        assert!(
+            msg.contains("'address' directive must not be empty"),
+            "{msg}"
+        );
     }
 
     #[test]
@@ -2529,7 +2492,6 @@ mod config_parsing_tests {
         let (addr, _) = result.bind_address.expect("should have bind_address");
         assert_eq!(addr, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
     }
-
 
     #[test]
     fn parse_socket_options_single_option() {
@@ -2560,8 +2522,7 @@ mod config_parsing_tests {
 
     #[test]
     fn parse_socket_options_duplicate_same_value_accepted() {
-        let file =
-            write_config("socket options = SO_KEEPALIVE\nsocket options = SO_KEEPALIVE\n");
+        let file = write_config("socket options = SO_KEEPALIVE\nsocket options = SO_KEEPALIVE\n");
         let result = parse_config_modules(file.path()).expect("identical duplicates accepted");
         let (opts, _) = result.socket_options.expect("should have socket_options");
         assert_eq!(opts, "SO_KEEPALIVE");
@@ -2569,8 +2530,7 @@ mod config_parsing_tests {
 
     #[test]
     fn parse_socket_options_duplicate_different_value_last_wins() {
-        let file =
-            write_config("socket options = SO_KEEPALIVE\nsocket options = TCP_NODELAY\n");
+        let file = write_config("socket options = SO_KEEPALIVE\nsocket options = TCP_NODELAY\n");
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         let (opts, _) = result.socket_options.expect("should have socket_options");
         assert_eq!(opts, "TCP_NODELAY");
@@ -2604,10 +2564,7 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!(
-            "proxy protocol = yes\n[mod]\npath = {}\n",
-            path.display()
-        );
+        let config = format!("proxy protocol = yes\n[mod]\npath = {}\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         let (enabled, _) = result.proxy_protocol.expect("should have proxy_protocol");
@@ -2620,10 +2577,7 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!(
-            "proxy protocol = no\n[mod]\npath = {}\n",
-            path.display()
-        );
+        let config = format!("proxy protocol = no\n[mod]\npath = {}\n", path.display());
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         let (enabled, _) = result.proxy_protocol.expect("should have proxy_protocol");
@@ -2648,7 +2602,10 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!("daemon chroot = /var/chroot\n[mod]\npath = {}\n", path.display());
+        let config = format!(
+            "daemon chroot = /var/chroot\n[mod]\npath = {}\n",
+            path.display()
+        );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
         let (chroot_path, _) = result.daemon_chroot.expect("should have daemon_chroot");
@@ -2678,7 +2635,6 @@ mod config_parsing_tests {
         let result = parse_config_modules(file.path());
         assert!(result.is_err());
     }
-
 
     #[test]
     fn parse_module_filter_single_rule() {
@@ -2743,10 +2699,7 @@ mod config_parsing_tests {
         );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
-        assert_eq!(
-            result.modules[0].exclude,
-            vec!["*.log", "*.tmp", "/cache/"]
-        );
+        assert_eq!(result.modules[0].exclude, vec!["*.log", "*.tmp", "/cache/"]);
     }
 
     #[test]
@@ -2805,7 +2758,6 @@ mod config_parsing_tests {
         assert_eq!(result.modules[0].exclude, vec!["*.tmp"]);
         assert!(result.modules[1].exclude.is_empty());
     }
-
 
     #[test]
     fn parse_global_rsync_port() {
@@ -2961,7 +2913,10 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!("[mod]\npath = {}\nlog file = rsync-mod.log\n", path.display());
+        let config = format!(
+            "[mod]\npath = {}\nlog file = rsync-mod.log\n",
+            path.display()
+        );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).unwrap();
         let log_file = result.modules[0].log_file.as_ref().expect("log_file set");
@@ -3436,7 +3391,10 @@ mod config_parsing_tests {
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
-        let config = format!("daemon uid = 0\ndaemon gid = 0\n[mod]\npath = {}\n", path.display());
+        let config = format!(
+            "daemon uid = 0\ndaemon gid = 0\n[mod]\npath = {}\n",
+            path.display()
+        );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
 
@@ -3444,7 +3402,10 @@ mod config_parsing_tests {
             result.modules[0].uid, None,
             "`daemon uid` is P_GLOBAL and must not seed the per-module uid default",
         );
-        assert_eq!(result.modules[0].gid, None, "`daemon gid` must not seed module gid");
+        assert_eq!(
+            result.modules[0].gid, None,
+            "`daemon gid` must not seed module gid"
+        );
         assert!(
             result.daemon_uid.is_some(),
             "`daemon uid` must arm the process-wide daemon drop",
@@ -3782,8 +3743,7 @@ mod config_parsing_tests {
     fn parse_quic_cert_file_resolves_relative_to_config_dir() {
         let dir = TempDir::new().expect("create temp dir");
         let config_path = dir.path().join("rsyncd.conf");
-        std::fs::write(&config_path, "quic cert file = quic/server.pem\n")
-            .expect("write config");
+        std::fs::write(&config_path, "quic cert file = quic/server.pem\n").expect("write config");
 
         let result = parse_config_modules(&config_path).expect("parse succeeds");
         let (cert, _) = result.quic_cert_file.expect("quic cert file stored");

--- a/crates/daemon/src/daemon/sections/config_paths.rs
+++ b/crates/daemon/src/daemon/sections/config_paths.rs
@@ -16,9 +16,10 @@ where
 
     let text = argument.to_string_lossy();
     if let Some(rest) = text.strip_prefix(option)
-        && let Some(value) = rest.strip_prefix('=') {
-            return Ok(Some(OsString::from(value)));
-        }
+        && let Some(value) = rest.strip_prefix('=')
+    {
+        return Ok(Some(OsString::from(value)));
+    }
 
     Ok(None)
 }
@@ -31,9 +32,10 @@ fn config_argument_present(arguments: &[OsString]) -> bool {
 
         let text = argument.to_string_lossy();
         if let Some(rest) = text.strip_prefix("--config")
-            && rest.starts_with('=') {
-                return true;
-            }
+            && rest.starts_with('=')
+        {
+            return true;
+        }
     }
 
     false

--- a/crates/daemon/src/daemon/sections/greeting.rs
+++ b/crates/daemon/src/daemon/sections/greeting.rs
@@ -159,8 +159,8 @@ mod greeting_validation_tests {
         ] {
             assert_eq!(
                 reject_malformed_client_greeting(not_a_banner)
-                .map(|e| e.to_string())
-                .as_deref(),
+                    .map(|e| e.to_string())
+                    .as_deref(),
                 Some("@ERROR: protocol startup error"),
                 "not a version banner: {not_a_banner:?}"
             );

--- a/crates/daemon/src/daemon/sections/hardening.rs
+++ b/crates/daemon/src/daemon/sections/hardening.rs
@@ -54,9 +54,8 @@ fn apply_no_new_privs(log_sink: Option<&SharedLogSink>) {
         }
         Err(err) => {
             if let Some(log) = log_sink {
-                let text = format!(
-                    "PR_SET_NO_NEW_PRIVS prctl failed: {err}; continuing without it"
-                );
+                let text =
+                    format!("PR_SET_NO_NEW_PRIVS prctl failed: {err}; continuing without it");
                 let message = rsync_warning!(text).with_role(Role::Daemon);
                 log_message(log, &message);
             }
@@ -181,9 +180,8 @@ mod hardening_tests {
         let captured = drain_capture(reader);
 
         assert!(
-            captured.contains(
-                "active Linux Security Modules: lockdown,capability,landlock,yama,bpf"
-            ),
+            captured
+                .contains("active Linux Security Modules: lockdown,capability,landlock,yama,bpf"),
             "expected trimmed LSM list in log output, got: {captured:?}",
         );
     }

--- a/crates/daemon/src/daemon/sections/log_format.rs
+++ b/crates/daemon/src/daemon/sections/log_format.rs
@@ -171,7 +171,6 @@ mod log_format_tests {
         }
     }
 
-
     #[test]
     fn transfer_operation_send_str() {
         assert_eq!(TransferOperation::Send.as_str(), "send");
@@ -214,12 +213,10 @@ mod log_format_tests {
         assert!(debug.contains("Send"));
     }
 
-
     #[test]
     fn default_log_format_matches_upstream() {
         assert_eq!(DEFAULT_LOG_FORMAT, "%o %h [%a] %m (%u) %f %l");
     }
-
 
     #[test]
     fn expand_operation() {
@@ -305,7 +302,6 @@ mod log_format_tests {
         assert_eq!(expand_log_format("%%", &ctx), "%");
     }
 
-
     #[test]
     fn expand_default_format() {
         let ctx = sample_context();
@@ -316,7 +312,6 @@ mod log_format_tests {
         );
     }
 
-
     #[test]
     fn expand_recv_operation() {
         let mut ctx = sample_context();
@@ -324,7 +319,6 @@ mod log_format_tests {
         let result = expand_log_format("%o", &ctx);
         assert_eq!(result, "recv");
     }
-
 
     #[test]
     fn expand_empty_format() {
@@ -335,10 +329,7 @@ mod log_format_tests {
     #[test]
     fn expand_no_escapes() {
         let ctx = sample_context();
-        assert_eq!(
-            expand_log_format("plain text", &ctx),
-            "plain text"
-        );
+        assert_eq!(expand_log_format("plain text", &ctx), "plain text");
     }
 
     #[test]
@@ -385,10 +376,7 @@ mod log_format_tests {
     fn expand_large_file_length() {
         let mut ctx = sample_context();
         ctx.file_length = u64::MAX;
-        assert_eq!(
-            expand_log_format("%l", &ctx),
-            u64::MAX.to_string()
-        );
+        assert_eq!(expand_log_format("%l", &ctx), u64::MAX.to_string());
     }
 
     #[test]
@@ -405,7 +393,6 @@ mod log_format_tests {
         let result = expand_log_format("%i %o %f %l %b", &ctx);
         assert_eq!(result, ">f+++++++++ send docs/report.pdf 1048576 524288");
     }
-
 
     #[test]
     fn effective_log_format_uses_module_setting() {
@@ -426,7 +413,6 @@ mod log_format_tests {
         };
         assert_eq!(effective_log_format(&module), DEFAULT_LOG_FORMAT);
     }
-
 
     #[test]
     fn push_u64_zero() {

--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -114,9 +114,7 @@ impl AuthDenial {
     pub(crate) fn log_suffix(&self) -> Option<String> {
         match self {
             Self::Credentials => None,
-            Self::UserRule { user, rule } => {
-                Some(format!(" for {user}: {}", rule.reason()))
-            }
+            Self::UserRule { user, rule } => Some(format!(" for {user}: {}", rule.reason())),
             Self::DigestFloorUnsupported { configured } => Some(format!(
                 ": the configured 'auth digest = {configured}' is not a supported digest on this build"
             )),
@@ -270,7 +268,7 @@ fn perform_module_authentication(
     let auth_match = match module.get_auth_user(username) {
         Some(matched) => matched,
         None => {
-                // upstream: authenticate.c:412 - the rule scan ended with no token,
+            // upstream: authenticate.c:412 - the rule scan ended with no token,
             // so `err = "no matching rule"`.
             return Ok(AuthenticationStatus::Denied(AuthDenial::UserRule {
                 user: username.to_owned(),
@@ -289,7 +287,14 @@ fn perform_module_authentication(
     // because upstream keys the `@group:` secrets lookup off the real group.
     let auth_group = auth_match.group.as_deref();
 
-    if !verify_secret_response(module, username, auth_group, &challenge, response_digest, digest)? {
+    if !verify_secret_response(
+        module,
+        username,
+        auth_group,
+        &challenge,
+        response_digest,
+        digest,
+    )? {
         return Ok(AuthenticationStatus::Denied(AuthDenial::Credentials));
     }
 
@@ -430,4 +435,3 @@ fn verify_secret_response(
 fn check_secrets_file_permissions(path: &Path) -> io::Result<()> {
     platform::secrets::check_secrets_file_permissions(path)
 }
-

--- a/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
@@ -29,9 +29,8 @@ fn unbackslash_arg(s: &str) -> String {
     // upstream: `unbackslash_arg` operates on a C string in place; we walk
     // the original UTF-8 bytes and only drop ASCII backslashes that precede
     // another byte, so the result remains valid UTF-8 whenever the input was.
-    String::from_utf8(out).unwrap_or_else(|err| {
-        String::from_utf8_lossy(err.as_bytes()).into_owned()
-    })
+    String::from_utf8(out)
+        .unwrap_or_else(|err| String::from_utf8_lossy(err.as_bytes()).into_owned())
 }
 
 /// Merges secluded-args phase 1 (cmdline) and phase 2 (stdin) arg lists.

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -172,19 +172,28 @@ fn apply_long_form_args(
             // upstream: options.c:2933-2941 - reference directories
             "--compare-dest" => {
                 if let Some(dir) = client_args.get(i + 1) {
-                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Compare, std::path::PathBuf::from(dir)));
+                    config.reference_directories.push(ReferenceDirectory::new(
+                        ReferenceDirectoryKind::Compare,
+                        std::path::PathBuf::from(dir),
+                    ));
                     i += 1;
                 }
             }
             "--copy-dest" => {
                 if let Some(dir) = client_args.get(i + 1) {
-                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Copy, std::path::PathBuf::from(dir)));
+                    config.reference_directories.push(ReferenceDirectory::new(
+                        ReferenceDirectoryKind::Copy,
+                        std::path::PathBuf::from(dir),
+                    ));
                     i += 1;
                 }
             }
             "--link-dest" => {
                 if let Some(dir) = client_args.get(i + 1) {
-                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Link, std::path::PathBuf::from(dir)));
+                    config.reference_directories.push(ReferenceDirectory::new(
+                        ReferenceDirectoryKind::Link,
+                        std::path::PathBuf::from(dir),
+                    ));
                     i += 1;
                 }
             }
@@ -298,7 +307,8 @@ fn apply_long_form_args(
                 // files within the window are not needlessly re-transferred.
                 } else if let Some(val) = arg.strip_prefix("--modify-window=") {
                     if let Ok(n) = val.trim_start_matches('+').parse::<i64>() {
-                        config.file_selection.modify_window = ::metadata::ModifyWindow::from_secs(n);
+                        config.file_selection.modify_window =
+                            ::metadata::ModifyWindow::from_secs(n);
                     }
                 // upstream: options.c:2953-2954 - the client forwards the block
                 // size as a standalone `-B%u` token, and options.c:1795-1805
@@ -318,7 +328,8 @@ fn apply_long_form_args(
                 // nanosecond-exact comparison (util1.c:1482).
                 } else if let Some(val) = arg.strip_prefix("-@") {
                     if let Ok(n) = val.parse::<i64>() {
-                        config.file_selection.modify_window = ::metadata::ModifyWindow::from_secs(n);
+                        config.file_selection.modify_window =
+                            ::metadata::ModifyWindow::from_secs(n);
                     }
                 // Fallback: =value format for reference directories and backup options.
                 // Handles both upstream (two-arg) and legacy (=value) formats.
@@ -330,11 +341,20 @@ fn apply_long_form_args(
                 } else if let Some(suffix) = arg.strip_prefix("--backup-suffix=") {
                     config.backup_suffix = Some(suffix.to_owned());
                 } else if let Some(dir) = arg.strip_prefix("--link-dest=") {
-                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Link, std::path::PathBuf::from(dir)));
+                    config.reference_directories.push(ReferenceDirectory::new(
+                        ReferenceDirectoryKind::Link,
+                        std::path::PathBuf::from(dir),
+                    ));
                 } else if let Some(dir) = arg.strip_prefix("--compare-dest=") {
-                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Compare, std::path::PathBuf::from(dir)));
+                    config.reference_directories.push(ReferenceDirectory::new(
+                        ReferenceDirectoryKind::Compare,
+                        std::path::PathBuf::from(dir),
+                    ));
                 } else if let Some(dir) = arg.strip_prefix("--copy-dest=") {
-                    config.reference_directories.push(ReferenceDirectory::new(ReferenceDirectoryKind::Copy, std::path::PathBuf::from(dir)));
+                    config.reference_directories.push(ReferenceDirectory::new(
+                        ReferenceDirectoryKind::Copy,
+                        std::path::PathBuf::from(dir),
+                    ));
                 } else if let Some(dir) = arg.strip_prefix("--temp-dir=") {
                     config.temp_dir = Some(std::path::PathBuf::from(dir));
                 } else if let Some(dir) = arg.strip_prefix("--partial-dir=") {
@@ -456,8 +476,9 @@ fn parse_transfer_size_limit(opt_name: &str, value: &str) -> Result<u64, String>
         Ok(parsed) if parsed.bytes as f64 >= SIZE_MAX_AS_DOUBLE => {
             Err(size_arg_error(opt_name, value, "too large"))
         }
-        Ok(parsed) => u64::try_from(parsed.bytes)
-            .map_err(|_| size_arg_error(opt_name, value, "too large")),
+        Ok(parsed) => {
+            u64::try_from(parsed.bytes).map_err(|_| size_arg_error(opt_name, value, "too large"))
+        }
         Err(::core::bandwidth::SizeArgError::Invalid) => {
             Err(size_arg_error(opt_name, value, "invalid"))
         }
@@ -500,5 +521,8 @@ fn size_arg_error(opt_name: &str, value: &str, reason: &str) -> String {
 /// - `options.c:1444-1449` - daemon-mode unknown option error path
 fn is_client_only_flag_reaching_daemon(arg: &str) -> bool {
     let bare = arg.split('=').next().unwrap_or(arg);
-    matches!(bare, "--write-batch" | "--only-write-batch" | "--read-batch")
+    matches!(
+        bare,
+        "--write-batch" | "--only-write-batch" | "--read-batch"
+    )
 }

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -335,9 +335,10 @@ fn expand_sender_source_globs(
     let mut out = Vec::with_capacity(sources.len());
     for path in sources {
         match path.strip_prefix(module_path) {
-            Ok(rel) if rel.components().any(|c| {
-                matches!(c, std::path::Component::Normal(s) if path_has_glob_metachar(s))
-            }) =>
+            Ok(rel)
+                if rel.components().any(
+                    |c| matches!(c, std::path::Component::Normal(s) if path_has_glob_metachar(s)),
+                ) =>
             {
                 let matches = expand_relative_glob(module_path, rel);
                 if matches.is_empty() {

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -168,20 +168,24 @@ fn build_server_config(
     // rejection to represent. Upstream has no such daemon error either - a
     // traversing tail is rewritten and served (util1.c:1183).
     let positional_args: Vec<OsString> = if role == ServerRole::Receiver {
-        let dest = resolve_receiver_dest(std::path::Path::new(&module.path), client_args, &module.name);
+        let dest = resolve_receiver_dest(
+            std::path::Path::new(&module.path),
+            client_args,
+            &module.name,
+        );
         vec![OsString::from(dest.as_os_str())]
     } else {
-        resolve_sender_sources(std::path::Path::new(&module.path), client_args, &module.name)
-            .into_iter()
-            .map(|p| OsString::from(p.as_os_str()))
-            .collect()
+        resolve_sender_sources(
+            std::path::Path::new(&module.path),
+            client_args,
+            &module.name,
+        )
+        .into_iter()
+        .map(|p| OsString::from(p.as_os_str()))
+        .collect()
     };
 
-    match ServerConfig::from_flag_string_and_args(
-        role,
-        flag_string,
-        positional_args,
-    ) {
+    match ServerConfig::from_flag_string_and_args(role, flag_string, positional_args) {
         Ok(mut cfg) => {
             // upstream: clientserver.c:1141 `limit_output_verbosity(lp_max_verbosity(i))`
             // caps the per-connection log verbosity once the module is selected.

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -296,7 +296,14 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
     // Prefixes that start a new rule token when found after whitespace.
     const SHORT_PREFIXES: &[&str] = &["+ ", "- ", "+/", "-/"];
     const KEYWORD_PREFIXES: &[&str] = &[
-        "include ", "exclude ", "hide ", "show ", "protect ", "risk ", "clear ", "merge ",
+        "include ",
+        "exclude ",
+        "hide ",
+        "show ",
+        "protect ",
+        "risk ",
+        "clear ",
+        "merge ",
         "dir-merge ",
     ];
 
@@ -372,10 +379,10 @@ fn parse_daemon_filter_token(token: &str) -> Option<FilterRuleWireFormat> {
     const KEYWORDS: &[(&str, bool, bool, bool)] = &[
         ("exclude", false, false, false),
         ("include", true, false, false),
-        ("hide", false, true, false),  // sender-side exclude
-        ("show", true, true, false),   // sender-side include
+        ("hide", false, true, false),    // sender-side exclude
+        ("show", true, true, false),     // sender-side include
         ("protect", false, false, true), // receiver-side exclude
-        ("risk", true, false, true),   // receiver-side include
+        ("risk", true, false, true),     // receiver-side include
     ];
 
     for &(keyword, is_include, sender, receiver) in KEYWORDS {
@@ -457,8 +464,8 @@ fn build_pattern_rule(pattern: &str, is_include: bool) -> FilterRuleWireFormat {
     // turn `**/*.o` into `/**/*.o` and destroy the leading-`**` that WILD2_PREFIX
     // depends on. Since root-anchoring of a `**`-prefixed pattern is already
     // implied by WILD2_PREFIX, leave such patterns unanchored.
-    let anchored = !pattern.starts_with("**")
-        && (pattern.starts_with('/') || pattern.contains('/'));
+    let anchored =
+        !pattern.starts_with("**") && (pattern.starts_with('/') || pattern.contains('/'));
     let directory_only = pattern.ends_with('/');
 
     // upstream: exclude.c:212-213 - XFLG_DIR2WILD3 applies only to

--- a/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
@@ -381,7 +381,10 @@ mod draining_reader_tests {
 
         let mut received = Vec::new();
         reader.read_to_end(&mut received).expect("read to end");
-        assert_eq!(received, payload, "DrainingReader must preserve every byte in order");
+        assert_eq!(
+            received, payload,
+            "DrainingReader must preserve every byte in order"
+        );
     }
 
     #[test]
@@ -523,7 +526,9 @@ mod draining_reader_tests {
         let (go_tx, go_rx) = channel::<()>();
         let peer = thread::spawn(move || {
             let (mut server, _) = listener.accept().expect("accept");
-            server.write_all(&first_for_peer).expect("write first burst");
+            server
+                .write_all(&first_for_peer)
+                .expect("write first burst");
             server.flush().expect("flush first");
             // Wait until the consumer has drained the first burst and stopped
             // the drain thread before writing the trailing goodbye bytes.
@@ -543,7 +548,10 @@ mod draining_reader_tests {
         // Consume the first burst through the drain reader.
         let mut got_first = vec![0u8; first.len()];
         reader.read_exact(&mut got_first).expect("read first burst");
-        assert_eq!(got_first, first, "drain reader must replay the first burst intact");
+        assert_eq!(
+            got_first, first,
+            "drain reader must replay the first burst intact"
+        );
 
         // Stop the drain thread (it clears the read timeout on exit, then the
         // drain clone is dropped), then let the peer send its trailing goodbye
@@ -625,7 +633,10 @@ mod draining_reader_tests {
             payload_len,
             "the sibling write clone must deliver every byte (no truncation)"
         );
-        assert_eq!(got, payload, "write clone bytes must arrive intact and in order");
+        assert_eq!(
+            got, payload,
+            "write clone bytes must arrive intact and in order"
+        );
         handle.stop();
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/graceful_close.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/graceful_close.rs
@@ -105,7 +105,10 @@ fn drain_until_peer_eof<S: PeerDrainStream + ?Sized>(stream: &mut S, timeout: Du
             // Idle-socket per-read timeout / EAGAIN: retry until the total budget
             // is spent, then stop so the close can proceed - upstream io.c:797.
             Err(ref e)
-                if matches!(e.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut) =>
+                if matches!(
+                    e.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                ) =>
             {
                 if std::time::Instant::now() >= deadline {
                     break;
@@ -128,7 +131,7 @@ mod graceful_close_tests {
     //! final `close()` emits a clean FIN instead of an abortive RST. These tests
     //! pin that invariant without depending on timing luck.
 
-    use super::{drain_until_peer_eof, PeerDrainStream};
+    use super::{PeerDrainStream, drain_until_peer_eof};
     use std::collections::VecDeque;
     use std::io::{self, Read, Write};
     use std::net::{TcpListener, TcpStream};
@@ -245,7 +248,9 @@ mod graceful_close_tests {
         let peer = thread::spawn(move || {
             let (mut server, _) = listener.accept().expect("accept");
             // Trailing bytes larger than one drain chunk, then FIN via drop.
-            server.write_all(&vec![0x5Au8; 20_000]).expect("write trailing");
+            server
+                .write_all(&vec![0x5Au8; 20_000])
+                .expect("write trailing");
             server.flush().expect("flush trailing");
             // Drop -> FIN -> EOF on the drain side.
         });

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -94,7 +94,8 @@ fn refuse_shell_hook(
     // never reached the daemon log at all - the operator's only record of a
     // fail-closed security decision, silently dropped.
     if let Some(log) = ctx.log_sink {
-        let message = rsync_error!(RERR_UNSUPPORTED_EXIT_CODE, text.clone()).with_role(Role::Daemon);
+        let message =
+            rsync_error!(RERR_UNSUPPORTED_EXIT_CODE, text.clone()).with_role(Role::Daemon);
         log_message(log, &message);
     }
 
@@ -353,12 +354,8 @@ fn process_approved_module(
     // immediately followed by `rwrite(FERROR, ...)`.
     if let Some(refused) = refused_client_arg(module, &client_args) {
         let host_owned = ctx.host_display().to_owned();
-        let result = handle_refused_option_post_handshake(
-            ctx,
-            &refused,
-            negotiated_protocol,
-            &client_args,
-        );
+        let result =
+            handle_refused_option_post_handshake(ctx, &refused, negotiated_protocol, &client_args);
         // upstream: clientserver.c:1079/1171 - parse_arguments() rejecting a
         // refused option runs after the post-xfer-exec fork point and exits
         // via exit_cleanup(RERR_UNSUPPORTED), which the waiting parent
@@ -525,29 +522,25 @@ fn process_approved_module(
         module
     };
 
-    let mut config = match build_server_config(
-        ctx,
-        &client_args,
-        config_module,
-        negotiated_protocol,
-    )? {
-        Some(cfg) => cfg,
-        None => {
-            // upstream: clientserver.c - config assembly runs after the
-            // post-xfer-exec fork point (post-chroot, post-args), so a
-            // failure here is a child exit the waiting parent still hooks.
-            let host_owned = ctx.host_display().to_owned();
-            run_post_xfer_finalizer(
-                ctx,
-                module,
-                &host_owned,
-                auth_user.as_deref(),
-                &client_args,
-                MODULE_ABORT_EXIT_CODE,
-            );
-            return Ok(());
-        }
-    };
+    let mut config =
+        match build_server_config(ctx, &client_args, config_module, negotiated_protocol)? {
+            Some(cfg) => cfg,
+            None => {
+                // upstream: clientserver.c - config assembly runs after the
+                // post-xfer-exec fork point (post-chroot, post-args), so a
+                // failure here is a child exit the waiting parent still hooks.
+                let host_owned = ctx.host_display().to_owned();
+                run_post_xfer_finalizer(
+                    ctx,
+                    module,
+                    &host_owned,
+                    auth_user.as_deref(),
+                    &client_args,
+                    MODULE_ABORT_EXIT_CODE,
+                );
+                return Ok(());
+            }
+        };
 
     // upstream: clientserver.c:rsync_module() - build daemon_filter_list from
     // module filter/exclude/include/exclude_from/include_from parameters.
@@ -923,8 +916,7 @@ fn process_approved_module(
         // kernel FIN as the process exits; the threaded daemon collapses
         // that pattern into the explicit shutdown here.
         if let Some(tcp) = stream.tcp_stream() {
-            if let Err(err) =
-                core::server::writer::shutdown_send_side(tcp, Duration::from_secs(5))
+            if let Err(err) = core::server::writer::shutdown_send_side(tcp, Duration::from_secs(5))
             {
                 if let Some(log) = ctx.log_sink {
                     let text = format!("daemon-sender drain-barrier shutdown failed: {err}");

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -364,8 +364,7 @@ fn execute_transfer(
                     let pid = std::process::id();
                     // upstream: log.c:664 `%t` renders timestring(time(NULL)) -
                     // the same localtime formatter that stamps log-file lines.
-                    let timestamp =
-                        logging_sink::logfile::format_log_timestamp(SystemTime::now());
+                    let timestamp = logging_sink::logfile::format_log_timestamp(SystemTime::now());
 
                     let log_ctx = LogFormatContext {
                         operation,
@@ -396,9 +395,11 @@ fn execute_transfer(
                     ServerStats::Generator(stats) => {
                         (stats.bytes_sent, stats.bytes_read, stats.total_size)
                     }
-                    ServerStats::Receiver(stats) => {
-                        (stats.bytes_sent, stats.bytes_received, stats.total_source_bytes)
-                    }
+                    ServerStats::Receiver(stats) => (
+                        stats.bytes_sent,
+                        stats.bytes_received,
+                        stats.total_source_bytes,
+                    ),
                 };
                 let text = format!(
                     "sent {sent} bytes  received {received} bytes  total size {total_size}"

--- a/crates/daemon/src/daemon/sections/module_definition/finish.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/finish.rs
@@ -104,9 +104,7 @@ impl ModuleDefinitionBuilder {
         // upstream: daemon-parm.h:273 - `auth digest` is P_LOCAL, so a value in
         // the global section is the default for every module that does not set
         // its own, exactly like `auth users` above.
-        let auth_digest = self
-            .auth_digest
-            .or_else(|| defaults.auth_digest.clone());
+        let auth_digest = self.auth_digest.or_else(|| defaults.auth_digest.clone());
         let secrets_file = if auth_users.is_empty() {
             self.secrets_file
         } else if let Some(path) = self.secrets_file {
@@ -146,8 +144,14 @@ impl ModuleDefinitionBuilder {
 
         // upstream: loadparm.c - hosts_allow/hosts_deny are STRING P_LOCAL
         // parameters with global defaults.
-        let hosts_allow = self.hosts_allow.or_else(|| defaults.hosts_allow.clone()).unwrap_or_default();
-        let hosts_deny = self.hosts_deny.or_else(|| defaults.hosts_deny.clone()).unwrap_or_default();
+        let hosts_allow = self
+            .hosts_allow
+            .or_else(|| defaults.hosts_allow.clone())
+            .unwrap_or_default();
+        let hosts_deny = self
+            .hosts_deny
+            .or_else(|| defaults.hosts_deny.clone())
+            .unwrap_or_default();
 
         Ok(ModuleDefinition {
             name: self.name,
@@ -190,17 +194,29 @@ impl ModuleDefinitionBuilder {
                 .insecure_links
                 .or(defaults.insecure_links)
                 .unwrap_or(false),
-            munge_symlinks: self.munge_symlinks.or(defaults.munge_symlinks).unwrap_or(None),
+            munge_symlinks: self
+                .munge_symlinks
+                .or(defaults.munge_symlinks)
+                .unwrap_or(None),
             max_verbosity: self.max_verbosity.or(defaults.max_verbosity).unwrap_or(1),
-            ignore_errors: self.ignore_errors.or(defaults.ignore_errors).unwrap_or(false),
-            ignore_nonreadable: self.ignore_nonreadable.or(defaults.ignore_nonreadable).unwrap_or(false),
-            transfer_logging: self.transfer_logging.or(defaults.transfer_logging).unwrap_or(false),
-            log_format: self
-                .log_format
-                .unwrap_or_else(|| {
-                    defaults.log_format.clone()
-                        .or_else(|| Some("%o %h [%a] %m (%u) %f %l".to_owned()))
-                }),
+            ignore_errors: self
+                .ignore_errors
+                .or(defaults.ignore_errors)
+                .unwrap_or(false),
+            ignore_nonreadable: self
+                .ignore_nonreadable
+                .or(defaults.ignore_nonreadable)
+                .unwrap_or(false),
+            transfer_logging: self
+                .transfer_logging
+                .or(defaults.transfer_logging)
+                .unwrap_or(false),
+            log_format: self.log_format.unwrap_or_else(|| {
+                defaults
+                    .log_format
+                    .clone()
+                    .or_else(|| Some("%o %h [%a] %m (%u) %f %l".to_owned()))
+            }),
             log_file: self.log_file.or_else(|| defaults.log_file.clone()),
             // upstream: loadparm.c:46 seeds `dont compress` with the built-in
             // DEFAULT_DONT_COMPRESS list when neither the module nor the global
@@ -209,20 +225,34 @@ impl ModuleDefinitionBuilder {
                 .dont_compress
                 .unwrap_or_else(|| defaults.dont_compress.clone())
                 .or_else(|| Some(DEFAULT_DONT_COMPRESS.to_owned())),
-            early_exec: self.early_exec.unwrap_or_else(|| defaults.early_exec.clone()),
-            pre_xfer_exec: self.pre_xfer_exec.unwrap_or_else(|| defaults.pre_xfer_exec.clone()),
-            post_xfer_exec: self.post_xfer_exec.unwrap_or_else(|| defaults.post_xfer_exec.clone()),
-            name_converter: self.name_converter.unwrap_or_else(|| defaults.name_converter.clone()),
+            early_exec: self
+                .early_exec
+                .unwrap_or_else(|| defaults.early_exec.clone()),
+            pre_xfer_exec: self
+                .pre_xfer_exec
+                .unwrap_or_else(|| defaults.pre_xfer_exec.clone()),
+            post_xfer_exec: self
+                .post_xfer_exec
+                .unwrap_or_else(|| defaults.post_xfer_exec.clone()),
+            name_converter: self
+                .name_converter
+                .unwrap_or_else(|| defaults.name_converter.clone()),
             temp_dir: self.temp_dir.unwrap_or_else(|| defaults.temp_dir.clone()),
             charset: self.charset.unwrap_or_else(|| defaults.charset.clone()),
-            forward_lookup: self.forward_lookup.or(defaults.forward_lookup).unwrap_or(true),
+            forward_lookup: self
+                .forward_lookup
+                .or(defaults.forward_lookup)
+                .unwrap_or(true),
             strict_modes: self.strict_modes.or(defaults.strict_modes).unwrap_or(true),
             exclude_from: self.exclude_from.or_else(|| defaults.exclude_from.clone()),
             include_from: self.include_from.or_else(|| defaults.include_from.clone()),
             open_noatime: self.open_noatime.or(defaults.open_noatime).unwrap_or(false),
             // upstream: daemon-parm.h:78 default True; module value overrides the
             // global-section default (defaults.reverse_lookup), else built-in True.
-            reverse_lookup: self.reverse_lookup.or(defaults.reverse_lookup).unwrap_or(true),
+            reverse_lookup: self
+                .reverse_lookup
+                .or(defaults.reverse_lookup)
+                .unwrap_or(true),
             // upstream: daemon-parm.h:46 - a module `lock file` overrides the
             // daemon-wide lock file; `None` inherits it at connection setup.
             lock_file: self.lock_file,

--- a/crates/daemon/src/daemon/sections/module_definition/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/tests.rs
@@ -153,10 +153,18 @@ fn set_auth_users_rejects_empty() {
 fn set_auth_users_last_assignment_wins() {
     let mut builder = ModuleDefinitionBuilder::new("mod".to_owned(), 1);
     builder
-        .set_auth_users(vec![AuthUser::new("alice".to_owned())], &test_config_path(), 5)
+        .set_auth_users(
+            vec![AuthUser::new("alice".to_owned())],
+            &test_config_path(),
+            5,
+        )
         .expect("first list accepted");
     builder
-        .set_auth_users(vec![AuthUser::new("bob".to_owned())], &test_config_path(), 10)
+        .set_auth_users(
+            vec![AuthUser::new("bob".to_owned())],
+            &test_config_path(),
+            10,
+        )
         .expect("repeat overwrites");
     assert_eq!(
         builder.auth_users,
@@ -479,7 +487,10 @@ fn set_strict_modes_last_assignment_wins() {
 fn set_exclude_from_stores_value() {
     let mut builder = ModuleDefinitionBuilder::new("mod".to_owned(), 1);
     builder.set_exclude_from(PathBuf::from("/etc/excludes.txt"));
-    assert_eq!(builder.exclude_from, Some(PathBuf::from("/etc/excludes.txt")));
+    assert_eq!(
+        builder.exclude_from,
+        Some(PathBuf::from("/etc/excludes.txt"))
+    );
 }
 
 #[test]
@@ -494,7 +505,10 @@ fn set_exclude_from_last_assignment_wins() {
 fn set_include_from_stores_value() {
     let mut builder = ModuleDefinitionBuilder::new("mod".to_owned(), 1);
     builder.set_include_from(PathBuf::from("/etc/includes.txt"));
-    assert_eq!(builder.include_from, Some(PathBuf::from("/etc/includes.txt")));
+    assert_eq!(
+        builder.include_from,
+        Some(PathBuf::from("/etc/includes.txt"))
+    );
 }
 
 #[test]
@@ -610,11 +624,22 @@ fn finish_applies_default_secrets_for_auth_users() {
     let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
     builder.set_path(PathBuf::from("/data"));
     builder
-        .set_auth_users(vec![AuthUser::new("alice".to_owned())], &test_config_path(), 3)
+        .set_auth_users(
+            vec![AuthUser::new("alice".to_owned())],
+            &test_config_path(),
+            3,
+        )
         .expect("auth users accepted");
     let default_secrets = PathBuf::from("/etc/secrets");
     let defaults = GlobalModuleDefaults::default();
-    let result = builder.finish(&test_config_path(), Some(&default_secrets), None, None, None, &defaults);
+    let result = builder.finish(
+        &test_config_path(),
+        Some(&default_secrets),
+        None,
+        None,
+        None,
+        &defaults,
+    );
     assert!(result.is_ok());
     let def = result.unwrap();
     assert_eq!(def.secrets_file, Some(PathBuf::from("/etc/secrets")));
@@ -625,7 +650,11 @@ fn finish_fails_auth_users_without_secrets() {
     let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
     builder.set_path(PathBuf::from("/data"));
     builder
-        .set_auth_users(vec![AuthUser::new("alice".to_owned())], &test_config_path(), 3)
+        .set_auth_users(
+            vec![AuthUser::new("alice".to_owned())],
+            &test_config_path(),
+            3,
+        )
         .expect("auth users accepted");
     let defaults = GlobalModuleDefaults::default();
     let result = builder.finish(&test_config_path(), None, None, None, None, &defaults);
@@ -688,7 +717,14 @@ fn finish_transfers_all_set_values() {
         NonZeroU32::new(5).expect("non-zero"),
     ));
 
-    let result = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default());
+    let result = builder.finish(
+        &test_config_path(),
+        None,
+        None,
+        None,
+        None,
+        &GlobalModuleDefaults::default(),
+    );
     assert!(result.is_ok());
     let def = result.unwrap();
 
@@ -713,7 +749,14 @@ fn finish_uses_default_values_for_unset_fields() {
     let mut builder = ModuleDefinitionBuilder::new("defaults".to_owned(), 1);
     builder.set_path(PathBuf::from("/data"));
 
-    let result = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default());
+    let result = builder.finish(
+        &test_config_path(),
+        None,
+        None,
+        None,
+        None,
+        &GlobalModuleDefaults::default(),
+    );
     assert!(result.is_ok());
     let def = result.unwrap();
 
@@ -736,10 +779,7 @@ fn finish_uses_default_values_for_unset_fields() {
     assert!(!def.ignore_errors); // default false
     assert!(!def.ignore_nonreadable); // default false
     assert!(!def.transfer_logging); // default false
-    assert_eq!(
-        def.log_format.as_deref(),
-        Some("%o %h [%a] %m (%u) %f %l")
-    ); // default format
+    assert_eq!(def.log_format.as_deref(), Some("%o %h [%a] %m (%u) %f %l")); // default format
     // upstream: loadparm.c:46 - `dont compress` defaults to the built-in
     // DEFAULT_DONT_COMPRESS suffix list, so a resolved module inherits it when
     // neither the module nor the global section sets the directive.
@@ -763,7 +803,14 @@ fn finish_preserves_fake_super_when_set() {
     builder.set_path(PathBuf::from("/backup"));
     builder.set_fake_super(true);
 
-    let result = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default());
+    let result = builder.finish(
+        &test_config_path(),
+        None,
+        None,
+        None,
+        None,
+        &GlobalModuleDefaults::default(),
+    );
     assert!(result.is_ok());
     let def = result.unwrap();
     assert!(def.fake_super);
@@ -774,7 +821,16 @@ fn finish_munge_symlinks_default_none() {
     let mut builder = ModuleDefinitionBuilder::new("mod".to_owned(), 1);
     builder.set_path(PathBuf::from("/data"));
 
-    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
+    let def = builder
+        .finish(
+            &test_config_path(),
+            None,
+            None,
+            None,
+            None,
+            &GlobalModuleDefaults::default(),
+        )
+        .unwrap();
     assert!(def.munge_symlinks.is_none());
 }
 
@@ -784,7 +840,16 @@ fn finish_munge_symlinks_explicit_true() {
     builder.set_path(PathBuf::from("/data"));
     builder.set_munge_symlinks(Some(true));
 
-    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
+    let def = builder
+        .finish(
+            &test_config_path(),
+            None,
+            None,
+            None,
+            None,
+            &GlobalModuleDefaults::default(),
+        )
+        .unwrap();
     assert_eq!(def.munge_symlinks, Some(true));
 }
 
@@ -794,7 +859,16 @@ fn finish_munge_symlinks_explicit_false() {
     builder.set_path(PathBuf::from("/data"));
     builder.set_munge_symlinks(Some(false));
 
-    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
+    let def = builder
+        .finish(
+            &test_config_path(),
+            None,
+            None,
+            None,
+            None,
+            &GlobalModuleDefaults::default(),
+        )
+        .unwrap();
     assert_eq!(def.munge_symlinks, Some(false));
 }
 
@@ -804,7 +878,16 @@ fn finish_transfers_exclude_from() {
     builder.set_path(PathBuf::from("/data"));
     builder.set_exclude_from(PathBuf::from("/etc/excludes.txt"));
 
-    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
+    let def = builder
+        .finish(
+            &test_config_path(),
+            None,
+            None,
+            None,
+            None,
+            &GlobalModuleDefaults::default(),
+        )
+        .unwrap();
     assert_eq!(def.exclude_from, Some(PathBuf::from("/etc/excludes.txt")));
 }
 
@@ -814,7 +897,16 @@ fn finish_transfers_include_from() {
     builder.set_path(PathBuf::from("/data"));
     builder.set_include_from(PathBuf::from("/etc/includes.txt"));
 
-    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
+    let def = builder
+        .finish(
+            &test_config_path(),
+            None,
+            None,
+            None,
+            None,
+            &GlobalModuleDefaults::default(),
+        )
+        .unwrap();
     assert_eq!(def.include_from, Some(PathBuf::from("/etc/includes.txt")));
 }
 
@@ -824,6 +916,15 @@ fn finish_preserves_open_noatime_when_set() {
     builder.set_path(PathBuf::from("/data"));
     builder.set_open_noatime(true);
 
-    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
+    let def = builder
+        .finish(
+            &test_config_path(),
+            None,
+            None,
+            None,
+            None,
+            &GlobalModuleDefaults::default(),
+        )
+        .unwrap();
     assert!(def.open_noatime);
 }

--- a/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
@@ -71,7 +71,10 @@ fn parse_max_connections(value: &OsString) -> Result<NonZeroUsize, DaemonError> 
         .ok_or_else(|| config_error("--max-connections must be greater than zero".to_owned()))
 }
 
-fn parse_tcp_fastopen_mode(value: &OsString, _brand: Brand) -> Result<TcpFastOpenMode, DaemonError> {
+fn parse_tcp_fastopen_mode(
+    value: &OsString,
+    _brand: Brand,
+) -> Result<TcpFastOpenMode, DaemonError> {
     let text = value.to_string_lossy();
     text.parse::<TcpFastOpenMode>()
         .map_err(|error| config_error(error.to_string()))
@@ -512,8 +515,8 @@ fn apply_daemon_param_overrides(
             }
             // Security-sensitive directives are not overridable via dparam.
             "hosts allow" | "hosts-allow" | "hosts deny" | "hosts-deny" | "auth users"
-            | "auth-users" | "auth digest" | "auth-digest" | "secrets file"
-            | "secrets-file" | "refuse options" | "refuse-options" | "uid" | "gid" => {
+            | "auth-users" | "auth digest" | "auth-digest" | "secrets file" | "secrets-file"
+            | "refuse options" | "refuse-options" | "uid" | "gid" => {
                 return Err(config_error(format!(
                     "daemon param '{key_raw}' cannot be overridden via --dparam"
                 )));

--- a/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
@@ -123,64 +123,217 @@ struct ShortOption {
 /// relative to upstream, which fails CLOSED, so they are an operator-visible
 /// policy decision rather than a bug fix; see the per-row comments below.
 const SHORT_OPTIONS: &[ShortOption] = &[
-    ShortOption { letter: '@', long_name: Some("modify-window") },
-    ShortOption { letter: '0', long_name: Some("from0") },
-    ShortOption { letter: '4', long_name: Some("ipv4") },
-    ShortOption { letter: '6', long_name: Some("ipv6") },
-    ShortOption { letter: '8', long_name: Some("8-bit-output") },
-    ShortOption { letter: 'a', long_name: Some("archive") },
-    ShortOption { letter: 'A', long_name: Some("acls") },
-    ShortOption { letter: 'b', long_name: Some("backup") },
-    ShortOption { letter: 'B', long_name: Some("block-size") },
-    ShortOption { letter: 'c', long_name: Some("checksum") },
-    ShortOption { letter: 'C', long_name: Some("cvs-exclude") },
-    ShortOption { letter: 'd', long_name: Some("dirs") },
+    ShortOption {
+        letter: '@',
+        long_name: Some("modify-window"),
+    },
+    ShortOption {
+        letter: '0',
+        long_name: Some("from0"),
+    },
+    ShortOption {
+        letter: '4',
+        long_name: Some("ipv4"),
+    },
+    ShortOption {
+        letter: '6',
+        long_name: Some("ipv6"),
+    },
+    ShortOption {
+        letter: '8',
+        long_name: Some("8-bit-output"),
+    },
+    ShortOption {
+        letter: 'a',
+        long_name: Some("archive"),
+    },
+    ShortOption {
+        letter: 'A',
+        long_name: Some("acls"),
+    },
+    ShortOption {
+        letter: 'b',
+        long_name: Some("backup"),
+    },
+    ShortOption {
+        letter: 'B',
+        long_name: Some("block-size"),
+    },
+    ShortOption {
+        letter: 'c',
+        long_name: Some("checksum"),
+    },
+    ShortOption {
+        letter: 'C',
+        long_name: Some("cvs-exclude"),
+    },
+    ShortOption {
+        letter: 'd',
+        long_name: Some("dirs"),
+    },
     // upstream longName is NULL: `-D` is its own row meaning
     // `--devices --specials`. oc keeps the `devices` association, which
     // over-refuses (a `refuse options = devices` rule also blocks `-D`).
     // That fails CLOSED, so it is left alone here.
-    ShortOption { letter: 'D', long_name: Some("devices") },
-    ShortOption { letter: 'e', long_name: Some("rsh") },
-    ShortOption { letter: 'E', long_name: Some("executability") },
-    ShortOption { letter: 'f', long_name: Some("filter") },
+    ShortOption {
+        letter: 'D',
+        long_name: Some("devices"),
+    },
+    ShortOption {
+        letter: 'e',
+        long_name: Some("rsh"),
+    },
+    ShortOption {
+        letter: 'E',
+        long_name: Some("executability"),
+    },
+    ShortOption {
+        letter: 'f',
+        long_name: Some("filter"),
+    },
     // upstream longName is NULL: `-F` is the repeated-filter shortcut. Same
     // fails-closed reasoning as `-D`.
-    ShortOption { letter: 'F', long_name: Some("filter") },
-    ShortOption { letter: 'g', long_name: Some("group") },
-    ShortOption { letter: 'h', long_name: Some("human-readable") },
-    ShortOption { letter: 'H', long_name: Some("hard-links") },
-    ShortOption { letter: 'i', long_name: Some("itemize-changes") },
-    ShortOption { letter: 'I', long_name: Some("ignore-times") },
-    ShortOption { letter: 'J', long_name: Some("omit-link-times") },
-    ShortOption { letter: 'k', long_name: Some("copy-dirlinks") },
-    ShortOption { letter: 'K', long_name: Some("keep-dirlinks") },
-    ShortOption { letter: 'l', long_name: Some("links") },
-    ShortOption { letter: 'L', long_name: Some("copy-links") },
-    ShortOption { letter: 'm', long_name: Some("prune-empty-dirs") },
-    ShortOption { letter: 'M', long_name: Some("remote-option") },
-    ShortOption { letter: 'n', long_name: Some("dry-run") },
-    ShortOption { letter: 'N', long_name: Some("crtimes") },
-    ShortOption { letter: 'o', long_name: Some("owner") },
-    ShortOption { letter: 'O', long_name: Some("omit-dir-times") },
-    ShortOption { letter: 'p', long_name: Some("perms") },
+    ShortOption {
+        letter: 'F',
+        long_name: Some("filter"),
+    },
+    ShortOption {
+        letter: 'g',
+        long_name: Some("group"),
+    },
+    ShortOption {
+        letter: 'h',
+        long_name: Some("human-readable"),
+    },
+    ShortOption {
+        letter: 'H',
+        long_name: Some("hard-links"),
+    },
+    ShortOption {
+        letter: 'i',
+        long_name: Some("itemize-changes"),
+    },
+    ShortOption {
+        letter: 'I',
+        long_name: Some("ignore-times"),
+    },
+    ShortOption {
+        letter: 'J',
+        long_name: Some("omit-link-times"),
+    },
+    ShortOption {
+        letter: 'k',
+        long_name: Some("copy-dirlinks"),
+    },
+    ShortOption {
+        letter: 'K',
+        long_name: Some("keep-dirlinks"),
+    },
+    ShortOption {
+        letter: 'l',
+        long_name: Some("links"),
+    },
+    ShortOption {
+        letter: 'L',
+        long_name: Some("copy-links"),
+    },
+    ShortOption {
+        letter: 'm',
+        long_name: Some("prune-empty-dirs"),
+    },
+    ShortOption {
+        letter: 'M',
+        long_name: Some("remote-option"),
+    },
+    ShortOption {
+        letter: 'n',
+        long_name: Some("dry-run"),
+    },
+    ShortOption {
+        letter: 'N',
+        long_name: Some("crtimes"),
+    },
+    ShortOption {
+        letter: 'o',
+        long_name: Some("owner"),
+    },
+    ShortOption {
+        letter: 'O',
+        long_name: Some("omit-dir-times"),
+    },
+    ShortOption {
+        letter: 'p',
+        long_name: Some("perms"),
+    },
     // upstream longName is NULL: `-P` means `--partial --progress`.
-    ShortOption { letter: 'P', long_name: Some("partial") },
-    ShortOption { letter: 'q', long_name: Some("quiet") },
-    ShortOption { letter: 'r', long_name: Some("recursive") },
-    ShortOption { letter: 'R', long_name: Some("relative") },
-    ShortOption { letter: 's', long_name: Some("secluded-args") },
-    ShortOption { letter: 'S', long_name: Some("sparse") },
-    ShortOption { letter: 't', long_name: Some("times") },
-    ShortOption { letter: 'T', long_name: Some("temp-dir") },
-    ShortOption { letter: 'u', long_name: Some("update") },
-    ShortOption { letter: 'U', long_name: Some("atimes") },
-    ShortOption { letter: 'v', long_name: Some("verbose") },
-    ShortOption { letter: 'V', long_name: Some("version") },
-    ShortOption { letter: 'W', long_name: Some("whole-file") },
-    ShortOption { letter: 'x', long_name: Some("one-file-system") },
-    ShortOption { letter: 'X', long_name: Some("xattrs") },
-    ShortOption { letter: 'y', long_name: Some("fuzzy") },
-    ShortOption { letter: 'z', long_name: Some("compress") },
+    ShortOption {
+        letter: 'P',
+        long_name: Some("partial"),
+    },
+    ShortOption {
+        letter: 'q',
+        long_name: Some("quiet"),
+    },
+    ShortOption {
+        letter: 'r',
+        long_name: Some("recursive"),
+    },
+    ShortOption {
+        letter: 'R',
+        long_name: Some("relative"),
+    },
+    ShortOption {
+        letter: 's',
+        long_name: Some("secluded-args"),
+    },
+    ShortOption {
+        letter: 'S',
+        long_name: Some("sparse"),
+    },
+    ShortOption {
+        letter: 't',
+        long_name: Some("times"),
+    },
+    ShortOption {
+        letter: 'T',
+        long_name: Some("temp-dir"),
+    },
+    ShortOption {
+        letter: 'u',
+        long_name: Some("update"),
+    },
+    ShortOption {
+        letter: 'U',
+        long_name: Some("atimes"),
+    },
+    ShortOption {
+        letter: 'v',
+        long_name: Some("verbose"),
+    },
+    ShortOption {
+        letter: 'V',
+        long_name: Some("version"),
+    },
+    ShortOption {
+        letter: 'W',
+        long_name: Some("whole-file"),
+    },
+    ShortOption {
+        letter: 'x',
+        long_name: Some("one-file-system"),
+    },
+    ShortOption {
+        letter: 'X',
+        long_name: Some("xattrs"),
+    },
+    ShortOption {
+        letter: 'y',
+        long_name: Some("fuzzy"),
+    },
+    ShortOption {
+        letter: 'z',
+        long_name: Some("compress"),
+    },
 ];
 
 /// Looks up one short option, or `None` when the byte is not an option letter.
@@ -310,8 +463,9 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
                 // `long_name` is `None` only for rows upstream leaves NULL, in
                 // which case the rule can only have named the bare letter.
                 let refused = match option.long_name {
-                    Some(long) => is_option_refused(module, long, Some(letter))
-                        .then(|| format!("--{long}")),
+                    Some(long) => {
+                        is_option_refused(module, long, Some(letter)).then(|| format!("--{long}"))
+                    }
                     None => is_option_refused(module, &letter.to_string(), Some(letter))
                         .then(|| format!("-{letter}")),
                 };
@@ -446,9 +600,9 @@ fn names_same_capability(pattern: &str, long_name: &str) -> bool {
     if pattern == long_name {
         return true;
     }
-    OPTION_ALIAS_GROUPS.iter().any(|group| {
-        group.contains(&pattern) && group.contains(&long_name)
-    })
+    OPTION_ALIAS_GROUPS
+        .iter()
+        .any(|group| group.contains(&pattern) && group.contains(&long_name))
 }
 
 /// Evaluates a canonical option (long name + optional short letter) against an

--- a/crates/daemon/src/daemon/sections/privilege.rs
+++ b/crates/daemon/src/daemon/sections/privilege.rs
@@ -64,11 +64,7 @@ fn apply_chroot(_module_path: &Path, _log_sink: &SharedLogSink) -> io::Result<()
 /// `setgroups`/`setuid` after chroot. Each failure returns `@ERROR: setgid
 /// failed`, `@ERROR: setgroups failed`, or `@ERROR: setuid failed` and the
 /// connection is dropped.
-fn drop_privileges(
-    uid: Option<u32>,
-    gids: &[u32],
-    log_sink: &SharedLogSink,
-) -> io::Result<()> {
+fn drop_privileges(uid: Option<u32>, gids: &[u32], log_sink: &SharedLogSink) -> io::Result<()> {
     if let Err(err) = platform::privilege::drop_privileges(uid, gids) {
         let text = format!("drop_privileges(uid={uid:?}, gids={gids:?}) failed: {err}");
         let message = rsync_error!(1, text).with_role(Role::Daemon);
@@ -632,8 +628,8 @@ mod privilege_tests {
             ..Default::default()
         };
         let sink = test_log_sink();
-        let (applied, _inner) = chroot_or_fallback(&module, &sink)
-            .expect("unset use chroot must fall back, not error");
+        let (applied, _inner) =
+            chroot_or_fallback(&module, &sink).expect("unset use chroot must fall back, not error");
         assert!(!applied, "rootless fallback must report chroot NOT applied");
     }
 

--- a/crates/daemon/src/daemon/sections/proxy_protocol.rs
+++ b/crates/daemon/src/daemon/sections/proxy_protocol.rs
@@ -360,7 +360,12 @@ mod proxy_protocol_tests {
         let mut cursor = io::Cursor::new(header);
         let result = parse_proxy_header_from(&mut cursor);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("unsupported PROXY v2 version"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported PROXY v2 version")
+        );
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -81,7 +81,7 @@ pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
         return SeccompOutcome::Unavailable;
     }
     use seccompiler::{
-        apply_filter, BpfProgram, SeccompAction, SeccompFilter, SeccompRule, TargetArch,
+        BpfProgram, SeccompAction, SeccompFilter, SeccompRule, TargetArch, apply_filter,
     };
     use std::collections::BTreeMap;
 

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
@@ -133,8 +133,7 @@ impl AcceptEngine for SingleListenerEngine {
             Ok((tcp_stream, raw_peer_addr)) => {
                 if let Err(error) = tcp_stream.set_nonblocking(false) {
                     if let Some(log) = self.log_sink.as_ref() {
-                        let text =
-                            format!("failed to set accepted socket to blocking: {error}");
+                        let text = format!("failed to set accepted socket to blocking: {error}");
                         let message = rsync_warning!(text).with_role(Role::Daemon);
                         log_message(log, &message);
                     }
@@ -245,8 +244,7 @@ impl MultiListenerEngine {
         let shutdown = Arc::clone(&state.signal_flags.shutdown);
         let graceful_exit = Arc::clone(&state.signal_flags.graceful_exit);
         let total_acceptors = listeners.len();
-        let mut acceptor_handles: Vec<thread::JoinHandle<()>> =
-            Vec::with_capacity(total_acceptors);
+        let mut acceptor_handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity(total_acceptors);
         let log_sink = state.log_sink.clone();
 
         for (listener, local_addr) in listeners.into_iter().zip(bound_addresses.iter().copied()) {
@@ -263,9 +261,7 @@ impl MultiListenerEngine {
             }
 
             let handle = thread::spawn(move || {
-                while !shutdown.load(Ordering::Relaxed)
-                    && !graceful_exit.load(Ordering::Relaxed)
-                {
+                while !shutdown.load(Ordering::Relaxed) && !graceful_exit.load(Ordering::Relaxed) {
                     match wait_for_incoming(&listener, READINESS_WAIT_MILLIS) {
                         Ok(true) => {}
                         // Timeout or EINTR: re-check the shutdown flags.
@@ -274,11 +270,7 @@ impl MultiListenerEngine {
                             // Transient like an accept(2) failure: log, back
                             // off so a persistent error cannot hot-spin, keep
                             // accepting.
-                            warn_transient_accept_failure(
-                                log_sink.as_ref(),
-                                local_addr,
-                                &error,
-                            );
+                            warn_transient_accept_failure(log_sink.as_ref(), local_addr, &error);
                             thread::sleep(Duration::from_millis(50));
                             continue;
                         }
@@ -292,12 +284,20 @@ impl MultiListenerEngine {
                             // greeting. Reset to blocking so the worker thread
                             // sees the upstream-compatible synchronous I/O model.
                             if let Err(error) = stream.set_nonblocking(false) {
-                                let _ =
-                                    relay_accept_item(&tx, Err((local_addr, error)), &shutdown, &graceful_exit);
+                                let _ = relay_accept_item(
+                                    &tx,
+                                    Err((local_addr, error)),
+                                    &shutdown,
+                                    &graceful_exit,
+                                );
                                 break;
                             }
-                            if !relay_accept_item(&tx, Ok((stream, peer_addr)), &shutdown, &graceful_exit)
-                            {
+                            if !relay_accept_item(
+                                &tx,
+                                Ok((stream, peer_addr)),
+                                &shutdown,
+                                &graceful_exit,
+                            ) {
                                 break;
                             }
                         }
@@ -318,11 +318,7 @@ impl MultiListenerEngine {
                             // engine. The relay-and-escalate path below stays
                             // reserved for a genuinely unusable accepted
                             // socket (set_nonblocking failure above).
-                            warn_transient_accept_failure(
-                                log_sink.as_ref(),
-                                local_addr,
-                                &error,
-                            );
+                            warn_transient_accept_failure(log_sink.as_ref(), local_addr, &error);
                             thread::sleep(Duration::from_millis(50));
                             continue;
                         }

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -44,9 +44,12 @@ fn serve_connections(
     // when QUIC is configured; unconfigured (the default, even under
     // `--all-features`) leaves this `None` and no UDP socket is opened.
     #[cfg(all(unix, feature = "quic"))]
-    let quic_bind = options
-        .quic_listener_enabled()
-        .then(|| (options.effective_quic_port(), options.resolve_quic_identity()));
+    let quic_bind = options.quic_listener_enabled().then(|| {
+        (
+            options.effective_quic_port(),
+            options.resolve_quic_identity(),
+        )
+    });
 
     let RuntimeOptions {
         bind_address,
@@ -351,9 +354,7 @@ fn serve_connections(
     }
 
     if let Some(log) = log_sink.as_ref() {
-        let text = format!(
-            "rsyncd version {version} starting, listening on port {port}"
-        );
+        let text = format!("rsyncd version {version} starting, listening on port {port}");
         let message = rsync_info!(text).with_role(Role::Daemon);
         log_message(log, &message);
     }

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -40,9 +40,8 @@ fn check_signals_and_maintain(
 
     if state.signal_flags.shutdown.load(Ordering::Relaxed) {
         if let Some(log) = state.log_sink.as_ref() {
-            let message =
-                rsync_info!("received shutdown signal, stopping accept loop")
-                    .with_role(Role::Daemon);
+            let message = rsync_info!("received shutdown signal, stopping accept loop")
+                .with_role(Role::Daemon);
             log_message(log, &message);
         }
         return Ok(Some(true));
@@ -59,17 +58,20 @@ fn check_signals_and_maintain(
             let message = rsync_info!(text).with_role(Role::Daemon);
             log_message(log, &message);
         }
-        if let Err(error) = state.notifier.status("Graceful exit: draining active transfers") {
-            log_sd_notify_failure(
-                state.log_sink.as_ref(),
-                "graceful exit status",
-                &error,
-            );
+        if let Err(error) = state
+            .notifier
+            .status("Graceful exit: draining active transfers")
+        {
+            log_sd_notify_failure(state.log_sink.as_ref(), "graceful exit status", &error);
         }
         return Ok(Some(true));
     }
 
-    if state.signal_flags.reload_config.swap(false, Ordering::Relaxed) {
+    if state
+        .signal_flags
+        .reload_config
+        .swap(false, Ordering::Relaxed)
+    {
         reload_daemon_config(
             state.config_path.as_deref(),
             state.connection_limiter,
@@ -81,7 +83,11 @@ fn check_signals_and_maintain(
     }
 
     // upstream: main.c - SIGUSR2 outputs transfer statistics.
-    if state.signal_flags.progress_dump.swap(false, Ordering::Relaxed) {
+    if state
+        .signal_flags
+        .progress_dump
+        .swap(false, Ordering::Relaxed)
+    {
         log_progress_summary(
             state.log_sink.as_ref(),
             state.workers.len(),
@@ -139,8 +145,7 @@ fn refuse_if_at_capacity(
     if let Err(error) = stream.write_all(&payload)
         && let Some(log) = state.log_sink.as_ref()
     {
-        let text =
-            format!("failed to deliver max-connections refusal to {peer_addr}: {error}");
+        let text = format!("failed to deliver max-connections refusal to {peer_addr}: {error}");
         let message = rsync_warning!(text).with_role(Role::Daemon);
         log_message(log, &message);
     }
@@ -249,11 +254,7 @@ fn update_connection_status_after_accept(state: &mut AcceptLoopState<'_>) {
     if current_active != state.active_connections {
         let status = format_connection_status(current_active);
         if let Err(error) = state.notifier.status(&status) {
-            log_sd_notify_failure(
-                state.log_sink.as_ref(),
-                "connection status update",
-                &error,
-            );
+            log_sd_notify_failure(state.log_sink.as_ref(), "connection status update", &error);
         }
         state.active_connections = current_active;
     }
@@ -281,7 +282,11 @@ fn handle_accepted_connection(
         return false;
     };
 
-    apply_client_options(&stream, &state.client_socket_options, state.log_sink.as_ref());
+    apply_client_options(
+        &stream,
+        &state.client_socket_options,
+        state.log_sink.as_ref(),
+    );
 
     if refuse_if_at_capacity(&mut stream, raw_peer_addr, state) {
         drop(stream);

--- a/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
@@ -65,11 +65,7 @@ impl ConnectionContext {
     ///
     /// upstream: clientserver.c - `start_daemon()` forks a child per
     /// connection which runs `rsync_module()`.
-    fn serve_session(
-        &self,
-        stream: DaemonStream,
-        raw_peer_addr: SocketAddr,
-    ) -> io::Result<()> {
+    fn serve_session(&self, stream: DaemonStream, raw_peer_addr: SocketAddr) -> io::Result<()> {
         let peer_addr = normalize_peer_address(raw_peer_addr);
         let log_for_worker = self.log_sink.clone();
 
@@ -95,8 +91,7 @@ impl ConnectionContext {
                 if let Some(log) = log_for_worker.as_ref() {
                     let text =
                         format!("connection handler for {peer_addr} panicked: {description}");
-                    let message =
-                        rsync_error!(SOCKET_IO_EXIT_CODE, text).with_role(Role::Daemon);
+                    let message = rsync_error!(SOCKET_IO_EXIT_CODE, text).with_role(Role::Daemon);
                     log_message(log, &message);
                 }
                 Ok(())

--- a/crates/daemon/src/daemon/sections/server_runtime/reload.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/reload.rs
@@ -18,8 +18,8 @@ fn reload_daemon_config(
     notifier: &systemd::ServiceNotifier,
 ) {
     if let Some(log) = log_sink {
-        let message = rsync_info!("received SIGHUP, reloading configuration")
-            .with_role(Role::Daemon);
+        let message =
+            rsync_info!("received SIGHUP, reloading configuration").with_role(Role::Daemon);
         log_message(log, &message);
     }
     if let Err(error) = notifier.status("Reloading configuration") {
@@ -30,10 +30,8 @@ fn reload_daemon_config(
         Some(path) => path,
         None => {
             if let Some(log) = log_sink {
-                let message = rsync_info!(
-                    "SIGHUP ignored: no config file was loaded at startup"
-                )
-                .with_role(Role::Daemon);
+                let message = rsync_info!("SIGHUP ignored: no config file was loaded at startup")
+                    .with_role(Role::Daemon);
                 log_message(log, &message);
             }
             return;
@@ -44,9 +42,7 @@ fn reload_daemon_config(
         Ok(parsed) => parsed,
         Err(error) => {
             if let Some(log) = log_sink {
-                let text = format!(
-                    "config reload failed, keeping old configuration: {error}"
-                );
+                let text = format!("config reload failed, keeping old configuration: {error}");
                 let message = rsync_warning!(text).with_role(Role::Daemon);
                 log_message(log, &message);
             }
@@ -54,20 +50,22 @@ fn reload_daemon_config(
         }
     };
 
-    let new_modules: Vec<ModuleRuntime> =
-        match build_module_runtimes(parsed.modules, connection_limiter) {
-            Ok(runtimes) => runtimes,
-            Err(error) => {
-                if let Some(log) = log_sink {
-                    let text = format!(
-                        "config reload failed opening a module lock file, keeping old configuration: {error}"
-                    );
-                    let message = rsync_warning!(text).with_role(Role::Daemon);
-                    log_message(log, &message);
-                }
-                return;
+    let new_modules: Vec<ModuleRuntime> = match build_module_runtimes(
+        parsed.modules,
+        connection_limiter,
+    ) {
+        Ok(runtimes) => runtimes,
+        Err(error) => {
+            if let Some(log) = log_sink {
+                let text = format!(
+                    "config reload failed opening a module lock file, keeping old configuration: {error}"
+                );
+                let message = rsync_warning!(text).with_role(Role::Daemon);
+                log_message(log, &message);
             }
-        };
+            return;
+        }
+    };
     let module_count = new_modules.len();
     *modules = Arc::new(new_modules);
     *motd_lines = Arc::new(parsed.motd_lines);

--- a/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
@@ -195,7 +195,9 @@ fn parse_bool_option_value(value: Option<&str>, name: &str) -> Result<bool, Stri
 /// Parses a required size value for a buffer-size socket option.
 fn parse_size_option_value(value: Option<&str>, name: &str) -> Result<usize, String> {
     match value {
-        None => Err(format!("{name} requires a numeric value (e.g., {name}=65536)")),
+        None => Err(format!(
+            "{name} requires a numeric value (e.g., {name}=65536)"
+        )),
         Some(s) => s
             .parse::<usize>()
             .map_err(|_| format!("invalid numeric value '{s}' for {name}")),
@@ -255,7 +257,10 @@ fn parse_tos_option_value(value: Option<&str>) -> Result<u32, String> {
         None => Err("IP_TOS requires a numeric value (e.g., IP_TOS=0x10)".to_string()),
         Some(s) => {
             let trimmed = s.trim();
-            if let Some(hex) = trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X")) {
+            if let Some(hex) = trimmed
+                .strip_prefix("0x")
+                .or_else(|| trimmed.strip_prefix("0X"))
+            {
                 u32::from_str_radix(hex, 16)
                     .map_err(|_| format!("invalid hex value '{trimmed}' for IP_TOS"))
             } else {

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -314,14 +314,7 @@ fn reload_config_with_no_config_path_is_noop() {
     let mut motd: Arc<Vec<String>> = Arc::new(Vec::new());
     let notifier = systemd::ServiceNotifier::new();
 
-    reload_daemon_config(
-        None,
-        &limiter,
-        &mut modules,
-        &mut motd,
-        None,
-        &notifier,
-    );
+    reload_daemon_config(None, &limiter, &mut modules, &mut motd, None, &notifier);
 
     assert!(modules.is_empty());
     assert!(motd.is_empty());
@@ -1333,7 +1326,10 @@ fn bind_listeners_per_family_replicates_acceptor_threads() {
     assert_eq!(bound_addresses.len(), 3);
     for addr in &bound_addresses {
         assert_eq!(addr.ip(), reachable, "every replica binds the same family");
-        assert!(addr.port() != 0, "each replica must get a real ephemeral port");
+        assert!(
+            addr.port() != 0,
+            "each replica must get a real ephemeral port"
+        );
     }
 }
 
@@ -1509,7 +1505,11 @@ fn bind_listeners_per_family_falls_back_from_ipv6_to_ipv4() {
     )
     .expect("IPv4 fallback must bind when IPv6 is unreachable");
 
-    assert_eq!(listeners.len(), 1, "only the reachable IPv4 family should bind");
+    assert_eq!(
+        listeners.len(),
+        1,
+        "only the reachable IPv4 family should bind"
+    );
     assert_eq!(bound_addresses.len(), 1);
     assert!(
         bound_addresses[0].is_ipv4(),
@@ -1845,8 +1845,7 @@ fn accept_loop_stops_after_shutdown_signal_while_parked() {
 
     thread::scope(|scope| {
         let handle = scope.spawn(|| {
-            let mut engine =
-                SingleListenerEngine::new(listener, local, None).expect("engine");
+            let mut engine = SingleListenerEngine::new(listener, local, None).expect("engine");
             let mut state = test_accept_loop_state(
                 &flags,
                 &config_path,
@@ -1903,8 +1902,7 @@ fn multi_listener_engine_shutdown_joins_parked_acceptors() {
         None,
     );
 
-    let mut engine =
-        MultiListenerEngine::new(vec![first, second], &addrs, &state).expect("engine");
+    let mut engine = MultiListenerEngine::new(vec![first, second], &addrs, &state).expect("engine");
     engine.shutdown();
 }
 
@@ -2165,7 +2163,10 @@ fn kqueue_engine_level_triggered_backlog_is_not_stranded() {
             AcceptOutcome::Closed => panic!("kqueue engine never reports Closed"),
         }
     }
-    assert_eq!(accepted, 3, "all queued connections must be delivered, not stranded");
+    assert_eq!(
+        accepted, 3,
+        "all queued connections must be delivered, not stranded"
+    );
 
     engine.shutdown();
     drop(clients);
@@ -2322,7 +2323,11 @@ fn bind_quic_listeners_binds_dual_stack_loopback() {
         bind_quic_listeners_per_family(&bind_addresses, 0, &QuicIdentity::Ephemeral, None)
             .expect("dual-stack QUIC bind");
 
-    assert_eq!(acceptors.len(), 2, "both families must bind a QUIC listener");
+    assert_eq!(
+        acceptors.len(),
+        2,
+        "both families must bind a QUIC listener"
+    );
     let bound: Vec<SocketAddr> = acceptors
         .iter()
         .map(|a| a.local_addr().expect("local addr"))
@@ -2352,7 +2357,10 @@ fn bind_quic_listeners_falls_back_from_ipv6_to_ipv4() {
 
     assert_eq!(acceptors.len(), 1, "only the reachable IPv4 family binds");
     let bound = acceptors[0].local_addr().expect("local addr");
-    assert!(bound.is_ipv4(), "fallback acceptor must be IPv4, got {bound}");
+    assert!(
+        bound.is_ipv4(),
+        "fallback acceptor must be IPv4, got {bound}"
+    );
 }
 
 #[cfg(all(unix, feature = "quic"))]

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -340,11 +340,12 @@ fn handle_legacy_session(
                 // the rest of it. `None` here is upstream's NULL and `Some("")`
                 // its non-NULL empty `strdup`; the two negotiate differently, so
                 // the empty case must survive the round trip through `String`.
-                client_digests = parse_legacy_daemon_greeting_details(&line)
-                    .ok()
-                    .and_then(|greeting| {
-                        greeting.advertised_digests().names().map(ToOwned::to_owned)
-                    });
+                client_digests =
+                    parse_legacy_daemon_greeting_details(&line)
+                        .ok()
+                        .and_then(|greeting| {
+                            greeting.advertised_digests().names().map(ToOwned::to_owned)
+                        });
                 // Record the negotiated protocol version but do NOT send @RSYNCD: OK here.
                 // The OK is only sent after the module is selected and approved, not after
                 // the version exchange. Sending OK here causes the client to misinterpret

--- a/crates/daemon/src/daemon/sections/stdio_session.rs
+++ b/crates/daemon/src/daemon/sections/stdio_session.rs
@@ -24,10 +24,7 @@
 ///
 /// Returns a `DaemonError` if config loading fails or the session handler
 /// encounters an I/O error.
-pub fn run_stdio_session(
-    arguments: &[OsString],
-    is_rsh_daemon: bool,
-) -> Result<(), DaemonError> {
+pub fn run_stdio_session(arguments: &[OsString], is_rsh_daemon: bool) -> Result<(), DaemonError> {
     let mut options = RuntimeOptions {
         brand: Brand::Oc,
         ..Default::default()
@@ -38,13 +35,15 @@ pub fn run_stdio_session(
     // Parse --config and --log-file from the provided arguments.
     let mut iter = arguments.iter();
     while let Some(argument) = iter.next() {
-        if let Some(value) = take_option_value(argument, &mut iter, "--config")
-            .map_err(|e| DaemonError::new(1, rsync_error!(1, format!("{e}")).with_role(Role::Daemon)))?
-        {
+        if let Some(value) = take_option_value(argument, &mut iter, "--config").map_err(|e| {
+            DaemonError::new(1, rsync_error!(1, format!("{e}")).with_role(Role::Daemon))
+        })? {
             options.load_config_modules(&value, &mut seen_modules)?;
             has_explicit_config = true;
-        } else if let Some(value) = take_option_value(argument, &mut iter, "--log-file")
-            .map_err(|e| DaemonError::new(1, rsync_error!(1, format!("{e}")).with_role(Role::Daemon)))?
+        } else if let Some(value) =
+            take_option_value(argument, &mut iter, "--log-file").map_err(|e| {
+                DaemonError::new(1, rsync_error!(1, format!("{e}")).with_role(Role::Daemon))
+            })?
         {
             options.set_log_file(PathBuf::from(value))?;
         }

--- a/crates/daemon/src/daemon/sections/symlink_munge.rs
+++ b/crates/daemon/src/daemon/sections/symlink_munge.rs
@@ -6,13 +6,13 @@
 // When enabled, symlink targets are prefixed with `/rsyncd-munged/` on send
 // and the prefix is stripped on receive, preventing symlinks from escaping
 // the module root on non-chrooted modules.
-#[allow(unused_imports)] // REASON: re-export for daemon file list processing; currently used in tests
+#[allow(unused_imports)]
+// REASON: re-export for daemon file list processing; currently used in tests
 pub(crate) use ::metadata::symlink_munge::{munge_symlink, unmunge_symlink};
 
 #[cfg(test)]
 mod symlink_munge_tests {
     use super::*;
-
 
     #[test]
     fn munge_prepends_prefix_to_absolute_path() {
@@ -43,7 +43,6 @@ mod symlink_munge_tests {
         let result = munge_symlink(".");
         assert_eq!(result, "/rsyncd-munged/.");
     }
-
 
     #[test]
     fn unmunge_strips_prefix() {
@@ -81,7 +80,6 @@ mod symlink_munge_tests {
         assert_eq!(result, Some(String::new()));
     }
 
-
     #[test]
     fn roundtrip_absolute_path() {
         let original = "/usr/local/bin/tool";
@@ -113,7 +111,6 @@ mod symlink_munge_tests {
         let restored = unmunge_symlink(&munged);
         assert_eq!(restored, Some(original.to_owned()));
     }
-
 
     #[test]
     fn effective_munge_auto_chroot_on() {

--- a/crates/daemon/src/daemon/sections/variable_expansion.rs
+++ b/crates/daemon/src/daemon/sections/variable_expansion.rs
@@ -122,11 +122,7 @@ fn env_expansion(name: &str) -> Option<String> {
 ///
 /// upstream: `loadparm.c` - string parameters are expanded via `lp_string()`
 /// which calls `alloc_sub_advanced()` for each access.
-fn expand_module_vars(
-    module: &mut ModuleDefinition,
-    client_addr: &str,
-    client_host: &str,
-) {
+fn expand_module_vars(module: &mut ModuleDefinition, client_addr: &str, client_host: &str) {
     let ctx = VarExpansionContext {
         module_name: &module.name.clone(),
         module_path: &module.path.display().to_string(),
@@ -581,7 +577,6 @@ mod variable_expansion_tests {
         }
     }
 
-
     #[test]
     fn expand_diffhost() {
         let ctx = sample_ctx();
@@ -594,10 +589,7 @@ mod variable_expansion_tests {
     #[test]
     fn expand_module() {
         let ctx = sample_ctx();
-        assert_eq!(
-            expand_config_vars("/srv/%MODULE%", &ctx),
-            "/srv/backup"
-        );
+        assert_eq!(expand_config_vars("/srv/%MODULE%", &ctx), "/srv/backup");
     }
 
     #[test]
@@ -636,12 +628,8 @@ mod variable_expansion_tests {
     #[test]
     fn expand_double_percent_mid_string() {
         let ctx = sample_ctx();
-        assert_eq!(
-            expand_config_vars("a%%b%%c", &ctx),
-            "a%b%c"
-        );
+        assert_eq!(expand_config_vars("a%%b%%c", &ctx), "a%b%c");
     }
-
 
     #[test]
     fn expand_unset_env_variable_preserved() {
@@ -650,7 +638,9 @@ mod variable_expansion_tests {
         // `%TOKEN%` in place (getenv returns NULL, so the raw chars pass
         // through). WHY: a config author's `%FOO%` must not silently vanish when
         // FOO is undefined.
-        let _lock = crate::test_env::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let _guard = crate::test_env::EnvGuard::remove("OC_RSYNC_TEST_EXPAND_UNSET");
         let ctx = sample_ctx();
         assert_eq!(
@@ -665,7 +655,9 @@ mod variable_expansion_tests {
         // %UPPERCASE% token that is not a built-in name and substitutes the
         // value when set. WHY: rsyncd.conf paths like `path = %HOME%/rsync` must
         // resolve against the daemon's environment exactly as upstream does.
-        let _lock = crate::test_env::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let _guard = crate::test_env::EnvGuard::set(
             "OC_RSYNC_TEST_EXPAND_VAR",
             std::ffi::OsStr::new("/srv/env"),
@@ -704,10 +696,7 @@ mod variable_expansion_tests {
     #[test]
     fn expand_trailing_percent_no_close() {
         let ctx = sample_ctx();
-        assert_eq!(
-            expand_config_vars("/path/%MODULE", &ctx),
-            "/path/%MODULE"
-        );
+        assert_eq!(expand_config_vars("/path/%MODULE", &ctx), "/path/%MODULE");
     }
 
     #[test]
@@ -738,8 +727,7 @@ mod variable_expansion_tests {
     fn expand_all_variables_combined() {
         let ctx = sample_ctx();
         let input = "%DIFFHOST%-%MODULE%-%RSYNC_MODULE_NAME%-%RSYNC_MODULE_PATH%-%ADDR%";
-        let expected =
-            "client.example.com-backup-backup-/srv/backup-192.168.1.100";
+        let expected = "client.example.com-backup-backup-/srv/backup-192.168.1.100";
         assert_eq!(expand_config_vars(input, &ctx), expected);
     }
 
@@ -764,17 +752,16 @@ mod variable_expansion_tests {
     #[test]
     fn expand_percent_before_variable() {
         let ctx = sample_ctx();
-        assert_eq!(
-            expand_config_vars("100%% %MODULE%", &ctx),
-            "100% backup"
-        );
+        assert_eq!(expand_config_vars("100%% %MODULE%", &ctx), "100% backup");
     }
-
 
     #[test]
     fn resolve_diffhost() {
         let ctx = sample_ctx();
-        assert_eq!(resolve_variable("DIFFHOST", &ctx), Some("client.example.com"));
+        assert_eq!(
+            resolve_variable("DIFFHOST", &ctx),
+            Some("client.example.com")
+        );
     }
 
     #[test]
@@ -792,7 +779,10 @@ mod variable_expansion_tests {
     #[test]
     fn resolve_rsync_module_path() {
         let ctx = sample_ctx();
-        assert_eq!(resolve_variable("RSYNC_MODULE_PATH", &ctx), Some("/srv/backup"));
+        assert_eq!(
+            resolve_variable("RSYNC_MODULE_PATH", &ctx),
+            Some("/srv/backup")
+        );
     }
 
     #[test]
@@ -806,7 +796,6 @@ mod variable_expansion_tests {
         let ctx = sample_ctx();
         assert_eq!(resolve_variable("NOPE", &ctx), None);
     }
-
 
     #[test]
     fn expand_module_vars_expands_path() {
@@ -955,7 +944,6 @@ mod variable_expansion_tests {
             Some(PathBuf::from("/etc/multi.include"))
         );
     }
-
 
     fn sample_path_ctx<'a>() -> PathExpansionContext<'a> {
         PathExpansionContext {
@@ -1164,10 +1152,7 @@ mod variable_expansion_tests {
         // The `'` inside `"..."` must not open a single-quoted run, or the
         // value after it would be escaped for the wrong context.
         // upstream: `loadparm.c:300-305`.
-        assert_eq!(
-            expanded("echo \"it's\" %u", &ctx),
-            "echo \"it's\" 'alice'"
-        );
+        assert_eq!(expanded("echo \"it's\" %u", &ctx), "echo \"it's\" 'alice'");
     }
 
     #[test]
@@ -1231,7 +1216,6 @@ mod variable_expansion_tests {
         // operator-configured path stays verbatim. upstream: `loadparm.c:266`.
         assert_eq!(expanded("du %P", &ctx), "du /srv/my backups");
     }
-
 
     #[test]
     fn log_file_path_expands_module_name() {

--- a/crates/daemon/src/daemon/sections/xfer_exec.rs
+++ b/crates/daemon/src/daemon/sections/xfer_exec.rs
@@ -447,8 +447,8 @@ mod xfer_exec_tests {
     #[test]
     fn run_early_exec_captures_stderr() {
         let ctx = test_context();
-        let result =
-            run_early_exec("echo 'early error' >&2; exit 1", &ctx, None).expect("command should run");
+        let result = run_early_exec("echo 'early error' >&2; exit 1", &ctx, None)
+            .expect("command should run");
         assert!(result.is_err());
         let msg = result.unwrap_err();
         assert!(msg.contains("early error"));
@@ -490,8 +490,8 @@ mod xfer_exec_tests {
     #[test]
     fn run_pre_xfer_exec_captures_stderr() {
         let ctx = test_context();
-        let result = run_pre_xfer_exec("echo 'custom error' >&2; exit 1", &ctx)
-            .expect("command should run");
+        let result =
+            run_pre_xfer_exec("echo 'custom error' >&2; exit 1", &ctx).expect("command should run");
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.message.contains("custom error"));
@@ -551,7 +551,11 @@ mod xfer_exec_tests {
             assert_eq!(exit, cooked, "cooked exit status should be passed through");
             assert_eq!(raw, cooked << 8, "raw status should be the wait encoding");
             // The raw value must decode back to the cooked code via WEXITSTATUS.
-            assert_eq!((raw >> 8) & 0xff, cooked, "WEXITSTATUS(raw) must equal cooked");
+            assert_eq!(
+                (raw >> 8) & 0xff,
+                cooked,
+                "WEXITSTATUS(raw) must equal cooked"
+            );
         }
     }
 
@@ -568,8 +572,7 @@ mod xfer_exec_tests {
         let ctx = test_context();
         // sh -c with a non-existent command will still run (sh exists), so
         // the command itself returns non-zero rather than an I/O error.
-        let result =
-            run_pre_xfer_exec("/nonexistent/binary/path", &ctx).expect("sh -c should run");
+        let result = run_pre_xfer_exec("/nonexistent/binary/path", &ctx).expect("sh -c should run");
         assert!(result.is_err());
     }
 
@@ -739,8 +742,8 @@ mod xfer_exec_tests {
     #[test]
     fn run_pre_xfer_exec_captures_stdout_on_failure() {
         let ctx = test_context();
-        let result = run_pre_xfer_exec("echo 'pre-xfer info'; exit 1", &ctx)
-            .expect("command should run");
+        let result =
+            run_pre_xfer_exec("echo 'pre-xfer info'; exit 1", &ctx).expect("command should run");
         let err = result.unwrap_err();
         assert_eq!(err.stdout, "pre-xfer info");
         assert!(err.message.contains("pre-xfer exec returned"));

--- a/crates/daemon/src/tests/chunks/advertised_capability_lines_empty_without_modules.rs
+++ b/crates/daemon/src/tests/chunks/advertised_capability_lines_empty_without_modules.rs
@@ -2,4 +2,3 @@
 fn advertised_capability_lines_empty_without_modules() {
     assert!(advertised_capability_lines(&[]).is_empty());
 }
-

--- a/crates/daemon/src/tests/chunks/advertised_capability_lines_include_authlist_when_required.rs
+++ b/crates/daemon/src/tests/chunks/advertised_capability_lines_include_authlist_when_required.rs
@@ -1,7 +1,9 @@
 #[test]
 fn advertised_capability_lines_include_authlist_when_required() {
     let mut definition = base_module("secure");
-    definition.auth_users.push(AuthUser::new(String::from("alice")));
+    definition
+        .auth_users
+        .push(AuthUser::new(String::from("alice")));
     definition.secrets_file = Some(PathBuf::from("secrets.txt"));
     let module = ModuleRuntime::from(definition);
 
@@ -10,4 +12,3 @@ fn advertised_capability_lines_include_authlist_when_required() {
         vec![String::from("modules authlist")]
     );
 }
-

--- a/crates/daemon/src/tests/chunks/advertised_capability_lines_report_modules_without_auth.rs
+++ b/crates/daemon/src/tests/chunks/advertised_capability_lines_report_modules_without_auth.rs
@@ -7,4 +7,3 @@ fn advertised_capability_lines_report_modules_without_auth() {
         vec![String::from("modules")]
     );
 }
-

--- a/crates/daemon/src/tests/chunks/builder_allows_brand_override.rs
+++ b/crates/daemon/src/tests/chunks/builder_allows_brand_override.rs
@@ -9,4 +9,3 @@ fn builder_allows_brand_override() {
     assert_eq!(config.brand(), Brand::Upstream);
     assert_eq!(config.arguments(), &[OsString::from("--daemon")]);
 }
-

--- a/crates/daemon/src/tests/chunks/builder_collects_arguments.rs
+++ b/crates/daemon/src/tests/chunks/builder_collects_arguments.rs
@@ -18,4 +18,3 @@ fn builder_collects_arguments() {
     assert!(config.has_runtime_request());
     assert_eq!(config.brand(), Brand::Oc);
 }
-

--- a/crates/daemon/src/tests/chunks/connection_limiter_enforces_limits_across_guards.rs
+++ b/crates/daemon/src/tests/chunks/connection_limiter_enforces_limits_across_guards.rs
@@ -30,6 +30,9 @@ fn connection_limiter_enforces_limits_across_guards() {
 
     drop(third);
     drop(first);
-    assert!(limiter.acquire("docs", MaxConnections::Limited(limit)).is_ok());
+    assert!(
+        limiter
+            .acquire("docs", MaxConnections::Limited(limit))
+            .is_ok()
+    );
 }
-

--- a/crates/daemon/src/tests/chunks/connection_limiter_open_preserves_existing_counts.rs
+++ b/crates/daemon/src/tests/chunks/connection_limiter_open_preserves_existing_counts.rs
@@ -10,4 +10,3 @@ fn connection_limiter_open_preserves_existing_counts() {
     let contents = fs::read_to_string(&lock_path).expect("read lock file");
     assert_eq!(contents, "docs 1\nother 2\n");
 }
-

--- a/crates/daemon/src/tests/chunks/connection_limiter_propagates_io_errors.rs
+++ b/crates/daemon/src/tests/chunks/connection_limiter_propagates_io_errors.rs
@@ -7,10 +7,12 @@ fn connection_limiter_propagates_io_errors() {
     fs::remove_file(&lock_path).expect("remove original lock file");
     fs::create_dir(&lock_path).expect("replace lock file with directory");
 
-    match limiter.acquire("docs", MaxConnections::Limited(NonZeroU32::new(1).expect("non-zero"))) {
+    match limiter.acquire(
+        "docs",
+        MaxConnections::Limited(NonZeroU32::new(1).expect("non-zero")),
+    ) {
         Err(ModuleConnectionError::Io(_)) => {}
         Err(other) => panic!("expected io error, got {other:?}"),
         Ok(_) => panic!("expected io error, got success"),
     }
 }
-

--- a/crates/daemon/src/tests/chunks/connection_limiter_reclaims_slot_on_close_without_decrement.rs
+++ b/crates/daemon/src/tests/chunks/connection_limiter_reclaims_slot_on_close_without_decrement.rs
@@ -20,7 +20,9 @@ fn connection_limiter_reclaims_slot_on_close_without_decrement() {
     let limiter = Arc::new(ConnectionLimiter::open(lock_path.clone()).expect("open lock file"));
     let limit = NonZeroU32::new(1).expect("non-zero");
 
-    let held = limiter.acquire("docs", MaxConnections::Limited(limit)).expect("first slot claimed");
+    let held = limiter
+        .acquire("docs", MaxConnections::Limited(limit))
+        .expect("first slot claimed");
 
     // At capacity: the sole slot's byte range is locked.
     assert!(matches!(

--- a/crates/daemon/src/tests/chunks/connection_status_messages_describe_active_sessions.rs
+++ b/crates/daemon/src/tests/chunks/connection_status_messages_describe_active_sessions.rs
@@ -4,4 +4,3 @@ fn connection_status_messages_describe_active_sessions() {
     assert_eq!(format_connection_status(1), "Serving 1 connection");
     assert_eq!(format_connection_status(3), "Serving 3 connections");
 }
-

--- a/crates/daemon/src/tests/chunks/daemon_acl_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_acl_push.rs
@@ -87,9 +87,7 @@ fn daemon_acl_push_preserves_acls() {
     });
 
     if !has_extended_entry {
-        eprintln!(
-            "skipping daemon_acl_push: extended ACL entry not preserved on this filesystem"
-        );
+        eprintln!("skipping daemon_acl_push: extended ACL entry not preserved on this filesystem");
         return;
     }
 
@@ -159,7 +157,8 @@ fn daemon_acl_push_preserves_acls() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -206,8 +205,7 @@ fn daemon_acl_push_preserves_acls() {
 
     let dest_alpha_acl =
         getfacl(&dest_alpha, acl_option).expect("getfacl on destination alpha.txt");
-    let dest_beta_acl =
-        getfacl(&dest_beta, acl_option).expect("getfacl on destination beta.txt");
+    let dest_beta_acl = getfacl(&dest_beta, acl_option).expect("getfacl on destination beta.txt");
 
     // Check that the extended user ACL entry (uid 65534 with read+execute) is present.
     let check_acl = |entries: &[AclEntry], file_name: &str| {

--- a/crates/daemon/src/tests/chunks/daemon_auth_digest_floor.rs
+++ b/crates/daemon/src/tests/chunks/daemon_auth_digest_floor.rs
@@ -8,7 +8,10 @@
 fn start_auth_digest_floor_daemon(
     dir: &Path,
     floor: &str,
-) -> (TcpStream, thread::JoinHandle<Result<(), crate::DaemonError>>) {
+) -> (
+    TcpStream,
+    thread::JoinHandle<Result<(), crate::DaemonError>>,
+) {
     let module_dir = dir.join("module");
     fs::create_dir_all(&module_dir).expect("module dir");
     let secrets_path = dir.join("secrets.txt");
@@ -17,7 +20,8 @@ fn start_auth_digest_floor_daemon(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&secrets_path, PermissionsExt::from_mode(0o600)).expect("chmod secrets");
+        fs::set_permissions(&secrets_path, PermissionsExt::from_mode(0o600))
+            .expect("chmod secrets");
     }
 
     let config_path = dir.join("rsyncd.conf");

--- a/crates/daemon/src/tests/chunks/daemon_auth_digest_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/daemon_auth_digest_negotiation.rs
@@ -3,7 +3,12 @@
 /// connected client socket plus the daemon thread handle.
 ///
 /// The caller has already consumed nothing: the server greeting is still queued.
-fn start_auth_digest_daemon(dir: &Path) -> (TcpStream, thread::JoinHandle<Result<(), crate::DaemonError>>) {
+fn start_auth_digest_daemon(
+    dir: &Path,
+) -> (
+    TcpStream,
+    thread::JoinHandle<Result<(), crate::DaemonError>>,
+) {
     let module_dir = dir.join("module");
     fs::create_dir_all(&module_dir).expect("module dir");
     let secrets_path = dir.join("secrets.txt");
@@ -55,12 +60,17 @@ fn negotiate_protected_module(
 ) -> String {
     let mut line = String::new();
     reader.read_line(&mut line).expect("server greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(greeting.as_bytes())
         .expect("send client greeting");
-    stream.write_all(b"protected\n").expect("send module request");
+    stream
+        .write_all(b"protected\n")
+        .expect("send module request");
     stream.flush().expect("flush handshake");
 
     line.clear();
@@ -98,8 +108,11 @@ fn daemon_auth_uses_the_first_client_offered_digest_it_supports() {
         "challenge must come from the negotiated MD5, not SHA-512"
     );
 
-    let response =
-        core::auth::compute_daemon_auth_response(b"correctpassword", challenge, DaemonAuthDigest::Md5);
+    let response = core::auth::compute_daemon_auth_response(
+        b"correctpassword",
+        challenge,
+        DaemonAuthDigest::Md5,
+    );
     stream
         .write_all(format!("alice {response}\n").as_bytes())
         .expect("send response");
@@ -144,8 +157,11 @@ fn daemon_auth_rejects_a_response_computed_with_a_non_negotiated_digest() {
     assert_eq!(challenge.len(), DaemonAuthDigest::Sha512.base64_len());
 
     // Answer with the correct password but the *wrong* (shorter) digest.
-    let short_response =
-        core::auth::compute_daemon_auth_response(b"correctpassword", challenge, DaemonAuthDigest::Md5);
+    let short_response = core::auth::compute_daemon_auth_response(
+        b"correctpassword",
+        challenge,
+        DaemonAuthDigest::Md5,
+    );
     assert_eq!(short_response.len(), DaemonAuthDigest::Md5.base64_len());
     stream
         .write_all(format!("alice {short_response}\n").as_bytes())
@@ -197,14 +213,20 @@ fn daemon_auth_refuses_a_client_with_no_mutual_digest() {
     // The refusal replaces the challenge: nothing else reaches the client.
     let mut line = String::new();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no challenge may follow the refusal, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no challenge may follow the refusal, got: {line:?}"
+    );
 
     drop(reader);
     drop(stream);
     // Bounded join: an unconditional join() can wedge on Windows, where a
     // blocking accept on a re-bound listener may linger (see finish_daemon).
     if let Some(result) = finish_daemon(handle) {
-        assert!(result.is_ok(), "the listener survives a refused client: {result:?}");
+        assert!(
+            result.is_ok(),
+            "the listener survives a refused client: {result:?}"
+        );
     }
 }
 
@@ -328,7 +350,10 @@ fn assert_empty_digest_list_refused(greeting: &str) {
     // No challenge may follow: upstream refuses before `gen_challenge()`.
     let mut line = String::new();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no challenge may follow the refusal, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no challenge may follow the refusal, got: {line:?}"
+    );
 
     drop(reader);
     drop(stream);

--- a/crates/daemon/src/tests/chunks/daemon_checksum_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_checksum_push.rs
@@ -71,7 +71,8 @@ fn daemon_checksum_push_detects_content_change_despite_matching_mtime() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Initial push (seeds destination with original content)
@@ -119,10 +120,12 @@ fn daemon_checksum_push_detects_content_change_despite_matching_mtime() {
 
     // Read back the source mtime so we can stamp the destination with it -
     // this makes quick-check see identical mtime + size and skip the files.
-    let source_alpha_mtime =
-        filetime::FileTime::from_last_modification_time(&fs::metadata(source_dir.join("alpha.txt")).expect("stat source alpha"));
-    let source_beta_mtime =
-        filetime::FileTime::from_last_modification_time(&fs::metadata(source_dir.join("beta.txt")).expect("stat source beta"));
+    let source_alpha_mtime = filetime::FileTime::from_last_modification_time(
+        &fs::metadata(source_dir.join("alpha.txt")).expect("stat source alpha"),
+    );
+    let source_beta_mtime = filetime::FileTime::from_last_modification_time(
+        &fs::metadata(source_dir.join("beta.txt")).expect("stat source beta"),
+    );
 
     filetime::set_file_mtime(dest_dir.join("alpha.txt"), source_alpha_mtime)
         .expect("set dest alpha.txt mtime");
@@ -165,13 +168,15 @@ fn daemon_checksum_push_detects_content_change_despite_matching_mtime() {
     }
 
     // Verify destination now has the modified content
-    let dest_alpha = fs::read(dest_dir.join("alpha.txt")).expect("read dest alpha.txt after checksum push");
+    let dest_alpha =
+        fs::read(dest_dir.join("alpha.txt")).expect("read dest alpha.txt after checksum push");
     assert_eq!(
         dest_alpha, modified_content,
         "alpha.txt must match modified source after checksum push"
     );
 
-    let dest_beta = fs::read(dest_dir.join("beta.txt")).expect("read dest beta.txt after checksum push");
+    let dest_beta =
+        fs::read(dest_dir.join("beta.txt")).expect("read dest beta.txt after checksum push");
     assert_eq!(
         dest_beta, modified_content,
         "beta.txt must match modified source after checksum push"

--- a/crates/daemon/src/tests/chunks/daemon_compare_dest_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_compare_dest_push.rs
@@ -47,8 +47,7 @@ fn daemon_compare_dest_push_skips_unchanged_files() {
     let old_time = filetime::FileTime::from_unix_time(1_000_000, 0);
     filetime::set_file_mtime(ref_dir.join("unchanged.txt"), old_time)
         .expect("backdate ref unchanged");
-    filetime::set_file_mtime(ref_dir.join("changed.txt"), old_time)
-        .expect("backdate ref changed");
+    filetime::set_file_mtime(ref_dir.join("changed.txt"), old_time).expect("backdate ref changed");
 
     // Match source unchanged.txt mtime to the reference so compare-dest sees it as identical
     filetime::set_file_mtime(source_dir.join("unchanged.txt"), old_time)
@@ -81,7 +80,8 @@ fn daemon_compare_dest_push_skips_unchanged_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -207,7 +207,8 @@ fn daemon_link_dest_push_creates_hardlinks() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -258,10 +259,7 @@ fn daemon_link_dest_push_creates_hardlinks() {
 
     // new_file.txt should be a regular copy (not in reference)
     let dest_new = dest_dir.join("new_file.txt");
-    assert!(
-        dest_new.exists(),
-        "new_file.txt must exist at destination"
-    );
+    assert!(dest_new.exists(), "new_file.txt must exist at destination");
     assert_eq!(
         fs::read(&dest_new).expect("read new_file.txt"),
         b"brand new\n",
@@ -324,8 +322,7 @@ fn daemon_copy_dest_push_copies_from_reference() {
     let old_time = filetime::FileTime::from_unix_time(1_000_000, 0);
     filetime::set_file_mtime(ref_dir.join("unchanged.txt"), old_time)
         .expect("backdate ref unchanged");
-    filetime::set_file_mtime(ref_dir.join("changed.txt"), old_time)
-        .expect("backdate ref changed");
+    filetime::set_file_mtime(ref_dir.join("changed.txt"), old_time).expect("backdate ref changed");
 
     // Match source unchanged.txt mtime to reference
     filetime::set_file_mtime(source_dir.join("unchanged.txt"), old_time)
@@ -358,7 +355,8 @@ fn daemon_copy_dest_push_copies_from_reference() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_compress_pull_drains_peer_goodbye.rs
+++ b/crates/daemon/src/tests/chunks/daemon_compress_pull_drains_peer_goodbye.rs
@@ -97,7 +97,8 @@ fn daemon_compress_pull_drains_peer_goodbye_for_uts_v3_cluster_a() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");

--- a/crates/daemon/src/tests/chunks/daemon_compress_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_compress_push.rs
@@ -83,7 +83,8 @@ fn daemon_compress_push_transfers_files_with_compression() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_copy_links_push_resolves_symlinks.rs
+++ b/crates/daemon/src/tests/chunks/daemon_copy_links_push_resolves_symlinks.rs
@@ -73,7 +73,8 @@ fn daemon_copy_links_push_resolves_symlinks() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
@@ -106,9 +107,16 @@ fn daemon_copy_links_push_resolves_symlinks() {
 
     // Verify destination has regular files where source had symlinks
     let dest_link = dest_dir.join("link_to_file.txt");
-    assert!(dest_link.exists(), "link_to_file.txt must exist at destination");
     assert!(
-        !dest_link.symlink_metadata().expect("metadata").file_type().is_symlink(),
+        dest_link.exists(),
+        "link_to_file.txt must exist at destination"
+    );
+    assert!(
+        !dest_link
+            .symlink_metadata()
+            .expect("metadata")
+            .file_type()
+            .is_symlink(),
         "link_to_file.txt must be a regular file, not a symlink"
     );
     assert_eq!(
@@ -118,7 +126,10 @@ fn daemon_copy_links_push_resolves_symlinks() {
     );
 
     let dest_real = dest_dir.join("real_file.txt");
-    assert!(dest_real.exists(), "real_file.txt must exist at destination");
+    assert!(
+        dest_real.exists(),
+        "real_file.txt must exist at destination"
+    );
     assert_eq!(
         fs::read(&dest_real).expect("read real_file.txt"),
         b"real content\n",
@@ -145,7 +156,10 @@ fn daemon_copy_links_push_resolves_symlinks() {
     );
 
     let dest_nested = dest_dir.join("subdir/nested.txt");
-    assert!(dest_nested.exists(), "subdir/nested.txt must exist at destination");
+    assert!(
+        dest_nested.exists(),
+        "subdir/nested.txt must exist at destination"
+    );
     assert_eq!(
         fs::read(&dest_nested).expect("read nested.txt"),
         b"nested content\n",

--- a/crates/daemon/src/tests/chunks/daemon_delete_pull_emits_stats.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delete_pull_emits_stats.rs
@@ -54,7 +54,8 @@ fn daemon_delete_pull_reports_delete_stats() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/pullmod/");

--- a/crates/daemon/src/tests/chunks/daemon_delete_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delete_push.rs
@@ -56,7 +56,8 @@ fn daemon_delete_push_removes_extraneous_destination_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Initial push - seed destination with A, B, C

--- a/crates/daemon/src/tests/chunks/daemon_delete_push_emits_stats.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delete_push_emits_stats.rs
@@ -65,7 +65,8 @@ fn daemon_delete_push_reports_delete_stats() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_delta_transfer.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delta_transfer.rs
@@ -67,7 +67,8 @@ fn daemon_delta_transfer_updates_modified_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Initial push (whole-file, seeds the destination)
@@ -112,8 +113,7 @@ fn daemon_delta_transfer_updates_modified_files() {
     // Backdate destination files so quick-check detects them as stale after
     // the source is modified (different mtime triggers re-transfer).
     let old_time = filetime::FileTime::from_unix_time(1_000_000, 0);
-    filetime::set_file_mtime(dest_dir.join("data.txt"), old_time)
-        .expect("backdate dest data.txt");
+    filetime::set_file_mtime(dest_dir.join("data.txt"), old_time).expect("backdate dest data.txt");
     filetime::set_file_mtime(dest_dir.join("other.txt"), old_time)
         .expect("backdate dest other.txt");
 
@@ -159,8 +159,7 @@ fn daemon_delta_transfer_updates_modified_files() {
         "data.txt must match modified source after delta push"
     );
 
-    let dest_other =
-        fs::read(dest_dir.join("other.txt")).expect("read dest other.txt after delta");
+    let dest_other = fs::read(dest_dir.join("other.txt")).expect("read dest other.txt after delta");
     assert_eq!(
         dest_other, modified_content,
         "other.txt must match modified source after delta push"

--- a/crates/daemon/src/tests/chunks/daemon_dry_run_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_dry_run_push.rs
@@ -64,7 +64,8 @@ fn daemon_dry_run_push() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_dry_run_push_across_protocol_versions.rs
+++ b/crates/daemon/src/tests/chunks/daemon_dry_run_push_across_protocol_versions.rs
@@ -55,7 +55,8 @@ fn run_dry_run_push_at_protocol(protocol: ProtocolVersion) {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -81,10 +82,7 @@ fn run_dry_run_push_at_protocol(protocol: ProtocolVersion) {
         }
         Err(e) => {
             let _ = daemon_handle.join();
-            panic!(
-                "dry-run push at protocol {} failed: {e}",
-                protocol.as_u8()
-            );
+            panic!("dry-run push at protocol {} failed: {e}", protocol.as_u8());
         }
     }
 

--- a/crates/daemon/src/tests/chunks/daemon_early_exec_receives_early_input_on_stdin.rs
+++ b/crates/daemon/src/tests/chunks/daemon_early_exec_receives_early_input_on_stdin.rs
@@ -48,7 +48,10 @@ fn early_exec_hook_capture(early_input: Option<&[u8]>) -> String {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")

--- a/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
+++ b/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
@@ -52,10 +52,7 @@ fn daemon_error_payloads_match_upstream_wording() {
     );
 
     // upstream: clientserver.c:694 - `@ERROR: chdir failed\n`
-    assert_eq!(
-        crate::daemon::CHDIR_FAILED_PAYLOAD,
-        "@ERROR: chdir failed",
-    );
+    assert_eq!(crate::daemon::CHDIR_FAILED_PAYLOAD, "@ERROR: chdir failed",);
 
     // upstream: clientserver.c:1129 - `@ERROR: setuid failed\n`
     assert_eq!(
@@ -128,7 +125,10 @@ fn send_error_framing_matches_upstream() {
     let expected_wire = format!("{payload}\n");
     assert!(expected_wire.starts_with("@ERROR: "));
     assert!(expected_wire.ends_with('\n'));
-    assert!(!expected_wire.ends_with("\n\n"), "must not double-terminate");
+    assert!(
+        !expected_wire.ends_with("\n\n"),
+        "must not double-terminate"
+    );
     assert!(
         !expected_wire.contains("@RSYNCD: EXIT"),
         "refusal wire must not contain a trailing EXIT marker"
@@ -147,8 +147,7 @@ fn deny_hidden_module_sends_unknown_module_error() {
 
     // When listable is false, the error should use the unknown module template
     // (masking the module's existence).
-    let hidden_payload =
-        UNKNOWN_MODULE_PAYLOAD.replace("{module}", "secret");
+    let hidden_payload = UNKNOWN_MODULE_PAYLOAD.replace("{module}", "secret");
     assert_eq!(hidden_payload, "@ERROR: Unknown module 'secret'");
     assert!(
         !hidden_payload.contains("access denied"),

--- a/crates/daemon/src/tests/chunks/daemon_fake_super_module_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_fake_super_module_push.rs
@@ -86,7 +86,8 @@ fn daemon_fake_super_module_directive_stores_ownership_in_xattr() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_files_from_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_files_from_push.rs
@@ -70,7 +70,8 @@ fn daemon_files_from_push_limits_transferred_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_files_from_stdin_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_files_from_stdin_pull.rs
@@ -83,7 +83,8 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
@@ -94,7 +95,10 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
     let rsync_url = format!("rsync://127.0.0.1:{port}/pullmod/");
 
     let client_config = core::client::ClientConfig::builder()
-        .transfer_args([OsString::from(&rsync_url), OsString::from(dest_dir.as_os_str())])
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
         .files_from(core::client::FilesFromSource::LocalFile(
             files_from_path.clone(),
         ))
@@ -126,7 +130,10 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
     );
 
     let dest_three = dest_dir.join("dir/three.txt");
-    assert!(dest_three.exists(), "dir/three.txt must exist at destination");
+    assert!(
+        dest_three.exists(),
+        "dir/three.txt must exist at destination"
+    );
     assert_eq!(
         fs::read(&dest_three).expect("read three.txt"),
         b"third content\n",

--- a/crates/daemon/src/tests/chunks/daemon_filter_merge_with_client_filters.rs
+++ b/crates/daemon/src/tests/chunks/daemon_filter_merge_with_client_filters.rs
@@ -56,7 +56,8 @@ fn daemon_exclude_overrides_client_include() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");
@@ -65,7 +66,10 @@ fn daemon_exclude_overrides_client_include() {
     // (server filter list is consulted first, so this MUST NOT win).
     let client_config = core::client::ClientConfig::builder()
         .recursive(true)
-        .transfer_args([OsString::from(&rsync_url), OsString::from(dest_dir.as_os_str())])
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
         .add_filter_rule(core::client::FilterRuleSpec::include("*.log"))
         .build();
 
@@ -140,13 +144,17 @@ fn daemon_exclude_directory_blocks_subtree() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");
     let client_config = core::client::ClientConfig::builder()
         .recursive(true)
-        .transfer_args([OsString::from(&rsync_url), OsString::from(dest_dir.as_os_str())])
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
         .build();
 
     let result = core::client::run_client(client_config);
@@ -223,13 +231,17 @@ fn daemon_include_then_exclude_all_keeps_only_included() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");
     let client_config = core::client::ClientConfig::builder()
         .recursive(true)
-        .transfer_args([OsString::from(&rsync_url), OsString::from(dest_dir.as_os_str())])
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
         .build();
 
     let result = core::client::run_client(client_config);
@@ -307,7 +319,8 @@ fn daemon_exclude_from_file_matches_inline_exclude() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");
@@ -316,7 +329,10 @@ fn daemon_exclude_from_file_matches_inline_exclude() {
     // win and exclude both *.tmp and *.bak.
     let client_config = core::client::ClientConfig::builder()
         .recursive(true)
-        .transfer_args([OsString::from(&rsync_url), OsString::from(dest_dir.as_os_str())])
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
         .add_filter_rule(core::client::FilterRuleSpec::include("*.tmp"))
         .build();
 

--- a/crates/daemon/src/tests/chunks/daemon_fuzzy_level2_pulls_basis_from_sibling_directories.rs
+++ b/crates/daemon/src/tests/chunks/daemon_fuzzy_level2_pulls_basis_from_sibling_directories.rs
@@ -84,7 +84,8 @@ fn daemon_fuzzy_level2_pulls_basis_from_sibling_directories() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_hardlinks_relative_receive.rs
+++ b/crates/daemon/src/tests/chunks/daemon_hardlinks_relative_receive.rs
@@ -99,7 +99,8 @@ fn daemon_hardlinks_relative_receive_preserves_links() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -139,10 +140,7 @@ fn daemon_hardlinks_relative_receive_preserves_links() {
         dest_alpha_link.exists(),
         "x/alpha_link.txt must exist at destination"
     );
-    assert!(
-        dest_beta.exists(),
-        "a/b/beta.txt must exist at destination"
-    );
+    assert!(dest_beta.exists(), "a/b/beta.txt must exist at destination");
     assert!(
         dest_beta_link.exists(),
         "a/b/beta_link.txt must exist at destination"

--- a/crates/daemon/src/tests/chunks/daemon_inc_recurse_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_inc_recurse_push.rs
@@ -83,7 +83,8 @@ fn daemon_inc_recurse_push_nested_directories() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_inplace_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_inplace_push.rs
@@ -46,8 +46,7 @@ fn daemon_inplace_push_preserves_destination_inodes() {
     let old_time = filetime::FileTime::from_unix_time(1_000_000, 0);
     filetime::set_file_mtime(dest_dir.join("alpha.txt"), old_time)
         .expect("backdate dest alpha.txt");
-    filetime::set_file_mtime(dest_dir.join("beta.txt"), old_time)
-        .expect("backdate dest beta.txt");
+    filetime::set_file_mtime(dest_dir.join("beta.txt"), old_time).expect("backdate dest beta.txt");
 
     // Record inode numbers before the push - these must be preserved by inplace.
     let inode_alpha_before = fs::metadata(dest_dir.join("alpha.txt"))
@@ -81,7 +80,8 @@ fn daemon_inplace_push_preserves_destination_inodes() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_itemize_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_itemize_pull.rs
@@ -74,13 +74,17 @@ fn daemon_itemize_pull_reports_events() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/pullmod/");
 
     let client_config = core::client::ClientConfig::builder()
-        .transfer_args([OsString::from(&rsync_url), OsString::from(dest_dir.as_os_str())])
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
         .verbosity(1)
         .force_event_collection(true)
         .build();

--- a/crates/daemon/src/tests/chunks/daemon_itemize_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_itemize_push.rs
@@ -74,7 +74,8 @@ fn daemon_itemize_push_reports_events() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_module_implicit_list_only.rs
+++ b/crates/daemon/src/tests/chunks/daemon_module_implicit_list_only.rs
@@ -44,7 +44,8 @@ fn daemon_module_implicit_list_only() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Single source operand, NO destination: the fix routes this to

--- a/crates/daemon/src/tests/chunks/daemon_munge_symlinks_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_munge_symlinks_pull.rs
@@ -60,8 +60,7 @@ fn daemon_munge_symlinks_pull_strips_prefix() {
     // upstream: flist.c:234 - targets that lack the prefix pass through
     // unchanged via the `llen > SYMLINK_PREFIX_LEN && strncmp(...) == 0`
     // guard. Cover that branch alongside the strip path.
-    unix_fs::symlink("already_unmunged", source_dir.join("bare_link"))
-        .expect("create bare_link");
+    unix_fs::symlink("already_unmunged", source_dir.join("bare_link")).expect("create bare_link");
 
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
@@ -91,13 +90,17 @@ fn daemon_munge_symlinks_pull_strips_prefix() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/mungemod/");
 
     let client_config = core::client::ClientConfig::builder()
-        .transfer_args([OsString::from(&rsync_url), OsString::from(dest_dir.as_os_str())])
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
         .links(true)
         .build();
 
@@ -124,8 +127,7 @@ fn daemon_munge_symlinks_pull_strips_prefix() {
          client side link points at the actual file",
     );
 
-    let parent_link =
-        fs::read_link(dest_dir.join("parent_link")).expect("read parent_link target");
+    let parent_link = fs::read_link(dest_dir.join("parent_link")).expect("read parent_link target");
     assert_eq!(
         parent_link,
         std::path::Path::new("../escape"),

--- a/crates/daemon/src/tests/chunks/daemon_munge_symlinks_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_munge_symlinks_push.rs
@@ -75,7 +75,8 @@ fn daemon_munge_symlinks_push_prepends_prefix() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -110,8 +111,7 @@ fn daemon_munge_symlinks_push_prepends_prefix() {
          disabled placeholder rather than a usable in-tree shortcut",
     );
 
-    let parent_link =
-        fs::read_link(dest_dir.join("parent_link")).expect("read parent_link target");
+    let parent_link = fs::read_link(dest_dir.join("parent_link")).expect("read parent_link target");
     assert_eq!(
         parent_link,
         std::path::Path::new("/rsyncd-munged/../escape"),

--- a/crates/daemon/src/tests/chunks/daemon_munge_symlinks_rejects_preexisting_munged_dir.rs
+++ b/crates/daemon/src/tests/chunks/daemon_munge_symlinks_rejects_preexisting_munged_dir.rs
@@ -59,7 +59,10 @@ fn daemon_munge_symlinks_rejects_preexisting_munged_dir() {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
@@ -85,7 +88,10 @@ fn daemon_munge_symlinks_rejects_preexisting_munged_dir() {
     // and the socket closes right after the error (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing line after the security error, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing line after the security error, got: {line:?}"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
@@ -136,7 +142,10 @@ fn daemon_munge_symlinks_without_munged_dir_proceeds_to_ok() {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
@@ -429,9 +429,7 @@ fn daemon_negotiation_auth_denies_empty_credentials() {
     assert!(line.starts_with("@RSYNCD: AUTHREQD"));
 
     // Send empty credentials
-    stream
-        .write_all(b"\n")
-        .expect("send empty credentials");
+    stream.write_all(b"\n").expect("send empty credentials");
     stream.flush().expect("flush");
 
     // upstream: clientserver.c:764 - auth failure sends

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_empty_module_lists_modules.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_empty_module_lists_modules.rs
@@ -15,7 +15,10 @@ fn daemon_negotiation_empty_module_lists_modules() {
 
     let (port, held_listener) = allocate_test_port();
 
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
@@ -41,7 +41,8 @@ fn daemon_negotiation_error_unknown_module() {
     line.clear();
     reader.read_line(&mut line).expect("error response");
     assert!(
-        line.contains("@ERROR:") && (line.contains("unknown module") || line.contains("Unknown module")),
+        line.contains("@ERROR:")
+            && (line.contains("unknown module") || line.contains("Unknown module")),
         "Expected unknown module error, got: {line}"
     );
 
@@ -50,7 +51,10 @@ fn daemon_negotiation_error_unknown_module() {
     // the refusal; the socket just closes (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
@@ -308,8 +312,8 @@ fn daemon_negotiation_error_max_connections_exceeded() {
     );
 
     // Keep first connection open and try second connection
-    let mut stream2 = TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port))
-        .expect("connect second stream");
+    let mut stream2 =
+        TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port)).expect("connect second stream");
     let mut reader2 = BufReader::new(stream2.try_clone().expect("clone2"));
 
     line.clear();

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
@@ -61,7 +61,10 @@ fn daemon_negotiation_error_host_allow_blocks_unlisted() {
     // the refusal; the socket just closes (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
@@ -16,7 +16,10 @@ fn daemon_negotiation_module_list_sends_listing_directly() {
     // Normalise to forward slashes for symmetry with the comment-bearing test
     // below; Windows accepts forward slashes, and this avoids any future
     // Windows-only parser surprises around `\` as an escape character.
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
@@ -33,7 +36,10 @@ fn daemon_negotiation_module_list_sends_listing_directly() {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "Expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "Expected greeting, got: {line}"
+    );
 
     send_client_greeting(&mut stream);
     stream.write_all(b"#list\n").expect("send list request");
@@ -43,7 +49,10 @@ fn daemon_negotiation_module_list_sends_listing_directly() {
     // Read module listing - upstream: clientserver.c:1254 uses %-15s\t%s\n format
     line.clear();
     reader.read_line(&mut line).expect("module listing");
-    assert_eq!(line, "test           \t\n", "Expected %-15s aligned module, got: {line}");
+    assert_eq!(
+        line, "test           \t\n",
+        "Expected %-15s aligned module, got: {line}"
+    );
 
     line.clear();
     reader.read_line(&mut line).expect("exit");
@@ -142,7 +151,10 @@ fn daemon_negotiation_module_list_includes_comments() {
     // natively) to keep the comma separator that delimits the comment from
     // being swallowed by the escape state machine in
     // `daemon::sections::module_parsing::split_module_path_comment_and_options`.
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([

--- a/crates/daemon/src/tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs
+++ b/crates/daemon/src/tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs
@@ -37,7 +37,10 @@ fn daemon_pre_xfer_exec_rejects_on_nonzero_exit() {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
@@ -63,10 +66,7 @@ fn daemon_pre_xfer_exec_rejects_on_nonzero_exit() {
     // Pre-xfer exec fails - daemon sends @ERROR with the stderr content
     line.clear();
     reader.read_line(&mut line).expect("error message");
-    assert!(
-        line.starts_with("@ERROR:"),
-        "expected @ERROR, got: {line}"
-    );
+    assert!(line.starts_with("@ERROR:"), "expected @ERROR, got: {line}");
     assert!(
         line.contains("denied by hook"),
         "expected stderr content in error, got: {line}"
@@ -77,7 +77,10 @@ fn daemon_pre_xfer_exec_rejects_on_nonzero_exit() {
     // the refusal; the socket just closes (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/daemon_protocol_28_forced_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/daemon_protocol_28_forced_negotiation.rs
@@ -220,7 +220,8 @@ fn daemon_protocol_28_forced_client_api_push() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -319,14 +320,18 @@ fn daemon_protocol_28_forced_client_api_pull() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/pullmod/");
 
     // Force protocol 28 via client config; client is the receiver.
     let client_config = core::client::ClientConfig::builder()
-        .transfer_args([OsString::from(&rsync_url), OsString::from(dest_dir.as_os_str())])
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
         .protocol_version(Some(ProtocolVersion::V28))
         .build();
 
@@ -385,10 +390,12 @@ fn daemon_protocol_28_forced_push_then_pull_roundtrip() {
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
 
     fs::write(source_dir.join("readme.txt"), b"protocol 28 readme\n").expect("write readme");
-    fs::write(source_dir.join("blob.bin"), b"\xde\xad\xbe\xef\x00\x11\x22\x33")
-        .expect("write blob");
-    fs::write(source_subdir.join("nested.txt"), b"nested under proto 28\n")
-        .expect("write nested");
+    fs::write(
+        source_dir.join("blob.bin"),
+        b"\xde\xad\xbe\xef\x00\x11\x22\x33",
+    )
+    .expect("write blob");
+    fs::write(source_subdir.join("nested.txt"), b"nested under proto 28\n").expect("write nested");
 
     let module_dir = temp.path().join("module");
     fs::create_dir(&module_dir).expect("create module dir");
@@ -420,7 +427,8 @@ fn daemon_protocol_28_forced_push_then_pull_roundtrip() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Push at forced protocol 28
@@ -471,7 +479,10 @@ fn daemon_protocol_28_forced_push_then_pull_roundtrip() {
         let rsync_url = format!("rsync://127.0.0.1:{port}/lifecycle28/");
 
         let client_config = core::client::ClientConfig::builder()
-            .transfer_args([OsString::from(&rsync_url), OsString::from(pull_dest.as_os_str())])
+            .transfer_args([
+                OsString::from(&rsync_url),
+                OsString::from(pull_dest.as_os_str()),
+            ])
             .protocol_version(Some(ProtocolVersion::V28))
             .build();
 

--- a/crates/daemon/src/tests/chunks/daemon_pull_subpath.rs
+++ b/crates/daemon/src/tests/chunks/daemon_pull_subpath.rs
@@ -63,8 +63,11 @@ fn build_subpath_module_tree(module_dir: &Path) {
     fs::write(d2.join("sibling.txt"), b"sibling under d2\n").expect("write sibling");
     // Add an unrelated file outside the requested sub-path so we can prove the
     // sender does NOT walk the whole module root for a sub-path request.
-    fs::write(module_dir.join("unrelated.txt"), b"should not be transferred\n")
-        .expect("write unrelated");
+    fs::write(
+        module_dir.join("unrelated.txt"),
+        b"should not be transferred\n",
+    )
+    .expect("write unrelated");
 }
 
 #[cfg(unix)]

--- a/crates/daemon/src/tests/chunks/daemon_push_pull_lifecycle.rs
+++ b/crates/daemon/src/tests/chunks/daemon_push_pull_lifecycle.rs
@@ -64,7 +64,8 @@ fn daemon_push_then_pull_roundtrip_preserves_content() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Push files to daemon module
@@ -116,7 +117,10 @@ fn daemon_push_then_pull_roundtrip_preserves_content() {
         let rsync_url = format!("rsync://127.0.0.1:{port}/lifecycle/");
 
         let client_config = core::client::ClientConfig::builder()
-            .transfer_args([OsString::from(&rsync_url), OsString::from(pull_dest.as_os_str())])
+            .transfer_args([
+                OsString::from(&rsync_url),
+                OsString::from(pull_dest.as_os_str()),
+            ])
             .build();
 
         let result = core::client::run_client(client_config);
@@ -212,7 +216,8 @@ fn daemon_push_incremental_update_lifecycle() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     // Phase 1: Initial push
@@ -240,10 +245,8 @@ fn daemon_push_incremental_update_lifecycle() {
 
     // Backdate destination so quick-check detects the change
     let old_time = filetime::FileTime::from_unix_time(1_000_000, 0);
-    filetime::set_file_mtime(module_dir.join("config.txt"), old_time)
-        .expect("backdate config.txt");
-    filetime::set_file_mtime(module_dir.join("stable.txt"), old_time)
-        .expect("backdate stable.txt");
+    filetime::set_file_mtime(module_dir.join("config.txt"), old_time).expect("backdate config.txt");
+    filetime::set_file_mtime(module_dir.join("stable.txt"), old_time).expect("backdate stable.txt");
 
     // Modify source: update config.txt, add new file
     fs::write(source_dir.join("config.txt"), b"version=2\nupdated=true\n")
@@ -311,10 +314,12 @@ fn daemon_pull_lifecycle_copies_full_tree() {
     fs::create_dir_all(&module_deep).expect("create module/docs/api");
 
     fs::write(module_dir.join("index.html"), b"<html>root</html>\n").expect("write index");
-    fs::write(module_subdir.join("guide.md"), b"# User Guide\n\nIntro paragraph.\n")
-        .expect("write guide");
-    fs::write(module_deep.join("reference.json"), b"{\"version\": 1}\n")
-        .expect("write reference");
+    fs::write(
+        module_subdir.join("guide.md"),
+        b"# User Guide\n\nIntro paragraph.\n",
+    )
+    .expect("write guide");
+    fs::write(module_deep.join("reference.json"), b"{\"version\": 1}\n").expect("write reference");
     // Include an empty file to verify zero-length files transfer correctly
     fs::write(module_dir.join("empty.txt"), b"").expect("write empty file");
 
@@ -345,13 +350,17 @@ fn daemon_pull_lifecycle_copies_full_tree() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let rsync_url = format!("rsync://127.0.0.1:{port}/docs/");
 
     let client_config = core::client::ClientConfig::builder()
-        .transfer_args([OsString::from(&rsync_url), OsString::from(dest_dir.as_os_str())])
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
         .build();
 
     let result = core::client::run_client(client_config);
@@ -423,8 +432,7 @@ fn daemon_push_lifecycle_preserves_permissions() {
 
     let script_path = source_dir.join("run.sh");
     fs::write(&script_path, b"#!/bin/sh\necho hello\n").expect("write script");
-    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))
-        .expect("chmod script 755");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script 755");
 
     let config_path = source_dir.join("settings.conf");
     fs::write(&config_path, b"key=value\n").expect("write settings");
@@ -458,7 +466,8 @@ fn daemon_push_lifecycle_preserves_permissions() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -554,7 +563,8 @@ fn daemon_push_lifecycle_rejects_read_only_module() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();

--- a/crates/daemon/src/tests/chunks/daemon_relative_receive.rs
+++ b/crates/daemon/src/tests/chunks/daemon_relative_receive.rs
@@ -71,7 +71,8 @@ fn daemon_relative_receive_preserves_nested_paths() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
@@ -104,7 +105,10 @@ fn daemon_relative_receive_preserves_nested_paths() {
 
     // Verify full nested directory structure was reconstructed
     let dest_deep = dest_dir.join("a").join("b").join("c").join("deep.txt");
-    assert!(dest_deep.exists(), "a/b/c/deep.txt must exist at destination");
+    assert!(
+        dest_deep.exists(),
+        "a/b/c/deep.txt must exist at destination"
+    );
     assert_eq!(
         fs::read(&dest_deep).expect("read deep.txt"),
         b"deep content\n",

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_copy_links_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_copy_links_push.rs
@@ -74,7 +74,8 @@ fn daemon_safe_links_push_excludes_unsafe_preserves_safe() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -208,7 +209,8 @@ fn daemon_copy_links_push_replaces_symlinks_with_file_contents() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -238,7 +240,10 @@ fn daemon_copy_links_push_replaces_symlinks_with_file_contents() {
     }
 
     let dest_link_same = dest_dir.join("link_same_dir");
-    assert!(dest_link_same.exists(), "link_same_dir must exist at destination");
+    assert!(
+        dest_link_same.exists(),
+        "link_same_dir must exist at destination"
+    );
     assert!(
         !dest_link_same
             .symlink_metadata()

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_pull.rs
@@ -45,12 +45,10 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_pull() {
     unix_fs::symlink("file.txt", source_dir.join("safe_link")).expect("create safe_link");
 
     // Safe symlink: relative target that stays within the module via parent traversal
-    unix_fs::symlink("../file.txt", source_subdir.join("inner_link"))
-        .expect("create inner_link");
+    unix_fs::symlink("../file.txt", source_subdir.join("inner_link")).expect("create inner_link");
 
     // Unsafe symlink: absolute path outside the transfer tree
-    unix_fs::symlink("/etc/passwd", source_dir.join("unsafe_link"))
-        .expect("create unsafe_link");
+    unix_fs::symlink("/etc/passwd", source_dir.join("unsafe_link")).expect("create unsafe_link");
 
     // Unsafe symlink: relative path that escapes the module root
     unix_fs::symlink("../../outside.txt", source_dir.join("escape_link"))
@@ -83,7 +81,8 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_pull() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_push.rs
@@ -45,12 +45,10 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_push() {
     unix_fs::symlink("file.txt", source_dir.join("safe_link")).expect("create safe_link");
 
     // Safe symlink: relative target that stays within the tree via parent traversal
-    unix_fs::symlink("../file.txt", source_subdir.join("inner_link"))
-        .expect("create inner_link");
+    unix_fs::symlink("../file.txt", source_subdir.join("inner_link")).expect("create inner_link");
 
     // Unsafe symlink: absolute path outside the transfer tree
-    unix_fs::symlink("/etc/passwd", source_dir.join("unsafe_link"))
-        .expect("create unsafe_link");
+    unix_fs::symlink("/etc/passwd", source_dir.join("unsafe_link")).expect("create unsafe_link");
 
     // Unsafe symlink: relative path that escapes the transfer root
     unix_fs::symlink("../../outside.txt", source_dir.join("escape_link"))
@@ -83,7 +81,8 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_push() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_receive.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_receive.rs
@@ -55,23 +55,20 @@ fn daemon_safe_links_receive() {
     unix_fs::symlink("file.txt", source_dir.join("safe_link")).expect("create safe_link");
 
     // Safe symlink: relative target that stays within the tree via parent traversal
-    unix_fs::symlink("../file.txt", source_subdir.join("inner_link"))
-        .expect("create inner_link");
+    unix_fs::symlink("../file.txt", source_subdir.join("inner_link")).expect("create inner_link");
 
     // Safe symlink: sibling file in the same subdirectory
     unix_fs::symlink("deep.txt", source_subdir.join("peer_link")).expect("create peer_link");
 
     // Unsafe symlink: absolute path outside the transfer tree
-    unix_fs::symlink("/etc/passwd", source_dir.join("unsafe_link"))
-        .expect("create unsafe_link");
+    unix_fs::symlink("/etc/passwd", source_dir.join("unsafe_link")).expect("create unsafe_link");
 
     // Unsafe symlink: relative path that escapes the transfer root
     unix_fs::symlink("../../outside.txt", source_dir.join("escape_link"))
         .expect("create escape_link");
 
     // Unsafe symlink: relative path that escapes from a subdirectory
-    unix_fs::symlink("../../outside.txt", source_subdir.join("deep_esc"))
-        .expect("create deep_esc");
+    unix_fs::symlink("../../outside.txt", source_subdir.join("deep_esc")).expect("create deep_esc");
 
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
@@ -101,7 +98,8 @@ fn daemon_safe_links_receive() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
 
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);

--- a/crates/daemon/src/tests/chunks/daemon_unicode_emoji_filenames.rs
+++ b/crates/daemon/src/tests/chunks/daemon_unicode_emoji_filenames.rs
@@ -74,7 +74,8 @@ fn daemon_unicode_emoji_filenames_roundtrip() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -109,8 +110,9 @@ fn daemon_unicode_emoji_filenames_roundtrip() {
                 .to_string_lossy()
                 .contains(expected_substring)
         });
-        let matching =
-            matching.unwrap_or_else(|| panic!("no file containing '{expected_substring}' in {dir:?}; found: {entries:?}"));
+        let matching = matching.unwrap_or_else(|| {
+            panic!("no file containing '{expected_substring}' in {dir:?}; found: {entries:?}")
+        });
         let content = fs::read(matching.path())
             .unwrap_or_else(|e| panic!("read {}: {e}", matching.path().display()));
         assert_eq!(

--- a/crates/daemon/src/tests/chunks/daemon_xattr_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_xattr_push.rs
@@ -66,8 +66,7 @@ fn daemon_xattr_push_preserves_extended_attributes() {
     fs::create_dir(&subdir).expect("create subdir");
     let nested_path = subdir.join("nested.txt");
     fs::write(&nested_path, b"nested content\n").expect("write nested.txt");
-    xattr::set(&nested_path, "user.nested_attr", b"deep_value")
-        .expect("set xattr on nested.txt");
+    xattr::set(&nested_path, "user.nested_attr", b"deep_value").expect("set xattr on nested.txt");
 
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
@@ -96,7 +95,8 @@ fn daemon_xattr_push_preserves_extended_attributes() {
         ])
         .build();
 
-    let (probe_stream, daemon_handle) = start_daemon_pending_no_detach(daemon_config, port, held_listener);
+    let (probe_stream, daemon_handle) =
+        start_daemon_pending_no_detach(daemon_config, port, held_listener);
     drop(probe_stream);
 
     let mut source_arg = source_dir.clone().into_os_string();
@@ -148,14 +148,12 @@ fn daemon_xattr_push_preserves_extended_attributes() {
         b"nested content\n"
     );
 
-
     // alpha.txt: user.test_key = "test_value"
     let alpha_xattr = xattr::get(&dest_alpha, "user.test_key")
         .expect("read user.test_key from dest alpha.txt")
         .expect("user.test_key must exist on dest alpha.txt");
     assert_eq!(
-        alpha_xattr,
-        b"test_value",
+        alpha_xattr, b"test_value",
         "user.test_key value mismatch on alpha.txt"
     );
 
@@ -164,8 +162,7 @@ fn daemon_xattr_push_preserves_extended_attributes() {
         .expect("read user.author from dest beta.txt")
         .expect("user.author must exist on dest beta.txt");
     assert_eq!(
-        beta_author,
-        b"oc-rsync",
+        beta_author, b"oc-rsync",
         "user.author value mismatch on beta.txt"
     );
 
@@ -182,8 +179,7 @@ fn daemon_xattr_push_preserves_extended_attributes() {
         .expect("read user.nested_attr from dest nested.txt")
         .expect("user.nested_attr must exist on dest nested.txt");
     assert_eq!(
-        nested_xattr,
-        b"deep_value",
+        nested_xattr, b"deep_value",
         "user.nested_attr value mismatch on nested.txt"
     );
 

--- a/crates/daemon/src/tests/chunks/default_config_candidates_prefer_legacy_for_upstream_brand.rs
+++ b/crates/daemon/src/tests/chunks/default_config_candidates_prefer_legacy_for_upstream_brand.rs
@@ -8,4 +8,3 @@ fn default_config_candidates_prefer_legacy_for_upstream_brand() {
         ]
     );
 }
-

--- a/crates/daemon/src/tests/chunks/default_config_candidates_prefer_oc_branding.rs
+++ b/crates/daemon/src/tests/chunks/default_config_candidates_prefer_oc_branding.rs
@@ -8,4 +8,3 @@ fn default_config_candidates_prefer_oc_branding() {
         ]
     );
 }
-

--- a/crates/daemon/src/tests/chunks/default_secrets_path_falls_back_to_secondary_candidate.rs
+++ b/crates/daemon/src/tests/chunks/default_secrets_path_falls_back_to_secondary_candidate.rs
@@ -11,4 +11,3 @@ fn default_secrets_path_falls_back_to_secondary_candidate() {
 
     assert_eq!(result, Some(fallback.into_os_string()));
 }
-

--- a/crates/daemon/src/tests/chunks/default_secrets_path_prefers_primary_candidate.rs
+++ b/crates/daemon/src/tests/chunks/default_secrets_path_prefers_primary_candidate.rs
@@ -12,4 +12,3 @@ fn default_secrets_path_prefers_primary_candidate() {
 
     assert_eq!(result, Some(primary.into_os_string()));
 }
-

--- a/crates/daemon/src/tests/chunks/default_secrets_path_returns_none_when_absent.rs
+++ b/crates/daemon/src/tests/chunks/default_secrets_path_returns_none_when_absent.rs
@@ -10,4 +10,3 @@ fn default_secrets_path_returns_none_when_absent() {
 
     assert!(result.is_none());
 }
-

--- a/crates/daemon/src/tests/chunks/first_existing_config_path_falls_back_to_legacy_candidate.rs
+++ b/crates/daemon/src/tests/chunks/first_existing_config_path_falls_back_to_legacy_candidate.rs
@@ -10,4 +10,3 @@ fn first_existing_config_path_falls_back_to_legacy_candidate() {
 
     assert_eq!(result, Some(expected));
 }
-

--- a/crates/daemon/src/tests/chunks/first_existing_config_path_prefers_primary_candidate.rs
+++ b/crates/daemon/src/tests/chunks/first_existing_config_path_prefers_primary_candidate.rs
@@ -11,4 +11,3 @@ fn first_existing_config_path_prefers_primary_candidate() {
 
     assert_eq!(result, Some(expected));
 }
-

--- a/crates/daemon/src/tests/chunks/first_existing_config_path_returns_none_when_absent.rs
+++ b/crates/daemon/src/tests/chunks/first_existing_config_path_returns_none_when_absent.rs
@@ -7,4 +7,3 @@ fn first_existing_config_path_returns_none_when_absent() {
 
     assert!(result.is_none());
 }
-

--- a/crates/daemon/src/tests/chunks/help_flag_renders_static_help_snapshot.rs
+++ b/crates/daemon/src/tests/chunks/help_flag_renders_static_help_snapshot.rs
@@ -8,4 +8,3 @@ fn help_flag_renders_static_help_snapshot() {
     let expected = render_help(ProgramName::Rsyncd);
     assert_eq!(stdout, expected.into_bytes());
 }
-

--- a/crates/daemon/src/tests/chunks/legacy_daemon_greeting_has_single_newline.rs
+++ b/crates/daemon/src/tests/chunks/legacy_daemon_greeting_has_single_newline.rs
@@ -4,7 +4,10 @@ fn legacy_daemon_greeting_has_single_newline() {
 
     // Greeting should end with exactly one newline
     assert!(greeting.ends_with('\n'));
-    assert!(!greeting.ends_with("\n\n"), "should not have double newline");
+    assert!(
+        !greeting.ends_with("\n\n"),
+        "should not have double newline"
+    );
 
     // The newline should be at the very end
     let newline_count = greeting.matches('\n').count();

--- a/crates/daemon/src/tests/chunks/legacy_daemon_greeting_includes_version_and_digests.rs
+++ b/crates/daemon/src/tests/chunks/legacy_daemon_greeting_includes_version_and_digests.rs
@@ -17,7 +17,10 @@ fn legacy_daemon_greeting_includes_version_and_digests() {
     // Second part is the version number (format: "31.0" or similar)
     let version_str = parts[1];
     // Version may be "31.0" or "31" - extract the major version
-    let major_str = version_str.split('.').next().expect("version must have major part");
+    let major_str = version_str
+        .split('.')
+        .next()
+        .expect("version must have major part");
     let major: u8 = major_str.parse().expect("valid protocol version number");
     assert!(major >= 28, "protocol version should be at least 28");
 

--- a/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
+++ b/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
@@ -3,7 +3,8 @@ fn log_module_limit_logs_cap_reached() {
     let dir = tempdir().expect("log dir");
     let path = dir.path().join("daemon.log");
     let log = open_log_sink(&path, Brand::Oc).expect("open log");
-    let limit = MaxConnections::Limited(NonZeroU32::new(4).expect("non-zero limit")).display_value();
+    let limit =
+        MaxConnections::Limited(NonZeroU32::new(4).expect("non-zero limit")).display_value();
 
     log_module_limit(
         &log,
@@ -19,7 +20,9 @@ fn log_module_limit_logs_cap_reached() {
     let contents = fs::read_to_string(&path).expect("read log");
     // upstream: log.c:122-132 logit() stamps `%Y/%m/%d %H:%M:%S [pid] ` ahead
     // of the rendered warning body.
-    let body = contents.split_once("] ").map_or(contents.as_str(), |(_, body)| body);
+    let body = contents
+        .split_once("] ")
+        .map_or(contents.as_str(), |(_, body)| body);
     assert!(
         body.starts_with("oc-rsync warning:"),
         "expected warning-level message, got: {contents}"

--- a/crates/daemon/src/tests/chunks/module_definition_empty_acls_allow_all.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_empty_acls_allow_all.rs
@@ -3,6 +3,9 @@ fn module_definition_empty_acls_allow_all() {
     // upstream: access.c - when neither hosts_allow nor hosts_deny is set,
     // all connections are permitted.
     let module = module_with_host_patterns(&[], &[]);
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        PeerHost::new(None, true)
+    ));
     assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_allow_matches_exact.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_allow_matches_exact.rs
@@ -6,4 +6,3 @@ fn module_definition_hostname_allow_matches_exact() {
     assert!(!module.permits(peer, PeerHost::new(Some("other.example.com"), true)));
     assert!(!module.permits(peer, PeerHost::new(None, true)));
 }
-

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_deny_takes_precedence.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_deny_takes_precedence.rs
@@ -27,11 +27,13 @@ fn module_definition_hostname_deny_applies_without_allow_match() {
     clear_test_hostname_overrides();
     let module = module_with_host_patterns(&[], &["bad.example.com"]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    set_test_forward_override("bad.example.com", &[IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9))]);
+    set_test_forward_override(
+        "bad.example.com",
+        &[IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9))],
+    );
 
     assert!(!module.permits(peer, PeerHost::new(Some("bad.example.com"), true)));
     assert!(module.permits(peer, PeerHost::new(Some("good.example.com"), true)));
 
     clear_test_hostname_overrides();
 }
-

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_suffix_matches.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_suffix_matches.rs
@@ -7,4 +7,3 @@ fn module_definition_hostname_suffix_matches() {
     assert!(!module.permits(peer, PeerHost::new(Some("example.net"), true)));
     assert!(!module.permits(peer, PeerHost::new(Some("sampleexample.com"), true)));
 }
-

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_collapses_consecutive_asterisks.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_collapses_consecutive_asterisks.rs
@@ -5,4 +5,3 @@ fn module_definition_hostname_wildcard_collapses_consecutive_asterisks() {
     assert!(module.permits(peer, PeerHost::new(Some("node.example.com"), true)));
     assert!(!module.permits(peer, PeerHost::new(Some("node.example.org"), true)));
 }
-

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_handles_multiple_asterisks.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_handles_multiple_asterisks.rs
@@ -2,8 +2,10 @@
 fn module_definition_hostname_wildcard_handles_multiple_asterisks() {
     let module = module_with_host_patterns(&["*build*node*.example.com"], &[]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    assert!(module.permits(peer, PeerHost::new(Some("fastbuild-node1.example.com"), true)));
+    assert!(module.permits(
+        peer,
+        PeerHost::new(Some("fastbuild-node1.example.com"), true)
+    ));
     assert!(module.permits(peer, PeerHost::new(Some("build-node.example.com"), true)));
     assert!(!module.permits(peer, PeerHost::new(Some("build.example.org"), true)));
 }
-

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_matches.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_matches.rs
@@ -6,4 +6,3 @@ fn module_definition_hostname_wildcard_matches() {
     assert!(module.permits(peer, PeerHost::new(Some("builda.example.org"), true)));
     assert!(!module.permits(peer, PeerHost::new(Some("build12.example.net"), true)));
 }
-

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_treats_question_as_single_character.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_wildcard_treats_question_as_single_character.rs
@@ -6,4 +6,3 @@ fn module_definition_hostname_wildcard_treats_question_as_single_character() {
     assert!(!module.permits(peer, PeerHost::new(Some("app1.example.com"), true)));
     assert!(!module.permits(peer, PeerHost::new(Some("app123.example.com"), true)));
 }
-

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
@@ -6,14 +6,23 @@ fn module_definition_ipv4_allow_short_circuits_deny() {
     // overlapping deny rule would otherwise match.
     let module = module_with_host_patterns(&["192.168.0.0/16"], &["192.168.1.0/24"]);
     // In the allowed subnet and outside the deny subnet - permitted by allow.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)),
+        PeerHost::new(None, true)
+    ));
     // In both the allowed and denied subnets - allow short-circuits the
     // deny rule, matching upstream.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)),
+        PeerHost::new(None, true)
+    ));
     // Outside both the allowed and denied subnets - admitted because
     // access.c:287 only refuses on a deny-list match; otherwise
     // access.c:291 falls through to "Allow all other access". The
     // allow-list non-match short-circuits to refuse only when the deny
     // list is empty (access.c:281-282).
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        PeerHost::new(None, true)
+    ));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_24_boundary.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_24_boundary.rs
@@ -2,9 +2,21 @@
 fn module_definition_ipv4_cidr_24_boundary() {
     let module = module_with_host_patterns(&["192.168.1.0/24"], &[]);
     // First and last address in /24.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 0)), PeerHost::new(None, true)));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 0)),
+        PeerHost::new(None, true)
+    ));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255)),
+        PeerHost::new(None, true)
+    ));
     // One address outside the /24 boundary on each side.
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 255)), PeerHost::new(None, true)));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 0)), PeerHost::new(None, true)));
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 0, 255)),
+        PeerHost::new(None, true)
+    ));
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 2, 0)),
+        PeerHost::new(None, true)
+    ));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_allow_matches_subnet.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_allow_matches_subnet.rs
@@ -1,8 +1,20 @@
 #[test]
 fn module_definition_ipv4_cidr_allow_matches_subnet() {
     let module = module_with_host_patterns(&["10.0.0.0/8"], &[]);
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), PeerHost::new(None, true)));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 255, 255, 255)), PeerHost::new(None, true)));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(11, 0, 0, 1)), PeerHost::new(None, true)));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        PeerHost::new(None, true)
+    ));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(10, 255, 255, 255)),
+        PeerHost::new(None, true)
+    ));
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(11, 0, 0, 1)),
+        PeerHost::new(None, true)
+    ));
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+        PeerHost::new(None, true)
+    ));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_cidr_blocks_subnet.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_cidr_blocks_subnet.rs
@@ -1,8 +1,20 @@
 #[test]
 fn module_definition_ipv4_deny_cidr_blocks_subnet() {
     let module = module_with_host_patterns(&[], &["172.16.0.0/12"]);
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)), PeerHost::new(None, true)));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(172, 31, 255, 254)), PeerHost::new(None, true)));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(172, 32, 0, 1)), PeerHost::new(None, true)));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), PeerHost::new(None, true)));
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)),
+        PeerHost::new(None, true)
+    ));
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(172, 31, 255, 254)),
+        PeerHost::new(None, true)
+    ));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(172, 32, 0, 1)),
+        PeerHost::new(None, true)
+    ));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        PeerHost::new(None, true)
+    ));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv6_allow_matches_exact.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv6_allow_matches_exact.rs
@@ -2,7 +2,10 @@
 fn module_definition_ipv6_allow_matches_exact() {
     let module = module_with_host_patterns(&["::1"], &[]);
     assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), PeerHost::new(None, true)));
-    assert!(!module.permits(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)), PeerHost::new(None, true)));
+    assert!(!module.permits(
+        IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)),
+        PeerHost::new(None, true)
+    ));
     // IPv4 peer does not match an IPv6 allow rule.
     assert!(!module.permits(IpAddr::V4(Ipv4Addr::LOCALHOST), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv6_cidr_allow_matches_prefix.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv6_cidr_allow_matches_prefix.rs
@@ -2,9 +2,15 @@
 fn module_definition_ipv6_cidr_allow_matches_prefix() {
     let module = module_with_host_patterns(&["fd00::/8"], &[]);
     assert!(module.permits(
-        IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)), PeerHost::new(None, true)));
+        IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)),
+        PeerHost::new(None, true)
+    ));
     assert!(module.permits(
-        IpAddr::V6(Ipv6Addr::new(0xfdff, 0xffff, 0, 0, 0, 0, 0, 1)), PeerHost::new(None, true)));
+        IpAddr::V6(Ipv6Addr::new(0xfdff, 0xffff, 0, 0, 0, 0, 0, 1)),
+        PeerHost::new(None, true)
+    ));
     assert!(!module.permits(
-        IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)), PeerHost::new(None, true)));
+        IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+        PeerHost::new(None, true)
+    ));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs
@@ -5,21 +5,28 @@ fn module_definition_mixed_ip_and_hostname_acl() {
     // immediately, so a peer admitted by the allow list bypasses the
     // deny list entirely. When the allow list does not match, the deny
     // list refuses only on a positive match.
-    let module = module_with_host_patterns(
-        &["192.168.0.0/16", "*.trusted.org"],
-        &["192.168.1.99"],
-    );
+    let module = module_with_host_patterns(&["192.168.0.0/16", "*.trusted.org"], &["192.168.1.99"]);
     // IP in allowed range, not in deny list - permitted by allow.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)),
+        PeerHost::new(None, true)
+    ));
     // IP in allowed range and also in deny list - the allow match short-
     // circuits the deny check, matching upstream `allow_access`.
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 99)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 99)),
+        PeerHost::new(None, true)
+    ));
     // IP outside allowed range but hostname matches allow pattern - allow.
     assert!(module.permits(
-        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), PeerHost::new(Some("build.trusted.org"), true)));
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)),
+        PeerHost::new(Some("build.trusted.org"), true)
+    ));
     // IP outside allowed range, hostname not in allow, IP not in deny -
     // fall-through after a non-matching allow list with a non-empty deny
     // list admits the peer per upstream access.c:290.
     assert!(module.permits(
-        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), PeerHost::new(Some("build.untrusted.org"), true)));
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)),
+        PeerHost::new(Some("build.untrusted.org"), true)
+    ));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_only_allow_denies_non_matching.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_only_allow_denies_non_matching.rs
@@ -3,7 +3,16 @@ fn module_definition_only_allow_denies_non_matching() {
     // upstream: access.c - when only hosts_allow is set, anything not allowed
     // is denied.
     let module = module_with_host_patterns(&["192.168.1.0/24"], &[]);
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), PeerHost::new(None, true)));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), PeerHost::new(None, true)));
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)),
+        PeerHost::new(None, true)
+    ));
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)),
+        PeerHost::new(None, true)
+    ));
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        PeerHost::new(None, true)
+    ));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_only_deny_allows_non_matching.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_only_deny_allows_non_matching.rs
@@ -3,7 +3,13 @@ fn module_definition_only_deny_allows_non_matching() {
     // upstream: access.c - when only hosts_deny is set, anything not denied
     // is allowed.
     let module = module_with_host_patterns(&[], &["10.0.0.0/8"]);
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)), PeerHost::new(None, true)));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), PeerHost::new(None, true)));
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)),
+        PeerHost::new(None, true)
+    ));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+        PeerHost::new(None, true)
+    ));
     assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), PeerHost::new(None, true)));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_wildcard_any_allows_all.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_wildcard_any_allows_all.rs
@@ -1,7 +1,13 @@
 #[test]
 fn module_definition_wildcard_any_allows_all() {
     let module = module_with_host_patterns(&["*"], &[]);
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), PeerHost::new(None, true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        PeerHost::new(None, true)
+    ));
     assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), PeerHost::new(None, true)));
-    assert!(module.permits(IpAddr::V4(Ipv4Addr::LOCALHOST), PeerHost::new(Some("anything.example.com"), true)));
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        PeerHost::new(Some("anything.example.com"), true)
+    ));
 }

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_missing_resolution_denies_hostname_only_rules.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_missing_resolution_denies_hostname_only_rules.rs
@@ -10,4 +10,3 @@ fn module_peer_hostname_missing_resolution_denies_hostname_only_rules() {
     }
     assert!(!module.permits(peer, PeerHost::new(resolved, true)));
 }
-

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_skips_lookup_when_disabled.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_skips_lookup_when_disabled.rs
@@ -10,4 +10,3 @@ fn module_peer_hostname_skips_lookup_when_disabled() {
     assert!(!module.permits(peer, PeerHost::new(resolved, true)));
     clear_test_hostname_overrides();
 }
-

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_uses_override.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_uses_override.rs
@@ -13,4 +13,3 @@ fn module_peer_hostname_uses_override() {
     assert!(module.permits(peer, PeerHost::new(resolved, true)));
     clear_test_hostname_overrides();
 }
-

--- a/crates/daemon/src/tests/chunks/msg_error_exit_payload_uses_little_endian_encoding.rs
+++ b/crates/daemon/src/tests/chunks/msg_error_exit_payload_uses_little_endian_encoding.rs
@@ -15,11 +15,8 @@ fn msg_error_exit_payload_uses_little_endian_encoding() {
     );
 
     // Round-trip through MessageFrame to confirm the payload is preserved.
-    let frame = protocol::MessageFrame::new(
-        protocol::MessageCode::ErrorExit,
-        payload.to_vec(),
-    )
-    .expect("valid frame");
+    let frame = protocol::MessageFrame::new(protocol::MessageCode::ErrorExit, payload.to_vec())
+        .expect("valid frame");
     let mut buf = Vec::new();
     frame.encode_into_writer(&mut buf).expect("encode");
     // The payload occupies the last 4 bytes of the encoded frame.

--- a/crates/daemon/src/tests/chunks/oc_help_flag_renders_branded_snapshot.rs
+++ b/crates/daemon/src/tests/chunks/oc_help_flag_renders_branded_snapshot.rs
@@ -8,4 +8,3 @@ fn oc_help_flag_renders_branded_snapshot() {
     let expected = render_help(ProgramName::OcRsyncd);
     assert_eq!(stdout, expected.into_bytes());
 }
-

--- a/crates/daemon/src/tests/chunks/oc_version_flag_renders_report.rs
+++ b/crates/daemon/src/tests/chunks/oc_version_flag_renders_report.rs
@@ -8,4 +8,3 @@ fn oc_version_flag_renders_report() {
     let expected = VersionInfoReport::for_daemon_brand(Brand::Oc).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
-

--- a/crates/daemon/src/tests/chunks/parse_auth_user_list_trims_and_deduplicates_case_insensitively.rs
+++ b/crates/daemon/src/tests/chunks/parse_auth_user_list_trims_and_deduplicates_case_insensitively.rs
@@ -8,4 +8,3 @@ fn parse_auth_user_list_trims_and_deduplicates_case_insensitively() {
     let err = parse_auth_user_list(" , ,  ").expect_err("blank list rejected");
     assert_eq!(err, "must specify at least one username");
 }
-

--- a/crates/daemon/src/tests/chunks/parse_config_modules_detects_recursive_include.rs
+++ b/crates/daemon/src/tests/chunks/parse_config_modules_detects_recursive_include.rs
@@ -21,4 +21,3 @@ fn parse_config_modules_detects_recursive_include() {
     let error = parse_config_modules(&first).expect_err("recursive include should fail");
     assert!(error.message().to_string().contains("recursive include"));
 }
-

--- a/crates/daemon/src/tests/chunks/parse_numeric_identifier_rejects_blank_or_invalid_input.rs
+++ b/crates/daemon/src/tests/chunks/parse_numeric_identifier_rejects_blank_or_invalid_input.rs
@@ -4,4 +4,3 @@ fn parse_numeric_identifier_rejects_blank_or_invalid_input() {
     assert_eq!(parse_numeric_identifier(""), None);
     assert_eq!(parse_numeric_identifier("not-a-number"), None);
 }
-

--- a/crates/daemon/src/tests/chunks/parse_refuse_option_list_normalises_and_deduplicates.rs
+++ b/crates/daemon/src/tests/chunks/parse_refuse_option_list_normalises_and_deduplicates.rs
@@ -7,4 +7,3 @@ fn parse_refuse_option_list_normalises_and_deduplicates() {
     let err = parse_refuse_option_list("   ,").expect_err("blank option list rejected");
     assert_eq!(err, "must specify at least one option");
 }
-

--- a/crates/daemon/src/tests/chunks/read_trimmed_line_strips_crlf_terminators.rs
+++ b/crates/daemon/src/tests/chunks/read_trimmed_line_strips_crlf_terminators.rs
@@ -12,4 +12,3 @@ fn read_trimmed_line_strips_crlf_terminators() {
     let eof = read_trimmed_line(&mut reader).expect("eof read");
     assert!(eof.is_none());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
@@ -108,4 +108,3 @@ fn run_daemon_accepts_valid_credentials() {
         );
     }
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
@@ -46,7 +46,10 @@ fn run_daemon_auth_failure_rejects_wrong_credentials() {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
@@ -92,17 +95,17 @@ fn run_daemon_auth_failure_rejects_wrong_credentials() {
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("denied message");
-    assert_eq!(
-        line.trim_end(),
-        "@ERROR: auth failed on module protected"
-    );
+    assert_eq!(line.trim_end(), "@ERROR: auth failed on module protected");
 
     // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
     // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
     // the refusal; the socket just closes (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
@@ -11,7 +11,10 @@ fn run_daemon_denies_module_when_host_not_allowed() {
     // resolve and the test then panics with WSAECONNRESET on the greeting
     // read. Forward-slash-normalised to avoid the daemon module-arg parser's
     // backslash escape behaviour (see PR #4560 for the same root cause).
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
@@ -64,10 +67,12 @@ fn run_daemon_denies_module_when_host_not_allowed() {
     // the refusal; the socket just closes (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
@@ -14,7 +14,10 @@ fn run_daemon_enforces_bwlimit_during_module_list() {
     // parser doesn't swallow the comma separator via backslash escapes on
     // Windows (see PR #4560), and so the paths actually exist on Windows
     // where /srv/docs and /var/log don't (see PR #4559).
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
@@ -81,4 +84,3 @@ fn run_daemon_enforces_bwlimit_during_module_list() {
         "expected sleep around {expected:?}, got {total_sleep:?}"
     );
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
@@ -96,10 +96,11 @@ fn run_daemon_enforces_module_connection_limit() {
     // returns before reading further, so no @RSYNCD: EXIT follows the refusal;
     // the socket just closes (next read is EOF).
     line.clear();
-    let read = second_reader
-        .read_line(&mut line)
-        .expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    let read = second_reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     first_stream
         .write_all(b"\n")
@@ -118,10 +119,11 @@ fn run_daemon_enforces_module_connection_limit() {
     // returns before reading further, so no @RSYNCD: EXIT follows the refusal;
     // the socket just closes (next read is EOF).
     line.clear();
-    let read = first_reader
-        .read_line(&mut line)
-        .expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    let read = first_reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(second_reader);
     drop(second_stream);
@@ -131,4 +133,3 @@ fn run_daemon_enforces_module_connection_limit() {
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_handles_binary_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_handles_binary_negotiation.rs
@@ -29,17 +29,13 @@ fn run_daemon_handles_binary_negotiation() {
 
     // Even if client sends binary data, daemon sends @RSYNCD greeting
     let binary_data = u32::from(ProtocolVersion::NEWEST.as_u8()).to_le_bytes();
-    stream
-        .write_all(&binary_data)
-        .expect("send binary data");
+    stream.write_all(&binary_data).expect("send binary data");
     stream.flush().expect("flush");
 
     // Daemon should send @RSYNCD greeting (text protocol)
     let mut greeting = String::new();
     let mut reader = BufReader::new(&mut stream);
-    reader
-        .read_line(&mut greeting)
-        .expect("read greeting");
+    reader.read_line(&mut greeting).expect("read greeting");
     assert!(
         greeting.starts_with("@RSYNCD:"),
         "Expected @RSYNCD greeting, got: {greeting}"
@@ -62,4 +58,3 @@ fn run_daemon_handles_binary_negotiation() {
     let _ = finish_daemon(handle);
     // Don't assert on result - daemon rightfully fails when client sends invalid data
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
@@ -50,7 +50,10 @@ fn run_daemon_handles_parallel_sessions() {
             // follows the refusal; the socket just closes (next read is EOF).
             line.clear();
             let read = reader.read_line(&mut line).expect("eof after error");
-            assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+            assert_eq!(
+                read, 0,
+                "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+            );
         }));
     }
 
@@ -61,4 +64,3 @@ fn run_daemon_handles_parallel_sessions() {
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
@@ -48,10 +48,12 @@ fn run_daemon_honours_max_sessions() {
         // refusal; the socket just closes (next read is EOF).
         line.clear();
         let read = reader.read_line(&mut line).expect("eof after error");
-        assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+        assert_eq!(
+            read, 0,
+            "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+        );
     }
 
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_host_denied_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_host_denied_module.rs
@@ -8,7 +8,10 @@ fn run_daemon_lists_host_denied_module() {
 
     // env::temp_dir() so the path exists on Windows; forward-slash normalised
     // so the daemon module-arg parser doesn't swallow escapes (see PR #4560).
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let mut file = NamedTempFile::new().expect("config file");
     // `private` restricts access to 10.0.0.0/8, so the loopback client is
     // denied on connect. It is still `list = yes` (the default), so it MUST
@@ -51,7 +54,9 @@ fn run_daemon_lists_host_denied_module() {
     assert_eq!(line, "public         \t\n");
 
     line.clear();
-    reader.read_line(&mut line).expect("host-denied private module");
+    reader
+        .read_line(&mut line)
+        .expect("host-denied private module");
     assert_eq!(line, "private        \t\n");
 
     line.clear();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
@@ -6,7 +6,10 @@ fn run_daemon_lists_modules_on_request() {
 
     let (port, held_listener) = allocate_test_port();
 
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
@@ -50,4 +53,3 @@ fn run_daemon_lists_modules_on_request() {
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_module_timeout.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_module_timeout.rs
@@ -21,7 +21,10 @@ fn run_daemon_lists_modules_with_module_timeout() {
 
     let (port, held_listener) = allocate_test_port();
 
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
@@ -14,7 +14,10 @@ fn run_daemon_lists_modules_with_motd_lines() {
     )
     .expect("write motd");
 
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
@@ -77,4 +80,3 @@ fn run_daemon_lists_modules_with_motd_lines() {
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
@@ -6,7 +6,10 @@ fn run_daemon_omits_unlisted_modules_from_listing() {
 
     let (port, held_listener) = allocate_test_port();
 
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
@@ -53,4 +56,3 @@ fn run_daemon_omits_unlisted_modules_from_listing() {
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
@@ -108,7 +108,10 @@ fn run_daemon_panic_isolation_keeps_daemon_alive() {
         let read = good_reader
             .read_line(&mut line)
             .expect("eof after error from good connection");
-        assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+        assert_eq!(
+            read, 0,
+            "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+        );
     } // good stream dropped here
 
     let result = daemon_handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
@@ -118,10 +118,11 @@ fn run_daemon_per_module_cap_overrides_global_max_connections() {
     // returns before reading further, so no @RSYNCD: EXIT follows the refusal;
     // the socket just closes (next read is EOF).
     line.clear();
-    let read = second_reader
-        .read_line(&mut line)
-        .expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    let read = second_reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     first_stream
         .write_all(b"\n")
@@ -138,10 +139,11 @@ fn run_daemon_per_module_cap_overrides_global_max_connections() {
     // returns before reading further, so no @RSYNCD: EXIT follows the refusal;
     // the socket just closes (next read is EOF).
     line.clear();
-    let read = first_reader
-        .read_line(&mut line)
-        .expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    let read = first_reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(second_reader);
     drop(second_stream);

--- a/crates/daemon/src/tests/chunks/run_daemon_post_ok_bad_option_value_uses_multiplexed_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_post_ok_bad_option_value_uses_multiplexed_error.rs
@@ -54,9 +54,7 @@ fn run_daemon_post_ok_bad_option_value_uses_multiplexed_error() {
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 
-    stream
-        .write_all(b"sizemod\n")
-        .expect("send module request");
+    stream.write_all(b"sizemod\n").expect("send module request");
     stream.flush().expect("flush module request");
 
     loop {

--- a/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
@@ -13,7 +13,10 @@ fn run_daemon_records_log_file_entries() {
     let temp = tempdir().expect("log dir");
     let log_path = temp.path().join("rsyncd.log");
 
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
@@ -58,7 +61,10 @@ fn run_daemon_records_log_file_entries() {
     // the refusal; the socket just closes (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(reader);
     // Bound the join: on Windows the daemon accept loop can linger past the
@@ -108,4 +114,3 @@ fn run_daemon_records_log_file_entries() {
         "log should record upstream module-access grant: {log_contents:?}"
     );
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
@@ -6,7 +6,10 @@ fn run_daemon_refuses_disallowed_module_options() {
 
     let (port, held_listener) = allocate_test_port();
 
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
@@ -60,10 +63,12 @@ fn run_daemon_refuses_disallowed_module_options() {
     // the refusal; the socket just closes (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_duplicate_session_limits.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_duplicate_session_limits.rs
@@ -18,4 +18,3 @@ fn run_daemon_rejects_duplicate_session_limits() {
             .contains("duplicate daemon argument '--max-sessions'")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_invalid_max_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_invalid_max_sessions.rs
@@ -14,4 +14,3 @@ fn run_daemon_rejects_invalid_max_sessions() {
             .contains("--max-sessions must be greater than zero")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_invalid_port.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_invalid_port.rs
@@ -14,4 +14,3 @@ fn run_daemon_rejects_invalid_port() {
             .contains("invalid value for --port")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
@@ -37,7 +37,10 @@ fn run_daemon_rejects_push_to_default_read_only_module() {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
@@ -36,7 +36,10 @@ fn run_daemon_rejects_push_to_read_only_module() {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
@@ -93,7 +96,9 @@ fn assert_read_only_multiplexed_rejection(reader: &mut BufReader<TcpStream>) {
         "daemon must advertise at least one compat flag, got {compat_flags}",
     );
     let mut seed_buf = [0u8; 4];
-    reader.read_exact(&mut seed_buf).expect("read checksum seed");
+    reader
+        .read_exact(&mut seed_buf)
+        .expect("read checksum seed");
 
     // MSG_ERROR_XFER frame with the plain `ERROR:` text (no `@ERROR:` prefix).
     let mut err_header = [0u8; 4];

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_argument.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_argument.rs
@@ -17,4 +17,3 @@ fn run_daemon_rejects_unknown_argument() {
         "diagnostic should point operators to the help output"
     );
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
@@ -12,7 +12,10 @@ fn run_daemon_rejects_unknown_hash_command() {
 
     let (port, held_listener) = allocate_test_port();
 
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
@@ -37,9 +40,7 @@ fn run_daemon_rejects_unknown_hash_command() {
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 
-    stream
-        .write_all(b"#bogus\n")
-        .expect("send unknown command");
+    stream.write_all(b"#bogus\n").expect("send unknown command");
     stream.flush().expect("flush unknown command");
 
     // upstream: clientserver.c:1563 - "@ERROR: Unknown command '%s'\n" keeps

--- a/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
@@ -75,20 +75,19 @@ fn run_daemon_requests_authentication_for_protected_module() {
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("denied message");
-    assert_eq!(
-        line.trim_end(),
-        "@ERROR: auth failed on module secure"
-    );
+    assert_eq!(line.trim_end(), "@ERROR: auth failed on module secure");
 
     // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
     // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
     // the refusal; the socket just closes (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_early_exec_failure.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_early_exec_failure.rs
@@ -52,7 +52,10 @@ fn run_daemon_runs_post_xfer_exec_on_early_exec_failure() {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
@@ -72,10 +75,7 @@ fn run_daemon_runs_post_xfer_exec_on_early_exec_failure() {
     // Early exec fails immediately - the daemon never waits for client args.
     line.clear();
     reader.read_line(&mut line).expect("error message");
-    assert!(
-        line.starts_with("@ERROR:"),
-        "expected @ERROR, got: {line}"
-    );
+    assert!(line.starts_with("@ERROR:"), "expected @ERROR, got: {line}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
@@ -63,7 +63,10 @@ fn run_daemon_runs_post_xfer_exec_on_read_only_refuse() {
 
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
-    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+    assert!(
+        line.starts_with("@RSYNCD:"),
+        "expected greeting, got: {line}"
+    );
 
     stream
         .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")

--- a/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
@@ -12,7 +12,10 @@ fn run_daemon_sends_motd_before_unknown_module_error() {
 
     let (port, held_listener) = allocate_test_port();
 
-    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([

--- a/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
@@ -40,10 +40,12 @@ fn run_daemon_serves_single_legacy_connection() {
     // the refusal; the socket just closes (next read is EOF).
     line.clear();
     let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    assert_eq!(
+        read, 0,
+        "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-

--- a/crates/daemon/src/tests/chunks/run_daemon_writes_and_removes_pid_file.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_writes_and_removes_pid_file.rs
@@ -51,4 +51,3 @@ fn run_daemon_writes_and_removes_pid_file() {
     assert!(result.is_ok());
     assert!(!pid_path.exists());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_allows_relative_path_when_use_chroot_disabled.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_allows_relative_path_when_use_chroot_disabled.rs
@@ -14,4 +14,3 @@ fn runtime_options_allows_relative_path_when_use_chroot_disabled() {
     assert_eq!(modules[0].path, PathBuf::from("data/docs"));
     assert!(!modules[0].use_chroot());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_allows_timeout_zero_in_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_allows_timeout_zero_in_config.rs
@@ -14,4 +14,3 @@ fn runtime_options_allows_timeout_zero_in_config() {
     let module = &modules[0];
     assert!(module.timeout().is_none());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_apply_global_refuse_options.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_apply_global_refuse_options.rs
@@ -19,4 +19,3 @@ fn runtime_options_apply_global_refuse_options() {
     );
     assert_eq!(options.modules()[1].refused_options(), ["stats"]);
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_bind_accepts_bracketed_ipv6.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_bind_accepts_bracketed_ipv6.rs
@@ -6,4 +6,3 @@ fn runtime_options_bind_accepts_bracketed_ipv6() {
     assert_eq!(options.bind_address(), IpAddr::V6(Ipv6Addr::LOCALHOST));
     assert_eq!(options.address_family(), Some(AddressFamily::Ipv6));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_bind_resolves_hostnames.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_bind_resolves_hostnames.rs
@@ -9,4 +9,3 @@ fn runtime_options_bind_resolves_hostnames() {
         "unexpected resolved address {address}",
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_branded_config_env_overrides_legacy_env.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_branded_config_env_overrides_legacy_env.rs
@@ -30,4 +30,3 @@ fn runtime_options_branded_config_env_overrides_legacy_env() {
     assert_eq!(module.name, "branded");
     assert_eq!(module.path, branded_dir);
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_branded_secrets_env_overrides_legacy_env.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_branded_secrets_env_overrides_legacy_env.rs
@@ -24,14 +24,10 @@ fn runtime_options_branded_secrets_env_overrides_legacy_env() {
     )
     .expect("parse env secrets");
 
-    assert_eq!(
-        options.global_secrets_file(),
-        Some(branded_path.as_path()),
-    );
+    assert_eq!(options.global_secrets_file(), Some(branded_path.as_path()),);
     assert_ne!(
         options.global_secrets_file(),
         Some(legacy_path.as_path()),
         "legacy secrets path should not override branded path"
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_cli_config_overrides_environment_variable.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_cli_config_overrides_environment_variable.rs
@@ -22,10 +22,7 @@ fn runtime_options_cli_config_overrides_environment_variable() {
     .expect("write cli config");
 
     let _env = EnvGuard::set(LEGACY_CONFIG_ENV, env_config.as_os_str());
-    let args = [
-        OsString::from("--config"),
-        cli_config.into_os_string(),
-    ];
+    let args = [OsString::from("--config"), cli_config.into_os_string()];
     let options = RuntimeOptions::parse(&args).expect("parse cli config");
 
     assert_eq!(options.modules().len(), 1);
@@ -33,4 +30,3 @@ fn runtime_options_cli_config_overrides_environment_variable() {
     assert_eq!(module.name, "cli");
     assert_eq!(module.path, cli_module_dir);
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_cli_modules_inherit_global_refuse_options.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_cli_modules_inherit_global_refuse_options.rs
@@ -13,4 +13,3 @@ fn runtime_options_cli_modules_inherit_global_refuse_options() {
 
     assert_eq!(options.modules()[0].refused_options(), ["compress"]);
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_config_lock_file_respects_cli_override.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_config_lock_file_respects_cli_override.rs
@@ -19,4 +19,3 @@ fn runtime_options_config_lock_file_respects_cli_override() {
 
     assert_eq!(options.lock_file(), Some(cli_lock.as_path()));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_config_pid_file_respects_cli_override.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_config_pid_file_respects_cli_override.rs
@@ -19,4 +19,3 @@ fn runtime_options_config_pid_file_respects_cli_override() {
 
     assert_eq!(options.pid_file(), Some(cli_pid.as_path()));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_default_enables_reverse_lookup.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_default_enables_reverse_lookup.rs
@@ -3,4 +3,3 @@ fn runtime_options_default_enables_reverse_lookup() {
     let options = RuntimeOptions::parse(&[]).expect("parse defaults");
     assert!(options.reverse_lookup());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_detach_default_matches_platform.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_detach_default_matches_platform.rs
@@ -7,10 +7,7 @@ fn runtime_options_detach_default_matches_platform() {
     let options = RuntimeOptions::default();
 
     #[cfg(unix)]
-    assert!(
-        options.detach(),
-        "detach should default to true on Unix"
-    );
+    assert!(options.detach(), "detach should default to true on Unix");
     #[cfg(not(unix))]
     assert!(
         !options.detach(),

--- a/crates/daemon/src/tests/chunks/runtime_options_detach_enables_detach.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_detach_enables_detach.rs
@@ -4,11 +4,7 @@ fn runtime_options_detach_enables_detach() {
     let _config = EnvGuard::remove(BRANDED_CONFIG_ENV);
     let _config_legacy = EnvGuard::remove(LEGACY_CONFIG_ENV);
 
-    let options = RuntimeOptions::parse(&[OsString::from("--detach")])
-        .expect("parse --detach");
+    let options = RuntimeOptions::parse(&[OsString::from("--detach")]).expect("parse --detach");
 
-    assert!(
-        options.detach(),
-        "--detach should explicitly enable detach"
-    );
+    assert!(options.detach(), "--detach should explicitly enable detach");
 }

--- a/crates/daemon/src/tests/chunks/runtime_options_detach_parsed_default_matches_platform.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_detach_parsed_default_matches_platform.rs
@@ -6,11 +6,8 @@ fn runtime_options_detach_parsed_default_matches_platform() {
 
     // Parse with no detach-related flags to verify the parsed default
     // matches the struct default (platform-dependent).
-    let options = RuntimeOptions::parse(&[
-        OsString::from("--port"),
-        OsString::from("8873"),
-    ])
-    .expect("parse without detach flags");
+    let options = RuntimeOptions::parse(&[OsString::from("--port"), OsString::from("8873")])
+        .expect("parse without detach flags");
 
     let default_options = RuntimeOptions::default();
     assert_eq!(

--- a/crates/daemon/src/tests/chunks/runtime_options_global_bwlimit_respects_cli_override.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_global_bwlimit_respects_cli_override.rs
@@ -18,4 +18,3 @@ fn runtime_options_global_bwlimit_respects_cli_override() {
         Some(NonZeroU64::new(8 * 1024 * 1024).unwrap())
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_inherits_global_secrets_file_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_inherits_global_secrets_file_from_config.rs
@@ -37,4 +37,3 @@ fn runtime_options_inherits_global_secrets_file_from_config() {
     assert_eq!(module.auth_users()[0].username, "alice");
     assert_eq!(module.secrets_file(), Some(secrets_path.as_path()));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_inline_module_uses_default_secrets_file.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_inline_module_uses_default_secrets_file.rs
@@ -32,4 +32,3 @@ fn runtime_options_inline_module_uses_default_secrets_file() {
     assert_eq!(module.name, "secure");
     assert_eq!(module.secrets_file(), Some(secrets_path.as_path()));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_inline_module_uses_global_secrets_file.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_inline_module_uses_global_secrets_file.rs
@@ -38,4 +38,3 @@ fn runtime_options_inline_module_uses_global_secrets_file() {
     assert_eq!(module.name, "secure");
     assert_eq!(module.secrets_file(), Some(secrets_path.as_path()));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_ipv4_rejects_ipv6_bind_address.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_ipv4_rejects_ipv6_bind_address.rs
@@ -14,4 +14,3 @@ fn runtime_options_ipv4_rejects_ipv6_bind_address() {
             .contains("cannot use --ipv4 with an IPv6 bind address")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_ipv6_accepts_ipv6_bind_address.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_ipv6_accepts_ipv6_bind_address.rs
@@ -10,4 +10,3 @@ fn runtime_options_ipv6_accepts_ipv6_bind_address() {
     assert_eq!(options.bind_address(), IpAddr::V6(Ipv6Addr::LOCALHOST));
     assert_eq!(options.address_family(), Some(AddressFamily::Ipv6));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_ipv6_rejects_ipv4_bind_address.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_ipv6_rejects_ipv4_bind_address.rs
@@ -14,4 +14,3 @@ fn runtime_options_ipv6_rejects_ipv4_bind_address() {
             .contains("cannot use --ipv6 with an IPv4 bind address")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_ipv6_sets_default_bind_address.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_ipv6_sets_default_bind_address.rs
@@ -6,4 +6,3 @@ fn runtime_options_ipv6_sets_default_bind_address() {
     assert_eq!(options.bind_address(), IpAddr::V6(Ipv6Addr::UNSPECIFIED));
     assert_eq!(options.address_family(), Some(AddressFamily::Ipv6));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_last_detach_flag_wins.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_last_detach_flag_wins.rs
@@ -4,16 +4,11 @@ fn runtime_options_last_detach_flag_wins_detach_after_no_detach() {
     let _config = EnvGuard::remove(BRANDED_CONFIG_ENV);
     let _config_legacy = EnvGuard::remove(LEGACY_CONFIG_ENV);
 
-    let options = RuntimeOptions::parse(&[
-        OsString::from("--no-detach"),
-        OsString::from("--detach"),
-    ])
-    .expect("parse --no-detach --detach");
+    let options =
+        RuntimeOptions::parse(&[OsString::from("--no-detach"), OsString::from("--detach")])
+            .expect("parse --no-detach --detach");
 
-    assert!(
-        options.detach(),
-        "last --detach flag should win"
-    );
+    assert!(options.detach(), "last --detach flag should win");
 }
 
 #[test]
@@ -22,14 +17,9 @@ fn runtime_options_last_detach_flag_wins_no_detach_after_detach() {
     let _config = EnvGuard::remove(BRANDED_CONFIG_ENV);
     let _config_legacy = EnvGuard::remove(LEGACY_CONFIG_ENV);
 
-    let options = RuntimeOptions::parse(&[
-        OsString::from("--detach"),
-        OsString::from("--no-detach"),
-    ])
-    .expect("parse --detach --no-detach");
+    let options =
+        RuntimeOptions::parse(&[OsString::from("--detach"), OsString::from("--no-detach")])
+            .expect("parse --detach --no-detach");
 
-    assert!(
-        !options.detach(),
-        "last --no-detach flag should win"
-    );
+    assert!(!options.detach(), "last --no-detach flag should win");
 }

--- a/crates/daemon/src/tests/chunks/runtime_options_load_modules_from_config_file.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_load_modules_from_config_file.rs
@@ -25,4 +25,3 @@ fn runtime_options_load_modules_from_config_file() {
     assert!(modules[1].listable());
     assert!(modules.iter().all(ModuleDefinition::use_chroot));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_boolean_and_id_directives_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_boolean_and_id_directives_from_config.rs
@@ -25,4 +25,3 @@ fn runtime_options_loads_boolean_and_id_directives_from_config() {
     assert!(!module.listable());
     assert!(module.use_chroot());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_config_from_branded_environment_variable.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_config_from_branded_environment_variable.rs
@@ -19,4 +19,3 @@ fn runtime_options_loads_config_from_branded_environment_variable() {
     assert_eq!(module.name, "data");
     assert_eq!(module.path, module_dir);
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_config_from_legacy_environment_variable.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_config_from_legacy_environment_variable.rs
@@ -19,4 +19,3 @@ fn runtime_options_loads_config_from_legacy_environment_variable() {
     assert_eq!(module.name, "legacy");
     assert_eq!(module.path, module_dir);
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_global_bwlimit_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_global_bwlimit_from_config.rs
@@ -22,4 +22,3 @@ fn runtime_options_loads_global_bwlimit_from_config() {
     let modules = options.modules();
     assert_eq!(modules.len(), 1);
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_lock_file_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_lock_file_from_config.rs
@@ -17,4 +17,3 @@ fn runtime_options_loads_lock_file_from_config() {
     let expected = dir.path().join("daemon.lock");
     assert_eq!(options.lock_file(), Some(expected.as_path()));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_max_connections_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_max_connections_from_config.rs
@@ -19,4 +19,3 @@ fn runtime_options_loads_max_connections_from_config() {
         MaxConnections::Limited(NonZeroU32::new(7).expect("non-zero"))
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_modules_from_included_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_modules_from_included_config.rs
@@ -26,4 +26,3 @@ fn runtime_options_loads_modules_from_included_config() {
     assert_eq!(options.modules().len(), 1);
     assert_eq!(options.modules()[0].name(), "docs");
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_motd_from_config_directives.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_motd_from_config_directives.rs
@@ -25,4 +25,3 @@ fn runtime_options_loads_motd_from_config_directives() {
 
     assert_eq!(options.motd_lines(), expected.as_slice());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_pid_file_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_pid_file_from_config.rs
@@ -17,4 +17,3 @@ fn runtime_options_loads_pid_file_from_config() {
     let expected = dir.path().join("daemon.pid");
     assert_eq!(options.pid_file(), Some(expected.as_path()));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_refuse_options_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_refuse_options_from_config.rs
@@ -22,4 +22,3 @@ fn runtime_options_loads_refuse_options_from_config() {
         &["delete", "compress", "progress"]
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_reverse_lookup_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_reverse_lookup_from_config.rs
@@ -15,4 +15,3 @@ fn runtime_options_loads_reverse_lookup_from_config() {
     let options = RuntimeOptions::parse(&args).expect("parse config");
     assert!(!options.reverse_lookup());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_secrets_from_branded_environment_variable.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_secrets_from_branded_environment_variable.rs
@@ -20,9 +20,5 @@ fn runtime_options_loads_secrets_from_branded_environment_variable() {
     )
     .expect("parse env secrets");
 
-    assert_eq!(
-        options.global_secrets_file(),
-        Some(secrets_path.as_path()),
-    );
+    assert_eq!(options.global_secrets_file(), Some(secrets_path.as_path()),);
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_secrets_from_legacy_environment_variable.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_secrets_from_legacy_environment_variable.rs
@@ -20,9 +20,5 @@ fn runtime_options_loads_secrets_from_legacy_environment_variable() {
     )
     .expect("parse env secrets");
 
-    assert_eq!(
-        options.global_secrets_file(),
-        Some(secrets_path.as_path()),
-    );
+    assert_eq!(options.global_secrets_file(), Some(secrets_path.as_path()),);
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_timeout_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_timeout_from_config.rs
@@ -18,4 +18,3 @@ fn runtime_options_loads_timeout_from_config() {
     let module = &modules[0];
     assert_eq!(module.timeout().map(NonZeroU64::get), Some(120));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_unlimited_global_bwlimit_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_unlimited_global_bwlimit_from_config.rs
@@ -16,4 +16,3 @@ fn runtime_options_loads_unlimited_global_bwlimit_from_config() {
     assert!(options.bandwidth_limit().is_none());
     assert!(options.bandwidth_limit_configured());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_unlimited_max_connections_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_unlimited_max_connections_from_config.rs
@@ -20,4 +20,3 @@ fn runtime_options_loads_unlimited_max_connections_from_config() {
         MaxConnections::Unlimited
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_use_chroot_directive_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_use_chroot_directive_from_config.rs
@@ -13,4 +13,3 @@ fn runtime_options_loads_use_chroot_directive_from_config() {
     assert_eq!(modules.len(), 1);
     assert!(!modules[0].use_chroot());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_module_definition_parses_inline_options.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_module_definition_parses_inline_options.rs
@@ -19,7 +19,9 @@ fn runtime_options_module_definition_parses_inline_options() {
     assert!(module.numeric_ids());
     assert!(!module.use_chroot());
     assert!(module.permits(
-        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 42)), PeerHost::new(Some("host.example"), true)));
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 42)),
+        PeerHost::new(Some("host.example"), true)
+    ));
     assert_eq!(module.auth_users().len(), 2);
     assert_eq!(module.auth_users()[0].username, "alice");
     assert_eq!(module.auth_users()[1].username, "bob");
@@ -38,4 +40,3 @@ fn runtime_options_module_definition_parses_inline_options() {
         MaxConnections::Limited(NonZeroU32::new(5).expect("non-zero"))
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_module_definition_preserves_escaped_backslash.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_module_definition_preserves_escaped_backslash.rs
@@ -12,4 +12,3 @@ fn runtime_options_module_definition_preserves_escaped_backslash() {
     assert_eq!(modules[0].comment.as_deref(), Some("Log share"));
     assert!(modules[0].read_only());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_module_definition_rejects_duplicate_inline_option.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_module_definition_rejects_duplicate_inline_option.rs
@@ -13,4 +13,3 @@ fn runtime_options_module_definition_rejects_duplicate_inline_option() {
             .contains("duplicate module option")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_module_definition_rejects_unknown_inline_option.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_module_definition_rejects_unknown_inline_option.rs
@@ -13,4 +13,3 @@ fn runtime_options_module_definition_rejects_unknown_inline_option() {
             .contains("unsupported module option")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_module_definition_requires_secrets_for_inline_auth_users.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_module_definition_requires_secrets_for_inline_auth_users.rs
@@ -13,4 +13,3 @@ fn runtime_options_module_definition_requires_secrets_for_inline_auth_users() {
             .contains("did not supply a secrets file")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_module_definition_supports_escaped_commas.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_module_definition_supports_escaped_commas.rs
@@ -13,4 +13,3 @@ fn runtime_options_module_definition_supports_escaped_commas() {
     assert_eq!(modules[0].comment.as_deref(), Some("Project, Docs"));
     assert!(modules[0].read_only());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_no_detach_disables_detach.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_no_detach_disables_detach.rs
@@ -4,8 +4,8 @@ fn runtime_options_no_detach_disables_detach() {
     let _config = EnvGuard::remove(BRANDED_CONFIG_ENV);
     let _config_legacy = EnvGuard::remove(LEGACY_CONFIG_ENV);
 
-    let options = RuntimeOptions::parse(&[OsString::from("--no-detach")])
-        .expect("parse --no-detach");
+    let options =
+        RuntimeOptions::parse(&[OsString::from("--no-detach")]).expect("parse --no-detach");
 
     assert!(
         !options.detach(),

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_auth_users_and_secrets_file.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_auth_users_and_secrets_file.rs
@@ -36,4 +36,3 @@ fn runtime_options_parse_auth_users_and_secrets_file() {
     assert_eq!(module.auth_users()[1].username, "bob");
     assert_eq!(module.secrets_file(), Some(secrets_path.as_path()));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_bwlimit_argument.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_bwlimit_argument.rs
@@ -12,4 +12,3 @@ fn runtime_options_parse_bwlimit_argument() {
     );
     assert!(options.bandwidth_limit_configured());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_bwlimit_unlimited.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_bwlimit_unlimited.rs
@@ -6,4 +6,3 @@ fn runtime_options_parse_bwlimit_unlimited() {
     assert!(options.bandwidth_limit().is_none());
     assert!(options.bandwidth_limit_configured());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_hostname_patterns.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_hostname_patterns.rs
@@ -23,4 +23,3 @@ fn runtime_options_parse_hostname_patterns() {
     assert_eq!(module.hosts_deny.len(), 1);
     assert!(matches!(module.hosts_deny[0], HostPattern::Hostname(_)));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_hosts_allow_and_deny.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_hosts_allow_and_deny.rs
@@ -32,4 +32,3 @@ fn runtime_options_parse_hosts_allow_and_deny() {
         HostPattern::Ipv4 { prefix: 32, .. }
     ));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_lock_file_argument.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_lock_file_argument.rs
@@ -8,4 +8,3 @@ fn runtime_options_parse_lock_file_argument() {
 
     assert_eq!(options.lock_file(), Some(Path::new("/var/run/rsyncd.lock")));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_log_file_argument.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_log_file_argument.rs
@@ -11,4 +11,3 @@ fn runtime_options_parse_log_file_argument() {
         Some(&PathBuf::from("/var/log/rsyncd.log"))
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_module_definitions.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_module_definitions.rs
@@ -21,4 +21,3 @@ fn runtime_options_parse_module_definitions() {
     assert!(modules[1].refused_options().is_empty());
     assert!(modules[1].read_only());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_motd_sources.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_motd_sources.rs
@@ -20,4 +20,3 @@ fn runtime_options_parse_motd_sources() {
 
     assert_eq!(options.motd_lines(), expected.as_slice());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_no_bwlimit_argument.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_no_bwlimit_argument.rs
@@ -6,4 +6,3 @@ fn runtime_options_parse_no_bwlimit_argument() {
     assert!(options.bandwidth_limit().is_none());
     assert!(options.bandwidth_limit_configured());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_parse_pid_file_argument.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_parse_pid_file_argument.rs
@@ -8,4 +8,3 @@ fn runtime_options_parse_pid_file_argument() {
 
     assert_eq!(options.pid_file(), Some(Path::new("/var/run/rsyncd.pid")));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_reject_duplicate_bwlimit.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_reject_duplicate_bwlimit.rs
@@ -15,4 +15,3 @@ fn runtime_options_reject_duplicate_bwlimit() {
             .contains("duplicate daemon argument '--bwlimit'")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_reject_duplicate_lock_file_argument.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_reject_duplicate_lock_file_argument.rs
@@ -15,4 +15,3 @@ fn runtime_options_reject_duplicate_lock_file_argument() {
             .contains("duplicate daemon argument '--lock-file'")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_reject_duplicate_log_file_argument.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_reject_duplicate_log_file_argument.rs
@@ -15,4 +15,3 @@ fn runtime_options_reject_duplicate_log_file_argument() {
             .contains("duplicate daemon argument '--log-file'")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_reject_duplicate_pid_file_argument.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_reject_duplicate_pid_file_argument.rs
@@ -10,4 +10,3 @@ fn runtime_options_reject_duplicate_pid_file_argument() {
 
     assert!(error.message().to_string().contains("--pid-file"));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_reject_invalid_bwlimit.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_reject_invalid_bwlimit.rs
@@ -10,4 +10,3 @@ fn runtime_options_reject_invalid_bwlimit() {
             .contains("--bwlimit=foo is invalid")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_reject_whitespace_wrapped_bwlimit_argument.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_reject_whitespace_wrapped_bwlimit_argument.rs
@@ -10,4 +10,3 @@ fn runtime_options_reject_whitespace_wrapped_bwlimit_argument() {
             .contains("--bwlimit= 8M \n is invalid")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_config_missing_path.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_config_missing_path.rs
@@ -16,4 +16,3 @@ fn runtime_options_rejects_config_missing_path() {
             .contains("missing required 'path' directive")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_duplicate_module_across_config_and_cli.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_duplicate_module_across_config_and_cli.rs
@@ -18,4 +18,3 @@ fn runtime_options_rejects_duplicate_module_across_config_and_cli() {
             .contains("duplicate module definition 'docs'")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_empty_refuse_options_directive.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_empty_refuse_options_directive.rs
@@ -12,4 +12,3 @@ fn runtime_options_rejects_empty_refuse_options_directive() {
     let rendered = error.message().to_string();
     assert!(rendered.contains("must specify at least one option"));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_bwlimit_in_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_bwlimit_in_config.rs
@@ -18,4 +18,3 @@ fn runtime_options_rejects_invalid_bwlimit_in_config() {
             .contains("invalid 'bwlimit' value 'nope'")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_uid.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_uid.rs
@@ -11,4 +11,3 @@ fn runtime_options_rejects_invalid_uid() {
 
     assert!(error.message().to_string().contains("invalid uid"));
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_ipv4_ipv6_combo.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_ipv4_ipv6_combo.rs
@@ -15,4 +15,3 @@ fn runtime_options_rejects_ipv4_ipv6_combo() {
         "dual_stack must be set when both family flags are given"
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_missing_secrets_from_environment.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_missing_secrets_from_environment.rs
@@ -14,4 +14,3 @@ fn runtime_options_rejects_missing_secrets_from_environment() {
         "no secrets override should be loaded when the environment path is missing"
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_relative_path_with_chroot_enabled.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_relative_path_with_chroot_enabled.rs
@@ -20,4 +20,3 @@ fn runtime_options_rejects_relative_path_with_chroot_enabled() {
             .contains("requires an absolute path when 'use chroot' is enabled")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_require_secrets_file_with_auth_users.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_require_secrets_file_with_auth_users.rs
@@ -16,4 +16,3 @@ fn runtime_options_require_secrets_file_with_auth_users() {
             .contains("missing the required 'secrets file' directive")
     );
 }
-

--- a/crates/daemon/src/tests/chunks/sanitize_module_identifier_preserves_clean_input.rs
+++ b/crates/daemon/src/tests/chunks/sanitize_module_identifier_preserves_clean_input.rs
@@ -6,4 +6,3 @@ fn sanitize_module_identifier_preserves_clean_input() {
         Cow::Owned(_) => panic!("clean identifiers should not allocate"),
     }
 }
-

--- a/crates/daemon/src/tests/chunks/sanitize_module_identifier_replaces_control_characters.rs
+++ b/crates/daemon/src/tests/chunks/sanitize_module_identifier_replaces_control_characters.rs
@@ -4,4 +4,3 @@ fn sanitize_module_identifier_replaces_control_characters() {
     let sanitized = sanitize_module_identifier(ident);
     assert_eq!(sanitized.as_ref(), "bad?name?");
 }
-

--- a/crates/daemon/src/tests/chunks/version_flag_renders_report.rs
+++ b/crates/daemon/src/tests/chunks/version_flag_renders_report.rs
@@ -8,4 +8,3 @@ fn version_flag_renders_report() {
     let expected = VersionInfoReport::for_daemon_brand(Brand::Upstream).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
-

--- a/crates/engine/src/local_copy/context_impl/backup.rs
+++ b/crates/engine/src/local_copy/context_impl/backup.rs
@@ -154,54 +154,54 @@ impl<'a> CopyContext<'a> {
             strategy
         } else {
             match backup_rename(destination, &backup_path) {
-            Ok(()) => BackupStrategy::Rename,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-            // upstream: backup.c:247-256 - link_or_rename failing with EEXIST or
-            // EISDIR is recoverable: lstat the target and call delete_item with
-            // DEL_RECURSE, then retry. EISDIR fires when the backup-dir already
-            // contains a directory at the path we need (e.g. user pre-created
-            // it, or a previous backup left a tree there); without this arm,
-            // backup test 4 from upstream backup.test fails as exit-23 fatal.
-            // Windows reports renaming a file onto an existing directory as
-            // ERROR_ACCESS_DENIED (PermissionDenied) rather than EEXIST/EISDIR,
-            // so it must enter the same recovery arm; the inner symlink_metadata
-            // re-stat below still gates removal on the target actually existing,
-            // so a genuine permission error falls through to the retry-and-fail
-            // path unchanged.
-            Err(error) if is_stale_backup_conflict(&error) => {
-                remove_stale_backup_entry(&backup_path)?;
-                fs::rename(destination, &backup_path).map_err(|rename_error| {
-                    LocalCopyError::io("create backup", backup_path.clone(), rename_error)
-                })?;
-                BackupStrategy::Rename
-            }
-            Err(error) if error.kind() == io::ErrorKind::CrossesDevices => {
-                // upstream: backup.c:368-375 - the copy fallback re-checks
-                // --safe-links before recreating the symlink. Upstream keeps
-                // this alongside the fast-path check above; both go through the
-                // one predicate so they cannot implement different rules.
-                if self.backup_refused_by_safe_links(destination, file_type) {
-                    return Ok(());
+                Ok(()) => BackupStrategy::Rename,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+                // upstream: backup.c:247-256 - link_or_rename failing with EEXIST or
+                // EISDIR is recoverable: lstat the target and call delete_item with
+                // DEL_RECURSE, then retry. EISDIR fires when the backup-dir already
+                // contains a directory at the path we need (e.g. user pre-created
+                // it, or a previous backup left a tree there); without this arm,
+                // backup test 4 from upstream backup.test fails as exit-23 fatal.
+                // Windows reports renaming a file onto an existing directory as
+                // ERROR_ACCESS_DENIED (PermissionDenied) rather than EEXIST/EISDIR,
+                // so it must enter the same recovery arm; the inner symlink_metadata
+                // re-stat below still gates removal on the target actually existing,
+                // so a genuine permission error falls through to the retry-and-fail
+                // path unchanged.
+                Err(error) if is_stale_backup_conflict(&error) => {
+                    remove_stale_backup_entry(&backup_path)?;
+                    fs::rename(destination, &backup_path).map_err(|rename_error| {
+                        LocalCopyError::io("create backup", backup_path.clone(), rename_error)
+                    })?;
+                    BackupStrategy::Rename
                 }
-                match copy_entry_to_backup(
-                    destination,
-                    &backup_path,
-                    file_type,
-                    self.options.devices_enabled(),
-                    self.options.specials_enabled(),
-                    self.options.fake_super_enabled(),
-                )? {
-                    Some(strategy) => strategy,
-                    // upstream: backup.c:306-317 - a non-regular file that is
-                    // neither backed up as a device/special (gates off) nor a
-                    // symlink is skipped; make_backup returns 3 and leaves no
-                    // backup, so emit no trace and no "backed up" notice.
-                    None => return Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::CrossesDevices => {
+                    // upstream: backup.c:368-375 - the copy fallback re-checks
+                    // --safe-links before recreating the symlink. Upstream keeps
+                    // this alongside the fast-path check above; both go through the
+                    // one predicate so they cannot implement different rules.
+                    if self.backup_refused_by_safe_links(destination, file_type) {
+                        return Ok(());
+                    }
+                    match copy_entry_to_backup(
+                        destination,
+                        &backup_path,
+                        file_type,
+                        self.options.devices_enabled(),
+                        self.options.specials_enabled(),
+                        self.options.fake_super_enabled(),
+                    )? {
+                        Some(strategy) => strategy,
+                        // upstream: backup.c:306-317 - a non-regular file that is
+                        // neither backed up as a device/special (gates off) nor a
+                        // symlink is skipped; make_backup returns 3 and leaves no
+                        // backup, so emit no trace and no "backed up" notice.
+                        None => return Ok(()),
+                    }
                 }
-            }
-            Err(error) => {
-                return Err(LocalCopyError::io("create backup", backup_path, error));
-            }
+                Err(error) => {
+                    return Err(LocalCopyError::io("create backup", backup_path, error));
+                }
             }
         };
 
@@ -458,7 +458,6 @@ impl<'a> CopyContext<'a> {
         });
         record_directory_subtree(self, &mut subtree_path, &mut subtree_relative)
     }
-
 }
 
 /// Returns `true` when a hard-link or rename attempt into the backup area
@@ -474,7 +473,9 @@ impl<'a> CopyContext<'a> {
 fn is_stale_backup_conflict(error: &io::Error) -> bool {
     matches!(
         error.kind(),
-        io::ErrorKind::AlreadyExists | io::ErrorKind::IsADirectory | io::ErrorKind::PermissionDenied
+        io::ErrorKind::AlreadyExists
+            | io::ErrorKind::IsADirectory
+            | io::ErrorKind::PermissionDenied
     )
 }
 
@@ -487,7 +488,11 @@ fn is_stale_backup_conflict(error: &io::Error) -> bool {
 fn remove_stale_backup_entry(backup_path: &Path) -> Result<(), LocalCopyError> {
     match fs::symlink_metadata(backup_path) {
         Ok(meta) if meta.is_dir() => fs::remove_dir_all(backup_path).map_err(|remove_error| {
-            LocalCopyError::io("remove existing backup directory", backup_path, remove_error)
+            LocalCopyError::io(
+                "remove existing backup directory",
+                backup_path,
+                remove_error,
+            )
         }),
         Ok(_) => {
             if let Err(remove_error) = fs::remove_file(backup_path)

--- a/crates/engine/src/local_copy/context_impl/batch_setup.rs
+++ b/crates/engine/src/local_copy/context_impl/batch_setup.rs
@@ -22,7 +22,9 @@ fn build_batch_delta_buffer(options: &LocalCopyOptions) -> Option<std::io::Curso
 /// Returns `None` when `--write-batch` is not in effect.
 fn build_batch_ndx_codec(options: &LocalCopyOptions) -> Option<protocol::codec::NdxCodecEnum> {
     options.get_batch_writer().map(|batch_writer_arc| {
-        let guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
+        let guard = batch_writer_arc
+            .lock()
+            .expect("batch writer mutex poisoned");
         let proto_version = guard.config().protocol_version;
         drop(guard);
         protocol::codec::NdxCodecEnum::new(proto_version as u8)
@@ -43,11 +45,11 @@ fn build_batch_ndx_codec(options: &LocalCopyOptions) -> Option<protocol::codec::
 /// header is what the reader configures itself from
 /// (`batch/src/reader/flist.rs`); deriving them from the live options instead
 /// lets the two sides drift into an undecodable batch.
-fn build_batch_flist_writer(
-    options: &LocalCopyOptions,
-) -> Option<protocol::flist::FileListWriter> {
+fn build_batch_flist_writer(options: &LocalCopyOptions) -> Option<protocol::flist::FileListWriter> {
     options.get_batch_writer().map(|batch_writer_arc| {
-        let guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
+        let guard = batch_writer_arc
+            .lock()
+            .expect("batch writer mutex poisoned");
         let proto_version = guard.config().protocol_version;
         let compat_flags_val = guard.config().compat_flags;
         let checksum_seed = guard.config().checksum_seed;
@@ -158,13 +160,13 @@ fn build_adaptive_level_controller(
         CompressionLevel::PreciseSigned(v) => v,
     };
     match options.compression_algorithm() {
-        CompressionAlgorithm::Zlib => Some(
-            compress::strategy::adaptive_level::AdaptiveLevelController::for_zlib(level_i32),
-        ),
+        CompressionAlgorithm::Zlib => {
+            Some(compress::strategy::adaptive_level::AdaptiveLevelController::for_zlib(level_i32))
+        }
         #[cfg(feature = "zstd")]
-        CompressionAlgorithm::Zstd => Some(
-            compress::strategy::adaptive_level::AdaptiveLevelController::for_zstd(level_i32),
-        ),
+        CompressionAlgorithm::Zstd => {
+            Some(compress::strategy::adaptive_level::AdaptiveLevelController::for_zstd(level_i32))
+        }
         _ => None,
     }
 }

--- a/crates/engine/src/local_copy/context_impl/deferred_updates.rs
+++ b/crates/engine/src/local_copy/context_impl/deferred_updates.rs
@@ -36,7 +36,9 @@ impl<'a> CopyContext<'a> {
         // upstream: receiver.c:718 handle_partial_dir(partialptr, PDIR_DELETE)
         // after the delayed rename succeeds.
         if let Some(dir) = update.guard.partial_dir_to_remove() {
-            self.deferred_ops.delay_staging_dirs.insert(dir.to_path_buf());
+            self.deferred_ops
+                .delay_staging_dirs
+                .insert(dir.to_path_buf());
         }
         let metadata = update.metadata.clone();
         let destination = update.destination.clone();

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -14,9 +14,7 @@ pub(super) struct SparseCopy<'state> {
 /// upstream: `generator.c:sum_sizes_sqroot()` fills `struct sum_struct`, whose
 /// four fields `io.c:write_sum_head()` serialises; `remainder` is the length of
 /// the trailing short block, or 0 when the basis divides evenly.
-fn batch_sum_head(
-    index: &DeltaSignatureIndex,
-) -> Result<protocol::wire::SumHead, LocalCopyError> {
+fn batch_sum_head(index: &DeltaSignatureIndex) -> Result<protocol::wire::SumHead, LocalCopyError> {
     let reject = |detail: String| {
         LocalCopyError::io(
             "derive batch sum_head",
@@ -25,7 +23,8 @@ fn batch_sum_head(
         )
     };
     let field = |value: usize, name: &str| {
-        u32::try_from(value).map_err(|_| reject(format!("basis {name} {value} exceeds the wire field")))
+        u32::try_from(value)
+            .map_err(|_| reject(format!("basis {name} {value} exceeds the wire field")))
     };
 
     let count = field(index.block_count(), "block count")?;
@@ -129,14 +128,13 @@ impl<'a> CopyContext<'a> {
             let _ = fast_io::mark_file_sparse(writer);
         }
 
-        let mut destination_reader =
-            Some(fs::File::open(destination).map_err(|error| {
-                LocalCopyError::io(
-                    "read existing destination",
-                    destination.to_path_buf(),
-                    error,
-                )
-            })?);
+        let mut destination_reader = Some(fs::File::open(destination).map_err(|error| {
+            LocalCopyError::io(
+                "read existing destination",
+                destination.to_path_buf(),
+                error,
+            )
+        })?);
         let mut compressor = self.start_compressor(compress, source)?;
         let mut compressed_progress = 0u64;
         let mut total_bytes = 0u64;
@@ -180,9 +178,9 @@ impl<'a> CopyContext<'a> {
                 bytes_since_timeout_check = 0;
             }
             if buffer_pos == buffer_len {
-                buffer_len = reader.read(&mut read_buffer).map_err(|error| {
-                    LocalCopyError::io("copy file", source, error)
-                })?;
+                buffer_len = reader
+                    .read(&mut read_buffer)
+                    .map_err(|error| LocalCopyError::io("copy file", source, error))?;
                 buffer_pos = 0;
                 if buffer_len == 0 {
                     break;
@@ -196,13 +194,9 @@ impl<'a> CopyContext<'a> {
             window.push_back(byte);
             if let Some(outgoing_byte) = outgoing.take() {
                 debug_assert!(window.len() <= index.block_length());
-                rolling
-                    .roll_many(&[outgoing_byte], &[byte])
-                    .map_err(|_| {
-                        LocalCopyError::invalid_argument(
-                            LocalCopyArgumentError::UnsupportedFileType,
-                        )
-                    })?;
+                rolling.roll_many(&[outgoing_byte], &[byte]).map_err(|_| {
+                    LocalCopyError::invalid_argument(LocalCopyArgumentError::UnsupportedFileType)
+                })?;
             } else {
                 rolling.update(&[byte]);
             }
@@ -219,9 +213,15 @@ impl<'a> CopyContext<'a> {
                 if !pending_literals.is_empty() {
                     let flushed_len = pending_literals.len();
                     if inplace_mode {
-                        writer.seek(SeekFrom::Start(output_position)).map_err(|error| {
-                            LocalCopyError::io("seek destination file", destination.to_path_buf(), error)
-                        })?;
+                        writer
+                            .seek(SeekFrom::Start(output_position))
+                            .map_err(|error| {
+                                LocalCopyError::io(
+                                    "seek destination file",
+                                    destination.to_path_buf(),
+                                    error,
+                                )
+                            })?;
                     }
                     let flushed = self.flush_literal_chunk(
                         writer,
@@ -242,12 +242,7 @@ impl<'a> CopyContext<'a> {
                     total_bytes = total_bytes.saturating_add(flushed_len as u64);
                     output_position = output_position.saturating_add(flushed_len as u64);
                     let progressed = initial_bytes.saturating_add(total_bytes);
-                    self.notify_progress(
-                        relative,
-                        Some(total_size),
-                        progressed,
-                        start.elapsed(),
-                    );
+                    self.notify_progress(relative, Some(total_size), progressed, start.elapsed());
                     pending_literals.clear();
                 }
 
@@ -298,9 +293,9 @@ impl<'a> CopyContext<'a> {
                             destination,
                         )?;
                     } else {
-                        writer.write_all(matched_bytes).map_err(|error| {
-                            LocalCopyError::io("copy file", destination, error)
-                        })?;
+                        writer
+                            .write_all(matched_bytes)
+                            .map_err(|error| LocalCopyError::io("copy file", destination, error))?;
                     }
                     self.write_batch_block_match_token(
                         matched.descriptor().index() as u32,
@@ -423,13 +418,15 @@ impl<'a> CopyContext<'a> {
             if !pending_literals.is_empty() {
                 let flushed_len = pending_literals.len();
                 if inplace_mode {
-                    writer.seek(SeekFrom::Start(output_position)).map_err(|error| {
-                        LocalCopyError::io(
-                            "seek destination file",
-                            destination.to_path_buf(),
-                            error,
-                        )
-                    })?;
+                    writer
+                        .seek(SeekFrom::Start(output_position))
+                        .map_err(|error| {
+                            LocalCopyError::io(
+                                "seek destination file",
+                                destination.to_path_buf(),
+                                error,
+                            )
+                        })?;
                 }
                 let flushed = self.flush_literal_chunk(
                     writer,
@@ -467,25 +464,23 @@ impl<'a> CopyContext<'a> {
                 )?;
                 output_position = output_position.saturating_add(block_len as u64);
             } else if inplace_mode {
-                writer.seek(SeekFrom::Start(output_position)).map_err(|error| {
-                    LocalCopyError::io(
-                        "seek destination file",
-                        destination.to_path_buf(),
-                        error,
-                    )
-                })?;
+                writer
+                    .seek(SeekFrom::Start(output_position))
+                    .map_err(|error| {
+                        LocalCopyError::io(
+                            "seek destination file",
+                            destination.to_path_buf(),
+                            error,
+                        )
+                    })?;
                 let matched_bytes = &scratch[..block_len];
                 if sparse {
-                    let _ = write_sparse_chunk(
-                        writer,
-                        &mut sparse_state,
-                        matched_bytes,
-                        destination,
-                    )?;
+                    let _ =
+                        write_sparse_chunk(writer, &mut sparse_state, matched_bytes, destination)?;
                 } else {
-                    writer.write_all(matched_bytes).map_err(|error| {
-                        LocalCopyError::io("copy file", destination, error)
-                    })?;
+                    writer
+                        .write_all(matched_bytes)
+                        .map_err(|error| LocalCopyError::io("copy file", destination, error))?;
                 }
                 self.write_batch_block_match_token(
                     matched.descriptor().index() as u32,
@@ -523,9 +518,15 @@ impl<'a> CopyContext<'a> {
         if !pending_literals.is_empty() {
             let flushed_len = pending_literals.len();
             if inplace_mode {
-                writer.seek(SeekFrom::Start(output_position)).map_err(|error| {
-                    LocalCopyError::io("seek destination file", destination.to_path_buf(), error)
-                })?;
+                writer
+                    .seek(SeekFrom::Start(output_position))
+                    .map_err(|error| {
+                        LocalCopyError::io(
+                            "seek destination file",
+                            destination.to_path_buf(),
+                            error,
+                        )
+                    })?;
             }
             let flushed = self.flush_literal_chunk(
                 writer,
@@ -587,9 +588,9 @@ impl<'a> CopyContext<'a> {
         self.summary.record_delta_probe(file_matches, probe);
 
         let outcome = if let Some(encoder) = compressor {
-            let compressed_total = encoder.finish().map_err(|error| {
-                LocalCopyError::io("compress file", source, error)
-            })?;
+            let compressed_total = encoder
+                .finish()
+                .map_err(|error| LocalCopyError::io("compress file", source, error))?;
             let delta = compressed_total.saturating_sub(compressed_progress);
             self.register_limiter_bytes(delta);
             self.record_adaptive_compression(literal_bytes, compressed_total);
@@ -633,16 +634,16 @@ impl<'a> CopyContext<'a> {
         let written = if sparse {
             write_sparse_chunk(writer, state, chunk, destination)?
         } else {
-            writer.write_all(chunk).map_err(|error| {
-                LocalCopyError::io("copy file", destination, error)
-            })?;
+            writer
+                .write_all(chunk)
+                .map_err(|error| LocalCopyError::io("copy file", destination, error))?;
             chunk.len()
         };
 
         if let Some(encoder) = compressor {
-            encoder.write(chunk).map_err(|error| {
-                LocalCopyError::io("compress file", source, error)
-            })?;
+            encoder
+                .write(chunk)
+                .map_err(|error| LocalCopyError::io("compress file", source, error))?;
             let total = encoder.bytes_written();
             let delta = total.saturating_sub(*compressed_progress);
             *compressed_progress = total;
@@ -726,7 +727,13 @@ impl<'a> CopyContext<'a> {
         // output either way - this is a local-only acceleration with no wire
         // impact.
         if !sparse.enabled
-            && self.try_reflink_matched_block(existing, writer, offset, block_length, destination)?
+            && self.try_reflink_matched_block(
+                existing,
+                writer,
+                offset,
+                block_length,
+                destination,
+            )?
         {
             return Ok(());
         }
@@ -763,12 +770,11 @@ impl<'a> CopyContext<'a> {
             }
 
             if sparse.enabled {
-                let _ =
-                    write_sparse_chunk(writer, sparse.state, &buffer[..read], destination)?;
+                let _ = write_sparse_chunk(writer, sparse.state, &buffer[..read], destination)?;
             } else {
-                writer.write_all(&buffer[..read]).map_err(|error| {
-                    LocalCopyError::io("copy file", destination, error)
-                })?;
+                writer
+                    .write_all(&buffer[..read])
+                    .map_err(|error| LocalCopyError::io("copy file", destination, error))?;
             }
 
             remaining -= read;

--- a/crates/engine/src/local_copy/context_impl/link_dest.rs
+++ b/crates/engine/src/local_copy/context_impl/link_dest.rs
@@ -91,7 +91,10 @@ impl<'a> CopyContext<'a> {
                 2
             };
 
-            if best.as_ref().is_none_or(|(_, best_level)| level > *best_level) {
+            if best
+                .as_ref()
+                .is_none_or(|(_, best_level)| level > *best_level)
+            {
                 best = Some((candidate, level));
             }
             // upstream: generator.c:979 - an exact match ends the scan.
@@ -244,7 +247,6 @@ impl<'a> CopyContext<'a> {
     ) -> Result<Option<PathBuf>, LocalCopyError> {
         Ok(None)
     }
-
 }
 
 /// Returns `true` when two nodes' modification times are equal within

--- a/crates/engine/src/local_copy/context_impl/options/batch.rs
+++ b/crates/engine/src/local_copy/context_impl/options/batch.rs
@@ -54,7 +54,9 @@ impl<'a> CopyContext<'a> {
             Some(w) => w.clone(),
             None => return Ok(()),
         };
-        let mut writer_guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
+        let mut writer_guard = batch_writer_arc
+            .lock()
+            .expect("batch writer mutex poisoned");
         writer_guard.write_data(&buf).map_err(|e| {
             crate::local_copy::LocalCopyError::io(
                 "write batch flist end marker",
@@ -90,7 +92,9 @@ impl<'a> CopyContext<'a> {
         };
 
         let (proto, compat_flags, numeric_ids, preserve_uid, preserve_gid, preserve_acls) = {
-            let cfg = batch_writer_arc.lock().expect("batch writer mutex poisoned");
+            let cfg = batch_writer_arc
+                .lock()
+                .expect("batch writer mutex poisoned");
             let flags = cfg.stream_flags();
             (
                 cfg.config().protocol_version,
@@ -154,7 +158,9 @@ impl<'a> CopyContext<'a> {
             })?;
         }
 
-        let mut writer_guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
+        let mut writer_guard = batch_writer_arc
+            .lock()
+            .expect("batch writer mutex poisoned");
         writer_guard.write_data(&buf).map_err(|e| {
             crate::local_copy::LocalCopyError::io(
                 "write batch id lists",
@@ -298,8 +304,16 @@ impl<'a> CopyContext<'a> {
 
         // upstream: rsync.c:383 - write iflags (u16 LE) for protocol >= 29.
         // ITEM_TRANSFER (0x8000) indicates delta data follows.
-        let batch_writer_arc = self.options.get_batch_writer().expect("batch writer set on the write-batch path").clone();
-        let proto = batch_writer_arc.lock().expect("batch writer mutex poisoned").config().protocol_version;
+        let batch_writer_arc = self
+            .options
+            .get_batch_writer()
+            .expect("batch writer set on the write-batch path")
+            .clone();
+        let proto = batch_writer_arc
+            .lock()
+            .expect("batch writer mutex poisoned")
+            .config()
+            .protocol_version;
         if proto >= 29 {
             const ITEM_TRANSFER: u16 = 0x8000;
             delta_file
@@ -576,16 +590,16 @@ impl<'a> CopyContext<'a> {
                 .unwrap_or(*traversal_idx);
 
             let mut ndx_buf = Vec::with_capacity(4);
-            protocol::codec::NdxCodec::write_ndx(codec, &mut ndx_buf, sorted_idx).map_err(
-                |e| {
-                    crate::local_copy::LocalCopyError::io(
-                        "write batch NDX",
-                        std::path::PathBuf::new(),
-                        e,
-                    )
-                },
-            )?;
-            let mut writer_guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
+            protocol::codec::NdxCodec::write_ndx(codec, &mut ndx_buf, sorted_idx).map_err(|e| {
+                crate::local_copy::LocalCopyError::io(
+                    "write batch NDX",
+                    std::path::PathBuf::new(),
+                    e,
+                )
+            })?;
+            let mut writer_guard = batch_writer_arc
+                .lock()
+                .expect("batch writer mutex poisoned");
             writer_guard.write_data(&ndx_buf).map_err(|e| {
                 crate::local_copy::LocalCopyError::io(
                     "write batch NDX",
@@ -610,7 +624,11 @@ impl<'a> CopyContext<'a> {
         // protocol >= 29, max_phase=2, so recv_files needs 3 NDX_DONEs
         // to break (phase 0->1->2->3, breaks when phase > max_phase).
         // For protocol < 29, max_phase=1, needs 2 NDX_DONEs.
-        let proto = batch_writer_arc.lock().expect("batch writer mutex poisoned").config().protocol_version;
+        let proto = batch_writer_arc
+            .lock()
+            .expect("batch writer mutex poisoned")
+            .config()
+            .protocol_version;
         let ndx_done_count = if proto >= 29 { 3 } else { 2 };
 
         for _ in 0..ndx_done_count {
@@ -622,7 +640,9 @@ impl<'a> CopyContext<'a> {
                     e,
                 )
             })?;
-            let mut writer_guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
+            let mut writer_guard = batch_writer_arc
+                .lock()
+                .expect("batch writer mutex poisoned");
             writer_guard.write_data(&done_buf).map_err(|e| {
                 crate::local_copy::LocalCopyError::io(
                     "write batch NDX_DONE",
@@ -706,8 +726,14 @@ fn batch_entry_compare(
         (false, false) => {}
     }
 
-    let last_slash_a = name_a.iter().rposition(|&b| b == b'/').unwrap_or(usize::MAX);
-    let last_slash_b = name_b.iter().rposition(|&b| b == b'/').unwrap_or(usize::MAX);
+    let last_slash_a = name_a
+        .iter()
+        .rposition(|&b| b == b'/')
+        .unwrap_or(usize::MAX);
+    let last_slash_b = name_b
+        .iter()
+        .rposition(|&b| b == b'/')
+        .unwrap_or(usize::MAX);
 
     let mut i = 0;
     loop {

--- a/crates/engine/src/local_copy/context_impl/options/dirs.rs
+++ b/crates/engine/src/local_copy/context_impl/options/dirs.rs
@@ -57,23 +57,23 @@ impl<'a> CopyContext<'a> {
             .filter(|path| !path.as_os_str().is_empty())
     }
 
-/// Is this symlink the operator's own, and therefore followable as a
-/// destination root?
-///
-/// Unix delegates to the single owner of the trust rule in `fast_io`. On other
-/// platforms there is no uid to consult, so the answer is `false` and the
-/// destination-root symlink keeps the pre-existing `--keep-dirlinks`-only
-/// behaviour rather than being followed on no evidence.
-#[cfg(unix)]
-fn operator_owns_symlink(metadata: &fs::Metadata) -> bool {
-    use std::os::unix::fs::MetadataExt;
-    fast_io::symlink_owner_is_trusted(metadata.uid())
-}
+    /// Is this symlink the operator's own, and therefore followable as a
+    /// destination root?
+    ///
+    /// Unix delegates to the single owner of the trust rule in `fast_io`. On other
+    /// platforms there is no uid to consult, so the answer is `false` and the
+    /// destination-root symlink keeps the pre-existing `--keep-dirlinks`-only
+    /// behaviour rather than being followed on no evidence.
+    #[cfg(unix)]
+    fn operator_owns_symlink(metadata: &fs::Metadata) -> bool {
+        use std::os::unix::fs::MetadataExt;
+        fast_io::symlink_owner_is_trusted(metadata.uid())
+    }
 
-#[cfg(not(unix))]
-fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
-    false
-}
+    #[cfg(not(unix))]
+    fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
+        false
+    }
 
     /// Whether a symlink occupying one destination path level is followed
     /// rather than deleted and recreated as a real directory.
@@ -309,10 +309,7 @@ fn operator_owns_symlink(_metadata: &fs::Metadata) -> bool {
                 // the destination arg's leading prefix, which still needs
                 // --mkpath (or --relative) exactly as a real run would.
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                    if allow_creation
-                        || parent_within_root
-                        || self.relative_paths_enabled()
-                    {
+                    if allow_creation || parent_within_root || self.relative_paths_enabled() {
                         Ok(())
                     } else {
                         Err(LocalCopyError::io(

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -221,7 +221,11 @@ impl<'a> CopyContext<'a> {
             .find(|entry| entry.destination == destination)
         {
             for name in keep {
-                if !existing.keep.iter().any(|existing_name| existing_name == &name) {
+                if !existing
+                    .keep
+                    .iter()
+                    .any(|existing_name| existing_name == &name)
+                {
                     existing.keep.push(name);
                 }
             }
@@ -327,7 +331,12 @@ impl<'a> CopyContext<'a> {
         // Deepest-first, mirroring upstream's reverse flist walk, so a child's
         // perm/mtime change cannot re-clobber a parent handled earlier.
         // upstream: generator.c:2083 for (i = dir_flist->used - 1; i >= 0; i--).
-        dirs.sort_by(|a, b| b.path.components().count().cmp(&a.path.components().count()));
+        dirs.sort_by(|a, b| {
+            b.path
+                .components()
+                .count()
+                .cmp(&a.path.components().count())
+        });
         for dir in dirs {
             // Reinstate the real (restricted) directory mode last, after every
             // deferred deletion/update ran while the directory was kept
@@ -398,8 +407,7 @@ impl<'a> CopyContext<'a> {
         // moved. oc's decision-time gate lives at
         // `decide_and_defer_delayed_deletions`, which is the analogue of
         // `delete_in_dir` and is where the check belongs.
-        let preserve_times = self.metadata_options().times()
-            && !self.omit_dir_times_enabled();
+        let preserve_times = self.metadata_options().times() && !self.omit_dir_times_enabled();
         let mut pending = std::mem::take(&mut self.deferred_ops.deletions);
         // Deferred entries are queued in post-order (a directory defers its own
         // sweep AFTER recursing into and deferring its children). Upstream's
@@ -414,9 +422,9 @@ impl<'a> CopyContext<'a> {
             self.enforce_timeout()?;
             // Capture directory mtime before deletion modifies it.
             let saved_times = if preserve_times {
-                fs::metadata(&entry.destination).ok().map(|m| {
-                    filetime::FileTime::from_last_modification_time(&m)
-                })
+                fs::metadata(&entry.destination)
+                    .ok()
+                    .map(|m| filetime::FileTime::from_last_modification_time(&m))
             } else {
                 None
             };
@@ -543,7 +551,6 @@ fn encoded_path_len(path: &Path) -> usize {
     }
 }
 
-
 #[cfg(test)]
 mod source_root_covers_tests {
     use super::source_root_covers;
@@ -588,7 +595,10 @@ mod source_root_covers_tests {
         let root = Path::new("a/b");
         assert!(!source_root_covers(root, Path::new("a/bc")));
         assert!(!source_root_covers(root, Path::new("a/bcd/e")));
-        assert!(!source_root_covers(root, Path::new("a")), "ancestor is not covered");
+        assert!(
+            !source_root_covers(root, Path::new("a")),
+            "ancestor is not covered"
+        );
         assert!(!source_root_covers(root, Path::new("x/y")), "unrelated");
     }
 }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -8,8 +8,7 @@ impl<'a> CopyContext<'a> {
         observer: Option<&'a mut dyn LocalCopyRecordHandler>,
         destination_root: PathBuf,
     ) -> Self {
-        let limiter =
-            BandwidthLimitComponents::new(options.bandwidth_limit_bytes()).into_limiter();
+        let limiter = BandwidthLimitComponents::new(options.bandwidth_limit_bytes()).into_limiter();
         let collect_events = options.events_enabled();
         let stop_at_wallclock = options.stop_at();
         let stop_deadline = stop_at_wallclock.map(|deadline| {
@@ -398,10 +397,7 @@ impl<'a> CopyContext<'a> {
 
     /// Stores destination `lstat` metadata gathered during checksum-mode
     /// prefetch so `copy_file` can reuse it instead of re-lstat'ing.
-    pub(super) fn set_destination_metadata_cache(
-        &mut self,
-        cache: HashMap<PathBuf, fs::Metadata>,
-    ) {
+    pub(super) fn set_destination_metadata_cache(&mut self, cache: HashMap<PathBuf, fs::Metadata>) {
         self.destination_metadata_cache = cache;
     }
 
@@ -449,7 +445,6 @@ impl<'a> CopyContext<'a> {
         }
         self.destination_metadata_cache.clear();
     }
-
 
     /// Returns the configured delete timing (before, during, after, or delay).
     pub(super) const fn delete_timing(&self) -> Option<DeleteTiming> {

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -125,7 +125,13 @@ impl<'a> CopyContext<'a> {
         destination: &Path,
         relative_dir: Option<&Path>,
     ) -> Result<DirectoryFilterGuard, LocalCopyError> {
-        self.enter_directory_for_path(destination, relative_dir, false, true, &self.delete_dir_merge)
+        self.enter_directory_for_path(
+            destination,
+            relative_dir,
+            false,
+            true,
+            &self.delete_dir_merge,
+        )
     }
 
     /// Advances the persistent destination delete-filter chain to `destination`.
@@ -208,21 +214,23 @@ impl<'a> CopyContext<'a> {
         // descendants. Seed the new frame's active rules AND inheritable loaded
         // segments from the parent frame, then look each active rule up in this
         // directory. Non-inheritable (`n`-modifier) segments are dropped.
-        let (inherited_active, inherited_segments): (Vec<NestedDirMerge>, Vec<LoadedDynamicSegment>) =
-            stacks
-                .dynamic
-                .borrow()
-                .last()
-                .map(|frame| {
-                    let segments = frame
-                        .loaded_segments
-                        .iter()
-                        .filter(|loaded| loaded.inherit)
-                        .cloned()
-                        .collect();
-                    (frame.active_rules.clone(), segments)
-                })
-                .unwrap_or_default();
+        let (inherited_active, inherited_segments): (
+            Vec<NestedDirMerge>,
+            Vec<LoadedDynamicSegment>,
+        ) = stacks
+            .dynamic
+            .borrow()
+            .last()
+            .map(|frame| {
+                let segments = frame
+                    .loaded_segments
+                    .iter()
+                    .filter(|loaded| loaded.inherit)
+                    .cloned()
+                    .collect();
+                (frame.active_rules.clone(), segments)
+            })
+            .unwrap_or_default();
         let mut new_frame = DynamicDirMergeFrame {
             active_rules: inherited_active,
             loaded_segments: inherited_segments,
@@ -253,11 +261,7 @@ impl<'a> CopyContext<'a> {
                 Err(error) => {
                     ephemeral_stack.pop();
                     marker_ephemeral_stack.pop();
-                    return Err(LocalCopyError::io(
-                        "inspect filter file",
-                        candidate,
-                        error,
-                    ));
+                    return Err(LocalCopyError::io("inspect filter file", candidate, error));
                 }
             };
 
@@ -329,10 +333,8 @@ impl<'a> CopyContext<'a> {
             // Append them to the dynamic frame's active set; the growing while
             // loop below picks them up so `dir-merge .filt2` in `bar/.filt` loads
             // `bar/.filt2` here as well as in descendants.
-            registry.retain_unregistered(
-                &mut new_frame.active_rules,
-                &mut entries.nested_dir_merges,
-            );
+            registry
+                .retain_unregistered(&mut new_frame.active_rules, &mut entries.nested_dir_merges);
 
             // If the filter file had a clear directive, we should clear inherited rules
             // from parent directories before adding any new rules from this directory.
@@ -375,9 +377,7 @@ impl<'a> CopyContext<'a> {
                     marker_counts.push((index, count));
                 }
             } else {
-                if has_segment
-                    && let Some(current) = ephemeral_stack.last_mut()
-                {
+                if has_segment && let Some(current) = ephemeral_stack.last_mut() {
                     current.push((index, segment));
                 }
                 if !markers.is_empty()
@@ -747,8 +747,18 @@ impl<'a> CopyContext<'a> {
 
         if sparse {
             return self.copy_file_contents_sparse(
-                reader, writer, buffer, compress, source, destination, relative,
-                total_size, initial_bytes, expected_remaining, preallocated_len, start,
+                reader,
+                writer,
+                buffer,
+                compress,
+                source,
+                destination,
+                relative,
+                total_size,
+                initial_bytes,
+                expected_remaining,
+                preallocated_len,
+                start,
             );
         }
 
@@ -796,17 +806,17 @@ impl<'a> CopyContext<'a> {
                 break;
             }
 
-            writer.write_all(&buffer[..read]).map_err(|error| {
-                LocalCopyError::io("copy file", destination, error)
-            })?;
+            writer
+                .write_all(&buffer[..read])
+                .map_err(|error| LocalCopyError::io("copy file", destination, error))?;
 
             self.register_progress();
 
             let mut compressed_delta = None;
             if let Some(encoder) = compressor.as_mut() {
-                encoder.write(&buffer[..read]).map_err(|error| {
-                    LocalCopyError::io("compress file", source, error)
-                })?;
+                encoder
+                    .write(&buffer[..read])
+                    .map_err(|error| LocalCopyError::io("compress file", source, error))?;
                 let total = encoder.bytes_written();
                 let delta = total.saturating_sub(compressed_progress);
                 compressed_progress = total;
@@ -834,9 +844,9 @@ impl<'a> CopyContext<'a> {
         self.note_short_source_read(source, total_bytes, expected_remaining);
 
         let outcome = if let Some(encoder) = compressor {
-            let compressed_total = encoder.finish().map_err(|error| {
-                LocalCopyError::io("compress file", source, error)
-            })?;
+            let compressed_total = encoder
+                .finish()
+                .map_err(|error| LocalCopyError::io("compress file", source, error))?;
             self.register_progress();
             let delta = compressed_total.saturating_sub(compressed_progress);
             self.register_limiter_bytes(delta);
@@ -923,9 +933,9 @@ impl<'a> CopyContext<'a> {
 
             let mut compressed_delta = None;
             if let Some(encoder) = compressor.as_mut() {
-                encoder.write(&buffer[..read]).map_err(|error| {
-                    LocalCopyError::io("compress file", source, error)
-                })?;
+                encoder
+                    .write(&buffer[..read])
+                    .map_err(|error| LocalCopyError::io("compress file", source, error))?;
                 let total = encoder.bytes_written();
                 let delta = total.saturating_sub(compressed_progress);
                 compressed_progress = total;
@@ -962,9 +972,9 @@ impl<'a> CopyContext<'a> {
         self.note_short_source_read(source, total_bytes, expected_remaining);
 
         let outcome = if let Some(encoder) = compressor {
-            let compressed_total = encoder.finish().map_err(|error| {
-                LocalCopyError::io("compress file", source, error)
-            })?;
+            let compressed_total = encoder
+                .finish()
+                .map_err(|error| LocalCopyError::io("compress file", source, error))?;
             self.register_progress();
             let delta = compressed_total.saturating_sub(compressed_progress);
             self.register_limiter_bytes(delta);
@@ -976,5 +986,4 @@ impl<'a> CopyContext<'a> {
 
         Ok(outcome)
     }
-
 }

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -1,4 +1,3 @@
-
 // `--backup` must hard-link the existing destination into the backup
 // location when it stays on the same filesystem, mirroring upstream's
 // `link_or_rename()` HLINK branch (backup.c:200-207) - the default whenever
@@ -75,10 +74,7 @@ fn backup_creation_uses_default_suffix() {
     let existing = dest_root.join("file.txt");
     write_stale_dest(&existing, b"original");
 
-    let operands = vec![
-        ctx.source.into_os_string(),
-        ctx.dest.into_os_string(),
-    ];
+    let operands = vec![ctx.source.into_os_string(), ctx.dest.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().backup(true);
 
@@ -110,10 +106,7 @@ fn backup_creation_respects_custom_suffix() {
     let existing = dest_root.join("file.txt");
     write_stale_dest(&existing, b"baseline");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().with_backup_suffix(Some(".bak"));
 
@@ -147,10 +140,7 @@ fn backup_creation_uses_relative_backup_directory() {
     let existing = existing_parent.join("file.txt");
     write_stale_dest(&existing, b"old contents");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().with_backup_directory(Some(PathBuf::from("backups")));
 
@@ -187,10 +177,7 @@ fn backup_creation_uses_absolute_backup_directory() {
     let existing = dest_root.join("file.txt");
     write_stale_dest(&existing, b"retained");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .with_backup_directory(Some(backup_root.as_path().to_path_buf()))
@@ -228,14 +215,16 @@ fn backup_dir_places_backups_in_specified_directory() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(backup_dir.clone()));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(backup_dir.clone()));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let backup_in_dest = dest_root.join("data.txt~");
-    assert!(!backup_in_dest.exists(), "backup should not be in destination directory");
+    assert!(
+        !backup_in_dest.exists(),
+        "backup should not be in destination directory"
+    );
 
     let backup = backup_dir.join("source").join("data.txt~");
     assert!(backup.exists(), "backup missing at {}", backup.display());
@@ -251,16 +240,22 @@ fn backup_dir_preserves_directory_structure() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("level1/level2/level3/file.txt", Some(b"updated")),
-        ("level1/file2.txt", Some(b"updated2")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("level1/level2/level3/file.txt", Some(b"updated")),
+            ("level1/file2.txt", Some(b"updated2")),
+        ],
+    );
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("level1/level2/level3/file.txt", Some(b"original")),
-        ("level1/file2.txt", Some(b"original2")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[
+            ("level1/level2/level3/file.txt", Some(b"original")),
+            ("level1/file2.txt", Some(b"original2")),
+        ],
+    );
 
     let backup_dir = ctx.dest.join("backups");
 
@@ -269,14 +264,17 @@ fn backup_dir_preserves_directory_structure() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(backup_dir.clone()));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(backup_dir.clone()));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let backup1 = backup_dir.join("source/level1/level2/level3/file.txt~");
-    assert!(backup1.exists(), "nested backup missing at {}", backup1.display());
+    assert!(
+        backup1.exists(),
+        "nested backup missing at {}",
+        backup1.display()
+    );
     assert_eq!(fs::read(&backup1).expect("read backup1"), b"original");
 
     let backup2 = backup_dir.join("source/level1/file2.txt~");
@@ -337,18 +335,24 @@ fn backup_dir_handles_multiple_backups_correctly() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("file1.txt", Some(b"content1-v2")),
-        ("file2.txt", Some(b"content2-v2")),
-        ("subdir/file3.txt", Some(b"content3-v2")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("file1.txt", Some(b"content1-v2")),
+            ("file2.txt", Some(b"content2-v2")),
+            ("subdir/file3.txt", Some(b"content3-v2")),
+        ],
+    );
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("file1.txt", Some(b"content1-v1")),
-        ("file2.txt", Some(b"content2-v1")),
-        ("subdir/file3.txt", Some(b"content3-v1")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[
+            ("file1.txt", Some(b"content1-v1")),
+            ("file2.txt", Some(b"content2-v1")),
+            ("subdir/file3.txt", Some(b"content3-v1")),
+        ],
+    );
 
     let backup_dir = ctx.dest.join("backups");
 
@@ -357,8 +361,7 @@ fn backup_dir_handles_multiple_backups_correctly() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(backup_dir.clone()));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(backup_dir.clone()));
 
     backdate_tree(&ctx.dest);
     plan.execute_with_options(LocalCopyExecution::Apply, options)
@@ -408,12 +411,14 @@ fn backup_dir_handles_repeated_syncs() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(backup_dir.clone()));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(backup_dir.clone()));
     backdate_tree(&ctx.dest);
     plan.execute_with_options(LocalCopyExecution::Apply, options.clone())
         .expect("first sync succeeds");
-    assert_eq!(fs::read(&dest_file).expect("read dest after sync 1"), b"version 1");
+    assert_eq!(
+        fs::read(&dest_file).expect("read dest after sync 1"),
+        b"version 1"
+    );
 
     // Second sync: update file, should create backup of version 1
     fs::write(&source_file, b"version 2").expect("write source v2");
@@ -425,7 +430,10 @@ fn backup_dir_handles_repeated_syncs() {
     let backup = backup_dir.join("source/evolving.txt~");
     assert!(backup.exists(), "backup after second sync missing");
     assert_eq!(fs::read(&backup).expect("read backup"), b"version 1");
-    assert_eq!(fs::read(&dest_file).expect("read dest after sync 2"), b"version 2");
+    assert_eq!(
+        fs::read(&dest_file).expect("read dest after sync 2"),
+        b"version 2"
+    );
 
     // Third sync: update again, backup should now contain version 2
     fs::write(&source_file, b"version 3").expect("write source v3");
@@ -434,8 +442,14 @@ fn backup_dir_handles_repeated_syncs() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("third sync succeeds");
 
-    assert_eq!(fs::read(&backup).expect("read backup after sync 3"), b"version 2");
-    assert_eq!(fs::read(&dest_file).expect("read dest after sync 3"), b"version 3");
+    assert_eq!(
+        fs::read(&backup).expect("read backup after sync 3"),
+        b"version 2"
+    );
+    assert_eq!(
+        fs::read(&dest_file).expect("read dest after sync 3"),
+        b"version 3"
+    );
 }
 
 #[test]
@@ -456,8 +470,8 @@ fn backup_dir_with_relative_path() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(PathBuf::from("relative_backups")));
+    let options =
+        LocalCopyOptions::default().with_backup_directory(Some(PathBuf::from("relative_backups")));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -473,14 +487,16 @@ fn backup_dir_creates_missing_directories() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("deep/nested/structure/file.txt", Some(b"content")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[("deep/nested/structure/file.txt", Some(b"content"))],
+    );
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("deep/nested/structure/file.txt", Some(b"original")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[("deep/nested/structure/file.txt", Some(b"original"))],
+    );
 
     let backup_dir = ctx.dest.join("backup_location");
     // Don't create backup_dir - it should be created automatically
@@ -490,8 +506,7 @@ fn backup_dir_creates_missing_directories() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(backup_dir.clone()));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(backup_dir.clone()));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -561,10 +576,20 @@ fn backup_created_when_deleting_with_delete_option() {
         .expect("copy succeeds");
 
     let backup_deleted = backup_dir.join("source/delete_me.txt~");
-    assert!(backup_deleted.exists(), "backup of deleted file missing at {}", backup_deleted.display());
-    assert_eq!(fs::read(&backup_deleted).expect("read backup"), b"delete me");
+    assert!(
+        backup_deleted.exists(),
+        "backup of deleted file missing at {}",
+        backup_deleted.display()
+    );
+    assert_eq!(
+        fs::read(&backup_deleted).expect("read backup"),
+        b"delete me"
+    );
 
-    assert!(!dest_root.join("delete_me.txt").exists(), "deleted file should not exist");
+    assert!(
+        !dest_root.join("delete_me.txt").exists(),
+        "deleted file should not exist"
+    );
 
     let backup_keep = backup_dir.join("source/keep.txt~");
     assert!(backup_keep.exists(), "backup of modified file missing");
@@ -602,8 +627,18 @@ fn backup_preserves_symlinks_in_directory() {
         .expect("copy succeeds");
 
     let backup = backup_dir.join("source/link~");
-    assert!(backup.symlink_metadata().is_ok(), "backup symlink missing at {}", backup.display());
-    assert!(backup.symlink_metadata().expect("metadata").file_type().is_symlink());
+    assert!(
+        backup.symlink_metadata().is_ok(),
+        "backup symlink missing at {}",
+        backup.display()
+    );
+    assert!(
+        backup
+            .symlink_metadata()
+            .expect("metadata")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(
         fs::read_link(&backup).expect("read backup link"),
         PathBuf::from("old_target")
@@ -663,7 +698,11 @@ fn cross_device_file_backup_preserves_mode_and_mtime() {
         |_, _| Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE)),
         || {
             with_backup_rename_override(
-                |_, _| Some(Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE))),
+                |_, _| {
+                    Some(Err(io::Error::from_raw_os_error(
+                        super::CROSS_DEVICE_ERROR_CODE,
+                    )))
+                },
                 || {
                     plan.execute_with_options(LocalCopyExecution::Apply, options)
                         .expect("copy succeeds")
@@ -730,7 +769,11 @@ fn cross_device_symlink_backup_preserves_target_and_mtime() {
         |_, _| Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE)),
         || {
             with_backup_rename_override(
-                |_, _| Some(Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE))),
+                |_, _| {
+                    Some(Err(io::Error::from_raw_os_error(
+                        super::CROSS_DEVICE_ERROR_CODE,
+                    )))
+                },
                 || {
                     plan.execute_with_options(LocalCopyExecution::Apply, options)
                         .expect("copy succeeds")
@@ -836,13 +879,9 @@ fn backup_directory_outside_destination_tree() {
     let existing = dest_root.join("file.txt");
     write_stale_dest(&existing, b"old version");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(external_backup.clone()));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(external_backup.clone()));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -852,7 +891,10 @@ fn backup_directory_outside_destination_tree() {
     assert_eq!(fs::read(&backup).expect("read backup"), b"old version");
 
     let backup_in_dest = dest_root.join("file.txt~");
-    assert!(!backup_in_dest.exists(), "backup should not be in destination");
+    assert!(
+        !backup_in_dest.exists(),
+        "backup should not be in destination"
+    );
 }
 
 #[test]
@@ -891,11 +933,20 @@ fn backup_only_when_content_differs() {
         .expect("copy succeeds");
 
     let backup_different = dest_root.join("different.txt~");
-    assert!(backup_different.exists(), "backup of different file should exist");
-    assert_eq!(fs::read(&backup_different).expect("read backup"), b"old content");
+    assert!(
+        backup_different.exists(),
+        "backup of different file should exist"
+    );
+    assert_eq!(
+        fs::read(&backup_different).expect("read backup"),
+        b"old content"
+    );
 
     let backup_same = dest_root.join("same.txt~");
-    assert!(!backup_same.exists(), "backup of identical file should not exist");
+    assert!(
+        !backup_same.exists(),
+        "backup of identical file should not exist"
+    );
 }
 
 #[test]
@@ -1001,8 +1052,16 @@ fn backup_with_delete_after() {
 
     let backup1 = backup_dir.join("source/extra1.txt~");
     let backup2 = backup_dir.join("source/extra2.txt~");
-    assert!(backup1.exists(), "backup of extra1 missing at {}", backup1.display());
-    assert!(backup2.exists(), "backup of extra2 missing at {}", backup2.display());
+    assert!(
+        backup1.exists(),
+        "backup of extra1 missing at {}",
+        backup1.display()
+    );
+    assert!(
+        backup2.exists(),
+        "backup of extra2 missing at {}",
+        backup2.display()
+    );
     assert_eq!(fs::read(&backup1).expect("read backup1"), b"extra1");
     assert_eq!(fs::read(&backup2).expect("read backup2"), b"extra2");
 
@@ -1016,16 +1075,17 @@ fn backup_with_nested_delete() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("keep/file.txt", Some(b"keep")),
-    ]);
+    test_helpers::create_test_tree(&ctx.source, &[("keep/file.txt", Some(b"keep"))]);
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("keep/file.txt", Some(b"old")),
-        ("delete_dir/nested/deep.txt", Some(b"deep content")),
-        ("delete_dir/shallow.txt", Some(b"shallow content")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[
+            ("keep/file.txt", Some(b"old")),
+            ("delete_dir/nested/deep.txt", Some(b"deep content")),
+            ("delete_dir/shallow.txt", Some(b"shallow content")),
+        ],
+    );
 
     let backup_dir = ctx.dest.join("backups");
 
@@ -1043,10 +1103,17 @@ fn backup_with_nested_delete() {
 
     // Note: directory deletion may not back up individual files - this tests the behavior
     let backup_keep = backup_dir.join("source/keep/file.txt~");
-    assert!(backup_keep.exists(), "backup of modified file missing at {}", backup_keep.display());
+    assert!(
+        backup_keep.exists(),
+        "backup of modified file missing at {}",
+        backup_keep.display()
+    );
     assert_eq!(fs::read(&backup_keep).expect("read backup"), b"old");
 
-    assert!(!dest_root.join("delete_dir").exists(), "delete_dir should be removed");
+    assert!(
+        !dest_root.join("delete_dir").exists(),
+        "delete_dir should be removed"
+    );
 }
 
 #[test]
@@ -1070,14 +1137,16 @@ fn backup_enabled_implicitly_by_backup_dir() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     // Only set backup_dir, not backup(true) - should still enable backups
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(backup_dir.clone()));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(backup_dir.clone()));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let backup = backup_dir.join("source/file.txt~");
-    assert!(backup.exists(), "backup should be created when backup_dir is set");
+    assert!(
+        backup.exists(),
+        "backup should be created when backup_dir is set"
+    );
     assert_eq!(fs::read(&backup).expect("read backup"), b"old");
 }
 
@@ -1100,14 +1169,16 @@ fn backup_enabled_implicitly_by_suffix() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     // Only set suffix, not backup(true) - should still enable backups
-    let options = LocalCopyOptions::default()
-        .with_backup_suffix(Some(".backup"));
+    let options = LocalCopyOptions::default().with_backup_suffix(Some(".backup"));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let backup = dest_root.join("file.txt.backup");
-    assert!(backup.exists(), "backup should be created when suffix is set");
+    assert!(
+        backup.exists(),
+        "backup should be created when suffix is set"
+    );
     assert_eq!(fs::read(&backup).expect("read backup"), b"old");
 }
 
@@ -1144,18 +1215,24 @@ fn backup_multiple_files_same_directory() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("file1.txt", Some(b"content1-new")),
-        ("file2.txt", Some(b"content2-new")),
-        ("file3.txt", Some(b"content3-new")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("file1.txt", Some(b"content1-new")),
+            ("file2.txt", Some(b"content2-new")),
+            ("file3.txt", Some(b"content3-new")),
+        ],
+    );
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("file1.txt", Some(b"content1-old")),
-        ("file2.txt", Some(b"content2-old")),
-        ("file3.txt", Some(b"content3-old")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[
+            ("file1.txt", Some(b"content1-old")),
+            ("file2.txt", Some(b"content2-old")),
+            ("file3.txt", Some(b"content3-old")),
+        ],
+    );
 
     let operands = vec![
         ctx.source.into_os_string(),
@@ -1172,7 +1249,12 @@ fn backup_multiple_files_same_directory() {
 
     for i in 1..=3 {
         let backup = dest_root.join(format!("file{i}.txt.bak"));
-        assert!(backup.exists(), "backup{} missing at {}", i, backup.display());
+        assert!(
+            backup.exists(),
+            "backup{} missing at {}",
+            i,
+            backup.display()
+        );
         assert_eq!(
             fs::read(&backup).expect("read backup"),
             format!("content{i}-old").as_bytes()
@@ -1211,15 +1293,28 @@ fn backup_with_delete_before() {
         .expect("copy succeeds");
 
     let backup_removed = backup_dir.join("source/remove.txt~");
-    assert!(backup_removed.exists(), "backup of deleted file missing at {}", backup_removed.display());
-    assert_eq!(fs::read(&backup_removed).expect("read backup"), b"to remove");
+    assert!(
+        backup_removed.exists(),
+        "backup of deleted file missing at {}",
+        backup_removed.display()
+    );
+    assert_eq!(
+        fs::read(&backup_removed).expect("read backup"),
+        b"to remove"
+    );
 
     let backup_keep = backup_dir.join("source/keep.txt~");
     assert!(backup_keep.exists(), "backup of modified file missing");
     assert_eq!(fs::read(&backup_keep).expect("read backup"), b"old keep");
 
-    assert!(!dest_root.join("remove.txt").exists(), "deleted file should not exist");
-    assert_eq!(fs::read(dest_root.join("keep.txt")).expect("read dest"), b"keep");
+    assert!(
+        !dest_root.join("remove.txt").exists(),
+        "deleted file should not exist"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("keep.txt")).expect("read dest"),
+        b"keep"
+    );
 }
 
 #[test]
@@ -1249,11 +1344,24 @@ fn backup_with_delete_delay() {
         .expect("copy succeeds");
 
     let backup_gone = backup_dir.join("source/gone.txt~");
-    assert!(backup_gone.exists(), "backup of deleted file missing at {}", backup_gone.display());
-    assert_eq!(fs::read(&backup_gone).expect("read backup"), b"gone content");
+    assert!(
+        backup_gone.exists(),
+        "backup of deleted file missing at {}",
+        backup_gone.display()
+    );
+    assert_eq!(
+        fs::read(&backup_gone).expect("read backup"),
+        b"gone content"
+    );
 
-    assert!(!dest_root.join("gone.txt").exists(), "deleted file should be removed");
-    assert_eq!(fs::read(dest_root.join("stay.txt")).expect("read dest"), b"stay content");
+    assert!(
+        !dest_root.join("gone.txt").exists(),
+        "deleted file should be removed"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("stay.txt")).expect("read dest"),
+        b"stay content"
+    );
 }
 
 #[test]
@@ -1272,10 +1380,7 @@ fn backup_with_trailing_slash_source() {
     let mut source_operand = source.clone().into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
 
-    let operands = vec![
-        source_operand,
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().backup(true);
 
@@ -1286,7 +1391,10 @@ fn backup_with_trailing_slash_source() {
     let backup = dest.join("file.txt~");
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), b"old data");
-    assert_eq!(fs::read(dest.join("file.txt")).expect("read dest"), b"new data");
+    assert_eq!(
+        fs::read(dest.join("file.txt")).expect("read dest"),
+        b"new data"
+    );
 }
 
 #[test]
@@ -1304,13 +1412,9 @@ fn backup_with_trailing_slash_and_backup_dir() {
     let mut source_operand = source.clone().into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
 
-    let operands = vec![
-        source_operand,
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(backup_root.clone()));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(backup_root.clone()));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -1318,7 +1422,10 @@ fn backup_with_trailing_slash_and_backup_dir() {
     let backup = backup_root.join("report.txt~");
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), b"original report");
-    assert_eq!(fs::read(dest.join("report.txt")).expect("read dest"), b"updated report");
+    assert_eq!(
+        fs::read(dest.join("report.txt")).expect("read dest"),
+        b"updated report"
+    );
 }
 
 #[test]
@@ -1339,9 +1446,7 @@ fn backup_with_inplace_mode() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .backup(true)
-        .inplace(true);
+    let options = LocalCopyOptions::default().backup(true).inplace(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -1349,7 +1454,10 @@ fn backup_with_inplace_mode() {
     let backup = dest_root.join("file.txt~");
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), b"inplace old");
-    assert_eq!(fs::read(dest_root.join("file.txt")).expect("read dest"), b"inplace new");
+    assert_eq!(
+        fs::read(dest_root.join("file.txt")).expect("read dest"),
+        b"inplace new"
+    );
 }
 
 // The inode-preservation contract for `--inplace --backup`. Under --inplace the
@@ -1439,8 +1547,16 @@ fn backup_dir_with_inplace_no_whole_file_copies_matched_blocks() {
     // the fix, the matched-block path is skipped for inplace mode, and the
     // destination loses the entire suffix.
     let common_tail = "y".repeat(8 * 1024);
-    let source_content = format!("source-only-prefix-{}\n{}", "x".repeat(2 * 1024), common_tail);
-    let basis_content = format!("BASIS-ONLY-PREFIX-{}\n{}", "Z".repeat(2 * 1024), common_tail);
+    let source_content = format!(
+        "source-only-prefix-{}\n{}",
+        "x".repeat(2 * 1024),
+        common_tail
+    );
+    let basis_content = format!(
+        "BASIS-ONLY-PREFIX-{}\n{}",
+        "Z".repeat(2 * 1024),
+        common_tail
+    );
 
     let source_file = ctx.source.join("payload.bin");
     fs::write(&source_file, source_content.as_bytes()).expect("write source");
@@ -1523,8 +1639,14 @@ fn backup_with_force_directory_replaced_by_file() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(dest_root.join("item").is_file(), "item should be a file now");
-    assert_eq!(fs::read(dest_root.join("item")).expect("read dest"), b"file content");
+    assert!(
+        dest_root.join("item").is_file(),
+        "item should be a file now"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("item")).expect("read dest"),
+        b"file content"
+    );
 }
 
 #[test]
@@ -1544,8 +1666,7 @@ fn backup_suffix_with_dot_prefix() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_suffix(Some(".orig"));
+    let options = LocalCopyOptions::default().with_backup_suffix(Some(".orig"));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -1574,8 +1695,8 @@ fn backup_suffix_with_long_extension() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_suffix(Some("_backup_2024-01-15T12:30:00"));
+    let options =
+        LocalCopyOptions::default().with_backup_suffix(Some("_backup_2024-01-15T12:30:00"));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -1603,10 +1724,7 @@ fn backup_with_delete_and_trailing_slash() {
     let mut source_operand = source.clone().into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
 
-    let operands = vec![
-        source_operand,
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .delete(true)
@@ -1615,17 +1733,33 @@ fn backup_with_delete_and_trailing_slash() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!dest.join("extra.txt").exists(), "extra file should be deleted");
+    assert!(
+        !dest.join("extra.txt").exists(),
+        "extra file should be deleted"
+    );
 
     let backup_extra = backup_dir.join("extra.txt~");
-    assert!(backup_extra.exists(), "backup of deleted file missing at {}", backup_extra.display());
-    assert_eq!(fs::read(&backup_extra).expect("read backup"), b"extra content");
+    assert!(
+        backup_extra.exists(),
+        "backup of deleted file missing at {}",
+        backup_extra.display()
+    );
+    assert_eq!(
+        fs::read(&backup_extra).expect("read backup"),
+        b"extra content"
+    );
 
     let backup_remain = backup_dir.join("remain.txt~");
     assert!(backup_remain.exists(), "backup of modified file missing");
-    assert_eq!(fs::read(&backup_remain).expect("read backup"), b"old remain");
+    assert_eq!(
+        fs::read(&backup_remain).expect("read backup"),
+        b"old remain"
+    );
 
-    assert_eq!(fs::read(dest.join("remain.txt")).expect("read dest"), b"remain");
+    assert_eq!(
+        fs::read(dest.join("remain.txt")).expect("read dest"),
+        b"remain"
+    );
 }
 
 #[test]
@@ -1655,7 +1789,10 @@ fn backup_large_file_preserves_content() {
     let backup = dest_root.join("large.bin~");
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), old_content);
-    assert_eq!(fs::read(dest_root.join("large.bin")).expect("read dest"), large_content);
+    assert_eq!(
+        fs::read(dest_root.join("large.bin")).expect("read dest"),
+        large_content
+    );
 }
 
 #[test]
@@ -1663,18 +1800,24 @@ fn backup_recursive_multiple_directories() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("dir_a/file_a.txt", Some(b"new_a")),
-        ("dir_b/file_b.txt", Some(b"new_b")),
-        ("dir_a/sub/file_sub.txt", Some(b"new_sub")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("dir_a/file_a.txt", Some(b"new_a")),
+            ("dir_b/file_b.txt", Some(b"new_b")),
+            ("dir_a/sub/file_sub.txt", Some(b"new_sub")),
+        ],
+    );
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("dir_a/file_a.txt", Some(b"old_a")),
-        ("dir_b/file_b.txt", Some(b"old_b")),
-        ("dir_a/sub/file_sub.txt", Some(b"old_sub")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[
+            ("dir_a/file_a.txt", Some(b"old_a")),
+            ("dir_b/file_b.txt", Some(b"old_b")),
+            ("dir_a/sub/file_sub.txt", Some(b"old_sub")),
+        ],
+    );
 
     let backup_dir = ctx.dest.join("backups");
 
@@ -1683,28 +1826,48 @@ fn backup_recursive_multiple_directories() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(backup_dir.clone()));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(backup_dir.clone()));
 
     backdate_tree(&ctx.dest);
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let backup_a = backup_dir.join("source/dir_a/file_a.txt~");
-    assert!(backup_a.exists(), "backup_a missing at {}", backup_a.display());
+    assert!(
+        backup_a.exists(),
+        "backup_a missing at {}",
+        backup_a.display()
+    );
     assert_eq!(fs::read(&backup_a).expect("read"), b"old_a");
 
     let backup_b = backup_dir.join("source/dir_b/file_b.txt~");
-    assert!(backup_b.exists(), "backup_b missing at {}", backup_b.display());
+    assert!(
+        backup_b.exists(),
+        "backup_b missing at {}",
+        backup_b.display()
+    );
     assert_eq!(fs::read(&backup_b).expect("read"), b"old_b");
 
     let backup_sub = backup_dir.join("source/dir_a/sub/file_sub.txt~");
-    assert!(backup_sub.exists(), "backup_sub missing at {}", backup_sub.display());
+    assert!(
+        backup_sub.exists(),
+        "backup_sub missing at {}",
+        backup_sub.display()
+    );
     assert_eq!(fs::read(&backup_sub).expect("read"), b"old_sub");
 
-    assert_eq!(fs::read(dest_root.join("dir_a/file_a.txt")).expect("read"), b"new_a");
-    assert_eq!(fs::read(dest_root.join("dir_b/file_b.txt")).expect("read"), b"new_b");
-    assert_eq!(fs::read(dest_root.join("dir_a/sub/file_sub.txt")).expect("read"), b"new_sub");
+    assert_eq!(
+        fs::read(dest_root.join("dir_a/file_a.txt")).expect("read"),
+        b"new_a"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("dir_b/file_b.txt")).expect("read"),
+        b"new_b"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("dir_a/sub/file_sub.txt")).expect("read"),
+        b"new_sub"
+    );
 }
 
 #[test]
@@ -1724,16 +1887,20 @@ fn backup_disabled_after_enabling_does_not_create_backups() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .backup(true)
-        .backup(false);
+    let options = LocalCopyOptions::default().backup(true).backup(false);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let backup = dest_root.join("file.txt~");
-    assert!(!backup.exists(), "backup should not exist when backup disabled");
-    assert_eq!(fs::read(dest_root.join("file.txt")).expect("read dest"), b"new content here");
+    assert!(
+        !backup.exists(),
+        "backup should not exist when backup disabled"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("file.txt")).expect("read dest"),
+        b"new content here"
+    );
 }
 
 #[test]
@@ -1741,15 +1908,16 @@ fn backup_with_delete_during() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("subdir/keep.txt", Some(b"keep new")),
-    ]);
+    test_helpers::create_test_tree(&ctx.source, &[("subdir/keep.txt", Some(b"keep new"))]);
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("subdir/keep.txt", Some(b"keep old")),
-        ("subdir/remove.txt", Some(b"remove me")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[
+            ("subdir/keep.txt", Some(b"keep old")),
+            ("subdir/remove.txt", Some(b"remove me")),
+        ],
+    );
 
     let backup_dir = ctx.dest.join("backups");
 
@@ -1768,15 +1936,28 @@ fn backup_with_delete_during() {
         .expect("copy succeeds");
 
     let backup_removed = backup_dir.join("source/subdir/remove.txt~");
-    assert!(backup_removed.exists(), "backup of deleted file missing at {}", backup_removed.display());
-    assert_eq!(fs::read(&backup_removed).expect("read backup"), b"remove me");
+    assert!(
+        backup_removed.exists(),
+        "backup of deleted file missing at {}",
+        backup_removed.display()
+    );
+    assert_eq!(
+        fs::read(&backup_removed).expect("read backup"),
+        b"remove me"
+    );
 
     let backup_keep = backup_dir.join("source/subdir/keep.txt~");
     assert!(backup_keep.exists(), "backup of modified file missing");
     assert_eq!(fs::read(&backup_keep).expect("read backup"), b"keep old");
 
-    assert!(!dest_root.join("subdir/remove.txt").exists(), "deleted file should be gone");
-    assert_eq!(fs::read(dest_root.join("subdir/keep.txt")).expect("read dest"), b"keep new");
+    assert!(
+        !dest_root.join("subdir/remove.txt").exists(),
+        "deleted file should be gone"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("subdir/keep.txt")).expect("read dest"),
+        b"keep new"
+    );
 }
 
 #[test]
@@ -1804,7 +1985,10 @@ fn backup_empty_file() {
     let backup = dest_root.join("empty.txt~");
     assert!(backup.exists(), "backup of empty file should exist");
     assert_eq!(fs::read(&backup).expect("read backup"), b"");
-    assert_eq!(fs::read(dest_root.join("empty.txt")).expect("read dest"), b"not empty anymore");
+    assert_eq!(
+        fs::read(dest_root.join("empty.txt")).expect("read dest"),
+        b"not empty anymore"
+    );
 }
 
 #[test]
@@ -1832,7 +2016,10 @@ fn backup_to_empty_file() {
     let backup = dest_root.join("zeroed.txt~");
     assert!(backup.exists(), "backup should exist");
     assert_eq!(fs::read(&backup).expect("read backup"), b"had content");
-    assert_eq!(fs::read(dest_root.join("zeroed.txt")).expect("read dest"), b"");
+    assert_eq!(
+        fs::read(dest_root.join("zeroed.txt")).expect("read dest"),
+        b""
+    );
 }
 
 #[test]
@@ -1840,14 +2027,10 @@ fn backup_dir_with_no_suffix_upstream_behavior() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("dir/file.txt", Some(b"new")),
-    ]);
+    test_helpers::create_test_tree(&ctx.source, &[("dir/file.txt", Some(b"new"))]);
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("dir/file.txt", Some(b"old")),
-    ]);
+    test_helpers::create_test_tree(&dest_root, &[("dir/file.txt", Some(b"old"))]);
 
     let backup_dir = ctx.dest.join("archive");
 
@@ -1898,7 +2081,10 @@ fn backup_hidden_files() {
     let backup = dest_root.join(".hidden~");
     assert!(backup.exists(), "backup of hidden file missing");
     assert_eq!(fs::read(&backup).expect("read backup"), b"old hidden");
-    assert_eq!(fs::read(dest_root.join(".hidden")).expect("read dest"), b"new hidden");
+    assert_eq!(
+        fs::read(dest_root.join(".hidden")).expect("read dest"),
+        b"new hidden"
+    );
 }
 
 #[test]
@@ -1906,16 +2092,17 @@ fn backup_delete_multiple_extraneous_in_subdirs() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("a/keep.txt", Some(b"keep")),
-    ]);
+    test_helpers::create_test_tree(&ctx.source, &[("a/keep.txt", Some(b"keep"))]);
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("a/keep.txt", Some(b"old keep")),
-        ("a/extra1.txt", Some(b"extra1")),
-        ("a/extra2.txt", Some(b"extra2")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[
+            ("a/keep.txt", Some(b"old keep")),
+            ("a/extra1.txt", Some(b"extra1")),
+            ("a/extra2.txt", Some(b"extra2")),
+        ],
+    );
 
     let backup_dir = ctx.dest.join("backups");
 
@@ -1945,7 +2132,10 @@ fn backup_delete_multiple_extraneous_in_subdirs() {
 
     assert!(!dest_root.join("a/extra1.txt").exists());
     assert!(!dest_root.join("a/extra2.txt").exists());
-    assert_eq!(fs::read(dest_root.join("a/keep.txt")).expect("read"), b"keep");
+    assert_eq!(
+        fs::read(dest_root.join("a/keep.txt")).expect("read"),
+        b"keep"
+    );
 }
 
 #[test]
@@ -1961,11 +2151,14 @@ fn backup_delete_recurses_into_extraneous_directory() {
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("keep.txt", Some(b"old keep")),
-        ("gone/top.txt", Some(b"top")),
-        ("gone/nested/deep.txt", Some(b"deep")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[
+            ("keep.txt", Some(b"old keep")),
+            ("gone/top.txt", Some(b"top")),
+            ("gone/nested/deep.txt", Some(b"deep")),
+        ],
+    );
 
     let backup_dir = ctx.dest.join("backups");
 
@@ -1984,13 +2177,24 @@ fn backup_delete_recurses_into_extraneous_directory() {
         .expect("copy succeeds");
 
     // The extraneous directory and its contents are gone from the destination.
-    assert!(!dest_root.join("gone").exists(), "extraneous directory not deleted");
+    assert!(
+        !dest_root.join("gone").exists(),
+        "extraneous directory not deleted"
+    );
 
     // Every recursively-deleted file is preserved in the backup tree.
     let backup_top = backup_dir.join("source/gone/top.txt");
     let backup_deep = backup_dir.join("source/gone/nested/deep.txt");
-    assert!(backup_top.exists(), "top-level file not backed up at {}", backup_top.display());
-    assert!(backup_deep.exists(), "nested file not backed up at {}", backup_deep.display());
+    assert!(
+        backup_top.exists(),
+        "top-level file not backed up at {}",
+        backup_top.display()
+    );
+    assert!(
+        backup_deep.exists(),
+        "nested file not backed up at {}",
+        backup_deep.display()
+    );
     assert_eq!(fs::read(&backup_top).expect("read top"), b"top");
     assert_eq!(fs::read(&backup_deep).expect("read deep"), b"deep");
 }
@@ -2008,10 +2212,13 @@ fn backup_delete_suffix_keeps_directory_holding_inplace_backup() {
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
     let dest_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&dest_root, &[
-        ("keep.txt", Some(b"old keep")),
-        ("gone/f.txt", Some(b"content")),
-    ]);
+    test_helpers::create_test_tree(
+        &dest_root,
+        &[
+            ("keep.txt", Some(b"old keep")),
+            ("gone/f.txt", Some(b"content")),
+        ],
+    );
 
     let operands = vec![
         ctx.source.into_os_string(),
@@ -2025,10 +2232,20 @@ fn backup_delete_suffix_keeps_directory_holding_inplace_backup() {
 
     // The in-place backup survives inside the directory, which is therefore kept.
     let inplace_backup = dest_root.join("gone/f.txt~");
-    assert!(inplace_backup.exists(), "in-place backup missing at {}", inplace_backup.display());
+    assert!(
+        inplace_backup.exists(),
+        "in-place backup missing at {}",
+        inplace_backup.display()
+    );
     assert_eq!(fs::read(&inplace_backup).expect("read backup"), b"content");
-    assert!(!dest_root.join("gone/f.txt").exists(), "original should be renamed away");
-    assert!(dest_root.join("gone").is_dir(), "non-empty directory must be kept");
+    assert!(
+        !dest_root.join("gone/f.txt").exists(),
+        "original should be renamed away"
+    );
+    assert!(
+        dest_root.join("gone").is_dir(),
+        "non-empty directory must be kept"
+    );
 }
 
 #[test]
@@ -2048,16 +2265,20 @@ fn backup_delete_with_suffix_only() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .delete(true)
-        .backup(true);
+    let options = LocalCopyOptions::default().delete(true).backup(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!dest_root.join("extra.txt").exists(), "deleted file should not exist");
+    assert!(
+        !dest_root.join("extra.txt").exists(),
+        "deleted file should not exist"
+    );
 
-    assert_eq!(fs::read(dest_root.join("keep.txt")).expect("read dest"), b"keep");
+    assert_eq!(
+        fs::read(dest_root.join("keep.txt")).expect("read dest"),
+        b"keep"
+    );
 
     // Without --backup-dir, backup + delete with suffix-only creates backups
     // in the same directory. The overwrite backup of keep.txt creates keep.txt~,
@@ -2067,7 +2288,11 @@ fn backup_delete_with_suffix_only() {
     // with --delete for clean backup organization.
     // The extraneous file extra.txt is backed up by the delete sweep.
     let backup_extra = dest_root.join("extra.txt~");
-    assert!(backup_extra.exists(), "backup of deleted file missing at {}", backup_extra.display());
+    assert!(
+        backup_extra.exists(),
+        "backup of deleted file missing at {}",
+        backup_extra.display()
+    );
     assert_eq!(fs::read(&backup_extra).expect("read backup"), b"extra");
 }
 
@@ -2076,9 +2301,7 @@ fn backup_not_created_for_new_directory() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("newdir/file.txt", Some(b"content")),
-    ]);
+    test_helpers::create_test_tree(&ctx.source, &[("newdir/file.txt", Some(b"content"))]);
 
     let dest_root = ctx.dest.join("source");
     fs::create_dir_all(&dest_root).expect("create dest root");
@@ -2116,8 +2339,7 @@ fn backup_dir_relative_uses_destination_root() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_backup_directory(Some(PathBuf::from(".old")));
+    let options = LocalCopyOptions::default().with_backup_directory(Some(PathBuf::from(".old")));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -2145,17 +2367,21 @@ fn backup_with_checksum_mode() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .backup(true)
-        .checksum(true);
+    let options = LocalCopyOptions::default().backup(true).checksum(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let backup = dest_root.join("file.txt~");
     assert!(backup.exists(), "backup missing");
-    assert_eq!(fs::read(&backup).expect("read backup"), b"old checksum content");
-    assert_eq!(fs::read(dest_root.join("file.txt")).expect("read dest"), b"new checksum content");
+    assert_eq!(
+        fs::read(&backup).expect("read backup"),
+        b"old checksum content"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("file.txt")).expect("read dest"),
+        b"new checksum content"
+    );
 }
 
 /// Verifies that backing up a destination file emits the upstream
@@ -2467,9 +2693,7 @@ fn backup_with_no_whole_file_does_not_produce_vanished_error() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .backup(true)
-        .whole_file(false);
+    let options = LocalCopyOptions::default().backup(true).whole_file(false);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("backup + no-whole-file must not fail with vanished error");
@@ -2645,7 +2869,11 @@ fn backup_dir_intermediate_inherits_source_dir_permissions() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    let backup = dest.join("backups").join("source").join("dir").join("file.txt~");
+    let backup = dest
+        .join("backups")
+        .join("source")
+        .join("dir")
+        .join("file.txt~");
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), b"old contents");
 
@@ -2745,8 +2973,9 @@ fn backup_without_backup_dir_omits_directory_mtime() {
         .expect("copy succeeds");
 
     let dest_empty = dest_root.join("source").join("e");
-    let dest_mtime =
-        FileTime::from_last_modification_time(&fs::metadata(&dest_empty).expect("dest subdir meta"));
+    let dest_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(&dest_empty).expect("dest subdir meta"),
+    );
     assert_ne!(
         dest_mtime, dir_mtime,
         "a plain --backup must imply omit-dir-times, leaving the empty dir's mtime unpreserved"
@@ -2788,8 +3017,9 @@ fn backup_dir_preserves_directory_mtime() {
         .expect("copy succeeds");
 
     let dest_empty = dest_root.join("source").join("e");
-    let dest_mtime =
-        FileTime::from_last_modification_time(&fs::metadata(&dest_empty).expect("dest subdir meta"));
+    let dest_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(&dest_empty).expect("dest subdir meta"),
+    );
     assert_eq!(
         dest_mtime, dir_mtime,
         "with --backup-dir the implication does not apply, so the source dir mtime is preserved"
@@ -2824,7 +3054,9 @@ fn write_stale_dest<P: AsRef<Path>>(path: P, contents: &[u8]) {
 /// nothing. Ageing the destination is how the fixture says "time passed".
 fn backdate_tree(dir: &Path) {
     let stale = FileTime::from_unix_time(1_500_000_000, 0);
-    let Ok(entries) = fs::read_dir(dir) else { return };
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {

--- a/crates/engine/src/local_copy/tests/bandwidth.rs
+++ b/crates/engine/src/local_copy/tests/bandwidth.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn execute_with_bandwidth_limit_records_sleep() {
     let mut recorder = bandwidth::recorded_sleep_session();

--- a/crates/engine/src/local_copy/tests/checksum_algorithm_behavior.rs
+++ b/crates/engine/src/local_copy/tests/checksum_algorithm_behavior.rs
@@ -82,10 +82,7 @@ fn checksum_md4_transfers_different_files() {
     // File should be copied because MD4 checksums differ
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"source!"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"source!");
 }
 
 /// Tests that MD5 algorithm (default for protocol >= 30) correctly identifies identical files.
@@ -268,10 +265,7 @@ fn checksum_sha1_transfers_different_files() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"sha1 source"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"sha1 source");
 }
 
 /// Tests that XXH64 algorithm (fast non-cryptographic) works correctly.
@@ -339,10 +333,7 @@ fn checksum_xxh64_transfers_different_files() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"xxh64 source"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"xxh64 source");
 }
 
 /// Tests that XXH64 with different seeds produces different results.
@@ -369,10 +360,7 @@ fn checksum_xxh64_different_seeds_are_independent() {
         set_file_mtime(path, older_time).expect("set dest time");
     }
 
-    let operands1 = vec![
-        source1.into_os_string(),
-        dest1.clone().into_os_string(),
-    ];
+    let operands1 = vec![source1.into_os_string(), dest1.clone().into_os_string()];
     let plan1 = LocalCopyPlan::from_operands(&operands1).expect("plan1");
     let summary1 = plan1
         .execute_with_options(
@@ -383,10 +371,7 @@ fn checksum_xxh64_different_seeds_are_independent() {
         )
         .expect("copy1 succeeds");
 
-    let operands2 = vec![
-        source2.into_os_string(),
-        dest2.clone().into_os_string(),
-    ];
+    let operands2 = vec![source2.into_os_string(), dest2.clone().into_os_string()];
     let plan2 = LocalCopyPlan::from_operands(&operands2).expect("plan2");
     let summary2 = plan2
         .execute_with_options(
@@ -467,10 +452,7 @@ fn checksum_xxh3_transfers_different_files() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"xxh3 source!"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"xxh3 source!");
 }
 
 /// Tests that XXH3-128 algorithm works correctly for checksum comparison.
@@ -561,9 +543,8 @@ fn checksum_ignores_mtime_when_content_matches() {
     set_file_mtime(&source, very_new).expect("set source time");
     set_file_mtime(&destination, very_old).expect("set dest time");
 
-    let dest_mtime_before = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata"),
-    );
+    let dest_mtime_before =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
 
     let operands = vec![
         source.into_os_string(),
@@ -582,9 +563,8 @@ fn checksum_ignores_mtime_when_content_matches() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 
-    let dest_mtime_after = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata"),
-    );
+    let dest_mtime_after =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
     assert_eq!(dest_mtime_before, dest_mtime_after);
 }
 
@@ -619,10 +599,7 @@ fn checksum_transfers_when_mtime_matches_but_content_differs() {
 
     // File SHOULD be copied because checksums differ
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"new content!"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"new content!");
 }
 
 /// Tests that without checksum mode, mtime+size match causes skip.
@@ -661,10 +638,7 @@ fn without_checksum_mtime_match_skips_even_with_different_content() {
     // File should be SKIPPED (mtime+size match, no checksum)
     assert_eq!(summary.files_copied(), 0);
     // Content remains different
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"dest!!!!"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"dest!!!!");
 }
 
 /// Tests that after transfer, content is verified correct.
@@ -764,10 +738,7 @@ fn checksum_large_file_differ_at_end() {
 
     // Should transfer (checksums differ even for last-byte change)
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        source_content
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), source_content);
 }
 
 /// Tests that checksum comparison handles empty files correctly.
@@ -977,10 +948,7 @@ fn no_checksum_falls_back_to_mtime() {
     // Without checksum, should skip (mtime+size match)
     assert_eq!(summary.files_copied(), 0);
     // Content remains different
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"bbbbbbb"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"bbbbbbb");
 }
 
 /// Tests that all algorithms produce consistent skip/copy decisions.

--- a/crates/engine/src/local_copy/tests/concurrent_modification.rs
+++ b/crates/engine/src/local_copy/tests/concurrent_modification.rs
@@ -430,7 +430,11 @@ fn checksum_mode_detects_content_change() {
     // Should detect mismatch and copy
     match result {
         Ok(summary) => {
-            assert_eq!(summary.files_copied(), 1, "file should be copied due to checksum mismatch");
+            assert_eq!(
+                summary.files_copied(),
+                1,
+                "file should be copied due to checksum mismatch"
+            );
             let dest_content = fs::read(dest_root.join("checksum.txt")).expect("read dest");
             assert_eq!(dest_content, b"original checksum content");
         }
@@ -465,7 +469,11 @@ fn checksum_mode_skips_identical_content() {
 
     match result {
         Ok(summary) => {
-            assert_eq!(summary.files_copied(), 0, "identical file should be skipped");
+            assert_eq!(
+                summary.files_copied(),
+                0,
+                "identical file should be skipped"
+            );
             assert_eq!(summary.regular_files_matched(), 1);
         }
         Err(e) => panic!("unexpected error: {e}"),

--- a/crates/engine/src/local_copy/tests/delete.rs
+++ b/crates/engine/src/local_copy/tests/delete.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn delete_respects_exclude_filters() {
     let ctx = test_helpers::setup_copy_test();
@@ -15,8 +14,8 @@ fn delete_respects_exclude_filters() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let filters = FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filters =
+        FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete(true)
         .filters(Some(filters));
@@ -50,8 +49,8 @@ fn delete_excluded_removes_excluded_entries() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let filters = FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filters =
+        FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete(true)
         .delete_excluded(true)
@@ -81,13 +80,10 @@ fn delete_excluded_removes_matching_source_files() {
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("skip.tmp"), b"dest skip").expect("write existing skip");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let filters = FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filters =
+        FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete(true)
         .delete_excluded(true)
@@ -105,8 +101,8 @@ fn delete_excluded_removes_matching_source_files() {
 
 #[test]
 fn delete_after_files_present_during_transfer() {
-    use std::sync::{Arc, Mutex};
     use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
 
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source");
@@ -150,10 +146,16 @@ fn delete_after_files_present_during_transfer() {
                 self.checked = true;
                 // At this point, files marked for deletion should still exist
                 if self.dest.join("delete_me.txt").exists() {
-                    self.files_seen.lock().unwrap().insert("delete_me.txt".to_string());
+                    self.files_seen
+                        .lock()
+                        .unwrap()
+                        .insert("delete_me.txt".to_string());
                 }
                 if self.dest.join("also_delete.txt").exists() {
-                    self.files_seen.lock().unwrap().insert("also_delete.txt".to_string());
+                    self.files_seen
+                        .lock()
+                        .unwrap()
+                        .insert("also_delete.txt".to_string());
                 }
             }
         }
@@ -173,15 +175,27 @@ fn delete_after_files_present_during_transfer() {
         .execute_with_options_and_handler(LocalCopyExecution::Apply, options, Some(&mut observer))
         .expect("copy succeeds");
 
-    assert!(!dest.join("delete_me.txt").exists(), "delete_me.txt should be deleted");
-    assert!(!dest.join("also_delete.txt").exists(), "also_delete.txt should be deleted");
+    assert!(
+        !dest.join("delete_me.txt").exists(),
+        "delete_me.txt should be deleted"
+    );
+    assert!(
+        !dest.join("also_delete.txt").exists(),
+        "also_delete.txt should be deleted"
+    );
     assert!(dest.join("keep.txt").exists(), "keep.txt should exist");
     assert!(dest.join("update.txt").exists(), "update.txt should exist");
     assert_eq!(summary.items_deleted(), 2);
 
     let seen = files_during_copy.lock().unwrap();
-    assert!(seen.contains("delete_me.txt"), "delete_me.txt should have existed during transfer");
-    assert!(seen.contains("also_delete.txt"), "also_delete.txt should have existed during transfer");
+    assert!(
+        seen.contains("delete_me.txt"),
+        "delete_me.txt should have existed during transfer"
+    );
+    assert!(
+        seen.contains("also_delete.txt"),
+        "also_delete.txt should have existed during transfer"
+    );
 }
 
 #[test]
@@ -369,7 +383,8 @@ fn delete_after_timing_differs_from_delete_during() {
     fs::write(dest_after.join("root_extra.txt"), b"root extra").expect("write root_extra");
     let dest_after_subdir = dest_after.join("subdir");
     fs::create_dir_all(&dest_after_subdir).expect("create dest_after subdir");
-    fs::write(dest_after_subdir.join("nested_extra.txt"), b"nested extra").expect("write nested_extra");
+    fs::write(dest_after_subdir.join("nested_extra.txt"), b"nested extra")
+        .expect("write nested_extra");
 
     let mut source_operand_after = source.clone().into_os_string();
     source_operand_after.push(std::path::MAIN_SEPARATOR.to_string());
@@ -389,7 +404,8 @@ fn delete_after_timing_differs_from_delete_during() {
     fs::write(dest_during.join("root_extra.txt"), b"root extra").expect("write root_extra");
     let dest_during_subdir = dest_during.join("subdir");
     fs::create_dir_all(&dest_during_subdir).expect("create dest_during subdir");
-    fs::write(dest_during_subdir.join("nested_extra.txt"), b"nested extra").expect("write nested_extra");
+    fs::write(dest_during_subdir.join("nested_extra.txt"), b"nested extra")
+        .expect("write nested_extra");
 
     let mut source_operand_during = source.into_os_string();
     source_operand_during.push(std::path::MAIN_SEPARATOR.to_string());
@@ -397,7 +413,7 @@ fn delete_after_timing_differs_from_delete_during() {
     let plan_during = LocalCopyPlan::from_operands(&operands_during).expect("plan during");
 
     let options_during = LocalCopyOptions::default()
-        .delete(true)  // delete-during is the default
+        .delete(true) // delete-during is the default
         .collect_events(true);
 
     let report_during = plan_during
@@ -436,7 +452,9 @@ fn delete_after_timing_differs_from_delete_during() {
     }
 
     // Verify delete-after: all copies before all deletes
-    if let (Some(&last_copy), Some(&first_delete)) = (after_copy_indices.last(), after_delete_indices.first()) {
+    if let (Some(&last_copy), Some(&first_delete)) =
+        (after_copy_indices.last(), after_delete_indices.first())
+    {
         assert!(
             last_copy < first_delete,
             "delete-after: all copies should complete before any deletes"
@@ -546,7 +564,10 @@ fn delete_after_works_with_dry_run() {
     let summary = report.summary();
 
     assert_eq!(fs::read(dest.join("keep.txt")).expect("read"), b"old keep");
-    assert!(dest.join("delete_me.txt").exists(), "file should still exist in dry-run");
+    assert!(
+        dest.join("delete_me.txt").exists(),
+        "file should still exist in dry-run"
+    );
 
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.items_deleted(), 1);
@@ -648,7 +669,6 @@ fn delete_during_deletes_directory_before_transferring_its_children() {
     );
 }
 
-
 #[test]
 fn delete_before_keeps_in_source_file() {
     // upstream: generator.c:286-358 delete_in_dir() / do_delete_pass() - a
@@ -726,7 +746,9 @@ fn delete_during_itemizes_deletion_before_directory_row() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default().delete_during().collect_events(true);
+    let options = LocalCopyOptions::default()
+        .delete_during()
+        .collect_events(true);
 
     let report = plan
         .execute_with_report(LocalCopyExecution::Apply, options)

--- a/crates/engine/src/local_copy/tests/delete_delay.rs
+++ b/crates/engine/src/local_copy/tests/delete_delay.rs
@@ -13,7 +13,6 @@
 // 5. Deferred deletions respect filter rules
 // 6. Works with max_deletions limit
 
-
 #[test]
 fn delete_delay_removes_extraneous_files_after_transfer() {
     let ctx = test_helpers::setup_copy_test();
@@ -84,7 +83,6 @@ fn delete_delay_defers_directory_deletions_until_end() {
     assert!(summary.items_deleted() >= 1);
 }
 
-
 #[test]
 fn delete_delay_differs_from_delete_during_timing() {
     // This test verifies that delete-delay and delete-during are semantically
@@ -140,7 +138,10 @@ fn delete_delay_differs_from_delete_during_timing() {
         .expect("copy succeeds with during");
 
     // Both should achieve the same end result
-    assert_eq!(summary_delay.items_deleted(), summary_during.items_deleted());
+    assert_eq!(
+        summary_delay.items_deleted(),
+        summary_during.items_deleted()
+    );
     assert!(!target_root.join("extra.txt").exists());
     assert!(!target_root2.join("extra.txt").exists());
 }
@@ -159,30 +160,35 @@ fn delete_during_option_enables_during_timing() {
     assert_eq!(options.delete_timing(), Some(DeleteTiming::During));
 }
 
-
 #[test]
 fn delete_delay_works_with_recursive_traversal() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("level1/level2/level3/file.txt", Some(b"deep")),
-        ("level1/keep.txt", Some(b"keep1")),
-        ("top.txt", Some(b"top")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("level1/level2/level3/file.txt", Some(b"deep")),
+            ("level1/keep.txt", Some(b"keep1")),
+            ("top.txt", Some(b"top")),
+        ],
+    );
 
     // Use shorter content than source to ensure different sizes, avoiding
     // quick-check (same mtime+size) skipping the transfer.
     let target_root = ctx.dest.join("source");
-    test_helpers::create_test_tree(&target_root, &[
-        ("level1/level2/level3/file.txt", Some(b"x")),
-        ("level1/level2/level3/extra_deep.txt", Some(b"extra")),
-        ("level1/level2/extra_mid.txt", Some(b"extra")),
-        ("level1/keep.txt", Some(b"x")),
-        ("level1/extra_shallow.txt", Some(b"extra")),
-        ("top.txt", Some(b"x")),
-        ("extra_top.txt", Some(b"extra")),
-    ]);
+    test_helpers::create_test_tree(
+        &target_root,
+        &[
+            ("level1/level2/level3/file.txt", Some(b"x")),
+            ("level1/level2/level3/extra_deep.txt", Some(b"extra")),
+            ("level1/level2/extra_mid.txt", Some(b"extra")),
+            ("level1/keep.txt", Some(b"x")),
+            ("level1/extra_shallow.txt", Some(b"extra")),
+            ("top.txt", Some(b"x")),
+            ("extra_top.txt", Some(b"extra")),
+        ],
+    );
 
     let operands = vec![
         ctx.source.clone().into_os_string(),
@@ -204,7 +210,11 @@ fn delete_delay_works_with_recursive_traversal() {
     assert!(!target_root.join("extra_top.txt").exists());
     assert!(!target_root.join("level1/extra_shallow.txt").exists());
     assert!(!target_root.join("level1/level2/extra_mid.txt").exists());
-    assert!(!target_root.join("level1/level2/level3/extra_deep.txt").exists());
+    assert!(
+        !target_root
+            .join("level1/level2/level3/extra_deep.txt")
+            .exists()
+    );
 
     assert_eq!(summary.files_copied(), 3);
     assert_eq!(summary.items_deleted(), 4);
@@ -224,8 +234,7 @@ fn delete_delay_handles_nested_empty_directories() {
     fs::create_dir_all(target_root.join("data")).expect("create data dir");
     fs::write(target_root.join("data/file.txt"), b"old").expect("write old file");
 
-    fs::create_dir_all(target_root.join("empty1/empty2/empty3"))
-        .expect("create nested empties");
+    fs::create_dir_all(target_root.join("empty1/empty2/empty3")).expect("create nested empties");
 
     let operands = vec![
         ctx.source.clone().into_os_string(),
@@ -245,7 +254,6 @@ fn delete_delay_handles_nested_empty_directories() {
     assert_eq!(summary.files_copied(), 1);
     assert!(summary.items_deleted() >= 1);
 }
-
 
 #[test]
 fn delete_delay_with_max_deletions_limit() {
@@ -383,7 +391,6 @@ fn delete_delay_batches_multiple_directory_deletions() {
     assert!(summary.items_deleted() >= 6);
 }
 
-
 #[test]
 fn delete_delay_respects_exclude_filters() {
     let ctx = test_helpers::setup_copy_test();
@@ -402,8 +409,7 @@ fn delete_delay_respects_exclude_filters() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let filters = FilterSet::from_rules([FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete_delay(true)
         .filters(Some(filters));
@@ -447,8 +453,7 @@ fn delete_delay_with_delete_excluded_removes_filtered_files() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let filters = FilterSet::from_rules([FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete_delay(true)
         .delete_excluded(true)
@@ -466,7 +471,6 @@ fn delete_delay_with_delete_excluded_removes_filtered_files() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.items_deleted(), 1);
 }
-
 
 #[test]
 fn delete_delay_with_no_files_to_delete() {
@@ -584,8 +588,7 @@ fn delete_delay_preserves_symlinks_when_appropriate() {
         fs::write(target_root.join("file.txt"), b"old").expect("write old");
 
         // Create a symlink that points to something outside the transfer
-        unix_fs::symlink("/etc/hosts", target_root.join("external_link"))
-            .expect("create symlink");
+        unix_fs::symlink("/etc/hosts", target_root.join("external_link")).expect("create symlink");
 
         let operands = vec![
             ctx.source.clone().into_os_string(),

--- a/crates/engine/src/local_copy/tests/delete_incremental_filter_stack.rs
+++ b/crates/engine/src/local_copy/tests/delete_incremental_filter_stack.rs
@@ -97,10 +97,7 @@ fn incremental_stack_preserves_source_state_with_nested_rsync_filter() {
         .enter_directory(&root.join("dir"), Some(std::path::Path::new("dir")))
         .expect("enter dir");
     let _g_sub = context
-        .enter_directory(
-            &root.join("dir/sub"),
-            Some(std::path::Path::new("dir/sub")),
-        )
+        .enter_directory(&root.join("dir/sub"), Some(std::path::Path::new("dir/sub")))
         .expect("enter dir/sub");
 
     // Sanity: the child-only rule is live at dir/sub.

--- a/crates/engine/src/local_copy/tests/delete_protect.rs
+++ b/crates/engine/src/local_copy/tests/delete_protect.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn delete_respects_protect_filters() {
     let temp = tempdir().expect("tempdir");
@@ -11,13 +10,10 @@ fn delete_respects_protect_filters() {
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"keep").expect("write keep");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let filters = FilterSet::from_rules([filters::FilterRule::protect("keep.txt")])
-        .expect("compile filters");
+    let filters =
+        FilterSet::from_rules([filters::FilterRule::protect("keep.txt")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete(true)
         .filters(Some(filters));
@@ -43,10 +39,7 @@ fn delete_risk_rule_overrides_protection() {
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"keep").expect("write keep");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     // With first-match-wins, risk must come before protect to override
     let filters = FilterSet::from_rules([

--- a/crates/engine/src/local_copy/tests/dest_guard.rs
+++ b/crates/engine/src/local_copy/tests/dest_guard.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn destination_write_guard_uses_custom_partial_directory() {
     let temp = tempdir().expect("tempdir");
@@ -21,8 +20,14 @@ fn destination_write_guard_uses_custom_partial_directory() {
     // into the partial dir by basename on interrupt.
     assert_eq!(temp_path.parent(), Some(destination_dir.as_path()));
     let expected_partial = destination_dir.join(partial_dir).join("file.txt");
-    assert!(!temp_path.exists(), "temp consumed by move into partial dir");
-    assert!(expected_partial.exists(), "partial preserved in partial dir");
+    assert!(
+        !temp_path.exists(),
+        "temp consumed by move into partial dir"
+    );
+    assert!(
+        expected_partial.exists(),
+        "partial preserved in partial dir"
+    );
     assert!(!destination.exists());
 }
 

--- a/crates/engine/src/local_copy/tests/disk_full_errors.rs
+++ b/crates/engine/src/local_copy/tests/disk_full_errors.rs
@@ -11,7 +11,6 @@
 // 5. Error messages include path context
 // 6. Guard behavior on disk full errors (temp file cleanup)
 
-
 #[test]
 fn local_copy_error_from_disk_full_io_error() {
     let disk_full = io::Error::new(io::ErrorKind::StorageFull, "No space left on device");
@@ -58,7 +57,6 @@ fn local_copy_error_disk_full_code_name_is_rerr_partial() {
     assert_eq!(error.code_name(), "RERR_PARTIAL");
 }
 
-
 #[test]
 fn detect_storage_full_error_kind() {
     let disk_full = io::Error::from(io::ErrorKind::StorageFull);
@@ -84,7 +82,6 @@ fn raw_os_error_enospc_detected_as_storage_full() {
     let enospc = io::Error::from_raw_os_error(28);
     assert_eq!(enospc.raw_os_error(), Some(28));
 }
-
 
 #[test]
 fn disk_full_error_message_includes_action_context() {
@@ -147,7 +144,6 @@ fn disk_full_error_preserves_original_io_error_message() {
     }
 }
 
-
 #[test]
 fn guard_discard_cleans_up_temp_file_on_disk_full() {
     let temp = tempdir().expect("tempdir");
@@ -203,7 +199,6 @@ fn guard_partial_mode_preserves_file_on_discard() {
     assert_eq!(fs::read(&dest).expect("read"), b"partial data");
 }
 
-
 #[test]
 fn remove_existing_destination_handles_disk_full_context() {
     let temp = tempdir().expect("tempdir");
@@ -236,7 +231,6 @@ fn remove_incomplete_destination_silent_on_not_found() {
     remove_incomplete_destination(&path);
 }
 
-
 #[test]
 fn io_error_exit_code_is_23_for_general_io_errors() {
     // General I/O errors (non-vanished) return exit code 23 (RERR_PARTIAL)
@@ -262,10 +256,7 @@ fn io_error_exit_code_is_24_for_vanished_files() {
     // NotFound I/O errors return exit code 24 (RERR_VANISHED)
     let io_error = io::Error::from(io::ErrorKind::NotFound);
     let error = LocalCopyError::io("read file", PathBuf::from("/vanished"), io_error);
-    assert_eq!(
-        error.exit_code(),
-        super::filter_program::VANISHED_EXIT_CODE,
-    );
+    assert_eq!(error.exit_code(), super::filter_program::VANISHED_EXIT_CODE,);
     assert_eq!(error.exit_code(), 24);
 }
 
@@ -277,7 +268,6 @@ fn io_error_exit_code_matches_upstream_rerr_partial() {
 
     assert_eq!(error.exit_code(), 23);
 }
-
 
 #[test]
 fn disk_full_error_has_source() {
@@ -293,14 +283,17 @@ fn disk_full_error_has_source() {
 #[test]
 fn disk_full_error_debug_format_includes_details() {
     let disk_full = io::Error::new(io::ErrorKind::StorageFull, "No space left on device");
-    let error = LocalCopyError::io("write file", PathBuf::from("/destination/file.txt"), disk_full);
+    let error = LocalCopyError::io(
+        "write file",
+        PathBuf::from("/destination/file.txt"),
+        disk_full,
+    );
 
     let debug = format!("{error:?}");
 
     assert!(debug.contains("Io"));
     assert!(debug.contains("write file"));
 }
-
 
 #[test]
 #[cfg(unix)]
@@ -353,7 +346,6 @@ fn directory_write_error_propagates_correctly() {
     }
 }
 
-
 #[test]
 fn local_copy_error_kind_as_io_returns_components() {
     let disk_full = io::Error::new(io::ErrorKind::StorageFull, "disk full");
@@ -382,7 +374,6 @@ fn local_copy_error_into_kind_consumes_error() {
     let kind = error.into_kind();
     assert!(matches!(kind, LocalCopyErrorKind::Io { .. }));
 }
-
 
 #[test]
 fn disk_full_vs_general_io_errors_have_same_exit_code() {
@@ -417,7 +408,6 @@ fn io_errors_have_different_code_name_than_timeout() {
     assert_ne!(io_error.code_name(), timeout_error.code_name());
 }
 
-
 #[test]
 fn error_context_preserved_for_large_file_paths() {
     // Test with maximum path length scenarios
@@ -434,10 +424,7 @@ fn error_context_preserved_for_large_file_paths() {
 
 #[test]
 fn error_for_special_characters_in_path() {
-    let special_paths = [
-        "/path/with spaces/file.txt",
-        "/path/with_quotes/file.txt",
-    ];
+    let special_paths = ["/path/with spaces/file.txt", "/path/with_quotes/file.txt"];
 
     for path_str in special_paths {
         let disk_full = io::Error::new(io::ErrorKind::StorageFull, "disk full");
@@ -450,16 +437,17 @@ fn error_for_special_characters_in_path() {
     }
 }
 
-
 #[test]
 fn multiple_disk_full_errors_are_independent() {
     let errors: Vec<_> = (0..5)
         .map(|i| {
-            let disk_full = io::Error::new(
-                io::ErrorKind::StorageFull,
-                format!("disk full error {i}"),
-            );
-            LocalCopyError::io("write file", PathBuf::from(format!("/test{i}.txt")), disk_full)
+            let disk_full =
+                io::Error::new(io::ErrorKind::StorageFull, format!("disk full error {i}"));
+            LocalCopyError::io(
+                "write file",
+                PathBuf::from(format!("/test{i}.txt")),
+                disk_full,
+            )
         })
         .collect();
 
@@ -471,7 +459,6 @@ fn multiple_disk_full_errors_are_independent() {
     }
 }
 
-
 #[test]
 fn disk_full_during_copy_preserves_partial_file_in_partial_mode() {
     let temp = tempdir().expect("tempdir");
@@ -482,7 +469,8 @@ fn disk_full_during_copy_preserves_partial_file_in_partial_mode() {
     let staging = guard.staging_path().to_path_buf();
 
     // Write some data before "disk full"
-    file.write_all(b"partial content before error").expect("write");
+    file.write_all(b"partial content before error")
+        .expect("write");
     drop(file);
 
     // Simulate disk full - in partial mode, discard moves the temp onto the
@@ -490,7 +478,10 @@ fn disk_full_during_copy_preserves_partial_file_in_partial_mode() {
     guard.discard();
 
     assert!(!staging.exists(), "temp is consumed by the move");
-    assert!(dest.exists(), "partial content preserved at the destination");
+    assert!(
+        dest.exists(),
+        "partial content preserved at the destination"
+    );
     let content = fs::read(&dest).expect("read partial");
     assert_eq!(content, b"partial content before error");
 }
@@ -511,9 +502,11 @@ fn disk_full_during_copy_removes_temp_file_in_normal_mode() {
     // Simulate disk full - in normal mode, discard should remove temp file
     guard.discard();
 
-    assert!(!staging.exists(), "Temp file should be removed in normal mode");
+    assert!(
+        !staging.exists(),
+        "Temp file should be removed in normal mode"
+    );
 }
-
 
 #[test]
 fn can_retry_after_disk_full_error() {
@@ -528,7 +521,8 @@ fn can_retry_after_disk_full_error() {
 
     // Second attempt - should succeed
     {
-        let (guard, mut file) = DestinationWriteGuard::new(&dest, false, None, None).expect("guard");
+        let (guard, mut file) =
+            DestinationWriteGuard::new(&dest, false, None, None).expect("guard");
         file.write_all(b"success on retry").expect("write");
         drop(file);
         guard.commit().expect("commit");
@@ -560,7 +554,6 @@ fn multiple_failed_attempts_clean_up_properly() {
 
     assert_eq!(fs::read(&dest).expect("read"), b"final success");
 }
-
 
 #[test]
 fn readonly_filesystem_error_maps_correctly() {

--- a/crates/engine/src/local_copy/tests/execute_append.rs
+++ b/crates/engine/src/local_copy/tests/execute_append.rs
@@ -15,7 +15,6 @@
 // 6. Mismatch detection with verification
 // 7. Works correctly with various file sizes
 
-
 #[test]
 fn append_adds_remaining_data_to_partial_file() {
     let temp = tempdir().expect("tempdir");
@@ -70,9 +69,7 @@ fn append_skips_when_destination_equals_source_size() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .append(true)
-                .times(true),
+            LocalCopyOptions::default().append(true).times(true),
         )
         .expect("copy succeeds");
 
@@ -166,12 +163,8 @@ fn append_handles_empty_destination() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"full content"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"full content");
 }
-
 
 #[test]
 fn append_correct_offset_with_small_partial() {
@@ -258,10 +251,7 @@ fn append_one_byte_partial() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"Hello World!"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"Hello World!");
 }
 
 #[test]
@@ -291,7 +281,6 @@ fn append_almost_complete_file() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&destination).expect("read dest"), full);
 }
-
 
 #[test]
 fn append_verify_succeeds_when_prefix_matches() {
@@ -393,7 +382,10 @@ fn append_verify_with_large_matching_prefix() {
         fs::read(&destination).expect("read dest").len(),
         full_content.len()
     );
-    assert_eq!(fs::read(&destination).expect("read dest"), full_content.as_bytes());
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        full_content.as_bytes()
+    );
 }
 
 #[test]
@@ -599,7 +591,6 @@ fn append_without_verify_blindly_appends() {
     assert_eq!(result, b"WRONG DATAABCDEFGHIJ");
 }
 
-
 #[test]
 fn append_combined_with_times_preserves_mtime() {
     let temp = tempdir().expect("tempdir");
@@ -621,17 +612,14 @@ fn append_combined_with_times_preserves_mtime() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .append(true)
-                .times(true),
+            LocalCopyOptions::default().append(true).times(true),
         )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata")
-    );
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
     assert_eq!(dest_mtime.unix_seconds(), source_mtime.unix_seconds());
 }
 
@@ -660,15 +648,15 @@ fn append_combined_with_permissions() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .append(true)
-                .permissions(true),
+            LocalCopyOptions::default().append(true).permissions(true),
         )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+    let dest_perms = fs::metadata(&destination)
+        .expect("dest metadata")
+        .permissions();
     assert_eq!(dest_perms.mode() & 0o777, 0o644);
 }
 
@@ -690,9 +678,7 @@ fn append_with_checksum_mode() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .append(true)
-                .checksum(true),
+            LocalCopyOptions::default().append(true).checksum(true),
         )
         .expect("copy succeeds");
 
@@ -702,7 +688,6 @@ fn append_with_checksum_mode() {
         b"content to append to file"
     );
 }
-
 
 #[test]
 fn append_recursive_directory_with_partial_files() {
@@ -716,18 +701,14 @@ fn append_recursive_directory_with_partial_files() {
     // File 1: Partial destination (should append)
     fs::write(source_root.join("file1.txt"), b"complete file one content")
         .expect("write file1 source");
-    fs::write(dest_root.join("file1.txt"), b"complete file")
-        .expect("write file1 partial");
+    fs::write(dest_root.join("file1.txt"), b"complete file").expect("write file1 partial");
 
     // File 2: Complete destination (should skip if mtime matches)
-    fs::write(source_root.join("file2.txt"), b"file two done")
-        .expect("write file2 source");
-    fs::write(dest_root.join("file2.txt"), b"file two done")
-        .expect("write file2 complete");
+    fs::write(source_root.join("file2.txt"), b"file two done").expect("write file2 source");
+    fs::write(dest_root.join("file2.txt"), b"file two done").expect("write file2 complete");
 
     // File 3: Missing destination (should create)
-    fs::write(source_root.join("file3.txt"), b"brand new file")
-        .expect("write file3 source");
+    fs::write(source_root.join("file3.txt"), b"brand new file").expect("write file3 source");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -770,8 +751,7 @@ fn append_nested_directory_structure() {
     // Root level file: partial
     fs::write(source_root.join("root.txt"), b"root file complete content")
         .expect("write root source");
-    fs::write(dest_root.join("root.txt"), b"root file")
-        .expect("write root partial");
+    fs::write(dest_root.join("root.txt"), b"root file").expect("write root partial");
 
     // Nested file: partial
     fs::write(
@@ -779,8 +759,11 @@ fn append_nested_directory_structure() {
         b"nested content in deep directory",
     )
     .expect("write nested source");
-    fs::write(dest_root.join("level1/level2/nested.txt"), b"nested content")
-        .expect("write nested partial");
+    fs::write(
+        dest_root.join("level1/level2/nested.txt"),
+        b"nested content",
+    )
+    .expect("write nested partial");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -805,7 +788,6 @@ fn append_nested_directory_structure() {
         b"nested content in deep directory"
     );
 }
-
 
 #[test]
 fn append_binary_data() {
@@ -864,7 +846,6 @@ fn append_verify_binary_data_with_matching_prefix() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&destination).expect("read dest"), full_binary);
 }
-
 
 #[test]
 fn append_with_empty_source_skips_when_dest_has_content() {
@@ -954,7 +935,6 @@ fn append_verify_enabled_implies_append() {
     );
 }
 
-
 #[test]
 fn append_dry_run_reports_but_preserves_files() {
     let temp = tempdir().expect("tempdir");
@@ -982,7 +962,6 @@ fn append_dry_run_reports_but_preserves_files() {
     // But destination should remain unchanged
     assert_eq!(fs::read(&destination).expect("read dest"), b"complete");
 }
-
 
 #[test]
 fn append_matches_upstream_append_semantics() {
@@ -1053,7 +1032,6 @@ fn append_matches_upstream_append_semantics() {
         "case4: no dest -> created"
     );
 }
-
 
 #[test]
 fn append_skips_when_destination_exactly_equals_source_size() {
@@ -1224,8 +1202,7 @@ fn append_recursive_skips_completed_files() {
     // File 1: dest shorter -> append
     fs::write(source_root.join("partial.txt"), b"full content of file")
         .expect("write partial source");
-    fs::write(dest_root.join("partial.txt"), b"full content")
-        .expect("write partial dest");
+    fs::write(dest_root.join("partial.txt"), b"full content").expect("write partial dest");
 
     // File 2: dest equal size -> skip
     fs::write(source_root.join("equal.txt"), b"equal").expect("write equal source");

--- a/crates/engine/src/local_copy/tests/execute_archive.rs
+++ b/crates/engine/src/local_copy/tests/execute_archive.rs
@@ -535,26 +535,14 @@ fn fluent_archive_options_match_builder_archive() {
         from_builder.recursive_enabled(),
         from_fluent.recursive_enabled()
     );
-    assert_eq!(
-        from_builder.links_enabled(),
-        from_fluent.links_enabled()
-    );
+    assert_eq!(from_builder.links_enabled(), from_fluent.links_enabled());
     assert_eq!(
         from_builder.preserve_permissions(),
         from_fluent.preserve_permissions()
     );
-    assert_eq!(
-        from_builder.preserve_times(),
-        from_fluent.preserve_times()
-    );
-    assert_eq!(
-        from_builder.preserve_group(),
-        from_fluent.preserve_group()
-    );
-    assert_eq!(
-        from_builder.preserve_owner(),
-        from_fluent.preserve_owner()
-    );
+    assert_eq!(from_builder.preserve_times(), from_fluent.preserve_times());
+    assert_eq!(from_builder.preserve_group(), from_fluent.preserve_group());
+    assert_eq!(from_builder.preserve_owner(), from_fluent.preserve_owner());
     assert_eq!(
         from_builder.devices_enabled(),
         from_fluent.devices_enabled()
@@ -586,10 +574,7 @@ fn archive_copies_single_file_content() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy");
 
-    test_helpers::assert_file_content(
-        &ctx.dest.join("hello.txt"),
-        b"archive content",
-    );
+    test_helpers::assert_file_content(&ctx.dest.join("hello.txt"), b"archive content");
 }
 
 #[test]
@@ -607,10 +592,7 @@ fn archive_copies_directory_recursively() {
 
     test_helpers::assert_file_content(&ctx.dest.join("top.txt"), b"top");
     test_helpers::assert_file_content(&ctx.dest.join("dir1/file1.txt"), b"file1");
-    test_helpers::assert_file_content(
-        &ctx.dest.join("dir1/dir2/file2.txt"),
-        b"file2",
-    );
+    test_helpers::assert_file_content(&ctx.dest.join("dir1/dir2/file2.txt"), b"file2");
 }
 
 #[test]
@@ -669,10 +651,7 @@ fn archive_preserves_symlinks_as_links() {
         .expect("copy");
 
     test_helpers::assert_is_symlink(&ctx.dest.join("link.txt"));
-    test_helpers::assert_symlink_target(
-        &ctx.dest.join("link.txt"),
-        Path::new("target.txt"),
-    );
+    test_helpers::assert_symlink_target(&ctx.dest.join("link.txt"), Path::new("target.txt"));
 }
 
 #[cfg(unix)]
@@ -791,10 +770,7 @@ fn archive_no_recursive_disables_recursion_in_options() {
     // The engine with recursive(false) skips subdirectory traversal entirely,
     // which is tested separately in execute_directories tests.
     let options = test_helpers::presets::archive_options().recursive(false);
-    assert!(
-        !options.recursive_enabled(),
-        "recursion should be disabled"
-    );
+    assert!(!options.recursive_enabled(), "recursion should be disabled");
     // All other archive components should remain
     assert!(options.links_enabled());
     assert!(options.preserve_permissions());
@@ -1020,14 +996,8 @@ fn archive_preserves_multiple_symlinks_and_targets() {
 
     test_helpers::assert_is_symlink(&ctx.dest.join("link1.txt"));
     test_helpers::assert_is_symlink(&ctx.dest.join("link2.txt"));
-    test_helpers::assert_symlink_target(
-        &ctx.dest.join("link1.txt"),
-        Path::new("target1.txt"),
-    );
-    test_helpers::assert_symlink_target(
-        &ctx.dest.join("link2.txt"),
-        Path::new("target2.txt"),
-    );
+    test_helpers::assert_symlink_target(&ctx.dest.join("link1.txt"), Path::new("target1.txt"));
+    test_helpers::assert_symlink_target(&ctx.dest.join("link2.txt"), Path::new("target2.txt"));
 }
 
 #[cfg(unix)]

--- a/crates/engine/src/local_copy/tests/execute_basic.rs
+++ b/crates/engine/src/local_copy/tests/execute_basic.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn execute_with_remove_source_files_deletes_source() {
     let temp = create_tempdir();
@@ -82,8 +81,14 @@ fn execute_file_replaces_directory_when_force_enabled() {
         )
         .expect("forced replacement succeeds");
 
-    assert!(destination.is_file(), "directory should be replaced by file");
-    assert_eq!(fs::read(&destination).expect("read destination"), b"replacement");
+    assert!(
+        destination.is_file(),
+        "directory should be replaced by file"
+    );
+    assert_eq!(
+        fs::read(&destination).expect("read destination"),
+        b"replacement"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -249,8 +254,7 @@ fn execute_copies_file_with_acls() {
     assert_eq!(summary.files_copied(), 1);
 
     // On Linux and other non-Apple Unix, ACLs are actually copied and visible.
-    let copied =
-        acl_to_text(&destination, acl_sys::ACL_TYPE_ACCESS).expect("dest acl");
+    let copied = acl_to_text(&destination, acl_sys::ACL_TYPE_ACCESS).expect("dest acl");
     assert!(copied.contains("user::rw-"));
 }
 
@@ -316,7 +320,6 @@ fn execute_copies_directory_tree() {
     assert!(summary.directories_created() >= 1);
 }
 
-
 #[test]
 fn execute_copies_empty_file() {
     let temp = create_tempdir();
@@ -363,7 +366,6 @@ fn execute_copies_empty_file_over_existing() {
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 0);
 }
 
-
 #[test]
 fn execute_copies_large_file() {
     let temp = create_tempdir();
@@ -389,7 +391,6 @@ fn execute_copies_large_file() {
     assert_eq!(fs::read(&destination).expect("read dest"), large_content);
 }
 
-
 #[test]
 fn execute_copies_multiple_files_to_directory() {
     let temp = create_tempdir();
@@ -411,11 +412,19 @@ fn execute_copies_multiple_files_to_directory() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 3);
-    assert_eq!(fs::read(dest_root.join("file1.txt")).expect("read"), b"content1");
-    assert_eq!(fs::read(dest_root.join("file2.txt")).expect("read"), b"content2");
-    assert_eq!(fs::read(dest_root.join("file3.txt")).expect("read"), b"content3");
+    assert_eq!(
+        fs::read(dest_root.join("file1.txt")).expect("read"),
+        b"content1"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("file2.txt")).expect("read"),
+        b"content2"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("file3.txt")).expect("read"),
+        b"content3"
+    );
 }
-
 
 #[test]
 fn execute_dry_run_does_not_create_destination() {
@@ -435,7 +444,10 @@ fn execute_dry_run_does_not_create_destination() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert!(!destination.exists(), "dry run should not create destination");
+    assert!(
+        !destination.exists(),
+        "dry run should not create destination"
+    );
 }
 
 #[test]
@@ -460,7 +472,6 @@ fn execute_dry_run_does_not_modify_existing_destination() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"original");
 }
 
-
 #[test]
 fn execute_with_inplace_updates_existing_file() {
     let temp = create_tempdir();
@@ -483,9 +494,11 @@ fn execute_with_inplace_updates_existing_file() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"updated content");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"updated content"
+    );
 }
-
 
 #[test]
 fn execute_with_partial_enabled_creates_partial_file_on_success() {
@@ -511,7 +524,6 @@ fn execute_with_partial_enabled_creates_partial_file_on_success() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"partial test");
 }
 
-
 #[cfg(unix)]
 #[test]
 fn execute_preserves_permissions_when_enabled() {
@@ -522,7 +534,9 @@ fn execute_preserves_permissions_when_enabled() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"perms").expect("write source");
 
-    let mut perms = fs::metadata(&source).expect("source metadata").permissions();
+    let mut perms = fs::metadata(&source)
+        .expect("source metadata")
+        .permissions();
     perms.set_mode(0o600);
     fs::set_permissions(&source, perms).expect("set source perms");
 
@@ -540,10 +554,11 @@ fn execute_preserves_permissions_when_enabled() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+    let dest_perms = fs::metadata(&destination)
+        .expect("dest metadata")
+        .permissions();
     assert_eq!(dest_perms.mode() & 0o777, 0o600);
 }
-
 
 #[test]
 fn execute_preserves_modification_time_when_enabled() {
@@ -569,12 +584,10 @@ fn execute_preserves_modification_time_when_enabled() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    let dest_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata"),
-    );
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
     assert_eq!(dest_mtime, past_time);
 }
-
 
 #[test]
 fn execute_with_whole_file_always_copies() {
@@ -586,9 +599,8 @@ fn execute_with_whole_file_always_copies() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write identical dest");
 
-    let source_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&source).expect("source metadata"),
-    );
+    let source_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&source).expect("source metadata"));
     set_file_mtime(&destination, source_mtime).expect("set dest mtime");
 
     let operands = vec![
@@ -600,13 +612,14 @@ fn execute_with_whole_file_always_copies() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().whole_file(true).ignore_times(true),
+            LocalCopyOptions::default()
+                .whole_file(true)
+                .ignore_times(true),
         )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
 }
-
 
 #[test]
 fn execute_copies_deeply_nested_directory() {
@@ -628,10 +641,18 @@ fn execute_copies_deeply_nested_directory() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    let dest_file = dest_root.join("source").join("a").join("b").join("c").join("d").join("deep.txt");
-    assert_eq!(fs::read(&dest_file).expect("read deep file"), b"deep content");
+    let dest_file = dest_root
+        .join("source")
+        .join("a")
+        .join("b")
+        .join("c")
+        .join("d")
+        .join("deep.txt");
+    assert_eq!(
+        fs::read(&dest_file).expect("read deep file"),
+        b"deep content"
+    );
 }
-
 
 #[test]
 fn execute_file_copy_to_directory_places_file_inside() {
@@ -657,7 +678,6 @@ fn execute_file_copy_to_directory_places_file_inside() {
     assert!(target_file.exists());
     assert_eq!(fs::read(&target_file).expect("read"), b"content");
 }
-
 
 #[test]
 fn execute_summary_tracks_total_source_bytes() {
@@ -688,7 +708,11 @@ fn execute_summary_tracks_directories_created() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(source_root.join("dir1").join("subdir")).expect("create dirs");
     fs::create_dir_all(source_root.join("dir2")).expect("create dir2");
-    fs::write(source_root.join("dir1").join("subdir").join("file.txt"), b"f").expect("write");
+    fs::write(
+        source_root.join("dir1").join("subdir").join("file.txt"),
+        b"f",
+    )
+    .expect("write");
 
     let dest_root = temp.path().join("dest");
     let operands = vec![
@@ -702,10 +726,15 @@ fn execute_summary_tracks_directories_created() {
         .expect("copy succeeds");
 
     assert!(summary.directories_created() >= 3);
-    assert!(dest_root.join("source").join("dir1").join("subdir").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir1")
+            .join("subdir")
+            .exists()
+    );
     assert!(dest_root.join("source").join("dir2").exists());
 }
-
 
 #[test]
 fn execute_basic_single_file_copy() {
@@ -726,7 +755,10 @@ fn execute_basic_single_file_copy() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"basic copy test");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"basic copy test"
+    );
 }
 
 #[test]
@@ -756,7 +788,10 @@ fn execute_overwrites_existing_file_with_different_content() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"new content here");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"new content here"
+    );
 }
 
 #[test]
@@ -812,7 +847,6 @@ fn execute_creates_intermediate_directories_with_mkpath() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"nested");
 }
 
-
 #[test]
 fn execute_copies_empty_directory() {
     let temp = create_tempdir();
@@ -856,8 +890,14 @@ fn execute_copies_directory_with_files() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 2);
-    assert_eq!(fs::read(dest_root.join("source").join("file1.txt")).expect("read"), b"content1");
-    assert_eq!(fs::read(dest_root.join("source").join("file2.txt")).expect("read"), b"content2");
+    assert_eq!(
+        fs::read(dest_root.join("source").join("file1.txt")).expect("read"),
+        b"content1"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("source").join("file2.txt")).expect("read"),
+        b"content2"
+    );
 }
 
 #[test]
@@ -881,10 +921,15 @@ fn execute_copies_nested_directories() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 2);
-    assert_eq!(fs::read(dest_root.join("source").join("root.txt")).expect("read"), b"root");
-    assert_eq!(fs::read(dest_root.join("source").join("subdir").join("nested.txt")).expect("read"), b"nested");
+    assert_eq!(
+        fs::read(dest_root.join("source").join("root.txt")).expect("read"),
+        b"root"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("source").join("subdir").join("nested.txt")).expect("read"),
+        b"nested"
+    );
 }
-
 
 // Gated to unix until the Windows local-copy executor honours
 // `times(false)` after `CopyFileExW` preserves the source timestamps.
@@ -915,9 +960,8 @@ fn execute_does_not_preserve_timestamps_by_default() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata"),
-    );
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
 
     assert_ne!(dest_mtime, past_time);
 }
@@ -958,12 +1002,10 @@ fn execute_preserves_timestamps_across_multiple_files() {
     let dest_file1 = dest_root.join("source").join("file1.txt");
     let dest_file2 = dest_root.join("source").join("file2.txt");
 
-    let dest_mtime1 = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file1).expect("file1 metadata"),
-    );
-    let dest_mtime2 = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file2).expect("file2 metadata"),
-    );
+    let dest_mtime1 =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file1).expect("file1 metadata"));
+    let dest_mtime2 =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file2).expect("file2 metadata"));
 
     assert_eq!(dest_mtime1, time1);
     assert_eq!(dest_mtime2, time2);
@@ -996,12 +1038,10 @@ fn execute_preserves_very_old_timestamps() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata"),
-    );
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
     assert_eq!(dest_mtime, very_old);
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1014,7 +1054,9 @@ fn execute_does_not_preserve_permissions_by_default() {
 
     fs::write(&source, b"perms").expect("write source");
 
-    let mut perms = fs::metadata(&source).expect("source metadata").permissions();
+    let mut perms = fs::metadata(&source)
+        .expect("source metadata")
+        .permissions();
     // 0o777 makes every umask bit observable in the destination mode.
     perms.set_mode(0o777);
     fs::set_permissions(&source, perms).expect("set source perms");
@@ -1031,7 +1073,9 @@ fn execute_does_not_preserve_permissions_by_default() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+    let dest_perms = fs::metadata(&destination)
+        .expect("dest metadata")
+        .permissions();
     // Without --perms a new destination takes `flist_mode & (~CHMOD_BITS |
     // dflt_perms)` where dflt_perms is `ACCESSPERMS & ~orig_umask`
     // (upstream: rsync.c dest_mode(), exists == 0) - i.e. the source mode with
@@ -1039,7 +1083,10 @@ fn execute_does_not_preserve_permissions_by_default() {
     // also fails at umask 000, where the old inequality could not distinguish
     // "not preserved" from "preserved".
     // `::` because `local_copy::test_support` shadows the crate name here.
-    assert_eq!(dest_perms.mode() & 0o777, ::test_support::umask_masked(0o777));
+    assert_eq!(
+        dest_perms.mode() & 0o777,
+        ::test_support::umask_masked(0o777)
+    );
 }
 
 #[cfg(unix)]
@@ -1053,7 +1100,9 @@ fn execute_preserves_executable_bit() {
 
     fs::write(&source, b"#!/bin/bash\necho test").expect("write source");
 
-    let mut perms = fs::metadata(&source).expect("source metadata").permissions();
+    let mut perms = fs::metadata(&source)
+        .expect("source metadata")
+        .permissions();
     perms.set_mode(0o755);
     fs::set_permissions(&source, perms).expect("set source perms");
 
@@ -1072,7 +1121,9 @@ fn execute_preserves_executable_bit() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+    let dest_perms = fs::metadata(&destination)
+        .expect("dest metadata")
+        .permissions();
     assert_eq!(dest_perms.mode() & 0o777, 0o755);
 }
 
@@ -1087,7 +1138,9 @@ fn execute_preserves_read_only_permissions() {
 
     fs::write(&source, b"readonly").expect("write source");
 
-    let mut perms = fs::metadata(&source).expect("source metadata").permissions();
+    let mut perms = fs::metadata(&source)
+        .expect("source metadata")
+        .permissions();
     perms.set_mode(0o444);
     fs::set_permissions(&source, perms).expect("set source perms");
 
@@ -1106,7 +1159,9 @@ fn execute_preserves_read_only_permissions() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+    let dest_perms = fs::metadata(&destination)
+        .expect("dest metadata")
+        .permissions();
     assert_eq!(dest_perms.mode() & 0o777, 0o444);
 }
 
@@ -1148,15 +1203,22 @@ fn execute_preserves_permissions_across_directory_tree() {
     let dest_file2 = dest_root.join("source").join("private.txt");
 
     assert_eq!(
-        fs::metadata(&dest_file1).expect("file1 metadata").permissions().mode() & 0o777,
+        fs::metadata(&dest_file1)
+            .expect("file1 metadata")
+            .permissions()
+            .mode()
+            & 0o777,
         0o644
     );
     assert_eq!(
-        fs::metadata(&dest_file2).expect("file2 metadata").permissions().mode() & 0o777,
+        fs::metadata(&dest_file2)
+            .expect("file2 metadata")
+            .permissions()
+            .mode()
+            & 0o777,
         0o600
     );
 }
-
 
 #[test]
 fn execute_preserves_both_times_and_permissions() {
@@ -1171,7 +1233,9 @@ fn execute_preserves_both_times_and_permissions() {
 
     #[cfg(unix)]
     {
-        let mut perms = fs::metadata(&source).expect("source metadata").permissions();
+        let mut perms = fs::metadata(&source)
+            .expect("source metadata")
+            .permissions();
         perms.set_mode(0o640);
         fs::set_permissions(&source, perms).expect("set source perms");
     }
@@ -1203,7 +1267,6 @@ fn execute_preserves_both_times_and_permissions() {
         assert_eq!(dest_metadata.permissions().mode() & 0o777, 0o640);
     }
 }
-
 
 #[test]
 fn execute_handles_various_file_sizes() {
@@ -1271,7 +1334,6 @@ fn execute_copies_file_exactly_one_block_size() {
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
 
-
 #[test]
 fn execute_copies_binary_data_correctly() {
     let temp = create_tempdir();
@@ -1323,7 +1385,6 @@ fn execute_copies_file_with_null_bytes() {
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
 
-
 #[test]
 fn execute_summary_counts_bytes_correctly() {
     let temp = create_tempdir();
@@ -1359,9 +1420,8 @@ fn execute_summary_reports_zero_for_no_changes() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
 
-    let source_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&source).expect("source metadata"),
-    );
+    let source_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&source).expect("source metadata"));
     set_file_mtime(&destination, source_mtime).expect("set dest mtime");
 
     let operands = vec![
@@ -1380,7 +1440,6 @@ fn execute_summary_reports_zero_for_no_changes() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.bytes_copied(), 0);
 }
-
 
 #[test]
 fn execute_handles_filename_with_spaces() {
@@ -1458,7 +1517,10 @@ fn execute_handles_deep_directory_nesting() {
     }
     expected_path = expected_path.join("deep.txt");
     assert!(expected_path.exists());
-    assert_eq!(fs::read(&expected_path).expect("read deep file"), b"very deep");
+    assert_eq!(
+        fs::read(&expected_path).expect("read deep file"),
+        b"very deep"
+    );
 }
 
 #[test]
@@ -1485,7 +1547,6 @@ fn execute_copies_multiple_empty_directories() {
     assert!(dest_root.join("source").join("empty2").is_dir());
     assert!(dest_root.join("source").join("empty3").is_dir());
 }
-
 
 #[test]
 fn execute_dry_run_reports_correct_statistics() {

--- a/crates/engine/src/local_copy/tests/execute_block_size.rs
+++ b/crates/engine/src/local_copy/tests/execute_block_size.rs
@@ -1,5 +1,3 @@
-
-
 #[test]
 fn block_size_override_default_is_none() {
     let opts = LocalCopyOptions::default();
@@ -51,7 +49,6 @@ fn block_size_builder_none_clears_override() {
         .expect("valid options");
     assert!(opts.block_size_override().is_none());
 }
-
 
 #[test]
 fn block_size_override_affects_delta_matching_small_block() {

--- a/crates/engine/src/local_copy/tests/execute_checksum_seed.rs
+++ b/crates/engine/src/local_copy/tests/execute_checksum_seed.rs
@@ -1,4 +1,3 @@
-
 //
 // Upstream rsync behavior:
 // - Without --checksum-seed: the seed is negotiated automatically (typically
@@ -6,7 +5,6 @@
 // - With --checksum-seed=N: a fixed seed is used for all checksum computations,
 //   producing deterministic results across runs. This is useful for debugging,
 //   testing, and batch mode reproducibility.
-
 
 #[test]
 fn checksum_seed_defaults_to_none() {
@@ -92,12 +90,9 @@ fn checksum_seed_new_defaults_to_none() {
     );
 }
 
-
 #[test]
 fn checksum_seed_builder_defaults_to_none() {
-    let opts = LocalCopyOptions::builder()
-        .build()
-        .expect("valid options");
+    let opts = LocalCopyOptions::builder().build().expect("valid options");
     assert_eq!(
         opts.checksum_seed(),
         None,
@@ -183,7 +178,6 @@ fn checksum_seed_build_unchecked_works() {
         "build_unchecked should preserve checksum_seed"
     );
 }
-
 
 #[test]
 fn checksum_seed_compatible_with_checksum_mode() {
@@ -451,7 +445,6 @@ fn transfer_with_checksum_seed_and_delete() {
     );
     assert!(summary.items_deleted() >= 1, "should report deletion");
 }
-
 
 #[test]
 fn checksum_seed_round_trip_direct() {

--- a/crates/engine/src/local_copy/tests/execute_chown.rs
+++ b/crates/engine/src/local_copy/tests/execute_chown.rs
@@ -1,4 +1,3 @@
-
 #[cfg(unix)]
 #[test]
 fn execute_applies_owner_override() {

--- a/crates/engine/src/local_copy/tests/execute_compare_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_compare_dest.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn compare_dest_skips_identical_file() {
     let temp = tempdir().expect("tempdir");
@@ -38,7 +37,10 @@ fn compare_dest_skips_identical_file() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(!dest_file.exists(), "file should not be created when identical to compare-dest");
+    assert!(
+        !dest_file.exists(),
+        "file should not be created when identical to compare-dest"
+    );
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 }
@@ -195,7 +197,10 @@ fn compare_dest_transfers_different_file() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(dest_file.exists(), "file should be created when different from compare-dest");
+    assert!(
+        dest_file.exists(),
+        "file should be created when different from compare-dest"
+    );
     assert_eq!(fs::read(&dest_file).expect("read dest"), b"source content");
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
@@ -241,8 +246,14 @@ fn compare_dest_transfers_when_mtime_differs() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(dest_file.exists(), "file should be created when mtime differs");
-    assert_eq!(fs::read(&dest_file).expect("read dest"), b"identical content");
+    assert!(
+        dest_file.exists(),
+        "file should be created when mtime differs"
+    );
+    assert_eq!(
+        fs::read(&dest_file).expect("read dest"),
+        b"identical content"
+    );
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
 }
@@ -283,7 +294,10 @@ fn compare_dest_transfers_file_not_in_compare() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(dest_file.exists(), "file should be created when not in compare-dest");
+    assert!(
+        dest_file.exists(),
+        "file should be created when not in compare-dest"
+    );
     assert_eq!(fs::read(&dest_file).expect("read dest"), b"new file");
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
@@ -333,7 +347,10 @@ fn compare_dest_multiple_directories_first_match_wins() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(!dest_file.exists(), "file should not be created when first compare-dest matches");
+    assert!(
+        !dest_file.exists(),
+        "file should not be created when first compare-dest matches"
+    );
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 }
@@ -382,7 +399,10 @@ fn compare_dest_multiple_directories_checks_all_until_match() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(!dest_file.exists(), "file should not be created when second compare-dest matches");
+    assert!(
+        !dest_file.exists(),
+        "file should not be created when second compare-dest matches"
+    );
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 }
@@ -431,7 +451,10 @@ fn compare_dest_multiple_directories_transfers_when_none_match() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(dest_file.exists(), "file should be created when no compare-dest matches");
+    assert!(
+        dest_file.exists(),
+        "file should be created when no compare-dest matches"
+    );
     assert_eq!(fs::read(&dest_file).expect("read dest"), b"source content");
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
@@ -473,10 +496,7 @@ fn compare_dest_with_recursive_transfer() {
     let mut source_operand = source_dir.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
 
-    let operands = vec![
-        source_operand,
-        dest_dir.clone().into_os_string(),
-    ];
+    let operands = vec![source_operand, dest_dir.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default()
@@ -494,8 +514,14 @@ fn compare_dest_with_recursive_transfer() {
     let dest_file1 = dest_dir.join("file1.txt");
     let dest_file2 = dest_dir.join("subdir/file2.txt");
 
-    assert!(!dest_file1.exists(), "file1 should not be created when identical");
-    assert!(dest_file2.exists(), "file2 should be created when different");
+    assert!(
+        !dest_file1.exists(),
+        "file1 should not be created when identical"
+    );
+    assert!(
+        dest_file2.exists(),
+        "file2 should be created when different"
+    );
     assert_eq!(fs::read(&dest_file2).expect("read dest file2"), b"content2");
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 1);
@@ -542,7 +568,10 @@ fn compare_dest_with_size_only_option() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(!dest_file.exists(), "file should not be created when size matches with --size-only");
+    assert!(
+        !dest_file.exists(),
+        "file should not be created when size matches with --size-only"
+    );
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 }
@@ -588,7 +617,10 @@ fn compare_dest_with_checksum_option() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(!dest_file.exists(), "file should not be created when checksum matches even with different mtime");
+    assert!(
+        !dest_file.exists(),
+        "file should not be created when checksum matches even with different mtime"
+    );
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 }
@@ -638,7 +670,10 @@ fn compare_dest_relative_path_resolution() {
         .expect("execution succeeds");
 
     let dest_file = dest_dir.join("sub/file.txt");
-    assert!(!dest_file.exists(), "file should not be created when identical to compare-dest");
+    assert!(
+        !dest_file.exists(),
+        "file should not be created when identical to compare-dest"
+    );
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 }
@@ -688,7 +723,10 @@ fn compare_dest_mixed_with_copy_dest() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(dest_file.exists(), "file should be created via copy-dest when compare-dest doesn't match");
+    assert!(
+        dest_file.exists(),
+        "file should be created via copy-dest when compare-dest doesn't match"
+    );
     assert_eq!(fs::read(&dest_file).expect("read dest"), b"content");
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
@@ -730,8 +768,14 @@ fn compare_dest_empty_reference_directory_transfers_file() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(dest_file.exists(), "file should be created when compare-dest is empty");
-    assert_eq!(fs::read(&dest_file).expect("read dest"), b"empty ref content");
+    assert!(
+        dest_file.exists(),
+        "file should be created when compare-dest is empty"
+    );
+    assert_eq!(
+        fs::read(&dest_file).expect("read dest"),
+        b"empty ref content"
+    );
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
 }
@@ -777,7 +821,10 @@ fn compare_dest_with_inplace_mode() {
         .expect("execution succeeds");
 
     // With --inplace and compare-dest matching, the file should still be skipped
-    assert!(!dest_file.exists(), "file should not be created when identical to compare-dest even with --inplace");
+    assert!(
+        !dest_file.exists(),
+        "file should not be created when identical to compare-dest even with --inplace"
+    );
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 }
@@ -818,7 +865,10 @@ fn compare_dest_with_nonexistent_directory() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(dest_file.exists(), "file should be created when compare-dest doesn't exist");
+    assert!(
+        dest_file.exists(),
+        "file should be created when compare-dest doesn't exist"
+    );
     assert_eq!(fs::read(&dest_file).expect("read dest"), b"content");
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
@@ -863,7 +913,10 @@ fn compare_dest_skips_identical_empty_file() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("execution succeeds");
 
-    assert!(!dest_file.exists(), "empty identical file should be skipped");
+    assert!(
+        !dest_file.exists(),
+        "empty identical file should be skipped"
+    );
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 }
@@ -922,11 +975,27 @@ fn compare_dest_content_match_attrs_differ_copies() {
         dest_file.exists(),
         "a level-2 compare-dest basis must be copied into the destination"
     );
-    assert_eq!(fs::read(&dest_file).expect("read dest"), b"identical content");
-    assert_eq!(dest_file.metadata().expect("dest meta").permissions().mode() & 0o777, 0o644);
+    assert_eq!(
+        fs::read(&dest_file).expect("read dest"),
+        b"identical content"
+    );
+    assert_eq!(
+        dest_file
+            .metadata()
+            .expect("dest meta")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o644
+    );
     // The compare basis inode is untouched.
     assert_eq!(
-        compare_file.metadata().expect("compare meta").permissions().mode() & 0o777,
+        compare_file
+            .metadata()
+            .expect("compare meta")
+            .permissions()
+            .mode()
+            & 0o777,
         0o600,
     );
 }

--- a/crates/engine/src/local_copy/tests/execute_contimeout.rs
+++ b/crates/engine/src/local_copy/tests/execute_contimeout.rs
@@ -203,8 +203,7 @@ fn transfer_works_with_contimeout_set() {
     let ctx = test_helpers::setup_copy_test();
     ctx.write_source("file.txt", b"hello contimeout");
 
-    let options = LocalCopyOptions::default()
-        .with_contimeout(Some(Duration::from_secs(30)));
+    let options = LocalCopyOptions::default().with_contimeout(Some(Duration::from_secs(30)));
 
     let operands = ctx.operands_with_trailing_separator();
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
@@ -242,8 +241,7 @@ fn transfer_works_with_zero_contimeout() {
     let ctx = test_helpers::setup_copy_test();
     ctx.write_source("file.txt", b"zero contimeout");
 
-    let options = LocalCopyOptions::default()
-        .with_contimeout(Some(Duration::ZERO));
+    let options = LocalCopyOptions::default().with_contimeout(Some(Duration::ZERO));
 
     let operands = ctx.operands_with_trailing_separator();
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");

--- a/crates/engine/src/local_copy/tests/execute_copy_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_copy_dest.rs
@@ -1,5 +1,3 @@
-
-
 #[test]
 fn copy_dest_identical_file_is_copied_not_linked() {
     let temp = tempdir().expect("tempdir");
@@ -37,8 +35,14 @@ fn copy_dest_identical_file_is_copied_not_linked() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(destination_file.exists(), "destination file should be created");
-    assert_eq!(fs::read(&destination_file).expect("read dest"), b"identical content");
+    assert!(
+        destination_file.exists(),
+        "destination file should be created"
+    );
+    assert_eq!(
+        fs::read(&destination_file).expect("read dest"),
+        b"identical content"
+    );
     assert_eq!(summary.files_copied(), 1);
 
     #[cfg(unix)]
@@ -46,7 +50,11 @@ fn copy_dest_identical_file_is_copied_not_linked() {
         use std::os::unix::fs::MetadataExt;
         let dest_meta = fs::metadata(&destination_file).expect("dest metadata");
         let copy_dest_meta = fs::metadata(&copy_dest_file).expect("copy_dest metadata");
-        assert_ne!(dest_meta.ino(), copy_dest_meta.ino(), "should be different files, not hard linked");
+        assert_ne!(
+            dest_meta.ino(),
+            copy_dest_meta.ino(),
+            "should be different files, not hard linked"
+        );
     }
 }
 
@@ -91,8 +99,14 @@ fn copy_dest_different_file_uses_delta_transfer() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(destination_file.exists(), "destination file should be created");
-    assert_eq!(fs::read(&destination_file).expect("read dest"), b"updated content here");
+    assert!(
+        destination_file.exists(),
+        "destination file should be created"
+    );
+    assert_eq!(
+        fs::read(&destination_file).expect("read dest"),
+        b"updated content here"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -118,8 +132,8 @@ fn copy_dest_missing_file_transfers_normally() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .extend_reference_directories([ReferenceDirectory::new(
+    let options =
+        LocalCopyOptions::default().extend_reference_directories([ReferenceDirectory::new(
             ReferenceDirectoryKind::Copy,
             &copy_dest_dir,
         )]);
@@ -128,11 +142,16 @@ fn copy_dest_missing_file_transfers_normally() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(destination_file.exists(), "destination file should be created");
-    assert_eq!(fs::read(&destination_file).expect("read dest"), b"new file content");
+    assert!(
+        destination_file.exists(),
+        "destination file should be created"
+    );
+    assert_eq!(
+        fs::read(&destination_file).expect("read dest"),
+        b"new file content"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
-
 
 #[test]
 fn copy_dest_multiple_directories_checks_in_order() {
@@ -176,8 +195,14 @@ fn copy_dest_multiple_directories_checks_in_order() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(destination_file.exists(), "destination file should be created");
-    assert_eq!(fs::read(&destination_file).expect("read dest"), b"source content");
+    assert!(
+        destination_file.exists(),
+        "destination file should be created"
+    );
+    assert_eq!(
+        fs::read(&destination_file).expect("read dest"),
+        b"source content"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -223,8 +248,14 @@ fn copy_dest_multiple_directories_uses_first_match() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(destination_file.exists(), "destination file should be created");
-    assert_eq!(fs::read(&destination_file).expect("read dest"), b"matching content");
+    assert!(
+        destination_file.exists(),
+        "destination file should be created"
+    );
+    assert_eq!(
+        fs::read(&destination_file).expect("read dest"),
+        b"matching content"
+    );
     assert_eq!(summary.files_copied(), 1);
 
     // Both directories had matching files, but first one should be used
@@ -239,7 +270,6 @@ fn copy_dest_multiple_directories_uses_first_match() {
         assert_ne!(dest_meta.ino(), copy_dest2_meta.ino());
     }
 }
-
 
 #[test]
 fn copy_dest_creates_file_while_compare_dest_skips() {
@@ -280,7 +310,10 @@ fn copy_dest_creates_file_while_compare_dest_skips() {
         .execute_with_options(LocalCopyExecution::Apply, options_compare)
         .expect("compare succeeds");
 
-    assert!(!dest_compare_file.exists(), "compare-dest should skip file creation");
+    assert!(
+        !dest_compare_file.exists(),
+        "compare-dest should skip file creation"
+    );
     assert_eq!(summary_compare.files_copied(), 0);
     assert_eq!(summary_compare.regular_files_matched(), 1);
 
@@ -307,7 +340,6 @@ fn copy_dest_creates_file_while_compare_dest_skips() {
     assert_eq!(summary_copy.files_copied(), 1);
 }
 
-
 #[test]
 fn copy_dest_works_with_directory_trees() {
     let temp = tempdir().expect("tempdir");
@@ -321,13 +353,17 @@ fn copy_dest_works_with_directory_trees() {
 
     fs::create_dir_all(copy_dest_root.join("dir1/subdir")).expect("create copy_dest tree");
     fs::write(copy_dest_root.join("dir1/file1.txt"), b"file1").expect("write copy_dest file1");
-    fs::write(copy_dest_root.join("dir1/subdir/file2.txt"), b"file2").expect("write copy_dest file2");
+    fs::write(copy_dest_root.join("dir1/subdir/file2.txt"), b"file2")
+        .expect("write copy_dest file2");
 
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(source_root.join("dir1/file1.txt"), timestamp).expect("source file1 mtime");
-    set_file_mtime(source_root.join("dir1/subdir/file2.txt"), timestamp).expect("source file2 mtime");
-    set_file_mtime(copy_dest_root.join("dir1/file1.txt"), timestamp).expect("copy_dest file1 mtime");
-    set_file_mtime(copy_dest_root.join("dir1/subdir/file2.txt"), timestamp).expect("copy_dest file2 mtime");
+    set_file_mtime(source_root.join("dir1/subdir/file2.txt"), timestamp)
+        .expect("source file2 mtime");
+    set_file_mtime(copy_dest_root.join("dir1/file1.txt"), timestamp)
+        .expect("copy_dest file1 mtime");
+    set_file_mtime(copy_dest_root.join("dir1/subdir/file2.txt"), timestamp)
+        .expect("copy_dest file2 mtime");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -348,8 +384,14 @@ fn copy_dest_works_with_directory_trees() {
 
     assert!(destination_root.join("dir1/file1.txt").exists());
     assert!(destination_root.join("dir1/subdir/file2.txt").exists());
-    assert_eq!(fs::read(destination_root.join("dir1/file1.txt")).expect("read"), b"file1");
-    assert_eq!(fs::read(destination_root.join("dir1/subdir/file2.txt")).expect("read"), b"file2");
+    assert_eq!(
+        fs::read(destination_root.join("dir1/file1.txt")).expect("read"),
+        b"file1"
+    );
+    assert_eq!(
+        fs::read(destination_root.join("dir1/subdir/file2.txt")).expect("read"),
+        b"file2"
+    );
     assert_eq!(summary.files_copied(), 2);
 }
 
@@ -399,12 +441,20 @@ fn copy_dest_mixed_existing_and_new_files() {
     assert!(destination_root.join("file1.txt").exists());
     assert!(destination_root.join("file2.txt").exists());
     assert!(destination_root.join("file3.txt").exists());
-    assert_eq!(fs::read(destination_root.join("file1.txt")).expect("read"), b"content1");
-    assert_eq!(fs::read(destination_root.join("file2.txt")).expect("read"), b"content2");
-    assert_eq!(fs::read(destination_root.join("file3.txt")).expect("read"), b"content3");
+    assert_eq!(
+        fs::read(destination_root.join("file1.txt")).expect("read"),
+        b"content1"
+    );
+    assert_eq!(
+        fs::read(destination_root.join("file2.txt")).expect("read"),
+        b"content2"
+    );
+    assert_eq!(
+        fs::read(destination_root.join("file3.txt")).expect("read"),
+        b"content3"
+    );
     assert_eq!(summary.files_copied(), 3);
 }
-
 
 #[test]
 fn copy_dest_with_checksum_validates_content() {
@@ -456,7 +506,6 @@ fn copy_dest_with_checksum_validates_content() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-
 #[test]
 fn copy_dest_ignores_non_regular_files() {
     let temp = tempdir().expect("tempdir");
@@ -481,8 +530,8 @@ fn copy_dest_ignores_non_regular_files() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .extend_reference_directories([ReferenceDirectory::new(
+    let options =
+        LocalCopyOptions::default().extend_reference_directories([ReferenceDirectory::new(
             ReferenceDirectoryKind::Copy,
             &copy_dest_dir,
         )]);
@@ -494,7 +543,10 @@ fn copy_dest_ignores_non_regular_files() {
     // Should transfer normally since copy_dest has a directory, not a file
     assert!(destination_file.exists());
     assert!(destination_file.is_file());
-    assert_eq!(fs::read(&destination_file).expect("read dest"), b"regular file");
+    assert_eq!(
+        fs::read(&destination_file).expect("read dest"),
+        b"regular file"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -516,7 +568,8 @@ fn copy_dest_with_size_only_mode() {
     fs::write(&copy_dest_file, b"abcde").expect("write copy_dest");
 
     set_file_mtime(&source_file, FileTime::from_unix_time(1_700_000_000, 0)).expect("source mtime");
-    set_file_mtime(&copy_dest_file, FileTime::from_unix_time(1_600_000_000, 0)).expect("copy_dest mtime");
+    set_file_mtime(&copy_dest_file, FileTime::from_unix_time(1_600_000_000, 0))
+        .expect("copy_dest mtime");
 
     let destination_file = destination_dir.join("file.txt");
     let operands = vec![
@@ -561,8 +614,8 @@ fn copy_dest_empty_reference_directory() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .extend_reference_directories([ReferenceDirectory::new(
+    let options =
+        LocalCopyOptions::default().extend_reference_directories([ReferenceDirectory::new(
             ReferenceDirectoryKind::Copy,
             &copy_dest_dir,
         )]);
@@ -575,7 +628,6 @@ fn copy_dest_empty_reference_directory() {
     assert_eq!(fs::read(&destination_file).expect("read dest"), b"content");
     assert_eq!(summary.files_copied(), 1);
 }
-
 
 #[test]
 fn copy_dest_with_inplace_mode_still_copies() {
@@ -618,10 +670,12 @@ fn copy_dest_with_inplace_mode_still_copies() {
 
     // With --inplace, copy-dest should still create the file
     assert!(destination_file.exists());
-    assert_eq!(fs::read(&destination_file).expect("read dest"), b"inplace content");
+    assert_eq!(
+        fs::read(&destination_file).expect("read dest"),
+        b"inplace content"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
-
 
 #[test]
 fn copy_dest_nonexistent_directory_transfers_normally() {
@@ -643,8 +697,8 @@ fn copy_dest_nonexistent_directory_transfers_normally() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .extend_reference_directories([ReferenceDirectory::new(
+    let options =
+        LocalCopyOptions::default().extend_reference_directories([ReferenceDirectory::new(
             ReferenceDirectoryKind::Copy,
             &copy_dest_dir,
         )]);
@@ -654,10 +708,12 @@ fn copy_dest_nonexistent_directory_transfers_normally() {
         .expect("copy succeeds");
 
     assert!(destination_file.exists());
-    assert_eq!(fs::read(&destination_file).expect("read dest"), b"orphan content");
+    assert_eq!(
+        fs::read(&destination_file).expect("read dest"),
+        b"orphan content"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
-
 
 #[test]
 fn copy_dest_copies_zero_length_file() {

--- a/crates/engine/src/local_copy/tests/execute_copy_links.rs
+++ b/crates/engine/src/local_copy/tests/execute_copy_links.rs
@@ -54,9 +54,7 @@ fn copy_links_follows_directory_symlink_recursively() {
     let operands = vec![link.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .copy_links(true)
-        .recursive(true);
+    let options = LocalCopyOptions::default().copy_links(true).recursive(true);
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
@@ -64,8 +62,14 @@ fn copy_links_follows_directory_symlink_recursively() {
     assert!(metadata.file_type().is_dir());
     assert!(!metadata.file_type().is_symlink());
 
-    assert_eq!(fs::read(dest.join("file1.txt")).expect("read file1"), b"content1");
-    assert_eq!(fs::read(dest.join("file2.txt")).expect("read file2"), b"content2");
+    assert_eq!(
+        fs::read(dest.join("file1.txt")).expect("read file1"),
+        b"content1"
+    );
+    assert_eq!(
+        fs::read(dest.join("file2.txt")).expect("read file2"),
+        b"content2"
+    );
     assert_eq!(
         fs::read(dest.join("subdir/file3.txt")).expect("read file3"),
         b"content3"
@@ -115,15 +119,10 @@ fn copy_links_skips_dangling_symlink_in_directory_tree() {
 
     let dest = temp.path().join("dest");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .copy_links(true)
-        .recursive(true);
+    let options = LocalCopyOptions::default().copy_links(true).recursive(true);
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
     assert!(result.is_err());
@@ -199,9 +198,7 @@ fn copy_links_detects_directory_loop_via_symlink() {
     let operands = vec![parent.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .copy_links(true)
-        .recursive(true);
+    let options = LocalCopyOptions::default().copy_links(true).recursive(true);
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
     // When copy_links is enabled, the symlink should be followed, which creates
@@ -320,26 +317,28 @@ fn copy_links_with_mixed_files_and_symlinks() {
 
     let dest = temp.path().join("dest");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .copy_links(true)
-        .recursive(true);
+    let options = LocalCopyOptions::default().copy_links(true).recursive(true);
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    let regular_meta = fs::symlink_metadata(dest.join("source").join("regular.txt")).expect("regular meta");
+    let regular_meta =
+        fs::symlink_metadata(dest.join("source").join("regular.txt")).expect("regular meta");
     assert!(regular_meta.file_type().is_file());
-    assert_eq!(fs::read(dest.join("source").join("regular.txt")).expect("read"), b"regular");
+    assert_eq!(
+        fs::read(dest.join("source").join("regular.txt")).expect("read"),
+        b"regular"
+    );
 
     let link_meta = fs::symlink_metadata(dest.join("source").join("link.txt")).expect("link meta");
     assert!(link_meta.file_type().is_file());
     assert!(!link_meta.file_type().is_symlink());
-    assert_eq!(fs::read(dest.join("source").join("link.txt")).expect("read"), b"linked");
+    assert_eq!(
+        fs::read(dest.join("source").join("link.txt")).expect("read"),
+        b"linked"
+    );
 
     assert_eq!(
         fs::read(dest.join("source").join("subdir/nested.txt")).expect("read"),
@@ -381,7 +380,7 @@ fn copy_links_without_recursive_follows_single_directory_symlink() {
 #[cfg(unix)]
 #[test]
 fn copy_links_preserves_file_permissions() {
-    use std::os::unix::fs::{symlink, PermissionsExt};
+    use std::os::unix::fs::{PermissionsExt, symlink};
 
     let temp = tempdir().expect("tempdir");
 
@@ -429,10 +428,7 @@ fn copy_links_does_not_follow_symlinks_in_tree_when_disabled() {
 
     let dest = temp.path().join("dest");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // Without copy_links, symlinks should be preserved
@@ -466,9 +462,7 @@ fn copy_links_with_symlink_to_empty_directory() {
     let operands = vec![link.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .copy_links(true)
-        .recursive(true);
+    let options = LocalCopyOptions::default().copy_links(true).recursive(true);
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
@@ -562,19 +556,15 @@ fn copy_links_nested_symlinks_in_directory_tree() {
 
     let dest = temp.path().join("dest");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .copy_links(true)
-        .recursive(true);
+    let options = LocalCopyOptions::default().copy_links(true).recursive(true);
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    let inner_meta = fs::symlink_metadata(dest.join("source").join("inner_link")).expect("inner meta");
+    let inner_meta =
+        fs::symlink_metadata(dest.join("source").join("inner_link")).expect("inner meta");
     assert!(inner_meta.file_type().is_file());
     assert!(!inner_meta.file_type().is_symlink());
     assert_eq!(
@@ -612,9 +602,7 @@ fn copy_links_preserves_timestamps_from_referent() {
     let operands = vec![link.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .copy_links(true)
-        .times(true);
+    let options = LocalCopyOptions::default().copy_links(true).times(true);
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
@@ -654,10 +642,7 @@ fn copy_links_follows_symlink_to_fifo_in_directory() {
 
     let dest = temp.path().join("dest");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default()
@@ -675,7 +660,10 @@ fn copy_links_follows_symlink_to_fifo_in_directory() {
     // The symlink to the FIFO should be dereferenced: the destination should
     // be a FIFO (not a symlink).
     let fifo_meta = fs::symlink_metadata(dest.join("source").join("fifo_link")).expect("fifo meta");
-    assert!(!fifo_meta.file_type().is_symlink(), "should not be a symlink");
+    assert!(
+        !fifo_meta.file_type().is_symlink(),
+        "should not be a symlink"
+    );
     {
         use std::os::unix::fs::FileTypeExt;
         assert!(
@@ -714,10 +702,7 @@ fn copy_links_follows_symlink_to_fifo_in_directory() {
 
     let dest = temp.path().join("dest");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default()
@@ -735,7 +720,10 @@ fn copy_links_follows_symlink_to_fifo_in_directory() {
     // The symlink to the FIFO should be dereferenced: the destination should
     // be a FIFO (not a symlink).
     let fifo_meta = fs::symlink_metadata(dest.join("source").join("fifo_link")).expect("fifo meta");
-    assert!(!fifo_meta.file_type().is_symlink(), "should not be a symlink");
+    assert!(
+        !fifo_meta.file_type().is_symlink(),
+        "should not be a symlink"
+    );
     {
         use std::os::unix::fs::FileTypeExt;
         assert!(
@@ -774,10 +762,7 @@ fn copy_links_replaces_existing_symlink_with_file() {
     let metadata = fs::symlink_metadata(&dest).expect("dest metadata");
     assert!(metadata.file_type().is_file());
     assert!(!metadata.file_type().is_symlink());
-    assert_eq!(
-        fs::read(&dest).expect("read dest"),
-        b"replacement content"
-    );
+    assert_eq!(fs::read(&dest).expect("read dest"), b"replacement content");
 }
 
 #[cfg(unix)]
@@ -802,22 +787,23 @@ fn copy_links_with_symlink_chain_in_directory_tree() {
 
     let dest = temp.path().join("dest");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .copy_links(true)
-        .recursive(true);
+    let options = LocalCopyOptions::default().copy_links(true).recursive(true);
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     for name in &["link_a", "link_b"] {
         let meta = fs::symlink_metadata(dest.join("source").join(name)).expect("meta");
-        assert!(meta.file_type().is_file(), "{name} should be a regular file");
-        assert!(!meta.file_type().is_symlink(), "{name} should not be a symlink");
+        assert!(
+            meta.file_type().is_file(),
+            "{name} should be a regular file"
+        );
+        assert!(
+            !meta.file_type().is_symlink(),
+            "{name} should not be a symlink"
+        );
         assert_eq!(
             fs::read(dest.join("source").join(name)).expect("read"),
             b"real data",

--- a/crates/engine/src/local_copy/tests/execute_created_stats.rs
+++ b/crates/engine/src/local_copy/tests/execute_created_stats.rs
@@ -78,7 +78,10 @@ fn updated_entries_are_not_counted_as_created() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::builder().archive().build().expect("options"),
+        LocalCopyOptions::builder()
+            .archive()
+            .build()
+            .expect("options"),
     )
     .expect("initial copy succeeds");
 
@@ -92,7 +95,10 @@ fn updated_entries_are_not_counted_as_created() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::builder().archive().build().expect("options"),
+            LocalCopyOptions::builder()
+                .archive()
+                .build()
+                .expect("options"),
         )
         .expect("second copy succeeds");
 
@@ -132,7 +138,10 @@ fn dry_run_counts_created_entries_like_a_real_run() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::DryRun,
-            LocalCopyOptions::builder().archive().build().expect("options"),
+            LocalCopyOptions::builder()
+                .archive()
+                .build()
+                .expect("options"),
         )
         .expect("dry run succeeds");
 

--- a/crates/engine/src/local_copy/tests/execute_delay_updates.rs
+++ b/crates/engine/src/local_copy/tests/execute_delay_updates.rs
@@ -14,7 +14,6 @@
 // 6. Hard links work correctly with delayed updates
 // 7. Metadata is applied after rename
 
-
 #[test]
 fn delay_updates_writes_to_temp_names_during_transfer() {
     let temp = create_tempdir();
@@ -109,8 +108,11 @@ fn delay_updates_no_temp_files_remain_after_success() {
 
     // Create multiple files to ensure all temp files are cleaned up
     for i in 0..10 {
-        fs::write(source_root.join(format!("file{i}.txt")), format!("content{i}"))
-            .expect("write source file");
+        fs::write(
+            source_root.join(format!("file{i}.txt")),
+            format!("content{i}"),
+        )
+        .expect("write source file");
     }
 
     let mut source_operand = source_root.into_os_string();
@@ -147,7 +149,6 @@ fn delay_updates_no_temp_files_remain_after_success() {
         "temp files should not remain after successful copy: {temp_files:?}"
     );
 }
-
 
 #[test]
 fn delay_updates_works_with_temp_dir() {
@@ -236,7 +237,6 @@ fn delay_updates_with_temp_dir_multiple_files() {
     assert!(staging_files.is_empty());
 }
 
-
 #[cfg(unix)]
 #[test]
 fn delay_updates_preserves_permissions() {
@@ -247,7 +247,9 @@ fn delay_updates_preserves_permissions() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"perms test").expect("write source");
 
-    let mut perms = fs::metadata(&source).expect("source metadata").permissions();
+    let mut perms = fs::metadata(&source)
+        .expect("source metadata")
+        .permissions();
     perms.set_mode(0o640);
     fs::set_permissions(&source, perms).expect("set source perms");
 
@@ -297,12 +299,10 @@ fn delay_updates_preserves_modification_time() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    let dest_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata"),
-    );
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
     assert_eq!(dest_mtime, past_time);
 }
-
 
 #[test]
 fn delay_updates_handles_nested_directories() {
@@ -313,11 +313,7 @@ fn delay_updates_handles_nested_directories() {
     fs::create_dir_all(source_root.join("a").join("b").join("c")).expect("nested dirs");
 
     fs::write(source_root.join("a").join("file1.txt"), b"level1").expect("write level1");
-    fs::write(
-        source_root.join("a").join("b").join("file2.txt"),
-        b"level2",
-    )
-    .expect("write level2");
+    fs::write(source_root.join("a").join("b").join("file2.txt"), b"level2").expect("write level2");
     fs::write(
         source_root.join("a").join("b").join("c").join("file3.txt"),
         b"level3",
@@ -343,15 +339,29 @@ fn delay_updates_handles_nested_directories() {
         b"level1"
     );
     assert_eq!(
-        fs::read(dest_root.join("source").join("a").join("b").join("file2.txt")).expect("read"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("a")
+                .join("b")
+                .join("file2.txt")
+        )
+        .expect("read"),
         b"level2"
     );
     assert_eq!(
-        fs::read(dest_root.join("source").join("a").join("b").join("c").join("file3.txt")).expect("read"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("a")
+                .join("b")
+                .join("c")
+                .join("file3.txt")
+        )
+        .expect("read"),
         b"level3"
     );
 }
-
 
 #[test]
 fn delay_updates_replaces_existing_files_atomically() {
@@ -377,7 +387,10 @@ fn delay_updates_replaces_existing_files_atomically() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"new content here");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"new content here"
+    );
 }
 
 #[test]
@@ -425,7 +438,6 @@ fn delay_updates_with_multiple_existing_files() {
         b"new content c"
     );
 }
-
 
 #[test]
 fn delay_updates_handles_empty_file() {
@@ -480,7 +492,6 @@ fn delay_updates_handles_large_file() {
     assert_eq!(fs::read(&destination).expect("read dest"), large_content);
 }
 
-
 #[test]
 fn delay_updates_dry_run_does_not_create_files() {
     let temp = create_tempdir();
@@ -502,7 +513,10 @@ fn delay_updates_dry_run_does_not_create_files() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert!(!destination.exists(), "destination should not exist in dry run");
+    assert!(
+        !destination.exists(),
+        "destination should not exist in dry run"
+    );
 }
 
 #[test]
@@ -529,7 +543,6 @@ fn delay_updates_dry_run_does_not_modify_existing() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&destination).expect("read dest"), b"original");
 }
-
 
 /// Asserts the `--delay-updates` staging contract survives a deletion sweep.
 ///
@@ -568,8 +581,7 @@ fn assert_delay_updates_finalizes_under_deletion(
     fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
     fs::write(dest_root.join("keep.txt"), b"stale keep").expect("write stale keep");
     fs::write(source_nested.join("keep.txt"), b"nested keep").expect("write nested keep");
-    fs::write(dest_nested.join("keep.txt"), b"stale nested keep")
-        .expect("write stale nested keep");
+    fs::write(dest_nested.join("keep.txt"), b"stale nested keep").expect("write stale nested keep");
 
     fs::write(dest_root.join("delete_me.txt"), b"extraneous").expect("write extraneous");
     fs::write(dest_nested.join("delete_me.txt"), b"extraneous nested")
@@ -636,7 +648,10 @@ fn delay_updates_with_delete_before_removes_extraneous() {
 
 #[test]
 fn delay_updates_with_delete_during_removes_extraneous() {
-    assert_delay_updates_finalizes_under_deletion("--delete-during", LocalCopyOptions::delete_during);
+    assert_delay_updates_finalizes_under_deletion(
+        "--delete-during",
+        LocalCopyOptions::delete_during,
+    );
 }
 
 #[test]
@@ -687,7 +702,6 @@ fn delay_updates_with_update_flag_skips_older_files() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(fs::read(&destination).expect("read dest"), b"dest content");
 }
-
 
 #[test]
 fn delay_updates_handles_files_with_spaces_in_name() {
@@ -740,7 +754,6 @@ fn delay_updates_handles_files_with_special_characters() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"special chars");
 }
 
-
 #[test]
 fn delay_updates_provides_atomic_directory_update() {
     // This test verifies that the destination directory transitions atomically
@@ -787,7 +800,6 @@ fn delay_updates_provides_atomic_directory_update() {
     assert_eq!(content3, b"new content 3");
 }
 
-
 #[test]
 fn delay_updates_differs_from_immediate_mode() {
     // This test documents the difference between delay_updates and normal mode.
@@ -833,14 +845,19 @@ fn delay_updates_differs_from_immediate_mode() {
     );
 }
 
-
 #[test]
 fn delay_updates_setting_enables_partial() {
     let opts = LocalCopyOptions::default().delay_updates(true);
 
-    assert!(opts.delay_updates_enabled(), "delay_updates should be enabled");
+    assert!(
+        opts.delay_updates_enabled(),
+        "delay_updates should be enabled"
+    );
     // delay_updates typically implies partial mode
-    assert!(opts.partial_enabled(), "partial should be enabled with delay_updates");
+    assert!(
+        opts.partial_enabled(),
+        "partial should be enabled with delay_updates"
+    );
 }
 
 #[test]
@@ -849,9 +866,11 @@ fn delay_updates_can_be_disabled() {
         .delay_updates(true)
         .delay_updates(false);
 
-    assert!(!opts.delay_updates_enabled(), "delay_updates should be disabled");
+    assert!(
+        !opts.delay_updates_enabled(),
+        "delay_updates should be disabled"
+    );
 }
-
 
 #[test]
 fn delay_updates_handles_mix_of_new_and_existing_files() {
@@ -897,7 +916,6 @@ fn delay_updates_handles_mix_of_new_and_existing_files() {
     );
 }
 
-
 /// Verify that delay_updates uses .~tmp~ prefix for staging files,
 /// matching upstream rsync behavior. We check this by running a transfer
 /// and verifying no .~tmp~ files remain afterward (they would be renamed).
@@ -909,8 +927,11 @@ fn delay_updates_temp_files_use_upstream_rsync_prefix() {
     fs::create_dir_all(&source_root).expect("create source");
 
     for i in 0..5 {
-        fs::write(source_root.join(format!("file{i}.txt")), format!("data {i}"))
-            .expect("write source");
+        fs::write(
+            source_root.join(format!("file{i}.txt")),
+            format!("data {i}"),
+        )
+        .expect("write source");
     }
 
     let mut source_operand = source_root.into_os_string();
@@ -953,7 +974,6 @@ fn delay_updates_temp_files_use_upstream_rsync_prefix() {
         );
     }
 }
-
 
 #[test]
 fn delay_updates_handles_multiple_subdirectories() {
@@ -1025,7 +1045,6 @@ fn delay_updates_handles_multiple_subdirectories() {
     assert_no_staging(&dest_root);
 }
 
-
 #[test]
 fn delay_updates_with_backup_creates_backup_files() {
     let temp = create_tempdir();
@@ -1049,9 +1068,7 @@ fn delay_updates_with_backup_creates_backup_files() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .delay_updates(true)
-                .backup(true),
+            LocalCopyOptions::default().delay_updates(true).backup(true),
         )
         .expect("copy succeeds");
 
@@ -1065,10 +1082,7 @@ fn delay_updates_with_backup_creates_backup_files() {
     // Backup should exist with old content
     let backup = dest_root.join("file.txt~");
     assert!(backup.exists(), "backup file should exist");
-    assert_eq!(
-        fs::read(&backup).expect("read backup"),
-        b"old"
-    );
+    assert_eq!(fs::read(&backup).expect("read backup"), b"old");
 }
 
 #[test]
@@ -1104,10 +1118,12 @@ fn delay_updates_with_backup_suffix() {
     );
 
     let backup = dest_root.join("data.txt.bak");
-    assert!(backup.exists(), "backup file with custom suffix should exist");
+    assert!(
+        backup.exists(),
+        "backup file with custom suffix should exist"
+    );
     assert_eq!(fs::read(&backup).expect("read backup"), b"old");
 }
-
 
 #[test]
 fn delay_updates_with_checksum_comparison() {
@@ -1188,7 +1204,6 @@ fn delay_updates_with_checksum_skips_identical_files() {
     );
 }
 
-
 #[cfg(unix)]
 #[test]
 fn delay_updates_preserves_symlinks() {
@@ -1198,8 +1213,7 @@ fn delay_updates_preserves_symlinks() {
     fs::create_dir_all(&source_root).expect("create source");
 
     fs::write(source_root.join("target.txt"), b"target content").expect("write target");
-    std::os::unix::fs::symlink("target.txt", source_root.join("link.txt"))
-        .expect("create symlink");
+    std::os::unix::fs::symlink("target.txt", source_root.join("link.txt")).expect("create symlink");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -1210,9 +1224,7 @@ fn delay_updates_preserves_symlinks() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .delay_updates(true)
-                .links(true),
+            LocalCopyOptions::default().delay_updates(true).links(true),
         )
         .expect("copy succeeds");
 
@@ -1232,7 +1244,6 @@ fn delay_updates_preserves_symlinks() {
         std::path::Path::new("target.txt")
     );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1299,7 +1310,6 @@ fn delay_updates_preserves_multiple_hard_link_groups() {
     assert!(summary.hard_links_created() >= 3);
 }
 
-
 #[test]
 fn delay_updates_with_ignore_existing_skips_existing_files() {
     let temp = create_tempdir();
@@ -1340,7 +1350,6 @@ fn delay_updates_with_ignore_existing_skips_existing_files() {
     );
 }
 
-
 #[test]
 fn delay_updates_with_existing_only_skips_new_files() {
     let temp = create_tempdir();
@@ -1379,7 +1388,6 @@ fn delay_updates_with_existing_only_skips_new_files() {
         "new file should not be created in existing-only mode"
     );
 }
-
 
 #[test]
 fn delay_updates_handles_unicode_filenames() {
@@ -1425,7 +1433,6 @@ fn delay_updates_handles_unicode_filenames() {
     );
 }
 
-
 #[test]
 fn delay_updates_with_size_only_skips_same_size_files() {
     let temp = create_tempdir();
@@ -1460,7 +1467,6 @@ fn delay_updates_with_size_only_skips_same_size_files() {
         b"BBBB"
     );
 }
-
 
 #[test]
 fn delay_updates_with_ignore_times_always_transfers() {
@@ -1497,7 +1503,6 @@ fn delay_updates_with_ignore_times_always_transfers() {
     // Should always transfer when --ignore-times is set
     assert_eq!(summary.files_copied(), 1);
 }
-
 
 #[test]
 fn delay_updates_handles_many_files() {
@@ -1550,7 +1555,6 @@ fn delay_updates_handles_many_files() {
     assert!(leftovers.is_empty(), "staging files remain: {leftovers:?}");
 }
 
-
 #[test]
 fn delay_updates_handles_deeply_nested_structure() {
     let temp = create_tempdir();
@@ -1589,7 +1593,6 @@ fn delay_updates_handles_deeply_nested_structure() {
     }
 }
 
-
 #[test]
 fn builder_rejects_inplace_with_delay_updates() {
     let result = LocalCopyOptions::builder()
@@ -1602,16 +1605,13 @@ fn builder_rejects_inplace_with_delay_updates() {
 
 #[test]
 fn builder_accepts_delay_updates_without_inplace() {
-    let result = LocalCopyOptions::builder()
-        .delay_updates(true)
-        .build();
+    let result = LocalCopyOptions::builder().delay_updates(true).build();
 
     assert!(result.is_ok());
     let opts = result.unwrap();
     assert!(opts.delay_updates_enabled());
     assert!(opts.partial_enabled());
 }
-
 
 #[test]
 fn delay_updates_is_idempotent_on_second_run() {
@@ -1660,7 +1660,6 @@ fn delay_updates_is_idempotent_on_second_run() {
         b"content b"
     );
 }
-
 
 #[test]
 fn delay_updates_only_transfers_changed_files() {
@@ -1711,7 +1710,6 @@ fn delay_updates_only_transfers_changed_files() {
     );
 }
 
-
 #[test]
 fn delay_updates_with_remove_source_files() {
     let temp = create_tempdir();
@@ -1748,7 +1746,6 @@ fn delay_updates_with_remove_source_files() {
         "source file should be removed after transfer"
     );
 }
-
 
 #[test]
 fn delay_updates_preserves_times_across_multiple_files() {
@@ -1796,7 +1793,6 @@ fn delay_updates_preserves_times_across_multiple_files() {
         );
     }
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1852,7 +1848,6 @@ fn delay_updates_preserves_permissions_across_multiple_files() {
     }
 }
 
-
 #[test]
 fn delay_updates_handles_binary_content() {
     let temp = create_tempdir();
@@ -1876,10 +1871,7 @@ fn delay_updates_handles_binary_content() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        binary_content
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), binary_content);
 }
 
 #[test]
@@ -1911,7 +1903,6 @@ fn delay_updates_handles_file_with_null_bytes() {
     );
 }
 
-
 #[test]
 fn delay_updates_option_is_false_by_default() {
     let opts = LocalCopyOptions::default();
@@ -1941,7 +1932,6 @@ fn delay_updates_disabled_does_not_set_partial() {
     assert!(!opts.delay_updates_enabled());
 }
 
-
 #[test]
 fn delay_updates_dry_run_with_nested_tree_no_changes() {
     let temp = create_tempdir();
@@ -1951,7 +1941,11 @@ fn delay_updates_dry_run_with_nested_tree_no_changes() {
     fs::create_dir_all(source_root.join("a").join("b")).expect("create dirs");
     fs::write(source_root.join("top.txt"), b"top").expect("write");
     fs::write(source_root.join("a").join("mid.txt"), b"mid").expect("write");
-    fs::write(source_root.join("a").join("b").join("bottom.txt"), b"bottom").expect("write");
+    fs::write(
+        source_root.join("a").join("b").join("bottom.txt"),
+        b"bottom",
+    )
+    .expect("write");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -1970,7 +1964,6 @@ fn delay_updates_dry_run_with_nested_tree_no_changes() {
 
     assert!(!dest_root.exists(), "dest should not be created in dry run");
 }
-
 
 #[test]
 fn delay_updates_replaces_smaller_file_with_larger() {
@@ -2024,12 +2017,8 @@ fn delay_updates_replaces_larger_file_with_smaller() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"sm"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"sm");
 }
-
 
 #[test]
 fn delay_updates_creates_destination_directories_as_needed() {
@@ -2044,8 +2033,7 @@ fn delay_updates_creates_destination_directories_as_needed() {
         b"deeply nested",
     )
     .expect("write");
-    fs::write(source_root.join("new_dir").join("sibling.txt"), b"sibling")
-        .expect("write");
+    fs::write(source_root.join("new_dir").join("sibling.txt"), b"sibling").expect("write");
 
     let operands = vec![
         source_root.into_os_string(),
@@ -2061,9 +2049,22 @@ fn delay_updates_creates_destination_directories_as_needed() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 2);
-    assert!(dest_root.join("source").join("new_dir").join("nested").is_dir());
+    assert!(
+        dest_root
+            .join("source")
+            .join("new_dir")
+            .join("nested")
+            .is_dir()
+    );
     assert_eq!(
-        fs::read(dest_root.join("source").join("new_dir").join("nested").join("file.txt")).expect("read"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("new_dir")
+                .join("nested")
+                .join("file.txt")
+        )
+        .expect("read"),
         b"deeply nested"
     );
     assert_eq!(
@@ -2071,7 +2072,6 @@ fn delay_updates_creates_destination_directories_as_needed() {
         b"sibling"
     );
 }
-
 
 /// Verifies that `--delay-updates` automatically sets the partial directory
 /// to `.~tmp~` (matching upstream rsync's `tmp_partialdir`).
@@ -2287,8 +2287,9 @@ fn delay_updates_restores_root_directory_mtime_after_rename() {
         .expect("copy succeeds");
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_dir_mtime =
-        FileTime::from_last_modification_time(&fs::metadata(&dest_root).expect("dest dir metadata"));
+    let dest_dir_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(&dest_root).expect("dest dir metadata"),
+    );
     assert_eq!(
         dest_dir_mtime, past,
         "the delayed-update rename bumps the dir mtime apply_final_directory_metadata \
@@ -2467,7 +2468,10 @@ fn delay_updates_removes_a_relative_partial_dir_after_the_rename() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(fs::read(dest_root.join("f0")).expect("read dest"), b"PAYLOAD-DATA");
+    assert_eq!(
+        fs::read(dest_root.join("f0")).expect("read dest"),
+        b"PAYLOAD-DATA"
+    );
     assert!(
         !dest_root.join(".pd").exists(),
         "a relative --partial-dir must be rmdir'd once emptied"
@@ -2504,5 +2508,8 @@ fn delay_updates_creates_the_partial_dir_private() {
         .permissions()
         .mode()
         & 0o777;
-    assert_eq!(mode, 0o700, "the partial dir must be created private (0700)");
+    assert_eq!(
+        mode, 0o700,
+        "the partial dir must be created private (0700)"
+    );
 }

--- a/crates/engine/src/local_copy/tests/execute_delay_updates_delete.rs
+++ b/crates/engine/src/local_copy/tests/execute_delay_updates_delete.rs
@@ -11,7 +11,6 @@
 // 2. No `.~tmp~` staging artifacts remain after the transfer.
 // 3. The summary correctly reports both transferred and deleted counts.
 
-
 /// Verifies that when --delay-updates and --delete (During timing) are both
 /// active, the extraneous destination file C is not removed until AFTER files
 /// A and B have been renamed from staging into their final locations.
@@ -47,9 +46,7 @@ fn delay_updates_delete_during_deletes_after_rename() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .delete(true)
-                .delay_updates(true),
+            LocalCopyOptions::default().delete(true).delay_updates(true),
         )
         .expect("copy succeeds");
 
@@ -111,9 +108,7 @@ fn delay_updates_delete_during_removes_extraneous_in_subdirs() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .delete(true)
-                .delay_updates(true),
+            LocalCopyOptions::default().delete(true).delay_updates(true),
         )
         .expect("copy succeeds");
 

--- a/crates/engine/src/local_copy/tests/execute_delete_excluded.rs
+++ b/crates/engine/src/local_copy/tests/execute_delete_excluded.rs
@@ -35,8 +35,7 @@ fn delete_preserves_excluded_log_files_at_dest() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filters =
-        FilterSet::from_rules([FilterRule::exclude("*.log")]).expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete(true)
         .filters(Some(filters));
@@ -93,8 +92,7 @@ fn delete_excluded_removes_log_files_matching_exclude_pattern() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filters =
-        FilterSet::from_rules([FilterRule::exclude("*.log")]).expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete(true)
         .delete_excluded(true)
@@ -143,7 +141,8 @@ fn delete_excluded_with_filter_exclude_rule_removes_tmp_files() {
     // Dest has the same files plus .tmp files that should be swept away.
     // Use different content sizes to avoid quick-check mtime+size skips.
     fs::write(dest.join("data.txt"), b"old data with more bytes here").expect("write old data.txt");
-    fs::write(dest.join("notes.txt"), b"old notes with more bytes here").expect("write old notes.txt");
+    fs::write(dest.join("notes.txt"), b"old notes with more bytes here")
+        .expect("write old notes.txt");
     fs::write(dest.join("cache.tmp"), b"temporary cache data").expect("write cache.tmp");
     fs::write(dest.join("scratch.tmp"), b"scratch file data").expect("write scratch.tmp");
 
@@ -153,8 +152,7 @@ fn delete_excluded_with_filter_exclude_rule_removes_tmp_files() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // Simulate --filter='exclude *.tmp' via FilterSet.
-    let filters =
-        FilterSet::from_rules([FilterRule::exclude("*.tmp")]).expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete(true)
         .delete_excluded(true)
@@ -200,7 +198,8 @@ fn delete_without_delete_excluded_preserves_filtered_tmp_files() {
 
     // Dest has both regular and .tmp files.
     // Use different content sizes to avoid quick-check mtime+size skips.
-    fs::write(dest.join("data.txt"), b"old data with extra bytes here").expect("write old data.txt");
+    fs::write(dest.join("data.txt"), b"old data with extra bytes here")
+        .expect("write old data.txt");
     fs::write(dest.join("extra.txt"), b"extraneous non-excluded file").expect("write extra.txt");
     fs::write(dest.join("keep.tmp"), b"preserved tmp file content").expect("write keep.tmp");
 
@@ -209,8 +208,7 @@ fn delete_without_delete_excluded_preserves_filtered_tmp_files() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filters =
-        FilterSet::from_rules([FilterRule::exclude("*.tmp")]).expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).expect("compile filters");
     // No delete_excluded: excluded files are protected from deletion.
     let options = LocalCopyOptions::default()
         .delete(true)
@@ -222,7 +220,10 @@ fn delete_without_delete_excluded_preserves_filtered_tmp_files() {
 
     // data.txt copied from source; extra.txt is extraneous and not excluded, so deleted.
     assert!(dest.join("data.txt").exists(), "data.txt must exist");
-    assert!(!dest.join("extra.txt").exists(), "extra.txt must be deleted");
+    assert!(
+        !dest.join("extra.txt").exists(),
+        "extra.txt must be deleted"
+    );
     // keep.tmp matches exclude rule and --delete-excluded is not set: must be preserved.
     assert!(
         dest.join("keep.tmp").exists(),

--- a/crates/engine/src/local_copy/tests/execute_delta.rs
+++ b/crates/engine/src/local_copy/tests/execute_delta.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn execute_delta_copy_reuses_existing_blocks() {
     let temp = tempdir().expect("tempdir");
@@ -56,10 +55,7 @@ fn execute_with_report_dry_run_records_file_event() {
     fs::write(&source, b"dry-run").expect("write source");
     let destination = temp.path().join("dest.txt");
 
-    let operands = vec![
-        source.into_os_string(),
-        destination.into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), destination.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().collect_events(true);
     let report = plan
@@ -84,10 +80,7 @@ fn execute_with_report_dry_run_records_directory_event() {
     fs::write(source_dir.join("file.txt"), b"data").expect("write nested file");
     let destination = temp.path().join("target");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        destination.into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), destination.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().collect_events(true);
     let report = plan
@@ -108,10 +101,7 @@ fn execute_with_report_records_min_size_skip_notice_without_copying() {
     fs::write(&source, b"abc").expect("write source");
     let destination = temp.path().join("dest.txt");
 
-    let operands = vec![
-        source.into_os_string(),
-        destination.into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), destination.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .collect_events(true)

--- a/crates/engine/src/local_copy/tests/execute_direct_write.rs
+++ b/crates/engine/src/local_copy/tests/execute_direct_write.rs
@@ -14,7 +14,6 @@
 // 6. Zero-length files use the direct write path
 // 7. Large files use the direct write path correctly
 
-
 #[test]
 fn direct_write_creates_file_at_final_destination() {
     let temp = tempdir().expect("tempdir");
@@ -69,10 +68,7 @@ fn direct_write_does_not_create_temp_files() {
         entries.len(),
         1,
         "only the destination file should exist, found: {:?}",
-        entries
-            .iter()
-            .map(|e| e.file_name())
-            .collect::<Vec<_>>()
+        entries.iter().map(|e| e.file_name()).collect::<Vec<_>>()
     );
     assert_eq!(entries[0].file_name(), "file.txt");
 }
@@ -132,7 +128,6 @@ fn direct_write_preserves_file_content_exactly() {
     );
 }
 
-
 #[test]
 fn direct_write_handles_multiple_files_in_directory() {
     let temp = tempdir().expect("tempdir");
@@ -182,7 +177,6 @@ fn direct_write_handles_multiple_files_in_directory() {
     );
 }
 
-
 #[test]
 fn direct_write_zero_length_file() {
     let temp = tempdir().expect("tempdir");
@@ -231,7 +225,6 @@ fn direct_write_large_file_content_intact() {
         "large file content must match"
     );
 }
-
 
 #[test]
 fn existing_destination_does_not_use_direct_write() {

--- a/crates/engine/src/local_copy/tests/execute_directories.rs
+++ b/crates/engine/src/local_copy/tests/execute_directories.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn execute_with_trailing_separator_copies_contents() {
     let temp = create_tempdir();
@@ -768,9 +767,26 @@ fn execute_nested_directory_preserves_permissions() {
     let dest_nested = dest_root.join("source").join("nested");
     let dest_deep = dest_nested.join("deep");
 
-    assert_eq!(fs::metadata(dest_root.join("source")).expect("root").permissions().mode() & 0o777, 0o755);
-    assert_eq!(fs::metadata(&dest_nested).expect("nested").permissions().mode() & 0o777, 0o750);
-    assert_eq!(fs::metadata(&dest_deep).expect("deep").permissions().mode() & 0o777, 0o700);
+    assert_eq!(
+        fs::metadata(dest_root.join("source"))
+            .expect("root")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o755
+    );
+    assert_eq!(
+        fs::metadata(&dest_nested)
+            .expect("nested")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o750
+    );
+    assert_eq!(
+        fs::metadata(&dest_deep).expect("deep").permissions().mode() & 0o777,
+        0o700
+    );
 }
 
 #[cfg(unix)]
@@ -781,7 +797,8 @@ fn execute_directory_without_preserve_permissions_uses_default() {
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source root");
-    fs::set_permissions(&source_root, PermissionsExt::from_mode(0o700)).expect("set restrictive perms");
+    fs::set_permissions(&source_root, PermissionsExt::from_mode(0o700))
+        .expect("set restrictive perms");
     fs::write(source_root.join("file.txt"), b"content").expect("write file");
 
     let dest_root = temp.path().join("dest");
@@ -813,7 +830,12 @@ fn execute_recursive_copies_deep_hierarchy() {
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
 
-    let deep_path = source_root.join("a").join("b").join("c").join("d").join("e");
+    let deep_path = source_root
+        .join("a")
+        .join("b")
+        .join("c")
+        .join("d")
+        .join("e");
     fs::create_dir_all(&deep_path).expect("create deep hierarchy");
     fs::write(deep_path.join("deep.txt"), b"deep content").expect("write deep file");
     fs::write(source_root.join("a").join("shallow.txt"), b"shallow").expect("write shallow");
@@ -827,11 +849,36 @@ fn execute_recursive_copies_deep_hierarchy() {
 
     let summary = plan.execute().expect("copy succeeds");
 
-    assert!(dest_root.join("source").join("a").join("b").join("c").join("d").join("e").join("deep.txt").exists());
-    assert!(dest_root.join("source").join("a").join("shallow.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("a")
+            .join("b")
+            .join("c")
+            .join("d")
+            .join("e")
+            .join("deep.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("a")
+            .join("shallow.txt")
+            .exists()
+    );
     assert_eq!(
-        fs::read(dest_root.join("source").join("a").join("b").join("c").join("d").join("e").join("deep.txt"))
-            .expect("read deep"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("a")
+                .join("b")
+                .join("c")
+                .join("d")
+                .join("e")
+                .join("deep.txt")
+        )
+        .expect("read deep"),
         b"deep content"
     );
     assert!(summary.directories_created() >= 5);
@@ -859,7 +906,10 @@ fn execute_recursive_copies_wide_hierarchy() {
     let summary = plan.execute().expect("copy succeeds");
 
     for i in 0..10 {
-        let dest_file = dest_root.join("source").join(format!("dir{i:02}")).join("file.txt");
+        let dest_file = dest_root
+            .join("source")
+            .join(format!("dir{i:02}"))
+            .join("file.txt");
         assert!(dest_file.exists(), "file in dir{i:02} should exist");
         assert_eq!(
             fs::read(&dest_file).expect("read file"),
@@ -891,7 +941,13 @@ fn execute_recursive_handles_empty_directories() {
     let summary = plan.execute().expect("copy succeeds");
 
     assert!(dest_root.join("source").join("empty").is_dir());
-    assert!(dest_root.join("source").join("nonempty").join("file.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("nonempty")
+            .join("file.txt")
+            .exists()
+    );
     assert!(summary.directories_created() >= 2);
 }
 
@@ -916,8 +972,17 @@ fn execute_recursive_with_prune_empty_dirs_removes_empty_directories() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!dest_root.join("source").join("empty").exists(), "empty dir should be pruned");
-    assert!(dest_root.join("source").join("nonempty").join("file.txt").exists());
+    assert!(
+        !dest_root.join("source").join("empty").exists(),
+        "empty dir should be pruned"
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("nonempty")
+            .join("file.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -943,8 +1008,14 @@ fn execute_recursive_disabled_only_copies_single_level() {
         .expect("copy succeeds");
 
     assert!(dest_root.join("source").is_dir());
-    assert!(!dest_root.join("source").join("nested").exists(), "nested dir should not be copied");
-    assert!(!dest_root.join("source").join("root.txt").exists(), "files should not be copied without recursion");
+    assert!(
+        !dest_root.join("source").join("nested").exists(),
+        "nested dir should not be copied"
+    );
+    assert!(
+        !dest_root.join("source").join("root.txt").exists(),
+        "files should not be copied without recursion"
+    );
 }
 
 #[cfg(unix)]
@@ -1030,8 +1101,14 @@ fn execute_directory_nested_already_exists_merges_content() {
 
     assert!(dest_nested.join("new.txt").exists());
     assert!(dest_nested.join("existing.txt").exists());
-    assert_eq!(fs::read(dest_nested.join("new.txt")).expect("read new"), b"new content");
-    assert_eq!(fs::read(dest_nested.join("existing.txt")).expect("read existing"), b"existing content");
+    assert_eq!(
+        fs::read(dest_nested.join("new.txt")).expect("read new"),
+        b"new content"
+    );
+    assert_eq!(
+        fs::read(dest_nested.join("existing.txt")).expect("read existing"),
+        b"existing content"
+    );
 }
 
 /// upstream: `generator.c:1839-1842` `recv_generator()` clears a non-directory
@@ -1054,9 +1131,13 @@ fn execute_directory_replaces_destination_file_without_force() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    plan.execute().expect("obstructing file is cleared, not refused");
+    plan.execute()
+        .expect("obstructing file is cleared, not refused");
 
-    assert!(destination.is_dir(), "destination file replaced by a directory");
+    assert!(
+        destination.is_dir(),
+        "destination file replaced by a directory"
+    );
     assert_eq!(
         fs::read(destination.join("source").join("child.txt")).expect("read copied child"),
         b"content"
@@ -1082,8 +1163,14 @@ fn execute_dry_run_does_not_create_directory() {
         .execute_with(LocalCopyExecution::DryRun)
         .expect("dry-run succeeds");
 
-    assert!(!dest_root.exists(), "destination should not be created in dry-run");
-    assert!(summary.directories_created() >= 1, "should report would-be created directories");
+    assert!(
+        !dest_root.exists(),
+        "destination should not be created in dry-run"
+    );
+    assert!(
+        summary.directories_created() >= 1,
+        "should report would-be created directories"
+    );
 }
 
 #[test]
@@ -1138,7 +1225,10 @@ fn execute_dry_run_with_existing_destination_reports_no_creation() {
         .execute_with(LocalCopyExecution::DryRun)
         .expect("dry-run succeeds");
 
-    assert_eq!(fs::read(dest_root.join("file.txt")).expect("read"), b"old content");
+    assert_eq!(
+        fs::read(dest_root.join("file.txt")).expect("read"),
+        b"old content"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -1169,7 +1259,10 @@ fn execute_dry_run_with_collect_events_records_directory_creation() {
         .filter(|r| r.action() == &LocalCopyAction::DirectoryCreated)
         .count();
 
-    assert!(dir_created_count >= 2, "should record directory creations, got {dir_created_count}");
+    assert!(
+        dir_created_count >= 2,
+        "should record directory creations, got {dir_created_count}"
+    );
     assert!(!dest_root.exists());
 }
 
@@ -1286,7 +1379,13 @@ fn execute_directory_with_special_characters_in_name() {
 
     plan.execute().expect("copy succeeds");
 
-    assert!(dest_root.join("source").join("dir with spaces & special-chars_123").join("file.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir with spaces & special-chars_123")
+            .join("file.txt")
+            .exists()
+    );
 }
 
 #[cfg(unix)]
@@ -1307,7 +1406,13 @@ fn execute_directory_with_unicode_name() {
 
     plan.execute().expect("copy succeeds");
 
-    assert!(dest_root.join("source").join("dir_with_unicode_\u{1F600}_\u{4E2D}\u{6587}").join("file.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir_with_unicode_\u{1F600}_\u{4E2D}\u{6587}")
+            .join("file.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -1331,7 +1436,13 @@ fn execute_directory_one_file_system_stays_on_same_device() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(dest_root.join("source").join("nested").join("file.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("nested")
+            .join("file.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -1456,7 +1567,12 @@ fn execute_multi_source_merge_dir_wins_over_colliding_file() {
     let mut from3_op = from3.into_os_string();
     from3_op.push(std::path::MAIN_SEPARATOR.to_string());
 
-    let operands = vec![from1_op, from2_op, from3_op, dest_root.clone().into_os_string()];
+    let operands = vec![
+        from1_op,
+        from2_op,
+        from3_op,
+        dest_root.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     plan.execute_with(LocalCopyExecution::Apply)
@@ -1508,7 +1624,10 @@ fn execute_directory_update_only_copies_newer() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert_eq!(fs::read(dest_root.join("file.txt")).expect("read"), b"new content");
+    assert_eq!(
+        fs::read(dest_root.join("file.txt")).expect("read"),
+        b"new content"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -1542,15 +1661,18 @@ fn execute_directory_update_skips_older_files() {
         .expect("copy succeeds");
 
     // Dest should keep its newer content
-    assert_eq!(fs::read(dest_root.join("file.txt")).expect("read"), b"new content");
+    assert_eq!(
+        fs::read(dest_root.join("file.txt")).expect("read"),
+        b"new content"
+    );
     assert_eq!(summary.files_copied(), 0);
 }
 
 #[cfg(unix)]
 #[test]
 fn execute_directory_archive_mode_preserves_all() {
-    use std::os::unix::fs::PermissionsExt;
     use filetime::{FileTime, set_file_mtime};
+    use std::os::unix::fs::PermissionsExt;
 
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
@@ -1588,11 +1710,28 @@ fn execute_directory_archive_mode_preserves_all() {
 
     let dest_nested = dest_root.join("source").join("nested");
 
-    assert_eq!(fs::metadata(dest_root.join("source")).expect("root").permissions().mode() & 0o777, 0o755);
-    assert_eq!(fs::metadata(&dest_nested).expect("nested").permissions().mode() & 0o777, 0o750);
+    assert_eq!(
+        fs::metadata(dest_root.join("source"))
+            .expect("root")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o755
+    );
+    assert_eq!(
+        fs::metadata(&dest_nested)
+            .expect("nested")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o750
+    );
 
-    let root_mtime = FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source")).expect("root"));
-    let nested_mtime = FileTime::from_last_modification_time(&fs::metadata(&dest_nested).expect("nested"));
+    let root_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(dest_root.join("source")).expect("root"),
+    );
+    let nested_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_nested).expect("nested"));
     assert_eq!(root_mtime, fixed_mtime);
     assert_eq!(nested_mtime, fixed_mtime);
 }
@@ -1626,7 +1765,10 @@ fn execute_dry_run_with_delete_and_force_reports_all_actions() {
 
     let summary = report.summary();
 
-    assert_eq!(fs::read(dest_nested.join("keep.txt")).expect("read keep"), b"old");
+    assert_eq!(
+        fs::read(dest_nested.join("keep.txt")).expect("read keep"),
+        b"old"
+    );
     assert!(dest_nested.join("extra.txt").exists());
 
     assert_eq!(summary.files_copied(), 1);
@@ -1668,7 +1810,8 @@ fn execute_recursive_creates_mixed_content_hierarchy() {
     );
     assert_eq!(
         fs::read(
-            dest_root.join("source")
+            dest_root
+                .join("source")
                 .join("a")
                 .join("b")
                 .join("c")
@@ -1678,10 +1821,23 @@ fn execute_recursive_creates_mixed_content_hierarchy() {
         b"deep"
     );
     assert_eq!(
-        fs::read(dest_root.join("source").join("x").join("y").join("leaf.txt")).expect("read leaf"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("x")
+                .join("y")
+                .join("leaf.txt")
+        )
+        .expect("read leaf"),
         b"leaf"
     );
-    assert!(dest_root.join("source").join("a").join("empty_sibling").is_dir());
+    assert!(
+        dest_root
+            .join("source")
+            .join("a")
+            .join("empty_sibling")
+            .is_dir()
+    );
     assert_eq!(summary.files_copied(), 4);
     // source + a + b + c + empty_sibling + x + y = 7
     assert!(summary.directories_created() >= 7);
@@ -1707,7 +1863,14 @@ fn execute_recursive_creates_only_subdirs_no_files() {
 
     assert!(dest_root.join("source").join("a").join("b").is_dir());
     assert!(dest_root.join("source").join("c").is_dir());
-    assert!(dest_root.join("source").join("d").join("e").join("f").is_dir());
+    assert!(
+        dest_root
+            .join("source")
+            .join("d")
+            .join("e")
+            .join("f")
+            .is_dir()
+    );
     assert_eq!(summary.files_copied(), 0);
     // source + a + b + c + d + e + f = 7
     assert!(summary.directories_created() >= 7);
@@ -1721,11 +1884,7 @@ fn execute_recursive_files_at_every_level() {
     fs::create_dir_all(source_root.join("l1").join("l2").join("l3")).expect("create dirs");
     fs::write(source_root.join("f0.txt"), b"level0").expect("write f0");
     fs::write(source_root.join("l1").join("f1.txt"), b"level1").expect("write f1");
-    fs::write(
-        source_root.join("l1").join("l2").join("f2.txt"),
-        b"level2",
-    )
-    .expect("write f2");
+    fs::write(source_root.join("l1").join("l2").join("f2.txt"), b"level2").expect("write f2");
     fs::write(
         source_root.join("l1").join("l2").join("l3").join("f3.txt"),
         b"level3",
@@ -1750,12 +1909,20 @@ fn execute_recursive_files_at_every_level() {
         b"level1"
     );
     assert_eq!(
-        fs::read(dest_root.join("source").join("l1").join("l2").join("f2.txt")).expect("read f2"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("l1")
+                .join("l2")
+                .join("f2.txt")
+        )
+        .expect("read f2"),
         b"level2"
     );
     assert_eq!(
         fs::read(
-            dest_root.join("source")
+            dest_root
+                .join("source")
                 .join("l1")
                 .join("l2")
                 .join("l3")
@@ -1804,7 +1971,8 @@ fn execute_trailing_separator_with_nested_empty_dirs() {
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
     fs::create_dir_all(source_root.join("empty1")).expect("create empty1");
-    fs::create_dir_all(source_root.join("empty2").join("nested_empty")).expect("create nested empty");
+    fs::create_dir_all(source_root.join("empty2").join("nested_empty"))
+        .expect("create nested empty");
     fs::write(source_root.join("file.txt"), b"root file").expect("write root file");
 
     let dest_root = temp.path().join("dest");
@@ -1822,7 +1990,10 @@ fn execute_trailing_separator_with_nested_empty_dirs() {
         fs::read(dest_root.join("file.txt")).expect("read"),
         b"root file"
     );
-    assert!(!dest_root.join("source").exists(), "should not contain source dir itself");
+    assert!(
+        !dest_root.join("source").exists(),
+        "should not contain source dir itself"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -1915,7 +2086,10 @@ fn execute_directory_source_deep_missing_dest_errors_without_mkpath() {
         }
         other => panic!("unexpected error kind: {other:?}"),
     }
-    assert!(!missing_prefix.exists(), "no ancestor chain must be created");
+    assert!(
+        !missing_prefix.exists(),
+        "no ancestor chain must be created"
+    );
     assert!(!dest_root.exists());
 }
 
@@ -2013,9 +2187,22 @@ fn execute_prune_empty_dirs_nested_hierarchy_file_at_bottom() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(dest_root.join("source").join("a").join("b").join("c").join("d").join("bottom.txt").exists());
     assert!(
-        !dest_root.join("source").join("a").join("empty_branch").exists(),
+        dest_root
+            .join("source")
+            .join("a")
+            .join("b")
+            .join("c")
+            .join("d")
+            .join("bottom.txt")
+            .exists()
+    );
+    assert!(
+        !dest_root
+            .join("source")
+            .join("a")
+            .join("empty_branch")
+            .exists(),
         "empty branch should be pruned"
     );
 }
@@ -2043,7 +2230,13 @@ fn execute_prune_empty_dirs_with_trailing_separator_and_nested() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(dest_root.join("populated").join("sub").join("data.txt").exists());
+    assert!(
+        dest_root
+            .join("populated")
+            .join("sub")
+            .join("data.txt")
+            .exists()
+    );
     assert!(
         !dest_root.join("barren").exists(),
         "barren directory tree should be pruned"
@@ -2077,7 +2270,14 @@ fn execute_prune_empty_dirs_preserves_dir_with_only_subdirs_containing_files() {
         dest_root.join("source").join("parent").is_dir(),
         "parent should be kept because grandchild has files"
     );
-    assert!(dest_root.join("source").join("parent").join("child").join("file.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("parent")
+            .join("child")
+            .join("file.txt")
+            .exists()
+    );
 }
 
 #[cfg(unix)]
@@ -2125,11 +2325,18 @@ fn execute_omit_dir_times_nested_dirs_preserves_file_times_at_all_levels() {
         &fs::metadata(dest_root.join("source").join("f_root.txt")).expect("root file metadata"),
     );
     let dest_sub1_file_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("sub1").join("f_sub1.txt")).expect("sub1 file metadata"),
+        &fs::metadata(dest_root.join("source").join("sub1").join("f_sub1.txt"))
+            .expect("sub1 file metadata"),
     );
     let dest_sub2_file_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("sub1").join("sub2").join("f_sub2.txt"))
-            .expect("sub2 file metadata"),
+        &fs::metadata(
+            dest_root
+                .join("source")
+                .join("sub1")
+                .join("sub2")
+                .join("f_sub2.txt"),
+        )
+        .expect("sub2 file metadata"),
     );
     assert_eq!(dest_root_file_mtime, root_file_mtime);
     assert_eq!(dest_sub1_file_mtime, sub1_file_mtime);
@@ -2143,7 +2350,8 @@ fn execute_omit_dir_times_nested_dirs_preserves_file_times_at_all_levels() {
         &fs::metadata(dest_root.join("source").join("sub1")).expect("sub1 dir metadata"),
     );
     let dest_sub2_dir_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("sub1").join("sub2")).expect("sub2 dir metadata"),
+        &fs::metadata(dest_root.join("source").join("sub1").join("sub2"))
+            .expect("sub2 dir metadata"),
     );
     assert_ne!(dest_root_dir_mtime, dir_mtime);
     assert_ne!(dest_sub1_dir_mtime, dir_mtime);
@@ -2201,8 +2409,11 @@ fn execute_directory_permissions_with_chmod_nested_applies_to_all_dirs() {
     let nested = source_root.join("a").join("b");
     fs::create_dir_all(&nested).expect("create nested");
     fs::set_permissions(&source_root, PermissionsExt::from_mode(0o777)).expect("set root perms");
-    fs::set_permissions(source_root.join("a").as_path(), PermissionsExt::from_mode(0o777))
-        .expect("set a perms");
+    fs::set_permissions(
+        source_root.join("a").as_path(),
+        PermissionsExt::from_mode(0o777),
+    )
+    .expect("set a perms");
     fs::set_permissions(&nested, PermissionsExt::from_mode(0o777)).expect("set b perms");
     fs::write(nested.join("file.txt"), b"content").expect("write file");
 
@@ -2223,11 +2434,19 @@ fn execute_directory_permissions_with_chmod_nested_applies_to_all_dirs() {
         .expect("copy succeeds");
 
     assert_eq!(
-        fs::metadata(dest_root.join("source")).expect("root").permissions().mode() & 0o777,
+        fs::metadata(dest_root.join("source"))
+            .expect("root")
+            .permissions()
+            .mode()
+            & 0o777,
         0o755
     );
     assert_eq!(
-        fs::metadata(dest_root.join("source").join("a")).expect("a").permissions().mode() & 0o777,
+        fs::metadata(dest_root.join("source").join("a"))
+            .expect("a")
+            .permissions()
+            .mode()
+            & 0o777,
         0o755
     );
     assert_eq!(
@@ -2275,7 +2494,11 @@ fn execute_directory_preserves_mixed_permissions_in_hierarchy() {
         .expect("copy succeeds");
 
     assert_eq!(
-        fs::metadata(dest_root.join("source")).expect("root").permissions().mode() & 0o777,
+        fs::metadata(dest_root.join("source"))
+            .expect("root")
+            .permissions()
+            .mode()
+            & 0o777,
         0o755
     );
     assert_eq!(
@@ -2327,7 +2550,10 @@ fn execute_directory_permissions_with_dry_run_does_not_set() {
         .execute_with_options(LocalCopyExecution::DryRun, options)
         .expect("dry-run succeeds");
 
-    assert!(!dest_root.exists(), "destination should not be created in dry-run");
+    assert!(
+        !dest_root.exists(),
+        "destination should not be created in dry-run"
+    );
     assert!(summary.directories_created() >= 1);
 }
 
@@ -2336,7 +2562,8 @@ fn execute_nested_hierarchy_with_overlapping_names() {
     // Test directories with similar names at different levels
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
-    fs::create_dir_all(source_root.join("dir").join("dir").join("dir")).expect("create same-name dirs");
+    fs::create_dir_all(source_root.join("dir").join("dir").join("dir"))
+        .expect("create same-name dirs");
     fs::write(source_root.join("dir").join("file.txt"), b"level1").expect("write level1");
     fs::write(
         source_root.join("dir").join("dir").join("file.txt"),
@@ -2367,12 +2594,20 @@ fn execute_nested_hierarchy_with_overlapping_names() {
         b"level1"
     );
     assert_eq!(
-        fs::read(dest_root.join("source").join("dir").join("dir").join("file.txt")).expect("l2"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("dir")
+                .join("dir")
+                .join("file.txt")
+        )
+        .expect("l2"),
         b"level2"
     );
     assert_eq!(
         fs::read(
-            dest_root.join("source")
+            dest_root
+                .join("source")
                 .join("dir")
                 .join("dir")
                 .join("dir")
@@ -2393,7 +2628,11 @@ fn execute_nested_hierarchy_mixed_empty_and_populated() {
     fs::create_dir_all(source_root.join("top").join("empty").join("bottom")).expect("create dirs");
     fs::write(source_root.join("top").join("top.txt"), b"top").expect("write top");
     fs::write(
-        source_root.join("top").join("empty").join("bottom").join("bottom.txt"),
+        source_root
+            .join("top")
+            .join("empty")
+            .join("bottom")
+            .join("bottom.txt"),
         b"bottom",
     )
     .expect("write bottom");
@@ -2417,7 +2656,8 @@ fn execute_nested_hierarchy_mixed_empty_and_populated() {
     );
     assert_eq!(
         fs::read(
-            dest_root.join("source")
+            dest_root
+                .join("source")
                 .join("top")
                 .join("empty")
                 .join("bottom")
@@ -2453,7 +2693,10 @@ fn execute_directory_with_many_siblings() {
     let summary = plan.execute().expect("copy succeeds");
 
     for i in 0..count {
-        let dest_file = dest_root.join("source").join(format!("dir_{i:04}")).join("f.txt");
+        let dest_file = dest_root
+            .join("source")
+            .join(format!("dir_{i:04}"))
+            .join("f.txt");
         assert!(dest_file.exists(), "dir_{i:04}/f.txt should exist");
         assert_eq!(
             fs::read(&dest_file).expect("read"),
@@ -2571,7 +2814,13 @@ fn execute_directory_mkpath_with_prune_empty_dirs() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(dest_root.join("source").join("kept").join("file.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("kept")
+            .join("file.txt")
+            .exists()
+    );
     assert!(
         !dest_root.join("source").join("empty").exists(),
         "empty dir should be pruned even with mkpath"
@@ -2688,7 +2937,11 @@ fn execute_directory_archive_preserves_permissions_and_times_nested() {
         .expect("copy succeeds");
 
     assert_eq!(
-        fs::metadata(dest_root.join("source")).expect("root").permissions().mode() & 0o777,
+        fs::metadata(dest_root.join("source"))
+            .expect("root")
+            .permissions()
+            .mode()
+            & 0o777,
         0o755
     );
     assert_eq!(
@@ -2708,10 +2961,12 @@ fn execute_directory_archive_preserves_permissions_and_times_nested() {
         0o700
     );
 
-    let dest_root_mtime =
-        FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source")).expect("root"));
-    let dest_a_mtime =
-        FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source").join("a")).expect("a"));
+    let dest_root_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(dest_root.join("source")).expect("root"),
+    );
+    let dest_a_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(dest_root.join("source").join("a")).expect("a"),
+    );
     let dest_b_mtime = FileTime::from_last_modification_time(
         &fs::metadata(dest_root.join("source").join("a").join("b")).expect("b"),
     );
@@ -2739,8 +2994,14 @@ fn execute_single_nonempty_dir_without_trailing_slash_keeps_source_name() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     plan.execute().expect("copy single dir succeeds");
 
-    assert_eq!(fs::read(dest.join("a").join("b")).expect("read n/a/b"), b"b");
-    assert_eq!(fs::read(dest.join("a").join("c")).expect("read n/a/c"), b"c");
+    assert_eq!(
+        fs::read(dest.join("a").join("b")).expect("read n/a/b"),
+        b"b"
+    );
+    assert_eq!(
+        fs::read(dest.join("a").join("c")).expect("read n/a/c"),
+        b"c"
+    );
     assert!(
         !dest.join("b").exists(),
         "source directory name was dropped: found n/b instead of n/a/b"

--- a/crates/engine/src/local_copy/tests/execute_dirlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_dirlinks.rs
@@ -1,4 +1,3 @@
-
 #[cfg(unix)]
 #[test]
 fn execute_with_copy_unsafe_links_materialises_file_target() {
@@ -312,7 +311,10 @@ fn keep_dirlinks_replaces_symlink_to_file_without_force() {
     .expect("symlink-to-file is an obstruction, not a dirlink");
 
     let meta = fs::symlink_metadata(dest_root.join("subdir")).expect("subdir metadata");
-    assert!(meta.file_type().is_dir(), "symlink replaced by a real directory");
+    assert!(
+        meta.file_type().is_dir(),
+        "symlink replaced by a real directory"
+    );
     assert_eq!(
         fs::read(dest_root.join("subdir").join("child.txt")).expect("read copied child"),
         b"data"
@@ -494,9 +496,7 @@ fn keep_dirlinks_delete_preserves_symlink_removes_extraneous() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .keep_dirlinks(true)
-                .delete(true),
+            LocalCopyOptions::default().keep_dirlinks(true).delete(true),
         )
         .expect("copy with -K and --delete succeeds");
 
@@ -516,7 +516,10 @@ fn keep_dirlinks_delete_preserves_symlink_removes_extraneous() {
         !real_target.join("extra.txt").exists(),
         "extraneous file should be deleted"
     );
-    assert!(summary.items_deleted() >= 1, "should report at least one deletion");
+    assert!(
+        summary.items_deleted() >= 1,
+        "should report at least one deletion"
+    );
 }
 
 #[cfg(unix)]
@@ -633,7 +636,10 @@ fn keep_dirlinks_does_not_apply_when_source_sends_file_over_symlink_to_dir() {
         b"file-content"
     );
 
-    assert!(real_dir.join("inside.txt").exists(), "target contents should be preserved");
+    assert!(
+        real_dir.join("inside.txt").exists(),
+        "target contents should be preserved"
+    );
 }
 
 /// Regression test for upstream rsync 3.4.3 fix: `-K` (copy-dirlinks) must not
@@ -715,15 +721,10 @@ fn keep_dirlinks_delta_transfer_through_symlink_succeeds() {
     modified_content.extend_from_slice(&modified_suffix);
 
     fs::write(&source_file, &modified_content).expect("write modified source file");
-    set_file_mtime(
-        &source_file,
-        FileTime::from_unix_time(2_000_000, 0),
-    )
-    .expect("set source mtime");
+    set_file_mtime(&source_file, FileTime::from_unix_time(2_000_000, 0)).expect("set source mtime");
 
     // Backdate the destination file so quick-check does not skip it
-    set_file_mtime(&dest_file, FileTime::from_unix_time(1_000_000, 0))
-        .expect("set dest mtime");
+    set_file_mtime(&dest_file, FileTime::from_unix_time(1_000_000, 0)).expect("set dest mtime");
 
     // Step 3: second sync with -K and whole_file(false) to force a delta transfer.
     // This is the critical path - the receiver must resolve the temp file and

--- a/crates/engine/src/local_copy/tests/execute_dry_run.rs
+++ b/crates/engine/src/local_copy/tests/execute_dry_run.rs
@@ -8,7 +8,6 @@
 // providing a single, comprehensive test suite focused exclusively on dry-run
 // semantics as documented in the rsync(1) man page.
 
-
 #[test]
 fn dry_run_single_file_lists_but_does_not_copy() {
     let temp = tempdir().expect("tempdir");
@@ -32,7 +31,10 @@ fn dry_run_single_file_lists_but_does_not_copy() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), 0);
     assert_eq!(summary.transferred_file_size(), 7); // "payload" is 7 bytes
-    assert!(!destination.exists(), "dry run must not create destination file");
+    assert!(
+        !destination.exists(),
+        "dry run must not create destination file"
+    );
 }
 
 #[test]
@@ -123,7 +125,6 @@ fn dry_run_preserves_existing_destination_unmodified() {
     );
 }
 
-
 #[test]
 fn dry_run_directory_tree_not_created() {
     let ctx = test_helpers::setup_copy_test();
@@ -169,7 +170,10 @@ fn dry_run_multiple_directories_reported_but_not_created() {
         "expected at least 3 directories_created, got {}",
         summary.directories_created()
     );
-    assert!(!ctx.dest.exists(), "no destination directories should exist");
+    assert!(
+        !ctx.dest.exists(),
+        "no destination directories should exist"
+    );
 }
 
 #[test]
@@ -188,7 +192,6 @@ fn dry_run_empty_directory_tree_reported() {
     assert!(summary.directories_created() >= 1);
     assert!(!ctx.dest.exists(), "no destination should be created");
 }
-
 
 #[test]
 fn dry_run_with_delete_reports_deletions_but_preserves_files() {
@@ -263,8 +266,14 @@ fn dry_run_with_delete_before_reports_deletions_without_side_effects() {
         "expected at least 2 items_deleted, got {}",
         summary.items_deleted()
     );
-    assert!(dest.join("orphan1.txt").exists(), "orphan1 must still exist");
-    assert!(dest.join("orphan2.txt").exists(), "orphan2 must still exist");
+    assert!(
+        dest.join("orphan1.txt").exists(),
+        "orphan1 must still exist"
+    );
+    assert!(
+        dest.join("orphan2.txt").exists(),
+        "orphan2 must still exist"
+    );
     assert_eq!(
         fs::read(dest.join("file.txt")).expect("read file"),
         b"old",
@@ -315,7 +324,6 @@ fn dry_run_with_delete_during_reports_interleaved_events() {
     assert_eq!(fs::read(dest.join("keep.txt")).expect("read"), b"old");
 }
 
-
 #[test]
 fn dry_run_with_exclude_filter_omits_excluded_files() {
     let ctx = test_helpers::setup_copy_test();
@@ -326,8 +334,7 @@ fn dry_run_with_exclude_filter_omits_excluded_files() {
     let operands = ctx.operands_with_trailing_separator();
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")])
-        .expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")]).expect("compile filters");
 
     let options = LocalCopyOptions::default()
         .filters(Some(filters))
@@ -391,7 +398,6 @@ fn dry_run_with_include_exclude_filter_chain() {
         .collect();
     assert_eq!(paths, vec!["important.cfg"]);
 }
-
 
 #[test]
 fn dry_run_records_contain_file_metadata() {
@@ -487,7 +493,6 @@ fn dry_run_records_update_is_not_marked_as_created() {
     );
     assert_eq!(fs::read(&destination).expect("read"), b"old");
 }
-
 
 #[test]
 fn dry_run_statistics_match_apply_mode_statistics() {
@@ -592,7 +597,6 @@ fn dry_run_empty_files_reported() {
     assert_eq!(summary.bytes_copied(), 0);
     assert!(!ctx.dest.exists());
 }
-
 
 #[test]
 fn dry_run_with_times_does_not_set_timestamps() {
@@ -752,7 +756,6 @@ fn dry_run_with_checksum_mode_reports_correctly() {
     assert!(!destination.exists());
 }
 
-
 #[cfg(unix)]
 #[test]
 fn dry_run_does_not_create_symlinks() {
@@ -773,9 +776,11 @@ fn dry_run_does_not_create_symlinks() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.symlinks_copied(), 1);
-    assert!(!ctx.dest.exists(), "no destination should be created in dry run");
+    assert!(
+        !ctx.dest.exists(),
+        "no destination should be created in dry run"
+    );
 }
-
 
 #[test]
 fn dry_run_delete_respects_exclude_filters() {
@@ -796,8 +801,7 @@ fn dry_run_delete_respects_exclude_filters() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")])
-        .expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete(true)
         .filters(Some(filters));
@@ -813,7 +817,6 @@ fn dry_run_delete_respects_exclude_filters() {
     assert!(dest.join("extra.txt").exists());
     assert!(dest.join("keep.txt").exists());
 }
-
 
 #[test]
 fn dry_run_multiple_files_all_reported() {
@@ -853,7 +856,6 @@ fn dry_run_multiple_files_all_reported() {
     assert!(!ctx.dest.exists());
 }
 
-
 #[test]
 fn dry_run_is_idempotent() {
     // Running dry-run multiple times should produce the same result because
@@ -876,7 +878,6 @@ fn dry_run_is_idempotent() {
         assert!(!ctx.dest.exists());
     }
 }
-
 
 #[test]
 fn dry_run_large_file_reports_correct_byte_count() {
@@ -903,7 +904,6 @@ fn dry_run_large_file_reports_correct_byte_count() {
     assert_eq!(summary.transferred_file_size(), 256 * 1024);
     assert!(!destination.exists());
 }
-
 
 #[test]
 fn dry_run_reports_up_to_date_file_as_unchanged() {
@@ -946,7 +946,6 @@ fn dry_run_reports_up_to_date_file_as_unchanged() {
     );
 }
 
-
 #[test]
 fn dry_run_with_backup_does_not_create_backup_files() {
     let temp = tempdir().expect("tempdir");
@@ -981,7 +980,6 @@ fn dry_run_with_backup_does_not_create_backup_files() {
     assert_eq!(fs::read(&destination).expect("read"), b"old");
 }
 
-
 #[test]
 fn dry_run_deeply_nested_tree_all_reported() {
     let ctx = test_helpers::setup_copy_test();
@@ -1015,7 +1013,6 @@ fn dry_run_deeply_nested_tree_all_reported() {
     assert!(!ctx.dest.exists());
 }
 
-
 #[test]
 fn dry_run_whole_file_reports_transfer() {
     let temp = tempdir().expect("tempdir");
@@ -1042,7 +1039,6 @@ fn dry_run_whole_file_reports_transfer() {
     assert_eq!(summary.transferred_file_size(), 18);
     assert!(!destination.exists());
 }
-
 
 #[test]
 fn dry_run_with_inplace_does_not_modify_destination() {

--- a/crates/engine/src/local_copy/tests/execute_executability.rs
+++ b/crates/engine/src/local_copy/tests/execute_executability.rs
@@ -1,4 +1,3 @@
-
 #[cfg(unix)]
 #[test]
 fn execute_preserves_execute_bit_when_source_has_it() {
@@ -87,7 +86,8 @@ fn execute_executability_only_affects_regular_files() {
     fs::set_permissions(&source_file, PermissionsExt::from_mode(0o755)).expect("set source perms");
 
     // Set directory permissions explicitly
-    fs::set_permissions(&source_dir, PermissionsExt::from_mode(0o755)).expect("set source dir perms");
+    fs::set_permissions(&source_dir, PermissionsExt::from_mode(0o755))
+        .expect("set source dir perms");
     fs::set_permissions(&dest_dir, PermissionsExt::from_mode(0o700)).expect("set dest dir perms");
 
     let operands = vec![
@@ -106,7 +106,11 @@ fn execute_executability_only_affects_regular_files() {
     let dest_file = dest_dir.join("source").join("file.txt");
     let file_metadata = fs::metadata(&dest_file).expect("dest file metadata");
     let file_mode = file_metadata.permissions().mode();
-    assert_ne!(file_mode & 0o111, 0, "file execute bits should be preserved");
+    assert_ne!(
+        file_mode & 0o111,
+        0,
+        "file execute bits should be preserved"
+    );
 
     // Directory permissions should not be affected by executability flag
     // (directories need execute bits for traversal, so this test just ensures
@@ -192,7 +196,11 @@ fn execute_executability_without_permissions_preserves_only_execute_bits() {
         mode, 0o720,
         "expected upstream dest_mode() result 0o720 (rwx-w-----) for pre-transfer dest 0o620 + source 0o751"
     );
-    assert_eq!(mode & 0o111, 0o100, "only owner x is granted (dest had only owner-read)");
+    assert_eq!(
+        mode & 0o111,
+        0o100,
+        "only owner x is granted (dest had only owner-read)"
+    );
     assert_eq!(
         mode & 0o666,
         0o620,
@@ -375,12 +383,20 @@ fn execute_executability_multiple_files() {
     // Verify executable file has execute bits
     let dest_exec = dest_dir.join("source").join("executable.sh");
     let exec_metadata = fs::metadata(&dest_exec).expect("exec file metadata");
-    assert_ne!(exec_metadata.permissions().mode() & 0o111, 0, "executable file should have execute bits");
+    assert_ne!(
+        exec_metadata.permissions().mode() & 0o111,
+        0,
+        "executable file should have execute bits"
+    );
 
     // Verify non-executable file does not have execute bits
     let dest_noexec = dest_dir.join("source").join("data.txt");
     let noexec_metadata = fs::metadata(&dest_noexec).expect("noexec file metadata");
-    assert_eq!(noexec_metadata.permissions().mode() & 0o111, 0, "data file should not have execute bits");
+    assert_eq!(
+        noexec_metadata.permissions().mode() & 0o111,
+        0,
+        "data file should not have execute bits"
+    );
 
     assert_eq!(summary.files_copied(), 2);
 }

--- a/crates/engine/src/local_copy/tests/execute_existing.rs
+++ b/crates/engine/src/local_copy/tests/execute_existing.rs
@@ -126,7 +126,9 @@ fn existing_recursive_skips_new_files() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().existing_only(true).recursive(true),
+            LocalCopyOptions::default()
+                .existing_only(true)
+                .recursive(true),
         )
         .expect("copy succeeds");
 
@@ -170,7 +172,9 @@ fn existing_recursive_skips_new_directories() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().existing_only(true).recursive(true),
+            LocalCopyOptions::default()
+                .existing_only(true)
+                .recursive(true),
         )
         .expect("copy succeeds");
 
@@ -204,8 +208,7 @@ fn existing_nested_directories_mixed_states() {
     fs::write(source_root.join("dir1/new.txt"), b"new").expect("write new source");
 
     // File at dir2 level: new directory (should skip)
-    fs::write(source_root.join("dir1/dir2/file.txt"), b"nested")
-        .expect("write nested source");
+    fs::write(source_root.join("dir1/dir2/file.txt"), b"nested").expect("write nested source");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -215,7 +218,9 @@ fn existing_nested_directories_mixed_states() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().existing_only(true).recursive(true),
+            LocalCopyOptions::default()
+                .existing_only(true)
+                .recursive(true),
         )
         .expect("copy succeeds");
 
@@ -224,8 +229,11 @@ fn existing_nested_directories_mixed_states() {
     assert_eq!(summary.files_copied(), 1);
     // Current implementation may count directory skip separately from file skip
     // Adjust to match actual behavior: may only count direct files, not files in skipped dirs
-    assert!(summary.regular_files_skipped_missing() >= 1,
-        "should skip at least new.txt, got {}", summary.regular_files_skipped_missing());
+    assert!(
+        summary.regular_files_skipped_missing() >= 1,
+        "should skip at least new.txt, got {}",
+        summary.regular_files_skipped_missing()
+    );
 
     assert_eq!(
         fs::read(dest_root.join("dir1/exists.txt")).expect("read exists"),
@@ -370,9 +378,7 @@ fn existing_combined_with_times_preserves_mtime() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .existing_only(true)
-                .times(true),
+            LocalCopyOptions::default().existing_only(true).times(true),
         )
         .expect("copy succeeds");
 
@@ -405,7 +411,9 @@ fn existing_dry_run_reports_skipped_files() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::DryRun,
-            LocalCopyOptions::default().existing_only(true).recursive(true),
+            LocalCopyOptions::default()
+                .existing_only(true)
+                .recursive(true),
         )
         .expect("dry run succeeds");
 
@@ -539,7 +547,9 @@ fn existing_with_empty_destination_directory() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().existing_only(true).recursive(true),
+            LocalCopyOptions::default()
+                .existing_only(true)
+                .recursive(true),
         )
         .expect("copy succeeds");
 
@@ -747,8 +757,7 @@ fn existing_matches_upstream_rsync_semantics() {
 
     // Case 3: Directory doesn't exist at destination -> skip
     fs::create_dir_all(source_root.join("new_dir")).expect("create new_dir");
-    fs::write(source_root.join("new_dir/file.txt"), b"in new dir")
-        .expect("write new_dir/file.txt");
+    fs::write(source_root.join("new_dir/file.txt"), b"in new dir").expect("write new_dir/file.txt");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -758,7 +767,9 @@ fn existing_matches_upstream_rsync_semantics() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().existing_only(true).recursive(true),
+            LocalCopyOptions::default()
+                .existing_only(true)
+                .recursive(true),
         )
         .expect("copy succeeds");
 
@@ -777,7 +788,10 @@ fn existing_matches_upstream_rsync_semantics() {
         b"updated_data",
         "existing file should be updated"
     );
-    assert!(!dest_root.join("new.txt").exists(), "new file should be skipped");
+    assert!(
+        !dest_root.join("new.txt").exists(),
+        "new file should be skipped"
+    );
     assert!(
         !dest_root.join("new_dir").exists(),
         "new directory should be skipped"
@@ -816,9 +830,15 @@ fn existing_combined_with_ignore_existing_skips_all_files() {
     assert_eq!(summary.regular_files_total(), 3);
     assert!(summary.regular_files_skipped_missing() >= 1);
     assert!(summary.regular_files_ignored_existing() >= 2);
-    assert_eq!(fs::read(dest_root.join("changed.txt")).expect("read"), b"old content");
+    assert_eq!(
+        fs::read(dest_root.join("changed.txt")).expect("read"),
+        b"old content"
+    );
     assert!(!dest_root.join("new.txt").exists());
-    assert_eq!(fs::read(dest_root.join("same.txt")).expect("read"), b"identical");
+    assert_eq!(
+        fs::read(dest_root.join("same.txt")).expect("read"),
+        b"identical"
+    );
 }
 
 #[test]
@@ -849,8 +869,14 @@ fn existing_combined_with_ignore_existing_and_delete_removes_extraneous() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 0, "no files should be transferred");
-    assert_eq!(fs::read(dest_root.join("keep.txt")).expect("read keep"), b"dest content");
-    assert!(!dest_root.join("extra.txt").exists(), "extraneous file should be deleted");
+    assert_eq!(
+        fs::read(dest_root.join("keep.txt")).expect("read keep"),
+        b"dest content"
+    );
+    assert!(
+        !dest_root.join("extra.txt").exists(),
+        "extraneous file should be deleted"
+    );
     assert!(summary.items_deleted() >= 1);
 }
 
@@ -884,7 +910,10 @@ fn existing_combined_with_ignore_existing_dry_run() {
     assert_eq!(summary.regular_files_total(), 2);
     assert!(summary.regular_files_skipped_missing() >= 1);
     assert!(summary.regular_files_ignored_existing() >= 1);
-    assert_eq!(fs::read(dest_root.join("present.txt")).expect("read"), b"old");
+    assert_eq!(
+        fs::read(dest_root.join("present.txt")).expect("read"),
+        b"old"
+    );
     assert!(!dest_root.join("missing.txt").exists());
 }
 
@@ -897,7 +926,10 @@ fn existing_combined_with_ignore_existing_single_file_existing() {
     fs::write(&source, b"updated content").expect("write source");
     fs::write(&destination, b"original content").expect("write dest");
 
-    let operands = vec![source.into_os_string(), destination.clone().into_os_string()];
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let summary = plan
@@ -912,7 +944,10 @@ fn existing_combined_with_ignore_existing_single_file_existing() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_ignored_existing(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"original content");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"original content"
+    );
 }
 
 #[test]
@@ -923,7 +958,10 @@ fn existing_combined_with_ignore_existing_single_file_missing() {
 
     fs::write(&source, b"new content").expect("write source");
 
-    let operands = vec![source.into_os_string(), destination.clone().into_os_string()];
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let summary = plan
@@ -1021,8 +1059,14 @@ fn existing_combined_with_ignore_existing_recursive_nested() {
     assert_eq!(summary.regular_files_total(), 4);
     assert!(summary.regular_files_skipped_missing() >= 2);
     assert!(summary.regular_files_ignored_existing() >= 2);
-    assert_eq!(fs::read(dest_root.join("root_exists.txt")).expect("read"), b"original");
-    assert_eq!(fs::read(dest_root.join("subdir/sub_exists.txt")).expect("read"), b"original sub");
+    assert_eq!(
+        fs::read(dest_root.join("root_exists.txt")).expect("read"),
+        b"original"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("subdir/sub_exists.txt")).expect("read"),
+        b"original sub"
+    );
     assert!(!dest_root.join("root_new.txt").exists());
     assert!(!dest_root.join("subdir/sub_new.txt").exists());
 }
@@ -1056,6 +1100,9 @@ fn existing_combined_with_ignore_existing_and_update() {
 
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 2);
-    assert_eq!(fs::read(dest_root.join("file.txt")).expect("read"), b"older");
+    assert_eq!(
+        fs::read(dest_root.join("file.txt")).expect("read"),
+        b"older"
+    );
     assert!(!dest_root.join("new.txt").exists());
 }

--- a/crates/engine/src/local_copy/tests/execute_force.rs
+++ b/crates/engine/src/local_copy/tests/execute_force.rs
@@ -28,7 +28,10 @@ fn force_file_replaces_non_empty_directory() {
         )
         .expect("forced replacement succeeds");
 
-    assert!(destination.is_file(), "directory should be replaced by file");
+    assert!(
+        destination.is_file(),
+        "directory should be replaced by file"
+    );
     assert_eq!(
         fs::read(&destination).expect("read destination"),
         b"file-content"
@@ -93,7 +96,10 @@ fn force_file_replaces_deeply_nested_directory() {
     )
     .expect("forced replacement succeeds");
 
-    assert!(destination.is_file(), "deeply nested directory replaced by file");
+    assert!(
+        destination.is_file(),
+        "deeply nested directory replaced by file"
+    );
     assert_eq!(fs::read(&destination).expect("read"), b"flat");
 }
 
@@ -186,7 +192,10 @@ fn force_replaces_directory_entry_with_file_during_recursive_copy() {
     .expect("forced replacement succeeds");
 
     let item_path = dest_root.join("item");
-    assert!(item_path.is_file(), "directory entry should be replaced by file");
+    assert!(
+        item_path.is_file(),
+        "directory entry should be replaced by file"
+    );
     assert_eq!(fs::read(&item_path).expect("read"), b"file-data");
 }
 
@@ -216,7 +225,10 @@ fn force_replaces_file_entry_with_directory_during_recursive_copy() {
     .expect("forced replacement succeeds");
 
     let item_path = dest_root.join("item");
-    assert!(item_path.is_dir(), "file entry should be replaced by directory");
+    assert!(
+        item_path.is_dir(),
+        "file entry should be replaced by directory"
+    );
     assert_eq!(
         fs::read(item_path.join("child.txt")).expect("read child"),
         b"child"
@@ -276,7 +288,10 @@ fn force_dry_run_does_not_modify_directory() {
     )
     .expect("dry-run succeeds");
 
-    assert!(destination.is_dir(), "directory should not be modified in dry-run");
+    assert!(
+        destination.is_dir(),
+        "directory should not be modified in dry-run"
+    );
     assert_eq!(
         fs::read(destination.join("inner/keep.txt")).expect("read"),
         b"keep"
@@ -353,10 +368,7 @@ fn force_symlink_replaces_non_empty_directory() {
         metadata.file_type().is_symlink(),
         "directory should be replaced by symlink"
     );
-    assert_eq!(
-        fs::read_link(&destination).expect("read link"),
-        link_target
-    );
+    assert_eq!(fs::read_link(&destination).expect("read link"), link_target);
 }
 
 #[cfg(unix)]
@@ -392,10 +404,7 @@ fn force_disabled_symlink_cannot_replace_directory_in_recursive_copy() {
 
     match error.kind() {
         LocalCopyErrorKind::InvalidArgument(reason) => {
-            assert_eq!(
-                *reason,
-                LocalCopyArgumentError::ReplaceDirectoryWithSymlink
-            );
+            assert_eq!(*reason, LocalCopyArgumentError::ReplaceDirectoryWithSymlink);
         }
         other => panic!("unexpected error kind: {other:?}"),
     }
@@ -618,10 +627,11 @@ fn force_overwrite_file_with_file_is_normal_copy() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(
-        fs::read(&destination).expect("read"),
-        b"new-content"
-    );
+    assert_eq!(fs::read(&destination).expect("read"), b"new-content");
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(summary.items_deleted(), 0, "no force deletion needed for same-type overwrite");
+    assert_eq!(
+        summary.items_deleted(),
+        0,
+        "no force deletion needed for same-type overwrite"
+    );
 }

--- a/crates/engine/src/local_copy/tests/execute_fsync.rs
+++ b/crates/engine/src/local_copy/tests/execute_fsync.rs
@@ -1,5 +1,5 @@
 use crate::local_copy::{
-    test_support::take_fsync_call_count, LocalCopyExecution, LocalCopyOptions, LocalCopyPlan,
+    LocalCopyExecution, LocalCopyOptions, LocalCopyPlan, test_support::take_fsync_call_count,
 };
 
 /// Tests that fsync-enabled transfers complete successfully.
@@ -25,8 +25,7 @@ fn execute_succeeds_with_fsync_enabled() {
     take_fsync_call_count();
 
     let options = LocalCopyOptions::default().fsync(true);
-    plan
-        .execute_with_options(LocalCopyExecution::Apply, options)
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     // Immediate fsync count is 0 because DeferredSync handles batched syncing.
@@ -50,8 +49,7 @@ fn execute_skips_fsync_when_not_requested() {
 
     take_fsync_call_count();
 
-    plan
-        .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
+    plan.execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("copy succeeds");
 
     assert_eq!(take_fsync_call_count(), 0);

--- a/crates/engine/src/local_copy/tests/execute_hardlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_hardlinks.rs
@@ -1,4 +1,3 @@
-
 #[cfg(unix)]
 #[test]
 fn execute_with_delay_updates_preserves_hard_links() {
@@ -147,9 +146,18 @@ fn execute_detects_hard_links_between_files() {
     assert_eq!(dest_metadata_b.nlink(), 2);
     assert_eq!(dest_metadata_c.nlink(), 1);
 
-    assert_eq!(fs::read(&dest_a).expect("read dest a"), b"hardlinked content");
-    assert_eq!(fs::read(&dest_b).expect("read dest b"), b"hardlinked content");
-    assert_eq!(fs::read(&dest_c).expect("read dest c"), b"independent content");
+    assert_eq!(
+        fs::read(&dest_a).expect("read dest a"),
+        b"hardlinked content"
+    );
+    assert_eq!(
+        fs::read(&dest_b).expect("read dest b"),
+        b"hardlinked content"
+    );
+    assert_eq!(
+        fs::read(&dest_c).expect("read dest c"),
+        b"independent content"
+    );
 
     assert!(summary.hard_links_created() >= 1);
 }
@@ -380,8 +388,14 @@ fn execute_hardlink_with_partial_and_delay_updates() {
     assert_eq!(metadata_b.nlink(), 2);
     assert_eq!(metadata_c.nlink(), 1);
 
-    assert_eq!(fs::read(&dest_a).expect("read dest a"), b"first hardlink set");
-    assert_eq!(fs::read(&dest_b).expect("read dest b"), b"first hardlink set");
+    assert_eq!(
+        fs::read(&dest_a).expect("read dest a"),
+        b"first hardlink set"
+    );
+    assert_eq!(
+        fs::read(&dest_b).expect("read dest b"),
+        b"first hardlink set"
+    );
     assert_eq!(fs::read(&dest_c).expect("read dest c"), b"independent");
 
     assert!(summary.hard_links_created() >= 1);
@@ -448,8 +462,16 @@ fn execute_hardlink_tracking_table_consistency() {
     let dest_meta3 = fs::metadata(&dest3).expect("dest meta3");
     let dest_meta4 = fs::metadata(&dest4).expect("dest meta4");
 
-    assert_eq!(dest_meta1.ino(), dest_meta2.ino(), "first group should share inode");
-    assert_eq!(dest_meta3.ino(), dest_meta4.ino(), "second group should share inode");
+    assert_eq!(
+        dest_meta1.ino(),
+        dest_meta2.ino(),
+        "first group should share inode"
+    );
+    assert_eq!(
+        dest_meta3.ino(),
+        dest_meta4.ino(),
+        "second group should share inode"
+    );
     assert_ne!(
         dest_meta1.ino(),
         dest_meta3.ino(),
@@ -499,7 +521,9 @@ fn execute_hardlink_with_existing_destination() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default().hard_links(true).ignore_times(true);
+    let options = LocalCopyOptions::default()
+        .hard_links(true)
+        .ignore_times(true);
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -514,8 +538,14 @@ fn execute_hardlink_with_existing_destination() {
     assert_eq!(dest_metadata_a.nlink(), 2);
     assert_eq!(dest_metadata_b.nlink(), 2);
 
-    assert_eq!(fs::read(&dest_a_actual).expect("read dest a"), b"new content");
-    assert_eq!(fs::read(&dest_b_actual).expect("read dest b"), b"new content");
+    assert_eq!(
+        fs::read(&dest_a_actual).expect("read dest a"),
+        b"new content"
+    );
+    assert_eq!(
+        fs::read(&dest_b_actual).expect("read dest b"),
+        b"new content"
+    );
 
     assert!(summary.hard_links_created() >= 1);
 }
@@ -619,9 +649,21 @@ fn execute_hardlink_detection_by_device_inode() {
         dest_meta_b.ino(),
         "files with same content but different source inodes should remain separate"
     );
-    assert_eq!(dest_meta_a.nlink(), 1, "standalone file should have nlink=1");
-    assert_eq!(dest_meta_b.nlink(), 1, "standalone file should have nlink=1");
-    assert_eq!(summary.hard_links_created(), 0, "no hardlinks should be created");
+    assert_eq!(
+        dest_meta_a.nlink(),
+        1,
+        "standalone file should have nlink=1"
+    );
+    assert_eq!(
+        dest_meta_b.nlink(),
+        1,
+        "standalone file should have nlink=1"
+    );
+    assert_eq!(
+        summary.hard_links_created(),
+        0,
+        "no hardlinks should be created"
+    );
 }
 
 /// Test hardlink detection with zero-length files.
@@ -663,7 +705,11 @@ fn execute_hardlink_zero_length_files() {
     let dest_meta_a = fs::metadata(&dest_a).expect("dest meta a");
     let dest_meta_b = fs::metadata(&dest_b).expect("dest meta b");
 
-    assert_eq!(dest_meta_a.ino(), dest_meta_b.ino(), "empty files should be hardlinked");
+    assert_eq!(
+        dest_meta_a.ino(),
+        dest_meta_b.ino(),
+        "empty files should be hardlinked"
+    );
     assert_eq!(dest_meta_a.nlink(), 2);
     assert!(summary.hard_links_created() >= 1);
 }
@@ -706,7 +752,11 @@ fn execute_hardlink_long_filenames() {
     let dest_meta_a = fs::metadata(&dest_a).expect("dest meta a");
     let dest_meta_b = fs::metadata(&dest_b).expect("dest meta b");
 
-    assert_eq!(dest_meta_a.ino(), dest_meta_b.ino(), "long-named files should be hardlinked");
+    assert_eq!(
+        dest_meta_a.ino(),
+        dest_meta_b.ino(),
+        "long-named files should be hardlinked"
+    );
     assert_eq!(dest_meta_a.nlink(), 2);
     assert!(summary.hard_links_created() >= 1);
 }
@@ -782,7 +832,10 @@ fn execute_hardlink_dry_run_mode() {
         .expect("dry run succeeds");
 
     // In dry-run mode, destination should not be created
-    assert!(!dest_root.exists(), "destination should not be created in dry-run");
+    assert!(
+        !dest_root.exists(),
+        "destination should not be created in dry-run"
+    );
 }
 
 /// Test that hardlink count tracking is accurate across operations.
@@ -879,7 +932,11 @@ fn execute_hardlink_nlink_changes_during_operation() {
     let dest_meta_a = fs::metadata(&dest_a).expect("dest meta a");
     let dest_meta_b = fs::metadata(&dest_b).expect("dest meta b");
 
-    assert_eq!(dest_meta_a.ino(), dest_meta_b.ino(), "files should share inode");
+    assert_eq!(
+        dest_meta_a.ino(),
+        dest_meta_b.ino(),
+        "files should share inode"
+    );
     assert_eq!(dest_meta_a.nlink(), 2);
     assert!(summary.hard_links_created() >= 1);
 }
@@ -960,9 +1017,7 @@ fn execute_hardlink_mixed_with_symlinks() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .hard_links(true)
-        .links(true);  // Also preserve symlinks
+    let options = LocalCopyOptions::default().hard_links(true).links(true); // Also preserve symlinks
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -973,11 +1028,18 @@ fn execute_hardlink_mixed_with_symlinks() {
 
     let dest_meta_regular = fs::metadata(&dest_regular).expect("dest meta regular");
     let dest_meta_hardlink = fs::metadata(&dest_hardlink).expect("dest meta hardlink");
-    assert_eq!(dest_meta_regular.ino(), dest_meta_hardlink.ino(), "hardlink should be preserved");
+    assert_eq!(
+        dest_meta_regular.ino(),
+        dest_meta_hardlink.ino(),
+        "hardlink should be preserved"
+    );
 
     // Verify symlink is preserved as symlink (not following target)
     let symlink_meta = fs::symlink_metadata(&dest_symlink).expect("symlink meta");
-    assert!(symlink_meta.is_symlink(), "symlink should be preserved as symlink");
+    assert!(
+        symlink_meta.is_symlink(),
+        "symlink should be preserved as symlink"
+    );
 
     assert!(summary.hard_links_created() >= 1);
 }

--- a/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
@@ -1,4 +1,3 @@
-
 //
 // Upstream rsync behavior:
 // - Without --ignore-errors: if I/O errors occurred during transfer,
@@ -6,7 +5,6 @@
 //   couldn't read all files)
 // - With --ignore-errors: --delete proceeds with deletions even when
 //   I/O errors occurred during the transfer
-
 
 #[test]
 fn ignore_errors_option_defaults_to_false() {
@@ -39,9 +37,7 @@ fn ignore_errors_option_can_be_disabled_after_enabling() {
 
 #[test]
 fn ignore_errors_builder_defaults_to_false() {
-    let opts = LocalCopyOptions::builder()
-        .build()
-        .expect("valid options");
+    let opts = LocalCopyOptions::builder().build().expect("valid options");
     assert!(
         !opts.ignore_errors_enabled(),
         "builder should default ignore_errors to false"
@@ -156,7 +152,10 @@ fn delete_works_normally_without_io_errors() {
         .expect("copy succeeds");
 
     assert!(dest.join("keep.txt").exists(), "kept file should remain");
-    assert!(!dest.join("extra.txt").exists(), "extra file should be deleted");
+    assert!(
+        !dest.join("extra.txt").exists(),
+        "extra file should be deleted"
+    );
     assert!(summary.items_deleted() >= 1, "should report deletion");
 }
 
@@ -179,16 +178,17 @@ fn delete_with_ignore_errors_works_normally_without_io_errors() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .delete(true)
-        .ignore_errors(true);
+    let options = LocalCopyOptions::default().delete(true).ignore_errors(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     assert!(dest.join("keep.txt").exists(), "kept file should remain");
-    assert!(!dest.join("extra.txt").exists(), "extra file should be deleted");
+    assert!(
+        !dest.join("extra.txt").exists(),
+        "extra file should be deleted"
+    );
     assert!(summary.items_deleted() >= 1, "should report deletion");
 }
 
@@ -213,8 +213,12 @@ fn ignore_errors_option_independent_of_delete_timing() {
 
         let options = match timing_setup {
             "delete" => LocalCopyOptions::default().delete(true).ignore_errors(true),
-            "delete_after" => LocalCopyOptions::default().delete_after(true).ignore_errors(true),
-            "delete_before" => LocalCopyOptions::default().delete_before(true).ignore_errors(true),
+            "delete_after" => LocalCopyOptions::default()
+                .delete_after(true)
+                .ignore_errors(true),
+            "delete_before" => LocalCopyOptions::default()
+                .delete_before(true)
+                .ignore_errors(true),
             _ => unreachable!(),
         };
 
@@ -376,7 +380,7 @@ fn ignore_errors_suppresses_io_error_skip_notice() {
     // notice must NOT appear and the extraneous file must be deleted. The
     // flag both silences the warning and re-enables deletion upstream.
     // upstream: generator.c:304 `io_error & IOERR_GENERAL && !ignore_errors`.
-    use logging::{DiagnosticEvent, drain_events, init, VerbosityConfig};
+    use logging::{DiagnosticEvent, VerbosityConfig, drain_events, init};
     use std::os::unix::fs::PermissionsExt;
 
     init(VerbosityConfig::from_verbose_level(0));
@@ -416,13 +420,10 @@ fn ignore_errors_suppresses_io_error_skip_notice() {
     );
 
     let notice = "IO error encountered -- skipping file deletion";
-    let saw_notice = drain_events().into_iter().any(|event| {
-        matches!(event, DiagnosticEvent::Info { ref message, .. } if message == notice)
-    });
-    assert!(
-        !saw_notice,
-        "--ignore-errors must suppress the skip notice"
+    let saw_notice = drain_events().into_iter().any(
+        |event| matches!(event, DiagnosticEvent::Info { ref message, .. } if message == notice),
     );
+    assert!(!saw_notice, "--ignore-errors must suppress the skip notice");
 }
 
 #[cfg(unix)]
@@ -441,11 +442,8 @@ fn delete_proceeds_when_io_errors_and_ignore_errors_set() {
     fs::write(source.join("good.txt"), b"good").expect("write good");
     // Create an unreadable source file to trigger I/O error
     fs::write(source.join("bad.txt"), b"bad").expect("write bad");
-    fs::set_permissions(
-        source.join("bad.txt"),
-        fs::Permissions::from_mode(0o000),
-    )
-    .expect("make unreadable");
+    fs::set_permissions(source.join("bad.txt"), fs::Permissions::from_mode(0o000))
+        .expect("make unreadable");
 
     fs::write(dest.join("good.txt"), b"old good").expect("write old good");
     fs::write(dest.join("extra.txt"), b"should be deleted").expect("write extra");
@@ -455,17 +453,12 @@ fn delete_proceeds_when_io_errors_and_ignore_errors_set() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .delete(true)
-        .ignore_errors(true);
+    let options = LocalCopyOptions::default().delete(true).ignore_errors(true);
 
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
     // Restore permissions for cleanup
-    let _ = fs::set_permissions(
-        source.join("bad.txt"),
-        fs::Permissions::from_mode(0o644),
-    );
+    let _ = fs::set_permissions(source.join("bad.txt"), fs::Permissions::from_mode(0o644));
 
     assert!(
         !dest.join("extra.txt").exists(),
@@ -488,11 +481,8 @@ fn ignore_errors_with_delete_after_timing() {
 
     fs::write(source.join("good.txt"), b"good").expect("write good");
     fs::write(source.join("bad.txt"), b"bad").expect("write bad");
-    fs::set_permissions(
-        source.join("bad.txt"),
-        fs::Permissions::from_mode(0o000),
-    )
-    .expect("make unreadable");
+    fs::set_permissions(source.join("bad.txt"), fs::Permissions::from_mode(0o000))
+        .expect("make unreadable");
 
     fs::write(dest.join("good.txt"), b"old good").expect("write old good");
     fs::write(dest.join("extra.txt"), b"should be deleted").expect("write extra");
@@ -508,10 +498,7 @@ fn ignore_errors_with_delete_after_timing() {
 
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
-    let _ = fs::set_permissions(
-        source.join("bad.txt"),
-        fs::Permissions::from_mode(0o644),
-    );
+    let _ = fs::set_permissions(source.join("bad.txt"), fs::Permissions::from_mode(0o644));
 
     assert!(
         !dest.join("extra.txt").exists(),
@@ -533,11 +520,8 @@ fn no_ignore_errors_with_delete_after_suppresses_deletions() {
 
     fs::write(source.join("good.txt"), b"good").expect("write good");
     fs::write(source.join("bad.txt"), b"bad").expect("write bad");
-    fs::set_permissions(
-        source.join("bad.txt"),
-        fs::Permissions::from_mode(0o000),
-    )
-    .expect("make unreadable");
+    fs::set_permissions(source.join("bad.txt"), fs::Permissions::from_mode(0o000))
+        .expect("make unreadable");
 
     fs::write(dest.join("good.txt"), b"old good").expect("write old good");
     fs::write(dest.join("extra.txt"), b"should survive").expect("write extra");
@@ -551,10 +535,7 @@ fn no_ignore_errors_with_delete_after_suppresses_deletions() {
 
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
-    let _ = fs::set_permissions(
-        source.join("bad.txt"),
-        fs::Permissions::from_mode(0o644),
-    );
+    let _ = fs::set_permissions(source.join("bad.txt"), fs::Permissions::from_mode(0o644));
 
     assert!(
         dest.join("extra.txt").exists(),
@@ -562,7 +543,6 @@ fn no_ignore_errors_with_delete_after_suppresses_deletions() {
     );
     assert!(result.is_err(), "copy should report I/O error");
 }
-
 
 #[test]
 fn ignore_errors_with_dry_run_reports_deletions() {
@@ -593,9 +573,16 @@ fn ignore_errors_with_dry_run_reports_deletions() {
 
     let summary = report.summary();
 
-    assert!(dest.join("extra.txt").exists(), "file should exist in dry-run");
+    assert!(
+        dest.join("extra.txt").exists(),
+        "file should exist in dry-run"
+    );
 
-    assert_eq!(summary.items_deleted(), 1, "should report 1 deletion in dry-run");
+    assert_eq!(
+        summary.items_deleted(),
+        1,
+        "should report 1 deletion in dry-run"
+    );
 }
 
 #[test]
@@ -617,9 +604,7 @@ fn ignore_errors_preserves_good_files_during_transfer() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .delete(true)
-        .ignore_errors(true);
+    let options = LocalCopyOptions::default().delete(true).ignore_errors(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -652,9 +637,7 @@ fn ignore_errors_with_nested_directories() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .delete(true)
-        .ignore_errors(true);
+    let options = LocalCopyOptions::default().delete(true).ignore_errors(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -662,8 +645,14 @@ fn ignore_errors_with_nested_directories() {
 
     assert!(dest.join("root.txt").exists());
     assert!(dest.join("subdir/nested.txt").exists());
-    assert!(!dest.join("subdir/extra.txt").exists(), "nested extra should be deleted");
-    assert!(!dest.join("root_extra.txt").exists(), "root extra should be deleted");
+    assert!(
+        !dest.join("subdir/extra.txt").exists(),
+        "nested extra should be deleted"
+    );
+    assert!(
+        !dest.join("root_extra.txt").exists(),
+        "root extra should be deleted"
+    );
     assert!(summary.items_deleted() >= 2);
 }
 
@@ -716,8 +705,8 @@ fn ignore_errors_combined_with_delete_excluded() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filter_set = FilterSet::from_rules([FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filter_set =
+        FilterSet::from_rules([FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .delete(true)
         .delete_excluded(true)
@@ -729,7 +718,10 @@ fn ignore_errors_combined_with_delete_excluded() {
         .expect("copy succeeds");
 
     assert!(dest.join("keep.txt").exists());
-    assert!(!dest.join("skip.tmp").exists(), "excluded file should be deleted");
+    assert!(
+        !dest.join("skip.tmp").exists(),
+        "excluded file should be deleted"
+    );
     assert_eq!(summary.items_deleted(), 1);
 }
 
@@ -756,8 +748,15 @@ fn ignore_errors_without_delete_no_deletions() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(dest.join("extra.txt").exists(), "extra file should remain without --delete");
-    assert_eq!(summary.items_deleted(), 0, "no deletions should occur without --delete");
+    assert!(
+        dest.join("extra.txt").exists(),
+        "extra file should remain without --delete"
+    );
+    assert_eq!(
+        summary.items_deleted(),
+        0,
+        "no deletions should occur without --delete"
+    );
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_ignore_existing.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_existing.rs
@@ -177,7 +177,9 @@ fn ignore_existing_recursive_mixed_scenarios() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().ignore_existing(true).recursive(true),
+            LocalCopyOptions::default()
+                .ignore_existing(true)
+                .recursive(true),
         )
         .expect("copy succeeds");
 
@@ -222,15 +224,21 @@ fn ignore_existing_nested_directories() {
     fs::write(source_root.join("level1/new_l1.txt"), b"l1 new").expect("write l1 new");
 
     // Level 1: existing file (skip)
-    fs::write(source_root.join("level1/exists_l1.txt"), b"l1 source").expect("write l1 exists source");
+    fs::write(source_root.join("level1/exists_l1.txt"), b"l1 source")
+        .expect("write l1 exists source");
     fs::write(dest_root.join("level1/exists_l1.txt"), b"l1 dest").expect("write l1 exists dest");
 
     // Level 2: new file (copy)
     fs::write(source_root.join("level1/level2/l2.txt"), b"l2 content").expect("write l2 source");
 
     // Level 2: existing file (skip)
-    fs::write(source_root.join("level1/level2/exists_l2.txt"), b"l2 source").expect("write l2 exists source");
-    fs::write(dest_root.join("level1/level2/exists_l2.txt"), b"l2 dest").expect("write l2 exists dest");
+    fs::write(
+        source_root.join("level1/level2/exists_l2.txt"),
+        b"l2 source",
+    )
+    .expect("write l2 exists source");
+    fs::write(dest_root.join("level1/level2/exists_l2.txt"), b"l2 dest")
+        .expect("write l2 exists dest");
 
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -240,7 +248,9 @@ fn ignore_existing_nested_directories() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().ignore_existing(true).recursive(true),
+            LocalCopyOptions::default()
+                .ignore_existing(true)
+                .recursive(true),
         )
         .expect("copy succeeds");
 
@@ -292,7 +302,9 @@ fn ignore_existing_handles_directories_correctly() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().ignore_existing(true).recursive(true),
+            LocalCopyOptions::default()
+                .ignore_existing(true)
+                .recursive(true),
         )
         .expect("copy succeeds");
 
@@ -346,10 +358,7 @@ fn ignore_existing_with_update_skips_all_existing() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_ignored_existing(), 1);
     assert_eq!(summary.regular_files_skipped_newer(), 0);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"older content"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"older content");
 }
 
 #[test]
@@ -361,15 +370,18 @@ fn ignore_existing_with_update_copies_new_files() {
     fs::create_dir_all(&dest_root).expect("create dest root");
 
     // File 1: exists at dest, source is newer (skip due to ignore_existing)
-    fs::write(source_root.join("exists_newer.txt"), b"newer_content").expect("write exists_newer source");
-    fs::write(dest_root.join("exists_newer.txt"), b"older_content").expect("write exists_newer dest");
+    fs::write(source_root.join("exists_newer.txt"), b"newer_content")
+        .expect("write exists_newer source");
+    fs::write(dest_root.join("exists_newer.txt"), b"older_content")
+        .expect("write exists_newer dest");
     let newer_time = FileTime::from_unix_time(1_700_000_100, 0);
     let older_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(source_root.join("exists_newer.txt"), newer_time).expect("set source time");
     set_file_mtime(dest_root.join("exists_newer.txt"), older_time).expect("set dest time");
 
     // File 2: exists at dest, source is older (skip due to ignore_existing)
-    fs::write(source_root.join("exists_older.txt"), b"older_value").expect("write exists_older source");
+    fs::write(source_root.join("exists_older.txt"), b"older_value")
+        .expect("write exists_older source");
     fs::write(dest_root.join("exists_older.txt"), b"newer_value").expect("write exists_older dest");
     set_file_mtime(source_root.join("exists_older.txt"), older_time).expect("set source time");
     set_file_mtime(dest_root.join("exists_older.txt"), newer_time).expect("set dest time");
@@ -444,10 +456,7 @@ fn ignore_existing_with_checksum() {
     // File exists, so skip regardless of checksum difference
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_ignored_existing(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"dest content"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"dest content");
 }
 
 #[test]
@@ -608,11 +617,15 @@ fn ignore_existing_with_permissions_difference() {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut source_perms = fs::metadata(&source).expect("source metadata").permissions();
+        let mut source_perms = fs::metadata(&source)
+            .expect("source metadata")
+            .permissions();
         source_perms.set_mode(0o755);
         fs::set_permissions(&source, source_perms).expect("set source perms");
 
-        let mut dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+        let mut dest_perms = fs::metadata(&destination)
+            .expect("dest metadata")
+            .permissions();
         dest_perms.set_mode(0o644);
         fs::set_permissions(&destination, dest_perms).expect("set dest perms");
     }
@@ -640,7 +653,9 @@ fn ignore_existing_with_permissions_difference() {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+        let dest_perms = fs::metadata(&destination)
+            .expect("dest metadata")
+            .permissions();
         assert_eq!(dest_perms.mode() & 0o777, 0o644);
     }
 }
@@ -666,7 +681,9 @@ fn ignore_existing_dry_run() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::DryRun,
-            LocalCopyOptions::default().ignore_existing(true).recursive(true),
+            LocalCopyOptions::default()
+                .ignore_existing(true)
+                .recursive(true),
         )
         .expect("dry run succeeds");
 

--- a/crates/engine/src/local_copy/tests/execute_ignore_times.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_times.rs
@@ -186,10 +186,7 @@ fn ignore_times_with_checksum_copies_different_content() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"source!"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"source!");
 }
 
 #[test]
@@ -289,10 +286,7 @@ fn ignore_times_with_size_only_skips_same_size() {
     // size_only wins over ignore_times - file is NOT transferred
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"dest!!!"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"dest!!!");
 }
 
 #[test]
@@ -377,10 +371,19 @@ fn ignore_times_allows_delta_transfer() {
 
     // Delta transfer should have matched most of the prefix
     // Note: Block boundaries may not align perfectly at 1000 bytes
-    assert!(summary.matched_bytes() >= 700, "should match at least 700 bytes of shared prefix");
-    assert!(summary.matched_bytes() <= 1000, "should not match more than the shared prefix");
+    assert!(
+        summary.matched_bytes() >= 700,
+        "should match at least 700 bytes of shared prefix"
+    );
+    assert!(
+        summary.matched_bytes() <= 1000,
+        "should not match more than the shared prefix"
+    );
 
-    assert!(summary.bytes_copied() >= 500, "should transfer at least the changed 500 bytes");
+    assert!(
+        summary.bytes_copied() >= 500,
+        "should transfer at least the changed 500 bytes"
+    );
 
     assert_eq!(fs::read(&destination).expect("read dest"), source_content);
 }
@@ -418,9 +421,15 @@ fn ignore_times_delta_transfer_with_matching_content() {
     assert_eq!(summary.regular_files_total(), 1);
 
     // Most bytes should be matched via delta (block alignment may not be perfect)
-    assert!(summary.matched_bytes() >= 1400, "should match most content via delta");
+    assert!(
+        summary.matched_bytes() >= 1400,
+        "should match most content via delta"
+    );
 
-    assert!(summary.bytes_copied() <= 600, "should transfer minimal bytes for identical content");
+    assert!(
+        summary.bytes_copied() <= 600,
+        "should transfer minimal bytes for identical content"
+    );
 
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
@@ -495,9 +504,7 @@ fn ignore_times_overrides_update_skip() {
     let summary_with = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .ignore_times(true)
-                .update(true),
+            LocalCopyOptions::default().ignore_times(true).update(true),
         )
         .expect("copy with flags");
 
@@ -505,10 +512,7 @@ fn ignore_times_overrides_update_skip() {
     // --ignore-times doesn't override --update's newer-dest logic
     assert_eq!(summary_with.files_copied(), 0);
     assert_eq!(summary_with.regular_files_skipped_newer(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"dest content"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"dest content");
 }
 
 #[test]
@@ -529,13 +533,10 @@ fn ignore_times_recursive_transfers_all_files() {
 
         fs::write(source_root.join(&filename), content_source.as_bytes())
             .expect("write source file");
-        fs::write(dest_root.join(&filename), content_dest.as_bytes())
-            .expect("write dest file");
+        fs::write(dest_root.join(&filename), content_dest.as_bytes()).expect("write dest file");
 
-        set_file_mtime(source_root.join(&filename), timestamp)
-            .expect("set source time");
-        set_file_mtime(dest_root.join(&filename), timestamp)
-            .expect("set dest time");
+        set_file_mtime(source_root.join(&filename), timestamp).expect("set source time");
+        set_file_mtime(dest_root.join(&filename), timestamp).expect("set dest time");
     }
 
     let mut source_operand = source_root.clone().into_os_string();
@@ -577,28 +578,19 @@ fn ignore_times_with_nested_directories() {
 
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
 
-    fs::write(source_root.join("root.txt"), b"root source")
-        .expect("write root source");
-    fs::write(dest_root.join("root.txt"), b"root dest!!")
-        .expect("write root dest");
-    set_file_mtime(source_root.join("root.txt"), timestamp)
-        .expect("set root source time");
-    set_file_mtime(dest_root.join("root.txt"), timestamp)
-        .expect("set root dest time");
+    fs::write(source_root.join("root.txt"), b"root source").expect("write root source");
+    fs::write(dest_root.join("root.txt"), b"root dest!!").expect("write root dest");
+    set_file_mtime(source_root.join("root.txt"), timestamp).expect("set root source time");
+    set_file_mtime(dest_root.join("root.txt"), timestamp).expect("set root dest time");
 
-    fs::write(source_root.join("dir1/level1.txt"), b"level1 source")
-        .expect("write level1 source");
-    fs::write(dest_root.join("dir1/level1.txt"), b"level1 dest!!")
-        .expect("write level1 dest");
-    set_file_mtime(source_root.join("dir1/level1.txt"), timestamp)
-        .expect("set level1 source time");
-    set_file_mtime(dest_root.join("dir1/level1.txt"), timestamp)
-        .expect("set level1 dest time");
+    fs::write(source_root.join("dir1/level1.txt"), b"level1 source").expect("write level1 source");
+    fs::write(dest_root.join("dir1/level1.txt"), b"level1 dest!!").expect("write level1 dest");
+    set_file_mtime(source_root.join("dir1/level1.txt"), timestamp).expect("set level1 source time");
+    set_file_mtime(dest_root.join("dir1/level1.txt"), timestamp).expect("set level1 dest time");
 
     fs::write(source_root.join("dir1/dir2/level2.txt"), b"level2 source")
         .expect("write level2 source");
-    fs::write(dest_root.join("dir1/dir2/level2.txt"), b"level2 dest!!")
-        .expect("write level2 dest");
+    fs::write(dest_root.join("dir1/dir2/level2.txt"), b"level2 dest!!").expect("write level2 dest");
     set_file_mtime(source_root.join("dir1/dir2/level2.txt"), timestamp)
         .expect("set level2 source time");
     set_file_mtime(dest_root.join("dir1/dir2/level2.txt"), timestamp)
@@ -726,10 +718,7 @@ fn ignore_times_with_large_files() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.bytes_copied(), 150_000);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        source_content
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), source_content);
 }
 
 #[test]
@@ -761,10 +750,7 @@ fn ignore_times_dry_run_reports_correctly() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
 
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"dest content"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"dest content");
 }
 
 #[test]
@@ -782,7 +768,9 @@ fn ignore_times_with_permissions_and_times_preserves_metadata() {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&source).expect("source metadata").permissions();
+        let mut perms = fs::metadata(&source)
+            .expect("source metadata")
+            .permissions();
         perms.set_mode(0o644);
         fs::set_permissions(&source, perms).expect("set source perms");
     }

--- a/crates/engine/src/local_copy/tests/execute_inplace.rs
+++ b/crates/engine/src/local_copy/tests/execute_inplace.rs
@@ -14,7 +14,6 @@
 // 5. File permissions preserved during update
 // 6. Inode preservation (unlike temp file replacement)
 
-
 #[test]
 fn execute_inplace_updates_file_directly() {
     let temp = tempdir().expect("tempdir");
@@ -38,7 +37,10 @@ fn execute_inplace_updates_file_directly() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"new content here");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"new content here"
+    );
 }
 
 #[test]
@@ -64,9 +66,11 @@ fn execute_inplace_creates_new_file_when_destination_missing() {
 
     assert_eq!(summary.files_copied(), 1);
     assert!(destination.exists());
-    assert_eq!(fs::read(&destination).expect("read dest"), b"brand new file");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"brand new file"
+    );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -153,7 +157,6 @@ fn execute_without_inplace_changes_inode() {
     );
 }
 
-
 #[test]
 fn execute_inplace_does_not_leave_temp_files() {
     let temp = tempdir().expect("tempdir");
@@ -184,12 +187,8 @@ fn execute_inplace_does_not_leave_temp_files() {
         .collect();
 
     assert_eq!(entries.len(), 1, "only destination file should exist");
-    assert_eq!(
-        entries[0].file_name().to_string_lossy(),
-        "target.txt"
-    );
+    assert_eq!(entries[0].file_name().to_string_lossy(), "target.txt");
 }
-
 
 #[test]
 fn execute_inplace_partial_update_small_to_large() {
@@ -217,10 +216,7 @@ fn execute_inplace_partial_update_small_to_large() {
 
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&destination).expect("read dest"), large_content);
-    assert_eq!(
-        fs::metadata(&destination).expect("metadata").len(),
-        10000
-    );
+    assert_eq!(fs::metadata(&destination).expect("metadata").len(), 10000);
 }
 
 #[test]
@@ -253,7 +249,6 @@ fn execute_inplace_partial_update_large_to_small() {
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 4);
 }
 
-
 #[test]
 fn execute_inplace_with_whole_file_transfer() {
     let temp = tempdir().expect("tempdir");
@@ -273,9 +268,7 @@ fn execute_inplace_with_whole_file_transfer() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .whole_file(true),
+            LocalCopyOptions::default().inplace(true).whole_file(true),
         )
         .expect("copy succeeds");
 
@@ -303,9 +296,7 @@ fn execute_inplace_with_whole_file_large_file() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .whole_file(true),
+            LocalCopyOptions::default().inplace(true).whole_file(true),
         )
         .expect("copy succeeds");
 
@@ -313,7 +304,6 @@ fn execute_inplace_with_whole_file_large_file() {
     assert_eq!(summary.bytes_copied(), 300 * 1024);
     assert_eq!(fs::read(&destination).expect("read dest"), large_content);
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -340,15 +330,15 @@ fn execute_inplace_preserves_permissions() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .permissions(true),
+            LocalCopyOptions::default().inplace(true).permissions(true),
         )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+    let dest_perms = fs::metadata(&destination)
+        .expect("dest metadata")
+        .permissions();
     assert_eq!(dest_perms.mode() & 0o777, 0o755);
 }
 
@@ -377,18 +367,17 @@ fn execute_inplace_preserves_restricted_permissions() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .permissions(true),
+            LocalCopyOptions::default().inplace(true).permissions(true),
         )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+    let dest_perms = fs::metadata(&destination)
+        .expect("dest metadata")
+        .permissions();
     assert_eq!(dest_perms.mode() & 0o777, 0o600);
 }
-
 
 #[test]
 fn execute_inplace_preserves_timestamps() {
@@ -411,20 +400,16 @@ fn execute_inplace_preserves_timestamps() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .times(true),
+            LocalCopyOptions::default().inplace(true).times(true),
         )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata"),
-    );
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
     assert_eq!(dest_mtime, past_time);
 }
-
 
 #[test]
 fn execute_inplace_with_empty_source() {
@@ -476,7 +461,10 @@ fn execute_inplace_with_empty_destination() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"content to write");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"content to write"
+    );
 }
 
 #[test]
@@ -503,16 +491,13 @@ fn execute_inplace_identical_files_skips_copy() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .times(true),
+            LocalCopyOptions::default().inplace(true).times(true),
         )
         .expect("copy succeeds");
 
     // File should be skipped (size and mtime match)
     assert_eq!(summary.files_copied(), 0);
 }
-
 
 #[test]
 fn execute_inplace_recursive_directory() {
@@ -552,11 +537,10 @@ fn execute_inplace_recursive_directory() {
     );
 }
 
-
 #[cfg(unix)]
 #[test]
 fn execute_inplace_in_read_only_directory() {
-    use rustix::fs::{chmod, Mode};
+    use rustix::fs::{Mode, chmod};
     use std::os::unix::fs::MetadataExt;
 
     let temp = tempdir().expect("tempdir");
@@ -606,7 +590,7 @@ fn execute_inplace_in_read_only_directory() {
 #[cfg(unix)]
 #[test]
 fn execute_without_inplace_fails_in_read_only_directory() {
-    use rustix::fs::{chmod, Mode};
+    use rustix::fs::{Mode, chmod};
 
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
@@ -634,7 +618,10 @@ fn execute_without_inplace_fails_in_read_only_directory() {
     );
 
     // Expect failure due to permission denied creating temp file
-    assert!(result.is_err(), "should fail without inplace in read-only dir");
+    assert!(
+        result.is_err(),
+        "should fail without inplace in read-only dir"
+    );
 
     assert_eq!(fs::read(&destination).expect("read"), b"original");
 
@@ -642,7 +629,6 @@ fn execute_without_inplace_fails_in_read_only_directory() {
     let restore = Mode::from_bits_truncate(0o755);
     chmod(&dest_dir, restore).expect("restore directory");
 }
-
 
 #[test]
 fn execute_inplace_combined_with_checksum() {
@@ -663,9 +649,7 @@ fn execute_inplace_combined_with_checksum() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .checksum(true),
+            LocalCopyOptions::default().inplace(true).checksum(true),
         )
         .expect("copy succeeds");
 
@@ -692,9 +676,7 @@ fn execute_inplace_combined_with_size_only() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .size_only(true),
+            LocalCopyOptions::default().inplace(true).size_only(true),
         )
         .expect("copy succeeds");
 
@@ -727,16 +709,13 @@ fn execute_inplace_combined_with_ignore_times() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .ignore_times(true),
+            LocalCopyOptions::default().inplace(true).ignore_times(true),
         )
         .expect("copy succeeds");
 
     // With ignore_times, should copy even though size/mtime match
     assert_eq!(summary.files_copied(), 1);
 }
-
 
 #[test]
 fn execute_inplace_with_binary_content() {
@@ -766,7 +745,6 @@ fn execute_inplace_with_binary_content() {
     assert_eq!(fs::read(&destination).expect("read dest"), binary_content);
 }
 
-
 #[test]
 fn execute_inplace_records_copy_event() {
     let temp = tempdir().expect("tempdir");
@@ -776,10 +754,7 @@ fn execute_inplace_records_copy_event() {
     fs::write(&source, b"event data").expect("write source");
     fs::write(&destination, b"old").expect("write destination");
 
-    let operands = vec![
-        source.into_os_string(),
-        destination.into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), destination.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default()
@@ -796,14 +771,14 @@ fn execute_inplace_records_copy_event() {
     assert_eq!(records[0].bytes_transferred(), 10);
 }
 
-
 #[test]
 fn execute_inplace_with_delta_transfer_skips_matched_blocks() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    let dest_content = b"Hello world! This is a test file with some content that will be partially reused.";
+    let dest_content =
+        b"Hello world! This is a test file with some content that will be partially reused.";
     fs::write(&destination, dest_content).expect("write destination");
 
     // Create a source file that reuses some blocks from destination
@@ -819,9 +794,7 @@ fn execute_inplace_with_delta_transfer_skips_matched_blocks() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .whole_file(false), // Enable delta transfer
+            LocalCopyOptions::default().inplace(true).whole_file(false), // Enable delta transfer
         )
         .expect("copy succeeds");
 
@@ -856,17 +829,17 @@ fn execute_inplace_with_delta_transfer_updates_existing_file() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .whole_file(false), // Enable delta transfer
+            LocalCopyOptions::default().inplace(true).whole_file(false), // Enable delta transfer
         )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1, "File should be copied");
 
     let final_content = fs::read(&destination).expect("read dest");
-    assert_eq!(final_content, source_content,
-        "Content should match after inplace delta transfer");
+    assert_eq!(
+        final_content, source_content,
+        "Content should match after inplace delta transfer"
+    );
 }
 
 #[test]
@@ -897,9 +870,7 @@ fn execute_inplace_with_delta_preserves_inode() {
 
         plan.execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .inplace(true)
-                .whole_file(false), // Enable delta transfer
+            LocalCopyOptions::default().inplace(true).whole_file(false), // Enable delta transfer
         )
         .expect("copy succeeds");
 
@@ -937,9 +908,7 @@ fn execute_inplace_with_delta_truncates_when_smaller() {
 
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default()
-            .inplace(true)
-            .whole_file(false), // Enable delta transfer
+        LocalCopyOptions::default().inplace(true).whole_file(false), // Enable delta transfer
     )
     .expect("copy succeeds");
 
@@ -951,7 +920,6 @@ fn execute_inplace_with_delta_truncates_when_smaller() {
         "file should be truncated to new size"
     );
 }
-
 
 // Regression test for read-after-write basis corruption in `--inplace
 // --no-whole-file` when the source is shorter than the destination basis.
@@ -1005,9 +973,7 @@ fn execute_inplace_no_whole_file_shorter_source_matches_content() {
 
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default()
-            .inplace(true)
-            .whole_file(false),
+        LocalCopyOptions::default().inplace(true).whole_file(false),
     )
     .expect("copy succeeds");
 
@@ -1058,9 +1024,7 @@ fn execute_inplace_no_whole_file_truncates_tail() {
 
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default()
-            .inplace(true)
-            .whole_file(false),
+        LocalCopyOptions::default().inplace(true).whole_file(false),
     )
     .expect("copy succeeds");
 

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -347,7 +347,11 @@ fn link_dest_best_match_prefers_exact_over_content_only() {
         "destination must not link the level-2 basis"
     );
     assert!(summary.hard_links_created() >= 1);
-    assert_eq!(summary.files_copied(), 0, "an exact basis is hard-linked, not copied");
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "an exact basis is hard-linked, not copied"
+    );
     // The level-2 basis inode must not be mutated (no attr reapply on a shared inode).
     assert_eq!(
         link_dest1_meta.permissions().mode() & 0o777,
@@ -1416,8 +1420,16 @@ fn link_dest_copies_when_only_xattrs_differ() {
         basis_meta.ino(),
         "a match_level-2 basis (attrs differ) must be copied, not hard-linked"
     );
-    assert_eq!(dest_meta.nlink(), 1, "copied file must not gain a hard link");
-    assert_eq!(summary.hard_links_created(), 0, "no hard link at match_level 2");
+    assert_eq!(
+        dest_meta.nlink(),
+        1,
+        "copied file must not gain a hard link"
+    );
+    assert_eq!(
+        summary.hard_links_created(),
+        0,
+        "no hard link at match_level 2"
+    );
 
     // The basis inode is left untouched - its xattr is not overwritten.
     let basis_xattr = xattr::get(&link_dest_file, "user.k")
@@ -1542,8 +1554,9 @@ fn link_dest_refused_hard_link_creates_the_node_instead() {
             );
 
             // The refusal must not fail the transfer (3.4.4 exited 23 here).
-            let summary = summary
-                .unwrap_or_else(|error| panic!("{case}: transfer failed instead of copying: {error}"));
+            let summary = summary.unwrap_or_else(|error| {
+                panic!("{case}: transfer failed instead of copying: {error}")
+            });
             let _ = &summary;
 
             // ...and the entry must exist, created from the source.
@@ -2062,6 +2075,8 @@ impl NanosecondBasis {
     }
 
     fn basis_ino(&self) -> u64 {
-        fs::metadata(&self.basis_file).expect("basis metadata").ino()
+        fs::metadata(&self.basis_file)
+            .expect("basis metadata")
+            .ino()
     }
 }

--- a/crates/engine/src/local_copy/tests/execute_log_file.rs
+++ b/crates/engine/src/local_copy/tests/execute_log_file.rs
@@ -11,7 +11,6 @@
 // 8. Transfers work with log_file set (verify file is created)
 // 9. Combination with other options
 
-
 #[test]
 fn log_file_default_is_none() {
     let opts = LocalCopyOptions::new();
@@ -24,14 +23,10 @@ fn log_file_format_default_is_none() {
     assert!(opts.log_file_format().is_none());
 }
 
-
 #[test]
 fn log_file_with_log_file_sets_path() {
     let opts = LocalCopyOptions::new().with_log_file(Some("/var/log/rsync.log"));
-    assert_eq!(
-        opts.log_file_path(),
-        Some(Path::new("/var/log/rsync.log"))
-    );
+    assert_eq!(opts.log_file_path(), Some(Path::new("/var/log/rsync.log")));
 }
 
 #[test]
@@ -46,10 +41,7 @@ fn log_file_with_log_file_none_clears_path() {
 fn log_file_with_log_file_accepts_pathbuf() {
     let path = PathBuf::from("/tmp/transfer.log");
     let opts = LocalCopyOptions::new().with_log_file(Some(path));
-    assert_eq!(
-        opts.log_file_path(),
-        Some(Path::new("/tmp/transfer.log"))
-    );
+    assert_eq!(opts.log_file_path(), Some(Path::new("/tmp/transfer.log")));
 }
 
 #[test]
@@ -73,7 +65,6 @@ fn log_file_format_with_log_file_format_accepts_string() {
     assert_eq!(opts.log_file_format(), Some("%o %n"));
 }
 
-
 #[test]
 fn log_file_effective_format_returns_default_when_not_set() {
     let opts = LocalCopyOptions::new();
@@ -93,7 +84,6 @@ fn log_file_effective_format_after_clear_returns_default() {
         .with_log_file_format::<String>(None);
     assert_eq!(opts.effective_log_file_format(), "%i %n%L");
 }
-
 
 #[test]
 fn log_file_builder_sets_log_file() {
@@ -120,10 +110,7 @@ fn log_file_builder_both_options() {
         .log_file_format(Some("%t %f %b"))
         .build()
         .expect("valid options");
-    assert_eq!(
-        opts.log_file_path(),
-        Some(Path::new("/var/log/rsync.log"))
-    );
+    assert_eq!(opts.log_file_path(), Some(Path::new("/var/log/rsync.log")));
     assert_eq!(opts.log_file_format(), Some("%t %f %b"));
     assert_eq!(opts.effective_log_file_format(), "%t %f %b");
 }
@@ -158,7 +145,6 @@ fn log_file_builder_unchecked_sets_values() {
     assert_eq!(opts.log_file_format(), Some("%o %n"));
 }
 
-
 #[test]
 fn log_file_round_trip_via_builder() {
     let opts = LocalCopyOptions::builder()
@@ -182,7 +168,6 @@ fn log_file_round_trip_via_setters() {
     assert_eq!(opts.log_file_format(), Some("%o %n %b"));
     assert_eq!(opts.effective_log_file_format(), "%o %n %b");
 }
-
 
 #[test]
 fn log_file_transfer_works_with_log_file_set() {
@@ -283,7 +268,6 @@ fn log_file_transfer_multiple_files_with_log_file() {
         b"content3"
     );
 }
-
 
 #[test]
 fn log_file_combined_with_delete() {
@@ -448,7 +432,6 @@ fn log_file_combined_with_builder_archive() {
     );
 }
 
-
 #[test]
 fn log_file_dry_run_does_not_fail() {
     let temp = tempdir().expect("tempdir");
@@ -478,7 +461,6 @@ fn log_file_dry_run_does_not_fail() {
     );
 }
 
-
 #[test]
 fn log_file_builder_defaults_match_options_defaults() {
     let from_builder = LocalCopyOptions::builder().build().expect("valid");
@@ -494,7 +476,6 @@ fn log_file_builder_defaults_match_options_defaults() {
         from_default.effective_log_file_format()
     );
 }
-
 
 #[test]
 fn log_file_config_propagation_setter_and_builder_agree() {
@@ -531,7 +512,6 @@ fn log_file_effective_format_uses_default_percent_i_n_l() {
     let opts = LocalCopyOptions::new().with_log_file(Some("/tmp/test.log"));
     assert_eq!(opts.effective_log_file_format(), "%i %n%L");
 }
-
 
 #[test]
 fn log_file_empty_format_string_is_stored() {

--- a/crates/engine/src/local_copy/tests/execute_long_paths.rs
+++ b/crates/engine/src/local_copy/tests/execute_long_paths.rs
@@ -300,10 +300,12 @@ fn execute_copies_symlink_to_deep_target() {
 
     // Symlink should be copied (not followed)
     assert_eq!(summary.symlinks_copied(), 1);
-    assert!(fs::symlink_metadata(dest.join("source").join("link_to_deep"))
-        .expect("metadata")
-        .file_type()
-        .is_symlink());
+    assert!(
+        fs::symlink_metadata(dest.join("source").join("link_to_deep"))
+            .expect("metadata")
+            .file_type()
+            .is_symlink()
+    );
 }
 
 #[cfg(unix)]
@@ -369,7 +371,12 @@ fn execute_follows_symlink_to_deep_directory() {
     // Destination should be a directory, not a symlink
     let dest_linked = dest.join("source").join("linked_dir");
     assert!(dest_linked.is_dir());
-    assert!(!fs::symlink_metadata(&dest_linked).expect("meta").file_type().is_symlink());
+    assert!(
+        !fs::symlink_metadata(&dest_linked)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 }
 
 #[test]
@@ -426,11 +433,15 @@ fn execute_handles_very_deep_structure_gracefully() {
         let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
         // Should copy whatever was successfully created
-        let result = plan.execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default());
+        let result =
+            plan.execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default());
 
         match result {
             Ok(summary) => {
-                println!("Copied {} directories successfully", summary.directories_created());
+                println!(
+                    "Copied {} directories successfully",
+                    summary.directories_created()
+                );
                 assert!(summary.directories_created() > 0);
             }
             Err(e) => {
@@ -470,7 +481,8 @@ fn execute_preserves_mtime_for_files_with_long_paths() {
     }
     dest_file = dest_file.join("timed.txt");
 
-    let dest_mtime = FileTime::from_last_modification_time(&fs::metadata(&dest_file).expect("meta"));
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file).expect("meta"));
     assert_eq!(dest_mtime, past_time);
 }
 

--- a/crates/engine/src/local_copy/tests/execute_max_delete.rs
+++ b/crates/engine/src/local_copy/tests/execute_max_delete.rs
@@ -14,7 +14,6 @@
 
 use super::filter_program::MAX_DELETE_EXIT_CODE;
 
-
 #[test]
 fn max_delete_stops_after_n_deletions() {
     let ctx = test_helpers::setup_copy_test();
@@ -73,8 +72,11 @@ fn max_delete_reports_correct_skipped_count() {
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
     for i in 1..=5 {
-        fs::write(target_root.join(format!("extra{i}.txt")), format!("extra{i}").as_bytes())
-            .expect("write extra");
+        fs::write(
+            target_root.join(format!("extra{i}.txt")),
+            format!("extra{i}").as_bytes(),
+        )
+        .expect("write extra");
     }
 
     let operands = vec![
@@ -92,7 +94,10 @@ fn max_delete_reports_correct_skipped_count() {
 
     match error.kind() {
         LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
-            assert_eq!(*skipped, 3, "should report 3 skipped entries (5 total - 2 deleted)");
+            assert_eq!(
+                *skipped, 3,
+                "should report 3 skipped entries (5 total - 2 deleted)"
+            );
         }
         other => panic!("unexpected error kind: {other:?}"),
     }
@@ -135,7 +140,6 @@ fn max_delete_error_message_format() {
         "error message should mention skipped: {message}"
     );
 }
-
 
 #[test]
 fn max_delete_zero_prevents_all_deletions() {
@@ -326,8 +330,11 @@ fn max_delete_none_allows_unlimited_deletions() {
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
     for i in 1..=10 {
-        fs::write(target_root.join(format!("extra{i}.txt")), format!("extra{i}").as_bytes())
-            .expect("write extra");
+        fs::write(
+            target_root.join(format!("extra{i}.txt")),
+            format!("extra{i}").as_bytes(),
+        )
+        .expect("write extra");
     }
 
     let operands = vec![
@@ -335,9 +342,7 @@ fn max_delete_none_allows_unlimited_deletions() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .delete(true)
-        .max_deletions(None);
+    let options = LocalCopyOptions::default().delete(true).max_deletions(None);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -351,7 +356,6 @@ fn max_delete_none_allows_unlimited_deletions() {
         );
     }
 }
-
 
 #[test]
 fn max_delete_with_delete_during() {
@@ -420,7 +424,10 @@ fn max_delete_with_delete_before() {
     match error.kind() {
         LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
             // delete-before may traverse directories differently, causing varying skip counts
-            assert!(*skipped >= 1, "should report at least 1 skipped entry, got {skipped}");
+            assert!(
+                *skipped >= 1,
+                "should report at least 1 skipped entry, got {skipped}"
+            );
         }
         other => panic!("unexpected error kind: {other:?}"),
     }
@@ -498,7 +505,6 @@ fn max_delete_with_delete_delay() {
     }
 }
 
-
 #[test]
 fn max_delete_with_dry_run_reports_limit_exceeded() {
     let ctx = test_helpers::setup_copy_test();
@@ -567,7 +573,6 @@ fn max_delete_dry_run_success_when_under_limit() {
 
     assert!(target_root.join("extra.txt").exists());
 }
-
 
 #[test]
 fn max_delete_counts_directory_deletions() {
@@ -641,7 +646,6 @@ fn max_delete_mixed_files_and_directories() {
     }
 }
 
-
 #[test]
 fn max_delete_no_effect_when_no_deletions_needed() {
     let ctx = test_helpers::setup_copy_test();
@@ -701,7 +705,6 @@ fn max_delete_without_delete_flag_has_no_effect() {
         "extra file should remain when delete not enabled"
     );
 }
-
 
 #[test]
 fn max_delete_survivor_set_matches_upstream_traversal() {
@@ -784,7 +787,6 @@ fn max_delete_error_code_name() {
     let error = LocalCopyError::delete_limit_exceeded(5);
     assert_eq!(error.code_name(), "RERR_DEL_LIMIT");
 }
-
 
 #[test]
 fn max_deletions_option_sets_correctly() {

--- a/crates/engine/src/local_copy/tests/execute_metadata.rs
+++ b/crates/engine/src/local_copy/tests/execute_metadata.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn reference_compare_destination_skips_matching_file() {
     let temp = tempdir().expect("tempdir");
@@ -303,7 +302,10 @@ fn execute_preserves_mode_0000_with_permissions() {
     assert_eq!(summary.files_copied(), 1);
 
     // Verify we can read the destination file (as the owner who created it)
-    assert_eq!(fs::read(&destination).expect("read dest"), b"no permissions");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"no permissions"
+    );
 }
 
 #[cfg(unix)]
@@ -415,7 +417,8 @@ fn execute_mode_0000_directory_with_files() {
 
     let source_file = source_root.join("file.txt");
     fs::write(&source_file, b"in restricted dir").expect("write source");
-    fs::set_permissions(&source_file, PermissionsExt::from_mode(0o000)).expect("set file mode 0000");
+    fs::set_permissions(&source_file, PermissionsExt::from_mode(0o000))
+        .expect("set file mode 0000");
 
     let operands = vec![
         source_root.into_os_string(),
@@ -436,7 +439,10 @@ fn execute_mode_0000_directory_with_files() {
 
     let file_metadata = fs::metadata(&dest_file).expect("dest file metadata");
     assert_eq!(file_metadata.permissions().mode() & 0o777, 0o000);
-    assert_eq!(fs::read(&dest_file).expect("read dest"), b"in restricted dir");
+    assert_eq!(
+        fs::read(&dest_file).expect("read dest"),
+        b"in restricted dir"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -514,7 +520,10 @@ fn execute_mode_0000_update_existing_destination() {
 
     // Should update because source is newer
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"updated content");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"updated content"
+    );
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(metadata.permissions().mode() & 0o777, 0o000);
@@ -546,7 +555,11 @@ fn execute_preserves_all_permission_bits_including_special() {
     let metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mode = metadata.permissions().mode();
 
-    assert_eq!(dest_mode & 0o7777, 0o7777, "all permission bits should be preserved");
+    assert_eq!(
+        dest_mode & 0o7777,
+        0o7777,
+        "all permission bits should be preserved"
+    );
     assert_eq!(dest_mode & 0o4000, 0o4000, "setuid bit should be set");
     assert_eq!(dest_mode & 0o2000, 0o2000, "setgid bit should be set");
     assert_eq!(dest_mode & 0o1000, 0o1000, "sticky bit should be set");
@@ -582,7 +595,11 @@ fn execute_preserves_setuid_bit() {
     let dest_mode = metadata.permissions().mode();
 
     assert_eq!(dest_mode & 0o4000, 0o4000, "setuid bit should be preserved");
-    assert_eq!(dest_mode & 0o777, 0o755, "standard permissions should match");
+    assert_eq!(
+        dest_mode & 0o777,
+        0o755,
+        "standard permissions should match"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -613,7 +630,11 @@ fn execute_preserves_setgid_bit() {
     let dest_mode = metadata.permissions().mode();
 
     assert_eq!(dest_mode & 0o2000, 0o2000, "setgid bit should be preserved");
-    assert_eq!(dest_mode & 0o777, 0o755, "standard permissions should match");
+    assert_eq!(
+        dest_mode & 0o777,
+        0o755,
+        "standard permissions should match"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -644,7 +665,11 @@ fn execute_preserves_sticky_bit() {
     let dest_mode = metadata.permissions().mode();
 
     assert_eq!(dest_mode & 0o1000, 0o1000, "sticky bit should be preserved");
-    assert_eq!(dest_mode & 0o777, 0o777, "standard permissions should match");
+    assert_eq!(
+        dest_mode & 0o777,
+        0o777,
+        "standard permissions should match"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -728,7 +753,11 @@ fn execute_special_bits_not_preserved_without_perms_flag() {
     let metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mode = metadata.permissions().mode();
 
-    assert_eq!(dest_mode & 0o7000, 0, "special bits should not be preserved without --perms");
+    assert_eq!(
+        dest_mode & 0o7000,
+        0,
+        "special bits should not be preserved without --perms"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -743,7 +772,8 @@ fn execute_combined_special_bits_with_restrictive_perms() {
     fs::write(&source, b"combined bits").expect("write source");
 
     // Set setuid + setgid + sticky with restrictive permissions (0600)
-    fs::set_permissions(&source, PermissionsExt::from_mode(0o7600)).expect("set special+restrictive");
+    fs::set_permissions(&source, PermissionsExt::from_mode(0o7600))
+        .expect("set special+restrictive");
 
     let operands = vec![
         source.into_os_string(),
@@ -758,9 +788,21 @@ fn execute_combined_special_bits_with_restrictive_perms() {
     let metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mode = metadata.permissions().mode();
 
-    assert_eq!(dest_mode & 0o7000, 0o7000, "all special bits should be preserved");
-    assert_eq!(dest_mode & 0o777, 0o600, "restrictive permissions should be preserved");
-    assert_eq!(dest_mode & 0o7777, 0o7600, "combined mode should match exactly");
+    assert_eq!(
+        dest_mode & 0o7000,
+        0o7000,
+        "all special bits should be preserved"
+    );
+    assert_eq!(
+        dest_mode & 0o777,
+        0o600,
+        "restrictive permissions should be preserved"
+    );
+    assert_eq!(
+        dest_mode & 0o7777,
+        0o7600,
+        "combined mode should match exactly"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -776,7 +818,8 @@ fn execute_directory_with_special_bits() {
     fs::create_dir(&source_dir).expect("create source dir");
 
     // Set setgid and sticky bits on directory (common for shared directories)
-    fs::set_permissions(&source_dir, PermissionsExt::from_mode(0o3775)).expect("set dir special perms");
+    fs::set_permissions(&source_dir, PermissionsExt::from_mode(0o3775))
+        .expect("set dir special perms");
 
     let source_file = source_dir.join("file.txt");
     fs::write(&source_file, b"in special dir").expect("write file");
@@ -786,7 +829,9 @@ fn execute_directory_with_special_bits() {
         dest_dir.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default().permissions(true).recursive(true);
+    let options = LocalCopyOptions::default()
+        .permissions(true)
+        .recursive(true);
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -794,9 +839,21 @@ fn execute_directory_with_special_bits() {
     let dest_metadata = fs::metadata(dest_dir.join("source")).expect("dest dir metadata");
     let dest_mode = dest_metadata.permissions().mode();
 
-    assert_eq!(dest_mode & 0o2000, 0o2000, "setgid bit should be preserved on directory");
-    assert_eq!(dest_mode & 0o1000, 0o1000, "sticky bit should be preserved on directory");
-    assert_eq!(dest_mode & 0o777, 0o775, "directory permissions should match");
+    assert_eq!(
+        dest_mode & 0o2000,
+        0o2000,
+        "setgid bit should be preserved on directory"
+    );
+    assert_eq!(
+        dest_mode & 0o1000,
+        0o1000,
+        "sticky bit should be preserved on directory"
+    );
+    assert_eq!(
+        dest_mode & 0o777,
+        0o775,
+        "directory permissions should match"
+    );
 
     assert!(summary.files_copied() >= 1);
 }
@@ -834,28 +891,42 @@ fn execute_multiple_files_with_different_special_bits() {
         dest_dir.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default().permissions(true).recursive(true);
+    let options = LocalCopyOptions::default()
+        .permissions(true)
+        .recursive(true);
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let setuid_dest = dest_dir.join("source").join("setuid.txt");
-    let setuid_mode = fs::metadata(&setuid_dest).expect("setuid metadata").permissions().mode();
+    let setuid_mode = fs::metadata(&setuid_dest)
+        .expect("setuid metadata")
+        .permissions()
+        .mode();
     assert_eq!(setuid_mode & 0o4000, 0o4000, "setuid bit preserved");
     assert_eq!(setuid_mode & 0o777, 0o755);
 
     let setgid_dest = dest_dir.join("source").join("setgid.txt");
-    let setgid_mode = fs::metadata(&setgid_dest).expect("setgid metadata").permissions().mode();
+    let setgid_mode = fs::metadata(&setgid_dest)
+        .expect("setgid metadata")
+        .permissions()
+        .mode();
     assert_eq!(setgid_mode & 0o2000, 0o2000, "setgid bit preserved");
     assert_eq!(setgid_mode & 0o777, 0o755);
 
     let sticky_dest = dest_dir.join("source").join("sticky.txt");
-    let sticky_mode = fs::metadata(&sticky_dest).expect("sticky metadata").permissions().mode();
+    let sticky_mode = fs::metadata(&sticky_dest)
+        .expect("sticky metadata")
+        .permissions()
+        .mode();
     assert_eq!(sticky_mode & 0o1000, 0o1000, "sticky bit preserved");
     assert_eq!(sticky_mode & 0o777, 0o777);
 
     let all_dest = dest_dir.join("source").join("all.txt");
-    let all_mode = fs::metadata(&all_dest).expect("all bits metadata").permissions().mode();
+    let all_mode = fs::metadata(&all_dest)
+        .expect("all bits metadata")
+        .permissions()
+        .mode();
     assert_eq!(all_mode & 0o7777, 0o7777, "all bits preserved");
 
     assert!(summary.files_copied() >= 4);

--- a/crates/engine/src/local_copy/tests/execute_min_size.rs
+++ b/crates/engine/src/local_copy/tests/execute_min_size.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn min_size_excludes_files_smaller_than_limit() {
     let temp = tempdir().expect("tempdir");
@@ -12,10 +11,7 @@ fn min_size_excludes_files_smaller_than_limit() {
     fs::write(source.join("medium.txt"), b"hello world!").expect("write 12-byte file");
     fs::write(source.join("large.txt"), vec![b'a'; 100]).expect("write 100-byte file");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default().min_file_size(Some(10));
@@ -26,11 +22,23 @@ fn min_size_excludes_files_smaller_than_limit() {
 
     let target_root = dest.join("source");
 
-    assert!(!target_root.join("tiny.txt").exists(), "1-byte file should be excluded");
-    assert!(!target_root.join("small.txt").exists(), "5-byte file should be excluded");
+    assert!(
+        !target_root.join("tiny.txt").exists(),
+        "1-byte file should be excluded"
+    );
+    assert!(
+        !target_root.join("small.txt").exists(),
+        "5-byte file should be excluded"
+    );
 
-    assert!(target_root.join("medium.txt").exists(), "12-byte file should be included");
-    assert!(target_root.join("large.txt").exists(), "100-byte file should be included");
+    assert!(
+        target_root.join("medium.txt").exists(),
+        "12-byte file should be included"
+    );
+    assert!(
+        target_root.join("large.txt").exists(),
+        "100-byte file should be included"
+    );
 
     assert_eq!(summary.files_copied(), 2);
 }
@@ -47,10 +55,7 @@ fn min_size_includes_files_equal_to_limit() {
     fs::write(source.join("exact.txt"), vec![b'x'; 100]).expect("write 100-byte file");
     fs::write(source.join("above.txt"), vec![b'x'; 101]).expect("write 101-byte file");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default().min_file_size(Some(100));
@@ -61,11 +66,20 @@ fn min_size_includes_files_equal_to_limit() {
 
     let target_root = dest.join("source");
 
-    assert!(!target_root.join("below.txt").exists(), "99-byte file should be excluded");
+    assert!(
+        !target_root.join("below.txt").exists(),
+        "99-byte file should be excluded"
+    );
 
-    assert!(target_root.join("exact.txt").exists(), "100-byte file should be included");
+    assert!(
+        target_root.join("exact.txt").exists(),
+        "100-byte file should be included"
+    );
 
-    assert!(target_root.join("above.txt").exists(), "101-byte file should be included");
+    assert!(
+        target_root.join("above.txt").exists(),
+        "101-byte file should be included"
+    );
 
     assert_eq!(summary.files_copied(), 2);
 }
@@ -83,10 +97,7 @@ fn min_size_includes_files_larger_than_limit() {
     fs::write(source.join("large2.txt"), vec![b'b'; 5000]).expect("write 5KB file");
     fs::write(source.join("huge.txt"), vec![b'c'; 10000]).expect("write 10KB file");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default().min_file_size(Some(500));
@@ -97,11 +108,23 @@ fn min_size_includes_files_larger_than_limit() {
 
     let target_root = dest.join("source");
 
-    assert!(!target_root.join("small.txt").exists(), "4-byte file should be excluded");
+    assert!(
+        !target_root.join("small.txt").exists(),
+        "4-byte file should be excluded"
+    );
 
-    assert!(target_root.join("large1.txt").exists(), "1000-byte file should be included");
-    assert!(target_root.join("large2.txt").exists(), "5000-byte file should be included");
-    assert!(target_root.join("huge.txt").exists(), "10000-byte file should be included");
+    assert!(
+        target_root.join("large1.txt").exists(),
+        "1000-byte file should be included"
+    );
+    assert!(
+        target_root.join("large2.txt").exists(),
+        "5000-byte file should be included"
+    );
+    assert!(
+        target_root.join("huge.txt").exists(),
+        "10000-byte file should be included"
+    );
 
     assert_eq!(summary.files_copied(), 3);
 }
@@ -118,10 +141,7 @@ fn min_size_with_kilobyte_suffix() {
     fs::write(source.join("exact.txt"), vec![b'x'; 1024]).expect("write 1KB file");
     fs::write(source.join("large.txt"), vec![b'x'; 2048]).expect("write 2KB file");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default().min_file_size(Some(1024));
@@ -132,10 +152,19 @@ fn min_size_with_kilobyte_suffix() {
 
     let target_root = dest.join("source");
 
-    assert!(!target_root.join("small.txt").exists(), "500-byte file should be excluded");
+    assert!(
+        !target_root.join("small.txt").exists(),
+        "500-byte file should be excluded"
+    );
 
-    assert!(target_root.join("exact.txt").exists(), "1KB file should be included");
-    assert!(target_root.join("large.txt").exists(), "2KB file should be included");
+    assert!(
+        target_root.join("exact.txt").exists(),
+        "1KB file should be included"
+    );
+    assert!(
+        target_root.join("large.txt").exists(),
+        "2KB file should be included"
+    );
 
     assert_eq!(summary.files_copied(), 2);
 }
@@ -152,10 +181,7 @@ fn min_size_with_megabyte_suffix() {
     fs::write(source.join("exact.txt"), vec![b'x'; 1024 * 1024]).expect("write 1MB file");
     fs::write(source.join("large.txt"), vec![b'x'; 2 * 1024 * 1024]).expect("write 2MB file");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default().min_file_size(Some(1024 * 1024));
@@ -166,10 +192,19 @@ fn min_size_with_megabyte_suffix() {
 
     let target_root = dest.join("source");
 
-    assert!(!target_root.join("small.txt").exists(), "512KB file should be excluded");
+    assert!(
+        !target_root.join("small.txt").exists(),
+        "512KB file should be excluded"
+    );
 
-    assert!(target_root.join("exact.txt").exists(), "1MB file should be included");
-    assert!(target_root.join("large.txt").exists(), "2MB file should be included");
+    assert!(
+        target_root.join("exact.txt").exists(),
+        "1MB file should be included"
+    );
+    assert!(
+        target_root.join("large.txt").exists(),
+        "2MB file should be included"
+    );
 
     assert_eq!(summary.files_copied(), 2);
 }
@@ -186,10 +221,7 @@ fn min_size_with_gigabyte_suffix() {
     fs::write(source.join("tiny.txt"), b"small").expect("write tiny file");
     fs::write(source.join("medium.txt"), vec![b'x'; 100 * 1024 * 1024]).expect("write 100MB file");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default().min_file_size(Some(1024u64 * 1024 * 1024));
@@ -200,8 +232,14 @@ fn min_size_with_gigabyte_suffix() {
 
     let target_root = dest.join("source");
 
-    assert!(!target_root.join("tiny.txt").exists(), "tiny file should be excluded");
-    assert!(!target_root.join("medium.txt").exists(), "100MB file should be excluded");
+    assert!(
+        !target_root.join("tiny.txt").exists(),
+        "tiny file should be excluded"
+    );
+    assert!(
+        !target_root.join("medium.txt").exists(),
+        "100MB file should be excluded"
+    );
 
     assert_eq!(summary.files_copied(), 0);
 }
@@ -218,10 +256,7 @@ fn min_size_zero_includes_all_files() {
     fs::write(source.join("small.txt"), b"x").expect("write 1-byte file");
     fs::write(source.join("medium.txt"), vec![b'x'; 100]).expect("write 100-byte file");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default().min_file_size(Some(0));
@@ -232,9 +267,18 @@ fn min_size_zero_includes_all_files() {
 
     let target_root = dest.join("source");
 
-    assert!(target_root.join("empty.txt").exists(), "empty file should be included");
-    assert!(target_root.join("small.txt").exists(), "1-byte file should be included");
-    assert!(target_root.join("medium.txt").exists(), "100-byte file should be included");
+    assert!(
+        target_root.join("empty.txt").exists(),
+        "empty file should be included"
+    );
+    assert!(
+        target_root.join("small.txt").exists(),
+        "1-byte file should be included"
+    );
+    assert!(
+        target_root.join("medium.txt").exists(),
+        "100-byte file should be included"
+    );
 
     assert_eq!(summary.files_copied(), 3);
 }
@@ -251,10 +295,7 @@ fn min_size_none_includes_all_files() {
     fs::write(source.join("small.txt"), b"hello").expect("write small file");
     fs::write(source.join("large.txt"), vec![b'x'; 1000]).expect("write large file");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default().min_file_size(None);
@@ -265,9 +306,18 @@ fn min_size_none_includes_all_files() {
 
     let target_root = dest.join("source");
 
-    assert!(target_root.join("tiny.txt").exists(), "tiny file should be included");
-    assert!(target_root.join("small.txt").exists(), "small file should be included");
-    assert!(target_root.join("large.txt").exists(), "large file should be included");
+    assert!(
+        target_root.join("tiny.txt").exists(),
+        "tiny file should be included"
+    );
+    assert!(
+        target_root.join("small.txt").exists(),
+        "small file should be included"
+    );
+    assert!(
+        target_root.join("large.txt").exists(),
+        "large file should be included"
+    );
 
     assert_eq!(summary.files_copied(), 3);
 }
@@ -282,13 +332,9 @@ fn min_size_does_not_affect_directories() {
     fs::create_dir_all(&dest).expect("create dest");
 
     fs::write(source.join("subdir1/small.txt"), b"x").expect("write small file");
-    fs::write(source.join("subdir2/nested/large.txt"), vec![b'x'; 1000])
-        .expect("write large file");
+    fs::write(source.join("subdir2/nested/large.txt"), vec![b'x'; 1000]).expect("write large file");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default().min_file_size(Some(100));
@@ -301,11 +347,20 @@ fn min_size_does_not_affect_directories() {
     // Directories should always be created regardless of min-size
     assert!(target_root.join("subdir1").is_dir(), "subdir1 should exist");
     assert!(target_root.join("subdir2").is_dir(), "subdir2 should exist");
-    assert!(target_root.join("subdir2/nested").is_dir(), "nested dir should exist");
+    assert!(
+        target_root.join("subdir2/nested").is_dir(),
+        "nested dir should exist"
+    );
 
-    assert!(!target_root.join("subdir1/small.txt").exists(), "small file should be excluded");
+    assert!(
+        !target_root.join("subdir1/small.txt").exists(),
+        "small file should be excluded"
+    );
 
-    assert!(target_root.join("subdir2/nested/large.txt").exists(), "large file should be included");
+    assert!(
+        target_root.join("subdir2/nested/large.txt").exists(),
+        "large file should be included"
+    );
 }
 
 #[test]
@@ -321,15 +376,11 @@ fn min_size_works_with_other_filters() {
     fs::write(source.join("small.tmp"), b"y").expect("write small tmp");
     fs::write(source.join("large.tmp"), vec![b'y'; 1000]).expect("write large tmp");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // Combine min-size filter with pattern filter
-    let filters = FilterSet::from_rules([FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default()
         .min_file_size(Some(100))
         .filters(Some(filters));
@@ -341,16 +392,28 @@ fn min_size_works_with_other_filters() {
     let target_root = dest.join("source");
 
     // small.txt: excluded by min-size
-    assert!(!target_root.join("small.txt").exists(), "small.txt excluded by size");
+    assert!(
+        !target_root.join("small.txt").exists(),
+        "small.txt excluded by size"
+    );
 
     // large.txt: included (passes both filters)
-    assert!(target_root.join("large.txt").exists(), "large.txt should be included");
+    assert!(
+        target_root.join("large.txt").exists(),
+        "large.txt should be included"
+    );
 
     // small.tmp: excluded by pattern filter
-    assert!(!target_root.join("small.tmp").exists(), "small.tmp excluded by pattern");
+    assert!(
+        !target_root.join("small.tmp").exists(),
+        "small.tmp excluded by pattern"
+    );
 
     // large.tmp: excluded by pattern filter (even though size is OK)
-    assert!(!target_root.join("large.tmp").exists(), "large.tmp excluded by pattern");
+    assert!(
+        !target_root.join("large.tmp").exists(),
+        "large.tmp excluded by pattern"
+    );
 
     assert_eq!(summary.files_copied(), 1);
 }
@@ -383,9 +446,17 @@ fn min_size_prunes_empty_directories_when_enabled() {
         .expect("copy succeeds");
 
     // Directories should be pruned since all files were filtered out
-    assert!(!ctx.dest.join("source").join("source/empty_dir").exists(), "empty_dir should be pruned");
-    assert!(!ctx.dest.join("source").join("source/dir_with_small_files").exists(),
-            "dir_with_small_files should be pruned");
+    assert!(
+        !ctx.dest.join("source").join("source/empty_dir").exists(),
+        "empty_dir should be pruned"
+    );
+    assert!(
+        !ctx.dest
+            .join("source")
+            .join("source/dir_with_small_files")
+            .exists(),
+        "dir_with_small_files should be pruned"
+    );
 }
 
 #[cfg(unix)]
@@ -394,15 +465,9 @@ fn min_size_prunes_empty_directories_when_enabled() {
 fn min_size_does_not_affect_symlinks() {
     let ctx = test_helpers::setup_copy_test();
 
-    test_helpers::create_test_tree(
-        &ctx.source,
-        &[
-            ("target.txt", Some(b"x")),
-        ],
-    );
+    test_helpers::create_test_tree(&ctx.source, &[("target.txt", Some(b"x"))]);
 
-    std::os::unix::fs::symlink("target.txt", ctx.source.join("link.txt"))
-        .expect("create symlink");
+    std::os::unix::fs::symlink("target.txt", ctx.source.join("link.txt")).expect("create symlink");
 
     let operands = vec![
         ctx.source.into_os_string(),
@@ -418,8 +483,14 @@ fn min_size_does_not_affect_symlinks() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!ctx.dest.join("source").join("source/target.txt").exists(), "small target excluded");
+    assert!(
+        !ctx.dest.join("source").join("source/target.txt").exists(),
+        "small target excluded"
+    );
 
     // Symlink should still be created (symlinks are not filtered by size)
-    assert!(ctx.dest.join("source").join("source/link.txt").exists(), "symlink should be included");
+    assert!(
+        ctx.dest.join("source").join("source/link.txt").exists(),
+        "symlink should be included"
+    );
 }

--- a/crates/engine/src/local_copy/tests/execute_modify_window.rs
+++ b/crates/engine/src/local_copy/tests/execute_modify_window.rs
@@ -46,10 +46,7 @@ fn modify_window_skips_files_within_one_second_window() {
     // File should be skipped because timestamps are within 1-second window and sizes match
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        content
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
 
 #[test]
@@ -189,10 +186,7 @@ fn modify_window_sixty_seconds_copies_when_outside() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"new content"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"new content");
 }
 
 #[test]
@@ -388,10 +382,7 @@ fn modify_window_with_update_skips_when_dest_newer_outside_window() {
     // File should be skipped by --update (dest is newer)
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"newer dest"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"newer dest");
 }
 
 /// When --update and --modify-window are combined, dest is 0.5s newer
@@ -469,10 +460,7 @@ fn modify_window_with_update_skips_when_dest_newer_within_window_despite_size_di
 
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"dest"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"dest");
 }
 
 #[test]
@@ -550,10 +538,7 @@ fn modify_window_with_update_skips_when_source_slightly_newer_within_window() {
 
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"old dest"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"old dest");
 }
 
 /// When source is newer than dest by exactly the window, `--update` does
@@ -618,7 +603,8 @@ fn modify_window_recursive_mixed_timestamps() {
     set_file_mtime(dest_root.join("within.txt"), within_window).expect("set within dest");
 
     // File 2: timestamps outside window (should copy) - different sizes to trigger copy
-    fs::write(source_root.join("outside.txt"), b"outside source content").expect("write outside source");
+    fs::write(source_root.join("outside.txt"), b"outside source content")
+        .expect("write outside source");
     fs::write(dest_root.join("outside.txt"), b"outside dest").expect("write outside dest");
     set_file_mtime(source_root.join("outside.txt"), outside_window).expect("set outside source");
     set_file_mtime(dest_root.join("outside.txt"), base_time).expect("set outside dest");
@@ -829,10 +815,7 @@ fn modify_window_dry_run_reports_correctly() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"old content"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"old content");
 }
 
 /// A dry-run itemize must apply `--modify-window` to the quick check exactly
@@ -906,10 +889,7 @@ fn modify_window_dry_run_zero_window_itemizes_one_second_drift() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let summary = plan
-        .execute_with_options(
-            LocalCopyExecution::DryRun,
-            LocalCopyOptions::default(),
-        )
+        .execute_with_options(LocalCopyExecution::DryRun, LocalCopyOptions::default())
         .expect("dry run succeeds");
 
     // Zero window: a whole-second mtime difference is reported as a transfer.

--- a/crates/engine/src/local_copy/tests/execute_munge_links.rs
+++ b/crates/engine/src/local_copy/tests/execute_munge_links.rs
@@ -134,11 +134,7 @@ fn munge_links_unmunges_already_munged_source() {
 
     // Source symlink is already munged (simulating a previous munge operation)
     let link = source_root.join("munged_link");
-    symlink(
-        Path::new("/rsyncd-munged//etc/passwd"),
-        &link,
-    )
-    .expect("create pre-munged symlink");
+    symlink(Path::new("/rsyncd-munged//etc/passwd"), &link).expect("create pre-munged symlink");
 
     let dest_root = temp.path().join("dest");
     let operands = vec![

--- a/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
@@ -4,7 +4,6 @@
 // - With implied dirs (default): parent directories are created automatically
 // - Without implied dirs: only explicitly listed directories are created
 
-
 #[test]
 #[ignore = "--no-implied-dirs not fully implemented; intermediate directories are still created implicitly"]
 fn no_implied_dirs_does_not_create_intermediate_directories() {
@@ -99,10 +98,7 @@ fn no_implied_dirs_works_with_relative_paths() {
     source_operand.push("/./");
     source_operand.push("dir1/dir2/file.txt");
 
-    let operands = vec![
-        source_operand,
-        dest_root.clone().into_os_string(),
-    ];
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // With --relative and --no-implied-dirs the implied leading dirs are still
@@ -141,10 +137,7 @@ fn no_implied_dirs_with_relative_creates_explicit_dirs_only() {
     source_dir_operand.push("/./");
     source_dir_operand.push("dir1");
 
-    let operands = vec![
-        source_dir_operand,
-        dest_root.clone().into_os_string(),
-    ];
+    let operands = vec![source_dir_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default()
@@ -161,7 +154,13 @@ fn no_implied_dirs_with_relative_creates_explicit_dirs_only() {
 
     // Nested directories should also exist because recursion includes them
     assert!(dest_root.join("dir1").join("dir2").exists());
-    assert!(dest_root.join("dir1").join("dir2").join("file2.txt").exists());
+    assert!(
+        dest_root
+            .join("dir1")
+            .join("dir2")
+            .join("file2.txt")
+            .exists()
+    );
 
     assert!(summary.files_copied() >= 2);
 }
@@ -217,10 +216,7 @@ fn no_implied_dirs_with_relative_and_deep_file() {
     source_operand.push("/./");
     source_operand.push("a/b/c/file.txt");
 
-    let operands = vec![
-        source_operand,
-        dest_root.clone().into_os_string(),
-    ];
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default()
@@ -257,9 +253,7 @@ fn no_implied_dirs_with_mkpath_creates_missing_parents() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // --mkpath overrides --no-implied-dirs
-    let options = LocalCopyOptions::default()
-        .implied_dirs(false)
-        .mkpath(true);
+    let options = LocalCopyOptions::default().implied_dirs(false).mkpath(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -297,8 +291,21 @@ fn no_implied_dirs_recursive_copy_with_nested_structure() {
     assert!(dest_root.join("source").join("root.txt").exists());
 
     // Nested structure should also be created as part of recursion
-    assert!(dest_root.join("source").join("parent").join("child").exists());
-    assert!(dest_root.join("source").join("parent").join("child").join("nested.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("parent")
+            .join("child")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("parent")
+            .join("child")
+            .join("nested.txt")
+            .exists()
+    );
 
     assert!(summary.files_copied() >= 2);
     assert!(summary.directories_created() >= 3);
@@ -381,10 +388,7 @@ fn no_implied_dirs_with_trailing_slash_copies_contents() {
     let mut source_operand = source_root.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
 
-    let operands = vec![
-        source_operand,
-        dest_root.clone().into_os_string(),
-    ];
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().implied_dirs(false);
 
@@ -507,14 +511,15 @@ fn no_implied_dirs_collection_reports_correct_events() {
 
     let records = report.records();
 
-    assert!(records
-        .iter()
-        .any(|r| r.action() == &LocalCopyAction::DirectoryCreated));
-    assert!(records
-        .iter()
-        .any(|r| matches!(r.action(),
-            LocalCopyAction::DataCopied |
-            LocalCopyAction::MetadataReused)));
+    assert!(
+        records
+            .iter()
+            .any(|r| r.action() == &LocalCopyAction::DirectoryCreated)
+    );
+    assert!(records.iter().any(|r| matches!(
+        r.action(),
+        LocalCopyAction::DataCopied | LocalCopyAction::MetadataReused
+    )));
 }
 
 // Mirrors the upstream `relative-implied` testsuite `--no-implied-dirs` half:
@@ -692,7 +697,12 @@ fn no_implied_dirs_follows_an_existing_dest_symlink_path_element() {
         .expect("--no-implied-dirs follows the existing dest symlink");
 
     assert!(
-        dest_root.join("path").symlink_metadata().expect("stat path").file_type().is_symlink(),
+        dest_root
+            .join("path")
+            .symlink_metadata()
+            .expect("stat path")
+            .file_type()
+            .is_symlink(),
         "--no-implied-dirs must KEEP the dest symlink, not replace it"
     );
     let through = dest_root.join("real").join("file");
@@ -726,7 +736,11 @@ fn implied_dirs_replaces_the_same_dest_symlink_with_a_real_directory() {
 
     let planted = dest_root.join("path");
     assert!(
-        !planted.symlink_metadata().expect("stat path").file_type().is_symlink(),
+        !planted
+            .symlink_metadata()
+            .expect("stat path")
+            .file_type()
+            .is_symlink(),
         "the default must REPLACE the dest symlink with a real directory"
     );
     assert_eq!(

--- a/crates/engine/src/local_copy/tests/execute_numeric_ids.rs
+++ b/crates/engine/src/local_copy/tests/execute_numeric_ids.rs
@@ -1,4 +1,3 @@
-
 #[cfg(unix)]
 #[test]
 fn numeric_ids_preserves_uid_without_name_lookup() {
@@ -31,9 +30,7 @@ fn numeric_ids_preserves_uid_without_name_lookup() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .owner(true)
-        .numeric_ids(true);
+    let options = LocalCopyOptions::default().owner(true).numeric_ids(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -76,9 +73,7 @@ fn numeric_ids_preserves_gid_without_name_lookup() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .group(true)
-        .numeric_ids(true);
+    let options = LocalCopyOptions::default().group(true).numeric_ids(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -168,9 +163,7 @@ fn numeric_ids_handles_non_existent_uid() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .owner(true)
-        .numeric_ids(true);
+    let options = LocalCopyOptions::default().owner(true).numeric_ids(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -213,9 +206,7 @@ fn numeric_ids_handles_non_existent_gid() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .group(true)
-        .numeric_ids(true);
+    let options = LocalCopyOptions::default().group(true).numeric_ids(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -309,9 +300,7 @@ fn numeric_ids_with_owner_flag_only() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // Only preserve owner, not group
-    let options = LocalCopyOptions::default()
-        .owner(true)
-        .numeric_ids(true);
+    let options = LocalCopyOptions::default().owner(true).numeric_ids(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -359,9 +348,7 @@ fn numeric_ids_with_group_flag_only() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // Only preserve group, not owner
-    let options = LocalCopyOptions::default()
-        .group(true)
-        .numeric_ids(true);
+    let options = LocalCopyOptions::default().group(true).numeric_ids(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -407,9 +394,7 @@ fn numeric_ids_disabled_attempts_name_lookup() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // numeric_ids is false, so it will attempt name lookup
-    let options = LocalCopyOptions::default()
-        .owner(true)
-        .numeric_ids(false);
+    let options = LocalCopyOptions::default().owner(true).numeric_ids(false);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)

--- a/crates/engine/src/local_copy/tests/execute_omit_dir_times.rs
+++ b/crates/engine/src/local_copy/tests/execute_omit_dir_times.rs
@@ -30,9 +30,7 @@ fn omit_dir_times_does_not_preserve_directory_mtime() {
         dest_root.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -70,9 +68,7 @@ fn omit_dir_times_still_preserves_file_timestamps() {
         dest_root.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -115,7 +111,8 @@ fn omit_dir_times_works_with_nested_directories() {
     set_file_mtime(&source_file, file_mtime).expect("set file mtime");
     set_file_mtime(&nested, level3_mtime).expect("set level3 mtime");
     set_file_mtime(nested.parent().unwrap(), level2_mtime).expect("set level2 mtime");
-    set_file_mtime(nested.parent().unwrap().parent().unwrap(), level1_mtime).expect("set level1 mtime");
+    set_file_mtime(nested.parent().unwrap().parent().unwrap(), level1_mtime)
+        .expect("set level1 mtime");
     set_file_mtime(&source_root, root_mtime).expect("set root mtime");
 
     let dest_root = temp.path().join("dest");
@@ -124,36 +121,54 @@ fn omit_dir_times_works_with_nested_directories() {
         dest_root.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    let dest_file = dest_root.join("source").join("level1").join("level2").join("level3").join("deep_file.txt");
+    let dest_file = dest_root
+        .join("source")
+        .join("level1")
+        .join("level2")
+        .join("level3")
+        .join("deep_file.txt");
     let dest_file_metadata = fs::metadata(&dest_file).expect("dest file metadata");
     let dest_file_mtime = FileTime::from_last_modification_time(&dest_file_metadata);
-    assert_eq!(dest_file_mtime, file_mtime, "file mtime should be preserved");
+    assert_eq!(
+        dest_file_mtime, file_mtime,
+        "file mtime should be preserved"
+    );
 
     let dest_root_metadata = fs::metadata(dest_root.join("source")).expect("root metadata");
     let dest_root_mtime = FileTime::from_last_modification_time(&dest_root_metadata);
-    assert_ne!(dest_root_mtime, root_mtime, "root mtime should not be preserved");
+    assert_ne!(
+        dest_root_mtime, root_mtime,
+        "root mtime should not be preserved"
+    );
 
     let dest_level1 = dest_root.join("source").join("level1");
     let dest_level1_metadata = fs::metadata(&dest_level1).expect("level1 metadata");
     let dest_level1_mtime = FileTime::from_last_modification_time(&dest_level1_metadata);
-    assert_ne!(dest_level1_mtime, level1_mtime, "level1 mtime should not be preserved");
+    assert_ne!(
+        dest_level1_mtime, level1_mtime,
+        "level1 mtime should not be preserved"
+    );
 
     let dest_level2 = dest_level1.join("level2");
     let dest_level2_metadata = fs::metadata(&dest_level2).expect("level2 metadata");
     let dest_level2_mtime = FileTime::from_last_modification_time(&dest_level2_metadata);
-    assert_ne!(dest_level2_mtime, level2_mtime, "level2 mtime should not be preserved");
+    assert_ne!(
+        dest_level2_mtime, level2_mtime,
+        "level2 mtime should not be preserved"
+    );
 
     let dest_level3 = dest_level2.join("level3");
     let dest_level3_metadata = fs::metadata(&dest_level3).expect("level3 metadata");
     let dest_level3_mtime = FileTime::from_last_modification_time(&dest_level3_metadata);
-    assert_ne!(dest_level3_mtime, level3_mtime, "level3 mtime should not be preserved");
+    assert_ne!(
+        dest_level3_mtime, level3_mtime,
+        "level3 mtime should not be preserved"
+    );
 }
 
 #[cfg(unix)]
@@ -194,8 +209,8 @@ fn omit_dir_times_without_times_flag_has_no_effect() {
 #[cfg(unix)]
 #[test]
 fn omit_dir_times_with_permissions_preserves_mode() {
-    use std::os::unix::fs::PermissionsExt;
     use filetime::{FileTime, set_file_mtime};
+    use std::os::unix::fs::PermissionsExt;
 
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
@@ -231,8 +246,8 @@ fn omit_dir_times_with_permissions_preserves_mode() {
 #[cfg(unix)]
 #[test]
 fn omit_dir_times_preserves_directory_permissions_multiple_dirs() {
-    use std::os::unix::fs::PermissionsExt;
     use filetime::{FileTime, set_file_mtime};
+    use std::os::unix::fs::PermissionsExt;
 
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
@@ -294,9 +309,7 @@ fn omit_dir_times_works_in_dry_run_mode() {
         dest_root.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::DryRun, options)
@@ -339,29 +352,24 @@ fn omit_dir_times_with_multiple_source_files() {
         dest_root.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let dest_file1 = dest_root.join("source").join("file1.txt");
-    let dest_file1_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file1).expect("file1 metadata")
-    );
+    let dest_file1_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file1).expect("file1 metadata"));
     assert_eq!(dest_file1_mtime, file1_mtime);
 
     let dest_file2 = dest_root.join("source").join("file2.txt");
-    let dest_file2_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file2).expect("file2 metadata")
-    );
+    let dest_file2_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file2).expect("file2 metadata"));
     assert_eq!(dest_file2_mtime, file2_mtime);
 
     let dest_file3 = dest_root.join("source").join("file3.txt");
-    let dest_file3_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file3).expect("file3 metadata")
-    );
+    let dest_file3_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file3).expect("file3 metadata"));
     assert_eq!(dest_file3_mtime, file3_mtime);
 
     let dest_dir_metadata = fs::metadata(dest_root.join("source")).expect("dir metadata");
@@ -389,9 +397,7 @@ fn omit_dir_times_with_empty_directories() {
         dest_root.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -401,11 +407,10 @@ fn omit_dir_times_with_empty_directories() {
     assert!(dest_empty.is_dir());
 
     let dest_root_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source")).expect("root metadata")
+        &fs::metadata(dest_root.join("source")).expect("root metadata"),
     );
-    let dest_empty_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_empty).expect("empty metadata")
-    );
+    let dest_empty_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_empty).expect("empty metadata"));
 
     assert_ne!(dest_root_mtime, dir_mtime);
     assert_ne!(dest_empty_mtime, dir_mtime);
@@ -442,9 +447,7 @@ fn omit_dir_times_performance_deep_hierarchy() {
         dest_root.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -458,9 +461,8 @@ fn omit_dir_times_performance_deep_hierarchy() {
     }
     assert!(dest_path.join("deep_file.txt").exists());
 
-    let dest_root_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_root).expect("root metadata")
-    );
+    let dest_root_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_root).expect("root metadata"));
     assert_ne!(dest_root_mtime, dir_mtime);
 
     let dest_file = dest_path.join("deep_file.txt");
@@ -492,9 +494,7 @@ fn omit_dir_times_with_trailing_slash_source() {
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -504,7 +504,7 @@ fn omit_dir_times_with_trailing_slash_source() {
     assert!(dest_nested.join("file.txt").exists());
 
     let dest_nested_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_nested).expect("nested metadata")
+        &fs::metadata(&dest_nested).expect("nested metadata"),
     );
     assert_ne!(dest_nested_mtime, dir_mtime);
 }
@@ -551,14 +551,12 @@ fn omit_dir_times_combined_with_update_flag() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&dest_file).expect("read dest"), b"new content");
 
-    let dest_file_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file).expect("file metadata")
-    );
+    let dest_file_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file).expect("file metadata"));
     assert_eq!(dest_file_mtime, file_mtime);
 
-    let dest_dir_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_root).expect("dir metadata")
-    );
+    let dest_dir_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_root).expect("dir metadata"));
     assert_ne!(dest_dir_mtime, dir_mtime);
 }
 
@@ -597,9 +595,8 @@ fn omit_dir_times_with_delete_flag() {
     assert!(!dest_root.join("extra.txt").exists());
     assert!(dest_root.join("keep.txt").exists());
 
-    let dest_dir_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_root).expect("dir metadata")
-    );
+    let dest_dir_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_root).expect("dir metadata"));
     assert_ne!(dest_dir_mtime, dir_mtime);
 }
 
@@ -713,18 +710,27 @@ fn without_omit_dir_times_nested_dirs_preserve_mtimes() {
         .expect("copy succeeds");
 
     let dest_root_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source")).expect("root metadata")
+        &fs::metadata(dest_root.join("source")).expect("root metadata"),
     );
     let dest_sub1_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("sub1")).expect("sub1 metadata")
+        &fs::metadata(dest_root.join("source").join("sub1")).expect("sub1 metadata"),
     );
     let dest_sub2_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("sub1").join("sub2")).expect("sub2 metadata")
+        &fs::metadata(dest_root.join("source").join("sub1").join("sub2")).expect("sub2 metadata"),
     );
 
-    assert_eq!(dest_root_mtime, root_mtime, "root mtime should be preserved");
-    assert_eq!(dest_sub1_mtime, sub1_mtime, "sub1 mtime should be preserved");
-    assert_eq!(dest_sub2_mtime, sub2_mtime, "sub2 mtime should be preserved");
+    assert_eq!(
+        dest_root_mtime, root_mtime,
+        "root mtime should be preserved"
+    );
+    assert_eq!(
+        dest_sub1_mtime, sub1_mtime,
+        "sub1 mtime should be preserved"
+    );
+    assert_eq!(
+        dest_sub2_mtime, sub2_mtime,
+        "sub2 mtime should be preserved"
+    );
 }
 
 #[cfg(unix)]
@@ -753,16 +759,13 @@ fn omit_dir_times_incremental_copy_does_not_update_dir_mtime() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
 
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("first copy succeeds");
 
-    let _first_dir_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_root).expect("dest metadata")
-    );
+    let _first_dir_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_root).expect("dest metadata"));
 
     // Second copy (incremental) - file unchanged so file matches, but dir
     // timestamp should still not be set from source
@@ -770,17 +773,14 @@ fn omit_dir_times_incremental_copy_does_not_update_dir_mtime() {
     source_operand2.push(std::path::MAIN_SEPARATOR.to_string());
     let operands2 = vec![source_operand2, dest_root.clone().into_os_string()];
     let plan2 = LocalCopyPlan::from_operands(&operands2).expect("plan");
-    let options2 = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options2 = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan2
         .execute_with_options(LocalCopyExecution::Apply, options2)
         .expect("second copy succeeds");
 
-    let second_dir_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_root).expect("dest metadata")
-    );
+    let second_dir_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_root).expect("dest metadata"));
 
     assert_ne!(
         second_dir_mtime, dir_mtime,
@@ -788,9 +788,8 @@ fn omit_dir_times_incremental_copy_does_not_update_dir_mtime() {
     );
 
     let dest_file = dest_root.join("file.txt");
-    let dest_file_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file).expect("file metadata")
-    );
+    let dest_file_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file).expect("file metadata"));
     assert_eq!(
         dest_file_mtime, file_mtime,
         "file mtime should be preserved on incremental copy"
@@ -823,9 +822,7 @@ fn omit_dir_times_incremental_with_new_file_preserves_new_file_time() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
 
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("first copy succeeds");
@@ -843,31 +840,32 @@ fn omit_dir_times_incremental_with_new_file_preserves_new_file_time() {
     source_operand2.push(std::path::MAIN_SEPARATOR.to_string());
     let operands2 = vec![source_operand2, dest_root.clone().into_os_string()];
     let plan2 = LocalCopyPlan::from_operands(&operands2).expect("plan");
-    let options2 = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options2 = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan2
         .execute_with_options(LocalCopyExecution::Apply, options2)
         .expect("second copy succeeds");
 
-    let dest_dir_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_root).expect("dest metadata")
-    );
+    let dest_dir_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_root).expect("dest metadata"));
     assert_ne!(dest_dir_mtime, dir_mtime);
     assert_ne!(dest_dir_mtime, new_dir_mtime);
 
     let dest_file1 = dest_root.join("file1.txt");
-    let dest_file1_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file1).expect("file1 metadata")
+    let dest_file1_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file1).expect("file1 metadata"));
+    assert_eq!(
+        dest_file1_mtime, file1_mtime,
+        "file1 mtime should be preserved"
     );
-    assert_eq!(dest_file1_mtime, file1_mtime, "file1 mtime should be preserved");
 
     let dest_file2 = dest_root.join("file2.txt");
-    let dest_file2_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file2).expect("file2 metadata")
+    let dest_file2_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file2).expect("file2 metadata"));
+    assert_eq!(
+        dest_file2_mtime, file2_mtime,
+        "file2 mtime should be preserved"
     );
-    assert_eq!(dest_file2_mtime, file2_mtime, "file2 mtime should be preserved");
 }
 
 #[cfg(unix)]
@@ -909,40 +907,58 @@ fn omit_dir_times_mixed_tree_files_have_correct_timestamps() {
         dest_root.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().times(true).omit_dir_times(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
     let dest_file_a_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("dir_a").join("file_a.txt")).expect("file_a metadata")
+        &fs::metadata(dest_root.join("source").join("dir_a").join("file_a.txt"))
+            .expect("file_a metadata"),
     );
     let dest_file_b_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("dir_b").join("file_b.txt")).expect("file_b metadata")
+        &fs::metadata(dest_root.join("source").join("dir_b").join("file_b.txt"))
+            .expect("file_b metadata"),
     );
     let dest_file_root_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("file_root.txt")).expect("file_root metadata")
+        &fs::metadata(dest_root.join("source").join("file_root.txt")).expect("file_root metadata"),
     );
 
-    assert_eq!(dest_file_a_mtime, file_a_mtime, "file_a mtime should be preserved");
-    assert_eq!(dest_file_b_mtime, file_b_mtime, "file_b mtime should be preserved");
-    assert_eq!(dest_file_root_mtime, file_root_mtime, "file_root mtime should be preserved");
+    assert_eq!(
+        dest_file_a_mtime, file_a_mtime,
+        "file_a mtime should be preserved"
+    );
+    assert_eq!(
+        dest_file_b_mtime, file_b_mtime,
+        "file_b mtime should be preserved"
+    );
+    assert_eq!(
+        dest_file_root_mtime, file_root_mtime,
+        "file_root mtime should be preserved"
+    );
 
     let dest_root_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source")).expect("root metadata")
+        &fs::metadata(dest_root.join("source")).expect("root metadata"),
     );
     let dest_dir_a_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("dir_a")).expect("dir_a metadata")
+        &fs::metadata(dest_root.join("source").join("dir_a")).expect("dir_a metadata"),
     );
     let dest_dir_b_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("dir_b")).expect("dir_b metadata")
+        &fs::metadata(dest_root.join("source").join("dir_b")).expect("dir_b metadata"),
     );
 
-    assert_ne!(dest_root_mtime, root_mtime, "root mtime should not be preserved");
-    assert_ne!(dest_dir_a_mtime, dir_a_mtime, "dir_a mtime should not be preserved");
-    assert_ne!(dest_dir_b_mtime, dir_b_mtime, "dir_b mtime should not be preserved");
+    assert_ne!(
+        dest_root_mtime, root_mtime,
+        "root mtime should not be preserved"
+    );
+    assert_ne!(
+        dest_dir_a_mtime, dir_a_mtime,
+        "dir_a mtime should not be preserved"
+    );
+    assert_ne!(
+        dest_dir_b_mtime, dir_b_mtime,
+        "dir_b mtime should not be preserved"
+    );
 }
 
 #[cfg(unix)]
@@ -992,12 +1008,10 @@ fn omit_dir_times_option_default_is_false() {
 
 #[test]
 fn omit_dir_times_option_builder_round_trip() {
-    let options = LocalCopyOptions::default()
-        .omit_dir_times(true);
+    let options = LocalCopyOptions::default().omit_dir_times(true);
     assert!(options.omit_dir_times_enabled());
 
-    let options = LocalCopyOptions::default()
-        .omit_dir_times(false);
+    let options = LocalCopyOptions::default().omit_dir_times(false);
     assert!(!options.omit_dir_times_enabled());
 
     let options = LocalCopyOptions::default()
@@ -1050,25 +1064,36 @@ fn omit_dir_times_with_archive_style_options() {
         .expect("copy succeeds");
 
     let dest_file = dest_root.join("source").join("subdir").join("file.txt");
-    let dest_file_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&dest_file).expect("file metadata")
+    let dest_file_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file).expect("file metadata"));
+    assert_eq!(
+        dest_file_mtime, file_mtime,
+        "file mtime should be preserved"
     );
-    assert_eq!(dest_file_mtime, file_mtime, "file mtime should be preserved");
 
     let dest_root_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source")).expect("root metadata")
+        &fs::metadata(dest_root.join("source")).expect("root metadata"),
     );
-    assert_ne!(dest_root_mtime, dir_mtime, "root dir mtime should not be preserved");
+    assert_ne!(
+        dest_root_mtime, dir_mtime,
+        "root dir mtime should not be preserved"
+    );
 
     let dest_nested_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(dest_root.join("source").join("subdir")).expect("nested metadata")
+        &fs::metadata(dest_root.join("source").join("subdir")).expect("nested metadata"),
     );
-    assert_ne!(dest_nested_mtime, dir_mtime, "nested dir mtime should not be preserved");
+    assert_ne!(
+        dest_nested_mtime, dir_mtime,
+        "nested dir mtime should not be preserved"
+    );
 
     let dest_nested_mode = fs::metadata(dest_root.join("source").join("subdir"))
         .expect("nested metadata")
         .permissions()
         .mode()
         & 0o777;
-    assert_eq!(dest_nested_mode, 0o755, "directory permissions should be preserved");
+    assert_eq!(
+        dest_nested_mode, 0o755,
+        "directory permissions should be preserved"
+    );
 }

--- a/crates/engine/src/local_copy/tests/execute_one_file_system.rs
+++ b/crates/engine/src/local_copy/tests/execute_one_file_system.rs
@@ -38,9 +38,29 @@ fn one_file_system_traverses_same_filesystem_directories() {
 
     // All files should be copied since they're on the same filesystem
     assert_eq!(summary.files_copied(), 3);
-    assert!(dest_root.join("source").join("dir1").join("file1.txt").exists());
-    assert!(dest_root.join("source").join("dir1").join("nested").join("deep").join("file2.txt").exists());
-    assert!(dest_root.join("source").join("dir2").join("file3.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir1")
+            .join("file1.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir1")
+            .join("nested")
+            .join("deep")
+            .join("file2.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir2")
+            .join("file3.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -69,7 +89,10 @@ fn one_file_system_skips_mount_point_directories() {
     let report = with_device_id_override(
         |path, _metadata| {
             // Simulate mount_point being on device 2, everything else on device 1
-            if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("mount_point")) {
+            if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("mount_point"))
+            {
                 Some(2)
             } else {
                 Some(1)
@@ -87,15 +110,30 @@ fn one_file_system_skips_mount_point_directories() {
     .expect("copy executes");
 
     // Only the file from same filesystem should be copied
-    assert!(dest_root.join("source").join("same_fs").join("local.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("same_fs")
+            .join("local.txt")
+            .exists()
+    );
     assert!(!dest_root.join("source").join("mount_point").exists());
-    assert!(!dest_root.join("source").join("mount_point").join("mount_root.txt").exists());
+    assert!(
+        !dest_root
+            .join("source")
+            .join("mount_point")
+            .join("mount_root.txt")
+            .exists()
+    );
 
     // Verify that mount point was recorded as skipped
     let records = report.records();
     let skipped_mount = records.iter().any(|record| {
         record.action() == &LocalCopyAction::SkippedMountPoint
-            && record.relative_path().to_string_lossy().contains("mount_point")
+            && record
+                .relative_path()
+                .to_string_lossy()
+                .contains("mount_point")
     });
     assert!(skipped_mount, "mount point should be recorded as skipped");
 }
@@ -136,10 +174,37 @@ fn one_file_system_transfers_files_on_same_filesystem() {
     .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 4);
-    assert_eq!(fs::read(dest_root.join("source").join("root.txt")).expect("read root"), b"root");
-    assert_eq!(fs::read(dest_root.join("source").join("level1").join("l1.txt")).expect("read l1"), b"level1");
-    assert_eq!(fs::read(dest_root.join("source").join("level1").join("level2").join("l2.txt")).expect("read l2"), b"level2");
-    assert_eq!(fs::read(dest_root.join("source").join("level1").join("level2").join("level3").join("l3.txt")).expect("read l3"), b"level3");
+    assert_eq!(
+        fs::read(dest_root.join("source").join("root.txt")).expect("read root"),
+        b"root"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("source").join("level1").join("l1.txt")).expect("read l1"),
+        b"level1"
+    );
+    assert_eq!(
+        fs::read(
+            dest_root
+                .join("source")
+                .join("level1")
+                .join("level2")
+                .join("l2.txt")
+        )
+        .expect("read l2"),
+        b"level2"
+    );
+    assert_eq!(
+        fs::read(
+            dest_root
+                .join("source")
+                .join("level1")
+                .join("level2")
+                .join("level3")
+                .join("l3.txt")
+        )
+        .expect("read l3"),
+        b"level3"
+    );
 }
 
 #[test]
@@ -177,9 +242,15 @@ fn one_file_system_respects_flag_during_directory_walking() {
     let report = with_device_id_override(
         |path, _metadata| {
             // mount1 is device 2, mount2 is device 3, everything else is device 1
-            if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("mount1")) {
+            if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("mount1"))
+            {
                 Some(2)
-            } else if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("mount2")) {
+            } else if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("mount2"))
+            {
                 Some(3)
             } else {
                 Some(1)
@@ -197,14 +268,54 @@ fn one_file_system_respects_flag_during_directory_walking() {
     .expect("copy executes");
 
     // Files on device 1 should be copied
-    assert!(dest_root.join("source").join("dir_a").join("file_a.txt").exists());
-    assert!(dest_root.join("source").join("dir_a").join("regular").join("reg_a.txt").exists());
-    assert!(dest_root.join("source").join("dir_b").join("file_b.txt").exists());
-    assert!(dest_root.join("source").join("dir_b").join("regular").join("reg_b.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir_a")
+            .join("file_a.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir_a")
+            .join("regular")
+            .join("reg_a.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir_b")
+            .join("file_b.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir_b")
+            .join("regular")
+            .join("reg_b.txt")
+            .exists()
+    );
 
     // Files on other devices should be skipped
-    assert!(!dest_root.join("source").join("dir_a").join("mount1").join("mount1_file.txt").exists());
-    assert!(!dest_root.join("source").join("dir_b").join("mount2").join("mount2_file.txt").exists());
+    assert!(
+        !dest_root
+            .join("source")
+            .join("dir_a")
+            .join("mount1")
+            .join("mount1_file.txt")
+            .exists()
+    );
+    assert!(
+        !dest_root
+            .join("source")
+            .join("dir_b")
+            .join("mount2")
+            .join("mount2_file.txt")
+            .exists()
+    );
 
     // Verify both mount points were skipped
     let records = report.records();
@@ -213,7 +324,11 @@ fn one_file_system_respects_flag_during_directory_walking() {
         .filter(|r| r.action() == &LocalCopyAction::SkippedMountPoint)
         .collect();
 
-    assert_eq!(mount_skips.len(), 2, "should have skipped exactly 2 mount points");
+    assert_eq!(
+        mount_skips.len(),
+        2,
+        "should have skipped exactly 2 mount points"
+    );
 }
 
 #[test]
@@ -240,7 +355,10 @@ fn one_file_system_disabled_crosses_filesystem_boundaries() {
     let summary = with_device_id_override(
         |path, _metadata| {
             // other_fs is on device 2, everything else on device 1
-            if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("other_fs")) {
+            if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("other_fs"))
+            {
                 Some(2)
             } else {
                 Some(1)
@@ -257,8 +375,20 @@ fn one_file_system_disabled_crosses_filesystem_boundaries() {
 
     // Both files should be copied when flag is disabled
     assert_eq!(summary.files_copied(), 2);
-    assert!(dest_root.join("source").join("same_fs").join("file1.txt").exists());
-    assert!(dest_root.join("source").join("other_fs").join("file2.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("same_fs")
+            .join("file1.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("other_fs")
+            .join("file2.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -315,13 +445,43 @@ fn one_file_system_handles_multiple_mount_points_in_single_directory() {
     .expect("copy executes");
 
     // Local files should be copied
-    assert!(dest_root.join("source").join("local1").join("f1.txt").exists());
-    assert!(dest_root.join("source").join("local2").join("f2.txt").exists());
-    assert!(dest_root.join("source").join("local3").join("f3.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("local1")
+            .join("f1.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("local2")
+            .join("f2.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("local3")
+            .join("f3.txt")
+            .exists()
+    );
 
     // Mount point files should not be copied
-    assert!(!dest_root.join("source").join("mount1").join("m1.txt").exists());
-    assert!(!dest_root.join("source").join("mount2").join("m2.txt").exists());
+    assert!(
+        !dest_root
+            .join("source")
+            .join("mount1")
+            .join("m1.txt")
+            .exists()
+    );
+    assert!(
+        !dest_root
+            .join("source")
+            .join("mount2")
+            .join("m2.txt")
+            .exists()
+    );
 
     // Verify skip events
     let records = report.records();
@@ -366,8 +526,20 @@ fn one_file_system_with_empty_directories_on_same_fs() {
     .expect("copy succeeds");
 
     assert!(dest_root.join("source").join("empty1").is_dir());
-    assert!(dest_root.join("source").join("subdir").join("empty2").is_dir());
-    assert!(dest_root.join("source").join("with_file").join("file.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("subdir")
+            .join("empty2")
+            .is_dir()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("with_file")
+            .join("file.txt")
+            .exists()
+    );
     assert!(summary.directories_created() >= 3);
 }
 
@@ -393,7 +565,10 @@ fn one_file_system_dry_run_reports_would_skip_mount() {
 
     let report = with_device_id_override(
         |path, _metadata| {
-            if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("mount")) {
+            if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("mount"))
+            {
                 Some(2)
             } else {
                 Some(1)
@@ -419,7 +594,10 @@ fn one_file_system_dry_run_reports_would_skip_mount() {
         r.action() == &LocalCopyAction::SkippedMountPoint
             && r.relative_path().to_string_lossy().contains("mount")
     });
-    assert!(would_skip, "dry run should report mount point would be skipped");
+    assert!(
+        would_skip,
+        "dry run should report mount point would be skipped"
+    );
 }
 
 #[test]
@@ -441,14 +619,15 @@ fn one_file_system_with_filters_skips_mount_first() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // Include filter that would match files in mount
-    let program = FilterProgram::new([
-        FilterProgramEntry::Rule(FilterRule::include("*.txt")),
-    ])
-    .expect("compile program");
+    let program = FilterProgram::new([FilterProgramEntry::Rule(FilterRule::include("*.txt"))])
+        .expect("compile program");
 
     let report = with_device_id_override(
         |path, _metadata| {
-            if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("mount")) {
+            if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("mount"))
+            {
                 Some(2)
             } else {
                 Some(1)
@@ -517,11 +696,22 @@ fn one_file_system_with_symlinks_follows_on_same_fs() {
     .expect("copy succeeds");
 
     // Both the file and symlink should be copied
-    assert!(dest_root.join("source").join("target").join("file.txt").exists());
-    assert!(dest_root.join("source").join("linkdir").join("link").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("target")
+            .join("file.txt")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("linkdir")
+            .join("link")
+            .exists()
+    );
     assert!(summary.files_copied() >= 1);
 }
-
 
 #[test]
 fn double_one_file_system_skips_root_source_that_is_mount_point() {
@@ -547,8 +737,12 @@ fn double_one_file_system_skips_root_source_that_is_mount_point() {
     // Parent directory is on device 1, source directory is on device 2 (mount point)
     let report = with_device_id_override(
         |path, _metadata| {
-            if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("mounted_src"))
-                || path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("sub"))
+            if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("mounted_src"))
+                || path
+                    .components()
+                    .any(|c| c.as_os_str() == std::ffi::OsStr::new("sub"))
             {
                 Some(2) // mount point
             } else {
@@ -575,7 +769,10 @@ fn double_one_file_system_skips_root_source_that_is_mount_point() {
     let skipped = records
         .iter()
         .any(|r| r.action() == &LocalCopyAction::SkippedMountPoint);
-    assert!(skipped, "root mount point should be recorded as skipped with -xx");
+    assert!(
+        skipped,
+        "root mount point should be recorded as skipped with -xx"
+    );
 }
 
 #[test]
@@ -612,7 +809,13 @@ fn double_one_file_system_allows_source_on_same_device_as_parent() {
     // All files should be copied since source is on same device as parent
     assert_eq!(summary.files_copied(), 2);
     assert!(dest_root.join("source").join("file.txt").exists());
-    assert!(dest_root.join("source").join("sub").join("nested.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("sub")
+            .join("nested.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -637,7 +840,10 @@ fn single_x_does_not_skip_root_mount_point() {
     // but with single -x, root mount points are NOT skipped.
     let summary = with_device_id_override(
         |path, _metadata| {
-            if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("mounted_src")) {
+            if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("mounted_src"))
+            {
                 Some(2) // mount point
             } else {
                 Some(1) // parent
@@ -681,7 +887,10 @@ fn double_one_file_system_still_skips_subdirectory_mount_points() {
 
     let report = with_device_id_override(
         |path, _metadata| {
-            if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("mount_point")) {
+            if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("mount_point"))
+            {
                 Some(2) // different device
             } else {
                 Some(1) // same device
@@ -699,16 +908,31 @@ fn double_one_file_system_still_skips_subdirectory_mount_points() {
     .expect("copy executes");
 
     // File on same filesystem should be copied
-    assert!(dest_root.join("source").join("same_fs").join("local.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("same_fs")
+            .join("local.txt")
+            .exists()
+    );
     // Mount point subdirectory should be skipped
-    assert!(!dest_root.join("source").join("mount_point").join("other.txt").exists());
+    assert!(
+        !dest_root
+            .join("source")
+            .join("mount_point")
+            .join("other.txt")
+            .exists()
+    );
 
     // Verify skip was recorded
     let records = report.records();
     let mount_skipped = records
         .iter()
         .any(|r| r.action() == &LocalCopyAction::SkippedMountPoint);
-    assert!(mount_skipped, "subdirectory mount point should still be skipped with -xx");
+    assert!(
+        mount_skipped,
+        "subdirectory mount point should still be skipped with -xx"
+    );
 }
 
 #[test]
@@ -731,7 +955,10 @@ fn level_zero_does_not_skip_any_mount_points() {
 
     let summary = with_device_id_override(
         |path, _metadata| {
-            if path.components().any(|c| c.as_os_str() == std::ffi::OsStr::new("mount")) {
+            if path
+                .components()
+                .any(|c| c.as_os_str() == std::ffi::OsStr::new("mount"))
+            {
                 Some(2)
             } else {
                 Some(1)
@@ -749,7 +976,13 @@ fn level_zero_does_not_skip_any_mount_points() {
     // Everything should be copied
     assert_eq!(summary.files_copied(), 2);
     assert!(dest_root.join("source").join("local.txt").exists());
-    assert!(dest_root.join("source").join("mount").join("other.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("mount")
+            .join("other.txt")
+            .exists()
+    );
 }
 
 /// Verifies that pruning a cross-device child directory emits the upstream
@@ -854,10 +1087,7 @@ fn one_file_system_default_verbosity_suppresses_info_mount_notice() {
     fs::write(mount_point.join("mount_root.txt"), b"other fs").expect("write mount_root");
 
     let dest_root = temp.path().join("dest");
-    let operands = vec![
-        source_root.into_os_string(),
-        dest_root.into_os_string(),
-    ];
+    let operands = vec![source_root.into_os_string(), dest_root.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     with_device_id_override(
@@ -970,7 +1200,10 @@ fn one_file_system_delete_preserves_mount_nested_in_doomed_dir() {
     .expect("copy succeeds");
 
     // The source file was copied and kept.
-    assert!(dest_tree.join("keep.txt").exists(), "kept source file survives");
+    assert!(
+        dest_tree.join("keep.txt").exists(),
+        "kept source file survives"
+    );
 
     // The nested mount and its contents are preserved: had `remove_dir_all` run
     // across the boundary, `mnt/data.txt` would be gone.
@@ -998,7 +1231,10 @@ fn one_file_system_delete_preserves_mount_nested_in_doomed_dir() {
 
     // Deletions were counted (regular.txt, purge/gone.txt, purge/); the mount
     // and its contents were not.
-    assert!(summary.items_deleted() >= 2, "same-device extras were deleted");
+    assert!(
+        summary.items_deleted() >= 2,
+        "same-device extras were deleted"
+    );
 }
 
 /// On Windows, `--one-file-system` cannot consult a POSIX `st_dev` (Windows has

--- a/crates/engine/src/local_copy/tests/execute_ownership_preservation.rs
+++ b/crates/engine/src/local_copy/tests/execute_ownership_preservation.rs
@@ -51,7 +51,11 @@ fn owner_flag_preserves_source_uid() {
         .expect("copy succeeds");
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
-    assert_eq!(metadata.uid(), test_uid, "destination should have source UID");
+    assert_eq!(
+        metadata.uid(),
+        test_uid,
+        "destination should have source UID"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -95,7 +99,11 @@ fn owner_flag_disabled_does_not_preserve_uid() {
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
     // Without owner flag, destination should have current user's UID (root = 0)
-    assert_ne!(metadata.uid(), test_uid, "destination should not preserve source UID");
+    assert_ne!(
+        metadata.uid(),
+        test_uid,
+        "destination should not preserve source UID"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -180,7 +188,11 @@ fn group_flag_preserves_source_gid() {
         .expect("copy succeeds");
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
-    assert_eq!(metadata.gid(), test_gid, "destination should have source GID");
+    assert_eq!(
+        metadata.gid(),
+        test_gid,
+        "destination should have source GID"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -223,7 +235,11 @@ fn group_flag_disabled_does_not_preserve_gid() {
         .expect("copy succeeds");
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
-    assert_ne!(metadata.gid(), test_gid, "destination should not preserve source GID");
+    assert_ne!(
+        metadata.gid(),
+        test_gid,
+        "destination should not preserve source GID"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -309,8 +325,16 @@ fn owner_and_group_flags_preserve_both() {
         .expect("copy succeeds");
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
-    assert_eq!(metadata.uid(), test_uid, "destination should have source UID");
-    assert_eq!(metadata.gid(), test_gid, "destination should have source GID");
+    assert_eq!(
+        metadata.uid(),
+        test_uid,
+        "destination should have source UID"
+    );
+    assert_eq!(
+        metadata.gid(),
+        test_gid,
+        "destination should have source GID"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -510,8 +534,14 @@ fn owner_preserved_recursively_in_directory_tree() {
     let dest_subdir = dest_dir.join("source").join("subdir");
     let dest_file2 = dest_subdir.join("file2.txt");
 
-    assert_eq!(fs::metadata(dest_dir.join("source")).expect("dir").uid(), test_uid);
-    assert_eq!(fs::metadata(dest_dir.join("source")).expect("dir").gid(), test_gid);
+    assert_eq!(
+        fs::metadata(dest_dir.join("source")).expect("dir").uid(),
+        test_uid
+    );
+    assert_eq!(
+        fs::metadata(dest_dir.join("source")).expect("dir").gid(),
+        test_gid
+    );
     assert_eq!(fs::metadata(&dest_file1).expect("file1").uid(), test_uid);
     assert_eq!(fs::metadata(&dest_file1).expect("file1").gid(), test_gid);
     assert_eq!(fs::metadata(&dest_subdir).expect("subdir").uid(), test_uid);

--- a/crates/engine/src/local_copy/tests/execute_permissions.rs
+++ b/crates/engine/src/local_copy/tests/execute_permissions.rs
@@ -1,4 +1,3 @@
-
 #[cfg(unix)]
 #[test]
 #[ignore = "mode 0000 files cannot be read by owner on most systems"]
@@ -191,7 +190,10 @@ fn mode_0000_dry_run() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert!(!destination.exists(), "destination should not be created in dry run");
+    assert!(
+        !destination.exists(),
+        "destination should not be created in dry run"
+    );
 }
 
 #[cfg(unix)]
@@ -219,9 +221,7 @@ fn mode_0000_with_sparse_file() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .permissions(true)
-        .sparse(true);
+    let options = LocalCopyOptions::default().permissions(true).sparse(true);
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -277,10 +277,26 @@ fn mode_0000_nested_directory_structure() {
     assert_eq!(summary.files_copied(), 4);
 
     let dest_files = [
-        (dest_root.join("source").join("source/root.txt"), b"root" as &[u8]),
-        (dest_root.join("source").join("source/level1/one.txt"), b"level1"),
-        (dest_root.join("source").join("source/level1/level2/two.txt"), b"level2"),
-        (dest_root.join("source").join("source/level1/level2/level3/three.txt"), b"level3"),
+        (
+            dest_root.join("source").join("source/root.txt"),
+            b"root" as &[u8],
+        ),
+        (
+            dest_root.join("source").join("source/level1/one.txt"),
+            b"level1",
+        ),
+        (
+            dest_root
+                .join("source")
+                .join("source/level1/level2/two.txt"),
+            b"level2",
+        ),
+        (
+            dest_root
+                .join("source")
+                .join("source/level1/level2/level3/three.txt"),
+            b"level3",
+        ),
     ];
 
     for (path, expected_content) in &dest_files {
@@ -548,7 +564,10 @@ fn dir_setgid_inheritance_preserved_without_perms() {
     // Probe whether the filesystem supports directory setgid inheritance.
     let probe = parent.join("probe");
     fs::create_dir(&probe).expect("create probe");
-    let probe_mode = fs::metadata(&probe).expect("probe meta").permissions().mode();
+    let probe_mode = fs::metadata(&probe)
+        .expect("probe meta")
+        .permissions()
+        .mode();
     if probe_mode & 0o2000 == 0 {
         // Filesystem does not propagate setgid - skip gracefully.
         return;

--- a/crates/engine/src/local_copy/tests/execute_prune_empty_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_prune_empty_dirs.rs
@@ -1,25 +1,30 @@
-
 #[test]
 fn prune_empty_dirs_does_not_create_empty_directories() {
     let ctx = test_helpers::setup_copy_test();
 
     test_helpers::create_test_tree(
         &ctx.source,
-        &[
-            ("empty_dir", None),
-            ("file.txt", Some(b"content")),
-        ],
+        &[("empty_dir", None), ("file.txt", Some(b"content"))],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!ctx.dest.join("source").join("empty_dir").exists(), "empty dir should not be created");
-    assert!(ctx.dest.join("source").join("file.txt").exists(), "file should be copied");
+    assert!(
+        !ctx.dest.join("source").join("empty_dir").exists(),
+        "empty dir should not be created"
+    );
+    assert!(
+        ctx.dest.join("source").join("file.txt").exists(),
+        "file should be copied"
+    );
 }
 
 #[test]
@@ -34,16 +39,32 @@ fn prune_empty_dirs_creates_directories_with_files() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(ctx.dest.join("source").join("dir_with_files").is_dir(), "directory with files should be created");
-    assert!(ctx.dest.join("source").join("dir_with_files/file1.txt").exists());
-    assert!(ctx.dest.join("source").join("dir_with_files/file2.txt").exists());
+    assert!(
+        ctx.dest.join("source").join("dir_with_files").is_dir(),
+        "directory with files should be created"
+    );
+    assert!(
+        ctx.dest
+            .join("source")
+            .join("dir_with_files/file1.txt")
+            .exists()
+    );
+    assert!(
+        ctx.dest
+            .join("source")
+            .join("dir_with_files/file2.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -59,15 +80,24 @@ fn prune_empty_dirs_prunes_nested_empty_directories() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!ctx.dest.join("source").join("level1").exists(), "nested empty dirs should be pruned");
-    assert!(ctx.dest.join("source").join("keep").is_dir(), "directory with file should be created");
+    assert!(
+        !ctx.dest.join("source").join("level1").exists(),
+        "nested empty dirs should be pruned"
+    );
+    assert!(
+        ctx.dest.join("source").join("keep").is_dir(),
+        "directory with file should be created"
+    );
     assert!(ctx.dest.join("source").join("keep/file.txt").exists());
 }
 
@@ -85,7 +115,10 @@ fn prune_empty_dirs_with_filter_excluding_all_files() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let filters = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default()
@@ -103,8 +136,18 @@ fn prune_empty_dirs_with_filter_excluding_all_files() {
         ctx.dest.join("source").join("included_dir").is_dir(),
         "directory with non-excluded files should exist"
     );
-    assert!(ctx.dest.join("source").join("included_dir/keep.txt").exists());
-    assert!(!ctx.dest.join("source").join("included_dir/also_temp.tmp").exists());
+    assert!(
+        ctx.dest
+            .join("source")
+            .join("included_dir/keep.txt")
+            .exists()
+    );
+    assert!(
+        !ctx.dest
+            .join("source")
+            .join("included_dir/also_temp.tmp")
+            .exists()
+    );
 }
 
 #[test]
@@ -119,16 +162,25 @@ fn prune_empty_dirs_preserves_non_empty_parent_of_empty_child() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(ctx.dest.join("source").join("parent").is_dir(), "parent with file should exist");
+    assert!(
+        ctx.dest.join("source").join("parent").is_dir(),
+        "parent with file should exist"
+    );
     assert!(ctx.dest.join("source").join("parent/file.txt").exists());
-    assert!(!ctx.dest.join("source").join("parent/empty_child").exists(), "empty child should be pruned");
+    assert!(
+        !ctx.dest.join("source").join("parent/empty_child").exists(),
+        "empty child should be pruned"
+    );
 }
 
 #[test]
@@ -145,19 +197,39 @@ fn prune_empty_dirs_with_multiple_branches() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!ctx.dest.join("source").join("branch1").exists(), "branch1 with only empty child should be pruned");
-    assert!(ctx.dest.join("source").join("branch2").is_dir(), "branch2 with file should exist");
+    assert!(
+        !ctx.dest.join("source").join("branch1").exists(),
+        "branch1 with only empty child should be pruned"
+    );
+    assert!(
+        ctx.dest.join("source").join("branch2").is_dir(),
+        "branch2 with file should exist"
+    );
     assert!(ctx.dest.join("source").join("branch2/full").is_dir());
-    assert!(ctx.dest.join("source").join("branch2/full/file.txt").exists());
-    assert!(!ctx.dest.join("source").join("branch3").exists(), "branch3 with nested empty should be pruned");
-    assert!(!ctx.dest.join("source").join("branch4").exists(), "empty branch4 should be pruned");
+    assert!(
+        ctx.dest
+            .join("source")
+            .join("branch2/full/file.txt")
+            .exists()
+    );
+    assert!(
+        !ctx.dest.join("source").join("branch3").exists(),
+        "branch3 with nested empty should be pruned"
+    );
+    assert!(
+        !ctx.dest.join("source").join("branch4").exists(),
+        "empty branch4 should be pruned"
+    );
 }
 
 #[test]
@@ -166,13 +238,13 @@ fn prune_empty_dirs_respects_dry_run() {
 
     test_helpers::create_test_tree(
         &ctx.source,
-        &[
-            ("empty", None),
-            ("nonempty/file.txt", Some(b"content")),
-        ],
+        &[("empty", None), ("nonempty/file.txt", Some(b"content"))],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
@@ -180,8 +252,14 @@ fn prune_empty_dirs_respects_dry_run() {
         .execute_with_options(LocalCopyExecution::DryRun, options)
         .expect("dry-run succeeds");
 
-    assert!(!ctx.dest.exists(), "destination should not exist in dry-run");
-    assert!(summary.directories_created() >= 1, "should report non-empty dir creation");
+    assert!(
+        !ctx.dest.exists(),
+        "destination should not exist in dry-run"
+    );
+    assert!(
+        summary.directories_created() >= 1,
+        "should report non-empty dir creation"
+    );
 }
 
 #[test]
@@ -190,10 +268,7 @@ fn prune_empty_dirs_with_trailing_separator() {
 
     test_helpers::create_test_tree(
         &ctx.source,
-        &[
-            ("empty", None),
-            ("nonempty/file.txt", Some(b"content")),
-        ],
+        &[("empty", None), ("nonempty/file.txt", Some(b"content"))],
     );
 
     let mut source_operand = ctx.source.into_os_string();
@@ -205,7 +280,10 @@ fn prune_empty_dirs_with_trailing_separator() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!ctx.dest.join("empty").exists(), "empty dir should be pruned");
+    assert!(
+        !ctx.dest.join("empty").exists(),
+        "empty dir should be pruned"
+    );
     assert!(ctx.dest.join("nonempty").is_dir());
     assert!(ctx.dest.join("nonempty/file.txt").exists());
 }
@@ -224,7 +302,10 @@ fn prune_empty_dirs_with_min_size_filter() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .min_file_size(Some(10))
@@ -237,7 +318,10 @@ fn prune_empty_dirs_with_min_size_filter() {
         !ctx.dest.join("source").join("small_files_only").exists(),
         "directory with only small files should be pruned"
     );
-    assert!(ctx.dest.join("source").join("mixed_dir").is_dir(), "directory with large file should exist");
+    assert!(
+        ctx.dest.join("source").join("mixed_dir").is_dir(),
+        "directory with large file should exist"
+    );
     assert!(ctx.dest.join("source").join("mixed_dir/large.txt").exists());
     assert!(!ctx.dest.join("source").join("mixed_dir/tiny.txt").exists());
 }
@@ -249,14 +333,23 @@ fn prune_empty_dirs_with_max_size_filter() {
     test_helpers::create_test_tree(
         &ctx.source,
         &[
-            ("large_files_only/huge1.bin", Some(b"this is a very large file content here")),
-            ("large_files_only/huge2.bin", Some(b"another very large file content")),
+            (
+                "large_files_only/huge1.bin",
+                Some(b"this is a very large file content here"),
+            ),
+            (
+                "large_files_only/huge2.bin",
+                Some(b"another very large file content"),
+            ),
             ("mixed_dir/small.txt", Some(b"ok")),
             ("mixed_dir/huge.bin", Some(b"this is huge content file")),
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .max_file_size(Some(10))
@@ -269,7 +362,10 @@ fn prune_empty_dirs_with_max_size_filter() {
         !ctx.dest.join("source").join("large_files_only").exists(),
         "directory with only large files should be pruned"
     );
-    assert!(ctx.dest.join("source").join("mixed_dir").is_dir(), "directory with small file should exist");
+    assert!(
+        ctx.dest.join("source").join("mixed_dir").is_dir(),
+        "directory with small file should exist"
+    );
     assert!(ctx.dest.join("source").join("mixed_dir/small.txt").exists());
     assert!(!ctx.dest.join("source").join("mixed_dir/huge.bin").exists());
 }
@@ -287,16 +383,28 @@ fn prune_empty_dirs_disabled_creates_all_directories() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(false);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(ctx.dest.join("source").join("empty1").is_dir(), "empty1 should be created");
-    assert!(ctx.dest.join("source").join("empty2").is_dir(), "empty2 should be created");
-    assert!(ctx.dest.join("source").join("empty2/nested").is_dir(), "nested empty should be created");
+    assert!(
+        ctx.dest.join("source").join("empty1").is_dir(),
+        "empty1 should be created"
+    );
+    assert!(
+        ctx.dest.join("source").join("empty2").is_dir(),
+        "empty2 should be created"
+    );
+    assert!(
+        ctx.dest.join("source").join("empty2/nested").is_dir(),
+        "nested empty should be created"
+    );
     assert!(ctx.dest.join("source").join("nonempty").is_dir());
     assert!(ctx.dest.join("source").join("nonempty/file.txt").exists());
 }
@@ -307,13 +415,13 @@ fn prune_empty_dirs_with_collect_events_reports_pruning() {
 
     test_helpers::create_test_tree(
         &ctx.source,
-        &[
-            ("empty", None),
-            ("nonempty/file.txt", Some(b"content")),
-        ],
+        &[("empty", None), ("nonempty/file.txt", Some(b"content"))],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .prune_empty_dirs(true)
@@ -332,7 +440,10 @@ fn prune_empty_dirs_with_collect_events_reports_pruning() {
         .filter(|r| r.action() == &LocalCopyAction::DirectoryCreated)
         .count();
 
-    assert!(dir_created >= 1, "should report directory creation for non-empty dir");
+    assert!(
+        dir_created >= 1,
+        "should report directory creation for non-empty dir"
+    );
 }
 
 #[test]
@@ -368,7 +479,10 @@ fn prune_empty_dirs_with_symlink_in_directory() {
         .expect("create symlink");
     }
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .links(true)
@@ -377,7 +491,10 @@ fn prune_empty_dirs_with_symlink_in_directory() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!ctx.dest.join("source").join("empty").exists(), "empty dir should be pruned");
+    assert!(
+        !ctx.dest.join("source").join("empty").exists(),
+        "empty dir should be pruned"
+    );
     assert!(
         ctx.dest.join("source").join("dir_with_link").is_dir(),
         "directory with symlink should exist"
@@ -397,7 +514,10 @@ fn prune_empty_dirs_deep_hierarchy_partial_pruning() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
@@ -421,15 +541,15 @@ fn prune_empty_dirs_with_existing_only_option() {
 
     test_helpers::create_test_tree(
         &ctx.source,
-        &[
-            ("new_dir/new_file.txt", Some(b"new")),
-            ("empty", None),
-        ],
+        &[("new_dir/new_file.txt", Some(b"new")), ("empty", None)],
     );
 
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .existing_only(true)
@@ -458,14 +578,14 @@ fn prune_empty_dirs_with_include_exclude_filters() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filters = FilterSet::from_rules([
-        FilterRule::include("*.txt"),
-        FilterRule::exclude("*"),
-    ])
-    .expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::include("*.txt"), FilterRule::exclude("*")])
+        .expect("compile filters");
 
     let options = LocalCopyOptions::default()
         .filters(Some(filters))
@@ -474,13 +594,19 @@ fn prune_empty_dirs_with_include_exclude_filters() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(ctx.dest.join("source").join("docs").is_dir(), "docs has .txt files");
+    assert!(
+        ctx.dest.join("source").join("docs").is_dir(),
+        "docs has .txt files"
+    );
     assert!(ctx.dest.join("source").join("docs/readme.txt").exists());
     assert!(ctx.dest.join("source").join("docs/notes.txt").exists());
     assert!(!ctx.dest.join("source").join("docs/secret.doc").exists());
 
     // code directory should be pruned (only has .rs and .tmp)
-    assert!(!ctx.dest.join("source").join("code").exists(), "code has no .txt files");
+    assert!(
+        !ctx.dest.join("source").join("code").exists(),
+        "code has no .txt files"
+    );
 }
 
 #[test]
@@ -488,12 +614,12 @@ fn prune_empty_dirs_single_file_at_root_no_dirs() {
     // Verify that a source with only a file (no subdirs) works fine with prune
     let ctx = test_helpers::setup_copy_test();
 
-    test_helpers::create_test_tree(
-        &ctx.source,
-        &[("only_file.txt", Some(b"hello"))],
-    );
+    test_helpers::create_test_tree(&ctx.source, &[("only_file.txt", Some(b"hello"))]);
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
@@ -509,7 +635,10 @@ fn prune_empty_dirs_source_is_completely_empty() {
     let ctx = test_helpers::setup_copy_test();
     // source is already created but empty
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
@@ -536,21 +665,39 @@ fn prune_empty_dirs_mixed_empty_and_nonempty_siblings() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    assert!(!ctx.dest.join("source").join("alpha").exists(), "alpha is empty");
-    assert!(ctx.dest.join("source").join("bravo").is_dir(), "bravo has a file");
+    assert!(
+        !ctx.dest.join("source").join("alpha").exists(),
+        "alpha is empty"
+    );
+    assert!(
+        ctx.dest.join("source").join("bravo").is_dir(),
+        "bravo has a file"
+    );
     assert!(ctx.dest.join("source").join("bravo/file.txt").exists());
-    assert!(!ctx.dest.join("source").join("charlie").exists(), "charlie is empty");
-    assert!(ctx.dest.join("source").join("delta").is_dir(), "delta has nested file");
+    assert!(
+        !ctx.dest.join("source").join("charlie").exists(),
+        "charlie is empty"
+    );
+    assert!(
+        ctx.dest.join("source").join("delta").is_dir(),
+        "delta has nested file"
+    );
     assert!(ctx.dest.join("source").join("delta/sub").is_dir());
     assert!(ctx.dest.join("source").join("delta/sub/file.txt").exists());
-    assert!(!ctx.dest.join("source").join("echo").exists(), "echo is empty");
+    assert!(
+        !ctx.dest.join("source").join("echo").exists(),
+        "echo is empty"
+    );
 }
 
 #[test]
@@ -570,7 +717,10 @@ fn prune_empty_dirs_with_filter_partial_exclusion_preserves_dir() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let filters = FilterSet::from_rules([FilterRule::exclude("*.bak")]).expect("compile filters");
     let options = LocalCopyOptions::default()
@@ -584,12 +734,27 @@ fn prune_empty_dirs_with_filter_partial_exclusion_preserves_dir() {
     assert!(ctx.dest.join("source").join("project/src").is_dir());
     assert!(ctx.dest.join("source").join("project/src/main.rs").exists());
     assert!(ctx.dest.join("source").join("project/src/lib.rs").exists());
-    assert!(!ctx.dest.join("source").join("project/src/temp.bak").exists());
+    assert!(
+        !ctx.dest
+            .join("source")
+            .join("project/src/temp.bak")
+            .exists()
+    );
 
     // build/ should exist because output.o is included
     assert!(ctx.dest.join("source").join("project/build").is_dir());
-    assert!(ctx.dest.join("source").join("project/build/output.o").exists());
-    assert!(!ctx.dest.join("source").join("project/build/output.bak").exists());
+    assert!(
+        ctx.dest
+            .join("source")
+            .join("project/build/output.o")
+            .exists()
+    );
+    assert!(
+        !ctx.dest
+            .join("source")
+            .join("project/build/output.bak")
+            .exists()
+    );
 }
 
 #[test]
@@ -599,12 +764,13 @@ fn prune_empty_dirs_deeply_nested_single_file() {
 
     test_helpers::create_test_tree(
         &ctx.source,
-        &[
-            ("a/b/c/d/e/f/g/h/i/j/leaf.txt", Some(b"deep")),
-        ],
+        &[("a/b/c/d/e/f/g/h/i/j/leaf.txt", Some(b"deep"))],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().prune_empty_dirs(true);
 
@@ -612,7 +778,12 @@ fn prune_empty_dirs_deeply_nested_single_file() {
         .expect("copy succeeds");
 
     assert!(ctx.dest.join("source").join("a/b/c/d/e/f/g/h/i/j").is_dir());
-    assert!(ctx.dest.join("source").join("a/b/c/d/e/f/g/h/i/j/leaf.txt").exists());
+    assert!(
+        ctx.dest
+            .join("source")
+            .join("a/b/c/d/e/f/g/h/i/j/leaf.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -624,12 +795,18 @@ fn prune_empty_dirs_min_and_max_size_combined() {
         &ctx.source,
         &[
             ("too_small/tiny.txt", Some(b"hi")),
-            ("too_large/huge.txt", Some(b"this is a very large file that exceeds max size limit")),
+            (
+                "too_large/huge.txt",
+                Some(b"this is a very large file that exceeds max size limit"),
+            ),
             ("just_right/medium.txt", Some(b"just right size")),
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .min_file_size(Some(5))
@@ -647,8 +824,16 @@ fn prune_empty_dirs_min_and_max_size_combined() {
         !ctx.dest.join("source").join("too_large").exists(),
         "directory with only too-large files should be pruned"
     );
-    assert!(ctx.dest.join("source").join("just_right").is_dir(), "directory with right-sized file should exist");
-    assert!(ctx.dest.join("source").join("just_right/medium.txt").exists());
+    assert!(
+        ctx.dest.join("source").join("just_right").is_dir(),
+        "directory with right-sized file should exist"
+    );
+    assert!(
+        ctx.dest
+            .join("source")
+            .join("just_right/medium.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -658,10 +843,7 @@ fn prune_empty_dirs_with_delete_option() {
 
     test_helpers::create_test_tree(
         &ctx.source,
-        &[
-            ("kept/file.txt", Some(b"content")),
-            ("empty", None),
-        ],
+        &[("kept/file.txt", Some(b"content")), ("empty", None)],
     );
 
     // Pre-create destination with some extra content that should be deleted
@@ -682,9 +864,15 @@ fn prune_empty_dirs_with_delete_option() {
 
     assert!(ctx.dest.join("kept").is_dir());
     assert!(ctx.dest.join("kept/file.txt").exists());
-    assert!(!ctx.dest.join("empty").exists(), "empty dir should be pruned");
+    assert!(
+        !ctx.dest.join("empty").exists(),
+        "empty dir should be pruned"
+    );
     // extra_dir should be deleted by --delete since it's not in source
-    assert!(!ctx.dest.join("extra_dir").exists(), "extra dir should be deleted");
+    assert!(
+        !ctx.dest.join("extra_dir").exists(),
+        "extra dir should be deleted"
+    );
 }
 
 #[test]
@@ -693,10 +881,16 @@ fn prune_empty_dirs_option_setter_and_getter() {
     assert!(!opts.prune_empty_dirs_enabled(), "default should be false");
 
     let opts = opts.prune_empty_dirs(true);
-    assert!(opts.prune_empty_dirs_enabled(), "should be true after setting");
+    assert!(
+        opts.prune_empty_dirs_enabled(),
+        "should be true after setting"
+    );
 
     let opts = opts.prune_empty_dirs(false);
-    assert!(!opts.prune_empty_dirs_enabled(), "should be false after unsetting");
+    assert!(
+        !opts.prune_empty_dirs_enabled(),
+        "should be false after unsetting"
+    );
 }
 
 #[test]
@@ -706,10 +900,7 @@ fn prune_empty_dirs_idempotent_run() {
 
     test_helpers::create_test_tree(
         &ctx.source,
-        &[
-            ("empty", None),
-            ("kept/file.txt", Some(b"content")),
-        ],
+        &[("empty", None), ("kept/file.txt", Some(b"content"))],
     );
 
     let operands = vec![
@@ -755,7 +946,10 @@ fn prune_empty_dirs_cascading_after_filter_removes_all_files() {
         ],
     );
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let filters = FilterSet::from_rules([FilterRule::exclude("*.log")]).expect("compile filters");
     let options = LocalCopyOptions::default()
@@ -769,7 +963,10 @@ fn prune_empty_dirs_cascading_after_filter_removes_all_files() {
     assert!(ctx.dest.join("source").join("root_dir").is_dir());
     assert!(ctx.dest.join("source").join("root_dir/keep.txt").exists());
     // sub1 should be pruned because after excluding .log files, it's empty
-    assert!(!ctx.dest.join("source").join("root_dir/sub1").exists(), "sub1 should be pruned (all .log files excluded)");
+    assert!(
+        !ctx.dest.join("source").join("root_dir/sub1").exists(),
+        "sub1 should be pruned (all .log files excluded)"
+    );
 }
 
 /// A directory whose only child is a non-regular file that is skipped because
@@ -790,7 +987,10 @@ fn prune_empty_dirs_keeps_dir_with_only_skipped_symlink() {
     std::os::unix::fs::symlink("nowhere", ctx.source.join("has_link").join("link"))
         .expect("create symlink");
 
-    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     // Symlinks are not preserved by default, so `link` is skipped as a
     // non-regular file; its parent directory must survive the prune pass.

--- a/crates/engine/src/local_copy/tests/execute_remove_source.rs
+++ b/crates/engine/src/local_copy/tests/execute_remove_source.rs
@@ -1,4 +1,3 @@
-
 // Tests for --remove-source-files flag
 
 #[test]
@@ -22,18 +21,27 @@ fn remove_source_files_removes_successfully_transferred_file() {
 
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.sources_removed(), 1);
-    assert!(!ctx.source.join("file.txt").exists(), "source file should be removed");
-    assert_eq!(fs::read(ctx.dest.join("file.txt")).expect("read dest"), b"content");
+    assert!(
+        !ctx.source.join("file.txt").exists(),
+        "source file should be removed"
+    );
+    assert_eq!(
+        fs::read(ctx.dest.join("file.txt")).expect("read dest"),
+        b"content"
+    );
 }
 
 #[test]
 fn remove_source_files_removes_multiple_files() {
     let ctx = test_helpers::setup_copy_test();
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("file1.txt", Some(b"content1")),
-        ("file2.txt", Some(b"content2")),
-        ("file3.txt", Some(b"content3")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("file1.txt", Some(b"content1")),
+            ("file2.txt", Some(b"content2")),
+            ("file3.txt", Some(b"content3")),
+        ],
+    );
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
     let mut source_operand = ctx.source.clone().into_os_string();
@@ -69,10 +77,8 @@ fn remove_source_files_preserves_unchanged_files() {
 
     // Set same mtime on both files so they're considered identical
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
-    set_file_times(ctx.source.join("file.txt"), timestamp, timestamp)
-        .expect("set source times");
-    set_file_times(ctx.dest.join("file.txt"), timestamp, timestamp)
-        .expect("set dest times");
+    set_file_times(ctx.source.join("file.txt"), timestamp, timestamp).expect("set source times");
+    set_file_times(ctx.dest.join("file.txt"), timestamp, timestamp).expect("set dest times");
 
     let operands = vec![
         ctx.source.join("file.txt").into_os_string(),
@@ -90,7 +96,11 @@ fn remove_source_files_preserves_unchanged_files() {
         .expect("execution succeeds");
 
     assert_eq!(summary.files_copied(), 0, "file should not be copied");
-    assert_eq!(summary.sources_removed(), 0, "unchanged files should not be removed");
+    assert_eq!(
+        summary.sources_removed(),
+        0,
+        "unchanged files should not be removed"
+    );
     assert!(ctx.source.join("file.txt").exists(), "source should remain");
     assert!(ctx.dest.join("file.txt").exists(), "dest should remain");
 }
@@ -98,10 +108,13 @@ fn remove_source_files_preserves_unchanged_files() {
 #[test]
 fn remove_source_files_does_not_remove_directories() {
     let ctx = test_helpers::setup_copy_test();
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("dir1/file.txt", Some(b"content1")),
-        ("dir2/file.txt", Some(b"content2")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("dir1/file.txt", Some(b"content1")),
+            ("dir2/file.txt", Some(b"content2")),
+        ],
+    );
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
     let mut source_operand = ctx.source.clone().into_os_string();
@@ -121,17 +134,26 @@ fn remove_source_files_does_not_remove_directories() {
     assert_eq!(summary.sources_removed(), 2);
     assert!(!ctx.source.join("dir1/file.txt").exists());
     assert!(!ctx.source.join("dir2/file.txt").exists());
-    assert!(ctx.source.join("dir1").is_dir(), "directory should not be removed");
-    assert!(ctx.source.join("dir2").is_dir(), "directory should not be removed");
+    assert!(
+        ctx.source.join("dir1").is_dir(),
+        "directory should not be removed"
+    );
+    assert!(
+        ctx.source.join("dir2").is_dir(),
+        "directory should not be removed"
+    );
 }
 
 #[test]
 fn remove_source_files_with_filter_only_removes_transferred() {
     let ctx = test_helpers::setup_copy_test();
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("include.txt", Some(b"included")),
-        ("exclude.log", Some(b"excluded")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("include.txt", Some(b"included")),
+            ("exclude.log", Some(b"excluded")),
+        ],
+    );
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
     let mut source_operand = ctx.source.clone().into_os_string();
@@ -140,8 +162,7 @@ fn remove_source_files_with_filter_only_removes_transferred() {
     let operands = vec![source_operand, ctx.dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")])
-        .expect("compile filters");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")]).expect("compile filters");
 
     let summary = plan
         .execute_with_options(
@@ -171,10 +192,8 @@ fn remove_source_files_with_update_preserves_newer_dest() {
     // Make source older than dest
     let old_time = FileTime::from_unix_time(1_600_000_000, 0);
     let new_time = FileTime::from_unix_time(1_700_000_000, 0);
-    set_file_times(ctx.source.join("file.txt"), old_time, old_time)
-        .expect("set source times");
-    set_file_times(ctx.dest.join("file.txt"), new_time, new_time)
-        .expect("set dest times");
+    set_file_times(ctx.source.join("file.txt"), old_time, old_time).expect("set source times");
+    set_file_times(ctx.dest.join("file.txt"), new_time, new_time).expect("set dest times");
 
     let operands = vec![
         ctx.source.join("file.txt").into_os_string(),
@@ -192,8 +211,16 @@ fn remove_source_files_with_update_preserves_newer_dest() {
         )
         .expect("execution succeeds");
 
-    assert_eq!(summary.files_copied(), 0, "older file should not overwrite newer");
-    assert_eq!(summary.sources_removed(), 0, "source should not be removed when not transferred");
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "older file should not overwrite newer"
+    );
+    assert_eq!(
+        summary.sources_removed(),
+        0,
+        "source should not be removed when not transferred"
+    );
     assert!(ctx.source.join("file.txt").exists(), "source should remain");
     assert_eq!(
         fs::read(ctx.dest.join("file.txt")).expect("read dest"),
@@ -224,8 +251,16 @@ fn remove_source_files_with_ignore_existing_preserves_source() {
         )
         .expect("execution succeeds");
 
-    assert_eq!(summary.files_copied(), 0, "file should not be copied when dest exists");
-    assert_eq!(summary.sources_removed(), 0, "source should not be removed when not transferred");
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "file should not be copied when dest exists"
+    );
+    assert_eq!(
+        summary.sources_removed(),
+        0,
+        "source should not be removed when not transferred"
+    );
     assert!(ctx.source.join("file.txt").exists(), "source should remain");
     assert_eq!(
         fs::read(ctx.dest.join("file.txt")).expect("read dest"),
@@ -253,9 +288,19 @@ fn remove_source_files_dry_run_does_not_remove() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(summary.sources_removed(), 0, "dry run should not remove sources");
-    assert!(ctx.source.join("file.txt").exists(), "source should remain in dry run");
-    assert!(!ctx.dest.join("file.txt").exists(), "dest should not exist in dry run");
+    assert_eq!(
+        summary.sources_removed(),
+        0,
+        "dry run should not remove sources"
+    );
+    assert!(
+        ctx.source.join("file.txt").exists(),
+        "source should remain in dry run"
+    );
+    assert!(
+        !ctx.dest.join("file.txt").exists(),
+        "dest should not exist in dry run"
+    );
 }
 
 #[test]
@@ -292,11 +337,14 @@ fn remove_source_files_with_inplace_removes_after_update() {
 #[test]
 fn remove_source_files_removes_nested_files() {
     let ctx = test_helpers::setup_copy_test();
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("a/b/c/file1.txt", Some(b"deep1")),
-        ("a/b/file2.txt", Some(b"mid")),
-        ("a/file3.txt", Some(b"shallow")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("a/b/c/file1.txt", Some(b"deep1")),
+            ("a/b/file2.txt", Some(b"mid")),
+            ("a/file3.txt", Some(b"shallow")),
+        ],
+    );
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
     let mut source_operand = ctx.source.clone().into_os_string();
@@ -332,11 +380,7 @@ fn remove_source_files_removes_symlinks() {
 
     let ctx = test_helpers::setup_copy_test();
     fs::write(ctx.source.join("target.txt"), b"target").expect("write target");
-    symlink(
-        ctx.source.join("target.txt"),
-        ctx.source.join("link.txt"),
-    )
-    .expect("create symlink");
+    symlink(ctx.source.join("target.txt"), ctx.source.join("link.txt")).expect("create symlink");
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
     let operands = vec![
@@ -356,9 +400,18 @@ fn remove_source_files_removes_symlinks() {
 
     assert_eq!(summary.symlinks_copied(), 1);
     assert_eq!(summary.sources_removed(), 1);
-    assert!(!ctx.source.join("link.txt").exists(), "symlink should be removed");
-    assert!(ctx.source.join("target.txt").exists(), "target should remain");
-    assert!(ctx.dest.join("link.txt").exists(), "symlink should be copied");
+    assert!(
+        !ctx.source.join("link.txt").exists(),
+        "symlink should be removed"
+    );
+    assert!(
+        ctx.source.join("target.txt").exists(),
+        "target should remain"
+    );
+    assert!(
+        ctx.dest.join("link.txt").exists(),
+        "symlink should be copied"
+    );
 }
 
 #[test]
@@ -410,10 +463,24 @@ fn remove_source_files_with_min_size_only_removes_matching() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 1, "only large file should be copied");
-    assert_eq!(summary.sources_removed(), 1, "only large file should be removed");
-    assert!(ctx.source.join("small.txt").exists(), "small file should remain");
-    assert!(!ctx.source.join("large.txt").exists(), "large file should be removed");
+    assert_eq!(
+        summary.files_copied(),
+        1,
+        "only large file should be copied"
+    );
+    assert_eq!(
+        summary.sources_removed(),
+        1,
+        "only large file should be removed"
+    );
+    assert!(
+        ctx.source.join("small.txt").exists(),
+        "small file should remain"
+    );
+    assert!(
+        !ctx.source.join("large.txt").exists(),
+        "large file should be removed"
+    );
     assert!(!ctx.dest.join("small.txt").exists());
     assert!(ctx.dest.join("large.txt").exists());
 }
@@ -440,10 +507,24 @@ fn remove_source_files_with_max_size_only_removes_matching() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 1, "only small file should be copied");
-    assert_eq!(summary.sources_removed(), 1, "only small file should be removed");
-    assert!(!ctx.source.join("small.txt").exists(), "small file should be removed");
-    assert!(ctx.source.join("large.txt").exists(), "large file should remain");
+    assert_eq!(
+        summary.files_copied(),
+        1,
+        "only small file should be copied"
+    );
+    assert_eq!(
+        summary.sources_removed(),
+        1,
+        "only small file should be removed"
+    );
+    assert!(
+        !ctx.source.join("small.txt").exists(),
+        "small file should be removed"
+    );
+    assert!(
+        ctx.source.join("large.txt").exists(),
+        "large file should remain"
+    );
     assert!(ctx.dest.join("small.txt").exists());
     assert!(!ctx.dest.join("large.txt").exists());
 }
@@ -472,10 +553,24 @@ fn remove_source_files_with_existing_only_when_updated() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 1, "only existing file should be updated");
-    assert_eq!(summary.sources_removed(), 1, "only updated file should be removed");
-    assert!(!ctx.source.join("update.txt").exists(), "updated file should be removed");
-    assert!(ctx.source.join("new.txt").exists(), "new file should remain (not transferred)");
+    assert_eq!(
+        summary.files_copied(),
+        1,
+        "only existing file should be updated"
+    );
+    assert_eq!(
+        summary.sources_removed(),
+        1,
+        "only updated file should be removed"
+    );
+    assert!(
+        !ctx.source.join("update.txt").exists(),
+        "updated file should be removed"
+    );
+    assert!(
+        ctx.source.join("new.txt").exists(),
+        "new file should remain (not transferred)"
+    );
     assert!(ctx.dest.join("update.txt").exists());
     assert!(!ctx.dest.join("new.txt").exists());
 }
@@ -517,17 +612,24 @@ fn remove_source_files_with_permissions_removes_after_copy() {
     let dest_perms = fs::metadata(ctx.dest.join("file.txt"))
         .expect("dest metadata")
         .permissions();
-    assert_eq!(dest_perms.mode() & 0o777, 0o600, "permissions should be preserved");
+    assert_eq!(
+        dest_perms.mode() & 0o777,
+        0o600,
+        "permissions should be preserved"
+    );
 }
 
 #[test]
 fn remove_source_files_summary_tracks_count() {
     let ctx = test_helpers::setup_copy_test();
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("file1.txt", Some(b"one")),
-        ("file2.txt", Some(b"two")),
-        ("file3.txt", Some(b"three")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("file1.txt", Some(b"one")),
+            ("file2.txt", Some(b"two")),
+            ("file3.txt", Some(b"three")),
+        ],
+    );
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
     let mut source_operand = ctx.source.clone().into_os_string();
@@ -602,15 +704,26 @@ fn remove_source_files_unlink_failure_exits_partial() {
 #[test]
 fn remove_source_files_with_relative_paths() {
     let ctx = test_helpers::setup_copy_test();
-    test_helpers::create_test_tree(&ctx.source, &[
-        ("dir1/file1.txt", Some(b"content1")),
-        ("dir2/file2.txt", Some(b"content2")),
-    ]);
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[
+            ("dir1/file1.txt", Some(b"content1")),
+            ("dir2/file2.txt", Some(b"content2")),
+        ],
+    );
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
     let operands = vec![
-        ctx.source.join(".").join("dir1").join("file1.txt").into_os_string(),
-        ctx.source.join(".").join("dir2").join("file2.txt").into_os_string(),
+        ctx.source
+            .join(".")
+            .join("dir1")
+            .join("file1.txt")
+            .into_os_string(),
+        ctx.source
+            .join(".")
+            .join("dir2")
+            .join("file2.txt")
+            .into_os_string(),
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");

--- a/crates/engine/src/local_copy/tests/execute_skip.rs
+++ b/crates/engine/src/local_copy/tests/execute_skip.rs
@@ -338,7 +338,11 @@ fn execute_with_checksum_skips_matching_directory_contents() {
         2,
         "2 identical files should match"
     );
-    assert_eq!(summary.files_copied(), 2, "2 different/new files should copy");
+    assert_eq!(
+        summary.files_copied(),
+        2,
+        "2 different/new files should copy"
+    );
 
     assert_eq!(
         fs::read(target_root.join("same1.txt")).expect("read same1"),
@@ -536,10 +540,7 @@ fn execute_skip_checksum_large_files_single_byte_difference() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read"),
-        source_data
-    );
+    assert_eq!(fs::read(&destination).expect("read"), source_data);
 }
 
 /// Dry run with `--checksum` runs the same quick check as a real run, so a
@@ -581,8 +582,14 @@ fn execute_skip_checksum_dry_run_reports_correctly() {
     // would-be-copy; the content-identical file is matched.
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 1);
-    assert_eq!(fs::read(dest_root.join("same.txt")).expect("read"), b"identical");
-    assert_eq!(fs::read(dest_root.join("diff.txt")).expect("read"), b"dest_vvv");
+    assert_eq!(
+        fs::read(dest_root.join("same.txt")).expect("read"),
+        b"identical"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("diff.txt")).expect("read"),
+        b"dest_vvv"
+    );
 }
 
 #[test]
@@ -956,10 +963,7 @@ fn execute_with_size_only_copies_larger_file() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read"),
-        b"source is larger"
-    );
+    assert_eq!(fs::read(&destination).expect("read"), b"source is larger");
 }
 
 #[test]
@@ -969,8 +973,7 @@ fn execute_with_size_only_copies_smaller_file() {
     let destination = temp.path().join("dest.txt");
 
     fs::write(&source, b"tiny").expect("write source");
-    fs::write(&destination, b"destination is much larger")
-        .expect("write dest");
+    fs::write(&destination, b"destination is much larger").expect("write dest");
 
     let operands = vec![
         source.into_os_string(),
@@ -1418,9 +1421,7 @@ fn execute_skip_existing_only_with_update() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .existing_only(true)
-                .update(true),
+            LocalCopyOptions::default().existing_only(true).update(true),
         )
         .expect("copy succeeds");
 
@@ -1525,8 +1526,14 @@ fn execute_with_multiple_sources_and_ignore_existing() {
     assert_eq!(summary.files_copied(), 2);
     assert_eq!(summary.regular_files_ignored_existing(), 1);
     assert_eq!(fs::read(dest_root.join("new.txt")).expect("read"), b"new");
-    assert_eq!(fs::read(dest_root.join("another_new.txt")).expect("read"), b"also new");
-    assert_eq!(fs::read(dest_root.join("exists.txt")).expect("read"), b"original");
+    assert_eq!(
+        fs::read(dest_root.join("another_new.txt")).expect("read"),
+        b"also new"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("exists.txt")).expect("read"),
+        b"original"
+    );
 }
 
 /// Ignore-existing takes precedence over update (source newer, but dest exists -> skip).
@@ -1913,10 +1920,7 @@ fn execute_with_delete_missing_args_removes_destination_entries() {
     let destination = destination_root.join("absent.txt");
     fs::write(&destination, b"stale").expect("write destination");
 
-    let operands = vec![
-        missing.into_os_string(),
-        destination_root.into_os_string(),
-    ];
+    let operands = vec![missing.into_os_string(), destination_root.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let summary = plan
@@ -2189,9 +2193,8 @@ fn execute_skip_checksum_with_times_syncs_mtime_on_skip() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
     // But mtime should be synced from source
-    let final_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata"),
-    );
+    let final_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
     assert_eq!(final_mtime, source_mtime);
 }
 

--- a/crates/engine/src/local_copy/tests/execute_skip_compress.rs
+++ b/crates/engine/src/local_copy/tests/execute_skip_compress.rs
@@ -117,7 +117,10 @@ fn skip_compress_no_compression_when_disabled() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(fs::read(&destination).expect("read dest"), content.as_slice());
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        content.as_slice()
+    );
     assert!(!summary.compression_used());
     assert_eq!(summary.compressed_bytes(), 0);
 }
@@ -264,17 +267,30 @@ fn skip_compress_mixed_directory_transfer() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(fs::read(dest_dir.join("archive.gz")).expect("read .gz"), gz_content);
-    assert_eq!(fs::read(dest_dir.join("image.png")).expect("read .png"), png_content);
-    assert_eq!(fs::read(dest_dir.join("readme.txt")).expect("read .txt"), txt_content);
-    assert_eq!(fs::read(dest_dir.join("main.rs")).expect("read .rs"), rs_content);
+    assert_eq!(
+        fs::read(dest_dir.join("archive.gz")).expect("read .gz"),
+        gz_content
+    );
+    assert_eq!(
+        fs::read(dest_dir.join("image.png")).expect("read .png"),
+        png_content
+    );
+    assert_eq!(
+        fs::read(dest_dir.join("readme.txt")).expect("read .txt"),
+        txt_content
+    );
+    assert_eq!(
+        fs::read(dest_dir.join("main.rs")).expect("read .rs"),
+        rs_content
+    );
 
     // At least some compression was used (for .txt and .rs files).
     assert!(summary.compression_used());
     assert!(summary.compressed_bytes() > 0);
 
     // The total literal bytes should cover all four files.
-    let total_literal = (gz_content.len() + png_content.len() + txt_content.len() + rs_content.len()) as u64;
+    let total_literal =
+        (gz_content.len() + png_content.len() + txt_content.len() + rs_content.len()) as u64;
     assert_eq!(summary.bytes_copied(), total_literal);
 }
 

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -1,7 +1,6 @@
 #[cfg(unix)]
 #[test]
 fn execute_with_sparse_enabled_creates_holes() {
-
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("sparse.bin");
     let mut source_file = fs::File::create(&source).expect("create source");
@@ -100,11 +99,9 @@ fn execute_preallocate_sparse_punches_the_reserved_extent() {
     let apparent = fs::metadata(&source).expect("meta").len();
 
     let dest = temp.path().join("dst.bin");
-    let plan = LocalCopyPlan::from_operands(&[
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ])
-    .expect("plan");
+    let plan =
+        LocalCopyPlan::from_operands(&[source.into_os_string(), dest.clone().into_os_string()])
+            .expect("plan");
     plan.execute_with_options(
         LocalCopyExecution::Apply,
         LocalCopyOptions::default().preallocate(true).sparse(true),
@@ -143,12 +140,8 @@ fn execute_inplace_sparse_punches_hole() {
     source_file
         .seek(SeekFrom::Start(2 * 1024 * 1024))
         .expect("seek to create hole");
-    source_file
-        .write_all(&[0x22])
-        .expect("write trailing byte");
-    source_file
-        .set_len(4 * 1024 * 1024)
-        .expect("extend source");
+    source_file.write_all(&[0x22]).expect("write trailing byte");
+    source_file.set_len(4 * 1024 * 1024).expect("extend source");
     drop(source_file);
 
     let sparse_dest = temp.path().join("sparse-inplace.bin");
@@ -241,11 +234,9 @@ fn execute_inplace_sparse_whole_file_seeks_over_stale_basis() {
     // Backdate so rsync's quick-check treats the destination as stale.
     set_file_mtime(&dest, FileTime::from_unix_time(1_000_000, 0)).expect("destination mtime");
 
-    let plan = LocalCopyPlan::from_operands(&[
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ])
-    .expect("plan");
+    let plan =
+        LocalCopyPlan::from_operands(&[source.into_os_string(), dest.clone().into_os_string()])
+            .expect("plan");
     plan.execute_with_options(
         LocalCopyExecution::Apply,
         // whole_file defaults to true for local copies; set it explicitly to
@@ -259,15 +250,24 @@ fn execute_inplace_sparse_whole_file_seeks_over_stale_basis() {
 
     // Length matches the source: the larger pre-existing tail was discarded.
     let meta = fs::metadata(&dest).expect("dest metadata");
-    assert_eq!(meta.len(), src.len() as u64, "destination truncated to source length");
+    assert_eq!(
+        meta.len(),
+        src.len() as u64,
+        "destination truncated to source length"
+    );
 
     // Content is byte-for-byte the source. Critically the 2 MiB middle reads as
     // zeros, not the pre-existing 0xCC: the whole-file rewrite truncated to zero
     // so the seeked-over run is a genuine hole, not stale basis data.
     let readback = fs::read(&dest).expect("read destination");
-    assert_eq!(readback, src, "whole-file inplace sparse content must equal the source");
+    assert_eq!(
+        readback, src,
+        "whole-file inplace sparse content must equal the source"
+    );
     assert!(
-        readback[4096..4096 + 2 * 1024 * 1024].iter().all(|&b| b == 0),
+        readback[4096..4096 + 2 * 1024 * 1024]
+            .iter()
+            .all(|&b| b == 0),
         "seeked hole must read as zeros, proving the destination was truncated to zero first"
     );
 
@@ -295,10 +295,7 @@ fn execute_with_sparse_enabled_counts_literal_data() {
     file.set_len(1_048_576).expect("extend source");
 
     let destination = temp.path().join("dest.bin");
-    let operands = vec![
-        source.into_os_string(),
-        destination.into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), destination.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let summary = plan
@@ -351,9 +348,7 @@ fn execute_delta_with_sparse_counts_zero_literal_data() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .whole_file(false)
-                .sparse(true),
+            LocalCopyOptions::default().whole_file(false).sparse(true),
         )
         .expect("delta sparse copy succeeds");
 
@@ -366,7 +361,6 @@ fn execute_delta_with_sparse_counts_zero_literal_data() {
 #[cfg(unix)]
 #[test]
 fn execute_without_inplace_replaces_destination_file() {
-
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     fs::write(&source, b"updated").expect("write source");
@@ -407,7 +401,7 @@ fn execute_without_inplace_replaces_destination_file() {
 #[cfg(unix)]
 #[test]
 fn execute_inplace_succeeds_with_read_only_directory() {
-    use rustix::fs::{chmod, Mode};
+    use rustix::fs::{Mode, chmod};
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     let temp = tempdir().expect("tempdir");
@@ -459,28 +453,33 @@ fn execute_inplace_succeeds_with_read_only_directory() {
 #[cfg(unix)]
 #[test]
 fn execute_sparse_with_multiple_hole_patterns() {
-
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("multi-pattern.bin");
     let mut source_file = fs::File::create(&source).expect("create source");
 
     // Pattern: data-hole-data-hole-data (interleaved)
     let data_block = vec![0xAA; 10 * 1024];
-    source_file.write_all(&data_block).expect("write data block 1");
+    source_file
+        .write_all(&data_block)
+        .expect("write data block 1");
 
     source_file
         .seek(SeekFrom::Start(1024 * 1024))
         .expect("seek for hole 1");
 
     let data_block_2 = vec![0xBB; 20 * 1024];
-    source_file.write_all(&data_block_2).expect("write data block 2");
+    source_file
+        .write_all(&data_block_2)
+        .expect("write data block 2");
 
     source_file
         .seek(SeekFrom::Start(3 * 1024 * 1024))
         .expect("seek for hole 2");
 
     let data_block_3 = vec![0xCC; 10 * 1024];
-    source_file.write_all(&data_block_3).expect("write data block 3");
+    source_file
+        .write_all(&data_block_3)
+        .expect("write data block 3");
 
     source_file.set_len(5 * 1024 * 1024).expect("extend source");
     drop(source_file);
@@ -592,7 +591,9 @@ fn execute_sparse_verifies_hole_data_integrity() {
     dest_file.read_exact(&mut buffer_end).expect("read end");
     assert_eq!(&buffer_end, b"END");
 
-    dest_file.seek(SeekFrom::Start(5)).expect("seek after start");
+    dest_file
+        .seek(SeekFrom::Start(5))
+        .expect("seek after start");
     let mut hole_sample = vec![0xFF; 100];
     dest_file.read_exact(&mut hole_sample).expect("read hole");
     assert!(
@@ -606,7 +607,6 @@ fn execute_sparse_verifies_hole_data_integrity() {
 #[cfg(unix)]
 #[test]
 fn execute_sparse_with_small_holes() {
-
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("small-holes.bin");
     let mut source_file = fs::File::create(&source).expect("create source");
@@ -664,7 +664,6 @@ fn execute_sparse_with_small_holes() {
 #[cfg(unix)]
 #[test]
 fn execute_sparse_with_aligned_holes() {
-
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("aligned.bin");
     let mut source_file = fs::File::create(&source).expect("create source");
@@ -712,10 +711,7 @@ fn execute_sparse_with_aligned_holes() {
 
     assert!(content[1..16].iter().all(|&b| b == 0), "hole before B");
     assert!(content[17..1024].iter().all(|&b| b == 0), "hole before C");
-    assert!(
-        content[1025..2048].iter().all(|&b| b == 0),
-        "hole before D"
-    );
+    assert!(content[1025..2048].iter().all(|&b| b == 0), "hole before D");
 }
 
 /// Test: Zero regions exactly at threshold (32KB) are detected as holes.
@@ -729,7 +725,9 @@ fn execute_sparse_detects_zero_regions_at_threshold() {
     // SPARSE_WRITE_SIZE is 32KB - write exactly that amount of zeros
     let threshold = 32 * 1024;
     source_file.write_all(b"HEADER").expect("write header");
-    source_file.write_all(&vec![0u8; threshold]).expect("write zeros at threshold");
+    source_file
+        .write_all(&vec![0u8; threshold])
+        .expect("write zeros at threshold");
     source_file.write_all(b"FOOTER").expect("write footer");
     drop(source_file);
 
@@ -794,7 +792,9 @@ fn execute_sparse_skips_zero_regions_under_threshold() {
     // Write zeros just under the threshold - should be written densely
     let under_threshold = 32 * 1024 - 1;
     source_file.write_all(b"START").expect("write start");
-    source_file.write_all(&vec![0u8; under_threshold]).expect("write zeros under threshold");
+    source_file
+        .write_all(&vec![0u8; under_threshold])
+        .expect("write zeros under threshold");
     source_file.write_all(b"END").expect("write end");
     drop(source_file);
 
@@ -814,7 +814,10 @@ fn execute_sparse_skips_zero_regions_under_threshold() {
     let content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(&content[0..5], b"START");
     assert!(content[5..5 + under_threshold].iter().all(|&b| b == 0));
-    assert_eq!(&content[5 + under_threshold..5 + under_threshold + 3], b"END");
+    assert_eq!(
+        &content[5 + under_threshold..5 + under_threshold + 3],
+        b"END"
+    );
 }
 
 /// Test: Zero regions just over threshold (32KB + 1) are treated as holes.
@@ -828,7 +831,9 @@ fn execute_sparse_detects_zero_regions_over_threshold() {
     // Write zeros just over the threshold - should create holes
     let over_threshold = 32 * 1024 + 1;
     source_file.write_all(b"BEGIN").expect("write begin");
-    source_file.write_all(&vec![0u8; over_threshold]).expect("write zeros over threshold");
+    source_file
+        .write_all(&vec![0u8; over_threshold])
+        .expect("write zeros over threshold");
     source_file.write_all(b"FINISH").expect("write finish");
     drop(source_file);
 
@@ -858,8 +863,15 @@ fn execute_sparse_detects_zero_regions_over_threshold() {
 
     let sparse_content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(&sparse_content[0..5], b"BEGIN");
-    assert!(sparse_content[5..5 + over_threshold].iter().all(|&b| b == 0));
-    assert_eq!(&sparse_content[5 + over_threshold..5 + over_threshold + 6], b"FINISH");
+    assert!(
+        sparse_content[5..5 + over_threshold]
+            .iter()
+            .all(|&b| b == 0)
+    );
+    assert_eq!(
+        &sparse_content[5 + over_threshold..5 + over_threshold + 6],
+        b"FINISH"
+    );
 
     // Verify sparse optimization occurred (platform-dependent)
     use std::os::unix::fs::MetadataExt;
@@ -887,9 +899,13 @@ fn execute_sparse_creates_actual_filesystem_holes() {
     let mut source_file = fs::File::create(&source).expect("create source");
 
     source_file.write_all(b"DATA1").expect("write data1");
-    source_file.write_all(&vec![0u8; 64 * 1024]).expect("write 64KB zeros");
+    source_file
+        .write_all(&vec![0u8; 64 * 1024])
+        .expect("write 64KB zeros");
     source_file.write_all(b"DATA2").expect("write data2");
-    source_file.write_all(&vec![0u8; 128 * 1024]).expect("write 128KB zeros");
+    source_file
+        .write_all(&vec![0u8; 128 * 1024])
+        .expect("write 128KB zeros");
     source_file.write_all(b"DATA3").expect("write data3");
     drop(source_file);
 
@@ -926,11 +942,17 @@ fn execute_sparse_creates_actual_filesystem_holes() {
         // Find first hole
         let first_hole = libc::lseek(fd, 0, SEEK_HOLE);
         assert!(first_hole > 0, "should find first hole after initial data");
-        assert!(first_hole < 64 * 1024 + 100, "first hole should be in first zero region");
+        assert!(
+            first_hole < 64 * 1024 + 100,
+            "first hole should be in first zero region"
+        );
 
         // Find second data region
         let second_data = libc::lseek(fd, first_hole, SEEK_DATA);
-        assert!(second_data > first_hole, "should find data after first hole");
+        assert!(
+            second_data > first_hole,
+            "should find data after first hole"
+        );
     }
 
     let content = fs::read(&sparse_dest).expect("read sparse");
@@ -950,11 +972,17 @@ fn execute_sparse_detects_multiple_threshold_zero_regions() {
 
     // Create pattern: data - zeros@threshold - data - zeros@threshold - data
     source_file.write_all(b"BLOCK1").expect("write block1");
-    source_file.write_all(&vec![0u8; threshold]).expect("write zeros 1");
+    source_file
+        .write_all(&vec![0u8; threshold])
+        .expect("write zeros 1");
     source_file.write_all(b"BLOCK2").expect("write block2");
-    source_file.write_all(&vec![0u8; threshold]).expect("write zeros 2");
+    source_file
+        .write_all(&vec![0u8; threshold])
+        .expect("write zeros 2");
     source_file.write_all(b"BLOCK3").expect("write block3");
-    source_file.write_all(&vec![0u8; threshold]).expect("write zeros 3");
+    source_file
+        .write_all(&vec![0u8; threshold])
+        .expect("write zeros 3");
     source_file.write_all(b"BLOCK4").expect("write block4");
     drop(source_file);
 
@@ -1021,11 +1049,17 @@ fn execute_sparse_preserves_nonzero_data_integrity() {
     let pattern4: Vec<u8> = (0..=255u8).cycle().take(4096).collect();
 
     source_file.write_all(&pattern1).expect("write pattern1");
-    source_file.write_all(&vec![0u8; 64 * 1024]).expect("write hole");
+    source_file
+        .write_all(&vec![0u8; 64 * 1024])
+        .expect("write hole");
     source_file.write_all(&pattern2).expect("write pattern2");
-    source_file.write_all(&vec![0u8; 32 * 1024]).expect("write hole");
+    source_file
+        .write_all(&vec![0u8; 32 * 1024])
+        .expect("write hole");
     source_file.write_all(&pattern3).expect("write pattern3");
-    source_file.write_all(&vec![0u8; 96 * 1024]).expect("write hole");
+    source_file
+        .write_all(&vec![0u8; 96 * 1024])
+        .expect("write hole");
     source_file.write_all(&pattern4).expect("write pattern4");
     drop(source_file);
 
@@ -1065,9 +1099,15 @@ fn execute_sparse_reduces_disk_allocation() {
 
     // Create 10MB file with only 100KB of data
     source_file.write_all(b"START").expect("write start");
-    source_file.write_all(&vec![0u8; 5 * 1024 * 1024]).expect("write 5MB zeros");
-    source_file.write_all(&vec![0xFF; 100 * 1024]).expect("write 100KB data");
-    source_file.write_all(&vec![0u8; 5 * 1024 * 1024 - 5]).expect("write remaining zeros");
+    source_file
+        .write_all(&vec![0u8; 5 * 1024 * 1024])
+        .expect("write 5MB zeros");
+    source_file
+        .write_all(&vec![0xFF; 100 * 1024])
+        .expect("write 100KB data");
+    source_file
+        .write_all(&vec![0u8; 5 * 1024 * 1024 - 5])
+        .expect("write remaining zeros");
     drop(source_file);
 
     let dense_dest = temp.path().join("dense-alloc.bin");
@@ -1137,7 +1177,9 @@ fn execute_sparse_handles_boundary_split_zeros() {
 
     // Write data, then zeros that span exactly 2x threshold
     source_file.write_all(b"PREFIX").expect("write prefix");
-    source_file.write_all(&vec![0u8; threshold * 2]).expect("write 2x threshold zeros");
+    source_file
+        .write_all(&vec![0u8; threshold * 2])
+        .expect("write 2x threshold zeros");
     source_file.write_all(b"SUFFIX").expect("write suffix");
     drop(source_file);
 
@@ -1157,14 +1199,16 @@ fn execute_sparse_handles_boundary_split_zeros() {
     let content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(&content[0..6], b"PREFIX");
     assert!(content[6..6 + threshold * 2].iter().all(|&b| b == 0));
-    assert_eq!(&content[6 + threshold * 2..6 + threshold * 2 + 6], b"SUFFIX");
+    assert_eq!(
+        &content[6 + threshold * 2..6 + threshold * 2 + 6],
+        b"SUFFIX"
+    );
 }
 
 /// Phase 2 test: Large sparse file - verify handling of files >> RAM size.
 #[cfg(unix)]
 #[test]
 fn execute_sparse_with_large_file() {
-
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("large-sparse.bin");
     let mut source_file = fs::File::create(&source).expect("create source");
@@ -1447,7 +1491,9 @@ fn execute_sparse_nonzero_file_written_normally() {
     // Block counts should be similar since there are no zeros to sparse-ify
     use std::os::unix::fs::MetadataExt;
     let dense_blocks = fs::metadata(&dense_dest).expect("dense metadata").blocks();
-    let sparse_blocks = fs::metadata(&sparse_dest).expect("sparse metadata").blocks();
+    let sparse_blocks = fs::metadata(&sparse_dest)
+        .expect("sparse metadata")
+        .blocks();
 
     // Non-zero file should use roughly the same number of blocks
     assert!(
@@ -1690,8 +1736,16 @@ fn execute_sparse_hole_in_middle() {
     let dense_content = fs::read(&dense_dest).expect("read dense");
     assert_eq!(sparse_content, dense_content);
     assert!(sparse_content[..4096].iter().all(|&b| b == 0xCC));
-    assert!(sparse_content[4096..4096 + 128 * 1024].iter().all(|&b| b == 0));
-    assert!(sparse_content[4096 + 128 * 1024..].iter().all(|&b| b == 0xDD));
+    assert!(
+        sparse_content[4096..4096 + 128 * 1024]
+            .iter()
+            .all(|&b| b == 0)
+    );
+    assert!(
+        sparse_content[4096 + 128 * 1024..]
+            .iter()
+            .all(|&b| b == 0xDD)
+    );
 
     // Verify sparse uses fewer blocks
     use std::os::unix::fs::MetadataExt;
@@ -1724,15 +1778,11 @@ fn execute_preallocate_disables_sparse_writes() {
     let mut source_file = fs::File::create(&source).expect("create source");
 
     // Create file with a large zero region that would normally be sparsified
-    source_file
-        .write_all(&[0x11])
-        .expect("write leading byte");
+    source_file.write_all(&[0x11]).expect("write leading byte");
     source_file
         .write_all(&vec![0u8; 256 * 1024])
         .expect("write 256KB zeros");
-    source_file
-        .write_all(&[0x22])
-        .expect("write trailing byte");
+    source_file.write_all(&[0x22]).expect("write trailing byte");
     drop(source_file);
 
     let sparse_only_dest = temp.path().join("sparse-only.bin");
@@ -1815,22 +1865,14 @@ fn execute_append_disables_sparse_writes() {
 
     // Create a partial destination for append mode
     fs::write(&dest, [0xFF]).expect("write partial dest");
-    filetime::set_file_mtime(
-        &dest,
-        filetime::FileTime::from_unix_time(1, 0),
-    )
-    .expect("set dest mtime");
-    filetime::set_file_mtime(
-        &source,
-        filetime::FileTime::from_unix_time(2, 0),
-    )
-    .expect("set source mtime");
+    filetime::set_file_mtime(&dest, filetime::FileTime::from_unix_time(1, 0))
+        .expect("set dest mtime");
+    filetime::set_file_mtime(&source, filetime::FileTime::from_unix_time(2, 0))
+        .expect("set source mtime");
 
-    let plan = LocalCopyPlan::from_operands(&[
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ])
-    .expect("plan");
+    let plan =
+        LocalCopyPlan::from_operands(&[source.into_os_string(), dest.clone().into_os_string()])
+            .expect("plan");
 
     // Even with sparse enabled, append should prevent hole creation
     let summary = plan
@@ -2026,7 +2068,6 @@ fn execute_with_sparse_enabled_marks_ntfs_sparse() {
         "sparse copy on NTFS must carry FILE_ATTRIBUTE_SPARSE_FILE"
     );
 }
-
 
 /// A `--sparse` transfer must write byte-identical DATA on Windows/NTFS. NTFS
 /// may not deallocate the hole the way Linux does (a dense fallback is allowed),

--- a/crates/engine/src/local_copy/tests/execute_special.rs
+++ b/crates/engine/src/local_copy/tests/execute_special.rs
@@ -1,4 +1,3 @@
-
 #[cfg(unix)]
 #[test]
 fn execute_copies_fifo() {
@@ -20,9 +19,7 @@ fn execute_copies_fifo() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .permissions(true)
-                .specials(true),
+            LocalCopyOptions::default().permissions(true).specials(true),
         )
         .expect("fifo copy succeeds");
 
@@ -52,7 +49,9 @@ fn execute_fifo_replaces_directory_when_force_enabled() {
 
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default().specials(true).force_replacements(true),
+        LocalCopyOptions::default()
+            .specials(true)
+            .force_replacements(true),
     )
     .expect("forced replacement succeeds");
 
@@ -84,9 +83,7 @@ fn execute_copies_fifo_within_directory() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .permissions(true)
-                .specials(true),
+            LocalCopyOptions::default().permissions(true).specials(true),
         )
         .expect("fifo copy succeeds");
 
@@ -375,7 +372,13 @@ fn execute_with_one_file_system_skips_mount_points() {
     )
     .expect("copy executes");
 
-    assert!(destination.join("source").join("data").join("file.txt").exists());
+    assert!(
+        destination
+            .join("source")
+            .join("data")
+            .join("file.txt")
+            .exists()
+    );
     assert!(!destination.join("source").join("mount").exists());
     assert!(report.records().iter().any(|record| {
         record.action() == &LocalCopyAction::SkippedMountPoint
@@ -419,7 +422,13 @@ fn execute_without_one_file_system_crosses_mount_points() {
     )
     .expect("copy executes");
 
-    assert!(destination.join("source").join("mount").join("inside.txt").exists());
+    assert!(
+        destination
+            .join("source")
+            .join("mount")
+            .join("inside.txt")
+            .exists()
+    );
     assert!(
         report
             .records()
@@ -427,7 +436,6 @@ fn execute_without_one_file_system_crosses_mount_points() {
             .all(|record| { record.action() != &LocalCopyAction::SkippedMountPoint })
     );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -521,15 +529,18 @@ fn execute_copies_symlink_with_safe_links_keeps_safe() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .links(true)
-                .safe_links(true),
+            LocalCopyOptions::default().links(true).safe_links(true),
         )
         .expect("copy succeeds");
 
     assert_eq!(summary.symlinks_copied(), 1);
     let dest_link = dest_root.join("source").join("safe_link");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 }
 
 #[cfg(unix)]
@@ -569,11 +580,13 @@ fn execute_with_safe_links_skips_unsafe() {
     let summary = report.summary();
     assert_eq!(summary.symlinks_copied(), 0);
     assert!(!dest_root.join("source").join("unsafe_link").exists());
-    assert!(report.records().iter().any(|record| {
-        matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink)
-    }));
+    assert!(
+        report
+            .records()
+            .iter()
+            .any(|record| { matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink) })
+    );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -650,7 +663,6 @@ fn execute_without_hard_links_copies_separately() {
     assert_eq!(summary.files_copied(), 2);
 }
 
-
 #[cfg(unix)]
 #[test]
 fn execute_dry_run_does_not_create_symlink() {
@@ -706,7 +718,6 @@ fn execute_dry_run_does_not_create_fifo() {
     assert!(!dest_fifo.exists());
 }
 
-
 #[cfg(unix)]
 #[test]
 fn execute_copies_broken_symlink() {
@@ -734,7 +745,6 @@ fn execute_copies_broken_symlink() {
     let dest_target = fs::read_link(&dest_link).expect("read dest link");
     assert_eq!(dest_target, Path::new("nonexistent_target"));
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -764,9 +774,7 @@ fn execute_copies_mixed_special_files() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .links(true)
-                .specials(true),
+            LocalCopyOptions::default().links(true).specials(true),
         )
         .expect("copy succeeds");
 
@@ -776,21 +784,24 @@ fn execute_copies_mixed_special_files() {
 
     assert!(dest_root.join("source").join("regular.txt").is_file());
     assert!(dest_root.join("source").join("target.txt").is_file());
-    assert!(fs::symlink_metadata(dest_root.join("source").join("link"))
-        .expect("meta")
-        .file_type()
-        .is_symlink());
-    assert!(fs::symlink_metadata(dest_root.join("source").join("fifo"))
-        .expect("meta")
-        .file_type()
-        .is_fifo());
+    assert!(
+        fs::symlink_metadata(dest_root.join("source").join("link"))
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        fs::symlink_metadata(dest_root.join("source").join("fifo"))
+            .expect("meta")
+            .file_type()
+            .is_fifo()
+    );
 }
-
 
 #[cfg(unix)]
 #[test]
 fn execute_symlink_pointing_to_fifo_preserved_as_symlink() {
-    use std::os::unix::fs::{symlink, FileTypeExt};
+    use std::os::unix::fs::{FileTypeExt, symlink};
 
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
@@ -812,9 +823,7 @@ fn execute_symlink_pointing_to_fifo_preserved_as_symlink() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .links(true)
-                .specials(true),
+            LocalCopyOptions::default().links(true).specials(true),
         )
         .expect("copy succeeds");
 
@@ -847,7 +856,7 @@ fn execute_symlink_pointing_to_fifo_preserved_as_symlink() {
 ))]
 #[test]
 fn execute_symlink_pointing_to_socket_preserved_as_symlink() {
-    use std::os::unix::fs::{symlink, FileTypeExt};
+    use std::os::unix::fs::{FileTypeExt, symlink};
 
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
@@ -869,9 +878,7 @@ fn execute_symlink_pointing_to_socket_preserved_as_symlink() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .links(true)
-                .specials(true),
+            LocalCopyOptions::default().links(true).specials(true),
         )
         .expect("copy succeeds");
 
@@ -893,11 +900,10 @@ fn execute_symlink_pointing_to_socket_preserved_as_symlink() {
     assert_eq!(summary.fifos_created(), 1);
 }
 
-
 #[cfg(unix)]
 #[test]
 fn execute_fifo_replaces_existing_symlink() {
-    use std::os::unix::fs::{symlink, FileTypeExt};
+    use std::os::unix::fs::{FileTypeExt, symlink};
 
     let temp = create_tempdir();
     let source_fifo = temp.path().join("source.pipe");
@@ -909,10 +915,7 @@ fn execute_fifo_replaces_existing_symlink() {
     fs::write(&dummy_target, b"dummy").expect("write dummy");
     symlink(&dummy_target, &dest).expect("create dest symlink");
 
-    let operands = vec![
-        source_fifo.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_fifo.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     plan.execute_with_options(
@@ -945,10 +948,7 @@ fn execute_fifo_replaces_existing_regular_file() {
     let dest = temp.path().join("dest.pipe");
     fs::write(&dest, b"regular file content").expect("write dest file");
 
-    let operands = vec![
-        source_fifo.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_fifo.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     plan.execute_with_options(
@@ -980,10 +980,7 @@ fn execute_symlink_replaces_existing_fifo() {
     let dest = temp.path().join("dest_link");
     mkfifo_for_tests(&dest, 0o600).expect("mkfifo at dest");
 
-    let operands = vec![
-        source_link.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_link.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     plan.execute_with_options(
@@ -1024,10 +1021,7 @@ fn execute_symlink_replaces_existing_socket() {
     let dest = temp.path().join("dest_link");
     mksocket_for_tests(&dest).expect("mksocket at dest");
 
-    let operands = vec![
-        source_link.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_link.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     plan.execute_with_options(
@@ -1043,7 +1037,6 @@ fn execute_symlink_replaces_existing_socket() {
     );
     assert_eq!(fs::read_link(&dest).expect("read link"), target);
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1067,9 +1060,7 @@ fn execute_recopy_fifo_replaces_existing_fifo() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .specials(true)
-                .permissions(true),
+            LocalCopyOptions::default().specials(true).permissions(true),
         )
         .expect("re-copy succeeds");
 
@@ -1077,7 +1068,6 @@ fn execute_recopy_fifo_replaces_existing_fifo() {
     assert!(metadata.file_type().is_fifo());
     assert_eq!(summary.fifos_created(), 1);
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1114,9 +1104,7 @@ fn execute_copies_multiple_fifos_with_different_permissions() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .specials(true)
-                .permissions(true),
+            LocalCopyOptions::default().specials(true).permissions(true),
         )
         .expect("copy succeeds");
 
@@ -1126,24 +1114,50 @@ fn execute_copies_multiple_fifos_with_different_permissions() {
     let dest_private = dest_root.join("source").join("private.pipe");
     let dest_group = dest_root.join("source").join("group.pipe");
 
-    assert!(fs::symlink_metadata(&dest_public).expect("meta").file_type().is_fifo());
-    assert!(fs::symlink_metadata(&dest_private).expect("meta").file_type().is_fifo());
-    assert!(fs::symlink_metadata(&dest_group).expect("meta").file_type().is_fifo());
+    assert!(
+        fs::symlink_metadata(&dest_public)
+            .expect("meta")
+            .file_type()
+            .is_fifo()
+    );
+    assert!(
+        fs::symlink_metadata(&dest_private)
+            .expect("meta")
+            .file_type()
+            .is_fifo()
+    );
+    assert!(
+        fs::symlink_metadata(&dest_group)
+            .expect("meta")
+            .file_type()
+            .is_fifo()
+    );
 
     assert_eq!(
-        fs::symlink_metadata(&dest_public).expect("meta").permissions().mode() & 0o777,
+        fs::symlink_metadata(&dest_public)
+            .expect("meta")
+            .permissions()
+            .mode()
+            & 0o777,
         0o666
     );
     assert_eq!(
-        fs::symlink_metadata(&dest_private).expect("meta").permissions().mode() & 0o777,
+        fs::symlink_metadata(&dest_private)
+            .expect("meta")
+            .permissions()
+            .mode()
+            & 0o777,
         0o600
     );
     assert_eq!(
-        fs::symlink_metadata(&dest_group).expect("meta").permissions().mode() & 0o777,
+        fs::symlink_metadata(&dest_group)
+            .expect("meta")
+            .permissions()
+            .mode()
+            & 0o777,
         0o660
     );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1169,9 +1183,7 @@ fn execute_delete_removes_extraneous_fifo() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .specials(true)
-                .delete(true),
+            LocalCopyOptions::default().specials(true).delete(true),
         )
         .expect("delete copy succeeds");
 
@@ -1179,10 +1191,12 @@ fn execute_delete_removes_extraneous_fifo() {
         !extraneous_fifo.exists(),
         "extraneous FIFO should be deleted"
     );
-    assert!(dest_root.join("keep.txt").is_file(), "keep.txt should remain");
+    assert!(
+        dest_root.join("keep.txt").is_file(),
+        "keep.txt should remain"
+    );
     assert!(summary.items_deleted() >= 1);
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1209,11 +1223,13 @@ fn execute_device_file_skipped_without_devices_or_copy_devices() {
     assert_eq!(summary.devices_created(), 0);
     assert_eq!(summary.files_copied(), 0);
     assert!(!dest_root.join("zero").exists());
-    assert!(report.records().iter().any(|record| {
-        record.action() == &LocalCopyAction::SkippedNonRegular
-    }));
+    assert!(
+        report
+            .records()
+            .iter()
+            .any(|record| { record.action() == &LocalCopyAction::SkippedNonRegular })
+    );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1236,10 +1252,7 @@ fn execute_copy_links_follows_symlink_to_fifo_specials_disabled_skips() {
     fs::write(source_dir.join("regular.txt"), b"regular file").expect("write regular");
 
     let dest = temp.path().join("dest");
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // copy_links follows the symlink, but specials is disabled so the FIFO
@@ -1262,11 +1275,13 @@ fn execute_copy_links_follows_symlink_to_fifo_specials_disabled_skips() {
     // The symlink to the FIFO should have been dereferenced by copy_links,
     // but since specials is disabled, the FIFO should be skipped
     assert_eq!(report.summary().fifos_created(), 0);
-    assert!(report.records().iter().any(|record| {
-        record.action() == &LocalCopyAction::SkippedNonRegular
-    }));
+    assert!(
+        report
+            .records()
+            .iter()
+            .any(|record| { record.action() == &LocalCopyAction::SkippedNonRegular })
+    );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1279,8 +1294,11 @@ fn execute_copy_unsafe_links_broken_target_errors() {
 
     // Create a symlink pointing to a nonexistent path outside the tree
     let link_path = source_dir.join("broken_unsafe");
-    symlink(Path::new("/nonexistent/path/that/does/not/exist.txt"), &link_path)
-        .expect("create broken absolute symlink");
+    symlink(
+        Path::new("/nonexistent/path/that/does/not/exist.txt"),
+        &link_path,
+    )
+    .expect("create broken absolute symlink");
 
     let dest_dir = temp.path().join("dest");
     fs::create_dir_all(&dest_dir).expect("create dest");
@@ -1300,10 +1318,12 @@ fn execute_copy_unsafe_links_broken_target_errors() {
             .copy_unsafe_links(true),
     );
 
-    assert!(result.is_err(), "copy should fail when unsafe symlink target is missing");
+    assert!(
+        result.is_err(),
+        "copy should fail when unsafe symlink target is missing"
+    );
     assert!(!dest_dir.join("broken_unsafe").exists());
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1336,9 +1356,7 @@ fn execute_copy_dirlinks_follows_dir_symlink_but_preserves_file_symlink_in_tree(
 
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default()
-            .links(true)
-            .copy_dirlinks(true),
+        LocalCopyOptions::default().links(true).copy_dirlinks(true),
     )
     .expect("copy succeeds");
 
@@ -1370,7 +1388,6 @@ fn execute_copy_dirlinks_follows_dir_symlink_but_preserves_file_symlink_in_tree(
         Path::new("target.txt")
     );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1434,7 +1451,6 @@ fn execute_safe_links_with_copy_dirlinks_follows_unsafe_dir_symlink() {
     );
 }
 
-
 #[cfg(unix)]
 #[test]
 fn execute_fifo_produces_fifo_copied_event() {
@@ -1460,9 +1476,10 @@ fn execute_fifo_produces_fifo_copied_event() {
 
     assert_eq!(report.summary().fifos_created(), 1);
     assert!(
-        report.records().iter().any(|record| {
-            record.action() == &LocalCopyAction::FifoCopied
-        }),
+        report
+            .records()
+            .iter()
+            .any(|record| { record.action() == &LocalCopyAction::FifoCopied }),
         "should record a FifoCopied event for the FIFO"
     );
 }
@@ -1515,7 +1532,6 @@ fn execute_fifo_creation_sets_was_created_for_itemize() {
         "a newly materialised FIFO must flag creation so itemize renders `cS+++++++++`"
     );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1572,7 +1588,6 @@ fn execute_copy_links_follows_nested_symlink_chain_to_regular_file() {
     assert_eq!(summary.files_copied(), 3);
 }
 
-
 #[cfg(unix)]
 #[test]
 fn execute_copy_links_overrides_links_option() {
@@ -1599,9 +1614,7 @@ fn execute_copy_links_overrides_links_option() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .copy_links(true)
-                .links(true),
+            LocalCopyOptions::default().copy_links(true).links(true),
         )
         .expect("copy succeeds");
 
@@ -1618,7 +1631,6 @@ fn execute_copy_links_overrides_links_option() {
     assert_eq!(fs::read(&dest_link).expect("read"), b"overridden");
     assert_eq!(summary.symlinks_copied(), 0);
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1653,13 +1665,21 @@ fn execute_without_links_skips_symlink_records_event() {
     let summary = report.summary();
     assert_eq!(summary.symlinks_copied(), 0);
     assert_eq!(summary.files_copied(), 1);
-    assert!(!dest_root.join("source").join("link").exists(), "symlink should not be copied");
-    assert!(dest_root.join("source").join("target.txt").exists(), "regular file should be copied");
-    assert!(report.records().iter().any(|record| {
-        record.action() == &LocalCopyAction::SkippedNonRegular
-    }));
+    assert!(
+        !dest_root.join("source").join("link").exists(),
+        "symlink should not be copied"
+    );
+    assert!(
+        dest_root.join("source").join("target.txt").exists(),
+        "regular file should be copied"
+    );
+    assert!(
+        report
+            .records()
+            .iter()
+            .any(|record| { record.action() == &LocalCopyAction::SkippedNonRegular })
+    );
 }
-
 
 #[cfg(all(
     unix,
@@ -1680,8 +1700,7 @@ fn execute_fifo_with_archive_options_preserves_all_metadata() {
 
     let fifo = source_root.join("archive.pipe");
     mkfifo_for_tests(&fifo, 0o640).expect("mkfifo");
-    fs::set_permissions(&fifo, PermissionsExt::from_mode(0o640))
-        .expect("set fifo permissions");
+    fs::set_permissions(&fifo, PermissionsExt::from_mode(0o640)).expect("set fifo permissions");
 
     let socket = source_root.join("archive.sock");
     mksocket_for_tests(&socket).expect("mksocket");
@@ -1728,7 +1747,6 @@ fn execute_fifo_with_archive_options_preserves_all_metadata() {
     assert_eq!(summary.fifos_created(), 2);
     assert_eq!(summary.files_copied(), 1);
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1831,10 +1849,7 @@ fn copy_unsafe_links_emits_info_symsafe_notice() {
     symlink(&outside_target, &unsafe_link).expect("create unsafe symlink");
 
     let dest_root = temp.path().join("dest");
-    let operands = vec![
-        source_root.into_os_string(),
-        dest_root.into_os_string(),
-    ];
+    let operands = vec![source_root.into_os_string(), dest_root.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     plan.execute_with_options(
@@ -1891,10 +1906,7 @@ fn copy_unsafe_links_default_verbosity_suppresses_info_symsafe_notice() {
     symlink(&outside_target, &unsafe_link).expect("create unsafe symlink");
 
     let dest_root = temp.path().join("dest");
-    let operands = vec![
-        source_root.into_os_string(),
-        dest_root.into_os_string(),
-    ];
+    let operands = vec![source_root.into_os_string(), dest_root.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     plan.execute_with_options(
@@ -1922,7 +1934,6 @@ fn copy_unsafe_links_default_verbosity_suppresses_info_symsafe_notice() {
         "expected no SYMSAFE notice at default verbosity; got {symsafe_msgs:?}"
     );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1982,7 +1993,6 @@ fn execute_keep_dirlinks_multiple_symlink_subdirs_all_preserved() {
     assert_eq!(fs::read(real_beta.join("b.txt")).expect("read"), b"beta");
 }
 
-
 #[cfg(all(
     unix,
     not(any(
@@ -2020,9 +2030,7 @@ fn execute_dry_run_mixed_specials_and_symlinks_no_side_effects() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::DryRun,
-            LocalCopyOptions::default()
-                .links(true)
-                .specials(true),
+            LocalCopyOptions::default().links(true).specials(true),
         )
         .expect("dry run succeeds");
 

--- a/crates/engine/src/local_copy/tests/execute_special_characters.rs
+++ b/crates/engine/src/local_copy/tests/execute_special_characters.rs
@@ -147,11 +147,7 @@ fn copy_directory_with_spaces_in_name() {
 
     let dirname = "dir with spaces";
     fs::create_dir(source_root.join(dirname)).expect("create dir");
-    fs::write(
-        source_root.join(dirname).join("inner file.txt"),
-        b"inner",
-    )
-    .expect("write inner");
+    fs::write(source_root.join(dirname).join("inner file.txt"), b"inner").expect("write inner");
 
     let operands = vec![
         source_root.into_os_string(),
@@ -164,7 +160,13 @@ fn copy_directory_with_spaces_in_name() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert!(dest_root.join("source").join(dirname).join("inner file.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join(dirname)
+            .join("inner file.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -361,7 +363,10 @@ fn copy_file_with_escape_like_sequences() {
 
     assert_eq!(summary.files_copied(), filenames.len() as u64);
     for filename in &filenames {
-        assert!(dest_root.join("source").join(filename).exists(), "should copy {filename}");
+        assert!(
+            dest_root.join("source").join(filename).exists(),
+            "should copy {filename}"
+        );
     }
 }
 
@@ -606,7 +611,10 @@ fn copy_file_with_redirection_like_name() {
 
     assert_eq!(summary.files_copied(), filenames.len() as u64);
     for filename in &filenames {
-        assert!(dest_root.join("source").join(filename).exists(), "should copy {filename}");
+        assert!(
+            dest_root.join("source").join(filename).exists(),
+            "should copy {filename}"
+        );
     }
 }
 
@@ -827,7 +835,10 @@ fn copy_file_with_variable_like_name() {
 
     assert_eq!(summary.files_copied(), filenames.len() as u64);
     for filename in &filenames {
-        assert!(dest_root.join("source").join(filename).exists(), "should copy {filename}");
+        assert!(
+            dest_root.join("source").join(filename).exists(),
+            "should copy {filename}"
+        );
     }
 }
 
@@ -925,7 +936,13 @@ fn copy_directory_with_newline() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert!(dest_root.join("source").join(dirname).join("inner.txt").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join(dirname)
+            .join("inner.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -1216,7 +1233,12 @@ fn copy_file_with_del_character() {
     assert!(dest_root.join("source").join(filename).exists());
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos")))]
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+)))]
 #[test]
 fn copy_file_with_high_ascii_128() {
     let temp = create_tempdir();
@@ -1241,7 +1263,12 @@ fn copy_file_with_high_ascii_128() {
     assert!(dest_root.join("source").join(filename).exists());
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos")))]
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+)))]
 #[test]
 fn copy_file_with_high_ascii_255() {
     let temp = create_tempdir();
@@ -1266,7 +1293,12 @@ fn copy_file_with_high_ascii_255() {
     assert!(dest_root.join("source").join(filename).exists());
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos")))]
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+)))]
 #[test]
 fn copy_files_with_various_high_ascii() {
     let temp = create_tempdir();
@@ -1278,8 +1310,11 @@ fn copy_files_with_various_high_ascii() {
     for byte in byte_values {
         let filename_bytes = [b'f', b'i', b'l', b'e', *byte, b'.', b't', b'x', b't'];
         let filename = OsStr::from_bytes(&filename_bytes);
-        fs::write(source_root.join(filename), format!("high {byte}").as_bytes())
-            .expect("write source");
+        fs::write(
+            source_root.join(filename),
+            format!("high {byte}").as_bytes(),
+        )
+        .expect("write source");
     }
 
     let operands = vec![
@@ -1295,7 +1330,12 @@ fn copy_files_with_various_high_ascii() {
     assert_eq!(summary.files_copied(), byte_values.len() as u64);
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos")))]
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+)))]
 #[test]
 fn copy_file_with_non_utf8_sequence() {
     let temp = create_tempdir();
@@ -1402,7 +1442,10 @@ fn copy_file_with_shell_injection_like_name() {
 
     assert_eq!(summary.files_copied(), filenames.len() as u64);
     for filename in &filenames {
-        assert!(dest_root.join("source").join(filename).exists(), "should copy {filename}");
+        assert!(
+            dest_root.join("source").join(filename).exists(),
+            "should copy {filename}"
+        );
     }
 }
 
@@ -1467,7 +1510,10 @@ fn copy_multiple_files_with_various_special_characters() {
 
     assert_eq!(summary.files_copied(), filenames.len() as u64);
     for filename in &filenames {
-        assert!(dest_root.join("source").join(filename).exists(), "should copy {filename}");
+        assert!(
+            dest_root.join("source").join(filename).exists(),
+            "should copy {filename}"
+        );
     }
 }
 

--- a/crates/engine/src/local_copy/tests/execute_specials.rs
+++ b/crates/engine/src/local_copy/tests/execute_specials.rs
@@ -1,4 +1,3 @@
-
 // Tests for upstream rsync --specials behavior.
 //
 // In upstream rsync, IS_SPECIAL(mode) covers both S_ISSOCK and S_ISFIFO.
@@ -28,7 +27,6 @@ fn mksocket_for_tests(path: &Path) -> io::Result<()> {
     // Dropping the listener closes it, but the socket node on disk persists.
     Ok(())
 }
-
 
 #[cfg(all(
     unix,
@@ -141,7 +139,6 @@ fn execute_without_specials_records_socket_skip_event() {
     );
 }
 
-
 #[cfg(all(
     unix,
     not(any(
@@ -171,9 +168,7 @@ fn execute_copies_socket_preserving_permissions() {
 
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default()
-            .specials(true)
-            .permissions(true),
+        LocalCopyOptions::default().specials(true).permissions(true),
     )
     .expect("socket copy succeeds");
 
@@ -223,15 +218,13 @@ fn execute_copies_socket_preserving_timestamps() {
     // socket may fail with ENXIO on the same kernels.
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default()
-            .specials(true),
+        LocalCopyOptions::default().specials(true),
     )
     .expect("socket copy succeeds");
 
     let dest_metadata = fs::symlink_metadata(&dest_socket).expect("dest metadata");
     assert!(dest_metadata.file_type().is_socket());
 }
-
 
 #[cfg(all(
     unix,
@@ -275,7 +268,6 @@ fn execute_copies_socket_within_directory() {
     );
     assert_eq!(summary.fifos_created(), 1);
 }
-
 
 // Socket creation in temp dirs requires elevated privileges on macOS.
 #[cfg(all(
@@ -394,7 +386,6 @@ fn execute_without_specials_skips_both_fifos_and_sockets() {
         "both FIFO and socket should produce SkippedNonRegular events"
     );
 }
-
 
 #[cfg(all(
     unix,
@@ -527,8 +518,7 @@ fn execute_archive_mode_copies_fifo_preserving_mode_and_mtime() {
 
     let fifo = source_root.join("archive.pipe");
     mkfifo_for_tests(&fifo, 0o640).expect("mkfifo");
-    fs::set_permissions(&fifo, PermissionsExt::from_mode(0o640))
-        .expect("set fifo permissions");
+    fs::set_permissions(&fifo, PermissionsExt::from_mode(0o640)).expect("set fifo permissions");
 
     // Must be the NOFOLLOW setter. Plain set_file_times() open(2)s the path
     // first, and open(2) on a FIFO blocks until a peer opens the other end -
@@ -577,7 +567,6 @@ fn execute_archive_mode_copies_fifo_preserving_mode_and_mtime() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-
 #[cfg(all(
     unix,
     not(any(
@@ -612,9 +601,11 @@ fn execute_dry_run_does_not_create_socket() {
         1,
         "dry run should still count the socket"
     );
-    assert!(!dest_socket.exists(), "dry run should not create the socket");
+    assert!(
+        !dest_socket.exists(),
+        "dry run should not create the socket"
+    );
 }
-
 
 #[cfg(all(
     unix,
@@ -696,7 +687,6 @@ fn execute_socket_replaces_regular_file() {
     );
 }
 
-
 #[cfg(all(
     unix,
     not(any(
@@ -729,9 +719,7 @@ fn execute_preserves_socket_hard_links() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .hard_links(true)
-                .specials(true),
+            LocalCopyOptions::default().hard_links(true).specials(true),
         )
         .expect("copy succeeds");
 
@@ -751,7 +739,6 @@ fn execute_preserves_socket_hard_links() {
         "only one socket should be created; the other is a hard link"
     );
 }
-
 
 #[cfg(all(
     unix,
@@ -785,9 +772,7 @@ fn execute_delete_removes_extraneous_socket() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .specials(true)
-                .delete(true),
+            LocalCopyOptions::default().specials(true).delete(true),
         )
         .expect("delete copy succeeds");
 
@@ -795,10 +780,12 @@ fn execute_delete_removes_extraneous_socket() {
         !extraneous_socket.exists(),
         "extraneous socket should be deleted"
     );
-    assert!(dest_root.join("keep.txt").is_file(), "keep.txt should remain");
+    assert!(
+        dest_root.join("keep.txt").is_file(),
+        "keep.txt should remain"
+    );
     assert!(summary.items_deleted() >= 1);
 }
-
 
 #[cfg(all(
     unix,
@@ -846,7 +833,6 @@ fn execute_without_specials_with_delete_does_not_delete_socket_from_keep_list() 
     assert_eq!(summary.fifos_created(), 0);
 }
 
-
 #[cfg(all(
     unix,
     not(any(
@@ -880,13 +866,13 @@ fn execute_socket_produces_fifo_copied_event() {
 
     assert_eq!(report.summary().fifos_created(), 1);
     assert!(
-        report.records().iter().any(|record| {
-            record.action() == &LocalCopyAction::FifoCopied
-        }),
+        report
+            .records()
+            .iter()
+            .any(|record| { record.action() == &LocalCopyAction::FifoCopied }),
         "should record a FifoCopied event for the socket"
     );
 }
-
 
 #[cfg(all(
     unix,
@@ -927,7 +913,6 @@ fn execute_recopy_socket_replaces_existing_socket() {
     assert_eq!(summary.fifos_created(), 1);
 }
 
-
 #[cfg(all(
     unix,
     not(any(
@@ -962,9 +947,7 @@ fn execute_copies_socket_and_symlink_together() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .specials(true)
-                .links(true),
+            LocalCopyOptions::default().specials(true).links(true),
         )
         .expect("copy succeeds");
 
@@ -984,7 +967,6 @@ fn execute_copies_socket_and_symlink_together() {
     assert_eq!(summary.symlinks_copied(), 1);
     assert_eq!(summary.files_copied(), 1);
 }
-
 
 #[test]
 fn options_specials_enabled_returns_false_by_default() {

--- a/crates/engine/src/local_copy/tests/execute_super.rs
+++ b/crates/engine/src/local_copy/tests/execute_super.rs
@@ -626,10 +626,9 @@ fn super_mode_with_times_preserves_timestamps() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    let dest_mtime =
-        filetime::FileTime::from_last_modification_time(
-            &fs::metadata(ctx.dest.join("file.txt")).expect("dest metadata"),
-        );
+    let dest_mtime = filetime::FileTime::from_last_modification_time(
+        &fs::metadata(ctx.dest.join("file.txt")).expect("dest metadata"),
+    );
     assert_eq!(dest_mtime, mtime);
 }
 
@@ -656,10 +655,9 @@ fn no_super_with_times_still_preserves_timestamps() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    let dest_mtime =
-        filetime::FileTime::from_last_modification_time(
-            &fs::metadata(ctx.dest.join("file.txt")).expect("dest metadata"),
-        );
+    let dest_mtime = filetime::FileTime::from_last_modification_time(
+        &fs::metadata(ctx.dest.join("file.txt")).expect("dest metadata"),
+    );
     assert_eq!(dest_mtime, mtime);
 }
 
@@ -1034,9 +1032,7 @@ fn fake_super_with_empty_source_directory() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .fake_super(true)
-                .owner(true),
+            LocalCopyOptions::default().fake_super(true).owner(true),
         )
         .expect("copy succeeds");
 

--- a/crates/engine/src/local_copy/tests/execute_symlink_edge_cases.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlink_edge_cases.rs
@@ -8,7 +8,6 @@
 // - Self-referencing symlinks
 // - Permission handling for symlinks
 
-
 #[cfg(unix)]
 #[test]
 fn symlink_absolute_target_within_source_tree() {
@@ -42,7 +41,12 @@ fn symlink_absolute_target_within_source_tree() {
 
     // Symlink should be copied (absolute path preserved)
     let dest_link = dest_root.join("src").join("abs_link");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     // Absolute target path should be preserved exactly
     let copied_target = fs::read_link(&dest_link).expect("read link");
@@ -79,7 +83,12 @@ fn symlink_relative_target_stays_relative() {
     .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("rel_link");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     // Relative target should be preserved exactly (not converted to absolute)
     let copied_target = fs::read_link(&dest_link).expect("read link");
@@ -123,9 +132,11 @@ fn symlink_complex_relative_path_with_dotdot() {
     assert_eq!(copied_target, Path::new("../dir2/target.txt"));
 
     // The link should resolve correctly in destination
-    assert!(dest_link.exists(), "symlink should resolve to target in dest");
+    assert!(
+        dest_link.exists(),
+        "symlink should resolve to target in dest"
+    );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -155,7 +166,12 @@ fn broken_symlink_with_relative_target_preserved() {
         .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("broken");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     // Broken symlinks are still copied
     let copied_target = fs::read_link(&dest_link).expect("read link");
@@ -191,7 +207,12 @@ fn broken_symlink_with_absolute_target_preserved() {
     .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("broken_abs");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     let copied_target = fs::read_link(&dest_link).expect("read link");
     assert_eq!(copied_target, Path::new("/nonexistent/absolute/path.txt"));
@@ -232,13 +253,17 @@ fn broken_symlink_becomes_valid_when_target_copied() {
     let dest_link = dest_root.join("src").join("link");
 
     assert!(dest_target.is_file());
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     // Link should resolve to target in destination
     assert!(dest_link.exists(), "symlink should resolve correctly");
     assert_eq!(fs::read(&dest_link).expect("read via link"), b"content");
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -274,15 +299,34 @@ fn symlink_chain_two_levels() {
         .expect("copy succeeds");
 
     assert!(dest_root.join("src").join("target.txt").is_file());
-    assert!(fs::symlink_metadata(dest_root.join("src").join("link1")).expect("meta").file_type().is_symlink());
-    assert!(fs::symlink_metadata(dest_root.join("src").join("link2")).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(dest_root.join("src").join("link1"))
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        fs::symlink_metadata(dest_root.join("src").join("link2"))
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     // Chain should resolve correctly
-    assert_eq!(fs::read_link(dest_root.join("src").join("link1")).expect("read"), Path::new("target.txt"));
-    assert_eq!(fs::read_link(dest_root.join("src").join("link2")).expect("read"), Path::new("link1"));
+    assert_eq!(
+        fs::read_link(dest_root.join("src").join("link1")).expect("read"),
+        Path::new("target.txt")
+    );
+    assert_eq!(
+        fs::read_link(dest_root.join("src").join("link2")).expect("read"),
+        Path::new("link1")
+    );
 
     // Following full chain should reach content
-    assert_eq!(fs::read(dest_root.join("src").join("link2")).expect("read content"), b"final content");
+    assert_eq!(
+        fs::read(dest_root.join("src").join("link2")).expect("read content"),
+        b"final content"
+    );
     assert_eq!(summary.symlinks_copied(), 2);
 }
 
@@ -324,13 +368,19 @@ fn symlink_chain_three_levels_deep() {
     for link_name in ["link1", "link2", "link3"] {
         let dest_link = dest_root.join("src").join(link_name);
         assert!(
-            fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink(),
+            fs::symlink_metadata(&dest_link)
+                .expect("meta")
+                .file_type()
+                .is_symlink(),
             "{link_name} should be a symlink"
         );
     }
 
     // Full chain resolution should work
-    assert_eq!(fs::read(dest_root.join("src").join("link3")).expect("read"), b"deep content");
+    assert_eq!(
+        fs::read(dest_root.join("src").join("link3")).expect("read"),
+        b"deep content"
+    );
 }
 
 #[cfg(unix)]
@@ -372,13 +422,20 @@ fn symlink_chain_across_directories() {
 
     // Cross-directory chain should work
     let dest_link2 = dest_root.join("src").join("b/link2");
-    assert!(fs::symlink_metadata(&dest_link2).expect("meta").file_type().is_symlink());
-    assert_eq!(fs::read_link(&dest_link2).expect("read"), Path::new("../a/link1"));
+    assert!(
+        fs::symlink_metadata(&dest_link2)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(
+        fs::read_link(&dest_link2).expect("read"),
+        Path::new("../a/link1")
+    );
 
     // Should resolve to content
     assert_eq!(fs::read(&dest_link2).expect("read content"), b"content");
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -434,8 +491,11 @@ fn symlink_multiple_dotdot_levels_escape() {
     // plus the file name counts too, so we need MORE parent dirs to be sure.
     // Using 10 parent dirs ensures this will escape no matter what.
     let link = deep_dir.join("escape");
-    symlink(Path::new("../../../../../../../../../../outside.txt"), &link)
-        .expect("create escaping symlink");
+    symlink(
+        Path::new("../../../../../../../../../../outside.txt"),
+        &link,
+    )
+    .expect("create escaping symlink");
 
     let dest_root = temp.path().join("dest");
     let operands = vec![
@@ -453,7 +513,10 @@ fn symlink_multiple_dotdot_levels_escape() {
         .expect("copy completes");
 
     let dest_link = dest_root.join("src").join("a/b/c/escape");
-    assert!(!dest_link.exists(), "deeply escaping symlink should be skipped");
+    assert!(
+        !dest_link.exists(),
+        "deeply escaping symlink should be skipped"
+    );
     assert_eq!(report.summary().symlinks_copied(), 0);
 }
 
@@ -502,7 +565,6 @@ fn symlink_escapes_but_copy_unsafe_links_dereferences() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-
 #[cfg(unix)]
 #[test]
 fn self_referencing_symlink_handled() {
@@ -532,7 +594,12 @@ fn self_referencing_symlink_handled() {
         .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("self");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(fs::read_link(&dest_link).expect("read"), Path::new("self"));
     assert_eq!(summary.symlinks_copied(), 1);
 }
@@ -572,10 +639,26 @@ fn mutual_symlink_cycle_preserved() {
     let dest_link_a = dest_root.join("src").join("link_a");
     let dest_link_b = dest_root.join("src").join("link_b");
 
-    assert!(fs::symlink_metadata(&dest_link_a).expect("meta").file_type().is_symlink());
-    assert!(fs::symlink_metadata(&dest_link_b).expect("meta").file_type().is_symlink());
-    assert_eq!(fs::read_link(&dest_link_a).expect("read"), Path::new("link_b"));
-    assert_eq!(fs::read_link(&dest_link_b).expect("read"), Path::new("link_a"));
+    assert!(
+        fs::symlink_metadata(&dest_link_a)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        fs::symlink_metadata(&dest_link_b)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(
+        fs::read_link(&dest_link_a).expect("read"),
+        Path::new("link_b")
+    );
+    assert_eq!(
+        fs::read_link(&dest_link_b).expect("read"),
+        Path::new("link_a")
+    );
     assert_eq!(summary.symlinks_copied(), 2);
 }
 
@@ -615,19 +698,21 @@ fn three_way_symlink_cycle() {
     for name in ["a", "b", "c"] {
         let dest_link = dest_root.join("src").join(name);
         assert!(
-            fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink(),
+            fs::symlink_metadata(&dest_link)
+                .expect("meta")
+                .file_type()
+                .is_symlink(),
             "link {name} should be preserved"
         );
     }
     assert_eq!(summary.symlinks_copied(), 3);
 }
 
-
 #[cfg(unix)]
 #[test]
 fn symlink_preserves_target_timestamp_not_link() {
-    use std::os::unix::fs::symlink;
     use filetime::{FileTime, set_file_mtime};
+    use std::os::unix::fs::symlink;
 
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("src");
@@ -658,7 +743,12 @@ fn symlink_preserves_target_timestamp_not_link() {
 
     // The symlink itself is preserved
     let dest_link = dest_root.join("src").join("link");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     // Target should have its mtime preserved
     let dest_target = dest_root.join("src").join("target.txt");
@@ -670,7 +760,7 @@ fn symlink_preserves_target_timestamp_not_link() {
 #[cfg(unix)]
 #[test]
 fn symlink_to_directory_with_permissions() {
-    use std::os::unix::fs::{symlink, PermissionsExt};
+    use std::os::unix::fs::{PermissionsExt, symlink};
 
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("src");
@@ -701,7 +791,12 @@ fn symlink_to_directory_with_permissions() {
 
     // Symlink should be preserved
     let dest_link = dest_root.join("src").join("dir_link");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     // Original directory should have permissions preserved
     let dest_dir = dest_root.join("src").join("target_dir");
@@ -747,12 +842,16 @@ fn symlink_omit_link_times_option() {
     .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("link");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     // The symlink should exist and work
     assert!(dest_link.exists());
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -783,8 +882,16 @@ fn symlink_with_spaces_in_name() {
     .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("link with spaces");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
-    assert_eq!(fs::read_link(&dest_link).expect("read"), Path::new("target file.txt"));
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(
+        fs::read_link(&dest_link).expect("read"),
+        Path::new("target file.txt")
+    );
 }
 
 #[cfg(unix)]
@@ -816,7 +923,12 @@ fn symlink_with_unicode_characters() {
     .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("link_\u{00f1}");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(
         fs::read_link(&dest_link).expect("read"),
         Path::new("target_\u{00e9}\u{00e0}\u{00fc}.txt")
@@ -853,13 +965,17 @@ fn symlink_target_with_newline() {
     .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("link");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(
         fs::read_link(&dest_link).expect("read"),
         Path::new("target\nwith\nnewlines.txt")
     );
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -888,7 +1004,12 @@ fn symlink_to_current_directory() {
     .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("dot_link");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(fs::read_link(&dest_link).expect("read"), Path::new("."));
 }
 
@@ -924,15 +1045,19 @@ fn symlink_to_parent_within_safe_boundary() {
     .expect("copy succeeds");
 
     let dest_link = dest_root.join("src").join("subdir/parent_link");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(fs::read_link(&dest_link).expect("read"), Path::new(".."));
 }
-
 
 #[cfg(unix)]
 #[test]
 fn hard_link_to_symlink_preserved() {
-    use std::os::unix::fs::{symlink, MetadataExt};
+    use std::os::unix::fs::{MetadataExt, symlink};
 
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("src");
@@ -972,8 +1097,18 @@ fn hard_link_to_symlink_preserved() {
     let dest_link1 = dest_root.join("src").join("link1");
     let dest_link2 = dest_root.join("src").join("link2");
 
-    assert!(fs::symlink_metadata(&dest_link1).expect("meta").file_type().is_symlink());
-    assert!(fs::symlink_metadata(&dest_link2).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link1)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        fs::symlink_metadata(&dest_link2)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
 
     // They should share the same inode (hard link preserved)
     let dest_meta1 = fs::symlink_metadata(&dest_link1).expect("dest meta1");
@@ -981,13 +1116,18 @@ fn hard_link_to_symlink_preserved() {
     assert_eq!(dest_meta1.ino(), dest_meta2.ino());
 
     // Both should point to the same target
-    assert_eq!(fs::read_link(&dest_link1).expect("read"), Path::new("target.txt"));
-    assert_eq!(fs::read_link(&dest_link2).expect("read"), Path::new("target.txt"));
+    assert_eq!(
+        fs::read_link(&dest_link1).expect("read"),
+        Path::new("target.txt")
+    );
+    assert_eq!(
+        fs::read_link(&dest_link2).expect("read"),
+        Path::new("target.txt")
+    );
 
     assert!(summary.hard_links_created() >= 1);
     assert_eq!(summary.symlinks_copied(), 2);
 }
-
 
 // upstream reference: native Windows has no upstream rsync; the contract is
 // docs/user/windows-support-matrix.md. `CreateSymbolicLinkW` needs privilege
@@ -1051,7 +1191,7 @@ fn windows_file_symlink_reports_privilege_gracefully() {
 #[cfg(unix)]
 #[test]
 fn symlink_size_is_target_path_length() {
-    use std::os::unix::fs::{symlink, MetadataExt};
+    use std::os::unix::fs::{MetadataExt, symlink};
 
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("src");

--- a/crates/engine/src/local_copy/tests/execute_symlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlinks.rs
@@ -1,4 +1,3 @@
-
 #[cfg(unix)]
 #[test]
 fn execute_copies_symbolic_link() {
@@ -238,7 +237,7 @@ fn execute_with_safe_links_skips_unsafe_symlink() {
 #[cfg(unix)]
 #[test]
 fn execute_preserves_symlink_hard_links() {
-    use std::os::unix::fs::{symlink, MetadataExt};
+    use std::os::unix::fs::{MetadataExt, symlink};
 
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("src");
@@ -288,7 +287,6 @@ fn execute_preserves_symlink_hard_links() {
     assert_eq!(summary.symlinks_copied(), 2);
 }
 
-
 #[cfg(unix)]
 #[test]
 fn safe_links_skips_symlink_pointing_outside_transfer_tree() {
@@ -329,13 +327,18 @@ fn safe_links_skips_symlink_pointing_outside_transfer_tree() {
 
     assert_eq!(summary.symlinks_copied(), 0);
     assert_eq!(summary.symlinks_total(), 2);
-    assert!(!dest_root.join("source").join("unsafe_absolute_link").exists());
+    assert!(
+        !dest_root
+            .join("source")
+            .join("unsafe_absolute_link")
+            .exists()
+    );
     assert!(!dest_root.join("source").join("source/escape_link").exists());
 
     let skip_count = report
         .records()
         .iter()
-        .filter(|record| { matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink) })
+        .filter(|record| matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink))
         .count();
     assert_eq!(skip_count, 2);
 }
@@ -383,21 +386,36 @@ fn safe_links_preserves_symlink_pointing_inside_transfer_tree() {
     assert_eq!(summary.symlinks_copied(), 3);
 
     let dest_link1 = dest_root.join("source").join("link_to_subdir");
-    assert!(fs::symlink_metadata(&dest_link1).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link1)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(
         fs::read_link(&dest_link1).expect("read link"),
         Path::new("subdir/target.txt")
     );
 
     let dest_link2 = dest_root.join("source").join("subdir/link_to_sibling");
-    assert!(fs::symlink_metadata(&dest_link2).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link2)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(
         fs::read_link(&dest_link2).expect("read link"),
         Path::new("target.txt")
     );
 
     let dest_link3 = dest_root.join("source").join("subdir/link_via_parent");
-    assert!(fs::symlink_metadata(&dest_link3).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link3)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(
         fs::read_link(&dest_link3).expect("read link"),
         Path::new("../subdir/target.txt")
@@ -456,7 +474,12 @@ fn safe_links_evaluates_relative_symlinks_correctly() {
     assert_eq!(summary.symlinks_copied(), 2);
     assert_eq!(summary.symlinks_total(), 3);
 
-    assert!(dest_root.join("source").join("level1/level2/level3/link_to_level1").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("level1/level2/level3/link_to_level1")
+            .exists()
+    );
     assert!(dest_root.join("source").join("root_link").exists());
 
     assert!(!dest_root.join("source").join("level1/escape_link").exists());
@@ -464,7 +487,7 @@ fn safe_links_evaluates_relative_symlinks_correctly() {
     let skip_count = report
         .records()
         .iter()
-        .filter(|record| { matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink) })
+        .filter(|record| matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink))
         .count();
     assert_eq!(skip_count, 1);
 }
@@ -525,7 +548,7 @@ fn safe_links_filters_absolute_symlinks_when_unsafe() {
     let skip_count = report
         .records()
         .iter()
-        .filter(|record| { matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink) })
+        .filter(|record| matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink))
         .count();
     assert_eq!(skip_count, 3);
 }
@@ -587,10 +610,25 @@ fn safe_links_handles_complex_relative_paths() {
     assert_eq!(summary.symlinks_copied(), 2);
     assert_eq!(summary.symlinks_total(), 4);
 
-    assert!(dest_root.join("source").join("dir_a/link_to_sibling").exists());
-    assert!(dest_root.join("source").join("dir_a/link_with_dots").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir_a/link_to_sibling")
+            .exists()
+    );
+    assert!(
+        dest_root
+            .join("source")
+            .join("dir_a/link_with_dots")
+            .exists()
+    );
     assert!(!dest_root.join("source").join("dir_a/backdoor").exists());
-    assert!(!dest_root.join("source").join("dir_a/ending_parent").exists());
+    assert!(
+        !dest_root
+            .join("source")
+            .join("dir_a/ending_parent")
+            .exists()
+    );
 }
 
 #[cfg(unix)]
@@ -625,9 +663,13 @@ fn safe_links_preserves_symlink_to_directory_when_safe() {
         )
         .expect("copy succeeds");
 
-
     let dest_link = dest_root.join("source").join("link_to_dir");
-    assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(
         fs::read_link(&dest_link).expect("read link"),
         Path::new("subdir")
@@ -676,7 +718,7 @@ fn safe_links_skips_symlink_to_directory_when_unsafe() {
     let skip_count = report
         .records()
         .iter()
-        .filter(|record| { matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink) })
+        .filter(|record| matches!(record.action(), LocalCopyAction::SkippedUnsafeSymlink))
         .count();
     assert_eq!(skip_count, 1);
 }
@@ -736,7 +778,12 @@ fn safe_links_with_multiple_depth_levels() {
     assert_eq!(summary.symlinks_copied(), 3);
     assert_eq!(summary.symlinks_total(), 4);
 
-    assert!(dest_root.join("source").join("a/b/c/d/link_to_root").exists());
+    assert!(
+        dest_root
+            .join("source")
+            .join("a/b/c/d/link_to_root")
+            .exists()
+    );
     assert!(dest_root.join("source").join("a/b/c/d/link_to_a").exists());
     assert!(dest_root.join("source").join("a/b/c/d/link_to_b").exists());
     assert!(!dest_root.join("source").join("a/b/c/d/escape").exists());
@@ -801,10 +848,22 @@ fn safe_links_trailing_slash_vs_no_trailing_slash() {
     let summary1 = report1.summary();
     let summary2 = report2.summary();
 
-    assert_eq!(summary1.symlinks_copied(), 1, "no-trailing-slash: 1 safe link");
-    assert_eq!(summary1.symlinks_total(), 2, "no-trailing-slash: 2 total links");
+    assert_eq!(
+        summary1.symlinks_copied(),
+        1,
+        "no-trailing-slash: 1 safe link"
+    );
+    assert_eq!(
+        summary1.symlinks_total(),
+        2,
+        "no-trailing-slash: 2 total links"
+    );
     assert_eq!(summary2.symlinks_copied(), 1, "trailing-slash: 1 safe link");
-    assert_eq!(summary2.symlinks_total(), 2, "trailing-slash: 2 total links");
+    assert_eq!(
+        summary2.symlinks_total(),
+        2,
+        "trailing-slash: 2 total links"
+    );
 
     assert!(dest1.join("source").join("sub/safe").exists());
     assert!(!dest1.join("source").join("sub/unsafe").exists());
@@ -867,7 +926,6 @@ fn safe_links_disabled_allows_all_symlinks() {
     assert!(fs::symlink_metadata(dest_root.join("source").join("abs_link")).is_ok());
     assert!(fs::symlink_metadata(dest_root.join("source").join("escape_link")).is_ok());
 }
-
 
 #[cfg(unix)]
 #[test]
@@ -1221,10 +1279,7 @@ fn copy_unsafe_links_combined_with_safe_links_behavior() {
     let dest_path_2 = dest_dir.join("escape-link");
     let metadata = fs::symlink_metadata(&dest_path_2).expect("destination metadata");
     assert!(metadata.file_type().is_file());
-    assert_eq!(
-        fs::read(&dest_path_2).expect("read file"),
-        b"external"
-    );
+    assert_eq!(fs::read(&dest_path_2).expect("read file"), b"external");
     assert_eq!(summary_copy.files_copied(), 1);
     assert_eq!(summary_copy.symlinks_copied(), 0);
 }
@@ -1245,11 +1300,8 @@ fn copy_unsafe_links_deeply_nested_symlink() {
 
     // Symlink deep in the tree that escapes
     let link_path = nested_dir.join("deep-escape");
-    symlink(
-        Path::new("../../../../external.txt"),
-        &link_path,
-    )
-    .expect("create deep escaping symlink");
+    symlink(Path::new("../../../../external.txt"), &link_path)
+        .expect("create deep escaping symlink");
 
     let dest_root = temp.path().join("dest");
     let operands = vec![
@@ -1336,7 +1388,12 @@ fn copy_unsafe_links_with_mixed_safe_and_unsafe_in_tree() {
 
     // Verify safe link remains a symlink
     let dest_safe = dest_root.join("src").join("subdir/safe_link");
-    assert!(fs::symlink_metadata(&dest_safe).expect("meta").file_type().is_symlink());
+    assert!(
+        fs::symlink_metadata(&dest_safe)
+            .expect("meta")
+            .file_type()
+            .is_symlink()
+    );
     assert_eq!(
         fs::read_link(&dest_safe).expect("read link"),
         Path::new("../safe_target.txt")
@@ -1406,10 +1463,7 @@ fn copy_unsafe_links_dereferences_symlink_chain() {
     let dest_path = dest_dir.join("chain-link");
     let metadata = fs::symlink_metadata(&dest_path).expect("destination metadata");
     assert!(metadata.file_type().is_file());
-    assert_eq!(
-        fs::read(&dest_path).expect("read file"),
-        b"final content"
-    );
+    assert_eq!(fs::read(&dest_path).expect("read file"), b"final content");
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.symlinks_copied(), 0);
 }

--- a/crates/engine/src/local_copy/tests/execute_temp_dir.rs
+++ b/crates/engine/src/local_copy/tests/execute_temp_dir.rs
@@ -7,7 +7,6 @@
 // 4. Atomic rename semantics
 // 5. Comparison with upstream rsync behavior
 
-
 #[test]
 fn execute_with_temp_dir_places_temp_files_in_specified_directory() {
     let temp = tempdir().expect("tempdir");
@@ -114,7 +113,6 @@ fn execute_with_temp_dir_same_filesystem_uses_atomic_rename() {
     assert_eq!(fs::read(&destination).expect("read dest"), large_content);
 }
 
-
 #[cfg(unix)]
 #[test]
 fn execute_with_temp_dir_different_filesystem_falls_back_to_copy() {
@@ -155,7 +153,6 @@ fn execute_with_temp_dir_different_filesystem_falls_back_to_copy() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
-
 
 #[test]
 fn execute_with_temp_dir_handles_multiple_files() {
@@ -205,7 +202,6 @@ fn execute_with_temp_dir_handles_multiple_files() {
     assert!(staging_files.is_empty(), "no temp files should remain");
 }
 
-
 #[test]
 fn execute_with_temp_dir_handles_nested_directories() {
     let temp = tempdir().expect("tempdir");
@@ -242,11 +238,26 @@ fn execute_with_temp_dir_handles_nested_directories() {
         b"level1"
     );
     assert_eq!(
-        fs::read(dest_root.join("source").join("a").join("b").join("file2.txt")).expect("read"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("a")
+                .join("b")
+                .join("file2.txt")
+        )
+        .expect("read"),
         b"level2"
     );
     assert_eq!(
-        fs::read(dest_root.join("source").join("a").join("b").join("c").join("file3.txt")).expect("read"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("a")
+                .join("b")
+                .join("c")
+                .join("file3.txt")
+        )
+        .expect("read"),
         b"level3"
     );
 
@@ -257,7 +268,6 @@ fn execute_with_temp_dir_handles_nested_directories() {
         .collect();
     assert!(staging_files.is_empty());
 }
-
 
 #[test]
 fn execute_with_absolute_temp_dir_path() {
@@ -291,7 +301,6 @@ fn execute_with_absolute_temp_dir_path() {
     );
 }
 
-
 #[test]
 fn execute_with_temp_dir_replaces_existing_destination() {
     let temp = tempdir().expect("tempdir");
@@ -322,7 +331,6 @@ fn execute_with_temp_dir_replaces_existing_destination() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"new content");
 }
 
-
 #[test]
 fn execute_with_temp_dir_handles_empty_file() {
     let temp = tempdir().expect("tempdir");
@@ -350,7 +358,6 @@ fn execute_with_temp_dir_handles_empty_file() {
     assert!(destination.exists());
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 0);
 }
-
 
 #[test]
 fn execute_with_temp_dir_handles_large_file() {
@@ -389,7 +396,6 @@ fn execute_with_temp_dir_handles_large_file() {
     assert!(staging_files.is_empty());
 }
 
-
 #[cfg(unix)]
 #[test]
 fn execute_with_temp_dir_preserves_permissions() {
@@ -402,7 +408,9 @@ fn execute_with_temp_dir_preserves_permissions() {
     fs::create_dir_all(&temp_staging).expect("staging dir");
 
     fs::write(&source, b"perms test").expect("write source");
-    let mut perms = fs::metadata(&source).expect("source metadata").permissions();
+    let mut perms = fs::metadata(&source)
+        .expect("source metadata")
+        .permissions();
     perms.set_mode(0o600);
     fs::set_permissions(&source, perms).expect("set source perms");
 
@@ -461,7 +469,6 @@ fn execute_with_temp_dir_preserves_modification_time() {
     assert_eq!(dest_mtime, past_time);
 }
 
-
 #[test]
 fn execute_with_nonexistent_temp_dir_fails() {
     let temp = tempdir().expect("tempdir");
@@ -491,7 +498,6 @@ fn execute_with_nonexistent_temp_dir_fails() {
         "destination should not be created on failure"
     );
 }
-
 
 #[test]
 fn execute_with_temp_dir_and_partial_mode() {
@@ -559,7 +565,6 @@ fn execute_with_temp_dir_and_delay_updates() {
     );
 }
 
-
 #[test]
 fn execute_dry_run_with_temp_dir_does_not_create_files() {
     let temp = tempdir().expect("tempdir");
@@ -584,7 +589,10 @@ fn execute_dry_run_with_temp_dir_does_not_create_files() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert!(!destination.exists(), "destination should not exist in dry run");
+    assert!(
+        !destination.exists(),
+        "destination should not exist in dry run"
+    );
 
     // Staging directory should also be empty
     let staging_files: Vec<_> = fs::read_dir(&temp_staging)
@@ -593,7 +601,6 @@ fn execute_dry_run_with_temp_dir_does_not_create_files() {
         .collect();
     assert!(staging_files.is_empty(), "no temp files in dry run");
 }
-
 
 #[test]
 fn execute_inplace_mode_ignores_temp_dir() {
@@ -635,7 +642,6 @@ fn execute_inplace_mode_ignores_temp_dir() {
         .collect();
     assert!(staging_files.is_empty());
 }
-
 
 #[test]
 fn execute_with_temp_dir_cleans_up_on_successful_multi_file_transfer() {
@@ -683,7 +689,6 @@ fn execute_with_temp_dir_cleans_up_on_successful_multi_file_transfer() {
     );
 }
 
-
 #[test]
 fn execute_with_temp_dir_containing_spaces() {
     let temp = tempdir().expect("tempdir");
@@ -714,7 +719,6 @@ fn execute_with_temp_dir_containing_spaces() {
     );
 }
 
-
 #[test]
 fn execute_with_temp_dir_containing_special_chars() {
     let temp = tempdir().expect("tempdir");
@@ -741,7 +745,6 @@ fn execute_with_temp_dir_containing_special_chars() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&destination).expect("read dest"), b"special chars");
 }
-
 
 #[test]
 fn execute_with_temp_dir_provides_atomic_destination_update() {
@@ -777,7 +780,6 @@ fn execute_with_temp_dir_provides_atomic_destination_update() {
     let final_content = fs::read(&destination).expect("read dest");
     assert_eq!(final_content, new_content);
 }
-
 
 #[test]
 fn execute_with_temp_dir_and_delete_removes_extraneous() {
@@ -816,7 +818,6 @@ fn execute_with_temp_dir_and_delete_removes_extraneous() {
     );
 }
 
-
 #[test]
 fn execute_without_temp_dir_creates_temps_alongside_destination() {
     let temp = tempdir().expect("tempdir");
@@ -854,16 +855,12 @@ fn execute_without_temp_dir_creates_temps_alongside_destination() {
     );
 }
 
-
 #[test]
 fn execute_with_temp_dir_uses_upstream_temp_name() {
     // upstream get_tmpname(): beside the destination the temp is `.<name>.XXXXXX`
     // with a leading dot and a six-character suffix.
     let temp_path = temp_name_with_suffix(Path::new("/path/to/file.txt"), None, "ABCDEF");
-    let name = temp_path
-        .file_name()
-        .expect("file name")
-        .to_string_lossy();
+    let name = temp_path.file_name().expect("file name").to_string_lossy();
     assert_eq!(name, ".file.txt.ABCDEF", "got {name}");
     assert_eq!(
         temp_path.parent().unwrap(),
@@ -877,16 +874,16 @@ fn execute_with_temp_dir_format_in_custom_directory() {
     // When temp_dir is set, the temp goes into that directory with no leading
     // dot: upstream get_tmpname() only prepends a dot without --temp-dir.
     let temp_dir = Path::new("/my/temp");
-    let temp_path =
-        temp_name_with_suffix(Path::new("/destination/subdir/file.txt"), Some(temp_dir), "ABCDEF");
+    let temp_path = temp_name_with_suffix(
+        Path::new("/destination/subdir/file.txt"),
+        Some(temp_dir),
+        "ABCDEF",
+    );
     assert!(
         temp_path.starts_with(temp_dir),
         "temp file should be in custom temp directory"
     );
-    let name = temp_path
-        .file_name()
-        .expect("file name")
-        .to_string_lossy();
+    let name = temp_path.file_name().expect("file name").to_string_lossy();
     assert_eq!(
         name, "file.txt.ABCDEF",
         "temp file should use filename only, not full subpath"
@@ -897,7 +894,6 @@ fn execute_with_temp_dir_format_in_custom_directory() {
         "temp file should be directly in temp_dir, not nested"
     );
 }
-
 
 #[test]
 fn execute_with_temp_dir_and_whole_file_mode() {
@@ -938,7 +934,6 @@ fn execute_with_temp_dir_and_whole_file_mode() {
     assert!(staging_files.is_empty());
 }
 
-
 #[test]
 fn temp_dir_option_round_trip_via_builder() {
     let options = LocalCopyOptions::builder()
@@ -978,7 +973,6 @@ fn temp_dir_option_does_not_affect_partial_mode() {
     );
 }
 
-
 #[test]
 fn execute_with_temp_dir_preserves_binary_content_exactly() {
     let temp = tempdir().expect("tempdir");
@@ -1011,7 +1005,6 @@ fn execute_with_temp_dir_preserves_binary_content_exactly() {
         "binary content must be preserved exactly"
     );
 }
-
 
 #[test]
 fn execute_with_temp_dir_second_run_skips_identical_files() {
@@ -1053,11 +1046,11 @@ fn execute_with_temp_dir_second_run_skips_identical_files() {
         .expect("second copy succeeds");
 
     assert_eq!(
-        summary2.files_copied(), 0,
+        summary2.files_copied(),
+        0,
         "identical file should be skipped on second run"
     );
 }
-
 
 #[test]
 fn execute_with_temp_dir_and_checksum_mode() {
@@ -1091,7 +1084,6 @@ fn execute_with_temp_dir_and_checksum_mode() {
     );
 }
 
-
 #[test]
 fn execute_with_temp_dir_unique_temp_names_across_files() {
     // Verify that multiple files in the same temp dir get distinct temp names,
@@ -1124,7 +1116,6 @@ fn execute_with_temp_dir_unique_suffix_per_file() {
         "different suffixes should get different temp paths"
     );
 }
-
 
 #[test]
 fn execute_with_temp_dir_and_backup() {
@@ -1171,7 +1162,6 @@ fn execute_with_temp_dir_and_backup() {
     );
 }
 
-
 #[test]
 fn execute_with_temp_dir_nested_source_uses_flat_staging() {
     // When copying nested directory structures with --temp-dir,
@@ -1215,7 +1205,14 @@ fn execute_with_temp_dir_nested_source_uses_flat_staging() {
         b"mid level"
     );
     assert_eq!(
-        fs::read(dest_root.join("source").join("a").join("b").join("deep.txt")).expect("read"),
+        fs::read(
+            dest_root
+                .join("source")
+                .join("a")
+                .join("b")
+                .join("deep.txt")
+        )
+        .expect("read"),
         b"deep level"
     );
 

--- a/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
+++ b/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
@@ -38,7 +38,10 @@ fn times_flag_preserves_mtime_on_copied_file() {
 
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
-    assert_eq!(dest_mtime, mtime, "mtime should be preserved when --times is set");
+    assert_eq!(
+        dest_mtime, mtime,
+        "mtime should be preserved when --times is set"
+    );
 }
 
 #[test]
@@ -72,7 +75,10 @@ fn times_flag_disabled_does_not_preserve_mtime() {
 
     // Destination mtime should NOT match the old source mtime
     // It should be close to "now" (the copy time)
-    assert_ne!(dest_mtime, old_mtime, "mtime should not be preserved when --times is disabled");
+    assert_ne!(
+        dest_mtime, old_mtime,
+        "mtime should not be preserved when --times is disabled"
+    );
 }
 
 #[test]
@@ -114,9 +120,12 @@ fn times_flag_preserves_mtime_on_multiple_files() {
     let dest_file2 = dest_root.join("source").join("file2.txt");
     let dest_file3 = dest_root.join("source").join("file3.txt");
 
-    let dest_mtime1 = FileTime::from_last_modification_time(&fs::metadata(&dest_file1).expect("file1 meta"));
-    let dest_mtime2 = FileTime::from_last_modification_time(&fs::metadata(&dest_file2).expect("file2 meta"));
-    let dest_mtime3 = FileTime::from_last_modification_time(&fs::metadata(&dest_file3).expect("file3 meta"));
+    let dest_mtime1 =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file1).expect("file1 meta"));
+    let dest_mtime2 =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file2).expect("file2 meta"));
+    let dest_mtime3 =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_file3).expect("file3 meta"));
 
     assert_eq!(dest_mtime1, mtime1, "file1 mtime should be preserved");
     assert_eq!(dest_mtime2, mtime2, "file2 mtime should be preserved");
@@ -202,8 +211,14 @@ fn atime_and_mtime_can_differ() {
         atime.unix_seconds(),
         "atime seconds should be preserved with --atimes"
     );
-    assert_eq!(dest_mtime, mtime, "mtime should be preserved as distinct value");
-    assert_ne!(dest_atime, dest_mtime, "atime and mtime should remain different");
+    assert_eq!(
+        dest_mtime, mtime,
+        "mtime should be preserved as distinct value"
+    );
+    assert_ne!(
+        dest_atime, dest_mtime,
+        "atime and mtime should remain different"
+    );
 }
 
 // Windows NTFS truncates nanoseconds to 100ns intervals.
@@ -234,8 +249,15 @@ fn subsecond_precision_is_preserved_full_nanoseconds() {
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
 
-    assert_eq!(dest_mtime, mtime, "nanosecond precision should be preserved");
-    assert_eq!(dest_mtime.nanoseconds(), 123_456_789, "nanoseconds component should match exactly");
+    assert_eq!(
+        dest_mtime, mtime,
+        "nanosecond precision should be preserved"
+    );
+    assert_eq!(
+        dest_mtime.nanoseconds(),
+        123_456_789,
+        "nanoseconds component should match exactly"
+    );
 }
 
 // Windows NTFS truncates nanoseconds to 100ns intervals.
@@ -300,10 +322,7 @@ fn subsecond_precision_round_trip() {
     let original_mtime = FileTime::from_unix_time(1_700_000_000, 987_654_321);
     set_file_mtime(&file1, original_mtime).expect("set file1 mtime");
 
-    let operands = vec![
-        file1.into_os_string(),
-        file2.clone().into_os_string(),
-    ];
+    let operands = vec![file1.into_os_string(), file2.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan1");
     plan.execute_with_options(
         LocalCopyExecution::Apply,
@@ -311,10 +330,7 @@ fn subsecond_precision_round_trip() {
     )
     .expect("first copy");
 
-    let operands = vec![
-        file2.into_os_string(),
-        file3.clone().into_os_string(),
-    ];
+    let operands = vec![file2.into_os_string(), file3.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan2");
     plan.execute_with_options(
         LocalCopyExecution::Apply,
@@ -322,7 +338,8 @@ fn subsecond_precision_round_trip() {
     )
     .expect("second copy");
 
-    let final_mtime = FileTime::from_last_modification_time(&fs::metadata(&file3).expect("file3 meta"));
+    let final_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&file3).expect("file3 meta"));
     assert_eq!(
         final_mtime, original_mtime,
         "nanosecond precision should be preserved through round trip"
@@ -350,9 +367,7 @@ fn times_flag_with_archive_mode() {
     // Simulate archive mode: times + permissions
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default()
-            .times(true)
-            .permissions(true),
+        LocalCopyOptions::default().times(true).permissions(true),
     )
     .expect("copy succeeds");
 
@@ -397,7 +412,10 @@ fn times_flag_on_directory() {
     let dest_metadata = fs::metadata(dest_dir.join("source_dir")).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
 
-    assert_eq!(dest_mtime, dir_mtime, "directory mtime should be preserved with --times");
+    assert_eq!(
+        dest_mtime, dir_mtime,
+        "directory mtime should be preserved with --times"
+    );
 }
 
 #[cfg(unix)]
@@ -463,7 +481,11 @@ fn skip_file_when_timestamps_match() {
         .expect("copy succeeds");
 
     // File should be skipped because size and mtime match
-    assert_eq!(summary.files_copied(), 0, "file should be skipped when timestamps match");
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "file should be skipped when timestamps match"
+    );
     assert_eq!(summary.regular_files_total(), 1);
 }
 
@@ -496,9 +518,14 @@ fn copy_file_when_timestamps_differ() {
         .expect("copy succeeds");
 
     // File should be copied because timestamps differ
-    assert_eq!(summary.files_copied(), 1, "file should be copied when timestamps differ");
+    assert_eq!(
+        summary.files_copied(),
+        1,
+        "file should be copied when timestamps differ"
+    );
 
-    let final_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
+    let final_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
     assert_eq!(final_mtime, source_mtime);
 }
 
@@ -579,7 +606,11 @@ fn modify_window_tolerates_small_differences() {
         .expect("copy succeeds");
 
     // File should be skipped because 0.5s difference is within 1s window
-    assert_eq!(summary.files_copied(), 0, "file should be skipped with modify_window tolerance");
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "file should be skipped with modify_window tolerance"
+    );
 }
 
 #[test]
@@ -606,8 +637,12 @@ fn unix_epoch_timestamp_preserved() {
     )
     .expect("copy succeeds");
 
-    let dest_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
-    assert_eq!(dest_mtime, epoch_time, "Unix epoch timestamp should be preserved");
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
+    assert_eq!(
+        dest_mtime, epoch_time,
+        "Unix epoch timestamp should be preserved"
+    );
 }
 
 // Windows NTFS truncates nanoseconds to 100ns intervals.
@@ -636,8 +671,12 @@ fn far_future_timestamp_preserved() {
     )
     .expect("copy succeeds");
 
-    let dest_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
-    assert_eq!(dest_mtime, future_time, "far future timestamp should be preserved");
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
+    assert_eq!(
+        dest_mtime, future_time,
+        "far future timestamp should be preserved"
+    );
 }
 
 // Windows NTFS truncates nanoseconds to 100ns intervals.
@@ -666,8 +705,12 @@ fn year_2038_boundary_timestamp_preserved() {
     )
     .expect("copy succeeds");
 
-    let dest_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
-    assert_eq!(dest_mtime, y2038_time, "Y2K38 boundary timestamp should be preserved");
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
+    assert_eq!(
+        dest_mtime, y2038_time,
+        "Y2K38 boundary timestamp should be preserved"
+    );
 }
 
 #[test]
@@ -694,8 +737,12 @@ fn post_2038_timestamp_preserved() {
     )
     .expect("copy succeeds");
 
-    let dest_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
-    assert_eq!(dest_mtime, post_2038_time, "post-Y2K38 timestamp should be preserved");
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
+    assert_eq!(
+        dest_mtime, post_2038_time,
+        "post-Y2K38 timestamp should be preserved"
+    );
 }
 
 #[test]
@@ -722,8 +769,12 @@ fn empty_file_timestamp_preserved() {
     )
     .expect("copy succeeds");
 
-    let dest_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
-    assert_eq!(dest_mtime, mtime, "empty file timestamp should be preserved");
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
+    assert_eq!(
+        dest_mtime, mtime,
+        "empty file timestamp should be preserved"
+    );
 }
 
 #[test]
@@ -751,8 +802,12 @@ fn large_file_timestamp_preserved() {
     )
     .expect("copy succeeds");
 
-    let dest_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
-    assert_eq!(dest_mtime, mtime, "large file timestamp should be preserved");
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
+    assert_eq!(
+        dest_mtime, mtime,
+        "large file timestamp should be preserved"
+    );
 }
 
 #[test]
@@ -778,9 +833,7 @@ fn times_with_checksum_and_matching_timestamps() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .times(true)
-                .checksum(true),
+            LocalCopyOptions::default().times(true).checksum(true),
         )
         .expect("copy succeeds");
 
@@ -813,9 +866,7 @@ fn times_with_update_flag() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .times(true)
-                .update(true),
+            LocalCopyOptions::default().times(true).update(true),
         )
         .expect("copy succeeds");
 
@@ -823,7 +874,8 @@ fn times_with_update_flag() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
 
-    let final_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
+    let final_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
     assert_eq!(final_mtime, newer_mtime);
 }
 
@@ -856,8 +908,12 @@ fn times_flag_in_dry_run_mode() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    let final_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
-    assert_eq!(final_mtime, original_dest_mtime, "dry run should not modify destination");
+    let final_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
+    assert_eq!(
+        final_mtime, original_dest_mtime,
+        "dry run should not modify destination"
+    );
     assert_eq!(fs::read(&destination).expect("read dest"), b"original");
 }
 
@@ -890,13 +946,28 @@ fn nested_directory_timestamps_preserved() {
     )
     .expect("copy succeeds");
 
-    let dest_root_mtime = FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source")).expect("root meta"));
-    let dest_level1_mtime = FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source").join("level1")).expect("level1 meta"));
-    let dest_level2_mtime = FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source").join("level1/level2")).expect("level2 meta"));
+    let dest_root_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(dest_root.join("source")).expect("root meta"),
+    );
+    let dest_level1_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(dest_root.join("source").join("level1")).expect("level1 meta"),
+    );
+    let dest_level2_mtime = FileTime::from_last_modification_time(
+        &fs::metadata(dest_root.join("source").join("level1/level2")).expect("level2 meta"),
+    );
 
-    assert_eq!(dest_root_mtime, root_mtime, "root directory mtime should be preserved");
-    assert_eq!(dest_level1_mtime, level1_mtime, "level1 directory mtime should be preserved");
-    assert_eq!(dest_level2_mtime, level2_mtime, "level2 directory mtime should be preserved");
+    assert_eq!(
+        dest_root_mtime, root_mtime,
+        "root directory mtime should be preserved"
+    );
+    assert_eq!(
+        dest_level1_mtime, level1_mtime,
+        "level1 directory mtime should be preserved"
+    );
+    assert_eq!(
+        dest_level2_mtime, level2_mtime,
+        "level2 directory mtime should be preserved"
+    );
 }
 
 #[test]
@@ -935,7 +1006,11 @@ fn incremental_sync_skips_unchanged_files() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 0, "unchanged files should be skipped");
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "unchanged files should be skipped"
+    );
     assert_eq!(summary.regular_files_total(), 5);
 }
 
@@ -988,7 +1063,11 @@ fn incremental_sync_updates_changed_files_only() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 2, "only changed files should be copied");
+    assert_eq!(
+        summary.files_copied(),
+        2,
+        "only changed files should be copied"
+    );
     assert_eq!(summary.regular_files_total(), 5);
 
     for i in 1..=2 {
@@ -996,7 +1075,8 @@ fn incremental_sync_updates_changed_files_only() {
         let content = fs::read(&dest_file).expect("read changed file");
         assert_eq!(content, format!("new content {i}").as_bytes());
 
-        let final_mtime = FileTime::from_last_modification_time(&fs::metadata(&dest_file).expect("meta"));
+        let final_mtime =
+            FileTime::from_last_modification_time(&fs::metadata(&dest_file).expect("meta"));
         assert_eq!(final_mtime, new_mtime);
     }
 }

--- a/crates/engine/src/local_copy/tests/execute_update.rs
+++ b/crates/engine/src/local_copy/tests/execute_update.rs
@@ -43,10 +43,7 @@ fn update_skips_file_when_destination_is_newer() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"dest content"
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), b"dest content");
 }
 
 #[test]
@@ -448,9 +445,8 @@ fn update_combined_with_times_preserves_mtime() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata")
-    );
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
     // Note: Some filesystems don't preserve full nanosecond precision
     assert_eq!(dest_mtime.unix_seconds(), source_mtime.unix_seconds());
 }
@@ -712,7 +708,11 @@ fn update_matches_upstream_rsync_semantics() {
     assert_eq!(summary.files_copied(), 2, "should copy case3 and case4");
     // Case1 is skipped because dest is newer (counted in skipped_newer)
     // Case2 is skipped because dest mtime == source mtime (also counted in skipped_newer with --update flag)
-    assert_eq!(summary.regular_files_skipped_newer(), 1, "should skip case1 (newer)");
+    assert_eq!(
+        summary.regular_files_skipped_newer(),
+        1,
+        "should skip case1 (newer)"
+    );
     // Note: case2 with equal mtime + same size is skipped, but may not increment skipped_newer counter
 
     assert_eq!(

--- a/crates/engine/src/local_copy/tests/execute_usermap_groupmap.rs
+++ b/crates/engine/src/local_copy/tests/execute_usermap_groupmap.rs
@@ -12,8 +12,8 @@
 #[cfg(unix)]
 #[test]
 fn usermap_remaps_numeric_uid() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root (cannot set arbitrary UIDs)
     if rustix::process::geteuid().as_raw() != 0 {
@@ -61,8 +61,8 @@ fn usermap_remaps_numeric_uid() {
 #[cfg(unix)]
 #[test]
 fn usermap_wildcard_maps_all_users() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -110,8 +110,8 @@ fn usermap_wildcard_maps_all_users() {
 #[cfg(unix)]
 #[test]
 fn usermap_multiple_rules_first_match_wins() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -161,8 +161,8 @@ fn usermap_multiple_rules_first_match_wins() {
 #[cfg(unix)]
 #[test]
 fn usermap_range_mapping() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -211,8 +211,8 @@ fn usermap_range_mapping() {
 #[cfg(unix)]
 #[test]
 fn usermap_no_match_preserves_original_uid() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -261,8 +261,8 @@ fn usermap_no_match_preserves_original_uid() {
 #[cfg(unix)]
 #[test]
 fn groupmap_remaps_numeric_gid() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -310,8 +310,8 @@ fn groupmap_remaps_numeric_gid() {
 #[cfg(unix)]
 #[test]
 fn groupmap_wildcard_maps_all_groups() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -359,8 +359,8 @@ fn groupmap_wildcard_maps_all_groups() {
 #[cfg(unix)]
 #[test]
 fn groupmap_multiple_rules() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -434,8 +434,8 @@ fn groupmap_multiple_rules() {
 #[cfg(unix)]
 #[test]
 fn groupmap_range_mapping() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -484,8 +484,8 @@ fn groupmap_range_mapping() {
 #[cfg(unix)]
 #[test]
 fn usermap_and_groupmap_work_together() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -536,8 +536,8 @@ fn usermap_and_groupmap_work_together() {
 #[cfg(unix)]
 #[test]
 fn usermap_and_groupmap_with_wildcards() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -589,8 +589,8 @@ fn usermap_and_groupmap_with_wildcards() {
 #[cfg(unix)]
 #[test]
 fn usermap_requires_owner_preservation_flag() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -641,8 +641,8 @@ fn usermap_requires_owner_preservation_flag() {
 #[cfg(unix)]
 #[test]
 fn groupmap_requires_group_preservation_flag() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -693,8 +693,8 @@ fn groupmap_requires_group_preservation_flag() {
 #[cfg(unix)]
 #[test]
 fn usermap_applies_to_directory_tree() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -748,16 +748,25 @@ fn usermap_applies_to_directory_tree() {
     let dest_file2 = dest_dir.join("source").join("subdir").join("file2.txt");
     let dest_subdir = dest_dir.join("source").join("subdir");
 
-    assert_eq!(fs::metadata(&dest_file1).expect("file1 metadata").uid(), 2000);
-    assert_eq!(fs::metadata(&dest_file2).expect("file2 metadata").uid(), 2000);
-    assert_eq!(fs::metadata(&dest_subdir).expect("subdir metadata").uid(), 2000);
+    assert_eq!(
+        fs::metadata(&dest_file1).expect("file1 metadata").uid(),
+        2000
+    );
+    assert_eq!(
+        fs::metadata(&dest_file2).expect("file2 metadata").uid(),
+        2000
+    );
+    assert_eq!(
+        fs::metadata(&dest_subdir).expect("subdir metadata").uid(),
+        2000
+    );
 }
 
 #[cfg(unix)]
 #[test]
 fn groupmap_applies_to_directory_tree() {
-    use std::os::unix::fs::MetadataExt;
     use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::MetadataExt;
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {
@@ -811,17 +820,26 @@ fn groupmap_applies_to_directory_tree() {
     let dest_file2 = dest_dir.join("source").join("subdir").join("file2.txt");
     let dest_subdir = dest_dir.join("source").join("subdir");
 
-    assert_eq!(fs::metadata(&dest_file1).expect("file1 metadata").gid(), 3000);
-    assert_eq!(fs::metadata(&dest_file2).expect("file2 metadata").gid(), 3000);
-    assert_eq!(fs::metadata(&dest_subdir).expect("subdir metadata").gid(), 3000);
+    assert_eq!(
+        fs::metadata(&dest_file1).expect("file1 metadata").gid(),
+        3000
+    );
+    assert_eq!(
+        fs::metadata(&dest_file2).expect("file2 metadata").gid(),
+        3000
+    );
+    assert_eq!(
+        fs::metadata(&dest_subdir).expect("subdir metadata").gid(),
+        3000
+    );
 }
 
 #[cfg(unix)]
 #[test]
 fn usermap_works_with_permissions_and_times() {
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
-    use rustix::fs::{AtFlags, chownat};
     use filetime::{FileTime, set_file_times};
+    use rustix::fs::{AtFlags, chownat};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     // Skip test if not running as root
     if rustix::process::geteuid().as_raw() != 0 {

--- a/crates/engine/src/local_copy/tests/execute_whole_file.rs
+++ b/crates/engine/src/local_copy/tests/execute_whole_file.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn execute_whole_file_transfers_complete_file_without_delta() {
     let temp = tempdir().expect("tempdir");
@@ -28,7 +27,11 @@ fn execute_whole_file_transfers_complete_file_without_delta() {
 
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), source_content.len() as u64);
-    assert_eq!(summary.matched_bytes(), 0, "whole file should not match any blocks");
+    assert_eq!(
+        summary.matched_bytes(),
+        0,
+        "whole file should not match any blocks"
+    );
     assert_eq!(
         fs::read(&destination).expect("read destination"),
         source_content
@@ -107,7 +110,11 @@ fn execute_whole_file_transfers_large_file_completely() {
 
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), 1024 * 1024);
-    assert_eq!(summary.matched_bytes(), 0, "large file should not use basis");
+    assert_eq!(
+        summary.matched_bytes(),
+        0,
+        "large file should not use basis"
+    );
     assert_eq!(
         fs::read(&destination).expect("read destination"),
         large_content
@@ -172,12 +179,18 @@ fn execute_whole_file_in_recursive_directory_copy() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().whole_file(true).ignore_times(true),
+            LocalCopyOptions::default()
+                .whole_file(true)
+                .ignore_times(true),
         )
         .expect("recursive whole file copy succeeds");
 
     assert!(summary.files_copied() >= 3);
-    assert_eq!(summary.matched_bytes(), 0, "recursive copy should not use delta");
+    assert_eq!(
+        summary.matched_bytes(),
+        0,
+        "recursive copy should not use delta"
+    );
 
     assert_eq!(
         fs::read(dest_root.join("source").join("file1.txt")).expect("read file1"),
@@ -313,10 +326,7 @@ fn execute_whole_file_with_compression() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), content.len() as u64);
     assert_eq!(summary.matched_bytes(), 0);
-    assert!(
-        summary.compression_used(),
-        "compression should be used"
-    );
+    assert!(summary.compression_used(), "compression should be used");
     assert_eq!(fs::read(&destination).expect("read destination"), content);
 }
 
@@ -341,9 +351,7 @@ fn execute_whole_file_preserves_timestamps() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .whole_file(true)
-                .times(true),
+            LocalCopyOptions::default().whole_file(true).times(true),
         )
         .expect("copy with times succeeds");
 
@@ -374,9 +382,7 @@ fn execute_whole_file_with_inplace() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .whole_file(true)
-                .inplace(true),
+            LocalCopyOptions::default().whole_file(true).inplace(true),
         )
         .expect("inplace whole file copy succeeds");
 
@@ -544,11 +550,25 @@ fn execute_whole_file_vs_delta_transfer_comparison() {
         )
         .expect("delta copy succeeds");
 
-    assert_eq!(summary_whole.matched_bytes(), 0, "whole file should not match");
-    assert_eq!(summary_whole.bytes_copied(), source_len, "whole file copies everything");
+    assert_eq!(
+        summary_whole.matched_bytes(),
+        0,
+        "whole file should not match"
+    );
+    assert_eq!(
+        summary_whole.bytes_copied(),
+        source_len,
+        "whole file copies everything"
+    );
 
-    assert!(summary_delta.matched_bytes() > 0, "delta should match common blocks");
-    assert!(summary_delta.bytes_copied() < source_len, "delta copies less data");
+    assert!(
+        summary_delta.matched_bytes() > 0,
+        "delta should match common blocks"
+    );
+    assert!(
+        summary_delta.bytes_copied() < source_len,
+        "delta copies less data"
+    );
 
     assert_eq!(
         fs::read(&dest_whole).expect("read dest whole"),
@@ -622,7 +642,6 @@ fn delta_identical_basis_matches_trailing_partial_block() {
     );
 }
 
-
 #[test]
 fn whole_file_auto_defaults_to_whole_for_local_copy() {
     let temp = tempdir().expect("tempdir");
@@ -643,8 +662,14 @@ fn whole_file_auto_defaults_to_whole_for_local_copy() {
 
     // Default options: whole_file is None (auto-detect)
     let options = LocalCopyOptions::default();
-    assert!(options.whole_file_raw().is_none(), "default should be auto (None)");
-    assert!(options.whole_file_enabled(), "auto should resolve to true for local copy");
+    assert!(
+        options.whole_file_raw().is_none(),
+        "default should be auto (None)"
+    );
+    assert!(
+        options.whole_file_enabled(),
+        "auto should resolve to true for local copy"
+    );
 
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -652,7 +677,11 @@ fn whole_file_auto_defaults_to_whole_for_local_copy() {
 
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), content.len() as u64);
-    assert_eq!(summary.matched_bytes(), 0, "auto mode should use whole file for local");
+    assert_eq!(
+        summary.matched_bytes(),
+        0,
+        "auto mode should use whole file for local"
+    );
 }
 
 #[test]
@@ -748,9 +777,7 @@ fn whole_file_builder_sets_some_false() {
 
 #[test]
 fn whole_file_builder_default_is_none() {
-    let options = LocalCopyOptions::builder()
-        .build()
-        .expect("valid options");
+    let options = LocalCopyOptions::builder().build().expect("valid options");
     assert!(options.whole_file_raw().is_none());
     // Auto mode without batch writer defaults to whole-file
     assert!(options.whole_file_enabled());
@@ -808,8 +835,5 @@ fn execute_no_whole_file_explicit_forces_delta_even_for_local() {
         summary.bytes_copied() < source_len,
         "delta should transfer less than full size"
     );
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        source_content
-    );
+    assert_eq!(fs::read(&destination).expect("read dest"), source_content);
 }

--- a/crates/engine/src/local_copy/tests/execute_xattrs.rs
+++ b/crates/engine/src/local_copy/tests/execute_xattrs.rs
@@ -24,7 +24,6 @@ mod xattr_tests {
         }
     }
 
-
     #[test]
     fn execute_copies_file_with_single_xattr() {
         let temp = tempdir().expect("tempdir");
@@ -87,9 +86,11 @@ mod xattr_tests {
         assert_eq!(fs::read(&destination).expect("read dest"), b"no xattr copy");
 
         let dest_xattr = xattr::get(&destination, "user.test_attr").expect("read xattr");
-        assert!(dest_xattr.is_none(), "xattr should not be copied without --xattrs");
+        assert!(
+            dest_xattr.is_none(),
+            "xattr should not be copied without --xattrs"
+        );
     }
-
 
     #[test]
     fn execute_copies_multiple_xattrs_on_same_file() {
@@ -125,23 +126,33 @@ mod xattr_tests {
         assert_eq!(summary.files_copied(), 1);
 
         assert_eq!(
-            xattr::get(&destination, "user.attr1").expect("read").expect("present"),
+            xattr::get(&destination, "user.attr1")
+                .expect("read")
+                .expect("present"),
             b"value1"
         );
         assert_eq!(
-            xattr::get(&destination, "user.attr2").expect("read").expect("present"),
+            xattr::get(&destination, "user.attr2")
+                .expect("read")
+                .expect("present"),
             b"value2"
         );
         assert_eq!(
-            xattr::get(&destination, "user.attr3").expect("read").expect("present"),
+            xattr::get(&destination, "user.attr3")
+                .expect("read")
+                .expect("present"),
             b"value3"
         );
         assert_eq!(
-            xattr::get(&destination, "user.metadata.author").expect("read").expect("present"),
+            xattr::get(&destination, "user.metadata.author")
+                .expect("read")
+                .expect("present"),
             b"test_user"
         );
         assert_eq!(
-            xattr::get(&destination, "user.metadata.version").expect("read").expect("present"),
+            xattr::get(&destination, "user.metadata.version")
+                .expect("read")
+                .expect("present"),
             b"1.0"
         );
     }
@@ -188,7 +199,6 @@ mod xattr_tests {
             assert_eq!(copied, expected_value.as_bytes());
         }
     }
-
 
     #[test]
     fn execute_copies_large_xattr_value() {
@@ -301,7 +311,6 @@ mod xattr_tests {
         assert!(copied.is_empty());
     }
 
-
     #[test]
     fn execute_copies_xattr_on_directory() {
         let temp = tempdir().expect("tempdir");
@@ -351,7 +360,8 @@ mod xattr_tests {
         }
 
         xattr::set(&source_root, "user.root_attr", b"root").expect("set root xattr");
-        xattr::set(source_root.join("level1"), "user.level1_attr", b"level1").expect("set level1 xattr");
+        xattr::set(source_root.join("level1"), "user.level1_attr", b"level1")
+            .expect("set level1 xattr");
         xattr::set(&nested, "user.level2_attr", b"level2").expect("set level2 xattr");
 
         let dest_root = temp.path().join("dest");
@@ -384,9 +394,12 @@ mod xattr_tests {
             b"level1"
         );
         assert_eq!(
-            xattr::get(dest_root.join("source").join("level1").join("level2"), "user.level2_attr")
-                .expect("read")
-                .expect("present"),
+            xattr::get(
+                dest_root.join("source").join("level1").join("level2"),
+                "user.level2_attr"
+            )
+            .expect("read")
+            .expect("present"),
             b"level2"
         );
     }
@@ -404,8 +417,12 @@ mod xattr_tests {
         }
 
         xattr::set(&source_root, "user.dir_metadata", b"dir_value").expect("set dir xattr");
-        xattr::set(source_root.join("file.txt"), "user.file_metadata", b"file_value")
-            .expect("set file xattr");
+        xattr::set(
+            source_root.join("file.txt"),
+            "user.file_metadata",
+            b"file_value",
+        )
+        .expect("set file xattr");
 
         let dest_root = temp.path().join("dest");
         let operands = vec![
@@ -430,13 +447,15 @@ mod xattr_tests {
             b"dir_value"
         );
         assert_eq!(
-            xattr::get(dest_root.join("source").join("file.txt"), "user.file_metadata")
-                .expect("read")
-                .expect("present"),
+            xattr::get(
+                dest_root.join("source").join("file.txt"),
+                "user.file_metadata"
+            )
+            .expect("read")
+            .expect("present"),
             b"file_value"
         );
     }
-
 
     #[test]
     fn execute_updates_existing_xattr_value() {
@@ -567,7 +586,6 @@ mod xattr_tests {
         );
     }
 
-
     #[test]
     fn execute_xattr_filter_excludes_specific_attrs() {
         let temp = tempdir().expect("tempdir");
@@ -678,7 +696,6 @@ mod xattr_tests {
         );
     }
 
-
     #[test]
     fn execute_dry_run_does_not_copy_xattrs() {
         let temp = tempdir().expect("tempdir");
@@ -709,7 +726,6 @@ mod xattr_tests {
         assert_eq!(summary.files_copied(), 1);
         assert!(!destination.exists(), "dry run should not create file");
     }
-
 
     #[test]
     fn execute_handles_special_characters_in_xattr_name() {
@@ -825,7 +841,10 @@ mod xattr_tests {
 
         assert_eq!(summary.files_copied(), 1);
 
-        assert_eq!(fs::read(&destination).expect("read dest"), b"updated content");
+        assert_eq!(
+            fs::read(&destination).expect("read dest"),
+            b"updated content"
+        );
         let copied = xattr::get(&destination, "user.preserved")
             .expect("read xattr")
             .expect("xattr present");
@@ -890,7 +909,6 @@ mod xattr_tests {
         );
     }
 
-
     #[cfg(unix)]
     #[test]
     fn execute_preserves_xattrs_with_symlinks() {
@@ -920,9 +938,7 @@ mod xattr_tests {
         ];
         let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-        let options = LocalCopyOptions::default()
-            .xattrs(true)
-            .links(true);
+        let options = LocalCopyOptions::default().xattrs(true).links(true);
 
         let summary = plan
             .execute_with_options(LocalCopyExecution::Apply, options)

--- a/crates/engine/src/local_copy/tests/execute_zero_length.rs
+++ b/crates/engine/src/local_copy/tests/execute_zero_length.rs
@@ -32,8 +32,16 @@ fn execute_empty_file_basic_transfer() {
 
     assert_eq!(summary.files_copied(), 1, "empty file should be copied");
     assert!(destination.exists(), "destination should exist");
-    assert_eq!(fs::read(&destination).expect("read dest"), b"", "destination should be empty");
-    assert_eq!(fs::metadata(&destination).expect("metadata").len(), 0, "file size should be 0");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"",
+        "destination should be empty"
+    );
+    assert_eq!(
+        fs::metadata(&destination).expect("metadata").len(),
+        0,
+        "file size should be 0"
+    );
 }
 
 #[test]
@@ -56,7 +64,11 @@ fn execute_empty_file_replaces_nonempty_destination() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"", "destination should now be empty");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"",
+        "destination should now be empty"
+    );
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 0);
 }
 
@@ -78,8 +90,15 @@ fn execute_empty_file_dry_run_does_not_create_file() {
         .execute_with_options(LocalCopyExecution::DryRun, LocalCopyOptions::default())
         .expect("dry run succeeds");
 
-    assert_eq!(summary.files_copied(), 1, "dry run should report file would be copied");
-    assert!(!destination.exists(), "dry run should not create destination");
+    assert_eq!(
+        summary.files_copied(),
+        1,
+        "dry run should report file would be copied"
+    );
+    assert!(
+        !destination.exists(),
+        "dry run should not create destination"
+    );
 }
 
 #[cfg(unix)]
@@ -111,8 +130,12 @@ fn execute_empty_file_preserves_permissions() {
     let dest_mode = fs::metadata(&destination)
         .expect("dest metadata")
         .permissions()
-        .mode() & 0o777;
-    assert_eq!(dest_mode, 0o600, "permissions should be preserved for empty file");
+        .mode()
+        & 0o777;
+    assert_eq!(
+        dest_mode, 0o600,
+        "permissions should be preserved for empty file"
+    );
 }
 
 #[test]
@@ -140,11 +163,13 @@ fn execute_empty_file_preserves_timestamp() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    let dest_mtime = FileTime::from_last_modification_time(
-        &fs::metadata(&destination).expect("dest metadata")
+    let dest_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
+    assert_eq!(
+        dest_mtime.unix_seconds(),
+        source_mtime.unix_seconds(),
+        "timestamp should be preserved for empty file"
     );
-    assert_eq!(dest_mtime.unix_seconds(), source_mtime.unix_seconds(),
-        "timestamp should be preserved for empty file");
 }
 
 #[cfg(unix)]
@@ -171,9 +196,7 @@ fn execute_empty_file_preserves_both_permissions_and_timestamp() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .permissions(true)
-                .times(true),
+            LocalCopyOptions::default().permissions(true).times(true),
         )
         .expect("copy succeeds");
 
@@ -206,7 +229,8 @@ fn execute_empty_file_delta_transfer_from_empty() {
 
     // Set different mtimes to force delta evaluation
     set_file_mtime(&source, FileTime::from_unix_time(2_000_000_000, 0)).expect("set source mtime");
-    set_file_mtime(&destination, FileTime::from_unix_time(1_000_000_000, 0)).expect("set dest mtime");
+    set_file_mtime(&destination, FileTime::from_unix_time(1_000_000_000, 0))
+        .expect("set dest mtime");
 
     let operands = vec![
         source.into_os_string(),
@@ -222,8 +246,16 @@ fn execute_empty_file_delta_transfer_from_empty() {
         .expect("delta copy succeeds");
 
     // Delta transfer of empty to empty should be trivial
-    assert_eq!(summary.files_copied(), 1, "file should be counted as copied");
-    assert_eq!(summary.bytes_copied(), 0, "no data bytes should be transferred");
+    assert_eq!(
+        summary.files_copied(),
+        1,
+        "file should be counted as copied"
+    );
+    assert_eq!(
+        summary.bytes_copied(),
+        0,
+        "no data bytes should be transferred"
+    );
     assert_eq!(summary.matched_bytes(), 0, "no bytes should be matched");
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 0);
 }
@@ -238,7 +270,8 @@ fn execute_empty_file_delta_transfer_from_nonempty() {
     fs::write(&destination, b"old content that will be removed").expect("write dest");
 
     set_file_mtime(&source, FileTime::from_unix_time(2_000_000_000, 0)).expect("set source mtime");
-    set_file_mtime(&destination, FileTime::from_unix_time(1_000_000_000, 0)).expect("set dest mtime");
+    set_file_mtime(&destination, FileTime::from_unix_time(1_000_000_000, 0))
+        .expect("set dest mtime");
 
     let operands = vec![
         source.into_os_string(),
@@ -254,7 +287,11 @@ fn execute_empty_file_delta_transfer_from_nonempty() {
         .expect("delta copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"", "destination should be truncated to empty");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"",
+        "destination should be truncated to empty"
+    );
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 0);
 }
 
@@ -268,7 +305,8 @@ fn execute_empty_file_delta_transfer_to_nonempty() {
     fs::write(&destination, b"").expect("write empty dest");
 
     set_file_mtime(&source, FileTime::from_unix_time(2_000_000_000, 0)).expect("set source mtime");
-    set_file_mtime(&destination, FileTime::from_unix_time(1_000_000_000, 0)).expect("set dest mtime");
+    set_file_mtime(&destination, FileTime::from_unix_time(1_000_000_000, 0))
+        .expect("set dest mtime");
 
     let operands = vec![
         source.into_os_string(),
@@ -313,7 +351,11 @@ fn execute_multiple_empty_files_recursive() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 3, "all three empty files should be copied");
+    assert_eq!(
+        summary.files_copied(),
+        3,
+        "all three empty files should be copied"
+    );
     assert!(dest_root.join("empty1.txt").exists());
     assert!(dest_root.join("empty2.txt").exists());
     assert!(dest_root.join("empty3.txt").exists());
@@ -352,10 +394,19 @@ fn execute_mixed_empty_and_nonempty_files() {
     assert_eq!(summary.files_copied(), 4, "all files should be copied");
 
     assert_eq!(fs::read(dest_root.join("empty.txt")).expect("read"), b"");
-    assert_eq!(fs::read(dest_root.join("another_empty.txt")).expect("read"), b"");
+    assert_eq!(
+        fs::read(dest_root.join("another_empty.txt")).expect("read"),
+        b""
+    );
 
-    assert_eq!(fs::read(dest_root.join("content.txt")).expect("read"), b"has content");
-    assert_eq!(fs::read(dest_root.join("more_content.txt")).expect("read"), b"more data");
+    assert_eq!(
+        fs::read(dest_root.join("content.txt")).expect("read"),
+        b"has content"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("more_content.txt")).expect("read"),
+        b"more data"
+    );
 }
 
 #[test]
@@ -388,9 +439,18 @@ fn execute_nested_directories_with_empty_files() {
     assert!(dest_root.join("root_empty.txt").exists());
     assert!(dest_root.join("level1/l1_empty.txt").exists());
     assert!(dest_root.join("level1/level2/l2_empty.txt").exists());
-    assert_eq!(fs::read(dest_root.join("root_empty.txt")).expect("read"), b"");
-    assert_eq!(fs::read(dest_root.join("level1/l1_empty.txt")).expect("read"), b"");
-    assert_eq!(fs::read(dest_root.join("level1/level2/l2_empty.txt")).expect("read"), b"");
+    assert_eq!(
+        fs::read(dest_root.join("root_empty.txt")).expect("read"),
+        b""
+    );
+    assert_eq!(
+        fs::read(dest_root.join("level1/l1_empty.txt")).expect("read"),
+        b""
+    );
+    assert_eq!(
+        fs::read(dest_root.join("level1/level2/l2_empty.txt")).expect("read"),
+        b""
+    );
 }
 
 #[test]
@@ -416,14 +476,16 @@ fn execute_empty_file_with_checksum_mode() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .checksum(true)
-                .times(true),
+            LocalCopyOptions::default().checksum(true).times(true),
         )
         .expect("copy succeeds");
 
     // Checksum of two empty files should match, so file should be skipped
-    assert_eq!(summary.files_copied(), 0, "identical empty files should be skipped in checksum mode");
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "identical empty files should be skipped in checksum mode"
+    );
     assert_eq!(summary.regular_files_matched(), 1);
 }
 
@@ -438,7 +500,8 @@ fn execute_empty_file_with_update_flag() {
 
     // Source is newer
     set_file_mtime(&source, FileTime::from_unix_time(2_000_000_000, 0)).expect("set source time");
-    set_file_mtime(&destination, FileTime::from_unix_time(1_000_000_000, 0)).expect("set dest time");
+    set_file_mtime(&destination, FileTime::from_unix_time(1_000_000_000, 0))
+        .expect("set dest time");
 
     let operands = vec![
         source.into_os_string(),
@@ -469,7 +532,8 @@ fn execute_empty_file_update_skips_when_dest_newer() {
 
     // Destination is newer
     set_file_mtime(&source, FileTime::from_unix_time(1_000_000_000, 0)).expect("set source time");
-    set_file_mtime(&destination, FileTime::from_unix_time(2_000_000_000, 0)).expect("set dest time");
+    set_file_mtime(&destination, FileTime::from_unix_time(2_000_000_000, 0))
+        .expect("set dest time");
 
     let operands = vec![
         source.into_os_string(),
@@ -512,7 +576,11 @@ fn execute_empty_file_with_inplace() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), b"", "destination should be truncated in-place");
+    assert_eq!(
+        fs::read(&destination).expect("read dest"),
+        b"",
+        "destination should be truncated in-place"
+    );
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 0);
 }
 
@@ -544,10 +612,11 @@ fn execute_empty_file_with_temp_dir() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"");
 
     // Verify no temp files left behind
-    let staging_files: Vec<_> = fs::read_dir(&temp_dir)
-        .expect("read temp dir")
-        .collect();
-    assert!(staging_files.is_empty(), "no temp files should remain after empty file transfer");
+    let staging_files: Vec<_> = fs::read_dir(&temp_dir).expect("read temp dir").collect();
+    assert!(
+        staging_files.is_empty(),
+        "no temp files should remain after empty file transfer"
+    );
 }
 
 #[cfg(unix)]
@@ -582,7 +651,8 @@ fn execute_empty_file_preserves_permissions_with_chmod() {
     let dest_mode = fs::metadata(&destination)
         .expect("dest metadata")
         .permissions()
-        .mode() & 0o777;
+        .mode()
+        & 0o777;
 
     // 0o640 from the source plus the execute bits `+x` adds. `+x` names no
     // who-class, so upstream masks the implied bits with the umask
@@ -616,7 +686,11 @@ fn execute_empty_file_with_bytes_transferred_counter() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert_eq!(summary.bytes_copied(), 0, "zero bytes should be transferred for empty file");
+    assert_eq!(
+        summary.bytes_copied(),
+        0,
+        "zero bytes should be transferred for empty file"
+    );
     assert_eq!(summary.regular_files_total(), 1);
 }
 
@@ -648,7 +722,11 @@ fn execute_empty_file_to_empty_file_skipped_with_times() {
         .expect("copy succeeds");
 
     // With times preservation and identical timestamps, should skip
-    assert_eq!(summary.files_copied(), 0, "identical empty files should be skipped");
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "identical empty files should be skipped"
+    );
     assert_eq!(summary.regular_files_matched(), 1);
 }
 
@@ -740,7 +818,11 @@ fn execute_empty_file_collect_events() {
     assert_eq!(records.len(), 1, "should have one record for empty file");
     let record = &records[0];
     assert_eq!(record.action(), &LocalCopyAction::DataCopied);
-    assert_eq!(record.bytes_transferred(), 0, "record should show 0 bytes transferred");
+    assert_eq!(
+        record.bytes_transferred(),
+        0,
+        "record should show 0 bytes transferred"
+    );
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/executor_file_operations.rs
+++ b/crates/engine/src/local_copy/tests/executor_file_operations.rs
@@ -30,13 +30,7 @@ mod file_operations_tests {
         let dest_root = temp.path().to_path_buf();
         let dest = dest_root.join("file.txt");
 
-        let backup = compute_backup_path(
-            &dest_root,
-            &dest,
-            None,
-            None,
-            OsStr::new("~"),
-        );
+        let backup = compute_backup_path(&dest_root, &dest, None, None, OsStr::new("~"));
 
         assert_eq!(backup, dest_root.join("file.txt~"));
     }
@@ -48,13 +42,8 @@ mod file_operations_tests {
         let dest = dest_root.join("file.txt");
         let backup_dir = temp.path().join("backups");
 
-        let backup = compute_backup_path(
-            &dest_root,
-            &dest,
-            None,
-            Some(&backup_dir),
-            OsStr::new("~"),
-        );
+        let backup =
+            compute_backup_path(&dest_root, &dest, None, Some(&backup_dir), OsStr::new("~"));
 
         assert_eq!(backup, backup_dir.join("file.txt~"));
     }
@@ -83,13 +72,7 @@ mod file_operations_tests {
         let dest_root = temp.path().to_path_buf();
         let dest = dest_root.join("file.txt");
 
-        let backup = compute_backup_path(
-            &dest_root,
-            &dest,
-            None,
-            None,
-            OsStr::new(""),
-        );
+        let backup = compute_backup_path(&dest_root, &dest, None, None, OsStr::new(""));
 
         assert_eq!(backup, dest_root.join("file.txt"));
     }
@@ -103,7 +86,8 @@ mod file_operations_tests {
         fs::write(&source, b"original content").expect("write");
 
         let metadata = fs::metadata(&source).expect("metadata");
-        let result = copy_entry_to_backup(&source, &backup, metadata.file_type(), true, true, false);
+        let result =
+            copy_entry_to_backup(&source, &backup, metadata.file_type(), true, true, false);
 
         assert!(result.is_ok());
         assert!(backup.exists());
@@ -128,7 +112,8 @@ mod file_operations_tests {
         std::os::windows::fs::symlink_file(&target, &symlink).expect("symlink");
 
         let metadata = fs::symlink_metadata(&symlink).expect("metadata");
-        let result = copy_entry_to_backup(&symlink, &backup, metadata.file_type(), true, true, false);
+        let result =
+            copy_entry_to_backup(&symlink, &backup, metadata.file_type(), true, true, false);
 
         assert!(result.is_ok());
         assert!(backup.exists());
@@ -148,8 +133,14 @@ mod file_operations_tests {
         fs::write(source_dir.join("file.txt"), b"content").expect("write");
 
         let metadata = fs::metadata(&source_dir).expect("metadata");
-        let result =
-            copy_entry_to_backup(&source_dir, &backup, metadata.file_type(), true, true, false);
+        let result = copy_entry_to_backup(
+            &source_dir,
+            &backup,
+            metadata.file_type(),
+            true,
+            true,
+            false,
+        );
 
         // Should succeed but not copy directory
         assert!(result.is_ok());
@@ -240,7 +231,8 @@ mod file_operations_tests {
         fs::write(&dummy_file, b"dummy").expect("write");
         let metadata = fs::metadata(&dummy_file).expect("metadata");
 
-        let result = copy_entry_to_backup(&source, &backup, metadata.file_type(), true, true, false);
+        let result =
+            copy_entry_to_backup(&source, &backup, metadata.file_type(), true, true, false);
 
         // Should fail because source doesn't exist
         assert!(result.is_err());
@@ -302,13 +294,7 @@ mod file_operations_tests {
         let dest_root = temp.path().join("root");
         let dest = temp.path().join("outside").join("file.txt");
 
-        let backup = compute_backup_path(
-            &dest_root,
-            &dest,
-            None,
-            None,
-            OsStr::new("~"),
-        );
+        let backup = compute_backup_path(&dest_root, &dest, None, None, OsStr::new("~"));
 
         // Should use dest's parent when dest is not under dest_root
         assert_eq!(backup, temp.path().join("outside").join("file.txt~"));
@@ -330,7 +316,10 @@ mod file_operations_tests {
         );
 
         // dest_root.join("../backups") should work
-        let expected = dest_root.join("../backups").join("subdir").join("file.txt~");
+        let expected = dest_root
+            .join("../backups")
+            .join("subdir")
+            .join("file.txt~");
         assert_eq!(backup, expected);
     }
 
@@ -344,13 +333,11 @@ mod file_operations_tests {
         fs::write(&backup, b"old backup").expect("write old backup");
 
         let metadata = fs::metadata(&source).expect("metadata");
-        let result = copy_entry_to_backup(&source, &backup, metadata.file_type(), true, true, false);
+        let result =
+            copy_entry_to_backup(&source, &backup, metadata.file_type(), true, true, false);
 
         assert!(result.is_ok());
-        assert_eq!(
-            fs::read_to_string(&backup).expect("read"),
-            "new content"
-        );
+        assert_eq!(fs::read_to_string(&backup).expect("read"), "new content");
     }
 
     #[test]
@@ -367,7 +354,8 @@ mod file_operations_tests {
         std::os::windows::fs::symlink_file(&target, &symlink).expect("symlink");
 
         let metadata = fs::symlink_metadata(&symlink).expect("metadata");
-        let result = copy_entry_to_backup(&symlink, &backup, metadata.file_type(), true, true, false);
+        let result =
+            copy_entry_to_backup(&symlink, &backup, metadata.file_type(), true, true, false);
 
         assert!(result.is_ok());
 
@@ -376,9 +364,6 @@ mod file_operations_tests {
         assert!(backup_meta.is_symlink());
 
         // The target should be the same (even though it doesn't exist)
-        assert_eq!(
-            fs::read_link(&backup).expect("read backup link"),
-            target
-        );
+        assert_eq!(fs::read_link(&backup).expect("read backup link"), target);
     }
 }

--- a/crates/engine/src/local_copy/tests/files_from_vanished.rs
+++ b/crates/engine/src/local_copy/tests/files_from_vanished.rs
@@ -205,7 +205,8 @@ fn delete_missing_args_removes_destination_for_vanished_source() {
     fs::create_dir_all(&dest_root).expect("create dest");
 
     // Pre-populate destination with the file that should be deleted.
-    fs::write(dest_root.join("disappear.txt"), b"old destination copy").expect("write dest disappear");
+    fs::write(dest_root.join("disappear.txt"), b"old destination copy")
+        .expect("write dest disappear");
     // Also pre-populate a file that should remain.
     fs::write(dest_root.join("stay.txt"), b"old stay").expect("write dest stay");
 

--- a/crates/engine/src/local_copy/tests/filters.rs
+++ b/crates/engine/src/local_copy/tests/filters.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn parse_filter_directive_show_is_sender_only() {
     let rule = match parse_filter_directive_line("show images/**").expect("parse") {
@@ -307,12 +306,7 @@ fn deferred_updates_flush_commits_pending_files() {
     let options = LocalCopyOptions::default()
         .partial(true)
         .delay_updates(true);
-    let mut context = CopyContext::new(
-        LocalCopyExecution::Apply,
-        options,
-        None,
-        destination_root,
-    );
+    let mut context = CopyContext::new(LocalCopyExecution::Apply, options, None, destination_root);
 
     let (guard, mut file) =
         DestinationWriteGuard::new(destination.as_path(), true, None, None).expect("guard");
@@ -373,8 +367,7 @@ fn dir_merge_modifiers_override_rule_side_overrides() {
     let receiver_only_options = DirMergeOptions::default().receiver_modifier();
 
     let rule = FilterRule::include("logs/**").with_receiver(false);
-    let sender_adjusted =
-        apply_dir_merge_rule_defaults(rule.clone(), &sender_only_options, false);
+    let sender_adjusted = apply_dir_merge_rule_defaults(rule.clone(), &sender_only_options, false);
     assert!(sender_adjusted.applies_to_sender());
     assert!(!sender_adjusted.applies_to_receiver());
 

--- a/crates/engine/src/local_copy/tests/filters_runtime.rs
+++ b/crates/engine/src/local_copy/tests/filters_runtime.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn execute_respects_exclude_filter() {
     let temp = tempdir().expect("tempdir");
@@ -9,13 +8,10 @@ fn execute_respects_exclude_filter() {
     fs::write(source.join("keep.txt"), b"keep").expect("write keep");
     fs::write(source.join("skip.tmp"), b"skip").expect("write skip");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let filters = FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filters =
+        FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options = LocalCopyOptions::default().filters(Some(filters));
 
     let summary = plan
@@ -48,8 +44,8 @@ fn execute_prunes_empty_directories_when_enabled() {
         dest_without_prune.clone().into_os_string(),
     ];
     let plan_without = LocalCopyPlan::from_operands(&operands_without).expect("plan");
-    let filters_without = FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filters_without =
+        FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options_without = LocalCopyOptions::default().filters(Some(filters_without));
     let summary_without = plan_without
         .execute_with_options(LocalCopyExecution::Apply, options_without)
@@ -60,8 +56,8 @@ fn execute_prunes_empty_directories_when_enabled() {
         dest_with_prune.clone().into_os_string(),
     ];
     let plan_with = LocalCopyPlan::from_operands(&operands_with).expect("plan");
-    let filters_with = FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")])
-        .expect("compile filters");
+    let filters_with =
+        FilterSet::from_rules([filters::FilterRule::exclude("*.tmp")]).expect("compile filters");
     let options_with = LocalCopyOptions::default()
         .filters(Some(filters_with))
         .prune_empty_dirs(true);
@@ -125,10 +121,7 @@ fn execute_respects_include_filter_override() {
     fs::write(source.join("keep.tmp"), b"keep").expect("write keep");
     fs::write(source.join("skip.tmp"), b"skip").expect("write skip");
 
-    let operands = vec![
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ];
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     // With first-match-wins, specific include must come before general exclude
     let filters = FilterSet::from_rules([

--- a/crates/engine/src/local_copy/tests/itemize_changes.rs
+++ b/crates/engine/src/local_copy/tests/itemize_changes.rs
@@ -129,9 +129,7 @@ fn itemize_unchanged_file_shows_metadata_reused() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .collect_events(true);
+    let options = LocalCopyOptions::default().times(true).collect_events(true);
     let report = plan
         .execute_with_report(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -167,10 +165,8 @@ fn itemize_permission_change_shows_p_indicator() {
     fs::write(&destination, content).expect("write dest");
 
     // Set different permissions
-    fs::set_permissions(&source, fs::Permissions::from_mode(0o644))
-        .expect("set source perms");
-    fs::set_permissions(&destination, fs::Permissions::from_mode(0o600))
-        .expect("set dest perms");
+    fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).expect("set source perms");
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o600)).expect("set dest perms");
 
     // Set same modification time to avoid time changes
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
@@ -227,9 +223,7 @@ fn itemize_time_change_shows_t_indicator_when_preserved() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .times(true)
-        .collect_events(true);
+    let options = LocalCopyOptions::default().times(true).collect_events(true);
     let report = plan
         .execute_with_report(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -288,15 +282,13 @@ fn itemize_multiple_changes_shows_all_indicators() {
 
     // Create destination with old content and permissions
     fs::write(&destination, b"old").expect("write dest");
-    fs::set_permissions(&destination, fs::Permissions::from_mode(0o600))
-        .expect("set dest perms");
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o600)).expect("set dest perms");
     let old_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(&destination, old_time).expect("set dest mtime");
 
     // Create source with new content, different permissions and time
     fs::write(&source, b"new content here").expect("write source");
-    fs::set_permissions(&source, fs::Permissions::from_mode(0o644))
-        .expect("set source perms");
+    fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).expect("set source perms");
     let new_time = FileTime::from_unix_time(1_700_001_000, 0);
     set_file_mtime(&source, new_time).expect("set source mtime");
 
@@ -324,8 +316,15 @@ fn itemize_multiple_changes_shows_all_indicators() {
     let change_set = record.change_set();
     assert!(change_set.checksum_changed(), "checksum should change");
     assert!(change_set.size_changed(), "size should change");
-    assert_eq!(change_set.time_change(), Some(TimeChange::Modified), "time should change");
-    assert!(change_set.permissions_changed(), "permissions should change");
+    assert_eq!(
+        change_set.time_change(),
+        Some(TimeChange::Modified),
+        "time should change"
+    );
+    assert!(
+        change_set.permissions_changed(),
+        "permissions should change"
+    );
 }
 
 #[test]
@@ -359,9 +358,13 @@ fn itemize_new_directory_shows_creation() {
     // Should have records for directory and file
     assert!(!records.is_empty());
 
-    let dir_record = records.iter()
+    let dir_record = records
+        .iter()
         .find(|r| r.action() == &LocalCopyAction::DirectoryCreated);
-    assert!(dir_record.is_some(), "should have directory creation record");
+    assert!(
+        dir_record.is_some(),
+        "should have directory creation record"
+    );
 
     let dir_record = dir_record.unwrap();
     assert!(dir_record.was_created());
@@ -386,9 +389,7 @@ fn itemize_symlink_shows_correct_type() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default()
-        .links(true)
-        .collect_events(true);
+    let options = LocalCopyOptions::default().links(true).collect_events(true);
     let report = plan
         .execute_with_report(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -434,7 +435,8 @@ fn itemize_hard_link_shows_correct_action() {
     let records = report.records();
 
     // Should have at least one hard link record
-    let hard_link_record = records.iter()
+    let hard_link_record = records
+        .iter()
         .find(|r| r.action() == &LocalCopyAction::HardLink);
     assert!(hard_link_record.is_some(), "should have hard link record");
 }
@@ -460,10 +462,7 @@ fn itemize_new_hard_link_follower_marked_created() {
     fs::write(&file1, b"linked content").expect("write a");
     fs::hard_link(&file1, &file2).expect("hard link b -> a");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest_dir.into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest_dir.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default()
@@ -646,10 +645,7 @@ fn itemize_copy_dest_hard_link_follower_not_marked_created() {
     set_file_mtime(&copy_leader, timestamp).expect("copy_dest leader mtime");
     set_file_mtime(&copy_follower, timestamp).expect("copy_dest follower mtime");
 
-    let operands = vec![
-        source_dir.into_os_string(),
-        dest_dir.into_os_string(),
-    ];
+    let operands = vec![source_dir.into_os_string(), dest_dir.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let options = LocalCopyOptions::default()
@@ -769,10 +765,8 @@ fn itemize_chmod_modifier_shows_permission_change() {
     fs::write(&destination, content).expect("write dest");
 
     // Set same permissions initially
-    fs::set_permissions(&source, fs::Permissions::from_mode(0o644))
-        .expect("set source perms");
-    fs::set_permissions(&destination, fs::Permissions::from_mode(0o644))
-        .expect("set dest perms");
+    fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).expect("set source perms");
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o644)).expect("set dest perms");
 
     // Set same modification time
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
@@ -854,15 +848,13 @@ fn itemize_format_matches_upstream_for_changed_file() {
 
     // Create destination with specific state
     fs::write(&destination, b"old").expect("write dest");
-    fs::set_permissions(&destination, fs::Permissions::from_mode(0o644))
-        .expect("set dest perms");
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o644)).expect("set dest perms");
     let old_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(&destination, old_time).expect("set dest mtime");
 
     // Create source with changes
     fs::write(&source, b"new content").expect("write source");
-    fs::set_permissions(&source, fs::Permissions::from_mode(0o644))
-        .expect("set source perms");
+    fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).expect("set source perms");
     let new_time = FileTime::from_unix_time(1_700_001_000, 0);
     set_file_mtime(&source, new_time).expect("set source mtime");
 

--- a/crates/engine/src/local_copy/tests/list_only.rs
+++ b/crates/engine/src/local_copy/tests/list_only.rs
@@ -50,7 +50,8 @@ fn list_only_enumerates_files_without_transfer() {
     // actually copied; the meaningful check is that files were enumerated.
     assert!(!collector.records.is_empty());
 
-    let paths: Vec<_> = collector.records
+    let paths: Vec<_> = collector
+        .records
         .iter()
         .map(|r| r.relative_path().to_string_lossy().to_string())
         .collect();
@@ -59,9 +60,7 @@ fn list_only_enumerates_files_without_transfer() {
     assert!(paths.iter().any(|p| p == "file2.txt"));
     assert!(paths.iter().any(|p| p.contains("subdir")));
 
-    let dest_entries: Vec<_> = fs::read_dir(&dest)
-        .expect("read dest")
-        .collect();
+    let dest_entries: Vec<_> = fs::read_dir(&dest).expect("read dest").collect();
     assert_eq!(dest_entries.len(), 0, "destination should remain empty");
 }
 
@@ -80,8 +79,7 @@ fn list_only_provides_file_metadata() {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&file, fs::Permissions::from_mode(0o644))
-            .expect("set permissions");
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).expect("set permissions");
     }
 
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
@@ -102,7 +100,8 @@ fn list_only_provides_file_metadata() {
     )
     .expect("dry run succeeds");
 
-    let file_record = collector.records
+    let file_record = collector
+        .records
         .iter()
         .find(|r| r.relative_path().to_string_lossy() == "data.bin")
         .expect("file record present");
@@ -158,7 +157,8 @@ fn list_only_shows_symlinks_correctly() {
         )
         .expect("dry run succeeds");
 
-        let link_record = collector.records
+        let link_record = collector
+            .records
             .iter()
             .find(|r| r.relative_path().to_string_lossy() == "link.txt")
             .expect("link record present");
@@ -213,7 +213,8 @@ fn list_only_shows_directories_with_metadata() {
     )
     .expect("dry run succeeds");
 
-    let dir_record = collector.records
+    let dir_record = collector
+        .records
         .iter()
         .find(|r| {
             r.relative_path().to_string_lossy().contains("testdir")
@@ -255,8 +256,7 @@ fn list_only_respects_filter_rules() {
     let operands = vec![source_operand, dest.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")])
-        .expect("create filter");
+    let filters = FilterSet::from_rules([FilterRule::exclude("*.log")]).expect("create filter");
 
     let mut collector = RecordCollector::new();
 
@@ -267,14 +267,18 @@ fn list_only_respects_filter_rules() {
     )
     .expect("dry run succeeds");
 
-    let paths: Vec<_> = collector.records
+    let paths: Vec<_> = collector
+        .records
         .iter()
         .map(|r| r.relative_path().to_string_lossy().to_string())
         .collect();
 
     assert!(paths.iter().any(|p| p == "include.txt"));
     assert!(paths.iter().any(|p| p == "exclude.txt"));
-    assert!(!paths.iter().any(|p| p == "data.log"), "*.log should be filtered");
+    assert!(
+        !paths.iter().any(|p| p == "data.log"),
+        "*.log should be filtered"
+    );
 }
 
 #[test]
@@ -296,11 +300,8 @@ fn list_only_with_include_filter() {
     let operands = vec![source_operand, dest.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let filters = FilterSet::from_rules([
-        FilterRule::include("*.txt"),
-        FilterRule::exclude("*"),
-    ])
-    .expect("create filter");
+    let filters = FilterSet::from_rules([FilterRule::include("*.txt"), FilterRule::exclude("*")])
+        .expect("create filter");
 
     let mut collector = RecordCollector::new();
 
@@ -311,14 +312,24 @@ fn list_only_with_include_filter() {
     )
     .expect("dry run succeeds");
 
-    let paths: Vec<_> = collector.records
+    let paths: Vec<_> = collector
+        .records
         .iter()
         .map(|r| r.relative_path().to_string_lossy().to_string())
         .collect();
 
-    assert!(paths.iter().any(|p| p == "data.txt"), "*.txt should be included");
-    assert!(!paths.iter().any(|p| p == "image.jpg"), "*.jpg should be excluded");
-    assert!(!paths.iter().any(|p| p == "doc.pdf"), "*.pdf should be excluded");
+    assert!(
+        paths.iter().any(|p| p == "data.txt"),
+        "*.txt should be included"
+    );
+    assert!(
+        !paths.iter().any(|p| p == "image.jpg"),
+        "*.jpg should be excluded"
+    );
+    assert!(
+        !paths.iter().any(|p| p == "doc.pdf"),
+        "*.pdf should be excluded"
+    );
 }
 
 #[test]
@@ -348,12 +359,9 @@ fn list_only_shows_special_permission_bits() {
         fs::write(&setgid_file, b"setgid").expect("write setgid");
         fs::write(&sticky_file, b"sticky").expect("write sticky");
 
-        fs::set_permissions(&setuid_file, fs::Permissions::from_mode(0o4755))
-            .expect("set setuid");
-        fs::set_permissions(&setgid_file, fs::Permissions::from_mode(0o2755))
-            .expect("set setgid");
-        fs::set_permissions(&sticky_file, fs::Permissions::from_mode(0o1755))
-            .expect("set sticky");
+        fs::set_permissions(&setuid_file, fs::Permissions::from_mode(0o4755)).expect("set setuid");
+        fs::set_permissions(&setgid_file, fs::Permissions::from_mode(0o2755)).expect("set setgid");
+        fs::set_permissions(&sticky_file, fs::Permissions::from_mode(0o1755)).expect("set sticky");
 
         let mut source_operand = source.into_os_string();
         source_operand.push(std::path::MAIN_SEPARATOR_STR);
@@ -370,21 +378,24 @@ fn list_only_shows_special_permission_bits() {
         )
         .expect("dry run succeeds");
 
-        let setuid_record = collector.records
+        let setuid_record = collector
+            .records
             .iter()
             .find(|r| r.relative_path().to_string_lossy() == "setuid")
             .expect("setuid record present");
         let setuid_mode = setuid_record.metadata().unwrap().mode().unwrap();
         assert_ne!(setuid_mode & 0o4000, 0, "setuid bit should be set");
 
-        let setgid_record = collector.records
+        let setgid_record = collector
+            .records
             .iter()
             .find(|r| r.relative_path().to_string_lossy() == "setgid")
             .expect("setgid record present");
         let setgid_mode = setgid_record.metadata().unwrap().mode().unwrap();
         assert_ne!(setgid_mode & 0o2000, 0, "setgid bit should be set");
 
-        let sticky_record = collector.records
+        let sticky_record = collector
+            .records
             .iter()
             .find(|r| r.relative_path().to_string_lossy() == "sticky")
             .expect("sticky record present");
@@ -445,8 +456,11 @@ fn list_only_with_recursive_shows_nested_structure() {
     fs::create_dir(source.join("level1")).expect("create level1");
     fs::create_dir(source.join("level1").join("level2")).expect("create level2");
     fs::write(source.join("level1").join("file1.txt"), b"l1").expect("write l1");
-    fs::write(source.join("level1").join("level2").join("file2.txt"), b"l2")
-        .expect("write l2");
+    fs::write(
+        source.join("level1").join("level2").join("file2.txt"),
+        b"l2",
+    )
+    .expect("write l2");
 
     let mut source_operand = source.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR_STR);
@@ -463,7 +477,8 @@ fn list_only_with_recursive_shows_nested_structure() {
     )
     .expect("dry run succeeds");
 
-    let paths: Vec<_> = collector.records
+    let paths: Vec<_> = collector
+        .records
         .iter()
         .map(|r| r.relative_path().to_string_lossy().to_string())
         .collect();
@@ -474,7 +489,13 @@ fn list_only_with_recursive_shows_nested_structure() {
     assert!(paths.iter().any(|p| p.contains("file2.txt")));
 
     assert!(!dest.join("level1").join("file1.txt").exists());
-    assert!(!dest.join("level1").join("level2").join("file2.txt").exists());
+    assert!(
+        !dest
+            .join("level1")
+            .join("level2")
+            .join("file2.txt")
+            .exists()
+    );
 }
 
 #[test]
@@ -506,7 +527,8 @@ fn list_only_without_recursive_shows_only_top_level() {
     )
     .expect("dry run succeeds");
 
-    let paths: Vec<_> = collector.records
+    let paths: Vec<_> = collector
+        .records
         .iter()
         .map(|r| r.relative_path().to_string_lossy().to_string())
         .collect();
@@ -773,7 +795,8 @@ fn list_only_handles_size_zero_files() {
     )
     .expect("dry run succeeds");
 
-    let empty_record = collector.records
+    let empty_record = collector
+        .records
         .iter()
         .find(|r| r.relative_path().to_string_lossy() == "empty.txt")
         .expect("empty file record present");
@@ -852,14 +875,13 @@ fn list_only_shows_multiple_file_types_in_single_listing() {
 
         plan.execute_with_options_and_handler(
             LocalCopyExecution::DryRun,
-            LocalCopyOptions::default()
-                .recursive(true)
-                .links(true),
+            LocalCopyOptions::default().recursive(true).links(true),
             Some(&mut collector),
         )
         .expect("dry run succeeds");
 
-        let kinds: Vec<_> = collector.records
+        let kinds: Vec<_> = collector
+            .records
             .iter()
             .filter_map(|r| r.metadata().map(|m| m.kind()))
             .collect();

--- a/crates/engine/src/local_copy/tests/max_size_filter.rs
+++ b/crates/engine/src/local_copy/tests/max_size_filter.rs
@@ -30,11 +30,27 @@ fn execute_excludes_files_larger_than_max_size() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 2, "should copy only small and medium files");
-    assert!(dest_root.join("small.txt").exists(), "small file should be copied");
-    assert!(dest_root.join("medium.txt").exists(), "medium file should be copied");
-    assert!(!dest_root.join("large.txt").exists(), "large file should be excluded");
-    assert!(!dest_root.join("huge.txt").exists(), "huge file should be excluded");
+    assert_eq!(
+        summary.files_copied(),
+        2,
+        "should copy only small and medium files"
+    );
+    assert!(
+        dest_root.join("small.txt").exists(),
+        "small file should be copied"
+    );
+    assert!(
+        dest_root.join("medium.txt").exists(),
+        "medium file should be copied"
+    );
+    assert!(
+        !dest_root.join("large.txt").exists(),
+        "large file should be excluded"
+    );
+    assert!(
+        !dest_root.join("huge.txt").exists(),
+        "huge file should be excluded"
+    );
 }
 
 #[test]
@@ -59,7 +75,11 @@ fn execute_includes_files_equal_to_max_size() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 1, "file equal to max-size should be copied");
+    assert_eq!(
+        summary.files_copied(),
+        1,
+        "file equal to max-size should be copied"
+    );
     assert!(destination.exists(), "destination should exist");
     assert_eq!(
         fs::read(&destination).expect("read destination"),
@@ -121,9 +141,18 @@ fn execute_max_size_with_kilobyte_suffix() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 2, "files <= 1K should be copied");
-    assert!(dest_root.join("under.txt").exists(), "file under 1K should be copied");
-    assert!(dest_root.join("exact.txt").exists(), "file exactly 1K should be copied");
-    assert!(!dest_root.join("over.txt").exists(), "file over 1K should be excluded");
+    assert!(
+        dest_root.join("under.txt").exists(),
+        "file under 1K should be copied"
+    );
+    assert!(
+        dest_root.join("exact.txt").exists(),
+        "file exactly 1K should be copied"
+    );
+    assert!(
+        !dest_root.join("over.txt").exists(),
+        "file over 1K should be excluded"
+    );
 }
 
 #[test]
@@ -133,9 +162,17 @@ fn execute_max_size_with_megabyte_suffix() {
     fs::create_dir_all(&source_root).expect("create source");
 
     let one_mb: u64 = 1024 * 1024;
-    fs::write(source_root.join("under.txt"), vec![0u8; (one_mb - 1024) as usize]).expect("write under 1M");
+    fs::write(
+        source_root.join("under.txt"),
+        vec![0u8; (one_mb - 1024) as usize],
+    )
+    .expect("write under 1M");
     fs::write(source_root.join("exact.txt"), vec![0u8; one_mb as usize]).expect("write exactly 1M");
-    fs::write(source_root.join("over.txt"), vec![0u8; (one_mb + 1024) as usize]).expect("write over 1M");
+    fs::write(
+        source_root.join("over.txt"),
+        vec![0u8; (one_mb + 1024) as usize],
+    )
+    .expect("write over 1M");
 
     let dest_root = temp.path().join("dest");
     let mut source_operand = source_root.into_os_string();
@@ -151,9 +188,18 @@ fn execute_max_size_with_megabyte_suffix() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 2, "files <= 1M should be copied");
-    assert!(dest_root.join("under.txt").exists(), "file under 1M should be copied");
-    assert!(dest_root.join("exact.txt").exists(), "file exactly 1M should be copied");
-    assert!(!dest_root.join("over.txt").exists(), "file over 1M should be excluded");
+    assert!(
+        dest_root.join("under.txt").exists(),
+        "file under 1M should be copied"
+    );
+    assert!(
+        dest_root.join("exact.txt").exists(),
+        "file exactly 1M should be copied"
+    );
+    assert!(
+        !dest_root.join("over.txt").exists(),
+        "file over 1M should be excluded"
+    );
 }
 
 #[test]
@@ -181,7 +227,11 @@ fn execute_max_size_with_gigabyte_suffix() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 2, "files much smaller than 1G should be copied");
+    assert_eq!(
+        summary.files_copied(),
+        2,
+        "files much smaller than 1G should be copied"
+    );
     assert!(dest_root.join("small.txt").exists());
     assert!(dest_root.join("medium.txt").exists());
 }
@@ -209,7 +259,11 @@ fn execute_max_size_excludes_very_large_files() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 0, "10MB file should be excluded by 5MB limit");
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "10MB file should be excluded by 5MB limit"
+    );
     assert!(!destination.exists(), "destination should not be created");
 }
 
@@ -265,11 +319,27 @@ fn execute_max_size_combined_with_min_size() {
         )
         .expect("copy succeeds");
 
-    assert_eq!(summary.files_copied(), 2, "only files in range should be copied");
-    assert!(!dest_root.join("too_small.txt").exists(), "file below min should be excluded");
-    assert!(dest_root.join("just_right1.txt").exists(), "file at min boundary should be copied");
-    assert!(dest_root.join("just_right2.txt").exists(), "file in range should be copied");
-    assert!(!dest_root.join("too_large.txt").exists(), "file above max should be excluded");
+    assert_eq!(
+        summary.files_copied(),
+        2,
+        "only files in range should be copied"
+    );
+    assert!(
+        !dest_root.join("too_small.txt").exists(),
+        "file below min should be excluded"
+    );
+    assert!(
+        dest_root.join("just_right1.txt").exists(),
+        "file at min boundary should be copied"
+    );
+    assert!(
+        dest_root.join("just_right2.txt").exists(),
+        "file in range should be copied"
+    );
+    assert!(
+        !dest_root.join("too_large.txt").exists(),
+        "file above max should be excluded"
+    );
 }
 
 #[test]
@@ -297,14 +367,30 @@ fn execute_max_size_does_not_affect_directories() {
         .expect("copy succeeds");
 
     // Directory should be created regardless of max-size
-    assert!(dest_root.join("nested").exists(), "directory should be created");
-    assert!(dest_root.join("nested").is_dir(), "nested should be a directory");
+    assert!(
+        dest_root.join("nested").exists(),
+        "directory should be created"
+    );
+    assert!(
+        dest_root.join("nested").is_dir(),
+        "nested should be a directory"
+    );
 
-    assert!(dest_root.join("nested").join("small.txt").exists(), "small file should be copied");
+    assert!(
+        dest_root.join("nested").join("small.txt").exists(),
+        "small file should be copied"
+    );
 
-    assert!(!dest_root.join("large.txt").exists(), "large file should be excluded");
+    assert!(
+        !dest_root.join("large.txt").exists(),
+        "large file should be excluded"
+    );
 
-    assert_eq!(summary.files_copied(), 1, "only the small file should be copied");
+    assert_eq!(
+        summary.files_copied(),
+        1,
+        "only the small file should be copied"
+    );
 }
 
 #[test]
@@ -330,7 +416,11 @@ fn execute_max_size_with_dry_run() {
         .expect("dry run succeeds");
 
     // In dry run, files would be copied but destination doesn't exist
-    assert_eq!(summary.files_copied(), 1, "dry run should report small file would be copied");
+    assert_eq!(
+        summary.files_copied(),
+        1,
+        "dry run should report small file would be copied"
+    );
     assert!(!dest_root.exists(), "dry run should not create destination");
 }
 
@@ -342,12 +432,17 @@ fn execute_max_size_boundary_off_by_one() {
 
     // Test exact boundaries: limit - 1, limit, limit + 1
     let limit = 1000u64;
-    fs::write(source_root.join("one_under.txt"), vec![0u8; (limit - 1) as usize])
-        .expect("write limit - 1");
-    fs::write(source_root.join("exact.txt"), vec![0u8; limit as usize])
-        .expect("write exact limit");
-    fs::write(source_root.join("one_over.txt"), vec![0u8; (limit + 1) as usize])
-        .expect("write limit + 1");
+    fs::write(
+        source_root.join("one_under.txt"),
+        vec![0u8; (limit - 1) as usize],
+    )
+    .expect("write limit - 1");
+    fs::write(source_root.join("exact.txt"), vec![0u8; limit as usize]).expect("write exact limit");
+    fs::write(
+        source_root.join("one_over.txt"),
+        vec![0u8; (limit + 1) as usize],
+    )
+    .expect("write limit + 1");
 
     let dest_root = temp.path().join("dest");
     let mut source_operand = source_root.into_os_string();
@@ -363,9 +458,18 @@ fn execute_max_size_boundary_off_by_one() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 2, "files <= limit should be copied");
-    assert!(dest_root.join("one_under.txt").exists(), "file one byte under limit should be copied");
-    assert!(dest_root.join("exact.txt").exists(), "file exactly at limit should be copied");
-    assert!(!dest_root.join("one_over.txt").exists(), "file one byte over limit should be excluded");
+    assert!(
+        dest_root.join("one_under.txt").exists(),
+        "file one byte under limit should be copied"
+    );
+    assert!(
+        dest_root.join("exact.txt").exists(),
+        "file exactly at limit should be copied"
+    );
+    assert!(
+        !dest_root.join("one_over.txt").exists(),
+        "file one byte over limit should be excluded"
+    );
 }
 
 #[test]
@@ -399,7 +503,16 @@ fn execute_max_size_with_filter_rules() {
 
     // Only small.txt should be copied (small.bak excluded by filter, large.txt excluded by size)
     assert_eq!(summary.files_copied(), 1, "only small.txt should be copied");
-    assert!(dest_root.join("small.txt").exists(), "small.txt should be copied");
-    assert!(!dest_root.join("small.bak").exists(), "small.bak should be excluded by filter");
-    assert!(!dest_root.join("large.txt").exists(), "large.txt should be excluded by size");
+    assert!(
+        dest_root.join("small.txt").exists(),
+        "small.txt should be copied"
+    );
+    assert!(
+        !dest_root.join("small.bak").exists(),
+        "small.bak should be excluded by filter"
+    );
+    assert!(
+        !dest_root.join("large.txt").exists(),
+        "large.txt should be excluded by size"
+    );
 }

--- a/crates/engine/src/local_copy/tests/options.rs
+++ b/crates/engine/src/local_copy/tests/options.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn local_copy_options_numeric_ids_round_trip() {
     let options = LocalCopyOptions::default().numeric_ids(true);
@@ -32,7 +31,10 @@ fn local_copy_options_modify_window_round_trip() {
     let window = ModifyWindow::from_secs(5);
     let options = LocalCopyOptions::default().with_modify_window(window);
     assert_eq!(options.modify_window(), window);
-    assert_eq!(LocalCopyOptions::default().modify_window(), ModifyWindow::ZERO);
+    assert_eq!(
+        LocalCopyOptions::default().modify_window(),
+        ModifyWindow::ZERO
+    );
 }
 
 #[test]
@@ -445,7 +447,11 @@ fn preallocate_destination_skips_when_disabled() {
     maybe_preallocate_destination(&mut file, &path, 4096, 0, None).expect("should succeed");
 
     let metadata = fs::metadata(&path).expect("metadata");
-    assert_eq!(metadata.len(), 0, "disabled preallocate should not change file size");
+    assert_eq!(
+        metadata.len(),
+        0,
+        "disabled preallocate should not change file size"
+    );
 }
 
 #[test]
@@ -463,7 +469,11 @@ fn preallocate_destination_skips_zero_length() {
         .expect("should succeed");
 
     let metadata = fs::metadata(&path).expect("metadata");
-    assert_eq!(metadata.len(), 0, "zero-length preallocate should not change file");
+    assert_eq!(
+        metadata.len(),
+        0,
+        "zero-length preallocate should not change file"
+    );
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/partial_dir.rs
+++ b/crates/engine/src/local_copy/tests/partial_dir.rs
@@ -12,7 +12,6 @@
 // 5. Works correctly with nested directory structures
 // 6. Behavior matches upstream rsync
 
-
 #[test]
 fn partial_dir_places_partial_file_in_specified_directory() {
     let temp = tempdir().expect("tempdir");
@@ -116,12 +115,15 @@ fn partial_dir_moves_file_to_destination_on_commit() {
     guard.commit().expect("commit");
 
     // After commit: file should be at destination, not in partial dir
-    assert!(!staging_path.exists(), "staging path should be removed after commit");
-    assert!(destination.exists(), "destination should exist after commit");
-    assert_eq!(
-        fs::read(&destination).expect("read"),
-        b"content to commit"
+    assert!(
+        !staging_path.exists(),
+        "staging path should be removed after commit"
     );
+    assert!(
+        destination.exists(),
+        "destination should exist after commit"
+    );
+    assert_eq!(fs::read(&destination).expect("read"), b"content to commit");
 }
 
 #[test]
@@ -144,7 +146,8 @@ fn partial_dir_preserves_partial_file_on_discard() {
     .expect("guard");
 
     let staging_path = guard.staging_path().to_path_buf();
-    file.write_all(b"partial content before interrupt").expect("write");
+    file.write_all(b"partial content before interrupt")
+        .expect("write");
     drop(file);
 
     // Discard simulates an interrupted transfer
@@ -153,15 +156,23 @@ fn partial_dir_preserves_partial_file_on_discard() {
     // upstream: on interrupt the temp is moved into the (created) partial dir
     // by basename; the destination is left untouched.
     let partial_entry = partial_dir.join("interrupted.txt");
-    assert!(!staging_path.exists(), "temp consumed by the move into the partial dir");
-    assert!(partial_entry.exists(), "partial preserved inside the partial dir");
-    assert!(!destination.exists(), "destination should not exist after discard");
+    assert!(
+        !staging_path.exists(),
+        "temp consumed by the move into the partial dir"
+    );
+    assert!(
+        partial_entry.exists(),
+        "partial preserved inside the partial dir"
+    );
+    assert!(
+        !destination.exists(),
+        "destination should not exist after discard"
+    );
     assert_eq!(
         fs::read(&partial_entry).expect("read partial"),
         b"partial content before interrupt"
     );
 }
-
 
 #[test]
 fn partial_dir_works_with_nested_source_directories() {
@@ -194,9 +205,21 @@ fn partial_dir_works_with_nested_source_directories() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert!(dest_root.join("source/level1").join("level2").join("deep.txt").exists());
+    assert!(
+        dest_root
+            .join("source/level1")
+            .join("level2")
+            .join("deep.txt")
+            .exists()
+    );
     assert_eq!(
-        fs::read(dest_root.join("source/level1").join("level2").join("deep.txt")).expect("read"),
+        fs::read(
+            dest_root
+                .join("source/level1")
+                .join("level2")
+                .join("deep.txt")
+        )
+        .expect("read"),
         b"deep nested content"
     );
 }
@@ -246,7 +269,13 @@ fn partial_dir_handles_multiple_files_in_nested_directories() {
         b"middle level"
     );
     assert_eq!(
-        fs::read(dest_root.join("source/dir1").join("subdir").join("deep.txt")).expect("read deep"),
+        fs::read(
+            dest_root
+                .join("source/dir1")
+                .join("subdir")
+                .join("deep.txt")
+        )
+        .expect("read deep"),
         b"deep level"
     );
     assert_eq!(
@@ -254,7 +283,6 @@ fn partial_dir_handles_multiple_files_in_nested_directories() {
         b"sibling dir"
     );
 }
-
 
 #[test]
 fn partial_dir_supports_absolute_path() {
@@ -319,13 +347,15 @@ fn partial_dir_absolute_path_preserves_partial_on_discard() {
     // basename.
     let partial_entry = partial_dir.join("file.txt");
     assert!(!staging_path.exists(), "temp consumed by the move");
-    assert!(partial_entry.exists(), "partial moved into absolute partial dir");
+    assert!(
+        partial_entry.exists(),
+        "partial moved into absolute partial dir"
+    );
     assert_eq!(
         fs::read(&partial_entry).expect("read"),
         b"absolute path partial"
     );
 }
-
 
 #[test]
 fn partial_dir_relative_to_destination_directory() {
@@ -359,7 +389,6 @@ fn partial_dir_relative_to_destination_directory() {
     guard.commit().expect("commit");
     assert!(destination.exists());
 }
-
 
 #[test]
 fn partial_dir_handles_empty_file() {
@@ -458,7 +487,6 @@ fn partial_dir_overwrites_existing_partial_file() {
     guard.discard();
 }
 
-
 #[test]
 fn partial_dir_differs_from_non_partial_behavior() {
     let temp = tempdir().expect("tempdir");
@@ -496,10 +524,12 @@ fn partial_dir_differs_from_non_partial_behavior() {
         !staging1.exists(),
         "partial temp consumed by move into partial dir"
     );
-    assert!(partial_entry.exists(), "partial preserved in the partial dir");
+    assert!(
+        partial_entry.exists(),
+        "partial preserved in the partial dir"
+    );
     assert!(!staging2.exists(), "non-partial mode should remove file");
 }
-
 
 #[test]
 fn partial_dir_handles_special_characters_in_filename() {
@@ -533,7 +563,6 @@ fn partial_dir_handles_special_characters_in_filename() {
         b"special chars content"
     );
 }
-
 
 #[test]
 fn partial_dir_with_times_preservation() {
@@ -584,7 +613,9 @@ fn partial_dir_with_permissions_preservation() {
     fs::create_dir_all(&dest_dir).expect("create dest dir");
     fs::write(&source, b"perms test").expect("write source");
 
-    let mut perms = fs::metadata(&source).expect("source metadata").permissions();
+    let mut perms = fs::metadata(&source)
+        .expect("source metadata")
+        .permissions();
     perms.set_mode(0o640);
     fs::set_permissions(&source, perms).expect("set source perms");
 
@@ -606,10 +637,11 @@ fn partial_dir_with_permissions_preservation() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    let dest_perms = fs::metadata(&destination).expect("dest metadata").permissions();
+    let dest_perms = fs::metadata(&destination)
+        .expect("dest metadata")
+        .permissions();
     assert_eq!(dest_perms.mode() & 0o777, 0o640);
 }
-
 
 #[test]
 fn partial_dir_dry_run_does_not_create_directory() {
@@ -639,21 +671,23 @@ fn partial_dir_dry_run_does_not_create_directory() {
 
     assert_eq!(summary.files_copied(), 1);
     // In dry run mode, no actual changes should be made
-    assert!(!destination.exists(), "destination should not be created in dry run");
+    assert!(
+        !destination.exists(),
+        "destination should not be created in dry run"
+    );
     // Note: The partial dir creation behavior in dry run depends on implementation
     // The test documents expected behavior - partial dir should NOT be created
 }
-
 
 #[test]
 fn partial_dir_setting_enables_partial_flag() {
     let opts = LocalCopyOptions::default().with_partial_directory(Some(".partial"));
 
-    assert!(opts.partial_enabled(), "setting partial_dir should enable partial");
-    assert_eq!(
-        opts.partial_directory_path(),
-        Some(Path::new(".partial"))
+    assert!(
+        opts.partial_enabled(),
+        "setting partial_dir should enable partial"
     );
+    assert_eq!(opts.partial_directory_path(), Some(Path::new(".partial")));
 }
 
 #[test]
@@ -797,8 +831,11 @@ fn partial_dir_delete_only_removes_non_partial_entries() {
 
     let partial_dir = target_root.join(".rsync-partial");
     fs::create_dir_all(&partial_dir).expect("create partial dir");
-    fs::write(partial_dir.join("in-progress.dat"), b"partial transfer data")
-        .expect("write partial file");
+    fs::write(
+        partial_dir.join("in-progress.dat"),
+        b"partial transfer data",
+    )
+    .expect("write partial file");
 
     let operands = ctx.operands();
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
@@ -861,8 +898,7 @@ fn partial_dir_without_delete_does_not_affect_extraneous_files() {
 
     let operands = ctx.operands();
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default()
-        .with_partial_directory(Some(".rsync-partial"));
+    let options = LocalCopyOptions::default().with_partial_directory(Some(".rsync-partial"));
 
     let _summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -971,16 +1007,12 @@ fn partial_dir_delete_with_dry_run_does_not_modify_anything() {
         target_root.join("extra.txt").exists(),
         "dry run should not delete extraneous files"
     );
-    assert!(
-        partial_dir.exists(),
-        "dry run should not touch partial dir"
-    );
+    assert!(partial_dir.exists(), "dry run should not touch partial dir");
     assert!(
         partial_dir.join("partial.dat").exists(),
         "dry run should not touch partial files"
     );
 }
-
 
 #[test]
 fn partial_dir_find_basis_locates_existing_partial_for_resume() {
@@ -994,9 +1026,7 @@ fn partial_dir_find_basis_locates_existing_partial_for_resume() {
     let partial = partial_dir.join("target.txt");
     fs::write(&partial, b"previously interrupted content").expect("write partial");
 
-    let manager = PartialFileManager::new(PartialMode::PartialDir(
-        PathBuf::from(".rsync-partial"),
-    ));
+    let manager = PartialFileManager::new(PartialMode::PartialDir(PathBuf::from(".rsync-partial")));
     let basis = manager.find_basis(&dest).expect("find_basis");
     assert_eq!(basis, Some(partial));
 }
@@ -1006,9 +1036,7 @@ fn partial_dir_find_basis_returns_none_when_no_partial_exists() {
     let dir = tempdir().expect("tempdir");
     let dest = dir.path().join("target.txt");
 
-    let manager = PartialFileManager::new(PartialMode::PartialDir(
-        PathBuf::from(".rsync-partial"),
-    ));
+    let manager = PartialFileManager::new(PartialMode::PartialDir(PathBuf::from(".rsync-partial")));
     let basis = manager.find_basis(&dest).expect("find_basis");
     assert_eq!(basis, None);
 }
@@ -1032,7 +1060,10 @@ fn partial_dir_cleanup_removes_partial_after_successful_transfer() {
     manager.cleanup_partial(&dest).expect("cleanup");
 
     // After cleanup, partial file should be gone
-    assert!(!partial.exists(), "partial file should be removed after cleanup");
+    assert!(
+        !partial.exists(),
+        "partial file should be removed after cleanup"
+    );
     // But the partial directory itself should remain
     assert!(
         partial_dir.exists(),
@@ -1072,14 +1103,16 @@ fn partial_dir_full_resume_workflow() {
 
     // Step 4: Clean up partial file
     manager.cleanup_partial(&dest).expect("cleanup");
-    assert!(!partial.exists(), "partial should be cleaned up after success");
+    assert!(
+        !partial.exists(),
+        "partial should be cleaned up after success"
+    );
     assert!(dest.exists(), "destination should exist after completion");
     assert_eq!(
         fs::read(&dest).expect("read dest"),
         b"complete final content"
     );
 }
-
 
 #[test]
 fn partial_dir_relative_path_independent_per_directory() {
@@ -1103,25 +1136,15 @@ fn partial_dir_relative_path_independent_per_directory() {
 
     let manager = PartialFileManager::new(PartialMode::PartialDir(PathBuf::from(".partial")));
 
-    let basis_a = manager
-        .find_basis(&dir_a.join("data.txt"))
-        .expect("find A");
-    let basis_b = manager
-        .find_basis(&dir_b.join("data.txt"))
-        .expect("find B");
+    let basis_a = manager.find_basis(&dir_a.join("data.txt")).expect("find A");
+    let basis_b = manager.find_basis(&dir_b.join("data.txt")).expect("find B");
 
     assert_eq!(basis_a, Some(partial_a.join("data.txt")));
     assert_eq!(basis_b, Some(partial_b.join("data.txt")));
 
     // Verify content independence
-    assert_eq!(
-        fs::read(basis_a.unwrap()).expect("read A"),
-        b"partial A"
-    );
-    assert_eq!(
-        fs::read(basis_b.unwrap()).expect("read B"),
-        b"partial B"
-    );
+    assert_eq!(fs::read(basis_a.unwrap()).expect("read A"), b"partial A");
+    assert_eq!(fs::read(basis_b.unwrap()).expect("read B"), b"partial B");
 }
 
 #[test]
@@ -1141,8 +1164,7 @@ fn partial_dir_absolute_path_shared_across_directories() {
     fs::write(shared_partial.join("common.txt"), b"shared partial data")
         .expect("write shared partial");
 
-    let manager =
-        PartialFileManager::new(PartialMode::PartialDir(shared_partial.clone()));
+    let manager = PartialFileManager::new(PartialMode::PartialDir(shared_partial.clone()));
 
     // Both destinations should find the same partial file
     let basis_a = manager
@@ -1155,7 +1177,6 @@ fn partial_dir_absolute_path_shared_across_directories() {
     assert_eq!(basis_a, Some(shared_partial.join("common.txt")));
     assert_eq!(basis_b, Some(shared_partial.join("common.txt")));
 }
-
 
 #[test]
 fn partial_dir_guard_staging_path_is_inside_partial_dir() {
@@ -1269,7 +1290,6 @@ fn partial_dir_guard_discard_preserves_for_later_resume() {
     );
 }
 
-
 #[test]
 fn partial_dir_with_deeply_nested_relative_path() {
     // Test that partial-dir can be a multi-component relative path
@@ -1288,7 +1308,8 @@ fn partial_dir_with_deeply_nested_relative_path() {
     )
     .expect("guard");
 
-    file.write_all(b"nested partial dir content").expect("write");
+    file.write_all(b"nested partial dir content")
+        .expect("write");
     drop(file);
 
     // upstream: the temp stages beside the destination regardless of how deep
@@ -1416,7 +1437,6 @@ fn partial_dir_empty_partial_dir_survives_delete() {
         "empty partial dir should survive --delete"
     );
 }
-
 
 #[test]
 fn partial_dir_successful_copy_creates_and_uses_partial_dir() {

--- a/crates/engine/src/local_copy/tests/plan.rs
+++ b/crates/engine/src/local_copy/tests/plan.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn plan_from_operands_requires_destination() {
     let operands = vec![OsString::from("only-source")];
@@ -199,6 +198,12 @@ fn local_copy_stop_at_enforced() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect_err("stop-at should fail copy");
 
-    assert!(matches!(error.kind(), LocalCopyErrorKind::StopAtReached { .. }));
-    assert!(!destination.exists(), "destination should not exist on stop-at");
+    assert!(matches!(
+        error.kind(),
+        LocalCopyErrorKind::StopAtReached { .. }
+    ));
+    assert!(
+        !destination.exists(),
+        "destination should not exist on stop-at"
+    );
 }

--- a/crates/engine/src/local_copy/tests/timeout_handling.rs
+++ b/crates/engine/src/local_copy/tests/timeout_handling.rs
@@ -192,7 +192,10 @@ fn timeout_and_stop_at_are_distinct_kinds() {
     let stop_at_error = LocalCopyError::stop_at_reached(SystemTime::now());
 
     let timeout_kind_match = matches!(timeout_error.kind(), LocalCopyErrorKind::Timeout { .. });
-    let stop_at_kind_match = matches!(stop_at_error.kind(), LocalCopyErrorKind::StopAtReached { .. });
+    let stop_at_kind_match = matches!(
+        stop_at_error.kind(),
+        LocalCopyErrorKind::StopAtReached { .. }
+    );
 
     assert!(timeout_kind_match);
     assert!(stop_at_kind_match);
@@ -268,8 +271,8 @@ fn zero_duration_timeout_message_is_sensible() {
 #[test]
 fn connection_timeout_exit_code_documented() {
     // Document the expected exit codes
-    const RERR_TIMEOUT: i32 = 30;     // I/O timeout during transfer
-    const RERR_CONTIMEOUT: i32 = 35;  // Connection timeout during setup
+    const RERR_TIMEOUT: i32 = 30; // I/O timeout during transfer
+    const RERR_CONTIMEOUT: i32 = 35; // Connection timeout during setup
 
     assert_ne!(RERR_TIMEOUT, RERR_CONTIMEOUT);
 

--- a/crates/protocol/src/negotiation/tests/detector.rs
+++ b/crates/protocol/src/negotiation/tests/detector.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn prologue_detector_caches_decision() {
     let mut detector = NegotiationPrologueDetector::new();
@@ -389,10 +388,7 @@ fn prologue_detector_observe_byte_matches_slice_behavior() {
             last
         };
 
-        assert_eq!(
-            byte_result, slice_result,
-            "decision mismatch for {data:?}"
-        );
+        assert_eq!(byte_result, slice_result, "decision mismatch for {data:?}");
         assert_eq!(
             byte_detector.decision(),
             slice_detector.decision(),
@@ -419,4 +415,3 @@ fn prologue_detector_observe_byte_matches_slice_behavior() {
     run_case(b"modern");
     run_case(&[0x00, 0x20, 0x00, 0x00]);
 }
-

--- a/crates/protocol/src/negotiation/tests/legacy.rs
+++ b/crates/protocol/src/negotiation/tests/legacy.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn prologue_sniffer_reports_binary_prefix_state() {
     let mut sniffer = NegotiationPrologueSniffer::new();

--- a/crates/protocol/src/negotiation/tests/sniffer_read.rs
+++ b/crates/protocol/src/negotiation/tests/sniffer_read.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn prologue_sniffer_observe_empty_chunk_after_complete_legacy_prefix() {
     let mut sniffer = NegotiationPrologueSniffer::new();

--- a/crates/protocol/src/negotiation/tests/sniffer_reset.rs
+++ b/crates/protocol/src/negotiation/tests/sniffer_reset.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn prologue_sniffer_reset_restores_canonical_capacity_after_shrink() {
     let mut sniffer = NegotiationPrologueSniffer::new();

--- a/crates/protocol/src/negotiation/tests/sniffer_take.rs
+++ b/crates/protocol/src/negotiation/tests/sniffer_take.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn prologue_sniffer_take_buffered_remainder_into_reuses_destination() {
     let mut sniffer = NegotiationPrologueSniffer::new();

--- a/crates/rsync_io/src/negotiation/tests/legacy_negotiation_sniffer_tests.rs
+++ b/crates/rsync_io/src/negotiation/tests/legacy_negotiation_sniffer_tests.rs
@@ -471,4 +471,3 @@ fn negotiated_stream_copy_buffered_into_slice_copies_bytes() {
         .expect("buffered bytes remain available after slicing copy");
     assert_eq!(replay, expected);
 }
-

--- a/crates/rsync_io/src/negotiation/tests/legacy_negotiation_test_support.rs
+++ b/crates/rsync_io/src/negotiation/tests/legacy_negotiation_test_support.rs
@@ -1,4 +1,3 @@
-
 #[test]
 fn map_line_reserve_error_for_io_marks_out_of_memory() {
     let mut buf = Vec::<u8>::new();
@@ -573,4 +572,3 @@ fn negotiation_buffered_slices_into_iter_consumes_segments() {
 
     assert_eq!(lengths, vec![prefix.len(), remainder.len()]);
 }
-

--- a/crates/rsync_io/src/negotiation/tests/negotiated_stream_buffer_tests.rs
+++ b/crates/rsync_io/src/negotiation/tests/negotiated_stream_buffer_tests.rs
@@ -489,4 +489,3 @@ fn negotiated_stream_parts_copy_buffered_remaining_into_vec_copies_unread_bytes(
     assert_eq!(target, expected[consumed..]);
     assert_eq!(parts.buffered_consumed(), consumed);
 }
-

--- a/crates/rsync_io/src/negotiation/tests/negotiated_stream_clone_tests.rs
+++ b/crates/rsync_io/src/negotiation/tests/negotiated_stream_clone_tests.rs
@@ -515,4 +515,3 @@ fn sniff_negotiation_buffered_remaining_vectored_tracks_consumption() {
         .collect();
     assert_eq!(flattened, stream.buffered_remaining_slice());
 }
-

--- a/crates/rsync_io/src/negotiation/tests/negotiated_stream_parts_tests.rs
+++ b/crates/rsync_io/src/negotiation/tests/negotiated_stream_parts_tests.rs
@@ -480,4 +480,3 @@ fn negotiated_stream_try_clone_with_clones_inner_reader() {
         .expect("original stream remains usable after clone");
     assert_eq!(original_replay, legacy);
 }
-

--- a/crates/rsync_io/src/negotiation/tests/negotiation_error_handling_tests.rs
+++ b/crates/rsync_io/src/negotiation/tests/negotiation_error_handling_tests.rs
@@ -544,4 +544,3 @@ fn read_and_parse_legacy_daemon_message_routes_keywords() {
     }
     assert_eq!(line, b"@RSYNCD: AUTHREQD module\n");
 }
-

--- a/tools/ci/check_include_fmt.py
+++ b/tools/ci/check_include_fmt.py
@@ -19,6 +19,7 @@ import argparse
 import re
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 # `include!("path")`, allowing the newlines rustfmt itself inserts when the
@@ -27,7 +28,9 @@ from pathlib import Path
 # the source tree and are deliberately not matched.
 INCLUDE_RE = re.compile(r"""include!\s*\(\s*"([^"]+)"\s*,?\s*\)""")
 
-EDITION = "2024"
+
+class EditionError(Exception):
+    """The workspace Rust edition could not be resolved."""
 
 
 def repo_root() -> Path:
@@ -38,6 +41,35 @@ def repo_root() -> Path:
         text=True,
     )
     return Path(out.stdout.strip())
+
+
+def workspace_edition(root: Path) -> str:
+    """Read `edition` from `[workspace.package]` in the workspace manifest.
+
+    rustfmt has no notion of a workspace and defaults to edition 2015, so the
+    edition has to be handed to it explicitly. Restating the value here would
+    let it drift from the manifest unnoticed - formatting against a stale
+    edition either reports spurious diffs or masks real ones - so it is read at
+    runtime and a missing value is a hard error, never a silent default.
+    """
+    manifest = root / "Cargo.toml"
+    try:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise EditionError(f"cannot read {manifest}: {error}") from error
+    except tomllib.TOMLDecodeError as error:
+        raise EditionError(f"cannot parse {manifest}: {error}") from error
+
+    section = data.get("workspace")
+    package = section.get("package") if isinstance(section, dict) else None
+    edition = package.get("edition") if isinstance(package, dict) else None
+    if not isinstance(edition, str) or not edition:
+        raise EditionError(
+            f"{manifest} declares no [workspace.package] edition; rustfmt would\n"
+            "fall back to edition 2015 and format every include!()d file against\n"
+            "the wrong edition"
+        )
+    return edition
 
 
 def tracked_rust_sources(root: Path) -> list[Path]:
@@ -78,6 +110,14 @@ def main() -> int:
     args = parser.parse_args()
 
     root = repo_root()
+
+    try:
+        edition = workspace_edition(root)
+    except EditionError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(f"rustfmt edition {edition} (from [workspace.package] in Cargo.toml)")
+
     targets, missing = included_files(root)
 
     if missing:
@@ -90,7 +130,7 @@ def main() -> int:
         print("no include!() targets found - the enumerator matched nothing", file=sys.stderr)
         return 1
 
-    cmd = ["rustfmt", "--edition", EDITION]
+    cmd = ["rustfmt", "--edition", edition]
     if not args.write:
         cmd.append("--check")
     cmd += [str(path) for path in targets]
@@ -107,7 +147,7 @@ def main() -> int:
         return result.returncode
 
     verb = "reformatted" if args.write else "checked"
-    print(f"{verb} {len(targets)} include!()d file(s)")
+    print(f"{verb} {len(targets)} include!()d file(s) at edition {edition}")
     return 0
 
 

--- a/tools/ci/check_include_fmt.py
+++ b/tools/ci/check_include_fmt.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Format-check the source files that `cargo fmt` cannot see.
+
+rustfmt walks the module tree through `mod` declarations only; it never
+expands `include!()`. Every file pulled in with `include!("...")` is therefore
+invisible to `cargo fmt --all -- --check`, which exits 0 no matter how the
+included file is formatted. This script closes that hole: it collects the
+literal paths named by `include!()` across the workspace and runs
+`rustfmt --check` on each one directly.
+
+Usage:
+    python3 tools/ci/check_include_fmt.py           # check, exit 1 on diff
+    python3 tools/ci/check_include_fmt.py --write   # reformat in place
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# `include!("path")`, allowing the newlines rustfmt itself inserts when the
+# path literal is too long to fit on one line. Non-literal forms such as
+# `include!(concat!(env!("OUT_DIR"), ...))` refer to generated files outside
+# the source tree and are deliberately not matched.
+INCLUDE_RE = re.compile(r"""include!\s*\(\s*"([^"]+)"\s*,?\s*\)""")
+
+EDITION = "2024"
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def tracked_rust_sources(root: Path) -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z", "--", "*.rs"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [root / name for name in out.stdout.split("\0") if name]
+
+
+def included_files(root: Path) -> tuple[list[Path], list[str]]:
+    """Return the `include!()` targets and any unresolvable references."""
+    found: set[Path] = set()
+    missing: list[str] = []
+    for source in tracked_rust_sources(root):
+        text = source.read_text(encoding="utf-8", errors="replace")
+        if "include!" not in text:
+            continue
+        for rel in INCLUDE_RE.findall(text):
+            target = (source.parent / rel).resolve()
+            if target.is_file():
+                found.add(target)
+            else:
+                missing.append(f"{source.relative_to(root)}: include!(\"{rel}\")")
+    return sorted(found), missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="reformat the included files in place instead of checking them",
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    targets, missing = included_files(root)
+
+    if missing:
+        print("include!() targets that do not resolve to a file:", file=sys.stderr)
+        for entry in missing:
+            print(f"  {entry}", file=sys.stderr)
+        return 1
+
+    if not targets:
+        print("no include!() targets found - the enumerator matched nothing", file=sys.stderr)
+        return 1
+
+    cmd = ["rustfmt", "--edition", EDITION]
+    if not args.write:
+        cmd.append("--check")
+    cmd += [str(path) for path in targets]
+
+    result = subprocess.run(cmd, cwd=root)
+    if result.returncode != 0:
+        if not args.write:
+            print(
+                f"\n{len(targets)} include!()d file(s) checked; the diffs above are "
+                "invisible to `cargo fmt --all -- --check`.\n"
+                "Fix with: python3 tools/ci/check_include_fmt.py --write",
+                file=sys.stderr,
+            )
+        return result.returncode
+
+    verb = "reformatted" if args.write else "checked"
+    print(f"{verb} {len(targets)} include!()d file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The hole

`cargo fmt --all -- --check` reaches a file only by walking the module tree through `mod` declarations. It never expands `include!()`. Every file pulled in with `include!("...")` is therefore invisible to the format gate, which exits 0 no matter how those files are formatted.

This workspace has **498** such files (daemon, engine, core, protocol, rsync_io). **360 of them had drifted** out of rustfmt shape without any gate noticing.

## Positive control (measured on master, before this branch)

Appended to `crates/daemon/src/daemon/sections/signals.rs`, which is reached via `include!("daemon/sections/signals.rs")`:

```rust
fn __fmt_positive_control(){let x=1;let    y   =2;   let z=x+y;let _=z;}
```

```
$ cargo fmt --all -- --check
EXIT=0
```

The existing gate is blind.

## Mechanism

`tools/ci/check_include_fmt.py` — chosen over the alternatives because it matches the established `tools/ci/check_*.{sh,py}` + one lint-job-step convention already used by `check_envguard.sh`, `check_daemon_no_detach.sh`, and `check_shared_ring_removal.sh`, and because the enumeration must be derived from the source (a hand-maintained file list would rot the first time a module is split).

It scans the tracked `*.rs` sources for `include!("...")`, resolves each literal path against the including file's directory, and runs `rustfmt --edition 2024 --check` on the resolved set. `--write` reformats in place. Non-literal forms (`include!(concat!(env!("OUT_DIR"), ...))`) name generated files outside the tree and are deliberately not matched; an `include!()` whose target does not resolve is a hard failure, so the enumerator cannot silently go empty.

Run locally with one command:

```sh
python3 tools/ci/check_include_fmt.py           # check
python3 tools/ci/check_include_fmt.py --write   # fix
```

Wired into the `lint` job immediately after the existing `cargo fmt --all -- --check` step.

## No baseline

The 360 pre-existing violations are **fixed**, not frozen. `style:` commit `f6739fb58` is pure rustfmt output. The gate starts at zero, so the one mutation that matters stays visible.

## RED / GREEN proof

**RED** — control defect present:

```
### OLD GATE: cargo fmt --all -- --check
EXIT=0

### NEW GATE: python3 tools/ci/check_include_fmt.py
Diff in crates/daemon/src/daemon/sections/signals.rs:118:
     }
 }

-fn __fmt_positive_control(){let x=1;let    y   =2;   let z=x+y;let _=z;}
+fn __fmt_positive_control() {
+    let x = 1;
+    let y = 2;
+    let z = x + y;
+    let _ = z;
+}

498 include!()d file(s) checked; the diffs above are invisible to `cargo fmt --all -- --check`.
Fix with: python3 tools/ci/check_include_fmt.py --write
EXIT=1
```

**GREEN** — control removed:

```
$ python3 tools/ci/check_include_fmt.py
checked 498 include!()d file(s)
EXIT=0
```

`signals.rs` is byte-identical to its pre-control state (`git diff` on it is empty).

## Verification

- `cargo fmt --all -- --check` — exit 0
- `python3 tools/ci/check_include_fmt.py` — exit 0, 498 files checked
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` — exit 0, zero warnings, run after the reformat

## Edition derivation (commit `f406e3a36`)

The edition was initially restated as a constant in the checker. A copied value that must be updated in lockstep with its source is the drift class this repo keeps getting bitten by, and here it is not cosmetic: rustfmt has no notion of a workspace and defaults to **edition 2015**, so a stale constant would silently format all 498 files against the wrong edition — spurious diffs, or masked real ones, with no signal.

`[workspace.package] edition` is now read from `Cargo.toml` at runtime via `tomllib`, and the resolved value is printed on every run:

```
$ python3 tools/ci/check_include_fmt.py
rustfmt edition 2024 (from [workspace.package] in Cargo.toml)
checked 498 include!()d file(s) at edition 2024
```

A missing or unparseable declaration is a **hard error**, never a fallback.

### Non-vacuity: the value is genuinely derived

Temporarily set `Cargo.toml:218` to `edition = "1999"` — rustfmt itself rejects it, proving the manifest value reaches the command rather than being cosmetic:

```
$ python3 tools/ci/check_include_fmt.py
rustfmt edition 1999 (from [workspace.package] in Cargo.toml)
Invalid value for `--edition`
EXIT=1
```

### Non-vacuity: a missing edition fails loudly

Temporarily deleted the `edition` line from `[workspace.package]`:

```
$ python3 tools/ci/check_include_fmt.py
error: /.../Cargo.toml declares no [workspace.package] edition; rustfmt would
fall back to edition 2015 and format every include!()d file against
the wrong edition
EXIT=1
```

rustfmt is never invoked and no "checked N file(s)" line is printed — the gate cannot pass vacuously when its input is missing.

`Cargo.toml` was restored after both legs; `git diff --name-only Cargo.toml` is empty.

### Re-verified after restore

- `python3 tools/ci/check_include_fmt.py` — exit 0, 498 files, edition 2024
- `cargo fmt --all -- --check` — exit 0
