### PR TITLE
fix(receiver): skip the delayed rename when the backup fails

### DIFF
--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -457,21 +457,26 @@ pub(in crate::receiver) enum DeletePassPhase {
 /// When `backup_config` is `Some`, backs up the existing destination file
 /// before the rename (upstream: `receiver.c:538 make_backup(fname, False)`).
 ///
-/// A failed rename (or backup) is logged and does not abort the sweep -
-/// remaining files are still renamed, matching upstream which calls
-/// `rsyserr(FERROR_XFER, ...)` and continues. The failure is NOT silently
-/// swallowed, though: this returns the accumulated `io_error` bitfield
-/// (`IOERR_GENERAL` when any rename/backup failed, else 0) so the caller can
-/// fold it into the transfer's `io_error` and surface exit code 23
-/// (`RERR_PARTIAL`). Upstream achieves the same via the
-/// `FERROR_XFER -> got_xfer_error -> RERR_PARTIAL` side channel
-/// (log.c:309-316, cleanup.c:210-218, main.c:1630-1631).
+/// A failure does not abort the sweep - remaining files are still renamed -
+/// but the two failure kinds part company, exactly as upstream's do:
 ///
-/// This matters on Linux kernels 5.13-5.18: those have Landlock but lack
-/// `LANDLOCK_ACCESS_FS_REFER` (added in 5.19), so the cross-directory rename
-/// out of the `.~tmp~` staging dir is denied with `EACCES` under a sandbox.
-/// Without the returned io_error bit the file would silently not be updated
-/// while the process still exited 0 - silent data loss.
+/// - A failed BACKUP skips the staged rename for that file
+///   (`receiver.c:694` - `if (make_backups > 0 && !make_backup(fname, False))
+///   continue;`). Renaming anyway would overwrite the very pre-image the
+///   backup was meant to preserve, leaving no copy of it anywhere. The
+///   diagnostic `make_backup()` prints is `FERROR`, which carries no
+///   exit-code bit (log.c:336-341), so the run's status is unchanged -
+///   measured against rsync 3.5.0.
+/// - A failed RENAME is `rsyserr(FERROR_XFER, ...)` (`receiver.c:709-712`),
+///   which sets `got_xfer_error` and forces exit 23 (`RERR_PARTIAL`). That is
+///   what the returned `IOERR_GENERAL` bit stands in for
+///   (log.c:309-316, cleanup.c:210-218, main.c:1630-1631).
+///
+/// The rename half matters on Linux kernels 5.13-5.18: those have Landlock but
+/// lack `LANDLOCK_ACCESS_FS_REFER` (added in 5.19), so the cross-directory
+/// rename out of the `.~tmp~` staging dir is denied with `EACCES` under a
+/// sandbox. Without the returned io_error bit the file would silently not be
+/// updated while the process still exited 0 - silent data loss.
 pub(in crate::receiver) fn handle_delayed_updates(
     delayed: &[(PathBuf, PathBuf)],
     backup_config: Option<crate::disk_commit::BackupConfig>,
@@ -481,58 +486,74 @@ pub(in crate::receiver) fn handle_delayed_updates(
 
     use crate::generator::io_error_flags::IOERR_GENERAL;
 
-    // Mirrors upstream's got_xfer_error: any rename/backup failure here is a
-    // transfer error that must yield exit 23 (RERR_PARTIAL), not a silent 0.
+    // Mirrors upstream's got_xfer_error: a failed rename here is a transfer
+    // error that must yield exit 23 (RERR_PARTIAL), not a silent 0. A failed
+    // backup is upstream's FERROR-only path and contributes no bit.
     let mut io_error = 0;
 
     for (staging_path, final_path) in delayed {
-        // upstream: receiver.c:538-539 - make_backup(fname, False)
-        if let Some(ref bc) = backup_config {
-            if final_path.exists() {
-                let backup_path = engine::compute_backup_path(
-                    &bc.dest_dir,
-                    final_path,
-                    None,
-                    bc.backup_dir.as_deref(),
-                    &bc.suffix,
-                );
-                if let Some(parent) = backup_path.parent() {
-                    if !parent.exists() {
-                        let _ = fs::create_dir_all(parent);
-                    }
+        // upstream: receiver.c:694 - make_backup(fname, False)
+        if let Some(ref bc) = backup_config
+            && final_path.exists()
+        {
+            let backup_path = engine::compute_backup_path(
+                &bc.dest_dir,
+                final_path,
+                None,
+                bc.backup_dir.as_deref(),
+                &bc.suffix,
+            );
+            // upstream: backup.c:128-139 copy_valid_path() - the backup parent
+            // tree is built inside get_backup_name(), and a `backup mkdir %s
+            // failed` there makes make_backup() return 0. Discarding this
+            // error hid the real errno: the sweep went on to rename into a
+            // directory that was never created, so the reported failure was
+            // the derived `ENOENT` from the rename rather than the `EACCES`
+            // that actually stopped the backup.
+            let placed = match backup_path.parent() {
+                Some(parent) if !parent.exists() => fs::create_dir_all(parent),
+                _ => Ok(()),
+            }
+            .and_then(|()| fs::rename(final_path, &backup_path));
+
+            match placed {
+                Ok(()) => {
+                    // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1)
+                    // RENAME success notice. The delayed-updates sweep is
+                    // the third backup site (alongside disk-commit and
+                    // local-copy); upstream emits this from
+                    // backup.c:make_backup() regardless of caller.
+                    engine::trace_make_backup_rename(&final_path.display().to_string());
+                    // upstream: backup.c:352-353 - INFO_GTE(BACKUP, 1)
+                    // rprintf(FINFO, "backed up %s to %s\n", fname, buf)
+                    // fires on success label of make_backup() after the
+                    // rename completes. Paths are displayed relative to
+                    // the destination root to match the upstream test
+                    // assertions (testsuite/backup.test:29,43,56).
+                    let final_rel = final_path.strip_prefix(&bc.dest_dir).unwrap_or(final_path);
+                    let backup_rel = backup_path
+                        .strip_prefix(&bc.dest_dir)
+                        .unwrap_or(&backup_path);
+                    info_log!(
+                        Backup,
+                        1,
+                        "backed up {} to {}",
+                        final_rel.display(),
+                        backup_rel.display()
+                    );
                 }
-                match fs::rename(final_path, &backup_path) {
-                    Ok(()) => {
-                        // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1)
-                        // RENAME success notice. The delayed-updates sweep is
-                        // the third backup site (alongside disk-commit and
-                        // local-copy); upstream emits this from
-                        // backup.c:make_backup() regardless of caller.
-                        engine::trace_make_backup_rename(&final_path.display().to_string());
-                        // upstream: backup.c:352-353 - INFO_GTE(BACKUP, 1)
-                        // rprintf(FINFO, "backed up %s to %s\n", fname, buf)
-                        // fires on success label of make_backup() after the
-                        // rename completes. Paths are displayed relative to
-                        // the destination root to match the upstream test
-                        // assertions (testsuite/backup.test:29,43,56).
-                        let final_rel = final_path.strip_prefix(&bc.dest_dir).unwrap_or(final_path);
-                        let backup_rel = backup_path
-                            .strip_prefix(&bc.dest_dir)
-                            .unwrap_or(&backup_path);
-                        info_log!(
-                            Backup,
-                            1,
-                            "backed up {} to {}",
-                            final_rel.display(),
-                            backup_rel.display()
-                        );
-                    }
-                    Err(e) => {
-                        // upstream: make_backup() -> rsyserr(FERROR_XFER, ...)
-                        // sets got_xfer_error -> RERR_PARTIAL.
-                        eprintln!("rsync: backup failed for {}: {e}", final_path.display());
-                        io_error |= IOERR_GENERAL;
-                    }
+                Err(e) => {
+                    // upstream: receiver.c:694 - `!make_backup(...)` skips
+                    // straight to the next delayed entry. The staged file
+                    // stays in the partial dir and the destination keeps its
+                    // pre-transfer contents, so the pre-image the backup
+                    // could not preserve is not destroyed instead.
+                    //
+                    // No io_error bit: make_backup() reports through FERROR,
+                    // which log.c:336-341 routes to stderr without setting
+                    // got_xfer_error, so upstream still exits 0 here.
+                    eprintln!("rsync: backup failed for {}: {e}", final_path.display());
+                    continue;
                 }
             }
         }

--- a/tests/delay_updates_backup_failure.rs
+++ b/tests/delay_updates_backup_failure.rs
@@ -1,0 +1,207 @@
+//! `--delay-updates --backup`: a failed backup must NOT be followed by the
+//! staged rename.
+//!
+//! upstream `receiver.c:694`:
+//!
+//! ```text
+//! if (make_backups > 0 && !make_backup(fname, False))
+//!         continue;
+//! ```
+//!
+//! The `continue` is the whole contract: when the backup cannot be placed, the
+//! delayed rename is skipped, the destination keeps its pre-transfer contents,
+//! and the staged file stays behind in the `.~tmp~` partial dir. oc renamed
+//! anyway, so the pre-image the backup was meant to preserve was overwritten
+//! and existed nowhere afterwards - and the `create_dir_all` that actually
+//! failed was discarded with `let _ =`, so the diagnostic named the derived
+//! `ENOENT` from the rename instead of the real `EACCES`.
+//!
+//! Measured against rsync 3.5.0 (push and pull, `--backup-dir` under a mode
+//! 555 directory): `rc=0`, `backup mkdir <dir> failed: Permission denied
+//! (13)` on stderr, destination file UNCHANGED, `dst/sub/.~tmp~` left in
+//! place. `make_backup()` reports through `FERROR`, which `log.c:336-341`
+//! routes to stderr without setting `got_xfer_error`, so the exit status stays
+//! 0 - the destination content, not the exit code, is what distinguishes a
+//! honoured backup failure from a swallowed one.
+//!
+//! ⚠ This must run over a REAL `--server` process: `handle_delayed_updates`
+//! belongs to the network receiver. A local transfer takes the engine's
+//! local-copy executor, which has its own backup path and would exercise none
+//! of this.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+fn oc_rsync_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Root ignores the mode bits that make the backup `mkdir` fail, so the
+/// fixture would report the post-fix state on a broken binary. Skip instead of
+/// emitting a false pass on the root CI leg.
+fn running_as_root() -> bool {
+    std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "0")
+        .unwrap_or(false)
+}
+
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+const OLD: &str = "pre-transfer contents\n";
+const NEW: &str = "replacement contents that are longer\n";
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    shim: PathBuf,
+}
+
+/// `src/sub/f` holds new content; `dst/sub/f` holds older, backdated content,
+/// so the quick check sees a genuine update and the sweep has something to
+/// back up.
+///
+/// The backup lives at `dst/bak/sub/f` (upstream clears the suffix when a
+/// `--backup-dir` is named, options.c:2438-2439), and `dst/bak` is mode 555: the leaf
+/// `mkdir` of `dst/bak/sub` is the step that fails with `EACCES`, which is
+/// upstream's `backup mkdir %s failed` (`backup.c:128-139`). Nesting the file
+/// one level down is load-bearing - a top-level file would need no new backup
+/// subdirectory and the fixture would never fail.
+fn fixture() -> Fixture {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().to_path_buf();
+    fs::create_dir_all(root.join("src/sub")).expect("create src");
+    fs::create_dir_all(root.join("dst/sub")).expect("create dst");
+    fs::create_dir_all(root.join("dst/bak")).expect("create backup root");
+    fs::write(root.join("src/sub/f"), NEW).expect("write src");
+    fs::write(root.join("dst/sub/f"), OLD).expect("write dst");
+    filetime::set_file_mtime(
+        root.join("dst/sub/f"),
+        filetime::FileTime::from_unix_time(1_000_000, 0),
+    )
+    .expect("backdate dst");
+    let shim = write_rsh_shim(&root);
+    Fixture {
+        _temp: temp,
+        root,
+        shim,
+    }
+}
+
+/// Pushes through the shim against an external `--server` receiver.
+fn push(fx: &Fixture, backup_dir: &str) -> (Option<i32>, String) {
+    let binary = oc_rsync_binary();
+    let out = test_support::OcRsyncCliRunner::new()
+        .binary(&binary)
+        .args(["-r", "--delay-updates", "--backup"])
+        .arg(format!("--backup-dir={backup_dir}"))
+        .arg("--rsh")
+        .arg(&fx.shim)
+        .arg("--rsync-path")
+        .arg(&binary)
+        .arg(format!("{}/src/", fx.root.display()))
+        .arg(format!("bkhost:{}/dst/", fx.root.display()))
+        .run()
+        .expect("push did not finish");
+    (
+        out.status,
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// The headline. A backup that cannot be placed must leave the destination
+/// alone; overwriting it destroys the only copy of the pre-image.
+#[test]
+fn a_failed_backup_leaves_the_destination_untouched() {
+    if running_as_root() {
+        return;
+    }
+    let fx = fixture();
+    let bak = fx.root.join("dst/bak");
+    fs::set_permissions(&bak, fs::Permissions::from_mode(0o555)).expect("chmod backup root");
+
+    let (status, stderr) = push(&fx, "bak");
+
+    fs::set_permissions(&bak, fs::Permissions::from_mode(0o755)).expect("restore backup root");
+
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/sub/f")).expect("read dst"),
+        OLD,
+        "upstream's receiver.c:694 `continue` skips the delayed rename when the \
+         backup fails; overwriting the destination here leaves the pre-image \
+         nowhere - not at dst/sub/f, and not in the backup dir either"
+    );
+    assert!(
+        fx.root.join("dst/sub/.~tmp~").exists(),
+        "upstream leaves the staged file in the partial dir when it skips the \
+         rename (measured against 3.5.0); an absent .~tmp~ means the rename ran"
+    );
+    assert!(
+        !fx.root.join("dst/bak/sub").exists(),
+        "the fixture is only meaningful while the backup genuinely cannot be \
+         placed"
+    );
+    assert!(
+        stderr.contains("backup failed for") && stderr.contains("Permission denied"),
+        "the diagnostic must name the error that actually stopped the backup. \
+         Swallowing the create_dir_all reported the rename's derived `No such \
+         file or directory` instead. stderr was: {stderr}"
+    );
+    // upstream: log.c:336-341 - make_backup()'s FERROR reaches stderr without
+    // setting got_xfer_error, so 3.5.0 exits 0 for this cell (measured, push
+    // and pull alike). Pinned so a future io_error bit here is a deliberate,
+    // visible divergence rather than a drift.
+    assert_eq!(status, Some(0), "stderr was: {stderr}");
+}
+
+/// Non-vacuity for the cell above: with a writable `--backup-dir` the SAME
+/// fixture backs up and renames, so "dst/sub/f is unchanged" cannot be passing
+/// because the transfer never moved anything.
+#[test]
+fn a_placeable_backup_still_updates_the_destination() {
+    if running_as_root() {
+        return;
+    }
+    let fx = fixture();
+
+    let (status, stderr) = push(&fx, "bak");
+
+    assert_eq!(status, Some(0), "stderr was: {stderr}");
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/sub/f")).expect("read dst"),
+        NEW,
+        "the delayed rename must still land when the backup succeeds"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/bak/sub/f")).expect("read backup"),
+        OLD,
+        "the pre-image belongs under the named backup dir"
+    );
+    assert!(
+        !fx.root.join("dst/sub/.~tmp~").exists(),
+        "the sweep removes the emptied staging dir on the success path"
+    );
+}


### PR DESCRIPTION
## The defect

`--delay-updates --backup`: `handle_delayed_updates` renamed each staged file
into place whether or not the backup of the existing destination had succeeded.
When the backup could not be placed, the destination was overwritten anyway and
the pre-image existed nowhere afterwards - not under `--backup-dir`, and no
longer at its own path. Exit status 0.

The `create_dir_all` that builds the backup parent was discarded with
`let _ =`, so the failure was then reported with the rename's derived `ENOENT`
rather than the `EACCES` that actually stopped the backup.

## The upstream rule

`receiver.c:694` is a bare `continue`:

```c
if (make_backups > 0 && !make_backup(fname, False))
        continue;
```

The delayed rename is skipped, the staged file stays in the partial dir, the
destination keeps its pre-transfer contents. The exit status is unchanged:
`make_backup()` reports through `FERROR`, and `log.c:336-341` routes `FERROR`
to stderr without setting `got_xfer_error`.

This is deliberately not the rule at the other two `make_backup` callers, and
the difference is why the site-specific reading matters:

| caller | on failure |
|---|---|
| `rsync.c:897-900` `finish_transfer` | `exit_cleanup(RERR_FILEIO)` - aborts, exit 11 |
| `receiver.c:694` `handle_delayed_updates` | `continue` - skip the file, exit unchanged |
| `generator.c:2477-2479` `atomic_create` | `return 0` - skip the entry, exit unchanged |
| `delete.c:228-233` `delete_item` | `rsyserr(FERROR_XFER, ...)` - exit 23 |

## Measured against rsync 3.5.0

Fixture: `dst/sub/f` backdated, `--backup-dir` whose root is mode 555, so the
leaf `mkdir` fails with `EACCES`. Push and pull through an rsh shim.

| | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| exit | 0 | 0 | 0 |
| `dst/sub/f` | **unchanged** | **overwritten, no backup** | **unchanged** |
| `dst/sub/.~tmp~` | left behind | removed | left behind |
| stderr | `backup mkdir ... failed: Permission denied (13)` | `backup failed for ...: No such file or directory (os error 2)` | `backup failed for ...: Permission denied (os error 13)` |

## The change

- On a backup failure, `continue` past the staged rename (`receiver.c:694`).
- Propagate the backup-parent `create_dir_all` error into the same arm so the
  diagnostic names the real errno.
- No `IOERR_GENERAL` bit for a backup failure - upstream's `FERROR` carries
  none. The rename failure keeps its bit, which is upstream's separate
  `rsyserr(FERROR_XFER, ...)` at `receiver.c:709-712`.

## Tests

`tests/delay_updates_backup_failure.rs` drives a real `--server` receiver
through an rsh shim; a local transfer takes the engine's own backup path and
would exercise none of this. It pins destination content, the `.~tmp~`
leftover, the diagnostic, and the exit code, and carries a writable-backup-dir
non-vacuity cell so "destination unchanged" cannot pass because nothing moved.

Both halves of the fix are individually necessary:

- restoring the rename (dropping the `continue`) fails the destination cell:
  `left: "replacement contents that are longer\n" right: "pre-transfer contents\n"`
- re-swallowing the `create_dir_all` fails the diagnostic cell:
  `stderr was: rsync: backup failed for .../dst/sub/f: No such file or directory (os error 2)`

`cargo nextest run -p transfer --all-features`: 2742 passed. fmt and clippy
clean.

## Note for the reviewer

Two adjacent divergences were measured but deliberately left alone as separate
concerns:

1. On the **non**-`--delay-updates` path a failed backup gives oc exit 23 where
   upstream gives 11 (`RERR_FILEIO`, `rsync.c:900`), and over the network the
   error is relabelled as `mkstemp "<dest>" failed` rather than naming the
   backup step.
2. The `io_error` returned by `handle_delayed_updates` never reaches the exit
   code: all three receiver drivers build `stats.io_error` from
   `self.flist_io_error` *before* the delayed-updates sweep ORs into it
   (`pipelined.rs:135` vs `:316`, `pipelined_incremental.rs:78`,
   `sync.rs:667`). That makes the rename-failure bit - the Landlock
   `ACCESS_FS_REFER` case the existing comment describes - dead today. It is
   untouched here because fixing it needs its own rename-failure fixture.
