### PR TITLE
fix(daemon): honour the server options the daemon parser dropped

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -164,6 +164,84 @@ fn apply_long_form_args(
             // `- /*/*` over the wire filter list. Consumed here without mkpath
             // semantics so a stray forward is not mistaken for a positional path.
             "--old-dirs" | "--old-d" => {}
+            // upstream: options.c:2914 - `if (list_only > 1) args[ac++] =
+            // "--list-only"`, forwarded only when the operator asked for a
+            // listing explicitly (options.c:809 stores 2, not 1). It reaches
+            // whichever end the server plays: a daemon receiver renders the
+            // file list without requesting any file, and a daemon sender's
+            // flist build descends the named directories instead of listing
+            // them as entries.
+            "--list-only" => {
+                config.flags.list_only = true;
+            }
+            // upstream: options.c:2917-2919 - a client running `-d --delete`
+            // emits `--no-r` so a remote that only got `-d` may still delete.
+            // options.c:632 clears the same `recurse` global the compact `r`
+            // letter sets, so the negation has to be applied after the flag
+            // string has been parsed.
+            "--no-r" => {
+                config.flags.recursive = false;
+            }
+            // upstream: options.c:2926-2932 - `preserve_specials` never rides
+            // the compact flag string, because `-D` covers devices only. The
+            // long form carries it instead: `--no-specials` when devices are
+            // preserved but specials are not, `--specials` when specials are
+            // preserved without devices (options.c:686-687).
+            "--specials" => {
+                config.flags.specials = true;
+            }
+            "--no-specials" => {
+                config.flags.specials = false;
+            }
+            // upstream: options.c:2948-2951 - `--msgs2stderr` /
+            // `--no-msgs2stderr` (options.c:619-620) tell the peer where to
+            // route its own name and info output.
+            "--msgs2stderr" => {
+                config.flags.msgs_to_stderr = true;
+            }
+            "--no-msgs2stderr" => {
+                config.flags.msgs_to_stderr = false;
+            }
+            // upstream: options.c:3059-3060 - `else if (keep_partial &&
+            // am_sender)` emits the bare `--partial` (options.c:788) to a
+            // server receiver, which then keeps a partially transferred file
+            // instead of unlinking it.
+            "--partial" => {
+                config.flags.partial = true;
+            }
+            // upstream: options.c:3129-3130 - an `--inplace --sparse` sender
+            // emits `--no-W` so the receiver still asks for a delta rather
+            // than the whole file. options.c:760 clears the same `whole_file`
+            // global the compact `W` letter sets.
+            "--no-W" => {
+                config.flags.whole_file = false;
+            }
+            // upstream: options.c:3143-3144 - a `--files-from` transfer with
+            // relative paths off emits the long `--no-relative` in place of
+            // the compact `R`. options.c:707-708 spell it both ways.
+            "--no-relative" | "--no-R" => {
+                config.flags.relative = false;
+            }
+            // upstream: options.c:3153-3156 - `--remove-source-files`, and the
+            // deprecated `--remove-sent-files` alias (options.c:744-745), tell
+            // a server sender to unlink each source file once the receiver has
+            // acknowledged it. Dropping it left the sources in place on every
+            // daemon pull that asked for them to be moved.
+            "--remove-source-files" | "--remove-sent-files" => {
+                config.flags.remove_source_files = true;
+            }
+            // upstream: options.c:3161-3162 - `if (preallocate_files &&
+            // am_sender)` forwards `--preallocate` (options.c:729) to a server
+            // receiver so it fallocate()s each destination file before writing.
+            "--preallocate" => {
+                config.flags.preallocate = true;
+            }
+            // upstream: options.c:3164-3165 - `--open-noatime` (options.c:658)
+            // is forwarded so the server sender opens source files with
+            // O_NOATIME and leaves their access times untouched.
+            "--open-noatime" => {
+                config.write.open_noatime = true;
+            }
             // upstream: options.c:2849 - backup
             "--backup" => {
                 config.flags.backup = true;
@@ -364,6 +442,34 @@ fn apply_long_form_args(
                     if let Ok(mapping) = ::metadata::GroupMapping::parse(spec) {
                         config.group_mapping = Some(mapping);
                     }
+                // upstream: options.c:2981-2982 - `safe_arg("--checksum-choice",
+                // checksum_choice)` forwards the raw spec, and compat.c:544
+                // then makes it load-bearing on the WIRE: the checksum vstring
+                // is sent only `if (!checksum_choice)`. A daemon that drops the
+                // option sends a list its peer never reads, so the exchange
+                // desyncs - the failure `negotiate.rs:335-343` already warns
+                // about for the reverse direction.
+                } else if let Some(spec) = arg.strip_prefix("--checksum-choice=") {
+                    match parse_transfer_checksum_choice(spec) {
+                        Ok(algorithm) => config.checksum_choice = Some(algorithm),
+                        Err(message) => {
+                            rejection.get_or_insert(ClientArgRejection::InvalidValue(message));
+                        }
+                    }
+                // upstream: options.c:3046-3049 - `--checksum-seed=%d` is
+                // forwarded from an `int` global (options.c:861 is POPT_ARG_INT),
+                // and compat.c:823-825 has the SERVER pick the seed and write it
+                // on the wire. Dropping the value made `--checksum-seed` a no-op
+                // over a daemon while it worked over a remote shell.
+                //
+                // Parsed as `i32` and reinterpreted, because that is the width
+                // upstream prints from and the width `write_seed` puts back on
+                // the wire; a `u32`-only parse would reject the negative values
+                // upstream's `%d` can emit.
+                } else if let Some(seed) = arg.strip_prefix("--checksum-seed=") {
+                    if let Ok(value) = seed.trim().parse::<i32>() {
+                        config.checksum_seed = Some(value as u32);
+                    }
                 } else if arg == "--from0" {
                     // upstream: options.c:940 - --from0 sets NUL-delimited mode
                     // for --files-from content read from the protocol stream.
@@ -422,6 +528,31 @@ pub(crate) enum ClientArgRejection {
     /// The payload is the message verbatim, already in upstream's
     /// `--%s=%s is %s` shape (`options.c:1253`).
     InvalidValue(String),
+}
+
+/// Resolves the TRANSFER half of a `--checksum-choice=SPEC` value.
+///
+/// upstream: `checksum.c:196-202 parse_checksum_choice()` - the spec is split on
+/// its first `,`; the part before names the transfer sum and the part after
+/// names the whole-file sum, and without a comma both take the same name. Only
+/// the transfer sum reaches the wire negotiation, which is the single thing
+/// `ServerConfig::checksum_choice` feeds, so the file half is left to the client
+/// that chose it.
+///
+/// upstream: `checksum.c:127-160 parse_csum_name()` - a missing name or the
+/// case-insensitive literal `auto` resolves to md5 rather than being an error,
+/// and any other unknown name aborts with `RERR_UNSUPPORTED`. oc's client
+/// resolves `auto` the same way before forwarding
+/// (`core::client::config::enums::checksum::transfer_protocol_override`), so
+/// both ends land on the same algorithm and skip the vstring exchange together.
+fn parse_transfer_checksum_choice(spec: &str) -> Result<::protocol::ChecksumAlgorithm, String> {
+    let transfer = spec.split(',').next().unwrap_or(spec);
+    if transfer.is_empty() || transfer.eq_ignore_ascii_case("auto") {
+        return Ok(::protocol::ChecksumAlgorithm::MD5);
+    }
+    ::protocol::ChecksumAlgorithm::parse(transfer)
+        // upstream: checksum.c:156 - `"unknown checksum name: %s\n"`.
+        .map_err(|_| format!("unknown checksum name: {transfer}"))
 }
 
 /// Parses a `--max-size`/`--min-size` value the way upstream's popt case does.

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1306,6 +1306,242 @@ mod module_access_tests {
         assert_eq!(config.file_selection.min_file_size, Some(1024));
     }
 
+    /// Builds the client argv a daemon sees: the compact flag string, then the
+    /// long-form options, then the `.` separator upstream's `server_options()`
+    /// emits before the module-relative paths.
+    fn daemon_argv(flag_string: &str, long_form: &[&str]) -> Vec<String> {
+        let mut args = vec!["--server".to_owned(), flag_string.to_owned()];
+        args.extend(long_form.iter().map(|a| (*a).to_owned()));
+        args.push(".".to_owned());
+        args.push("module/".to_owned());
+        args
+    }
+
+    // Every case below is an option upstream's `server_options()` emits to a
+    // daemon and that oc's own `--server` argv parser already honours, but that
+    // the daemon's long-form parser dropped. Dropping is silent
+    // (`is_client_only_flag_reaching_daemon` only ever fires for the batch
+    // family), so each of these was a live behaviour difference between the two
+    // transports rather than a diagnostic.
+
+    // upstream: options.c:2914 - `if (list_only > 1) args[ac++] = "--list-only"`.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_list_only() {
+        let args = daemon_argv("-logDtpr", &["--list-only"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(config.flags.list_only);
+    }
+
+    // The negations below run against a config whose field is already `true`,
+    // because that is the state the compact flag string leaves behind:
+    // `ServerConfig::from_flag_string_and_args` parses the letters first and
+    // `apply_long_form_args` runs on its result. Starting from the struct
+    // default would let a missing arm pass, since the default is already the
+    // value being asserted.
+
+    // upstream: options.c:2917-2919 - `-d --delete` on the client emits `--no-r`
+    // so the remote may delete without `-r`; options.c:632 clears the same
+    // `recurse` global the compact `r` letter set.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_no_r() {
+        let args = daemon_argv("-logDtpr", &["--no-r"]);
+        let mut config = ServerConfig::default();
+        config.flags.recursive = true;
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(!config.flags.recursive);
+    }
+
+    // upstream: options.c:2926-2930 - `-D` covers devices only, so a client that
+    // preserves devices but not specials sends `--no-specials`.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_no_specials() {
+        let args = daemon_argv("-logDtpr", &["--no-specials"]);
+        let mut config = ServerConfig::default();
+        config.flags.specials = true;
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(!config.flags.specials);
+    }
+
+    // upstream: options.c:2931-2932 - `--specials` without `-D` is the other
+    // half of the same branch: specials preserved, devices not.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_specials() {
+        let args = daemon_argv("-logtpr", &["--specials"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(config.flags.specials);
+    }
+
+    // upstream: options.c:2948-2951 - the two spellings set the same global to 1
+    // and 0. Feeding both in order proves the negation arm exists and wins,
+    // which asserting the default alone could not.
+    #[test]
+    fn apply_long_form_args_honours_both_msgs2stderr_spellings() {
+        let mut config = ServerConfig::default();
+        let args = daemon_argv("-logDtpr", &["--msgs2stderr"]);
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(config.flags.msgs_to_stderr);
+
+        let args = daemon_argv("-logDtpr", &["--msgs2stderr", "--no-msgs2stderr"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(!config.flags.msgs_to_stderr);
+    }
+
+    // upstream: options.c:3059-3060 - `else if (keep_partial && am_sender)`
+    // sends the bare `--partial` to a daemon receiver.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_partial() {
+        let args = daemon_argv("-logDtpr", &["--partial"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(config.flags.partial);
+    }
+
+    // upstream: options.c:3128-3130 - an `--inplace --sparse` sender emits
+    // `--no-W` so the receiver still asks for a delta; options.c:760 clears the
+    // same `whole_file` global the compact `W` letter set.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_no_whole_file() {
+        let args = daemon_argv("-logDtprW", &["--inplace", "--no-W"]);
+        let mut config = ServerConfig::default();
+        config.flags.whole_file = true;
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(!config.flags.whole_file);
+    }
+
+    // upstream: options.c:3143-3144 - a `--files-from` transfer with relative
+    // paths off sends `--no-relative`; options.c:707-708 spell it both ways.
+    #[test]
+    fn apply_long_form_args_honours_both_no_relative_spellings() {
+        for spelling in ["--no-relative", "--no-R"] {
+            let args = daemon_argv("-logDtprR", &[spelling]);
+            let mut config = ServerConfig::default();
+            config.flags.relative = true;
+            assert!(apply_long_form_args(&args, &mut config).is_none());
+            assert!(!config.flags.relative, "{spelling} must clear relative");
+        }
+    }
+
+    // upstream: options.c:3153-3156 - the daemon SENDER unlinks each source file
+    // once the receiver acknowledges it. Dropping this left every source in
+    // place on a daemon pull that asked for them to be moved.
+    #[test]
+    fn apply_long_form_args_honours_both_remove_source_files_spellings() {
+        for spelling in ["--remove-source-files", "--remove-sent-files"] {
+            let args = daemon_argv("-logDtpr", &[spelling]);
+            let mut config = ServerConfig::default();
+            assert!(apply_long_form_args(&args, &mut config).is_none());
+            assert!(
+                config.flags.remove_source_files,
+                "{spelling} must request source removal"
+            );
+        }
+    }
+
+    // upstream: options.c:3161-3162 - forwarded to a daemon receiver so it
+    // fallocate()s each destination file before writing.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_preallocate() {
+        let args = daemon_argv("-logDtpr", &["--preallocate"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(config.flags.preallocate);
+    }
+
+    // upstream: options.c:3164-3165 - forwarded so the daemon sender opens
+    // source files O_NOATIME.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_open_noatime() {
+        let args = daemon_argv("-logDtpr", &["--open-noatime"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(config.write.open_noatime);
+    }
+
+    // upstream: compat.c:544 - the checksum vstring is sent only when
+    // `!checksum_choice`. A daemon that dropped the option kept sending a list
+    // its peer had already decided not to read, which desyncs the exchange;
+    // this is the wire-affecting member of the set, not a preference.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_checksum_choice() {
+        let args = daemon_argv("-logDtpr", &["--checksum-choice=xxh3"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert_eq!(
+            config.checksum_choice,
+            Some(::protocol::ChecksumAlgorithm::XXH3)
+        );
+    }
+
+    // upstream: checksum.c:196-202 - a comma splits the spec into the transfer
+    // sum and the whole-file sum; only the transfer half reaches the wire
+    // negotiation, so taking the whole string would reject a legal spec.
+    #[test]
+    fn apply_long_form_args_takes_the_transfer_half_of_a_checksum_choice_pair() {
+        let args = daemon_argv("-logDtpr", &["--checksum-choice=xxh3,md5"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert_eq!(
+            config.checksum_choice,
+            Some(::protocol::ChecksumAlgorithm::XXH3)
+        );
+    }
+
+    // upstream: checksum.c:127-140 parse_csum_name() - `auto` is a legal name
+    // that resolves to md5, not an error. oc's client resolves `auto,<file>` to
+    // MD5 before forwarding it, so the daemon must land on the same algorithm
+    // or the two ends disagree about a checksum neither of them negotiated.
+    #[test]
+    fn apply_long_form_args_resolves_an_auto_checksum_choice_to_md5() {
+        let args = daemon_argv("-logDtpr", &["--checksum-choice=auto,md5"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert_eq!(
+            config.checksum_choice,
+            Some(::protocol::ChecksumAlgorithm::MD5)
+        );
+    }
+
+    // upstream: checksum.c:156 - an unknown name is `RERR_UNSUPPORTED`, not a
+    // silent fallback. Falling back would pick an algorithm the peer is not
+    // using, which corrupts the comparison rather than failing it.
+    #[test]
+    fn apply_long_form_args_rejects_an_unknown_checksum_choice() {
+        let args = daemon_argv("-logDtpr", &["--checksum-choice=nope"]);
+        let mut config = ServerConfig::default();
+        assert_eq!(
+            apply_long_form_args(&args, &mut config),
+            Some(ClientArgRejection::InvalidValue(
+                "unknown checksum name: nope".to_owned()
+            ))
+        );
+    }
+
+    // upstream: options.c:3046-3049 + compat.c:823-825 - the SERVER picks the
+    // seed and writes it on the wire, so a daemon that drops the client's value
+    // makes `--checksum-seed` a no-op over a daemon while it works over ssh.
+    #[test]
+    fn apply_long_form_args_honours_a_forwarded_checksum_seed() {
+        let args = daemon_argv("-logDtpr", &["--checksum-seed=12345"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert_eq!(config.checksum_seed, Some(12345));
+    }
+
+    // upstream: options.c:861 is POPT_ARG_INT and options.c:3047 prints `%d`, so
+    // the value can be negative. `write_seed` puts it back on the wire as the
+    // same 32 bits, so a u32-only parse would drop exactly the values upstream
+    // can emit.
+    #[test]
+    fn apply_long_form_args_accepts_a_negative_checksum_seed() {
+        let args = daemon_argv("-logDtpr", &["--checksum-seed=-5"]);
+        let mut config = ServerConfig::default();
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert_eq!(config.checksum_seed, Some(-5i32 as u32));
+    }
+
     // upstream: options.c:1172-1175 - the digit scan leaves the cursor on the
     // terminator, so an empty value parses as 0. For `--max-size` that means
     // "exclude every non-empty file", NOT "no limit"; treating it as absent

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
@@ -62,7 +62,7 @@ pub use read_dir::{DirEntryView, EntryKind, ReadDirOutcome, read_dir_via_sandbox
 pub use rename::{confined_rename, renameat, renameat_via_sandbox_or_fallback};
 pub use unlink::{
     UnlinkFlags, UnlinkResidue, recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback,
-    unlink_via_sandbox_or_fallback, unlinkat,
+    unlink_path, unlink_via_sandbox_or_fallback, unlinkat,
 };
 
 // Bring the leaf types the `#[cfg(test)]` module references via

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
@@ -145,6 +145,48 @@ pub fn unlinkat(dirfd: BorrowedFd<'_>, name: &OsStr, flags: UnlinkFlags) -> io::
     }
 }
 
+/// Remove `path`, resolved against the process working directory, via
+/// `unlinkat(2)` instead of the legacy `unlink(2)` / `rmdir(2)` pair.
+///
+/// # This is NOT a confinement improvement
+///
+/// `AT_FDCWD` with an absolute `path` makes the kernel ignore the directory
+/// fd entirely, so resolution is **identical to `unlink(2)`** - every path
+/// component is still followed, and a parent-symlink swap can still redirect
+/// the removal. This is a syscall-number substitution to stay inside the
+/// daemon worker seccomp allowlist, nothing more. Do not read a call to this
+/// helper as evidence that the site is confined.
+///
+/// # Why it diverges from the pinned upstream
+///
+/// Behaviourally the divergence is measured against the 3.4.4 **behaviour**
+/// pin (`Cargo.toml:461`): there `successful_send()` removes the source with a
+/// plain `do_unlink(fname)` - path-based, exactly what `std::fs::remove_file`
+/// compiles to. oc carries seccomp hardening upstream does not, and that filter
+/// admits only the `*at` syscall forms, so the legacy number returns `EPERM`
+/// inside a sandboxed worker. The substitution is semantically null and costs
+/// no extra syscall.
+///
+/// Line references below resolve against the 3.5.0 **citation** pin
+/// (`xtask/src/commands/citations.rs:61`), which is what the drift gate reads.
+/// At 3.5.0 `successful_send()` is `sender.c:395` and it goes further than this
+/// helper does: it resolves a confined parent dirfd via
+/// `secure_sender_parent_fd()` (`sender.c:416`), re-stats fd-relative
+/// (`sender.c:426-428`), and removes through `secure_remove_source_file()`
+/// (`sender.c:201-203`, itself `do_unlink_atfd`) at the `sender.c:453` removal
+/// ternary. Adopting that shape is the U350-4d site tracked as task 1043; this
+/// helper deliberately does not attempt it.
+///
+/// Callers holding a `DirSandbox` should prefer [`unlinkat`] against the
+/// sandbox dirfd, which does pin the parent against a TOCTOU swap.
+///
+/// # Errors
+///
+/// Surfaces the `unlinkat(2)` error verbatim; see [`unlinkat`].
+pub fn unlink_path(path: &Path, flags: UnlinkFlags) -> io::Result<()> {
+    unlinkat(rustix::fs::CWD, path.as_os_str(), flags)
+}
+
 /// Issue `unlinkat` against `link_path` when the `sandbox` root is the
 /// immediate parent.
 ///

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -89,8 +89,8 @@ pub use at_syscalls::{
     readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
     recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
     secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
-    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
-    utimensat_via_sandbox_or_fallback,
+    symlinkat_via_sandbox_or_fallback, unlink_path, unlink_via_sandbox_or_fallback, unlinkat,
+    utimensat, utimensat_via_sandbox_or_fallback,
 };
 
 /// Parent-dirfd carrier threaded through the receiver pipeline.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -393,8 +393,8 @@ pub use dir_sandbox::{
     readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
     recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
     secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
-    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
-    utimensat_via_sandbox_or_fallback,
+    symlinkat_via_sandbox_or_fallback, unlink_path, unlink_via_sandbox_or_fallback, unlinkat,
+    utimensat, utimensat_via_sandbox_or_fallback,
 };
 pub use inplace_open::{InplaceResolution, open_inplace_output};
 pub use kernel_version::{

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -1365,7 +1365,20 @@ impl GeneratorContext {
         }
 
         // upstream: sender.c:171 - do_unlink(fname) once every guard passed.
-        match std::fs::remove_file(source_path) {
+        //
+        // Routed through `fast_io::unlink_path` rather than
+        // `std::fs::remove_file`: the latter lowers to the legacy `unlink(2)`,
+        // which the daemon worker seccomp allowlist does not admit, so a
+        // sandboxed daemon sender failed every removal with EPERM while every
+        // other syscall on the path succeeded. `unlinkat(AT_FDCWD, ..)`
+        // resolves identically to `unlink(2)` - this is a syscall-number
+        // substitution, NOT confinement. Fd-anchoring this site the way 3.5.0
+        // does is tracked as task 1043; see `unlink_path`'s doc comment.
+        #[cfg(unix)]
+        let removal = fast_io::unlink_path(source_path, fast_io::UnlinkFlags::File);
+        #[cfg(not(unix))]
+        let removal = std::fs::remove_file(source_path);
+        match removal {
             Ok(()) => {
                 // upstream: sender.c:179-180 - INFO_GTE(REMOVE,1) success notice.
                 info_log!(Remove, 1, "removing source {}", source_path.display());

--- a/tests/daemon_honours_forwarded_remove_source_files.rs
+++ b/tests/daemon_honours_forwarded_remove_source_files.rs
@@ -22,20 +22,30 @@
 //! split, because both parsers can be "correct" about a field nothing reads;
 //! this test asserts the files are GONE from the module after a real transfer.
 //!
-//! WHY THIS WAITS INSTEAD OF STATTING IMMEDIATELY. The unlink is DEFERRED, not
-//! done inline at send time: the sender marks the entry pending and only
-//! removes the file once the receiver confirms the commit with `MSG_SUCCESS`
-//! (`sender.c:131-182 successful_send()`, mirrored at
-//! `generator/transfer/transfer_loop.rs:1145-1157`). The client process can
-//! therefore exit before the daemon's removal has landed, so reading the
-//! filesystem the instant `status()` returns is an UNSYNCHRONISED read of a
-//! peer's work - it measures which process won a race, not what the daemon
-//! did. Measured: it passed on macOS and on the musl cell and failed on the
-//! Linux `--all-features` cell, where the client exits sooner.
+//! WHY THIS CELL IS FEATURE-SENSITIVE, AND WHAT A RED HERE MEANS.
 //!
-//! The bounded wait below is a synchronisation barrier, not a retry: nothing is
-//! re-attempted, and a daemon that never removes the file still fails the test
-//! when the deadline expires.
+//! The daemon worker runs behind a seccomp filter whose allowlist is built by
+//! `worker_seccomp_allowlist()` (`daemon/sections/seccomp.rs:152`). That list
+//! carries `SYS_unlinkat` and has no `SYS_unlink`. `std::fs::remove_file` calls
+//! glibc `unlink()`, which is `__NR_unlink` on x86_64, so the kernel refuses
+//! the removal outright:
+//!
+//! ```text
+//! unlink(".../mod/f.txt") = -1 EPERM (Operation not permitted)
+//! rsync: [sender] sender failed to remove <path>: Operation not permitted (1)
+//! ```
+//!
+//! The filter is gated `cfg(all(target_os = "linux", feature =
+//! "daemon-seccomp"))`, which is why the cell splits by FEATURE SET and not by
+//! platform or by speed: a `--no-default-features` build never compiles the
+//! filter in and the unlink succeeds, while `--all-features` engages it and the
+//! unlink is refused. On a non-Linux host the filter does not exist at all, so
+//! a green run there says nothing about CI.
+//!
+//! A red here is therefore a REFUSED SYSCALL, not a lost race, and it is
+//! permanent - no amount of waiting changes it. Verify any green with the
+//! filter provably engaged (the daemon log line `seccomp BPF filter engaged`),
+//! using `OC_RSYNC_NO_SECCOMP=1` as the control leg.
 //!
 //! Skip conditions (the test passes with a printed reason):
 //! - Loopback TCP is unavailable.
@@ -129,7 +139,12 @@ fn pull_removing_sources(spelling: &str) -> Option<(bool, bool, bool)> {
     // Observe BEFORE killing the daemon: it is the daemon that performs the
     // removal, so tearing it down first would guarantee the very absence of
     // work this test is trying to detect.
-    let source_remains = source_still_present_after_settling(&module.join("f.txt"));
+    //
+    // Observed, not waited for. A bounded wait here would be a waiver: the
+    // removal either happens or is refused outright, and a wait cannot turn a
+    // refusal into a pass - it can only spend the deadline and report the same
+    // failure later, while hiding the shape of it from anyone reading the test.
+    let source_remains = module.join("f.txt").exists();
 
     let _ = daemon.kill();
     let _ = daemon.wait();
@@ -139,23 +154,6 @@ fn pull_removing_sources(spelling: &str) -> Option<(bool, bool, bool)> {
         source_remains,
         dest.join("f.txt").exists(),
     ))
-}
-
-/// Waits for the daemon's deferred source removal to land, and reports whether
-/// the file is STILL there once the wait is over.
-///
-/// The deadline is generous because it bounds a failure, not a success: a
-/// daemon that removes the file returns as soon as it has, and a daemon that
-/// never removes it pays the full wait exactly once and then fails the test.
-fn source_still_present_after_settling(source: &Path) -> bool {
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while Instant::now() < deadline {
-        if !source.exists() {
-            return false;
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    source.exists()
 }
 
 /// Both spellings name the same option in `parse_arguments()`;

--- a/tests/daemon_honours_forwarded_remove_source_files.rs
+++ b/tests/daemon_honours_forwarded_remove_source_files.rs
@@ -22,6 +22,21 @@
 //! split, because both parsers can be "correct" about a field nothing reads;
 //! this test asserts the files are GONE from the module after a real transfer.
 //!
+//! WHY THIS WAITS INSTEAD OF STATTING IMMEDIATELY. The unlink is DEFERRED, not
+//! done inline at send time: the sender marks the entry pending and only
+//! removes the file once the receiver confirms the commit with `MSG_SUCCESS`
+//! (`sender.c:131-182 successful_send()`, mirrored at
+//! `generator/transfer/transfer_loop.rs:1145-1157`). The client process can
+//! therefore exit before the daemon's removal has landed, so reading the
+//! filesystem the instant `status()` returns is an UNSYNCHRONISED read of a
+//! peer's work - it measures which process won a race, not what the daemon
+//! did. Measured: it passed on macOS and on the musl cell and failed on the
+//! Linux `--all-features` cell, where the client exits sooner.
+//!
+//! The bounded wait below is a synchronisation barrier, not a retry: nothing is
+//! re-attempted, and a daemon that never removes the file still fails the test
+//! when the deadline expires.
+//!
 //! Skip conditions (the test passes with a printed reason):
 //! - Loopback TCP is unavailable.
 
@@ -111,14 +126,36 @@ fn pull_removing_sources(spelling: &str) -> Option<(bool, bool, bool)> {
         ])
         .status()
         .expect("run client");
+    // Observe BEFORE killing the daemon: it is the daemon that performs the
+    // removal, so tearing it down first would guarantee the very absence of
+    // work this test is trying to detect.
+    let source_remains = source_still_present_after_settling(&module.join("f.txt"));
+
     let _ = daemon.kill();
     let _ = daemon.wait();
 
     Some((
         status.success(),
-        module.join("f.txt").exists(),
+        source_remains,
         dest.join("f.txt").exists(),
     ))
+}
+
+/// Waits for the daemon's deferred source removal to land, and reports whether
+/// the file is STILL there once the wait is over.
+///
+/// The deadline is generous because it bounds a failure, not a success: a
+/// daemon that removes the file returns as soon as it has, and a daemon that
+/// never removes it pays the full wait exactly once and then fails the test.
+fn source_still_present_after_settling(source: &Path) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if !source.exists() {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    source.exists()
 }
 
 /// Both spellings name the same option in `parse_arguments()`;

--- a/tests/daemon_honours_forwarded_remove_source_files.rs
+++ b/tests/daemon_honours_forwarded_remove_source_files.rs
@@ -1,0 +1,147 @@
+//! A daemon SENDER must unlink its sources when the client sends
+//! `--remove-source-files`.
+//!
+//! ```c
+//! /* options.c:3153-3156 - server_options() */
+//! if (remove_source_files == 1)
+//!         args[ac++] = "--remove-source-files";
+//! else if (remove_source_files)
+//!         args[ac++] = "--remove-sent-files";
+//! ```
+//!
+//! The option is forwarded to the SERVER because the removal happens where the
+//! files are: on the sender, after the receiver acknowledges each file. On a
+//! daemon pull the sender is the daemon, so the whole feature lives behind the
+//! daemon's own parse of this argument.
+//!
+//! oc's `--server` argv parser (the remote-shell transport) recognised it; the
+//! daemon's long-form parser did not, and that parser only ever ignores an
+//! option it does not know - so `--remove-source-files` over `rsync://` copied
+//! the files and silently left every source in place, exiting 0. The same
+//! command over ssh removed them. A parser-level assertion cannot see that
+//! split, because both parsers can be "correct" about a field nothing reads;
+//! this test asserts the files are GONE from the module after a real transfer.
+//!
+//! Skip conditions (the test passes with a printed reason):
+//! - Loopback TCP is unavailable.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+/// Starts a daemon and waits until its port answers.
+///
+/// `stdin` is `/dev/null` deliberately: with an inherited terminal or pipe the
+/// daemon takes its single-connection inetd path and never listens, and the
+/// client then reports "connection refused" instead of the behaviour under
+/// test.
+fn spawn_daemon(binary: &Path, conf: &Path, port: u16) -> Child {
+    let child = Command::new(binary)
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return child;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    child
+}
+
+/// Pulls `mod/` from a loopback daemon with `--remove-source-files` and reports
+/// (transfer succeeded, source still present).
+///
+/// The module is deliberately NOT `read only`: upstream refuses a source
+/// removal on a read-only module, so a read-only fixture would report the same
+/// "source still there" as the bug and prove nothing.
+fn pull_removing_sources(spelling: &str) -> Option<(bool, bool, bool)> {
+    let root = tempfile::tempdir().expect("temp dir");
+    let port = free_port()?;
+    let module = root.path().join("mod");
+    fs::create_dir_all(&module).expect("module dir");
+    fs::write(module.join("f.txt"), b"payload\n").expect("module file");
+    let dest = root.path().join("dest");
+    fs::create_dir_all(&dest).expect("dest dir");
+
+    let conf = format!(
+        "port = {port}\n\
+         use chroot = no\n\
+         log file = {log}\n\
+         \n\
+         [m]\n\
+         \tpath = {module}\n\
+         \tread only = no\n",
+        log = root.path().join("daemon.log").display(),
+        module = module.display(),
+    );
+    let conf_path = root.path().join("rsyncd.conf");
+    fs::write(&conf_path, conf).expect("config");
+
+    let binary = oc_binary();
+    let mut daemon = spawn_daemon(&binary, &conf_path, port);
+    let status = Command::new(&binary)
+        .args([
+            "-q",
+            "-r",
+            spelling,
+            &format!("rsync://127.0.0.1:{port}/m/"),
+            &format!("{}/", dest.display()),
+        ])
+        .status()
+        .expect("run client");
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+
+    Some((
+        status.success(),
+        module.join("f.txt").exists(),
+        dest.join("f.txt").exists(),
+    ))
+}
+
+/// Both spellings name the same option in `parse_arguments()`;
+/// `--remove-sent-files` is upstream's deprecated alias (options.c:744-745) and
+/// is what an older client sends, so a daemon that honours only the modern
+/// spelling still drops the request from half its peers.
+#[test]
+fn daemon_sender_removes_sources_for_both_spellings() {
+    for spelling in ["--remove-source-files", "--remove-sent-files"] {
+        let Some((succeeded, source_remains, delivered)) = pull_removing_sources(spelling) else {
+            println!("SKIP: no loopback port available");
+            return;
+        };
+        assert!(succeeded, "{spelling}: the pull itself must succeed");
+        assert!(
+            delivered,
+            "{spelling}: the file must reach the destination - without this the \
+             source-removal assertion below would pass on a transfer that never ran"
+        );
+        assert!(
+            !source_remains,
+            "{spelling}: the daemon sender must unlink the source after the \
+             receiver acknowledges it (options.c:3153-3156)"
+        );
+    }
+}


### PR DESCRIPTION
> **⚠ DELIBERATE DIVERGENCE FROM PINNED UPSTREAM - see "Upstream divergence"
> below.** This PR changes how the daemon sender removes a source file, and at
> the pinned 3.4.4 upstream does it the other way. The divergence is
> justified by oc's own seccomp hardening, which upstream does not carry, and
> is called out rather than buried.

## The parser

`apply_long_form_args` in
`crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs`.

oc has **two** parsers for the argv upstream's `server_options()` produces:

| | parser | behaviour on an option it does not know |
|---|---|---|
| remote shell | `crates/cli/src/frontend/server/flags.rs:558` | may leak the token into the positional path list |
| daemon | `.../client_args/long_form_args.rs:25` | **silently ignores it** - the only diagnostic is `is_client_only_flag_reaching_daemon`, which fires for the batch family alone |

That silence is why the gaps were invisible: the two transports disagreed
about the same command line and nothing said so.

## The gap

Every long-form option `server_options()` (options.c:2768-3180) can send to a
daemon, cross-checked against the daemon parser and against whether the field
has a live consumer:

| option | upstream | daemon before | consumer |
|---|---|---|---|
| `--list-only` | options.c:2914 | dropped | `receiver/transfer/mode.rs:70`, `generator/file_list/mod.rs:155` |
| `--no-r` | options.c:2919 | dropped | `generator/file_list/walk.rs:301` |
| `--specials` / `--no-specials` | options.c:2930-2932 | dropped | `generator/file_list/walk.rs:251`, `receiver/directory/special.rs:73` |
| `--msgs2stderr` / `--no-msgs2stderr` | options.c:2949-2951 | dropped | `generator/transfer/orchestrator.rs:40` |
| `--partial` | options.c:3060 | dropped | `receiver/transfer/pipeline.rs:443` |
| `--no-W` | options.c:3130 | dropped | `receiver/transfer/pipeline.rs:541` |
| `--no-relative` / `--no-R` | options.c:3144 | dropped | `generator/file_list/mod.rs:85`, `receiver/file_list/sanitize.rs:33` |
| `--remove-source-files` / `--remove-sent-files` | options.c:3154-3156 | dropped | `generator/transfer/transfer_loop.rs:1155` |
| `--preallocate` | options.c:3162 | dropped | `disk_commit/process/file_ops.rs:957` |
| `--open-noatime` | options.c:3165 | dropped | `generator/context.rs:936` -> `generator/open_source.rs:110` |
| `--checksum-choice=SPEC` | options.c:2982 | dropped | `transfer/src/lib.rs:742` -> `setup/mod.rs:175` |
| `--checksum-seed=N` | options.c:3047 | dropped | `transfer/src/lib.rs:743` -> `setup/negotiator.rs:186` |

All twelve rows are fixed here. Each was traced to a consumer **before** the arm
was written, so none of them is an inert parse into a field nothing reads.

## The two that are more than a preference

**`--checksum-choice` is load-bearing on the wire.** `compat.c:544` sends the
checksum vstring only `if (!checksum_choice)`. A client that forced the
algorithm therefore sends nothing and reads nothing; a daemon that dropped the
option went on sending a list its peer had already decided not to read. oc's own
negotiator documents this hazard for the reverse direction
(`negotiate.rs:335-343`) - the daemon was sitting on the other half of it.

The spec is split on its first comma (`checksum.c:196-202`): only the transfer
half reaches the negotiation. `auto` resolves to md5 (`checksum.c:127-160`),
which is what oc's client already resolves before forwarding
(`enums/checksum.rs:237`), so both ends land on the same algorithm. An unknown
name is refused rather than silently downgraded (`checksum.c:156`) - a fallback
would pick an algorithm the peer is not using, which corrupts the comparison
instead of failing it.

**`--remove-source-files` means a daemon SENDER unlinks its sources.** Dropped,
a `rsync://` pull copied the files, left every source in place, and exited 0 -
while the identical command over ssh removed them.

## Non-vacuity

- **RED:** all 17 new parser cases fail on master's parser (`--no-fail-fast`, so
  the roster is the whole set, not the first failure).
- **GREEN:** 54/54 in the filter, 1881/1881 for the crate.
- **Mutations, each run separately:**
  - drop the comma split -> 2 fail (`..._transfer_half_...`, `..._auto_...`)
  - narrow the seed parse to `u32` -> 1 fail (`..._negative_checksum_seed`)
  - flip every new boolean assignment -> 11 fail
  - make an unknown checksum name fall back to md5 -> 1 fail
- **End to end:** `tests/daemon_honours_forwarded_remove_source_files.rs` pulls
  from a real loopback daemon and asserts the sources are gone. It is **green
  on a seccomp-engaged x86_64 build** under the real CI command
  (`cargo nextest run --workspace --all-features`), for both option spellings.
  The discriminator is the syscall, not the test outcome - see the strace pair
  below. With the parser arm mutated away it fails **on the removal assertion,
  not on its delivery control**, so the transfer demonstrably ran and the
  removal demonstrably did not.

  This test found a real product defect that had nothing to do with the parser,
  and it took two wrong turns to get there. I first misdiagnosed the red as a
  race and pushed a bounded wait; that was a waiver over a permanent `EPERM`
  and is reverted (`d4f87a2af`). The obvious fix - rerouting through the
  existing `unlink_via_sandbox_or_fallback` - would have been **inert**, for
  reasons set out below. Both detours are recorded because the reasoning that
  caught them is the reusable part.

The negation cases (`--no-r`, `--no-W`, `--no-relative`, `--no-specials`) set
the field to `true` first, because that is the state the compact flag string
leaves behind; asserting from the struct default would let a missing arm pass.

## Deliberately not in this PR

- `--force`, `--super`, `--skip-compress`, `--max-alloc`: **no field exists** on
  `ServerConfig` / `ParsedServerFlags` to receive them. An arm would parse into
  nothing. The `--server` parser already consumes `--force` and `--super` as
  explicit no-ops with the reasoning written out; the daemon does not need even
  that, because an unrecognised token there cannot be mistaken for a path.
- `--timeout=N`: the daemon seeds `io_timeout` from the module's `timeout`
  (`transfer/streams.rs:271`), never from the client. Reconciling the two is a
  policy decision, not a missing arm.
- `--only-write-batch=X`: an interop defect, now tracked separately. At the
  pin, upstream both **accepts** it (`options.c:798`) and **emits** it
  (`options.c:2851`), so an upstream client is turned away by a conforming
  peer's own emission. oc's daemon rejects it while oc's own `--server` parser
  accepts it and latches `only_write_batch` - the two parsers contradict each
  other, and one contradicts upstream. Deliberately not bundled here: this PR
  already carries a 12-option parser change plus a deliberate divergence, and
  adding a behaviour change would make its mutation proofs unattributable.
  Note for that work: the literal `X` is the point - upstream sends a
  placeholder, not a batch name, because the server needs the MODE; the value
  must never be treated as a path. The test pinning today's refusal **encodes
  the defect and should be inverted, not deleted**.
- `--checksum-seed` width: the daemon arm added here parses `i32`, which
  **matches the pin** - `int checksum_seed` (`options.c:145`), `POPT_ARG_INT`
  (`options.c:847`), emitted `%d` signed (`options.c:2881`). The `u32` on oc's
  `--server` path is the defect, and it is that path that needs fixing, not
  this one. Severity honestly stated: `compat.c` derives the seed from
  `time(NULL) ^ (getpid() << 6)`, which stays positive until 2038, so the
  generated case is latent; the live case is a peer sending an explicit
  `--checksum-seed=-N`, which upstream's parser accepts. Tracked separately.
- `--iconv=`, `--info=`, `--debug=`, the two-arg `--files-from` form, and
  `--max-delete=-1` (upstream's spelling for "allow no deletes", which the
  current `n >= 0` guard drops).

## Verification

```
cargo fmt --all -- --check                                            clean
cargo clippy --workspace --all-targets --all-features --no-deps -D warnings  clean
cargo nextest run -p daemon --all-features --no-fail-fast             1881 passed
cargo nextest run -p bin -E 'binary(~daemon) + ...'                   126 passed
cargo xtask citations                                                 8582 checked, clean
```

Run on the merged head `da69ebb9f`. The range count rises from 8568 at the
parser commit to 8582 here, across the doc rewrite and the fix: the new comment
ranges all resolve against the pin, so the gate is doing work rather than
passing vacuously.

Both edited files are `include!`d, which `cargo fmt` does not see. They were
checked by running `rustfmt` on a copy: the new code is clean, and the only
drift reported is pre-existing lines this PR does not touch.

## The seccomp boundary: why the cell is red

The daemon worker's allowlist (`worker_seccomp_allowlist()`,
`daemon/sections/seccomp.rs:152`) carries `SYS_unlinkat` and has **no
`SYS_unlink`** - zero hits workspace-wide. `std::fs::remove_file` calls glibc
`unlink()`, which is `__NR_unlink` on x86_64, so the kernel refuses the
sender's source removal.

The discriminator is the syscall, not the test outcome (x86_64, with
`seccomp BPF filter engaged` present in the daemon log in every cell):

```text
BEFORE:  unlink("…/mod/f.txt")                = -1 EPERM   source PRESENT
AFTER:   unlinkat(AT_FDCWD, "…/mod/f.txt", 0) =  0         source REMOVED
```

`unlink(` is absent from the after-trace. Restoring `remove_file` brings
`unlink(...) = -1 EPERM` straight back. Both option spellings pass under
`cargo nextest run --workspace --all-features` - the second spelling had never
previously been observed passing on a seccomp-engaged build.

**Fix** (`da69ebb9f`): one call site at
`generator/transfer/transfer_loop.rs`, `std::fs::remove_file` -> a new
`fast_io::unlink_path` wrapper over `unlinkat(CWD, ..)`. It lives in `fast_io`
because that is where FFI is permitted, adds no new `unsafe`, and leaves
`crates/transfer` under `deny(unsafe_code)`. The non-unix arm keeps
`remove_file`. `SYS_unlinkat` is already allowlisted, so the allowlist is
untouched - widening it was rejected anyway, since `readlink("/home")` `EPERM`s
in the same trace and that route is whack-a-mole. Upstream's guards are
preserved: the re-stat and the benign-`ENOENT` notice both still fire
(`ENOENT` -> `NotFound` unchanged).

## Upstream divergence - stated, not buried

**This is a syscall-number substitution, NOT a confinement improvement.** Do
not read the diff as hardening the site. `AT_FDCWD` with an absolute path makes
the kernel ignore the directory fd entirely, so resolution is **identical to
`unlink(2)`**: the same symlink following, the same parent-swap exposure.

At the pinned upstream (`Cargo.toml:461` -> 3.4.4), `successful_send()`
(`sender.c:131-182`) removes the source with a plain path-based
`do_unlink(fname)` - precisely what `std::fs::remove_file` compiles to. **oc's
previous code was a faithful mirror of the pin.** This diverges from it
deliberately, for one reason: oc runs the daemon worker behind a seccomp filter
upstream does not have, and that filter admits only the `*at` forms. The
substitution is semantically null and costs no extra syscall.

**It is also not a detour that later gets reverted - it is one arm of the final
shape.** Upstream 3.5.0's `successful_send()` is a two-arm ternary
(`sender.c:453`):

```c
if (dfd >= 0 ? secure_remove_source_file(dfd, bname) < 0 : do_unlink(fname) < 0) {
```

(Line references to upstream in this PR follow the repo's two pins: behaviour
claims are measured against the **3.4.4 behaviour pin** (`Cargo.toml:461`),
while line numbers resolve against the **3.5.0 citation pin**
(`xtask/src/commands/citations.rs:61`), which is what the drift gate reads. The
gate itself only checks a cited line *exists* - `citations.rs:422` is
`lines().count()` - so it cannot catch a citation pointing at the wrong code,
and green CI is not evidence of citation correctness.)

The path-based arm is live upstream behaviour, not a placeholder: when the
confined parent is declined - `insecure links = yes` / `--insecure-links`,
which `secure_sender_parent_fd()` signals with `errno = 0; return -1`
(`sender.c:88-91`) - `dfd < 0` and upstream takes `do_unlink(fname)`. oc today
has no branch at all; adding the confined arm (module-root-anchored parent
dirfd, fd-relative re-stat, `do_unlink_atfd`) is **task 1043**, and this call
site survives it unchanged as the declined-confinement arm.

And because 3.5.0 independently moves this site toward the `*at` forms, the gap
between oc and upstream here **closes at the pin flip rather than widening** -
which is what makes this a defensible deliberate divergence rather than drift.

No citation was changed by this commit. `sender.c:131-182` is correct **at the
pin**; retargeting it at 3.5.0's `:395` would have *introduced* drift, since
the gate validates against the pinned release.

### Why it split by feature set, and how a wrong fix was caught

| route | passes | fails |
|---|---|---|
| CI cells (this PR) | `Linux musl` (`--no-default-features`) | `nextest` (`--all-features`) |
| local build scope | `-p bin --all-features` | `-p bin -p daemon --all-features` |

Same fact from both sides: `daemon-seccomp` feature-unifies into the binary
only at workspace `--all-features` scope. Same-binary control:

| daemon env | source removed? |
|---|---|
| default (filter engaged) | **never**, 3/3, polled 5s with the daemon alive |
| `OC_RSYNC_NO_SECCOMP=1` | yes, lag 0.0000s, 3/3 |

The obvious fix - routing the call through the existing
`unlink_via_sandbox_or_fallback` - would have been **inert**. Its fallback arm
(`fast_io/.../unlink.rs:221`) is `std::fs::remove_file`, and both of its safe
arms need a sandbox: `anchor_parent` (`nested.rs:95-97`) returns `Fallback`
the moment `sandbox` is `None`, which is what the sender passes (zero
`sandbox` references in `transfer_loop.rs` or `generator/context.rs`). It
would have re-executed the same refused syscall and read as a failed fix
rather than an unreached one.

A companion hardening of that fallback arm was considered and **deliberately
not made** - the arm still calls `remove_file` today. It was measured
unreachable: mutating only that arm and re-running a daemon push with
`--delete` still succeeded, because every daemon-receiver deletion takes the
sandbox-dirfd branch (`unlinkat(11, "stale2.txt", 0) = 0`). Adding an unwired
guard while task 249 (unwired code as a dominant defect class) is open would
have been indefensible under Rule 2, so it was dropped rather than shipped as
defence-in-depth.

### My own error, for the record

I first misdiagnosed this red as a race and pushed a bounded wait. That was a
waiver over a permanent `EPERM` and is reverted (`d4f87a2af`). My "green" for
it was an untested configuration: macOS/aarch64 under `-p bin`, where the
filter is not compiled, the scope does not unify `daemon-seccomp`, and aarch64
has no `__NR_unlink` so glibc routes to the allowlisted `unlinkat` regardless.
Three independent reasons it could not have failed. The musl-vs-nextest split
was the right evidence read the wrong way - it is the feature set, not host
speed.
