### PR TITLE
docs: refresh the 3.5.0 testsuite divergence counts from the manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict
 
 **Release:** 0.6.4 - Wire-compatible drop-in replacement for rsync 3.5.0 and the 3.4.x series (protocols 28-32).
 
-All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop scenarios run in CI against upstream rsync 3.0.9, 3.1.3, 3.4.4 and 3.5.0, with 2.6.9 built and cached; 3.4.4 represents the whole 3.4.x series (3.4.1/3.4.2/3.4.3 share protocol 32 and are superseded by it). Upstream rsync's own testsuite runs in CI against `oc-rsync` as `$RSYNC`: against the 3.4.4 corpus all tests pass and the known-failures roster is empty, and against the newer 3.5.0 corpus **11 of 349 tests currently diverge** (see below).
+All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop scenarios run in CI against upstream rsync 3.0.9, 3.1.3, 3.4.4 and 3.5.0, with 2.6.9 built and cached; 3.4.4 represents the whole 3.4.x series (3.4.1/3.4.2/3.4.3 share protocol 32 and are superseded by it). Upstream rsync's own testsuite runs in CI against `oc-rsync` as `$RSYNC`: against the 3.4.4 corpus all tests pass and the known-failures roster is empty, and against the newer 3.5.0 corpus **9 of 349 tests currently diverge** (see below).
 
 **Tracking rsync 3.5.0.** Upstream released 3.5.0 on 13 Aug 2026. It is wire-identical to 3.4.4 - `PROTOCOL_VERSION` 32, `SUBPROTOCOL_VERSION` 0, unchanged `errcode.h` - so protocol compatibility carries over unchanged and is what the "wire-compatible" claim above rests on. What 3.5.0 changes is *behaviour*: 33 CVEs concentrated in path handling and the daemon, a rewritten path resolver, five new options (`--confine-root`, `--drop-D`, `--no-drop-D`, `--insecure-links`, `--no-insecure-links`), three new daemon directives (`proxy protocol hosts`, `auth digest`, `insecure links`), and a test suite rebuilt from shell scripts into Python. Aligning oc-rsync to those behaviours is in progress and tracked openly.
 
@@ -36,12 +36,12 @@ Current outcomes, as recorded in each leg's committed manifest:
 
 | leg | pass | fail | skip | corpus |
 |---|---:|---:|---:|---:|
-| non-root, pipe | 251 | 9 | 89 | 349 |
-| root, pipe | 278 | 11 | 60 | 349 |
+| non-root, pipe | 252 | 8 | 89 | 349 |
+| root, pipe | 280 | 9 | 60 | 349 |
 | non-root, tcp | 100 | 22 | 36 | 158 |
 | root, tcp | 112 | 28 | 18 | 158 |
 
-**11 distinct tests** diverge across the two full-corpus legs, and 35 across all four. Every leg carries its own expected-outcome manifest, generated from a real run rather than hand-written, so only a *change* in outcome turns a badge red - and that includes an unexpected **pass**, which is what stops a divergence being quietly re-baselined instead of fixed. A fix flips its manifest rows in the same commit. The divergences are genuine and tracked openly: each was re-run against the real upstream 3.5.0 binary as a negative control, so they are oc-rsync behaviour gaps, not harness artefacts.
+**9 distinct tests** diverge across the two full-corpus legs, and 34 across all four. Every leg carries its own expected-outcome manifest, generated from a real run rather than hand-written, so only a *change* in outcome turns a badge red - and that includes an unexpected **pass**, which is what stops a divergence being quietly re-baselined instead of fixed. A fix flips its manifest rows in the same commit. The divergences are genuine and tracked openly: each was re-run against the real upstream 3.5.0 binary as a negative control, so they are oc-rsync behaviour gaps, not harness artefacts.
 
 Separately, [Upstream Testsuite 3.5.0dev](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml) is a **development** tracker, not a gate and not the 3.5.0 release: it builds RsyncProject git master (`version.h` == `3.5.0dev`), a moving target, and is deliberately non-blocking so an upstream-side break can never fail a PR here.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,12 +85,12 @@ rsync 3.5.0 is a major security release closing **33 CVEs**, concentrated in pat
 
 | leg | pass | fail | skip | corpus |
 |---|---:|---:|---:|---:|
-| non-root, pipe | 251 | 9 | 89 | 349 |
-| root, pipe | 278 | 11 | 60 | 349 |
+| non-root, pipe | 252 | 8 | 89 | 349 |
+| root, pipe | 280 | 9 | 60 | 349 |
 | non-root, tcp | 100 | 22 | 36 | 158 |
 | root, tcp | 112 | 28 | 18 | 158 |
 
-The two pipe legs run the whole corpus; the tcp legs add `--daemon-tests-only`, so they re-run the 158 tests that can observe the transport. **11 distinct tests** diverge across the two full-corpus legs, and **35** across all four. That set is the triage input, not a vulnerability count: it mixes real behavioural gaps, harness differences, and probes for C-level memory errors that have no Rust analogue. Classification requires per-test evidence, and a fix flips its manifest rows in the same commit - re-baselining a row without a fix would be a waiver, and the gate fails on an unexpected *pass* for exactly that reason.
+The two pipe legs run the whole corpus; the tcp legs add `--daemon-tests-only`, so they re-run the 158 tests that can observe the transport. **9 distinct tests** diverge across the two full-corpus legs, and **34** across all four. That set is the triage input, not a vulnerability count: it mixes real behavioural gaps, harness differences, and probes for C-level memory errors that have no Rust analogue. Classification requires per-test evidence, and a fix flips its manifest rows in the same commit - re-baselining a row without a fix would be a waiver, and the gate fails on an unexpected *pass* for exactly that reason.
 
 **Highest-severity items and their oc-rsync bearing:**
 


### PR DESCRIPTION
`README.md` and `SECURITY.md` both carry the same four-row testsuite outcome table and the same two divergence figures. They were copied by hand rather than generated, so both drifted as fixes landed and manifest rows flipped from `fail` to `pass`.

## Measured

Read from `tools/ci/upstream-3.5.0-expect.*.txt` at this commit:

| leg | pass | fail | other | total |
|---|---|---|---|---|
| non-root, pipe | 252 | 8 | 89 | 349 |
| root, pipe | 280 | 9 | 60 | 349 |
| non-root, tcp | 100 | 22 | 36 | 158 |
| root, tcp | 112 | 28 | 18 | 158 |

Union across the two full-corpus (pipe) legs: **9** distinct tests, previously stated as 11. Union across all four legs: **34**, previously stated as 35.

The two tcp rows were already current, so only the pipe rows and the two union figures move. No manifest row is touched - this changes prose to match the committed manifests, it does not re-baseline anything.

## Why it survived

The drift is entirely in the favourable direction: three `fail` rows became passes and the prose was never updated. A number that overstates the gap reads as conservative rather than wrong, so nothing prompted a re-check.

## How the numbers were produced

Derived from the manifests by a script that asserts each substitution matches exactly once, rather than typed in - a silent no-op is precisely the failure mode that let the drift accumulate. Re-running it now is a no-op, which is the check that it is current.