### PR TITLE
fix(fast_io): warn on fd exhaustion from the confined walk

### DIFF
--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -476,23 +476,34 @@ fn should_warn_fd_exhaustion(err: &io::Error, warned: &AtomicBool) -> bool {
 /// would not. Upstream prints a one-shot hint on `EMFILE`/`ENFILE` for
 /// exactly this reason (upstream: syscall.c:2924-2936); without it the
 /// bare "Too many open files" is opaque about which limit to raise.
-///
-/// Upstream brackets its `rprintf` with `int e = errno; ... errno = e;`
-/// because `rprintf` can itself clobber the global `errno`. Rust has no
-/// such hazard here: the failure is an owned [`io::Error`] moved through
-/// this function, so nothing the emit does can alter what the caller
-/// observes. The guarantee is pinned by test rather than by copying a
-/// save/restore dance that would be a no-op.
+/// [`warn_once_on_fd_exhaustion`] owns that decision for both walks.
 fn openat_dir(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
     let result = openat_dir_strict(parent_fd, child_name);
 
-    if let Err(err) = &result
-        && should_warn_fd_exhaustion(err, &FD_EXHAUSTION_WARNED)
-    {
-        eprintln!("{FD_EXHAUSTION_HINT}");
+    if let Err(err) = &result {
+        warn_once_on_fd_exhaustion(err);
     }
 
     result
+}
+
+/// Print the descriptor-exhaustion hint if `err` is the first `EMFILE` or
+/// `ENFILE` this process has seen from a component open.
+///
+/// The sole owner of the text, the gate and the channel. Both walks that
+/// hold a dirfd per path component route their failures here - the
+/// unconfined [`openat_dir`] and the confined
+/// [`ConfinedWalk::descend`] - so there is one latch, and therefore one
+/// line per process however many walks hit the ceiling.
+///
+/// `err` is borrowed and the return is `()`: the emit cannot touch what the
+/// caller propagates. That is the port's answer to upstream's
+/// `int e = errno; ... errno = e;` bracket, which exists only because
+/// `rprintf` can clobber the global `errno`.
+fn warn_once_on_fd_exhaustion(err: &io::Error) {
+    if should_warn_fd_exhaustion(err, &FD_EXHAUSTION_WARNED) {
+        eprintln!("{FD_EXHAUSTION_HINT}");
+    }
 }
 
 /// The resolution itself, with no diagnostics attached.
@@ -793,9 +804,23 @@ impl<O: ConfinementOracle> ConfinedWalk<'_, O> {
 
     /// Descend one component, following an in-tree directory symlink.
     ///
+    /// # Descriptor exhaustion
+    ///
+    /// This walk pushes one dirfd per path component and holds them all for
+    /// the duration, so a deep peer tail can exhaust the open-file limit
+    /// where a single path-based `open()` would not. A hard open failure is
+    /// therefore offered to [`warn_once_on_fd_exhaustion`], which prints the
+    /// one-shot hint for `EMFILE`/`ENFILE` and stays silent otherwise.
+    ///
+    /// The call sits on the hard-error arm alone, mirroring upstream: its
+    /// `EMFILE`/`ENFILE` test is nested inside
+    /// `if (errno != ENOTDIR && !NOFOLLOW_HIT_SYMLINK(errno))`, so the two
+    /// errnos that fall through to the `readlink` probe never reach it.
+    ///
     /// # Upstream Reference
     ///
     /// - `rsync-3.5.0/syscall.c:2891-2965` `ds_descend()`
+    /// - `rsync-3.5.0/syscall.c:2924-2936` - the hint itself
     fn descend(&mut self, part: &std::ffi::OsStr) -> io::Result<()> {
         if part == "." {
             return Ok(());
@@ -818,7 +843,10 @@ impl<O: ConfinementOracle> ConfinedWalk<'_, O> {
             Err(err) if nofollow_hit_symlink(&err) || err.raw_os_error() == Some(libc::ENOTDIR) => {
                 self.follow_symlink(part, err)
             }
-            Err(err) => Err(err),
+            Err(err) => {
+                warn_once_on_fd_exhaustion(&err);
+                Err(err)
+            }
         }
     }
 

--- a/crates/fast_io/src/dir_sandbox/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/tests.rs
@@ -1144,3 +1144,165 @@ fn real_fd_exhaustion_warns_once_and_surfaces_emfile_to_the_caller() {
         "the caller must still see EMFILE, not an error re-derived after the hint"
     );
 }
+
+/// The lowest descriptor number the kernel would hand out right now.
+///
+/// `open(2)` always returns the lowest free number, so opening and closing
+/// one probe file names the number the *next* allocation will take. Setting
+/// `RLIMIT_NOFILE` to that number plus one therefore admits exactly one
+/// further descriptor.
+fn next_free_fd() -> u64 {
+    let probe = tempfile::tempfile().expect("probe descriptor");
+    let raw = probe.as_raw_fd();
+    assert!(raw >= 0, "probe descriptor must be valid");
+    raw as u64
+}
+
+/// The *confined* peer-tail walk must emit the descriptor-exhaustion hint
+/// too, and must stay silent when the same open fails for an ordinary
+/// reason.
+///
+/// `ConfinedWalk::descend` is the walk that can genuinely exhaust the
+/// descriptor table: it holds one dirfd per live path component, so a deep
+/// peer tail costs a descriptor per level where a single path-based
+/// `open()` costs one in total. Upstream warns from exactly that function -
+/// the `EMFILE`/`ENFILE` arm sits inside `ds_descend()`, not at the anchor
+/// open - so a silent `descend` was the divergence, while the pre-existing
+/// emit in `openat_dir` covers only the unconfined sibling walk.
+///
+/// Three cells, each failing for a different reason:
+///
+/// 1. A walk that resolves proves the fixture is a *working* confined walk
+///    rather than one failing for an unrelated reason, and warms any
+///    one-shot capability probe before the ceiling drops.
+/// 2. A walk refused with `ENOENT` is the negative control. It leaves
+///    `descend` through the *same* `Err(err)` arm the hint now hangs off,
+///    so widening [`should_warn_fd_exhaustion`](super::should_warn_fd_exhaustion)
+///    to fire on any error - the mutation a positives-only suite cannot
+///    see - turns this leg red.
+/// 3. The measured run pins both halves of the emit: the hint appears
+///    exactly once, and the caller still observes `EMFILE` rather than an
+///    errno re-derived after the warning was printed.
+///
+/// Both the `RLIMIT_NOFILE` change and the stderr redirect are
+/// process-global. That is safe only because nextest runs each test in its
+/// own process. Every descriptor the measured run needs is allocated
+/// *before* the limit drops, and both globals are restored before any
+/// assertion runs so a failing assert can still allocate for its output.
+///
+/// upstream: syscall.c:2924-2936, inside `ds_descend()` (`syscall.c:2891`).
+#[test]
+fn confined_walk_warns_on_fd_exhaustion_and_stays_silent_on_enoent() {
+    use rustix::io::{Errno, dup};
+    use rustix::process::{Resource, Rlimit, getrlimit, setrlimit};
+    use rustix::stdio::{dup2_stderr, stderr};
+    use std::io::{Read, Seek, SeekFrom};
+    use std::path::Path;
+
+    let (_keep, anchor) = canonical_tempdir();
+    let peer_tail = Path::new("archive/2026/hosts");
+    std::fs::create_dir_all(anchor.join(peer_tail)).expect("build peer tail");
+
+    // Controls, both under the ambient limit, both required to be silent.
+    let mut control_capture = tempfile::tempfile().expect("control capture file");
+    let saved_stderr = dup(stderr()).expect("save stderr");
+    dup2_stderr(&control_capture).expect("redirect stderr");
+    let resolved = DirSandbox::open_dest_anchor_confined(
+        &anchor,
+        peer_tail,
+        super::ConfinePolicy::confined(ExcludeNothing),
+    );
+    let missing = DirSandbox::open_dest_anchor_confined(
+        &anchor,
+        Path::new("archive/absent"),
+        super::ConfinePolicy::confined(ExcludeNothing),
+    );
+    dup2_stderr(&saved_stderr).expect("restore stderr");
+
+    let mut control_stderr = String::new();
+    control_capture
+        .seek(SeekFrom::Start(0))
+        .expect("rewind control capture");
+    control_capture
+        .read_to_string(&mut control_stderr)
+        .expect("read control stderr");
+
+    resolved.expect("the confined walk must resolve an existing tail under the ambient limit");
+    let missing = missing.expect_err("a peer tail component that does not exist must fail");
+    assert_eq!(
+        missing.raw_os_error(),
+        Some(Errno::NOENT.raw_os_error()),
+        "the negative control must leave `descend` with ENOENT, not some other errno"
+    );
+    assert_eq!(
+        control_stderr, "",
+        "neither a resolving walk nor an ordinary ENOENT may print the \
+         descriptor-exhaustion hint; got: {control_stderr:?}"
+    );
+
+    // Every descriptor the measured run needs is allocated here, before the
+    // ceiling drops.
+    let mut captured = tempfile::tempfile().expect("stderr capture file");
+    let saved_stderr = dup(stderr()).expect("save stderr");
+    let original = getrlimit(Resource::Nofile);
+
+    // One descriptor of headroom: `open_trusted_dir` is a single `open()`
+    // and takes it, so the first `descend` component is the allocation the
+    // kernel refuses.
+    let ceiling = next_free_fd() + 1;
+
+    dup2_stderr(&captured).expect("redirect stderr");
+    let lowered = setrlimit(
+        Resource::Nofile,
+        Rlimit {
+            current: Some(ceiling),
+            maximum: original.maximum,
+        },
+    );
+    let observed = getrlimit(Resource::Nofile).current;
+
+    // Gate the measurement on the drop actually landing. `setrlimit` refuses
+    // a request above `rlim_max`, and running the walk regardless would turn
+    // a failed drop into a silent pass.
+    let outcome = (lowered.is_ok() && observed == Some(ceiling)).then(|| {
+        DirSandbox::open_dest_anchor_confined(
+            &anchor,
+            peer_tail,
+            super::ConfinePolicy::confined(ExcludeNothing),
+        )
+    });
+
+    setrlimit(Resource::Nofile, original).expect("restore RLIMIT_NOFILE");
+    dup2_stderr(&saved_stderr).expect("restore stderr");
+
+    let mut emitted = String::new();
+    captured.seek(SeekFrom::Start(0)).expect("rewind capture");
+    captured
+        .read_to_string(&mut emitted)
+        .expect("read captured stderr");
+
+    assert_eq!(
+        observed,
+        Some(ceiling),
+        "the harness could not lower RLIMIT_NOFILE to {ceiling} \
+         (setrlimit: {lowered:?}, original: {original:?}); nothing below this \
+         point would have been exercised"
+    );
+    let outcome = outcome.expect("the measurement is gated on the drop above");
+
+    let err = outcome.expect_err(
+        "the confined walk completed with one descriptor of headroom; no \
+         descriptor pressure was applied, so this cell asserted nothing",
+    );
+    assert_eq!(
+        err.raw_os_error(),
+        Some(Errno::MFILE.raw_os_error()),
+        "the caller must still see EMFILE, not an error re-derived after the hint"
+    );
+    assert_eq!(
+        emitted.matches(super::FD_EXHAUSTION_HINT).count(),
+        1,
+        "the confined walk must print the hint exactly once under \
+         RLIMIT_NOFILE={ceiling}; got: {emitted:?}"
+    );
+}


### PR DESCRIPTION
## Problem

`ConfinedWalk::descend` pushes one dirfd per path component and holds them all for the duration of the walk. A deep peer tail therefore costs a descriptor per level, where a single path-based `open()` costs one in total. It was the only component open in the dirfd sandbox that failed **silently** on `EMFILE`/`ENFILE`, leaving an operator with a bare "Too many open files" and nothing naming which limit to raise.

The descriptor-exhaustion hint existed, but was attached to `openat_dir` — which serves the *unconfined* `open_dest_anchor` walk, the one that holds a single descriptor at a time. So the diagnostic sat on the walk that cannot realistically exhaust descriptors and was absent from the one that can.

## Upstream

This is a placement fix against upstream, not an oc-side invention. Upstream 3.5.0 emits this hint from inside `ds_descend()` itself:

```c
/* rsync-3.5.0/syscall.c:2924-2936, inside ds_descend() */
if (errno != ENOTDIR && !NOFOLLOW_HIT_SYMLINK(errno)) {
        if (errno == EMFILE || errno == ENFILE) {
                /* The resolver holds one dirfd per path component, so a deep path
                 * can exhaust descriptors where plain open() would not.  Hint at
                 * the fix once -- otherwise "Too many open files" is opaque. */
                static int warned = 0;
                if (!warned) {
                        int e = errno;
                        warned = 1;
                        rprintf(FWARNING, "out of file descriptors resolving a deep path;"
                                " raise the open-file limit (e.g. `ulimit -n`)\n");
                        errno = e;
                }
        }
        return -1;
}
```

`ds_descend()` is precisely what `ConfinedWalk::descend` ports — the existing doc comment already cites it. The hint's own citation (`syscall.c:2924-2936`) was likewise already in the tree, hanging off `openat_dir`; it names lines that live inside `ds_descend`.

## Change

- Extract `warn_once_on_fd_exhaustion`, the single owner of the hint text, the errno gate and the stderr channel. `openat_dir` now calls it instead of inlining the emit, so `FD_EXHAUSTION_HINT` and `should_warn_fd_exhaustion` keep exactly one consumer path.
- Call it from `descend`'s hard-error arm.

Both walks share the one process latch, so the line still appears at most once however many walks hit the ceiling — matching upstream's single `static int warned`.

The call sits on the **hard-error arm alone**, mirroring upstream's nesting inside `if (errno != ENOTDIR && !NOFOLLOW_HIT_SYMLINK(errno))`: the two errnos that fall through to the `readlink` probe never reach it. Only the `Err` arm is touched, so the success path is byte-for-byte unchanged. No `unsafe` added.

Upstream's `int e = errno; ... errno = e;` bracket has no analogue here and is deliberately not copied: the failure is an owned `io::Error` borrowed by the helper, so the emit cannot reach what the caller propagates. The test asserts the caller still sees `EMFILE`, making that a checked claim rather than a stated one.

## Test

`confined_walk_warns_on_fd_exhaustion_and_stays_silent_on_enoent` drives a real kernel refusal rather than a synthetic error. It lowers `RLIMIT_NOFILE` to one above the next free descriptor number — `open_trusted_dir` is a single `open()` and takes it, so the first `descend` component is the allocation the kernel refuses — and gates the measurement on the drop having actually landed, so a `setrlimit` refused against `rlim_max` reports rather than silently passing.

The **`ENOENT` negative control** is the load-bearing half. It leaves `descend` through the *same* `Err(err)` arm the hint now hangs off, so it shares the code path with the positive cell. A predicate widened to fire on any error starts printing on ordinary missing-path traffic and turns that leg red; a positives-only cell cannot see that mutation.

Mutation check — widening the predicate to `true` fails on the control, not the positive:

```
assertion `left == right` failed: neither a resolving walk nor an ordinary ENOENT
may print the descriptor-exhaustion hint;
got: "out of file descriptors resolving a deep path; raise the open-file limit (e.g. `ulimit -n`)\n"
```

Both the `RLIMIT_NOFILE` change and the stderr redirect are process-global, which is safe only because nextest runs each test in its own process. Every descriptor the measured run needs is allocated before the limit drops, and both globals are restored before any assertion so a failing assert can still allocate for its output. `dir_sandbox` is `#[cfg(unix)]` in its entirety, so Windows is unaffected.

## Verification

- `cargo fmt --all -- --check` — clean (cross-checked with `rustfmt --check` directly on both touched files)
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` — no issues
- `cargo nextest run -p fast_io --all-features` — 783 tests run, 783 passed
- `python3 tools/ci/citation_drift_audit.py --ratchet` — ratchet OK; `fast_io: suspected-drift=0`

## Interaction with #7530

Additive, verified by running it rather than by inspection. #7530 adds a test observing this hint on `open_dest_anchor`, which resolves through `openat_dir` and never constructs a `ConfinedWalk`. That emit site is preserved. Test-merging #7530 onto this branch merges cleanly and its `daemon_anchored_walk_warns_once_when_descriptors_run_out` passes with this change applied. The two are independent and can land in either order.
