### PR TITLE
fix(backup): confine the in-place backup copy to the module root

### DIFF
--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -17,7 +17,8 @@ use crate::local_copy::create_symlink;
 use crate::local_copy::map_metadata_error;
 
 /// Duplicates a destination's pre-transfer bytes into the operator-named
-/// backup path, resolving that path with the ownership walk.
+/// backup path, resolving that path with the ownership walk and confining the
+/// result to the session's confinement root.
 ///
 /// Used by the `--inplace --backup` paths, where the destination inode is
 /// rewritten in place rather than replaced, so the pre-image must be COPIED
@@ -31,6 +32,15 @@ use crate::local_copy::map_metadata_error;
 /// at the `--backup-dir` leaf. `std::fs::copy` has exactly that behaviour,
 /// which is what upstream's `operator-path-inplace-backup-dir` cell observes as
 /// an escape out of the transfer tree.
+///
+/// `operator_path_resolve` is BOTH halves of upstream's rule, so the open is
+/// the confined one: the ownership walk follows a trusted-owned symlink by
+/// design, and a non-chrooted daemon's own `--backup-dir` entries are
+/// trusted-owned by construction, so ownership alone would let a backup entry
+/// pointing outside the module carry an in-module file's contents out of it
+/// (syscall.c:186-240 `abspath_outside_confinement()`). A session with no
+/// confinement root - every plain local client - is unaffected: there is
+/// nothing to be outside of.
 ///
 /// Permissions are taken from the source and applied through the open
 /// descriptor, matching `fs::copy` (and upstream's
@@ -49,7 +59,7 @@ pub fn copy_pre_image_to_backup(source: &Path, backup_path: &Path) -> io::Result
 
         // Mask to the permission bits: `mode()` carries the file-type bits too,
         // and only the low 12 are meaningful as an `O_CREAT` mode.
-        fast_io::operator_open_write_create(backup_path, permissions.mode() & 0o7777)?
+        fast_io::operator_open_write_create_confined(backup_path, permissions.mode() & 0o7777)?
     };
     // Non-Unix has no ownership walk to run; degrade to a plain create, as the
     // other operator-path helpers do.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -409,8 +409,8 @@ pub use nofollow_open::open_basis_nofollow;
 pub use owner_walk::{
     operator_link, operator_mkdir, operator_open_append, operator_open_create_new,
     operator_open_read, operator_open_read_confined, operator_open_recv, operator_open_rw_create,
-    operator_open_write_create, operator_read_to_string, operator_rename,
-    operator_symlink_metadata, owner_trusted_parent, symlink_owner_is_trusted,
+    operator_open_write_create, operator_open_write_create_confined, operator_read_to_string,
+    operator_rename, operator_symlink_metadata, owner_trusted_parent, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -747,6 +747,44 @@ pub fn operator_open_write_create(path: &Path, mode: u32) -> io::Result<std::fs:
     )
 }
 
+/// Open an operator-supplied path for writing, creating or truncating it,
+/// additionally bound to the session's confinement root.
+///
+/// The `--backup-dir` shape under `--inplace`. The in-place backup has to
+/// duplicate the destination's pre-transfer bytes into the operator-named
+/// backup path, and the ownership walk follows a trusted-owned symlink at that
+/// path by design. A non-chrooted daemon writes its `--backup-dir` entries as
+/// its own uid, so a backup entry is TRUSTED-owned by construction: point one
+/// outside the module and the follow carries an in-module file's contents out
+/// of the tree. Ownership decides whether to follow; the root decides whether
+/// the landing site is acceptable.
+///
+/// The `Ancillary` twin [`operator_open_write_create`] stays with the opens
+/// that may legitimately live outside the tree - the `--write-batch` files.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/backup.c:443-449` `make_backup()` - `operator_path_resolve =
+///   1` around the whole backup, naming `--backup-dir` as an operator path.
+/// - `rsync-3.5.0/generator.c:2281-2301` and `:2327-2349` - the in-place backup
+///   bypasses `make_backup()`, so the generator raises the same flag around its
+///   own `copy_file()` / `do_open_at()`.
+/// - `rsync-3.5.0/syscall.c:186-240` `abspath_outside_confinement()`.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component is an untrusted-owner symlink, or when the
+///   resolved path lands outside the confinement root.
+/// - Otherwise see `operator_open_with`.
+pub fn operator_open_write_create_confined(path: &Path, mode: u32) -> io::Result<std::fs::File> {
+    operator_open_kind(
+        path,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::TRUNC,
+        Mode::from_bits_truncate(mode as rustix::fs::RawMode),
+        crate::confinement::PathKind::Confined,
+    )
+}
+
 /// Exclusively create an operator-supplied path through the ownership walk.
 ///
 /// The `O_EXCL` twin of [`operator_open_write_create`], for the receiver's

--- a/crates/fast_io/tests/operator_open_module_confinement.rs
+++ b/crates/fast_io/tests/operator_open_module_confinement.rs
@@ -181,6 +181,62 @@ fn a_plain_path_inside_the_module_opens() {
     assert_eq!(read_all(file), "PLAIN");
 }
 
+/// THE WRITE-SIDE PIN. The same rule on the create-and-truncate entry point
+/// the `--inplace --backup-dir` pre-image copy uses. A read-side leak returns
+/// out-of-module TEXT to the peer; this one WRITES an in-module file's contents
+/// to a path outside the module, so both entry points have to carry the check.
+///
+/// upstream: `rsync-3.5.0/backup.c:443-449` `make_backup()` and
+/// `generator.c:2281-2301` - `operator_path_resolve = 1` around the backup and
+/// around the in-place copy that bypasses it.
+#[test]
+fn a_confined_create_leaving_the_module_is_refused() {
+    let fixture = fixture();
+    let planted = fixture.module.join("backup/sub/evil");
+    symlink(&fixture.secret, &planted).expect("plant the symlink");
+
+    let _session = serve_module(&fixture.module);
+    let error = fast_io::operator_open_write_create_confined(&planted, 0o600)
+        .expect_err("a confined create must not resolve out of the module");
+
+    assert_eq!(
+        error.raw_os_error(),
+        Some(libc::ELOOP),
+        "the refusal must be ELOOP, as on the read side"
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.secret).expect("the outside file survives"),
+        "SECRET-MARKER",
+        "a refused create must not have truncated the outside file: O_TRUNC \
+         does its damage at open time, so a refusal that happened after the \
+         open would leave nothing to read back"
+    );
+}
+
+/// NEGATIVE CONTROL for the write side. A trusted symlink whose target stays
+/// inside the module is still followed and written through - the ordinary
+/// operator layout the walk exists to keep working. Without this, "refuse every
+/// symlink at the backup leaf" would satisfy the pin above.
+#[test]
+fn a_confined_create_staying_inside_the_module_is_followed() {
+    let fixture = fixture();
+    let inside = fixture.module.join("data");
+    fs::write(&inside, "IN-MODULE").expect("write in-module target");
+    let link = fixture.module.join("backup/sub/benign");
+    symlink(&inside, &link).expect("plant the in-module symlink");
+
+    let _session = serve_module(&fixture.module);
+    let mut file = fast_io::operator_open_write_create_confined(&link, 0o600)
+        .expect("an in-module target must still be written through");
+    std::io::Write::write_all(&mut file, b"REWRITTEN").expect("write");
+    drop(file);
+
+    assert_eq!(
+        fs::read_to_string(&inside).expect("read the in-module target"),
+        "REWRITTEN"
+    );
+}
+
 /// The other half of upstream's rule: the confinement applies to CONFINED opens
 /// only. `--log-file`, the `--*-from` family and the daemon's lock and motd
 /// files may legitimately live outside the tree, so the ANCILLARY entry point

--- a/crates/transfer/tests/daemon_inplace_backup_dir_confinement.rs
+++ b/crates/transfer/tests/daemon_inplace_backup_dir_confinement.rs
@@ -1,0 +1,328 @@
+//! A daemon's `--inplace --backup-dir` must not write outside the module root
+//! through a *trusted-owned* symlink planted at the backup leaf.
+//!
+//! # Why the ownership walk is not enough here
+//!
+//! `--inplace --backup` bypasses the rename-to-backup mechanism: the
+//! destination inode is rewritten in place, so its pre-transfer bytes must be
+//! COPIED aside first. That copy opens the operator-named backup path with
+//! `O_WRONLY|O_CREAT|O_TRUNC`, and the ownership walk deliberately FOLLOWS a
+//! symlink owned by uid 0 or our own euid - that is the operator's own layout
+//! and refusing it would break the ordinary case. A non-chrooted daemon writes
+//! its `--backup-dir` entries as its own uid, so a backup entry left behind by
+//! an earlier transfer is TRUSTED-owned by construction. Point one at a file
+//! outside the module and the follow carries the in-module destination's
+//! contents out of the tree.
+//!
+//! Upstream closes this with the second half of the rule: `make_backup()`
+//! raises `operator_path_resolve` around the whole backup, and the in-place
+//! backup - which never reaches `make_backup()` - raises it around its own
+//! `copy_file()`. That flag is what arms `abspath_outside_confinement()`, which
+//! refuses a resolved path that has left the module root. Ownership decides
+//! whether to follow; the module root decides whether the landing site is
+//! acceptable.
+//!
+//! # Deterministic, not a race
+//!
+//! The symlink is planted before the transfer starts, so nothing here depends
+//! on timing. That is also the honest threat model: the escape needs only a
+//! trusted-owned symlink to EXIST at the backup leaf, not to appear inside a
+//! window.
+//!
+//! # Why these cells run unprivileged
+//!
+//! Upstream refuses only `st_uid != 0 && st_uid != trusted_uid`
+//! (`syscall.c:406`), so uid 0 and the euid take one identical follow path into
+//! one identical confinement check. The daemon spawned here runs as the test's
+//! own uid, so a plant owned by that uid is exactly the root-owned case a
+//! privileged daemon would see, and needs no privilege to stage. The distinct
+//! third-uid REFUSAL arm stays with the root leg of the upstream testsuite,
+//! matching `crates/fast_io/tests/operator_open_module_confinement.rs`.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/backup.c:443-449` `make_backup()` - `operator_path_resolve =
+//!   1` around the entire backup.
+//! - `rsync-3.5.0/generator.c:2281-2301` and `:2327-2349` - the in-place backup
+//!   bypasses `make_backup()`, so the generator raises the flag around
+//!   `get_backup_name()` and the `copy_file()` / `do_open_at()` that follow.
+//! - `rsync-3.5.0/syscall.c:186-240` `abspath_outside_confinement()` - refuses a
+//!   resolved path outside `confinement_root()`, but only while
+//!   `operator_path_resolve` is set.
+//! - `rsync-3.5.0/syscall.c:136-144` `confinement_root()` - a daemon's root is
+//!   `module_dir`.
+
+#![cfg(unix)]
+
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+/// The destination's pre-transfer contents - what a successful escape would
+/// deposit outside the module root.
+const PRE_IMAGE: &str = "PRE-IMAGE-IN-MODULE";
+/// What the client pushes over the destination.
+const NEW_CONTENT: &str = "NEW-CONTENT-FROM-THE-PEER";
+/// The out-of-module file's contents. Distinct from both of the above so an
+/// overwrite is unmistakable rather than inferred from a size or an mtime.
+const OUTSIDE_MARKER: &str = "OUTSIDE-THE-MODULE-UNTOUCHED";
+
+struct DaemonGuard(Child);
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// What, if anything, occupies the backup leaf before the push.
+#[derive(Clone, Copy)]
+enum Plant {
+    /// Nothing: the backup leaf is created fresh by the transfer.
+    None,
+    /// A trusted-owned symlink pointing OUTSIDE the module root.
+    SymlinkOutsideModule,
+    /// A trusted-owned symlink pointing to another path INSIDE the module.
+    SymlinkInsideModule,
+}
+
+/// The filesystem state the assertions are made against.
+struct Outcome {
+    /// Contents of the file outside the module root.
+    outside: String,
+    /// Contents of the in-module symlink target used by [`Plant::SymlinkInsideModule`].
+    inside_target: io::Result<String>,
+    /// Contents at the backup leaf, resolved through whatever it names.
+    backup_leaf: io::Result<String>,
+    /// Whether the backup leaf is still a symlink.
+    backup_leaf_is_symlink: bool,
+    /// Contents of the destination after the push.
+    destination: io::Result<String>,
+    /// The client's exit code, recorded beside every measurement so a
+    /// "nothing moved" run cannot be mistaken for a refusal.
+    client_exit: Option<i32>,
+    /// The client's stderr, for the failure messages.
+    client_stderr: String,
+}
+
+fn write_config(config: &Path, module_root: &Path, log_root: &Path) -> io::Result<()> {
+    fs::write(
+        config,
+        format!(
+            "pid file = {pid}\n\
+             log file = {log}\n\
+             use chroot = false\n\
+             \n\
+             [data]\n\
+             path = {root}\n\
+             read only = false\n",
+            pid = log_root.join("rsyncd.pid").display(),
+            log = log_root.join("rsyncd.log").display(),
+            root = module_root.display(),
+        ),
+    )
+}
+
+fn spawn_daemon(oc_bin: &Path, config: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard(child), port))
+}
+
+/// Stages the module, plants `plant` at the backup leaf, pushes one file over
+/// the destination with `--inplace --backup --backup-dir=bak`, and reports the
+/// resulting filesystem state.
+///
+/// Returns `None` when the daemon could not be started, so a harness failure is
+/// reported by the caller rather than passing vacuously.
+fn push_over_destination(plant: Plant) -> Option<Outcome> {
+    let oc_bin = test_support::oc_rsync_bin();
+    let tmp = test_support::create_tempdir();
+    let root = tmp.path();
+
+    let source_dir = root.join("src");
+    let module_root = root.join("module");
+    let outside_dir = root.join("outside");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::create_dir_all(module_root.join("bak")).expect("create module root and backup dir");
+    fs::create_dir_all(&outside_dir).expect("create the out-of-module dir");
+
+    let outside = outside_dir.join("secret");
+    fs::write(&outside, OUTSIDE_MARKER).expect("seed the out-of-module file");
+
+    let source = source_dir.join("payload");
+    fs::write(&source, NEW_CONTENT).expect("seed source");
+
+    let destination = module_root.join("payload");
+    fs::write(&destination, PRE_IMAGE).expect("seed destination");
+
+    let inside_target = module_root.join("in-module-target");
+    let backup_leaf = module_root.join("bak/payload");
+    match plant {
+        Plant::None => {}
+        Plant::SymlinkOutsideModule => {
+            symlink(&outside, &backup_leaf).expect("plant the out-of-module symlink");
+        }
+        Plant::SymlinkInsideModule => {
+            fs::write(&inside_target, "IN-MODULE-PLACEHOLDER").expect("seed in-module target");
+            symlink(&inside_target, &backup_leaf).expect("plant the in-module symlink");
+        }
+    }
+
+    // The plant must be TRUSTED-owned, or a refusal would only be the ownership
+    // arm firing and would prove nothing about the module root.
+    if let Ok(meta) = fs::symlink_metadata(&backup_leaf) {
+        assert!(
+            fast_io::symlink_owner_is_trusted(meta.uid()),
+            "the planted backup leaf must be owned by uid 0 or our euid; \
+             got uid {}",
+            meta.uid()
+        );
+    }
+
+    let config = root.join("rsyncd.conf");
+    write_config(&config, &module_root, root).expect("write daemon config");
+    let (_daemon, port) = spawn_daemon(&oc_bin, &config).ok()?;
+
+    let output = Command::new(&oc_bin)
+        .args([
+            OsStr::new("--inplace"),
+            OsStr::new("--backup"),
+            OsStr::new("--backup-dir=bak"),
+            OsStr::new("--ignore-times"),
+            source.as_os_str(),
+            OsStr::new(&format!("rsync://127.0.0.1:{port}/data/")),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run oc-rsync client");
+
+    Some(Outcome {
+        outside: fs::read_to_string(&outside).expect("the out-of-module file must still exist"),
+        inside_target: fs::read_to_string(&inside_target),
+        backup_leaf: fs::read_to_string(&backup_leaf),
+        backup_leaf_is_symlink: fs::symlink_metadata(&backup_leaf)
+            .map(|meta| meta.file_type().is_symlink())
+            .unwrap_or(false),
+        destination: fs::read_to_string(&destination),
+        client_exit: output.status.code(),
+        client_stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+fn measured(plant: Plant, what: &str) -> Outcome {
+    push_over_destination(plant)
+        .unwrap_or_else(|| panic!("{what}: could not start the daemon, so nothing was measured"))
+}
+
+/// THE PIN. A trusted-owned symlink at the backup leaf points outside the
+/// module root. The walk follows it - that part is correct and deliberate - so
+/// the module root has to refuse the landing site, or the destination's
+/// pre-transfer bytes are written to a file the operator never named and the
+/// peer never had access to.
+///
+/// Without the confinement half this cell observes `outside` holding
+/// [`PRE_IMAGE`]: an in-module file's contents, deposited outside the module.
+#[test]
+fn a_backup_symlink_leaving_the_module_must_not_be_written_through() {
+    let outcome = measured(
+        Plant::SymlinkOutsideModule,
+        "out-of-module backup leaf plant",
+    );
+
+    assert_eq!(
+        outcome.outside, OUTSIDE_MARKER,
+        "the in-place backup escaped the module root: the destination's \
+         pre-transfer bytes were written through a trusted-owned symlink to a \
+         file outside it (client exit {:?})\nstderr:\n{}",
+        outcome.client_exit, outcome.client_stderr,
+    );
+    assert!(
+        outcome.backup_leaf_is_symlink,
+        "the plant must survive as a symlink: a refusal that instead REPLACED \
+         it would be a different resolver (client exit {:?})",
+        outcome.client_exit,
+    );
+}
+
+/// POSITIVE CONTROL for over-refusal. The same shape of trusted-owned symlink,
+/// pointing at a path that stays INSIDE the module, must still be followed and
+/// written through. Upstream follows an in-tree trusted symlink by design;
+/// "refuse every symlink at the backup leaf" would satisfy the pin above while
+/// breaking the operator layouts the walk exists to keep working.
+#[test]
+fn a_backup_symlink_staying_inside_the_module_is_still_followed() {
+    let outcome = measured(Plant::SymlinkInsideModule, "in-module backup leaf plant");
+
+    assert_eq!(
+        outcome.client_exit,
+        Some(0),
+        "an in-module backup target must not fail the transfer\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.inside_target.as_deref().ok(),
+        Some(PRE_IMAGE),
+        "the in-module symlink target must receive the pre-transfer bytes: the \
+         confinement applies to the LANDING SITE, not to symlinks as such\
+         \nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert!(
+        outcome.backup_leaf_is_symlink,
+        "following the link must not replace it",
+    );
+}
+
+/// NON-VACUITY companion. With nothing planted, the very same push creates an
+/// ordinary backup holding the pre-transfer bytes and updates the destination
+/// in place. Without this the two cells above would also hold if the fixture
+/// never reached the backup path at all - if `--inplace --backup-dir` were
+/// silently ignored, or the transfer never ran.
+#[test]
+fn an_unplanted_backup_leaf_gets_the_pre_transfer_bytes() {
+    let outcome = measured(Plant::None, "unplanted backup leaf");
+
+    assert_eq!(
+        outcome.client_exit,
+        Some(0),
+        "the plain push must succeed\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.backup_leaf.as_deref().ok(),
+        Some(PRE_IMAGE),
+        "the backup must hold the destination's pre-transfer bytes, or this \
+         fixture never exercised the in-place backup path\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.destination.as_deref().ok(),
+        Some(NEW_CONTENT),
+        "the destination must have been rewritten in place\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.outside, OUTSIDE_MARKER,
+        "the unplanted run must leave the out-of-module file alone, or the \
+         marker used by the pin above proves nothing",
+    );
+}


### PR DESCRIPTION
The `--inplace --backup` pre-image copy opened the operator-named backup path
through the ownership walk alone. The walk FOLLOWS a symlink owned by uid 0 or
our euid by design - that is the operator's own layout - and a non-chrooted
daemon writes its `--backup-dir` entries as its own uid, so a backup entry is
TRUSTED-owned by construction. Ownership therefore cannot be the whole defence
here, exactly as it was not for the merge-file open in #7512.

## The escape

Measured end-to-end against a real daemon (module root `.../module`, `path =`
that directory, `read only = false`, no chroot):

```
module/payload            "PRE-IMAGE-IN-MODULE"      the destination
module/bak/payload   ->   ../../outside/secret       trusted-owned plant
outside/secret            "OUTSIDE-THE-MODULE-UNTOUCHED"
```

`oc-rsync --inplace --backup --backup-dir=bak --ignore-times src/payload
rsync://127.0.0.1:PORT/data/` leaves `outside/secret` holding
`PRE-IMAGE-IN-MODULE` and the client exits **0**. An in-module file's contents
are written to a path outside the module root, silently, with no diagnostic.

The plant is deliberate and pre-transfer, not a race: the escape needs only a
trusted-owned symlink to EXIST at the backup leaf.

## Why upstream does not have it

Upstream raises `operator_path_resolve` around the whole backup
(`backup.c:443-449` `make_backup()`) and again around the in-place backup that
bypasses `make_backup()` (`generator.c:2281-2301` and `:2327-2349`). That flag
is precisely what arms `abspath_outside_confinement()`
(`syscall.c:186-240`), which refuses a resolved path that has left
`confinement_root()` - `module_dir` for a daemon. oc carried the ownership half
of that rule and not the root half.

## Change

`fast_io` grows the `PathKind::Confined` twin of the create-and-truncate
operator open, and `copy_pre_image_to_backup` takes it. The walk still follows
a trusted symlink; the module root then judges where the walk actually landed.
Refusal is `ELOOP`, matching `syscall.c:464-466` - `EXDEV` would be laundered by
callers that treat it as cross-device.

Scope is the one measured sink. The surrounding backup tiers already anchor
through the receiver's destination sandbox (rename, hard link, `mkdir`); the
in-place copy was the unanchored one, which is the same asymmetry upstream calls
out in its own comment. The `Ancillary` twin stays with `--write-batch`, which
may legitimately live outside the tree.

A session with no confinement root - every plain local client, which installs a
local session with `root: None` - is unaffected.

## Verification

`crates/transfer/tests/daemon_inplace_backup_dir_confinement.rs`, three cells
through a real daemon:

| cell | asserts |
|---|---|
| `a_backup_symlink_leaving_the_module_must_not_be_written_through` | the out-of-module file is untouched and the plant survives |
| `a_backup_symlink_staying_inside_the_module_is_still_followed` | POSITIVE CONTROL - an in-module symlink target still receives the pre-transfer bytes, exit 0 |
| `an_unplanted_backup_leaf_gets_the_pre_transfer_bytes` | NON-VACUITY - the same push with nothing planted still makes a backup and rewrites the destination |

Plus two `fast_io` cells for the new entry point, in the file #7512 established.
They run unprivileged: upstream refuses only `st_uid != 0 && st_uid !=
trusted_uid` (`syscall.c:406`), so uid 0 and the euid take one identical follow
path into one identical confinement check, and the daemon here runs as the
test's own uid.

### Mutation-proven three ways

1. `refuse_if_outside` neutered to `Ok(())` - the confinement half - fails
   `a_backup_symlink_leaving_the_module_must_not_be_written_through` (`left:
   "PRE-IMAGE-IN-MODULE"`) and `a_confined_create_leaving_the_module_is_refused`,
   with both positive controls still green.
2. The call site reverted to the unconfined open, everything else intact: 3
   tests run, 2 passed, 1 failed - exactly the escape cell. So the change is
   load-bearing and not over-refusing.
3. The walk made to refuse EVERY symlink: both in-module follow cells and the
   unplanted cell go red, so the positive controls really do bite.

`fast_io` 784/784, `engine -E 'test(backup)'` 133/133, `transfer -E 'test(backup)
+ binary(daemon_inplace_backup_dir_confinement)'` 51/51, and the root
`integration_delete_backup` / `server_backup_temp_dir` / `append_implies_inplace`
targets 29/29. fmt and clippy clean.

## Noted, not fixed here

A daemon push whose destination operand names a FILE rather than a directory
fails with `Not a directory (os error 20)` as soon as `--backup-dir` is present,
independently of this change. It reproduces on master and is a separate defect.
