### PR TITLE
fix(engine): let --no-whole-file read the source in userspace

### DIFF
--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -679,6 +679,7 @@ impl<'a> CopyContext<'a> {
         buffer: &mut [u8],
         sparse: bool,
         compress: bool,
+        whole_file_enabled: bool,
         source: &Path,
         destination: &Path,
         relative: &Path,
@@ -722,7 +723,25 @@ impl<'a> CopyContext<'a> {
         // and io_uring on Linux do not reliably respect the seeked file position
         // when both source and destination have been seeked to non-zero offsets.
         // upstream: receiver.c - append path uses standard read/write loop.
-        if self.options.kernel_content_copy_allowed()
+        //
+        // `--no-whole-file` disqualifies it as well. This is the fourth mover
+        // that hands a whole file to the kernel unread, and the other three
+        // already refuse on that flag - `clonefile::eligible`,
+        // `ficlone::eligible` and `wincopy::eligible` each carry
+        // `whole_file_enabled`. Leaving it off here made the executor decline a
+        // reflink of a file while still handing the identical file to io_uring
+        // or copy_file_range, so the operator's request was honoured by three
+        // tiers and ignored by the fourth. It also hid the source read from
+        // everything that observes one, which is how upstream's
+        // `source-change-size-continues` cell sees a changing source at all.
+        //
+        // The default local copy keeps the fast path: upstream forces
+        // `whole_file = 1` for a local transfer that did not ask otherwise
+        // (main.c:653-657, `if (whole_file < 0 && !write_batch) whole_file = 1;`),
+        // so only an explicit --no-whole-file, --append or --write-batch lands
+        // in the read loop below.
+        if whole_file_enabled
+            && self.options.kernel_content_copy_allowed()
             && !sparse
             && !compress
             && self.limiter.is_none()

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -621,6 +621,7 @@ pub(in crate::local_copy) fn execute_transfer_once(
         buffer,
         use_sparse_writes,
         compress_enabled,
+        whole_file_enabled,
         source,
         delta_basis,
         record_path,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
@@ -13,7 +13,10 @@ use ::metadata::MetadataOptions;
 
 use super::TransferFlags;
 use super::execute::execute_transfer_once;
-use crate::local_copy::{CopyContext, LocalCopyExecution, LocalCopyOptions};
+use crate::local_copy::{
+    CopyContext, LocalCopyExecution, LocalCopyOptions, LocalCopyProgress, LocalCopyRecord,
+    LocalCopyRecordHandler,
+};
 
 /// Length the file list recorded, and the length the copy must NOT stop at.
 const RECORDED_LEN: usize = 4096;
@@ -102,6 +105,7 @@ fn assert_copy_stops_at_the_declared_length(sparse: bool) {
             &mut buffer,
             sparse,
             false,
+            true,
             &source,
             &destination,
             Path::new("src.bin"),
@@ -261,6 +265,7 @@ fn assert_short_source_is_recorded(sparse: bool, paced: bool) {
             &mut buffer,
             sparse,
             false,
+            true,
             &source,
             &destination,
             Path::new("src.bin"),
@@ -326,6 +331,7 @@ fn a_complete_source_records_no_read_error() {
             &mut buffer,
             false,
             false,
+            true,
             &source,
             &destination,
             Path::new("src.bin"),
@@ -342,5 +348,188 @@ fn a_complete_source_records_no_read_error() {
     assert!(
         !context.source_read_error_occurred(),
         "a source that matched its recorded length was reported as short"
+    );
+}
+
+/// Buffer the mover-selection fixture drives the copy with.
+const MOVER_BUFFER_LEN: usize = 64 * 1024;
+
+/// Source length for that fixture: several buffers, so a chunked userspace
+/// read loop reports one progress update per chunk while a single handoff to
+/// the kernel reports exactly one for the whole file.
+const MOVER_SOURCE_LEN: usize = 3 * MOVER_BUFFER_LEN;
+
+/// Counts the in-flight progress updates a copy produces, which is how this
+/// module tells the two movers apart from outside the executor.
+#[derive(Default)]
+struct ProgressCounter {
+    updates: usize,
+    transferred: u64,
+}
+
+impl LocalCopyRecordHandler for ProgressCounter {
+    fn handle(&mut self, _record: LocalCopyRecord) {}
+
+    fn handle_progress(&mut self, progress: LocalCopyProgress<'_>) {
+        self.updates += 1;
+        self.transferred = progress.bytes_transferred();
+    }
+}
+
+/// Runs one whole-file copy and reports how many progress updates it produced
+/// and how many bytes the last update accounted for.
+fn mover_progress_updates(whole_file_enabled: bool) -> (usize, u64) {
+    let temp = TempDir::new().expect("tempdir");
+    let source = temp.path().join("src.bin");
+    let destination = temp.path().join("dst.bin");
+
+    write_bytes(&source, MOVER_SOURCE_LEN);
+
+    let mut reader = File::open(&source).expect("open source");
+    let mut writer = File::create(&destination).expect("create destination");
+    let mut buffer = vec![0u8; MOVER_BUFFER_LEN];
+
+    let mut counter = ProgressCounter::default();
+    {
+        let mut context = CopyContext::new(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default(),
+            Some(&mut counter),
+            temp.path().to_path_buf(),
+        );
+
+        context
+            .copy_file_contents(
+                &mut reader,
+                &mut writer,
+                &mut buffer,
+                false,
+                false,
+                whole_file_enabled,
+                &source,
+                &destination,
+                Path::new("src.bin"),
+                None,
+                MOVER_SOURCE_LEN as u64,
+                0,
+                0,
+                Instant::now(),
+                false,
+            )
+            .expect("copy");
+    }
+    drop(writer);
+
+    assert_eq!(
+        fs::metadata(&destination).expect("stat destination").len(),
+        MOVER_SOURCE_LEN as u64,
+        "whole_file_enabled={whole_file_enabled}: the destination is incomplete, so the \
+         update count describes a copy that did not happen"
+    );
+
+    (counter.updates, counter.transferred)
+}
+
+/// `--no-whole-file` must reach the userspace read loop, not a kernel handoff.
+///
+/// The kernel content tier (io_uring, then `copy_file_range`) moves the file
+/// without the process ever reading it. That is the same "send the whole file
+/// as-is" that `--whole-file` names, and the executor's three other tiers -
+/// `clonefile::eligible`, `ficlone::eligible`, `wincopy::eligible` - already
+/// decline it when the operator asked for the delta algorithm. This tier did
+/// not, so a reflink of a file was refused while an identical io_uring handoff
+/// of the same file was not, and nothing that observes the source being read
+/// could see the transfer at all.
+///
+/// upstream keeps the default local copy on the fast tier: `main.c:653-657`
+/// forces `whole_file = 1` for a local transfer that did not ask otherwise
+/// (`if (whole_file < 0 && !write_batch) whole_file = 1;`), so only an explicit
+/// `--no-whole-file`, `--append` or `--write-batch` gets here.
+///
+/// Both legs are asserted together because either alone is satisfiable by a
+/// blanket answer: pinning only the `false` leg passes for a build that always
+/// reads in userspace, and pinning only the `true` leg passes for a build that
+/// always hands off.
+#[test]
+fn no_whole_file_reads_the_source_in_userspace() {
+    let (chunked_updates, chunked_bytes) = mover_progress_updates(false);
+    let (handoff_updates, handoff_bytes) = mover_progress_updates(true);
+
+    assert!(
+        chunked_updates > 1,
+        "--no-whole-file produced {chunked_updates} progress update(s) for a \
+         {MOVER_SOURCE_LEN}-byte source read through a {MOVER_BUFFER_LEN}-byte buffer: \
+         the copy was handed to the kernel instead of being read in userspace"
+    );
+    assert_eq!(
+        handoff_updates, 1,
+        "the default whole-file copy produced {handoff_updates} progress updates, so it \
+         no longer takes the kernel content tier and this test can no longer tell the \
+         two movers apart"
+    );
+    assert_eq!(
+        chunked_bytes, MOVER_SOURCE_LEN as u64,
+        "the --no-whole-file copy accounted for {chunked_bytes} of {MOVER_SOURCE_LEN} bytes"
+    );
+    assert_eq!(
+        handoff_bytes, MOVER_SOURCE_LEN as u64,
+        "the whole-file copy accounted for {handoff_bytes} of {MOVER_SOURCE_LEN} bytes"
+    );
+}
+
+/// Non-vacuity companion for the cell above: a `--no-whole-file` copy of a
+/// source that matches its recorded length must still reproduce it byte for
+/// byte and must leave the short-read flag clear. Without this, routing every
+/// copy through a loop that reported an error unconditionally would satisfy
+/// the mover assertion.
+#[test]
+fn no_whole_file_copy_of_a_complete_source_records_no_read_error() {
+    let temp = TempDir::new().expect("tempdir");
+    let source = temp.path().join("src.bin");
+    let destination = temp.path().join("dst.bin");
+
+    write_bytes(&source, MOVER_SOURCE_LEN);
+
+    let mut reader = File::open(&source).expect("open source");
+    let mut writer = File::create(&destination).expect("create destination");
+    let mut buffer = vec![0u8; MOVER_BUFFER_LEN];
+
+    let mut context = CopyContext::new(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default(),
+        None,
+        temp.path().to_path_buf(),
+    );
+
+    context
+        .copy_file_contents(
+            &mut reader,
+            &mut writer,
+            &mut buffer,
+            false,
+            false,
+            false,
+            &source,
+            &destination,
+            Path::new("src.bin"),
+            None,
+            MOVER_SOURCE_LEN as u64,
+            0,
+            0,
+            Instant::now(),
+            false,
+        )
+        .expect("copy");
+    drop(writer);
+
+    assert!(
+        !context.source_read_error_occurred(),
+        "a --no-whole-file copy of a source that matched its recorded length was \
+         reported as short"
+    );
+    assert_eq!(
+        fs::read(&destination).expect("read destination"),
+        fs::read(&source).expect("read source"),
+        "the --no-whole-file copy did not reproduce the source"
     );
 }

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -312,7 +312,7 @@ sender-scan-dir-escape pass
 simd-checksum pass
 size-filter pass
 skiplist-spec pass
-source-change-size-continues fail
+source-change-size-continues pass
 sparse pass
 ssh-basic pass
 stop-time pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -312,7 +312,7 @@ sender-scan-dir-escape pass
 simd-checksum pass
 size-filter pass
 skiplist-spec pass
-source-change-size-continues fail
+source-change-size-continues pass
 sparse pass
 ssh-basic pass
 stop-time pass


### PR DESCRIPTION
## What

The local-copy executor has four movers that hand a whole file to the kernel unread. Three of them - `clonefile::eligible`, `ficlone::eligible`, `wincopy::eligible` - already decline when the operator asked for the delta algorithm, because that handoff is exactly the "send the whole file as-is" that `--whole-file` names. The fourth, the kernel content tier that runs when no clone applied (io_uring, then `copy_file_range`), carried every other conjunct of that gate but not this one.

So a `--no-whole-file` local copy refused a reflink of a file and then handed the identical file to io_uring anyway. The request was honoured by three tiers and ignored by the fourth, and the transfer moved the file without the process ever reading it.

This carries the same conjunct on the fourth tier.

The default local copy is unchanged. Upstream forces `whole_file = 1` for a local transfer that did not ask otherwise (`main.c:653-657`, `if (whole_file < 0 && !write_batch) whole_file = 1;`), so only an explicit `--no-whole-file`, `--append` or `--write-batch` now reaches the read loop.

## The cell this fixes

`source-change-size-continues` (upstream 3.5.0) runs `-a --no-whole-file` on a local copy under an `LD_PRELOAD` shim that truncates the source immediately before the first `read()` of that fd. A mover that never issues one leaves the source untouched, so the cell failed with `source-read shim loaded but did not target the changing source file` - not with a wrong exit code.

## The filed framing was wrong

The report said oc silently truncated the destination and exited 0 where upstream exits 23, i.e. that the diagnosis was missing. Measured against the real rsync 3.5.0 binary on the same fixture, that is not what happens - the shim never fires, the source is never truncated, and oc produces a complete, correct 1 MiB copy. The diagnosis added in #7472 was already right and is untouched here:

| | exit | shim fired | src after | dest bytes | later entry | stderr |
|---|---|---|---|---|---|---|
| rsync 3.5.0 | 23 | yes | 0 | 0 | transferred | `read errors mapping ...: No data available (61)` |
| oc, before | **0** | **no** | **1048576** | **1048576** | transferred | *(none)* |
| oc, `--no-zero-copy` | 23 | yes | 0 | 0 | transferred | same line |
| oc, after | 23 | yes | 0 | 0 | transferred | same line |

Both kernel movers report a short source correctly too: forcing `copy_file_range` to return short exits 23 with the same line, and a sysfs source (`st_size` 4096, four readable bytes) does likewise. Nothing about the reporting needed changing. Only the mover did.

## Which mover ran

`strace` on the built binary, 1 MiB source:

```
[default]       rc=0 dest=1048576 io_uring_enter=32 copy_file_range=0 big_reads=0
[nowholefile]   rc=0 dest=1048576 io_uring_enter=0  copy_file_range=0 big_reads=8
```

The default keeps the kernel tier; only `--no-whole-file` moves to the read loop. Both still exit 0 with a complete destination.

## Tests

`no_whole_file_reads_the_source_in_userspace` tells the two movers apart from outside the executor by counting in-flight progress updates: the kernel tier emits exactly one for the whole file, the userspace loop one per buffer. Both legs are asserted together because either alone is satisfiable by a blanket answer.

`no_whole_file_copy_of_a_complete_source_records_no_read_error` is the non-vacuity companion: a complete source must still be reproduced byte for byte with the short-read flag clear.

RED before GREEN - the gate conjunct removed:

```
--no-whole-file produced 1 progress update(s) for a 196608-byte source read
through a 65536-byte buffer: the copy was handed to the kernel instead of
being read in userspace
Summary [0.034s] 2 tests run: 1 passed, 1 failed
```

The complete-source companion still passes under that mutation, so it is not what detects the fix.

Blanket-off mutation (gate forced false, i.e. always read in userspace) kills the other leg:

```
assertion `left == right` failed: the default whole-file copy produced 3
progress updates, so it no longer takes the kernel content tier and this
test can no longer tell the two movers apart
  left: 3
 right: 1
```

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run -p engine --all-features` - 5048 passed
- `cargo nextest run --all-features --test integration_basic --test integration_sparse --test integration_preallocate --test integration_server_delta --test integration_checksum --test integration_links --test append_implies_inplace --test block_size_wire --test block_size_suffix_grammar --test only_write_batch_remote_pull` - 129 passed
- upstream 3.5.0 suite, nonroot leg, on x86_64 Linux against a freshly built binary: `254 passed, 7 failed, 84 skipped`, with `source-change-size-continues` matching its new `pass` row and one unrelated environmental mismatch (`protected-regular: expected skip, got pass` - the host has `fs.protected_regular` where the CI image does not).

The `3.5.0` expect manifests move that row from `fail` to `pass` on both the root and nonroot legs.
