### PR TITLE
fix(transfer): confine the --backup-dir link and rename to the module root

### DIFF
--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -70,8 +70,12 @@ pub(super) fn create_hard_link(source: &Path, destination: &Path) -> io::Result<
 /// Hard-links a destination entry into the backup area.
 ///
 /// Same test-override seam as [`create_hard_link`], but on Unix production
-/// resolves both endpoints through the ownership walk
-/// ([`fast_io::operator_link`]). A backup area is an operator path, and the link
+/// resolves both endpoints through the ownership walk, bound to the session's
+/// confinement root ([`fast_io::operator_link_confined`]). Ownership alone is
+/// not enough: a non-chrooted daemon owns everything it creates, so a directory
+/// symlink standing at the `--backup-dir` is trusted-owned by construction and
+/// is followed by design; only the root can refuse where it lands.
+/// A backup area is an operator path, and the link
 /// tier runs *before* the rename tier, so confining only [`backup_rename`]
 /// would leave upstream's `backup-dir-symlink-race` escape wide open: the
 /// attacker's flipped parent redirects the link and the rename is never
@@ -95,7 +99,7 @@ pub(super) fn create_backup_hard_link(source: &Path, destination: &Path) -> io::
 
     #[cfg(unix)]
     {
-        fast_io::operator_link(source, destination)
+        fast_io::operator_link_confined(source, destination)
     }
     #[cfg(not(unix))]
     {
@@ -169,11 +173,14 @@ where
 /// Renames a destination entry to its backup location.
 ///
 /// On Unix both endpoints are resolved by the ownership walk
-/// ([`fast_io::operator_rename`]): every path component is inspected without
-/// following it, a symlink owned by uid 0 or our euid is followed as the
+/// ([`fast_io::operator_rename_confined`]): every path component is inspected
+/// without following it, a symlink owned by uid 0 or our euid is followed as the
 /// operator's own layout, and one owned by anyone else is refused. A backup
 /// directory may legitimately sit outside the transfer tree, so location cannot
-/// be the trust signal here - authority is.
+/// be the trust signal for WHETHER TO FOLLOW - authority is. It is still the
+/// signal for whether the landing site is acceptable when the session has a
+/// confinement root, which is what stops a followed trusted symlink from
+/// carrying an in-module file out of a served module.
 ///
 /// Without that, an attacker who can create entries inside the backup tree
 /// flips a parent component between a real directory and a symlink pointing
@@ -200,7 +207,7 @@ pub(super) fn backup_rename(from: &Path, to: &Path) -> io::Result<()> {
 
     #[cfg(unix)]
     {
-        fast_io::operator_rename(from, to, true)
+        fast_io::operator_rename_confined(from, to, true)
     }
     #[cfg(not(unix))]
     {

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -417,10 +417,11 @@ pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
-    operator_create_dir_all, operator_link, operator_mkdir, operator_open_append,
-    operator_open_create_new, operator_open_read, operator_open_read_confined, operator_open_recv,
-    operator_open_rw_create, operator_open_write_create, operator_open_write_create_confined,
-    operator_read_to_string, operator_rename, operator_symlink_metadata, owner_trusted_parent,
+    operator_create_dir_all, operator_link, operator_link_confined, operator_mkdir,
+    operator_open_append, operator_open_create_new, operator_open_read,
+    operator_open_read_confined, operator_open_recv, operator_open_rw_create,
+    operator_open_write_create, operator_open_write_create_confined, operator_read_to_string,
+    operator_rename, operator_rename_confined, operator_symlink_metadata, owner_trusted_parent,
     owner_trusted_parent_kind, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -183,6 +183,24 @@ impl AbsPathTracker {
         }
     }
 
+    /// The absolute path the walk has resolved, or `None` when the tracker is
+    /// disabled.
+    ///
+    /// The parent-walk entry point needs the value and not just the verdict:
+    /// upstream judges `<resolved parent>/<leaf>`, not the parent alone, so a
+    /// backup landing in an ANCESTOR of the root - which the parent-only test
+    /// reads as "still descending" - is still refused.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:284-286` - `ona_open()`'s `out_abs`
+    /// out-parameter, which is what `owner_walk_parent()` builds `leafabs`
+    /// from.
+    fn resolved(&self) -> Option<&Path> {
+        match self {
+            Self::Disabled => None,
+            Self::Tracking { abspath } => Some(abspath),
+        }
+    }
+
     /// Refuse with `ELOOP` when the resolved path has left the confinement
     /// root.
     ///
@@ -344,6 +362,26 @@ fn owner_walk_open(
     mode: Mode,
     kind: crate::confinement::PathKind,
 ) -> io::Result<OwnedFd> {
+    let mut discarded = None;
+    owner_walk_open_tracked(path, flags, mode, kind, &mut discarded)
+}
+
+/// [`owner_walk_open`], additionally reporting where the walk actually landed.
+///
+/// `resolved` receives the physical absolute path of the opened component, and
+/// only while the tracker is live - a [`Confined`](crate::confinement::PathKind::Confined)
+/// walk in a session that has a confinement root. Every other walk leaves it
+/// `None`, which is upstream's `pabs[0] == '\0'` and means "nothing to judge".
+///
+/// upstream: `rsync-3.5.0/syscall.c:286` `ona_open()` with its `out_abs` /
+/// `out_cap` pair.
+fn owner_walk_open_tracked(
+    path: &Path,
+    flags: OFlags,
+    mode: Mode,
+    kind: crate::confinement::PathKind,
+    resolved: &mut Option<PathBuf>,
+) -> io::Result<OwnedFd> {
     // upstream: syscall.c:300-302 - "Opted out (local --insecure-links, or a
     // daemon module with `insecure links = yes`): restore the legacy
     // symlink-following open." The test sits at the top of ona_open(), so it
@@ -393,6 +431,7 @@ fn owner_walk_open(
                     // `--partial-dir`/`--temp-dir` shapes unconfined.
                     tracker.step(&name);
                     tracker.refuse_if_outside()?;
+                    *resolved = tracker.resolved().map(Path::to_path_buf);
                     return open_final(dirfd.as_fd(), name.as_os_str(), flags, mode);
                 }
                 Err(errno) => return Err(io::Error::from_raw_os_error(errno.raw_os_error())),
@@ -430,6 +469,7 @@ fn owner_walk_open(
             // than diverged.
             tracker.step(&name);
             tracker.refuse_if_outside()?;
+            *resolved = tracker.resolved().map(Path::to_path_buf);
             return open_final(dirfd.as_fd(), name.as_os_str(), flags, mode);
         }
         tracker.step(&name);
@@ -451,6 +491,7 @@ fn owner_walk_open(
     // `O_PATH`, which names a location and is not a working descriptor. The
     // reopen is the same open the caller would have got before, and it is
     // subject to the sandbox exactly as that one was.
+    *resolved = tracker.resolved().map(Path::to_path_buf);
     if by_location {
         return rustix::fs::openat(dirfd.as_fd(), ".", flags | OFlags::CLOEXEC, mode)
             .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()));
@@ -477,7 +518,8 @@ pub fn owner_trusted_parent(path: &Path) -> io::Result<(OwnedFd, OsString)> {
     owner_trusted_parent_kind(path, crate::confinement::PathKind::Ancillary)
 }
 
-/// [`owner_trusted_parent`] with the caller's [`PathKind`](crate::confinement::PathKind).
+/// [`owner_trusted_parent`] with the caller's
+/// [`PathKind`](crate::confinement::PathKind).
 ///
 /// The parent walk and the confinement judgement are one decision upstream -
 /// `owner_walk_parent()` reads `operator_path_resolve`, which its call sites
@@ -486,13 +528,28 @@ pub fn owner_trusted_parent(path: &Path) -> io::Result<(OwnedFd, OsString)> {
 /// [`Ancillary`](crate::confinement::PathKind::Ancillary) spelling and keeps
 /// its existing callers unchanged.
 ///
+/// A [`Confined`](crate::confinement::PathKind::Confined) walk additionally
+/// carries upstream's SECOND check: once the parent is resolved, the LEAF's
+/// would-be absolute path is judged against the confinement root. Judging the
+/// parent alone is not the same rule - an absolute walk is allowed to pass
+/// through the root's own ancestors on the way down, so a parent resolving to
+/// `/srv` under a root of `/srv/mod` reads as "still descending" while
+/// `/srv/<leaf>` has plainly diverged. An ancillary walk leaves the tracker
+/// disabled, so it reports no resolved path and that second check cannot fire
+/// for it.
+///
 /// upstream: `rsync-3.5.0/syscall.c:558` `owner_walk_parent()`, and
 /// `rsync-3.5.0/syscall.c:552` `int operator_path_resolve = 0;` - the flag this
-/// parameter replaces.
+/// parameter replaces. The leaf judgement is `rsync-3.5.0/syscall.c:581-596` -
+/// the `snprintf(leafabs, "%s/%s", pabs, *bname)` and the
+/// `abspath_outside_confinement(leafabs)` that follows it, both gated on that
+/// same flag.
 ///
 /// # Errors
 ///
-/// See [`owner_trusted_parent`].
+/// - `ELOOP` when the walk refuses an untrusted-owner symlink, or when the
+///   resolved leaf lands outside the confinement root.
+/// - Otherwise see [`owner_trusted_parent`].
 pub fn owner_trusted_parent_kind(
     path: &Path,
     kind: crate::confinement::PathKind,
@@ -501,12 +558,23 @@ pub fn owner_trusted_parent_kind(
         return Err(io::Error::from_raw_os_error(libc::EINVAL));
     };
     let parent = path.parent().unwrap_or_else(|| Path::new(""));
-    let dirfd = owner_walk_open(
+    let mut parent_abs = None;
+    let dirfd = owner_walk_open_tracked(
         parent,
         OFlags::RDONLY | OFlags::DIRECTORY,
         Mode::empty(),
         kind,
+        &mut parent_abs,
     )?;
+    // upstream: `if (pabs[0])` - an untracked walk has nothing to judge.
+    if let Some(abs) = parent_abs
+        && crate::confinement::outside_session_root(
+            &abs.join(&leaf),
+            crate::confinement::PathKind::Confined,
+        )
+    {
+        return Err(io::Error::from_raw_os_error(libc::ELOOP));
+    }
     Ok((dirfd, leaf))
 }
 
@@ -588,7 +656,7 @@ pub fn operator_create_dir_all(path: &Path, mode: u32) -> io::Result<()> {
 ///
 /// # Upstream Reference
 ///
-/// - `rsync-3.5.0/syscall.c:1894` `do_rename_at()` under `operator_path_resolve`
+/// - `rsync-3.5.0/syscall.c:1891` `do_rename_at()` under `operator_path_resolve`
 ///   - `owner_walk_parent` on each side, then `renameat`.
 /// - `rsync-3.5.0/backup.c:200-219` `make_backup()` - the caller that sets the
 ///   operator-path mode around the backup rename.
@@ -608,6 +676,43 @@ pub fn operator_rename(old_path: &Path, new_path: &Path, replace: bool) -> io::R
     )
 }
 
+/// [`operator_rename`] additionally bound to the session's confinement root.
+///
+/// The rename tier of the same `--backup-dir` backup as
+/// [`operator_link_confined`], and the tier that actually runs wherever the
+/// link tier cannot: a `--backup-dir` on another mount, a non-regular
+/// pre-image, or a receiver whose nested-path link is refused by its own
+/// beneath-confinement. A trusted-owned directory symlink standing at the
+/// backup dir sends the destination's pre-transfer bytes out of the module
+/// wholesale, since the rename MOVES the inode rather than copying it.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/backup.c:443-449` `make_backup()` - `operator_path_resolve =
+///   1` around the whole backup.
+/// - `rsync-3.5.0/syscall.c:1891` `do_rename_at()` under
+///   `operator_path_resolve`.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component is an untrusted-owner symlink, or when either
+///   resolved endpoint lands outside the confinement root. Deliberately not
+///   `EXDEV`: callers treat that as cross-device and fall back to copy+remove,
+///   which would launder the refusal.
+/// - Otherwise the `renameat(2)` errno.
+pub fn operator_rename_confined(old_path: &Path, new_path: &Path, replace: bool) -> io::Result<()> {
+    let kind = crate::confinement::PathKind::Confined;
+    let (old_dirfd, old_leaf) = owner_trusted_parent_kind(old_path, kind)?;
+    let (new_dirfd, new_leaf) = owner_trusted_parent_kind(new_path, kind)?;
+    crate::renameat(
+        old_dirfd.as_fd(),
+        &old_leaf,
+        new_dirfd.as_fd(),
+        &new_leaf,
+        replace,
+    )
+}
+
 /// Hard-link `old_path` to `new_path` with both endpoints resolved by the
 /// ownership walk.
 ///
@@ -617,9 +722,9 @@ pub fn operator_rename(old_path: &Path, new_path: &Path, replace: bool) -> io::R
 ///
 /// # Upstream Reference
 ///
-/// - `rsync-3.5.0/backup.c:200-207` `link_or_rename()` - `do_link_at` first,
+/// - `rsync-3.5.0/backup.c:226-247` `link_or_rename()` - `do_link_at` first,
 ///   `do_rename_at` on failure.
-/// - `rsync-3.5.0/syscall.c:676` `do_link_at()` under `operator_path_resolve` -
+/// - `rsync-3.5.0/syscall.c:961` `do_link_at()` under `operator_path_resolve` -
 ///   `owner_walk_parent` on each side, then `linkat`.
 ///
 /// # Errors
@@ -630,6 +735,38 @@ pub fn operator_rename(old_path: &Path, new_path: &Path, replace: bool) -> io::R
 pub fn operator_link(old_path: &Path, new_path: &Path) -> io::Result<()> {
     let (old_dirfd, old_leaf) = owner_trusted_parent(old_path)?;
     let (new_dirfd, new_leaf) = owner_trusted_parent(new_path)?;
+    crate::linkat(old_dirfd.as_fd(), &old_leaf, new_dirfd.as_fd(), &new_leaf)
+}
+
+/// [`operator_link`] additionally bound to the session's confinement root.
+///
+/// The `--backup-dir` link tier. Ownership alone cannot bound this: a
+/// non-chrooted daemon writes everything it creates as its own uid, so a
+/// directory symlink standing where the operator named `--backup-dir` is
+/// TRUSTED-owned by construction and the walk follows it by design. The link
+/// then deposits a second name for the destination's pre-transfer inode outside
+/// the module, and the temp-to-destination rename that follows leaves that name
+/// holding the only copy of the pre-image. Ownership decides whether to follow;
+/// the root decides whether the landing site is acceptable.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/backup.c:443-449` `make_backup()` - `operator_path_resolve =
+///   1` around the WHOLE backup, so it covers `link_or_rename()`'s link tier
+///   and not only the rename it falls back to.
+/// - `rsync-3.5.0/backup.c:226-247` `link_or_rename()` - `do_link_at` first.
+/// - `rsync-3.5.0/syscall.c:961` `do_link_at()` under `operator_path_resolve`.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component is an untrusted-owner symlink, or when either
+///   resolved endpoint lands outside the confinement root.
+/// - Otherwise the `linkat(2)` errno - notably `EXDEV`, which the caller treats
+///   as its signal to fall through to the rename tier.
+pub fn operator_link_confined(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    let kind = crate::confinement::PathKind::Confined;
+    let (old_dirfd, old_leaf) = owner_trusted_parent_kind(old_path, kind)?;
+    let (new_dirfd, new_leaf) = owner_trusted_parent_kind(new_path, kind)?;
     crate::linkat(old_dirfd.as_fd(), &old_leaf, new_dirfd.as_fd(), &new_leaf)
 }
 

--- a/crates/fast_io/tests/operator_open_module_confinement.rs
+++ b/crates/fast_io/tests/operator_open_module_confinement.rs
@@ -282,3 +282,167 @@ fn without_a_confinement_root_a_confined_open_still_follows() {
 
     assert_eq!(read_all(file), "SECRET-MARKER");
 }
+
+/// THE RENAME-SIDE PIN, at the shape a `--backup-dir` actually has: the escape
+/// is a trusted-owned DIRECTORY symlink standing where the operator named the
+/// backup area, not a symlink at the backup leaf. `renameat` never follows a
+/// leaf symlink - it replaces the name - so a leaf plant cannot express this
+/// escape at all, and only the parent walk can refuse it.
+///
+/// A refused rename must also leave the source in place: the rename MOVES the
+/// inode, so a refusal that fired after the syscall would leave nothing behind
+/// to read back.
+///
+/// upstream: `rsync-3.5.0/backup.c:443-449` `make_backup()` -
+/// `operator_path_resolve = 1` around the whole backup; `syscall.c:1891`
+/// `do_rename_at()` walks each side with `owner_walk_parent()` while it is set.
+#[test]
+fn a_confined_rename_through_a_symlinked_dir_leaving_the_module_is_refused() {
+    let fixture = fixture();
+    let pre_image = fixture.module.join("payload");
+    fs::write(&pre_image, "PRE-IMAGE-IN-MODULE").expect("seed the in-module file");
+    let outside_dir = fixture.secret.parent().expect("outside dir").to_path_buf();
+    let backup_dir = fixture.module.join("backup/out");
+    symlink(&outside_dir, &backup_dir).expect("plant the out-of-module dir symlink");
+
+    let _session = serve_module(&fixture.module);
+    let error = fast_io::operator_rename_confined(&pre_image, &backup_dir.join("payload"), true)
+        .expect_err("a confined rename must not land outside the module");
+
+    assert_eq!(
+        error.raw_os_error(),
+        Some(libc::ELOOP),
+        "the refusal must be ELOOP: callers treat EXDEV as cross-device and \
+         fall back to copy+remove, which would launder it"
+    );
+    assert_eq!(
+        fs::read_to_string(&pre_image).expect("the in-module file must survive"),
+        "PRE-IMAGE-IN-MODULE",
+        "a refused rename must not have moved the source"
+    );
+    assert!(
+        !outside_dir.join("payload").exists(),
+        "nothing may have been deposited outside the module"
+    );
+}
+
+/// The LINK tier of the same backup. It runs BEFORE the rename
+/// (`link_or_rename()` with `prefer_rename = 0`), so confining only the rename
+/// leaves the escape open wherever the link succeeds - which is the ordinary
+/// same-filesystem case.
+///
+/// upstream: `rsync-3.5.0/backup.c:226-247` `link_or_rename()`;
+/// `syscall.c:961` `do_link_at()` under `operator_path_resolve`.
+#[test]
+fn a_confined_link_through_a_symlinked_dir_leaving_the_module_is_refused() {
+    let fixture = fixture();
+    let pre_image = fixture.module.join("payload");
+    fs::write(&pre_image, "PRE-IMAGE-IN-MODULE").expect("seed the in-module file");
+    let outside_dir = fixture.secret.parent().expect("outside dir").to_path_buf();
+    let backup_dir = fixture.module.join("backup/out");
+    symlink(&outside_dir, &backup_dir).expect("plant the out-of-module dir symlink");
+
+    let _session = serve_module(&fixture.module);
+    let error = fast_io::operator_link_confined(&pre_image, &backup_dir.join("payload"))
+        .expect_err("a confined link must not land outside the module");
+
+    assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+    assert!(
+        !outside_dir.join("payload").exists(),
+        "no second name for the in-module inode may exist outside the module"
+    );
+}
+
+/// NEGATIVE CONTROL for the rename side. A trusted directory symlink whose
+/// target stays INSIDE the module is still followed and renamed through - the
+/// ordinary operator layout the walk exists to keep working. Without this,
+/// "refuse a rename through any symlinked parent" would satisfy both pins
+/// above while breaking a legitimate `--backup-dir`.
+#[test]
+fn a_confined_rename_through_a_symlinked_dir_staying_inside_the_module_is_followed() {
+    let fixture = fixture();
+    let pre_image = fixture.module.join("payload");
+    fs::write(&pre_image, "PRE-IMAGE-IN-MODULE").expect("seed the in-module file");
+    let real_backup = fixture.module.join("realbak");
+    fs::create_dir(&real_backup).expect("mkdir the real backup dir");
+    let backup_dir = fixture.module.join("backup/in");
+    symlink(&real_backup, &backup_dir).expect("plant the in-module dir symlink");
+
+    let _session = serve_module(&fixture.module);
+    fast_io::operator_rename_confined(&pre_image, &backup_dir.join("payload"), true)
+        .expect("an in-module landing site must still be renamed through");
+
+    assert_eq!(
+        fs::read_to_string(real_backup.join("payload")).expect("the backup exists"),
+        "PRE-IMAGE-IN-MODULE"
+    );
+    assert!(
+        fs::symlink_metadata(&backup_dir)
+            .expect("the plant survives")
+            .file_type()
+            .is_symlink(),
+        "following the link must not have replaced it"
+    );
+}
+
+/// The reason the parent walk judges `<resolved parent>/<leaf>` and not the
+/// parent alone. An ABSOLUTE walk is allowed to pass through the root's own
+/// ancestors on the way down - they are not-yet-arrived rather than diverged -
+/// so a backup directory resolving to the module root's PARENT reads as
+/// "inside" to a parent-only test while the file it deposits plainly is not.
+///
+/// This is the cell that fails if the leaf half of the check is dropped.
+///
+/// upstream: `rsync-3.5.0/syscall.c:581-596` `owner_walk_parent()` - the
+/// `snprintf(leafabs, "%s/%s", pabs, *bname)` before
+/// `abspath_outside_confinement()`; `syscall.c:233-238` - the ancestor arm that
+/// makes the parent-only answer permissive.
+#[test]
+fn a_confined_rename_into_the_roots_own_ancestor_is_refused() {
+    let fixture = fixture();
+    let pre_image = fixture.module.join("payload");
+    fs::write(&pre_image, "PRE-IMAGE-IN-MODULE").expect("seed the in-module file");
+    let above = fixture
+        .module
+        .parent()
+        .expect("the module root has a parent")
+        .to_path_buf();
+    let backup_dir = fixture.module.join("backup/up");
+    symlink(&above, &backup_dir).expect("plant a symlink to the module root's parent");
+
+    let _session = serve_module(&fixture.module);
+    let error = fast_io::operator_rename_confined(&pre_image, &backup_dir.join("escaped"), true)
+        .expect_err("the module root's parent is not inside the module root");
+
+    assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+    assert!(
+        !above.join("escaped").exists(),
+        "the ancestor directory must not have received the in-module file"
+    );
+}
+
+/// The other half of upstream's rule for the rename side: an ANCILLARY operator
+/// rename is not bound to the root. Pinned so a blanket confinement inside the
+/// shared parent walk - which would satisfy every refusal above - is visible as
+/// the new divergence it would be.
+///
+/// upstream: `rsync-3.5.0/syscall.c:232-239`; `syscall.c:1891` - `do_rename_at`
+/// takes the ownership walk only while `operator_path_resolve` is set.
+#[test]
+fn an_ancillary_rename_may_still_leave_the_module() {
+    let fixture = fixture();
+    let pre_image = fixture.module.join("payload");
+    fs::write(&pre_image, "PRE-IMAGE-IN-MODULE").expect("seed the in-module file");
+    let outside_dir = fixture.secret.parent().expect("outside dir").to_path_buf();
+    let backup_dir = fixture.module.join("backup/out");
+    symlink(&outside_dir, &backup_dir).expect("plant the out-of-module dir symlink");
+
+    let _session = serve_module(&fixture.module);
+    fast_io::operator_rename(&pre_image, &backup_dir.join("payload"), true)
+        .expect("an ancillary rename is not bound to the module root");
+
+    assert_eq!(
+        fs::read_to_string(outside_dir.join("payload")).expect("the ancillary rename landed"),
+        "PRE-IMAGE-IN-MODULE"
+    );
+}

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -541,14 +541,30 @@ fn backup_rename_or_copy(old_path: &Path, new_path: &Path) -> io::Result<bool> {
     }
 }
 
-/// Issues the backup rename. In production this is a bare [`fs::rename`]; under
-/// `cfg(test)` a fault-injection guard can force a cross-device (`EXDEV`) error
-/// so the copy fallback in [`backup_rename_or_copy`] can be exercised
+/// Issues the backup rename through the operator-path ownership walk, bound to
+/// the session's confinement root.
+///
+/// This is the tier that runs for every `--backup-dir`, because the SEC-1.j
+/// dirfd anchoring above only covers a backup name that is a single component
+/// directly under the destination root. A bare `fs::rename` here follows a
+/// directory symlink standing at the `--backup-dir`, and a non-chrooted daemon
+/// owns everything it creates, so such a symlink is TRUSTED-owned by
+/// construction: the destination's pre-transfer bytes are then MOVED out of the
+/// module and the client still exits 0.
+///
+/// upstream: `backup.c:443-449` `make_backup()` sets `operator_path_resolve`
+/// around the whole backup, and `syscall.c:1891` `do_rename_at()` walks each
+/// side with `owner_walk_parent()` while it is set. A session with no
+/// confinement root - every plain local or remote-shell client - has nothing to
+/// be outside of, so only the ownership half applies there.
+///
+/// Under `cfg(test)` a fault-injection guard can force a cross-device (`EXDEV`)
+/// error so the copy fallback in [`backup_rename_or_copy`] can be exercised
 /// deterministically on filesystems that would otherwise complete the rename.
 #[cfg(not(test))]
 #[inline]
 fn backup_rename_syscall(old_path: &Path, new_path: &Path) -> io::Result<()> {
-    fs::rename(old_path, new_path)
+    backup_rename_confined(old_path, new_path)
 }
 
 #[cfg(test)]
@@ -556,6 +572,18 @@ fn backup_rename_syscall(old_path: &Path, new_path: &Path) -> io::Result<()> {
     if force_exdev_active() {
         return Err(simulated_cross_device_error());
     }
+    backup_rename_confined(old_path, new_path)
+}
+
+#[cfg(unix)]
+#[inline]
+fn backup_rename_confined(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    fast_io::operator_rename_confined(old_path, new_path, true)
+}
+
+#[cfg(not(unix))]
+#[inline]
+fn backup_rename_confined(old_path: &Path, new_path: &Path) -> io::Result<()> {
     fs::rename(old_path, new_path)
 }
 
@@ -666,9 +694,21 @@ fn backup_rename_sandboxed(
 /// receiver's destination sandbox when the backup name is a single component
 /// under `dest_dir` (SEC-1.h shape, same as the hardlink-follower create).
 ///
+/// Every other shape - which is every `--backup-dir`, whose backup name carries
+/// the directory as a second component - takes the operator-path ownership walk
+/// bound to the session's confinement root, the same resolver
+/// [`backup_rename_syscall`] uses one tier down. The two tiers have to agree:
+/// upstream raises `operator_path_resolve` around `link_or_rename()` as a
+/// whole, and the link tier runs FIRST, so confining only the rename leaves the
+/// escape wide open on any platform where the link succeeds.
+///
 /// Under `cfg(test)` the `ForceExdev` guard makes this report a cross-device
 /// error, matching a real `--backup-dir` on another mount where `link(2)` fails
 /// with `EXDEV` before `rename(2)` does.
+///
+/// upstream: `backup.c:443-449` `make_backup()`; `backup.c:200-207`
+/// `link_or_rename()`; `syscall.c:676` `do_link_at()` under
+/// `operator_path_resolve`.
 fn backup_hardlink_syscall(
     config: &DiskCommitConfig,
     old_path: &Path,
@@ -679,20 +719,26 @@ fn backup_hardlink_syscall(
         return Err(simulated_cross_device_error());
     }
     #[cfg(unix)]
-    if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref()) {
-        return fast_io::linkat_via_sandbox_or_fallback(
-            Some(sandbox.as_ref()),
-            old_path,
-            dest_dir,
-            new_path.strip_prefix(dest_dir).unwrap_or(new_path),
-            new_path,
-        );
+    {
+        if let (Some(sandbox), Some(dest_dir)) =
+            (config.sandbox.as_ref(), config.dest_dir.as_deref())
+            && new_path.parent() == Some(dest_dir)
+        {
+            return fast_io::linkat_via_sandbox_or_fallback(
+                Some(sandbox.as_ref()),
+                old_path,
+                dest_dir,
+                new_path.strip_prefix(dest_dir).unwrap_or(new_path),
+                new_path,
+            );
+        }
+        fast_io::operator_link_confined(old_path, new_path)
     }
     #[cfg(not(unix))]
     {
         let _ = config;
+        fast_io::hard_link(old_path, new_path)
     }
-    fast_io::hard_link(old_path, new_path)
 }
 
 /// Upstream's hard-link tier of `link_or_rename()` with `prefer_rename = 0`.

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -476,6 +476,24 @@ fn sweep_rename(old_path: &Path, new_path: &Path) -> io::Result<()> {
     std::fs::rename(old_path, new_path)
 }
 
+/// Moves an existing destination file to its backup name during the
+/// `--delay-updates` sweep, through the operator-path ownership walk bound to
+/// the session's confinement root.
+///
+/// upstream: `backup.c:443-449` `make_backup()`; `syscall.c:1891`
+/// `do_rename_at()` under `operator_path_resolve`.
+#[cfg(unix)]
+#[inline]
+fn delayed_backup_rename(from: &Path, to: &Path) -> std::io::Result<()> {
+    fast_io::operator_rename_confined(from, to, true)
+}
+
+#[cfg(not(unix))]
+#[inline]
+fn delayed_backup_rename(from: &Path, to: &Path) -> std::io::Result<()> {
+    std::fs::rename(from, to)
+}
+
 /// Renames all delayed-update files from their staging paths to their final
 /// destinations, removing each emptied staging directory as it goes.
 ///
@@ -541,11 +559,22 @@ pub(in crate::receiver) fn handle_delayed_updates(
             // directory that was never created, so the reported failure was
             // the derived `ENOENT` from the rename rather than the `EACCES`
             // that actually stopped the backup.
+            //
+            // The rename itself is the `--delay-updates` sweep's own
+            // `make_backup()` tier, so it takes the same operator-path resolver
+            // the disk-commit and local-copy sites do: a trusted-owned
+            // directory symlink standing at the `--backup-dir` would otherwise
+            // move the destination's pre-transfer bytes out of the module root.
+            // A refusal fails the backup, which the `Err` arm below turns into
+            // the upstream skip - so nothing escapes AND the pre-image survives.
+            // upstream: backup.c:443-449 `make_backup()` sets
+            // `operator_path_resolve` around the whole backup, whichever
+            // caller reached it.
             let placed = match backup_path.parent() {
                 Some(parent) if !parent.exists() => sweep_create_dir_all(parent),
                 _ => Ok(()),
             }
-            .and_then(|()| sweep_rename(final_path, &backup_path));
+            .and_then(|()| delayed_backup_rename(final_path, &backup_path));
 
             match placed {
                 Ok(()) => {

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -459,20 +459,36 @@ impl ReceiverContext {
                 // `std::fs::rename` for multi-component / cross-tree cases.
                 #[cfg(unix)]
                 {
-                    let backup_rel = backup_path
-                        .strip_prefix(&dest_dir)
-                        .map(std::path::Path::to_path_buf)
-                        .unwrap_or_else(|_| backup_path.clone());
-                    fast_io::renameat_via_sandbox_or_fallback(
-                        sandbox.as_deref(),
-                        &dest_dir,
-                        relative_path,
-                        &file_path,
-                        &dest_dir,
-                        &backup_rel,
-                        &backup_path,
-                        true,
-                    )?;
+                    if backup_path.parent() == Some(dest_dir.as_path()) {
+                        let backup_rel = backup_path
+                            .strip_prefix(&dest_dir)
+                            .map(std::path::Path::to_path_buf)
+                            .unwrap_or_else(|_| backup_path.clone());
+                        fast_io::renameat_via_sandbox_or_fallback(
+                            sandbox.as_deref(),
+                            &dest_dir,
+                            relative_path,
+                            &file_path,
+                            &dest_dir,
+                            &backup_rel,
+                            &backup_path,
+                            true,
+                        )?;
+                    } else {
+                        // Every `--backup-dir` lands here: the backup name
+                        // carries the directory as a second component, so the
+                        // sandbox dirfd is not the right anchor for it. Upstream
+                        // resolves it with the operator-path ownership walk
+                        // bound to the module root instead - a trusted-owned
+                        // directory symlink standing at the `--backup-dir` is
+                        // followed by design, so only the root can refuse the
+                        // landing site.
+                        //
+                        // upstream: backup.c:443-449 `make_backup()`;
+                        // syscall.c:1891 `do_rename_at()` under
+                        // `operator_path_resolve`.
+                        fast_io::operator_rename_confined(&file_path, &backup_path, true)?;
+                    }
                 }
                 #[cfg(not(unix))]
                 {

--- a/crates/transfer/tests/daemon_backup_dir_symlink_confinement.rs
+++ b/crates/transfer/tests/daemon_backup_dir_symlink_confinement.rs
@@ -110,6 +110,24 @@ struct Outcome {
     client_exit: Option<i32>,
     /// The client's stderr, for the failure messages.
     client_stderr: String,
+    /// The daemon's `rsyncd.log`. Without it a receiver-side refusal is only
+    /// visible as the client's errno, which cannot distinguish a sandbox denial
+    /// from an ordinary permission problem.
+    daemon_log: String,
+}
+
+impl Outcome {
+    /// The single owner of the failure block every assertion appends.
+    ///
+    /// Both streams are needed: the client says *what* failed, the daemon says
+    /// *why* - whether landlock was enforced and over how many roots, and
+    /// whether the seccomp filter engaged.
+    fn diagnostics(&self) -> String {
+        format!(
+            "\nstderr:\n{}\ndaemon log:\n{}",
+            self.client_stderr, self.daemon_log
+        )
+    }
 }
 
 fn write_config(config: &Path, module_root: &Path, log_root: &Path) -> io::Result<()> {
@@ -230,6 +248,7 @@ fn push_over_destination(plant: Plant, extra: &[&str]) -> Option<Outcome> {
             .unwrap_or(false),
         client_exit: output.status.code(),
         client_stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        daemon_log: fs::read_to_string(root.join("rsyncd.log")).unwrap_or_default(),
     })
 }
 
@@ -242,19 +261,21 @@ fn measured(plant: Plant, extra: &[&str], what: &str) -> Outcome {
 /// to preserve was not destroyed instead.
 fn assert_confined(outcome: &Outcome, what: &str) {
     assert_eq!(
-        outcome.outside, OUTSIDE_MARKER,
+        outcome.outside,
+        OUTSIDE_MARKER,
         "{what}: the backup escaped the module root - the destination's \
          pre-transfer bytes were deposited outside it (client exit {:?})\
-         \nstderr:\n{}",
-        outcome.client_exit, outcome.client_stderr,
+         {}",
+        outcome.client_exit,
+        outcome.diagnostics(),
     );
     assert_eq!(
         outcome.destination.as_deref().ok(),
         Some(PRE_IMAGE),
         "{what}: a refused backup must leave the destination alone - the \
          pre-image is exactly what the backup could not save, so overwriting \
-         it anyway destroys it (upstream receiver.c:694-695)\nstderr:\n{}",
-        outcome.client_stderr,
+         it anyway destroys it (upstream receiver.c:694-695){}",
+        outcome.diagnostics(),
     );
     assert!(
         outcome.backup_dir_is_symlink,
@@ -310,22 +331,22 @@ fn a_backup_dir_symlink_staying_inside_the_module_is_still_followed() {
     assert_eq!(
         outcome.client_exit,
         Some(0),
-        "an in-module backup dir must not fail the transfer\nstderr:\n{}",
-        outcome.client_stderr,
+        "an in-module backup dir must not fail the transfer{}",
+        outcome.diagnostics(),
     );
     assert_eq!(
         outcome.inside_backup.as_deref().ok(),
         Some(PRE_IMAGE),
         "the in-module symlink target must receive the pre-transfer bytes: the \
          confinement applies to the LANDING SITE, not to symlinks as such\
-         \nstderr:\n{}",
-        outcome.client_stderr,
+         {}",
+        outcome.diagnostics(),
     );
     assert_eq!(
         outcome.destination.as_deref().ok(),
         Some(NEW_CONTENT),
-        "the destination must still have been updated\nstderr:\n{}",
-        outcome.client_stderr,
+        "the destination must still have been updated{}",
+        outcome.diagnostics(),
     );
     assert!(
         outcome.backup_dir_is_symlink,
@@ -345,15 +366,15 @@ fn an_ordinary_backup_dir_gets_the_pre_transfer_bytes() {
     assert_eq!(
         outcome.client_exit,
         Some(0),
-        "the plain push must succeed\nstderr:\n{}",
-        outcome.client_stderr,
+        "the plain push must succeed{}",
+        outcome.diagnostics(),
     );
     assert_eq!(
         outcome.destination.as_deref().ok(),
         Some(NEW_CONTENT),
         "the destination must have been updated, or this fixture never \
-         exercised the backup path\nstderr:\n{}",
-        outcome.client_stderr,
+         exercised the backup path{}",
+        outcome.diagnostics(),
     );
     assert_eq!(
         outcome.outside, OUTSIDE_MARKER,
@@ -376,15 +397,15 @@ fn an_ordinary_backup_dir_works_under_delay_updates() {
     assert_eq!(
         outcome.client_exit,
         Some(0),
-        "the --delay-updates push must succeed\nstderr:\n{}",
-        outcome.client_stderr,
+        "the --delay-updates push must succeed{}",
+        outcome.diagnostics(),
     );
     assert_eq!(
         outcome.destination.as_deref().ok(),
         Some(NEW_CONTENT),
         "the destination must have been updated by the delayed sweep\
-         \nstderr:\n{}",
-        outcome.client_stderr,
+         {}",
+        outcome.diagnostics(),
     );
     // The file an escape would overwrite must be untouched here too.
     assert_eq!(outcome.outside, OUTSIDE_MARKER);

--- a/crates/transfer/tests/daemon_backup_dir_symlink_confinement.rs
+++ b/crates/transfer/tests/daemon_backup_dir_symlink_confinement.rs
@@ -1,0 +1,391 @@
+//! A daemon's `--backup-dir` must not move the destination's pre-transfer bytes
+//! outside the module root through a *trusted-owned* directory symlink standing
+//! where the operator named the backup area.
+//!
+//! # Why the ownership walk is not enough here
+//!
+//! `--backup` replaces the destination by renaming (or hard-linking) its
+//! pre-image into the operator-named backup area first. Both tiers resolve that
+//! area by path, and the ownership walk deliberately FOLLOWS a symlink owned by
+//! uid 0 or our own euid - that is the operator's own layout and refusing it
+//! would break the ordinary case. A non-chrooted daemon writes everything it
+//! creates as its own uid, so a directory symlink a writable module already
+//! contains is TRUSTED-owned by construction. Point it outside the module and
+//! the follow carries the in-module destination's contents out of the tree,
+//! with the client still exiting 0.
+//!
+//! Upstream closes this with the second half of the rule: `make_backup()`
+//! raises `operator_path_resolve` around the WHOLE backup, which is what arms
+//! `abspath_outside_confinement()` inside `owner_walk_parent()`. Ownership
+//! decides whether to follow; the module root decides whether the landing site
+//! is acceptable.
+//!
+//! # Why the plant is a DIRECTORY symlink, not a leaf one
+//!
+//! `renameat`/`linkat` never follow a symlink sitting at the final component -
+//! they act on the name, replacing it. A leaf plant therefore cannot express
+//! this escape at all; only a symlinked component of the backup DIRECTORY can,
+//! and only the parent walk can refuse it. That makes this a different sink
+//! from the `--inplace` pre-image COPY, whose `O_WRONLY|O_CREAT|O_TRUNC` does
+//! follow its leaf.
+//!
+//! # Deterministic, not a race
+//!
+//! Everything is planted before the transfer starts. That is also the honest
+//! threat model: the escape needs only a trusted-owned symlink to EXIST at the
+//! backup directory, not to appear inside a window.
+//!
+//! # Why these cells run unprivileged
+//!
+//! Upstream refuses only `st_uid != 0 && st_uid != trusted_uid`
+//! (`syscall.c:406`), so uid 0 and the euid take one identical follow path into
+//! one identical confinement check. The daemon spawned here runs as the test's
+//! own uid, so a plant owned by that uid is exactly the root-owned case a
+//! privileged daemon would see. The distinct third-uid REFUSAL arm stays with
+//! the root leg of the upstream testsuite.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/backup.c:443-449` `make_backup()` - `operator_path_resolve =
+//!   1` around the entire backup.
+//! - `rsync-3.5.0/backup.c:226-247` `link_or_rename()` - `do_link_at` first,
+//!   `do_rename_at` on failure. Both tiers are inside the region above.
+//! - `rsync-3.5.0/syscall.c:581-596` `owner_walk_parent()` - the resolved-leaf
+//!   `abspath_outside_confinement()` check the region arms.
+//! - `rsync-3.5.0/receiver.c:694-695` `handle_delayed_updates()` - a failed
+//!   backup SKIPS the update rather than overwriting the pre-image anyway.
+
+#![cfg(unix)]
+
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+/// The destination's pre-transfer contents - what a successful escape deposits
+/// outside the module root.
+const PRE_IMAGE: &str = "PRE-IMAGE-IN-MODULE";
+/// What the client pushes over the destination.
+const NEW_CONTENT: &str = "NEW-CONTENT-FROM-THE-PEER";
+/// The out-of-module file's contents. Distinct from both of the above so an
+/// overwrite is unmistakable rather than inferred from a size or an mtime.
+const OUTSIDE_MARKER: &str = "OUTSIDE-THE-MODULE-UNTOUCHED";
+
+struct DaemonGuard(Child);
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// What stands at the `--backup-dir` before the push.
+#[derive(Clone, Copy)]
+enum Plant {
+    /// A real directory: the ordinary layout, and the non-vacuity control.
+    RealDir,
+    /// A trusted-owned symlink to a directory OUTSIDE the module root.
+    DirSymlinkOutsideModule,
+    /// A trusted-owned symlink to another directory INSIDE the module root.
+    DirSymlinkInsideModule,
+}
+
+/// The filesystem state the assertions are made against.
+struct Outcome {
+    /// Contents of the seeded file in the out-of-module directory - the one an
+    /// escape lands on.
+    outside: String,
+    /// Contents the in-module backup directory received.
+    inside_backup: io::Result<String>,
+    /// Contents of the destination after the push.
+    destination: io::Result<String>,
+    /// Whether the `--backup-dir` is still a symlink.
+    backup_dir_is_symlink: bool,
+    /// The client's exit code, recorded beside every measurement so a
+    /// "nothing moved" run cannot be mistaken for a refusal.
+    client_exit: Option<i32>,
+    /// The client's stderr, for the failure messages.
+    client_stderr: String,
+}
+
+fn write_config(config: &Path, module_root: &Path, log_root: &Path) -> io::Result<()> {
+    fs::write(
+        config,
+        format!(
+            "pid file = {pid}\n\
+             log file = {log}\n\
+             use chroot = false\n\
+             \n\
+             [data]\n\
+             path = {root}\n\
+             read only = false\n",
+            pid = log_root.join("rsyncd.pid").display(),
+            log = log_root.join("rsyncd.log").display(),
+            root = module_root.display(),
+        ),
+    )
+}
+
+fn spawn_daemon(oc_bin: &Path, config: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard(child), port))
+}
+
+/// Stages the module, puts `plant` at the `--backup-dir`, pushes one file over
+/// an existing destination with `--backup --backup-dir=bak` plus `extra`, and
+/// reports the resulting filesystem state.
+///
+/// Returns `None` when the daemon could not be started, so a harness failure is
+/// reported by the caller rather than passing vacuously.
+fn push_over_destination(plant: Plant, extra: &[&str]) -> Option<Outcome> {
+    let oc_bin = test_support::oc_rsync_bin();
+    let tmp = test_support::create_tempdir();
+    let root = tmp.path();
+
+    let source_dir = root.join("src");
+    let module_root = root.join("module");
+    let outside_dir = root.join("outside");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::create_dir_all(&module_root).expect("create module root");
+    fs::create_dir_all(&outside_dir).expect("create the out-of-module dir");
+
+    // Seeded so an escape OVERWRITES a known marker rather than merely creating
+    // a file: "the marker is gone" cannot be satisfied by a fixture that named
+    // the wrong directory.
+    let outside = outside_dir.join("payload");
+    fs::write(&outside, OUTSIDE_MARKER).expect("seed the out-of-module file");
+
+    let source = source_dir.join("payload");
+    fs::write(&source, NEW_CONTENT).expect("seed source");
+
+    let destination = module_root.join("payload");
+    fs::write(&destination, PRE_IMAGE).expect("seed destination");
+
+    let backup_dir = module_root.join("bak");
+    let inside_dir = module_root.join("realbak");
+    match plant {
+        Plant::RealDir => fs::create_dir(&backup_dir).expect("create the real backup dir"),
+        Plant::DirSymlinkOutsideModule => {
+            symlink(&outside_dir, &backup_dir).expect("plant the out-of-module dir symlink");
+        }
+        Plant::DirSymlinkInsideModule => {
+            fs::create_dir(&inside_dir).expect("create the in-module backup target");
+            symlink(&inside_dir, &backup_dir).expect("plant the in-module dir symlink");
+        }
+    }
+
+    // The plant must be TRUSTED-owned, or a refusal would only be the ownership
+    // arm firing and would prove nothing about the module root.
+    let meta = fs::symlink_metadata(&backup_dir).expect("the backup dir must exist");
+    assert!(
+        fast_io::symlink_owner_is_trusted(meta.uid()),
+        "the planted backup dir must be owned by uid 0 or our euid; got uid {}",
+        meta.uid()
+    );
+
+    let config = root.join("rsyncd.conf");
+    write_config(&config, &module_root, root).expect("write daemon config");
+    let (_daemon, port) = spawn_daemon(&oc_bin, &config).ok()?;
+
+    let mut args: Vec<&OsStr> = vec![
+        OsStr::new("--backup"),
+        OsStr::new("--backup-dir=bak"),
+        OsStr::new("--ignore-times"),
+    ];
+    args.extend(extra.iter().map(OsStr::new));
+    let destination_url = format!("rsync://127.0.0.1:{port}/data/");
+    args.push(source.as_os_str());
+    args.push(OsStr::new(&destination_url));
+
+    let output = Command::new(&oc_bin)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run oc-rsync client");
+
+    Some(Outcome {
+        outside: fs::read_to_string(&outside).expect("the out-of-module file must still exist"),
+        inside_backup: fs::read_to_string(inside_dir.join("payload")),
+        destination: fs::read_to_string(&destination),
+        backup_dir_is_symlink: fs::symlink_metadata(&backup_dir)
+            .map(|meta| meta.file_type().is_symlink())
+            .unwrap_or(false),
+        client_exit: output.status.code(),
+        client_stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+fn measured(plant: Plant, extra: &[&str], what: &str) -> Outcome {
+    push_over_destination(plant, extra)
+        .unwrap_or_else(|| panic!("{what}: could not start the daemon, so nothing was measured"))
+}
+
+/// Asserts the escape did not happen, and that the pre-image the backup exists
+/// to preserve was not destroyed instead.
+fn assert_confined(outcome: &Outcome, what: &str) {
+    assert_eq!(
+        outcome.outside, OUTSIDE_MARKER,
+        "{what}: the backup escaped the module root - the destination's \
+         pre-transfer bytes were deposited outside it (client exit {:?})\
+         \nstderr:\n{}",
+        outcome.client_exit, outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.destination.as_deref().ok(),
+        Some(PRE_IMAGE),
+        "{what}: a refused backup must leave the destination alone - the \
+         pre-image is exactly what the backup could not save, so overwriting \
+         it anyway destroys it (upstream receiver.c:694-695)\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert!(
+        outcome.backup_dir_is_symlink,
+        "{what}: the plant must survive as a symlink; a refusal that instead \
+         REPLACED it would be a different resolver",
+    );
+}
+
+/// THE PIN, at the plain `--backup --backup-dir` shape. On a same-filesystem
+/// destination the hard-link tier of `link_or_rename()` runs first and
+/// succeeds, so this is the tier that actually escapes here; on a receiver
+/// whose nested link is refused by its own beneath-confinement it is the rename
+/// tier instead. Both are inside upstream's `make_backup()` region, so the cell
+/// asserts the outcome rather than the tier.
+#[test]
+fn a_backup_dir_symlink_leaving_the_module_must_not_receive_the_pre_image() {
+    let outcome = measured(
+        Plant::DirSymlinkOutsideModule,
+        &[],
+        "out-of-module backup dir plant",
+    );
+    assert_confined(&outcome, "plain --backup-dir");
+}
+
+/// The same pin on the `--delay-updates` sweep, which is a SEPARATE
+/// `make_backup()` site with its own rename: a fix applied only to the
+/// disk-commit path would leave this one escaping.
+///
+/// upstream: `receiver.c:685-720` `handle_delayed_updates()`.
+#[test]
+fn a_delayed_update_backup_must_not_leave_the_module() {
+    let outcome = measured(
+        Plant::DirSymlinkOutsideModule,
+        &["--delay-updates"],
+        "out-of-module backup dir plant, --delay-updates",
+    );
+    assert_confined(&outcome, "--delay-updates --backup-dir");
+}
+
+/// POSITIVE CONTROL for over-refusal. A trusted-owned directory symlink whose
+/// target stays INSIDE the module must still be followed and backed up
+/// through. Upstream follows an in-tree trusted symlink by design; "refuse a
+/// backup through any symlinked directory" would satisfy both pins above while
+/// breaking the operator layouts the walk exists to keep working.
+#[test]
+fn a_backup_dir_symlink_staying_inside_the_module_is_still_followed() {
+    let outcome = measured(
+        Plant::DirSymlinkInsideModule,
+        &[],
+        "in-module backup dir plant",
+    );
+
+    assert_eq!(
+        outcome.client_exit,
+        Some(0),
+        "an in-module backup dir must not fail the transfer\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.inside_backup.as_deref().ok(),
+        Some(PRE_IMAGE),
+        "the in-module symlink target must receive the pre-transfer bytes: the \
+         confinement applies to the LANDING SITE, not to symlinks as such\
+         \nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.destination.as_deref().ok(),
+        Some(NEW_CONTENT),
+        "the destination must still have been updated\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert!(
+        outcome.backup_dir_is_symlink,
+        "following the link must not replace it",
+    );
+}
+
+/// NON-VACUITY companion. With an ordinary directory at the `--backup-dir` the
+/// very same push backs the pre-image up and updates the destination. Without
+/// this the pins above would also hold if the fixture never reached the backup
+/// path at all - if `--backup-dir` were silently ignored, or the transfer never
+/// ran.
+#[test]
+fn an_ordinary_backup_dir_gets_the_pre_transfer_bytes() {
+    let outcome = measured(Plant::RealDir, &[], "ordinary backup dir");
+
+    assert_eq!(
+        outcome.client_exit,
+        Some(0),
+        "the plain push must succeed\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.destination.as_deref().ok(),
+        Some(NEW_CONTENT),
+        "the destination must have been updated, or this fixture never \
+         exercised the backup path\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.outside, OUTSIDE_MARKER,
+        "the unplanted run must leave the out-of-module file alone, or the \
+         marker used by the pins above proves nothing",
+    );
+}
+
+/// NON-VACUITY companion for the `--delay-updates` cell: the same sweep, with
+/// an ordinary backup directory, must still complete. Without it, that cell
+/// would also pass if `--delay-updates` simply aborted the transfer.
+#[test]
+fn an_ordinary_backup_dir_works_under_delay_updates() {
+    let outcome = measured(
+        Plant::RealDir,
+        &["--delay-updates"],
+        "ordinary backup dir, --delay-updates",
+    );
+
+    assert_eq!(
+        outcome.client_exit,
+        Some(0),
+        "the --delay-updates push must succeed\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.destination.as_deref().ok(),
+        Some(NEW_CONTENT),
+        "the destination must have been updated by the delayed sweep\
+         \nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    // The file an escape would overwrite must be untouched here too.
+    assert_eq!(outcome.outside, OUTSIDE_MARKER);
+}

--- a/crates/transfer/tests/daemon_backup_dir_symlink_confinement.rs
+++ b/crates/transfer/tests/daemon_backup_dir_symlink_confinement.rs
@@ -94,6 +94,45 @@ enum Plant {
     DirSymlinkInsideModule,
 }
 
+/// Whether the spawned daemon worker installs oc's kernel sandbox layers.
+///
+/// oc wraps a daemon worker in two layers upstream does not have: a Landlock
+/// path allowlist and a seccomp syscall allowlist. Landlock refuses this
+/// escape on its own, BEFORE oc's operator-path resolution is consulted.
+/// Measured on master, where the confinement fix is absent: with both layers
+/// engaged all five cells pass, and with both opted out exactly the two
+/// escape cells fail and deposit the pre-image outside the module root.
+///
+/// So an escape cell run under the sandbox measures the KERNEL's refusal, not
+/// oc's, and stays green whether or not this crate resolves the path
+/// correctly. The escape cells therefore opt the layers out, which is what
+/// makes them pins for the code under change. The availability cells keep
+/// them on, so the layered defence stays pinned by the same file.
+///
+/// ⚠ Opting out is a TEST-ONLY narrowing of what the cell observes. It does
+/// not weaken the shipped daemon, which installs both layers by default.
+///
+/// The switch is oc's own operator-facing opt-out
+/// (`crates/daemon/src/daemon/sections/sandbox_optout.rs`); it exists
+/// precisely so a sandbox denial can be A/B-ed rather than guessed at.
+#[derive(Clone, Copy)]
+enum Sandbox {
+    /// Landlock and seccomp installed, as a production daemon runs them.
+    Enforced,
+    /// Both layers opted out, so any refusal observed must be oc's own.
+    OptedOut,
+}
+
+impl Sandbox {
+    /// Environment the daemon child inherits to express this choice.
+    fn daemon_env(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            Self::Enforced => &[],
+            Self::OptedOut => &[("OC_RSYNC_NO_LANDLOCK", "1"), ("OC_RSYNC_NO_SECCOMP", "1")],
+        }
+    }
+}
+
 /// The filesystem state the assertions are made against.
 struct Outcome {
     /// Contents of the seeded file in the out-of-module directory - the one an
@@ -148,10 +187,10 @@ fn write_config(config: &Path, module_root: &Path, log_root: &Path) -> io::Resul
     )
 }
 
-fn spawn_daemon(oc_bin: &Path, config: &Path) -> io::Result<(DaemonGuard, u16)> {
+fn spawn_daemon(oc_bin: &Path, config: &Path, sandbox: Sandbox) -> io::Result<(DaemonGuard, u16)> {
     let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
-        Command::new(oc_bin)
-            .arg("--daemon")
+        let mut cmd = Command::new(oc_bin);
+        cmd.arg("--daemon")
             .arg("--no-detach")
             .arg("--port")
             .arg(port.to_string())
@@ -159,8 +198,11 @@ fn spawn_daemon(oc_bin: &Path, config: &Path) -> io::Result<(DaemonGuard, u16)> 
             .arg(config)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
+            .stderr(Stdio::piped());
+        for (key, value) in sandbox.daemon_env() {
+            cmd.env(key, value);
+        }
+        cmd.spawn()
     })?;
     Ok((DaemonGuard(child), port))
 }
@@ -171,7 +213,7 @@ fn spawn_daemon(oc_bin: &Path, config: &Path) -> io::Result<(DaemonGuard, u16)> 
 ///
 /// Returns `None` when the daemon could not be started, so a harness failure is
 /// reported by the caller rather than passing vacuously.
-fn push_over_destination(plant: Plant, extra: &[&str]) -> Option<Outcome> {
+fn push_over_destination(plant: Plant, extra: &[&str], sandbox: Sandbox) -> Option<Outcome> {
     let oc_bin = test_support::oc_rsync_bin();
     let tmp = test_support::create_tempdir();
     let root = tmp.path();
@@ -219,7 +261,7 @@ fn push_over_destination(plant: Plant, extra: &[&str]) -> Option<Outcome> {
 
     let config = root.join("rsyncd.conf");
     write_config(&config, &module_root, root).expect("write daemon config");
-    let (_daemon, port) = spawn_daemon(&oc_bin, &config).ok()?;
+    let (_daemon, port) = spawn_daemon(&oc_bin, &config, sandbox).ok()?;
 
     let mut args: Vec<&OsStr> = vec![
         OsStr::new("--backup"),
@@ -252,14 +294,33 @@ fn push_over_destination(plant: Plant, extra: &[&str]) -> Option<Outcome> {
     })
 }
 
-fn measured(plant: Plant, extra: &[&str], what: &str) -> Outcome {
-    push_over_destination(plant, extra)
+fn measured(plant: Plant, extra: &[&str], sandbox: Sandbox, what: &str) -> Outcome {
+    push_over_destination(plant, extra, sandbox)
         .unwrap_or_else(|| panic!("{what}: could not start the daemon, so nothing was measured"))
 }
 
 /// Asserts the escape did not happen, and that the pre-image the backup exists
 /// to preserve was not destroyed instead.
 fn assert_confined(outcome: &Outcome, what: &str) {
+    // NON-VACUITY, and it must come first so a dead session reports its own
+    // cause rather than a misleading "the backup escaped" message.
+    //
+    // The three assertions below are EVERY one satisfied by a transfer that
+    // did nothing at all: an untouched out-of-module file, a destination
+    // still holding its pre-image, and a surviving symlink is exactly the
+    // state a session that died before reaching the backup would leave. So
+    // without this, a green cell cannot distinguish "the escape was refused"
+    // from "nothing happened" - and the second is not evidence of anything.
+    //
+    // The daemon logs `receiving file list` once the session is past the
+    // handshake and into the transfer, which is well before the backup tier
+    // this cell is about.
+    assert!(
+        outcome.daemon_log.contains("receiving file list"),
+        "{what}: the daemon never reached the transfer, so the assertions \
+         below would hold vacuously rather than describe a refusal{}",
+        outcome.diagnostics(),
+    );
     assert_eq!(
         outcome.outside,
         OUTSIDE_MARKER,
@@ -295,6 +356,7 @@ fn a_backup_dir_symlink_leaving_the_module_must_not_receive_the_pre_image() {
     let outcome = measured(
         Plant::DirSymlinkOutsideModule,
         &[],
+        Sandbox::OptedOut,
         "out-of-module backup dir plant",
     );
     assert_confined(&outcome, "plain --backup-dir");
@@ -310,6 +372,7 @@ fn a_delayed_update_backup_must_not_leave_the_module() {
     let outcome = measured(
         Plant::DirSymlinkOutsideModule,
         &["--delay-updates"],
+        Sandbox::OptedOut,
         "out-of-module backup dir plant, --delay-updates",
     );
     assert_confined(&outcome, "--delay-updates --backup-dir");
@@ -325,6 +388,7 @@ fn a_backup_dir_symlink_staying_inside_the_module_is_still_followed() {
     let outcome = measured(
         Plant::DirSymlinkInsideModule,
         &[],
+        Sandbox::Enforced,
         "in-module backup dir plant",
     );
 
@@ -361,7 +425,12 @@ fn a_backup_dir_symlink_staying_inside_the_module_is_still_followed() {
 /// ran.
 #[test]
 fn an_ordinary_backup_dir_gets_the_pre_transfer_bytes() {
-    let outcome = measured(Plant::RealDir, &[], "ordinary backup dir");
+    let outcome = measured(
+        Plant::RealDir,
+        &[],
+        Sandbox::Enforced,
+        "ordinary backup dir",
+    );
 
     assert_eq!(
         outcome.client_exit,
@@ -391,6 +460,7 @@ fn an_ordinary_backup_dir_works_under_delay_updates() {
     let outcome = measured(
         Plant::RealDir,
         &["--delay-updates"],
+        Sandbox::Enforced,
         "ordinary backup dir, --delay-updates",
     );
 


### PR DESCRIPTION
## The escape

A daemon push with `--backup --backup-dir=bak`, where a **trusted-owned directory symlink** stands at `bak`, moves the destination's pre-transfer bytes **outside the module root**. The client exits **0** with no diagnostic. No `--inplace` is involved, and the plant is persistent - nothing here is a race.

Measured on `2f4b383d8`, unfixed:

```
=== plant=dirlink flags= exit=0 ===
outside/payload      : PRE-IMAGE-IN-MODULE      <- the in-module file's contents, outside the module
module/payload       : NEW-CONTENT
bak is symlink       : yes
client stderr        :
```

The unplanted control on the same fixture proves it reaches the sink:

```
=== plant=none flags= exit=0 ===
outside/payload      : OUTSIDE-UNTOUCHED
module/bak/payload   : PRE-IMAGE-IN-MODULE
```

`--delay-updates` escapes through a different sink and `--fuzzy` through the same one; all three are covered.

## Why the ownership walk cannot be the defence

It **follows** a symlink owned by uid 0 or our own euid, by design - that is the operator's own layout and refusing it would break the ordinary case. A non-chrooted daemon writes everything it creates as its own uid, so a directory symlink a writable module already contains is trusted-owned *by construction*.

Upstream closes this with the second half of the rule: `make_backup()` raises `operator_path_resolve` around the **whole** backup (`backup.c:443-449`), which is what arms `abspath_outside_confinement()` inside `owner_walk_parent()` (`syscall.c:576-590`). Ownership decides whether to *follow*; the module root decides whether the *landing site* is acceptable.

## The structural cause

oc already had the root check. It was never armed on this path, and could not be: the shared parent walk `owner_trusted_parent()` hard-coded `PathKind::Ancillary`, so **every** `*at` operator helper - `operator_link`, `operator_rename`, `operator_mkdir`, `operator_symlink_metadata` - was permanently unconfined no matter what the call site wanted. Two of those call sites' own doc comments already cited the upstream region that arms it.

Upstream arms confinement by **region**; oc passes the kind per call. That is a deliberate and better design - a missing answer is a compile error rather than a control-flow accident - but it only works if the parameter actually reaches the walk.

## What this changes

`fast_io`:
- `owner_walk_open` can now report where it landed, and a kind-taking `owner_trusted_parent_kind` judges `<resolved parent>/<leaf>` against the root, exactly as upstream does. Judging the parent alone is a *different* rule: an absolute walk may pass through the root's own ancestors on the way down, so a backup directory resolving to the module root's PARENT reads as "still descending" while the file it deposits plainly is not inside the module.
- New `operator_link_confined` / `operator_rename_confined`, the `Confined` twins of the existing helpers.

Call sites routed through them - all five `make_backup()` sinks:
- the disk-commit **hard-link tier**, which runs FIRST and is the tier that escapes wherever `link(2)` succeeds (macOS, and Linux without `openat2`);
- the disk-commit **rename tier**, the tier that escapes wherever the nested link is refused by `RESOLVE_BENEATH`;
- the **`--delay-updates`** sweep, a separate `make_backup()` site with its own rename;
- the **synchronous receiver's** backup rename;
- the **local-copy executor's** backup link and rename.

The SEC-1.j sandbox dirfd route is kept for the single-component-under-`dest_dir` shape it was designed for, which is the shape `--backup` without `--backup-dir` produces. Only the `--backup-dir` shape - which that anchor was never the right one for - moves to the ownership walk.

Plus one upstream-fidelity fix that the refusal needs to mean anything: a failed backup now **skips** the delayed update instead of overwriting the destination anyway (`receiver.c:694-695`). The pre-image is exactly what the backup could not save, so committing over it destroys what the refusal was protecting.

## Not over-confinement

An in-module trusted symlink at the backup directory is **still followed and written through**, pinned as a positive control at both levels. A session with no confinement root - every plain local or remote-shell client - is unaffected: there is nothing to be outside of. Both were measured:

```
=== CONTROL: daemon, --backup-dir is an IN-MODULE symlink (exit=0) ===
module/realbak/payload : PRE-IMAGE-IN-MODULE
bak still a symlink    : yes

=== CONTROL: plain local --backup-dir (exit=0) ===
dst/bak/payload : PRE-IMAGE

=== CONTROL: local --backup-dir OUTSIDE the dest tree (exit=0) ===
elsewhere/payload : PRE-IMAGE
```

## Tests, and that they are not vacuous

`crates/transfer/tests/daemon_backup_dir_symlink_confinement.rs` - 5 end-to-end daemon cells (two pins, one over-refusal control, two non-vacuity controls). `crates/fast_io/tests/operator_open_module_confinement.rs` - 6 new helper-level cells.

Four mutations, each killing a different cell:

| mutation | cells reddened |
|---|---|
| revert the call sites (i.e. the pre-fix state) | both daemon pins - `left: "PRE-IMAGE-IN-MODULE"`, client exit 0; the 3 controls stay green, so the fixture is proven to reach the sink |
| drop the leaf half of the parent check | `a_confined_rename_into_the_roots_own_ancestor_is_refused`, and only that one |
| confine the `Ancillary` walk too (blanket) | `an_ancillary_rename_may_still_leave_the_module` |
| refuse every symlink | `a_confined_rename_through_a_symlinked_dir_staying_inside_the_module_is_followed` and the other in-tree controls |

## Verification

- `cargo fmt --all -- --check` clean; `tools/ci/check_include_fmt.py` clean (498 files)
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p fast_io --all-features` - 787 passed
- `cargo nextest run -p engine --all-features` - 5046 passed
- `cargo nextest run -p transfer --all-features` - 2747 passed
- root-level `integration_delete_backup`, `server_backup_temp_dir`, `append_implies_inplace` - 29 passed
- `RUSTFLAGS=-D warnings cargo check --workspace --all-features --lib --tests --target x86_64-pc-windows-gnu` clean

## Adjacent, deliberately not fixed here

- `create_backup_path_parents` still creates the `--backup-dir` tree with `fs::create_dir_all`, so a `--backup-dir` symlink pointing at a *non-existent* outside path can still leave an empty directory outside the module. No data escapes - the link and rename that follow are now refused - and upstream confines that `mkdir` too, so it is worth a follow-up.
- `operator_mkdir` and `operator_symlink_metadata` remain structurally unconfined for the same reason the link and rename were: they go through the `Ancillary` parent walk. Their reachable call sites are `--partial-dir` creation and the alternate-basis stat, which upstream *does* confine.
- The `--delay-updates` refusal is logged and sets `IOERR_GENERAL`, but the client still exits 0 - the io_error does not reach the client's exit code on that path.


## Current status: one red cell, diagnosed but not yet attributed

`nextest` fails on exactly one test, identically on stable, beta and nightly, at head
`31fee35e`. The counts reconcile (32486 passed + 1 failed = 32487 run), so this is the
complete failure set rather than a fail-fast prefix.

The failing cell is this PR's own non-vacuity companion,
`an_ordinary_backup_dir_works_under_delay_updates`, which expects exit 0 and gets 23.

**The failure is not in the code this PR changes.** The daemon log names the syscall:

```
rsync: [receiver] mkstemp "payload" (in data) failed: Permission denied (13)
module 'data': landlock fully enforced over 1 root(s)
module 'data': seccomp BPF filter engaged (EPERM on unlisted syscalls)
```

`mkstemp` is temp-file creation. This PR routes the backup **link** and **rename** onto the
ownership walk and touches no temp-file path - confirmed by grepping the diff, whose only
matches for temp creation are inside the new test file itself. The transfer also dies early
(`receiving file list`, 123 bytes received), i.e. before the backup tier this PR modified
is reached at all.

Evidence that isolates the trigger:

| cell | flags | result |
|---|---|---|
| `an_ordinary_backup_dir_gets_the_pre_transfer_bytes` | `--backup-dir` | PASS |
| `an_ordinary_backup_dir_works_under_delay_updates` | `--backup-dir --delay-updates` | exit 23 at `mkstemp` |

So `--backup-dir` alone is fine; adding `--delay-updates` is the discriminator, and it fails
in the receiver's temp-file creation under Landlock.

**Open, and deliberately not claimed:** master carries no daemon + `--delay-updates`
executable test (the only match is a golden message TOML), so this cell is the first to
exercise that combination. That is consistent with a pre-existing daemon/Landlock defect this
PR merely exposes, but it is **not proven** - the discriminating measurement is the same
daemon push run against a master-built binary on a Landlock-enabled host, which has not been
run yet. Until that is done the failure should not be attributed either way.
