### PR TITLE
feat(sender): size the INC_RECURSE lookahead window

### DIFF
--- a/crates/transfer/src/generator/segments.rs
+++ b/crates/transfer/src/generator/segments.rs
@@ -1,16 +1,18 @@
 //! Segment scheduling and incremental recursion state for the generator.
 //!
 //! Defines the per-directory sub-list types (`PendingSegment`, `DirSegment`,
-//! `TaggedIndex`), the cursor-based `SegmentScheduler` that throttles segment
-//! dispatch via `MIN_FILECNT_LOOKAHEAD`, and the `IncrementalState` mutable
-//! state carried by `GeneratorContext` for INC_RECURSE segmented file list
-//! sending.
+//! `TaggedIndex`), the cursor-based `SegmentScheduler` that sizes the segment
+//! lookahead window between `MIN_FILECNT_LOOKAHEAD` and
+//! `MAX_FILECNT_LOOKAHEAD`, and the `IncrementalState` mutable state carried by
+//! `GeneratorContext` for INC_RECURSE segmented file list sending.
 //!
 //! # Upstream Reference
 //!
-//! - `rsync.h:151` - `#define MIN_FILECNT_LOOKAHEAD 1000`
-//! - `flist.c:2124-2139` - `send_extra_file_list()` lookahead throttling
-//! - `sender.c:231,265` - send loop calls into segment scheduling at top/bottom
+//! - `rsync.h:151-152` - `MIN_FILECNT_LOOKAHEAD` / `MAX_FILECNT_LOOKAHEAD`
+//! - `flist.c:2396-2411` - `send_extra_file_list()` lookahead loop head
+//! - `sender.c:515,549` - send loop tops the window up to the minimum
+//! - `io.c:836-857` - `perform_io()` grows the window towards the maximum
+//!   whenever the sender would otherwise idle
 
 /// Entries the sender keeps queued in sub-lists beyond the one the receiver is
 /// currently working through. Once the backlog reaches this many entries the
@@ -20,8 +22,26 @@
 /// # Upstream Reference
 ///
 /// - `rsync.h:151` - `#define MIN_FILECNT_LOOKAHEAD 1000`
-/// - `sender.c:231,265` - `send_extra_file_list(f_out, MIN_FILECNT_LOOKAHEAD)`
+/// - `sender.c:515,549` - `send_extra_file_list(f_out, MIN_FILECNT_LOOKAHEAD)`
 pub const MIN_FILECNT_LOOKAHEAD: usize = 1000;
+
+/// Ceiling on the lookahead backlog the sender will grow to while it is idle.
+///
+/// [`MIN_FILECNT_LOOKAHEAD`] is a floor, not a target: upstream's send loop
+/// only ever tops the backlog *up to* it. The window past that floor is grown
+/// opportunistically, one sub-list at a time, at moments the sender would
+/// otherwise sit blocked on receiver input - and this constant is what stops
+/// that growth, so the sender never queues the whole remaining tree ahead of a
+/// receiver that has not asked for it.
+///
+/// # Upstream Reference
+///
+/// - `rsync.h:152` - `#define MAX_FILECNT_LOOKAHEAD 10000`
+/// - `io.c:836-843` - `perform_io()` keeps `extra_flist_sending_enabled` set,
+///   and the poll timeout at zero, only while
+///   `file_total - file_old_total < MAX_FILECNT_LOOKAHEAD`; at or above the
+///   ceiling it clears the flag and reverts to the blocking poll timeout.
+pub const MAX_FILECNT_LOOKAHEAD: usize = 10000;
 
 /// A pending file list sub-segment for incremental recursion sending.
 ///
@@ -30,7 +50,8 @@ pub const MIN_FILECNT_LOOKAHEAD: usize = 1000;
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:send_extra_file_list()` - sends one directory's entries as a sub-list
+/// - `flist.c:2396` - `send_extra_file_list()` sends one directory's entries
+///   as a sub-list
 /// - `flist.c:2966` - `ndx_start = prev->ndx_start + prev->used + 1`
 #[derive(Debug)]
 pub(crate) struct PendingSegment {
@@ -82,16 +103,18 @@ pub(crate) struct DirSegment {
 
 /// Cursor-based scheduler that yields pending segments on demand.
 ///
-/// Owns the whole of upstream's `send_extra_file_list()` throttling rule: both
-/// the `MIN_FILECNT_LOOKAHEAD` threshold and the `file_total - file_old_total`
-/// backlog it is compared against. The transfer loop drives it at the top and
-/// bottom of each iteration (upstream `sender.c:231,265`) and tells it when the
-/// receiver has finished a sub-list, but never re-derives the condition itself.
+/// Sole owner of upstream's lookahead sizing rule: the `MIN_FILECNT_LOOKAHEAD`
+/// floor, the `MAX_FILECNT_LOOKAHEAD` ceiling, and the
+/// `file_total - file_old_total` backlog both are compared against. The
+/// transfer loop drives it at the top of each iteration (upstream
+/// `sender.c:515,549`), again at the point it is about to block for receiver
+/// input (upstream `io.c:855`), and tells it when the receiver has finished a
+/// sub-list - but never re-derives either bound itself.
 ///
 /// # Lookahead accounting
 ///
 /// Upstream's loop condition is `file_total - file_old_total < at_least`
-/// (`flist.c:2139`), where `file_total` counts entries in every live file-list
+/// (`flist.c:2411`), where `file_total` counts entries in every live file-list
 /// and `file_old_total` counts entries in the lists from `first_flist` through
 /// `cur_flist`. The difference is therefore the number of entries queued in
 /// sub-lists *beyond the one the receiver is currently working through* - a
@@ -99,16 +122,17 @@ pub(crate) struct DirSegment {
 /// whole sub-lists, at `flist_free()` time, never per transferred file.
 ///
 /// [`Self::lookahead_total`] reproduces that difference directly: dispatching a
-/// sub-list adds its entry count (`flist.c:2195` `file_total += flist->used`,
+/// sub-list adds its entry count (`flist.c:2467` `file_total += flist->used`,
 /// with `file_old_total` untouched), and retiring the current sub-list on the
 /// receiver's `NDX_DONE` subtracts the count of the sub-list promoted in its
-/// place (`sender.c:247-251`).
+/// place (`sender.c:531-535`).
 ///
 /// # Upstream Reference
 ///
-/// - `sender.c:231,265` - checks `inc_recurse` at top/bottom of send loop
-/// - `flist.c:2124-2139` - `send_extra_file_list()` re-tests the lookahead
+/// - `sender.c:515,549` - checks `inc_recurse` at top/bottom of send loop
+/// - `flist.c:2411` - `send_extra_file_list()` re-tests the lookahead
 ///   condition on every iteration
+/// - `io.c:836-857` - the idle-time growth path and its ceiling
 #[derive(Debug)]
 pub(crate) struct SegmentScheduler {
     segments: Vec<PendingSegment>,
@@ -152,6 +176,34 @@ impl SegmentScheduler {
         self.advance()
     }
 
+    /// Returns one further segment when the sender is about to block for
+    /// receiver input and the backlog is still under
+    /// [`MAX_FILECNT_LOOKAHEAD`], growing the window past the floor.
+    ///
+    /// Upstream reaches the same effect through its poll loop rather than a
+    /// second call site: `perform_io()` drops the poll timeout to zero while
+    /// the backlog is under the ceiling (`io.c:836-843`), and when that poll
+    /// finds no input ready it calls `send_extra_file_list(sock_f_out, -1)`
+    /// (`io.c:855`), whose `at_least` resolves to `backlog + 1` - exactly one
+    /// more sub-list per idle turn. oc has no poll loop to hang that off, so
+    /// the caller signals the same "about to block" moment directly and this
+    /// method supplies the one-segment step and the ceiling.
+    ///
+    /// Like the floor gate - and like upstream's loop head - the bound is
+    /// tested against the backlog *before* the segment is folded in, never
+    /// against the segment's own count. A directory larger than the whole
+    /// ceiling is therefore still admitted whole the moment the backlog is
+    /// under it. Sub-lists are never split to fit: `send1extra()` emits one
+    /// entire directory per iteration (`flist.c:2427`), and truncating a
+    /// sub-list would change the wire framing the receiver reconstructs its
+    /// `dir_flist` from.
+    pub(crate) fn next_when_idle(&mut self) -> Option<&PendingSegment> {
+        if self.lookahead_total >= MAX_FILECNT_LOOKAHEAD {
+            return None;
+        }
+        self.advance()
+    }
+
     /// Returns the next segment unconditionally, ignoring the lookahead.
     ///
     /// Used for the end-of-transfer flush, where every sub-list must reach the
@@ -174,7 +226,7 @@ impl SegmentScheduler {
     ///
     /// # Upstream Reference
     ///
-    /// - `sender.c:247-251` - `file_old_total -= first_flist->used` followed by
+    /// - `sender.c:531-535` - `file_old_total -= first_flist->used` followed by
     ///   `flist_free()` and `file_old_total = cur_flist->used`
     pub(crate) fn retire_current_flist(&mut self) {
         if self.promoted < self.cursor {

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -4950,6 +4950,133 @@ fn segment_scheduler_many_files_deadlock_scenario() {
 }
 
 #[test]
+fn segment_scheduler_idle_growth_stops_at_the_ceiling() {
+    // upstream io.c:836-843 - while `file_total - file_old_total` is under
+    // MAX_FILECNT_LOOKAHEAD the sender keeps the poll timeout at zero and keeps
+    // topping the window up on idle turns; at or above it, it clears
+    // extra_flist_sending_enabled and stops. Without this ceiling the idle path
+    // has no bound at all and would queue the entire remaining tree ahead of a
+    // receiver that has not asked for it.
+    use super::segments::{MAX_FILECNT_LOOKAHEAD, MIN_FILECNT_LOOKAHEAD};
+
+    // 40 sub-lists of 1000 -> 40 000 entries, four times the ceiling, so the
+    // bound is what stops the drain rather than running out of segments.
+    let mut scheduler = scheduler_with(40, MIN_FILECNT_LOOKAHEAD);
+
+    let mut admitted = 0;
+    while scheduler.next_when_idle().is_some() {
+        admitted += 1;
+    }
+
+    assert_eq!(
+        admitted,
+        MAX_FILECNT_LOOKAHEAD / MIN_FILECNT_LOOKAHEAD,
+        "idle growth must stop at MAX_FILECNT_LOOKAHEAD queued entries"
+    );
+    assert_eq!(scheduler.lookahead_total(), MAX_FILECNT_LOOKAHEAD);
+    assert!(
+        !scheduler.is_exhausted(),
+        "the ceiling, not exhaustion, must be what stopped the growth"
+    );
+}
+
+#[test]
+fn segment_scheduler_admits_a_directory_larger_than_the_whole_ceiling() {
+    // upstream flist.c:2411 tests the backlog BEFORE send1extra() runs, and
+    // send1extra() emits one entire directory (flist.c:2417-2430). A directory
+    // with more children than the whole ceiling is therefore still sent whole
+    // the moment the backlog is under the bound - upstream has the same
+    // property and lives with it.
+    //
+    // This is the test that says the ceiling was implemented as "stop admitting
+    // the NEXT sub-list", not as "truncate this one". Splitting a sub-list would
+    // change the wire framing the receiver rebuilds its dir_flist from, so it
+    // must stay impossible: set MAX_FILECNT_LOOKAHEAD to 1 and this still holds.
+    use super::segments::MAX_FILECNT_LOOKAHEAD;
+
+    let oversized = MAX_FILECNT_LOOKAHEAD * 5;
+    let mut scheduler = scheduler_with(2, oversized);
+
+    let seg = scheduler
+        .next_when_idle()
+        .expect("an empty backlog must admit the directory however large it is");
+    assert_eq!(
+        seg.count, oversized,
+        "the sub-list must be handed over whole, never truncated to fit"
+    );
+    assert_eq!(scheduler.lookahead_total(), oversized);
+
+    // Overshooting the ceiling stops the *next* sub-list, which is the only
+    // lever the bound is allowed to pull.
+    assert!(
+        scheduler.next_when_idle().is_none(),
+        "an overshot backlog must stop the following sub-list"
+    );
+    assert_eq!(scheduler.dispatched_count(), 1);
+}
+
+#[test]
+fn segment_scheduler_idle_growth_resumes_as_the_receiver_retires_sub_lists() {
+    // The ceiling is a window, not a latch: each sub-list the receiver finishes
+    // drops out of the backlog (upstream sender.c:531-535) and makes room for
+    // one more. A bound that failed to reopen would stall a transfer whose tree
+    // is larger than the ceiling.
+    use super::segments::{MAX_FILECNT_LOOKAHEAD, MIN_FILECNT_LOOKAHEAD};
+
+    let mut scheduler = scheduler_with(40, MIN_FILECNT_LOOKAHEAD);
+    while scheduler.next_when_idle().is_some() {}
+    let filled = scheduler.dispatched_count();
+    assert_eq!(scheduler.lookahead_total(), MAX_FILECNT_LOOKAHEAD);
+
+    assert!(
+        scheduler.next_when_idle().is_none(),
+        "window is full before the receiver retires anything"
+    );
+
+    scheduler.retire_current_flist();
+    assert!(
+        scheduler.next_when_idle().is_some(),
+        "retiring one sub-list must reopen the window by exactly one"
+    );
+    assert!(scheduler.next_when_idle().is_none(), "and only by one");
+    assert_eq!(scheduler.dispatched_count(), filled + 1);
+}
+
+#[test]
+fn segment_scheduler_floor_is_unchanged_by_the_ceiling() {
+    // Negative control for the ceiling: a backlog that never approaches
+    // MAX_FILECNT_LOOKAHEAD must dispatch exactly the sub-lists it did before
+    // the bound existed. Without this, a mutation that throttles everything -
+    // or one that lowers the effective bound onto the floor's territory - would
+    // still pass the tests above.
+    use super::segments::{MAX_FILECNT_LOOKAHEAD, MIN_FILECNT_LOOKAHEAD};
+
+    let per_segment = 100;
+    // 20 sub-lists of 100 -> 2000 entries: enough that the floor, not
+    // exhaustion, is what ends the burst, and far enough below 10 000 that the
+    // ceiling is out of reach.
+    let mut scheduler = scheduler_with(20, per_segment);
+
+    let mut floor_burst = 0;
+    while scheduler.next_to_send().is_some() {
+        floor_burst += 1;
+    }
+    assert_eq!(
+        floor_burst,
+        MIN_FILECNT_LOOKAHEAD / per_segment,
+        "the floor must still stop the burst at MIN_FILECNT_LOOKAHEAD entries"
+    );
+    assert!(
+        !scheduler.is_exhausted(),
+        "the floor, not exhaustion, must be what ended the burst"
+    );
+    assert!(
+        scheduler.lookahead_total() < MAX_FILECNT_LOOKAHEAD,
+        "fixture must stay clear of the ceiling for this to be a control"
+    );
+}
+
+#[test]
 fn segment_scheduler_forced_drain_ignores_the_backlog() {
     // The end-of-transfer flush must land every sub-list before NDX_FLIST_EOF:
     // the receiver will not send its final NDX_DONE until it sees EOF, so no

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -253,6 +253,65 @@ impl GeneratorContext {
         Ok(())
     }
 
+    /// Emits `NDX_FLIST_EOF` once the scheduler has handed out every sub-list.
+    ///
+    /// Must run at every point inside the send loop that can exhaust the
+    /// scheduler, not just after the floor top-up: the receiver will not send
+    /// its final `NDX_DONE` until it has seen `NDX_FLIST_EOF`, so a dispatch
+    /// that empties the queue and then parks on a read would deadlock.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2848-2849` - `write_ndx(f, NDX_FLIST_EOF); flist_eof = 1`
+    fn send_flist_eof_if_exhausted<W: Write>(
+        &mut self,
+        writer: &mut W,
+        scheduler: &SegmentScheduler,
+        ndx_codec: &mut protocol::codec::NdxCodecEnum,
+    ) -> io::Result<()> {
+        if !self.incremental.flist_eof_sent && scheduler.is_exhausted() {
+            self.send_flist_eof(writer, ndx_codec, scheduler.dispatched_count())?;
+        }
+        Ok(())
+    }
+
+    /// Queues one further sub-list at the moment the sender is about to block
+    /// for receiver input, growing the lookahead window past
+    /// `MIN_FILECNT_LOOKAHEAD` towards `MAX_FILECNT_LOOKAHEAD`.
+    ///
+    /// [`Self::send_extra_file_lists`] only tops the backlog *up to* the floor,
+    /// which leaves the window pinned there for the whole transfer. Upstream
+    /// does not stop at the floor: while the backlog is under the ceiling it
+    /// polls with a zero timeout (`io.c:836-843`), and on a poll that finds no
+    /// input ready it sends exactly one more sub-list (`io.c:855`,
+    /// `at_least = -1` resolving to `backlog + 1` at `flist.c:2407`). oc has no
+    /// poll loop, but `has_buffered_input()` marks the same instant - the read
+    /// that is genuinely about to block - so the top-up hangs off that instead.
+    ///
+    /// One segment per idle turn, matching upstream's `backlog + 1`: this is a
+    /// use of time the sender was going to spend waiting, not a spin. The
+    /// caller is already committed to blocking on the receiver immediately
+    /// afterwards, so nothing here polls, retries, or busy-waits.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:836-843` - the `MAX_FILECNT_LOOKAHEAD` ceiling on this path
+    /// - `io.c:851-857` - the idle poll result that triggers the top-up
+    fn grow_lookahead_while_idle<W: Write>(
+        &mut self,
+        writer: &mut super::super::super::writer::ServerWriter<W>,
+        scheduler: &mut SegmentScheduler,
+        flist_writer: &mut protocol::flist::FileListWriter,
+        ndx_codec: &mut MonotonicNdxWriter,
+        flist_done_remaining: &mut usize,
+    ) -> io::Result<()> {
+        if let Some(seg) = scheduler.next_when_idle() {
+            self.encode_and_send_segment(&mut *writer, seg, flist_writer, ndx_codec.inner_mut())?;
+            *flist_done_remaining += 1;
+        }
+        Ok(())
+    }
+
     /// Runs the main file transfer loop, reading NDX requests from receiver.
     ///
     /// This method processes file transfer requests in phases until all phases complete.
@@ -415,16 +474,11 @@ impl GeneratorContext {
                     &mut flist_done_remaining,
                 )?;
 
-                // upstream: flist.c:2534-2545 - send NDX_FLIST_EOF when all sub-lists
-                // have been dispatched. Must happen inside the loop (not after) because
-                // the receiver waits for NDX_FLIST_EOF before sending NDX_DONE.
-                if !self.incremental.flist_eof_sent && scheduler.is_exhausted() {
-                    self.send_flist_eof(
-                        &mut *writer,
-                        ndx_write_codec.inner_mut(),
-                        scheduler.dispatched_count(),
-                    )?;
-                }
+                self.send_flist_eof_if_exhausted(
+                    &mut *writer,
+                    &scheduler,
+                    ndx_write_codec.inner_mut(),
+                )?;
             }
 
             // upstream: io.c:640-724 perform_io() flushes buffered output only
@@ -439,6 +493,25 @@ impl GeneratorContext {
             // - ~24 files per socket write, matching upstream's iobuf.out
             // batching instead of one write() per file.
             if !reader.has_buffered_input() {
+                // upstream: io.c:851-857 - a poll that finds nothing to read is
+                // the sender's cue to queue one more sub-list before it parks,
+                // which is what grows the lookahead past the floor. Emitting it
+                // here rather than after the flush keeps it in the same socket
+                // write as the deltas already buffered.
+                if inc_recurse {
+                    self.grow_lookahead_while_idle(
+                        &mut *writer,
+                        &mut scheduler,
+                        &mut flist_writer,
+                        &mut ndx_write_codec,
+                        &mut flist_done_remaining,
+                    )?;
+                    self.send_flist_eof_if_exhausted(
+                        &mut *writer,
+                        &scheduler,
+                        ndx_write_codec.inner_mut(),
+                    )?;
+                }
                 flush_with_count(writer)?;
             }
 
@@ -2223,6 +2296,16 @@ mod inc_recurse_lookahead_tests {
     struct FirstReadProbe {
         wire: Cursor<Vec<u8>>,
         dispatched_at_first_read: Rc<Cell<Option<u64>>>,
+        /// What the probe answers to `has_buffered_input()`, i.e. whether the
+        /// sender believes its next read can be served without blocking.
+        ///
+        /// This is the signal the sender reads as "am I idle?" (upstream's
+        /// `poll()` returning 0, io.c:851). Setting it decides which of the two
+        /// lookahead mechanisms the fixture exercises: `true` models a receiver
+        /// keeping pace, so only the `MIN_FILECNT_LOOKAHEAD` floor runs and the
+        /// burst is the floor's alone; `false` models a sender with time on its
+        /// hands, which is when upstream grows the window past the floor.
+        buffered_input: bool,
     }
 
     impl Read for FirstReadProbe {
@@ -2235,11 +2318,46 @@ mod inc_recurse_lookahead_tests {
         }
     }
 
-    // The probe models a peer whose NDXs the sender must genuinely block for,
-    // so it keeps the conservative pre-read flush (the trait default). The
-    // pacing assertion measures dispatch-before-first-block, which the flush
-    // gate does not affect.
-    impl crate::reader::BufferedInputHint for FirstReadProbe {}
+    impl crate::reader::BufferedInputHint for FirstReadProbe {
+        fn has_buffered_input(&self) -> bool {
+            self.buffered_input
+        }
+    }
+
+    /// Runs the sender over the fixture tree and reports
+    /// `(sub-lists dispatched before the first receiver read, total dispatched)`.
+    fn run_and_count_first_burst(buffered_input: bool) -> (usize, usize) {
+        // The receiver acknowledges each completed file-list and then closes out
+        // the three phases; it never requests a transfer, so every read the
+        // sender performs is a genuine block on receiver progress.
+        let mut ndx = MonotonicNdxWriter::new(32);
+        let mut wire = Vec::new();
+        for _ in 0..(DIRS + 3) {
+            ndx.write_ndx_done(&mut wire).unwrap();
+        }
+
+        let dispatched_at_first_read = Rc::new(Cell::new(None));
+        let mut reader = FirstReadProbe {
+            wire: Cursor::new(wire),
+            dispatched_at_first_read: Rc::clone(&dispatched_at_first_read),
+            buffered_input,
+        };
+        let mut writer = ServerWriter::new_plain(Vec::new());
+        let mut progress: Option<&mut dyn crate::TransferProgressCallback> = None;
+        let mut itemize: Option<&mut dyn crate::ItemizeCallback> = None;
+
+        let mut ctx = generator_with_segmented_tree();
+        let before = segment_dispatch_totals().0;
+        ctx.run_transfer_loop(&mut reader, &mut writer, &mut progress, &mut itemize)
+            .expect("sender loop must run to completion");
+        let after = segment_dispatch_totals().0;
+
+        let first_burst = dispatched_at_first_read
+            .get()
+            .expect("sender must block for a receiver NDX")
+            - before;
+        ((first_burst) as usize, (after - before) as usize)
+    }
 
     /// Builds an INC_RECURSE generator over a `DIRS * FILES_PER_DIR` tree.
     ///
@@ -2303,47 +2421,55 @@ mod inc_recurse_lookahead_tests {
 
     #[test]
     fn sub_lists_are_paced_against_receiver_progress() {
-        // The receiver acknowledges each completed file-list and then closes out
-        // the three phases; it never requests a transfer, so every read the
-        // sender performs is a genuine block on receiver progress.
-        let mut ndx = MonotonicNdxWriter::new(32);
-        let mut wire = Vec::new();
-        for _ in 0..(DIRS + 3) {
-            ndx.write_ndx_done(&mut wire).unwrap();
-        }
-
-        let dispatched_at_first_read = Rc::new(Cell::new(None));
-        let mut reader = FirstReadProbe {
-            wire: Cursor::new(wire),
-            dispatched_at_first_read: Rc::clone(&dispatched_at_first_read),
-        };
-        let mut writer = ServerWriter::new_plain(Vec::new());
-        let mut progress: Option<&mut dyn crate::TransferProgressCallback> = None;
-        let mut itemize: Option<&mut dyn crate::ItemizeCallback> = None;
-
-        let mut ctx = generator_with_segmented_tree();
-        let before = segment_dispatch_totals().0;
-        ctx.run_transfer_loop(&mut reader, &mut writer, &mut progress, &mut itemize)
-            .expect("sender loop must run to completion");
-        let after = segment_dispatch_totals().0;
-
-        let first_burst = dispatched_at_first_read
-            .get()
-            .expect("sender must block for a receiver NDX")
-            - before;
+        // Receiver keeping pace: its NDXs are already buffered, so the sender is
+        // never idle and the MIN_FILECNT_LOOKAHEAD floor is the only mechanism
+        // that runs. This isolates the floor, which is what the burst count
+        // below measures.
+        let (first_burst, total) = run_and_count_first_burst(true);
 
         // Pre-fix, the lookahead was computed once outside the dispatch loop, so
         // the very first `while` drained all DIRS sub-lists before the sender
         // ever read a byte back. Upstream re-tests the condition each iteration
         // and stops at MIN_FILECNT_LOOKAHEAD queued entries.
         assert_eq!(
-            first_burst as usize, EXPECTED_FIRST_BURST,
+            first_burst, EXPECTED_FIRST_BURST,
             "sender must queue {MIN_FILECNT_LOOKAHEAD} entries ahead and then wait, \
              not push all {DIRS} sub-lists up front"
         );
         assert_eq!(
-            (after - before) as usize,
-            DIRS,
+            total, DIRS,
+            "every sub-list must still reach the receiver by end of transfer"
+        );
+    }
+
+    #[test]
+    fn an_idle_sender_grows_the_lookahead_past_the_floor() {
+        // upstream io.c:851-857 - when the poll ahead of a read finds nothing
+        // ready, the sender spends the wait queueing one more sub-list
+        // (`at_least = -1` resolves to `backlog + 1` at flist.c:2407) instead of
+        // parking with the window pinned at the floor.
+        //
+        // The WHY: the floor is a floor, not a target. Stopping at it leaves the
+        // sender idle with sub-lists in hand and the receiver with only
+        // MIN_FILECNT_LOOKAHEAD entries to work through, however much slack the
+        // link has. Measured on a 20 000-file push into an upstream 3.5.0
+        // receiver, holding the window at the floor costs ~6-9% wall clock
+        // against a window allowed to grow.
+        //
+        // This asserts the growth is exactly one sub-list per idle turn, which
+        // is what upstream's `backlog + 1` buys: a mechanism that drained to the
+        // ceiling in a single turn would also push past the floor and must not
+        // pass.
+        let (first_burst, total) = run_and_count_first_burst(false);
+
+        assert_eq!(
+            first_burst,
+            EXPECTED_FIRST_BURST + 1,
+            "an idle sender must add exactly one sub-list beyond the floor's \
+             {EXPECTED_FIRST_BURST} before it parks on the receiver"
+        );
+        assert_eq!(
+            total, DIRS,
             "every sub-list must still reach the receiver by end of transfer"
         );
     }


### PR DESCRIPTION
## What shipped

Both halves of the lookahead-sizing work, as one change, because the ceiling on
its own is unreachable. Detail below.

`MIN_FILECNT_LOOKAHEAD` is a floor, not a target. The sender topped the sub-list
backlog up to it and stopped, so the window stayed pinned at 1000 entries for
the whole transfer however much slack the link had.

Upstream does not stop at the floor. While the backlog is under
`MAX_FILECNT_LOOKAHEAD` it keeps the poll timeout at zero (`io.c:836-843`), and
a poll that finds no input ready sends one more sub-list (`io.c:855`,
`at_least = -1` resolving to `backlog + 1` at `flist.c:2405`). oc has no poll
loop, but `has_buffered_input()` already marks the same instant - the read that
is genuinely about to block - so the top-up hangs off that.

`SegmentScheduler` stays the sole owner of the sizing rule. It gained
`next_when_idle()` alongside `next_to_send()`; the send loop gained a call site,
not a second gate.

## Why the ceiling could not ship on its own

`MAX_FILECNT_LOOKAHEAD` (`rsync.h:152`) had no occurrence anywhere in `crates/`,
so the obvious change was to add it to `next_to_send()`. That would have been
dead code. `next_to_send()` already returns `None` at `>= 1000`, which subsumes
`>= 10000`; the gate could never fire. Measured over a 20 000-file push, the
floor path never took the backlog above exactly 1000, confirming the ceiling is
unreachable there rather than merely improbable.

The reason is structural: upstream's ceiling bounds its *opportunistic* idle
top-up, and oc had no such path. It was the ceiling of a mechanism oc did not
have, not a missing bound on a mechanism it did. Adding the growth and its
bound together is what makes either one meaningful - the growth is what the
ceiling exists to stop, and without the ceiling the growth is unbounded
(measured: an unbounded window queued the entire 20 000-entry tree).

## Never splitting a sub-list

The bound is tested against the backlog *before* the segment is folded in, never
against the segment's own count, so a directory with more children than the
whole ceiling is still admitted whole. `send1extra()` emits one entire directory
(`flist.c:2417`), and truncating one would change the wire framing the receiver
rebuilds its `dir_flist` from.

Pinned by `segment_scheduler_admits_a_directory_larger_than_the_whole_ceiling`,
which passes with `MAX_FILECNT_LOOKAHEAD` mutated to `1`.

## Half-B measurement

oc sender to an upstream 3.5.0 receiver over a loopback daemon - the only cell
that negotiates INC_RECURSE, since oc's own receiver strips `CF_INC_RECURSE`
(pinned by the existing `daemon_push_into_oc_receiver_does_not_negotiate_inc_recurse`).
20 000 files in 20 directories, 15 interleaved reps per cell, warm-up discarded:

| cell | median | min | max |
|---|---|---|---|
| window pinned at the floor | 5.423s | 5.102s | 6.810s |
| window allowed to grow | 5.142s | 4.848s | 9.386s |

-5.2% on the median, -5.0% on the minimum. A separate sweep holding the window
at a fixed size (1000 / 10 000 / unbounded) put the benefit at -6% to -9% and
showed it saturating at 10 000 entries - which is where upstream puts the
ceiling. All 30 runs exited 0 with a destination tree byte-identical to the
source.

Instrumenting the throttle directly was measured first and discarded as the
wrong instrument: it reported a 94.5% "throttle rate", but that counts loop
iterations where the window was *full*, which is the opposite of the sender
starving. The load-bearing counter was the backlog running *dry* with work
still pending, which happened exactly once per transfer - at startup - in every
cell. So the sender never starves the receiver; the gain is from depth, not
from closing a stall.

## Non-vacuity

RED before GREEN, with the idle top-up call removed from the send loop:

```
FAIL [ 0.030s] transfer generator::transfer::transfer_loop::inc_recurse_lookahead_tests::an_idle_sender_grows_the_lookahead_past_the_floor
assertion `left == right` failed: an idle sender must add exactly one sub-list beyond the floor's 10 before it parks on the receiver
  left: 10
 right: 11
```

`left: 10` is the pre-change floor-only behaviour. The floor test
`sub_lists_are_paced_against_receiver_progress` stayed green under that
mutation.

Ceiling check removed from `next_when_idle()` - 3 tests redden, floor control
stays green:

```
Summary [ 0.038s] 10 tests run: 7 passed, 3 failed
assertion `left == right` failed: idle growth must stop at MAX_FILECNT_LOOKAHEAD queued entries
  left: 40
 right: 10
```

Ceiling mutated to `1` - the oversized-directory test still passes, which is
what proves splitting was not implemented:

```
Summary [ 0.020s] 1 test run: 1 passed, 2749 skipped
```

Negative control: `segment_scheduler_floor_is_unchanged_by_the_ceiling` asserts
a tree that never approaches the ceiling dispatches exactly the sub-lists it did
before, and self-refutes if the fixture ever reaches the bound.

## The existing burst assertion

`transfer_loop.rs` asserted the first burst is exactly `1000 / FILES_PER_DIR`
directories. That number is unchanged and was not re-baselined.

It did need investigating. The assertion measures sub-lists dispatched before
the first receiver read, which equalled the floor only because the floor was the
only mechanism running. The probe answered the trait-default `false` to
`has_buffered_input()`, i.e. "this read may block" - which is now also the
signal to grow the window, so the burst became floor + 1.

Rather than move the number, the probe now states which peer it models. The
floor test sets `buffered_input: true` (a receiver keeping pace, so the sender
is never idle), isolating the floor and keeping its assertion at exactly the
same value. A new test sets `false` (an idle sender) and asserts the growth is
exactly one sub-list per idle turn, matching upstream's `backlog + 1`.

## Wire effect

This changes when sub-list frames are interleaved with file data, not which
frames are sent or what they contain. It is not byte-neutral on the wire and
cannot be: upstream's own interleaving here is poll-timing dependent. Every
sub-list still reaches the receiver, the destination tree is byte-identical, and
the 30 measured pushes into a real upstream 3.5.0 receiver all exited 0.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run -p transfer --all-features` - 2747 passed, 3 skipped
- `cargo nextest run -p bin --all-features` - 512 run, 509 passed, 33 skipped

Root-level targets, run with `OC_RSYNC_UPSTREAM_COMPAT=1` against a real
upstream 3.4.4 so they were not silently no-ops (4.95s, 0 skipped):

- `upstream_compat_inc_recurse_sender_oracle` - 4 passed
- `upstream_compat_inc_recurse_receiver_oracle` - 3 passed

`inc_recurse_multi_segment_push_isi_d` and `inc_recurse_single_segment_push_isi_c`
are `#![cfg(not(target_os = "macos"))]` and cannot run on the machine used here;
CI's Linux leg covers them.

## Pre-existing failure, not from this branch

`integration_protocol_versions::oc_rsync_compatible_with_rsync_{3_0_9,3_1_3,3_4_1}`
fail on macOS against locally built upstream binaries. Confirmed by reverting to
a pristine `origin/master` tree and re-running: identical 3 failures. They are
normally invisible because the harness skips when
`target/interop/upstream-install/` is absent. Flagging rather than absorbing.
