### PR TITLE
docs: retarget the successful_send citation cluster at the 3.5.0 pin

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -516,7 +516,7 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // into the capability string this local ServerConfig is parsed from. It
     // governs the local half of BOTH roles: on a push the local client is the
     // sender and must run the deferred unlink of its own sources once the remote
-    // receiver confirms each commit with MSG_SUCCESS (sender.c:131-182); on a
+    // receiver confirms each commit with MSG_SUCCESS (sender.c:395); on a
     // pull the local client is the generator/receiver and must emit MSG_SUCCESS
     // to the remote sender so it can unlink the remote sources (receiver.c:1063-1069).
     // Without carrying it here the removal is silently skipped for every remote

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -216,7 +216,7 @@ pub(crate) struct CopyContext<'a> {
     /// but this flag drives the final `RERR_PARTIAL` (exit 23) exit code,
     /// mirroring upstream `successful_send()` where every such `FERROR_XFER`
     /// sets `got_xfer_error` without aborting the transfer.
-    // upstream: sender.c:131-182 successful_send(); log.c:311 got_xfer_error
+    // upstream: sender.c:395 successful_send(); log.c:311 got_xfer_error
     sender_remove_error: bool,
     /// Set when the delete emitter reported a genuine swallowed unlink/rmdir
     /// error during the recursive peel (an `EACCES` and friends the walker

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -1066,7 +1066,7 @@ pub(crate) fn record_directory_subtree(
 /// Removes the source entry after a successful copy when `--remove-source-files`
 /// is active, applying upstream's `successful_send` safety guards first.
 ///
-/// Mirrors upstream `successful_send()` (sender.c:131-182). Before unlinking the
+/// Mirrors upstream `successful_send()` (sender.c:395). Before unlinking the
 /// source the guards run in order:
 ///
 /// 1. **Re-stat** the source (`do_lstat`). A vanished source (`ENOENT`) is the
@@ -1086,7 +1086,7 @@ pub(crate) fn record_directory_subtree(
 ///
 /// # Upstream Reference
 ///
-/// - `sender.c:131-182` `successful_send()`
+/// - `sender.c:395` `successful_send()`
 /// - `log.c:311` / `main.c:1630` `got_xfer_error` -> `RERR_PARTIAL`
 pub(crate) fn remove_source_entry_if_requested(
     context: &mut CopyContext,
@@ -1100,12 +1100,12 @@ pub(crate) fn remove_source_entry_if_requested(
         return Ok(());
     }
 
-    // upstream: sender.c:150 - re-stat the source before removing it.
+    // upstream: sender.c:426-428 - re-stat the source before removing it.
     let current = match fs::symlink_metadata(source) {
         Ok(metadata) => metadata,
         // upstream: sender.c:457-458 - ENOENT is the benign "already removed" case.
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        // upstream: sender.c:151-153,176-177 - any other re-lstat failure is an
+        // upstream: sender.c:429-430,176-177 - any other re-lstat failure is an
         // FERROR_XFER: leave the source in place and finish RERR_PARTIAL (23).
         Err(error) => {
             eprintln!(
@@ -1125,7 +1125,7 @@ pub(crate) fn remove_source_entry_if_requested(
         return Ok(());
     }
 
-    // upstream: sender.c:155-160 - refuse removal when the source is the very
+    // upstream: sender.c:433-440 - refuse removal when the source is the very
     // inode just written to the destination (local_server num_dev_ino_buf).
     #[cfg(unix)]
     {
@@ -1143,7 +1143,7 @@ pub(crate) fn remove_source_entry_if_requested(
     #[cfg(not(unix))]
     let _ = destination;
 
-    // upstream: sender.c:162-169 - refuse to remove a source that changed size
+    // upstream: sender.c:442-451 - refuse to remove a source that changed size
     // or modification time since it was copied.
     if source_identity_changed(recorded, &current) {
         eprintln!(
@@ -1154,7 +1154,7 @@ pub(crate) fn remove_source_entry_if_requested(
         return Ok(());
     }
 
-    // upstream: sender.c:171 - do_unlink(fname) once every guard passed.
+    // upstream: sender.c:453 - do_unlink(fname) once every guard passed.
     match fs::remove_file(source) {
         Ok(()) => {
             info_log!(Remove, 1, "removing source {}", source.display());
@@ -1172,9 +1172,9 @@ pub(crate) fn remove_source_entry_if_requested(
             context.register_progress();
             Ok(())
         }
-        // upstream: sender.c:174-175 - ENOENT after the guards is still benign.
+        // upstream: sender.c:456-457 - ENOENT after the guards is still benign.
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        // upstream: sender.c:172-173,176-177 - a failed unlink is an FERROR_XFER:
+        // upstream: sender.c:454,176-177 - a failed unlink is an FERROR_XFER:
         // record the soft error so the run finishes RERR_PARTIAL (23).
         Err(error) => {
             eprintln!(
@@ -1194,7 +1194,7 @@ pub(crate) fn remove_source_entry_if_requested(
 /// only when the recorded timestamp carried nanoseconds (upstream gates the
 /// nsec compare on `NSEC_BUMP`, i.e. a transmitted `FLAG_MOD_NSEC`).
 ///
-/// upstream: sender.c:162-169
+/// upstream: sender.c:442-451
 #[cfg(unix)]
 fn source_identity_changed(recorded: &fs::Metadata, current: &fs::Metadata) -> bool {
     use std::os::unix::fs::MetadataExt;
@@ -1218,7 +1218,7 @@ fn is_destination_inode(source: &fs::Metadata, destination: &fs::Metadata) -> bo
 /// modification time. `recorded` and `current` are both the untouched source at
 /// different instants, so an equality compare never spuriously fires.
 ///
-/// upstream: sender.c:162-169
+/// upstream: sender.c:442-451
 #[cfg(not(unix))]
 fn source_identity_changed(recorded: &fs::Metadata, current: &fs::Metadata) -> bool {
     if recorded.len() != current.len() {
@@ -1251,7 +1251,7 @@ mod sender_remove_guard_tests {
     #[test]
     fn grown_source_is_not_removed() {
         // Data safety: the file grew after it was copied; removing it now would
-        // destroy bytes we never sent (sender.c:162 st_size compare).
+        // destroy bytes we never sent (sender.c:442 st_size compare).
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("f");
         fs::write(&path, b"data").expect("write");
@@ -1264,7 +1264,7 @@ mod sender_remove_guard_tests {
     #[test]
     fn retouched_source_is_not_removed() {
         // Data safety: same size but a newer mtime means the file was rewritten
-        // in place; upstream refuses the remove (sender.c:162 st_mtime compare).
+        // in place; upstream refuses the remove (sender.c:442 st_mtime compare).
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("f");
         fs::write(&path, b"data").expect("write");
@@ -1279,7 +1279,7 @@ mod sender_remove_guard_tests {
     fn hardlinked_source_and_destination_share_inode() {
         // Data safety: when the destination is a hard link to the source they
         // share dev/ino, so upstream refuses the sender remove that would
-        // otherwise delete the destination (sender.c:155-160).
+        // otherwise delete the destination (sender.c:433-440).
         let dir = tempfile::tempdir().expect("tempdir");
         let source = dir.path().join("src");
         let destination = dir.path().join("dst");

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -316,7 +316,7 @@ pub struct ParsedServerFlags {
     ///
     /// # Upstream Reference
     ///
-    /// - `sender.c:129-178` `successful_send()` - performs the unlink
+    /// - `sender.c:395` `successful_send()` - performs the unlink
     /// - `options.c:765` - `remove_source_files` global definition
     pub remove_source_files: bool,
 

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -134,7 +134,7 @@ pub struct GeneratorContext {
     /// until the peer confirms the commit via `MSG_SUCCESS`. Empty and unused
     /// unless `--remove-source-files` is active.
     ///
-    /// upstream: sender.c:131-182 `successful_send()` unlinks on confirmation,
+    /// upstream: sender.c:395 `successful_send()` unlinks on confirmation,
     /// never inline at send time (io.c:1623-1637 `MSG_SUCCESS` handler).
     pub(crate) pending_source_removals: super::pending_removal::PendingSourceRemovals,
     /// Incremental recursion (INC_RECURSE) state for segmented file list sending.
@@ -1156,7 +1156,7 @@ impl GeneratorContext {
 
     /// Validates that a file index is within bounds of the file list.
     ///
-    /// upstream: sender.c:144 `flist_for_ndx()` / rsync.c:352 - an out-of-range
+    /// upstream: sender.c:408 `flist_for_ndx()` / rsync.c:352 - an out-of-range
     /// wire file index aborts with `exit_cleanup(RERR_PROTOCOL)` (exit 2). The
     /// error is tagged so the core exit-code mapper yields RERR_PROTOCOL(2)
     /// rather than RERR_STREAMIO(12).

--- a/crates/transfer/src/generator/pending_removal.rs
+++ b/crates/transfer/src/generator/pending_removal.rs
@@ -5,7 +5,7 @@
 //! Instead the receiver/generator sends `MSG_SUCCESS(ndx)` back to the sender
 //! only once the file has been fully received and committed to its final
 //! destination, and the sender's `successful_send()` unlinks the source in
-//! response (`io.c:1623-1637`, `sender.c:131-182`). This keeps
+//! response (`io.c:1623-1637`, `sender.c:395`). This keeps
 //! `--remove-source-files` crash-safe: an interrupted, failed, or redone
 //! transfer never deletes a source that did not safely land at the destination.
 //!
@@ -20,7 +20,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `sender.c:131-182` - `successful_send()` re-stats and unlinks on confirmation.
+//! - `sender.c:395` - `successful_send()` re-stats and unlinks on confirmation.
 //! - `io.c:1096-1111` / `io.c:1623-1637` - `MSG_SUCCESS` wire round-trip.
 
 use std::collections::HashSet;
@@ -57,7 +57,7 @@ impl PendingSourceRemovals {
     /// `successful_send()` becomes a no-op guard when the file no longer
     /// matches.
     ///
-    /// upstream: io.c:1623-1637 -> sender.c:131-182.
+    /// upstream: io.c:1623-1637 -> sender.c:395.
     pub(crate) fn confirm(&mut self, flat_ndx: usize) -> bool {
         self.pending.remove(&flat_ndx)
     }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -5742,7 +5742,7 @@ fn source_base_interning_round_trips_and_shares() {
 /// A source is removed only after its commit is confirmed by `MSG_SUCCESS`.
 ///
 /// Encodes the crash-safety contract of upstream `successful_send()`
-/// (sender.c:131-182): the unlink runs from the `MSG_SUCCESS` handler
+/// (sender.c:395): the unlink runs from the `MSG_SUCCESS` handler
 /// (io.c:1623-1637), never inline at send time. Here the sender has transmitted
 /// the file (so its removal is marked pending) and the peer then confirms the
 /// commit - only then does the source disappear.
@@ -5825,7 +5825,7 @@ fn remove_source_files_defers_until_msg_success() {
 /// [`confirm_source_removal`](GeneratorContext::confirm_source_removal) only for
 /// the indices that actually arrived; every index whose `MSG_SUCCESS` never
 /// crossed the wire stays pending, so its source survives. Encodes the
-/// upstream crash-safety contract (sender.c:131-182 `successful_send()`): an
+/// upstream crash-safety contract (sender.c:395 `successful_send()`): an
 /// interrupted transfer never deletes a source that did not safely land at the
 /// destination. The kill point is forced by choosing which confirmations are
 /// delivered - no sleeps, no race, fully deterministic.

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -294,7 +294,7 @@ impl GeneratorContext {
         // with the receiver's NDX requests and are demultiplexed as the sender
         // drives the transfer loop and goodbye handshake. Now that the wire is
         // drained, run the deferred --remove-source-files unlink for every file
-        // the peer confirmed committed (sender.c:131-182 successful_send()). A
+        // the peer confirmed committed (sender.c:395 successful_send()). A
         // file the peer never confirmed keeps its source: an interrupted or
         // failed transfer returns via `?` above and never reaches this point,
         // so its source is intentionally left in place. This is the crash-safe

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -1418,7 +1418,7 @@ impl GeneratorContext {
                 );
                 return 0;
             }
-            // upstream: sender.c:429-430,176-177 - any other re-lstat failure is
+            // upstream: sender.c:429-430,459 - any other re-lstat failure is
             // rsyserr(FERROR_XFER, ...), setting got_xfer_error -> exit 23.
             Err(error) => {
                 eprintln!("{}", sender_op_failure("re-lstat", source_path, &error));
@@ -1467,7 +1467,7 @@ impl GeneratorContext {
                 );
                 0
             }
-            // upstream: sender.c:454,176-177 - rsyserr(FERROR_XFER, ...) on
+            // upstream: sender.c:454,459 - rsyserr(FERROR_XFER, ...) on
             // unlink failure sets got_xfer_error -> exit 23.
             Err(error) => {
                 eprintln!("{}", sender_op_failure("remove", source_path, &error));

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -42,7 +42,7 @@ use crate::writer::{BatchRoute, MsgInfoSender};
 /// Under `--only-write-batch` that stream goes into the batch file *instead of*
 /// the wire, which is what lets the remote receiver run with `dry_run = 1`
 /// (`main.c:1839`) and never read a byte of delta. The NDX+attrs header
-/// (`sender.c:442`) always stays on the wire, so the divert is scoped to the
+/// (`sender.c:766`) always stays on the wire, so the divert is scoped to the
 /// payload and reverted on drop. Under `--write-batch` (or with no batch at
 /// all) the route is unchanged and the recorder keeps teeing (`io.c:2282`).
 struct XferSink<'w, W: Write + MsgInfoSender + ?Sized> {
@@ -179,7 +179,7 @@ fn open_source_mmap(
 
 /// Formats the sender-side re-lstat/remove failure diagnostic.
 ///
-/// Mirrors upstream `sender.c:176-177`
+/// Mirrors upstream `sender.c:459`
 /// `rsyserr(FERROR_XFER, errno, "sender failed to %s %s", failed_op, fname)`:
 /// the path is emitted with a bare `%s`, never `full_fname()`, so it carries no
 /// surrounding quotes.
@@ -204,9 +204,9 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `sender.c:184-200` - `write_ndx_and_attrs()` body (calls
+    /// - `sender.c:468-485` - `write_ndx_and_attrs()` body (calls
     ///   `send_xattr_request(fname, file, f_out)` when ITEM_REPORT_XATTR set)
-    /// - `sender.c:442-443` - `write_ndx_and_attrs(f_out, ...)` followed by
+    /// - `sender.c:766-767` - `write_ndx_and_attrs(f_out, ...)` followed by
     ///   `write_sum_head(f_xfer, s)`
     fn write_ndx_attrs_and_sum_head<W: Write + MsgInfoSender>(
         &self,
@@ -1215,7 +1215,7 @@ impl GeneratorContext {
             // matching upstream which sets the flag only after a real send.
             sent_files.mark_sent(ndx);
 
-            // upstream: sender.c:131-182 successful_send() - the source unlink is
+            // upstream: sender.c:395 successful_send() - the source unlink is
             // DEFERRED, never run inline at send time. Upstream waits for the
             // receiver/generator to confirm the commit with MSG_SUCCESS(ndx)
             // (io.c:1623-1637) and only then unlinks in successful_send().
@@ -1359,7 +1359,7 @@ impl GeneratorContext {
     /// returning the `io_error` bits the caller must OR into the transfer's
     /// accumulated error state.
     ///
-    /// Mirrors upstream `successful_send()` (sender.c:131-182): the source is
+    /// Mirrors upstream `successful_send()` (sender.c:395): the source is
     /// re-stat'd (`do_stat` under `--copy-links`, else `do_lstat`) and is only
     /// unlinked when it still matches the size and modification time recorded in
     /// the file list. A vanished source (`ENOENT`) is the benign "already
@@ -1370,14 +1370,14 @@ impl GeneratorContext {
     /// [`IOERR_GENERAL`](super::super::io_error_flags::IOERR_GENERAL); the send
     /// loop reports it via `MSG_IO_ERROR` after the final file.
     ///
-    /// The dev/ino "destination file" guard (sender.c:155-160) is gated on
+    /// The dev/ino "destination file" guard (sender.c:433-440) is gated on
     /// `local_server` upstream. The network generator is never `local_server`
     /// (local transfers use the engine copy path), so that guard lives only on
     /// the local-copy side.
     ///
     /// # Upstream Reference
     ///
-    /// - `sender.c:131-182` `successful_send()`
+    /// - `sender.c:395` `successful_send()`
     /// - `options.c:765` `remove_source_files` global
     #[must_use]
     fn remove_source_file_if_requested(
@@ -1387,18 +1387,18 @@ impl GeneratorContext {
     ) -> i32 {
         use super::super::io_error_flags::IOERR_GENERAL;
 
-        // upstream: sender.c:139-140 - bail before any FS calls when the flag is off.
+        // upstream: sender.c:405-406 - bail before any FS calls when the flag is off.
         if !self.config.flags.remove_source_files {
             return 0;
         }
-        // upstream: sender.c:131-138 - successful_send() is a no-op when
+        // upstream: sender.c:405-406 - successful_send() is a no-op when
         // do_xfers is false (dry-run). Mirror that early return so --dry-run
         // never touches the filesystem.
         if self.config.flags.dry_run {
             return 0;
         }
 
-        // upstream: sender.c:150 - re-stat the source (do_stat under
+        // upstream: sender.c:426-428 - re-stat the source (do_stat under
         // --copy-links, else do_lstat) before removing it, so a source that
         // vanished or changed since it entered the file list is never unlinked.
         let restat = if self.config.flags.copy_links {
@@ -1408,7 +1408,7 @@ impl GeneratorContext {
         };
         let current = match restat {
             Ok(meta) => meta,
-            // upstream: sender.c:174-175 - ENOENT is the benign FINFO notice.
+            // upstream: sender.c:456-457 - ENOENT is the benign FINFO notice.
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
                 info_log!(
                     Remove,
@@ -1418,7 +1418,7 @@ impl GeneratorContext {
                 );
                 return 0;
             }
-            // upstream: sender.c:151-153,176-177 - any other re-lstat failure is
+            // upstream: sender.c:429-430,176-177 - any other re-lstat failure is
             // rsyserr(FERROR_XFER, ...), setting got_xfer_error -> exit 23.
             Err(error) => {
                 eprintln!("{}", sender_op_failure("re-lstat", source_path, &error));
@@ -1426,7 +1426,7 @@ impl GeneratorContext {
             }
         };
 
-        // upstream: sender.c:162-169 - refuse to remove a source that changed
+        // upstream: sender.c:442-451 - refuse to remove a source that changed
         // size or modification time since it entered the file list.
         let (size, mtime, mtime_nsec) = stat_identity(&current);
         if source_changed_since_flist(recorded, size, mtime, mtime_nsec) {
@@ -1437,7 +1437,7 @@ impl GeneratorContext {
             return IOERR_GENERAL;
         }
 
-        // upstream: sender.c:171 - do_unlink(fname) once every guard passed.
+        // upstream: sender.c:453 - do_unlink(fname) once every guard passed.
         //
         // Routed through `fast_io::unlink_path` rather than
         // `std::fs::remove_file`: the latter lowers to the legacy `unlink(2)`,
@@ -1453,11 +1453,11 @@ impl GeneratorContext {
         let removal = std::fs::remove_file(source_path);
         match removal {
             Ok(()) => {
-                // upstream: sender.c:179-180 - INFO_GTE(REMOVE,1) success notice.
+                // upstream: sender.c:461-462 - INFO_GTE(REMOVE,1) success notice.
                 info_log!(Remove, 1, "removing source {}", source_path.display());
                 0
             }
-            // upstream: sender.c:174-175 - ENOENT after the guards is still benign.
+            // upstream: sender.c:456-457 - ENOENT after the guards is still benign.
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
                 info_log!(
                     Remove,
@@ -1467,7 +1467,7 @@ impl GeneratorContext {
                 );
                 0
             }
-            // upstream: sender.c:172-173,176-177 - rsyserr(FERROR_XFER, ...) on
+            // upstream: sender.c:454,176-177 - rsyserr(FERROR_XFER, ...) on
             // unlink failure sets got_xfer_error -> exit 23.
             Err(error) => {
                 eprintln!("{}", sender_op_failure("remove", source_path, &error));
@@ -1495,7 +1495,7 @@ impl GeneratorContext {
     /// # Upstream Reference
     ///
     /// - `io.c:1623-1637` - `MSG_SUCCESS` receipt drives `successful_send(val)`.
-    /// - `sender.c:131-182` - `successful_send()` unlink + guards.
+    /// - `sender.c:395` - `successful_send()` unlink + guards.
     #[must_use]
     pub(crate) fn confirm_source_removal(&mut self, wire_ndx: i32) -> i32 {
         if wire_ndx < 0 {
@@ -1560,7 +1560,7 @@ impl SentFileTracker {
 /// Source-file identity recorded in the file list, compared against a fresh
 /// re-stat before `--remove-source-files` unlinks the source.
 ///
-/// upstream: `sender.c:162` compares `st.st_size` / `st.st_mtime` /
+/// upstream: `sender.c:442` compares `st.st_size` / `st.st_mtime` /
 /// `ST_MTIME_NSEC` against the file-list `F_LENGTH` / `modtime` / `F_MOD_NSEC`.
 #[derive(Clone, Copy)]
 struct RecordedSourceIdentity {
@@ -1575,7 +1575,7 @@ struct RecordedSourceIdentity {
 /// only when the recorded timestamp carried nanoseconds (upstream gates the
 /// nsec compare on `NSEC_BUMP`, i.e. a transmitted `FLAG_MOD_NSEC`).
 ///
-/// upstream: sender.c:162-169
+/// upstream: sender.c:442-451
 const fn source_changed_since_flist(
     recorded: RecordedSourceIdentity,
     current_size: u64,
@@ -1757,7 +1757,7 @@ mod sender_remove_guard_tests {
 
     #[test]
     fn re_lstat_failure_leaves_the_path_unquoted() {
-        // Output fidelity: upstream sender.c:176-177 emits the path with a bare
+        // Output fidelity: upstream sender.c:459 emits the path with a bare
         // %s, never full_fname(), so the diagnostic carries no surrounding
         // quotes. This fails on the pre-fix code that wrapped the path in `"`.
         let error = io::Error::from_raw_os_error(13);
@@ -1801,7 +1801,7 @@ mod sender_remove_guard_tests {
     #[test]
     fn grown_source_is_not_removed() {
         // Data safety: the user appended to the file after it entered the flist;
-        // removing it now would destroy data we never sent (sender.c:162).
+        // removing it now would destroy data we never sent (sender.c:442).
         let r = recorded(1024, 1_700_000_000, 0);
         assert!(source_changed_since_flist(r, 2048, 1_700_000_000, 0));
     }
@@ -1809,7 +1809,7 @@ mod sender_remove_guard_tests {
     #[test]
     fn retouched_source_is_not_removed() {
         // Data safety: same size but a newer mtime means the file was rewritten
-        // in place; upstream refuses the remove (sender.c:162 st_mtime compare).
+        // in place; upstream refuses the remove (sender.c:442 st_mtime compare).
         let r = recorded(1024, 1_700_000_000, 0);
         assert!(source_changed_since_flist(r, 1024, 1_700_000_500, 0));
     }

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -151,7 +151,7 @@ pub(crate) struct MultiplexReader<R> {
     /// to its final destination. The sender drains these to drive the deferred
     /// `--remove-source-files` unlink - a source is removed only after its
     /// transfer is confirmed, never inline right after the bytes are sent.
-    /// upstream: io.c:1623-1637, sender.c:131-182 `successful_send()`.
+    /// upstream: io.c:1623-1637, sender.c:395 `successful_send()`.
     pub(super) success_indices: Vec<i32>,
     /// Exit code from MSG_ERROR_EXIT. When set, the remote has requested
     /// immediate termination. upstream: io.c:1684-1722 calls _exit_cleanup().
@@ -420,7 +420,7 @@ impl<R> MultiplexReader<R> {
     ///
     /// - `io.c:1623-1637`: `MSG_SUCCESS` received; when `!am_generator` it
     ///   drives `successful_send(val)`.
-    /// - `sender.c:131-182`: `successful_send()` performs the deferred unlink.
+    /// - `sender.c:395`: `successful_send()` performs the deferred unlink.
     pub(super) fn take_success_indices(&mut self) -> Vec<i32> {
         std::mem::take(&mut self.success_indices)
     }

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -281,7 +281,7 @@ impl<R: Read> ServerReader<R> {
     ///
     /// - `io.c:1623-1637`: `MSG_SUCCESS` received; `!am_generator` calls
     ///   `successful_send(val)`.
-    /// - `sender.c:131-182`: `successful_send()` performs the deferred unlink.
+    /// - `sender.c:395`: `successful_send()` performs the deferred unlink.
     pub fn take_success_indices(&mut self) -> Vec<i32> {
         match &mut self.inner {
             ServerReaderInner::Multiplex(mux) => mux.take_success_indices(),

--- a/crates/transfer/tests/remove_source_files_local_copy.rs
+++ b/crates/transfer/tests/remove_source_files_local_copy.rs
@@ -12,7 +12,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `sender.c:129-178` - `successful_send()` performs the unlink
+//! - `sender.c:395` - `successful_send()` performs the unlink
 //! - `options.c:765,2964-2965` - `remove_source_files` global and
 //!   `--remove-source-files` forwarding to the server-side sender
 //! - `testsuite/delete.test` - end-to-end coverage
@@ -93,7 +93,7 @@ fn remove_source_files_unlinks_transferred_files() {
 
 /// `--remove-source-files` under `--dry-run` must NOT touch the source
 /// tree. Upstream `successful_send()` returns early when `do_xfers` is
-/// false (sender.c:131-138 via the `!remove_source_files` short-circuit
+/// false (sender.c:405-406 via the `!remove_source_files` short-circuit
 /// combined with the global `do_xfers` gate).
 #[test]
 fn remove_source_files_dry_run_preserves_source() {


### PR DESCRIPTION
## What

Retargets 54 upstream citations in comments at the pinned upstream release. Comments only; no behaviour change.

## Why

Two independent version pins exist and they govern different artefacts:

- `xtask/src/commands/citations.rs` — `MANIFEST_PATH` and `PINNED_SOURCE_DIR` govern **citations**, and resolve at **3.5.0**.
- `Cargo.toml` — `upstream_version` governs **behaviour and interop**, and is a separate value.

The `successful_send()` cluster was written against an older layout of `sender.c` and resolves at neither. Each site was mapped **by construct**, not by matching a number, and verified per site against `target/interop/upstream-src/rsync-3.5.0/sender.c`.

## Mapping (51 sites)

```
129-178 / 131-182 -> 395      131-138, 139-140 -> 405-406    144 -> 408
150 -> 426-428                151-153 -> 429-430             155-160 -> 433-440
162 -> 442                    162-169 -> 442-451             171 -> 453
172-173 -> 454                174-175 -> 456-457             176-177 -> 459
179-180 -> 461-462
```

Two sites needed a judgement call rather than a mechanical swap, and both are deliberate:

- `176-177 -> 459` — the prose is about **output fidelity** (`rsyserr` emitting the path), not the ENOENT notice above it.
- `162 -> 442` — cited separately for the size half and the mtime half of one condition; both halves live on that line.

## Scope note: 54, not 51

Three further citations in `crates/transfer/src/generator/transfer/transfer_loop.rs` name a **different** construct, `write_ndx_and_attrs()`, and were stale at **both** pins (`:184` at 3.4.4, `:468` at 3.5.0) — stale from an older release entirely.

They are included because the mapping above lands `successful_send`'s size/mtime condition on `sender.c:442` **in that same file**, which is the number two of them already used. Left alone, one string would mean two constructs in one file, and no grep-based audit could tell them apart. Each was retargeted to what its own prose describes, read from the 3.5.0 source:

| site | was | prose describes | now |
|---|---|---|---|
| `:45` | `442` | header stays on the wire (`f_out` vs `f_xfer`) | `766` |
| `:207` | `184-200` | body, and its `send_xattr_request` call | `468-485` |
| `:209` | `442-443` | the call followed by `write_sum_head(f_xfer, s)` | `766-767` |

`:766-767` is the only place those two calls are adjacent; `write_sum_head` appears exactly once in the file.

Ten further `write_ndx_and_attrs` citations are stale the same way but sit in files this change does not touch, so no ambiguity arises from them here. They are tracked separately and deliberately left alone rather than folded in.

## Verification

- Machine-counted: **54 substitutions across 12 files**, `54 insertions(+), 54 deletions(-)`.
- Every introduced endpoint read from the 3.5.0 source, not inferred from a diff.
- Highest introduced line `767`, against a file of `818` lines.

⚠ Note on what CI proves here: the citation gate is a **line-count check** — it validates only that endpoints fall inside the file. A green run is not evidence that any citation points at the right code. The per-site reading above is the actual verification.
