### PR TITLE
fix(fast_io): open the walk anchor with openat so the worker filter admits it

### DIFF
--- a/crates/daemon/tests/seccomp_worker_filter.rs
+++ b/crates/daemon/tests/seccomp_worker_filter.rs
@@ -20,6 +20,8 @@ use std::collections::BTreeMap;
 use std::io;
 use std::os::unix::process::ExitStatusExt;
 
+use daemon::seccomp_test_support::{SeccompOutcome, apply_worker_seccomp_filter};
+
 /// Architecture detected at build time.
 fn target_arch() -> Option<TargetArch> {
     if cfg!(target_arch = "x86_64") {
@@ -169,5 +171,57 @@ fn blocked_syscall_traps_with_sigsys() {
     assert_ne!(
         code, 99,
         "child reached past blocked syscall - filter not enforcing",
+    );
+}
+
+/// The ownership walk must keep resolving once the worker filter engages.
+///
+/// The walk opens its starting directory - `/` for an absolute path - and
+/// that open has to be an `openat`. On x86_64 rustix lowers the no-dirfd
+/// `rustix::fs::open` to the legacy `SYS_open`, which this allowlist
+/// deliberately omits in favour of the `*at` variants, so a plain `open`
+/// returns `EPERM` inside a worker and every confined resolution beneath
+/// it fails. Regression pin: a daemon receiver could not create its
+/// destination temp file, surfacing as `mkstemp ... Permission denied`.
+///
+/// Installs the production filter through `apply_worker_seccomp_filter`
+/// rather than a hand-copied rule set, so the pin tracks the real
+/// allowlist as it changes.
+#[test]
+fn the_ownership_walk_resolves_under_the_worker_filter() {
+    let probe = std::env::temp_dir().join(format!("oc-owner-walk-probe-{}", std::process::id()));
+    std::fs::write(&probe, b"probe").expect("probe file must be creatable");
+    assert!(
+        probe.is_absolute(),
+        "the probe must be absolute so the walk starts at `/`",
+    );
+
+    let child_path = probe.clone();
+    let raw = fork_run(move || {
+        match apply_worker_seccomp_filter() {
+            SeccompOutcome::Installed => {}
+            // Kernel refused the filter, or this build cannot install one:
+            // treat as a skip, matching the sibling tests above.
+            _ => return 77,
+        }
+        match fast_io::owner_walk::operator_open_read(&child_path) {
+            Ok(_) => 0,
+            Err(_) => 99,
+        }
+    });
+
+    let _ = std::fs::remove_file(&probe);
+    let status = std::process::ExitStatus::from_raw(raw);
+    if let Some(sig) = status.signal() {
+        panic!("child killed by signal {sig} while walking under the worker filter");
+    }
+    let code = status.code().expect("child must exit");
+    if code == 77 {
+        eprintln!("seccomp filter install rejected by kernel; skipping");
+        return;
+    }
+    assert_eq!(
+        code, 0,
+        "the ownership walk was refused under the worker filter - a syscall the walk issues is missing from the allowlist",
     );
 }

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -264,8 +264,17 @@ const fn traversal_is_by_location() -> bool {
 /// `flags` comes from [`traversal_dir_flags`]; upstream opens the same two
 /// directories with the same meaning at `syscall.c:349-351`.
 fn open_start_dir(absolute: bool, flags: OFlags) -> io::Result<OwnedFd> {
-    rustix::fs::open(if absolute { "/" } else { "." }, flags, Mode::empty())
-        .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))
+    // `openat` with `CWD`, never the legacy `open`: on x86_64 rustix issues
+    // the raw `SYS_open` for the no-dirfd form, and the daemon's seccomp
+    // allowlist admits only the `*at` variants, so a plain `open` is EPERM'd
+    // inside a worker. `openat(AT_FDCWD, p, ..)` is the same operation.
+    rustix::fs::openat(
+        rustix::fs::CWD,
+        if absolute { "/" } else { "." },
+        flags,
+        Mode::empty(),
+    )
+    .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))
 }
 
 /// Open the walk's final component with the caller's flags.
@@ -352,7 +361,8 @@ fn owner_walk_open(
         } else {
             path
         };
-        return rustix::fs::open(target, flags, mode)
+        // `openat`/`CWD` for the same seccomp reason as `open_start_dir`.
+        return rustix::fs::openat(rustix::fs::CWD, target, flags, mode)
             .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()));
     }
 


### PR DESCRIPTION
## What breaks

A plain in-module daemon push with `--backup-dir` fails on x86_64 Linux under
`--all-features`:

```
rsync: [receiver] mkstemp "payload" (in data) failed: Permission denied (13)
```

The transfer dies when the receiver creates its destination temp file, before
any backup or symlink logic runs.

## Root cause

`open_start_dir` opened the walk's starting directory — `/` for an absolute
path — through `rustix::fs::open`. On x86_64 rustix lowers the no-dirfd form to
the **raw legacy `SYS_open`**, and the daemon's seccomp worker allowlist admits
only the `*at` variants. strace, in the daemon process:

```
open("/", O_RDONLY|O_LARGEFILE|O_CLOEXEC|O_PATH|O_DIRECTORY) = -1 EPERM
```

The anchor open is refused, so every confined resolution beneath it fails.

Measured A/B — same binary, same flags, one environment variable:

| run | config | result |
|---|---|---|
| A | `--all-features` | FAIL, `mkstemp … Permission denied (13)` |
| B | `--all-features` + `OC_RSYNC_NO_SECCOMP=1` | **1 passed** |

With the fix applied and seccomp left **on**, the same cell passes.

## Why the fix is at the call site

The allowlist is right and the callers were wrong. `openat(AT_FDCWD, p, ..)` is
the identical operation and is already permitted, so this uses the `at` form
rather than widening the filter.

**Two sites, not one.** `open_start_dir` is the one that fires today; the
opt-out arm in `operator_open_with_owner_walk` carried the same raw `open` and
is latent only because the confinement session is not yet installed. Both are
fixed here — leaving the second would resurface this the moment that gets
wired.

`aarch64` has no `SYS_open` at all, which is why only x86_64 could observe it,
and why the three `nextest` cells were the only ones affected.

## Provenance

`git log -S 'rustix::fs::open(if absolute'` returns exactly one commit:
`243836639` (#7541, merged earlier today), which rewrote this call into the raw
form. Same-day regression.

## Test

The pin installs the **production** worker filter through
`apply_worker_seccomp_filter` — not a hand-copied rule set — and then runs the
real ownership walk, so it tracks the live allowlist as that changes. No
existing test called `apply_worker_seccomp_filter` at all, which is the
coverage gap that let this land.

## Unblocks

#7535 and #7538 both fail on this shared cause, from two independently written
fixture files with a byte-identical error. Neither should be patched in
isolation; both should go green once this lands.
