### PR TITLE
feat(daemon): symmetric operator opt-out for both kernel sandbox layers

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -787,6 +787,8 @@ include!("daemon/sections/greeting.rs");
 
 include!("daemon/sections/privilege.rs");
 
+include!("daemon/sections/sandbox_optout.rs");
+
 include!("daemon/sections/seccomp.rs");
 
 include!("daemon/sections/capabilities.rs");

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1812,6 +1812,58 @@ mod module_access_tests {
         );
     }
 
+    /// BOTH kernel layers must stand aside for the same module, from the same
+    /// predicate. They used to disagree: Landlock skipped for the operator's
+    /// declared hook while the seccomp filter stayed engaged and EPERMed the
+    /// `execve` the hook needs, so the hook silently never ran.
+    #[test]
+    fn an_exec_hook_releases_both_kernel_sandbox_layers() {
+        for module in [
+            ModuleRuntime::from(ModuleDefinition {
+                pre_xfer_exec: Some("/usr/local/bin/before.sh".into()),
+                ..Default::default()
+            }),
+            ModuleRuntime::from(ModuleDefinition {
+                post_xfer_exec: Some("/usr/local/bin/after.sh".into()),
+                ..Default::default()
+            }),
+        ] {
+            let hook =
+                exec_hook_skip_reason(&module).expect("an exec hook must release the layers");
+            assert_eq!(
+                landlock_skip_reason(&module),
+                Some(hook),
+                "landlock must skip for the same reason the shared predicate gives"
+            );
+        }
+    }
+
+    /// Non-vacuity companion: without a hook neither layer stands aside, so the
+    /// test above cannot pass by making the skip unconditional.
+    #[test]
+    fn a_module_without_an_exec_hook_keeps_both_layers() {
+        let module = test_module_with_defaults();
+        assert_eq!(exec_hook_skip_reason(&module), None);
+        assert_eq!(landlock_skip_reason(&module), None);
+    }
+
+    /// `insecure links` releases Landlock ONLY - it is a path-confinement
+    /// decision and says nothing about the syscall filter. Pinning the
+    /// asymmetry keeps a future "make both layers agree" edit from widening it.
+    #[test]
+    fn insecure_links_does_not_release_the_seccomp_layer() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            insecure_links: true,
+            ..Default::default()
+        });
+        assert!(landlock_skip_reason(&module).is_some());
+        assert_eq!(
+            exec_hook_skip_reason(&module),
+            None,
+            "`insecure links` is about paths, not syscalls; seccomp must stay engaged"
+        );
+    }
+
     #[test]
     fn absent_insecure_links_leaves_the_confinement_engaged() {
         let module = test_module_with_defaults();

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -608,7 +608,7 @@ fn process_approved_module(
     // process IS the worker, so a process-scoped filter would restrict its
     // post-transfer cleanup. Failures do not abort the connection -
     // Landlock + SEC-1 `*at` remain the primary defenses.
-    engage_seccomp_sandbox(ctx)?;
+    engage_seccomp_sandbox(ctx, module)?;
 
     // #503: arm the background delta-drain thread only for a real transfer. An
     // empty client-arg list means the peer requested the module then dropped the

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -386,7 +386,9 @@ fn validate_client_paths_in_module(
 ///
 /// Both arms are per-module operator configuration, and both are skips rather
 /// than downgrades because a Landlock ruleset cannot be relaxed once applied -
-/// it is inherited by children and only ever narrows.
+/// it is inherited by children and only ever narrows. The process-wide
+/// operator opt-out ([`SandboxLayer::Landlock`]) is decided by the caller
+/// before this runs, so it is deliberately not an arm here.
 ///
 /// - **exec hooks**: rulesets are inherited across `exec()`, so an allowlist
 ///   pinned to the module path would block hook scripts that live outside it
@@ -431,7 +433,9 @@ fn landlock_skip_reason(module: &ModuleRuntime) -> Option<&'static str> {
 /// flip would EACCES the very paths the operator's configuration permits.
 ///
 /// Returns `Ok(true)` on every non-fatal outcome (engaged, downgraded,
-/// unavailable, or skipped because a pre/post-xfer-exec hook is configured).
+/// unavailable, skipped by the operator's `OC_RSYNC_NO_LANDLOCK` /
+/// `OC_RSYNC_DAEMON_LANDLOCK=0` opt-out, or skipped because a
+/// pre/post-xfer-exec hook is configured).
 /// Returns `Ok(false)` after emitting an `@ERROR` reply when the kernel
 /// advertised Landlock support but the helper failed to engage the ruleset -
 /// we treat that as a regression because the SEC-1.p design requires the
@@ -453,6 +457,19 @@ fn engage_landlock_sandbox(
         EnforcementStatus, LandlockOutcome, best_effort_fs_downgrade, is_supported,
         restrict_to_module_paths,
     };
+
+    // Operator opt-out first: it is the most explicit signal and it is
+    // process-wide, so it outranks the per-module skips below. Landlock had
+    // no escape hatch at all while seccomp had two, which made a Landlock
+    // denial the one sandbox failure an operator could not A/B in the field.
+    if let Some(var) = SandboxLayer::Landlock.operator_optout_var() {
+        if let Some(log) = ctx.log_sink {
+            let text = SandboxLayer::Landlock.optout_log_text(ctx.request, var);
+            let message = rsync_info!(text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        return Ok(true);
+    }
 
     if let Some(reason) = landlock_skip_reason(module) {
         if let Some(log) = ctx.log_sink {
@@ -573,7 +590,10 @@ fn engage_landlock_sandbox(
 ///
 /// On builds without the `daemon-seccomp` feature the helper is a no-op
 /// that returns `Unavailable`; the wire-in is unconditional so the call
-/// site does not need `#[cfg]` branching. Construction or installation
+/// site does not need `#[cfg]` branching. The operator opt-out
+/// (`OC_RSYNC_NO_SECCOMP` / `OC_RSYNC_DAEMON_SECCOMP=0`) is decided here
+/// rather than read out of `Unavailable`, which cannot distinguish a build
+/// without seccomp from a build whose operator turned it off. Construction or installation
 /// failure is logged as a warning and the connection continues - SEC-1
 /// `*at` helpers and Landlock remain the primary defenses.
 ///
@@ -597,6 +617,20 @@ fn engage_seccomp_sandbox(ctx: &mut ModuleRequestContext<'_>) -> io::Result<()> 
                 "module '{}': seccomp BPF skipped (stdio session - filter would restrict entire process)",
                 ctx.request,
             );
+            let message = rsync_info!(text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        return Ok(());
+    }
+
+    // Operator opt-out. Checked here as well as inside
+    // `apply_worker_seccomp_filter` because the filter can only answer
+    // `Unavailable`, which conflates "this build has no seccomp" with "the
+    // operator turned it off" - two facts an operator reading the log needs
+    // to tell apart.
+    if let Some(var) = SandboxLayer::Seccomp.operator_optout_var() {
+        if let Some(log) = ctx.log_sink {
+            let text = SandboxLayer::Seccomp.optout_log_text(ctx.request, var);
             let message = rsync_info!(text).with_role(Role::Daemon);
             log_message(log, &message);
         }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -407,13 +407,38 @@ fn validate_client_paths_in_module(
 /// `symlink_optout_allowed()` is the whole of its daemon-side rule, and it is
 /// read as `module_id >= 0 && lp_insecure_links(module_id)`.
 fn landlock_skip_reason(module: &ModuleRuntime) -> Option<&'static str> {
-    if module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some() {
-        return Some("pre-xfer-exec or post-xfer-exec configured (would block hook exec)");
+    if let Some(reason) = exec_hook_skip_reason(module) {
+        return Some(reason);
     }
     if module.insecure_links {
         return Some("insecure links = yes (operator opted this module out of path confinement)");
     }
     None
+}
+
+/// Why a kernel sandbox layer must be skipped for a module that runs an
+/// `exec()` hook, or `None` when no hook is configured.
+///
+/// Shared by BOTH layers because both are inherited across `exec()` and
+/// neither can be relaxed for the child:
+///
+/// - **Landlock**: the ruleset is inherited, so an allowlist pinned to
+///   `module.path` blocks a hook script living outside it.
+/// - **seccomp**: the filter is inherited too, and the worker allowlist
+///   deliberately omits `execve` / `fork` / `wait4` - the exact syscalls a
+///   hook needs. MEASURED on Linux 7.0 aarch64: with the filter engaged the
+///   daemon logs `failed to run post-xfer exec command for module 'data':
+///   Operation not permitted (os error 1)` and the hook never runs, while the
+///   same config with the filter disabled runs it.
+///
+/// Keeping one predicate is the point: the layers previously disagreed, so
+/// Landlock stood aside for the operator's declared hook while seccomp
+/// silently `EPERM`ed it. Widening the allowlist instead would hand `execve`
+/// to anything that hijacks the worker, which is the attack the filter exists
+/// to stop - so the layer stands aside per module, exactly as Landlock does.
+fn exec_hook_skip_reason(module: &ModuleRuntime) -> Option<&'static str> {
+    (module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some())
+        .then_some("pre-xfer-exec or post-xfer-exec configured (would block hook exec)")
 }
 
 /// Engages the SEC-1.p Landlock LSM allowlist for the receiver path.
@@ -597,6 +622,12 @@ fn engage_landlock_sandbox(
 /// failure is logged as a warning and the connection continues - SEC-1
 /// `*at` helpers and Landlock remain the primary defenses.
 ///
+/// **Modules with an exec hook are skipped**, for the same reason Landlock
+/// skips them: the filter is inherited across `exec()` and the worker
+/// allowlist omits `execve` / `fork` / `wait4`, so an engaged filter turns
+/// the operator's configured `pre-xfer exec` / `post-xfer exec` into an
+/// `EPERM` failure instead of hardening anything.
+///
 /// **Stdio sessions are skipped.** When the daemon runs as `--server
 /// --daemon` over stdin/stdout (remote-shell daemon mode via `lsh.sh` /
 /// SSH), the process IS the worker. A process-scoped filter would
@@ -606,7 +637,10 @@ fn engage_landlock_sandbox(
 /// daemon workers are disposable threads inside a long-lived process, so
 /// the filter dies with the thread and does not affect the daemon or any
 /// other connection.
-fn engage_seccomp_sandbox(ctx: &mut ModuleRequestContext<'_>) -> io::Result<()> {
+fn engage_seccomp_sandbox(
+    ctx: &mut ModuleRequestContext<'_>,
+    module: &ModuleRuntime,
+) -> io::Result<()> {
     // Stdio sessions: the process IS the worker. Applying seccomp here
     // would restrict the entire process (including post-transfer cleanup,
     // exit handlers, and the parent shell). Skip - Landlock + SEC-1 *at*
@@ -631,6 +665,19 @@ fn engage_seccomp_sandbox(ctx: &mut ModuleRequestContext<'_>) -> io::Result<()> 
     if let Some(var) = SandboxLayer::Seccomp.operator_optout_var() {
         if let Some(log) = ctx.log_sink {
             let text = SandboxLayer::Seccomp.optout_log_text(ctx.request, var);
+            let message = rsync_info!(text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        return Ok(());
+    }
+
+    // Exec hooks: the filter is inherited across `exec()` and the worker
+    // allowlist has no `execve` / `fork` / `wait4`, so leaving it engaged
+    // does not harden the module - it makes the operator's configured hook
+    // fail with EPERM. Same predicate, same decision as Landlock.
+    if let Some(reason) = exec_hook_skip_reason(module) {
+        if let Some(log) = ctx.log_sink {
+            let text = format!("module '{}': seccomp=skipped reason={reason}", ctx.request);
             let message = rsync_info!(text).with_role(Role::Daemon);
             log_message(log, &message);
         }

--- a/crates/daemon/src/daemon/sections/sandbox_optout.rs
+++ b/crates/daemon/src/daemon/sections/sandbox_optout.rs
@@ -1,0 +1,199 @@
+// Operator gating for the daemon's kernel-enforced sandbox layers.
+//
+// oc wraps a daemon worker in two layers upstream rsync does not have at
+// all: the Landlock LSM path allowlist (`fast_io::landlock`) and the
+// seccomp BPF syscall allowlist (`sections/seccomp.rs`). Neither ruleset
+// can be derived from upstream, but upstream does state a policy for
+// coexisting with an externally imposed syscall filter, and it is the
+// policy this module implements: `generator.c:1444-1487` decides whether a
+// confined primitive exists from the BUILD, never from a runtime errno,
+// because "a live mknodat() or mkfifoat() can return ENOSYS too (an
+// unimplemented FUSE mknod, or seccomp)". Whether a layer is installed is
+// therefore always a declared decision - a compile-time feature plus an
+// explicit operator opt-out - and never an inference from a syscall that
+// happened to fail.
+//
+// One owner for both layers. A layer names two environment variables of
+// opposite polarity; both are parsed by the shared predicates below, so
+// adding a third layer is one enum arm and no new parsing.
+
+/// A kernel-enforced sandbox layer the daemon installs around a worker.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SandboxLayer {
+    /// Landlock LSM path allowlist, engaged after chroot and privilege drop.
+    Landlock,
+    /// seccomp BPF syscall allowlist, engaged immediately after Landlock.
+    Seccomp,
+}
+
+impl SandboxLayer {
+    /// Lower-case layer name used in the `<layer>=skipped` operator log.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Landlock => "landlock",
+            Self::Seccomp => "seccomp",
+        }
+    }
+
+    /// Variable whose truthy value disables the layer (`OC_RSYNC_NO_*`).
+    const fn disable_var(self) -> &'static str {
+        match self {
+            Self::Landlock => "OC_RSYNC_NO_LANDLOCK",
+            Self::Seccomp => "OC_RSYNC_NO_SECCOMP",
+        }
+    }
+
+    /// Variable whose falsy value disables the layer (`OC_RSYNC_DAEMON_*`).
+    ///
+    /// Inverse polarity, kept because `OC_RSYNC_DAEMON_SECCOMP` was the
+    /// historical opt-in spelling: an operator who set it to `1` can flip
+    /// the same name to `0` rather than learn a second one.
+    const fn enable_var(self) -> &'static str {
+        match self {
+            Self::Landlock => "OC_RSYNC_DAEMON_LANDLOCK",
+            Self::Seccomp => "OC_RSYNC_DAEMON_SECCOMP",
+        }
+    }
+
+    /// Name of the variable that opted this layer out, or `None` to engage.
+    ///
+    /// The variable name is returned rather than a rendered sentence so the
+    /// caller can state exactly which knob the operator set - a skip that
+    /// does not name its own cause is indistinguishable from a layer that
+    /// was never available.
+    fn operator_optout_var(self) -> Option<&'static str> {
+        if env_flag_truthy(self.disable_var()) {
+            return Some(self.disable_var());
+        }
+        if env_flag_negated(self.enable_var()) {
+            return Some(self.enable_var());
+        }
+        None
+    }
+
+    /// Renders the operator-facing skip line for `module`'s request.
+    fn optout_log_text(self, request: &str, var: &str) -> String {
+        format!(
+            "module '{request}': {}=skipped reason={var} set by operator (this layer is NOT installed)",
+            self.label(),
+        )
+    }
+}
+
+/// True when `var` is set to anything other than empty, `0`, or `false`.
+fn env_flag_truthy(var: &str) -> bool {
+    std::env::var(var)
+        .is_ok_and(|v| !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"))
+}
+
+/// True when `var` is set to `0` or `false`.
+fn env_flag_negated(var: &str) -> bool {
+    std::env::var(var).is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("false"))
+}
+
+#[cfg(test)]
+mod sandbox_optout_tests {
+    use super::*;
+    use crate::test_env::{ENV_LOCK, EnvGuard};
+    use std::ffi::OsStr;
+
+    const LAYERS: [SandboxLayer; 2] = [SandboxLayer::Landlock, SandboxLayer::Seccomp];
+
+    #[test]
+    fn every_layer_engages_when_no_variable_is_set() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for layer in LAYERS {
+            let _disable = EnvGuard::remove(layer.disable_var());
+            let _enable = EnvGuard::remove(layer.enable_var());
+            assert_eq!(layer.operator_optout_var(), None, "{layer:?}");
+        }
+    }
+
+    #[test]
+    fn a_truthy_disable_variable_opts_the_layer_out() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for layer in LAYERS {
+            let _enable = EnvGuard::remove(layer.enable_var());
+            for value in ["1", "yes", "true", "on"] {
+                let _disable = EnvGuard::set(layer.disable_var(), OsStr::new(value));
+                assert_eq!(
+                    layer.operator_optout_var(),
+                    Some(layer.disable_var()),
+                    "{layer:?} value {value}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn an_empty_or_false_disable_variable_leaves_the_layer_engaged() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for layer in LAYERS {
+            let _enable = EnvGuard::remove(layer.enable_var());
+            for value in ["", "0", "false", "FALSE"] {
+                let _disable = EnvGuard::set(layer.disable_var(), OsStr::new(value));
+                assert_eq!(
+                    layer.operator_optout_var(),
+                    None,
+                    "{layer:?} value {value}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_negated_enable_variable_opts_the_layer_out() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for layer in LAYERS {
+            let _disable = EnvGuard::remove(layer.disable_var());
+            for value in ["0", "false", "False"] {
+                let _enable = EnvGuard::set(layer.enable_var(), OsStr::new(value));
+                assert_eq!(
+                    layer.operator_optout_var(),
+                    Some(layer.enable_var()),
+                    "{layer:?} value {value}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_truthy_enable_variable_leaves_the_layer_engaged() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for layer in LAYERS {
+            let _disable = EnvGuard::remove(layer.disable_var());
+            let _enable = EnvGuard::set(layer.enable_var(), OsStr::new("1"));
+            assert_eq!(layer.operator_optout_var(), None, "{layer:?}");
+        }
+    }
+
+    #[test]
+    fn the_two_layers_read_disjoint_variables() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for layer in LAYERS {
+            let other = if layer == SandboxLayer::Landlock {
+                SandboxLayer::Seccomp
+            } else {
+                SandboxLayer::Landlock
+            };
+            let _a = EnvGuard::remove(layer.disable_var());
+            let _b = EnvGuard::remove(layer.enable_var());
+            let _c = EnvGuard::remove(other.enable_var());
+            let _d = EnvGuard::set(other.disable_var(), OsStr::new("1"));
+            assert_eq!(
+                layer.operator_optout_var(),
+                None,
+                "{layer:?} must not read {}",
+                other.disable_var(),
+            );
+        }
+    }
+
+    #[test]
+    fn the_skip_line_names_the_layer_and_the_variable() {
+        let text = SandboxLayer::Landlock.optout_log_text("data", "OC_RSYNC_NO_LANDLOCK");
+        assert!(text.contains("module 'data'"), "{text}");
+        assert!(text.contains("landlock=skipped"), "{text}");
+        assert!(text.contains("reason=OC_RSYNC_NO_LANDLOCK"), "{text}");
+    }
+}

--- a/crates/daemon/src/daemon/sections/sandbox_optout.rs
+++ b/crates/daemon/src/daemon/sections/sandbox_optout.rs
@@ -82,8 +82,7 @@ impl SandboxLayer {
 
 /// True when `var` is set to anything other than empty, `0`, or `false`.
 fn env_flag_truthy(var: &str) -> bool {
-    std::env::var(var)
-        .is_ok_and(|v| !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"))
+    std::env::var(var).is_ok_and(|v| !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"))
 }
 
 /// True when `var` is set to `0` or `false`.
@@ -132,11 +131,7 @@ mod sandbox_optout_tests {
             let _enable = EnvGuard::remove(layer.enable_var());
             for value in ["", "0", "false", "FALSE"] {
                 let _disable = EnvGuard::set(layer.disable_var(), OsStr::new(value));
-                assert_eq!(
-                    layer.operator_optout_var(),
-                    None,
-                    "{layer:?} value {value}",
-                );
+                assert_eq!(layer.operator_optout_var(), None, "{layer:?} value {value}",);
             }
         }
     }

--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -328,28 +328,18 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
 /// Operator-driven runtime opt-out for the worker seccomp filter.
 ///
 /// The filter is ON by default when the `daemon-seccomp` feature is
-/// compiled in. Setting `OC_RSYNC_NO_SECCOMP=1` (or any truthy value)
-/// disables it. Empty, `0`, and `false` leave the filter engaged.
+/// compiled in; `OC_RSYNC_NO_SECCOMP=1` or `OC_RSYNC_DAEMON_SECCOMP=0`
+/// disables it. [`SandboxLayer`] owns the variable names and the parsing
+/// for both kernel sandbox layers, so Landlock and seccomp cannot drift
+/// apart on what counts as an opt-out.
 ///
-/// `OC_RSYNC_DAEMON_SECCOMP=0` is also accepted as an opt-out alias so
-/// operators who previously used `OC_RSYNC_DAEMON_SECCOMP=1` to opt in
-/// can flip the same variable to `0` instead of learning a new name.
+/// The wire-in (`engage_seccomp_sandbox`) checks the same predicate so it
+/// can log the operator's decision by name. This second check keeps the
+/// opt-out honoured for direct callers of
+/// [`apply_worker_seccomp_filter`] that never reach the wire-in.
 #[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
 fn seccomp_runtime_disabled() -> bool {
-    // OC_RSYNC_NO_SECCOMP=1 disables.
-    if let Ok(v) = std::env::var("OC_RSYNC_NO_SECCOMP") {
-        if !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false") {
-            return true;
-        }
-    }
-    // OC_RSYNC_DAEMON_SECCOMP=0 / false also disables (inverse of old
-    // opt-in semantics).
-    if let Ok(v) = std::env::var("OC_RSYNC_DAEMON_SECCOMP") {
-        if v == "0" || v.eq_ignore_ascii_case("false") {
-            return true;
-        }
-    }
-    false
+    SandboxLayer::Seccomp.operator_optout_var().is_some()
 }
 
 /// `rseq(2)` syscall number for the current target.

--- a/docs/oc-extension-env-reference.md
+++ b/docs/oc-extension-env-reference.md
@@ -277,6 +277,23 @@ Alias with inverse polarity for the same filter: `0` or `false` disables
 it, matching the variable's historical opt-in spelling. Same
 `daemon-seccomp` feature requirement as `OC_RSYNC_NO_SECCOMP`.
 
+### OC_RSYNC_NO_LANDLOCK
+
+Runtime opt-out for the daemon worker Landlock LSM path allowlist. The
+allowlist is on by default on kernels that support Landlock; any truthy
+value (not empty, `0`, or `false`) skips it, and the daemon logs
+`landlock=skipped reason=OC_RSYNC_NO_LANDLOCK ...`. Use to establish
+whether a failing transfer is being denied by path confinement (`EACCES`)
+rather than by the syscall filter (`EPERM`). Per-module `insecure links =
+yes` and a configured `pre-xfer exec` / `post-xfer exec` skip the layer
+too, independently of this variable.
+
+### OC_RSYNC_DAEMON_LANDLOCK
+
+Alias with inverse polarity for the same allowlist: `0` or `false`
+disables it. Mirrors the `OC_RSYNC_DAEMON_SECCOMP` spelling so both
+kernel sandbox layers answer to the same pair of variable shapes.
+
 ### OC_RSYNC_ASYNC_DAEMON
 
 Opt-in async accept loop for the TCP daemon. Requires the `async-daemon`

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -1265,6 +1265,12 @@ values, defaults, and required build features.
 **OC_RSYNC_DAEMON_SECCOMP**
 :   Set to **0** to disable the same seccomp filter (inverse alias).
 
+**OC_RSYNC_NO_LANDLOCK**
+:   Set to **1** to disable the daemon worker Landlock path allowlist.
+
+**OC_RSYNC_DAEMON_LANDLOCK**
+:   Set to **0** to disable the same Landlock allowlist (inverse alias).
+
 **OC_RSYNC_ASYNC_DAEMON**
 :   Opt in to the async daemon accept loop (builds with the
     async-daemon feature).


### PR DESCRIPTION
## Problem

The daemon installs two kernel sandbox layers around a worker - the Landlock LSM
path allowlist and the seccomp BPF syscall allowlist - and they were gated
asymmetrically:

| layer | runtime opt-out |
|---|---|
| seccomp | `OC_RSYNC_NO_SECCOMP=1`, `OC_RSYNC_DAEMON_SECCOMP=0` |
| Landlock | **none** |

That asymmetry has a measured cost. A Landlock `EACCES` was the one sandbox
denial an operator could not A/B in the field, which is what made the recent
walk-traversal defect (#7541) slow to attribute while the sibling worker-filter
defect (#7545) was A/B-able in minutes.

A second, smaller defect: with `OC_RSYNC_NO_SECCOMP=1` the daemon logged

```
module 'data': seccomp BPF unavailable in this build; ...
```

because the opt-out was decided inside `apply_worker_seccomp_filter`, whose only
way to report it is `SeccompOutcome::Unavailable` - a value that cannot
distinguish *this build has no seccomp* from *the operator turned it off*.

## Change

`SandboxLayer` becomes the single owner of the variable names and the parsing
for both layers:

- `OC_RSYNC_NO_<LAYER>` - any truthy value (not empty, `0`, `false`) disables.
- `OC_RSYNC_DAEMON_<LAYER>` - `0` or `false` disables, matching the historical
  opt-in spelling so an operator flips the variable they already set.

`seccomp_runtime_disabled()` delegates to it instead of carrying its own copy of
the parse. Both wire-ins now decide the opt-out at the same architectural level
and log it by name:

```
module 'data': landlock=skipped reason=OC_RSYNC_NO_LANDLOCK set by operator (this layer is NOT installed)
module 'data': seccomp=skipped  reason=OC_RSYNC_NO_SECCOMP  set by operator (this layer is NOT installed)
```

Adding a third layer is one enum arm and no new parsing.

## Upstream

Upstream has neither seccomp nor Landlock, so neither ruleset can be derived
from it. Upstream does state the *coexistence* rule, and it is the one this
module implements: `generator.c:1444-1487` decides whether a confined primitive
exists from the **build**, never from a runtime errno, because "a live
`mknodat()` or `mkfifoat()` can return ENOSYS too (an unimplemented FUSE mknod,
or seccomp)". Layer installation stays a declared decision here for the same
reason.

## Verification

- `cargo nextest run -p daemon --all-features`: **1888 run / 1888 passed**, 6 skipped.
- `cargo fmt --all --check`, `cargo clippy -p daemon --all-targets --all-features -D warnings`: clean.
- Three mutations proven lethal:
  1. drop the `OC_RSYNC_DAEMON_*` alias arm,
  2. treat falsy values (`0` / `false` / empty) as truthy,
  3. point both layers at one variable name.

Docs updated: `docs/oc-extension-env-reference.md` and `docs/oc-rsync.1.md`.
