### PR TITLE
fix(daemon): admit mknod/mknodat so the worker filter stops dropping specials

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -148,6 +148,11 @@ fast_io = { path = "../fast_io", default-features = false, features = ["io_uring
 # integration tests can build the filter independently of the production
 # allowlist.
 seccompiler = "0.5"
+# `metadata::create_fifo_node_from_parts` is the production special-file
+# creator; `tests/seccomp_worker_filter.rs` calls it under the real filter
+# rather than hand-copying an `mknod` call, so the pin tracks what the
+# receiver actually issues.
+metadata = { path = "../metadata", default-features = false }
 
 [[bench]]
 name = "daemon_benchmark"

--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -194,6 +194,15 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
         libc::SYS_renameat2,
         libc::SYS_unlinkat,
         libc::SYS_mkdirat,
+        // Device nodes, FIFOs and unix-socket nodes under `-D` / `--specials`.
+        // `metadata::special` materialises all three through
+        // `nix::sys::stat::mknod`, i.e. the libc `mknod()` SYMBOL (deliberate:
+        // fakeroot interposes the symbol, matching upstream `syscall.c`
+        // `do_mknod()`), which glibc lowers to `mknodat`. Omitting it made a
+        // `-a` push drop every special SILENTLY: MEASURED on Linux 7.0.0
+        // aarch64, a source tree holding `plain.txt` + a FIFO arrived with
+        // only `plain.txt` and the client still exited 0.
+        libc::SYS_mknodat,
         libc::SYS_symlinkat,
         libc::SYS_linkat,
         libc::SYS_readlinkat,
@@ -305,6 +314,13 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
     ]);
     #[cfg(target_arch = "x86_64")]
     s.push(libc::SYS_arch_prctl);
+
+    // glibc before 2.33 lowers `mknod()` to the legacy `mknod` syscall rather
+    // than `mknodat`. The legacy number exists only on x86_64 (aarch64 never
+    // had it), so gate the push on the arch, not on the libc version we
+    // cannot see from here. Same shape as the `arch_prctl` push above.
+    #[cfg(target_arch = "x86_64")]
+    s.push(libc::SYS_mknod);
 
     // glibc 2.35+ initialises restartable sequences per thread. `SYS_rseq`
     // is missing from older libc bindings; fall back to the documented
@@ -432,6 +448,24 @@ mod seccomp_tests {
         let mut dedup = list.clone();
         dedup.dedup();
         assert_eq!(list.len(), dedup.len(), "allowlist must be deduplicated");
+    }
+
+    /// `-D` / `--specials` materialises devices, FIFOs and socket nodes via
+    /// the libc `mknod()` symbol, which glibc lowers to `mknodat` (and, on
+    /// pre-2.33 x86_64 glibc, to the legacy `mknod`). Without these the
+    /// receiver drops every special SILENTLY and still exits 0.
+    #[test]
+    fn allowlist_admits_special_file_creation() {
+        let list = worker_seccomp_allowlist();
+        assert!(
+            list.binary_search(&libc::SYS_mknodat).is_ok(),
+            "mknodat missing: -D / --specials would silently drop every device, fifo and socket",
+        );
+        #[cfg(target_arch = "x86_64")]
+        assert!(
+            list.binary_search(&libc::SYS_mknod).is_ok(),
+            "legacy mknod missing: glibc < 2.33 on x86_64 lowers mknod() to it",
+        );
     }
 
     #[test]

--- a/crates/daemon/tests/seccomp_worker_filter.rs
+++ b/crates/daemon/tests/seccomp_worker_filter.rs
@@ -225,3 +225,57 @@ fn the_ownership_walk_resolves_under_the_worker_filter() {
         "the ownership walk was refused under the worker filter - a syscall the walk issues is missing from the allowlist",
     );
 }
+
+/// The receiver must still be able to materialise a FIFO under the worker
+/// filter. `-a` implies `-D`, so a source tree holding a fifo, a device or a
+/// unix-socket node reaches `metadata::special`, which creates all three
+/// through the libc `mknod()` symbol - and glibc lowers that to `mknodat`.
+///
+/// Regression pin. MEASURED on Linux 7.0.0 aarch64 before the allowlist
+/// admitted it: a daemon push of `{plain.txt, pipe}` landed only
+/// `plain.txt` in the module, with **exit 0 and no diagnostic** - a silent
+/// data loss, not a visible refusal. The control leg with
+/// `OC_RSYNC_NO_SECCOMP=1` landed both.
+///
+/// Calls the production creator rather than a hand-written `mknod`, so the
+/// pin tracks the syscall the receiver actually issues even if
+/// `metadata::special` changes how it issues it.
+#[test]
+fn a_special_file_is_creatable_under_the_worker_filter() {
+    let node = std::env::temp_dir().join(format!("oc-mknod-probe-{}", std::process::id()));
+    let _ = std::fs::remove_file(&node);
+
+    let child_path = node.clone();
+    let raw = fork_run(move || {
+        match apply_worker_seccomp_filter() {
+            SeccompOutcome::Installed => {}
+            // Kernel refused the filter, or this build cannot install one:
+            // treat as a skip, matching the sibling tests above.
+            _ => return 77,
+        }
+        match metadata::create_fifo_node_from_parts(&child_path, 0o644, false, false) {
+            Ok(()) => 0,
+            Err(_) => 99,
+        }
+    });
+
+    let created = node.exists();
+    let _ = std::fs::remove_file(&node);
+    let status = std::process::ExitStatus::from_raw(raw);
+    if let Some(sig) = status.signal() {
+        panic!("child killed by signal {sig} while creating a fifo under the worker filter");
+    }
+    let code = status.code().expect("child must exit");
+    if code == 77 {
+        eprintln!("seccomp filter install rejected by kernel; skipping");
+        return;
+    }
+    assert_eq!(
+        code, 0,
+        "fifo creation was refused under the worker filter - `-D`/`--specials` would silently drop every special file",
+    );
+    assert!(
+        created,
+        "the child reported success but no node exists - the pin would pass vacuously",
+    );
+}


### PR DESCRIPTION
## Problem

`-a` implies `-D`, so a daemon receiver materialises devices, FIFOs and
unix-socket nodes through `metadata::special`, which calls the libc `mknod()`
**symbol** — deliberately, because fakeroot interposes the symbol and upstream
`syscall.c` `do_mknod()` does the same. glibc lowers that to `mknodat`, and the
worker seccomp allowlist admitted neither `mknodat` nor the legacy `mknod`.

The filter's default action is `Errno(EPERM)`, not `KillProcess`, so the refusal
does not crash anything — it just makes the node not appear.

## Measured, with a control

Linux 7.0.0 aarch64, `oc-rsync` built with `-p bin --features
daemon/daemon-seccomp`, daemon push of a source tree holding `plain.txt` and
`pipe` (a FIFO), identical config both legs:

| leg | module contents afterwards | client |
|---|---|---|
| filter engaged | `plain.txt` only — **`pipe` absent** | exit 0, no warning, no log line |
| `OC_RSYNC_NO_SECCOMP=1` | `pipe` **and** `plain.txt` | exit 0 |

Silent data loss, not a visible refusal.

This is the case upstream discusses in `generator.c:1444-1487`, which decides
whether a confined `mknod` primitive exists from the **build** and warns
explicitly that an errno test is the wrong instrument because "a live
`mknodat()` or `mkfifoat()` can return ENOSYS too (an unimplemented FUSE mknod,
**or seccomp**)".

## Change

- `SYS_mknodat` added to bucket A (all architectures).
- `SYS_mknod` pushed on **x86_64 only**: glibc before 2.33 lowers `mknod()` to
  the legacy syscall, and aarch64 never had that number. Same shape as the
  existing `arch_prctl` push — gate on the arch, not on a libc version this code
  cannot observe.

## Verification

Two pins, both new:

1. **Allowlist unit assertion** — `mknodat` present, plus legacy `mknod` on x86_64.
2. **Behavioural pin** (`tests/seccomp_worker_filter.rs`) — forks, installs the
   **production** filter via `apply_worker_seccomp_filter`, then calls the
   **production** creator `metadata::create_fifo_node_from_parts`. It tracks the
   syscall the receiver actually issues rather than a hand-copied `mknod`, and it
   asserts the node exists afterwards so a child that reported success without
   creating anything cannot pass it vacuously.

`cargo fmt --all --check` and `cargo clippy -p daemon --all-targets
--all-features -D warnings` clean.
