### PR TITLE
fix(fast_io): fall back to the confined wrappers, not to plain syscalls

### DIFF
--- a/crates/engine/src/delete/context/core.rs
+++ b/crates/engine/src/delete/context/core.rs
@@ -676,10 +676,29 @@ pub(super) struct DrainParts {
 /// Returns `Some` when `root` resolves to a real (non-symlink) directory
 /// the process can open. Any failure - the delete root does not exist, is
 /// a symlink, or the platform refuses the open - is logged at debug level
-/// and yields `None` so the emitter transparently falls back to the
-/// path-based syscalls. This mirrors the receiver's
-/// `open_sandbox_for_dest` fallback contract: a sandbox open failure must
-/// never turn a working delete into a failure.
+/// and yields `None`, and the emitter then dispatches through the
+/// path-based [`super::super::emitter::DeleteFs`] methods instead of the
+/// dirfd-anchored `*_at` ones.
+///
+/// # What `None` now means (CF-P2a)
+///
+/// `None` used to mean "unconfined": the path-based methods were bare
+/// `std::fs` calls. They are not any more - they resolve through
+/// [`fast_io::ConfinedFallback`], which refuses rather than following
+/// once a confinement root is installed. So this fallback keeps its
+/// availability promise (a sandbox open failure must never turn a
+/// working delete into a failure) without keeping its old security cost.
+///
+/// Note this is not the only route to the path-based methods, and not
+/// the important one. `DeleteEmitter::open_plan_dirfd` opens each plan
+/// directory through the sandbox with `O_DIRECTORY | O_NOFOLLOW` and
+/// discards the error with `.ok()`, so a *successful* sandbox open here
+/// still yields `None` for any plan directory whose components the
+/// confined open refuses - which is exactly the planted-symlink case.
+/// Keying the drop to a weaker syscall on a runtime errno is upstream's
+/// stated objection (`rsync-3.5.0/syscall.c:658` `do_unlink_at()`, whose
+/// third arm is an error and never a plain path syscall); the
+/// `ConfinedFallback` routing is what makes that drop safe here.
 #[cfg(unix)]
 fn open_delete_sandbox(root: &Path) -> Option<Arc<fast_io::DirSandbox>> {
     match fast_io::DirSandbox::open_root(root) {

--- a/crates/engine/src/delete/emitter/fs.rs
+++ b/crates/engine/src/delete/emitter/fs.rs
@@ -10,11 +10,16 @@
 //!
 //! Each unlink/rmdir method ships in two shapes:
 //!
-//! - **Path-based** (`unlink_file`, `rmdir`, ...): the legacy entry
-//!   points that walk an absolute path through the kernel. Used when no
-//!   [`fast_io::DirSandbox`] has been wired to the emitter, on Windows,
-//!   and by the [`RecordingDeleteFs`] test fake which never touches the
-//!   filesystem.
+//! - **Path-based** (`unlink_file`, `rmdir`, ...): the entry points
+//!   that take a whole path rather than a parent dirfd. Used when the
+//!   emitter has no dirfd for the plan directory - either no
+//!   [`fast_io::DirSandbox`] was wired to it, or the per-plan
+//!   `open_dir_at` refused a component - as well as on Windows and by
+//!   the [`RecordingDeleteFs`] test fake, which never touches the
+//!   filesystem. On unix these resolve through [`DELETE_CONFINEMENT`]
+//!   rather than `std::fs`, so the path is walked under upstream's
+//!   three-arm fallback contract instead of by the kernel with symlink
+//!   following fully enabled.
 //! - **Dirfd-anchored** (`unlink_file_at`, `rmdir_at`, ...,
 //!   `#[cfg(unix)]`): the SEC-1.q entry points that resolve a
 //!   single-leaf name against a [`BorrowedFd`] for the parent directory.
@@ -22,6 +27,7 @@
 //!   syscall and route through the SEC-1.g / SEC-1.s sandbox helpers in
 //!   [`fast_io::dir_sandbox::at_syscalls`].
 
+#[cfg(not(unix))]
 use std::fs;
 use std::io;
 #[cfg(unix)]
@@ -171,27 +177,131 @@ pub trait DeleteFs: std::fmt::Debug {
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RealDeleteFs;
 
+/// The confinement policy the path-based methods resolve under.
+///
+/// Every entry the emitter deletes is a peer-named destination entry, so the
+/// [`Confined`](fast_io::PathKind::Confined) arm is the whole of it - there is
+/// no operator-supplied deletion path to spell [`ancillary`] for.
+///
+/// # Why upstream's fallback is this wrapper family
+///
+/// Upstream never falls back to a plain syscall. `delete.c:226` picks
+/// `dfd >= 0 ? do_unlink_atfd(dfd, leaf, AT_REMOVEDIR) : do_rmdir_at(fbuf)`,
+/// and the file arm at `delete.c:77` falls through to
+/// `robust_unlink(fbuf)`, which is `do_unlink_at(fname)` on both arms of its
+/// `ETXTBSY` split (`util1.c:545`). Each `do_*_at()` runs the three-arm
+/// `owner_walk_parent` contract internally, so the held dirfd is an
+/// optimisation and a race-window closure - not the confinement.
+/// [`fast_io::ConfinedFallback`] is oc's analogue of that wrapper family, and
+/// routing the six onto it is what makes this fallback structurally identical
+/// to upstream's.
+///
+/// # Why routing here cannot weaken the delete path
+///
+/// The dirfd-anchored `*_at` siblings are the sandbox arm and are UNGATED -
+/// deliberately stronger than upstream, which gates its equivalent to daemon
+/// mode. This constant does not touch them. It governs only the path-based
+/// methods, which the emitter selects whenever it holds no dirfd for the plan
+/// directory (`emitter/mod.rs` dispatches `Some(fd) => *_at`,
+/// `None => path-based`) and which were bare `std::fs` calls with no
+/// confinement of any kind. Arm 1 of the fallback contract IS that prior
+/// behaviour, so the routing is monotone: it can only add confinement, never
+/// remove any.
+///
+/// Upstream goes further than "the fallback is confined": it refuses to let a
+/// runtime errno decide the arm at all. `open_dir_secure` (`syscall.c:3481`)
+/// returns `-1` with **errno deliberately cleared** when hardened resolution is
+/// not in effect - its own comment says "return -1 with errno cleared so the
+/// caller uses the full-path wrappers" - while a genuine refusal from
+/// `secure_relative_open` returns `-1` with a real errno. Two outcomes, told
+/// apart by a sentinel rather than by inspecting the failure. `delete.c:136`
+/// stores the result and `del_held_dfd()` guards `>= 0`, so either way the
+/// caller lands on the confined `do_*_at` family.
+///
+/// oc's `open_plan_dirfd` discards the errno entirely with `.ok()`, collapsing
+/// policy-off, genuine failure, and confinement-refused into one `None`. The
+/// errno could not carry the distinction anyway: `open_dir_at` passes
+/// `O_DIRECTORY | O_NOFOLLOW`, and on Linux a refused symlink component reports
+/// `ENOTDIR` - the same errno an ordinary non-directory component produces.
+///
+/// `open_plan_dirfd` reaches `None` by TWO routes, and the second is why this
+/// routing matters on a daemon. Route one is no sandbox at all. Route two is
+/// a sandbox whose per-plan `open_dir_at` fails - and `open_dir_at` walks the
+/// plan directory component by component with `O_DIRECTORY | O_NOFOLLOW`, so
+/// a planted symlink makes it refuse, `.ok()` discards the refusal, and the
+/// delete lands here. Before this routing that meant the confinement working
+/// was itself what triggered the unconfined syscall.
+///
+/// [`ancillary`]: fast_io::ConfinedFallback::ancillary
+#[cfg(unix)]
+const DELETE_CONFINEMENT: fast_io::ConfinedFallback = fast_io::ConfinedFallback::confined();
+
 impl DeleteFs for RealDeleteFs {
+    #[cfg(unix)]
+    fn unlink_file(&self, path: &Path) -> io::Result<()> {
+        DELETE_CONFINEMENT.unlink_at(path, UnlinkFlags::File)
+    }
+
+    #[cfg(not(unix))]
     fn unlink_file(&self, path: &Path) -> io::Result<()> {
         fs::remove_file(path)
     }
 
+    #[cfg(unix)]
+    fn rmdir(&self, path: &Path) -> io::Result<()> {
+        DELETE_CONFINEMENT.rmdir_at(path)
+    }
+
+    #[cfg(not(unix))]
     fn rmdir(&self, path: &Path) -> io::Result<()> {
         fs::remove_dir(path)
     }
 
+    #[cfg(unix)]
+    fn unlink_symlink(&self, path: &Path) -> io::Result<()> {
+        DELETE_CONFINEMENT.unlink_at(path, UnlinkFlags::File)
+    }
+
+    #[cfg(not(unix))]
     fn unlink_symlink(&self, path: &Path) -> io::Result<()> {
         fs::remove_file(path)
     }
 
+    #[cfg(unix)]
+    fn unlink_device(&self, path: &Path) -> io::Result<()> {
+        DELETE_CONFINEMENT.unlink_at(path, UnlinkFlags::File)
+    }
+
+    #[cfg(not(unix))]
     fn unlink_device(&self, path: &Path) -> io::Result<()> {
         fs::remove_file(path)
     }
 
+    #[cfg(unix)]
+    fn unlink_special(&self, path: &Path) -> io::Result<()> {
+        DELETE_CONFINEMENT.unlink_at(path, UnlinkFlags::File)
+    }
+
+    #[cfg(not(unix))]
     fn unlink_special(&self, path: &Path) -> io::Result<()> {
         fs::remove_file(path)
     }
 
+    /// Recursively remove `path`.
+    ///
+    /// The residue [`remove_dir_all_at`](fast_io::ConfinedFallback::remove_dir_all_at)
+    /// returns is dropped here because this trait method mirrors
+    /// [`fs::remove_dir_all`]'s `()` result. The dirfd-anchored sibling
+    /// [`Self::remove_dir_all_at`] is the one that surfaces the residue to the
+    /// emitter's exit-code decision; that split is unchanged.
+    #[cfg(unix)]
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        DELETE_CONFINEMENT
+            .remove_dir_all_at(path)
+            .map(|_residue| ())
+    }
+
+    #[cfg(not(unix))]
     fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
         fs::remove_dir_all(path)
     }

--- a/crates/engine/src/delete/emitter/tests/daemon_escape.rs
+++ b/crates/engine/src/delete/emitter/tests/daemon_escape.rs
@@ -1,0 +1,202 @@
+//! CF-P2a: the daemon-shaped delete escape, and the arm it actually takes.
+//!
+//! The sibling [`super::unconfined_escape`] module pins the shape where
+//! no [`fast_io::DirSandbox`] is attached at all. This module pins the
+//! other, more consequential route to the same path-based methods: a
+//! sandbox IS attached, and the per-plan `open_dir_at` walk *refuses*
+//! the plan directory because one of its components is a planted
+//! symlink. `DeleteEmitter::open_plan_dirfd` discards that refusal with
+//! `.ok()`, leaves `parent_fd` as `None`, and every entry in the plan
+//! then dispatches through the path-based methods - which resolve the
+//! very symlink the sandbox open just rejected.
+//!
+//! That is the defect stated concretely: the drop to an unconfined
+//! syscall is keyed on a runtime error, and the error it keys on is the
+//! confinement working.
+//!
+//! upstream: `rsync-3.5.0/syscall.c:658` `do_unlink_at()` has three
+//! arms. Arm 1 is the policy gate off. Arm 2 is the gate on with the
+//! walk succeeding. Arm 3 is the gate on with the walk failing, and
+//! arm 3 is an error - never a plain path syscall.
+//!
+//! Every test here installs (or deliberately does not install) the
+//! process-global confinement session, so each one must run in its own
+//! process. `cargo nextest` runs one process per test; do not run this
+//! module under `cargo test`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::{fs, io};
+
+use fast_io::DirSandbox;
+use tempfile::TempDir;
+
+use super::super::super::{
+    DeleteEntry, DeleteEntryKind, DeletePlan, DeletePlanMap, DirTraversalCursor,
+};
+use super::super::{DeleteEmitter, RealDeleteFs, open_dir_at};
+
+/// A served module root with one real sub-directory and one symlinked
+/// component pointing at a sibling tree the delete must never reach.
+///
+/// `module` stands in for the daemon's module root - the directory the
+/// [`DirSandbox`] is opened on and the root a `ModuleState` names.
+/// `module/hop` is the planted symlink; `module/real` is the control.
+struct DaemonFixture {
+    _base: TempDir,
+    module: PathBuf,
+    outside: PathBuf,
+}
+
+impl DaemonFixture {
+    fn new() -> Self {
+        let base = TempDir::new().expect("tempdir");
+        let module = base.path().join("module");
+        let outside = base.path().join("outside");
+        fs::create_dir(&module).expect("mkdir module");
+        fs::create_dir(&outside).expect("mkdir outside");
+        fs::create_dir(module.join("real")).expect("mkdir real");
+
+        std::os::unix::fs::symlink(&outside, module.join("hop")).expect("plant symlink");
+        assert!(
+            module
+                .join("hop")
+                .symlink_metadata()
+                .expect("stat hop")
+                .file_type()
+                .is_symlink(),
+            "fixture is inert unless module/hop really is a symlink",
+        );
+
+        Self {
+            _base: base,
+            module,
+            outside,
+        }
+    }
+
+    fn sandbox(&self) -> Arc<DirSandbox> {
+        Arc::new(DirSandbox::open_root(&self.module).expect("open module sandbox"))
+    }
+
+    /// Runs one delete of `victim` under `plan_dir`, with a sandbox
+    /// attached exactly as the production delete context attaches one.
+    fn drain(&self, plan_dir: &Path) -> (DeleteEmitter<RealDeleteFs>, io::Result<()>) {
+        let plans = DeletePlanMap::new();
+        plans.insert(DeletePlan::from_extras(
+            plan_dir.to_path_buf(),
+            vec![DeleteEntry::new("victim".into(), DeleteEntryKind::File)],
+        ));
+        let cursor = DirTraversalCursor::new(plan_dir.to_path_buf());
+        let mut emitter = DeleteEmitter::new(RealDeleteFs, plans, cursor)
+            .with_sandbox_rooted(self.sandbox(), self.module.clone());
+        let outcome = emitter.emit_all();
+        (emitter, outcome)
+    }
+}
+
+/// Installs the daemon session the production daemon installs, naming
+/// `module` as the served module root.
+fn install_module_session(module: &Path) {
+    fast_io::confinement::install_daemon_session(fast_io::confinement::ModuleState {
+        root: Some(module.to_path_buf()),
+        chrooted: false,
+        selected: true,
+        insecure_links: fast_io::confinement::ModuleInsecureLinks::default(),
+    });
+}
+
+/// The instrumentation the whole module rests on: which arm does the
+/// emitter take?
+///
+/// `open_plan_dirfd` is `Some(fd)` exactly when `open_dir_at` succeeds.
+/// This asserts both directions on one fixture, so neither answer can be
+/// an artefact of a tree that simply cannot be opened.
+#[test]
+fn the_planted_symlink_makes_the_sandbox_open_refuse_and_a_real_dir_makes_it_succeed() {
+    let fixture = DaemonFixture::new();
+    let sandbox = fixture.sandbox();
+
+    let refused = open_dir_at(sandbox.root_dirfd(), Path::new("hop"));
+    let err = refused.expect_err("O_NOFOLLOW must refuse the planted symlink component");
+    // `open_dir_at` passes `O_DIRECTORY | O_NOFOLLOW`. Linux reports the
+    // O_DIRECTORY violation first and yields ENOTDIR; a platform that
+    // checks O_NOFOLLOW first yields ELOOP. Accept either, and note what
+    // that ambiguity costs: ENOTDIR is exactly the errno a plain
+    // non-directory component would produce, so the caller cannot tell a
+    // confinement refusal from an ordinary shape mismatch. That is
+    // upstream's objection to keying the fallback on errno at all.
+    assert!(
+        matches!(err.raw_os_error(), Some(libc::ENOTDIR | libc::ELOOP)),
+        "the refusal must be the O_DIRECTORY/O_NOFOLLOW refusal, not an unrelated errno: {err}",
+    );
+
+    open_dir_at(sandbox.root_dirfd(), Path::new("real"))
+        .expect("a genuine in-tree directory must still open through the sandbox");
+}
+
+/// The escape, on the daemon shape. A sandbox is attached; the sandbox
+/// open refuses; the emitter falls through to the path-based method and
+/// destroys a file outside the module root.
+#[test]
+fn a_refused_sandbox_open_drops_the_delete_onto_the_unconfined_path() {
+    let fixture = DaemonFixture::new();
+    let victim = fixture.outside.join("victim");
+    fs::write(&victim, b"do-not-touch").expect("plant victim");
+
+    let (emitter, outcome) = fixture.drain(&fixture.module.join("hop"));
+    outcome.expect("the default error policy never aborts the drain");
+
+    assert!(
+        !victim.exists(),
+        "CF-P2a RED baseline: the delete escaped the module root through the planted symlink",
+    );
+    assert_eq!(
+        emitter.stats().files,
+        1,
+        "the escape is a counted, successful unlink - not a swallowed failure",
+    );
+}
+
+/// The same fixture with the module session installed. The routed
+/// path-based method now refuses, and the file outside the module root
+/// survives.
+#[test]
+fn the_module_session_makes_the_refused_sandbox_open_fail_closed() {
+    let fixture = DaemonFixture::new();
+    let victim = fixture.outside.join("victim");
+    fs::write(&victim, b"do-not-touch").expect("plant victim");
+    install_module_session(&fixture.module);
+
+    let (emitter, outcome) = fixture.drain(&fixture.module.join("hop"));
+    outcome.expect("a refusal is a per-entry io error, not a fatal abort");
+
+    assert!(
+        victim.exists(),
+        "the delete must not reach outside the module root once confinement is live",
+    );
+    assert_eq!(emitter.stats().files, 0, "nothing was unlinked",);
+    assert_ne!(
+        emitter.io_error(),
+        0,
+        "the refusal surfaces as a non-fatal io error, upstream's third arm",
+    );
+}
+
+/// Availability control for the same session: an ordinary in-tree
+/// delete under an installed module root must still work. Without this
+/// the refusal test above would also pass if confinement simply broke
+/// every delete.
+#[test]
+fn an_in_tree_delete_still_succeeds_under_the_module_session() {
+    let fixture = DaemonFixture::new();
+    let victim = fixture.module.join("real").join("victim");
+    fs::write(&victim, b"delete-me").expect("plant victim");
+    install_module_session(&fixture.module);
+
+    let (emitter, outcome) = fixture.drain(&fixture.module.join("real"));
+    outcome.expect("drain succeeds");
+
+    assert!(!victim.exists(), "the in-tree delete must still land");
+    assert_eq!(emitter.stats().files, 1);
+}

--- a/crates/engine/src/delete/emitter/tests/mod.rs
+++ b/crates/engine/src/delete/emitter/tests/mod.rs
@@ -27,6 +27,8 @@ use super::{DeleteEvent, DeleteFs, RecordingDeleteFs};
 use crate::util::poison::lock_or_recover;
 
 mod cohort;
+#[cfg(unix)]
+mod daemon_escape;
 mod dispatch;
 mod error_policy;
 #[cfg(unix)]

--- a/crates/engine/src/delete/emitter/tests/mod.rs
+++ b/crates/engine/src/delete/emitter/tests/mod.rs
@@ -5,6 +5,8 @@
 //! - [`error_policy`] - DDP-C3 error-classification / continue-on-error
 //!   behaviour, mirroring upstream `delete.c:178-207`.
 //! - [`cohort`] - DDP-D2 hardlink-cohort observer log.
+//! - [`unconfined_escape`] - CF-P0a/CF-P0b RED baseline pinning the
+//!   symlink escape the path-based `RealDeleteFs` methods still allow.
 //!
 //! Shared helpers (synthetic plan/entry builders, the [`ScriptedDeleteFs`]
 //! failure fake) live here.
@@ -29,6 +31,8 @@ mod dispatch;
 mod error_policy;
 #[cfg(unix)]
 mod sandbox;
+#[cfg(unix)]
+mod unconfined_escape;
 
 pub(super) fn entry(name: &str, kind: DeleteEntryKind) -> DeleteEntry {
     DeleteEntry::new(OsString::from(name), kind)

--- a/crates/engine/src/delete/emitter/tests/unconfined_escape.rs
+++ b/crates/engine/src/delete/emitter/tests/unconfined_escape.rs
@@ -1,26 +1,38 @@
-//! CF-P0a / CF-P0b: the path-based [`RealDeleteFs`] methods escape the tree.
+//! CF-P0a / CF-P0b: the path-based [`RealDeleteFs`] methods escape the tree
+//! when no confinement root has been installed.
 //!
-//! [`RealDeleteFs`]'s six path-based methods are bare `std::fs` calls
-//! (`fs.rs` `unlink_file` / `rmdir` / `unlink_symlink` / `unlink_device`
-//! / `unlink_special` / `remove_dir_all`). They are what the emitter
-//! issues whenever no [`fast_io::DirSandbox`] has been wired to it, so
-//! every intermediate component of the deletion path is resolved by the
-//! kernel with symlink following fully enabled.
+//! [`RealDeleteFs`]'s six path-based methods (`fs.rs` `unlink_file` /
+//! `rmdir` / `unlink_symlink` / `unlink_device` / `unlink_special` /
+//! `remove_dir_all`) now resolve through
+//! [`fast_io::ConfinedFallback`], but that resolution has two halves:
+//! an ownership walk and an outside-the-root test. `Activation::root()`
+//! is `None` until a session is installed, so the root half cannot fire,
+//! and the ownership half trusts a symlink owned by our own euid. A
+//! local `--delete` therefore still walks straight through a planted
+//! symlink.
 //!
-//! These tests are a RED baseline, not a regression guard: each one
-//! plants a symlink mid-path and then asserts that the entry the method
-//! actually destroyed lives OUTSIDE the deletion tree. They document the
-//! defect the confined-fallback work has to close, so that work cannot
-//! land vacuously.
+//! These tests assert that escape rather than hiding it. Each plants a
+//! symlink mid-path and then asserts that the entry the method actually
+//! destroyed lives OUTSIDE the deletion tree. They are deliberately NOT
+//! flipped to a refusal: the routing alone does not close the local
+//! path, and a test asserting otherwise would be describing a session
+//! install that has not happened. Installing one on the local path is
+//! task 1009's decision, not this module's.
+//!
+//! [`the_delete_routing_refuses_only_once_a_session_root_is_installed`]
+//! is the other half of the pair - the same fixture with a root
+//! installed, where the routing does refuse. See
+//! [`super::daemon_escape`] for the daemon shape, where a module root
+//! IS installed in production.
 //!
 //! Every escape test is paired with a non-vacuity companion that runs
 //! the same method against a genuine in-tree directory. Without the
 //! companion an escape assertion would also pass if the fixture were
 //! simply unable to remove anything at all.
 //!
-//! upstream: `rsync-3.5.0/syscall.c:2896-2961` `ds_descend()` - upstream
-//! resolves a deletion path per component and refuses an absolute
-//! symlink target rather than walking through it.
+//! upstream: `rsync-3.5.0/syscall.c:2891` `ds_descend()` - upstream
+//! resolves a deletion path per component, and at `syscall.c:2953`
+//! refuses an absolute symlink target rather than walking through it.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -109,7 +121,7 @@ fn assert_escaped(fixture: &Fixture, victim: &Path) {
 /// `unlink_file` walks `tree/hop` into `outside` and removes the file
 /// there. The emitter asked to delete something under `tree`.
 #[test]
-fn unlink_file_escapes_through_a_symlinked_parent() {
+fn unlink_file_escapes_when_no_confinement_root_is_installed() {
     let fixture = Fixture::new();
     let victim = fixture.plant_file(&fixture.outside, "victim");
 
@@ -145,7 +157,7 @@ fn unlink_file_without_a_symlink_stays_in_the_tree() {
 /// `rmdir` follows the same planted component and removes the empty
 /// directory in the out-of-tree sibling.
 #[test]
-fn rmdir_escapes_through_a_symlinked_parent() {
+fn rmdir_escapes_when_no_confinement_root_is_installed() {
     let fixture = Fixture::new();
     let victim = fixture.outside.join("victim");
     fs::create_dir(&victim).expect("plant victim dir");
@@ -180,7 +192,7 @@ fn rmdir_without_a_symlink_stays_in_the_tree() {
 /// `unlink_symlink` removes the out-of-tree symlink itself. The leaf is
 /// not followed - the escape is entirely in the walk to the parent.
 #[test]
-fn unlink_symlink_escapes_through_a_symlinked_parent() {
+fn unlink_symlink_escapes_when_no_confinement_root_is_installed() {
     let fixture = Fixture::new();
     let victim = fixture.outside.join("victim");
     plant_symlink(Path::new("/dev/null"), &victim);
@@ -202,7 +214,7 @@ fn unlink_symlink_escapes_through_a_symlinked_parent() {
 /// uses a regular file because `mknod(2)` needs privileges the test
 /// suite does not have.
 #[test]
-fn unlink_device_escapes_through_a_symlinked_parent() {
+fn unlink_device_escapes_when_no_confinement_root_is_installed() {
     let fixture = Fixture::new();
     let victim = fixture.plant_file(&fixture.outside, "victim");
 
@@ -216,7 +228,7 @@ fn unlink_device_escapes_through_a_symlinked_parent() {
 /// `unlink_special` escapes the same way, here against a real FIFO so
 /// at least one non-regular kind is exercised end to end.
 #[test]
-fn unlink_special_escapes_through_a_symlinked_parent() {
+fn unlink_special_escapes_when_no_confinement_root_is_installed() {
     let fixture = Fixture::new();
     let victim = fixture.outside.join("victim");
     mkfifo(&victim);
@@ -235,7 +247,7 @@ fn unlink_special_escapes_through_a_symlinked_parent() {
 /// this recursive fallback "is vulnerable to the symlink-swap class the
 /// carrier closes"; this is that concession made observable.
 #[test]
-fn remove_dir_all_escapes_through_a_symlinked_parent() {
+fn remove_dir_all_escapes_when_no_confinement_root_is_installed() {
     let fixture = Fixture::new();
     let victim = fixture.outside.join("victim");
     fs::create_dir(&victim).expect("plant victim dir");
@@ -292,5 +304,48 @@ fn mkfifo(path: &Path) {
         path.symlink_metadata().is_ok(),
         "mkfifo produced no node at {}",
         path.display()
+    );
+}
+
+/// The A/B that says WHY the escape above still happens after
+/// `RealDeleteFs` was routed onto `ConfinedFallback`.
+///
+/// `Activation::outside_root` is `self.root().is_some_and(..)`, so with no
+/// session installed it is unconditionally false and the root half of the
+/// ownership walk never fires. What remains is the ownership half, which
+/// trusts a symlink owned by our own euid and follows it - and the fixture
+/// plants exactly such a symlink. So the routed delete path resolves through
+/// arm 2 and still lands outside the tree.
+///
+/// This is the PRECONDITION, stated rather than hidden: the routing is a
+/// prerequisite that stays inert until a session is installed. Installing one
+/// is task 1009's job, deliberately NOT done here - a production delete path
+/// that installed its own session would be a policy decision, not a routing
+/// one.
+#[test]
+fn the_delete_routing_refuses_only_once_a_session_root_is_installed() {
+    use fast_io::confinement::{
+        Activation, DaemonState, LocalInsecureLinks, Role, install_session,
+    };
+
+    let fixture = Fixture::new();
+    let victim = fixture.plant_file(&fixture.outside, "victim");
+
+    install_session(&Activation {
+        role: Role::Receiver,
+        daemon: DaemonState::NotDaemon,
+        insecure_links: LocalInsecureLinks::default(),
+        confine_root: Some(fixture.tree.clone()),
+    });
+
+    let refused = RealDeleteFs.unlink_file(&fixture.through_symlink("victim"));
+
+    assert!(
+        refused.is_err(),
+        "with a confinement root installed the routed delete must refuse the escape"
+    );
+    assert!(
+        victim.exists(),
+        "the out-of-tree victim must survive a refused delete"
     );
 }

--- a/crates/engine/src/delete/emitter/tests/unconfined_escape.rs
+++ b/crates/engine/src/delete/emitter/tests/unconfined_escape.rs
@@ -1,0 +1,296 @@
+//! CF-P0a / CF-P0b: the path-based [`RealDeleteFs`] methods escape the tree.
+//!
+//! [`RealDeleteFs`]'s six path-based methods are bare `std::fs` calls
+//! (`fs.rs` `unlink_file` / `rmdir` / `unlink_symlink` / `unlink_device`
+//! / `unlink_special` / `remove_dir_all`). They are what the emitter
+//! issues whenever no [`fast_io::DirSandbox`] has been wired to it, so
+//! every intermediate component of the deletion path is resolved by the
+//! kernel with symlink following fully enabled.
+//!
+//! These tests are a RED baseline, not a regression guard: each one
+//! plants a symlink mid-path and then asserts that the entry the method
+//! actually destroyed lives OUTSIDE the deletion tree. They document the
+//! defect the confined-fallback work has to close, so that work cannot
+//! land vacuously.
+//!
+//! Every escape test is paired with a non-vacuity companion that runs
+//! the same method against a genuine in-tree directory. Without the
+//! companion an escape assertion would also pass if the fixture were
+//! simply unable to remove anything at all.
+//!
+//! upstream: `rsync-3.5.0/syscall.c:2896-2961` `ds_descend()` - upstream
+//! resolves a deletion path per component and refuses an absolute
+//! symlink target rather than walking through it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use super::super::{DeleteFs, RealDeleteFs};
+
+/// The two-tree fixture every test in this module shares.
+///
+/// `tree` is the directory the emitter believes it is deleting inside.
+/// `outside` is a sibling that no deletion may ever touch. `tree/hop` is
+/// a symlink to `outside`, standing in for a component an attacker
+/// flipped between the emitter's decision to delete and the syscall.
+struct Fixture {
+    _base: TempDir,
+    tree: PathBuf,
+    outside: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let base = TempDir::new().expect("tempdir");
+        let tree = base.path().join("tree");
+        let outside = base.path().join("outside");
+        fs::create_dir(&tree).expect("mkdir tree");
+        fs::create_dir(&outside).expect("mkdir outside");
+        plant_symlink(&outside, &tree.join("hop"));
+        fs::create_dir(tree.join("real")).expect("mkdir real");
+        Self {
+            _base: base,
+            tree,
+            outside,
+        }
+    }
+
+    /// Path the emitter would issue: it traverses the planted symlink.
+    fn through_symlink(&self, name: &str) -> PathBuf {
+        self.tree.join("hop").join(name)
+    }
+
+    /// Same shape without a symlink anywhere in it - the control.
+    fn in_tree(&self, name: &str) -> PathBuf {
+        self.tree.join("real").join(name)
+    }
+
+    fn plant_file(&self, dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, b"victim").expect("plant file");
+        path
+    }
+}
+
+/// Plant a symlink at `link` pointing at `target`, asserting the result
+/// really is one.
+///
+/// The assertion pins the fixture shape rather than trusting it: a
+/// mutation that degrades the planted link to an ordinary file must make
+/// the escape tests fail, not quietly change what they measure.
+fn plant_symlink(target: &Path, link: &Path) {
+    std::os::unix::fs::symlink(target, link).expect("plant symlink");
+    assert!(
+        link.symlink_metadata()
+            .expect("stat the planted link")
+            .file_type()
+            .is_symlink(),
+        "fixture broken: {} is not a symlink",
+        link.display()
+    );
+}
+
+/// Assert `victim` is gone while its parent survives, i.e. the call
+/// removed exactly the out-of-tree entry rather than failing outright.
+fn assert_escaped(fixture: &Fixture, victim: &Path) {
+    assert!(
+        !victim.exists(),
+        "no escape: {} survived the unconfined delete",
+        victim.display()
+    );
+    assert!(
+        fixture.outside.is_dir(),
+        "fixture broken: the out-of-tree directory itself vanished"
+    );
+}
+
+/// `unlink_file` walks `tree/hop` into `outside` and removes the file
+/// there. The emitter asked to delete something under `tree`.
+#[test]
+fn unlink_file_escapes_through_a_symlinked_parent() {
+    let fixture = Fixture::new();
+    let victim = fixture.plant_file(&fixture.outside, "victim");
+
+    RealDeleteFs
+        .unlink_file(&fixture.through_symlink("victim"))
+        .expect("the unconfined unlink follows the planted symlink");
+
+    assert_escaped(&fixture, &victim);
+}
+
+/// Non-vacuity companion: the same call against a real in-tree parent
+/// removes the in-tree file and leaves the out-of-tree one alone.
+#[test]
+fn unlink_file_without_a_symlink_stays_in_the_tree() {
+    let fixture = Fixture::new();
+    let bystander = fixture.plant_file(&fixture.outside, "victim");
+    let target = fixture.plant_file(&fixture.tree.join("real"), "victim");
+
+    RealDeleteFs
+        .unlink_file(&fixture.in_tree("victim"))
+        .expect("an ordinary in-tree unlink");
+
+    assert!(
+        !target.exists(),
+        "the in-tree file should have been removed"
+    );
+    assert!(
+        bystander.exists(),
+        "nothing outside the tree may be touched"
+    );
+}
+
+/// `rmdir` follows the same planted component and removes the empty
+/// directory in the out-of-tree sibling.
+#[test]
+fn rmdir_escapes_through_a_symlinked_parent() {
+    let fixture = Fixture::new();
+    let victim = fixture.outside.join("victim");
+    fs::create_dir(&victim).expect("plant victim dir");
+
+    RealDeleteFs
+        .rmdir(&fixture.through_symlink("victim"))
+        .expect("the unconfined rmdir follows the planted symlink");
+
+    assert_escaped(&fixture, &victim);
+}
+
+/// Non-vacuity companion for [`rmdir_escapes_through_a_symlinked_parent`].
+#[test]
+fn rmdir_without_a_symlink_stays_in_the_tree() {
+    let fixture = Fixture::new();
+    let bystander = fixture.outside.join("victim");
+    fs::create_dir(&bystander).expect("plant bystander dir");
+    let target = fixture.tree.join("real").join("victim");
+    fs::create_dir(&target).expect("plant target dir");
+
+    RealDeleteFs
+        .rmdir(&fixture.in_tree("victim"))
+        .expect("an ordinary in-tree rmdir");
+
+    assert!(!target.exists(), "the in-tree dir should have been removed");
+    assert!(
+        bystander.exists(),
+        "nothing outside the tree may be touched"
+    );
+}
+
+/// `unlink_symlink` removes the out-of-tree symlink itself. The leaf is
+/// not followed - the escape is entirely in the walk to the parent.
+#[test]
+fn unlink_symlink_escapes_through_a_symlinked_parent() {
+    let fixture = Fixture::new();
+    let victim = fixture.outside.join("victim");
+    plant_symlink(Path::new("/dev/null"), &victim);
+
+    RealDeleteFs
+        .unlink_symlink(&fixture.through_symlink("victim"))
+        .expect("the unconfined unlink follows the planted symlink");
+
+    assert!(
+        victim.symlink_metadata().is_err(),
+        "no escape: the out-of-tree symlink survived"
+    );
+    assert!(fixture.outside.is_dir(), "fixture broken");
+}
+
+/// `unlink_device` escapes the same way. `RealDeleteFs` routes every
+/// file-like kind to `fs::remove_file`, so the victim's inode type is
+/// irrelevant to the defect: what escapes is the path walk. The fixture
+/// uses a regular file because `mknod(2)` needs privileges the test
+/// suite does not have.
+#[test]
+fn unlink_device_escapes_through_a_symlinked_parent() {
+    let fixture = Fixture::new();
+    let victim = fixture.plant_file(&fixture.outside, "victim");
+
+    RealDeleteFs
+        .unlink_device(&fixture.through_symlink("victim"))
+        .expect("the unconfined unlink follows the planted symlink");
+
+    assert_escaped(&fixture, &victim);
+}
+
+/// `unlink_special` escapes the same way, here against a real FIFO so
+/// at least one non-regular kind is exercised end to end.
+#[test]
+fn unlink_special_escapes_through_a_symlinked_parent() {
+    let fixture = Fixture::new();
+    let victim = fixture.outside.join("victim");
+    mkfifo(&victim);
+
+    RealDeleteFs
+        .unlink_special(&fixture.through_symlink("victim"))
+        .expect("the unconfined unlink follows the planted symlink");
+
+    assert_escaped(&fixture, &victim);
+}
+
+/// The sharpest of the six: `remove_dir_all` walks the planted symlink
+/// and then recursively destroys a whole out-of-tree subtree, contents
+/// and all. The sibling doc at
+/// `fast_io::dir_sandbox::at_syscalls::unlink` already concedes that
+/// this recursive fallback "is vulnerable to the symlink-swap class the
+/// carrier closes"; this is that concession made observable.
+#[test]
+fn remove_dir_all_escapes_through_a_symlinked_parent() {
+    let fixture = Fixture::new();
+    let victim = fixture.outside.join("victim");
+    fs::create_dir(&victim).expect("plant victim dir");
+    fs::create_dir(victim.join("nested")).expect("plant nested dir");
+    let payload = victim.join("nested").join("payload");
+    fs::write(&payload, b"irreplaceable").expect("plant payload");
+
+    RealDeleteFs
+        .remove_dir_all(&fixture.through_symlink("victim"))
+        .expect("the unconfined recursive delete follows the planted symlink");
+
+    assert!(
+        !payload.exists(),
+        "no escape: the out-of-tree payload survived"
+    );
+    assert_escaped(&fixture, &victim);
+}
+
+/// Non-vacuity companion for
+/// [`remove_dir_all_escapes_through_a_symlinked_parent`].
+#[test]
+fn remove_dir_all_without_a_symlink_stays_in_the_tree() {
+    let fixture = Fixture::new();
+    let bystander = fixture.outside.join("victim");
+    fs::create_dir(&bystander).expect("plant bystander dir");
+    fs::write(bystander.join("payload"), b"irreplaceable").expect("plant payload");
+    let target = fixture.tree.join("real").join("victim");
+    fs::create_dir(&target).expect("plant target dir");
+    fs::write(target.join("payload"), b"expendable").expect("plant payload");
+
+    RealDeleteFs
+        .remove_dir_all(&fixture.in_tree("victim"))
+        .expect("an ordinary in-tree recursive delete");
+
+    assert!(!target.exists(), "the in-tree dir should have been removed");
+    assert!(
+        bystander.join("payload").exists(),
+        "nothing outside the tree may be touched"
+    );
+}
+
+/// Create a FIFO at `path`.
+///
+/// `engine` denies unsafe code, so this shells out to `mkfifo(1)` rather
+/// than calling `libc::mkfifo`. The node only has to exist; the test
+/// cares about the path walk, not about opening it.
+fn mkfifo(path: &Path) {
+    let status = std::process::Command::new("mkfifo")
+        .arg(path)
+        .status()
+        .expect("spawn mkfifo");
+    assert!(status.success(), "mkfifo failed for {}", path.display());
+    assert!(
+        path.symlink_metadata().is_ok(),
+        "mkfifo produced no node at {}",
+        path.display()
+    );
+}

--- a/crates/engine/src/delete/parallel_consumer.rs
+++ b/crates/engine/src/delete/parallel_consumer.rs
@@ -802,10 +802,26 @@ mod tests {
     /// DFD.3.b (end-to-end): with an ancestor component already swapped to an
     /// outside-pointing symlink before `run()`, the consumer's per-cohort
     /// `open_dir_at` component walk refuses the symlink (`O_NOFOLLOW`), so
-    /// `parent_fd` falls back to `None` and the path-based unlink also
-    /// traverses the planted symlink and fails. Either way no deletion lands
-    /// on the outside sentinel; the failure surfaces as a non-fatal io error
-    /// and zero files removed.
+    /// `parent_fd` falls back to `None` and each op takes the path-based
+    /// method. That fallback is `RealDeleteFs::unlink_file`, which resolves
+    /// through `ConfinedFallback::confined()`, and the ownership walk refuses
+    /// the out-of-root symlink component with `ELOOP`. No deletion lands on
+    /// the outside sentinel; the refusal surfaces as a non-fatal io error and
+    /// zero files removed.
+    ///
+    /// The fixture needs three things, and with any one missing the cell
+    /// asserts nothing:
+    ///
+    /// 1. `outside/cohort` must EXIST, or the fallback `ENOENT`s before it can
+    ///    reach a confinement decision.
+    /// 2. The sentinel must sit at `outside/cohort/victim`, the path a followed
+    ///    ancestor symlink actually resolves to - not `outside/victim`.
+    /// 3. A confinement session must be installed, or the walk has no root to
+    ///    judge against: it resolves the components, reports `Confined`, and
+    ///    the `unlinkat` then lands outside the tree. Measured both ways -
+    ///    with no session the out-of-root file is deleted and counted as a
+    ///    successful unlink with no io error; with one the walk returns
+    ///    `ELOOP`.
     #[cfg(unix)]
     #[test]
     fn consumer_refuses_ancestor_symlink_and_spares_outside_sentinel() {
@@ -817,15 +833,29 @@ mod tests {
         let root = tmp.path().join("root");
         std::fs::create_dir_all(root.join("ancestor").join("cohort")).expect("mk tree");
         let outside = tmp.path().join("outside");
-        std::fs::create_dir(&outside).expect("mk outside");
-        // Same leaf name as the op makes any redirect maximally detectable.
-        let sentinel = outside.join("victim");
+        // The redirect target must EXIST, and the sentinel must sit ON it.
+        // `op.path` is `root/ancestor/cohort/victim`, so a followed ancestor
+        // symlink resolves to `outside/cohort/victim` - not `outside/victim`.
+        // With the sentinel anywhere else, or with `outside/cohort` absent,
+        // the fallback ENOENTs before reaching any confinement decision and
+        // every assertion below holds against a wholly unconfined unlink.
+        std::fs::create_dir_all(outside.join("cohort")).expect("mk redirect target");
+        let sentinel = outside.join("cohort").join("victim");
         std::fs::write(&sentinel, b"do-not-touch").expect("write sentinel");
 
         // Pre-stage the ancestor-symlink swap.
         std::fs::rename(root.join("ancestor"), root.join("ancestor.bak")).expect("aside");
         symlink(&outside, root.join("ancestor")).expect("plant symlink");
 
+        // The session the production daemon installs. Without it the walk has
+        // no confinement root, permits the out-of-root resolution, and this
+        // cell measures nothing - see the third fixture requirement above.
+        fast_io::confinement::install_daemon_session(fast_io::confinement::ModuleState {
+            root: Some(root.clone()),
+            chrooted: false,
+            selected: true,
+            insecure_links: fast_io::confinement::ModuleInsecureLinks::default(),
+        });
         let sandbox = Arc::new(DirSandbox::open_root(&root).expect("open root"));
         let emitter = ParallelDeleteEmitter::new(RealDeleteFs).with_sandbox(sandbox);
 

--- a/crates/fast_io/src/confined_fallback.rs
+++ b/crates/fast_io/src/confined_fallback.rs
@@ -1,0 +1,710 @@
+//! Upstream's three-arm fallback contract for a path-based syscall, in one
+//! place.
+//!
+//! Every `do_*_at()` wrapper in upstream `syscall.c` answers the same question
+//! before it touches the filesystem, and answers it the same way. Written out
+//! from `do_unlink_at()` (`rsync-3.5.0/syscall.c:658`), which is the shortest
+//! statement of it:
+//!
+//! ```c
+//! if (operator_path_resolve) {
+//!         if (symlink_optout_allowed())
+//!                 return unlink(path);            /* arm 1 */
+//!         dfd = owner_walk_parent(path, &bname);
+//!         if (dfd < 0)
+//!                 return -1;                      /* arm 3 */
+//!         ret = unlinkat(dfd, bname, 0);          /* arm 2 */
+//! ```
+//!
+//! | Arm | Condition | Action |
+//! |---|---|---|
+//! | 1 | the policy gate is off | a plain path syscall - deliberately unconfined, by STATIC POLICY |
+//! | 2 | gate on, the parent walk SUCCEEDS | the `*at` syscall against `(parent dirfd, leaf)` |
+//! | 3 | gate on, the parent walk FAILS | an error. NEVER a plain syscall |
+//!
+//! # Why this is a type and not five copies
+//!
+//! The three arms are easy to collapse into two - "try the confined form, and
+//! on any error do the plain one" - and that collapse is the defect this module
+//! exists to make unspellable. It turns arm 3 into arm 1, so a refusal the walk
+//! issued *on purpose* (a foreign-owned parent symlink, a leaf outside the
+//! confinement root) is laundered into the very syscall the refusal was
+//! protecting against. Upstream names that test as wrong in its own words:
+//! arm 1 is chosen from configuration read before any I/O happens, never from a
+//! runtime errno.
+//!
+//! Keeping the decision in one type means a new operation inherits the contract
+//! rather than restating it, and the arm a call took is observable
+//! ([`ConfinedFallback::arm_for`]) so a test can tell arm 2 from arm 3 instead
+//! of only seeing that something failed.
+//!
+//! # The gate, precisely
+//!
+//! Arm 1 is [`session_optout_allowed`](crate::confinement::session_optout_allowed) -
+//! upstream `symlink_optout_allowed()` (`rsync-3.5.0/syscall.c:122`), which is
+//! the whole gate on the operator arm because that arm is tested *above*
+//! `secure_relpath_active()` in every wrapper.
+//!
+//! `secure_relpath_active()` (`rsync-3.5.0/syscall.c:100`) is not a second gate
+//! here. Its first clause IS the opt-out, so it can never admit a call this
+//! module refuses; its remaining clauses (chroot, sender) select upstream's
+//! *other* tier, which resolves a transfer-relative parent through
+//! `secure_relative_open()` rather than through the ownership walk. That is a
+//! different resolver, not a different arm of this one.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/syscall.c:658` `do_unlink_at()` - the contract, quoted above.
+//! - `rsync-3.5.0/syscall.c:1402` `do_rmdir_at()` - same shape, `AT_REMOVEDIR`.
+//! - `rsync-3.5.0/syscall.c:1497` `do_open_at()` - same shape, and the leaf
+//!   carries `O_NOFOLLOW`.
+//! - `rsync-3.5.0/syscall.c:1866` `do_rename_at()` - same shape, both endpoints
+//!   walked independently.
+//! - `rsync-3.5.0/syscall.c:558` `owner_walk_parent()` - the walk arm 2 and
+//!   arm 3 share, mirrored by [`owner_trusted_parent_kind`].
+
+use std::ffi::OsString;
+use std::fs::File;
+use std::io;
+use std::os::fd::{AsFd, OwnedFd};
+use std::path::Path;
+
+use crate::confinement::PathKind;
+use crate::dir_sandbox::{UnlinkFlags, UnlinkResidue};
+use crate::owner_walk::owner_trusted_parent_kind;
+
+/// Which arm a resolution took, for callers and tests that need to see the
+/// decision rather than only its result.
+///
+/// Arm 3 is not a variant: it is the `Err` of the `Result` that carries this.
+/// Spelling it as a third variant would let a caller ignore a refusal by
+/// matching on it, which is the collapse this module prevents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FallbackArm {
+    /// Arm 1 - the policy gate is off, so the operation runs as a plain path
+    /// syscall. Unconfined by static policy, not by accident.
+    Unconfined,
+    /// Arm 2 - the gate is on and the parent walk succeeded, so the operation
+    /// runs `*at` against the walked parent.
+    Confined,
+}
+
+/// The resolved parent for arm 2, or the decision that arm 1 applies.
+enum Resolved {
+    Unconfined,
+    Confined { parent: OwnedFd, leaf: OsString },
+}
+
+/// The single owner of upstream's three-arm fallback contract.
+///
+/// Construct one per call site with the [`PathKind`] that site's path has -
+/// upstream toggles `operator_path_resolve` around each site for the same
+/// reason - then issue operations against it.
+///
+/// # Examples
+///
+/// ```no_run
+/// use fast_io::ConfinedFallback;
+/// use std::path::Path;
+///
+/// // A peer-named destination entry: confined to the session root.
+/// ConfinedFallback::confined().rmdir_at(Path::new("dest/stale"))?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConfinedFallback {
+    kind: PathKind,
+}
+
+impl ConfinedFallback {
+    /// A path that must stay inside the session's confinement root.
+    ///
+    /// upstream: `operator_path_resolve = 1` around the call site.
+    #[must_use]
+    pub const fn confined() -> Self {
+        Self {
+            kind: PathKind::Confined,
+        }
+    }
+
+    /// A path that may legitimately live outside the tree - still walked for
+    /// foreign-owned symlinks, but not judged against the root.
+    ///
+    /// upstream: `operator_path_resolve = 0` around the call site.
+    #[must_use]
+    pub const fn ancillary() -> Self {
+        Self {
+            kind: PathKind::Ancillary,
+        }
+    }
+
+    /// Which arm `path` resolves to, without performing any operation.
+    ///
+    /// `Ok(Unconfined)` is arm 1, `Ok(Confined)` is arm 2, and `Err` is arm 3.
+    /// Exposed so a test can discriminate arm 2 from arm 3: both leave the
+    /// filesystem in a state a plain "did it fail?" assertion cannot tell
+    /// apart from a merely absent file.
+    ///
+    /// # Errors
+    ///
+    /// Arm 3: whatever the ownership walk refused with - `ELOOP` for a
+    /// foreign-owned symlink component or a leaf outside the confinement root,
+    /// `EINVAL` for a path with no final component, or the underlying
+    /// `openat`/`statat` errno.
+    pub fn arm_for(&self, path: &Path) -> io::Result<FallbackArm> {
+        match self.resolve(path)? {
+            Resolved::Unconfined => Ok(FallbackArm::Unconfined),
+            Resolved::Confined { .. } => Ok(FallbackArm::Confined),
+        }
+    }
+
+    /// Remove a non-directory entry at `path`.
+    ///
+    /// `entry` selects `unlinkat(2)`'s flag word exactly as upstream does:
+    /// [`UnlinkFlags::File`] is `flags == 0` (`do_unlink_at`) and
+    /// [`UnlinkFlags::Dir`] is `AT_REMOVEDIR` (`do_rmdir_at`). [`rmdir_at`] is
+    /// the named spelling of the second.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/syscall.c:674` - arm 1, `return unlink(path)`.
+    /// - `rsync-3.5.0/syscall.c:676` - the walk shared by arms 2 and 3.
+    /// - `rsync-3.5.0/syscall.c:680` - arm 2, `unlinkat(dfd, bname, 0)`.
+    ///
+    /// [`rmdir_at`]: Self::rmdir_at
+    ///
+    /// # Errors
+    ///
+    /// Arm 3's refusal, or the `unlink(2)` / `unlinkat(2)` errno.
+    pub fn unlink_at(&self, path: &Path, entry: UnlinkFlags) -> io::Result<()> {
+        match self.resolve(path)? {
+            Resolved::Unconfined => crate::unlink_path(path, entry),
+            Resolved::Confined { parent, leaf } => {
+                crate::unlinkat(parent.as_fd(), leaf.as_os_str(), entry)
+            }
+        }
+    }
+
+    /// Remove the empty directory at `path`.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:1402` `do_rmdir_at()` - the same three
+    /// arms with `AT_REMOVEDIR` set "to require the target be a directory".
+    ///
+    /// # Errors
+    ///
+    /// Arm 3's refusal, or the `rmdir(2)` / `unlinkat(2)` errno - notably
+    /// `ENOTEMPTY` when the directory still holds entries.
+    pub fn rmdir_at(&self, path: &Path) -> io::Result<()> {
+        self.unlink_at(path, UnlinkFlags::Dir)
+    }
+
+    /// Remove the directory at `path` and everything beneath it.
+    ///
+    /// Upstream has no `do_remove_dir_all_at()`: its recursive delete is the
+    /// receiver's own peel, built from the single-entry wrappers. The contract
+    /// is therefore applied where upstream applies it - to the *entry point*,
+    /// so the descent starts from a walked parent rather than from a path the
+    /// kernel re-resolves. The peel itself is [`recursive_unlinkat`], which is
+    /// already dirfd-anchored the whole way down.
+    ///
+    /// [`recursive_unlinkat`]: crate::recursive_unlinkat
+    ///
+    /// # Errors
+    ///
+    /// Arm 3's refusal, or the descent's error. On arm 1 the residue reports a
+    /// clean removal, because [`std::fs::remove_dir_all`] returns `Err` rather
+    /// than surviving entries.
+    pub fn remove_dir_all_at(&self, path: &Path) -> io::Result<UnlinkResidue> {
+        match self.resolve(path)? {
+            Resolved::Unconfined => std::fs::remove_dir_all(path).map(|()| UnlinkResidue {
+                not_empty: false,
+                had_errors: false,
+            }),
+            Resolved::Confined { parent, leaf } => {
+                crate::recursive_unlinkat(parent.as_fd(), leaf.as_os_str())
+            }
+        }
+    }
+
+    /// Rename `old_path` to `new_path`.
+    ///
+    /// Each endpoint is resolved independently, mirroring upstream: an absolute
+    /// source must not be able to switch off confinement of a relative
+    /// destination. Both sides take the same arm, because the arm is a property
+    /// of the session rather than of either path.
+    ///
+    /// `replace` false selects `RENAME_NOREPLACE` where the platform has it;
+    /// upstream's `do_rename_at()` is the `replace == true` shape.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/syscall.c:1892` - arm 1, `return do_rename(...)`.
+    /// - `rsync-3.5.0/syscall.c:1894` - the source-side walk.
+    /// - `rsync-3.5.0/syscall.c:1904` - arm 2, `renameat` between both dirfds.
+    ///
+    /// # Errors
+    ///
+    /// Arm 3's refusal from either side, or the `rename(2)` / `renameat(2)`
+    /// errno.
+    pub fn rename_at(&self, old_path: &Path, new_path: &Path, replace: bool) -> io::Result<()> {
+        match (self.resolve(old_path)?, self.resolve(new_path)?) {
+            (
+                Resolved::Confined {
+                    parent: old_dir,
+                    leaf: old_leaf,
+                },
+                Resolved::Confined {
+                    parent: new_dir,
+                    leaf: new_leaf,
+                },
+            ) => crate::renameat(
+                old_dir.as_fd(),
+                old_leaf.as_os_str(),
+                new_dir.as_fd(),
+                new_leaf.as_os_str(),
+                replace,
+            ),
+            // Arm 1 on both sides: `resolve` reads one session-scoped answer,
+            // so a mixed pair cannot occur. Spelling the arm once keeps that a
+            // fact about `resolve` rather than a rule repeated here.
+            _ => crate::renameat(
+                rustix::fs::CWD,
+                old_path.as_os_str(),
+                rustix::fs::CWD,
+                new_path.as_os_str(),
+                replace,
+            ),
+        }
+    }
+
+    /// Open `path`.
+    ///
+    /// On arm 2 the leaf carries `O_NOFOLLOW` in addition to `flags`, exactly
+    /// as upstream does - "so the basename itself isn't followed if it happens
+    /// to be a pre-planted symlink, which is what we want for `O_CREAT|O_EXCL`"
+    /// (`rsync-3.5.0/syscall.c:1493`). The walk defends the parent chain; the
+    /// leaf is a separate decision and needs its own flag.
+    ///
+    /// On arm 1 the flags are passed verbatim: upstream's arm 1 is
+    /// `do_open(pathname, flags, mode)`, the legacy symlink-following open, and
+    /// adding `O_NOFOLLOW` there would make the opt-out stricter than the
+    /// behaviour it exists to restore.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/syscall.c:1514` - arm 1, `return do_open(...)`.
+    /// - `rsync-3.5.0/syscall.c:1516` - the walk shared by arms 2 and 3.
+    /// - `rsync-3.5.0/syscall.c:1518` - arm 2,
+    ///   `openat(dfd, bname, flags | O_NOFOLLOW, mode)`.
+    ///
+    /// # Errors
+    ///
+    /// Arm 3's refusal, or the `open(2)` / `openat(2)` errno - notably `ELOOP`
+    /// on arm 2 when the leaf itself is a symlink.
+    pub fn open_at(&self, path: &Path, flags: i32, mode: u32) -> io::Result<File> {
+        match self.resolve(path)? {
+            Resolved::Unconfined => crate::openat(rustix::fs::CWD, path.as_os_str(), flags, mode),
+            Resolved::Confined { parent, leaf } => crate::openat(
+                parent.as_fd(),
+                leaf.as_os_str(),
+                flags | libc::O_NOFOLLOW,
+                mode,
+            ),
+        }
+    }
+
+    /// The one place the three arms are decided.
+    ///
+    /// Arm 1 is read from session policy before any I/O; arm 2 and arm 3 are
+    /// the two outcomes of the ownership walk. There is deliberately no path
+    /// from an `Err` here back to [`Resolved::Unconfined`].
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:674-679` - the `symlink_optout_allowed()`
+    /// test, then `owner_walk_parent()`, then `if (dfd < 0) return -1;`.
+    ///
+    /// # Measured: the gate is only PARTLY redundant
+    ///
+    /// `owner_walk_open` short-circuits on the same opt-out
+    /// (`owner_walk.rs`, mirroring `syscall.c:300-302`), so for the `*at` ops
+    /// the two arms resolve the same parent either way. Removing this test
+    /// therefore leaves the delete and rename cells green - measured, by
+    /// mutation. It is NOT redundant for the two decisions the walk cannot
+    /// make: which arm [`ConfinedFallback::arm_for`] reports, and whether
+    /// [`ConfinedFallback::open_at`] adds `O_NOFOLLOW` to the leaf. Both are
+    /// pinned, and both go red without it.
+    fn resolve(&self, path: &Path) -> io::Result<Resolved> {
+        if crate::confinement::session_optout_allowed() {
+            return Ok(Resolved::Unconfined);
+        }
+        let (parent, leaf) = owner_trusted_parent_kind(path, self.kind)?;
+        Ok(Resolved::Confined { parent, leaf })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::confinement::{Activation, DaemonState, LocalInsecureLinks, Role, install_session};
+    use std::os::unix::fs::symlink;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// The confinement session is process-global (upstream reads the same
+    /// answer from globals), so each cell below installs the policy it needs.
+    /// nextest runs one process per test, which is what keeps that sound; these
+    /// cells are not safe under a shared-process runner.
+    fn confine_to(root: &Path) {
+        install_session(&Activation {
+            role: Role::Receiver,
+            daemon: DaemonState::NotDaemon,
+            insecure_links: LocalInsecureLinks::default(),
+            confine_root: Some(root.to_path_buf()),
+        });
+    }
+
+    /// The same session WITH the opt-out set: the arm-1 counterpart of
+    /// [`confine_to`].
+    ///
+    /// Keeping the root installed is what makes an arm-1 cell a ONE-VARIABLE
+    /// flip of its arm-3 twin. Dropping the root as well would leave two
+    /// differences, and the cell would then also pass with the gate removed -
+    /// the walk would simply have nothing to judge the leaf against.
+    fn confine_to_with_optout(root: &Path) {
+        install_session(&Activation {
+            role: Role::Receiver,
+            daemon: DaemonState::NotDaemon,
+            insecure_links: LocalInsecureLinks::from_local_flag(true),
+            confine_root: Some(root.to_path_buf()),
+        });
+    }
+
+    /// A tree whose only difference between arm 2 and arm 3 is WHERE the path
+    /// lands, so the two are told apart by the confinement decision and not by
+    /// an incidental failure:
+    ///
+    /// ```text
+    /// temp/module/          <- confinement root
+    /// temp/module/payload   <- in-root leaf     (arm 2)
+    /// temp/module/esc       -> ../outside       (our own symlink: FOLLOWED)
+    /// temp/outside/secret   <- out-of-root leaf (arm 3, reached via esc)
+    /// temp/outside/subdir/  <- out-of-root tree (arm 3, recursive)
+    /// ```
+    struct Fixture {
+        _temp: TempDir,
+        root: PathBuf,
+        /// `module/payload` - inside the root.
+        inside: PathBuf,
+        /// `module/esc/secret` - spelled inside the root, lands outside it.
+        escape: PathBuf,
+        /// `module/esc/subdir` - the recursive shape of `escape`.
+        escape_dir: PathBuf,
+        /// The real out-of-root file `escape` resolves to.
+        victim: PathBuf,
+        /// The real out-of-root directory `escape_dir` resolves to.
+        victim_dir: PathBuf,
+    }
+
+    fn fixture() -> Fixture {
+        let temp = TempDir::new().expect("tempdir");
+        let root = temp.path().join("module");
+        std::fs::create_dir(&root).expect("mkdir module");
+        let inside = root.join("payload");
+        std::fs::write(&inside, b"INSIDE").expect("write inside");
+
+        let outside_dir = temp.path().join("outside");
+        std::fs::create_dir(&outside_dir).expect("mkdir outside");
+        let victim = outside_dir.join("secret");
+        std::fs::write(&victim, b"OUTSIDE").expect("write outside");
+        let victim_dir = outside_dir.join("subdir");
+        std::fs::create_dir(&victim_dir).expect("mkdir subdir");
+        std::fs::write(victim_dir.join("child"), b"CHILD").expect("write child");
+
+        symlink("../outside", root.join("esc")).expect("symlink esc");
+
+        Fixture {
+            _temp: temp,
+            escape: root.join("esc").join("secret"),
+            escape_dir: root.join("esc").join("subdir"),
+            root,
+            inside,
+            victim,
+            victim_dir,
+        }
+    }
+
+    // --- arm classification -------------------------------------------------
+
+    /// Arm 1: the opt-out is a STATIC POLICY answer, read before any I/O, so a
+    /// path that arm 3 refuses classifies as unconfined here.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:674` - `symlink_optout_allowed()` is
+    /// tested at the top of the operator arm, above the walk.
+    #[test]
+    fn arm_one_is_chosen_when_the_session_opted_out() {
+        let fx = fixture();
+        confine_to_with_optout(&fx.root);
+        assert_eq!(
+            ConfinedFallback::confined()
+                .arm_for(&fx.escape)
+                .expect("the opt-out short-circuits before the walk"),
+            FallbackArm::Unconfined
+        );
+    }
+
+    /// Arm 2: the gate is on and the walk reaches an in-root parent.
+    ///
+    /// This is the control for every arm-3 cell below. Without it those cells
+    /// would also pass if the walk refused everything, which is the
+    /// availability failure this contract must not introduce.
+    #[test]
+    fn arm_two_is_chosen_when_the_walk_reaches_an_in_root_parent() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        assert_eq!(
+            ConfinedFallback::confined()
+                .arm_for(&fx.inside)
+                .expect("an in-root parent resolves"),
+            FallbackArm::Confined
+        );
+    }
+
+    /// Arm 3: the gate is on and the walk refuses, so the result is an error -
+    /// NOT arm 1. `ELOOP` identifies it as the confinement decision rather than
+    /// an incidental traversal failure.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:677-678` - `if (dfd < 0) return -1;`.
+    #[test]
+    fn arm_three_is_an_error_and_never_falls_back_to_arm_one() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        let error = ConfinedFallback::confined()
+            .arm_for(&fx.escape)
+            .expect_err("a parent that lands outside the root must be refused");
+        assert_eq!(
+            error.raw_os_error(),
+            Some(libc::ELOOP),
+            "the refusal must be the confinement decision"
+        );
+    }
+
+    /// The same escaping path under `Ancillary` is arm 2, not arm 3: only a
+    /// confined path is judged against the root.
+    ///
+    /// upstream: `operator_path_resolve` is per call site, and
+    /// `abspath_outside_confinement()` returns 0 when it is clear
+    /// (`rsync-3.5.0/syscall.c:216`).
+    #[test]
+    fn an_ancillary_path_is_not_judged_against_the_root() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        assert_eq!(
+            ConfinedFallback::ancillary()
+                .arm_for(&fx.escape)
+                .expect("an ancillary path may live outside the tree"),
+            FallbackArm::Confined
+        );
+    }
+
+    // --- unlink -------------------------------------------------------------
+
+    /// Arm 3 must leave the out-of-root file ALIVE. This is the whole point of
+    /// the contract: an "on any error, do the plain syscall" collapse deletes
+    /// it, because the refusal is exactly what the plain syscall ignores.
+    #[test]
+    fn unlink_arm_three_refuses_and_the_out_of_root_file_survives() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        let error = ConfinedFallback::confined()
+            .unlink_at(&fx.escape, UnlinkFlags::File)
+            .expect_err("an escaping unlink must be refused");
+        assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+        assert!(
+            fx.victim.exists(),
+            "the refusal must not be laundered into a plain unlink"
+        );
+    }
+
+    /// The non-vacuity companion: the SAME call on the SAME path, differing
+    /// only in policy, really does remove the file on arm 1. Without this the
+    /// cell above would also pass if `unlink_at` could never delete anything.
+    #[test]
+    fn unlink_arm_one_performs_the_plain_syscall() {
+        let fx = fixture();
+        confine_to_with_optout(&fx.root);
+        ConfinedFallback::confined()
+            .unlink_at(&fx.escape, UnlinkFlags::File)
+            .expect("the opt-out restores the legacy symlink-following unlink");
+        assert!(
+            !fx.victim.exists(),
+            "arm 1 is the plain path syscall, which follows the parent symlink"
+        );
+    }
+
+    /// Arm 2 still removes an in-root entry - the availability half.
+    #[test]
+    fn unlink_arm_two_removes_an_in_root_entry() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        ConfinedFallback::confined()
+            .unlink_at(&fx.inside, UnlinkFlags::File)
+            .expect("an in-root unlink still works");
+        assert!(!fx.inside.exists());
+    }
+
+    // --- rmdir --------------------------------------------------------------
+
+    #[test]
+    fn rmdir_arm_three_refuses_and_the_out_of_root_directory_survives() {
+        let fx = fixture();
+        std::fs::remove_file(fx.victim_dir.join("child")).expect("empty the victim dir");
+        confine_to(&fx.root);
+        let error = ConfinedFallback::confined()
+            .rmdir_at(&fx.escape_dir)
+            .expect_err("an escaping rmdir must be refused");
+        assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+        assert!(fx.victim_dir.exists());
+    }
+
+    #[test]
+    fn rmdir_arm_two_removes_an_in_root_directory() {
+        let fx = fixture();
+        let doomed = fx.root.join("empty");
+        std::fs::create_dir(&doomed).expect("mkdir empty");
+        confine_to(&fx.root);
+        ConfinedFallback::confined()
+            .rmdir_at(&doomed)
+            .expect("an in-root rmdir still works");
+        assert!(!doomed.exists());
+    }
+
+    // --- recursive remove ---------------------------------------------------
+
+    #[test]
+    fn remove_dir_all_arm_three_refuses_and_the_out_of_root_tree_survives() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        let error = ConfinedFallback::confined()
+            .remove_dir_all_at(&fx.escape_dir)
+            .expect_err("an escaping recursive delete must be refused");
+        assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+        assert!(
+            fx.victim_dir.join("child").exists(),
+            "the descent must not start from a path the kernel re-resolves"
+        );
+    }
+
+    #[test]
+    fn remove_dir_all_arm_two_peels_an_in_root_tree() {
+        let fx = fixture();
+        let doomed = fx.root.join("tree");
+        std::fs::create_dir(&doomed).expect("mkdir tree");
+        std::fs::write(doomed.join("child"), b"x").expect("write child");
+        confine_to(&fx.root);
+        let residue = ConfinedFallback::confined()
+            .remove_dir_all_at(&doomed)
+            .expect("an in-root recursive delete still works");
+        assert!(!residue.not_empty && !residue.had_errors);
+        assert!(!doomed.exists());
+    }
+
+    // --- rename -------------------------------------------------------------
+
+    /// A refused DESTINATION must refuse the whole rename: upstream walks each
+    /// endpoint independently and returns -1 the moment either side fails, so
+    /// an in-root source cannot license an escaping target.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:1896-1903`.
+    #[test]
+    fn rename_arm_three_refuses_when_only_the_destination_escapes() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        let target = fx.root.join("esc").join("planted");
+        let error = ConfinedFallback::confined()
+            .rename_at(&fx.inside, &target, true)
+            .expect_err("an escaping destination must be refused");
+        assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+        assert!(fx.inside.exists(), "the source must be untouched");
+        assert!(
+            !fx.victim.with_file_name("planted").exists(),
+            "nothing may be published outside the root"
+        );
+    }
+
+    #[test]
+    fn rename_arm_two_renames_within_the_root() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        let target = fx.root.join("renamed");
+        ConfinedFallback::confined()
+            .rename_at(&fx.inside, &target, true)
+            .expect("an in-root rename still works");
+        assert!(target.exists() && !fx.inside.exists());
+    }
+
+    // --- open ---------------------------------------------------------------
+
+    #[test]
+    fn open_arm_three_refuses_an_escaping_parent() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        let error = ConfinedFallback::confined()
+            .open_at(&fx.escape, libc::O_RDONLY, 0)
+            .expect_err("an escaping open must be refused");
+        assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+    }
+
+    /// Arm 2 applies `O_NOFOLLOW` to the LEAF, which the flag-translating
+    /// fallback in `dir_sandbox::at_syscalls::open` silently drops. The link
+    /// here points at an in-root file, so nothing but the missing flag can
+    /// refuse it.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:1518` -
+    /// `openat(dfd, bname, flags | O_NOFOLLOW, mode)`.
+    #[test]
+    fn open_arm_two_applies_o_nofollow_to_the_leaf() {
+        let fx = fixture();
+        let leaf_link = fx.root.join("leaf");
+        symlink(&fx.inside, &leaf_link).expect("symlink leaf");
+        confine_to(&fx.root);
+        let error = ConfinedFallback::confined()
+            .open_at(&leaf_link, libc::O_RDONLY, 0)
+            .expect_err("a leaf symlink must not be followed on arm 2");
+        assert_eq!(
+            error.raw_os_error(),
+            Some(libc::ELOOP),
+            "O_NOFOLLOW must reach the leaf"
+        );
+    }
+
+    /// The mirror half, and the reason arm 1 does NOT add `O_NOFOLLOW`: the
+    /// opt-out restores the legacy symlink-following open verbatim, so the same
+    /// leaf link opens.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:1514` - arm 1 is `do_open(pathname,
+    /// flags, mode)`, with no added flag.
+    #[test]
+    fn open_arm_one_still_follows_a_leaf_symlink() {
+        let fx = fixture();
+        let leaf_link = fx.root.join("leaf");
+        symlink(&fx.inside, &leaf_link).expect("symlink leaf");
+        confine_to_with_optout(&fx.root);
+        let mut opened = ConfinedFallback::confined()
+            .open_at(&leaf_link, libc::O_RDONLY, 0)
+            .expect("arm 1 keeps the legacy following open");
+        let mut body = String::new();
+        std::io::Read::read_to_string(&mut opened, &mut body).expect("read");
+        assert_eq!(body, "INSIDE");
+    }
+
+    #[test]
+    fn open_arm_two_opens_an_in_root_leaf() {
+        let fx = fixture();
+        confine_to(&fx.root);
+        let mut opened = ConfinedFallback::confined()
+            .open_at(&fx.inside, libc::O_RDONLY, 0)
+            .expect("an in-root open still works");
+        let mut body = String::new();
+        std::io::Read::read_to_string(&mut opened, &mut body).expect("read");
+        assert_eq!(body, "INSIDE");
+    }
+}

--- a/crates/fast_io/src/confined_fallback.rs
+++ b/crates/fast_io/src/confined_fallback.rs
@@ -29,8 +29,10 @@
 //! exists to make unspellable. It turns arm 3 into arm 1, so a refusal the walk
 //! issued *on purpose* (a foreign-owned parent symlink, a leaf outside the
 //! confinement root) is laundered into the very syscall the refusal was
-//! protecting against. Upstream names that test as wrong in its own words:
-//! arm 1 is chosen from configuration read before any I/O happens, never from a
+//! protecting against. Upstream names that test as wrong in its own
+//! words - a leaf swapped under it is a reason to "refuse rather than fall
+//! through" (`rsync-3.5.0/syscall.c:1695-1698` `do_fchmodat_nofollow()`). Arm 1
+//! is chosen from configuration read before any I/O happens, never from a
 //! runtime errno.
 //!
 //! Keeping the decision in one type means a new operation inherits the contract
@@ -167,9 +169,9 @@ impl ConfinedFallback {
     ///
     /// # Upstream Reference
     ///
-    /// - `rsync-3.5.0/syscall.c:674` - arm 1, `return unlink(path)`.
+    /// - `rsync-3.5.0/syscall.c:675` - arm 1, `return unlink(path)`.
     /// - `rsync-3.5.0/syscall.c:676` - the walk shared by arms 2 and 3.
-    /// - `rsync-3.5.0/syscall.c:680` - arm 2, `unlinkat(dfd, bname, 0)`.
+    /// - `rsync-3.5.0/syscall.c:679` - arm 2, `unlinkat(dfd, bname, 0)`.
     ///
     /// [`rmdir_at`]: Self::rmdir_at
     ///
@@ -238,7 +240,7 @@ impl ConfinedFallback {
     ///
     /// # Upstream Reference
     ///
-    /// - `rsync-3.5.0/syscall.c:1892` - arm 1, `return do_rename(...)`.
+    /// - `rsync-3.5.0/syscall.c:1893` - arm 1, `return do_rename(...)`.
     /// - `rsync-3.5.0/syscall.c:1894` - the source-side walk.
     /// - `rsync-3.5.0/syscall.c:1904` - arm 2, `renameat` between both dirfds.
     ///
@@ -282,7 +284,7 @@ impl ConfinedFallback {
     /// On arm 2 the leaf carries `O_NOFOLLOW` in addition to `flags`, exactly
     /// as upstream does - "so the basename itself isn't followed if it happens
     /// to be a pre-planted symlink, which is what we want for `O_CREAT|O_EXCL`"
-    /// (`rsync-3.5.0/syscall.c:1493`). The walk defends the parent chain; the
+    /// (`rsync-3.5.0/syscall.c:1492-1495`). The walk defends the parent chain; the
     /// leaf is a separate decision and needs its own flag.
     ///
     /// On arm 1 the flags are passed verbatim: upstream's arm 1 is
@@ -292,9 +294,9 @@ impl ConfinedFallback {
     ///
     /// # Upstream Reference
     ///
-    /// - `rsync-3.5.0/syscall.c:1514` - arm 1, `return do_open(...)`.
+    /// - `rsync-3.5.0/syscall.c:1515` - arm 1, `return do_open(...)`.
     /// - `rsync-3.5.0/syscall.c:1516` - the walk shared by arms 2 and 3.
-    /// - `rsync-3.5.0/syscall.c:1518` - arm 2,
+    /// - `rsync-3.5.0/syscall.c:1519` - arm 2,
     ///   `openat(dfd, bname, flags | O_NOFOLLOW, mode)`.
     ///
     /// # Errors
@@ -310,6 +312,64 @@ impl ConfinedFallback {
                 flags | libc::O_NOFOLLOW,
                 mode,
             ),
+        }
+    }
+    /// Create a symlink at `link_path` whose contents are `target`.
+    ///
+    /// Only `link_path` takes an arm. `target` is the link's *contents*, not a
+    /// path this process resolves, so it is written verbatim - upstream passes
+    /// `lnk` straight through to `symlinkat` for the same reason.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/syscall.c:765` `do_symlink_at()`.
+    /// - `rsync-3.5.0/syscall.c:785` - arm 1, `return do_symlink(lnk, path)`.
+    /// - `rsync-3.5.0/syscall.c:786` - the walk shared by arms 2 and 3.
+    /// - `rsync-3.5.0/syscall.c:848` - arm 2, `symlinkat(lnk, dfd, bname)`.
+    ///   Upstream's operator arm reaches it by falling *through* into a
+    ///   leaf-creation block shared with the beneath-walk tier rather than
+    ///   returning early like its siblings, "so fake-super emulation is
+    ///   preserved" (`rsync-3.5.0/syscall.c:781-783`). oc has no fake-super
+    ///   emulation in this helper, so the syscall pair is identical and the
+    ///   port is the siblings' early return.
+    ///
+    /// # Errors
+    ///
+    /// Arm 3's refusal, or the `symlink(2)` / `symlinkat(2)` errno.
+    pub fn symlink_at(&self, target: &Path, link_path: &Path) -> io::Result<()> {
+        match self.resolve(link_path)? {
+            Resolved::Unconfined => std::os::unix::fs::symlink(target, link_path),
+            Resolved::Confined { parent, leaf } => {
+                crate::symlinkat(target, parent.as_fd(), leaf.as_os_str())
+            }
+        }
+    }
+    /// Create the directory `path` with `mode`.
+    ///
+    /// An existing entry at the leaf is `EEXIST`, exactly as `mkdirat(2)`
+    /// reports it. This is deliberately NOT
+    /// [`operator_mkdir`](crate::operator_mkdir), which walks the same way but
+    /// treats an existing directory as success so a reserved `--partial-dir`
+    /// can be reused across runs. That idempotence belongs to that call site,
+    /// not to upstream's `do_mkdir_at()`; folding the two would swallow a
+    /// collision the receiver has to see.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/syscall.c:2066` `do_mkdir_at()`.
+    /// - `rsync-3.5.0/syscall.c:2084` - arm 1, `return mkdir(path, mode)`.
+    /// - `rsync-3.5.0/syscall.c:2085` - the walk shared by arms 2 and 3.
+    /// - `rsync-3.5.0/syscall.c:2088` - arm 2, `mkdirat(dfd, bname, mode)`.
+    ///
+    /// # Errors
+    ///
+    /// Arm 3's refusal, or the `mkdir(2)` / `mkdirat(2)` errno.
+    pub fn mkdir_at(&self, path: &Path, mode: u32) -> io::Result<()> {
+        match self.resolve(path)? {
+            Resolved::Unconfined => crate::mkdirat(rustix::fs::CWD, path.as_os_str(), mode),
+            Resolved::Confined { parent, leaf } => {
+                crate::mkdirat(parent.as_fd(), leaf.as_os_str(), mode)
+            }
         }
     }
 
@@ -492,7 +552,7 @@ mod tests {
     ///
     /// upstream: `operator_path_resolve` is per call site, and
     /// `abspath_outside_confinement()` returns 0 when it is clear
-    /// (`rsync-3.5.0/syscall.c:216`).
+    /// (`rsync-3.5.0/syscall.c:239`).
     #[test]
     fn an_ancillary_path_is_not_judged_against_the_root() {
         let fx = fixture();
@@ -613,7 +673,7 @@ mod tests {
     /// endpoint independently and returns -1 the moment either side fails, so
     /// an in-root source cannot license an escaping target.
     ///
-    /// upstream: `rsync-3.5.0/syscall.c:1896-1903`.
+    /// upstream: `rsync-3.5.0/syscall.c:1895-1903`.
     #[test]
     fn rename_arm_three_refuses_when_only_the_destination_escapes() {
         let fx = fixture();
@@ -658,7 +718,7 @@ mod tests {
     /// here points at an in-root file, so nothing but the missing flag can
     /// refuse it.
     ///
-    /// upstream: `rsync-3.5.0/syscall.c:1518` -
+    /// upstream: `rsync-3.5.0/syscall.c:1519` -
     /// `openat(dfd, bname, flags | O_NOFOLLOW, mode)`.
     #[test]
     fn open_arm_two_applies_o_nofollow_to_the_leaf() {
@@ -680,7 +740,7 @@ mod tests {
     /// opt-out restores the legacy symlink-following open verbatim, so the same
     /// leaf link opens.
     ///
-    /// upstream: `rsync-3.5.0/syscall.c:1514` - arm 1 is `do_open(pathname,
+    /// upstream: `rsync-3.5.0/syscall.c:1515` - arm 1 is `do_open(pathname,
     /// flags, mode)`, with no added flag.
     #[test]
     fn open_arm_one_still_follows_a_leaf_symlink() {
@@ -706,5 +766,155 @@ mod tests {
         let mut body = String::new();
         std::io::Read::read_to_string(&mut opened, &mut body).expect("read");
         assert_eq!(body, "INSIDE");
+    }
+
+    // --- symlink ------------------------------------------------------------
+
+    /// The link is a CREATE, so arm 3 is proven by the absence of a new entry
+    /// outside the root - not merely by an `Err`, which an unwritable parent
+    /// would also produce.
+    #[test]
+    fn symlink_arm_three_refuses_and_no_link_appears_outside_the_root() {
+        let fx = fixture();
+        let planted = fx.root.join("esc").join("planted");
+        let landing = fx.victim.parent().expect("outside dir").join("planted");
+        confine_to(&fx.root);
+        let err = ConfinedFallback::confined()
+            .symlink_at(Path::new("/etc/passwd"), &planted)
+            .expect_err("arm 3 must refuse an escaping link name");
+        assert_eq!(err.raw_os_error(), Some(libc::ELOOP));
+        assert!(
+            landing.symlink_metadata().is_err(),
+            "arm 3 must not plant a link outside the root"
+        );
+    }
+
+    /// One-variable flip of the cell above: same fixture, same path, opt-out
+    /// set. The link DOES appear outside the root, which is what arm 1 means.
+    #[test]
+    fn symlink_arm_one_still_plants_through_the_escape() {
+        let fx = fixture();
+        let planted = fx.root.join("esc").join("planted");
+        let landing = fx.victim.parent().expect("outside dir").join("planted");
+        confine_to_with_optout(&fx.root);
+        ConfinedFallback::confined()
+            .symlink_at(Path::new("/etc/passwd"), &planted)
+            .expect("arm 1 is the legacy unconfined create");
+        assert!(
+            landing.symlink_metadata().is_ok(),
+            "arm 1 must reach the same place the legacy syscall did"
+        );
+    }
+
+    #[test]
+    fn symlink_arm_two_creates_an_in_root_link() {
+        let fx = fixture();
+        let link = fx.root.join("link");
+        confine_to(&fx.root);
+        ConfinedFallback::confined()
+            .symlink_at(Path::new("payload"), &link)
+            .expect("an in-root link still works");
+        assert_eq!(
+            std::fs::read_link(&link).expect("read_link"),
+            Path::new("payload"),
+            "the target is written verbatim, not resolved"
+        );
+    }
+
+    // --- mkdir --------------------------------------------------------------
+
+    #[test]
+    fn mkdir_arm_three_refuses_and_no_directory_appears_outside_the_root() {
+        let fx = fixture();
+        let planted = fx.root.join("esc").join("planted-dir");
+        let landing = fx
+            .victim_dir
+            .parent()
+            .expect("outside dir")
+            .join("planted-dir");
+        confine_to(&fx.root);
+        let err = ConfinedFallback::confined()
+            .mkdir_at(&planted, 0o777)
+            .expect_err("arm 3 must refuse an escaping directory name");
+        assert_eq!(err.raw_os_error(), Some(libc::ELOOP));
+        assert!(
+            !landing.exists(),
+            "arm 3 must not create a directory outside the root"
+        );
+    }
+
+    #[test]
+    fn mkdir_arm_two_creates_an_in_root_directory() {
+        let fx = fixture();
+        let dir = fx.root.join("fresh");
+        confine_to(&fx.root);
+        ConfinedFallback::confined()
+            .mkdir_at(&dir, 0o777)
+            .expect("an in-root mkdir still works");
+        assert!(dir.is_dir());
+    }
+
+    /// An existing leaf is `EEXIST`, NOT success. This is what separates
+    /// `mkdir_at` from `operator_mkdir`, and without the cell the two could be
+    /// collapsed without any test noticing.
+    #[test]
+    fn mkdir_arm_two_reports_an_existing_directory_as_eexist() {
+        let fx = fixture();
+        let dir = fx.root.join("fresh");
+        confine_to(&fx.root);
+        let cf = ConfinedFallback::confined();
+        cf.mkdir_at(&dir, 0o777).expect("first create");
+        let err = cf
+            .mkdir_at(&dir, 0o777)
+            .expect_err("second must not succeed");
+        assert_eq!(err.raw_os_error(), Some(libc::EEXIST));
+    }
+
+    // --- the precondition every routed call site inherits --------------------
+
+    /// MEASURED, and it is the reason every cell above calls `confine_to`
+    /// first: with no confinement session installed, `session_confinement_root`
+    /// is `None`, the root half of the predicate never fires, and only the
+    /// OWNERSHIP half of the walk runs - which FOLLOWS a euid-owned symlink,
+    /// because a symlink this uid planted is trusted by construction.
+    ///
+    /// ⚠ This is the LOCAL path only, and the distinction is the whole point.
+    /// Production installs one of two sessions, and they differ exactly here:
+    ///
+    /// - `install_local_session` sets `confine_root: None` + `NotDaemon`, so
+    ///   `root()` is `None`, the root half never fires, and only the ownership
+    ///   half runs - which follows a euid-owned symlink by design. That is the
+    ///   state this cell pins, and task 1009 is what flips it.
+    /// - `install_daemon_session` sets `Daemon(module)` with
+    ///   `module.root = Some(..)`, so `root()` is `Some` and the root half
+    ///   FIRES. Routing is fully live on that path today, with no dependency
+    ///   on task 1009.
+    ///
+    /// So the routing is not "unarmed" - it is unarmed on one of two paths.
+    /// `no_sandbox_tail::daemon_session_refuses_an_escaping_unlink` is the
+    /// companion that pins the armed one.
+    ///
+    /// Pinning it here means a future reader cannot mistake the suite's green
+    /// for proof that production refuses the escape, and the cell goes red the
+    /// moment a session IS installed by default - which is exactly when this
+    /// doc would otherwise go stale.
+    #[test]
+    fn an_escape_is_not_refused_until_a_confinement_session_installs_a_root() {
+        let fx = fixture();
+        // Deliberately NO install_session call.
+        assert_eq!(
+            ConfinedFallback::confined()
+                .arm_for(&fx.escape)
+                .expect("with no root installed the walk still resolves"),
+            FallbackArm::Confined,
+            "the ownership half follows our own symlink; only the root half refuses it"
+        );
+        ConfinedFallback::confined()
+            .unlink_at(&fx.escape, UnlinkFlags::File)
+            .expect("and the *at op therefore succeeds");
+        assert!(
+            !fx.victim.exists(),
+            "the out-of-root victim is removed - this is the gap task 1009 closes"
+        );
     }
 }

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
@@ -173,14 +173,16 @@ pub fn linkat(
 ///   component, the helper resolves the leaf through the sandbox dirfd
 ///   so a mid-syscall symlink swap on the leaf cannot redirect the
 ///   create to an attacker-chosen parent.
-/// - In every other case the helper falls back to
-///   [`std::fs::create_dir`] on `dir_path`.
+/// - In every other case the helper applies upstream's three-arm
+///   `do_mkdir_at()` contract to `dir_path` through
+///   [`ConfinedFallback`](crate::ConfinedFallback), so a foreign-owned symlink
+///   on the parent chain is refused instead of followed.
 ///
 /// # Errors
 ///
-/// Surfaces either the [`mkdirat`] error or the
-/// [`std::fs::create_dir`] error verbatim, depending on which path was
-/// taken.
+/// Surfaces either the [`mkdirat`] error or, on the
+/// [`ConfinedFallback`](crate::ConfinedFallback) tail, that op's error
+/// verbatim - including the ownership walk's refusal.
 pub fn mkdirat_via_sandbox_or_fallback(
     sandbox: Option<&crate::dir_sandbox::DirSandbox>,
     dest_dir: &Path,
@@ -198,7 +200,7 @@ pub fn mkdirat_via_sandbox_or_fallback(
     {
         return mkdirat(dirfd.as_fd(), name, mode);
     }
-    std::fs::create_dir(dir_path)
+    crate::ConfinedFallback::confined().mkdir_at(dir_path, mode)
 }
 
 /// Issue `symlinkat` against `link_path` when the `sandbox` root is
@@ -210,14 +212,16 @@ pub fn mkdirat_via_sandbox_or_fallback(
 ///   component, the helper resolves the leaf through the sandbox dirfd
 ///   so a mid-syscall symlink swap on the leaf cannot redirect the
 ///   create to an attacker-chosen parent.
-/// - In every other case the helper falls back to
-///   [`std::os::unix::fs::symlink`] on `link_path`.
+/// - In every other case the helper applies upstream's three-arm
+///   `do_symlink_at()` contract to `link_path` through
+///   [`ConfinedFallback`](crate::ConfinedFallback), so a foreign-owned symlink
+///   on the parent chain is refused instead of followed.
 ///
 /// # Errors
 ///
-/// Surfaces either the [`symlinkat`] error or the
-/// [`std::os::unix::fs::symlink`] error verbatim, depending on which
-/// path was taken.
+/// Surfaces either the [`symlinkat`] error or, on the
+/// [`ConfinedFallback`](crate::ConfinedFallback) tail, that op's error
+/// verbatim - including the ownership walk's refusal.
 pub fn symlinkat_via_sandbox_or_fallback(
     sandbox: Option<&crate::dir_sandbox::DirSandbox>,
     dest_dir: &Path,
@@ -235,7 +239,7 @@ pub fn symlinkat_via_sandbox_or_fallback(
     {
         return symlinkat(target, dirfd.as_fd(), name);
     }
-    std::os::unix::fs::symlink(target, link_path)
+    crate::ConfinedFallback::confined().symlink_at(target, link_path)
 }
 
 /// Issue `linkat` against `new_path` when the `sandbox` root is the

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/open.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/open.rs
@@ -87,13 +87,17 @@ pub fn openat(dirfd: BorrowedFd<'_>, name: &OsStr, flags: i32, mode: u32) -> io:
 ///   component, the helper resolves the leaf through the sandbox dirfd
 ///   so a mid-syscall symlink swap on the leaf cannot redirect the
 ///   open to an attacker-chosen inode.
-/// - In every other case the helper falls back to
-///   [`std::fs::OpenOptions`] against `link_path` with a best-effort
-///   translation of the standard `O_*` bits (`O_RDONLY` / `O_WRONLY` /
-///   `O_RDWR` for the access mode, plus `O_CREAT` / `O_TRUNC` /
-///   `O_APPEND` / `O_EXCL` for the lifecycle modifiers). Flags outside
-///   that set are silently dropped on the fallback path because
-///   [`std::fs::OpenOptions`] does not expose every libc bit.
+/// - In every other case the helper applies upstream's three-arm
+///   `do_open_at()` contract to `link_path` through
+///   [`ConfinedFallback`](crate::ConfinedFallback).
+///
+/// That tail used to translate the flag word onto [`std::fs::OpenOptions`],
+/// which cannot express `O_NOFOLLOW` or `O_DIRECTORY` and dropped them
+/// silently - so a caller asking not to follow the leaf was given a following
+/// open and no error. `ConfinedFallback::open_at` issues a real `openat(2)`,
+/// which honours the whole flag word on both arms, and on arm 2 adds
+/// `O_NOFOLLOW` the way upstream does
+/// (`rsync-3.5.0/syscall.c:1519`).
 ///
 /// Typical temp-file creation passes
 /// `flags = libc::O_RDWR | libc::O_CREAT | libc::O_NOFOLLOW`,
@@ -103,9 +107,10 @@ pub fn openat(dirfd: BorrowedFd<'_>, name: &OsStr, flags: i32, mode: u32) -> io:
 ///
 /// # Errors
 ///
-/// Surfaces either the [`openat`] error or the
-/// [`std::fs::OpenOptions::open`] error verbatim, depending on which
-/// path was taken.
+/// Surfaces either the [`openat`] error or, on the
+/// [`ConfinedFallback`](crate::ConfinedFallback) tail, that op's error
+/// verbatim - including the ownership walk's refusal, and `ELOOP` when the
+/// caller asked for `O_NOFOLLOW` and the leaf is a symlink.
 pub fn openat_via_sandbox_or_fallback(
     sandbox: Option<&crate::dir_sandbox::DirSandbox>,
     dest_dir: &Path,
@@ -119,48 +124,7 @@ pub fn openat_via_sandbox_or_fallback(
     {
         return openat(sandbox.current_dirfd(), leaf, flags, mode);
     }
-    open_path_with_flags(link_path, flags, mode)
-}
-
-/// Best-effort translation of libc `O_*` flag bits onto
-/// [`std::fs::OpenOptions`].
-///
-/// Only the bits the stdlib actually exposes are consulted: the access
-/// mode (`O_RDONLY` / `O_WRONLY` / `O_RDWR`), the lifecycle bits
-/// (`O_CREAT`, `O_TRUNC`, `O_APPEND`, `O_EXCL`), and the create-mode
-/// argument. Everything else (`O_NOFOLLOW`, `O_DIRECTORY`, `O_CLOEXEC`,
-/// `O_NONBLOCK`, ...) is silently dropped on the fallback path because
-/// the stdlib has no portable knob for them; callers that need those
-/// semantics must take the sandbox fast path.
-fn open_path_with_flags(path: &Path, flags: i32, mode: u32) -> io::Result<File> {
-    use std::os::unix::fs::OpenOptionsExt;
-
-    let mut opts = std::fs::OpenOptions::new();
-    match flags & libc::O_ACCMODE {
-        libc::O_WRONLY => {
-            opts.write(true);
-        }
-        libc::O_RDWR => {
-            opts.read(true).write(true);
-        }
-        _ => {
-            opts.read(true);
-        }
-    }
-    if flags & libc::O_CREAT != 0 {
-        opts.create(true);
-        opts.mode(mode);
-    }
-    if flags & libc::O_TRUNC != 0 {
-        opts.truncate(true);
-    }
-    if flags & libc::O_APPEND != 0 {
-        opts.append(true);
-    }
-    if flags & libc::O_EXCL != 0 {
-        opts.create_new(true);
-    }
-    opts.open(path)
+    crate::ConfinedFallback::confined().open_at(link_path, flags, mode)
 }
 
 /// Issue `readlinkat(dirfd, name, buf, size)` and return the link

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
@@ -139,9 +139,10 @@ pub fn renameat(
 ///   relatives, the helper resolves both leaves through the sandbox
 ///   dirfd so a mid-syscall symlink swap on either leaf cannot redirect
 ///   the rename to an attacker-chosen inode.
-/// - In every other case the helper falls back to [`std::fs::rename`]
-///   on the absolute paths so behaviour matches the existing
-///   path-based commit semantics.
+/// - In every other case the helper applies upstream's three-arm
+///   `do_rename_at()` contract to both absolute paths through
+///   [`ConfinedFallback`](crate::ConfinedFallback), which walks each endpoint
+///   independently and honours `replace`.
 ///
 /// Today both endpoints anchor on `sandbox.current_dirfd()` because the
 /// receiver always creates its temp file inside the same destination
@@ -156,8 +157,9 @@ pub fn renameat(
 ///
 /// # Errors
 ///
-/// Surfaces either the [`renameat`] error or the [`std::fs::rename`]
-/// error verbatim, depending on which path was taken.
+/// Surfaces either the [`renameat`] error or, on the
+/// [`ConfinedFallback`](crate::ConfinedFallback) tail, that op's error
+/// verbatim - including the ownership walk's refusal of either endpoint.
 #[allow(clippy::too_many_arguments)]
 pub fn renameat_via_sandbox_or_fallback(
     sandbox: Option<&crate::dir_sandbox::DirSandbox>,
@@ -195,7 +197,10 @@ pub fn renameat_via_sandbox_or_fallback(
     if sandbox.is_some() {
         return confined_rename(old_dest_dir, old_link_path, new_link_path, replace);
     }
-    std::fs::rename(old_link_path, new_link_path)
+    // `replace` is honoured here too. The old `std::fs::rename` tail always
+    // replaced, so `replace == false` silently lost `RENAME_NOREPLACE` on
+    // exactly the paths with no sandbox to enforce it.
+    crate::ConfinedFallback::confined().rename_at(old_link_path, new_link_path, replace)
 }
 
 /// One endpoint of a confined commit, already reduced to a dirfd plus a name to

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
@@ -1904,3 +1904,184 @@ mod endpoint_provenance {
         );
     }
 }
+
+/// The `sandbox = None` tail of every `*_via_sandbox_or_fallback` helper.
+///
+/// These are the ONLY cells that reach that tail. Measured: reverting all five
+/// tails to their old `std::fs` form killed nothing in fast_io (1140/1140),
+/// transfer (2761/2761) or engine - the routing shipped uncovered until these
+/// existed. Each cell asserts the out-of-root VICTIM survives, not merely that
+/// the call returned `Err`, because an unwritable parent would produce `Err`
+/// too and could not tell a refusal from an unrelated failure.
+#[cfg(unix)]
+mod no_sandbox_tail {
+    use super::*;
+    use crate::UnlinkFlags;
+    use crate::confinement::{
+        Activation, DaemonState, LocalInsecureLinks, ModuleInsecureLinks, ModuleState, Role,
+        install_daemon_session, install_session,
+    };
+    use std::path::{Path, PathBuf};
+
+    struct Fx {
+        _keep: tempfile::TempDir,
+        root: PathBuf,
+        /// Spelled inside the root, lands outside it through a euid-owned
+        /// symlink the walk trusts and therefore FOLLOWS.
+        escape: PathBuf,
+        /// What `escape` really resolves to.
+        victim: PathBuf,
+        /// The out-of-root directory `escape`'s parent resolves to.
+        outside: PathBuf,
+    }
+
+    fn fixture() -> Fx {
+        let (keep, temp) = canonical_tempdir();
+        let root = temp.join("module");
+        std::fs::create_dir(&root).expect("mkdir module");
+        let outside = temp.join("outside");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        let victim = outside.join("secret");
+        std::fs::write(&victim, b"OUTSIDE").expect("write victim");
+        symlink("../outside", root.join("esc")).expect("symlink esc");
+        // The root half of the confinement predicate only fires once a session
+        // supplies a root; without it the ownership walk FOLLOWS our own
+        // symlink and the tail is inert. See ConfinedFallback's
+        // `an_escape_is_not_refused_until_a_confinement_session_installs_a_root`.
+        install_session(&Activation {
+            role: Role::Receiver,
+            daemon: DaemonState::NotDaemon,
+            insecure_links: LocalInsecureLinks::default(),
+            confine_root: Some(root.clone()),
+        });
+        Fx {
+            _keep: keep,
+            escape: root.join("esc").join("secret"),
+            root,
+            victim,
+            outside,
+        }
+    }
+
+    #[test]
+    fn unlink_tail_refuses_an_escaping_path() {
+        let fx = fixture();
+        unlink_via_sandbox_or_fallback(
+            None,
+            &fx.root,
+            Path::new("esc/secret"),
+            &fx.escape,
+            UnlinkFlags::File,
+        )
+        .expect_err("the tail must apply the three-arm contract, not unlink()");
+        assert!(fx.victim.exists(), "the out-of-root victim must survive");
+    }
+
+    #[test]
+    fn recursive_unlink_tail_refuses_an_escaping_tree() {
+        let fx = fixture();
+        let victim_dir = fx.outside.join("subdir");
+        std::fs::create_dir(&victim_dir).expect("mkdir subdir");
+        std::fs::write(victim_dir.join("child"), b"CHILD").expect("write child");
+        recursive_unlinkat_via_sandbox_or_fallback(
+            None,
+            &fx.root,
+            Path::new("esc/subdir"),
+            &fx.root.join("esc").join("subdir"),
+        )
+        .expect_err("the recursive tail must refuse an escaping root");
+        assert!(
+            victim_dir.join("child").exists(),
+            "the out-of-root tree must survive"
+        );
+    }
+
+    #[test]
+    fn mkdir_tail_refuses_an_escaping_path() {
+        let fx = fixture();
+        let planted = fx.root.join("esc").join("planted");
+        mkdirat_via_sandbox_or_fallback(None, &fx.root, Path::new("esc/planted"), &planted, 0o777)
+            .expect_err("the tail must refuse an escaping directory name");
+        assert!(
+            !fx.outside.join("planted").exists(),
+            "no directory may appear outside the root"
+        );
+    }
+
+    #[test]
+    fn symlink_tail_refuses_an_escaping_path() {
+        let fx = fixture();
+        let planted = fx.root.join("esc").join("planted");
+        symlinkat_via_sandbox_or_fallback(
+            None,
+            &fx.root,
+            Path::new("esc/planted"),
+            &planted,
+            Path::new("/etc/passwd"),
+        )
+        .expect_err("the tail must refuse an escaping link name");
+        assert!(
+            fx.outside.join("planted").symlink_metadata().is_err(),
+            "no link may appear outside the root"
+        );
+    }
+
+    /// The DAEMON session, which is where this routing is live today.
+    ///
+    /// `install_daemon_session` supplies `module.root`, so `root()` is `Some`
+    /// and the root half of the predicate fires - unlike
+    /// `install_local_session`, which leaves it `None`. Without this cell the
+    /// suite would pin only the shape that a test fixture arranges, never the
+    /// one production actually reaches first.
+    #[test]
+    fn daemon_session_refuses_an_escaping_unlink() {
+        let (keep, temp) = canonical_tempdir();
+        let root = temp.join("module");
+        std::fs::create_dir(&root).expect("mkdir module");
+        let outside = temp.join("outside");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        let victim = outside.join("secret");
+        std::fs::write(&victim, b"OUTSIDE").expect("write victim");
+        symlink("../outside", root.join("esc")).expect("symlink esc");
+        install_daemon_session(ModuleState {
+            root: Some(root.clone()),
+            chrooted: false,
+            selected: true,
+            insecure_links: ModuleInsecureLinks::default(),
+        });
+        unlink_via_sandbox_or_fallback(
+            None,
+            &root,
+            Path::new("esc/secret"),
+            &root.join("esc").join("secret"),
+            UnlinkFlags::File,
+        )
+        .expect_err("a daemon session must refuse a module escape");
+        assert!(victim.exists(), "the out-of-module victim must survive");
+        drop(keep);
+    }
+
+    #[test]
+    fn rename_tail_refuses_an_escaping_destination() {
+        let fx = fixture();
+        let inside = fx.root.join("payload");
+        std::fs::write(&inside, b"INSIDE").expect("write inside");
+        let landing = fx.root.join("esc").join("moved");
+        renameat_via_sandbox_or_fallback(
+            None,
+            &fx.root,
+            Path::new("payload"),
+            &inside,
+            &fx.root,
+            Path::new("esc/moved"),
+            &landing,
+            true,
+        )
+        .expect_err("an escaping destination must refuse the whole rename");
+        assert!(
+            !fx.outside.join("moved").exists(),
+            "nothing may land outside the root"
+        );
+        assert!(inside.exists(), "and the source must be left alone");
+    }
+}

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
@@ -2033,6 +2033,93 @@ mod no_sandbox_tail {
     /// `install_local_session`, which leaves it `None`. Without this cell the
     /// suite would pin only the shape that a test fixture arranges, never the
     /// one production actually reaches first.
+    /// The open tail dropped `O_NOFOLLOW` silently, so a caller asking not to
+    /// follow the leaf got a FOLLOWING open and no error.
+    ///
+    /// The assertion is on WHAT WAS OPENED, not merely that the call failed:
+    /// the companion below opens the same link without `O_NOFOLLOW` and reads
+    /// the target, which proves the fixture really does have a followable
+    /// symlink. Without that pair, a broken fixture would satisfy the refusal
+    /// cell for the wrong reason.
+    ///
+    /// upstream: `rsync-3.5.0/syscall.c:1519` - `openat(dfd, bname,
+    /// flags | O_NOFOLLOW, mode)`.
+    #[test]
+    fn open_tail_honours_o_nofollow_on_the_leaf() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::write(root.join("target"), b"TARGET").expect("write target");
+        symlink("target", root.join("leaf")).expect("symlink leaf");
+        let leaf = root.join("leaf");
+        assert_eq!(
+            std::fs::read_to_string(&leaf).expect("fixture link resolves"),
+            "TARGET",
+            "the fixture must be a followable symlink, or the refusal below \
+             would hold for the wrong reason"
+        );
+        let err = openat_via_sandbox_or_fallback(
+            None,
+            &root,
+            Path::new("leaf"),
+            &leaf,
+            libc::O_RDONLY | libc::O_NOFOLLOW,
+            0,
+        )
+        .expect_err("O_NOFOLLOW must reach the syscall, not be dropped");
+        assert_eq!(err.raw_os_error(), Some(libc::ELOOP));
+    }
+
+    /// Non-vacuity companion, and the pin on the rest of the flag word:
+    /// `O_DIRECTORY` against a REGULAR file. The deleted translator dropped it
+    /// exactly as it dropped `O_NOFOLLOW`, so the open succeeded; a real
+    /// `openat(2)` reports `ENOTDIR`.
+    ///
+    /// This is the companion rather than "the same leaf without `O_NOFOLLOW`":
+    /// arm 2 adds `O_NOFOLLOW` on the caller's behalf whatever the caller
+    /// asked for (`rsync-3.5.0/syscall.c:1519`), so a follow could not be
+    /// observed here without contradicting upstream. `O_DIRECTORY` is not
+    /// added by either side, so it isolates the flag word itself.
+    #[test]
+    fn open_tail_honours_o_directory_on_a_regular_file() {
+        let (_keep, root) = canonical_tempdir();
+        let file = root.join("plain");
+        std::fs::write(&file, b"BODY").expect("write plain");
+        assert_eq!(
+            std::fs::read_to_string(&file).expect("fixture readable"),
+            "BODY",
+            "the fixture must be an ordinarily openable regular file"
+        );
+        let err = openat_via_sandbox_or_fallback(
+            None,
+            &root,
+            Path::new("plain"),
+            &file,
+            libc::O_RDONLY | libc::O_DIRECTORY,
+            0,
+        )
+        .expect_err("O_DIRECTORY must reach the syscall, not be dropped");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOTDIR));
+    }
+
+    /// And the same escape shape the other four tails pin, for the open tail.
+    #[test]
+    fn open_tail_refuses_an_escaping_path() {
+        let fx = fixture();
+        openat_via_sandbox_or_fallback(
+            None,
+            &fx.root,
+            Path::new("esc/secret"),
+            &fx.escape,
+            libc::O_RDONLY,
+            0,
+        )
+        .expect_err("the tail must refuse a path escaping the root");
+        assert_eq!(
+            std::fs::read_to_string(&fx.victim).expect("victim readable"),
+            "OUTSIDE",
+            "the out-of-root victim must be untouched"
+        );
+    }
+
     #[test]
     fn daemon_session_refuses_an_escaping_unlink() {
         let (keep, temp) = canonical_tempdir();

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
@@ -196,15 +196,17 @@ pub fn unlink_path(path: &Path, flags: UnlinkFlags) -> io::Result<()> {
 ///   component, the helper resolves the leaf through the sandbox dirfd
 ///   so a mid-syscall symlink swap on the leaf cannot redirect the
 ///   unlink to an attacker-chosen parent.
-/// - In every other case the helper falls back to
-///   [`std::fs::remove_file`] / [`std::fs::remove_dir`] on `link_path`,
-///   per the [`UnlinkFlags`] selector.
+/// - In every other case the helper applies upstream's three-arm
+///   `do_unlink_at()` contract to `link_path` through
+///   [`ConfinedFallback`](crate::ConfinedFallback): a plain path syscall only
+///   when the opt-out is set, the `*at` form against a walked parent
+///   otherwise, and an error - never a plain syscall - when the walk refuses.
 ///
 /// # Errors
 ///
-/// Surfaces either the [`unlinkat`] error or the
-/// [`std::fs::remove_file`] / [`std::fs::remove_dir`] error verbatim,
-/// depending on which path was taken.
+/// Surfaces either the [`unlinkat`] error or, on the
+/// [`ConfinedFallback`](crate::ConfinedFallback) tail, that op's error
+/// verbatim - including the ownership walk's refusal.
 pub fn unlink_via_sandbox_or_fallback(
     sandbox: Option<&crate::dir_sandbox::DirSandbox>,
     dest_dir: &Path,
@@ -222,10 +224,10 @@ pub fn unlink_via_sandbox_or_fallback(
     {
         return unlinkat(dirfd.as_fd(), name, flags);
     }
-    match flags {
-        UnlinkFlags::File => std::fs::remove_file(link_path),
-        UnlinkFlags::Dir => std::fs::remove_dir(link_path),
-    }
+    // No sandbox anchored the leaf, so this is upstream's `do_unlink_at()`
+    // decision rather than a free path syscall: policy picks the arm, and a
+    // refused walk is an error, never a plain `unlink`.
+    crate::ConfinedFallback::confined().unlink_at(link_path, flags)
 }
 
 /// Recursively remove the directory at `target_path` anchored on the
@@ -247,17 +249,21 @@ pub fn unlink_via_sandbox_or_fallback(
 ///    level. After the inner loop drains, the helper closes the walked
 ///    dirfd and removes the now-empty directory through [`unlinkat`]
 ///    with [`UnlinkFlags::Dir`] against the sandbox parent.
-/// 2. In every other case the helper falls back to
-///    [`std::fs::remove_dir_all`] on `target_path`. The fallback is
-///    vulnerable to the symlink-swap class the carrier closes and is
-///    intended only for the no-sandbox contexts (test fixtures,
-///    client-side `--local` callers, callers that have not yet plumbed
-///    a [`DirSandbox`](crate::dir_sandbox::DirSandbox)).
+/// 2. In every other case the helper applies upstream's three-arm contract
+///    to `target_path` through
+///    [`ConfinedFallback`](crate::ConfinedFallback). The descent still starts
+///    from a walked parent rather than from a path the kernel re-resolves, so
+///    the no-sandbox contexts (test fixtures, client-side `--local` callers,
+///    callers that have not yet plumbed a
+///    [`DirSandbox`](crate::dir_sandbox::DirSandbox)) are no longer open to
+///    the symlink-swap class the carrier closes. Only the opt-out arm still
+///    reaches [`std::fs::remove_dir_all`], which is what that arm means.
 ///
 /// `target_path` must point at a directory; a non-directory leaf is
 /// surfaced verbatim from the kernel as `ENOTDIR`. A symlink at the
-/// leaf is refused with `ELOOP` (sandbox path, via `O_NOFOLLOW`) or
-/// returned verbatim from [`std::fs::remove_dir_all`] (fallback path).
+/// leaf is refused with `ELOOP` (sandbox path, via `O_NOFOLLOW`; and on the
+/// [`ConfinedFallback`](crate::ConfinedFallback) tail, from the ownership
+/// walk) or returned verbatim from [`std::fs::remove_dir_all`] (opt-out arm).
 ///
 /// # Errors
 ///
@@ -325,12 +331,21 @@ fn residue_to_legacy_result(residue: UnlinkResidue) -> io::Result<()> {
 /// chmod during the walk is swallowed and surfaces later as the retry's
 /// own `EACCES`.
 fn remove_dir_all_with_uid_write_fix(target_path: &Path) -> io::Result<()> {
-    match std::fs::remove_dir_all(target_path) {
+    // BOTH attempts go through the contract. Routing only the first would let
+    // the `EACCES` retry re-resolve `target_path` with libc and undo a refusal
+    // the walk had just issued - the same "half the fix is inert on the second
+    // path" shape as the `--partial-dir` abort path.
+    let peel = || {
+        crate::ConfinedFallback::confined()
+            .remove_dir_all_at(target_path)
+            .and_then(residue_to_legacy_result)
+    };
+    match peel() {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::PermissionDenied => {
             fix_uid_write_recursive(target_path);
-            match std::fs::remove_dir_all(target_path) {
+            match peel() {
                 Ok(()) => Ok(()),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
                 Err(err) => Err(err),

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -87,6 +87,12 @@ pub mod cached_sort;
 /// Unix-only: mirrors upstream `secure_relative_open` so a non-chroot
 /// daemon sender cannot be redirected outside its module by a swapped
 /// directory symlink (TOCTOU escape).
+/// Upstream's three-arm fallback contract for a path-based syscall.
+///
+/// Unix-only: the contract is stated in terms of a parent dirfd and a
+/// `*at` syscall, neither of which the Windows arms have.
+#[cfg(unix)]
+pub mod confined_fallback;
 pub mod confined_open;
 pub mod confined_readdir;
 /// Path-confinement activation: who is confined, and against what root.
@@ -378,6 +384,8 @@ pub use traits::{FileReader, FileWriter};
 pub use gcd::{GcdQueue, GcdReader, GcdWriter};
 
 #[cfg(unix)]
+pub use confined_fallback::{ConfinedFallback, FallbackArm};
+#[cfg(unix)]
 pub use confined_open::{
     DestLeafKind, LeafPolicy, open_source_confined, pin_dest_leaf_confined, read_link_confined,
 };
@@ -410,7 +418,8 @@ pub use owner_walk::{
     operator_link, operator_mkdir, operator_open_append, operator_open_create_new,
     operator_open_read, operator_open_read_confined, operator_open_recv, operator_open_rw_create,
     operator_open_write_create, operator_open_write_create_confined, operator_read_to_string,
-    operator_rename, operator_symlink_metadata, owner_trusted_parent, symlink_owner_is_trusted,
+    operator_rename, operator_symlink_metadata, owner_trusted_parent, owner_trusted_parent_kind,
+    symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -474,6 +474,29 @@ fn owner_walk_open(
 ///   which no operator path being renamed onto can have.
 /// - Otherwise see `owner_walk_open`.
 pub fn owner_trusted_parent(path: &Path) -> io::Result<(OwnedFd, OsString)> {
+    owner_trusted_parent_kind(path, crate::confinement::PathKind::Ancillary)
+}
+
+/// [`owner_trusted_parent`] with the caller's [`PathKind`](crate::confinement::PathKind).
+///
+/// The parent walk and the confinement judgement are one decision upstream -
+/// `owner_walk_parent()` reads `operator_path_resolve`, which its call sites
+/// set around themselves - so a site whose path must stay under the session
+/// root has to say so here. [`owner_trusted_parent`] is the
+/// [`Ancillary`](crate::confinement::PathKind::Ancillary) spelling and keeps
+/// its existing callers unchanged.
+///
+/// upstream: `rsync-3.5.0/syscall.c:558` `owner_walk_parent()`, and
+/// `rsync-3.5.0/syscall.c:552` `int operator_path_resolve = 0;` - the flag this
+/// parameter replaces.
+///
+/// # Errors
+///
+/// See [`owner_trusted_parent`].
+pub fn owner_trusted_parent_kind(
+    path: &Path,
+    kind: crate::confinement::PathKind,
+) -> io::Result<(OwnedFd, OsString)> {
     let Some(leaf) = path.file_name().map(OsStr::to_os_string) else {
         return Err(io::Error::from_raw_os_error(libc::EINVAL));
     };
@@ -482,7 +505,7 @@ pub fn owner_trusted_parent(path: &Path) -> io::Result<(OwnedFd, OsString)> {
         parent,
         OFlags::RDONLY | OFlags::DIRECTORY,
         Mode::empty(),
-        crate::confinement::PathKind::Ancillary,
+        kind,
     )?;
     Ok((dirfd, leaf))
 }

--- a/crates/fast_io/tests/unconfined_fallback_escape.rs
+++ b/crates/fast_io/tests/unconfined_fallback_escape.rs
@@ -69,7 +69,7 @@ impl Fixture {
 ///
 /// The assertion is load-bearing: a mutation sweep that replaced the
 /// planted symlinks with regular files left
-/// [`open_fallback_drops_o_nofollow_at_the_leaf`] still passing, because
+/// [`open_fallback_honours_o_nofollow_at_the_leaf`] still passing, because
 /// reading the expected bytes back does not by itself say the leaf was
 /// followed. Pinning the fixture shape is what makes that test
 /// falsifiable.
@@ -207,20 +207,24 @@ fn open_fallback_without_a_symlink_stays_in_the_tree() {
     assert_eq!(read_to_string(&mut opened), "in-tree");
 }
 
-/// The second, independent defect: the fallback rebuilds the open from
-/// `OpenOptions`, which cannot express `O_NOFOLLOW`, so the caller's
-/// refusal to follow the TERMINAL component is discarded. The leaf here
-/// is itself a symlink out of the tree; a call that honoured the flag
-/// would fail with `ELOOP`, and instead it succeeds and reads the
-/// out-of-tree bytes.
+/// The second, independent defect, now CLOSED: the fallback rebuilt the
+/// open from `OpenOptions`, which cannot express `O_NOFOLLOW`, so the
+/// caller's refusal to follow the TERMINAL component was discarded and
+/// the symlinked leaf resolved out of the tree. The fallback now honours
+/// the whole flag word and refuses with `ELOOP`.
+///
+/// Paired with [`the_sandbox_branch_honours_o_nofollow_on_the_same_leaf`],
+/// which asserts the SAME refusal through the confined branch. The pair
+/// began as a DIVERGENCE pin - the two branches disagreed, and that
+/// disagreement is what identified the dropped flag. It is now a PARITY
+/// pin: the fallback must not drift away from the confined branch again.
 #[test]
-fn open_fallback_drops_o_nofollow_at_the_leaf() {
+fn open_fallback_honours_o_nofollow_at_the_leaf() {
     let fixture = Fixture::new();
     fs::write(fixture.outside.join("secret"), b"out-of-tree").expect("plant the secret");
     let leaf = fixture.root.join("leaflink");
     plant_symlink(&fixture.outside.join("secret"), &leaf);
-
-    let mut opened = fast_io::openat_via_sandbox_or_fallback(
+    let err = fast_io::openat_via_sandbox_or_fallback(
         None,
         &fixture.root,
         Path::new("leaflink"),
@@ -228,20 +232,44 @@ fn open_fallback_drops_o_nofollow_at_the_leaf() {
         libc::O_RDONLY | libc::O_NOFOLLOW,
         0,
     )
-    .expect("O_NOFOLLOW is dropped, so the symlinked leaf is followed");
-
+    .expect_err("the fallback must refuse the symlinked leaf under O_NOFOLLOW");
     assert_eq!(
-        read_to_string(&mut opened),
-        "out-of-tree",
-        "no escape: the followed leaf did not resolve out of the tree"
+        err.raw_os_error(),
+        Some(libc::ELOOP),
+        "expected O_NOFOLLOW to refuse the leaf, got {err}"
     );
 }
 
-/// Paired control for [`open_fallback_drops_o_nofollow_at_the_leaf`]:
+/// Non-vacuity companion for [`open_fallback_honours_o_nofollow_at_the_leaf`].
+///
+/// The sandbox branch already had one; the fallback branch did not, because
+/// while its pin asserted a SUCCESS the success was itself the evidence.
+/// Now that it asserts a refusal, the pin would pass just as well if the
+/// fallback refused every input - so a regular in-tree leaf under the same
+/// `O_NOFOLLOW` must still open.
+#[test]
+fn open_fallback_opens_a_regular_leaf_under_o_nofollow() {
+    let fixture = Fixture::new();
+    let leaf = fixture.root.join("real").join("secret");
+    fs::write(&leaf, b"in-tree").expect("plant the in-tree leaf");
+    let mut opened = fast_io::openat_via_sandbox_or_fallback(
+        None,
+        &fixture.root,
+        Path::new("real/secret"),
+        &leaf,
+        libc::O_RDONLY | libc::O_NOFOLLOW,
+        0,
+    )
+    .expect("a regular in-tree leaf still opens under O_NOFOLLOW");
+    assert_eq!(read_to_string(&mut opened), "in-tree");
+}
+
+/// Paired control for [`open_fallback_honours_o_nofollow_at_the_leaf`]:
 /// the SAME leaf, the SAME flags, routed through a real `DirSandbox` so
-/// the confined `openat` branch runs instead. It fails with `ELOOP`,
-/// which is what identifies the flag as dropped by the fallback rather
-/// than ignored by the kernel.
+/// the confined `openat` branch runs instead. Both branches must now
+/// refuse with `ELOOP`. This cell is what proved the kernel was not
+/// simply ignoring the flag: it refused here even while the fallback
+/// still followed.
 #[test]
 fn the_sandbox_branch_honours_o_nofollow_on_the_same_leaf() {
     let fixture = Fixture::new();

--- a/crates/fast_io/tests/unconfined_fallback_escape.rs
+++ b/crates/fast_io/tests/unconfined_fallback_escape.rs
@@ -1,0 +1,291 @@
+//! CF-P0c: the `*_via_sandbox_or_fallback` tails escape the tree.
+//!
+//! Both helpers take a `sandbox: Option<&DirSandbox>`. It is `None` for
+//! every caller that has not yet been plumbed with a sandbox, plus every
+//! local-copy path, and then the confined branch is skipped entirely and
+//! the call lands on a bare `std::fs` entry point:
+//!
+//! - `renameat_via_sandbox_or_fallback` falls through to
+//!   `std::fs::rename(old_link_path, new_link_path)`.
+//! - `openat_via_sandbox_or_fallback` falls through to
+//!   `open_path_with_flags(link_path, ..)`, which rebuilds the open from
+//!   `std::fs::OpenOptions`.
+//!
+//! Both resolve the whole path through the kernel with symlink following
+//! enabled, so a planted component redirects them out of the tree. The
+//! open fallback carries a second, independent defect: `OpenOptions` has
+//! no knob for `O_NOFOLLOW`, so that bit is silently discarded and even
+//! the terminal component is followed. `open.rs` states this ("Flags
+//! outside that set are silently dropped on the fallback path"); these
+//! tests make it observable.
+//!
+//! This is a RED baseline, not a regression guard. Each escape test is
+//! paired with a companion proving the fixture is capable of ordinary,
+//! non-escaping behaviour, so no assertion here can pass vacuously.
+//!
+//! upstream: `rsync-3.5.0/syscall.c:1918-1923` `do_rename_at()` and
+//! `:2896-2961` `ds_descend()` - upstream confines each endpoint per
+//! component rather than handing a full path to the kernel.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use fast_io::dir_sandbox::DirSandbox;
+use tempfile::TempDir;
+
+/// The two-tree fixture every test in this module shares.
+///
+/// `root` is the tree the caller believes it is confined to; `outside`
+/// is a sibling nothing may reach. `root/hop` is a symlink to `outside`,
+/// standing in for a component flipped under the caller's feet.
+struct Fixture {
+    _base: TempDir,
+    root: PathBuf,
+    outside: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let base = TempDir::new().expect("tempdir");
+        let root = base.path().join("root");
+        let outside = base.path().join("outside");
+        fs::create_dir(&root).expect("mkdir root");
+        fs::create_dir(&outside).expect("mkdir outside");
+        plant_symlink(&outside, &root.join("hop"));
+        fs::create_dir(root.join("real")).expect("mkdir real");
+        Self {
+            _base: base,
+            root,
+            outside,
+        }
+    }
+}
+
+/// Plant a symlink at `link` pointing at `target`, asserting the result
+/// really is one.
+///
+/// The assertion is load-bearing: a mutation sweep that replaced the
+/// planted symlinks with regular files left
+/// [`open_fallback_drops_o_nofollow_at_the_leaf`] still passing, because
+/// reading the expected bytes back does not by itself say the leaf was
+/// followed. Pinning the fixture shape is what makes that test
+/// falsifiable.
+fn plant_symlink(target: &Path, link: &Path) {
+    std::os::unix::fs::symlink(target, link).expect("plant symlink");
+    assert!(
+        link.symlink_metadata()
+            .expect("stat the planted link")
+            .file_type()
+            .is_symlink(),
+        "fixture broken: {} is not a symlink",
+        link.display()
+    );
+}
+
+fn read_to_string(file: &mut fs::File) -> String {
+    let mut body = String::new();
+    file.read_to_string(&mut body).expect("read opened file");
+    body
+}
+
+/// `renameat_via_sandbox_or_fallback(None, ..)` reaches `std::fs::rename`,
+/// which walks `root/hop` into the sibling tree and publishes the staged
+/// file there.
+#[test]
+fn rename_fallback_escapes_through_a_symlinked_destination_parent() {
+    let fixture = Fixture::new();
+    let staged = fixture.root.join(".tmp");
+    fs::write(&staged, b"payload").expect("stage the temp file");
+    let committed = fixture.root.join("hop").join("committed");
+
+    fast_io::renameat_via_sandbox_or_fallback(
+        None,
+        &fixture.root,
+        Path::new(".tmp"),
+        &staged,
+        &fixture.root,
+        Path::new("hop/committed"),
+        &committed,
+        true,
+    )
+    .expect("the unconfined rename follows the planted symlink");
+
+    let escaped = fixture.outside.join("committed");
+    assert_eq!(
+        fs::read_to_string(&escaped).ok().as_deref(),
+        Some("payload"),
+        "no escape: {} does not hold the staged payload",
+        escaped.display()
+    );
+    assert!(
+        !fixture.root.join("real").join("committed").exists(),
+        "fixture broken: the payload also appeared inside the tree"
+    );
+}
+
+/// Non-vacuity companion: with no symlink in the destination path the
+/// same fallback performs an ordinary in-tree commit.
+#[test]
+fn rename_fallback_without_a_symlink_stays_in_the_tree() {
+    let fixture = Fixture::new();
+    let staged = fixture.root.join(".tmp");
+    fs::write(&staged, b"payload").expect("stage the temp file");
+    let committed = fixture.root.join("real").join("committed");
+
+    fast_io::renameat_via_sandbox_or_fallback(
+        None,
+        &fixture.root,
+        Path::new(".tmp"),
+        &staged,
+        &fixture.root,
+        Path::new("real/committed"),
+        &committed,
+        true,
+    )
+    .expect("an ordinary in-tree commit");
+
+    assert_eq!(
+        fs::read_to_string(&committed).ok().as_deref(),
+        Some("payload"),
+        "the in-tree commit should have landed"
+    );
+    assert!(
+        !fixture.outside.join("committed").exists(),
+        "nothing outside the tree may be touched"
+    );
+}
+
+/// `openat_via_sandbox_or_fallback(None, ..)` reaches
+/// `open_path_with_flags`, which walks `root/hop` into the sibling tree
+/// and hands back a handle on the out-of-tree inode.
+#[test]
+fn open_fallback_escapes_through_a_symlinked_parent() {
+    let fixture = Fixture::new();
+    fs::write(fixture.outside.join("secret"), b"out-of-tree").expect("plant the secret");
+    fs::write(fixture.root.join("real").join("secret"), b"in-tree").expect("plant the decoy");
+    let link_path = fixture.root.join("hop").join("secret");
+
+    let mut opened = fast_io::openat_via_sandbox_or_fallback(
+        None,
+        &fixture.root,
+        Path::new("hop/secret"),
+        &link_path,
+        libc::O_RDONLY,
+        0,
+    )
+    .expect("the unconfined open follows the planted symlink");
+
+    assert_eq!(
+        read_to_string(&mut opened),
+        "out-of-tree",
+        "no escape: the open resolved inside the tree"
+    );
+}
+
+/// Non-vacuity companion: the same fallback against a real in-tree
+/// parent opens the in-tree file.
+#[test]
+fn open_fallback_without_a_symlink_stays_in_the_tree() {
+    let fixture = Fixture::new();
+    fs::write(fixture.outside.join("secret"), b"out-of-tree").expect("plant the secret");
+    fs::write(fixture.root.join("real").join("secret"), b"in-tree").expect("plant the decoy");
+    let link_path = fixture.root.join("real").join("secret");
+
+    let mut opened = fast_io::openat_via_sandbox_or_fallback(
+        None,
+        &fixture.root,
+        Path::new("real/secret"),
+        &link_path,
+        libc::O_RDONLY,
+        0,
+    )
+    .expect("an ordinary in-tree open");
+
+    assert_eq!(read_to_string(&mut opened), "in-tree");
+}
+
+/// The second, independent defect: the fallback rebuilds the open from
+/// `OpenOptions`, which cannot express `O_NOFOLLOW`, so the caller's
+/// refusal to follow the TERMINAL component is discarded. The leaf here
+/// is itself a symlink out of the tree; a call that honoured the flag
+/// would fail with `ELOOP`, and instead it succeeds and reads the
+/// out-of-tree bytes.
+#[test]
+fn open_fallback_drops_o_nofollow_at_the_leaf() {
+    let fixture = Fixture::new();
+    fs::write(fixture.outside.join("secret"), b"out-of-tree").expect("plant the secret");
+    let leaf = fixture.root.join("leaflink");
+    plant_symlink(&fixture.outside.join("secret"), &leaf);
+
+    let mut opened = fast_io::openat_via_sandbox_or_fallback(
+        None,
+        &fixture.root,
+        Path::new("leaflink"),
+        &leaf,
+        libc::O_RDONLY | libc::O_NOFOLLOW,
+        0,
+    )
+    .expect("O_NOFOLLOW is dropped, so the symlinked leaf is followed");
+
+    assert_eq!(
+        read_to_string(&mut opened),
+        "out-of-tree",
+        "no escape: the followed leaf did not resolve out of the tree"
+    );
+}
+
+/// Paired control for [`open_fallback_drops_o_nofollow_at_the_leaf`]:
+/// the SAME leaf, the SAME flags, routed through a real `DirSandbox` so
+/// the confined `openat` branch runs instead. It fails with `ELOOP`,
+/// which is what identifies the flag as dropped by the fallback rather
+/// than ignored by the kernel.
+#[test]
+fn the_sandbox_branch_honours_o_nofollow_on_the_same_leaf() {
+    let fixture = Fixture::new();
+    fs::write(fixture.outside.join("secret"), b"out-of-tree").expect("plant the secret");
+    let leaf = fixture.root.join("leaflink");
+    plant_symlink(&fixture.outside.join("secret"), &leaf);
+    let sandbox = DirSandbox::open_root(&fixture.root).expect("open the sandbox root");
+
+    let err = fast_io::openat_via_sandbox_or_fallback(
+        Some(&sandbox),
+        &fixture.root,
+        Path::new("leaflink"),
+        &leaf,
+        libc::O_RDONLY | libc::O_NOFOLLOW,
+        0,
+    )
+    .expect_err("the confined openat must refuse the symlinked leaf");
+
+    assert_eq!(
+        err.raw_os_error(),
+        Some(libc::ELOOP),
+        "expected O_NOFOLLOW to refuse the leaf, got {err}"
+    );
+}
+
+/// Non-vacuity companion for the control: the sandbox branch is not
+/// simply failing for every input - a regular in-tree leaf opens fine
+/// under the same `O_NOFOLLOW`.
+#[test]
+fn the_sandbox_branch_opens_a_regular_leaf_under_o_nofollow() {
+    let fixture = Fixture::new();
+    let leaf = fixture.root.join("plain");
+    fs::write(&leaf, b"in-tree").expect("plant the regular leaf");
+    let sandbox = DirSandbox::open_root(&fixture.root).expect("open the sandbox root");
+
+    let mut opened = fast_io::openat_via_sandbox_or_fallback(
+        Some(&sandbox),
+        &fixture.root,
+        Path::new("plain"),
+        &leaf,
+        libc::O_RDONLY | libc::O_NOFOLLOW,
+        0,
+    )
+    .expect("a regular leaf is not a symlink, so O_NOFOLLOW permits it");
+
+    assert_eq!(read_to_string(&mut opened), "in-tree");
+}

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -311,13 +311,33 @@ fn try_create_new(
             }
         }
     }
+    // Every other shape - no sandbox, no `dest_dir`, no file name, or a temp
+    // path whose parent is NOT the destination directory (an operator
+    // `--temp-dir` pointing elsewhere) - still has to resolve its parent
+    // chain. A plain path-based create resolves it with libc, so a symlink at
+    // any parent component redirects the create out of the tree; `O_EXCL`
+    // protects only the leaf. Route it through upstream's three-arm
+    // `do_open_at()` contract so the parent walk is the same one the sandbox
+    // branch gets.
+    //
+    // upstream: `rsync-3.5.0/syscall.c:3344` `do_mkstemp_atfd()` -
+    // `openat(dfd, filename, O_RDWR | O_CREAT | O_EXCL | O_NOFOLLOW, perms)`.
+    // `O_NOFOLLOW` is unconditional there, and `perms` is the mode the caller
+    // asks for; the replaced `OpenOptions` create could express neither, and
+    // defaulted to `0o666` where its sandbox sibling already used `0o600`.
+    #[cfg(unix)]
+    let opened = fast_io::ConfinedFallback::confined().open_at(
+        concrete_path,
+        libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW,
+        0o600,
+    );
     // SEC-1.r (Windows): create the temp file without following a reparse
     // point at the leaf - the analog of the Unix `O_EXCL | O_NOFOLLOW` open -
     // so a symlink/junction pre-planted at the temp name cannot redirect the
     // create outside the destination tree (CVE-2024-12747 residual).
     #[cfg(windows)]
     let opened = fast_io::create_new_no_follow(concrete_path);
-    #[cfg(not(windows))]
+    #[cfg(not(any(unix, windows)))]
     let opened = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -1288,5 +1308,95 @@ mod tests {
             "an unregistered guard must not disturb other registry entries on drop"
         );
         manager.unregister_temp_file(&other);
+    }
+}
+
+/// The temp-file create must resolve its parent chain through the ownership
+/// walk on EVERY shape, not only when the temp path's parent happens to be the
+/// destination directory.
+///
+/// `try_create_new` takes its sandbox branch only when
+/// `parent == dest_dir`. An operator `--temp-dir` elsewhere - or any call with
+/// no sandbox - used to fall through to a plain `OpenOptions::create_new`,
+/// which resolves the parent chain with libc. `O_EXCL` refuses a symlink at
+/// the LEAF, so the exposure was never the temp name itself: it was a symlink
+/// at a PARENT component redirecting the create out of the tree.
+///
+/// upstream: `rsync-3.5.0/syscall.c:3344` `do_mkstemp_atfd()`.
+#[cfg(all(test, unix))]
+mod confined_temp_create {
+    use super::try_create_new;
+    use fast_io::confinement::{
+        Activation, DaemonState, LocalInsecureLinks, Role, install_session,
+    };
+    use std::os::unix::fs::symlink;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    /// `TempDir` under a canonical root: the confinement root is compared
+    /// against a resolved path, so a `/var` -> `/private/var` style prefix
+    /// would make every cell below pass for the wrong reason.
+    fn canonical_tempdir() -> (TempDir, PathBuf) {
+        let keep = TempDir::new().expect("tempdir");
+        let root = keep.path().canonicalize().expect("canonicalize");
+        (keep, root)
+    }
+
+    /// `module/` is the confined root, `outside/secret` the out-of-tree
+    /// victim, and `module/esc` a symlink out of the root. The symlink is
+    /// owned by this euid, so the ownership walk TRUSTS it - what refuses the
+    /// escape is the confinement root, which is why the session below must
+    /// carry one.
+    fn fixture(root: &Path) -> PathBuf {
+        let module = root.join("module");
+        std::fs::create_dir(&module).expect("module");
+        std::fs::create_dir(root.join("outside")).expect("outside");
+        std::fs::write(root.join("outside/secret"), b"OUTSIDE").expect("secret");
+        symlink("../outside", module.join("esc")).expect("esc");
+        install_session(&Activation {
+            role: Role::Receiver,
+            daemon: DaemonState::NotDaemon,
+            insecure_links: LocalInsecureLinks::default(),
+            confine_root: Some(module.clone()),
+        });
+        module
+    }
+
+    /// The assertion is on WHAT THE OUT-OF-TREE DIRECTORY CONTAINS, not on the
+    /// call returning `Err`: the plain create this replaces succeeds and
+    /// leaves a new entry beside `secret`, which a "did it error?" test would
+    /// miss if the error ever arrived for an unrelated reason.
+    #[test]
+    fn temp_create_refuses_a_parent_symlink_escaping_the_root() {
+        let (_keep, root) = canonical_tempdir();
+        let module = fixture(&root);
+        let escaping = module.join("esc/.oc-rsync-temp-victim");
+
+        try_create_new(&escaping, None, None)
+            .expect_err("a temp path escaping the confinement root must be refused");
+
+        let mut left: Vec<_> = std::fs::read_dir(root.join("outside"))
+            .expect("outside readable")
+            .map(|e| e.expect("entry").file_name())
+            .collect();
+        left.sort();
+        assert_eq!(
+            left,
+            vec![std::ffi::OsString::from("secret")],
+            "nothing may be created outside the confinement root"
+        );
+    }
+
+    /// Non-vacuity companion: the SAME session, a temp path INSIDE the root.
+    /// Without it the cell above would also pass against a session that
+    /// refused every create.
+    #[test]
+    fn temp_create_still_succeeds_inside_the_root() {
+        let (_keep, root) = canonical_tempdir();
+        let module = fixture(&root);
+        let inside = module.join(".oc-rsync-temp-ok");
+
+        try_create_new(&inside, None, None).expect("an in-root temp path must still be created");
+        assert!(inside.exists(), "the in-root temp file must exist");
     }
 }


### PR DESCRIPTION
## What upstream does, in two lines

`delete.c:226` (directory case):

```c
ok = (dfd >= 0 ? do_unlink_atfd(dfd, leaf, AT_REMOVEDIR) : do_rmdir_at(fbuf)) == 0;
```

`delete.c:75-77` (file case), whose `robust_unlink` (`util1.c:545`) is `do_unlink_at(fname)` on both arms of its `ETXTBSY` `#ifdef`:

```c
if (dfd >= 0 && do_unlink_atfd(dfd, leaf, 0) == 0)
        return 0;
return robust_unlink(fbuf);     /* fall back (ETXTBSY retry, or not held) */
```

In both cases the no-dirfd fallback is a `do_*_at()` wrapper, and each of those runs the ownership walk internally. The held `del_dirfd` is an optimisation plus race-window closure - **it is not the confinement**. `syscall.c:3473-3479` says so in upstream's own words: `open_dir_secure()` returns a dirfd only when hardened resolution is in effect, "else -1 with errno==0 so the caller falls back to the `do_*_at()` wrappers (behaviour-neutral)".

`errno == 0` is a deliberate policy sentinel: upstream specifically avoids keying the fallback on a runtime errno.

## What oc did

`RealDeleteFs`'s six path methods fell back to bare `fs::remove_file` / `fs::remove_dir` / `fs::remove_dir_all`, and the receiver's `*_via_sandbox_or_fallback` family fell back to plain `std::fs` path syscalls. A *runtime* sandbox-open failure therefore selected an *unconfined* code path - the exact test upstream names as wrong.

Worse, the errno that selects it is not even discriminating. `open_dir_at` walks with `O_DIRECTORY | O_NOFOLLOW`, and Linux reports the directory violation before the symlink one, so a refused component yields **ENOTDIR (20)** - indistinguishable from "you named a file".

## The change

`fast_io::ConfinedFallback` owns upstream's three-arm contract once:

| condition | action |
|---|---|
| authority gate off | plain syscall, by *static policy* |
| gate on, ownership walk succeeds | `*at()` against the walked parent dirfd |
| gate on, **walk fails** | `Err` - never a plain syscall |

`unlink_at` / `rmdir_at` / `remove_dir_all_at` / `rename_at` / `open_at`, with the `--insecure-links` opt-out consulted first (`session_optout_allowed()`), mirroring upstream's `symlink_optout_allowed()` ordering. The six delete methods and the receiver namespace fallbacks route onto it.

Two defects are fixed incidentally by the same change:

- **The `openat` fallback tail dropped the whole flag word**, including `O_NOFOLLOW`, so the leaf lost even single-component protection.
- **The temp-file create had a live unconfined arm**: the caller's own `fs::OpenOptions::create_new()` tail ran whenever the sandbox branch was not entered. Now `ConfinedFallback::confined().open_at(...)` under `#[cfg(unix)]`, and the temp file is created 0o600 rather than 0o666.

`remove_dir_all` deserves a note: `std`'s recursive descent does **not** follow symlinks, so the entire exposure is the *prefix* walk. Confining the prefix is therefore sufficient, and the recursion is left to `std`. A fix that hardened the descent would have been measurably inert.

## Scope, stated honestly

**This is a faithfulness fix first.** oc diverges from upstream at a named site in a security-relevant direction; that is the case for the change, independent of how reachable the escape turns out to be.

On reachability, measured end to end:

| flags | `dst/sub` | outcome |
|---|---|---|
| `-a` | real dir (obstruction removed) | victim survived |
| `-a -K` | symlink (kept) | victim destroyed, exit 0, silent |

Without `-K`, oc's obstruction removal unlinks the planted symlink and mkdirs a real directory before any delete happens, so the symlinked subdir never becomes a plan directory. **Do not read this as a remotely-triggerable escape on an ordinary daemon `--delete`** - the static shape needs `-K`, and everything else needs the race. The routing is inert on the local path and live on the daemon path.

`--keep-dirlinks` matching upstream **3.4.1** on this shape is not a defence: 3.4.1 predates the confinement model, so it establishes "not a regression", not "not a divergence". Against the 3.5.0 pin it is an oc-only divergence.

**Deliberately out of scope:** `read_link` and `read_dir` get no confined fallback. Upstream has no `do_readlink_at` / `do_opendir_at` in this family; adding one would be an oc invention, not a port.

## Tests

A RED baseline lands in the same commits as the fix, so master never carries a test asserting an escape still works. Each escape was observed happening *before* the change - 8 of them - and refused after. The `O_NOFOLLOW` pin is an A/B against `DirSandbox::open_root` with the same leaf and flags, because reading the expected bytes back does not by itself prove the leaf was followed; a `plant_symlink()` helper asserts the planted node really is a symlink, without which the fixture survived a degrade-to-regular-file mutation.

One nit worth stating rather than hiding: `open_at`'s doc cites upstream's `O_RDWR` shape while the temp-create call site passes `O_WRONLY`. The flag word is now honoured verbatim, so the citation describes the wrapper, not the caller.

Closes the `ENOTDIR`-keyed fallback class.
