### PR TITLE
ci: reconcile PR labels with the title instead of accumulating

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,33 +18,50 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const title = context.payload.pull_request.title;
-            const labels = [];
+            // One table, not a nine-arm if/else: the prefix set is also
+            // documented in CONTRIBUTING and the release config, so it is
+            // spelled once here and read twice below.
+            const PREFIX_LABELS = {
+              feat: 'enhancement',
+              perf: 'performance',
+              fix: 'bug',
+              docs: 'documentation',
+              ci: 'ci',
+              test: 'test',
+              refactor: 'refactor',
+              chore: 'chore',
+              style: 'style',
+            };
 
-            if (/^feat[:(]/.test(title))
-              labels.push('enhancement');
-            else if (/^perf[:(]/.test(title))
-              labels.push('performance');
-            else if (/^fix[:(]/.test(title))
-              labels.push('bug');
-            else if (/^docs[:(]/.test(title))
-              labels.push('documentation');
-            else if (/^ci[:(]/.test(title))
-              labels.push('ci');
-            else if (/^test[:(]/.test(title))
-              labels.push('test');
-            else if (/^refactor[:(]/.test(title))
-              labels.push('refactor');
-            else if (/^chore[:(]/.test(title))
-              labels.push('chore');
-            else if (/^style[:(]/.test(title))
-              labels.push('style');
+            const pr = context.payload.pull_request;
+            const prefix = /^([a-z]+)[:(]/.exec(pr.title);
+            const wanted = prefix ? PREFIX_LABELS[prefix[1]] : undefined;
 
-            if (labels.length > 0) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                labels: labels,
-              });
+            // A title left without a recognised prefix is a policy problem,
+            // not a labelling one - leave whatever is there alone.
+            if (!wanted) return;
+
+            // This workflow runs on `edited`, so a corrected prefix
+            // (feat: -> fix:) used to ADD `bug` and leave `enhancement`
+            // behind. GitHub files a PR under the FIRST matching category of
+            // .github/release.yml, so the stale label wins and a bug fix is
+            // released under Features. The label set is DERIVED from the
+            // title: reconcile it rather than accumulate. Only the labels in
+            // the table are touched, so anything applied by hand survives.
+            const managed = new Set(Object.values(PREFIX_LABELS));
+            const current = (pr.labels || []).map((label) => label.name);
+            const issue = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            };
+
+            if (!current.includes(wanted)) {
+              await github.rest.issues.addLabels({ ...issue, labels: [wanted] });
+            }
+
+            for (const name of current) {
+              if (name !== wanted && managed.has(name)) {
+                await github.rest.issues.removeLabel({ ...issue, name });
+              }
             }

--- a/tools/tests/test_labeler.py
+++ b/tools/tests/test_labeler.py
@@ -1,0 +1,118 @@
+"""Behavioural tests for the PR labeller in .github/workflows/labeler.yml.
+
+The script under test is EXTRACTED from the committed YAML and executed, never
+retyped here. A hand copy would keep passing after a YAML-level quoting change
+broke the real workflow, which is the failure mode these tests exist to catch.
+
+The labeller runs on `edited`, so it sees a PR whose title has been corrected.
+It used to only ever add, leaving the previous category label in place; GitHub
+files a PR under the FIRST matching category of .github/release.yml, so a
+corrected `feat:` -> `fix:` was still released under Features.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+WORKFLOW = os.path.join(REPO_ROOT, ".github", "workflows", "labeler.yml")
+
+HARNESS = """
+const calls = { added: [], removed: [] };
+const github = {
+  rest: {
+    issues: {
+      addLabels: async (a) => { calls.added.push(...a.labels); },
+      removeLabel: async (a) => { calls.removed.push(a.name); },
+    },
+  },
+};
+const context = {
+  repo: { owner: 'oferchen', repo: 'rsync' },
+  payload: { pull_request: INPUT },
+};
+(async () => {
+SCRIPT
+})().then(() => console.log(JSON.stringify(calls)));
+"""
+
+
+def extract_script():
+    with open(WORKFLOW, encoding="utf-8") as handle:
+        workflow = yaml.safe_load(handle)
+    steps = workflow["jobs"]["label"]["steps"]
+    scripts = [s["with"]["script"] for s in steps if "with" in s and "script" in s["with"]]
+    if len(scripts) != 1:
+        raise AssertionError(f"expected exactly one github-script step, found {len(scripts)}")
+    return scripts[0]
+
+
+def run_labeler(title, labels):
+    """Run the extracted script against one PR payload; return the API calls."""
+    payload = {"title": title, "number": 1, "labels": [{"name": n} for n in labels]}
+    program = HARNESS.replace("INPUT", json.dumps(payload)).replace("SCRIPT", extract_script())
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "harness.mjs")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(program)
+        out = subprocess.run(
+            ["node", path], capture_output=True, text=True, timeout=30, check=True
+        )
+    return json.loads(out.stdout)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is required to execute the workflow script")
+class LabelerTests(unittest.TestCase):
+    def test_a_corrected_prefix_drops_the_previous_category_label(self):
+        # The defect: `enhancement` used to survive and win the release category.
+        calls = run_labeler("fix(transfer): confine the rename", ["enhancement"])
+        self.assertEqual(calls["added"], ["bug"])
+        self.assertEqual(calls["removed"], ["enhancement"])
+
+    def test_an_already_correct_label_set_is_left_alone(self):
+        calls = run_labeler("fix: something", ["bug"])
+        self.assertEqual(calls["added"], [])
+        self.assertEqual(calls["removed"], [])
+
+    def test_labels_applied_by_hand_survive_the_reconcile(self):
+        # Only the prefix table's own labels are managed; `security` is not one.
+        calls = run_labeler("fix: something", ["enhancement", "security"])
+        self.assertEqual(calls["removed"], ["enhancement"])
+        self.assertNotIn("security", calls["removed"])
+
+    def test_an_unrecognised_prefix_touches_nothing(self):
+        # A title without a conventional prefix is a policy problem, not a
+        # licence to strip whatever a human put there.
+        calls = run_labeler("wip: still thinking", ["enhancement"])
+        self.assertEqual(calls["added"], [])
+        self.assertEqual(calls["removed"], [])
+
+    def test_a_scoped_prefix_is_recognised(self):
+        calls = run_labeler("feat(engine): add a thing", [])
+        self.assertEqual(calls["added"], ["enhancement"])
+
+    def test_every_documented_prefix_maps_to_a_label(self):
+        expected = {
+            "feat": "enhancement",
+            "perf": "performance",
+            "fix": "bug",
+            "docs": "documentation",
+            "ci": "ci",
+            "test": "test",
+            "refactor": "refactor",
+            "chore": "chore",
+            "style": "style",
+        }
+        for prefix, label in expected.items():
+            with self.subTest(prefix=prefix):
+                calls = run_labeler(f"{prefix}: subject", [])
+                self.assertEqual(calls["added"], [label])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

`.github/workflows/labeler.yml` runs on `pull_request: [opened, edited]`, so it
sees titles *after* a correction - but it only ever called `addLabels`.
Correcting `feat:` to `fix:` therefore added `bug` and left `enhancement` in
place.

That is not cosmetic. GitHub files a PR under the **first matching category**
of `.github/release.yml`, and `Features` (`enhancement`) is listed above
`Bug Fixes` (`bug`). So the stale label wins, and a corrected bug fix is
released under Features.

## The change

The label set is derived from the title, so reconcile it instead of
accumulating: add the wanted label if absent, and drop any *other* label the
prefix table owns.

Two boundaries are deliberate:

- **Labels applied by hand survive.** Only the nine labels in the table are
  managed; a hand-applied `security` or `flaky` is untouched.
- **A title with no recognised prefix is left alone**, not stripped. That is a
  policy problem, not a licence to remove what a human put there.

The nine-arm if/else becomes one table, read twice - once to map the prefix,
once to know what this workflow is allowed to remove.

## Tests

`tools/tests/test_labeler.py` runs in the existing blocking `tools unit tests`
job (pattern discovery, so no wiring needed).

The script under test is **extracted from the committed YAML** and executed,
never retyped - a hand copy would keep passing after a YAML-level quoting
change broke the real workflow, which is the failure mode the test exists to
catch.

Both arms are mutation-proven, each killing only the tests that own it:

| mutation | result |
|---|---|
| remove the reconcile loop | 2 failures (both removal tests), other 4 green |
| remove the unrecognised-prefix guard | 1 failure (that test), other 5 green |

Local: 47/47 tools tests green.
