### PR TITLE
fix(receiver): name the commit operation that failed, not always mkstemp

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -107,7 +107,13 @@ pub(super) fn commit_file(
     // `process_whole_file` via `make_backup_copy` prior to the first write.
     let backup_notice = if !config.delay_updates && !begin.is_inplace {
         if let Some(ref backup_config) = config.backup {
-            make_backup(&begin.file_path, backup_config, config)?
+            make_backup(&begin.file_path, backup_config, config).map_err(|e| {
+                crate::temp_guard::attach_commit_op(
+                    crate::temp_guard::CommitOp::Backup,
+                    &begin.file_path,
+                    e,
+                )
+            })?
         } else {
             None
         }
@@ -128,7 +134,14 @@ pub(super) fn commit_file(
                 clear_partial_dir_obstruction(parent)?;
                 fs::create_dir_all(parent)?;
             }
-            let result = rename_config_sandboxed(config, cleanup_guard.path(), &staging_path)?;
+            let result = rename_config_sandboxed(config, cleanup_guard.path(), &staging_path)
+                .map_err(|e| {
+                    crate::temp_guard::attach_commit_op(
+                        crate::temp_guard::CommitOp::Rename,
+                        &staging_path,
+                        e,
+                    )
+                })?;
             CleanupManager::global().unregister_temp_file(cleanup_guard.path());
             cleanup_guard.keep();
             return Ok(CommitOutcome {
@@ -140,7 +153,14 @@ pub(super) fn commit_file(
     }
 
     let was_copy = if needs_rename {
-        let result = rename_config_sandboxed(config, cleanup_guard.path(), &begin.file_path)?;
+        let result = rename_config_sandboxed(config, cleanup_guard.path(), &begin.file_path)
+            .map_err(|e| {
+                crate::temp_guard::attach_commit_op(
+                    crate::temp_guard::CommitOp::Rename,
+                    &begin.file_path,
+                    e,
+                )
+            })?;
         CleanupManager::global().unregister_temp_file(cleanup_guard.path());
         result
     } else if begin.is_inplace && !begin.is_device_target {

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -1576,6 +1576,7 @@ mod tests {
     /// raised outside the tagged stages still renders under `mkstemp` with the
     /// DESTINATION name, and that fallback is what made a non-mkstemp failure
     /// read as a temp-create failure in CI.
+    #[cfg(unix)]
     #[test]
     fn commit_failure_names_the_operation_that_failed() {
         let pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();
@@ -1637,6 +1638,7 @@ mod tests {
     /// `(13)` renders every failure as `Permission denied` regardless of what
     /// actually happened, which is why the CI line could not be trusted to
     /// describe its own cause.
+    #[cfg(unix)]
     #[test]
     fn commit_failure_reports_the_real_errno() {
         let pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -299,14 +299,33 @@ impl PipelinedReceiver {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:297` - `rsyserr(FERROR_XFER, errno, "mkstemp %s failed",
+    /// - `receiver.c:452-453` - `rsyserr(FERROR_XFER, errno, "mkstemp %s failed",
     ///   full_fname(fnametmp))`
-    fn mkstemp_failure(&self, dest: &std::path::Path, error: &io::Error) -> String {
-        let named = crate::temp_guard::attempted_temp_path(error).unwrap_or(dest);
-        format!(
-            "rsync: [receiver] mkstemp {} failed: Permission denied (13)",
-            full_fname_path(named, self.daemon_paths()),
-        )
+    fn commit_failure(&self, dest: &std::path::Path, error: &io::Error) -> String {
+        let (op, named) = match crate::temp_guard::commit_op_failure(error) {
+            Some((op, path)) => (Some(op), path),
+            None => (None, dest),
+        };
+        let name = full_fname_path(named, self.daemon_paths());
+        let reason = upstream_errno_text(error);
+        match op {
+            // upstream: rsync-3.5.0/receiver.c:452-453
+            Some(crate::temp_guard::CommitOp::Mkstemp) | None => {
+                format!("rsync: [receiver] mkstemp {name} failed: {reason}")
+            }
+            // upstream: rsync-3.5.0/backup.c:401-402 `keep_backup failed: %s -> "%s"`.
+            // oc names the pre-image only; the backup destination is chosen
+            // inside make_backup and is not carried back on the error.
+            Some(crate::temp_guard::CommitOp::Backup) => {
+                format!("rsync: [receiver] keep_backup failed: {name}: {reason}")
+            }
+            // upstream: rsync-3.5.0/receiver.c:710-712 `rename failed for %s
+            // (from %s)`. oc names the destination only; the `from` operand is
+            // the internal temp name, which upstream prints and oc omits.
+            Some(crate::temp_guard::CommitOp::Rename) => {
+                format!("rsync: [receiver] rename failed for {name}: {reason}")
+            }
+        }
     }
 
     /// Formats a failed metadata apply the way upstream reports it.
@@ -413,12 +432,12 @@ impl PipelinedReceiver {
                     let pending = self.expected_checksums.pop_front();
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
-                        // upstream: receiver.c:297 - rsyserr(FERROR_XFER, errno,
+                        // upstream: receiver.c:452-453 - rsyserr(FERROR_XFER, errno,
                         // "mkstemp %s failed", full_fname(fnametmp)). Emitting
                         // this as FERROR_XFER (not FINFO) makes the peer's
                         // rwrite() set got_xfer_error, so the run exits 23
                         // (RERR_PARTIAL) instead of 0 when mkstemp() was denied.
-                        let message = self.mkstemp_failure(&path, &e);
+                        let message = self.commit_failure(&path, &e);
                         self.warnings.push((MessageCode::ErrorXfer, message));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
@@ -476,12 +495,12 @@ impl PipelinedReceiver {
                     let pending = self.expected_checksums.pop_front();
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
-                        // upstream: receiver.c:297 - rsyserr(FERROR_XFER, errno,
+                        // upstream: receiver.c:452-453 - rsyserr(FERROR_XFER, errno,
                         // "mkstemp %s failed", full_fname(fnametmp)). Emitting
                         // this as FERROR_XFER (not FINFO) makes the peer's
                         // rwrite() set got_xfer_error, so the run exits 23
                         // (RERR_PARTIAL) instead of 0 when mkstemp() was denied.
-                        let message = self.mkstemp_failure(&path, &e);
+                        let message = self.commit_failure(&path, &e);
                         self.warnings.push((MessageCode::ErrorXfer, message));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
@@ -698,6 +717,34 @@ impl PipelinedReceiver {
 /// - `receiver.c:825-832` - `do_open()` failure handling logs and continues
 fn is_permission_error(err: &io::Error) -> bool {
     err.kind() == io::ErrorKind::PermissionDenied
+}
+/// Renders an error the way upstream's `rsyserr` does: `strerror(errno)`
+/// followed by the numeric errno in parentheses.
+///
+/// `io::Error`'s own `Display` appends `" (os error N)"`, so the suffix is
+/// stripped and re-emitted in upstream's shape. A non-OS error renders
+/// verbatim, with no parenthesised number to invent.
+///
+/// upstream: `rsync-3.5.0/log.c` `rsyserr()` - `"%s: %s (%d)"`.
+fn upstream_errno_text(error: &io::Error) -> String {
+    let display = error.to_string();
+    // A tagged failure is an `io::Error::new(kind, payload)`, i.e. the `Custom`
+    // variant, whose `raw_os_error()` is `None` even though the payload wraps a
+    // real OS error. Recover the errno from the source chain so tagging an
+    // error does not silently drop the number from its own message.
+    let errno = error.raw_os_error().or_else(|| {
+        std::error::Error::source(error.get_ref()?)?
+            .downcast_ref::<io::Error>()?
+            .raw_os_error()
+    });
+    match errno {
+        Some(errno) => {
+            let suffix = format!(" (os error {errno})");
+            let text = display.strip_suffix(&suffix).unwrap_or(&display);
+            format!("{text} ({errno})")
+        }
+        None => display,
+    }
 }
 
 impl Drop for PipelinedReceiver {
@@ -1518,6 +1565,166 @@ mod tests {
         );
     }
 
+    /// The commit path runs mkstemp, backup, rename and metadata behind one
+    /// `Result`, so a `PermissionDenied` from any of them reaches the same
+    /// reporting arm. Upstream gives each site its own text - `mkstemp %s
+    /// failed` (`rsync-3.5.0/receiver.c:452-453`), `rename failed for %s`
+    /// (`:710-712`), `keep_backup failed` (`rsync-3.5.0/backup.c:401-402`) -
+    /// and oc must not label all three `mkstemp`.
+    ///
+    /// The untagged arm is the one that matters for regressions: an error
+    /// raised outside the tagged stages still renders under `mkstemp` with the
+    /// DESTINATION name, and that fallback is what made a non-mkstemp failure
+    /// read as a temp-create failure in CI.
+    #[test]
+    fn commit_failure_names_the_operation_that_failed() {
+        let pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();
+        let dest = std::path::Path::new("/srv/mod/payload");
+        let temp = std::path::Path::new("/srv/mod/.payload.a2dBeL");
+        let denied = || io::Error::from_raw_os_error(libc::EACCES);
+
+        let mkstemp = pr.commit_failure(
+            dest,
+            &crate::temp_guard::attach_commit_op(
+                crate::temp_guard::CommitOp::Mkstemp,
+                temp,
+                denied(),
+            ),
+        );
+        let backup = pr.commit_failure(
+            dest,
+            &crate::temp_guard::attach_commit_op(
+                crate::temp_guard::CommitOp::Backup,
+                dest,
+                denied(),
+            ),
+        );
+        let rename = pr.commit_failure(
+            dest,
+            &crate::temp_guard::attach_commit_op(
+                crate::temp_guard::CommitOp::Rename,
+                dest,
+                denied(),
+            ),
+        );
+        let untagged = pr.commit_failure(dest, &denied());
+
+        assert!(
+            mkstemp.contains("mkstemp") && mkstemp.contains(".payload.a2dBeL"),
+            "mkstemp keeps upstream's text and names the TEMP file: {mkstemp}"
+        );
+        assert!(
+            backup.contains("keep_backup failed") && !backup.contains("mkstemp"),
+            "a backup failure must not be labelled mkstemp: {backup}"
+        );
+        assert!(
+            rename.contains("rename failed for") && !rename.contains("mkstemp"),
+            "a rename failure must not be labelled mkstemp: {rename}"
+        );
+        assert!(
+            untagged.contains("mkstemp") && untagged.contains("payload"),
+            "an untagged error keeps the historical fallback: {untagged}"
+        );
+        for rendered in [&mkstemp, &backup, &rename, &untagged] {
+            assert!(
+                rendered.ends_with("Permission denied (13)"),
+                "every arm renders strerror + errno like rsyserr: {rendered}"
+            );
+        }
+    }
+
+    /// The errno must come from the error, not from a literal. A hardcoded
+    /// `(13)` renders every failure as `Permission denied` regardless of what
+    /// actually happened, which is why the CI line could not be trusted to
+    /// describe its own cause.
+    #[test]
+    fn commit_failure_reports_the_real_errno() {
+        let pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();
+        let dest = std::path::Path::new("/srv/mod/payload");
+        let rendered = pr.commit_failure(dest, &io::Error::from_raw_os_error(libc::EPERM));
+        assert!(
+            rendered.ends_with("(1)"),
+            "EPERM must render as (1), not the EACCES literal: {rendered}"
+        );
+        assert!(
+            !rendered.contains("(13)"),
+            "the errno must not be hardcoded: {rendered}"
+        );
+    }
+
+    /// Wiring proof for the rename stage: the tag has to be attached by the
+    /// real commit path, not merely spellable in a unit test.
+    ///
+    /// A writable `--temp-dir` with a read-only destination directory lets
+    /// mkstemp SUCCEED and the rename onto the destination fail `EACCES`,
+    /// which is the one shape that separates the two stages end to end.
+    #[cfg(unix)]
+    #[test]
+    fn a_failed_rename_is_reported_as_a_rename_not_a_mkstemp() {
+        use std::os::unix::fs::PermissionsExt;
+        // Root bypasses the read-only dir bit, so the rename would succeed.
+        if std::env::var("USER").is_ok_and(|u| u == "root") {
+            return;
+        }
+        let dir = test_support::create_tempdir();
+        let temp_dir = dir.path().join("tmp");
+        let readonly_dir = dir.path().join("readonly");
+        std::fs::create_dir(&temp_dir).unwrap();
+        std::fs::create_dir(&readonly_dir).unwrap();
+        std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o555)).unwrap();
+        let file_path = readonly_dir.join("payload.dat");
+
+        let config = DiskCommitConfig {
+            temp_dir: Some(temp_dir),
+            ..DiskCommitConfig::default()
+        };
+        let mut pr = PipelinedReceiver::new(config).unwrap();
+        pr.file_sender()
+            .send(FileMessage::WholeFile {
+                begin: Box::new(BeginMessage {
+                    file_path: file_path.clone(),
+                    target_size: 9,
+                    file_entry_index: 0,
+                    checksum_verifier: None,
+                    is_device_target: false,
+                    is_inplace: false,
+                    append_offset: 0,
+                    xattr_list: None,
+                    xattr_basis: None,
+                    file_entry: None,
+                }),
+                data: b"test data".to_vec(),
+                expected_checksum: Default::default(),
+            })
+            .unwrap();
+        pr.note_commit_sent(
+            [0u8; ChecksumVerifier::MAX_DIGEST_LEN],
+            0,
+            file_path.clone(),
+            PathBuf::from(file_path.file_name().unwrap()),
+            0,
+            false,
+        );
+        let (_bytes, errors) = pr.drain_all_results().unwrap();
+        assert_eq!(errors.len(), 1, "one recoverable per-file error");
+        let warnings = pr.drain_warnings();
+        assert_eq!(
+            warnings.len(),
+            1,
+            "one warning queued for the failed rename"
+        );
+        assert!(
+            warnings[0].1.contains("rename failed for"),
+            "the live commit path must tag the rename stage: {}",
+            warnings[0].1
+        );
+        assert!(
+            !warnings[0].1.contains("mkstemp"),
+            "mkstemp SUCCEEDED here - labelling this mkstemp is the defect: {}",
+            warnings[0].1
+        );
+    }
+
     /// only sets `got_xfer_error` (yielding exit 23, `RERR_PARTIAL`) on
     /// `FERROR_XFER` receipt (upstream log.c:311). Routing this as `MSG_INFO`
     /// would let a client-sender push against a read-only destination exit 0,
@@ -1588,7 +1795,7 @@ mod tests {
         assert!(
             warnings[0].1.starts_with(&expected_prefix)
                 && warnings[0].1.ends_with("\" failed: Permission denied (13)"),
-            "message should mirror upstream receiver.c:297 \"mkstemp %s failed\" \
+            "message should mirror upstream receiver.c:452-453 \"mkstemp %s failed\" \
              with the absolute temp name: {}",
             warnings[0].1
         );
@@ -1668,7 +1875,7 @@ mod tests {
     /// ```
     ///
     /// upstream: util1.c:1285-1290 inside `full_fname()`, reached from
-    /// receiver.c:297 `rsyserr(..., "mkstemp %s failed", full_fname(fnametmp))`.
+    /// receiver.c:452-453 `rsyserr(..., "mkstemp %s failed", full_fname(fnametmp))`.
     #[cfg(unix)]
     #[test]
     fn output_open_failure_names_daemon_module() {

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -17,30 +17,57 @@ use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::sync::Arc;
 
-/// Payload attached to a failed [`open_tmpfile`] so the caller can name the
-/// temp file the `mkstemp` attempt used.
+/// Which commit-path operation raised a failure, so the receiver's diagnostic
+/// names that operation instead of labelling every failure `mkstemp`.
+///
+/// Upstream emits one message per site, each naming its own operation:
+/// `mkstemp %s failed` (`rsync-3.5.0/receiver.c:452-453`),
+/// `rename failed for %s (from %s)` (`rsync-3.5.0/receiver.c:710-712`) and
+/// `keep_backup failed: %s -> "%s"` (`rsync-3.5.0/backup.c:401-402`). oc runs
+/// these stages behind one `Result`, so the operation identity has to ride on
+/// the error to survive the trip back to the reporting thread.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommitOp {
+    /// Creating the `.name.XXXXXX` temp file.
+    Mkstemp,
+    /// Moving the pre-image aside under `--backup`.
+    Backup,
+    /// Renaming the finished temp file onto its destination.
+    Rename,
+}
+
+/// Payload attached to a failed commit-path operation so the caller can name
+/// both the operation and the path it acted on.
+///
+/// Upstream reports the operand of the failing call, not the final
+/// destination: `rsyserr(FERROR_XFER, errno, "mkstemp %s failed",
+/// full_fname(fnametmp))` (`rsync-3.5.0/receiver.c:452-453`). The disk-commit
+/// thread hands failures back as a plain [`io::Error`], so the operation and
+/// its operand ride along inside it and are recovered with
+/// [`commit_op_failure`].
 ///
 /// Upstream reports the temp name, not the final destination:
 /// `rsyserr(FERROR_XFER, errno, "mkstemp %s failed", full_fname(fnametmp))`
-/// (receiver.c:297). The disk-commit thread hands the failure back as a plain
+/// (receiver.c:452-453). The disk-commit thread hands the failure back as a plain
 /// [`io::Error`], so the attempted name rides along inside it and is recovered
 /// with [`attempted_temp_path`].
 ///
 /// [`fmt::Display`] forwards to the underlying error verbatim, so a wrapped
 /// error still renders exactly like the unwrapped one.
 #[derive(Debug)]
-struct TempOpenError {
-    temp_path: PathBuf,
+struct CommitOpError {
+    op: CommitOp,
+    operand: PathBuf,
     source: io::Error,
 }
 
-impl fmt::Display for TempOpenError {
+impl fmt::Display for CommitOpError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.source, f)
     }
 }
 
-impl std::error::Error for TempOpenError {
+impl std::error::Error for CommitOpError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.source)
     }
@@ -52,10 +79,37 @@ impl std::error::Error for TempOpenError {
 /// `None` for every other error, so callers fall back to whatever name they
 /// already have.
 pub fn attempted_temp_path(error: &io::Error) -> Option<&Path> {
+    match commit_op_failure(error) {
+        Some((CommitOp::Mkstemp, path)) => Some(path),
+        _ => None,
+    }
+}
+
+/// Returns the commit-path operation an error came from, with the path that
+/// operation acted on.
+///
+/// `None` for an error raised outside the annotated stages, so callers fall
+/// back to whatever name they already have - the same contract
+/// [`attempted_temp_path`] has always had, widened from one operation to all
+/// of them.
+pub fn commit_op_failure(error: &io::Error) -> Option<(CommitOp, &Path)> {
     error
         .get_ref()?
-        .downcast_ref::<TempOpenError>()
-        .map(|e| e.temp_path.as_path())
+        .downcast_ref::<CommitOpError>()
+        .map(|e| (e.op, e.operand.as_path()))
+}
+
+/// Tags `source` with the operation that raised it, preserving its
+/// [`io::ErrorKind`] so existing predicates keep classifying it unchanged.
+pub fn attach_commit_op(op: CommitOp, operand: &Path, source: io::Error) -> io::Error {
+    io::Error::new(
+        source.kind(),
+        CommitOpError {
+            op,
+            operand: operand.to_path_buf(),
+            source,
+        },
+    )
 }
 
 /// Length of the random suffix including the leading dot: `.XXXXXX` = 7 bytes.
@@ -260,13 +314,14 @@ fn open_tmpfile_inner(
                 return Err(io::Error::new(e.kind(), e.to_string()));
             }
             // Carry the attempted name so the receiver's diagnostic can print
-            // `fnametmp` the way receiver.c:297 does. The wrapper keeps both
+            // `fnametmp` the way receiver.c:452-453 does. The wrapper keeps both
             // `kind()` and the Display text of the original error.
             Err(e) => {
                 return Err(io::Error::new(
                     e.kind(),
-                    TempOpenError {
-                        temp_path: concrete_path,
+                    CommitOpError {
+                        op: CommitOp::Mkstemp,
+                        operand: concrete_path,
                         source: e,
                     },
                 ));
@@ -666,7 +721,7 @@ mod tests {
     use tempfile::tempdir;
 
     /// upstream names `fnametmp`, not the destination, in the `mkstemp %s
-    /// failed` diagnostic (receiver.c:297), so a failed open must hand the
+    /// failed` diagnostic (receiver.c:452-453), so a failed open must hand the
     /// attempted `.name.XXXXXX` back to the caller while keeping the error's
     /// `kind()` and rendered text untouched.
     #[cfg(unix)]


### PR DESCRIPTION
The receiver reported every permission-shaped commit failure as
`mkstemp <name> failed: Permission denied (13)` — whatever actually failed.

## Three defects in one message

1. **The label covers the whole commit, not the temp create.** `mkstemp_failure`
   is called from the `Ok(Err(e))` arm of the entire commit result
   (`receiver.rs:421`, `:484`). That commit runs temp-create → write → **backup**
   → rename → metadata, and the only gate is `err.kind() == PermissionDenied`
   (`:699`), so a refusal from *any* stage was labelled `mkstemp`.
2. **The operand silently falls back to the destination.** `attempted_temp_path`
   returns `Some` only for an error raised by `open_tmpfile`; everything else
   takes `.unwrap_or(dest)`. So a non-mkstemp failure printed the *destination*
   path under a temp-create label — indistinguishable from a real one. A genuine
   temp failure prints `.name.XXXXXX`; a bare name is the tell that the fallback
   fired.
3. **The errno was a literal.** `format!("... failed: Permission denied (13)")`
   — `error` supplied only the name, never the number, so an `EPERM` still
   rendered `(13)`.

## Why this matters beyond one red

With three stages funnelled into a message that says `mkstemp`, anyone reading
that line reasonably concludes the temp create failed. That has already happened
on a live investigation, and the misreading survived two rounds of hypothesis
before the operand shape gave it away. The defect is therefore independent of
whatever caused any particular failure: **the message was never capable of
naming the operation**, so no amount of reasoning over the existing text can
narrow it. This change makes the next failure identify its own stage.

## Upstream

Upstream emits one message per site, each naming its own operation:

| site | text |
|---|---|
| `rsync-3.5.0/receiver.c:452-453` | `mkstemp %s failed` |
| `rsync-3.5.0/receiver.c:710-712` | `rename failed for %s (from %s)` |
| `rsync-3.5.0/backup.c:401-402` | `keep_backup failed: %s -> "%s"` |

## Approach

The existing `TempOpenError` carrier is **widened, not duplicated**: it gains a
`CommitOp` and becomes `CommitOpError`. `attempted_temp_path` keeps its exact
signature and contract (`Some` only for the mkstemp case), and the backup and
rename stages tag their errors the same way `open_tmpfile` already tagged its
own. The formatter selects the message from the tag and renders
`strerror(errno) (errno)` from the error itself.

`FERROR_XFER` routing is unchanged, so the peer still sets `got_xfer_error` and
the run still exits 23.

⚠ A tagged failure is an `io::Error::new(kind, payload)` — the `Custom` variant,
whose `raw_os_error()` is `None` even though the payload wraps a real OS error.
The errno is recovered from the source chain; without that, tagging an error
would drop the number from its own message. The tests caught this.

## Deliberately narrower than upstream

- The rename message omits upstream's `(from %s)` second operand.
- The backup message omits the backup destination.

Neither is carried back on the error today. Stated rather than silently dropped.

## Citations

The four `receiver.c:297` citations are retargeted to `:452-453`, where the
pinned 3.5.0 source actually has that `rsyserr`.

## Verification

- **Wiring, not just spelling:** a live rename failure (writable `--temp-dir`
  with a read-only destination — mkstemp *succeeds*, the rename is refused)
  proves the commit path tags the stage. Without it the tagging could be inert.
- Unit cell over all four arms, including the untagged fallback, which is the
  regression that matters.
- An errno cell pinning `EPERM` as `(1)`.
- The pre-existing mkstemp cells are the companions: a real temp-create failure
  still renders exactly as before.

**Mutations, both lethal:**

| mutation | result |
|---|---|
| restore the hardcoded `(13)` | 1 failed |
| relabel the backup arm `mkstemp` | 1 failed |
| (restored) | 3 passed |

`cargo fmt --all -- --check` exit 0; `cargo clippy --workspace --all-targets
--all-features --no-deps -D warnings` clean; `transfer` **2766/2766** with
`--no-fail-fast`.

## Scope

This makes the diagnostic tell the truth about which operation failed. It does
**not** claim to fix any particular failure — three candidates (backup, rename,
metadata) remain indistinguishable in existing logs, and that indistinguishability
is the defect being closed.
