### PR TITLE
refactor(transfer): narrow the backup ladder to the fields it reads

### DIFF
--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -6,7 +6,7 @@
 
 use std::env;
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use filters::FilterSet;
@@ -274,6 +274,29 @@ impl Default for DiskCommitConfig {
     }
 }
 
+/// The destination-anchoring inputs the backup ladder actually reads.
+///
+/// `make_backup` and its hard-link / rename / copy tiers consult exactly three
+/// things from the commit configuration: the receiver's destination sandbox,
+/// the destination root that sandbox is anchored on, and the metadata options
+/// applied when a `--backup-dir` parent has to be created. Borrowing those
+/// three keeps the ladder callable from any receiver path instead of only the
+/// ones that hold a whole [`DiskCommitConfig`].
+///
+/// Upstream reaches the same state through file-scope globals that
+/// `make_backup()` (`backup.c:437`) consults directly, so there is no upstream
+/// aggregate to mirror; this is oc's explicit spelling of that ambient state.
+#[derive(Clone, Copy)]
+pub(crate) struct BackupEnv<'a> {
+    /// Destination sandbox anchoring the backup `*at()` syscalls.
+    #[cfg(unix)]
+    pub(crate) sandbox: Option<&'a fast_io::DirSandbox>,
+    /// Destination root the sandbox is anchored on.
+    pub(crate) dest_dir: Option<&'a Path>,
+    /// Metadata options applied to `--backup-dir` parents created on demand.
+    pub(crate) metadata_opts: Option<&'a MetadataOptions>,
+}
+
 impl DiskCommitConfig {
     /// Returns the effective channel capacity, clamped to valid bounds.
     ///
@@ -283,5 +306,19 @@ impl DiskCommitConfig {
     pub fn effective_channel_capacity(&self) -> usize {
         self.channel_capacity
             .clamp(MIN_CHANNEL_CAPACITY, MAX_CHANNEL_CAPACITY)
+    }
+
+    /// Borrows the three fields the backup ladder reads.
+    ///
+    /// The ladder takes [`BackupEnv`] rather than the whole configuration so it
+    /// declares its real dependency; see that type's documentation.
+    #[must_use]
+    pub(crate) fn backup_env(&self) -> BackupEnv<'_> {
+        BackupEnv {
+            #[cfg(unix)]
+            sandbox: self.sandbox.as_deref(),
+            dest_dir: self.dest_dir.as_deref(),
+            metadata_opts: self.metadata_opts.as_ref(),
+        }
     }
 }

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -6,7 +6,9 @@
 
 use std::env;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use filters::FilterSet;
@@ -292,6 +294,11 @@ pub(crate) struct BackupEnv<'a> {
     #[cfg(unix)]
     pub(crate) sandbox: Option<&'a fast_io::DirSandbox>,
     /// Destination root the sandbox is anchored on.
+    ///
+    /// Paired with `sandbox`: every reader consults the two together to decide
+    /// whether an operation reduces to a single `*at()` call anchored on the
+    /// destination, so the field is Unix-only for the same reason `sandbox` is.
+    #[cfg(unix)]
     pub(crate) dest_dir: Option<&'a Path>,
     /// Metadata options applied to `--backup-dir` parents created on demand.
     pub(crate) metadata_opts: Option<&'a MetadataOptions>,
@@ -317,6 +324,7 @@ impl DiskCommitConfig {
         BackupEnv {
             #[cfg(unix)]
             sandbox: self.sandbox.as_deref(),
+            #[cfg(unix)]
             dest_dir: self.dest_dir.as_deref(),
             metadata_opts: self.metadata_opts.as_ref(),
         }

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -19,7 +19,7 @@ use engine::{
 use crate::pipeline::messages::{BackupNotice, BeginMessage};
 use crate::temp_guard::TempFileGuard;
 
-use super::super::config::{BackupConfig, DiskCommitConfig, PartialMode};
+use super::super::config::{BackupConfig, BackupEnv, DiskCommitConfig, PartialMode};
 
 /// Sparse finalization carried from the write pass.
 ///
@@ -107,7 +107,7 @@ pub(super) fn commit_file(
     // `process_whole_file` via `make_backup_copy` prior to the first write.
     let backup_notice = if !config.delay_updates && !begin.is_inplace {
         if let Some(ref backup_config) = config.backup {
-            make_backup(&begin.file_path, backup_config, config).map_err(|e| {
+            make_backup(&begin.file_path, backup_config, config.backup_env()).map_err(|e| {
                 crate::temp_guard::attach_commit_op(
                     crate::temp_guard::CommitOp::Backup,
                     &begin.file_path,
@@ -657,17 +657,17 @@ impl Drop for ForceExdev {
 /// upstream `make_backup: COPY` trace instead of `RENAME`.
 #[cfg(unix)]
 fn backup_rename_sandboxed(
-    config: &DiskCommitConfig,
+    env: BackupEnv<'_>,
     old_path: &Path,
     new_path: &Path,
 ) -> io::Result<bool> {
-    if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref())
+    if let (Some(sandbox), Some(dest_dir)) = (env.sandbox, env.dest_dir)
         && let (Some(old_leaf), Some(new_leaf)) = (old_path.file_name(), new_path.file_name())
         && old_path.parent() == Some(dest_dir)
         && new_path.parent() == Some(dest_dir)
     {
         fast_io::renameat_via_sandbox_or_fallback(
-            Some(sandbox.as_ref()),
+            Some(sandbox),
             dest_dir,
             Path::new(old_leaf),
             old_path,
@@ -683,7 +683,7 @@ fn backup_rename_sandboxed(
 
 #[cfg(not(unix))]
 fn backup_rename_sandboxed(
-    _config: &DiskCommitConfig,
+    _env: BackupEnv<'_>,
     old_path: &Path,
     new_path: &Path,
 ) -> io::Result<bool> {
@@ -709,23 +709,18 @@ fn backup_rename_sandboxed(
 /// upstream: `backup.c:443-449` `make_backup()`; `backup.c:200-207`
 /// `link_or_rename()`; `syscall.c:676` `do_link_at()` under
 /// `operator_path_resolve`.
-fn backup_hardlink_syscall(
-    config: &DiskCommitConfig,
-    old_path: &Path,
-    new_path: &Path,
-) -> io::Result<()> {
+fn backup_hardlink_syscall(env: BackupEnv<'_>, old_path: &Path, new_path: &Path) -> io::Result<()> {
     #[cfg(test)]
     if force_exdev_active() {
         return Err(simulated_cross_device_error());
     }
     #[cfg(unix)]
     {
-        if let (Some(sandbox), Some(dest_dir)) =
-            (config.sandbox.as_ref(), config.dest_dir.as_deref())
+        if let (Some(sandbox), Some(dest_dir)) = (env.sandbox, env.dest_dir)
             && new_path.parent() == Some(dest_dir)
         {
             return fast_io::linkat_via_sandbox_or_fallback(
-                Some(sandbox.as_ref()),
+                Some(sandbox),
                 old_path,
                 dest_dir,
                 new_path.strip_prefix(dest_dir).unwrap_or(new_path),
@@ -736,7 +731,7 @@ fn backup_hardlink_syscall(
     }
     #[cfg(not(unix))]
     {
-        let _ = config;
+        let _ = env;
         fast_io::hard_link(old_path, new_path)
     }
 }
@@ -752,12 +747,12 @@ fn backup_hardlink_syscall(
 /// 2; a link failure on a regular file falls through to `do_rename_at`.
 /// upstream: `backup.c:246-255` `make_backup()` - an `EEXIST`/`EISDIR` collision
 /// deletes the stale backup entry and retries `link_or_rename` once.
-fn backup_hardlink_tier(config: &DiskCommitConfig, old_path: &Path, new_path: &Path) -> bool {
-    match backup_hardlink_syscall(config, old_path, new_path) {
+fn backup_hardlink_tier(env: BackupEnv<'_>, old_path: &Path, new_path: &Path) -> bool {
+    match backup_hardlink_syscall(env, old_path, new_path) {
         Ok(()) => true,
         Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
             fs::remove_file(new_path).is_ok()
-                && backup_hardlink_syscall(config, old_path, new_path).is_ok()
+                && backup_hardlink_syscall(env, old_path, new_path).is_ok()
         }
         Err(_) => false,
     }
@@ -776,21 +771,21 @@ fn backup_hardlink_tier(config: &DiskCommitConfig, old_path: &Path, new_path: &P
 fn create_backup_path_parents(
     parent: &Path,
     backup_config: &BackupConfig,
-    config: &DiskCommitConfig,
+    env: BackupEnv<'_>,
 ) -> io::Result<()> {
     match backup_config.backup_dir.as_deref() {
         Some(backup_dir) => {
-            let metadata_opts = config.metadata_opts.clone().unwrap_or_default();
+            let metadata_opts = env.metadata_opts.cloned().unwrap_or_default();
             create_backup_dir_parents(
                 &backup_config.dest_dir,
                 backup_dir,
                 parent,
                 &metadata_opts,
-                |path| create_dir_all_sandboxed(config, path),
+                |path| create_dir_all_sandboxed(env, path),
             )
         }
         None if parent.exists() => Ok(()),
-        None => create_dir_all_sandboxed(config, parent),
+        None => create_dir_all_sandboxed(env, parent),
     }
 }
 
@@ -804,13 +799,13 @@ fn create_backup_path_parents(
 /// go through [`fast_io::operator_create_dir_all`], which is recursive like
 /// `std::fs::create_dir_all` but issues `mkdirat` per component.
 #[cfg(unix)]
-fn create_dir_all_sandboxed(config: &DiskCommitConfig, parent: &Path) -> io::Result<()> {
-    if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref())
+fn create_dir_all_sandboxed(env: BackupEnv<'_>, parent: &Path) -> io::Result<()> {
+    if let (Some(sandbox), Some(dest_dir)) = (env.sandbox, env.dest_dir)
         && parent.parent() == Some(dest_dir)
         && let Some(leaf) = parent.file_name()
     {
         return match fast_io::mkdirat_via_sandbox_or_fallback(
-            Some(sandbox.as_ref()),
+            Some(sandbox),
             dest_dir,
             Path::new(leaf),
             parent,
@@ -827,7 +822,7 @@ fn create_dir_all_sandboxed(config: &DiskCommitConfig, parent: &Path) -> io::Res
 }
 
 #[cfg(not(unix))]
-fn create_dir_all_sandboxed(_config: &DiskCommitConfig, parent: &Path) -> io::Result<()> {
+fn create_dir_all_sandboxed(_env: BackupEnv<'_>, parent: &Path) -> io::Result<()> {
     fs::create_dir_all(parent)
 }
 
@@ -848,7 +843,7 @@ fn create_dir_all_sandboxed(_config: &DiskCommitConfig, parent: &Path) -> io::Re
 pub(super) fn make_backup(
     file_path: &Path,
     backup_config: &BackupConfig,
-    config: &DiskCommitConfig,
+    env: BackupEnv<'_>,
 ) -> io::Result<Option<BackupNotice>> {
     if !file_path.exists() {
         return Ok(None);
@@ -863,7 +858,7 @@ pub(super) fn make_backup(
     );
 
     if let Some(parent) = backup_path.parent() {
-        create_backup_path_parents(parent, backup_config, config)?;
+        create_backup_path_parents(parent, backup_config, env)?;
     }
 
     // upstream: backup.c:191-207 - `prefer_rename` is False here (rsync.c:739),
@@ -872,7 +867,7 @@ pub(super) fn make_backup(
     // CAN_HARDLINK_SPECIAL (backup.c:192-199), and this commit path only ever
     // replaces a regular destination anyway.
     let is_regular = fs::symlink_metadata(file_path).is_ok_and(|m| m.is_file());
-    if is_regular && backup_hardlink_tier(config, file_path, &backup_path) {
+    if is_regular && backup_hardlink_tier(env, file_path, &backup_path) {
         // upstream: backup.c:201-202 - DEBUG_GTE(BACKUP, 1) HLINK success. The
         // original is deliberately left in place (upstream returns 2 and
         // finish_transfer does not redirect fnamecmp); the temp->destination
@@ -881,7 +876,7 @@ pub(super) fn make_backup(
         return Ok(Some(backup_notice(backup_config, file_path, &backup_path)));
     }
 
-    let was_copy = backup_rename_sandboxed(config, file_path, &backup_path)?;
+    let was_copy = backup_rename_sandboxed(env, file_path, &backup_path)?;
     if was_copy {
         // upstream: backup.c:284 - DEBUG_GTE(BACKUP, 1) "make_backup: COPY %s
         // successful." when the cross-device copy tier moved the pre-image.
@@ -939,7 +934,7 @@ fn backup_notice(
 pub(super) fn make_backup_copy(
     file_path: &Path,
     backup_config: &BackupConfig,
-    config: &DiskCommitConfig,
+    env: BackupEnv<'_>,
 ) -> io::Result<Option<BackupNotice>> {
     if !file_path.exists() {
         return Ok(None);
@@ -954,7 +949,7 @@ pub(super) fn make_backup_copy(
     );
 
     if let Some(parent) = backup_path.parent() {
-        create_backup_path_parents(parent, backup_config, config)?;
+        create_backup_path_parents(parent, backup_config, env)?;
     }
 
     // upstream: generator.c:1866 copy_file() - duplicate the pre-transfer bytes

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -146,7 +146,7 @@ pub(super) fn commit_file(
             // glibc to lower to, which is why the defect was architecture-only.
             if let Some(parent) = staging_path.parent() {
                 clear_partial_dir_obstruction(parent)?;
-                create_dir_all_sandboxed(config, parent)?;
+                create_dir_all_sandboxed(config.backup_env(), parent)?;
             }
             let result = rename_config_sandboxed(config, cleanup_guard.path(), &staging_path)
                 .map_err(|e| {

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -819,7 +819,7 @@ fn make_inplace_backup(
     let Some(ref backup_config) = config.backup else {
         return Ok(None);
     };
-    make_backup_copy(&begin.file_path, backup_config, config)
+    make_backup_copy(&begin.file_path, backup_config, config.backup_env())
 }
 
 /// Stats the destination before an inplace write so `dest_mode()` keeps its

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -394,9 +394,13 @@ fn make_backup_returns_destination_relative_notice() {
         backup_dir: None,
         suffix: OsString::from("~"),
     };
-    let notice = make_backup(&file_path, &config, &DiskCommitConfig::default())
-        .expect("make_backup succeeds")
-        .expect("notice produced when an existing file is backed up");
+    let notice = make_backup(
+        &file_path,
+        &config,
+        DiskCommitConfig::default().backup_env(),
+    )
+    .expect("make_backup succeeds")
+    .expect("notice produced when an existing file is backed up");
 
     let backup_path = file_path.with_extension("bin~");
     assert!(
@@ -441,9 +445,13 @@ fn make_backup_regular_file_traces_hlink() {
         backup_dir: None,
         suffix: OsString::from("~"),
     };
-    make_backup(&file_path, &config, &DiskCommitConfig::default())
-        .expect("make_backup succeeds")
-        .expect("notice produced when an existing file is backed up");
+    make_backup(
+        &file_path,
+        &config,
+        DiskCommitConfig::default().backup_env(),
+    )
+    .expect("make_backup succeeds")
+    .expect("notice produced when an existing file is backed up");
 
     let traces: Vec<String> = drain_events()
         .into_iter()
@@ -495,9 +503,13 @@ fn make_backup_cross_device_uses_copy_fallback() {
 
     let notice = {
         let _force = ForceExdev::new();
-        make_backup(&file_path, &config, &DiskCommitConfig::default())
-            .expect("cross-device backup must succeed via the copy fallback")
-            .expect("notice produced when an existing file is backed up")
+        make_backup(
+            &file_path,
+            &config,
+            DiskCommitConfig::default().backup_env(),
+        )
+        .expect("cross-device backup must succeed via the copy fallback")
+        .expect("notice produced when an existing file is backed up")
     };
 
     let backup_path = file_path.with_extension("bin~");
@@ -534,8 +546,12 @@ fn make_backup_missing_file_is_noop() {
         backup_dir: None,
         suffix: OsString::from("~"),
     };
-    let notice = make_backup(&file_path, &config, &DiskCommitConfig::default())
-        .expect("make_backup succeeds");
+    let notice = make_backup(
+        &file_path,
+        &config,
+        DiskCommitConfig::default().backup_env(),
+    )
+    .expect("make_backup succeeds");
     assert!(notice.is_none(), "no notice when nothing was backed up");
 }
 
@@ -583,7 +599,7 @@ fn make_backup_backup_dir_subdir_inherits_source_mode() {
         ..DiskCommitConfig::default()
     };
 
-    make_backup(&file_path, &config, &disk_config)
+    make_backup(&file_path, &config, disk_config.backup_env())
         .expect("make_backup succeeds")
         .expect("notice produced for the backed-up file");
 
@@ -635,7 +651,7 @@ fn make_backup_backup_dir_clears_nondir_obstruction() {
         ..DiskCommitConfig::default()
     };
 
-    make_backup(&file_path, &config, &disk_config)
+    make_backup(&file_path, &config, disk_config.backup_env())
         .expect("make_backup must succeed after clearing the obstruction")
         .expect("notice produced for the backed-up file");
 
@@ -670,9 +686,13 @@ fn make_backup_copy_duplicates_and_keeps_original() {
         backup_dir: None,
         suffix: OsString::from("~"),
     };
-    let notice = make_backup_copy(&file_path, &config, &DiskCommitConfig::default())
-        .expect("make_backup_copy succeeds")
-        .expect("notice produced when an existing file is copied");
+    let notice = make_backup_copy(
+        &file_path,
+        &config,
+        DiskCommitConfig::default().backup_env(),
+    )
+    .expect("make_backup_copy succeeds")
+    .expect("notice produced when an existing file is copied");
 
     let backup_path = file_path.with_extension("bin~");
     assert!(backup_path.exists(), "backup copy must exist");
@@ -710,8 +730,12 @@ fn make_backup_copy_missing_file_is_noop() {
         backup_dir: None,
         suffix: OsString::from("~"),
     };
-    let notice = make_backup_copy(&file_path, &config, &DiskCommitConfig::default())
-        .expect("make_backup_copy succeeds");
+    let notice = make_backup_copy(
+        &file_path,
+        &config,
+        DiskCommitConfig::default().backup_env(),
+    )
+    .expect("make_backup_copy succeeds");
     assert!(notice.is_none(), "no notice when nothing was backed up");
     assert!(
         !file_path.with_extension("bin~").exists(),


### PR DESCRIPTION
## What

`make_backup` and its hard-link / rename / copy tiers took the whole
`DiskCommitConfig` while reading exactly three of its ~20 fields:

| field | read by |
|---|---|
| `sandbox` | `backup_rename_sandboxed`, `backup_hardlink_syscall`, `create_dir_all_sandboxed` |
| `dest_dir` | the same three |
| `metadata_opts` | `create_backup_path_parents` (the `--backup-dir` arm only) |

This introduces `BackupEnv<'a>`, a borrowed view of exactly those three, plus
`DiskCommitConfig::backup_env()`. The ladder now declares its real dependency
instead of the whole configuration.

## Why

Interface Segregation, but with a concrete motivation: the ladder is callable
only from code holding a `DiskCommitConfig`, and the receiver's delayed-updates
sweep does not hold one. Narrowing the parameter is the prerequisite for routing
that sweep onto this ladder instead of its own hand-rolled rename.

## Upstream

Upstream reaches the same state through file-scope globals that `make_backup()`
(`backup.c:437`) consults directly, so there is no upstream aggregate to mirror.
`BackupEnv` is the explicit spelling of that ambient state, not an invention of
new policy. The ladder's tier structure and its citations are untouched.

## Behaviour

Neutral. Both production call sites (`commit.rs`, `file_ops.rs`) pass
`config.backup_env()` and every field arrives unchanged; the types make a
mis-wiring a compile error.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p transfer --all-targets --all-features --no-deps -D warnings` clean
- `cargo nextest run -p transfer --all-features --no-fail-fast`: **2769 run, 2769 passed**, 3 skipped

⚠ **Mutation result, reported as measured rather than as a proof.** Two
mutations of `backup_env()` were run, each with the binary rebuilt so the
integration cells exercised them:

- `dest_dir: None` -> 56/56 backup tests still pass
- `sandbox: None` -> 56/56 backup tests still pass, and **2769/2769 crate-wide**

So this change is not covered by any discriminating test, in either direction.
That is a pre-existing coverage gap in the backup ladder's sandbox anchoring,
not something this PR introduces, and it is filed separately. I am explicitly
**not** claiming this refactor is mutation-proven.

## Base

Stacked on #7538 — it rewrites the same two functions, and cherry-picking onto
master conflicts in exactly that region. Retargets to master automatically when
#7538 lands.