### PR TITLE
test(daemon): pin the --delay-updates staging sequence under the worker filter

### DIFF
--- a/crates/daemon/tests/seccomp_worker_filter.rs
+++ b/crates/daemon/tests/seccomp_worker_filter.rs
@@ -279,3 +279,152 @@ fn a_special_file_is_creatable_under_the_worker_filter() {
         "the child reported success but no node exists - the pin would pass vacuously",
     );
 }
+
+/// Every syscall the `--delay-updates` receiver issues must be admitted by
+/// the worker filter.
+///
+/// `--delay-updates` substitutes the implicit `.~tmp~` partial directory
+/// (upstream `options.c:2563-2564`), which puts the receiver on a strictly
+/// larger set of operations than a plain push: it creates a staging
+/// directory, opens the temp through the operator-path fallback rather
+/// than the destination sandbox, moves the pre-image aside for
+/// `--backup-dir`, and renames the staged file into place. The plain push
+/// reaches none of the four.
+///
+/// Regression pin. MEASURED on x86_64 CI at PR head `6664b588e`: a daemon
+/// push with `--backup --backup-dir=bak --delay-updates` died with
+/// `rsync: [receiver] mkstemp "payload" (in data) failed: Operation not
+/// permitted (1)` and exit 23, while the identical push WITHOUT
+/// `--delay-updates` succeeded on the same run. `EPERM` is this filter's
+/// configured denial errno - Landlock reports `EACCES`, and
+/// `LANDLOCK_ACCESS_FS_REFER` reports `EXDEV` - so the refusal is the
+/// seccomp allowlist, not the path sandbox. The same push passes on
+/// aarch64, where the legacy non-`*at` syscalls this allowlist omits do
+/// not exist and glibc therefore has no alternative to lower to.
+///
+/// Same class as [`the_ownership_walk_resolves_under_the_worker_filter`]
+/// and the same visible symptom (`mkstemp ... Permission denied`), but a
+/// different caller: that pin covers the walk's starting `open`, this one
+/// covers the `--delay-updates` staging sequence.
+///
+/// Each step reports a distinct exit code and its errno, so a failure
+/// names the operation instead of leaving the caller to be guessed at.
+#[test]
+fn the_delay_updates_staging_sequence_runs_under_the_worker_filter() {
+    let root = std::env::temp_dir().join(format!("oc-delay-updates-probe-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir(&root).expect("probe root must be creatable");
+    let staging = root.join(".~tmp~");
+    let backup_dir = root.join("bak");
+    let destination = root.join("payload");
+    std::fs::create_dir(&backup_dir).expect("backup dir must be creatable");
+    std::fs::write(&destination, b"PRE-IMAGE").expect("destination must be creatable");
+    assert!(
+        root.is_absolute(),
+        "the probe root must be absolute so the ownership walk starts at `/`",
+    );
+
+    let mut fds: [libc::c_int; 2] = [-1, -1];
+    // SAFETY: `pipe` fills two ints; the array outlives the call.
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    assert!(rc == 0, "pipe failed: {}", io::Error::last_os_error());
+    let (read_fd, write_fd) = (fds[0], fds[1]);
+
+    let staged = staging.join("payload");
+    let child_paths = (
+        staging,
+        staged,
+        destination.clone(),
+        backup_dir.join("payload"),
+    );
+    let raw = fork_run(move || {
+        let (staging, staged, destination, backup) = child_paths;
+        match apply_worker_seccomp_filter() {
+            SeccompOutcome::Installed => {}
+            // Kernel refused the filter, or this build cannot install one:
+            // treat as a skip, matching the sibling tests above.
+            _ => return 77,
+        }
+        // Reports the failing step's errno through the inherited pipe. The
+        // exit code alone cannot carry it, and without the errno a red cell
+        // says only "something was refused".
+        let report = |step: i32, err: &io::Error| -> i32 {
+            let line = format!("step {step} errno {:?}\n", err.raw_os_error());
+            // SAFETY: `write` on an inherited pipe fd with a borrowed buffer
+            // whose length is passed explicitly; async-signal-safe.
+            #[allow(unsafe_code)]
+            unsafe {
+                libc::write(write_fd, line.as_ptr().cast(), line.len())
+            };
+            step
+        };
+
+        // upstream: util1.c:1518-1530 handle_partial_dir(PDIR_CREATE).
+        if let Err(e) = std::fs::create_dir_all(&staging) {
+            return report(10, &e);
+        }
+        // upstream: receiver.c:426-434 open_tmpfile() -> secure_mkstemp().
+        // The temp's parent is the staging dir, not the destination root,
+        // so this takes the operator-path fallback rather than the
+        // destination `DirSandbox` the plain push uses.
+        if let Err(e) = fast_io::ConfinedFallback::confined().open_at(
+            &staged,
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW,
+            0o600,
+        ) {
+            return report(11, &e);
+        }
+        // upstream: receiver.c:694 make_backup(fname, False) - the delayed
+        // sweep's own backup tier. `operator_rename` is the ownership walk
+        // plus `renameat`, which is the syscall shape the allowlist has to
+        // admit; the confinement variant the sweep uses adds a root check in
+        // userspace and issues the same calls.
+        if let Err(e) = fast_io::operator_rename(&destination, &backup, true) {
+            return report(12, &e);
+        }
+        // upstream: receiver.c:709 do_rename(partialptr, fname).
+        if let Err(e) = std::fs::rename(&staged, &destination) {
+            return report(13, &e);
+        }
+        0
+    });
+
+    // SAFETY: closing the parent's write end so the read below sees EOF.
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::close(write_fd)
+    };
+    let mut detail = String::new();
+    {
+        use std::io::Read;
+        use std::os::fd::FromRawFd;
+        // SAFETY: `read_fd` is owned by this scope and not used elsewhere.
+        #[allow(unsafe_code)]
+        let mut reader = unsafe { std::fs::File::from_raw_fd(read_fd) };
+        let _ = reader.read_to_string(&mut detail);
+    }
+    let _ = std::fs::remove_dir_all(&root);
+
+    let status = std::process::ExitStatus::from_raw(raw);
+    if let Some(sig) = status.signal() {
+        panic!("child killed by signal {sig} during the --delay-updates staging sequence");
+    }
+    let code = status.code().expect("child must exit");
+    if code == 77 {
+        eprintln!("seccomp filter install rejected by kernel; skipping");
+        return;
+    }
+    let step = match code {
+        10 => "create the `.~tmp~` staging directory",
+        11 => "open the staged temp file through the operator-path fallback",
+        12 => "move the pre-image into the `--backup-dir`",
+        13 => "rename the staged file over the destination",
+        _ => "an unrecognised step",
+    };
+    assert_eq!(
+        code, 0,
+        "the worker filter refused the --delay-updates receiver at: {step} ({detail}) - \
+         a syscall that step issues is missing from the allowlist",
+    );
+}

--- a/crates/daemon/tests/seccomp_worker_filter.rs
+++ b/crates/daemon/tests/seccomp_worker_filter.rs
@@ -361,7 +361,13 @@ fn the_delay_updates_staging_sequence_runs_under_the_worker_filter() {
         };
 
         // upstream: util1.c:1518-1530 handle_partial_dir(PDIR_CREATE).
-        if let Err(e) = std::fs::create_dir_all(&staging) {
+        // The receiver creates this through the ownership walk, so the probe
+        // calls the same primitive rather than `std::fs::create_dir_all`:
+        // glibc lowers `mkdir()` to the legacy `mkdir(2)` on x86_64, which
+        // this allowlist deliberately omits in favour of the `*at` variants,
+        // so a bare `create_dir_all` would pin a syscall production no longer
+        // issues.
+        if let Err(e) = fast_io::operator_mkdir(&staging, 0o777) {
             return report(10, &e);
         }
         // upstream: receiver.c:426-434 open_tmpfile() -> secure_mkstemp().

--- a/crates/daemon/tests/seccomp_worker_filter.rs
+++ b/crates/daemon/tests/seccomp_worker_filter.rs
@@ -389,8 +389,12 @@ fn the_delay_updates_staging_sequence_runs_under_the_worker_filter() {
         if let Err(e) = fast_io::operator_rename(&destination, &backup, true) {
             return report(12, &e);
         }
-        // upstream: receiver.c:709 do_rename(partialptr, fname).
-        if let Err(e) = std::fs::rename(&staged, &destination) {
+        // upstream: receiver.c:709 do_rename(partialptr, fname). The sweep
+        // issues this through the ownership walk (`operator_rename`), so the
+        // probe does too: a bare `std::fs::rename` reaches glibc's wrapper,
+        // lowered to the legacy `rename(2)` on x86_64, which this allowlist
+        // omits in favour of `renameat`.
+        if let Err(e) = fast_io::operator_rename(&staged, &destination, true) {
             return report(13, &e);
         }
         0

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -417,11 +417,11 @@ pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
-    operator_link, operator_mkdir, operator_open_append, operator_open_create_new,
-    operator_open_read, operator_open_read_confined, operator_open_recv, operator_open_rw_create,
-    operator_open_write_create, operator_open_write_create_confined, operator_read_to_string,
-    operator_rename, operator_symlink_metadata, owner_trusted_parent, owner_trusted_parent_kind,
-    symlink_owner_is_trusted,
+    operator_create_dir_all, operator_link, operator_mkdir, operator_open_append,
+    operator_open_create_new, operator_open_read, operator_open_read_confined, operator_open_recv,
+    operator_open_rw_create, operator_open_write_create, operator_open_write_create_confined,
+    operator_read_to_string, operator_rename, operator_symlink_metadata, owner_trusted_parent,
+    owner_trusted_parent_kind, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -545,6 +545,39 @@ pub fn operator_mkdir(path: &Path, mode: u32) -> io::Result<()> {
     }
 }
 
+/// Recursive directory create that issues `mkdirat` for every component.
+///
+/// Mirrors [`std::fs::create_dir_all`]'s contract - build missing ancestors,
+/// treat an existing directory as success - but routes each component through
+/// [`operator_mkdir`], so the syscall is always `mkdirat` and never the legacy
+/// `mkdir(2)`.
+///
+/// The daemon worker's seccomp allowlist admits only the `*at` syscall
+/// variants. On x86_64 glibc lowers `mkdir()` to the legacy `SYS_mkdir`, which
+/// that allowlist omits, so a bare `create_dir_all` is refused with `EPERM`;
+/// aarch64 has no legacy form to lower to and succeeds either way. That split
+/// is why the defect is invisible on one architecture.
+///
+/// # Errors
+///
+/// Surfaces any walk or `mkdirat` error. Only a missing ancestor is recursed
+/// on; every other failure is reported as-is so a refused component stays
+/// refused rather than being retried unconfined.
+pub fn operator_create_dir_all(path: &Path, mode: u32) -> io::Result<()> {
+    if path.as_os_str().is_empty() {
+        return Ok(());
+    }
+    match operator_mkdir(path, mode) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let parent = path.parent().ok_or(error)?;
+            operator_create_dir_all(parent, mode)?;
+            operator_mkdir(path, mode)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 /// Rename `old_path` to `new_path` with both endpoints resolved by the
 /// ownership walk.
 ///

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -755,7 +755,7 @@ fn create_backup_path_parents(
 /// under `dest_dir`, the final directory component is created via
 /// [`fast_io::mkdirat_via_sandbox_or_fallback`] so a symlink swap on the
 /// destination root cannot redirect it. Deeper trees, and the no-sandbox case,
-/// go through [`create_dir_all_at`], which is recursive like
+/// go through [`fast_io::operator_create_dir_all`], which is recursive like
 /// `std::fs::create_dir_all` but issues `mkdirat` per component.
 #[cfg(unix)]
 fn create_dir_all_sandboxed(config: &DiskCommitConfig, parent: &Path) -> io::Result<()> {
@@ -777,43 +777,7 @@ fn create_dir_all_sandboxed(config: &DiskCommitConfig, parent: &Path) -> io::Res
             Err(e) => Err(e),
         };
     }
-    create_dir_all_at(parent)
-}
-
-/// Recursive directory create that issues `mkdirat` for every component.
-///
-/// Mirrors [`std::fs::create_dir_all`]'s contract - build missing ancestors,
-/// treat an existing directory as success - but routes each component through
-/// the ownership walk so the syscall is `mkdirat`, never the legacy
-/// `mkdir(2)`.
-///
-/// The daemon worker's seccomp allowlist deliberately admits only the `*at`
-/// syscall variants (`worker_seccomp_allowlist`, `crates/daemon`). On x86_64
-/// glibc lowers `mkdir()` to the legacy `SYS_mkdir`, which that allowlist
-/// omits, so a bare `create_dir_all` is refused with EPERM; aarch64 has no
-/// legacy form to lower to and succeeds. MEASURED on x86_64 CI: the
-/// `--delay-updates` receiver failed at the `.~tmp~` create with
-/// `errno Some(1)` while the same commit passed on aarch64.
-#[cfg(unix)]
-fn create_dir_all_at(path: &Path) -> io::Result<()> {
-    if path.as_os_str().is_empty() {
-        return Ok(());
-    }
-    match fast_io::operator_mkdir(path, 0o777) {
-        Ok(()) => Ok(()),
-        // A missing ancestor is the only error worth recursing on; every other
-        // failure is reported as-is so a refused component stays refused.
-        Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            let parent = path.parent().ok_or(e)?;
-            create_dir_all_at(parent)?;
-            match fast_io::operator_mkdir(path, 0o777) {
-                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
-                other => other,
-            }
-        }
-        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
-        Err(e) => Err(e),
-    }
+    fast_io::operator_create_dir_all(parent, 0o777)
 }
 
 #[cfg(not(unix))]

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -130,9 +130,23 @@ pub(super) fn commit_file(
             // `AlreadyExists` for that shape and the `?` fails the whole
             // transfer where upstream unlinks the obstruction and proceeds -
             // measured against real 3.5.0 over a daemon push, which exits 0.
+            //
+            // The create goes through [`create_dir_all_sandboxed`], the same
+            // helper the `--backup-dir` parent already uses, rather than a bare
+            // `std::fs::create_dir_all`. `.~tmp~` is a single component beneath
+            // `dest_dir`, so that helper reduces it to one `mkdirat` anchored on
+            // the destination sandbox. A bare `create_dir_all` reaches glibc's
+            // `mkdir()` wrapper, which lowers to the legacy `mkdir(2)` on
+            // x86_64 - a syscall the daemon worker's seccomp allowlist
+            // deliberately omits in favour of the `*at` variants. MEASURED on
+            // x86_64 CI: the whole `--delay-updates` push died here with
+            // `Operation not permitted`, surfacing downstream as
+            // `mkstemp ... failed`, while the identical push without
+            // `--delay-updates` succeeded. aarch64 has no legacy `mkdir(2)` for
+            // glibc to lower to, which is why the defect was architecture-only.
             if let Some(parent) = staging_path.parent() {
                 clear_partial_dir_obstruction(parent)?;
-                fs::create_dir_all(parent)?;
+                create_dir_all_sandboxed(config, parent)?;
             }
             let result = rename_config_sandboxed(config, cleanup_guard.path(), &staging_path)
                 .map_err(|e| {

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -754,9 +754,9 @@ fn create_backup_path_parents(
 /// When the sandbox is present and `parent` is a single component directly
 /// under `dest_dir`, the final directory component is created via
 /// [`fast_io::mkdirat_via_sandbox_or_fallback`] so a symlink swap on the
-/// destination root cannot redirect it. Deeper trees, or the no-sandbox case,
-/// keep the original recursive [`std::fs::create_dir_all`] so behavior is
-/// unchanged (`create_dir_all` is idempotent for already-existing ancestors).
+/// destination root cannot redirect it. Deeper trees, and the no-sandbox case,
+/// go through [`create_dir_all_at`], which is recursive like
+/// `std::fs::create_dir_all` but issues `mkdirat` per component.
 #[cfg(unix)]
 fn create_dir_all_sandboxed(config: &DiskCommitConfig, parent: &Path) -> io::Result<()> {
     if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref())
@@ -777,7 +777,43 @@ fn create_dir_all_sandboxed(config: &DiskCommitConfig, parent: &Path) -> io::Res
             Err(e) => Err(e),
         };
     }
-    fs::create_dir_all(parent)
+    create_dir_all_at(parent)
+}
+
+/// Recursive directory create that issues `mkdirat` for every component.
+///
+/// Mirrors [`std::fs::create_dir_all`]'s contract - build missing ancestors,
+/// treat an existing directory as success - but routes each component through
+/// the ownership walk so the syscall is `mkdirat`, never the legacy
+/// `mkdir(2)`.
+///
+/// The daemon worker's seccomp allowlist deliberately admits only the `*at`
+/// syscall variants (`worker_seccomp_allowlist`, `crates/daemon`). On x86_64
+/// glibc lowers `mkdir()` to the legacy `SYS_mkdir`, which that allowlist
+/// omits, so a bare `create_dir_all` is refused with EPERM; aarch64 has no
+/// legacy form to lower to and succeeds. MEASURED on x86_64 CI: the
+/// `--delay-updates` receiver failed at the `.~tmp~` create with
+/// `errno Some(1)` while the same commit passed on aarch64.
+#[cfg(unix)]
+fn create_dir_all_at(path: &Path) -> io::Result<()> {
+    if path.as_os_str().is_empty() {
+        return Ok(());
+    }
+    match fast_io::operator_mkdir(path, 0o777) {
+        Ok(()) => Ok(()),
+        // A missing ancestor is the only error worth recursing on; every other
+        // failure is reported as-is so a refused component stays refused.
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            let parent = path.parent().ok_or(e)?;
+            create_dir_all_at(parent)?;
+            match fast_io::operator_mkdir(path, 0o777) {
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+                other => other,
+            }
+        }
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(not(unix))]

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -443,6 +443,39 @@ pub(in crate::receiver) enum DeletePassPhase {
     Late,
 }
 
+/// Creates a delayed-sweep directory, through the ownership walk where one
+/// exists.
+///
+/// On Unix this issues `mkdirat` per component. glibc lowers `mkdir()` to the
+/// legacy `mkdir(2)` on x86_64, and the daemon worker's seccomp allowlist
+/// admits only the `*at` variants, so a plain `create_dir_all` is refused with
+/// EPERM there while succeeding on aarch64, which has no legacy form to lower
+/// to. Other platforms have neither the ownership walk nor the filter.
+#[cfg(unix)]
+fn sweep_create_dir_all(path: &Path) -> io::Result<()> {
+    fast_io::operator_create_dir_all(path, 0o777)
+}
+
+#[cfg(not(unix))]
+fn sweep_create_dir_all(path: &Path) -> io::Result<()> {
+    std::fs::create_dir_all(path)
+}
+
+/// Renames a delayed-sweep file, through the ownership walk where one exists.
+///
+/// Unix issues `renameat` for the same reason [`sweep_create_dir_all`] issues
+/// `mkdirat`: the worker's seccomp allowlist omits the legacy `rename(2)` that
+/// glibc's `rename()` lowers to on x86_64.
+#[cfg(unix)]
+fn sweep_rename(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    fast_io::operator_rename(old_path, new_path, true)
+}
+
+#[cfg(not(unix))]
+fn sweep_rename(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    std::fs::rename(old_path, new_path)
+}
+
 /// Renames all delayed-update files from their staging paths to their final
 /// destinations, removing each emptied staging directory as it goes.
 ///
@@ -482,8 +515,6 @@ pub(in crate::receiver) fn handle_delayed_updates(
     backup_config: Option<crate::disk_commit::BackupConfig>,
     partial_dir: Option<&Path>,
 ) -> i32 {
-    use std::fs;
-
     use crate::generator::io_error_flags::IOERR_GENERAL;
 
     // Mirrors upstream's got_xfer_error: a failed rename here is a transfer
@@ -511,10 +542,10 @@ pub(in crate::receiver) fn handle_delayed_updates(
             // the derived `ENOENT` from the rename rather than the `EACCES`
             // that actually stopped the backup.
             let placed = match backup_path.parent() {
-                Some(parent) if !parent.exists() => fs::create_dir_all(parent),
+                Some(parent) if !parent.exists() => sweep_create_dir_all(parent),
                 _ => Ok(()),
             }
-            .and_then(|()| fs::rename(final_path, &backup_path));
+            .and_then(|()| sweep_rename(final_path, &backup_path));
 
             match placed {
                 Ok(()) => {
@@ -568,7 +599,7 @@ pub(in crate::receiver) fn handle_delayed_updates(
         );
 
         // upstream: receiver.c:546 - do_rename(partialptr, fname)
-        if let Err(e) = fs::rename(staging_path, final_path) {
+        if let Err(e) = sweep_rename(staging_path, final_path) {
             // upstream: rsyserr(FERROR_XFER, ...) sets got_xfer_error ->
             // RERR_PARTIAL (exit 23). On kernels 5.13-5.18 the Landlock
             // sandbox lacks ACCESS_FS_REFER, so this cross-dir rename is


### PR DESCRIPTION
## What this measures

A daemon push with `--backup --backup-dir=bak --delay-updates` dies on x86_64 with

```
rsync: [receiver] mkstemp "payload" (in data) failed: Operation not permitted (1)
```

and exit 23, while the **identical push without `--delay-updates` succeeds on the same
run**. Observed on #7538's CI (run 33127409523, `nextest (stable)`), where the failing
cell is that PR's own availability control.

`EPERM` is the seccomp worker filter's configured denial errno. Landlock reports
`EACCES`, and `LANDLOCK_ACCESS_FS_REFER` reports `EXDEV`, so the refusal comes from the
syscall allowlist rather than the path sandbox. The daemon log confirms both layers
engaged:

```
module 'data': landlock fully enforced over 1 root(s)
module 'data': seccomp BPF filter engaged (EPERM on unlisted syscalls)
```

## Why `--delay-updates` and not the plain push

`--delay-updates` substitutes the implicit `.~tmp~` partial directory (upstream
`options.c:2563-2564`), which puts the receiver on four operations a plain push never
reaches:

1. creating the `.~tmp~` staging directory,
2. opening the temp through the operator-path fallback instead of the destination
   `DirSandbox` — `try_create_new` takes the sandbox branch only when the temp's parent
   *is* `dest_dir`, and under `--delay-updates` it is not,
3. moving the pre-image aside for `--backup-dir`,
4. renaming the staged file over the destination.

This test exercises all four under the production filter and reports the failing step
with its errno, so a refusal names its caller instead of leaving it to be inferred.

## Same class as an existing pin

`the_ownership_walk_resolves_under_the_worker_filter` records the same symptom string
(`mkstemp ... Permission denied`) for a different caller: on x86_64 a no-dirfd open
lowers to the legacy `SYS_open`, which this allowlist deliberately omits in favour of the
`*at` variants. aarch64 has no legacy non-`*at` syscalls at all, so glibc has no
alternative to lower to — which is why the defect is x86_64-only and why the cell passes
on aarch64.

## Status

Draft. This first CI run **is** the measurement: the x86_64 cells are expected to name
the failing step, and the fix for whichever syscall they name lands in this PR before it
leaves draft. Verified to compile and pass on aarch64 Linux, the expected control.
