### PR TITLE
docs: resolve the four rustdoc links breaking the Pages build

### DIFF
--- a/crates/engine/src/delete/emitter/fs.rs
+++ b/crates/engine/src/delete/emitter/fs.rs
@@ -167,7 +167,7 @@ pub trait DeleteFs: std::fmt::Debug {
 /// Production [`DeleteFs`] implementation backed by `std::fs` (path
 /// fallback) and the `fast_io` `*at` syscall wrappers (sandbox path).
 ///
-/// All file-like kinds route to [`fs::remove_file`] (Unix `unlink(2)`,
+/// All file-like kinds route to [`std::fs::remove_file`] (Unix `unlink(2)`,
 /// Windows `DeleteFileW`) on the path fallback. The sandbox path routes
 /// every leaf-removal through [`fast_io::unlinkat`] for the non-recursive
 /// kinds and [`fast_io::recursive_unlinkat`] for the recursive fallback,
@@ -291,7 +291,7 @@ impl DeleteFs for RealDeleteFs {
     ///
     /// The residue [`remove_dir_all_at`](fast_io::ConfinedFallback::remove_dir_all_at)
     /// returns is dropped here because this trait method mirrors
-    /// [`fs::remove_dir_all`]'s `()` result. The dirfd-anchored sibling
+    /// [`std::fs::remove_dir_all`]'s `()` result. The dirfd-anchored sibling
     /// [`Self::remove_dir_all_at`] is the one that surfaces the residue to the
     /// emitter's exit-code decision; that split is unchanged.
     #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -844,7 +844,7 @@ pub fn operator_open_write_create_confined(path: &Path, mode: u32) -> io::Result
 ///
 /// # Errors
 ///
-/// See [`operator_open_with`]. `AlreadyExists` is the expected, retryable
+/// See `operator_open_with`. `AlreadyExists` is the expected, retryable
 /// outcome when the generated name collides.
 pub fn operator_open_create_new(path: &Path, mode: u32) -> io::Result<std::fs::File> {
     operator_open_with(
@@ -881,7 +881,7 @@ pub fn operator_open_create_new(path: &Path, mode: u32) -> io::Result<std::fs::F
 ///
 /// # Errors
 ///
-/// See [`operator_open_with`].
+/// See `operator_open_with`.
 pub fn operator_open_recv(
     path: &Path,
     create: bool,


### PR DESCRIPTION
Master's `Pages` workflow has been failing. `cargo doc` runs with `-D warnings`, so an unresolved intra-doc link fails the job outright.

Four links, two causes:

**`crates/engine/src/delete/emitter/fs.rs:170,294`** — the module is itself named `fs`, so `` [`fs::remove_file`] `` resolves against *that* module, not `std::fs`, and finds no such item. Both now name `std::fs` explicitly.

**`crates/fast_io/src/owner_walk.rs:847,884`** — `operator_open_create_new` and `operator_open_recv` are public and link to `operator_open_with`, which is private; rustdoc rejects a public item linking to a private one. Both become plain backticks, matching what the surrounding docs already do for items that are named but not linkable.

Verified with the same invocation the workflow uses:

```
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

Zero errors, zero warnings. Docs-only; no code path changes.