### PR TITLE
fix(transfer): retain into the partial-dir through the shared owner

### DIFF
--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -576,15 +576,20 @@ impl TempFileGuard {
             io::Error::new(io::ErrorKind::InvalidInput, "destination has no filename")
         })?;
 
-        // Create the partial directory if it does not exist.
+        // Create the partial directory through the shared owner, which runs
+        // upstream's confined reuse probe before the confined `mkdirat`
+        // (util1.c:1518-1530 `handle_partial_dir(PDIR_CREATE)`). A bare
+        // `parent.exists()` guard here would be a FOLLOWING stat, skipping the
+        // create - and therefore the walk - on exactly the case that matters:
+        // a foreign-owned symlink already standing at the partial-dir name.
+        // The `?` keeps the create a precondition, so a refusal aborts the
+        // retention instead of renaming into the refused location.
         if let Some(parent) = partial_path.parent() {
-            if !parent.exists() {
-                fs::create_dir_all(parent)?;
-            }
+            engine::create_partial_dir(parent)?;
         }
 
         // Rename temp file to the partial path, with cross-device fallback.
-        match fs::rename(self.path(), &partial_path) {
+        match partial_dir_rename(self.path(), &partial_path) {
             Ok(()) => {
                 self.keep_on_drop = true;
                 Ok(partial_path)
@@ -631,6 +636,28 @@ pub fn partial_dir_fname(dest_path: &Path, partial_dir: &Path) -> Option<PathBuf
 /// with the engine local-copy commit guard and the disk-commit path.
 fn is_cross_device_error(e: &io::Error) -> bool {
     fast_io::is_cross_device(e)
+}
+
+/// Renames a temp file into the `--partial-dir` through the ownership walk
+/// where one exists.
+///
+/// Unix issues `renameat` for the same reason
+/// [`engine::create_partial_dir`] issues `mkdirat`: upstream wraps the whole
+/// retention in `operator_path_resolve` (util1.c:1518-1530), so a foreign-owned
+/// symlink on the way to the partial dir cannot redirect the staged file - a
+/// complete copy of the source - out of the tree. It is also what the daemon
+/// worker's seccomp allowlist admits: that filter carries only the `*at`
+/// variants, and glibc lowers `rename()` to the legacy `rename(2)` on x86_64.
+///
+/// Other platforms have neither the ownership walk nor the filter.
+#[cfg(unix)]
+fn partial_dir_rename(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    fast_io::operator_rename(old_path, new_path, true)
+}
+
+#[cfg(not(unix))]
+fn partial_dir_rename(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    fs::rename(old_path, new_path)
 }
 
 /// Commits a temp file to its final destination on Windows with a


### PR DESCRIPTION
`TempFileGuard::rename_to_partial_dir` — the `--partial-dir` retention on abort (upstream `cleanup.c:105-115`) — carried its own copy of the partial-dir create rule, and that copy predates the correction made to the shared one.

## The duplicate

```rust
if let Some(parent) = partial_path.parent() {
    if !parent.exists() {          // FOLLOWING stat
        fs::create_dir_all(parent)?;
    }
}
match fs::rename(self.path(), &partial_path) { ... }
```

`parent.exists()` follows symlinks, so a symlink already standing at the partial-dir name *resolves* — the create is skipped entirely, and the plain `fs::rename` follows the link. That is the same shape corrected in `engine::create_partial_dir`, which probes with `operator_symlink_metadata` and creates with `operator_mkdir`, both under the ownership walk. Upstream keeps the probe and the create inside one `operator_path_resolve` (`util1.c:1518-1530`).

## The change

Call the shared owner instead of repairing the copy, so the two cannot drift again — and its existing tests now cover this site. `transfer` already depends on `engine` and already calls the sibling `engine::remove_partial_dir` from this same area, so the routing follows an established pattern.

The rename moves to `fast_io::operator_rename` for the same reason the delayed-updates sweep did in #7554: it is what the daemon worker's seccomp allowlist admits. That filter carries only the `*at` variants, and glibc lowers `rename()` to the legacy `rename(2)` on x86_64.

`engine::create_partial_dir` already has both platform arms, so the create needs no `cfg` split here; only the rename does.

## On testing

No same-uid unit test discriminates this change, and I want to be explicit rather than ship a test that looks like proof and is not. The two conditions that make the old code observably wrong are a **foreign-owned** ancestor (the ownership walk deliberately trusts your own symlinks) and the **daemon worker seccomp filter** (x86_64, `renameat` vs legacy `rename`). Neither is reachable from a single-uid test process.

I wrote a symlink-escape test first and it failed — asserting a refusal the design does not make for a self-owned link. Removed rather than weakened.

What the change rests on instead: it deletes a duplicate and calls an owner that is already tested. Existing coverage confirms no regression — `-p transfer` partial-dir cells 38/38.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo check -p transfer --target x86_64-pc-windows-gnu --all-features` clean
- `cargo nextest run -p transfer --all-features -E 'test(partial_dir)'` — 38/38