### PR TITLE
test(io_uring): attribute drop-contract registration failures

### DIFF
--- a/crates/fast_io/src/io_uring/registered_buffers/tests/drop_contract.rs
+++ b/crates/fast_io/src/io_uring/registered_buffers/tests/drop_contract.rs
@@ -153,7 +153,12 @@ fn buffers_freed_with_or_without_explicit_unregister() {
         let Some(group) = try_group(&ring, 4096, 4) else {
             return;
         };
-        let _ = group.unregister(&ring);
+        let cleanup = group.unregister(&ring);
+        assert!(
+            cleanup.is_ok(),
+            "path A: unregister on the live ring must succeed, otherwise the \
+             registration stays live and paths B and C silently skip: {cleanup:?}"
+        );
         drop(group);
     }
 
@@ -170,7 +175,13 @@ fn buffers_freed_with_or_without_explicit_unregister() {
     // ring remains in a clean state for further registrations.
     for _ in 0..3 {
         if let Some(group) = RegisteredBufferGroup::try_new(&ring, 4096, 2) {
-            let _ = group.unregister(&ring);
+            let cleanup = group.unregister(&ring);
+            assert!(
+                cleanup.is_ok(),
+                "path C: unregister must succeed, otherwise the next \
+                 iteration re-registers against a still-live registration \
+                 and silently skips: {cleanup:?}"
+            );
         }
     }
 }
@@ -211,11 +222,18 @@ fn drop_does_not_release_kernel_registration() {
     // the live ring fd. After this, fresh registration must succeed -
     // confirming the ring itself is not poisoned by the silent-Drop
     // policy, only the prior kernel-side registration was still live.
-    let _ = ring.submitter().unregister_buffers();
+    let cleanup = ring.submitter().unregister_buffers();
+    assert!(
+        cleanup.is_ok(),
+        "explicit unregister_buffers on the live ring must succeed before \
+         the re-registration probe: {cleanup:?}"
+    );
     let third = RegisteredBufferGroup::new(&ring, 4096, 2);
+    let third_err = third.as_ref().err();
     assert!(
         third.is_ok(),
-        "after explicit unregister, the ring must accept a fresh registration"
+        "after explicit unregister, the ring must accept a fresh \
+         registration; the fresh `new` reported {third_err:?}"
     );
 }
 
@@ -285,10 +303,9 @@ fn drop_on_construction_failure_does_not_double_register() {
     // update semantics the second `new` succeeds; in that case we
     // cannot probe the failure-recovery branch and skip out cleanly.
     let second = RegisteredBufferGroup::new(&ring, 4096, 2);
-    if second.is_ok() {
+    let Err(second_err) = second else {
         return;
-    }
-    drop(second);
+    };
 
     // The first group is still functional - registration-failure
     // recovery in the second call did not poison its state.
@@ -296,15 +313,28 @@ fn drop_on_construction_failure_does_not_double_register() {
     let s = first.checkout().expect("first group still usable");
     drop(s);
 
-    // Explicit unregister on the live group clears kernel state.
-    let _ = first.unregister(&ring);
+    // Explicit unregister on the live group clears kernel state. This is a
+    // precondition of the reuse probe below, not incidental teardown: a
+    // failed unregister leaves the first registration live, so the fresh
+    // `new` would be rejected with EBUSY for a reason that has nothing to
+    // do with failure-recovery. Assert it so the panic names the real step.
+    let cleanup = first.unregister(&ring);
+    assert!(
+        cleanup.is_ok(),
+        "unregister on the live ring must clear the kernel registration \
+         before the reuse probe (the rejected second `new` reported \
+         {second_err}): {cleanup:?}"
+    );
     drop(first);
 
     // After cleanup, a fresh group constructs cleanly. This proves the
     // failure-recovery branch did not leave dangling kernel state.
     let third = RegisteredBufferGroup::new(&ring, 4096, 2);
+    let third_err = third.as_ref().err();
     assert!(
         third.is_ok(),
-        "ring must be reusable after a failed registration was cleaned up"
+        "ring must be reusable after a failed registration was cleaned up \
+         (the rejected second `new` reported {second_err}); the fresh `new` \
+         reported {third_err:?}"
     );
 }


### PR DESCRIPTION
The `io_uring` fixed-buffer drop-contract tests are undiagnosable when
they fail. A recent x86_64 CI failure in the `Feature flag combinations /
io_uring (linux)` cell reported only:

```
panicked at .../drop_contract.rs:306:5:
ring must be reusable after a failed registration was cleaned up
```

That message cannot be acted on, for two reasons.

1. `let _ = first.unregister(&ring);` discarded its `Result`. That
   unregister is a precondition of the claim the test makes, not
   teardown: `unregister_buffers` clears the ring-wide registration, so
   if it fails the first registration is still live and the following
   `RegisteredBufferGroup::new` is rejected with EBUSY. The assertion
   then blames "reusability" for an unregister failure.
2. The final `assert!(third.is_ok(), ...)` threw away the `io::Error` -
   the one value that distinguishes EBUSY (state not cleared) from
   ENOMEM / EPERM (a memlock or sandbox limit on the runner).

Each unregister whose success a later assertion depends on is now
asserted with its error in the message, and the reuse assertions carry
the actual `io::Error`. Assertions are only added; none are relaxed.
The unregister assertion matches a contract this file already enforces
in `unregister_after_ring_closed_returns_error_or_ok`, which asserts
that the first unregister against a live ring succeeds.

The same shape is fixed in the two siblings that share it:
`drop_does_not_release_kernel_registration` (identical discarded
`unregister_buffers` plus errorless assert) and
`buffers_freed_with_or_without_explicit_unregister` (paths A and C,
where a failed unregister makes the following paths skip silently).
Trailing `let _ = group.unregister(&ring)` calls that are the last
statement of a test are pure teardown and are left alone.

The skip-versus-assert asymmetry between `try_group` and the final
`new` is deliberate and is kept: at `try_group` the environment has not
yet shown it can register buffers at all, so a refusal is an
unavailable feature; at the final `new` it already has, so a refusal is
a defect in the cleanup path under test. Softening it to a skip would
make the test vacuous.

Verified on an aarch64 Linux host (kernel 7.0.0), which refuses
double-registration and therefore exercises the recovery branch rather
than skipping it:

- `cargo fmt --all -- --check` - clean
- `cargo clippy -p fast_io --all-targets --features io_uring --no-deps
  -- -D warnings` - clean
- `cargo nextest run -p fast_io --features io_uring -E
  "test(drop_contract)"` - 9 tests run, 9 passed

Both new messages were proven to surface by temporarily forcing each
branch and then reverting:

unregister forced to EBUSY:

```
unregister on the live ring must clear the kernel registration before
the reuse probe (the rejected second `new` reported
IORING_REGISTER_BUFFERS failed: Device or resource busy (os error 16)):
Err(Os { code: 16, kind: ResourceBusy, message: "Device or resource busy" })
```

cleanup removed so the fresh registration fails naturally:

```
ring must be reusable after a failed registration was cleaned up (the
rejected second `new` reported IORING_REGISTER_BUFFERS failed: Device
or resource busy (os error 16)); the fresh `new` reported
Some(Custom { kind: Other, error: "IORING_REGISTER_BUFFERS failed:
Device or resource busy (os error 16)" })
```

No retry logic, no `#[ignore]`, no waivers.