### PR TITLE
fix(daemon): accept the forwarded --only-write-batch

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -510,6 +510,40 @@ fn apply_long_form_args(
                     if fmt.contains("%I") {
                         config.flags.info_flags.itemize_unchanged = true;
                     }
+                // `--only-write-batch` is NOT client-only: it rides the same
+                // popt table the daemon runs (`options.c:812` -
+                // `{"only-write-batch", 0, POPT_ARG_STRING, &batch_name,
+                // OPT_ONLY_WRITE_BATCH, ...}`, whose case at
+                // `options.c:1779-1781` sets `write_batch = -1`), and a
+                // conforming client emits it at `options.c:3016-3017`
+                // (`if (write_batch < 0) args[ac++] = "--only-write-batch=X"`).
+                // The server-side reset at `options.c:2261-2273` that prints
+                // "ignoring --write-batch option sent to server" fires only for
+                // `write_batch > 0 || read_batch`, so `write_batch = -1`
+                // survives on the daemon. Refusing it turned away upstream
+                // 3.5.0 with `@ERROR: unrecognized option (in daemon mode)`.
+                //
+                // The value is upstream's literal placeholder `X`, never a real
+                // path: `main.c:1912` gates `open_batch_files()` on `!am_server`,
+                // so the daemon never opens a batch file. What it must take from
+                // the flag is the mode switch - `clientserver.c:1195`
+                // `if (write_batch < 0) dry_run = 1` - and the receiver body at
+                // `receiver.c:987-993`, which logs the item and writes nothing
+                // while the generator still sends real block checksums.
+                //
+                // Gated on the receiver role because `server_options()` emits the
+                // token only inside its `am_sender` block, so a daemon serving a
+                // pull never sees it. This mirrors the sibling `--server` argv
+                // parser (`cli/src/frontend/server/run.rs`).
+                } else if arg
+                    .split('=')
+                    .next()
+                    .is_some_and(|name| name == "--only-write-batch")
+                {
+                    if config.role == ServerRole::Receiver {
+                        config.flags.only_write_batch = true;
+                        config.flags.dry_run = true;
+                    }
                 } else if rejection.is_none() && is_client_only_flag_reaching_daemon(arg) {
                     // upstream: options.c:1460-1465 - the daemon's popt loop
                     // emits `rsync: <BAD>: <err> (in daemon mode)` on the
@@ -632,28 +666,27 @@ fn size_arg_error(opt_name: &str, value: &str, reason: &str) -> String {
 /// Reports whether `arg` is a client-only flag that should never reach the
 /// daemon.
 ///
-/// `--write-batch`, `--only-write-batch`, and `--read-batch` set up local
-/// batch-file recording or replay on the CLIENT side only. Upstream
-/// `options.c:server_options()` deliberately omits them from the argv sent
-/// to the server; the only related token upstream emits is the literal
-/// `--only-write-batch=X` placeholder at `options.c:2832-2833`, which
-/// carries no real path. Encountering one here means the client-side
-/// sanitiser failed - the previous behaviour was a silent connection close
-/// in the middle of file-list framing. Surface this as a Rule-12 fail-loud
-/// `@ERROR` instead.
+/// `--write-batch` and `--read-batch` set up local batch-file recording or
+/// replay on the CLIENT side only. Upstream `options.c:server_options()`
+/// deliberately omits them from the argv sent to the server. Encountering one
+/// here means the client-side sanitiser failed - the previous behaviour was a
+/// silent connection close in the middle of file-list framing. Surface this as
+/// a Rule-12 fail-loud `@ERROR` instead.
+///
+/// `--only-write-batch` is deliberately NOT in this set: upstream emits it to
+/// the server on purpose (`options.c:3016-3017`) and keeps `write_batch = -1`
+/// there, so it is handled as a real option by the caller.
 ///
 /// Both bare-flag (`--write-batch`) and key=value (`--write-batch=PATH`)
 /// forms are detected.
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:784-786` - `read-batch`, `write-batch`, `only-write-batch`
-///   popt entries (client-only)
+/// - `options.c:810-811` - `read-batch` and `write-batch` popt entries
+/// - `options.c:2261-2273` - the server-side reset that fires for
+///   `write_batch > 0 || read_batch`
 /// - `options.c:1444-1449` - daemon-mode unknown option error path
 fn is_client_only_flag_reaching_daemon(arg: &str) -> bool {
     let bare = arg.split('=').next().unwrap_or(arg);
-    matches!(
-        bare,
-        "--write-batch" | "--only-write-batch" | "--read-batch"
-    )
+    matches!(bare, "--write-batch" | "--read-batch")
 }

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1254,21 +1254,57 @@ mod module_access_tests {
         );
     }
 
+    // `--only-write-batch` is the one member of the batch family upstream
+    // deliberately forwards to the server: `options.c:3016-3017` emits the
+    // literal `--only-write-batch=X` inside `server_options()`'s `am_sender`
+    // block, and `options.c:812` accepts it into the same popt table the daemon
+    // runs. Refusing it here turned away a conforming upstream 3.5.0 client with
+    // `@ERROR: --only-write-batch=X: unrecognized option (in daemon mode)` and
+    // exit 4, where upstream's own daemon completes the push writing nothing.
+    //
+    // The daemon must take the mode switch from it, not the value: the `X` is a
+    // placeholder (`main.c:1912` gates `open_batch_files()` on `!am_server`),
+    // while `clientserver.c:1195` sets `dry_run = 1` and `receiver.c:987-993`
+    // logs each item without touching the destination.
     #[test]
-    fn apply_long_form_args_reports_only_write_batch_kv_as_unknown() {
+    fn apply_long_form_args_accepts_only_write_batch_and_forces_dry_run() {
         let args = vec![
             "--server".to_owned(),
-            "--only-write-batch=/tmp/dry.batch".to_owned(),
+            "--only-write-batch=X".to_owned(),
             ".".to_owned(),
         ];
         let mut config = ServerConfig::default();
-        let offender = apply_long_form_args(&args, &mut config);
-        assert_eq!(
-            offender,
-            Some(ClientArgRejection::Unrecognized(
-                "--only-write-batch=/tmp/dry.batch".to_owned()
-            ))
+        assert_eq!(config.role, ServerRole::Receiver);
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(
+            config.flags.only_write_batch,
+            "--only-write-batch=X must select the receiver's only-write-batch loop"
         );
+        assert!(
+            config.flags.dry_run,
+            "upstream clientserver.c:1195 forces dry_run when write_batch < 0"
+        );
+    }
+
+    // `server_options()` emits the token only inside its `am_sender` block, so a
+    // daemon serving a PULL is the sender and never sees it. A generator that
+    // switched itself into dry-run would stop streaming the data the client
+    // needs to record, so the arm must stay inert for that role.
+    #[test]
+    fn apply_long_form_args_leaves_a_sender_daemon_untouched_by_only_write_batch() {
+        let args = vec![
+            "--server".to_owned(),
+            "--sender".to_owned(),
+            "--only-write-batch=X".to_owned(),
+            ".".to_owned(),
+        ];
+        let mut config = ServerConfig {
+            role: ServerRole::Generator,
+            ..ServerConfig::default()
+        };
+        assert!(apply_long_form_args(&args, &mut config).is_none());
+        assert!(!config.flags.only_write_batch);
+        assert!(!config.flags.dry_run);
     }
 
     // upstream: options.c:2998-3001 - `server_options()` forwards


### PR DESCRIPTION
## The bug

An upstream rsync 3.5.0 client pushing with `--only-write-batch` to an oc daemon is turned away:

```
$ rsync -av --only-write-batch=/tmp/b.batch src/ rsync://127.0.0.1:28933/mod/
sending incremental file list
@ERROR: --only-write-batch=X: unrecognized option (in daemon mode)
rsync: [sender] read error: Connection reset by peer (54)
exit=4
```

The same command against an upstream 3.5.0 daemon exits 0, leaves the destination untouched, and writes the batch locally.

## The upstream rule

`--only-write-batch` is not a client-only flag. It sits in the same popt table the daemon runs:

```c
/* options.c:812 */
{"only-write-batch", 0,  POPT_ARG_STRING, &batch_name, OPT_ONLY_WRITE_BATCH, 0, 0 },
```

whose case sets the mode:

```c
/* options.c:1779-1781 */
case OPT_ONLY_WRITE_BATCH:
        /* batch_name is already set */
        write_batch = -1;
        break;
```

and `server_options()` emits it to the server on purpose:

```c
/* options.c:3016-3017, inside the am_sender block */
if (write_batch < 0)
        args[ac++] = "--only-write-batch=X";
```

The server-side reset that prints `ignoring --write-batch option sent to server` (`options.c:2261-2273`) is guarded by `write_batch > 0 || read_batch`, so `write_batch = -1` survives on the server.

This is **not** accept-and-ignore - the server reads it:

- `clientserver.c:1195` - `if (write_batch < 0) dry_run = 1;`
- `receiver.c:987-993` - logs the item and writes nothing, while the generator still sends real block checksums.

The value is never opened: `main.c:1912` gates `open_batch_files()` on `!am_server`, which is why upstream passes the literal placeholder `X` rather than a path.

## The fix

`apply_long_form_args` now recognises `--only-write-batch` and takes the mode switch from it, discarding the value: it sets the receiver's existing `only_write_batch` + `dry_run` flags. `--write-batch` and `--read-batch` keep their fail-loud `@ERROR`, which is correct - `server_options()` never forwards those.

The wiring is the same one oc's sibling `--server` argv parser already had (`cli/src/frontend/server/run.rs`), which is why the divergence was visible only over `rsync://` and not over ssh. The arm is gated on the receiver role for the same reason upstream's emission is: `server_options()` writes the token only inside its `am_sender` block, so a daemon serving a pull never sees it.

No new field and no new consumer: `TransferFlags::only_write_batch` already drives `receiver/transfer/mode.rs:72` into `run_only_write_batch_loop`.

## Verification

Measured with rsync 3.5.0 as both the client and the oracle.

After the fix, oc's daemon matches upstream's:

```
--- subject: --only-write-batch push to the oc daemon
a.txt
sent 91 bytes  received 38 bytes
total size is 43  speedup is 0.33 (BATCH ONLY)
exit=0
--- dest listing
(empty)
--- replay of the recorded batch with `rsync --read-batch`
a.txt   ->   43 bytes, content intact
```

Test mutation (revert the parser arm, keep the tests):

- fixed: `4 tests run: 4 passed, 1894 skipped`
- mutated: `4 tests run: 2 passed, 2 failed, 1894 skipped`

The two that stay green in both runs are the `--write-batch` / `--read-batch` refusal tests, which confirms the new tests fail for the intended reason rather than from a broken fixture.

Also run:

- `cargo fmt --all -- --check` - clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run -p daemon --all-features` - `1892 tests run: 1892 passed, 6 skipped`
- `cargo nextest run -p transfer --all-features --test uts_15_e_daemon_pull_write_batch` - 1 passed
- root-level batch integration tests (`only_write_batch_remote_pull`, `only_write_batch_remote_push`, `batch_only_write_no_dest_dir`, `batch_local_write_flag_roundtrip`, `batch_files_created_with_upstream_modes`) - `9 tests run: 9 passed`

## Adjacent, not in this PR

oc's own client still strips `--only-write-batch` from a daemon-bound argv (`core/.../orchestration/arguments.rs`, `CLIENT_ONLY`), where upstream forwards it. That is a separate client-side divergence and is left for its own change.
