### PR TITLE
docs(transfer): pin backup ladder citations to rsync 3.5.0

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -80,8 +80,8 @@ pub(super) struct CommitOutcome {
 ///
 /// # Upstream Reference
 ///
-/// - `receiver.c:1029-1052`: delay_updates stages to partial dir
-/// - `receiver.c:529-557`: `handle_delayed_updates()` bulk rename
+/// - `receiver.c:1285-1314`: delay_updates stages to partial dir
+/// - `receiver.c:685-720`: `handle_delayed_updates()` bulk rename
 pub(super) fn commit_file(
     begin: &BeginMessage,
     config: &DiskCommitConfig,
@@ -103,7 +103,7 @@ pub(super) fn commit_file(
     // inode is rewritten in place, so a rename-to-backup here would move the very
     // file we already overwrote (its pre-transfer contents are gone by commit).
     // Upstream instead COPIES the pre-image aside BEFORE the inplace rewrite
-    // (generator.c:1862,1898); oc mirrors that in `process_file` /
+    // (generator.c:2281,2328); oc mirrors that in `process_file` /
     // `process_whole_file` via `make_backup_copy` prior to the first write.
     let backup_notice = if !config.delay_updates && !begin.is_inplace {
         if let Some(ref backup_config) = config.backup {
@@ -178,7 +178,7 @@ pub(super) fn commit_file(
         CleanupManager::global().unregister_temp_file(cleanup_guard.path());
         result
     } else if begin.is_inplace && !begin.is_device_target {
-        // upstream: receiver.c:496 gates the in-place ftruncate on
+        // upstream: receiver.c:652 gates the in-place ftruncate on
         // `!IS_DEVICE(file->mode)`, so `--write-devices` never truncates the
         // target device - its data lands via the in-place writes and a
         // block/char device has no length to set (ftruncate would fail EINVAL).
@@ -203,7 +203,7 @@ pub(super) fn commit_file(
         false
     };
     cleanup_guard.keep();
-    // upstream: receiver.c:1035-1037 - once the file is committed, a basis that
+    // upstream: receiver.c:1291-1299 - once the file is committed, a basis that
     // came from the partial directory (FNAMECMP_PARTIAL_DIR) is unlinked and the
     // now-empty partial-dir is rmdir'd via handle_partial_dir(PDIR_DELETE). The
     // removal is unconditional for --partial-dir successes: when no partial
@@ -277,9 +277,9 @@ pub(super) fn delay_updates_staging_path(
 ///   modtime (`cleanup_file->modtime = 0`, `tweak_modtime = 1`) so an
 ///   interrupted partial stands out in `ls` and is not skipped by `--update`.
 ///   Used by the interrupt paths (channel disconnect, `Abort`, `Shutdown`).
-/// - `false` (normal failed-verify keep): upstream `receiver.c:1047` calls
+/// - `false` (normal failed-verify keep): upstream `receiver.c:1309` calls
 ///   `finish_transfer(..., recv_ok, ...)` with `recv_ok == 0`, which maps to
-///   `ATTRS_SKIP_MTIME` (`rsync.c:748-749`), so the retained stub keeps its
+///   `ATTRS_SKIP_MTIME` (`rsync.c:911-912`), so the retained stub keeps its
 ///   recent temp-creation mtime rather than being reset to the epoch.
 ///
 /// `--partial-dir` never zeros the mtime in either case (upstream routes it
@@ -287,10 +287,10 @@ pub(super) fn delay_updates_staging_path(
 ///
 /// # Upstream Reference
 ///
-/// - `cleanup.c:105-115` - `handle_partial_dir()` moves temp to partial-dir
+/// - `cleanup.c:169-170` - `handle_partial_dir()` moves temp to partial-dir
 /// - `cleanup.c:174-180` - signal cleanup zeros modtime for plain `--partial`
-/// - `receiver.c:1047` - normal keep uses `ok_to_set_time = recv_ok` (0 on fail)
-/// - `rsync.c:748-749` - `ok_to_set_time ? ATTRS_ACCURATE_TIME : ATTRS_SKIP_MTIME`
+/// - `receiver.c:1309` - normal keep uses `ok_to_set_time = recv_ok` (0 on fail)
+/// - `rsync.c:911-912` - `ok_to_set_time ? ATTRS_ACCURATE_TIME : ATTRS_SKIP_MTIME`
 pub(super) fn retain_partial_file(
     config: &DiskCommitConfig,
     cleanup_guard: &mut TempFileGuard,
@@ -300,7 +300,7 @@ pub(super) fn retain_partial_file(
     match &config.partial_mode {
         PartialMode::None => {}
         PartialMode::Partial => {
-            // upstream: cleanup.c:130-135 - rename temp file directly to
+            // upstream: cleanup.c:181-182 - finish_transfer() puts the temp at
             // the destination. The incomplete content replaces any existing
             // file at the destination path.
             let temp_path = cleanup_guard.path().to_path_buf();
@@ -311,7 +311,7 @@ pub(super) fn retain_partial_file(
                     // stands out as unfinished in an ls and --update does not
                     // skip it as "up to date". Only for plain --partial, not
                     // --partial-dir (handle_partial_dir() leaves the mtime
-                    // alone). The normal failed-verify keep (receiver.c:1047,
+                    // alone). The normal failed-verify keep (receiver.c:1309,
                     // ok_to_set_time=0 -> ATTRS_SKIP_MTIME) does NOT zero it,
                     // preserving the recent temp-creation mtime - so zero only
                     // when `zero_mtime` is set (the interrupt paths).
@@ -351,7 +351,7 @@ pub(super) fn retain_partial_file(
             }
         }
         PartialMode::PartialDir(dir) => {
-            // upstream: cleanup.c:105-115 - move temp file into partial-dir
+            // upstream: cleanup.c:169-170 - move temp file into partial-dir
             let temp_path = cleanup_guard.path().to_path_buf();
             match cleanup_guard.rename_to_partial_dir(dest_path, dir) {
                 Ok(partial_path) => {
@@ -435,10 +435,10 @@ pub(super) fn rename_with_io_uring_fallback(old_path: &Path, new_path: &Path) ->
 /// (`transfer_ops::response.rs`) and the primary #6808 ownership/timestamp
 /// anchoring.
 ///
-/// upstream: `syscall.c:910` `do_rename_at()` opens each slashed path's parent
+/// upstream: `syscall.c:1866` `do_rename_at()` opens each slashed path's parent
 /// via `secure_relative_open()` (openat2 `RESOLVE_BENEATH`) and issues
-/// `renameat()` against the resulting dirfd, gated on `am_daemon &&
-/// !am_chrooted`.
+/// `renameat()` against the resulting dirfd, gated on `secure_relpath_active()`
+/// (`syscall.c:100`).
 ///
 /// In every other case (no sandbox, or a `--temp-dir`/partial-dir on a
 /// different tree than `dest_dir`) it falls back to the existing io_uring /
@@ -521,18 +521,20 @@ pub(super) fn is_cross_device(e: &io::Error) -> bool {
 /// `--backup-dir` (or `--backup` suffix landing on another mount) on a
 /// different filesystem than the destination triggers.
 ///
-/// upstream: `backup.c:226` `make_backup()` - after `link_or_rename()` cannot
-/// move the pre-image across the mount (`do_rename_at` fails with `EXDEV`),
-/// rsync falls back to `copy_file()` + unlink (`backup.c:270`). oc reuses the
-/// same `fs::copy` + `fs::remove_file` mechanism the tmp->dest commit uses in
+/// upstream: `backup.c:265` `make_backup_inner()` - after `link_or_rename()`
+/// cannot move the pre-image across the mount (`do_rename_at` fails with
+/// `EXDEV`), rsync falls back to `copy_file()` (`backup.c:401`), leaving the
+/// original for the temp->destination rename to replace. oc reuses the same
+/// `fs::copy` + `fs::remove_file` mechanism the tmp->dest commit uses in
 /// [`rename_with_io_uring_fallback`] (`util1.c:robust_rename()`), so `fs::copy`
 /// carries the mode bits exactly as upstream's `copy_file(..., file->mode)`.
 fn backup_rename_or_copy(old_path: &Path, new_path: &Path) -> io::Result<bool> {
     match backup_rename_syscall(old_path, new_path) {
         Ok(()) => Ok(false),
         Err(e) if is_cross_device(&e) => {
-            // upstream: backup.c:270-284 - copy_file() then keep_backup unlinks
-            // the source; the backup ends up on the other filesystem.
+            // upstream: backup.c:400-416 - the keep_backup copy tier duplicates
+            // the pre-image with copy_file(); oc unlinks the source afterwards so
+            // the backup ends up on the other filesystem.
             fs::copy(old_path, new_path)?;
             fs::remove_file(old_path)?;
             Ok(true)
@@ -652,7 +654,7 @@ impl Drop for ForceExdev {
 /// Otherwise - the common `--backup-dir` case, where the backup tree may live
 /// on a different mount than the destination - it falls back to
 /// [`backup_rename_or_copy`], which renames and, on a cross-device failure,
-/// copies the pre-image and unlinks the original (upstream `backup.c:226`).
+/// copies the pre-image and unlinks the original (upstream `backup.c:265`).
 /// Returns `Ok(true)` when that copy fallback ran so the caller can emit the
 /// upstream `make_backup: COPY` trace instead of `RENAME`.
 #[cfg(unix)]
@@ -706,8 +708,8 @@ fn backup_rename_sandboxed(
 /// error, matching a real `--backup-dir` on another mount where `link(2)` fails
 /// with `EXDEV` before `rename(2)` does.
 ///
-/// upstream: `backup.c:443-449` `make_backup()`; `backup.c:200-207`
-/// `link_or_rename()`; `syscall.c:676` `do_link_at()` under
+/// upstream: `backup.c:443-449` `make_backup()`; `backup.c:239-246`
+/// `link_or_rename()`; `syscall.c:961` `do_link_at()` under
 /// `operator_path_resolve`.
 fn backup_hardlink_syscall(env: BackupEnv<'_>, old_path: &Path, new_path: &Path) -> io::Result<()> {
     #[cfg(test)]
@@ -743,10 +745,10 @@ fn backup_hardlink_syscall(env: BackupEnv<'_>, old_path: &Path, new_path: &Path)
 /// the temp->destination rename to replace. Any failure returns `false` so the
 /// caller falls through to the unchanged rename/copy tier.
 ///
-/// upstream: `backup.c:200-207` - `do_link_at` success traces HLINK and returns
+/// upstream: `backup.c:239-246` - `do_link_at` success traces HLINK and returns
 /// 2; a link failure on a regular file falls through to `do_rename_at`.
-/// upstream: `backup.c:246-255` `make_backup()` - an `EEXIST`/`EISDIR` collision
-/// deletes the stale backup entry and retries `link_or_rename` once.
+/// upstream: `backup.c:318-327` `make_backup_inner()` - an `EEXIST`/`EISDIR`
+/// collision deletes the stale backup entry and retries `link_or_rename` once.
 fn backup_hardlink_tier(env: BackupEnv<'_>, old_path: &Path, new_path: &Path) -> bool {
     match backup_hardlink_syscall(env, old_path, new_path) {
         Ok(()) => true,
@@ -763,11 +765,11 @@ fn backup_hardlink_tier(env: BackupEnv<'_>, old_path: &Path, new_path: &Path) ->
 /// With `--backup-dir`, each freshly-created subdirectory inherits its
 /// corresponding destination directory's attributes and any non-directory
 /// obstruction is removed, mirroring upstream `copy_valid_path`
-/// (backup.c:61-154) via the shared [`create_backup_dir_parents`] helper; the
+/// (backup.c:88-190) via the shared [`create_backup_dir_parents`] helper; the
 /// leaf `mkdir` stays SEC-1.j sandbox-anchored through the injected
 /// [`create_dir_all_sandboxed`]. Without `--backup-dir` the backup lands
 /// alongside the destination, whose parent already exists, so upstream runs no
-/// `copy_valid_path` (backup.c:159) and a plain create suffices.
+/// `copy_valid_path` (backup.c:195) and a plain create suffices.
 fn create_backup_path_parents(
     parent: &Path,
     backup_config: &BackupConfig,
@@ -828,16 +830,16 @@ fn create_dir_all_sandboxed(_env: BackupEnv<'_>, parent: &Path) -> io::Result<()
 
 /// Creates a backup of the destination file before overwriting.
 ///
-/// Mirrors upstream `backup.c:make_backup()`, called from `rsync.c:739`
+/// Mirrors upstream `backup.c:make_backup()`, called from `rsync.c:897`
 /// `finish_transfer()` as `make_backup(fname, False)`: `link_or_rename()` tries
 /// `do_link_at` first (HLINK, upstream `ret == 2`, the original stays in place
 /// for the temp->destination rename to replace) and only falls back to
 /// `do_rename_at` (RENAME) or the cross-device copy tier (COPY) when the link
 /// cannot be made. Parent directories are created if needed when using
 /// `--backup-dir`. On success, emits the matching `--debug=BACKUP` mechanism
-/// notice (`backup.c:201-202`/`:216-217`/`:284`) and returns a [`BackupNotice`] carrying the
+/// notice (`backup.c:240-241`/`:255-256`/`:414`) and returns a [`BackupNotice`] carrying the
 /// destination-relative paths so the main thread can emit upstream's
-/// `INFO_GTE(BACKUP, 1)` line (`backup.c:352`). The disk thread cannot emit
+/// `INFO_GTE(BACKUP, 1)` line (`backup.c:432`). The disk thread cannot emit
 /// the info line directly because its thread-local [`logging::VerbosityConfig`]
 /// is never seeded with the user's `--info=backup` selection.
 pub(super) fn make_backup(
@@ -861,14 +863,14 @@ pub(super) fn make_backup(
         create_backup_path_parents(parent, backup_config, env)?;
     }
 
-    // upstream: backup.c:191-207 - `prefer_rename` is False here (rsync.c:739),
+    // upstream: backup.c:230-246 - `prefer_rename` is False here (rsync.c:897),
     // so `do_link_at` runs first. The tier is limited to a regular pre-image:
     // upstream gates symlinks and specials on CAN_HARDLINK_SYMLINK /
-    // CAN_HARDLINK_SPECIAL (backup.c:192-199), and this commit path only ever
+    // CAN_HARDLINK_SPECIAL (backup.c:231-238), and this commit path only ever
     // replaces a regular destination anyway.
     let is_regular = fs::symlink_metadata(file_path).is_ok_and(|m| m.is_file());
     if is_regular && backup_hardlink_tier(env, file_path, &backup_path) {
-        // upstream: backup.c:201-202 - DEBUG_GTE(BACKUP, 1) HLINK success. The
+        // upstream: backup.c:240-241 - DEBUG_GTE(BACKUP, 1) HLINK success. The
         // original is deliberately left in place (upstream returns 2 and
         // finish_transfer does not redirect fnamecmp); the temp->destination
         // rename that follows replaces it.
@@ -878,11 +880,11 @@ pub(super) fn make_backup(
 
     let was_copy = backup_rename_sandboxed(env, file_path, &backup_path)?;
     if was_copy {
-        // upstream: backup.c:284 - DEBUG_GTE(BACKUP, 1) "make_backup: COPY %s
+        // upstream: backup.c:414 - DEBUG_GTE(BACKUP, 1) "make_backup: COPY %s
         // successful." when the cross-device copy tier moved the pre-image.
         trace_make_backup_copy(&file_path.display().to_string());
     } else {
-        // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) on the RENAME success
+        // upstream: backup.c:255-256 - DEBUG_GTE(BACKUP, 1) on the RENAME success
         // branch of link_or_rename.
         trace_make_backup_rename(&file_path.display().to_string());
     }
@@ -891,7 +893,7 @@ pub(super) fn make_backup(
 
 /// Builds the destination-relative [`BackupNotice`] for a completed backup.
 ///
-/// upstream: `backup.c:352` - INFO_GTE(BACKUP, 1) fires on the `success:` label
+/// upstream: `backup.c:432` - INFO_GTE(BACKUP, 1) fires on the `success:` label
 /// for every successful backup, whichever mechanism ran. Paths are displayed
 /// relative to the destination root to match upstream test assertions
 /// (`testsuite/backup.test`). The actual `info_log!` emission happens on the
@@ -918,15 +920,15 @@ fn backup_notice(
 /// rewritten in place rather than replaced by a temp+rename.
 ///
 /// upstream: backup.c make_backup() inplace copy path - the generator makes the
-/// backup a COPY (`generator.c:1862` `copy_file(fname, backupptr, ...)`, and the
-/// delta twin at `generator.c:1898`) BEFORE the receiver rewrites the
+/// backup a COPY (`generator.c:2281` `copy_file(fname, backupptr, ...)`, and the
+/// delta twin at `generator.c:2328`) BEFORE the receiver rewrites the
 /// destination in place, keeping `fnamecmp_type == FNAMECMP_FNAME`. A plain
 /// rename-to-backup would move the very inode we are about to update, so the
 /// pre-image must be duplicated first. Unlike the rename path this does NOT emit
 /// the `make_backup: RENAME` debug line (upstream's inplace copy bypasses
 /// `make_backup()` and so emits no `DEBUG_GTE(BACKUP, 1)` trace), but it still
 /// returns a [`BackupNotice`] so the main thread emits the same
-/// `INFO_GTE(BACKUP, 1)` "backed up X to Y" line (`generator.c:1990-1992`).
+/// `INFO_GTE(BACKUP, 1)` "backed up X to Y" line (`generator.c:2448-2450`).
 ///
 /// Called before the first inplace write; the caller has already confirmed
 /// `begin.is_inplace`. Returns `Ok(None)` when the destination does not yet
@@ -952,16 +954,16 @@ pub(super) fn make_backup_copy(
         create_backup_path_parents(parent, backup_config, env)?;
     }
 
-    // upstream: generator.c:1866 copy_file() - duplicate the pre-transfer bytes
+    // upstream: generator.c:2295 copy_file() - duplicate the pre-transfer bytes
     // into the backup, leaving the original inode in place to be updated. A
     // pre-existing backup at this path is overwritten (upstream robust_unlinks
-    // it at generator.c:1901); the O_TRUNC create reaches the same end state.
+    // it at generator.c:2340); the O_TRUNC create reaches the same end state.
     // The backup path is operator-named and resolves through the ownership
     // walk: generator.c:2283 raises `operator_path_resolve` around this copy
     // precisely because the in-place backup bypasses `make_backup()`.
     copy_pre_image_to_backup(file_path, &backup_path)?;
 
-    // upstream: generator.c:1990-1992 - INFO_GTE(BACKUP, 1) "backed up X to Y".
+    // upstream: generator.c:2448-2450 - INFO_GTE(BACKUP, 1) "backed up X to Y".
     // Paths are relative to the destination root to match test assertions; the
     // `info_log!` emission happens on the main thread (see
     // `crate::pipeline::receiver::emit_backup_notice`).


### PR DESCRIPTION
## Governing pin

Two citation gates exist in this repo and both pin **rsync 3.5.0** for `crates/`:

- `.github/workflows/citations.yml` runs `cargo xtask citations`, whose constants are
  `MANIFEST_PATH = "tools/ci/upstream-3.5.0-lines.tsv"` and
  `PINNED_SOURCE_DIR = "target/interop/upstream-src/rsync-3.5.0"`
  (`xtask/src/commands/citations.rs:61,64`). The same assertion also runs required under `nextest (stable)`.
- `.github/workflows/citation-drift.yml` runs `tools/ci/citation_drift_audit.py`, which fetches
  `rsync-3.5.0.tar.gz` and scans `target/interop/upstream-src/rsync-3.5.0`.

`Cargo.toml`'s `workspace.metadata.oc_rsync.upstream_version = "3.4.4"` is the interop/branding
pin, not a citation pin - it does not feed either gate.

`crates/transfer/src/disk_commit/process/commit.rs` carried both generations of anchor. Every
citation below was opened in `rsync-3.5.0/` (and `rsync-3.4.4/` for comparison) before being
touched. The line-count manifest matches the local 3.5.0 tree exactly.

## Retargeted (stale 3.4.4 anchors)

| Citation | Old | New | 3.5.0 line |
|---|---|---|---|
| `receiver.c` delay_updates staging | 1029-1052 | 1285-1314 | `if ((recv_ok && (!delay_updates \|\| !partialptr)) \|\| inplace) {` |
| `receiver.c` `handle_delayed_updates()` | 529-557 | 685-720 | `static void handle_delayed_updates(char *local_name)` |
| `receiver.c` `!IS_DEVICE` ftruncate gate | 496 | 652 | `if ((inplace_sizing \|\| preallocated_len > offset) && fd != -1 && !IS_DEVICE(file->mode)) {` |
| `receiver.c` partial-dir basis unlink | 1035-1037 | 1291-1299 | `handle_partial_dir(partialptr, PDIR_DELETE);` |
| `receiver.c` failed-verify keep | 1047 (x3) | 1309 | `} else if (!finish_transfer(partialptr, fnametmp, fnamecmp, NULL,` |
| `rsync.c` `make_backup(fname, False)` | 739 (x2) | 897 | `if (make_backups > 0 && overwriting_basis) {` (898 `int ok = make_backup(fname, False);`) |
| `rsync.c` `ATTRS_SKIP_MTIME` | 748-749 (x2) | 911-912 | `ok_to_set_time ? ATTRS_ACCURATE_TIME : ATTRS_SKIP_MTIME \| ...` |
| `generator.c` whole-file inplace backup | 1862 (x2) | 2281 | `if (inplace && make_backups > 0 && fnamecmp_type == FNAMECMP_FNAME) {` |
| `generator.c` `copy_file()` | 1866 | 2295 | `if (copy_file(fname, backupptr, -1, back_file->mode) < 0) {` |
| `generator.c` delta twin | 1898 (x2) | 2328 | `if (inplace && make_backups > 0 && fnamecmp_type == FNAMECMP_FNAME) {` |
| `generator.c` `robust_unlink` | 1901 | 2340 | `if (robust_unlink(backupptr) && errno != ENOENT) {` |
| `generator.c` "backed up X to Y" | 1990-1992 (x2) | 2448-2450 | `rprintf(FINFO, "backed up %s to %s\n",` |
| `backup.c` `copy_valid_path` | 61-154 | 88-190 | `static BOOL copy_valid_path(const char *fname)` |
| `backup.c` no-backup-dir branch | 159 | 195 | `if (backup_dir) {` |
| `backup.c` `!prefer_rename` hardlink tier | 191-207 | 230-246 | `if (!prefer_rename) {` |
| `backup.c` `CAN_HARDLINK_*` gates | 192-199 | 231-238 | `#ifndef CAN_HARDLINK_SYMLINK` |
| `backup.c` `do_link_at` success | 200-207 (x2) | 239-246 | `if (do_link_at(from, to) == 0) {` |
| `backup.c` HLINK debug | 201-202 (x2) | 240-241 | `rprintf(FINFO, "make_backup: HLINK %s successful.\n", from);` |
| `backup.c` RENAME debug | 216-217 (x2) | 255-256 | `rprintf(FINFO, "make_backup: RENAME %s successful.\n", from);` |
| `backup.c` `make_backup()` body | 226 (x2) | 265 | `static int make_backup_inner(const char *fname, BOOL prefer_rename)` |
| `backup.c` EEXIST/EISDIR retry | 246-255 | 318-327 | `if (errno == EEXIST \|\| errno == EISDIR) {` |
| `backup.c` `success:` INFO line | 352 (x2) | 432 | `if (INFO_GTE(BACKUP, 1))` (431 `success:`) |

Note the rename in the 226 -> 265 row: 3.5.0 split `make_backup()` into `make_backup_inner()`
plus a thin `make_backup()` wrapper at 437, so the prose now names `make_backup_inner()`.

## Corrected (resolved to the wrong construct at BOTH pins)

| Citation | Old | New | 3.5.0 line |
|---|---|---|---|
| `backup.c` COPY debug | 284 | 414 | `rprintf(FINFO, "make_backup: COPY %s successful.\n", fname);` (3.4.4:284 is `ret = 2;` in the DEVICE branch) |
| `backup.c` copy tier | 270-284 | 400-416 | `if (copy_file(fname, buf, -1, file->mode) < 0) {` (3.4.4:270 is `if (preserve_xattrs) {`) |
| `backup.c` copy fallback | 270 | 401 | same `copy_file(...)` call |
| `syscall.c` `do_rename_at()` | 910 | 1866 | `int do_rename_at(const char *old_path, const char *new_path)` |
| `syscall.c` `do_link_at()` operator walk | 676 | 961 | `if (operator_path_resolve) {` inside `do_link_at` (937). 3.4.4:676 and 3.5.0:676 are both `do_open`/unlink territory |
| `cleanup.c` `handle_partial_dir()` | 105-115 (x2) | 169-170 | `&& handle_partial_dir(cleanup_new_fname, PDIR_CREATE)) {` (105-115 is `_exit_cleanup`'s local declarations at both pins) |
| `cleanup.c` temp -> destination | 130-135 | 181-182 | `finish_transfer(cleanup_new_fname, fname, NULL, NULL,` (130-135 is `first_code = code; if (output_needs_newline)` at both pins) |

Two prose claims moved with their anchors because the 3.5.0 code no longer says what the
comment asserted:

- `syscall.c` `do_rename_at()` is gated on `secure_relpath_active()` (`syscall.c:100`) at 3.5.0,
  not `am_daemon && !am_chrooted` as at 3.4.4.
- The `backup.c` copy tier does **not** unlink the source at either pin - `copy_file()` leaves the
  original for the temp->destination rename to replace. The unlink in `backup_rename_or_copy` is
  oc's own, and the comment now says so.

## Already correct at 3.5.0 - left alone

`backup.c:443-449` (`operator_path_resolve` around `make_backup_inner`), `syscall.c:1891`
(`if (operator_path_resolve) {` in `do_rename_at`), `generator.c:2283` (in-place backup bypasses
`make_backup()`), `util1.c:1518-1530` and `:1523-1528` (`handle_partial_dir` PDIR_CREATE and its
non-directory clear), `util1.c:1506-1507` (absolute `--partial-dir` exemption; shared with
`crates/transfer/src/receiver/transfer.rs`), `options.c:2563-2564`
(`if (delay_updates && !partial_dir) partial_dir = tmp_partialdir;`).

Byte-identical at both pins, so pin-neutral and left alone: `fileio.c:43` and `fileio.c:47-52`
(`sparse_end()`), `cleanup.c:174-180` (`tweak_modtime = 1; cleanup_file->modtime = 0;`).
Line-free citations (`backup.c:make_backup()`, `util1.c:robust_rename()`, `receiver.c`) are
pin-neutral and untouched.

## Unresolved - deliberately NOT retargeted

**`receiver.c:340` - `set_file_length(fd, F_LENGTH(file))`** (commit.rs:190).

`set_file_length` exists in neither `rsync-3.5.0` nor `rsync-3.4.4` - `grep -rn set_file_length`
over both trees returns nothing, and the symbol is absent from oc's own tree too.
`receiver.c:340` is `if (fd_r >= 0 && size_r > 0) {` at 3.4.4 and unrelated code at 3.5.0. The
nearest genuine constructs are `receiver.c:468` (`OFF_T total_size = F_LENGTH(file);`) and the
`do_ftruncate(fd, offset)` at `receiver.c:653`, but neither is the named function, so the anchor
is left as-is rather than pointed at a plausible-looking neighbour.

The identical citation also appears at `crates/transfer/src/transfer_ops/response.rs:412`; it is
out of scope here and untouched.

## Verification

```
$ cargo fmt --all -- --check
FMT OK

$ cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 44s

$ cargo xtask citations
citations: 8624 name(s) and 8624 line range(s) checked across 5034 file(s) - every citation
names a file rsync 3.5.0 has, at a line that file has. This does NOT mean the cited line says
what the comment claims; nothing here checks that.

$ python3 tools/ci/citation_drift_audit.py --ratchet
transfer: string-anchored=149 suspected-drift=6 (4%) unresolved=77
ratchet OK against tools/ci/citation_drift_baseline.json

$ cargo nextest run -p transfer --all-features -E 'test(backup)'
    Summary [   6.782s] 56 tests run: 56 passed, 2716 skipped
```

The `xtask citations` gate is a line-COUNT check, so it cannot tell a correct anchor from one
that resolves to the wrong function. Every row above was confirmed by reading the C at the cited
line, not by the gate going green.
