### PR TITLE
fix(cli): carry --checksum-seed as a signed int

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -200,7 +200,9 @@ pub struct ParsedArgs {
     pub checksum_choice_arg: Option<OsString>,
 
     /// `--checksum-seed` - seed for reproducible checksums.
-    pub checksum_seed: Option<u32>,
+    ///
+    /// upstream: options.c:151 `int checksum_seed` - a signed value.
+    pub checksum_seed: Option<i32>,
 
     /// `--size-only` - skip based on size only, ignore mtime.
     pub size_only: bool,

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -2685,11 +2685,29 @@ mod checksum_choice_tests {
         assert_eq!(parsed.checksum_seed, Some(0));
     }
 
+    /// upstream: options.c:861 parses the seed with `POPT_ARG_INT`, which popt
+    /// bounds to `INT_MIN..=INT_MAX` and otherwise fails with
+    /// `POPT_ERROR_OVERFLOW`. Accepting `4294967295` here would let us forward
+    /// `--checksum-seed=4294967295` (options.c:3047) to a peer that cannot
+    /// parse it, aborting the transfer with a usage error.
     #[test]
-    fn checksum_seed_max_u32() {
+    fn checksum_seed_above_i32_max_is_rejected() {
+        assert!(parse_test_args(["--checksum-seed=4294967295", "src/", "dst/"]).is_err());
+    }
+
+    /// upstream: options.c:151 declares `int checksum_seed`, so a negative seed
+    /// is legal and reaches the remote verbatim as `--checksum-seed=-1`.
+    #[test]
+    fn checksum_seed_negative() {
+        let parsed = parse_test_args(["--checksum-seed=-1", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.checksum_seed, Some(-1));
+    }
+
+    #[test]
+    fn checksum_seed_min_i32() {
         let parsed =
-            parse_test_args(["--checksum-seed=4294967295", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.checksum_seed, Some(u32::MAX));
+            parse_test_args(["--checksum-seed=-2147483648", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.checksum_seed, Some(i32::MIN));
     }
 
     #[test]
@@ -2708,13 +2726,15 @@ mod checksum_choice_tests {
     #[test]
     fn checksum_seed_overflow_rejected() {
         let result = parse_test_args(["--checksum-seed=4294967296", "src/", "dst/"]);
-        assert!(result.is_err(), "u32::MAX + 1 should be rejected");
+        assert!(result.is_err(), "i32::MAX + 1 should be rejected");
     }
 
+    /// upstream: options.c:861 is `POPT_ARG_INT`, so a value below `INT_MIN`
+    /// fails with `POPT_ERROR_OVERFLOW` (popt/popt.c poptSaveArg).
     #[test]
-    fn checksum_seed_negative_rejected() {
-        let result = parse_test_args(["--checksum-seed=-1", "src/", "dst/"]);
-        assert!(result.is_err(), "negative seed should be rejected");
+    fn checksum_seed_below_i32_min_rejected() {
+        let result = parse_test_args(["--checksum-seed=-2147483649", "src/", "dst/"]);
+        assert!(result.is_err(), "below i32::MIN should be rejected");
     }
 
     #[test]

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -101,7 +101,7 @@ pub(crate) struct ConfigInputs {
     pub(crate) drop_devices: bool,
     pub(crate) force_replacements: bool,
     pub(crate) checksum: bool,
-    pub(crate) checksum_seed: Option<u32>,
+    pub(crate) checksum_seed: Option<i32>,
     pub(crate) size_only: bool,
     pub(crate) ignore_times: bool,
     pub(crate) ignore_existing: bool,

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -1200,12 +1200,11 @@ fn resolve_old_args(explicit: Option<u8>, protect_args: Option<bool>) -> Option<
 /// parsed `--checksum-seed=N` (options.c:847, an `int` defaulting to 0) is only
 /// treated as user-supplied when it is non-zero. An explicit `--checksum-seed=0`
 /// is indistinguishable from an unset seed and therefore derives a fresh one,
-/// exactly like omitting the flag. The bit pattern of `N` is preserved across
-/// the `u32 -> i32` cast so that seeds above `i32::MAX` round-trip through the
-/// batch header verbatim.
-fn explicit_batch_seed(parsed: Option<u32>) -> Option<i32> {
+/// exactly like omitting the flag. `N` is already an `i32`, matching upstream's
+/// `int checksum_seed` (options.c:151), so it reaches the batch header verbatim.
+fn explicit_batch_seed(parsed: Option<i32>) -> Option<i32> {
     match parsed {
-        Some(n) if n != 0 => Some(n as i32),
+        Some(n) if n != 0 => Some(n),
         _ => None,
     }
 }
@@ -1336,14 +1335,17 @@ mod tests {
         assert_eq!(explicit_batch_seed(Some(12345)), Some(12345));
     }
 
-    /// Seeds above `i32::MAX` must round-trip by bit pattern, matching upstream's
-    /// `int checksum_seed` storage.
+    /// A negative seed must reach the batch header verbatim. upstream:
+    /// options.c:151 stores the seed in an `int` and io.c:2524
+    /// `write_int(batch_fd, checksum_seed)` writes those same 32 bits, so a
+    /// batch oc-rsync writes stays readable by upstream `--read-batch`.
     #[test]
-    fn explicit_large_seed_preserves_bit_pattern() {
+    fn explicit_negative_seed_flows_through() {
         assert_eq!(
-            explicit_batch_seed(Some(0xDEAD_BEEF)),
+            explicit_batch_seed(Some(0xDEAD_BEEFu32 as i32)),
             Some(0xDEAD_BEEFu32 as i32)
         );
+        assert_eq!(explicit_batch_seed(Some(-1)), Some(-1));
     }
 
     /// upstream: compat.c:823 `if (!checksum_seed)` treats an explicit

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -135,7 +135,11 @@ mod tests {
 
     #[test]
     fn parse_checksum_seed_argument_negative() {
-        assert!(parse_checksum_seed_argument(&os("-1")).is_err());
+        // upstream: options.c:151 declares `int checksum_seed`, a signed global.
+        // The popt entry at options.c:861 binds it with `POPT_ARG_INT`, so a
+        // negative seed is valid, and options.c:3047 forwards it verbatim as
+        // `--checksum-seed=-1`.
+        assert_eq!(parse_checksum_seed_argument(&os("-1")).unwrap(), -1);
     }
 
     #[test]

--- a/crates/cli/src/frontend/execution/options/numeric.rs
+++ b/crates/cli/src/frontend/execution/options/numeric.rs
@@ -108,10 +108,15 @@ pub(crate) fn parse_max_delete_argument(value: &OsStr) -> Result<u64, Message> {
     }
 }
 
-/// Parses the `--checksum-seed` argument as a non-negative `u32`.
+/// Parses the `--checksum-seed` argument as a signed `i32`.
 ///
-/// A leading `+` prefix is permitted and ignored.
-pub(crate) fn parse_checksum_seed_argument(value: &OsStr) -> Result<u32, Message> {
+/// A leading `+` prefix is permitted and ignored. Negative values are accepted:
+/// upstream declares `int checksum_seed` (options.c:151) and parses the option
+/// with `POPT_ARG_INT` (options.c:861), which popt accepts over the full
+/// `INT_MIN..=INT_MAX` range and rejects outside it with `POPT_ERROR_OVERFLOW`
+/// (popt/popt.c poptSaveArg). The emitter then forwards it with `"%d"`
+/// (options.c:3047), so a value outside `i32` could never be parsed by a peer.
+pub(crate) fn parse_checksum_seed_argument(value: &OsStr) -> Result<i32, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
     let display = if trimmed.is_empty() {
@@ -126,26 +131,16 @@ pub(crate) fn parse_checksum_seed_argument(value: &OsStr) -> Result<u32, Message
         );
     }
 
-    if trimmed.starts_with('-') {
-        return Err(rsync_error!(
-            1,
-            format!(
-                "invalid --checksum-seed value '{}': must be non-negative",
-                display
-            )
-        )
-        .with_role(Role::Client));
-    }
-
     let normalized = trimmed.strip_prefix('+').unwrap_or(trimmed);
 
-    normalized.parse::<u32>().map_err(|_| {
+    normalized.parse::<i32>().map_err(|_| {
         rsync_error!(
             1,
             format!(
-                "invalid --checksum-seed value '{}': must be between 0 and {}",
+                "invalid --checksum-seed value '{}': must be between {} and {}",
                 display,
-                u32::MAX
+                i32::MIN,
+                i32::MAX
             )
         )
         .with_role(Role::Client)

--- a/crates/cli/src/frontend/server/parse.rs
+++ b/crates/cli/src/frontend/server/parse.rs
@@ -124,16 +124,21 @@ pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, V
 
 /// Parses a `--checksum-seed=NUM` value from the server argument list.
 ///
-/// upstream: options.c - `--checksum-seed=NUM` parsed in `server_options()`.
-pub(super) fn parse_server_checksum_seed(value: &str) -> Result<u32, String> {
+/// upstream: options.c:151 declares `int checksum_seed`, a signed global.
+/// The popt entry at options.c:861 binds it with `POPT_ARG_INT`, so the server
+/// side accepts the full signed range, and the client emits it at
+/// options.c:3047 with `"--checksum-seed=%d"`. A negative seed therefore
+/// reaches us as `--checksum-seed=-1` and must not be refused.
+pub(super) fn parse_server_checksum_seed(value: &str) -> Result<i32, String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Err("--checksum-seed value must not be empty".to_owned());
     }
-    trimmed.parse::<u32>().map_err(|_| {
+    trimmed.parse::<i32>().map_err(|_| {
         format!(
-            "invalid --checksum-seed value '{value}': must be 0..{}",
-            u32::MAX
+            "invalid --checksum-seed value '{value}': must be {}..{}",
+            i32::MIN,
+            i32::MAX
         )
     })
 }

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -1507,7 +1507,70 @@ fn known_flag_rejects_unknown() {
 fn checksum_seed_parses_valid() {
     assert_eq!(parse_server_checksum_seed("0").unwrap(), 0);
     assert_eq!(parse_server_checksum_seed("12345").unwrap(), 12345);
-    assert_eq!(parse_server_checksum_seed("4294967295").unwrap(), u32::MAX);
+    assert_eq!(parse_server_checksum_seed("2147483647").unwrap(), i32::MAX);
+}
+
+/// upstream: options.c:151 `int checksum_seed`, parsed with `POPT_ARG_INT`
+/// (options.c:861) and forwarded by the client with `"%d"` (options.c:3047). An
+/// upstream client run with `--checksum-seed=-1` therefore invokes us as
+/// `--server --checksum-seed=-1`; refusing that value aborts the transfer with
+/// exit 1 before a single byte moves.
+#[test]
+fn checksum_seed_accepts_negative() {
+    assert_eq!(parse_server_checksum_seed("-1").unwrap(), -1);
+    assert_eq!(parse_server_checksum_seed("-2147483648").unwrap(), i32::MIN);
+}
+
+/// popt rejects an out-of-`int` value with `POPT_ERROR_OVERFLOW`
+/// (popt/popt.c poptSaveArg), so no upstream peer can send one.
+#[test]
+fn checksum_seed_rejects_above_i32_max() {
+    assert!(parse_server_checksum_seed("4294967295").is_err());
+}
+
+/// Emits the remote-shell argv for `seed`, asserts its rendered text, and reads
+/// the seed back out through the same `--server` flag scanner the remote end
+/// runs.
+fn checksum_seed_round_trip(seed: i32) -> i32 {
+    let config = ClientConfig::builder().checksum_seed(Some(seed)).build();
+    let argv = RemoteInvocationBuilder::new(&config, RemoteRole::Sender)
+        .build(std::ffi::OsStr::new("/path"));
+
+    let expected = format!("--checksum-seed={seed}");
+    assert!(
+        argv.iter().any(|a| a == expected.as_str()),
+        "expected {expected} in argv: {argv:?}"
+    );
+
+    let flags = parse_server_long_flags(&argv);
+    let text = flags
+        .checksum_seed
+        .as_deref()
+        .expect("the emitted argv must carry --checksum-seed");
+    parse_server_checksum_seed(text).expect("the emitted seed must parse on the server side")
+}
+
+/// The client emit and the `--server` parse are the two ends of one value, and
+/// a negative seed is the case that separates them: upstream stores the seed in
+/// an `int` (options.c:151) and forwards it with `"%d"` (options.c:3047), so
+/// `-1` must render as `--checksum-seed=-1` and come back as `-1`. Rendering it
+/// unsigned yields `--checksum-seed=4294967295`, which upstream's
+/// `POPT_ARG_INT` (options.c:861) refuses with `POPT_ERROR_OVERFLOW` - the
+/// transfer dies at argument parsing rather than mis-seeding a checksum, so
+/// this test fails loudly rather than silently.
+#[test]
+fn checksum_seed_negative_survives_emit_and_server_parse() {
+    assert_eq!(checksum_seed_round_trip(-1), -1);
+    assert_eq!(checksum_seed_round_trip(i32::MIN), i32::MIN);
+}
+
+/// Positive-seed companion: the round trip must stay intact for the values that
+/// already worked, so a regression in the signed handling cannot hide behind a
+/// wholesale break of the path.
+#[test]
+fn checksum_seed_positive_survives_emit_and_server_parse() {
+    assert_eq!(checksum_seed_round_trip(12345), 12345);
+    assert_eq!(checksum_seed_round_trip(i32::MAX), i32::MAX);
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/parse_checksum.rs
+++ b/crates/cli/src/frontend/tests/parse_checksum.rs
@@ -8,19 +8,47 @@ fn parse_checksum_seed_argument_accepts_zero() {
 }
 
 #[test]
-fn parse_checksum_seed_argument_accepts_max_u32() {
-    let seed = parse_checksum_seed_argument(OsStr::new("4294967295")).expect("parse checksum seed");
-    assert_eq!(seed, u32::MAX);
+fn parse_checksum_seed_argument_accepts_max_i32() {
+    let seed = parse_checksum_seed_argument(OsStr::new("2147483647")).expect("parse checksum seed");
+    assert_eq!(seed, i32::MAX);
+}
+
+/// upstream: options.c:861 uses `POPT_ARG_INT`, which popt bounds to
+/// `INT_MIN..=INT_MAX` (popt/popt.c poptSaveArg returns `POPT_ERROR_OVERFLOW`
+/// otherwise). Accepting a larger value would have us forward
+/// `--checksum-seed=4294967295` (options.c:3047) to a peer that answers
+/// "number too large or too small" and exits 1.
+#[test]
+fn parse_checksum_seed_argument_rejects_above_i32_max() {
+    let error = parse_checksum_seed_argument(OsStr::new("4294967295"))
+        .expect_err("a value above i32::MAX should fail");
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("invalid --checksum-seed value"),
+        "diagnostic missing invalid message: {rendered}"
+    );
+}
+
+/// upstream: options.c:151 declares `int checksum_seed`, so `-1` is a legal
+/// seed. Refusing it makes oc-rsync unable to express a value upstream accepts,
+/// and - on the `--server` side - unable to serve an upstream client that used
+/// it.
+#[test]
+fn parse_checksum_seed_argument_accepts_negative() {
+    let seed = parse_checksum_seed_argument(OsStr::new("-1")).expect("negative seed should parse");
+    assert_eq!(seed, -1);
+    let min = parse_checksum_seed_argument(OsStr::new("-2147483648")).expect("i32::MIN parses");
+    assert_eq!(min, i32::MIN);
 }
 
 #[test]
-fn parse_checksum_seed_argument_rejects_negative() {
-    let error =
-        parse_checksum_seed_argument(OsStr::new("-1")).expect_err("negative seed should fail");
+fn parse_checksum_seed_argument_rejects_below_i32_min() {
+    let error = parse_checksum_seed_argument(OsStr::new("-2147483649"))
+        .expect_err("a value below i32::MIN should fail");
     let rendered = error.to_string();
     assert!(
-        rendered.contains("must be non-negative"),
-        "diagnostic missing negativity detail: {rendered}"
+        rendered.contains("invalid --checksum-seed value"),
+        "diagnostic missing invalid message: {rendered}"
     );
 }
 
@@ -36,8 +64,7 @@ fn parse_checksum_seed_argument_rejects_non_numeric() {
 }
 
 #[test]
-fn parse_checksum_seed_argument_rejects_overflow_u32() {
-    // u32::MAX + 1 = 4294967296 should fail
+fn parse_checksum_seed_argument_rejects_overflow() {
     let error =
         parse_checksum_seed_argument(OsStr::new("4294967296")).expect_err("overflow should fail");
     let rendered = error.to_string();

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -213,7 +213,7 @@ pub struct ClientConfigBuilder {
     whole_file: Option<bool>,
     checksum: bool,
     checksum_choice: StrongChecksumChoice,
-    checksum_seed: Option<u32>,
+    checksum_seed: Option<i32>,
     size_only: bool,
     ignore_times: bool,
     ignore_existing: bool,

--- a/crates/core/src/client/config/builder/validation.rs
+++ b/crates/core/src/client/config/builder/validation.rs
@@ -21,7 +21,7 @@ impl ClientConfigBuilder {
     /// Configures the checksum seed forwarded to the engine and fallback binary.
     #[must_use]
     #[doc(alias = "--checksum-seed")]
-    pub const fn checksum_seed(mut self, seed: Option<u32>) -> Self {
+    pub const fn checksum_seed(mut self, seed: Option<i32>) -> Self {
         self.checksum_seed = seed;
         self
     }

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -168,7 +168,7 @@ pub struct ClientConfig {
     pub(super) whole_file: Option<bool>,
     pub(super) checksum: bool,
     pub(super) checksum_choice: StrongChecksumChoice,
-    pub(super) checksum_seed: Option<u32>,
+    pub(super) checksum_seed: Option<i32>,
     pub(super) size_only: bool,
     pub(super) ignore_times: bool,
     pub(super) ignore_existing: bool,

--- a/crates/core/src/client/config/client/validation.rs
+++ b/crates/core/src/client/config/client/validation.rs
@@ -20,6 +20,9 @@ impl ClientConfig {
     #[must_use]
     pub const fn checksum_signature_algorithm(&self) -> SignatureAlgorithm {
         let algorithm = self.checksum_choice.file_signature_algorithm();
+        // upstream: checksum.c:342 `XXH64(buf, len, checksum_seed)` - and the
+        // XXH3 siblings just below it - pass the signed seed straight into an
+        // unsigned 64-bit parameter, so C sign-extends and `as u64` must too.
         match (algorithm, self.checksum_seed) {
             (SignatureAlgorithm::Xxh64 { .. }, Some(seed)) => {
                 SignatureAlgorithm::Xxh64 { seed: seed as u64 }
@@ -35,8 +38,12 @@ impl ClientConfig {
     }
 
     /// Returns the checksum seed configured via `--checksum-seed`, if any.
+    ///
+    /// upstream: options.c:151 declares `int checksum_seed`, a signed global.
+    /// It is forwarded to the remote at options.c:3047 as
+    /// `"--checksum-seed=%d"`.
     #[doc(alias = "--checksum-seed")]
-    pub const fn checksum_seed(&self) -> Option<u32> {
+    pub const fn checksum_seed(&self) -> Option<i32> {
         self.checksum_seed
     }
 

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -1669,6 +1669,22 @@ mod server_option_fidelity_tests {
         );
     }
 
+    // upstream: options.c:151 stores the seed in an `int` and options.c:3047
+    // prints it with `"%d"`, so a negative seed goes over as `-1`. Rendering it
+    // unsigned would emit `--checksum-seed=4294967295`, which the daemon's own
+    // `POPT_ARG_INT` equivalent (options.c:861) rejects as an overflow.
+    #[test]
+    fn negative_checksum_seed_forwarded_signed() {
+        let config = ClientConfig::builder().checksum_seed(Some(-1)).build();
+        assert!(
+            args(&config, false)
+                .iter()
+                .any(|a| a == "--checksum-seed=-1"),
+            "expected --checksum-seed=-1: {:?}",
+            args(&config, false)
+        );
+    }
+
     // upstream: options.c:2886-2894 - --partial-dir and --delay-updates are
     // am_sender only; the remote receiver stages partial/updated files there.
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -482,13 +482,13 @@ fn apply_long_form_args(
                 // on the wire. Dropping the value made `--checksum-seed` a no-op
                 // over a daemon while it worked over a remote shell.
                 //
-                // Parsed as `i32` and reinterpreted, because that is the width
-                // upstream prints from and the width `write_seed` puts back on
-                // the wire; a `u32`-only parse would reject the negative values
-                // upstream's `%d` can emit.
+                // Parsed as `i32`, because that is the width upstream prints
+                // from and the width `write_seed` puts back on the wire; a
+                // `u32`-only parse would reject the negative values upstream's
+                // `%d` can emit.
                 } else if let Some(seed) = arg.strip_prefix("--checksum-seed=") {
                     if let Ok(value) = seed.trim().parse::<i32>() {
-                        config.checksum_seed = Some(value as u32);
+                        config.checksum_seed = Some(value);
                     }
                 } else if arg == "--from0" {
                     // upstream: options.c:940 - --from0 sets NUL-delimited mode

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1539,7 +1539,7 @@ mod module_access_tests {
         let args = daemon_argv("-logDtpr", &["--checksum-seed=-5"]);
         let mut config = ServerConfig::default();
         assert!(apply_long_form_args(&args, &mut config).is_none());
-        assert_eq!(config.checksum_seed, Some(-5i32 as u32));
+        assert_eq!(config.checksum_seed, Some(-5));
     }
 
     // upstream: options.c:1172-1175 - the digit scan leaves the cursor on the

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -72,7 +72,7 @@ pub struct ServerConfigBuilder {
     reference_directories: Vec<ReferenceDirectory>,
     deletion: DeletionConfig,
     write: WriteConfig,
-    checksum_seed: Option<u32>,
+    checksum_seed: Option<i32>,
     checksum_choice: Option<protocol::ChecksumAlgorithm>,
     block_size: Option<NonZeroU32>,
     trust_sender: bool,
@@ -350,7 +350,7 @@ impl ServerConfigBuilder {
     }
 
     /// Sets an optional user-specified checksum seed.
-    pub fn checksum_seed(&mut self, seed: Option<u32>) -> &mut Self {
+    pub fn checksum_seed(&mut self, seed: Option<i32>) -> &mut Self {
         self.checksum_seed = seed;
         self
     }

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -448,9 +448,10 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:847`: `--checksum-seed=NUM`
+    /// - `options.c:151`: `int checksum_seed = 0;` (signed storage)
+    /// - `options.c:861`: `POPT_ARG_INT` parse, so the full `i32` range is legal
     /// - `compat.c:750`: `checksum_seed = (int32)time(NULL);` (default)
-    pub checksum_seed: Option<u32>,
+    pub checksum_seed: Option<i32>,
     /// Optional checksum algorithm override from `--checksum-choice`.
     ///
     /// When set, forces the negotiated checksum algorithm for the transfer

--- a/crates/transfer/src/setup/negotiator.rs
+++ b/crates/transfer/src/setup/negotiator.rs
@@ -101,7 +101,7 @@ pub trait ChecksumSeedExchanger {
     ///
     /// - `None` or `Some(0)`: generate from `time() ^ (pid << 6)`
     /// - `Some(n)`: use `n` as the fixed seed
-    fn write_seed(&self, writer: &mut dyn Write, fixed_seed: Option<u32>) -> io::Result<i32>;
+    fn write_seed(&self, writer: &mut dyn Write, fixed_seed: Option<i32>) -> io::Result<i32>;
 
     /// Reads the 4-byte LE checksum seed sent by the server.
     fn read_seed(&self, reader: &mut dyn Read) -> io::Result<i32>;
@@ -183,7 +183,7 @@ impl CapabilityNegotiator for RsyncNegotiator {
 }
 
 impl ChecksumSeedExchanger for RsyncNegotiator {
-    fn write_seed(&self, writer: &mut dyn Write, fixed_seed: Option<u32>) -> io::Result<i32> {
+    fn write_seed(&self, writer: &mut dyn Write, fixed_seed: Option<i32>) -> io::Result<i32> {
         // upstream: options.c:847 - seed generation
         let seed = match fixed_seed {
             Some(0) | None => {
@@ -195,7 +195,7 @@ impl ChecksumSeedExchanger for RsyncNegotiator {
                 let pid = std::process::id() as i32;
                 timestamp ^ (pid << 6)
             }
-            Some(fixed) => fixed as i32,
+            Some(fixed) => fixed,
         };
         writer.write_all(&seed.to_le_bytes())?;
         writer.flush()?;

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -911,28 +911,28 @@ fn setup_protocol_server_seed_zero_uses_time_based_generation() {
 }
 
 #[test]
-fn setup_protocol_server_max_u32_seed() {
-    // --checksum-seed=4294967295 (u32::MAX) should work
+fn setup_protocol_server_negative_seed() {
+    // upstream: options.c:151 `int checksum_seed` - `--checksum-seed=-1` is a
+    // legal value an upstream client can forward (options.c:3047 prints `%d`),
+    // so the server must carry it to the wire unchanged rather than refuse it.
     let protocol = ProtocolVersion::try_from(29).unwrap();
     let mut stdin = &b""[..];
     let mut stdout = Vec::new();
 
-    let config = ProtocolSetupConfig::new(protocol, true).with_checksum_seed(Some(u32::MAX));
+    let config = ProtocolSetupConfig::new(protocol, true).with_checksum_seed(Some(-1));
 
     let result = setup_protocol(&mut stdout, &mut stdin, &config)
-        .expect("setup with max seed should succeed");
+        .expect("setup with negative seed should succeed");
 
-    // u32::MAX as i32 is -1
     assert_eq!(
-        result.checksum_seed,
-        u32::MAX as i32,
-        "u32::MAX seed should be transmitted as i32 (-1)"
+        result.checksum_seed, -1_i32,
+        "a negative seed must survive the exchange verbatim"
     );
 
     let written_seed = i32::from_le_bytes(stdout[..4].try_into().unwrap());
     assert_eq!(
         written_seed, -1_i32,
-        "Wire representation of u32::MAX is -1 as i32"
+        "wire representation of seed -1 is the i32 -1"
     );
 }
 
@@ -959,9 +959,9 @@ fn setup_protocol_client_reads_fixed_seed_from_server() {
 
 #[test]
 fn setup_protocol_client_reads_negative_seed_from_server() {
-    // Server may send a negative i32 seed (from u32::MAX cast)
+    // Server may send a negative i32 seed
     let protocol = ProtocolVersion::try_from(29).unwrap();
-    let test_seed: i32 = -1; // This is what u32::MAX becomes
+    let test_seed: i32 = -1;
     let seed_bytes = test_seed.to_le_bytes();
 
     let mut stdin = &seed_bytes[..];
@@ -1407,7 +1407,7 @@ impl ChecksumSeedExchanger for MockNegotiator {
     fn write_seed(
         &self,
         _writer: &mut dyn std::io::Write,
-        _fixed_seed: Option<u32>,
+        _fixed_seed: Option<i32>,
     ) -> std::io::Result<i32> {
         Ok(self.fixed_seed)
     }

--- a/crates/transfer/src/setup/types.rs
+++ b/crates/transfer/src/setup/types.rs
@@ -121,7 +121,10 @@ pub struct ProtocolSetupConfig<'a> {
     ///
     /// A value of `0` means "use current time" in upstream rsync, which is
     /// equivalent to `None` (the default random seed generation).
-    pub checksum_seed: Option<u32>,
+    ///
+    /// upstream: options.c:151 `int checksum_seed` - the seed is signed and the
+    /// `POPT_ARG_INT` parse (options.c:861) accepts the whole `i32` range.
+    pub checksum_seed: Option<i32>,
 
     /// Whether incremental recursion is allowed for this transfer.
     ///
@@ -235,7 +238,7 @@ impl<'a> ProtocolSetupConfig<'a> {
 
     /// Sets [`Self::checksum_seed`].
     #[must_use]
-    pub const fn with_checksum_seed(mut self, seed: Option<u32>) -> Self {
+    pub const fn with_checksum_seed(mut self, seed: Option<i32>) -> Self {
         self.checksum_seed = seed;
         self
     }


### PR DESCRIPTION
## Upstream

`rsync-3.5.0/options.c`:

```
151:  int checksum_seed = 0;
861:  {"checksum-seed",    0,  POPT_ARG_INT,    &checksum_seed, 0, 0, 0 },
3046: if (checksum_seed) {
3047:         if (asprintf(&arg, "--checksum-seed=%d", checksum_seed) < 0)
```

Declared signed, parsed with `POPT_ARG_INT`, emitted with `"%d"`. popt bounds
`POPT_ARG_INT` to `INT_MIN..=INT_MAX` and fails outside it with
`POPT_ERROR_OVERFLOW` (`popt/popt.c` `poptSaveArg`).

## What was broken

The remote-shell / `--server` path carried the seed as `u32`. Measured against
the pinned upstream 3.5.0 build, both directions failed:

| Case | upstream 3.5.0 | oc-rsync (before) |
|---|---|---|
| client `--checksum-seed=-1` | emits `--checksum-seed=-1` | **exit 1**, "must be non-negative" |
| client `--checksum-seed=4294967295` | **exit 1**, "number too large or too small" | emits `--checksum-seed=4294967295` (unparseable by the peer) |
| `--server --checksum-seed=-1` | accepted, proceeds to protocol | **exit 1**, "must be 0..4294967295" |

So an upstream client run with a negative seed could not talk to an oc-rsync
server at all, and an oc-rsync client could emit an argv no upstream peer can
parse.

The daemon's own client-arg parser (`long_form_args.rs`) already parsed the
seed as `i32` and carried a comment explaining why; it only cast back to `u32`
to store it. The divergence was therefore internal as well as upstream-facing.

## Wire impact

None. `write_seed` already reinterpreted the fixed seed as `i32` before writing
the 4 LE bytes, so a value that reached the wire was byte-identical either way.
The defect was in the **rendered argv text** and in the **two parse ends**, both
of which reject or emit values the peer disagrees about. The negative-seed
protocol test asserts the same `-1` bytes as before.

One behavioural improvement falls out: `checksum.c:342-350` passes the signed
`int` straight into `XXH64` / `XXH3_*_withSeed`, where C sign-extends to 64
bits. `seed as u64` on an `i32` now sign-extends too; on the old `u32` it
zero-extended.

## Change

The user-specified seed is `i32` end to end: CLI parse, `ParsedArgs`,
`ClientConfig`, both argv emitters (remote-shell and daemon), the `--server`
parse, `ServerConfig`, `ProtocolSetupConfig`, and `write_seed`. Out-of-range
values are refused on both ends, matching popt.

`LocalCopyOptions::checksum_seed` was left alone: it has no production caller
and is not on this path.

## Tests

- `checksum_seed_negative_survives_emit_and_server_parse` - a true cross-crate
  round trip: build a `ClientConfig` with `-1`, emit the remote-shell argv via
  `RemoteInvocationBuilder`, assert the rendered token is `--checksum-seed=-1`,
  then read it back through the same `--server` flag scanner the remote end
  runs and assert equality. Covers `-1` and `i32::MIN`.
- `checksum_seed_positive_survives_emit_and_server_parse` - the companion, so a
  regression cannot hide behind a wholesale break of the path.
- Negative-seed emit test on the daemon argv path.
- `setup_protocol_server_negative_seed` - the seed reaches the wire verbatim.
- Range tests on both parsers; the pre-fix tests that asserted "negative is
  rejected" and "4294967295 is accepted" encoded the bug and were inverted.

Mutation-verified. Reverting the emit to unsigned rendering reddens only the
negative round trip (43 passed, 1 failed); making the `--server` parse refuse
negatives reddens the negative round trip plus the server parse test (42
passed, 2 failed). The positive companion stays green under both.
