### PR TITLE
fix(metadata): answer upstream am_root for the receiver xattr screen

### DIFF
--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -33,26 +33,27 @@ use crate::xattr_unix as backend;
 #[cfg(windows)]
 use crate::xattr_windows as backend;
 
-/// Caches the euid check since it does not change during a transfer.
-#[cfg(target_os = "linux")]
-fn is_root() -> bool {
-    use std::sync::OnceLock;
-    static IS_ROOT: OnceLock<bool> = OnceLock::new();
-    *IS_ROOT.get_or_init(|| rustix::process::geteuid().is_root())
-}
-
 /// Returns upstream's `user_only` value for the receiver/local xattr paths.
 ///
-/// upstream: xattrs.c:249 `int user_only = am_sender ? 0 : !am_root;` - the
-/// sender never restricts to the user namespace (see
+/// upstream: xattrs.c:249 `int user_only = am_sender ? 0 : !am_root;` and
+/// xattrs.c:1002 `int user_only = am_root <= 0;` - the sender never restricts
+/// to the user namespace (see
 /// [`XattrRole::user_only`](crate::xattr_send::XattrRole::user_only)); every
 /// receiver-side or local-copy path restricts a non-root process to the
 /// `user.*` namespace, matching upstream's non-root receiver behaviour
-/// (`xattrs.c:830` allows a non-root process to store only the user namespace).
+/// (`xattrs.c:876` allows a non-root process to store only the user namespace).
+///
+/// The privilege test goes through [`crate::am_root`], which reads the cached
+/// **libc** `geteuid` (`identity::is_root`), never a `rustix` raw syscall.
+/// Upstream's `am_root` comes from `MY_UID()` (`rsync.h:1455` = libc
+/// `geteuid()`, sampled at `main.c:1844`), so `fakeroot`'s LD_PRELOAD
+/// interposition is visible to it. A raw syscall reports the real
+/// unprivileged uid under `fakeroot` and would confine the receiver to
+/// `user.*` in exactly the runs where upstream keeps `security.*`/`trusted.*`.
 fn receiver_user_only() -> bool {
     #[cfg(target_os = "linux")]
     {
-        !is_root()
+        !crate::am_root()
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -1651,6 +1652,86 @@ mod tests {
         assert!(!is_xattr_permitted("security.selinux", true));
         assert!(!is_xattr_permitted("trusted.test", true));
         assert!(!is_xattr_permitted("system.posix_acl_access", true));
+    }
+
+    /// The receiver screen must answer upstream's `am_root`, not a raw euid.
+    ///
+    /// upstream: `xattrs.c:1002` `int user_only = am_root <= 0;` where
+    /// `am_root` is `main.c:1846`'s cached `MY_UID() == ROOT_UID`, and
+    /// `MY_UID()` is the **libc** `geteuid()` (`rsync.h:1455`). `fakeroot`
+    /// interposes that libc symbol, so upstream under `fakeroot` sees
+    /// `am_root == 1` and keeps every namespace but `system.*`. A raw
+    /// `geteuid` syscall is invisible to the interposition, still reports the
+    /// real unprivileged uid, and would drop `security.*`/`trusted.*` on the
+    /// receiver that upstream stores.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn receiver_user_only_answers_the_libc_am_root() {
+        assert_eq!(
+            receiver_user_only(),
+            !crate::am_root(),
+            "the receiver xattr screen must be the negation of the crate's \
+             canonical am_root, which reads the libc geteuid"
+        );
+    }
+
+    /// Under `fakeroot` the receiver screen must open up, as upstream's does.
+    ///
+    /// The two euid sources only disagree under an LD_PRELOAD identity fake,
+    /// so this re-execs the unit-test binary under `fakeroot(1)` and asserts
+    /// there. Without `fakeroot` on `PATH` the check cannot be made at all and
+    /// says so rather than passing quietly.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn receiver_user_only_is_false_under_fakeroot() {
+        const MARKER: &str = "OC_RSYNC_XATTR_FAKEROOT_CHILD";
+        const TEST_PATH: &str = "xattr::tests::receiver_user_only_is_false_under_fakeroot";
+
+        if std::env::var_os(MARKER).is_some() {
+            assert!(
+                crate::am_root(),
+                "fakeroot must fake the libc geteuid; without that the child \
+                 proves nothing"
+            );
+            assert!(
+                !receiver_user_only(),
+                "upstream keeps security.*/trusted.* on a fakeroot receiver \
+                 because am_root is 1 there (xattrs.c:1002)"
+            );
+            return;
+        }
+
+        let Some(fakeroot) = find_in_path("fakeroot") else {
+            eprintln!(
+                "SKIPPED {TEST_PATH}: fakeroot(1) is not on PATH, so the libc \
+                 and raw-syscall effective uids cannot be made to disagree"
+            );
+            return;
+        };
+
+        let exe = std::env::current_exe().expect("locate the unit-test binary");
+        let output = std::process::Command::new(fakeroot)
+            .arg(&exe)
+            .args(["--exact", TEST_PATH, "--nocapture", "--test-threads=1"])
+            .env(MARKER, "1")
+            .output()
+            .expect("re-exec the unit-test binary under fakeroot");
+
+        assert!(
+            output.status.success(),
+            "the fakeroot leg failed:\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Resolves a bare program name against `PATH`, returning the first
+    /// existing candidate. Used to decide whether the `fakeroot` leg can run.
+    #[cfg(target_os = "linux")]
+    fn find_in_path(program: &str) -> Option<std::path::PathBuf> {
+        std::env::split_paths(&std::env::var_os("PATH")?)
+            .map(|dir| dir.join(program))
+            .find(|candidate| candidate.is_file())
     }
 
     #[test]

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -1679,8 +1679,9 @@ mod tests {
     ///
     /// The two euid sources only disagree under an LD_PRELOAD identity fake,
     /// so this re-execs the unit-test binary under `fakeroot(1)` and asserts
-    /// there. Without `fakeroot` on `PATH` the check cannot be made at all and
-    /// says so rather than passing quietly.
+    /// there. Two environments cannot host the check - no `fakeroot` on
+    /// `PATH`, and a statically linked build where LD_PRELOAD is inert - and
+    /// each says so rather than passing quietly.
     #[test]
     #[cfg(target_os = "linux")]
     fn receiver_user_only_is_false_under_fakeroot() {
@@ -1688,11 +1689,21 @@ mod tests {
         const TEST_PATH: &str = "xattr::tests::receiver_user_only_is_false_under_fakeroot";
 
         if std::env::var_os(MARKER).is_some() {
-            assert!(
-                crate::am_root(),
-                "fakeroot must fake the libc geteuid; without that the child \
-                 proves nothing"
-            );
+            // fakeroot fakes the identity by interposing the libc symbol with
+            // LD_PRELOAD, which a statically linked binary (the musl CI cell)
+            // ignores entirely - measured: a `-static` probe reports the real
+            // uid from both libc and the raw syscall under fakeroot, while the
+            // dynamic build of the same source reports 0 from libc. Where the
+            // interposition did not take, the two euid sources cannot be made
+            // to disagree and there is nothing here to observe.
+            if !crate::am_root() {
+                eprintln!(
+                    "SKIPPED {TEST_PATH}: fakeroot(1) ran but could not \
+                     interpose the libc geteuid, so this binary is statically \
+                     linked and LD_PRELOAD is inert"
+                );
+                return;
+            }
             assert!(
                 !receiver_user_only(),
                 "upstream keeps security.*/trusted.* on a fakeroot receiver \
@@ -1723,6 +1734,15 @@ mod tests {
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+
+        // Re-emit a skip the child decided on, so a leg that could not observe
+        // anything says so here too instead of reading as a clean pass.
+        for line in String::from_utf8_lossy(&output.stderr)
+            .lines()
+            .filter(|line| line.starts_with("SKIPPED"))
+        {
+            eprintln!("{line}");
+        }
     }
 
     /// Resolves a bare program name against `PATH`, returning the first


### PR DESCRIPTION
## Problem

`crates/metadata/src/xattr.rs` decided "am I root?" for the receiver/local-copy
xattr namespace screen through `rustix::process::geteuid()`. On Linux `rustix`
uses its `linux_raw` backend and issues the syscall directly, bypassing libc.
`fakeroot` virtualises identity by interposing the **libc symbol** via
`LD_PRELOAD`, so it is invisible to a raw syscall.

Measured on aarch64 Linux with a probe that prints both values from one process:

```
=== plain ===
libc::geteuid()            = 1000
rustix::process::geteuid() = 1000
AGREE                      = true

=== under fakeroot ===
libc::geteuid()            = 0
rustix::process::geteuid() = 1000
AGREE                      = false
```

## Why it matters

Upstream samples the identity once, through libc:

- `rsync.h:1455` - `#define MY_UID() geteuid()`
- `main.c:1844-1846` - `our_uid = MY_UID(); am_root = our_uid == ROOT_UID;`

and the xattr screens are derived from that global:

- `xattrs.c:249` - `int user_only = am_sender ? 0 : !am_root;`
- `xattrs.c:1002` - `int user_only = am_root <= 0;` (`rsync_xal_set`)
- `xattrs.c:876` - `if (am_root <= 0 && !HAS_PREFIX(name, USER_PREFIX))`

Under `fakeroot` upstream therefore has `am_root == 1`, takes `user_only == 0`,
and keeps every namespace except `system.*`. oc took the opposite branch and
confined the receiver to `user.*`, silently dropping `security.*` (SELinux
labels) and `trusted.*` that upstream stores - and it also removed them from the
destination in the stale-attr sweep, which reads the same screen.

## Fix

Route the screen through `crate::am_root()`, which is
`identity::is_root()` - the cached **libc** `geteuid`. Besides being
fakeroot-visible it is the only accessor that honours the permanent `--copy-as`
privilege drop. The local `OnceLock` is dropped; `identity` already caches, so
this removes a duplicate cache rather than adding a syscall.

## Tests

- `receiver_user_only_answers_the_libc_am_root` pins the invariant that the
  screen is the negation of the crate's canonical `am_root`.
- `receiver_user_only_is_false_under_fakeroot` re-execs the unit-test binary
  under `fakeroot(1)` and asserts there. Two environments cannot host the
  check, and each emits a reason-carrying `SKIPPED` line rather than passing
  quietly:
  - no `fakeroot` on `PATH` (verified by running the binary with
    `PATH=/nonexistent`);
  - a statically linked build, where fakeroot's LD_PRELOAD interposition is
    inert. This is the musl CI cell, which runs
    `cargo nextest run --target x86_64-unknown-linux-musl`. Measured with one C
    probe built both ways on aarch64 Linux:

    ```
    dynamic under fakeroot   libc geteuid() = 0     raw SYS_geteuid = 1000
    static  under fakeroot   libc geteuid() = 1000  raw SYS_geteuid = 1000
    ```

    The parent re-emits the child's skip so a leg that observed nothing never
    reads as a clean pass.

RED/GREEN, on aarch64 Linux with `fakeroot` present:

- pre-fix (production line reverted to `rustix`): `3 tests run: 2 passed, 1 failed`,
  failing at `!receiver_user_only()` inside the fakeroot child - past the
  interposition check, so the fake was live.
- post-fix: `3 tests run: 3 passed`; `-E 'test(xattr)'` is `58 tests run: 58 passed`.

## Sibling inventory

Every root/euid determination in `crates/metadata` (production, excluding test
modules):

| site | source | verdict |
|---|---|---|
| `identity.rs:57,64` `live_euid`/`live_egid` | libc | canonical |
| `lib.rs:213` `am_root()` | delegates to `identity::is_root` | correct |
| `apply/mod.rs:144` | `identity::is_root` | correct |
| `apply/ownership.rs:226,264,278,299` | `identity::{effective_gid,is_root}` | correct |
| `apply/permissions.rs:32` | `nix::unistd::geteuid()` | libc, so fakeroot-visible, but bypasses the `identity` cache and the `--copy-as` override |
| `xattr.rs` receiver screen | `rustix` raw syscall | **fixed here** |

So one raw-syscall site in the crate, and it is the one this PR changes.

Noted, not touched: `crates/engine/src/local_copy/options/metadata/accessors.rs:182`
`is_effective_root()` is the same `rustix` raw-syscall class outside this crate
(it backs the `--super` default). Every other `rustix::process::gete*` call in
the tree is inside a test module.
