### PR TITLE
fix(daemon): exit 4 on a refused option, not 1

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -303,6 +303,14 @@ fn handle_refused_option(ctx: &mut ModuleRequestContext<'_>, refused: &str) -> i
 /// `unexpected tag 72` (65 + `MPLEX_BASE`) on the receiver. Raw
 /// `@ERROR: ...\n` text would similarly produce `unexpected tag 77` (the
 /// byte `T` from "The server ..." minus `MPLEX_BASE = 7`).
+///
+/// The `MSG_ERROR_EXIT` payload carries `RERR_UNSUPPORTED`, not
+/// `RERR_SYNTAX`. upstream: clientserver.c:1254-1268 - the single post-OK
+/// fatal branch (`if (!ret || err_msg)`) covers both a refused option and a
+/// failed `pre-xfer exec`, and it ends in `exit_cleanup(RERR_UNSUPPORTED)`
+/// at clientserver.c:1267. That is the code the peer observes; the sibling
+/// read-only/write-only rejection is a different decision made later in
+/// `do_server_recv()`/`do_server_sender()` and keeps `RERR_SYNTAX`.
 fn handle_refused_option_post_handshake(
     ctx: &mut ModuleRequestContext<'_>,
     refused: &str,
@@ -315,7 +323,7 @@ fn handle_refused_option_post_handshake(
         ctx.reader.get_mut(),
         ctx.limiter,
         &error.line(),
-        FEATURE_UNAVAILABLE_EXIT_CODE,
+        RERR_UNSUPPORTED_EXIT_CODE,
     )?;
     if let Some(log) = ctx.log_sink {
         log_module_refused_option(log, ctx.host_display(), ctx.peer_ip, ctx.request, refused);

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -1293,7 +1293,7 @@ fn refuse_emits_msg_error_xfer_post_handshake() {
         &mut stream,
         &mut limiter,
         "@ERROR: The server is configured to refuse --compress",
-        FEATURE_UNAVAILABLE_EXIT_CODE,
+        RERR_UNSUPPORTED_EXIT_CODE,
     )
     .expect("send multiplexed error");
 
@@ -1324,7 +1324,7 @@ fn refuse_emits_msg_error_xfer_post_handshake() {
     let mut expected_exit = Vec::new();
     MessageFrame::new(
         MessageCode::ErrorExit,
-        FEATURE_UNAVAILABLE_EXIT_CODE.to_le_bytes().to_vec(),
+        RERR_UNSUPPORTED_EXIT_CODE.to_le_bytes().to_vec(),
     )
     .expect("frame")
     .encode_into_writer(&mut expected_exit)

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -33,6 +33,7 @@ use crate::daemon::{
     // From sections/cli_args.rs
     ProgramName,
     RERR_SYNTAX_EXIT_CODE,
+    RERR_UNSUPPORTED_EXIT_CODE,
     // From runtime_options.rs
     RuntimeOptions,
     TestSecretsEnvOverride,

--- a/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
@@ -181,8 +181,11 @@ fn run_daemon_post_ok_refused_option_uses_multiplexed_error() {
         .expect("read MSG_ERROR_EXIT payload");
     assert_eq!(
         i32::from_le_bytes(exit_buf),
-        FEATURE_UNAVAILABLE_EXIT_CODE,
-        "refused-options exit code must mirror upstream's unsupported-feature path",
+        RERR_UNSUPPORTED_EXIT_CODE,
+        "refused-options exit code must be RERR_UNSUPPORTED (4), not RERR_SYNTAX (1): \
+         upstream's single post-OK fatal branch ends in exit_cleanup(RERR_UNSUPPORTED) \
+         at clientserver.c:1267, and that code reaches the peer verbatim through \
+         MSG_ERROR_EXIT - a client scripting on `rsync -z` being refused sees 4",
     );
 
     drop(reader);

--- a/crates/daemon/src/tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs
@@ -156,8 +156,9 @@ fn run_daemon_refusal_lingers_so_the_peer_can_read_it() {
         .expect("MSG_ERROR_EXIT payload must survive the daemon's close");
     assert_eq!(
         i32::from_le_bytes(exit_buf),
-        FEATURE_UNAVAILABLE_EXIT_CODE,
-        "refusal exit code",
+        RERR_UNSUPPORTED_EXIT_CODE,
+        "refusal exit code must be RERR_UNSUPPORTED (4), matching the \
+         exit_cleanup(RERR_UNSUPPORTED) this test's own header cites",
     );
 
     // Drain until the connection ends: the daemon closes only after its linger


### PR DESCRIPTION
## Problem

A daemon that refuses a client-requested option terminated the peer with
`MSG_ERROR_EXIT` carrying `RERR_SYNTAX` (1). Upstream reports
`RERR_UNSUPPORTED` (4).

## Upstream

`clientserver.c:1254-1268` is upstream's single post-`@RSYNCD: OK` fatal
branch:

```c
	if (!ret || err_msg) {
		if (err_msg) { ... } else
			option_error();
		msleep(400);
		exit_cleanup(RERR_UNSUPPORTED);      /* clientserver.c:1267 */
	}
```

`!ret` is `parse_arguments()` failing, which is where a refused option lands
(`options.c:2041-2043` -> `create_refuse_error(opt)` -> `goto cleanup`).
`err_msg` is a failed `pre-xfer exec`. Both arms exit 4. `--write-devices`
and `--copy-devices` reach that branch because a daemon seeds them into the
refuse list unconditionally (`options.c:1057-1059`
`parse_one_refuse_match(0, "write-devices", list_end)`).

`RERR_UNSUPPORTED` is used for many unrelated refusals upstream, so the
constant name alone is not the argument - the citation above is the specific
site, confirmed by measurement below.

## Measured, pinned upstream 3.5.0 daemon vs oc daemon, same client

Same upstream 3.5.0 client against each daemon in turn; push direction (a
pull never forwards `--write-devices`, `options.c:3150` gates it on
`am_sender`).

| cell | upstream rc | oc rc before | oc rc after |
|---|---|---|---|
| `--write-devices` (push) | 4 | 1 | 4 |
| `refuse options = compress`, `-z` (push) | 4 | 1 | 4 |
| `refuse options = delete`, `-r --delete` (push) | 4 | 1 | 4 |
| `--copy-devices` (pull) | 10 | 1 | 4 |
| `refuse options = compress`, `-z` (pull) | 10 | 1 | 4 |
| read-only push | 1 | 1 | 1 |
| write-only pull | 1 | 1 | 1 |

The pull rows are a client-side race inside upstream, not a daemon
divergence: upstream's receiver prints the refusal text (so it read
`MSG_ERROR_XFER`) and then loses to the RST, exiting
`RERR_SOCKETIO` at `io.c(907)` before it can honour `MSG_ERROR_EXIT`. The
daemon's own code is 4 in both directions. This change does not chase that
race.

## Scope

Only the exit code. The `@ERROR: ` payload prefix (upstream writes
`rsync: The server is configured to refuse ...`) is a separate divergence and
is deliberately left alone - it is a different argument to
`send_multiplexed_error_and_exit`, and the measurement above confirms it is
unchanged on both sides of the fix. The absent
`rsync error: requested action not supported (code 4) at clientserver.c(1267)`
summary line is part of that same payload divergence and is likewise untouched.

## Class, not a one-off

Three post-OK multiplexed abort sites exist in
`module_access/request.rs`:

| site | upstream decision | code before | code after |
|---|---|---|---|
| `handle_refused_option_post_handshake` | `clientserver.c:1267` | 1 | **4** |
| `handle_client_arg_rejection_post_handshake` | `clientserver.c:1267` | 4 | 4 (already correct) |
| `handle_access_denied_post_handshake` | `main.c:934` / `main.c:1167` `exit_cleanup(RERR_SYNTAX)` | 1 | 1 (correct, unchanged) |

The first two are the same upstream branch; the refused-option arm was the
straggler and this makes the branch uniform. The read-only/write-only
rejection is a genuinely different decision made later in
`do_server_recv()` / `do_server_sender()` and keeps `RERR_SYNTAX`.

## Tests

`run_daemon_post_ok_refused_option_uses_multiplexed_error` and
`run_daemon_refusal_lingers_so_the_peer_can_read_it` now pin the
`MSG_ERROR_EXIT` payload at `RERR_UNSUPPORTED_EXIT_CODE`. Both fail on the
pre-fix source (`left: 1, right: 4`) and pass after. The linger test's own
header already cited `exit_cleanup(RERR_UNSUPPORTED)` while asserting 1, so
that assertion was drifting from its own citation.

`refuse_emits_msg_error_xfer_post_handshake` uses the constant on both sides
of its comparison, so it is a framing test rather than a policy test; its
fixture is moved to 4 so it keeps modelling the real refusal.

Mutating the fix back reddens exactly those two tests and leaves the
read-only/write-only companions green.
