### PR TITLE
fix(transfer): anchor the source unlink to a confined parent dirfd

### DIFF
--- a/crates/fast_io/src/confined_fallback.rs
+++ b/crates/fast_io/src/confined_fallback.rs
@@ -160,6 +160,36 @@ impl ConfinedFallback {
         }
     }
 
+    /// The resolved parent descriptor and leaf name for `path`, or `None` when
+    /// arm 1 applies and there is no descriptor to hold.
+    ///
+    /// # Why a call site would want the descriptor rather than an operation
+    ///
+    /// Every other method here resolves, acts, and drops the descriptor, so two
+    /// consecutive calls walk twice and a parent flipped between them is a
+    /// window the pair does not close. A site that must *inspect* an entry and
+    /// then *act* on the very entry it inspected has to hold one descriptor
+    /// across both, which is what upstream's `successful_send()` does: it
+    /// resolves the parent once (`sender.c:416`), re-stats through it
+    /// (`sender.c:426-428`), and unlinks through the same descriptor
+    /// (`sender.c:453`) before closing it.
+    ///
+    /// `None` is arm 1 and `Err` is arm 3, exactly as for [`arm_for`]; the
+    /// caller supplies the arm-1 path-based operation itself, as upstream does
+    /// with its `dfd >= 0 ? ..._atfd(...) : ...(fname)` ternaries.
+    ///
+    /// [`arm_for`]: Self::arm_for
+    ///
+    /// # Errors
+    ///
+    /// Arm 3: whatever the ownership walk refused with - see [`arm_for`].
+    pub fn parent_at(&self, path: &Path) -> io::Result<Option<(OwnedFd, OsString)>> {
+        match self.resolve(path)? {
+            Resolved::Unconfined => Ok(None),
+            Resolved::Confined { parent, leaf } => Ok(Some((parent, leaf))),
+        }
+    }
+
     /// Remove a non-directory entry at `path`.
     ///
     /// `entry` selects `unlinkat(2)`'s flag word exactly as upstream does:

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/metadata.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/metadata.rs
@@ -89,6 +89,29 @@ impl AtMetadata {
     pub fn size(&self) -> u64 {
         widen_size(self.stat.st_size)
     }
+
+    /// Whole-second modification time (`st_mtime`), matching
+    /// [`std::os::unix::fs::MetadataExt::mtime`].
+    ///
+    /// Paired with [`mtime_nsec`](Self::mtime_nsec) and [`size`](Self::size)
+    /// this is the whole of upstream's changed-file guard, so a caller holding
+    /// a parent descriptor can decide "still the entry I chose" without a
+    /// second, path-based stat.
+    ///
+    /// upstream: `rsync-3.5.0/sender.c:442` - `st.st_mtime != file->modtime`.
+    #[must_use]
+    pub fn mtime(&self) -> i64 {
+        widen_time(self.stat.st_mtime)
+    }
+
+    /// Sub-second component of the modification time (`st_mtime_nsec`),
+    /// matching [`std::os::unix::fs::MetadataExt::mtime_nsec`].
+    ///
+    /// upstream: `rsync-3.5.0/sender.c:445` - the `ST_MTIME_NSEC` compare.
+    #[must_use]
+    pub fn mtime_nsec(&self) -> i64 {
+        widen_time(self.stat.st_mtime_nsec)
+    }
 }
 
 /// Widen `st_dev` to `u64`. `dev_t` is `i32` on macOS and `u64` on
@@ -116,6 +139,12 @@ fn widen_ino(value: libc::ino_t) -> u64 {
 /// supported Unix target.
 fn widen_size(value: libc::off_t) -> u64 {
     value as u64
+}
+
+/// Widen a `struct stat` time field to `i64`. `time_t` is `i64` everywhere we
+/// ship, but `st_mtime_nsec` is `c_long`, which is `i32` on 32-bit targets.
+fn widen_time(value: impl Into<i64>) -> i64 {
+    value.into()
 }
 
 /// Widen `st_mode` to `u32`. `mode_t` is `u16` on macOS and `u32` on
@@ -154,6 +183,38 @@ pub(super) fn widen_mode(value: libc::mode_t) -> u32 {
 /// - `EINVAL` when `name` contains an interior NUL byte (translated
 ///   from [`std::ffi::NulError`]).
 pub fn fstatat_nofollow(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<AtMetadata> {
+    fstatat_with_flags(dirfd, name, libc::AT_SYMLINK_NOFOLLOW)
+}
+
+/// Issue `fstatat(dirfd, name, &mut stat, 0)` - the leaf **is** followed.
+///
+/// The dirfd still pins the parent, so no component above the leaf can be
+/// swapped out from under the call; only the leaf itself resolves as a
+/// symlink would. This is the `--copy-links` half of a stat pair whose other
+/// half is [`fstatat_nofollow`], mirroring upstream's one call site that
+/// chooses between the two by that flag.
+///
+/// upstream: `rsync-3.5.0/sender.c:426-428` - `copy_links ? do_stat_atfd(dfd,
+/// bname, &st) : do_lstat_atfd(dfd, bname, &st)`.
+///
+/// `name` must not contain an interior NUL byte; callers that pull names from
+/// `Path::file_name` cannot trigger this (paths cannot contain NUL on Unix).
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim; see [`fstatat_nofollow`],
+/// plus `ELOOP` for a symlink chain at the leaf that does not terminate.
+pub fn fstatat_follow(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<AtMetadata> {
+    fstatat_with_flags(dirfd, name, 0)
+}
+
+/// The single `fstatat(2)` call behind [`fstatat_nofollow`] and
+/// [`fstatat_follow`]; `flags` is the only difference between them.
+fn fstatat_with_flags(
+    dirfd: BorrowedFd<'_>,
+    name: &OsStr,
+    flags: libc::c_int,
+) -> io::Result<AtMetadata> {
     let c_name =
         CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 
@@ -168,17 +229,12 @@ pub fn fstatat_nofollow(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<AtMet
     //   success we assume the struct is fully initialised (the kernel
     //   contract for `fstatat(2)` on success); on failure we never read
     //   from it.
-    // - `AT_SYMLINK_NOFOLLOW` selects the no-follow variant so a
-    //   symlink at the leaf is rejected/reported, not resolved.
+    // - `flags` is `0` or `AT_SYMLINK_NOFOLLOW`, the only two values the
+    //   two public wrappers above pass, and both are valid for `fstatat(2)`.
     #[allow(unsafe_code)]
     let (rc, stat) = unsafe {
         let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-        let rc = libc::fstatat(
-            dirfd.as_raw_fd(),
-            c_name.as_ptr(),
-            stat.as_mut_ptr(),
-            libc::AT_SYMLINK_NOFOLLOW,
-        );
+        let rc = libc::fstatat(dirfd.as_raw_fd(), c_name.as_ptr(), stat.as_mut_ptr(), flags);
         (rc, stat)
     };
 

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
@@ -49,7 +49,7 @@ pub use create::{
     symlinkat_via_sandbox_or_fallback,
 };
 pub use lstat::{LstatOutcome, lstat_via_sandbox_or_fallback};
-pub use metadata::{AtMetadata, fstatat_nofollow};
+pub use metadata::{AtMetadata, fstatat_follow, fstatat_nofollow};
 pub use metadata_ops::{
     fchmodat, fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback,
     secure_chmod_at, secure_chown_at, secure_utimes_at, utimensat,

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
@@ -157,28 +157,30 @@ pub fn unlinkat(dirfd: BorrowedFd<'_>, name: &OsStr, flags: UnlinkFlags) -> io::
 /// daemon worker seccomp allowlist, nothing more. Do not read a call to this
 /// helper as evidence that the site is confined.
 ///
-/// # Why it diverges from the pinned upstream
+/// # Why the legacy syscall is not used
 ///
-/// Behaviourally the divergence is measured against the 3.4.4 **behaviour**
-/// pin (`Cargo.toml:461`): there `successful_send()` removes the source with a
-/// plain `do_unlink(fname)` - path-based, exactly what `std::fs::remove_file`
-/// compiles to. oc carries seccomp hardening upstream does not, and that filter
-/// admits only the `*at` syscall forms, so the legacy number returns `EPERM`
-/// inside a sandboxed worker. The substitution is semantically null and costs
-/// no extra syscall.
+/// oc carries seccomp hardening upstream does not, and that filter admits only
+/// the `*at` syscall forms, so the legacy number returns `EPERM` inside a
+/// sandboxed worker. The substitution is semantically null and costs no extra
+/// syscall.
 ///
-/// Line references below resolve against the 3.5.0 **citation** pin
-/// (`xtask/src/commands/citations.rs:61`), which is what the drift gate reads.
-/// At 3.5.0 `successful_send()` is `sender.c:395` and it goes further than this
-/// helper does: it resolves a confined parent dirfd via
+/// # What this helper is, and is not, for
+///
+/// It is the **declined arm** of upstream's fallback contract - the plain
+/// path-based removal a site performs when the ownership walk has been opted
+/// out of (`insecure links = yes` / `--insecure-links`) or when there is no
+/// parent to anchor at. `successful_send()` spells that arm as the
+/// `do_unlink(fname)` half of its `dfd >= 0 ? ... : ...` removal ternary
+/// (`sender.c:453`); its confined half resolves the parent once with
 /// `secure_sender_parent_fd()` (`sender.c:416`), re-stats fd-relative
-/// (`sender.c:426-428`), and removes through `secure_remove_source_file()`
-/// (`sender.c:201-203`, itself `do_unlink_atfd`) at the `sender.c:453` removal
-/// ternary. Adopting that shape is the U350-4d site tracked as task 1043; this
-/// helper deliberately does not attempt it.
+/// (`sender.c:426-428`) and removes with `secure_remove_source_file()`
+/// (`sender.c:201-203`, itself `do_unlink_atfd`).
 ///
+/// So a site that has a parent to anchor at should not reach here directly.
 /// Callers holding a `DirSandbox` should prefer [`unlinkat`] against the
-/// sandbox dirfd, which does pin the parent against a TOCTOU swap.
+/// sandbox dirfd; callers working from a path should go through
+/// [`ConfinedFallback`](crate::ConfinedFallback), which owns all three arms and
+/// picks this one only when the policy says so.
 ///
 /// # Errors
 ///

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -83,14 +83,14 @@ pub use at_syscalls::{
     AtMetadata, CloneAttempt, DirEntryView, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,
     UnlinkResidue, confined_clone_file, confined_create_new, confined_link_anonymous,
     confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
-    fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
-    lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
-    openat_via_sandbox_or_fallback, read_dir_via_sandbox_or_fallback, readlinkat,
-    readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
-    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
-    secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
-    symlinkat_via_sandbox_or_fallback, unlink_path, unlink_via_sandbox_or_fallback, unlinkat,
-    utimensat, utimensat_via_sandbox_or_fallback,
+    fchownat_via_sandbox_or_fallback, fstatat_follow, fstatat_nofollow, linkat,
+    linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
+    mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
+    read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
+    recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
+    renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at,
+    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_path, unlink_via_sandbox_or_fallback,
+    unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
 };
 
 /// Parent-dirfd carrier threaded through the receiver pipeline.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -397,14 +397,14 @@ pub use dir_sandbox::{
     AtMetadata, CloneAttempt, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome,
     UnlinkFlags, UnlinkResidue, confined_clone_file, confined_create_new, confined_link_anonymous,
     confined_rename, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
-    fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
-    lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
-    openat_via_sandbox_or_fallback, read_dir_via_sandbox_or_fallback, readlinkat,
-    readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
-    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
-    secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
-    symlinkat_via_sandbox_or_fallback, unlink_path, unlink_via_sandbox_or_fallback, unlinkat,
-    utimensat, utimensat_via_sandbox_or_fallback,
+    fchownat_via_sandbox_or_fallback, fstatat_follow, fstatat_nofollow, linkat,
+    linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
+    mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
+    read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
+    recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
+    renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at,
+    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_path, unlink_via_sandbox_or_fallback,
+    unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
 };
 pub use inplace_open::{InplaceResolution, open_inplace_output};
 pub use kernel_version::{

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -1360,9 +1360,10 @@ impl GeneratorContext {
     /// accumulated error state.
     ///
     /// Mirrors upstream `successful_send()` (sender.c:395): the source is
-    /// re-stat'd (`do_stat` under `--copy-links`, else `do_lstat`) and is only
-    /// unlinked when it still matches the size and modification time recorded in
-    /// the file list. A vanished source (`ENOENT`) is the benign "already
+    /// re-stat'd through a confined parent descriptor (`do_stat_atfd` under
+    /// `--copy-links`, else `do_lstat_atfd`) and is only unlinked - through that
+    /// same descriptor - when it still matches the size and modification time
+    /// recorded in the file list. A vanished source (`ENOENT`) is the benign "already
     /// removed" notice (`FINFO`); a re-stat failure, a source that changed since
     /// it entered the file list, or an unlink failure is an `FERROR_XFER`, which
     /// upstream turns into `got_xfer_error` -> exit 23 (`RERR_PARTIAL`) without
@@ -1385,8 +1386,6 @@ impl GeneratorContext {
         source_path: &Path,
         recorded: RecordedSourceIdentity,
     ) -> i32 {
-        use super::super::io_error_flags::IOERR_GENERAL;
-
         // upstream: sender.c:405-406 - bail before any FS calls when the flag is off.
         if !self.config.flags.remove_source_files {
             return 0;
@@ -1398,82 +1397,11 @@ impl GeneratorContext {
             return 0;
         }
 
-        // upstream: sender.c:426-428 - re-stat the source (do_stat under
-        // --copy-links, else do_lstat) before removing it, so a source that
-        // vanished or changed since it entered the file list is never unlinked.
-        let restat = if self.config.flags.copy_links {
-            std::fs::metadata(source_path)
-        } else {
-            std::fs::symlink_metadata(source_path)
-        };
-        let current = match restat {
-            Ok(meta) => meta,
-            // upstream: sender.c:456-457 - ENOENT is the benign FINFO notice.
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                info_log!(
-                    Remove,
-                    1,
-                    "sender file already removed: {}",
-                    source_path.display()
-                );
-                return 0;
-            }
-            // upstream: sender.c:429-430,459 - any other re-lstat failure is
-            // rsyserr(FERROR_XFER, ...), setting got_xfer_error -> exit 23.
-            Err(error) => {
-                eprintln!("{}", sender_op_failure("re-lstat", source_path, &error));
-                return IOERR_GENERAL;
-            }
-        };
-
-        // upstream: sender.c:442-451 - refuse to remove a source that changed
-        // size or modification time since it entered the file list.
-        let (size, mtime, mtime_nsec) = stat_identity(&current);
-        if source_changed_since_flist(recorded, size, mtime, mtime_nsec) {
-            eprintln!(
-                "ERROR: Skipping sender remove for changed file: {}",
-                source_path.display()
-            );
-            return IOERR_GENERAL;
-        }
-
-        // upstream: sender.c:453 - do_unlink(fname) once every guard passed.
-        //
-        // Routed through `fast_io::unlink_path` rather than
-        // `std::fs::remove_file`: the latter lowers to the legacy `unlink(2)`,
-        // which the daemon worker seccomp allowlist does not admit, so a
-        // sandboxed daemon sender failed every removal with EPERM while every
-        // other syscall on the path succeeded. `unlinkat(AT_FDCWD, ..)`
-        // resolves identically to `unlink(2)` - this is a syscall-number
-        // substitution, NOT confinement. Fd-anchoring this site the way 3.5.0
-        // does is tracked as task 1043; see `unlink_path`'s doc comment.
-        #[cfg(unix)]
-        let removal = fast_io::unlink_path(source_path, fast_io::UnlinkFlags::File);
-        #[cfg(not(unix))]
-        let removal = std::fs::remove_file(source_path);
-        match removal {
-            Ok(()) => {
-                // upstream: sender.c:461-462 - INFO_GTE(REMOVE,1) success notice.
-                info_log!(Remove, 1, "removing source {}", source_path.display());
-                0
-            }
-            // upstream: sender.c:456-457 - ENOENT after the guards is still benign.
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                info_log!(
-                    Remove,
-                    1,
-                    "sender file already removed: {}",
-                    source_path.display()
-                );
-                0
-            }
-            // upstream: sender.c:454,459 - rsyserr(FERROR_XFER, ...) on
-            // unlink failure sets got_xfer_error -> exit 23.
-            Err(error) => {
-                eprintln!("{}", sender_op_failure("remove", source_path, &error));
-                IOERR_GENERAL
-            }
-        }
+        // upstream: sender.c:408-455 - the parent resolve, the fd-relative
+        // re-stat and the unlink are ONE decision about ONE directory entry,
+        // so they live together in a free function the guard tests drive
+        // directly.
+        remove_confirmed_source(source_path, recorded, self.config.flags.copy_links)
     }
 
     /// Runs the deferred `--remove-source-files` unlink for a file the peer has
@@ -1603,6 +1531,174 @@ const fn source_changed_since_flist(
 /// upstream: sender.c:745 - `if (append_mode > 0 && st.st_size < F_LENGTH(file))`
 fn source_diminished_below_flist(source_path: &Path, flist_len: u64) -> bool {
     std::fs::metadata(source_path).is_ok_and(|meta| meta.len() < flist_len)
+}
+
+/// Re-stats a confirmed source through a confined parent descriptor and unlinks
+/// it through that same descriptor.
+///
+/// This is the body of upstream `successful_send()` from its parent resolve
+/// down to its unlink, with upstream's three outcomes preserved:
+///
+/// - the walk resolves a parent (`dfd >= 0`): the re-stat is `fstatat` against
+///   that descriptor and the removal is `unlinkat` against it, so the entry
+///   confirmed is provably the entry removed - no path component is re-resolved
+///   in between, and a directory symlink swapped in over the parent after the
+///   stat cannot redirect the unlink;
+/// - the walk declines (`dfd < 0` with `errno == 0`, i.e. `insecure links = yes`
+///   or `--insecure-links`): the pre-3.5.0 path-based `lstat` + `unlink` pair,
+///   which is what the opt-out asks for;
+/// - the walk refuses (`dfd < 0` with `errno` set): `failed_op =
+///   "secure-open-parent"`, reported like any other failure and never silently
+///   downgraded to the path-based removal.
+///
+/// The re-stat compares exactly what upstream compares - size, whole-second
+/// mtime, and the sub-second component when the file list carried one - and
+/// nothing else. It is deliberately NOT a `(dev, ino)` comparison: the file
+/// list records no inode to compare against, and upstream's one dev/ino test
+/// here is the separate `local_server` guard that refuses to delete the
+/// *destination* file, which reads the receiver's dev/ino off the wire and
+/// lives on the local-copy side.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/sender.c:416` - `dfd = secure_sender_parent_fd(file, fname, &bname)`
+/// - `rsync-3.5.0/sender.c:421-425` - the `secure-open-parent` failure arm
+/// - `rsync-3.5.0/sender.c:426-428` - `do_stat_atfd` / `do_lstat_atfd` on `dfd`
+/// - `rsync-3.5.0/sender.c:442-451` - the size/mtime changed-file guard
+/// - `rsync-3.5.0/sender.c:453` - `secure_remove_source_file(dfd, bname)`
+/// - `rsync-3.5.0/sender.c:201-203` - that function, `do_unlink_atfd(dfd, bname, 0)`
+/// - `rsync-3.5.0/sender.c:455-459` - the shared `failed:` label, where `ENOENT`
+///   from ANY of the three operations is the benign "already removed" notice
+#[cfg(unix)]
+#[must_use]
+fn remove_confirmed_source(
+    source_path: &Path,
+    recorded: RecordedSourceIdentity,
+    copy_links: bool,
+) -> i32 {
+    use std::os::fd::AsFd as _;
+
+    use super::super::io_error_flags::IOERR_GENERAL;
+
+    // upstream: sender.c:416 - resolve the parent ONCE. Both the re-stat and
+    // the unlink below run against this one descriptor.
+    let parent = match fast_io::ConfinedFallback::confined().parent_at(source_path) {
+        Ok(parent) => parent,
+        // upstream: sender.c:421-425 + 455-459 - a refused parent is
+        // failed_op = "secure-open-parent", which shares the `failed:` label,
+        // and therefore the ENOENT-is-benign arm, with the other two failures.
+        Err(error) => return report_removal_failure("secure-open-parent", source_path, &error),
+    };
+
+    // upstream: sender.c:426-428 - do_stat_atfd under --copy-links, else
+    // do_lstat_atfd; the path-based pair only on the declined arm.
+    let restat = match &parent {
+        Some((dirfd, leaf)) => {
+            let at = if copy_links {
+                fast_io::fstatat_follow(dirfd.as_fd(), leaf)
+            } else {
+                fast_io::fstatat_nofollow(dirfd.as_fd(), leaf)
+            };
+            at.map(|meta| (meta.size(), meta.mtime(), meta.mtime_nsec() as u32))
+        }
+        None => if copy_links {
+            std::fs::metadata(source_path)
+        } else {
+            std::fs::symlink_metadata(source_path)
+        }
+        .map(|meta| stat_identity(&meta)),
+    };
+    let (size, mtime, mtime_nsec) = match restat {
+        Ok(identity) => identity,
+        // upstream: sender.c:429-430,455-459 - ENOENT is the benign FINFO
+        // notice, anything else is rsyserr(FERROR_XFER) -> exit 23.
+        Err(error) => return report_removal_failure("re-lstat", source_path, &error),
+    };
+
+    // upstream: sender.c:442-451 - refuse to remove a source that changed size
+    // or modification time since it entered the file list.
+    if source_changed_since_flist(recorded, size, mtime, mtime_nsec) {
+        eprintln!(
+            "ERROR: Skipping sender remove for changed file: {}",
+            source_path.display()
+        );
+        return IOERR_GENERAL;
+    }
+
+    // upstream: sender.c:453 - secure_remove_source_file(dfd, bname) through the
+    // very descriptor the re-stat used, or do_unlink(fname) on the declined arm.
+    let removal = match &parent {
+        Some((dirfd, leaf)) => fast_io::unlinkat(dirfd.as_fd(), leaf, fast_io::UnlinkFlags::File),
+        None => fast_io::unlink_path(source_path, fast_io::UnlinkFlags::File),
+    };
+    match removal {
+        Ok(()) => {
+            // upstream: sender.c:461-462 - INFO_GTE(REMOVE,1) success notice.
+            info_log!(Remove, 1, "removing source {}", source_path.display());
+            0
+        }
+        Err(error) => report_removal_failure("remove", source_path, &error),
+    }
+}
+
+/// Windows has neither the `*at` family nor the ownership walk, so the removal
+/// stays the path-based pair upstream itself uses on its declined arm.
+#[cfg(not(unix))]
+#[must_use]
+fn remove_confirmed_source(
+    source_path: &Path,
+    recorded: RecordedSourceIdentity,
+    copy_links: bool,
+) -> i32 {
+    use super::super::io_error_flags::IOERR_GENERAL;
+
+    let restat = if copy_links {
+        std::fs::metadata(source_path)
+    } else {
+        std::fs::symlink_metadata(source_path)
+    };
+    let current = match restat {
+        Ok(meta) => meta,
+        Err(error) => return report_removal_failure("re-lstat", source_path, &error),
+    };
+
+    let (size, mtime, mtime_nsec) = stat_identity(&current);
+    if source_changed_since_flist(recorded, size, mtime, mtime_nsec) {
+        eprintln!(
+            "ERROR: Skipping sender remove for changed file: {}",
+            source_path.display()
+        );
+        return IOERR_GENERAL;
+    }
+
+    match std::fs::remove_file(source_path) {
+        Ok(()) => {
+            info_log!(Remove, 1, "removing source {}", source_path.display());
+            0
+        }
+        Err(error) => report_removal_failure("remove", source_path, &error),
+    }
+}
+
+/// Upstream's shared `failed:` label: `ENOENT` from the parent resolve, the
+/// re-stat or the unlink alike is the benign "already removed" notice and no
+/// error bit; anything else is `rsyserr(FERROR_XFER, ...)`, which upstream
+/// turns into `got_xfer_error` -> exit 23.
+///
+/// upstream: `rsync-3.5.0/sender.c:455-459`
+#[must_use]
+fn report_removal_failure(op: &str, source_path: &Path, error: &io::Error) -> i32 {
+    if error.kind() == io::ErrorKind::NotFound {
+        info_log!(
+            Remove,
+            1,
+            "sender file already removed: {}",
+            source_path.display()
+        );
+        return 0;
+    }
+    eprintln!("{}", sender_op_failure(op, source_path, error));
+    super::super::io_error_flags::IOERR_GENERAL
 }
 
 /// Extracts `(size, mtime_seconds, mtime_nanoseconds)` from a re-stat result in
@@ -1842,6 +1938,162 @@ mod sender_remove_guard_tests {
         assert_eq!(size, 11);
         let r = recorded(size, mtime, mtime_nsec);
         assert!(!source_changed_since_flist(r, size, mtime, mtime_nsec));
+    }
+}
+
+/// The `--remove-source-files` unlink must land on the entry the re-stat
+/// confirmed, and must not be steerable out of the confinement root by a
+/// directory symlink planted above the leaf.
+///
+/// These cells install a process-global confinement session
+/// (`fast_io::confinement::install_session`), which is sound only because
+/// nextest runs one process per test.
+///
+/// # Why the fixture uses a symlink the test itself owns
+///
+/// The ownership walk deliberately FOLLOWS a symlink owned by root or by our
+/// own euid - that is the operator's own layout, and refusing it would break
+/// every ordinary deployment. So a non-root fixture cannot make the walk refuse
+/// on ownership grounds, and a cell built that way would be inert. What it can
+/// exercise is the other half of the same walk: the confinement-root judgement,
+/// which asks where the leaf LANDS and does not care who owns the link. That is
+/// exactly upstream's daemon arm, where `secure_sender_parent_fd()` anchors at
+/// `module_dir` so a parent flipped to point outside the module cannot be
+/// walked through.
+///
+/// upstream: `rsync-3.5.0/sender.c:395` `successful_send()`
+#[cfg(all(test, unix))]
+mod sender_remove_confinement_tests {
+    use super::{RecordedSourceIdentity, remove_confirmed_source, stat_identity};
+    use fast_io::confinement::{
+        Activation, DaemonState, LocalInsecureLinks, Role, install_session,
+    };
+    use std::path::Path;
+
+    /// Publish `root` as the session's confinement root, the way a daemon
+    /// publishes its module root before serving a request.
+    fn confine_to(root: &Path) {
+        install_session(&Activation {
+            role: Role::Receiver,
+            daemon: DaemonState::NotDaemon,
+            insecure_links: LocalInsecureLinks::default(),
+            confine_root: Some(root.to_path_buf()),
+        });
+    }
+
+    /// The identity the file list would have recorded for `path`.
+    fn recorded_for(path: &Path) -> RecordedSourceIdentity {
+        let meta = std::fs::symlink_metadata(path).expect("stat the source");
+        let (size, mtime, mtime_nsec) = stat_identity(&meta);
+        RecordedSourceIdentity {
+            size,
+            mtime,
+            mtime_nsec,
+        }
+    }
+
+    /// A parent component flipped to point outside the confinement root must
+    /// not be walked through, so the file it leads to is NOT the file removed.
+    ///
+    /// WHY this matters and not merely "an unlink failed": the sender decided
+    /// to delete an entry inside the module. Resolving that decision through
+    /// `AT_FDCWD` on the path string re-walks every component at unlink time,
+    /// so whoever controls a parent directory name controls which inode the
+    /// deletion lands on - here, a file the transfer never touched and that
+    /// lives outside the served module entirely. The pre-fix code removes it.
+    #[test]
+    fn a_parent_symlink_out_of_the_root_cannot_steer_the_removal() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("module");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir(&root).expect("mkdir module");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        let victim = outside.join("data.bin");
+        std::fs::write(&victim, b"not ours to delete").expect("write the victim");
+        // The parent the sender's path names, pointing out of the module.
+        std::os::unix::fs::symlink("../outside", root.join("sub")).expect("plant the symlink");
+        let spelled = root.join("sub").join("data.bin");
+        // Recorded identity MATCHES, so the changed-file guard cannot be what
+        // saves the victim - only the confined resolve can.
+        let recorded = recorded_for(&spelled);
+
+        confine_to(&root);
+        let io_error = remove_confirmed_source(&spelled, recorded, false);
+
+        assert!(
+            victim.exists(),
+            "the out-of-root file was removed: the unlink followed the planted parent symlink"
+        );
+        assert_ne!(
+            io_error, 0,
+            "a refused parent is upstream's secure-open-parent failure (FERROR_XFER -> exit 23)"
+        );
+    }
+
+    /// The companion that keeps the cell above honest: an ordinary source
+    /// inside the root is still removed, and reports no error.
+    ///
+    /// Without this, "confine everything" and "refuse everything" would look
+    /// identical - and refusing every removal would silently turn
+    /// `--remove-source-files` into a no-op.
+    #[test]
+    fn an_ordinary_in_root_source_is_still_removed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("module");
+        std::fs::create_dir_all(root.join("sub")).expect("mkdir module/sub");
+        let source = root.join("sub").join("data.bin");
+        std::fs::write(&source, b"sent and confirmed").expect("write the source");
+        let recorded = recorded_for(&source);
+
+        confine_to(&root);
+        let io_error = remove_confirmed_source(&source, recorded, false);
+
+        assert_eq!(io_error, 0, "an in-root removal must report no error");
+        assert!(!source.exists(), "the confirmed source was not removed");
+    }
+
+    /// The fd-relative re-stat must still be a re-stat: a source rewritten
+    /// since it entered the file list is kept, exactly as on the path-based
+    /// arm (sender.c:442-451). A stat that compared nothing would delete it.
+    #[test]
+    fn a_source_that_changed_since_the_flist_is_kept() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("module");
+        std::fs::create_dir_all(root.join("sub")).expect("mkdir module/sub");
+        let source = root.join("sub").join("data.bin");
+        std::fs::write(&source, b"short").expect("write the source");
+        let mut recorded = recorded_for(&source);
+        // The file list saw a longer file than the one on disk now.
+        recorded.size += 4096;
+
+        confine_to(&root);
+        let io_error = remove_confirmed_source(&source, recorded, false);
+
+        assert_ne!(io_error, 0, "a changed source is FERROR_XFER -> exit 23");
+        assert!(source.exists(), "a changed source must not be removed");
+    }
+
+    /// A source that vanished before the confirmation arrived is upstream's
+    /// benign "already removed" notice, not an error bit - the shared `failed:`
+    /// label folds `ENOENT` from the parent resolve and the re-stat alike into
+    /// the same `FINFO` (sender.c:455-458).
+    #[test]
+    fn a_vanished_source_is_not_an_error() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("module");
+        std::fs::create_dir_all(root.join("sub")).expect("mkdir module/sub");
+        let source = root.join("sub").join("data.bin");
+        std::fs::write(&source, b"transient").expect("write the source");
+        let recorded = recorded_for(&source);
+        std::fs::remove_file(&source).expect("the source vanishes");
+
+        confine_to(&root);
+
+        assert_eq!(
+            remove_confirmed_source(&source, recorded, false),
+            0,
+            "ENOENT is the benign FINFO notice, never an error bit"
+        );
     }
 }
 


### PR DESCRIPTION
## The defect

The sender's `--remove-source-files` removal ran entirely on the path string. At
`crates/transfer/src/generator/transfer/transfer_loop.rs` the re-stat was
`std::fs::symlink_metadata(source_path)` (or `metadata` under `--copy-links`) and
the removal was `fast_io::unlink_path(source_path, ..)`, which is
`unlinkat(AT_FDCWD, <absolute path>)` - resolution identical to `unlink(2)`, as
that helper's own doc says. Two independent full path walks, so every component
was re-resolved at unlink time and nothing tied the entry the guards confirmed to
the entry the kernel deleted.

The consequence is not "an unlink failed". The sender decided to delete an entry
inside the served tree; whoever controls a parent directory name controls which
inode the deletion lands on, including a file outside a served daemon module that
the transfer never touched.

## Upstream's shape

`rsync-3.5.0/sender.c:395` `successful_send()` resolves the parent once with
`secure_sender_parent_fd()` (`sender.c:416`) - anchored at `module_dir` for a
daemon, at the held ancestor-dirfd stack otherwise - re-stats through that
descriptor (`sender.c:426-428`, `do_stat_atfd` under `copy_links` else
`do_lstat_atfd`), and removes through the same descriptor via
`secure_remove_source_file()` (`sender.c:453`, itself `do_unlink_atfd`).

It has three arms, and all three are reproduced here:

| upstream | condition | behaviour |
|---|---|---|
| `dfd >= 0` | walk resolved | `fstatat` + `unlinkat` on the one descriptor |
| `dfd < 0`, `errno == 0` | `symlink_optout_allowed()` | path-based `lstat` + `unlink` |
| `dfd < 0`, `errno` set | walk refused | `failed_op = "secure-open-parent"` |

`ENOENT` from any of the three operations reaches the shared `failed:` label and
is the benign "sender file already removed" notice (`sender.c:455-459`), never an
error bit. That includes `ENOENT` out of the parent resolve.

The re-stat compares **size, whole-second mtime, and the sub-second component**
when the file list carried one (`sender.c:442-451`) - and nothing else. It is
deliberately not a `(dev, ino)` comparison: the file list records no inode, and
upstream's only dev/ino test here is the separate `local_server` guard that
refuses to delete the *destination* file, which reads the receiver's dev/ino off
the wire and lives on oc's local-copy side.

## The change

`remove_confirmed_source` holds one parent descriptor across the re-stat and the
unlink. The walk itself is reused, not reinvented: `ConfinedFallback` already
owns upstream's three-arm contract over the `fast_io` ownership walk. It gained
one method, `parent_at`, which returns the resolved descriptor instead of
performing an operation with it - every existing method resolves, acts and drops,
so a stat/act pair built from two of them would walk twice and reopen exactly the
window this fixes. `PathKind::Confined` matches upstream's daemon anchoring: the
daemon publishes its module root as the session root, and a non-daemon session
publishes none, so the root judgement engages exactly where upstream's does.

The fd-relative half of the re-stat needed two small additions in the same owning
crate: `fstatat_follow` beside the existing `fstatat_nofollow` (upstream's
`copy_links` fork), and `mtime`/`mtime_nsec` accessors on `AtMetadata`, which
already owned the whole `struct stat`.

`unlink_path`'s doc comment previously said this site was unanchored and pointed
forward to this work; it now describes the helper as what it is, the declined arm.

## RED / GREEN

Four cells in `sender_remove_confinement_tests`. The escape fixture plants
`module/sub -> ../outside` and records an identity that **matches**, so the
changed-file guard cannot be what saves the victim.

The symlink is one the test owns, and that is deliberate: the ownership walk
follows a symlink owned by root or by our own euid, because that is the
operator's own layout. A fixture built on ownership refusal would be inert for a
non-root run. What this exercises is the other half of the same walk, the
confinement-root judgement, which asks where the leaf lands and does not care who
owns the link - upstream's daemon arm exactly.

| variant | result |
|---|---|
| fixed | `4 tests run: 4 passed, 2772 skipped` |
| mutation A - parent forced to the declined arm (the pre-fix path-based pair) | `4 tests run: 3 passed, 1 failed` - `the out-of-root file was removed: the unlink followed the planted parent symlink` |
| mutation B - `confined()` -> `ancillary()` | `4 tests run: 3 passed, 1 failed`, same cell |

Mutation A is the pre-fix code, so the failure message is the measurement of the
defect itself: today's binary deletes the out-of-root file. Mutation B shows the
`PathKind` is load-bearing and not decorative - an ancillary walk pins the parent
but still resolves through the trusted symlink and deletes the victim.

The three companions stay green in both mutations, so the fix is not the
degenerate "refuse every removal": an ordinary in-root source is still removed
and reports no error, a source that changed since the file list is still kept,
and a vanished source is still the benign notice rather than an error bit.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo nextest run -p fast_io --all-features` - `839 tests run: 839 passed`
- `cargo nextest run -p transfer --all-features -E 'test(generator)'` - `464 tests run: 464 passed, 2312 skipped`
- `cargo nextest run -p transfer --all-features -E 'test(remove_source) or test(sender_remove) or test(source_removal)'` - `20 tests run: 20 passed, 2756 skipped`
- `cargo run -p xtask -- citations` - `8624 name(s) and 8624 line range(s) checked`
- `cargo check --target x86_64-pc-windows-gnu -p transfer -p fast_io --all-targets --all-features` - clean; Windows has no `*at` family, so it keeps the path-based pair upstream itself uses on its declined arm
