### PR TITLE
fix(transfer): stop pre-empting the confined -R implied-parent mkdir

### DIFF
--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -79,7 +79,25 @@ impl ReceiverContext {
     /// destination symlink-to-directory would always be treated as an existing
     /// directory and never replaced, diverging from upstream when
     /// `--keep-dirlinks` is off.
-    fn classify_dir_destination(&self, dir_path: &Path) -> io::Result<DirDestination> {
+    ///
+    /// The removal is confined. The entry being unlinked is a symlink the peer
+    /// chose the target of, sitting on the receiver's destination path, so a
+    /// path-based `unlink(2)` here re-resolves every component under the peer's
+    /// influence. `sandbox` may be `None`: that is a supported arm of
+    /// [`fast_io::unlink_via_sandbox_or_fallback`], not a gap - it then applies
+    /// upstream's three-arm `do_unlink_at()` contract, which errors rather than
+    /// falling back to a plain syscall when the ownership walk refuses.
+    fn classify_dir_destination(
+        &self,
+        dir_path: &Path,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
+        dest_dir: &Path,
+        relative_path: &Path,
+    ) -> io::Result<DirDestination> {
+        // `dest_dir` / `relative_path` anchor the confined unlink, which only
+        // exists on Unix.
+        #[cfg(not(unix))]
+        let _ = (dest_dir, relative_path);
         match fs::symlink_metadata(dir_path) {
             Ok(existing) if existing.file_type().is_symlink() => {
                 let resolves_to_dir = fs::metadata(dir_path)
@@ -90,12 +108,23 @@ impl ReceiverContext {
                     // destination symlink-to-directory instead of replacing it.
                     Ok(DirDestination::Existing)
                 } else {
-                    // upstream: generator.c:1454 - delete_item(fname, ...,
-                    // DEL_FOR_DIR) removes the conflicting symlink before mkdir.
-                    // upstream: syscall.c do_unlink() - `if (dry_run) return 0;`,
-                    // so delete_item() reports success without unlinking and the
-                    // caller still proceeds as if the destination became absent.
+                    // upstream: generator.c:1841 - delete_item(fname, ...,
+                    // del_opts | DEL_FOR_DIR) removes the conflicting symlink
+                    // before mkdir. That reaches delete.c:71-78 del_unlink(),
+                    // which takes do_unlink_atfd() against a held dirfd or else
+                    // robust_unlink() -> util1.c:545 -> do_unlink_at() - the
+                    // CONFINED wrapper. Upstream issues no plain unlink() on
+                    // this path, so neither do we.
                     if !self.config.flags.skip_dest_writes() {
+                        #[cfg(unix)]
+                        fast_io::unlink_via_sandbox_or_fallback(
+                            sandbox,
+                            dest_dir,
+                            relative_path,
+                            dir_path,
+                            fast_io::UnlinkFlags::File,
+                        )?;
+                        #[cfg(not(unix))]
                         fs::remove_file(dir_path)?;
                     }
                     Ok(DirDestination::ReplacedSymlink)
@@ -254,15 +283,48 @@ impl ReceiverContext {
             // upstream: generator.c:1356 / 1451-1455 - classify the destination
             // via lstat (not exists()) so a symlink-to-directory is replaced by
             // a real directory unless --keep-dirlinks is set, in which case it is
-            // followed. A remove failure is non-fatal (matches upstream
-            // skipping_dir_contents): fall back to the exists() probe.
-            let dir_dest = self.classify_dir_destination(dir_path).unwrap_or_else(|_| {
-                if dir_path.exists() {
-                    DirDestination::Existing
-                } else {
-                    DirDestination::Missing
+            // followed.
+            //
+            // upstream: generator.c:1840-1843 - a failed
+            // `delete_item(..., DEL_FOR_DIR)` does `goto skipping_dir_contents`;
+            // it does NOT re-probe and carry on. The previous
+            // `.unwrap_or_else(|_| if dir_path.exists() { .. })` recovery was
+            // wrong twice over: `exists()` FOLLOWS symlinks, so the very entry
+            // whose removal just failed reported as an existing directory, and
+            // the transfer then proceeded through a symlink the peer controls.
+            // It also swallowed the errno, which is how a denied unlink
+            // surfaced three layers later as an opaque EXDEV from the confined
+            // walk. upstream generator.c:1443-1467 states the rule for the
+            // whole family: a runtime denial is a real failure and is
+            // deliberately NOT retried unconfined.
+            let dir_dest = match self.classify_dir_destination(
+                dir_path,
+                #[cfg(unix)]
+                sandbox,
+                dest_dir,
+                relative_path,
+            ) {
+                Ok(dest) => dest,
+                Err(error) => {
+                    if self.config.flags.verbose && self.config.connection.client_mode {
+                        info_log!(
+                            Misc,
+                            1,
+                            "failed to prepare directory {}: {}",
+                            dir_path.display(),
+                            error
+                        );
+                    }
+                    emit_lsm_audit_hint_once();
+                    // Mirrors the mkdir-failure arm below: record the directory
+                    // as failed so the itemize and metadata passes skip it and
+                    // `dir_creation_errors` folds IOERR_GENERAL into the exit
+                    // code, matching upstream's "any errors get reported later".
+                    dir_was_new.push(false);
+                    failed_dir_paths.insert(dir_path.clone());
+                    continue;
                 }
-            });
+            };
             let is_new = dir_dest.needs_mkdir();
             dir_was_new.push(is_new);
             // upstream: generator.c:1401 - --existing (ignore_non_existing) only
@@ -727,17 +789,38 @@ impl ReceiverContext {
         // `--relative` shapes.
         // upstream: generator.c:1356 / 1451-1455 - lstat-classify the
         // destination so a symlink-to-directory is replaced by a real directory
-        // unless --keep-dirlinks follows it. Non-fatal on error: fall back to
-        // the exists() probe (matches upstream's skipping_dir_contents path).
-        let dir_dest = self
-            .classify_dir_destination(&dir_path)
-            .unwrap_or_else(|_| {
-                if dir_path.exists() {
-                    DirDestination::Existing
-                } else {
-                    DirDestination::Missing
+        // unless --keep-dirlinks follows it.
+        //
+        // upstream: generator.c:1840-1843 - a failed
+        // `delete_item(..., DEL_FOR_DIR)` goes to `skipping_dir_contents`, so
+        // the directory and its contents are skipped and the error is reported.
+        // This is the incremental-recursion twin of the `create_directories`
+        // arm above; both previously recovered via a FOLLOWING `exists()`,
+        // which reports the un-removed symlink as an existing directory and
+        // walks the transfer straight through it.
+        let dir_dest = match self.classify_dir_destination(
+            &dir_path,
+            #[cfg(unix)]
+            sandbox,
+            dest_dir,
+            relative_path,
+        ) {
+            Ok(dest) => dest,
+            Err(error) => {
+                if self.config.flags.verbose && self.config.connection.client_mode {
+                    info_log!(
+                        Misc,
+                        1,
+                        "failed to prepare directory {}: {}",
+                        dir_path.display(),
+                        error
+                    );
                 }
-            });
+                emit_lsm_audit_hint_once();
+                failed_dirs.mark_failed(entry.name());
+                return Ok(None);
+            }
+        };
         let is_new = dir_dest.needs_mkdir();
         // upstream: generator.c:1368-1383 - with --existing (ignore_non_existing),
         // a directory missing at the destination is never created; the dir is
@@ -1215,6 +1298,80 @@ mod touch_up_dirs_tests {
         );
     }
 
+    /// A refused obstruction removal must be REPORTED, not laundered into
+    /// "the destination already exists".
+    ///
+    /// upstream: generator.c:1840-1843 - when
+    /// `delete_item(..., del_opts | DEL_FOR_DIR)` fails, upstream does
+    /// `goto skipping_dir_contents`; it never re-probes the destination and
+    /// carries on. oc previously recovered with
+    /// `.unwrap_or_else(|_| if dir_path.exists() { Existing } else { Missing })`,
+    /// and `exists()` FOLLOWS symlinks - so the very entry whose removal had
+    /// just been denied reported back as an existing directory, the transfer
+    /// proceeded through a peer-controlled symlink, and the errno was
+    /// discarded. That discarded errno is what made a denied `unlink` surface
+    /// three layers later as an opaque EXDEV from the confined walk.
+    ///
+    /// The fixture denies the removal with a read-only parent, which is the
+    /// portable stand-in for any refusal - a confined-walk rejection or a
+    /// syscall-filter denial reaches the same arm.
+    #[cfg(unix)]
+    #[test]
+    fn a_refused_obstruction_removal_is_reported_not_reclassified() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        if metadata::am_root() {
+            // root bypasses the directory write bit, so the fixture cannot
+            // deny the removal and the cell would pass vacuously.
+            return;
+        }
+
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        let target = dest.join("real");
+        fs::create_dir(&target).unwrap();
+        symlink(&target, dest.join("d")).unwrap();
+
+        // Deny the unlink by removing write permission from the parent.
+        let original = fs::metadata(dest).unwrap().permissions();
+        fs::set_permissions(dest, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let hs = handshake();
+        let mut ctx = ReceiverContext::new_for_test(&hs, config_with_times(false));
+        ctx.file_list = vec![FileEntry::new_directory("d".into(), 0o755)];
+
+        let opts = metadata::MetadataOptions::default();
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        let errors = ctx.create_directories(
+            dest,
+            &opts,
+            None,
+            None,
+            &mut writer,
+            #[cfg(unix)]
+            None,
+        );
+
+        // Restore before asserting so a failure does not leave the tempdir
+        // undeletable.
+        fs::set_permissions(dest, original).unwrap();
+
+        let errors = errors.expect("create_directories returns the error set, not Err");
+        assert!(
+            !errors.is_empty(),
+            "a denied obstruction removal must be reported so io_error reaches \
+             the exit code; reclassifying it as an existing directory walks the \
+             transfer through the surviving symlink"
+        );
+        assert!(
+            fs::symlink_metadata(dest.join("d"))
+                .expect("the entry still exists")
+                .file_type()
+                .is_symlink(),
+            "the fixture is only meaningful while the removal actually failed"
+        );
+    }
+
     /// Regression: creating a child subdirectory inside an already-present
     /// transfer root bumps the root's on-disk mtime. The batch
     /// `create_directories` pass mkdir's every directory before it itemizes any,
@@ -1615,7 +1772,13 @@ mod touch_up_dirs_tests {
         let ctx = ReceiverContext::new_for_test(&hs, config_with_keep_dirlinks(false));
 
         let decision = ctx
-            .classify_dir_destination(&link)
+            .classify_dir_destination(
+                &link,
+                #[cfg(unix)]
+                None,
+                dir.path(),
+                std::path::Path::new("d"),
+            )
             .expect("classify succeeds");
         assert_eq!(
             decision,
@@ -1647,7 +1810,13 @@ mod touch_up_dirs_tests {
         let ctx = ReceiverContext::new_for_test(&hs, config_with_keep_dirlinks(true));
 
         let decision = ctx
-            .classify_dir_destination(&link)
+            .classify_dir_destination(
+                &link,
+                #[cfg(unix)]
+                None,
+                dir.path(),
+                std::path::Path::new("d"),
+            )
             .expect("classify succeeds");
         assert_eq!(
             decision,
@@ -1683,7 +1852,13 @@ mod touch_up_dirs_tests {
         let ctx = ReceiverContext::new_for_test(&hs, config_with_keep_dirlinks(true));
 
         let decision = ctx
-            .classify_dir_destination(&link)
+            .classify_dir_destination(
+                &link,
+                #[cfg(unix)]
+                None,
+                dir.path(),
+                std::path::Path::new("d"),
+            )
             .expect("classify succeeds");
         assert_eq!(
             decision,

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -541,24 +541,47 @@ impl ReceiverContext {
         Ok(all_errors)
     }
 
-    /// Creates implied parent directories for `--relative` path components.
+    /// Creates the still-missing implied parent directories of `--relative`
+    /// path components.
     ///
-    /// When `--relative` is active, the file list may contain entries with deep paths
-    /// (e.g., `a/b/c/file.txt`). If `--no-implied-dirs` was used, the intermediate
-    /// directories (`a/`, `a/b/`, `a/b/c/`) may not appear as explicit directory
-    /// entries in the file list. This method ensures all parent directories exist
-    /// before files, symlinks, or other entries are processed.
+    /// When `--relative` is active the file list may contain entries with deep
+    /// paths (`a/b/c/file.txt`). With `--no-implied-dirs` at protocol < 30 the
+    /// intermediate directories (`a/`, `a/b/`, `a/b/c/`) never appear as
+    /// directory entries, so nothing else would create them. This method fills
+    /// exactly that gap.
     ///
-    /// Uses a set to track already-created paths, avoiding redundant `mkdir` syscalls
-    /// when many entries share common parent directories.
+    /// It is a **fallback, not a pre-pass**: the caller must run it *after* the
+    /// file list's own directory entries have been created and itemized. That
+    /// ordering is upstream's. `recv_generator()` walks the file list in order;
+    /// a directory entry is created and itemized by `gen_entry_mkdir()`
+    /// (`generator.c:1873`) when its own entry is reached, and the parent
+    /// `make_path()` at `generator.c:1718-1725` fires only for an entry whose
+    /// `do_stat_at(dn, ...)` still reports the parent absent. Running it first
+    /// pre-empts the directory pass: the directories then already exist when
+    /// they are classified, so a real run reports `.d..t......` where its own
+    /// `--dry-run` (which skips destination writes) reports `cd+++++++++`, and
+    /// the unconfined `create_dir` displaces the confined `mkdirat` that the
+    /// classified path would have issued.
+    ///
+    /// Uses a set to track already-created paths, avoiding redundant `mkdir`
+    /// syscalls when many entries share common parent directories.
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:1329-1338` - `make_path()` for missing parents when
-    ///   `relative_paths && !implied_dirs`
-    /// - `generator.c:1484-1487` - retry `mkdir` after `make_path()` when
-    ///   `relative_paths` and initial `mkdir` returns `ENOENT`
-    pub(in crate::receiver) fn ensure_relative_parents(&self, dest_dir: &Path) {
+    /// - `generator.c:1718-1725` - `make_path(fname, MKP_DROP_NAME |
+    ///   MKP_SKIP_SLASH)` for a parent that `do_stat_at()` reports missing
+    /// - `generator.c:1876-1878` - retry `gen_entry_mkdir()` after `make_path()`
+    ///   when `relative_paths` and the initial mkdir returns `ENOENT`
+    /// - `util1.c:238` / `util1.c:277` - every component `make_path()` creates
+    ///   goes through `do_mkdir_at()`, i.e. the confined mkdir, never a bare
+    ///   `mkdir(2)`. `syscall.c:2066 do_mkdir_at()` opens the parent with
+    ///   `owner_walk_parent()` and issues `mkdirat()` against that dirfd, so a
+    ///   symlinked component cannot redirect the create out of the module.
+    pub(in crate::receiver) fn ensure_relative_parents(
+        &self,
+        dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
+    ) {
         if !self.config.flags.relative || self.config.flags.skip_dest_writes() {
             return;
         }
@@ -591,23 +614,34 @@ impl ReceiverContext {
 
             // Walk up the path to find the deepest ancestor that needs creation.
             // Build the list of paths to create from shallowest to deepest.
-            let mut ancestors_to_create: Vec<PathBuf> = Vec::new();
+            let mut ancestors_to_create: Vec<(PathBuf, &Path)> = Vec::new();
             let mut current = target;
             loop {
                 let abs_path = dest_dir.join(current);
                 if created.contains(&abs_path) || abs_path.exists() {
                     break;
                 }
-                ancestors_to_create.push(abs_path);
+                ancestors_to_create.push((abs_path, current));
                 match current.parent() {
                     Some(p) if !p.as_os_str().is_empty() => current = p,
                     _ => break,
                 }
             }
 
-            // Create from shallowest to deepest.
-            for dir_path in ancestors_to_create.into_iter().rev() {
-                if let Err(e) = fs::create_dir(&dir_path) {
+            // Create from shallowest to deepest. Each component goes through
+            // the confined mkdir, mirroring `make_path()`'s use of
+            // `do_mkdir_at()` (util1.c:238/277) rather than a bare `mkdir(2)`.
+            for (dir_path, rel_path) in ancestors_to_create.into_iter().rev() {
+                #[cfg(unix)]
+                let create_result = fast_io::mkdirat_via_sandbox_or_fallback(
+                    sandbox, dest_dir, rel_path, &dir_path, 0o777,
+                );
+                #[cfg(not(unix))]
+                let create_result = {
+                    let _ = rel_path;
+                    fs::create_dir(&dir_path)
+                };
+                if let Err(e) = create_result {
                     if e.kind() != io::ErrorKind::AlreadyExists {
                         debug_log!(
                             Recv,

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -133,8 +133,27 @@ impl ReceiverContext {
             // An existing real directory (or any other existing non-symlink
             // entry, matching the prior `.exists()` semantics) is reused.
             Ok(_) => Ok(DirDestination::Existing),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(DirDestination::Missing),
-            Err(error) => Err(error),
+            // A stat failure of ANY errno class classifies as `Missing`; it is
+            // never raised from here.
+            //
+            // upstream: generator.c:1745-1746 - `statret = gen_entry_stat(...);
+            // stat_errno = errno;`. Every later branch tests `statret`, not the
+            // errno class, and `generator.c:1840` gates the obstruction removal
+            // on `statret == 0`. A stat that failed therefore never reaches
+            // `delete_item()`: it falls through to `gen_entry_mkdir()`
+            // (`generator.c:1831`/`1873`), and that mkdir's error is the one
+            // reported. `stat_errno` is consulted only by the `--existing`
+            // ENOENT test at generator.c:1758.
+            //
+            // Consequently the ONLY `Err` this function may return is the
+            // confined unlink above - upstream's `goto skipping_dir_contents`
+            // (`generator.c:1841-1842`), which the caller treats as a hard
+            // failure that skips the directory and its contents. Raising the
+            // stat error here instead would route ENOTDIR - the "a plain file
+            // sits where a parent directory should be" shape - into that same
+            // skip arm, laundering a hard mkdir failure into `Ok(None)` and
+            // hiding it from the caller's exit-code path.
+            Err(_) => Ok(DirDestination::Missing),
         }
     }
 
@@ -1369,6 +1388,71 @@ mod touch_up_dirs_tests {
                 .file_type()
                 .is_symlink(),
             "the fixture is only meaningful while the removal actually failed"
+        );
+    }
+
+    /// The twin of `surfaces_non_permission_error_from_mkdir`, for the BATCH
+    /// pass: a stat failure is not an obstruction refusal, and the two must not
+    /// share an arm.
+    ///
+    /// `classify_dir_destination` can fail for two unrelated reasons, and only
+    /// one of them is upstream's `skipping_dir_contents` case:
+    ///
+    /// - the confined unlink of an obstructing symlink was refused - upstream
+    ///   `generator.c:1841-1842` `goto skipping_dir_contents`, pinned by
+    ///   `a_refused_obstruction_removal_is_reported_not_reclassified` above;
+    /// - the destination could not be stat'd at all - upstream
+    ///   `generator.c:1745` just records `statret = -1`, and because
+    ///   `generator.c:1840` gates `delete_item()` on `statret == 0`, the entry
+    ///   falls through to `gen_entry_mkdir()` and that mkdir's error is what
+    ///   gets reported.
+    ///
+    /// Collapsing the second into the first turns a hard failure into a silent
+    /// "directory skipped": ENOTDIR from a plain file sitting where a parent
+    /// directory belongs stopped propagating and was folded into the failed-dir
+    /// set instead. This fixture shapes exactly that - `afile` is a regular
+    /// file, so stat'ing `afile/sub` fails ENOTDIR, which is neither NotFound
+    /// (the parent-walk retry) nor PermissionDenied (upstream's non-fatal
+    /// class) - and pins the hard error to `Err`.
+    #[cfg(unix)]
+    #[test]
+    fn a_stat_failure_is_not_an_obstruction_refusal_and_still_fails_loud() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+
+        // A regular file where a parent directory is expected forces ENOTDIR
+        // when the receiver stats and then creates `afile/sub` beneath it.
+        fs::write(dest.join("afile"), b"not a directory").expect("plant regular file");
+
+        let hs = handshake();
+        let mut ctx = ReceiverContext::new_for_test(&hs, config_with_times(false));
+        ctx.file_list = vec![FileEntry::new_directory("afile/sub".into(), 0o755)];
+
+        let opts = metadata::MetadataOptions::default();
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        let result = ctx.create_directories(
+            dest,
+            &opts,
+            None,
+            None,
+            &mut writer,
+            #[cfg(unix)]
+            None,
+        );
+
+        let err = result.expect_err(
+            "a non-EACCES mkdir failure must propagate as Err from the batch pass, \
+             not be laundered into the failed-directory set",
+        );
+        assert_ne!(
+            err.kind(),
+            std::io::ErrorKind::PermissionDenied,
+            "EACCES takes upstream's non-fatal branch; this fixture avoids it"
+        );
+        assert_ne!(
+            err.kind(),
+            std::io::ErrorKind::NotFound,
+            "NotFound would take the parent-walk retry, not the hard-error path"
         );
     }
 

--- a/crates/transfer/src/receiver/tests/partial_resume.rs
+++ b/crates/transfer/src/receiver/tests/partial_resume.rs
@@ -217,7 +217,11 @@ mod relative_parents {
         let entries = vec![FileEntry::new_file("a/b/c/file.txt".into(), 100, 0o644)];
         let ctx = receiver_with_relative(entries);
 
-        ctx.ensure_relative_parents(dest);
+        ctx.ensure_relative_parents(
+            dest,
+            #[cfg(unix)]
+            None,
+        );
 
         assert!(dest.join("a").is_dir());
         assert!(dest.join("a/b").is_dir());
@@ -236,7 +240,11 @@ mod relative_parents {
         ];
         let ctx = receiver_with_relative(entries);
 
-        ctx.ensure_relative_parents(dest);
+        ctx.ensure_relative_parents(
+            dest,
+            #[cfg(unix)]
+            None,
+        );
 
         assert!(dest.join("src").is_dir());
         assert!(dest.join("src/lib").is_dir());
@@ -251,7 +259,11 @@ mod relative_parents {
         let entries = vec![FileEntry::new_file("a/b/file.txt".into(), 100, 0o644)];
         let ctx = receiver_without_relative(entries);
 
-        ctx.ensure_relative_parents(dest);
+        ctx.ensure_relative_parents(
+            dest,
+            #[cfg(unix)]
+            None,
+        );
 
         assert!(!dest.join("a").exists());
     }
@@ -267,7 +279,11 @@ mod relative_parents {
         ];
         let ctx = receiver_with_relative(entries);
 
-        ctx.ensure_relative_parents(dest);
+        ctx.ensure_relative_parents(
+            dest,
+            #[cfg(unix)]
+            None,
+        );
     }
 
     #[test]
@@ -278,7 +294,11 @@ mod relative_parents {
         let entries = vec![FileEntry::new_directory("a/b/c".into(), 0o755)];
         let ctx = receiver_with_relative(entries);
 
-        ctx.ensure_relative_parents(dest);
+        ctx.ensure_relative_parents(
+            dest,
+            #[cfg(unix)]
+            None,
+        );
 
         assert!(dest.join("a").is_dir());
         assert!(dest.join("a/b").is_dir());
@@ -298,7 +318,11 @@ mod relative_parents {
         let entries = vec![FileEntry::new_file("a/b/c/new.txt".into(), 100, 0o644)];
         let ctx = receiver_with_relative(entries);
 
-        ctx.ensure_relative_parents(dest);
+        ctx.ensure_relative_parents(
+            dest,
+            #[cfg(unix)]
+            None,
+        );
 
         assert_eq!(
             std::fs::read_to_string(dest.join("a/b/existing.txt")).unwrap(),
@@ -332,7 +356,11 @@ mod relative_parents {
             0o644,
         )];
 
-        ctx.ensure_relative_parents(dest);
+        ctx.ensure_relative_parents(
+            dest,
+            #[cfg(unix)]
+            None,
+        );
 
         assert!(!dest.join("deep").exists());
     }
@@ -345,7 +373,11 @@ mod relative_parents {
         let entries = vec![FileEntry::new_file("file.txt".into(), 100, 0o644)];
         let ctx = receiver_with_relative(entries);
 
-        ctx.ensure_relative_parents(dest);
+        ctx.ensure_relative_parents(
+            dest,
+            #[cfg(unix)]
+            None,
+        );
 
         let dir_entries: Vec<_> = std::fs::read_dir(dest).unwrap().collect();
         assert!(dir_entries.is_empty());

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -89,8 +89,6 @@ impl ReceiverContext {
             Vec::new()
         };
 
-        // upstream: generator.c:1329-1338 - make_path() for relative_paths
-        self.ensure_relative_parents(&setup.dest_dir);
         let mut metadata_errors = self.create_directories(
             &setup.dest_dir,
             &setup.metadata_opts,
@@ -100,6 +98,16 @@ impl ReceiverContext {
             #[cfg(unix)]
             setup.sandbox.as_deref(),
         )?;
+        // upstream: generator.c:1718-1725 - make_path() fills in a parent that
+        // is still absent after its own file-list entry would have created it.
+        // Must follow create_directories: running it first would pre-empt the
+        // classified, confined mkdir there and make a real run report an
+        // existing directory where its own --dry-run reports a created one.
+        self.ensure_relative_parents(
+            &setup.dest_dir,
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
+        );
         #[cfg(unix)]
         self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
         #[cfg(not(unix))]

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -100,9 +100,6 @@ impl ReceiverContext {
             Vec::new()
         };
 
-        // upstream: generator.c:1329-1338 - make_path() for relative_paths
-        self.ensure_relative_parents(&setup.dest_dir);
-
         // A dry run reports its directories from the shared `plan_dry_run` pass
         // below, exactly like `run_pipelined`. Running this walk too would
         // record every directory row and created-dir tally twice; it creates
@@ -150,6 +147,18 @@ impl ReceiverContext {
                 }
             }
         }
+
+        // upstream: generator.c:1718-1725 - make_path() fills in a parent that
+        // is still absent after its own file-list entry would have created it.
+        // Must follow the directory walk above: running it first would pre-empt
+        // the classified, confined mkdir in `create_directory_incremental` and
+        // make a real run report an existing directory where its own --dry-run
+        // reports a created one.
+        self.ensure_relative_parents(
+            &setup.dest_dir,
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
+        );
 
         #[cfg(unix)]
         self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -76,8 +76,6 @@ impl ReceiverContext {
         let mut bytes_received = 0u64;
 
         // First pass: create directories and symlinks from file list.
-        // upstream: generator.c:1329-1338 - make_path() for relative_paths
-        self.ensure_relative_parents(&dest_dir);
         let mut metadata_errors = self.create_directories(
             &dest_dir,
             &metadata_opts,
@@ -87,6 +85,16 @@ impl ReceiverContext {
             #[cfg(unix)]
             sandbox.as_deref(),
         )?;
+        // upstream: generator.c:1718-1725 - make_path() fills in a parent that
+        // is still absent after its own file-list entry would have created it.
+        // Must follow create_directories: running it first would pre-empt the
+        // classified, confined mkdir there and make a real run report an
+        // existing directory where its own --dry-run reports a created one.
+        self.ensure_relative_parents(
+            &dest_dir,
+            #[cfg(unix)]
+            sandbox.as_deref(),
+        );
         #[cfg(unix)]
         self.create_symlinks(&dest_dir, sandbox.as_deref(), writer)?;
         #[cfg(not(unix))]

--- a/crates/transfer/tests/daemon_relative_implied_parent_confinement.rs
+++ b/crates/transfer/tests/daemon_relative_implied_parent_confinement.rs
@@ -1,0 +1,356 @@
+//! A `--relative` implied parent must never be built through a symlink that
+//! leaves the daemon's module root.
+//!
+//! The `-R` implied parents of `a/b/c/file.txt` are `a/`, `a/b/` and `a/b/c/`.
+//! Upstream builds every one of them through a confined mkdir. The file list's
+//! own directory pass uses `gen_entry_mkdir()`, which classifies the
+//! destination first and DELETES a conflicting symlink before creating a real
+//! directory in its place:
+//!
+//! ```c
+//! /* generator.c:1451-1455 */
+//! delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_DIR);
+//! /* generator.c:1873 */
+//! gen_entry_mkdir(fname, file, file->mode|added_perms)
+//! ```
+//!
+//! and the `relative_paths` fallback at `generator.c:1718-1725` uses
+//! `make_path()`, whose every component goes through `do_mkdir_at()`
+//! (`util1.c:238`, `util1.c:277`) - the ownership walk plus `mkdirat()`, not a
+//! bare `mkdir(2)` (`syscall.c:2066`).
+//!
+//! oc had a third, unconfined creator: `ensure_relative_parents` ran as a
+//! PRE-pass over the file list and built every implied parent with a
+//! path-based `std::fs::create_dir`. Path-based creation follows a symlinked
+//! component, and running first meant it always won the race with the confined
+//! creator that was supposed to handle the same directory. Measured on a
+//! daemon push where the module root holds `a -> <outside the module>`:
+//!
+//! ```text
+//! $ oc-rsync -a -i -R ./a/b/c/file.txt rsync://127.0.0.1:PORT/data/
+//! cd+++++++++ a/
+//! ...
+//! client exit=0
+//! --- outside/ ---
+//! outside/b            <-- created OUTSIDE the module root
+//! outside/b/c          <-- created OUTSIDE the module root
+//! outside/marker
+//! ```
+//!
+//! rsync 3.5.0 on the same fixture leaves `outside/` holding only its marker,
+//! and so does a fixed oc.
+//!
+//! ⚠ The escape cell opts out of oc's Landlock and seccomp layers. Landlock
+//! refuses this write on its own, BEFORE oc's operator-path resolution is
+//! consulted, so a cell run under the sandbox would measure the kernel's
+//! refusal and stay green whether or not this crate resolves the path
+//! correctly. The availability cell keeps the layers on. Opting out is a
+//! test-only narrowing; the shipped daemon installs both layers by default.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - The `oc-rsync` binary is not built.
+//! - The daemon could not be started.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+/// Seeded in the out-of-module directory so a stray creation there is
+/// distinguishable from a fixture that named the wrong directory.
+const OUTSIDE_MARKER: &str = "OUTSIDE-THE-MODULE-UNTOUCHED";
+/// The pushed file's contents.
+const PAYLOAD: &str = "PAYLOAD-FROM-THE-PEER\n";
+
+struct DaemonGuard(Child);
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// What stands at the first implied parent (`a`) inside the module root.
+#[derive(Clone, Copy)]
+enum Plant {
+    /// A trusted-owned directory symlink pointing OUTSIDE the module root.
+    DirSymlinkOutsideModule,
+    /// A trusted-owned directory symlink pointing to another directory INSIDE
+    /// the module root: the over-refusal control.
+    DirSymlinkInsideModule,
+}
+
+/// Whether the spawned daemon worker installs oc's kernel sandbox layers.
+#[derive(Clone, Copy)]
+enum Sandbox {
+    /// Landlock and seccomp installed, as a production daemon runs them.
+    Enforced,
+    /// Both layers opted out, so any refusal observed must be oc's own.
+    OptedOut,
+}
+
+impl Sandbox {
+    fn daemon_env(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            Self::Enforced => &[],
+            Self::OptedOut => &[("OC_RSYNC_NO_LANDLOCK", "1"), ("OC_RSYNC_NO_SECCOMP", "1")],
+        }
+    }
+}
+
+/// The filesystem state the assertions are made against.
+struct Outcome {
+    /// Every path under the out-of-module directory, sorted. An escape shows up
+    /// here as extra entries beside the marker.
+    outside: Vec<PathBuf>,
+    /// Every path under the module root, sorted: the availability half.
+    inside: Vec<PathBuf>,
+    client_exit: Option<i32>,
+    client_stderr: String,
+    daemon_log: String,
+}
+
+impl Outcome {
+    fn diagnostics(&self) -> String {
+        format!(
+            "\noutside: {:?}\ninside: {:?}\nstderr:\n{}\ndaemon log:\n{}",
+            self.outside, self.inside, self.client_stderr, self.daemon_log
+        )
+    }
+}
+
+fn tree(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+                stack.push(path.clone());
+            }
+            out.push(path.strip_prefix(root).unwrap_or(&path).to_path_buf());
+        }
+    }
+    out.sort();
+    out
+}
+
+fn write_config(config: &Path, module_root: &Path, log_root: &Path) -> std::io::Result<()> {
+    fs::write(
+        config,
+        format!(
+            "pid file = {pid}\n\
+             log file = {log}\n\
+             use chroot = false\n\
+             \n\
+             [data]\n\
+             path = {root}\n\
+             read only = false\n",
+            pid = log_root.join("rsyncd.pid").display(),
+            log = log_root.join("rsyncd.log").display(),
+            root = module_root.display(),
+        ),
+    )
+}
+
+fn spawn_daemon(
+    oc_bin: &Path,
+    config: &Path,
+    sandbox: Sandbox,
+) -> std::io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        let mut cmd = Command::new(oc_bin);
+        cmd.arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for (key, value) in sandbox.daemon_env() {
+            cmd.env(key, value);
+        }
+        cmd.spawn()
+    })?;
+    Ok((DaemonGuard(child), port))
+}
+
+/// Stages the module with `plant` at `a`, pushes `./a/b/c/file.txt` with `-R`
+/// plus `extra` over the daemon, and reports the resulting filesystem state.
+fn push_relative(plant: Plant, extra: &[&str], sandbox: Sandbox) -> Option<Outcome> {
+    let oc_bin = test_support::oc_rsync_bin();
+    if !oc_bin.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", oc_bin.display());
+        return None;
+    }
+    let tmp = test_support::create_tempdir();
+    let root = tmp.path();
+
+    let source_dir = root.join("src");
+    let module_root = root.join("module");
+    let outside_dir = root.join("outside");
+    fs::create_dir_all(source_dir.join("a/b/c")).expect("create source tree");
+    fs::create_dir_all(&module_root).expect("create module root");
+    fs::create_dir_all(&outside_dir).expect("create the out-of-module dir");
+    fs::write(source_dir.join("a/b/c/file.txt"), PAYLOAD).expect("seed source file");
+    fs::write(outside_dir.join("marker"), OUTSIDE_MARKER).expect("seed the out-of-module marker");
+
+    let inside_target = module_root.join("realdir");
+    let planted = module_root.join("a");
+    match plant {
+        Plant::DirSymlinkOutsideModule => {
+            symlink(&outside_dir, &planted).expect("plant the out-of-module dir symlink");
+        }
+        Plant::DirSymlinkInsideModule => {
+            fs::create_dir(&inside_target).expect("create the in-module target");
+            symlink(&inside_target, &planted).expect("plant the in-module dir symlink");
+        }
+    }
+
+    // The plant must be TRUSTED-owned, or a refusal would only be the ownership
+    // arm firing and would prove nothing about the module root.
+    let meta = fs::symlink_metadata(&planted).expect("the plant must exist");
+    assert!(
+        fast_io::symlink_owner_is_trusted(std::os::unix::fs::MetadataExt::uid(&meta)),
+        "the planted directory must be owned by uid 0 or our euid; got uid {}",
+        std::os::unix::fs::MetadataExt::uid(&meta),
+    );
+
+    let config = root.join("rsyncd.conf");
+    write_config(&config, &module_root, root).expect("write daemon config");
+    let (_daemon, port) = spawn_daemon(&oc_bin, &config, sandbox).ok()?;
+
+    let destination_url = format!("rsync://127.0.0.1:{port}/data/");
+    let output = Command::new(&oc_bin)
+        .current_dir(&source_dir)
+        .arg("-a")
+        .arg("-i")
+        .arg("-R")
+        .args(extra)
+        .arg("./a/b/c/file.txt")
+        .arg(&destination_url)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run oc-rsync client");
+
+    Some(Outcome {
+        outside: tree(&outside_dir),
+        inside: tree(&module_root),
+        client_exit: output.status.code(),
+        client_stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        daemon_log: fs::read_to_string(root.join("rsyncd.log")).unwrap_or_default(),
+    })
+}
+
+/// Asserts nothing was deposited outside the module root, non-vacuously.
+fn assert_nothing_escaped(outcome: &Outcome, what: &str) {
+    // NON-VACUITY first: an untouched out-of-module directory is exactly what a
+    // session that died before the directory pass would leave behind, so
+    // without this the pin below could not tell a refusal from a dead session.
+    assert!(
+        outcome.daemon_log.contains("receiving file list"),
+        "{what}: the daemon never reached the transfer, so the assertion below \
+         would hold vacuously rather than describe a refusal{}",
+        outcome.diagnostics(),
+    );
+    assert_eq!(
+        outcome.outside,
+        vec![PathBuf::from("marker")],
+        "{what}: a --relative implied parent was created OUTSIDE the module \
+         root (client exit {:?}){}",
+        outcome.client_exit,
+        outcome.diagnostics(),
+    );
+}
+
+/// THE PIN, at the default `-R` shape. The file list carries the implied
+/// parents as directory entries, so the confined directory pass owns them and
+/// nothing may create them ahead of it.
+#[test]
+fn relative_implied_parents_must_not_be_built_outside_the_module() {
+    let Some(outcome) = push_relative(Plant::DirSymlinkOutsideModule, &[], Sandbox::OptedOut)
+    else {
+        return;
+    };
+    assert_nothing_escaped(&outcome, "default -R");
+}
+
+/// THE SAME PIN where `ensure_relative_parents` is the SOLE creator.
+///
+/// `--no-implied-dirs` below protocol 30 omits the implied parents from the
+/// file list entirely (`flist.c:2468`, mirrored at
+/// `generator/file_list/mod.rs:134`), so the directory pass has nothing to
+/// create and the `make_path()` equivalent is the only thing that builds `a/b`.
+/// Without this cell the ordering fix alone would keep the pin above green and
+/// the unconfined `create_dir` inside `ensure_relative_parents` would kill
+/// nothing - measured: reverting just the confined mkdir leaves the cell above
+/// passing and fails only this one.
+#[test]
+fn a_sole_creator_relative_parent_must_not_escape_the_module() {
+    let Some(outcome) = push_relative(
+        Plant::DirSymlinkOutsideModule,
+        &["--no-implied-dirs", "--protocol", "29"],
+        Sandbox::OptedOut,
+    ) else {
+        return;
+    };
+    assert_nothing_escaped(&outcome, "--no-implied-dirs at protocol 29");
+}
+
+/// AVAILABILITY, on the same fixture. Confining the implied-parent creation
+/// must not turn a working transfer into a failure: the module still receives
+/// the whole `-R` path. Measured identical to rsync 3.5.0, which likewise
+/// replaces the conflicting symlink with a real directory
+/// (`generator.c:1451-1455`).
+#[test]
+fn a_confined_relative_push_still_delivers_the_whole_path() {
+    let Some(outcome) = push_relative(Plant::DirSymlinkOutsideModule, &[], Sandbox::OptedOut)
+    else {
+        return;
+    };
+
+    assert_eq!(
+        outcome.client_exit,
+        Some(0),
+        "the push must still succeed{}",
+        outcome.diagnostics(),
+    );
+    assert!(
+        outcome.inside.contains(&PathBuf::from("a/b/c/file.txt")),
+        "the module must receive the full --relative path{}",
+        outcome.diagnostics(),
+    );
+}
+
+/// OVER-REFUSAL CONTROL. A trusted-owned directory symlink whose target stays
+/// INSIDE the module is a legitimate operator layout. "Refuse to build an
+/// implied parent through any symlink" would satisfy the pin above while
+/// breaking it, so the transfer must still land the whole path.
+#[test]
+fn an_in_module_symlinked_component_still_receives_the_transfer() {
+    let Some(outcome) = push_relative(Plant::DirSymlinkInsideModule, &[], Sandbox::Enforced) else {
+        return;
+    };
+
+    assert_eq!(
+        outcome.client_exit,
+        Some(0),
+        "an in-module symlinked component must not fail the transfer{}",
+        outcome.diagnostics(),
+    );
+    assert!(
+        outcome.inside.contains(&PathBuf::from("a/b/c/file.txt")),
+        "the module must receive the full --relative path{}",
+        outcome.diagnostics(),
+    );
+}

--- a/tests/relative_implied_parents_dry_wet_parity.rs
+++ b/tests/relative_implied_parents_dry_wet_parity.rs
@@ -1,0 +1,230 @@
+//! A `--relative` transfer must report the same implied parent directories
+//! whether or not it is allowed to create them.
+//!
+//! Upstream builds a `-R` implied parent exactly once, in the file list's own
+//! directory pass, and reports it there:
+//!
+//! ```c
+//! /* generator.c:1869-1873 - itemize() then the mkdir, in that order */
+//! if (itemizing && f_out != -1)
+//!     itemize(fnamecmp, file, ndx, statret, &sx,
+//!             statret ? ITEM_LOCAL_CHANGE : 0, 0, NULL);
+//! if (real_ret != 0 && gen_entry_mkdir(fname, file, file->mode|added_perms) < 0 ...)
+//!
+//! /* generator.c:1718-1725 - and a *second* creator that fires only when the
+//!  * parent is STILL absent by the time an entry under it is reached */
+//! if (relative_paths && !implied_dirs && file->mode != 0
+//!  && do_stat_at(dn, &sx.st) < 0) {
+//!         if (dry_run)
+//!                 goto parent_is_dry_missing;
+//!         if (make_path(fname, MKP_DROP_NAME | MKP_SKIP_SLASH) < 0) { ... }
+//! }
+//! ```
+//!
+//! The ordering is the whole point. `make_path()` is a *fallback*: by the time
+//! it can fire, the directory pass has already classified and reported every
+//! directory the file list carries. oc ran its equivalent
+//! (`ensure_relative_parents`) as a *pre-pass* instead, so the directories
+//! existed before anything classified them and a real run reported them as
+//! pre-existing:
+//!
+//! ```text
+//! $ oc-rsync -a -i -R -n src/./a/b/c/file.txt dest/     # dry
+//! cd+++++++++ a/
+//! cd+++++++++ a/b/
+//! cd+++++++++ a/b/c/
+//! $ oc-rsync -a -i -R    src/./a/b/c/file.txt dest/     # the SAME transfer, wet
+//! .d..t...... a/
+//! .d..t...... a/b/
+//! .d..t...... a/b/c/
+//! ```
+//!
+//! Both runs describe one transfer into an empty destination, so they cannot
+//! both be right. rsync 3.5.0 prints `cd+++++++++` for all three in both runs,
+//! measured on the same tree.
+//!
+//! The dry/wet comparison is the discriminating assertion, not the row text:
+//! a fix that made the wet run wrong in a *new* way would still be caught, and
+//! it cannot be satisfied by letting `-n` create the destination (that is
+//! pinned separately by `dry_run_itemize_stats_remote.rs`).
+//!
+//! The "remote" is the oc-rsync binary itself behind a `--rsh` shim, because
+//! `ensure_relative_parents` lives on the receiver, which a local copy never
+//! reaches. Running both directions exercises the server receiver (push) and
+//! the client receiver (pull).
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the shim uses `/bin/sh`).
+//! - The `oc-rsync` binary is not built.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+/// The rows rsync 3.5.0 prints for [`setup`]'s tree, in flist order, for both
+/// `-i` and `-ni`. `%c` is `<` when the client sends, `>` when it receives.
+fn expected_rows(direction: char) -> Vec<String> {
+    vec![
+        "cd+++++++++ a/".to_owned(),
+        "cd+++++++++ a/b/".to_owned(),
+        "cd+++++++++ a/b/c/".to_owned(),
+        format!("{direction}f+++++++++ a/b/c/file.txt"),
+    ]
+}
+
+fn oc_rsync_binary() -> PathBuf {
+    test_support::oc_rsync_bin()
+}
+
+/// Writes the `--rsh` shim: drops the SSH-style options and the host, then
+/// execs the server command locally.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat rsh shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod rsh shim");
+    script
+}
+
+/// `src/a/b/c/file.txt`, transferred as `./a/b/c/file.txt` so `-R` has three
+/// implied parents to build and none of them exists at the destination.
+fn setup(root: &Path) -> PathBuf {
+    let src = root.join("src");
+    fs::create_dir_all(src.join("a/b/c")).expect("create source tree");
+    fs::write(src.join("a/b/c/file.txt"), b"payload\n").expect("seed source file");
+    src
+}
+
+/// Runs one `-a -i -R` transfer into a freshly created `dest`, optionally with
+/// `-n`, and returns the process output.
+fn run(shim: &Path, binary: &Path, src: &Path, dest: &Path, push: bool, dry: bool) -> Output {
+    fs::create_dir_all(dest).expect("create destination");
+    let operand = "./a/b/c/file.txt";
+    let (from, to) = if push {
+        (operand.to_owned(), format!("relhost:{}/", dest.display()))
+    } else {
+        (format!("relhost:{operand}"), format!("{}/", dest.display()))
+    };
+    let mut cmd = Command::new(binary);
+    cmd.current_dir(src)
+        .arg("-a")
+        .arg("-i")
+        .arg("-R")
+        .arg("--rsh")
+        .arg(shim)
+        .arg("--rsync-path")
+        .arg(binary)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if dry {
+        cmd.arg("-n");
+    }
+    cmd.arg(from).arg(to);
+    cmd.output().expect("run oc-rsync")
+}
+
+/// The itemize rows naming the implied parents and the transferred file.
+///
+/// The transfer root's own `./` row is dropped: it reports the mtime
+/// difference between two directories the fixture created seconds apart, which
+/// is not what this file is about.
+fn parent_rows(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .filter(|line| line.len() > 12 && line.as_bytes()[11] == b' ' && !line.ends_with(" ./"))
+        .map(str::to_owned)
+        .collect()
+}
+
+fn assert_dry_wet_parity(push: bool) {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let label = if push { "push" } else { "pull" };
+    let temp = test_support::create_tempdir();
+    let root = temp.path();
+    let src = setup(root);
+    let shim = write_rsh_shim(root);
+
+    let dry_dest = root.join("dest-dry");
+    let wet_dest = root.join("dest-wet");
+    let dry = run(&shim, &binary, &src, &dry_dest, push, true);
+    let wet = run(&shim, &binary, &src, &wet_dest, push, false);
+
+    for (what, output) in [("dry", &dry), ("wet", &wet)] {
+        assert!(
+            output.status.success(),
+            "{label} {what} run must exit 0, got {:?}\nstderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    let dry_stdout = String::from_utf8_lossy(&dry.stdout);
+    let wet_stdout = String::from_utf8_lossy(&wet.stdout);
+    let dry_rows = parent_rows(&dry_stdout);
+    let wet_rows = parent_rows(&wet_stdout);
+
+    // Non-vacuity first: an empty row set satisfies the equality below.
+    assert_eq!(
+        dry_rows.len(),
+        4,
+        "{label}: the fixture produced no implied-parent rows, so the parity \
+         assertion would hold vacuously\nstdout:\n{dry_stdout}"
+    );
+
+    assert_eq!(
+        dry_rows, wet_rows,
+        "{label}: -n and the real run disagree about the same transfer. The \
+         real run classified the implied parents against a tree an unconfined \
+         pre-pass had already built.\ndry stdout:\n{dry_stdout}\nwet stdout:\n{wet_stdout}"
+    );
+
+    let direction = if push { '<' } else { '>' };
+    assert_eq!(
+        wet_rows,
+        expected_rows(direction),
+        "{label}: rows must match rsync 3.5.0\nstdout:\n{wet_stdout}"
+    );
+
+    // The rows must describe a transfer that actually happened, or "they agree"
+    // would be a statement about two runs that both did nothing.
+    assert_eq!(
+        fs::read_to_string(wet_dest.join("a/b/c/file.txt")).expect("destination file"),
+        "payload\n",
+        "{label}: the real run must still deliver the file"
+    );
+    assert!(
+        !dry_dest.join("a").exists(),
+        "{label}: -n must leave the destination untouched"
+    );
+}
+
+#[test]
+fn relative_implied_parents_report_identically_dry_and_wet_on_push() {
+    assert_dry_wet_parity(true);
+}
+
+#[test]
+fn relative_implied_parents_report_identically_dry_and_wet_on_pull() {
+    assert_dry_wet_parity(false);
+}


### PR DESCRIPTION
## The upstream chain

Replacing a conflicting destination symlink with a real directory reaches the **confined** unlink wrapper upstream, not the plain one:

```
generator.c:1829/1841   delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_DIR)
delete.c:233/237        ok = del_unlink(fbuf) == 0
delete.c:71-78          do_unlink_atfd(dfd, leaf, 0) against a held dirfd,
                        else robust_unlink(fbuf)
util1.c:545-550         robust_unlink() -> rc = do_unlink_at(fname)
```

Both arms are the confined wrappers. **Upstream issues no plain `unlink()` on this path.** `do_unlink_at()` in `syscall.c` is the three-arm contract: `symlink_optout_allowed()` takes the plain syscall; otherwise `owner_walk_parent()` then `unlinkat(dfd, bname, 0)`; a refused walk returns `-1` rather than falling back.

oc did the opposite. `classify_dir_destination` removed the symlink with a path-based `fs::remove_file`, and the comment above it cited `syscall.c do_unlink()` - **a function this path never reaches**. That citation is what made a plain unlink look correct here. It is fixed in the same commit.

Both call sites now route through `fast_io::unlink_via_sandbox_or_fallback`, oc's port of `do_unlink_at()`. `sandbox` may be `None`; that is a supported arm, not a gap, and it errors rather than degrading to a plain syscall when the walk refuses.

## The rule this is an instance of

> **The seccomp allowlist is a deliberate completeness detector. An EPERM on the daemon worker path names an unported confinement site, and the fix is always to port the caller - never to widen the filter.**

The worker allowlist is `*at`-only by design: it was derived from the sites already routed onto the confined resolver, so anything still calling `std::fs` issues a path-based syscall the filter does not carry. Widening it silences the detector and moves oc away from upstream. Someone will hit this again on `mkdir` 83 within the week; the answer there is the same.

## Why this class is structurally invisible on aarch64

The defect only exists on x86_64, and not by accident of which host happened to fail. Disassembling Ubuntu amd64 `libc.so.6` (glibc 2.44) with a pure-ELF opcode scanner - `b8 imm32` followed by `0f 05` inside each symbol body, nothing executed - gives what glibc actually issues:

| libc entry point | x86_64 syscall |
|---|---|
| `unlink()` | 87 |
| `rmdir()` | 84 |
| `mkdir()` | 83 |
| `rename()` | 82 |
| `symlink()` | 88 |
| `link()` | 86 |
| `readlink()` | 89 |
| `chmod()` | 90 |
| `chown()` | 92 |
| `lchown()` | 94 |
| **`open()`** | **257 (`openat`)** |

`open()` is the exception, and it is why the gap survived: it already lowers to `openat`, so the first operation anyone reaches for to sanity-check the filter is the one that cannot show the defect. `stat`/`lstat` are the same shape (`newfstatat`).

aarch64 control, from `asm-generic/unistd.h`: `__NR_unlink`, `__NR_mkdir`, `__NR_rename`, `__NR_rmdir` are **absent**; `__NR_unlinkat` is 35. The architecture is `*at`-only, so an `*at`-only allowlist is complete there and **cannot** miss anything. An aarch64 green is not evidence the allowlist is correct - that arch is structurally unable to exercise the gap. Same class as the earlier `unlink`, `readlink` and `mkdir` findings.

The scanner is kept as `abiscan.py`. Note it enumerates *detector hits*, not additions to make.

## Reproducing a CI daemon defect locally

**Build the binary with `cargo build --workspace --all-features --bin oc-rsync`.** `-p bin --all-features` enables only the bin package's own features; `daemon-seccomp` is not a default feature and is not reachable from the root manifest, so it engages solely through workspace-wide feature unification - exactly what CI does. Every `-p bin` build measures a daemon with **no seccomp layer at all**, and the daemon says so in its own log:

```
seccomp BPF unavailable in this build     <- -p bin
seccomp BPF filter engaged                <- --workspace --all-features
```

Three separate investigations of this cell produced false passes on that difference before it was noticed.

## Mechanism proof

On aarch64, removing `libc::SYS_unlinkat` from the worker allowlist reproduces the CI failure character-for-character: exit 23, `multiplexed frame truncated`, daemon log `Invalid cross-device link (os error 18) (code 1) at streams.rs(420)`, `outside: ["marker"]`, `inside: ["a", "realdir"]`. That is the same defect expressed through the syscall aarch64 does use, which is why it is a valid mechanism proof on a host that cannot reproduce the x86_64 form.

## The swallow was two sites, not one

`create_directories` and `create_directory_incremental` each carried their own copy of:

```rust
.unwrap_or_else(|_| if dir_path.exists() { Existing } else { Missing })
```

Wrong twice over. `exists()` **follows symlinks**, so the entry whose removal had just been denied reported back as an existing directory and the transfer proceeded through a symlink the peer controls. And the errno was discarded, which is how a denied unlink surfaced three layers later as an opaque EXDEV from the confined walk.

Upstream does `goto skipping_dir_contents` (`generator.c:1840-1843`), and `generator.c:1443-1467` states the rule for the whole family: a runtime denial is a real failure and is deliberately NOT retried unconfined. Both sites now report the failure into the same set as a denied mkdir, so it reaches `io_error` and the exit code. Fixing only the first would have left the incremental-recursion path walking through the surviving symlink.

## Verification, and one claim that is inference

- The new test denies the removal with a read-only parent - the portable stand-in for any refusal, since a confined-walk rejection and a syscall-filter denial reach the same arm. It skips under root (root ignores the directory write bit, so the cell would pass vacuously) and asserts the symlink still exists, so the fixture cannot silently stop denying.
- **Mutation-proven:** restoring only the swallow fails that test on its own assertion; restoring the fix returns it green.
- 18/18 across `daemon_relative_implied_parent_confinement` and every `directory::creation` test. The sibling escape cells still refuse: `relative_implied_parents_must_not_be_built_outside_the_module`, `a_sole_creator_relative_parent_must_not_escape_the_module`, `a_confined_relative_push_still_delivers_the_whole_path`.
- fmt clean; `clippy -p transfer --all-features --all-targets -D warnings` clean.

⚠ **Stated plainly: "the fix works on x86_64" is inference, not measurement.** The change removes the EPERM by making the syscall `unlinkat`, which the allowlist carries on every architecture - but that has not been observed on a host where the filter is live. No seccomp layer exists on macOS or aarch64, so the local greens cannot show the CI cell flipping. The reasoning is sound and the mutation proved the mechanism through that exact syscall; CI is the instrument for the rest.

## Known adjacent site, deliberately not in scope

`fs::create_dir_all` at `creation.rs:325` issues `mkdir` 83 and is in the same gap on the same path. It is the next instance of this class and is left to its own change.
