### PR TITLE
test(fast_io): pin which caller the fd-exhaustion hint serves

### DIFF
--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -471,12 +471,24 @@ fn should_warn_fd_exhaustion(err: &io::Error, warned: &AtomicBool) -> bool {
 ///
 /// # Descriptor exhaustion
 ///
-/// The carrier holds one dirfd per live path component, so a deep descent
-/// can exhaust the open-file limit where a single path-based `open()`
-/// would not. Upstream prints a one-shot hint on `EMFILE`/`ENFILE` for
-/// exactly this reason (upstream: syscall.c:2924-2936); without it the
-/// bare "Too many open files" is opaque about which limit to raise.
-/// [`warn_once_on_fd_exhaustion`] owns that decision for both walks.
+/// The two callers do not share a descriptor cost, and only one of them can
+/// reach the ceiling:
+///
+/// - [`DirSandbox::enter`] retains a `DirFrame` per level, so the descent
+///   holds one dirfd per live component and a deep tree exhausts the
+///   open-file limit where a single path-based `open()` would not. This is
+///   the caller the emit below exists for.
+/// - `DirSandbox::open_dest_anchor_with_policy` rebinds one `OwnedFd` per
+///   component and drops the parent immediately, so its cost is constant in
+///   the tail's depth and it cannot exhaust. Measured: a 64-component tail
+///   resolves under `RLIMIT_NOFILE=8`
+///   (`the_anchor_walk_cannot_exhaust_but_the_entered_walk_can`).
+///
+/// Upstream prints a one-shot hint on `EMFILE`/`ENFILE` for exactly the
+/// accumulating shape (upstream: syscall.c:2924-2936); without it the bare
+/// "Too many open files" is opaque about which limit to raise.
+/// [`warn_once_on_fd_exhaustion`] owns that decision for both accumulating
+/// walks - this one and `ConfinedWalk::descend`.
 fn openat_dir(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
     let result = openat_dir_strict(parent_fd, child_name);
 

--- a/crates/fast_io/src/dir_sandbox/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/tests.rs
@@ -1306,3 +1306,147 @@ fn confined_walk_warns_on_fd_exhaustion_and_stays_silent_on_enoent() {
          RLIMIT_NOFILE={ceiling}; got: {emitted:?}"
     );
 }
+
+/// The peer-tail anchor walk cannot exhaust descriptors; the `enter()`
+/// descent that shares its open helper can.
+///
+/// Both walks go through [`openat_dir`](super::openat_dir), so the
+/// descriptor-exhaustion emit inside it appears to hang off
+/// [`open_dest_anchor`](DirSandbox::open_dest_anchor) - a walk that rebinds a
+/// single `OwnedFd` per component and drops the parent immediately, and
+/// therefore costs one descriptor no matter how deep the tail is. Reading only
+/// that call site, the emit looks unreachable and invites deletion. It is not:
+/// [`enter`](DirSandbox::enter) retains a frame per level, so it is the caller
+/// that reaches the ceiling, and the emit is load-bearing for it.
+///
+/// Two cells at the *same* depth under the *same* ceiling, so depth and limit
+/// are held fixed and only the descriptor discipline varies:
+///
+/// 1. The anchor walk resolves a 64-component tail with three descriptors of
+///    headroom, and prints nothing. This is both the proof of constant cost
+///    and the negative control for the emit: it is the same `openat_dir` code
+///    path, succeeding, and it must stay silent.
+/// 2. The identical descent through `enter()` fails with `EMFILE` before it
+///    reaches 64 and prints the hint exactly once.
+///
+/// Cell 1 failing means the anchor walk started retaining descriptors - a
+/// behaviour change worth catching on its own, since the peer controls the
+/// tail's depth. Cell 2 failing means the emit stopped firing for the walk
+/// that needs it.
+///
+/// Both the `RLIMIT_NOFILE` change and the stderr redirect are process-global,
+/// which is safe only because nextest runs each test in its own process. Every
+/// descriptor either cell needs is allocated before the ceiling drops - the
+/// `openat2` capability probe included, which is a `OnceLock` and is warmed
+/// deliberately - and both globals are restored before any assertion so a
+/// failing assert can still allocate for its output.
+///
+/// upstream: syscall.c:2797-2800 - "The walk holds one fd per component, so
+/// depth is bounded by RLIMIT_NOFILE anyway"; syscall.c:2924-2936 - the hint,
+/// which upstream places on the accumulating walk alone.
+#[test]
+fn the_anchor_walk_cannot_exhaust_but_the_entered_walk_can() {
+    use rustix::io::{Errno, dup};
+    use rustix::process::{Resource, Rlimit, getrlimit, setrlimit};
+    use rustix::stdio::{dup2_stderr, stderr};
+    use std::io::{Read, Seek, SeekFrom};
+
+    // Deep enough that a per-component descriptor cost cannot fit under the
+    // ceiling, shallow enough to stay well inside macOS's 1024-byte PATH_MAX.
+    const DEPTH: usize = 64;
+
+    let (_keep, anchor) = canonical_tempdir();
+    let deep: std::path::PathBuf = std::iter::repeat_n("a", DEPTH).collect();
+    std::fs::create_dir_all(anchor.join(&deep)).expect("build the deep peer tail");
+
+    // Warm the one-shot `openat2` capability probe under the ambient limit.
+    // It is a `OnceLock` that costs a descriptor on its first call, and it
+    // would otherwise fire inside the measurement and cache a verdict reached
+    // under descriptor pressure.
+    DirSandbox::open_dest_anchor(&anchor, std::path::Path::new("a"))
+        .expect("the warm-up resolve must succeed under the ambient limit");
+
+    let mut captured = tempfile::tempfile().expect("stderr capture file");
+    let saved_stderr = dup(stderr()).expect("save stderr");
+    let original = getrlimit(Resource::Nofile);
+
+    // Three descriptors of headroom. The anchor walk's peak is two (the
+    // parent is still borrowed while its child is opened), so it fits at any
+    // depth; a walk that retains a frame per level runs out almost at once.
+    let ceiling = next_free_fd() + 3;
+
+    dup2_stderr(&captured).expect("redirect stderr");
+    let lowered = setrlimit(
+        Resource::Nofile,
+        Rlimit {
+            current: Some(ceiling),
+            maximum: original.maximum,
+        },
+    );
+    let observed = getrlimit(Resource::Nofile).current;
+
+    // Gate both cells on the drop actually landing: `setrlimit` refuses a
+    // request above `rlim_max`, and running anyway would turn a failed drop
+    // into a silent pass.
+    let dropped = lowered.is_ok() && observed == Some(ceiling);
+
+    let anchor_walk = dropped.then(|| DirSandbox::open_dest_anchor(&anchor, &deep));
+    let entered = dropped.then(|| {
+        DirSandbox::open_root(&anchor).and_then(|mut sandbox| {
+            for _ in 0..DEPTH {
+                sandbox.enter(std::ffi::OsStr::new("a"))?;
+            }
+            Ok(sandbox.depth())
+        })
+    });
+
+    setrlimit(Resource::Nofile, original).expect("restore RLIMIT_NOFILE");
+    dup2_stderr(&saved_stderr).expect("restore stderr");
+
+    let mut emitted = String::new();
+    captured.seek(SeekFrom::Start(0)).expect("rewind capture");
+    captured
+        .read_to_string(&mut emitted)
+        .expect("read captured stderr");
+
+    assert_eq!(
+        observed,
+        Some(ceiling),
+        "the harness could not lower RLIMIT_NOFILE to {ceiling} \
+         (setrlimit: {lowered:?}, original: {original:?}); no descriptor \
+         pressure was applied and nothing below this point was exercised"
+    );
+
+    anchor_walk
+        .expect("the cells are gated on the drop above")
+        .unwrap_or_else(|err| {
+            panic!(
+                "the anchor walk must resolve a {DEPTH}-component tail under \
+                 RLIMIT_NOFILE={ceiling}; it costs one descriptor regardless of \
+                 depth. Failing with {err:?} means it now retains a descriptor \
+                 per component, which the peer controls the depth of"
+            )
+        });
+
+    let err = match entered.expect("the cells are gated on the drop above") {
+        Err(err) => err,
+        Ok(depth) => panic!(
+            "`enter()` holds a frame per level, so {DEPTH} levels cannot fit \
+             under RLIMIT_NOFILE={ceiling}; reaching depth {depth} means no \
+             descriptor pressure was applied and the emit was never reached"
+        ),
+    };
+    assert_eq!(
+        err.raw_os_error(),
+        Some(Errno::MFILE.raw_os_error()),
+        "the accumulating descent must surface EMFILE to its caller, not an \
+         errno re-derived after the hint was printed; got {err:?}"
+    );
+
+    assert_eq!(
+        emitted.matches(super::FD_EXHAUSTION_HINT).count(),
+        1,
+        "exactly one hint is expected: none from the anchor walk, which \
+         succeeded, and one from the descent that exhausted; got: {emitted:?}"
+    );
+}


### PR DESCRIPTION
The one-shot `EMFILE`/`ENFILE` hint in `fast_io` lives in `openat_dir`, which
has two callers with different descriptor costs. Reading it from the wrong
caller makes it look like dead code attached to a walk that cannot fail that
way — the shape that gets "cleaned up".

## Measured

Both cells at depth 64 under `RLIMIT_NOFILE = 8` (three descriptors of
headroom), on macOS aarch64:

| walk | descriptor discipline | result | stderr |
|---|---|---|---|
| `DirSandbox::open_dest_anchor` (peer-tail walk) | rebinds one `OwnedFd` per component, drops the parent immediately | resolves all 64 components | silent |
| `DirSandbox::enter` x64 (receiver descent) | retains a `DirFrame` per level | `EMFILE` (errno 24) | hint, once |
| `DirSandbox::open_dest_anchor_confined` (`ConfinedWalk::descend`) | retains a dirfd per level | `EMFILE` (errno 24) | hint, once |

So the anchor walk's cost is constant in the tail's depth and it cannot
exhaust; `enter()` and `descend()` are the two walks that can, and both already
route their failures to `warn_once_on_fd_exhaustion`. The emit stays where it
is — deleting it would silence `enter()`.

## Changes

- New test `the_anchor_walk_cannot_exhaust_but_the_entered_walk_can`. Two cells
  at the same depth under the same ceiling, so only the descriptor discipline
  varies. The anchor walk succeeding is simultaneously the constant-cost proof
  and the emit's negative control: same `openat_dir` code path, no error, must
  stay silent.
- Corrected the `openat_dir` doc, which attributed the per-component cost to the
  helper rather than to the single caller that has it.

No behaviour change.

## Mutation results

`cargo nextest run -p fast_io --all-features -E '<the 7 fd-exhaustion cells>'`,
`--no-fail-fast`. `passed + failed == run` in every row.

| mutation | run | passed | failed | reddened |
|---|---|---|---|---|
| none (HEAD) | 7 | 7 | 0 | - |
| strip the emit from `openat_dir` | 7 | 5 | 2 | `real_fd_exhaustion_warns_once…`, the new test |
| strip the emit from `ConfinedWalk::descend` | 7 | 6 | 1 | `confined_walk_warns_on_fd_exhaustion…` |
| widen `should_warn_fd_exhaustion` to any errno | 7 | 5 | 2 | `fd_exhaustion_predicate_matches_only…`, `confined_walk_warns…` |
| make the anchor walk retain its parents | 7 | 6 | 1 | the new test, alone |

The last row is the new coverage: nothing else in the suite notices the anchor
walk turning into an accumulating one, and the peer controls that walk's depth.

## Upstream

- `syscall.c:2797-2800` — "The walk holds one fd per component, so depth is
  bounded by `RLIMIT_NOFILE` anyway."
- `syscall.c:2924-2936` — the hint, inside `ds_descend()`, nested under
  `if (errno != ENOTDIR && !NOFOLLOW_HIT_SYMLINK(errno))`, and emitted bare via
  `rprintf(FWARNING, ...)` with no `(code N)` envelope. Upstream places it on
  the accumulating walk alone, which is what this pins.

`open_dest_anchor` has no upstream counterpart carrying the hint, and needs
none: it is `openat()` per component with a rolling descriptor.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` — clean
- `cargo nextest run -p fast_io --all-features` — 840 run, 840 passed, 0 skipped
- `cargo check --target x86_64-pc-windows-gnu -p fast_io --all-targets --all-features` — clean
